### PR TITLE
Mapify: character etc. sees + sundry others

### DIFF
--- a/src/action.cpp
+++ b/src/action.cpp
@@ -628,9 +628,9 @@ std::optional<input_event> hotkey_for_action( const action_id action,
     }
 }
 
-bool can_butcher_at( const tripoint_bub_ms &p )
+bool can_butcher_at( map &here, const tripoint_bub_ms &p )
 {
-    map_stack items = get_map().i_at( p );
+    map_stack items = here.i_at( p );
     // Early exit when there's definitely nothing to butcher
     if( items.empty() ) {
         return false;
@@ -655,13 +655,12 @@ bool can_butcher_at( const tripoint_bub_ms &p )
     return has_corpse || has_item;
 }
 
-bool can_move_vertical_at( const tripoint_bub_ms &p, int movez )
+bool can_move_vertical_at( const map &here, const tripoint_bub_ms &p, int movez )
 {
     if( p.z() + movez < -OVERMAP_DEPTH || p.z() + movez > OVERMAP_HEIGHT ) {
         return false;
     }
     Character &player_character = get_player_character();
-    map &here = get_map();
     // TODO: unify this with game::move_vertical
     if( here.has_flag( ter_furn_flag::TFLAG_SWIMMABLE, p ) &&
         here.has_flag( ter_furn_flag::TFLAG_DEEP_WATER, p ) ) {
@@ -680,9 +679,8 @@ bool can_move_vertical_at( const tripoint_bub_ms &p, int movez )
     }
 }
 
-bool can_examine_at( const tripoint_bub_ms &p, bool with_pickup )
+bool can_examine_at( map &here, const tripoint_bub_ms &p, bool with_pickup )
 {
-    map &here = get_map();
     if( here.veh_at( p ) ) {
         return true;
     }
@@ -713,9 +711,8 @@ bool can_examine_at( const tripoint_bub_ms &p, bool with_pickup )
     return here.can_see_trap_at( p, get_player_character() );
 }
 
-static bool can_pickup_at( const tripoint_bub_ms &p )
+static bool can_pickup_at( map &here, const tripoint_bub_ms &p )
 {
-    map &here = get_map();
     if( const std::optional<vpart_reference> ovp = here.veh_at( p ).cargo() ) {
         if( !ovp->items().empty() ) {
             return true;
@@ -726,9 +723,8 @@ static bool can_pickup_at( const tripoint_bub_ms &p )
            here.has_items( p );
 }
 
-bool can_interact_at( action_id action, const tripoint_bub_ms &p )
+bool can_interact_at( action_id action, map &here, const tripoint_bub_ms &p )
 {
-    map &here = get_map();
     if( here.impassable_field_at( p ) ) {
         return false;
     }
@@ -744,25 +740,25 @@ bool can_interact_at( action_id action, const tripoint_bub_ms &p )
                    here.close_door( p, !here.is_outside( player_pos ), true );
         }
         case ACTION_BUTCHER:
-            return can_butcher_at( p );
+            return can_butcher_at( here, p );
         case ACTION_MOVE_UP:
-            return can_move_vertical_at( p, 1 );
+            return can_move_vertical_at( here, p, 1 );
         case ACTION_MOVE_DOWN:
-            return can_move_vertical_at( p, -1 );
+            return can_move_vertical_at( here, p, -1 );
         case ACTION_EXAMINE:
-            return can_examine_at( p, false );
+            return can_examine_at( here, p, false );
         case ACTION_EXAMINE_AND_PICKUP:
-            return can_examine_at( p, true );
+            return can_examine_at( here, p, true );
         case ACTION_PICKUP:
-            return can_pickup_at( p );
+            return can_pickup_at( here, p );
         default:
             return false;
     }
 
-    return can_interact_at( action, p );
+    return can_interact_at( action, here, p );
 }
 
-action_id handle_action_menu()
+action_id handle_action_menu( map &here )
 {
     const input_context ctxt = get_default_mode_input_context();
     std::string catgname;
@@ -807,7 +803,6 @@ action_id handle_action_menu()
         action_weightings[ACTION_TOGGLE_PRONE] = 300;
     }
 
-    map &here = get_map();
     // Check if we're on a vehicle, if so, vehicle controls should be top.
     if( here.veh_at( player_character.pos_bub() ) ) {
         // Make it 300 to prioritize it before examining the vehicle.
@@ -819,24 +814,24 @@ action_id handle_action_menu()
     for( const tripoint_bub_ms &pos : here.points_in_radius( player_character.pos_bub(), 1 ) ) {
         if( pos != player_character.pos_bub() ) {
             // Check for actions that work on nearby tiles
-            if( can_interact_at( ACTION_OPEN, pos ) ) {
+            if( can_interact_at( ACTION_OPEN, here, pos ) ) {
                 action_weightings[ACTION_OPEN] = 200;
             }
-            if( can_interact_at( ACTION_CLOSE, pos ) ) {
+            if( can_interact_at( ACTION_CLOSE, here, pos ) ) {
                 action_weightings[ACTION_CLOSE] = 200;
             }
-            if( can_interact_at( ACTION_EXAMINE, pos ) ) {
+            if( can_interact_at( ACTION_EXAMINE, here, pos ) ) {
                 action_weightings[ACTION_EXAMINE] = 200;
             }
         } else {
             // Check for actions that work on own tile only
-            if( can_interact_at( ACTION_BUTCHER, pos ) ) {
+            if( can_interact_at( ACTION_BUTCHER, here, pos ) ) {
                 action_weightings[ACTION_BUTCHER] = 200;
             }
-            if( can_interact_at( ACTION_MOVE_UP, pos ) ) {
+            if( can_interact_at( ACTION_MOVE_UP, here, pos ) ) {
                 action_weightings[ACTION_MOVE_UP] = 200;
             }
-            if( can_interact_at( ACTION_MOVE_DOWN, pos ) ) {
+            if( can_interact_at( ACTION_MOVE_DOWN, here, pos ) ) {
                 action_weightings[ACTION_MOVE_DOWN] = 200;
             }
         }
@@ -1221,31 +1216,33 @@ std::optional<tripoint_bub_ms> choose_adjacent( const tripoint_bub_ms &pos,
     }
 }
 
-std::optional<tripoint_bub_ms> choose_adjacent_highlight( const std::string &message,
+std::optional<tripoint_bub_ms> choose_adjacent_highlight( map &here, const std::string &message,
         const std::string &failure_message, const action_id action,
         const bool allow_vertical, const bool allow_autoselect )
 {
-    const std::function<bool( const tripoint_bub_ms & )> f = [&action]( const tripoint_bub_ms & p ) {
-        return can_interact_at( action, p );
+    const std::function<bool( const tripoint_bub_ms & )> f = [&action,
+    &here]( const tripoint_bub_ms & p ) {
+        return can_interact_at( action, here, p );
     };
-    return choose_adjacent_highlight( message, failure_message, f, allow_vertical, allow_autoselect );
+    return choose_adjacent_highlight( here, message, failure_message, f, allow_vertical,
+                                      allow_autoselect );
 }
 
-std::optional<tripoint_bub_ms> choose_adjacent_highlight( const std::string &message,
+std::optional<tripoint_bub_ms> choose_adjacent_highlight( map &here, const std::string &message,
         const std::string &failure_message, const std::function<bool( const tripoint_bub_ms & )> &allowed,
         const bool allow_vertical, const bool allow_autoselect )
 {
-    return choose_adjacent_highlight( get_avatar().pos_bub(), message, failure_message, allowed,
+    return choose_adjacent_highlight( here, get_avatar().pos_bub( here ), message, failure_message,
+                                      allowed,
                                       allow_vertical, allow_autoselect );
 }
 
-std::optional<tripoint_bub_ms> choose_adjacent_highlight( const tripoint_bub_ms &pos,
+std::optional<tripoint_bub_ms> choose_adjacent_highlight( map &here, const tripoint_bub_ms &pos,
         const std::string &message,
         const std::string &failure_message, const std::function<bool( const tripoint_bub_ms & )> &allowed,
         bool allow_vertical, bool allow_autoselect )
 {
     std::vector<tripoint_bub_ms> valid;
-    map &here = get_map();
     if( allowed ) {
         for( const tripoint_bub_ms &pos : here.points_in_radius( pos, 1 ) ) {
             if( allowed( pos ) ) {

--- a/src/action.h
+++ b/src/action.h
@@ -12,6 +12,7 @@
 #include "coords_fwd.h"
 
 class input_context;
+class map;
 struct input_event;
 
 /**
@@ -525,7 +526,7 @@ std::optional<tripoint_rel_ms> choose_direction( const std::string &message,
  * @param[in] allow_vertical Allows direction vector to have vertical component if true
  * @param[in] allow_autoselect Automatically select location if there's only one valid option and the appropriate setting is enabled
  */
-std::optional<tripoint_bub_ms> choose_adjacent_highlight( const std::string &message,
+std::optional<tripoint_bub_ms> choose_adjacent_highlight( map &here, const std::string &message,
         const std::string &failure_message, action_id action,
         bool allow_vertical = false, bool allow_autoselect = true );
 
@@ -546,10 +547,10 @@ std::optional<tripoint_bub_ms> choose_adjacent_highlight( const std::string &mes
  * @param[in] allow_vertical Allows direction vector to have vertical component if true
  * @param[in] allow_autoselect Automatically select location if there's only one valid option and the appropriate setting is enabled
  */
-std::optional<tripoint_bub_ms> choose_adjacent_highlight( const std::string &message,
+std::optional<tripoint_bub_ms> choose_adjacent_highlight( map &here, const std::string &message,
         const std::string &failure_message, const std::function<bool( const tripoint_bub_ms & )> &allowed,
         bool allow_vertical = false, bool allow_autoselect = true );
-std::optional<tripoint_bub_ms> choose_adjacent_highlight( const tripoint_bub_ms &pos,
+std::optional<tripoint_bub_ms> choose_adjacent_highlight( map &here, const tripoint_bub_ms &pos,
         const std::string &message,
         const std::string &failure_message, const std::function<bool( const tripoint_bub_ms & )> &allowed,
         bool allow_vertical = false, bool allow_autoselect = true );
@@ -599,7 +600,7 @@ point_rel_ms get_delta_from_movement_action( action_id act, iso_rotate rot );
  *
  * @returns action_id ID of action requested by user at menu.
  */
-action_id handle_action_menu();
+action_id handle_action_menu( map &here );
 
 /**
  * Show in-game main menu
@@ -624,7 +625,7 @@ action_id handle_main_menu();
  * @param p Point to perform test at
  * @returns true if movement is possible in the indicated direction
  */
-bool can_interact_at( action_id action, const tripoint_bub_ms &p );
+bool can_interact_at( action_id action, map &here, const tripoint_bub_ms &p );
 
 /**
  * Test whether it is possible to perform butcher action
@@ -638,7 +639,7 @@ bool can_interact_at( action_id action, const tripoint_bub_ms &p );
  * @param p Point to perform the test at
  * @returns true if there is a corpse or item that can be disassembled at a point, otherwise false
  */
-bool can_butcher_at( const tripoint_bub_ms &p );
+bool can_butcher_at( map &here, const tripoint_bub_ms &p );
 
 /**
  * Test whether vertical movement is possible
@@ -654,7 +655,7 @@ bool can_butcher_at( const tripoint_bub_ms &p );
  * @param movez Direction to move. -1 for down, all other values for up
  * @returns true if movement is possible in the indicated direction, otherwise false
  */
-bool can_move_vertical_at( const tripoint_bub_ms &p, int movez );
+bool can_move_vertical_at( const map &here, const tripoint_bub_ms &p, int movez );
 
 /**
  * Test whether examine is possible
@@ -668,6 +669,6 @@ bool can_move_vertical_at( const tripoint_bub_ms &p, int movez );
  * @param with_pickup True if the presence of items to pick up is sufficient eligibility
  * @returns true if the examine action is possible at this point, otherwise false
  */
-bool can_examine_at( const tripoint_bub_ms &p, bool with_pickup = false );
+bool can_examine_at( map &here,  const tripoint_bub_ms &p, bool with_pickup = false );
 
 #endif // CATA_SRC_ACTION_H

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -454,7 +454,7 @@ void aim_activity_actor::finish( player_activity &act, Character &who )
     }
 
     gun_mode gun = weapon->gun_current_mode();
-    who.fire_gun( &here, fin_trajectory.back(), gun.qty, *gun, reload_loc );
+    who.fire_gun( here, fin_trajectory.back(), gun.qty, *gun, reload_loc );
 
     if( !get_option<bool>( "AIM_AFTER_FIRING" ) ) {
         restore_view();
@@ -1980,13 +1980,15 @@ bool read_activity_actor::player_readma( avatar &you )
 
 bool read_activity_actor::npc_read( npc &learner )
 {
+    map &here = get_map();
+
     const cata::value_ptr<islot_book> &islotbook = book->type->book;
     const skill_id &skill = islotbook->skill;
 
     // NPCs don't need to identify the book or learn recipes yet.
     // NPCs don't read to other NPCs yet.
     const bool display_messages = learner.get_fac_id() == faction_your_followers &&
-                                  get_player_character().sees( learner );
+                                  get_player_character().sees( here, learner );
 
     const int book_fun = learner.book_fun_for( *book, learner );
     if( book_fun != 0 ) {
@@ -2732,6 +2734,8 @@ void lockpick_activity_actor::finish( player_activity &act, Character &who )
 
 std::optional<tripoint_bub_ms> lockpick_activity_actor::select_location( avatar &you )
 {
+    map &here = get_map();
+
     if( you.cant_do_mounted() ) {
         return std::nullopt;
     }
@@ -2748,7 +2752,8 @@ std::optional<tripoint_bub_ms> lockpick_activity_actor::select_location( avatar 
     };
 
     std::optional<tripoint_bub_ms> target = choose_adjacent_highlight(
-            _( "Use your lockpick where?" ), _( "There is nothing to lockpick nearby." ), is_pickable, false );
+            here, _( "Use your lockpick where?" ), _( "There is nothing to lockpick nearby." ), is_pickable,
+            false );
     if( !target ) {
         return std::nullopt;
     }

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -479,6 +479,8 @@ void activity_handlers::butcher_do_turn( player_activity *act, Character * )
 
 static bool do_cannibalism_piss_people_off( Character &you )
 {
+    const map &here = get_map();
+
     if( !you.is_avatar() ) {
         return true; // NPCs dont accidentally cause player hate
     }
@@ -489,7 +491,7 @@ static bool do_cannibalism_piss_people_off( Character &you )
     }
 
     for( npc &guy : g->all_npcs() ) {
-        if( guy.is_active() && guy.sees( you ) && !guy.okay_with_eating_humans() ) {
+        if( guy.is_active() && guy.sees( here, you ) && !guy.okay_with_eating_humans() ) {
             guy.say( _( "<swear!>?  Are you butchering them?  That's not okay, <fuck_you>." ) );
             // massive opinion penalty
             guy.op_of_u.trust -= 5;
@@ -1237,7 +1239,7 @@ static bool butchery_drops_harvest( item *corpse_item, const mtype &mt, Characte
                 // TODO: smarter NPC liquid handling
                 // If we're not bleeding the animal we don't care about the blood being wasted
                 if( you.is_npc() || action != butcher_type::BLEED ) {
-                    drop_on_map( you, item_drop_reason::deliberate, { obj }, &here, you.pos_bub( &here ) );
+                    drop_on_map( you, item_drop_reason::deliberate, { obj }, &here, you.pos_bub( here ) );
                 } else {
                     liquid_handler::handle_all_liquid( obj, 1 );
                 }
@@ -2004,7 +2006,7 @@ void activity_handlers::start_fire_do_turn( player_activity *act, Character *you
 
     you->mod_moves( -you->get_moves() );
     const firestarter_actor *actor = dynamic_cast<const firestarter_actor *>( usef->get_actor_ptr() );
-    const float light = actor->light_mod( &here, you->pos_bub( &here ) );
+    const float light = actor->light_mod( &here, you->pos_bub( here ) );
     act->moves_left -= light * 100;
     if( light < 0.1 ) {
         add_msg( m_bad, _( "There is not enough sunlight to start a fire now.  You stop trying." ) );
@@ -3103,6 +3105,8 @@ void activity_handlers::socialize_finish( player_activity *act, Character *you )
 
 void activity_handlers::operation_do_turn( player_activity *act, Character *you )
 {
+    const map &here = get_map();
+
     /**
     - values[0]: Difficulty
     - values[1]: success
@@ -3122,7 +3126,7 @@ void activity_handlers::operation_do_turn( player_activity *act, Character *you 
     const bionic_id bid( act->str_values[cbm_id] );
     const bool autodoc = act->str_values[is_autodoc] == "true";
     Character &player_character = get_player_character();
-    const bool u_see = player_character.sees( you->pos_bub() ) &&
+    const bool u_see = player_character.sees( here, you->pos_bub( here ) ) &&
                        ( !player_character.has_effect( effect_narcosis ) ||
                          player_character.has_bionic( bio_painkiller ) ||
                          player_character.has_flag( json_flag_PAIN_IMMUNE ) );
@@ -3135,8 +3139,7 @@ void activity_handlers::operation_do_turn( player_activity *act, Character *you 
     const time_duration message_freq = difficulty * 2_minutes;
     time_duration time_left = time_duration::from_moves( act->moves_left );
 
-    map &here = get_map();
-    if( autodoc && here.inbounds( you->pos_bub() ) ) {
+    if( autodoc && here.inbounds( you->pos_bub( here ) ) ) {
         const std::list<tripoint_bub_ms> autodocs = here.find_furnitures_with_flag_in_radius(
                     you->pos_bub(), 1,
                     ter_furn_flag::TFLAG_AUTODOC );

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -446,7 +446,7 @@ void put_into_vehicle_or_drop( Character &you, item_drop_reason reason,
 {
     map &here = get_map();
 
-    put_into_vehicle_or_drop( you, reason, items, &here, you.pos_bub( &here ) );
+    put_into_vehicle_or_drop( you, reason, items, &here, you.pos_bub( here ) );
 }
 
 void put_into_vehicle_or_drop( Character &you, item_drop_reason reason,
@@ -3109,8 +3109,8 @@ static requirement_check_result generic_multi_activity_check_requirement(
                     for( const tripoint_bub_ms &point_elem :
                          here.points_in_radius( src_loc, /*radius=*/PICKUP_RANGE - 1, /*radiusz=*/0 ) ) {
                         // we don't want to place the components where they could interfere with our ( or someone else's ) construction spots
-                        if( !you.sees( point_elem ) || ( std::find( local_src_set.begin(), local_src_set.end(),
-                                                         point_elem ) != local_src_set.end() ) || !here.can_put_items_ter_furn( point_elem ) ) {
+                        if( !you.sees( here, point_elem ) || ( std::find( local_src_set.begin(), local_src_set.end(),
+                                                               point_elem ) != local_src_set.end() ) || !here.can_put_items_ter_furn( point_elem ) ) {
                             continue;
                         }
                         candidates.push_back( point_elem );

--- a/src/animation.cpp
+++ b/src/animation.cpp
@@ -697,12 +697,15 @@ void game::draw_line( const tripoint_bub_ms &p, const tripoint_bub_ms &center,
 void game::draw_line( const tripoint_bub_ms &p, const tripoint_bub_ms &center,
                       const std::vector<tripoint_bub_ms> &points, bool noreveal )
 {
-    if( !u.sees( p ) ) {
-        return;
-    }
+    const map &here = get_map();
 
-    draw_line_curses( *this, center, points, noreveal );
-}
+    if( !u.sees( here, p ) ) {
+        if( !u.sees( p ) ) {
+            return;
+        }
+
+        draw_line_curses( *this, center, points, noreveal );
+    }
 #endif
 
 namespace
@@ -722,35 +725,30 @@ void draw_line_curses( game &g, const std::vector<tripoint_bub_ms> &points )
 } //namespace
 
 #if defined(TILES)
-void game::draw_line( const tripoint_bub_ms &p, const std::vector<tripoint_bub_ms> &points )
-{
+void game::draw_line( const tripoint_bub_ms & p, const std::vector<tripoint_bub_ms> &points ) {
     draw_line_curses( *this, points );
     tilecontext->init_draw_line( p, points, "line_trail", false );
 }
 #else
-void game::draw_line( const tripoint_bub_ms &/*p*/, const std::vector<tripoint_bub_ms> &points )
-{
+void game::draw_line( const tripoint_bub_ms &/*p*/, const std::vector<tripoint_bub_ms> &points ) {
     draw_line_curses( *this, points );
 }
 #endif
 
 #if defined(TILES)
-void game::draw_cursor( const tripoint_bub_ms &p ) const
-{
+void game::draw_cursor( const tripoint_bub_ms & p ) const {
     const tripoint_rel_ms rp = relative_view_pos( *this, p );
     mvwputch_inv( w_terrain, rp.xy().raw(), c_light_green, 'X' );
     tilecontext->init_draw_cursor( p );
 }
 #else
-void game::draw_cursor( const tripoint_bub_ms &p ) const
-{
+void game::draw_cursor( const tripoint_bub_ms & p ) const {
     const tripoint_rel_ms rp = relative_view_pos( *this, p );
     mvwputch_inv( w_terrain, rp.xy().raw(), c_light_green, 'X' );
 }
 #endif
 
-void game::draw_cursor_unobscuring( const tripoint_bub_ms &p ) const
-{
+void game::draw_cursor_unobscuring( const tripoint_bub_ms & p ) const {
     const tripoint_rel_ms rp = relative_view_pos( *this, p );
     mvwputch_inv( w_terrain, ( rp.xy() + point::north_east ).raw(), c_cyan, "↙" );
     mvwputch_inv( w_terrain, ( rp.xy() + point::south_east ).raw(), c_cyan, "↖" );
@@ -762,13 +760,11 @@ void game::draw_cursor_unobscuring( const tripoint_bub_ms &p ) const
 }
 
 #if defined(TILES)
-void game::draw_highlight( const tripoint_bub_ms &p )
-{
+void game::draw_highlight( const tripoint_bub_ms & p ) {
     tilecontext->init_draw_highlight( p );
 }
 #else
-void game::draw_highlight( const tripoint_bub_ms & )
-{
+void game::draw_highlight( const tripoint_bub_ms & ) {
     // Do nothing
 }
 #endif
@@ -787,8 +783,7 @@ void draw_weather_curses( const catacurses::window &win, const weather_printable
 } //namespace
 
 #if defined(TILES)
-void game::draw_weather( const weather_printable &w ) const
-{
+void game::draw_weather( const weather_printable & w ) const {
     if( !use_tiles ) {
         draw_weather_curses( w_terrain, w );
         return;
@@ -797,8 +792,7 @@ void game::draw_weather( const weather_printable &w ) const
     tilecontext->init_draw_weather( w, w.wtype->tiles_animation );
 }
 #else
-void game::draw_weather( const weather_printable &w ) const
-{
+void game::draw_weather( const weather_printable & w ) const {
     draw_weather_curses( w_terrain, w );
 }
 #endif
@@ -831,8 +825,7 @@ void draw_sct_curses( const game &g )
 } //namespace
 
 #if defined(TILES)
-void game::draw_sct() const
-{
+void game::draw_sct() const {
     if( use_tiles ) {
         tilecontext->init_draw_sct();
     } else {
@@ -840,8 +833,7 @@ void game::draw_sct() const
     }
 }
 #else
-void game::draw_sct() const
-{
+void game::draw_sct() const {
     draw_sct_curses( *this );
 }
 #endif
@@ -865,9 +857,8 @@ void draw_zones_curses( const catacurses::window &w, const tripoint_bub_ms &star
 } //namespace
 
 #if defined(TILES)
-void game::draw_zones( const tripoint_bub_ms &start, const tripoint_bub_ms &end,
-                       const tripoint_rel_ms &offset ) const
-{
+void game::draw_zones( const tripoint_bub_ms & start, const tripoint_bub_ms & end,
+                       const tripoint_rel_ms & offset ) const {
     if( use_tiles ) {
         tilecontext->init_draw_zones( start, end, offset );
     } else {
@@ -875,18 +866,16 @@ void game::draw_zones( const tripoint_bub_ms &start, const tripoint_bub_ms &end,
     }
 }
 #else
-void game::draw_zones( const tripoint_bub_ms &start, const tripoint_bub_ms &end,
-                       const tripoint_rel_ms &offset ) const
-{
+void game::draw_zones( const tripoint_bub_ms & start, const tripoint_bub_ms & end,
+                       const tripoint_rel_ms & offset ) const {
     draw_zones_curses( w_terrain, start, end, offset );
 }
 #endif
 
 #if defined(TILES)
-void game::draw_async_anim( const tripoint_bub_ms &p, const std::string &tile_id,
-                            const std::string &ncstr,
-                            const nc_color &nccol )
-{
+void game::draw_async_anim( const tripoint_bub_ms & p, const std::string & tile_id,
+                            const std::string & ncstr,
+                            const nc_color & nccol ) {
     const map &here = get_map();
 
     if( test_mode ) {
@@ -913,9 +902,9 @@ void game::draw_async_anim( const tripoint_bub_ms &p, const std::string &tile_id
     g->invalidate_main_ui_adaptor();
 }
 #else
-void game::draw_async_anim( const tripoint_bub_ms &p, const std::string &, const std::string &ncstr,
-                            const nc_color &nccol )
-{
+void game::draw_async_anim( const tripoint_bub_ms & p, const std::string &,
+                            const std::string & ncstr,
+                            const nc_color & nccol ) {
     if( !ncstr.empty() ) {
         g->init_draw_async_anim_curses( p, ncstr, nccol );
     }
@@ -923,138 +912,118 @@ void game::draw_async_anim( const tripoint_bub_ms &p, const std::string &, const
 #endif
 
 #if defined(TILES)
-void game::draw_radiation_override( const tripoint_bub_ms &p, const int rad )
-{
+void game::draw_radiation_override( const tripoint_bub_ms & p, const int rad ) {
     if( use_tiles ) {
         tilecontext->init_draw_radiation_override( p, rad );
     }
 }
 #else
-void game::draw_radiation_override( const tripoint_bub_ms &, const int )
-{
+void game::draw_radiation_override( const tripoint_bub_ms &, const int ) {
 }
 #endif
 
 #if defined(TILES)
-void game::draw_terrain_override( const tripoint_bub_ms &p, const ter_id &id )
-{
+void game::draw_terrain_override( const tripoint_bub_ms & p, const ter_id & id ) {
     if( use_tiles ) {
         tilecontext->init_draw_terrain_override( p, id );
     }
 }
 #else
-void game::draw_terrain_override( const tripoint_bub_ms &, const ter_id & )
-{
+void game::draw_terrain_override( const tripoint_bub_ms &, const ter_id & ) {
 }
 #endif
 
 #if defined(TILES)
-void game::draw_furniture_override( const tripoint_bub_ms &p, const furn_id &id )
-{
+void game::draw_furniture_override( const tripoint_bub_ms & p, const furn_id & id ) {
     if( use_tiles ) {
         tilecontext->init_draw_furniture_override( p, id );
     }
 }
 #else
-void game::draw_furniture_override( const tripoint_bub_ms &, const furn_id & )
-{
+void game::draw_furniture_override( const tripoint_bub_ms &, const furn_id & ) {
 }
 #endif
 
 #if defined(TILES)
-void game::draw_graffiti_override( const tripoint_bub_ms &p, const bool has )
-{
+void game::draw_graffiti_override( const tripoint_bub_ms & p, const bool has ) {
     if( use_tiles ) {
         tilecontext->init_draw_graffiti_override( p, has );
     }
 }
 #else
-void game::draw_graffiti_override( const tripoint_bub_ms &, const bool )
-{
+void game::draw_graffiti_override( const tripoint_bub_ms &, const bool ) {
 }
 #endif
 
 #if defined(TILES)
-void game::draw_trap_override( const tripoint_bub_ms &p, const trap_id &id )
-{
+void game::draw_trap_override( const tripoint_bub_ms & p, const trap_id & id ) {
     if( use_tiles ) {
         tilecontext->init_draw_trap_override( p, id );
     }
 }
 #else
-void game::draw_trap_override( const tripoint_bub_ms &, const trap_id & )
-{
+void game::draw_trap_override( const tripoint_bub_ms &, const trap_id & ) {
 }
 #endif
 
 #if defined(TILES)
-void game::draw_field_override( const tripoint_bub_ms &p, const field_type_id &id )
-{
+void game::draw_field_override( const tripoint_bub_ms & p, const field_type_id & id ) {
     if( use_tiles ) {
         tilecontext->init_draw_field_override( p, id );
     }
 }
 #else
-void game::draw_field_override( const tripoint_bub_ms &, const field_type_id & )
-{
+void game::draw_field_override( const tripoint_bub_ms &, const field_type_id & ) {
 }
 #endif
 
 #if defined(TILES)
-void game::draw_item_override( const tripoint_bub_ms &p, const itype_id &id, const mtype_id &mid,
-                               const bool hilite )
-{
+void game::draw_item_override( const tripoint_bub_ms & p, const itype_id & id, const mtype_id & mid,
+                               const bool hilite ) {
     if( use_tiles ) {
         tilecontext->init_draw_item_override( p, id, mid, hilite );
     }
 }
 #else
 void game::draw_item_override( const tripoint_bub_ms &, const itype_id &, const mtype_id &,
-                               const bool )
-{
+                               const bool ) {
 }
 #endif
 
 #if defined(TILES)
 void game::draw_vpart_override(
-    const tripoint_bub_ms &p, const vpart_id &id, const int part_mod, const units::angle &veh_dir,
-    const bool hilite, const point_rel_ms &mount )
-{
+    const tripoint_bub_ms & p, const vpart_id & id, const int part_mod, const units::angle & veh_dir,
+    const bool hilite, const point_rel_ms & mount ) {
     if( use_tiles ) {
         tilecontext->init_draw_vpart_override( p, id, part_mod, veh_dir, hilite, mount );
     }
 }
 #else
 void game::draw_vpart_override( const tripoint_bub_ms &, const vpart_id &, const int,
-                                const units::angle &, const bool, const point_rel_ms & )
-{
+                                const units::angle &, const bool, const point_rel_ms & ) {
 }
 #endif
 
 #if defined(TILES)
-void game::draw_below_override( const tripoint_bub_ms &p, const bool draw )
-{
+void game::draw_below_override( const tripoint_bub_ms & p, const bool draw ) {
     if( use_tiles ) {
         tilecontext->init_draw_below_override( p, draw );
     }
 }
 #else
-void game::draw_below_override( const tripoint_bub_ms &, const bool )
-{
+void game::draw_below_override( const tripoint_bub_ms &, const bool ) {
 }
 #endif
 
 #if defined(TILES)
-void game::draw_monster_override( const tripoint_bub_ms &p, const mtype_id &id, const int count,
-                                  const bool more, const Creature::Attitude att )
-{
+void game::draw_monster_override( const tripoint_bub_ms & p, const mtype_id & id, const int count,
+                                  const bool more, const Creature::Attitude att ) {
     if( use_tiles ) {
         tilecontext->init_draw_monster_override( p, id, count, more, att );
     }
 }
 #else
 void game::draw_monster_override( const tripoint_bub_ms &, const mtype_id &, const int,
-                                  const bool, const Creature::Attitude )
-{
+                                  const bool, const Creature::Attitude ) {
 }
 #endif

--- a/src/animation.cpp
+++ b/src/animation.cpp
@@ -102,7 +102,9 @@ class bullet_animation : public basic_animation
 
 bool is_point_visible( const tripoint_bub_ms &p, int margin = 0 )
 {
-    return g->is_in_viewport( p, margin ) && get_player_view().sees( p );
+    const map &here = get_map();
+
+    return g->is_in_viewport( p, margin ) && get_player_view().sees( here, p );
 }
 
 bool is_radius_visible( const tripoint_bub_ms &center, int radius )
@@ -655,9 +657,9 @@ void draw_line_curses( game &g, const tripoint_bub_ms &center,
         const Creature *critter = creatures.creature_at( p, true );
 
         // NPCs and monsters get drawn with inverted colors
-        if( critter && player_character.sees( *critter ) ) {
+        if( critter && player_character.sees( here, *critter ) ) {
             critter->draw( g.w_terrain, center, true );
-        } else if( noreveal && !player_character.sees( p ) ) {
+        } else if( noreveal && !player_character.sees( here,  p ) ) {
             // Draw a meaningless symbol. Avoids revealing tile, but keeps feedback
             const char sym = '?';
             const nc_color col = c_dark_gray;
@@ -677,7 +679,9 @@ void draw_line_curses( game &g, const tripoint_bub_ms &center,
 void game::draw_line( const tripoint_bub_ms &p, const tripoint_bub_ms &center,
                       const std::vector<tripoint_bub_ms> &points, bool noreveal )
 {
-    if( !u.sees( p ) ) {
+    const map &here = get_map();
+
+    if( !u.sees( here, p ) ) {
         return;
     }
 
@@ -883,6 +887,8 @@ void game::draw_async_anim( const tripoint_bub_ms &p, const std::string &tile_id
                             const std::string &ncstr,
                             const nc_color &nccol )
 {
+    const map &here = get_map();
+
     if( test_mode ) {
         // avoid segfault from null tilecontext in tests
         return;
@@ -892,7 +898,7 @@ void game::draw_async_anim( const tripoint_bub_ms &p, const std::string &tile_id
         return;
     }
 
-    if( !u.sees( p ) ) {
+    if( !u.sees( here, p ) ) {
         return;
     }
 

--- a/src/animation.cpp
+++ b/src/animation.cpp
@@ -700,12 +700,11 @@ void game::draw_line( const tripoint_bub_ms &p, const tripoint_bub_ms &center,
     const map &here = get_map();
 
     if( !u.sees( here, p ) ) {
-        if( !u.sees( p ) ) {
-            return;
-        }
-
-        draw_line_curses( *this, center, points, noreveal );
+        return;
     }
+
+    draw_line_curses( *this, center, points, noreveal );
+}
 #endif
 
 namespace
@@ -725,30 +724,35 @@ void draw_line_curses( game &g, const std::vector<tripoint_bub_ms> &points )
 } //namespace
 
 #if defined(TILES)
-void game::draw_line( const tripoint_bub_ms & p, const std::vector<tripoint_bub_ms> &points ) {
+void game::draw_line( const tripoint_bub_ms &p, const std::vector<tripoint_bub_ms> &points )
+{
     draw_line_curses( *this, points );
     tilecontext->init_draw_line( p, points, "line_trail", false );
 }
 #else
-void game::draw_line( const tripoint_bub_ms &/*p*/, const std::vector<tripoint_bub_ms> &points ) {
+void game::draw_line( const tripoint_bub_ms &/*p*/, const std::vector<tripoint_bub_ms> &points )
+{
     draw_line_curses( *this, points );
 }
 #endif
 
 #if defined(TILES)
-void game::draw_cursor( const tripoint_bub_ms & p ) const {
+void game::draw_cursor( const tripoint_bub_ms &p ) const
+{
     const tripoint_rel_ms rp = relative_view_pos( *this, p );
     mvwputch_inv( w_terrain, rp.xy().raw(), c_light_green, 'X' );
     tilecontext->init_draw_cursor( p );
 }
 #else
-void game::draw_cursor( const tripoint_bub_ms & p ) const {
+void game::draw_cursor( const tripoint_bub_ms &p ) const
+{
     const tripoint_rel_ms rp = relative_view_pos( *this, p );
     mvwputch_inv( w_terrain, rp.xy().raw(), c_light_green, 'X' );
 }
 #endif
 
-void game::draw_cursor_unobscuring( const tripoint_bub_ms & p ) const {
+void game::draw_cursor_unobscuring( const tripoint_bub_ms &p ) const
+{
     const tripoint_rel_ms rp = relative_view_pos( *this, p );
     mvwputch_inv( w_terrain, ( rp.xy() + point::north_east ).raw(), c_cyan, "↙" );
     mvwputch_inv( w_terrain, ( rp.xy() + point::south_east ).raw(), c_cyan, "↖" );
@@ -760,11 +764,13 @@ void game::draw_cursor_unobscuring( const tripoint_bub_ms & p ) const {
 }
 
 #if defined(TILES)
-void game::draw_highlight( const tripoint_bub_ms & p ) {
+void game::draw_highlight( const tripoint_bub_ms &p )
+{
     tilecontext->init_draw_highlight( p );
 }
 #else
-void game::draw_highlight( const tripoint_bub_ms & ) {
+void game::draw_highlight( const tripoint_bub_ms & )
+{
     // Do nothing
 }
 #endif
@@ -783,7 +789,8 @@ void draw_weather_curses( const catacurses::window &win, const weather_printable
 } //namespace
 
 #if defined(TILES)
-void game::draw_weather( const weather_printable & w ) const {
+void game::draw_weather( const weather_printable &w ) const
+{
     if( !use_tiles ) {
         draw_weather_curses( w_terrain, w );
         return;
@@ -792,7 +799,8 @@ void game::draw_weather( const weather_printable & w ) const {
     tilecontext->init_draw_weather( w, w.wtype->tiles_animation );
 }
 #else
-void game::draw_weather( const weather_printable & w ) const {
+void game::draw_weather( const weather_printable &w ) const
+{
     draw_weather_curses( w_terrain, w );
 }
 #endif
@@ -825,7 +833,8 @@ void draw_sct_curses( const game &g )
 } //namespace
 
 #if defined(TILES)
-void game::draw_sct() const {
+void game::draw_sct() const
+{
     if( use_tiles ) {
         tilecontext->init_draw_sct();
     } else {
@@ -833,7 +842,8 @@ void game::draw_sct() const {
     }
 }
 #else
-void game::draw_sct() const {
+void game::draw_sct() const
+{
     draw_sct_curses( *this );
 }
 #endif
@@ -857,8 +867,9 @@ void draw_zones_curses( const catacurses::window &w, const tripoint_bub_ms &star
 } //namespace
 
 #if defined(TILES)
-void game::draw_zones( const tripoint_bub_ms & start, const tripoint_bub_ms & end,
-                       const tripoint_rel_ms & offset ) const {
+void game::draw_zones( const tripoint_bub_ms &start, const tripoint_bub_ms &end,
+                       const tripoint_rel_ms &offset ) const
+{
     if( use_tiles ) {
         tilecontext->init_draw_zones( start, end, offset );
     } else {
@@ -866,16 +877,18 @@ void game::draw_zones( const tripoint_bub_ms & start, const tripoint_bub_ms & en
     }
 }
 #else
-void game::draw_zones( const tripoint_bub_ms & start, const tripoint_bub_ms & end,
-                       const tripoint_rel_ms & offset ) const {
+void game::draw_zones( const tripoint_bub_ms &start, const tripoint_bub_ms &end,
+                       const tripoint_rel_ms &offset ) const
+{
     draw_zones_curses( w_terrain, start, end, offset );
 }
 #endif
 
 #if defined(TILES)
-void game::draw_async_anim( const tripoint_bub_ms & p, const std::string & tile_id,
-                            const std::string & ncstr,
-                            const nc_color & nccol ) {
+void game::draw_async_anim( const tripoint_bub_ms &p, const std::string &tile_id,
+                            const std::string &ncstr,
+                            const nc_color &nccol )
+{
     const map &here = get_map();
 
     if( test_mode ) {
@@ -902,9 +915,10 @@ void game::draw_async_anim( const tripoint_bub_ms & p, const std::string & tile_
     g->invalidate_main_ui_adaptor();
 }
 #else
-void game::draw_async_anim( const tripoint_bub_ms & p, const std::string &,
-                            const std::string & ncstr,
-                            const nc_color & nccol ) {
+void game::draw_async_anim( const tripoint_bub_ms &p, const std::string &,
+                            const std::string &ncstr,
+                            const nc_color &nccol )
+{
     if( !ncstr.empty() ) {
         g->init_draw_async_anim_curses( p, ncstr, nccol );
     }
@@ -912,118 +926,138 @@ void game::draw_async_anim( const tripoint_bub_ms & p, const std::string &,
 #endif
 
 #if defined(TILES)
-void game::draw_radiation_override( const tripoint_bub_ms & p, const int rad ) {
+void game::draw_radiation_override( const tripoint_bub_ms &p, const int rad )
+{
     if( use_tiles ) {
         tilecontext->init_draw_radiation_override( p, rad );
     }
 }
 #else
-void game::draw_radiation_override( const tripoint_bub_ms &, const int ) {
+void game::draw_radiation_override( const tripoint_bub_ms &, const int )
+{
 }
 #endif
 
 #if defined(TILES)
-void game::draw_terrain_override( const tripoint_bub_ms & p, const ter_id & id ) {
+void game::draw_terrain_override( const tripoint_bub_ms &p, const ter_id &id )
+{
     if( use_tiles ) {
         tilecontext->init_draw_terrain_override( p, id );
     }
 }
 #else
-void game::draw_terrain_override( const tripoint_bub_ms &, const ter_id & ) {
+void game::draw_terrain_override( const tripoint_bub_ms &, const ter_id & )
+{
 }
 #endif
 
 #if defined(TILES)
-void game::draw_furniture_override( const tripoint_bub_ms & p, const furn_id & id ) {
+void game::draw_furniture_override( const tripoint_bub_ms &p, const furn_id &id )
+{
     if( use_tiles ) {
         tilecontext->init_draw_furniture_override( p, id );
     }
 }
 #else
-void game::draw_furniture_override( const tripoint_bub_ms &, const furn_id & ) {
+void game::draw_furniture_override( const tripoint_bub_ms &, const furn_id & )
+{
 }
 #endif
 
 #if defined(TILES)
-void game::draw_graffiti_override( const tripoint_bub_ms & p, const bool has ) {
+void game::draw_graffiti_override( const tripoint_bub_ms &p, const bool has )
+{
     if( use_tiles ) {
         tilecontext->init_draw_graffiti_override( p, has );
     }
 }
 #else
-void game::draw_graffiti_override( const tripoint_bub_ms &, const bool ) {
+void game::draw_graffiti_override( const tripoint_bub_ms &, const bool )
+{
 }
 #endif
 
 #if defined(TILES)
-void game::draw_trap_override( const tripoint_bub_ms & p, const trap_id & id ) {
+void game::draw_trap_override( const tripoint_bub_ms &p, const trap_id &id )
+{
     if( use_tiles ) {
         tilecontext->init_draw_trap_override( p, id );
     }
 }
 #else
-void game::draw_trap_override( const tripoint_bub_ms &, const trap_id & ) {
+void game::draw_trap_override( const tripoint_bub_ms &, const trap_id & )
+{
 }
 #endif
 
 #if defined(TILES)
-void game::draw_field_override( const tripoint_bub_ms & p, const field_type_id & id ) {
+void game::draw_field_override( const tripoint_bub_ms &p, const field_type_id &id )
+{
     if( use_tiles ) {
         tilecontext->init_draw_field_override( p, id );
     }
 }
 #else
-void game::draw_field_override( const tripoint_bub_ms &, const field_type_id & ) {
+void game::draw_field_override( const tripoint_bub_ms &, const field_type_id & )
+{
 }
 #endif
 
 #if defined(TILES)
-void game::draw_item_override( const tripoint_bub_ms & p, const itype_id & id, const mtype_id & mid,
-                               const bool hilite ) {
+void game::draw_item_override( const tripoint_bub_ms &p, const itype_id &id, const mtype_id &mid,
+                               const bool hilite )
+{
     if( use_tiles ) {
         tilecontext->init_draw_item_override( p, id, mid, hilite );
     }
 }
 #else
 void game::draw_item_override( const tripoint_bub_ms &, const itype_id &, const mtype_id &,
-                               const bool ) {
+                               const bool )
+{
 }
 #endif
 
 #if defined(TILES)
 void game::draw_vpart_override(
-    const tripoint_bub_ms & p, const vpart_id & id, const int part_mod, const units::angle & veh_dir,
-    const bool hilite, const point_rel_ms & mount ) {
+    const tripoint_bub_ms &p, const vpart_id &id, const int part_mod, const units::angle &veh_dir,
+    const bool hilite, const point_rel_ms &mount )
+{
     if( use_tiles ) {
         tilecontext->init_draw_vpart_override( p, id, part_mod, veh_dir, hilite, mount );
     }
 }
 #else
 void game::draw_vpart_override( const tripoint_bub_ms &, const vpart_id &, const int,
-                                const units::angle &, const bool, const point_rel_ms & ) {
+                                const units::angle &, const bool, const point_rel_ms & )
+{
 }
 #endif
 
 #if defined(TILES)
-void game::draw_below_override( const tripoint_bub_ms & p, const bool draw ) {
+void game::draw_below_override( const tripoint_bub_ms &p, const bool draw )
+{
     if( use_tiles ) {
         tilecontext->init_draw_below_override( p, draw );
     }
 }
 #else
-void game::draw_below_override( const tripoint_bub_ms &, const bool ) {
+void game::draw_below_override( const tripoint_bub_ms &, const bool )
+{
 }
 #endif
 
 #if defined(TILES)
-void game::draw_monster_override( const tripoint_bub_ms & p, const mtype_id & id, const int count,
-                                  const bool more, const Creature::Attitude att ) {
+void game::draw_monster_override( const tripoint_bub_ms &p, const mtype_id &id, const int count,
+                                  const bool more, const Creature::Attitude att )
+{
     if( use_tiles ) {
         tilecontext->init_draw_monster_override( p, id, count, more, att );
     }
 }
 #else
 void game::draw_monster_override( const tripoint_bub_ms &, const mtype_id &, const int,
-                                  const bool, const Creature::Attitude ) {
+                                  const bool, const Creature::Attitude )
+{
 }
 #endif

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -655,8 +655,8 @@ void avatar_action::swim( map &m, avatar &you, const tripoint_bub_ms &p )
             return;
         }
     }
-    tripoint_abs_ms old_abs_pos = m.get_abs( you.pos_bub() );
-    you.setpos( p );
+    tripoint_abs_ms old_abs_pos = you.pos_abs();
+    you.setpos( m, p );
     g->update_map( you );
 
     cata_event_dispatch::avatar_moves( old_abs_pos, you, m );
@@ -971,6 +971,8 @@ void avatar_action::eat_or_use( avatar &you, item_location loc )
 void avatar_action::plthrow( avatar &you, item_location loc,
                              const std::optional<tripoint_bub_ms> &blind_throw_from_pos )
 {
+    map &here = get_map();
+
     bool in_shell = you.has_active_mutation( trait_SHELL2 ) ||
                     you.has_active_mutation( trait_SHELL3 );
     if( in_shell ) {
@@ -1061,9 +1063,9 @@ void avatar_action::plthrow( avatar &you, item_location loc,
     // Shift our position to our "peeking" position, so that the UI
     // for picking a throw point lets us target the location we couldn't
     // otherwise see.
-    const tripoint_bub_ms original_player_position = you.pos_bub();
+    const tripoint_abs_ms original_player_position = you.pos_abs();
     if( blind_throw_from_pos ) {
-        you.setpos( *blind_throw_from_pos, false );
+        you.setpos( here, *blind_throw_from_pos, false );
     }
 
     g->temp_exit_fullscreen();

--- a/src/ballistics.cpp
+++ b/src/ballistics.cpp
@@ -639,8 +639,8 @@ void projectile_attack( dealt_projectile_attack &attack, const projectile &proj_
                 return false;
             }
             // search for creatures in radius 4 around impact site
-            if( rl_dist( z.pos_bub( here ), tp ) <= 4 &&
-                here->sees( z.pos_bub( here ), tp, -1 ) ) {
+            if( rl_dist( z.pos_bub( *here ), tp ) <= 4 &&
+                here->sees( z.pos_bub( *here ), tp, -1 ) ) {
                 // don't hit targets that have already been hit
                 for( auto it : attack.targets_hit ) {
                     if( &z == it.first ) {

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -1214,6 +1214,8 @@ ret_val<void> Character::can_deactivate_bionic( bionic &bio, bool eff_only ) con
 
 bool Character::deactivate_bionic( bionic &bio, bool eff_only )
 {
+    const map &here = get_map();
+
     const auto can_deactivate = can_deactivate_bionic( bio, eff_only );
     bio_flag_cache.clear();
     if( !can_deactivate.success() ) {
@@ -1246,7 +1248,7 @@ bool Character::deactivate_bionic( bionic &bio, bool eff_only )
         if( bio.get_uid() == get_weapon_bionic_uid() ) {
             bio.set_weapon( *get_wielded_item() );
             add_msg_if_player( _( "You withdraw your %s." ), weapon.tname() );
-            if( get_player_view().sees( pos_bub() ) ) {
+            if( get_player_view().sees( here, pos_bub( here ) ) ) {
                 if( male ) {
                     add_msg_if_npc( m_info, _( "<npcname> withdraws his %s." ), weapon.tname() );
                 } else {
@@ -1815,6 +1817,7 @@ void Character::bionics_uninstall_failure( int difficulty, int success, float ad
 void Character::bionics_uninstall_failure( monster &installer, Character &patient, int difficulty,
         int success, float adjusted_skill )
 {
+    const map &here = get_map();
 
     // "success" should be passed in as a negative integer representing how far off we
     // were for a successful removal.  We use this to determine consequences for failing.
@@ -1828,7 +1831,7 @@ void Character::bionics_uninstall_failure( monster &installer, Character &patien
                               adjusted_skill ) );
     const int fail_type = std::min( 5, failure_level );
 
-    bool u_see = sees( patient );
+    bool u_see = sees( here, patient );
 
     if( u_see || patient.is_avatar() ) {
         if( fail_type <= 0 ) {
@@ -2219,6 +2222,8 @@ void Character::perform_uninstall( const bionic &bio, int difficulty, int succes
 bool Character::uninstall_bionic( const bionic &bio, monster &installer, Character &patient,
                                   float adjusted_skill )
 {
+    const map &here = get_map();
+
     viewer &player_view = get_player_view();
     if( installer.ammo[itype_anesthetic] <= 0 ) {
         add_msg_if_player_sees( installer, _( "The %s's anesthesia kit looks empty." ), installer.name() );
@@ -2263,7 +2268,7 @@ bool Character::uninstall_bionic( const bionic &bio, monster &installer, Charact
         if( patient.is_avatar() ) {
             add_msg( m_neutral, _( "Your parts are jiggled back into their familiar places." ) );
             add_msg( m_mixed, _( "Successfully removed %s." ), bio.info().name );
-        } else if( patient.is_npc() && player_view.sees( patient ) ) {
+        } else if( patient.is_npc() && player_view.sees( here, patient ) ) {
             add_msg( m_neutral, _( "%s's parts are jiggled back into their familiar places." ),
                      patient.disp_name() );
             add_msg( m_mixed, _( "Successfully removed %s." ), bio.info().name );

--- a/src/bionics_ui.cpp
+++ b/src/bionics_ui.cpp
@@ -574,6 +574,9 @@ static nc_color get_bionic_text_color( const bionic &bio, const bool isHighlight
 
 void avatar::power_bionics()
 {
+    // Required because available power includes electricity via cables.
+    const map &here = get_map();
+
     sorted_bionics passive = filtered_bionics( *my_bionics, TAB_PASSIVE );
     sorted_bionics active = filtered_bionics( *my_bionics, TAB_ACTIVE );
     bionic *bio_last = nullptr;
@@ -990,7 +993,7 @@ void avatar::power_bionics()
                             } else {
                                 activate_bionic( bio, false, &close_ui );
                                 // Exit this ui if we are firing a complex bionic
-                                if( close_ui && tmp->get_weapon().shots_remaining( this ) > 0 ) {
+                                if( close_ui && tmp->get_weapon().shots_remaining( here, this ) > 0 ) {
                                     break;
                                 }
                             }

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1625,7 +1625,7 @@ void cata_tiles::draw( const point &dest, const tripoint_bub_ms &center, int wid
 
                         if( g->display_overlay_state( ACTION_DISPLAY_VISIBILITY ) &&
                             g->displaying_visibility_creature && !invisible[0] ) {
-                            const bool visibility = g->displaying_visibility_creature->sees( pos );
+                            const bool visibility = g->displaying_visibility_creature->sees( here, pos );
 
                             // color overlay.
                             SDL_Color block_color = visibility ? windowsPalette[catacurses::green] :
@@ -4009,6 +4009,8 @@ bool cata_tiles::draw_vpart( const tripoint_bub_ms &p, lit_level ll, int &height
 bool cata_tiles::draw_critter_at_below( const tripoint_bub_ms &p, const lit_level, int &,
                                         const std::array<bool, 5> &invisible, const bool memorize_only )
 {
+    const map &here = get_map();
+
     if( memorize_only ) {
         return false;
     }
@@ -4017,7 +4019,7 @@ bool cata_tiles::draw_critter_at_below( const tripoint_bub_ms &p, const lit_leve
     const auto low_override = draw_below_override.find( p );
     const bool low_overridden = low_override != draw_below_override.end();
     if( low_overridden ? !low_override->second : ( invisible[0] ||
-            get_map().dont_draw_lower_floor( p ) ) ) {
+            here.dont_draw_lower_floor( p ) ) ) {
         return false;
     }
 
@@ -4034,7 +4036,7 @@ bool cata_tiles::draw_critter_at_below( const tripoint_bub_ms &p, const lit_leve
     // Check if the player can actually see the critter. We don't care if
     // it's via infrared or not, just whether or not they're seen. If not,
     // we can bail.
-    if( !you.sees( *critter ) && !you.sees_with_specials( *critter ) ) {
+    if( !you.sees( here, *critter ) && !you.sees_with_specials( *critter ) ) {
         return false;
     }
 
@@ -4046,6 +4048,8 @@ bool cata_tiles::draw_critter_at_below( const tripoint_bub_ms &p, const lit_leve
 bool cata_tiles::draw_critter_at( const tripoint_bub_ms &p, lit_level ll, int &height_3d,
                                   const std::array<bool, 5> &invisible, const bool memorize_only )
 {
+    const map &here = get_map();
+
     if( memorize_only ) {
         return false;
     }
@@ -4077,7 +4081,7 @@ bool cata_tiles::draw_critter_at( const tripoint_bub_ms &p, lit_level ll, int &h
         }
         const Creature &critter = *pcritter;
 
-        if( !you.sees( critter ) ) {
+        if( !you.sees( here, critter ) ) {
             const_dialogue d( get_const_talker_for( you ), get_const_talker_for( critter ) );
             enchant_cache::special_vision sees_with_special = you.enchantment_cache->get_vision( d );
             if( !sees_with_special.is_empty() ) {
@@ -4126,7 +4130,7 @@ bool cata_tiles::draw_critter_at( const tripoint_bub_ms &p, lit_level ll, int &h
                 result = draw_from_id_string( chosen_id, ent_category, ent_subcategory, p,
                                               subtile, rot_facing, ll, false, height_3d );
                 draw_entity_with_overlays( *m, p, ll, height_3d );
-                sees_player = m->sees( you );
+                sees_player = m->sees( here, you );
                 attitude = m->attitude_to( you );
             }
         }
@@ -4137,7 +4141,7 @@ bool cata_tiles::draw_critter_at( const tripoint_bub_ms &p, lit_level ll, int &h
             if( pl->is_avatar() ) {
                 is_player = true;
             } else {
-                sees_player = pl->sees( you );
+                sees_player = pl->sees( here, you );
                 attitude = pl->attitude_to( you );
             }
         }
@@ -4205,7 +4209,7 @@ bool cata_tiles::draw_critter_above( const tripoint_bub_ms &p, lit_level ll, int
 
     // Draw shadow
     if( draw_from_id_string( "shadow", TILE_CATEGORY::NONE, empty_string, p,
-                             0, 0, ll, false, height_3d ) && scan_p.z() - 1 > you.posz() && you.sees( critter ) ) {
+                             0, 0, ll, false, height_3d ) && scan_p.z() - 1 > you.posz() && you.sees( here, critter ) ) {
 
         bool is_player = false;
         bool sees_player = false;
@@ -4214,7 +4218,7 @@ bool cata_tiles::draw_critter_above( const tripoint_bub_ms &p, lit_level ll, int
         // Get critter status disposition if monster
         const monster *m = dynamic_cast<const monster *>( &critter );
         if( m != nullptr ) {
-            sees_player = m->sees( you );
+            sees_player = m->sees( here, you );
             attitude = m->attitude_to( you );
         }
 
@@ -4224,7 +4228,7 @@ bool cata_tiles::draw_critter_above( const tripoint_bub_ms &p, lit_level ll, int
             if( pl->is_avatar() ) {
                 is_player = true;
             } else {
-                sees_player = pl->sees( you );
+                sees_player = pl->sees( here, you );
                 attitude = pl->attitude_to( you );
             }
         }
@@ -4846,11 +4850,13 @@ void cata_tiles::draw_hit_frame()
 }
 void cata_tiles::draw_line()
 {
+    map &here = get_map();
+
     if( line_trajectory.empty() ) {
         return;
     }
     static std::string line_overlay = "animation_line";
-    if( !is_target_line || get_player_view().sees( line_pos ) ) {
+    if( !is_target_line || get_player_view().sees( here, line_pos ) ) {
         for( auto it = line_trajectory.begin(); it != line_trajectory.end() - 1; ++it ) {
             draw_from_id_string( line_overlay, *it, 0, 0, lit_level::LIT, false );
         }

--- a/src/character.h
+++ b/src/character.h
@@ -3182,7 +3182,7 @@ class Character : public Creature, public visitable
          *  @param gun item to fire (which does not necessary have to be in the players possession)
          *  @return number of shots actually fired
          */
-        int fire_gun( map *here, const tripoint_bub_ms &target, int shots, item &gun,
+        int fire_gun( map &here, const tripoint_bub_ms &target, int shots, item &gun,
                       item_location ammo = item_location() );
         /** Execute a throw */
         dealt_projectile_attack throw_item( const tripoint_bub_ms &target, const item &to_throw,
@@ -3780,9 +3780,10 @@ class Character : public Creature, public visitable
         void add_known_trap( const tripoint_bub_ms &pos, const trap &t );
 
         // see Creature::sees
-        bool sees( const tripoint_bub_ms &t, bool is_avatar = false, int range_mod = 0 ) const override;
+        bool sees( const map &here, const tripoint_bub_ms &t, bool is_avatar = false,
+                   int range_mod = 0 ) const override;
         // see Creature::sees
-        bool sees( const Creature &critter ) const override;
+        bool sees( const map &here, const Creature &critter ) const override;
         Attitude attitude_to( const Creature &other ) const override;
         virtual npc_attitude get_attitude() const;
 

--- a/src/character_armor.cpp
+++ b/src/character_armor.cpp
@@ -288,6 +288,8 @@ bool Character::armor_absorb( damage_unit &du, item &armor, const bodypart_id &b
 bool Character::ablative_armor_absorb( damage_unit &du, item &armor, const sub_bodypart_id &bp,
                                        int roll )
 {
+    const map &here = get_map();
+
     item::cover_type ctype = item::get_cover_type( du.type );
 
     for( item_pocket *const pocket : armor.get_all_ablative_pockets() ) {
@@ -356,7 +358,7 @@ bool Character::ablative_armor_absorb( damage_unit &du, item &armor, const sub_b
                 if( damaged == item::armor_status::DESTROYED ) {
                     //the plate is damaged like normal armor but also ends up destroyed
                     describe_damage( du, ablative_armor );
-                    if( get_player_view().sees( *this ) ) {
+                    if( get_player_view().sees( here, *this ) ) {
                         SCT.add( point( posx(), posy() ), direction::NORTH, remove_color_tags( ablative_armor.tname() ),
                                  m_neutral, _( "destroyed" ), m_info );
                     }

--- a/src/character_attire.cpp
+++ b/src/character_attire.cpp
@@ -25,6 +25,7 @@
 #include "fire.h"
 #include "flag.h"
 #include "flexbuffer_json.h"
+#include "game.h"
 #include "game_constants.h"
 #include "inventory.h"
 #include "item_contents.h"
@@ -33,6 +34,7 @@
 #include "json.h"
 #include "line.h"
 #include "make_static.h"
+#include "map.h"
 #include "melee.h"
 #include "messages.h"
 #include "mutation.h"
@@ -321,6 +323,8 @@ Character::wear( item_location item_wear, bool interactive )
 std::optional<std::list<item>::iterator> outfit::wear_item( Character &guy, const item &to_wear,
         bool interactive, bool do_calc_encumbrance, bool do_sort_items, bool quiet )
 {
+    const map &here = get_map();
+
     const bool was_deaf = guy.is_deaf();
     const bool supertinymouse = guy.get_size() == creature_size::tiny;
     guy.last_item = to_wear.typeId();
@@ -369,7 +373,7 @@ std::optional<std::list<item>::iterator> outfit::wear_item( Character &guy, cons
                                    _( "This %s is too small to wear comfortably!  Maybe it could be refitted." ),
                                    to_wear.tname() );
         }
-    } else if( guy.is_npc() && get_player_view().sees( guy ) && !quiet ) {
+    } else if( guy.is_npc() && get_player_view().sees( here, guy ) && !quiet ) {
         guy.add_msg_if_npc( _( "<npcname> puts on their %s." ), to_wear.tname() );
     }
 
@@ -1874,6 +1878,8 @@ item &outfit::front()
 void outfit::absorb_damage( Character &guy, damage_unit &elem, bodypart_id bp,
                             std::list<item> &worn_remains, bool &armor_destroyed )
 {
+    const map &here = get_map();
+
     sub_bodypart_id sbp;
     sub_bodypart_id secondary_sbp;
     // if this body part has sub part locations roll one
@@ -1930,7 +1936,7 @@ void outfit::absorb_damage( Character &guy, damage_unit &elem, bodypart_id bp,
         }
 
         if( destroy ) {
-            if( get_player_view().sees( guy ) ) {
+            if( get_player_view().sees( here, guy ) ) {
                 SCT.add( point( guy.posx(), guy.posy() ), direction::NORTH, remove_color_tags( pre_damage_name ),
                          m_neutral, _( "destroyed" ), m_info );
             }

--- a/src/character_attire.cpp
+++ b/src/character_attire.cpp
@@ -25,7 +25,6 @@
 #include "fire.h"
 #include "flag.h"
 #include "flexbuffer_json.h"
-#include "game.h"
 #include "game_constants.h"
 #include "inventory.h"
 #include "item_contents.h"

--- a/src/character_guns.cpp
+++ b/src/character_guns.cpp
@@ -122,7 +122,7 @@ std::vector<item_location> Character::find_ammo( const item &obj, bool empty, in
         for( map_cursor &cursor : map_selector( pos_bub(), radius ) ) {
             find_ammo_helper( cursor, obj, empty, std::back_inserter( res ), false );
         }
-        for( vehicle_cursor &cursor : vehicle_selector( here, pos_bub( &here ), radius ) ) {
+        for( vehicle_cursor &cursor : vehicle_selector( here, pos_bub( here ), radius ) ) {
             find_ammo_helper( cursor, obj, empty, std::back_inserter( res ), false );
         }
     }

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -1399,23 +1399,27 @@ conditional_t::func f_is_furniture( bool is_npc )
 
 conditional_t::func f_player_see( bool is_npc )
 {
-    return [is_npc]( const_dialogue const & d ) {
+    const map &here = get_map();
+
+    return [is_npc, &here]( const_dialogue const & d ) {
         const Creature *c = d.const_actor( is_npc )->get_const_creature();
         if( c ) {
-            return get_player_view().sees( *c );
+            return get_player_view().sees( here, *c );
         } else {
-            return get_player_view().sees( d.const_actor( is_npc )->pos_bub() );
+            return get_player_view().sees( here,  d.const_actor( is_npc )->pos_bub() );
         }
     };
 }
 
 conditional_t::func f_see_opposite( bool is_npc )
 {
-    return [is_npc]( const_dialogue const & d ) {
+    const map &here = get_map();
+
+    return [is_npc, &here]( const_dialogue const & d ) {
         if( d.const_actor( is_npc )->get_const_creature() &&
             d.const_actor( !is_npc )->get_const_creature() ) {
             return d.const_actor( is_npc )->get_const_creature()->sees(
-                       *d.const_actor( !is_npc )->get_const_creature() );
+                       here, *d.const_actor( !is_npc )->get_const_creature() );
         } else {
             return false;
         }

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -506,7 +506,7 @@ bool Character::check_eligible_containers_for_crafting( const recipe &rec, int b
 
         // also check if we're currently in a vehicle that has the necessary storage
         if( charges_to_store > 0 ) {
-            if( optional_vpart_position vp = here.veh_at( pos_bub( &here ) ) ) {
+            if( optional_vpart_position vp = here.veh_at( pos_bub( here ) ) ) {
                 const itype_id &ftype = prod.typeId();
                 int fuel_cap = vp->vehicle().fuel_capacity( here, ftype );
                 int fuel_amnt = vp->vehicle().fuel_left( here, ftype );
@@ -647,7 +647,7 @@ const inventory &Character::crafting_inventory( map *here, const tripoint_bub_ms
 {
     tripoint_bub_ms inv_pos = src_pos;
     if( src_pos == tripoint_bub_ms::zero ) {
-        inv_pos = pos_bub( here );
+        inv_pos = pos_bub( *here );
     }
     if( crafting_cache.valid
         && moves == crafting_cache.moves

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -206,28 +206,18 @@ tripoint_bub_ms Creature::pos_bub() const
     return get_map().get_bub( location );
 }
 
-tripoint_bub_ms Creature::pos_bub( map *here ) const
+tripoint_bub_ms Creature::pos_bub( const map &here ) const
 {
-    return here->get_bub( location );
+    return here.get_bub( location );
 }
 
-void Creature::setpos( const tripoint_bub_ms &p, bool check_gravity/* = true*/ )
+void Creature::setpos( map &here, const tripoint_bub_ms &p, bool check_gravity/* = true*/ )
 {
     const tripoint_abs_ms old_loc = pos_abs();
-    set_pos_bub_only( p );
+    set_pos_abs_only( here.get_abs( p ) );
     on_move( old_loc );
     if( check_gravity ) {
-        gravity_check();
-    }
-}
-
-void Creature::setpos( map *here, const tripoint_bub_ms &p, bool check_gravity/* = true*/ )
-{
-    const tripoint_abs_ms old_loc = pos_abs();
-    set_pos_abs_only( here->get_abs( p ) );
-    on_move( old_loc );
-    if( check_gravity ) {
-        gravity_check( here );
+        gravity_check( &here );
     }
 }
 
@@ -241,9 +231,8 @@ void Creature::setpos( const tripoint_abs_ms &p, bool check_gravity/* = true*/ )
     }
 }
 
-bool Creature::will_be_cramped_in_vehicle_tile( const tripoint_abs_ms &loc ) const
+bool Creature::will_be_cramped_in_vehicle_tile( map &here, const tripoint_abs_ms &loc ) const
 {
-    map &here = get_map();
     const optional_vpart_position vp_there = here.veh_at( loc );
     if( !vp_there ) {
         return false;
@@ -314,9 +303,9 @@ void Creature::move_to( const tripoint_abs_ms &loc )
     on_move( old_loc );
 }
 
-void Creature::set_pos_bub_only( const tripoint_bub_ms &p )
+void Creature::set_pos_bub_only( const map &here, const tripoint_bub_ms &p )
 {
-    location = get_map().get_abs( p );
+    location = here.get_abs( p );
 }
 
 void Creature::set_pos_abs_only( const tripoint_abs_ms &loc )
@@ -350,9 +339,9 @@ void Creature::reset()
     reset_stats();
 }
 
-void Creature::bleed() const
+void Creature::bleed( map &here ) const
 {
-    get_map().add_splatter( bloodType(), pos_bub() );
+    here.add_splatter( bloodType(), pos_bub( here ) );
 }
 
 void Creature::reset_bonuses()
@@ -417,10 +406,11 @@ bool Creature::is_underwater() const
     return underwater;
 }
 
-bool Creature::is_likely_underwater() const
+bool Creature::is_likely_underwater( const map &here ) const
 {
     return is_underwater() ||
-           ( has_flag( mon_flag_AQUATIC ) && get_map().has_flag( ter_furn_flag::TFLAG_SWIMMABLE, pos_bub() ) );
+           ( has_flag( mon_flag_AQUATIC ) &&
+             here.has_flag( ter_furn_flag::TFLAG_SWIMMABLE, pos_bub( here ) ) );
 }
 
 // Detects whether a target is sapient or not (or barely sapient, since ferals count)
@@ -488,7 +478,7 @@ static bool majority_rule( const bool a_vote, const bool b_vote, const bool c_vo
     return ( a_vote + b_vote + c_vote ) > 1;
 }
 
-bool Creature::sees( const Creature &critter ) const
+bool Creature::sees( const map &here, const Creature &critter ) const
 {
     const Character *ch = critter.as_character();
 
@@ -507,9 +497,7 @@ bool Creature::sees( const Creature &critter ) const
         return false;
     }
 
-    map &here = get_map();
-
-    const int target_range = rl_dist( pos_bub(), critter.pos_bub() );
+    const int target_range = rl_dist( pos_bub( here ), critter.pos_bub( here ) );
     if( target_range > MAX_VIEW_DISTANCE ) {
         return false;
     }
@@ -551,12 +539,12 @@ bool Creature::sees( const Creature &critter ) const
     // Can always see adjacent monsters on the same level.
     // We also bypass lighting for vertically adjacent monsters, but still check for floors.
     if( target_range <= 1 ) {
-        return ( posz() == critter.posz() || here.sees( pos_bub(), critter.pos_bub(), 1 ) ) &&
+        return ( posz() == critter.posz() || here.sees( pos_bub( here ), critter.pos_bub( here ), 1 ) ) &&
                visible( ch );
     }
 
     // If we cannot see without any of the penalties below, bail now.
-    if( !sees( critter.pos_bub(), critter.is_avatar() ) ) {
+    if( !sees( here, critter.pos_bub( here ), critter.is_avatar() ) ) {
         return false;
     }
 
@@ -567,25 +555,25 @@ bool Creature::sees( const Creature &critter ) const
     }
 
     if( ( target_range > 2 && critter.digging() &&
-          here.has_flag( ter_furn_flag::TFLAG_DIGGABLE, critter.pos_bub() ) ) ||
+          here.has_flag( ter_furn_flag::TFLAG_DIGGABLE, critter.pos_bub( here ) ) ) ||
         ( critter.has_flag( mon_flag_CAMOUFLAGE ) && target_range > this->get_eff_per() ) ||
         ( critter.has_flag( mon_flag_WATER_CAMOUFLAGE ) &&
           target_range > this->get_eff_per() &&
-          ( critter.is_likely_underwater() ||
+          ( critter.is_likely_underwater( here ) ||
             here.has_flag( ter_furn_flag::TFLAG_DEEP_WATER, critter.pos_bub() ) ||
-            ( here.has_flag( ter_furn_flag::TFLAG_SHALLOW_WATER, critter.pos_bub() ) &&
+            ( here.has_flag( ter_furn_flag::TFLAG_SHALLOW_WATER, critter.pos_bub( here ) ) &&
               critter.get_size() < creature_size::medium ) ) ) ||
         ( critter.has_flag( mon_flag_NIGHT_INVISIBILITY ) &&
           here.light_at( critter.pos_bub() ) <= lit_level::LOW ) ||
         critter.has_effect( effect_invisibility ) ||
-        ( !is_likely_underwater() && critter.is_likely_underwater() &&
+        ( !is_likely_underwater( here ) && critter.is_likely_underwater( here ) &&
           majority_rule( critter.has_flag( mon_flag_WATER_CAMOUFLAGE ),
-                         here.has_flag( ter_furn_flag::TFLAG_DEEP_WATER, critter.pos_bub() ),
+                         here.has_flag( ter_furn_flag::TFLAG_DEEP_WATER, critter.pos_bub( here ) ),
                          posz() != critter.posz() ) ) ||
-        ( here.has_flag_ter_or_furn( ter_furn_flag::TFLAG_HIDE_PLACE, critter.pos_bub() ) &&
+        ( here.has_flag_ter_or_furn( ter_furn_flag::TFLAG_HIDE_PLACE, critter.pos_bub( here ) ) &&
           !( std::abs( posx() - critter.posx() ) <= 1 && std::abs( posy() - critter.posy() ) <= 1 &&
              std::abs( posz() - critter.posz() ) <= 1 ) ) ||
-        ( here.has_flag_ter_or_furn( ter_furn_flag::TFLAG_SMALL_HIDE, critter.pos_bub() ) &&
+        ( here.has_flag_ter_or_furn( ter_furn_flag::TFLAG_SMALL_HIDE, critter.pos_bub( here ) ) &&
           critter.has_flag( mon_flag_SMALL_HIDER ) &&
           !( std::abs( posx() - critter.posx() ) <= 1 && std::abs( posy() - critter.posy() ) <= 1 &&
              std::abs( posz() - critter.posz() ) <= 1 ) ) ) {
@@ -594,8 +582,8 @@ bool Creature::sees( const Creature &critter ) const
     if( ch != nullptr ) {
         if( ch->is_crouching() || ch->has_effect( effect_all_fours ) || ch->is_prone() ||
             posz() != critter.posz() ) {
-            const int coverage = std::max( here.obstacle_coverage( pos_bub(), critter.pos_bub() ),
-                                           here.ledge_coverage( *this, critter.pos_bub() ) );
+            const int coverage = std::max( here.obstacle_coverage( pos_bub(), critter.pos_bub( here ) ),
+                                           here.ledge_coverage( *this, critter.pos_bub( here ) ) );
             if( coverage < 30 ) {
                 return visible( ch );
             }
@@ -637,19 +625,19 @@ bool Creature::sees( const Creature &critter ) const
     return visible( ch );
 }
 
-bool Creature::sees( const tripoint_bub_ms &t, bool is_avatar, int range_mod ) const
+bool Creature::sees( const map &here, const tripoint_bub_ms &t, bool is_avatar,
+                     int range_mod ) const
 {
     if( std::abs( posz() - t.z() ) > fov_3d_z_range ) {
         return false;
     }
 
-    map &here = get_map();
     const int range_cur = sight_range( here.ambient_light_at( t ) );
     const int range_day = sight_range( default_daylight_level() );
     const int range_night = sight_range( 0 );
     const int range_max = std::max( range_day, range_night );
     const int range_min = std::min( range_cur, range_max );
-    const int wanted_range = rl_dist( pos_bub(), t );
+    const int wanted_range = rl_dist( pos_bub( here ), t );
     if( wanted_range <= range_min ||
         ( wanted_range <= range_max &&
           here.ambient_light_at( t ) > here.get_cache_ref( t.z() ).natural_light_level_cache ) ) {
@@ -672,7 +660,7 @@ bool Creature::sees( const tripoint_bub_ms &t, bool is_avatar, int range_mod ) c
             return adj_range >= wanted_range &&
                    here.get_cache_ref( posz() ).seen_cache[posx()][posy()] > LIGHT_TRANSPARENCY_SOLID;
         } else {
-            return here.sees( pos_bub(), t, range );
+            return here.sees( pos_bub( here ), t, range );
         }
     } else {
         return false;
@@ -696,6 +684,8 @@ static bool overlaps_vehicle( const std::set<tripoint_abs_ms> &veh_area, const t
 
 Creature *Creature::auto_find_hostile_target( int range, int &boo_hoo, int area )
 {
+    map &here = get_map();
+
     Creature *target = nullptr;
     Character &player_character = get_player_character();
     tripoint_bub_ms player_pos = player_character.pos_bub();
@@ -708,10 +698,9 @@ Creature *Creature::auto_find_hostile_target( int range, int &boo_hoo, int area 
     boo_hoo = 0;         // how many targets were passed due to IFF. Tragically.
     bool self_area_iff = false; // Need to check if the target is near the vehicle we're a part of
     bool area_iff = false;      // Need to check distance from target to player
-    bool angle_iff = sees( player_character ); // Need to check if player is in cone to target
-    int pldist = rl_dist( pos_bub(), player_pos );
-    map &here = get_map();
-    vehicle *in_veh = is_fake() ? veh_pointer_or_null( here.veh_at( pos_bub() ) ) : nullptr;
+    bool angle_iff = sees( here, player_character ); // Need to check if player is in cone to target
+    int pldist = rl_dist( pos_bub( here ), player_pos );
+    vehicle *in_veh = is_fake() ? veh_pointer_or_null( here.veh_at( pos_bub( here ) ) ) : nullptr;
     if( pldist < iff_dist && angle_iff ) {
         area_iff = area > 0;
         // Player inside vehicle won't be hit by shots from the roof,
@@ -723,7 +712,7 @@ Creature *Creature::auto_find_hostile_target( int range, int &boo_hoo, int area 
             // granularity increases with proximity
             iff_hangle = ( pldist == 2 ? 30_degrees : 60_degrees );
         }
-        u_angle = coord_to_angle( pos_bub(), player_pos );
+        u_angle = coord_to_angle( pos_bub( here ), player_pos );
     }
 
     if( area > 0 && in_veh != nullptr ) {
@@ -743,15 +732,15 @@ Creature *Creature::auto_find_hostile_target( int range, int &boo_hoo, int area 
         return false;
     } );
     for( Creature *&m : targets ) {
-        if( !sees( *m ) ) {
+        if( !sees( here, *m ) ) {
             // can't see nor sense it
             if( is_fake() && in_veh ) {
                 // If turret in the vehicle then
                 // Hack: trying yo avoid turret LOS blocking by frames bug by trying to see target from vehicle boundary
                 // Or turret wallhack for turret's car
                 // TODO: to visibility checking another way, probably using 3D FOV
-                std::vector<tripoint_bub_ms> path_to_target = line_to( pos_bub(), m->pos_bub() );
-                path_to_target.insert( path_to_target.begin(), pos_bub() );
+                std::vector<tripoint_bub_ms> path_to_target = line_to( pos_bub( here ), m->pos_bub( here ) );
+                path_to_target.insert( path_to_target.begin(), pos_bub( here ) );
 
                 // Getting point on vehicle boundaries and on line between target and turret
                 bool continueFlag = true;
@@ -765,10 +754,10 @@ Creature *Creature::auto_find_hostile_target( int range, int &boo_hoo, int area 
                     }
                 } while( continueFlag );
 
-                tripoint_bub_ms oldPos = pos_bub();
-                setpos( path_to_target.back() ); //Temporary moving targeting npc on vehicle boundary position
-                bool seesFromVehBound = sees( *m ); // And look from there
-                setpos( oldPos );
+                tripoint_bub_ms oldPos = pos_bub( here );
+                setpos( here, path_to_target.back() ); //Temporary moving targeting npc on vehicle boundary position
+                bool seesFromVehBound = sees( here, *m ); // And look from there
+                setpos( here, oldPos );
                 if( !seesFromVehBound ) {
                     continue;
                 }
@@ -776,7 +765,7 @@ Creature *Creature::auto_find_hostile_target( int range, int &boo_hoo, int area 
                 continue;
             }
         }
-        int dist = rl_dist( pos_bub(), m->pos_bub() ) + 1; // rl_dist can be 0
+        int dist = rl_dist( pos_abs(), m->pos_abs() ) + 1; // rl_dist can be 0
         if( dist > range + 1 || dist < area ) {
             // Too near or too far
             continue;
@@ -789,11 +778,11 @@ Creature *Creature::auto_find_hostile_target( int range, int &boo_hoo, int area 
             continue;
         }
 
-        if( in_veh != nullptr && veh_pointer_or_null( here.veh_at( m->pos_bub() ) ) == in_veh ) {
+        if( in_veh != nullptr && veh_pointer_or_null( here.veh_at( m->pos_bub( here ) ) ) == in_veh ) {
             // No shooting stuff on vehicle we're a part of
             continue;
         }
-        if( area_iff && rl_dist( player_pos, m->pos_bub() ) <= area ) {
+        if( area_iff && rl_dist( player_pos, m->pos_bub( here ) ) <= area ) {
             // Player in AoE
             boo_hoo++;
             continue;
@@ -802,7 +791,7 @@ Creature *Creature::auto_find_hostile_target( int range, int &boo_hoo, int area 
         // only when the target is actually "hostile enough"
         bool maybe_boo = false;
         if( angle_iff ) {
-            units::angle tangle = coord_to_angle( pos_bub(), m->pos_bub() );
+            units::angle tangle = coord_to_angle( pos_abs(), m->pos_abs() );
             units::angle diff = units::fabs( u_angle - tangle );
             // Player is in the angle and not too far behind the target
             if( ( diff + iff_hangle > 360_degrees || diff < iff_hangle ) &&
@@ -992,6 +981,8 @@ double Creature::accuracy_projectile_attack( const int &speed, const double &mis
 void projectile::apply_effects_damage( Creature &target, Creature *source,
                                        const dealt_damage_instance &dealt_dam, bool critical ) const
 {
+    const map &here = get_map();
+
     int dam = dealt_dam.total_damage();
     // Apply ammo effects to target.
     if( proj_effects.count( ammo_effect_TANGLE ) ) {
@@ -1029,7 +1020,7 @@ void projectile::apply_effects_damage( Creature &target, Creature *source,
             }
             if( player_character.has_trait( trait_PYROMANIA ) &&
                 !player_character.has_morale( morale_pyromania_startfire ) &&
-                player_character.sees( target ) ) {
+                player_character.sees( here, target ) ) {
                 player_character.add_msg_if_player( m_good,
                                                     _( "You feel a surge of euphoria as flame engulfs %s!" ), target.get_name() );
                 player_character.add_morale( morale_pyromania_startfire, 15, 15, 8_hours, 6_hours );
@@ -1045,7 +1036,7 @@ void projectile::apply_effects_damage( Creature &target, Creature *source,
             }
             if( player_character.has_trait( trait_PYROMANIA ) &&
                 !player_character.has_morale( morale_pyromania_startfire ) &&
-                player_character.sees( target ) ) {
+                player_character.sees( here, target ) ) {
                 player_character.add_msg_if_player( m_good,
                                                     _( "You feel a surge of euphoria as flame engulfs %s!" ), target.get_name() );
                 player_character.add_morale( morale_pyromania_startfire, 15, 15, 8_hours, 6_hours );
@@ -1204,8 +1195,10 @@ projectile_attack_results Creature::select_body_part_projectile_attack(
 void Creature::messaging_projectile_attack( const Creature *source,
         const projectile_attack_results &hit_selection, const int total_damage ) const
 {
+    const map &here = get_map();
+
     const viewer &player_view = get_player_view();
-    const bool u_see_this = player_view.sees( *this );
+    const bool u_see_this = player_view.sees( here, *this );
 
     if( u_see_this ) {
         if( hit_selection.damage_mult == 0 ) {
@@ -1275,9 +1268,11 @@ void Creature::messaging_projectile_attack( const Creature *source,
 
 void Creature::print_proj_avoid_msg( Creature *source, viewer &player_view ) const
 {
+    const map &here = get_map();
+
     // "Avoid" rather than "dodge", because it includes removing self from the line of fire
     //  rather than just Matrix-style bullet dodging
-    if( source != nullptr && player_view.sees( *source ) ) {
+    if( source != nullptr && player_view.sees( here, *source ) ) {
         add_msg_player_or_npc(
             m_warning,
             _( "You avoid %s projectile!" ),
@@ -1459,6 +1454,8 @@ dealt_damage_instance Creature::deal_damage( Creature *source, bodypart_id bp,
 void Creature::deal_damage_handle_type( const effect_source &source, const damage_unit &du,
                                         bodypart_id bp, int &damage, int &pain )
 {
+    const map &here = get_map();
+
     // Handles ACIDPROOF, electric immunity etc.
     if( is_immune_damage( du.type ) ) {
         return;
@@ -1483,7 +1480,8 @@ void Creature::deal_damage_handle_type( const effect_source &source, const damag
 
             Character &player_character = get_player_character();
             if( player_character.has_trait( trait_PYROMANIA ) &&
-                !player_character.has_morale( morale_pyromania_startfire ) && player_character.sees( *this ) ) {
+                !player_character.has_morale( morale_pyromania_startfire ) &&
+                player_character.sees( here, *this ) ) {
                 player_character.add_msg_if_player( m_good,
                                                     _( "You feel a surge of euphoria as flame engulfs %s!" ), this->get_name() );
                 player_character.add_morale( morale_pyromania_startfire, 15, 15, 8_hours, 6_hours );
@@ -1527,16 +1525,18 @@ void Creature::heal_bp( bodypart_id /* bp */, int /* dam */ )
 
 void Creature::longpull( const std::string &name, const tripoint_bub_ms &p )
 {
-    if( pos_bub() == p ) {
+    const map &here = get_map();
+
+    if( pos_bub( here ) == p ) {
         add_msg_if_player( _( "You try to pull yourself together." ) );
         return;
     }
 
-    std::vector<tripoint_bub_ms> path = line_to( pos_bub(), p, 0, 0 );
+    std::vector<tripoint_bub_ms> path = line_to( pos_bub( here ), p, 0, 0 );
     Creature *c = nullptr;
     for( const tripoint_bub_ms &path_p : path ) {
         c = get_creature_tracker().creature_at( path_p );
-        if( c == nullptr && get_map().impassable( path_p ) ) {
+        if( c == nullptr && here.impassable( path_p ) ) {
             add_msg_if_player( m_warning, _( "There's an obstacle in the way!" ) );
             return;
         }
@@ -1544,7 +1544,7 @@ void Creature::longpull( const std::string &name, const tripoint_bub_ms &p )
             break;
         }
     }
-    if( c == nullptr || !sees( *c ) ) {
+    if( c == nullptr || !sees( here, *c ) ) {
         // TODO: Latch onto objects?
         add_msg_if_player( m_warning, _( "There's nothing here to latch onto with your %s!" ),
                            name );
@@ -1565,7 +1565,7 @@ void Creature::longpull( const std::string &name, const tripoint_bub_ms &p )
         c->move_to( tripoint_abs_ms( line_to( pos_abs().raw(), c->pos_abs().raw(), 0,
                                               0 ).front() ) );
         c->add_effect( effect_stunned, 1_seconds );
-        sounds::sound( c->pos_bub(), 5, sounds::sound_t::combat, _( "Shhhk!" ) );
+        sounds::sound( c->pos_bub( here ), 5, sounds::sound_t::combat, _( "Shhhk!" ) );
     } else {
         add_msg_if_player( m_bad, _( "%s weight makes it difficult to pull towards you." ),
                            c->disp_name( true, true ) );
@@ -1577,6 +1577,8 @@ void Creature::longpull( const std::string &name, const tripoint_bub_ms &p )
 
 bool Creature::stumble_invis( const Creature &player, const bool stumblemsg )
 {
+    map &here = get_map();
+
     // DEBUG insivibility can't be seen through
     if( player.has_trait( trait_DEBUG_CLOAK ) ) {
         return false;
@@ -1585,17 +1587,16 @@ bool Creature::stumble_invis( const Creature &player, const bool stumblemsg )
         return false;
     }
     if( stumblemsg ) {
-        const bool player_sees = player.sees( *this );
+        const bool player_sees = player.sees( here, *this );
         add_msg( m_bad, _( "%s stumbles into you!" ), player_sees ? this->disp_name( false,
                  true ) : _( "Something" ) );
     }
     add_effect( effect_stumbled_into_invisible, 6_seconds );
-    map &here = get_map();
     // Mark last known location, or extend duration if exists
-    if( here.has_field_at( player.pos_bub(), field_fd_last_known ) ) {
-        here.set_field_age( player.pos_bub(), field_fd_last_known, 0_seconds );
+    if( here.has_field_at( player.pos_bub( here ), field_fd_last_known ) ) {
+        here.set_field_age( player.pos_bub( here ), field_fd_last_known, 0_seconds );
     } else {
-        here.add_field( player.pos_bub(), field_fd_last_known );
+        here.add_field( player.pos_bub( here ), field_fd_last_known );
     }
     moves = 0;
     return true;

--- a/src/creature.h
+++ b/src/creature.h
@@ -310,7 +310,7 @@ class Creature : public viewer
         /** Sets a Creature's fake boolean. */
         virtual void set_fake( bool fake_value );
         tripoint_bub_ms pos_bub() const;
-        tripoint_bub_ms pos_bub( map *here ) const;
+        tripoint_bub_ms pos_bub( const map &here ) const;
         inline int posx() const {
             return pos_bub().x();
         }
@@ -322,12 +322,11 @@ class Creature : public viewer
         }
         virtual void gravity_check();
         virtual void gravity_check( map *here );
-        void setpos( const tripoint_bub_ms &p, bool check_gravity = true );
-        void setpos( map *here, const tripoint_bub_ms &p, bool check_gravity = true );
+        void setpos( map &here, const tripoint_bub_ms &p, bool check_gravity = true );
         void setpos( const tripoint_abs_ms &p, bool check_gravity = true );
 
         /** Checks if the creature fits confortably into a given tile. */
-        bool will_be_cramped_in_vehicle_tile( const tripoint_abs_ms &loc ) const;
+        bool will_be_cramped_in_vehicle_tile( map &here, const tripoint_abs_ms &loc ) const;
         /** Moves the creature to the given location and calls the on_move() handler. */
         void move_to( const tripoint_abs_ms &loc );
 
@@ -342,7 +341,7 @@ class Creature : public viewer
         /** Handles stat and bonus reset. */
         virtual void reset();
         /** Adds an appropriate blood splatter. */
-        virtual void bleed() const;
+        virtual void bleed( map &here ) const;
         /** Empty function. Should always be overwritten by the appropriate player/NPC/monster version. */
         virtual void die( map *here, Creature *killer ) = 0;
 
@@ -397,8 +396,9 @@ class Creature : public viewer
          * the other monster is visible.
          */
         /*@{*/
-        bool sees( const Creature &critter ) const override;
-        bool sees( const tripoint_bub_ms &t, bool is_avatar = false, int range_mod = 0 ) const override;
+        bool sees( const map &here, const Creature &critter ) const override;
+        bool sees( const map &here, const tripoint_bub_ms &t, bool is_avatar = false,
+                   int range_mod = 0 ) const override;
         /*@}*/
 
         /**
@@ -550,7 +550,8 @@ class Creature : public viewer
         virtual bool is_on_ground() const = 0;
         bool cant_do_underwater( bool msg = true ) const;
         virtual bool is_underwater() const;
-        bool is_likely_underwater() const; // Should eventually be virtual, although not pure
+        bool is_likely_underwater( const map &here )
+        const; // Should eventually be virtual, although not pure
         virtual bool is_warm() const; // is this creature warm, for IR vision, heat drain, etc
         virtual bool in_species( const species_id & ) const;
 
@@ -797,7 +798,7 @@ class Creature : public viewer
         tripoint_abs_ms location;
     protected:
         // Sets the creature's position without any side-effects.
-        void set_pos_bub_only( const tripoint_bub_ms &p );
+        void set_pos_bub_only( const map &here, const tripoint_bub_ms &p );
         // Sets the creature's position without any side-effects.
         void set_pos_abs_only( const tripoint_abs_ms &loc );
         // Invoked when the creature's position changes.

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -841,7 +841,7 @@ static void monster_edit_menu()
         }
         case D_TELE: {
             if( tripoint_abs_ms newpos = player_picks_tile(); newpos != get_avatar().pos_abs() ) {
-                critter->setpos( get_map().get_bub( newpos ) );
+                critter->setpos( newpos );
             }
             break;
         }
@@ -2311,6 +2311,8 @@ static faction *select_faction()
 
 static void character_edit_menu()
 {
+    map &here = get_map();
+
     std::vector< tripoint_bub_ms > locations;
     uilist charmenu;
     charmenu.title = _( "Edit which character?" );
@@ -2632,10 +2634,10 @@ static void character_edit_menu()
             break;
         case D_TELE: {
             if( const std::optional<tripoint_bub_ms> newpos = g->look_around() ) {
-                you.setpos( *newpos );
+                you.setpos( here, *newpos );
                 if( you.is_avatar() ) {
                     if( you.is_mounted() ) {
-                        you.mounted_creature->setpos( *newpos );
+                        you.mounted_creature->setpos( here, *newpos );
                     }
                     g->update_map( player_character );
                 }
@@ -3195,12 +3197,14 @@ static void debug_menu_spawn_vehicle()
 
 static void display_talk_topic()
 {
+    const map &here = get_map();
+
     avatar &a = get_avatar();
     int menu_ind = 0;
     uilist npc_menu;
     npc_menu.text = _( "Choose NPC to hold topic:" );
     std::vector<npc *> visible_npcs = g->get_npcs_if( [&]( const npc & n ) {
-        return a.sees( n );
+        return a.sees( here, n );
     } );
     int npc_count = static_cast<int>( visible_npcs.size() );
     if( npc_count > 0 ) {

--- a/src/do_turn.cpp
+++ b/src/do_turn.cpp
@@ -282,9 +282,9 @@ void monmove()
                            critter.name(),
                            critter.posx(), critter.posy(), critter.posz(), m.tername( critter.pos_bub() ) );
             bool okay = false;
-            for( const tripoint_bub_ms &dest : m.points_in_radius( critter.pos_bub(), 3 ) ) {
+            for( const tripoint_bub_ms &dest : m.points_in_radius( critter.pos_bub( m ), 3 ) ) {
                 if( critter.can_move_to( dest ) && g->is_empty( dest ) ) {
-                    critter.setpos( dest );
+                    critter.setpos( m, dest );
                     okay = true;
                     break;
                 }

--- a/src/editmap.cpp
+++ b/src/editmap.cpp
@@ -775,7 +775,7 @@ void editmap::update_view_with_help( const std::string &txt, const std::string &
     const level_cache &map_cache = here.get_cache( target.z() );
 
     Character &player_character = get_player_character();
-    const std::string u_see_msg = player_character.sees( target ) ? _( "yes" ) : _( "no" );
+    const std::string u_see_msg = player_character.sees( here, target ) ? _( "yes" ) : _( "no" );
     mvwprintw( w_info, point( 1, off++ ), _( "dist: %d u_see: %s veh: %s scent: %d" ),
                rl_dist( player_character.pos_bub(), target ), u_see_msg, veh_msg, get_scent().get( target ) ); // 6
     mvwprintw( w_info, point( 1, off++ ), _( "sight_range: %d, noon_sight_range: %d," ),

--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -687,9 +687,10 @@ void scrambler_blast( const tripoint_bub_ms &p )
 
 void emp_blast( const tripoint_bub_ms &p )
 {
-    Character &player_character = get_player_character();
-    const bool sight = player_character.sees( p );
     map &here = get_map();
+
+    Character &player_character = get_player_character();
+    const bool sight = player_character.sees( here, p );
     if( here.has_flag( ter_furn_flag::TFLAG_CONSOLE, p ) ) {
         if( sight ) {
             add_msg( _( "The %s is rendered non-functional!" ), here.tername( p ) );

--- a/src/faction.cpp
+++ b/src/faction.cpp
@@ -657,6 +657,8 @@ std::string npc::get_current_status() const
 
 int npc::faction_display( const catacurses::window &fac_w, const int width ) const
 {
+    const map &here = get_map();
+
     int retval = 0;
     int y = 2;
     const nc_color col = c_white;
@@ -723,8 +725,8 @@ int npc::faction_display( const catacurses::window &fac_w, const int width ) con
     bool guy_has_radio = cache_has_item_with_flag( json_flag_TWO_WAY_RADIO, true );
     // is the NPC even in the same area as the player?
     if( rl_dist( player_abspos, pos_abs_omt() ) > 3 ||
-        ( rl_dist( player_character.pos_bub(), pos_bub() ) > SEEX * 2 ||
-          !player_character.sees( pos_bub() ) ) ) {
+        ( rl_dist( player_character.pos_abs(), pos_abs() ) > SEEX * 2 ||
+          !player_character.sees( here, pos_bub( here ) ) ) ) {
         if( u_has_radio && guy_has_radio ) {
             if( !( player_character.posz() >= 0 && posz() >= 0 ) &&
                 !( player_character.posz() == posz() ) ) {

--- a/src/faction.cpp
+++ b/src/faction.cpp
@@ -24,6 +24,7 @@
 #include "input_context.h"
 #include "line.h"
 #include "localized_comparator.h"
+#include "map.h"
 #include "map_scale_constants.h"
 #include "memory_fast.h"
 #include "mission_companion.h"

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -1676,9 +1676,11 @@ drop_locations game_menus::inv::ebooksave( Character &who, item_location &ereade
 drop_locations game_menus::inv::edevice_select( Character &who, item_location &used_edevice,
         bool browse_equals, bool auto_include_used_edevice, bool unusable_only, efile_action action )
 {
+    const map &here = get_map();
+
     const inventory_filter_preset preset( [&]( const item_location & loc ) {
         //make sure this is an edevice before we make edevice calls
-        if( loc->is_estorage() && loc->is_owned_by( who, true ) && who.sees( loc.pos_bub() ) ) {
+        if( loc->is_estorage() && loc->is_owned_by( who, true ) && who.sees( here, loc.pos_bub() ) ) {
             efile_activity_actor::edevice_compatible compat =
                 efile_activity_actor::edevices_compatible( used_edevice, loc );
             bool is_tool_has_charge = !loc->is_tool() || loc->ammo_sufficient( &who );

--- a/src/gates.cpp
+++ b/src/gates.cpp
@@ -241,7 +241,7 @@ void gates::open_gate( const tripoint_bub_ms &pos )
         }
     }
 
-    if( get_player_view().sees( pos ) ) {
+    if( get_player_view().sees( here, pos ) ) {
         if( open ) {
             add_msg( gate.open_message );
         } else if( close ) {
@@ -394,7 +394,7 @@ bool doors::forced_door_closing( const tripoint_bub_ms &p,
     const tripoint_bub_ms displace = pos.value();
     //knockback trajectory requires the line be flipped
     const tripoint_bub_ms kbp( -displace.x() + x * 2, -displace.y() + y * 2, displace.z() );
-    const bool can_see = u.sees( kbp );
+    const bool can_see = u.sees( m, kbp );
     creature_tracker &creatures = get_creature_tracker();
     Character *npc_or_player = creatures.creature_at<Character>( p, false );
     if( npc_or_player != nullptr ) {

--- a/src/grab.cpp
+++ b/src/grab.cpp
@@ -24,7 +24,7 @@ bool game::grabbed_veh_move( const tripoint_rel_ms &dp )
 {
     map &here = get_map();
 
-    const optional_vpart_position grabbed_vehicle_vp = m.veh_at( u.pos_bub( &here ) + u.grab_point );
+    const optional_vpart_position grabbed_vehicle_vp = m.veh_at( u.pos_bub( here ) + u.grab_point );
     if( !grabbed_vehicle_vp ) {
         add_msg( m_info, _( "No vehicle at grabbed point." ) );
         u.grab( object_type::NONE );
@@ -42,7 +42,7 @@ bool game::grabbed_veh_move( const tripoint_rel_ms &dp )
         u.grab( object_type::NONE );
         return false;
     }
-    const vehicle *veh_under_player = veh_pointer_or_null( m.veh_at( u.pos_bub( &here ) ) );
+    const vehicle *veh_under_player = veh_pointer_or_null( m.veh_at( u.pos_bub( here ) ) );
     if( grabbed_vehicle == veh_under_player ) {
         u.grab_point = - dp;
         return false;
@@ -111,7 +111,7 @@ bool game::grabbed_veh_move( const tripoint_rel_ms &dp )
             units::angle face_delta = angle_delta( grabbed_vehicle->face.dir(), my_dir.dir() );
 
             tileray my_pos_dir;
-            tripoint_rel_ms my_angle = u.pos_bub( &here ) - grabbed_vehicle->pos_bub( here );
+            tripoint_rel_ms my_angle = u.pos_bub( here ) - grabbed_vehicle->pos_bub( here );
             my_pos_dir.init( my_angle.xy() );
             back_of_vehicle = ( angle_delta( grabbed_vehicle->face.dir(), my_pos_dir.dir() ) > 90_degrees );
             invalid_veh_face = ( face_delta > vehicles::steer_increment * 2 - 1_degrees &&
@@ -227,7 +227,7 @@ bool game::grabbed_veh_move( const tripoint_rel_ms &dp )
         // and in roughly the same direction.
         const tripoint_bub_ms new_part_pos = grabbed_vehicle->pos_bub( here ) +
                                              grabbed_vehicle->part( grabbed_part ).precalc[1];
-        const tripoint_bub_ms expected_pos = u.pos_bub( &here ) + dp + md_next_grab;
+        const tripoint_bub_ms expected_pos = u.pos_bub( here ) + dp + md_next_grab;
         tripoint_rel_ms actual_dir = tripoint_rel_ms( ( expected_pos - new_part_pos ).xy(), 0 );
 
         bool failed = false;
@@ -240,7 +240,7 @@ bool game::grabbed_veh_move( const tripoint_rel_ms &dp )
                 no_player_collision = true;
                 for( const vpart_reference &vp : grabbed_vehicle->get_all_parts() ) {
                     if( grabbed_vehicle->pos_bub( here ) +
-                        vp.part().precalc[1] + actual_dir == u.pos_bub( &here ) + skip ) {
+                        vp.part().precalc[1] + actual_dir == u.pos_bub( here ) + skip ) {
                         no_player_collision = false;
                         break;
                     }
@@ -258,8 +258,8 @@ bool game::grabbed_veh_move( const tripoint_rel_ms &dp )
             }
         }
         // Set player location to illegal value so it can't collide with vehicle.
-        const tripoint_bub_ms player_prev = u.pos_bub( &here );
-        u.setpos( tripoint_bub_ms::zero, false );
+        const tripoint_abs_ms player_prev = u.pos_abs( );
+        u.setpos( here, tripoint_bub_ms::zero, false );
         std::vector<veh_collision> colls;
         failed = grabbed_vehicle->collision( here, colls, actual_dir, true );
         u.setpos( player_prev );

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -1540,7 +1540,7 @@ void iexamine::elevator( Character &you, const tripoint_bub_ms &examp )
                 if( !here.has_flag( ter_furn_flag::TFLAG_ELEVATOR, candidate ) &&
                     here.passable( candidate ) &&
                     creatures.creature_at( candidate ) == nullptr ) {
-                    critter.setpos( candidate );
+                    critter.setpos( here, candidate );
                     break;
                 }
             }
@@ -1566,7 +1566,7 @@ void iexamine::elevator( Character &you, const tripoint_bub_ms &examp )
     for( Creature &critter : g->all_creatures() ) {
         auto const eit = std::find( this_elevator.cbegin(), this_elevator.cend(), critter.pos_bub() );
         if( eit != this_elevator.cend() ) {
-            critter.setpos( that_elevator[ std::distance( this_elevator.cbegin(), eit ) ] );
+            critter.setpos( here, that_elevator[ std::distance( this_elevator.cbegin(), eit ) ] );
         }
     }
 
@@ -1806,7 +1806,7 @@ void iexamine::chainfence( Character &you, const tripoint_bub_ms &examp )
     if( you.in_vehicle ) {
         here.unboard_vehicle( you.pos_bub() );
     }
-    you.setpos( examp );
+    you.setpos( here, examp );
     if( examp.x() < HALF_MAPSIZE_X || examp.y() < HALF_MAPSIZE_Y ||
         examp.x() >= HALF_MAPSIZE_X + SEEX || examp.y() >= HALF_MAPSIZE_Y + SEEY ) {
         if( you.is_avatar() ) {
@@ -1839,7 +1839,7 @@ void iexamine::bars( Character &you, const tripoint_bub_ms &examp )
     }
     you.mod_moves( -to_moves<int>( 2_seconds ) );
     add_msg( _( "You slide right between the bars." ) );
-    you.setpos( examp );
+    you.setpos( here, examp );
 }
 
 void iexamine::deployed_furniture( Character &you, const tripoint_bub_ms &pos )
@@ -5791,7 +5791,7 @@ void iexamine::ledge( Character &you, const tripoint_bub_ms &examp )
             you.remove_effect( effect_bouldering );
             you.assign_activity( glide );
             you.add_effect( effect_gliding, 1_turns, true );
-            you.setpos( examp );
+            you.setpos( here, examp );
             break;
         }
         case ledge_fall_down: {
@@ -5805,7 +5805,7 @@ void iexamine::ledge( Character &you, const tripoint_bub_ms &examp )
                 if( you.has_effect_with_flag( json_flag_LEVITATION ) ) {
                     you.add_effect( effect_slow_descent, 1_seconds, false );
                 }
-                you.setpos( examp );
+                you.setpos( here, examp );
                 you.gravity_check();
             } else {
                 // Just to highlight the trepidation

--- a/src/item.h
+++ b/src/item.h
@@ -2508,7 +2508,7 @@ class item : public visitable
          * Quantity of shots in the gun. Looks at both ammo and available energy.
          * @param carrier is used for UPS and bionic power
          */
-        int shots_remaining( const Character *carrier ) const;
+        int shots_remaining( const map &here, const Character *carrier ) const;
 
         /** Return true if this uses electrical or a different kind of energy. */
         bool uses_energy() const;

--- a/src/item_location.cpp
+++ b/src/item_location.cpp
@@ -543,7 +543,7 @@ class item_location::impl::item_on_vehicle : public item_location::impl
             map &here = get_map();
             item *obj = target();
             int mv = ch.item_handling_cost( *obj, true, VEHICLE_HANDLING_PENALTY, qty );
-            mv += 100 * rl_dist( ch.pos_bub( &here ), cur.veh.bub_part_pos( here, cur.part ) );
+            mv += 100 * rl_dist( ch.pos_bub( here ), cur.veh.bub_part_pos( here, cur.part ) );
 
             // TODO: handle unpacking costs
 

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -1983,14 +1983,14 @@ std::optional<int> iuse::extinguisher( Character *p, item *it, const tripoint_bu
             critter.add_effect( effect_blind, rng( 1_minutes, 2_minutes ) );
         }
         viewer &player_view = get_player_view();
-        if( player_view.sees( critter ) ) {
+        if( player_view.sees( here, critter ) ) {
             p->add_msg_if_player( _( "The %s is sprayed!" ), critter.name() );
             if( blind ) {
                 p->add_msg_if_player( _( "The %s looks blinded." ), critter.name() );
             }
         }
         if( critter.made_of( phase_id::LIQUID ) ) {
-            if( player_view.sees( critter ) ) {
+            if( player_view.sees( here, critter ) ) {
                 p->add_msg_if_player( _( "The %s is frozen!" ), critter.name() );
             }
             critter.apply_damage( p, bodypart_id( "torso" ), rng( 20, 60 ) );
@@ -2364,7 +2364,7 @@ std::optional<int> iuse::mace( Character *p, item *it, const tripoint_bub_ms & )
             p->add_msg_if_player( _( "The %s recoils in pain!" ), critter.name() );
         }
         viewer &player_view = get_player_view();
-        if( player_view.sees( critter ) ) {
+        if( player_view.sees( here, critter ) ) {
             p->add_msg_if_player( _( "The %s is sprayed!" ), critter.name() );
             if( blind ) {
                 p->add_msg_if_player( _( "The %s looks blinded." ), critter.name() );
@@ -2835,7 +2835,7 @@ std::optional<int> iuse::crowbar( Character *p, item *it, const tripoint_bub_ms 
     map &here = get_map();
     const std::function<bool( const tripoint_bub_ms & )> f =
     [&here, p]( const tripoint_bub_ms & pnt ) {
-        if( pnt == p->pos_bub() ) {
+        if( pnt == p->pos_bub( here ) ) {
             return false;
         } else if( here.has_furn( pnt ) ) {
             return here.furn( pnt )->prying->valid();
@@ -2845,9 +2845,9 @@ std::optional<int> iuse::crowbar( Character *p, item *it, const tripoint_bub_ms 
         return false;
     };
 
-    const std::optional<tripoint_bub_ms> pnt_ = ( pos != p->pos_bub() ) ?
+    const std::optional<tripoint_bub_ms> pnt_ = ( pos != p->pos_bub( here ) ) ?
             pos : choose_adjacent_highlight(
-                _( "Pry where?" ), _( "There is nothing to pry nearby." ), f, false );
+                here, _( "Pry where?" ), _( "There is nothing to pry nearby." ), f, false );
     if( !pnt_ ) {
         return std::nullopt;
     }
@@ -3034,7 +3034,7 @@ std::optional<int> iuse::siphon( Character *p, item *, const tripoint_bub_ms & )
 
     vehicle *v = nullptr;
     bool found_more_than_one = false;
-    for( const tripoint_bub_ms &pos : here.points_in_radius( p->pos_bub(), 1 ) ) {
+    for( const tripoint_bub_ms &pos : here.points_in_radius( p->pos_bub( here ), 1 ) ) {
         const optional_vpart_position vp = here.veh_at( pos );
         if( !vp ) {
             continue;
@@ -3053,7 +3053,7 @@ std::optional<int> iuse::siphon( Character *p, item *, const tripoint_bub_ms & )
     }
     if( found_more_than_one ) {
         std::optional<tripoint_bub_ms> pnt_ = choose_adjacent_highlight(
-                _( "Siphon from where?" ), _( "There is nothing to siphon from nearby." ), f, false );
+                here, _( "Siphon from where?" ), _( "There is nothing to siphon from nearby." ), f, false );
         if( !pnt_ ) {
             return std::nullopt;
         }
@@ -3237,6 +3237,8 @@ std::optional<int> iuse::pickaxe( Character *p, item *it, const tripoint_bub_ms 
 
 std::optional<int> iuse::geiger( Character *p, item *it, const tripoint_bub_ms & )
 {
+    map &here = get_map();
+
     int ch = uilist( _( "Geiger counter:" ), {
         _( "Scan yourself or other person" ), _( "Scan the ground" ), _( "Turn continuous scan on" )
     } );
@@ -3247,7 +3249,7 @@ std::optional<int> iuse::geiger( Character *p, item *it, const tripoint_bub_ms &
                 return creatures.creature_at<Character>( pnt ) != nullptr;
             };
 
-            const std::optional<tripoint_bub_ms> pnt_ = choose_adjacent_highlight( _( "Scan whom?" ),
+            const std::optional<tripoint_bub_ms> pnt_ = choose_adjacent_highlight( here,  _( "Scan whom?" ),
                     _( "There is no one to scan nearby." ), f, false );
             if( !pnt_ ) {
                 return std::nullopt;
@@ -3573,7 +3575,7 @@ std::optional<int> iuse::grenade_inc_act( Character *p, item *, const tripoint_b
     }
 
     avatar &player = get_avatar();
-    if( player.has_trait( trait_PYROMANIA ) && player.sees( pos ) ) {
+    if( player.has_trait( trait_PYROMANIA ) && player.sees( here, pos ) ) {
         player.add_morale( morale_pyromania_startfire, 15, 15, 8_hours, 6_hours );
         player.rem_morale( morale_pyromania_nofire );
         add_msg( m_good, _( "Fire…  Good…" ) );
@@ -3592,7 +3594,7 @@ std::optional<int> iuse::molotov_lit( Character *p, item *it, const tripoint_bub
             here.add_field( pt, fd_fire, intensity );
         }
         avatar &player = get_avatar();
-        if( player.has_trait( trait_PYROMANIA ) && player.sees( pos ) ) {
+        if( player.has_trait( trait_PYROMANIA ) && player.sees( here, pos ) ) {
             player.add_morale( morale_pyromania_startfire, 15, 15, 8_hours, 6_hours );
             player.rem_morale( morale_pyromania_nofire );
             add_msg( m_good, _( "Fire…  Good…" ) );
@@ -4162,6 +4164,8 @@ std::optional<int> iuse::gasmask( Character *p, item *it, const tripoint_bub_ms 
 
 std::optional<int> iuse::portable_game( Character *p, item *it, const tripoint_bub_ms & )
 {
+    const map &here = get_map();
+
     if( p->is_npc() ) {
         // Long action
         return std::nullopt;
@@ -4181,8 +4185,8 @@ std::optional<int> iuse::portable_game( Character *p, item *it, const tripoint_b
     } else {
         std::string loaded_software = "robot_finds_kitten";
         // number of nearby friends with gaming devices
-        std::vector<npc *> friends_w_game = g->get_npcs_if( [&it, p]( const npc & n ) {
-            return n.is_player_ally() && p->sees( n ) &&
+        std::vector<npc *> friends_w_game = g->get_npcs_if( [&it, p, &here]( const npc & n ) {
+            return n.is_player_ally() && p->sees( here,  n ) &&
                    n.can_hear( p->pos_bub(), p->get_shout_volume() ) &&
             n.has_item_with( [&it]( const item & i ) {
                 return i.typeId() == it->typeId() && i.ammo_sufficient( nullptr );
@@ -4457,6 +4461,8 @@ std::optional<int> iuse::vortex( Character *p, item *it, const tripoint_bub_ms &
 
 std::optional<int> iuse::dog_whistle( Character *p, item *, const tripoint_bub_ms & )
 {
+    const map &here = get_map();
+
     if( !p->is_avatar() ) {
         return std::nullopt;
     }
@@ -4466,8 +4472,8 @@ std::optional<int> iuse::dog_whistle( Character *p, item *, const tripoint_bub_m
     p->add_msg_if_player( _( "You blow your dog whistle." ) );
 
     // Can the Character hear the dog whistle?
-    auto hearing_check = [p]( const Character & who ) -> bool {
-        return !who.is_deaf() && p->sees( who ) &&
+    auto hearing_check = [p, &here]( const Character & who ) -> bool {
+        return !who.is_deaf() && p->sees( here, who ) &&
         who.has_trait( STATIC( trait_id( "THRESH_LUPINE" ) ) );
     };
 
@@ -4498,7 +4504,7 @@ std::optional<int> iuse::dog_whistle( Character *p, item *, const tripoint_bub_m
 
     for( monster &critter : g->all_monsters() ) {
         if( critter.friendly != 0 && critter.has_flag( mon_flag_DOGFOOD ) ) {
-            bool u_see = get_player_view().sees( critter );
+            bool u_see = get_player_view().sees( here, critter );
             if( critter.has_effect( effect_docile ) ) {
                 if( u_see ) {
                     p->add_msg_if_player( _( "Your %s looks ready to attack." ), critter.name() );
@@ -4702,13 +4708,13 @@ std::optional<int> iuse::chop_tree( Character *p, item *it, const tripoint_bub_m
     };
 
     const std::optional<tripoint_bub_ms> pnt_ = choose_adjacent_highlight(
-                _( "Chop down which tree?" ), _( "There is no tree to chop down nearby." ), f, false );
+                here, _( "Chop down which tree?" ), _( "There is no tree to chop down nearby." ), f, false );
     if( !pnt_ ) {
         return std::nullopt;
     }
     const tripoint_bub_ms &pnt = *pnt_;
     if( !f( pnt ) ) {
-        if( pnt == p->pos_bub() ) {
+        if( pnt == p->pos_bub( here ) ) {
             p->add_msg_if_player( m_info, _( "You're not stern enough to shave yourself with THIS." ) );
         } else {
             p->add_msg_if_player( m_info, _( "You can't chop down that." ) );
@@ -4753,7 +4759,7 @@ std::optional<int> iuse::chop_logs( Character *p, item *it, const tripoint_bub_m
     };
 
     const std::optional<tripoint_bub_ms> pnt_ = choose_adjacent_highlight(
-                _( "Chop which tree trunk?" ), _( "There is no tree trunk to chop nearby." ), f, false );
+                here, _( "Chop which tree trunk?" ), _( "There is no tree trunk to chop nearby." ), f, false );
     if( !pnt_ ) {
         return std::nullopt;
     }
@@ -4791,7 +4797,7 @@ std::optional<int> iuse::oxytorch( Character *p, item *it, const tripoint_bub_ms
     map &here = get_map();
     const std::function<bool( const tripoint_bub_ms & )> f =
     [&here, p]( const tripoint_bub_ms & pnt ) {
-        if( pnt == p->pos_bub() ) {
+        if( pnt == p->pos_bub( here ) ) {
             return false;
         } else if( here.has_furn( pnt ) ) {
             return here.furn( pnt )->oxytorch->valid();
@@ -4802,7 +4808,7 @@ std::optional<int> iuse::oxytorch( Character *p, item *it, const tripoint_bub_ms
     };
 
     const std::optional<tripoint_bub_ms> pnt_ = choose_adjacent_highlight(
-                _( "Cut up metal where?" ), _( "There is no metal to cut up nearby." ), f, false );
+                here, _( "Cut up metal where?" ), _( "There is no metal to cut up nearby." ), f, false );
     if( !pnt_ ) {
         return std::nullopt;
     }
@@ -4835,7 +4841,7 @@ std::optional<int> iuse::hacksaw( Character *p, item *it, const tripoint_bub_ms 
     map &here = get_map();
     const std::function<bool( const tripoint_bub_ms & )> f =
     [&here, p]( const tripoint_bub_ms & pnt ) {
-        if( pnt == p->pos_bub() ) {
+        if( pnt == p->pos_bub( here ) ) {
             return false;
         } else if( here.has_furn( pnt ) ) {
             return here.furn( pnt )->hacksaw->valid();
@@ -4846,7 +4852,7 @@ std::optional<int> iuse::hacksaw( Character *p, item *it, const tripoint_bub_ms 
     };
 
     const std::optional<tripoint_bub_ms> pnt_ = choose_adjacent_highlight(
-                _( "Cut up metal where?" ), _( "There is no metal to cut up nearby." ), f, false );
+                here, _( "Cut up metal where?" ), _( "There is no metal to cut up nearby." ), f, false );
     if( !pnt_ ) {
         return std::nullopt;
     }
@@ -4878,7 +4884,7 @@ std::optional<int> iuse::boltcutters( Character *p, item *it, const tripoint_bub
     map &here = get_map();
     const std::function<bool( const tripoint_bub_ms & )> f =
     [&here, p]( const tripoint_bub_ms & pnt ) {
-        if( pnt == p->pos_bub() ) {
+        if( pnt == p->pos_bub( here ) ) {
             return false;
         } else if( here.has_furn( pnt ) ) {
             return here.furn( pnt )->boltcut->valid();
@@ -4889,7 +4895,7 @@ std::optional<int> iuse::boltcutters( Character *p, item *it, const tripoint_bub
     };
 
     const std::optional<tripoint_bub_ms> pnt_ = choose_adjacent_highlight(
-                _( "Cut up metal where?" ), _( "There is no metal to cut up nearby." ), f, false );
+                here, _( "Cut up metal where?" ), _( "There is no metal to cut up nearby." ), f, false );
     if( !pnt_ ) {
         return std::nullopt;
     }
@@ -4919,7 +4925,7 @@ std::optional<int> iuse::mop( Character *p, item *, const tripoint_bub_ms & )
     };
 
     const std::optional<tripoint_bub_ms> pnt_ = choose_adjacent_highlight(
-                _( "Mop where?" ), _( "There is nothing to mop nearby." ), f, false );
+                here, _( "Mop where?" ), _( "There is nothing to mop nearby." ), f, false );
     if( !pnt_ ) {
         return std::nullopt;
     }
@@ -5469,6 +5475,7 @@ bool iuse::robotcontrol_can_target( Character *p, const monster &m )
 
 std::optional<int> iuse::robotcontrol( Character *p, item *it, const tripoint_bub_ms & )
 {
+    const map &here = get_map();
 
     bool isComputer = !it->has_flag( flag_MAGICAL );
     int choice = 0;
@@ -5523,7 +5530,7 @@ std::optional<int> iuse::robotcontrol( Character *p, item *it, const tripoint_bu
                     pick_robot.addentry( entry_num++, true, MENU_AUTOASSIGN, candidate.name() );
                     tripoint_bub_ms seen_loc;
                     // Show locations of seen robots, center on player if robot is not seen
-                    if( p->sees( candidate ) ) {
+                    if( p->sees( here, candidate ) ) {
                         seen_loc = candidate.pos_bub();
                     } else {
                         seen_loc = p->pos_bub();
@@ -8084,6 +8091,8 @@ int item::contain_monster( const tripoint_bub_ms &target )
 
 std::optional<int> iuse::capture_monster_act( Character *p, item *it, const tripoint_bub_ms &pos )
 {
+    map &here = get_map();
+
     if( p->is_mounted() ) {
         p->add_msg_if_player( m_info, _( "You can't capture a creature mounted." ) );
         return std::nullopt;
@@ -8135,7 +8144,7 @@ std::optional<int> iuse::capture_monster_act( Character *p, item *it, const trip
         };
         const std::string query = string_format( _( "Grab which creature to place in the %s?" ),
                                   it->tname() );
-        const std::optional<tripoint_bub_ms> target_ = choose_adjacent_highlight( query,
+        const std::optional<tripoint_bub_ms> target_ = choose_adjacent_highlight( here, query,
                 _( "There is no creature nearby you can capture." ), adjacent_capturable, false );
         if( !target_ ) {
             p->add_msg_if_player( m_info, _( "You can't use a %s there." ), it->tname() );
@@ -8194,7 +8203,8 @@ heating_requirements heating_requirements_for_weight( const units::mass &frozen,
 static std::optional<std::pair<tripoint_bub_ms, itype_id>> appliance_heater_selector( Character *p )
 {
     map &here = get_map();
-    const std::optional<tripoint_bub_ms> pt = choose_adjacent_highlight( _( "Select an appliance." ),
+    const std::optional<tripoint_bub_ms> pt = choose_adjacent_highlight( here,
+            _( "Select an appliance." ),
             _( "There is no appliance nearby." ), ACTION_EXAMINE, false );
     if( !pt ) {
         p->add_msg_if_player( m_info, _( "You haven't selected any appliance." ) );
@@ -8251,7 +8261,7 @@ heater find_heater( Character *p, item *it )
     if( it->has_flag( flag_PSEUDO ) && it->has_quality( qual_HOTPLATE ) ) {
         pseudo_flag = true;
     }
-    if( here.has_nearby_fire( p->pos_bub( &here ) ) && !it->has_quality( qual_HOTPLATE ) ) {
+    if( here.has_nearby_fire( p->pos_bub( here ) ) && !it->has_quality( qual_HOTPLATE ) ) {
         p->add_msg_if_player( m_info, _( "You put %1$s on fire to start heating." ), it->tname() );
         return {loc, false, 1, 0, vpt, pseudo_flag};
     } else if( it->has_quality( qual_HOTPLATE ) ) {
@@ -8803,7 +8813,7 @@ std::optional<int> iuse::post_up( Character *p, item *it, const tripoint_bub_ms 
     };
 
     const std::optional<tripoint_bub_ms> pnt_ = choose_adjacent_highlight(
-                _( "Post to which wall?" ), _( "There is no applicable wall nearby." ), f, false );
+                here, _( "Post to which wall?" ), _( "There is no applicable wall nearby." ), f, false );
     if( !pnt_ ) {
         return std::nullopt;
     }
@@ -8838,9 +8848,11 @@ std::optional<int> iuse::coin_flip( Character *p, item *it, const tripoint_bub_m
 
 std::optional<int> iuse::play_game( Character *p, item *it, const tripoint_bub_ms & )
 {
+    const map &here = get_map();
+
     if( p->is_avatar() ) {
-        std::vector<npc *> followers = g->get_npcs_if( [p]( const npc & n ) {
-            return n.is_ally( *p ) && p->sees( n ) && n.can_hear( p->pos_bub(), p->get_shout_volume() );
+        std::vector<npc *> followers = g->get_npcs_if( [p, &here]( const npc & n ) {
+            return n.is_ally( *p ) && p->sees( here, n ) && n.can_hear( p->pos_bub(), p->get_shout_volume() );
         } );
         int fcount = followers.size();
         if( fcount > 0 ) {

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -892,6 +892,8 @@ std::string spell::damage_string( const Character &caster ) const
 
 std::optional<tripoint_bub_ms> spell::select_target( Creature *source )
 {
+    const map &here = get_map();
+
     tripoint_bub_ms target = source->pos_bub();
     bool target_is_valid = false;
     if( range( *source ) > 0 && !is_valid_target( spell_target::none ) &&
@@ -904,7 +906,7 @@ std::optional<tripoint_bub_ms> spell::select_target( Creature *source )
                 if( !trajectory.empty() ) {
                     target = trajectory.back();
                     target_is_valid = is_valid_target( source_avatar, target );
-                    if( !( is_valid_target( spell_target::ground ) || source_avatar.sees( target ) ) ) {
+                    if( !( is_valid_target( spell_target::ground ) || source_avatar.sees( here, target ) ) ) {
                         target_is_valid = false;
                     }
                 } else {
@@ -1043,7 +1045,7 @@ std::vector<tripoint_bub_ms> spell::targetable_locations( const Character &sourc
         }
 
         if( !select_ground ) {
-            if( !source.sees( query ) ) {
+            if( !source.sees( here, query ) ) {
                 // can't target a critter you can't see
                 continue;
             }
@@ -2153,8 +2155,10 @@ int spell::heal( const tripoint_bub_ms &target, Creature &caster ) const
 
 void spell::cast_spell_effect( const tripoint_bub_ms &target ) const
 {
+    map &here = get_map();
+
     avatar fake_avatar;
-    fake_avatar.setpos( target );
+    fake_avatar.setpos( here, target );
 
     get_event_bus().send<event_type::character_casts_spell>( character_id( -1 ),
             this->id(), this->spell_class(),
@@ -2179,8 +2183,10 @@ void spell::cast_spell_effect( Creature &source, const tripoint_bub_ms &target )
 
 void spell::cast_all_effects( const tripoint_bub_ms &target ) const
 {
+    map &here = get_map();
+
     avatar fake_avatar;
-    fake_avatar.setpos( target );
+    fake_avatar.setpos( here, target );
 
     if( has_flag( spell_flag::WONDER ) ) {
         const auto iter = type->additional_spells.begin();
@@ -2252,8 +2258,10 @@ void spell::cast_all_effects( Creature &source, const tripoint_bub_ms &target ) 
 
 void spell::cast_extra_spell_effects( const tripoint_bub_ms &target ) const
 {
+    map &here = get_map();
+
     avatar fake_avatar;
-    fake_avatar.setpos( target );
+    fake_avatar.setpos( here, target );
     for( const fake_spell &extra_spell : type->additional_spells ) {
         spell sp = extra_spell.get_spell( fake_avatar, get_effective_level() );
         sp.cast_all_effects( target );

--- a/src/magic_ter_fur_transform.cpp
+++ b/src/magic_ter_fur_transform.cpp
@@ -234,7 +234,7 @@ void ter_furn_transform::transform( map &m, const tripoint_bub_ms &location ) co
             m.add_field( location, field_potential->first, fld.second.get_field_intensity(),
                          fld.second.get_field_age(), true );
             m.remove_field( location, fld.first );
-            if( you.sees( location ) && !field_potential->second.first.empty() ) {
+            if( you.sees( m, location ) && !field_potential->second.first.empty() ) {
                 you.add_msg_if_player( field_potential->second.first.translated(),
                                        field_potential->second.second ? m_good : m_bad );
             }
@@ -279,21 +279,21 @@ void ter_furn_transform::transform( map &m, const tripoint_bub_ms &location ) co
 
     if( ter_potential ) {
         m.ter_set( location, ter_potential->first );
-        if( you.sees( location ) && !ter_potential->second.first.empty() ) {
+        if( you.sees( m, location ) && !ter_potential->second.first.empty() ) {
             you.add_msg_if_player( ter_potential->second.first.translated(),
                                    ter_potential->second.second ? m_good : m_bad );
         }
     }
     if( furn_potential ) {
         m.furn_set( location, furn_potential->first );
-        if( you.sees( location ) && !furn_potential->second.first.empty() ) {
+        if( you.sees( m, location ) && !furn_potential->second.first.empty() ) {
             you.add_msg_if_player( furn_potential->second.first.translated(),
                                    furn_potential->second.second ? m_good : m_bad );
         }
     }
     if( trap_potential ) {
         m.trap_set( location, trap_potential->first );
-        if( you.sees( location ) && !trap_potential->second.first.empty() ) {
+        if( you.sees( m, location ) && !trap_potential->second.first.empty() ) {
             you.add_msg_if_player( trap_potential->second.first.translated(),
                                    trap_potential->second.second ? m_good : m_bad );
         }

--- a/src/map.h
+++ b/src/map.h
@@ -591,7 +591,7 @@ class map
 
         bool is_open_air( const tripoint_bub_ms &p ) const;
 
-        bool try_fall( const tripoint_bub_ms &p, Creature *c ) const;
+        bool try_fall( const tripoint_bub_ms &p, Creature *c );
 
         /**
         * Similar behavior to `move_cost()`, but ignores vehicles.

--- a/src/map_field.cpp
+++ b/src/map_field.cpp
@@ -1447,7 +1447,7 @@ If you wish for a field effect to do something over time (propagate, interact wi
 void map::player_in_field( Character &you )
 {
     // A copy of the current field for reference. Do not add fields to it, use map::add_field
-    field &curfield = get_field( you.pos_bub( this ) );
+    field &curfield = get_field( you.pos_bub( *this ) );
     // Are we inside?
     bool inside = false;
     // If we are in a vehicle figure out if we are inside (reduces effects usually)
@@ -1515,7 +1515,7 @@ void map::player_in_field( Character &you )
             // Sap does nothing to cars.
             if( !you.in_vehicle ) {
                 // Use up sap.
-                mod_field_intensity( you.pos_bub( this ), ft, -1 );
+                mod_field_intensity( you.pos_bub( *this ), ft, -1 );
             }
         }
         if( ft == fd_sludge ) {

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -693,7 +693,7 @@ bool Character::melee_attack_abstract( Creature &t, bool allow_special,
             } else {
                 add_msg( _( "You miss." ) );
             }
-        } else if( player_character.sees( *this ) ) {
+        } else if( player_character.sees( here, *this ) ) {
             if( miss_recovery.id != tec_none ) {
                 add_msg_if_npc( miss_recovery.npc_message.translated(), t.disp_name() );
             } else if( stumble_pen >= 60 ) {
@@ -723,7 +723,7 @@ bool Character::melee_attack_abstract( Creature &t, bool allow_special,
     } else {
         melee::melee_stats.hit_count += 1;
         // Remember if we see the monster at start - it may change
-        const bool seen = player_character.sees( t );
+        const bool seen = player_character.sees( here, t );
         // Start of attacks.
         const bool critical_hit = scored_crit( t.dodge_roll(), cur_weap );
         if( critical_hit ) {
@@ -895,7 +895,7 @@ bool Character::melee_attack_abstract( Creature &t, bool allow_special,
             }
 
             // Treat monster as seen if we see it before or after the attack
-            if( seen || player_character.sees( t ) ) {
+            if( seen || player_character.sees( here, t ) ) {
                 std::string message = melee_message( technique, *this, dealt_dam );
                 player_hit_message( this, message, t, dam, critical_hit, technique.id != tec_none,
                                     dealt_dam.wp_hit );
@@ -1720,6 +1720,8 @@ void Character::perform_technique( const ma_technique &technique, Creature &t,
                                    damage_instance &di,
                                    int &move_cost, item_location &cur_weapon )
 {
+    map &here = get_map();
+
     add_msg_debug( debugmode::DF_MELEE, "Chose technique %s\ndmg before tec:", technique.name );
     print_damage_info( di );
     int rep = rng( technique.repeat_min, technique.repeat_max );
@@ -1818,10 +1820,10 @@ void Character::perform_technique( const ma_technique &technique, Creature &t,
 
         const tripoint_bub_ms dest{ new_, b.z()};
         if( g->is_empty( dest ) ) {
-            t.setpos( dest );
+            t.setpos( here, dest );
         }
     }
-    map &here = get_map();
+
     if( technique.knockback_dist && !( t.has_flag( mon_flag_IMMOBILE ) ||
                                        t.has_flag( json_flag_CANNOT_MOVE ) ) ) {
         const tripoint_bub_ms prev_pos = t.pos_bub(); // track target startpoint for knockback_follow

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -10,6 +10,7 @@
 #include "game.h"
 #include "input_context.h"
 #include "json.h"
+#include "map.h"
 #include "output.h"
 #include "panels.h"
 #include "point.h"
@@ -1003,14 +1004,18 @@ void add_msg( const game_message_params &params, std::string msg )
 
 void add_msg_if_player_sees( const tripoint_bub_ms &target, std::string msg )
 {
-    if( get_player_view().sees( target ) ) {
+    const map &here = get_map();
+
+    if( get_player_view().sees( here, target ) ) {
         Messages::add_msg( std::move( msg ) );
     }
 }
 
 void add_msg_if_player_sees( const Creature &target, std::string msg )
 {
-    if( get_player_view().sees( target ) ) {
+    const map &here = get_map();
+
+    if( get_player_view().sees( here, target ) ) {
         Messages::add_msg( std::move( msg ) );
     }
 }
@@ -1018,7 +1023,9 @@ void add_msg_if_player_sees( const Creature &target, std::string msg )
 void add_msg_if_player_sees( const tripoint_bub_ms &target, const game_message_params &params,
                              std::string msg )
 {
-    if( get_player_view().sees( target ) ) {
+    const map &here = get_map();
+
+    if( get_player_view().sees( here, target ) ) {
         Messages::add_msg( params, std::move( msg ) );
     }
 }
@@ -1026,7 +1033,9 @@ void add_msg_if_player_sees( const tripoint_bub_ms &target, const game_message_p
 void add_msg_if_player_sees( const Creature &target, const game_message_params &params,
                              std::string msg )
 {
-    if( get_player_view().sees( target ) ) {
+    const map &here = get_map();
+
+    if( get_player_view().sees( here, target ) ) {
         Messages::add_msg( params, std::move( msg ) );
     }
 }

--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -555,7 +555,7 @@ bool mission::is_complete( const character_id &_npc_id ) const
                 }
             };
             for( const tripoint_bub_ms &p : here.points_in_radius( player_character.pos_bub(), 5 ) ) {
-                if( player_character.sees( p ) ) {
+                if( player_character.sees( here, p ) ) {
                     if( here.has_items( p ) && here.accessible_items( p ) ) {
                         count_items( here.i_at( p ) );
                     }

--- a/src/mission_companion.cpp
+++ b/src/mission_companion.cpp
@@ -2612,6 +2612,8 @@ std::vector<comp_rank> talk_function::companion_rank( const std::vector<npc_ptr>
 npc_ptr talk_function::companion_choose( const std::map<skill_id, int> &required_skills,
         bool silent_failure )
 {
+    const map &here = get_map();
+
     Character &player_character = get_player_character();
     std::vector<npc_ptr> available;
     std::optional<basecamp *> bcp = overmap_buffer.find_camp(
@@ -2626,8 +2628,8 @@ npc_ptr talk_function::companion_choose( const std::map<skill_id, int> &required
         // get non-assigned visible followers
         if( player_character.posz() == guy->posz() && !guy->has_companion_mission() &&
             !guy->is_travelling() &&
-            ( rl_dist( player_character.pos_bub(), guy->pos_bub() ) <= SEEX * 2 ) &&
-            player_character.sees( guy->pos_bub() ) ) {
+            ( rl_dist( player_character.pos_abs(), guy->pos_abs() ) <= SEEX * 2 ) &&
+            player_character.sees( here, guy->pos_bub( here ) ) ) {
             available.push_back( guy );
         } else if( bcp ) {
             basecamp *player_camp = *bcp;

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -231,20 +231,26 @@ static const trait_id trait_THRESH_MYCUS( "THRESH_MYCUS" );
 // shared utility functions
 static bool within_visual_range( monster *z, int max_range )
 {
+    const map &here = get_map();
+
     Character &player_character = get_player_character();
-    return !( rl_dist( z->pos_bub(), player_character.pos_bub() ) > max_range ||
-              !z->sees( player_character ) );
+    return !( rl_dist( z->pos_abs(), player_character.pos_abs() ) > max_range ||
+              !z->sees( here, player_character ) );
 }
 
 static bool within_target_range( const monster *const z, const Creature *const target, int range )
 {
+    const map &here = get_map();
+
     return target != nullptr &&
-           rl_dist( z->pos_bub(), target->pos_bub() ) <= range &&
-           z->sees( *target );
+           rl_dist( z->pos_abs(), target->pos_abs() ) <= range &&
+           z->sees( here, *target );
 }
 
 static Creature *sting_get_target( monster *z, float range = 5.0f )
 {
+    const map &here = get_map();
+
     Creature *target = z->attack_target();
 
     if( target == nullptr ) {
@@ -252,12 +258,12 @@ static Creature *sting_get_target( monster *z, float range = 5.0f )
     }
 
     // Can't see/reach target, no attack
-    if( !z->sees( *target ) ||
+    if( !z->sees( here,  *target ) ||
         !get_map().clear_path( z->pos_bub(), target->pos_bub(), range, 1, 100 ) ) {
         return nullptr;
     }
 
-    return rl_dist( z->pos_bub(), target->pos_bub() ) <= range ? target : nullptr;
+    return rl_dist( z->pos_abs(), target->pos_abs() ) <= range ? target : nullptr;
 }
 
 static bool sting_shoot( monster *z, Creature *target, damage_instance &dam, float range )
@@ -599,10 +605,12 @@ bool mattack::browse( monster *z )
 
 bool mattack::shriek( monster *z )
 {
+    const map &here = get_map();
+
     Creature *target = z->attack_target();
     if( target == nullptr ||
-        rl_dist( z->pos_bub(), target->pos_bub() ) > 4 ||
-        !z->sees( *target ) ) {
+        rl_dist( z->pos_abs(), target->pos_abs() ) > 4 ||
+        !z->sees( here, *target ) ) {
         return false;
     }
 
@@ -615,6 +623,8 @@ bool mattack::shriek( monster *z )
 
 bool mattack::shriek_alert( monster *z )
 {
+    const map &here = get_map();
+
     if( !z->can_act() || z->has_effect( effect_shrieking ) ) {
         return false;
     }
@@ -622,7 +632,7 @@ bool mattack::shriek_alert( monster *z )
     Creature *target = z->attack_target();
 
     if( target == nullptr || rl_dist( z->pos_bub(), target->pos_bub() ) > 15 ||
-        !z->sees( *target ) ) {
+        !z->sees( here, *target ) ) {
         return false;
     }
     add_msg_if_player_sees( *z, _( "The %s begins shrieking!" ), z->name() );
@@ -636,6 +646,8 @@ bool mattack::shriek_alert( monster *z )
 
 bool mattack::shriek_stun( monster *z )
 {
+    map &here = get_map();
+
     if( !z->can_act() || !z->has_effect( effect_shrieking ) ) {
         return false;
     }
@@ -649,13 +661,12 @@ bool mattack::shriek_stun( monster *z )
     // Currently the cone is 2D, so don't use it for 3D attacks
     if( dist > 7 ||
         z->posz() != target->posz() ||
-        !z->sees( *target ) ) {
+        !z->sees( here, *target ) ) {
         return false;
     }
 
     units::angle target_angle = coord_to_angle( z->pos_bub(), target->pos_bub() );
     units::angle cone_angle = 20_degrees;
-    map &here = get_map();
     creature_tracker &creatures = get_creature_tracker();
     for( const tripoint_bub_ms &cone : here.points_in_radius( z->pos_bub(), 4 ) ) {
         units::angle tile_angle = coord_to_angle( z->pos_bub().raw(), cone.raw() );
@@ -684,12 +695,14 @@ bool mattack::shriek_stun( monster *z )
 
 bool mattack::rattle( monster *z )
 {
+    const map &here = get_map();
+
     // TODO: Let it rattle at non-player friendlies
     const int min_dist = z->friendly != 0 ? 1 : 4;
     Creature *target = &get_player_character();
     // Can't use attack_target - the snake has no target
-    if( rl_dist( z->pos_bub(), target->pos_bub() ) > min_dist ||
-        !z->sees( *target ) ) {
+    if( rl_dist( z->pos_abs(), target->pos_abs() ) > min_dist ||
+        !z->sees( here, *target ) ) {
         return false;
     }
 
@@ -714,7 +727,7 @@ bool mattack::acid( monster *z )
 
     map &here = get_map();
     // Can't see/reach target, no attack
-    if( !z->sees( *target ) ||
+    if( !z->sees( here,  *target ) ||
         !here.clear_path( z->pos_bub(), target->pos_bub(), 10, 1, 100 ) ) {
         return false;
     }
@@ -824,6 +837,8 @@ bool mattack::acid_barf( monster *z )
 
 bool mattack::shockstorm( monster *z )
 {
+    map &here = get_map();
+
     if( !z->can_act() ) {
         return false;
     }
@@ -834,10 +849,9 @@ bool mattack::shockstorm( monster *z )
     }
 
     Character &player_character = get_player_character();
-    bool seen = player_character.sees( *z );
-    map &here = get_map();
+    bool seen = player_character.sees( here, *z );
 
-    bool can_attack = z->sees( *target ) && rl_dist( z->pos_bub(), target->pos_bub() ) <= 12;
+    bool can_attack = z->sees( here, *target ) && rl_dist( z->pos_abs(), target->pos_abs() ) <= 12;
     std::vector<tripoint_bub_ms> path = here.find_clear_path( z->pos_bub(), target->pos_bub() );
     for( const tripoint_bub_ms &point : path ) {
         if( here.impassable( point ) &&
@@ -897,6 +911,8 @@ bool mattack::shocking_reveal( monster *z )
 
 bool mattack::pull_metal_weapon( monster *z )
 {
+    map &here = get_map();
+
     ////////////////////////////////////////////////////////////////////////////////////////////////
     // Constants and Configuration
 
@@ -915,7 +931,7 @@ bool mattack::pull_metal_weapon( monster *z )
     }
 
     // Can't see/reach target, no attack
-    if( !z->sees( *target ) || !get_map().clear_path( z->pos_bub(), target->pos_bub(),
+    if( !z->sees( here, *target ) || !here.clear_path( z->pos_bub( here ), target->pos_bub( here ),
             max_distance, 1, 100 ) ) {
         return false;
     }
@@ -960,7 +976,7 @@ bool mattack::pull_metal_weapon( monster *z )
                     dealt_projectile_attack dealt;
                     projectile_attack( dealt, proj, foe->pos_bub(), z->pos_bub(),
                                        dispersion_sources{ 0 }, z );
-                    get_map().add_item( dealt.end_point, pulled_weapon );
+                    here.add_item( dealt.end_point, pulled_weapon );
                     target->add_msg_player_or_npc( m_type, _( "The %s is pulled away from your hands!" ),
                                                    _( "The %s is pulled away from <npcname>'s hands!" ), pulled_weapon.tname() );
                     if( foe->has_activity( ACT_RELOAD ) ) {
@@ -981,21 +997,23 @@ bool mattack::pull_metal_weapon( monster *z )
 
 bool mattack::boomer( monster *z )
 {
+    map &here = get_map();
+
     if( !z->can_act() ) {
         return false;
     }
 
     Creature *target = z->attack_target();
-    if( target == nullptr || rl_dist( z->pos_bub(), target->pos_bub() ) > 3 || !z->sees( *target ) ) {
+    if( target == nullptr || rl_dist( z->pos_abs(), target->pos_abs() ) > 3 ||
+        !z->sees( here, *target ) ) {
         return false;
     }
 
-    map &here = get_map();
     std::vector<tripoint_bub_ms> line = here.find_clear_path( z->pos_bub(), target->pos_bub() );
     // It takes a while
     z->mod_moves( -to_moves<int>( 1_seconds ) * 2.5 );
     Character &player_character = get_player_character();
-    bool u_see = player_character.sees( *z );
+    bool u_see = player_character.sees( here, *z );
     if( u_see ) {
         add_msg( m_warning, _( "The %s spews bile!" ), z->name() );
     }
@@ -1022,21 +1040,23 @@ bool mattack::boomer( monster *z )
 
 bool mattack::boomer_glow( monster *z )
 {
+    map &here = get_map();
+
     if( !z->can_act() ) {
         return false;
     }
 
     Creature *target = z->attack_target();
-    if( target == nullptr || rl_dist( z->pos_bub(), target->pos_bub() ) > 3 || !z->sees( *target ) ) {
+    if( target == nullptr || rl_dist( z->pos_abs(), target->pos_abs() ) > 3 ||
+        !z->sees( here, *target ) ) {
         return false;
     }
 
-    map &here = get_map();
     std::vector<tripoint_bub_ms> line = here.find_clear_path( z->pos_bub(), target->pos_bub() );
     // It takes a while
     z->mod_moves( -to_moves<int>( 1_seconds ) * 2.5 );
     Character &player_character = get_player_character();
-    bool u_see = player_character.sees( *z );
+    bool u_see = player_character.sees( here,  *z );
     if( u_see ) {
         add_msg( m_warning, _( "The %s spews bile!" ), z->name() );
     }
@@ -1069,6 +1089,8 @@ bool mattack::boomer_glow( monster *z )
 
 bool mattack::resurrect( monster *z )
 {
+    map &here = get_map();
+
     // Chance to recover some of our missing speed (yes this will regain
     // loses from being revived ourselves as well).
     // Multiplying by (current base speed / max speed) means that the
@@ -1087,13 +1109,12 @@ bool mattack::resurrect( monster *z )
     }
 
     Character &player_character = get_player_character();
-    bool sees_necromancer = player_character.sees( *z );
+    bool sees_necromancer = player_character.sees( here, *z );
     std::vector<std::pair<tripoint_bub_ms, item *>> corpses;
     // Find all corpses that we can see within 10 tiles.
     int range = 10;
     bool found_eligible_corpse = false;
     int lowest_raise_score = INT_MAX;
-    map &here = get_map();
     // Cache map stats.
     std::unordered_map<tripoint_bub_ms, bool> sees_and_is_empty_cache;
     auto sees_and_is_empty = [&sees_and_is_empty_cache, &z, &here]( const tripoint_bub_ms & T ) {
@@ -1208,7 +1229,7 @@ bool mattack::resurrect( monster *z )
         }
 
         zed->make_ally( *z );
-        if( player_character.sees( *zed ) ) {
+        if( player_character.sees( here, *zed ) ) {
             add_msg( m_warning, _( "A nearby %s rises from the dead!" ), zed->name() );
         } else if( sees_necromancer ) {
             // We saw the necromancer but not the revival
@@ -1537,14 +1558,16 @@ bool mattack::vine( monster *z )
 
 bool mattack::spit_sap( monster *z )
 {
+    const map &here = get_map();
+
     if( !z->can_act() ) {
         return false;
     }
 
     Creature *target = z->attack_target();
     if( target == nullptr ||
-        rl_dist( z->pos_bub(), target->pos_bub() ) > 12 ||
-        !z->sees( *target ) ) {
+        rl_dist( z->pos_abs(), target->pos_abs() ) > 12 ||
+        !z->sees( here, *target ) ) {
         return false;
     }
 
@@ -1681,9 +1704,11 @@ bool mattack::fungus( monster *z )
 
 bool mattack::fungus_corporate( monster *z )
 {
+    const map &here = get_map();
+
     if( x_in_y( 1, 20 ) ) {
         sounds::sound( z->pos_bub(), 10, sounds::sound_t::speech, _( "\"Buy SpOreos™ now!\"" ) );
-        if( get_player_view().sees( *z ) ) {
+        if( get_player_view().sees( here, *z ) ) {
             add_msg( m_warning, _( "Delicious snacks are released from the %s!" ), z->name() );
             get_map().add_item( z->pos_bub(), item( itype_sporeos ) );
         } // only spawns SpOreos if the player is near; can't have the COMMONERS stealing our product from good customers
@@ -1710,9 +1735,10 @@ bool mattack::fungus_haze( monster *z )
 
 bool mattack::fungus_big_blossom( monster *z )
 {
-    bool firealarm = false;
-    const bool u_see = get_player_view().sees( *z );
     map &here = get_map();
+
+    bool firealarm = false;
+    const bool u_see = get_player_view().sees( here, *z );
     // Fungal fire-suppressor! >:D
     for( const tripoint_bub_ms &dest : here.points_in_radius( z->pos_bub(), 6 ) ) {
         if( here.get_field_intensity( dest, fd_fire ) != 0 ) {
@@ -1832,7 +1858,7 @@ bool mattack::fungus_bristle( monster *z )
     Creature *target = z->attack_target();
     if( target == nullptr ||
         !z->is_adjacent( target, true ) ||
-        !z->sees( *target ) ) {
+        !z->sees( here, *target ) ) {
         return false;
     }
 
@@ -2327,7 +2353,9 @@ bool mattack::jackson( monster *z )
 
 bool mattack::dance( monster *z )
 {
-    if( get_player_view().sees( *z ) ) {
+    const map &here = get_map();
+
+    if( get_player_view().sees( here, *z ) ) {
         switch( rng( 1, 10 ) ) {
             case 1:
                 add_msg( m_neutral, _( "The %s swings its arms from side to side!" ), z->name() );
@@ -2367,19 +2395,21 @@ bool mattack::dance( monster *z )
 
 bool mattack::dogthing( monster *z )
 {
+    map &here = get_map();
+
     if( z == nullptr ) {
         // TODO: replace pointers with references
         return false;
     }
 
-    if( !one_in( 3 ) || !get_player_view().sees( *z ) ) {
+    if( !one_in( 3 ) || !get_player_view().sees( here, *z ) ) {
         return false;
     }
 
     add_msg( _( "The %s's head explodes in a mass of roiling tentacles!" ),
              z->name() );
 
-    get_map().add_splash( z->bloodType(), z->pos_bub(), 2, 3 );
+    here.add_splash( z->bloodType(), z->pos_bub(), 2, 3 );
 
     z->friendly = 0;
     z->poly( mon_headless_dog_thing );
@@ -2425,7 +2455,7 @@ bool mattack::nurse_check_up( monster *z )
     map &here = get_map();
     for( Creature *critter : here.get_creatures_in_radius( z->pos_bub(), 6 ) ) {
         Character *tmp_player = dynamic_cast<Character *>( critter );
-        if( tmp_player != nullptr && z->sees( *tmp_player ) &&
+        if( tmp_player != nullptr && z->sees( here, *tmp_player ) &&
             here.clear_path( z->pos_bub(), tmp_player->pos_bub(), 10, 0,
                              100 ) ) { // no need to scan players we can't reach
             if( rl_dist( z->pos_bub(), tmp_player->pos_bub() ) < rl_dist( z->pos_bub(), tmp_pos ) ) {
@@ -2464,8 +2494,9 @@ bool mattack::nurse_check_up( monster *z )
 }
 bool mattack::nurse_assist( monster *z )
 {
+    const map &here = get_map();
 
-    const bool u_see = get_player_view().sees( *z );
+    const bool u_see = get_player_view().sees( here, *z );
 
     if( u_see && one_in( 100 ) ) {
         add_msg( m_info, _( "The %s is scanning its surroundings." ), z->name() );
@@ -2473,14 +2504,13 @@ bool mattack::nurse_assist( monster *z )
 
     bool found_target = false;
     Character *target = nullptr;
-    map &here = get_map();
     tripoint_bub_ms tmp_pos( z->pos_bub() + point( 12, 12 ) );
     for( Creature *critter : here.get_creatures_in_radius( z->pos_bub(), 6 ) ) {
         Character *tmp_player = dynamic_cast<Character *>( critter );
         // No need to scan players we can't reach
-        if( tmp_player != nullptr && z->sees( *tmp_player ) &&
+        if( tmp_player != nullptr && z->sees( here, *tmp_player ) &&
             here.clear_path( z->pos_bub(), tmp_player->pos_bub(), 10, 0, 100 ) ) {
-            if( rl_dist( z->pos_bub(), tmp_player->pos_bub() ) < rl_dist( z->pos_bub(), tmp_pos ) ) {
+            if( rl_dist( z->pos_abs(), tmp_player->pos_abs() ) < rl_dist( z->pos_bub(), tmp_pos ) ) {
                 tmp_pos = tmp_player->pos_bub();
                 target = tmp_player;
                 found_target = true;
@@ -2503,11 +2533,13 @@ bool mattack::nurse_assist( monster *z )
 }
 bool mattack::nurse_operate( monster *z )
 {
+    const map &here = get_map();
+
     if( z->has_effect( effect_dragging ) || z->has_effect( effect_operating ) ) {
         return false;
     }
     Character &player_character = get_player_character();
-    const bool u_see = player_character.sees( *z );
+    const bool u_see = player_character.sees( here, *z );
 
     if( u_see && one_in( 100 ) ) {
         add_msg( m_info, _( "The %s is scanning its surroundings." ), z->name() );
@@ -2528,15 +2560,14 @@ bool mattack::nurse_operate( monster *z )
 
     bool found_target = false;
     Character *target = nullptr;
-    map &here = get_map();
     tripoint_bub_ms tmp_pos( z->pos_bub() + point( 12, 12 ) );
     for( Creature *critter : here.get_creatures_in_radius( z->pos_bub(), 6 ) ) {
         Character *tmp_player = dynamic_cast< Character *>( critter );
         // No need to scan players we can't reach
-        if( tmp_player != nullptr && z->sees( *tmp_player ) &&
+        if( tmp_player != nullptr && z->sees( here, *tmp_player ) &&
             here.clear_path( z->pos_bub(), tmp_player->pos_bub(), 10, 0, 100 ) ) {
             if( tmp_player->has_any_bionic() ) {
-                if( rl_dist( z->pos_bub(), tmp_player->pos_bub() ) < rl_dist( z->pos_bub(), tmp_pos ) ) {
+                if( rl_dist( z->pos_abs(), tmp_player->pos_abs() ) < rl_dist( z->pos_bub(), tmp_pos ) ) {
                     tmp_pos = tmp_player->pos_bub();
                     target = tmp_player;
                     found_target = true;
@@ -2842,6 +2873,7 @@ void mattack::taze( monster *z, Creature *target )
 
 bool mattack::searchlight( monster *z )
 {
+    map &here = get_map();
 
     int max_lamp_count = 3;
     if( z->get_hp() < z->get_hp_max() ) {
@@ -2853,7 +2885,6 @@ bool mattack::searchlight( monster *z )
 
     const point_bub_ms zpos( z->posx(), z->posy() );
 
-    map &here = get_map();
     //this searchlight is not initialized
     if( z->inv.empty() ) {
 
@@ -2950,7 +2981,7 @@ bool mattack::searchlight( monster *z )
 
         for( int i = 0; i < rng( 1, 2 ); i++ ) {
 
-            if( !z->sees( player_character ) ) {
+            if( !z->sees( here,  player_character ) ) {
                 shift = settings.get_var( "SL_DIR", shift );
 
                 switch( shift ) {
@@ -3019,7 +3050,7 @@ bool mattack::searchlight( monster *z )
         }
 
         tripoint_bub_ms t = tripoint_bub_ms( p, z->posz() );
-        if( z->sees( t, false, 0 ) ) {
+        if( z->sees( here, t, false, 0 ) ) {
             settings.set_var( "SL_SPOT_X", p.x() - zpos.x() );
             settings.set_var( "SL_SPOT_Y", p.y() - zpos.y() );
         } else {
@@ -3028,10 +3059,10 @@ bool mattack::searchlight( monster *z )
             // a window covered). If the searchlight cannot see the current location then
             // reset the searchlight to search from itself
             t = tripoint_bub_ms( preshift_p, z->posz() );
-            if( !z->sees( t, false, 0 ) ) {
+            if( !z->sees( here, t, false, 0 ) ) {
                 settings.set_var( "SL_SPOT_X", 0 );
                 settings.set_var( "SL_SPOT_Y", 0 );
-                t = z->pos_bub();
+                t = z->pos_bub( here );
             }
         }
 
@@ -3043,6 +3074,8 @@ bool mattack::searchlight( monster *z )
 
 bool mattack::copbot( monster *z )
 {
+    const map &here = get_map();
+
     Creature *target = z->attack_target();
     if( target == nullptr ) {
         return false;
@@ -3050,7 +3083,7 @@ bool mattack::copbot( monster *z )
 
     // TODO: Make it recognize zeds as human, but ignore animals
     Character *foe = dynamic_cast<Character *>( target );
-    bool sees_u = foe != nullptr && z->sees( *foe );
+    bool sees_u = foe != nullptr && z->sees( here, *foe );
     bool cuffed = foe != nullptr && foe->get_wielded_item() &&
                   foe->get_wielded_item()->typeId() == itype_e_handcuffs;
     // Taze first, then ask questions (simplifies later checks for non-humans)
@@ -3059,7 +3092,8 @@ bool mattack::copbot( monster *z )
         return true;
     }
 
-    if( rl_dist( z->pos_bub(), target->pos_bub() ) > 2 || foe == nullptr || !z->sees( *target ) ) {
+    if( rl_dist( z->pos_abs(), target->pos_abs() ) > 2 || foe == nullptr ||
+        !z->sees( here, *target ) ) {
         if( one_in( 3 ) ) {
             if( sees_u ) {
                 if( foe->unarmed_attack() ) {
@@ -3140,6 +3174,8 @@ bool mattack::generator( monster *z )
 
 bool mattack::upgrade( monster *z )
 {
+    const map &here = get_map();
+
     std::vector<monster *> targets;
     for( monster &zed : g->all_monsters() ) {
         // Check this first because it is a relatively cheap check
@@ -3167,11 +3203,11 @@ bool mattack::upgrade( monster *z )
 
     std::string old_name = target->name();
     viewer &player_view = get_player_view();
-    const bool could_see = player_view.sees( *target );
+    const bool could_see = player_view.sees( here, *target );
     target->hasten_upgrade();
     target->try_upgrade( false );
-    const bool can_see = player_view.sees( *target );
-    if( player_view.sees( *z ) ) {
+    const bool can_see = player_view.sees( here, *target );
+    if( player_view.sees( here, *z ) ) {
         if( could_see ) {
             add_msg( m_warning,
                      //~ %1$s is the name of the zombie upgrading the other, %2$s is the zombie being upgraded.
@@ -3230,12 +3266,14 @@ bool mattack::breathe( monster *z )
 
 bool mattack::brandish( monster *z )
 {
+    const map &here = get_map();
+
     if( z->friendly ) {
         // TODO: handle friendly monsters
         return false;
     }
     // Only brandish if we can see you!
-    if( !z->sees( get_player_character() ) ) {
+    if( !z->sees( here, get_player_character() ) ) {
         return false;
     }
     add_msg( m_warning, _( "He's brandishing a knife!" ) );
@@ -3257,9 +3295,9 @@ bool mattack::flesh_golem( monster *z )
         return false;
     }
 
-    int dist = rl_dist( z->pos_bub(), target->pos_bub() );
+    int dist = rl_dist( z->pos_abs(), target->pos_abs() );
     if( dist > 20 ||
-        !z->sees( *target ) ) {
+        !z->sees( here, *target ) ) {
         return false;
     }
 
@@ -3267,7 +3305,8 @@ bool mattack::flesh_golem( monster *z )
         if( one_in( 12 ) ) {
             z->mod_moves( -to_moves<int>( 2_seconds ) );
             // It doesn't "nearly deafen you" when it roars from the other side of bubble
-            sounds::sound( z->pos_bub(), 80, sounds::sound_t::alert, _( "a terrifying roar!" ), false, "shout",
+            sounds::sound( z->pos_bub( here ), 80, sounds::sound_t::alert, _( "a terrifying roar!" ), false,
+                           "shout",
                            "roar" );
             return true;
         }
@@ -3348,7 +3387,7 @@ bool mattack::absorb_meat( monster *z )
                     z->heal( hp_to_heal, true );
                     here.use_amount( p, 0, current_item.type->get_id(), meat_absorbed );
                 }
-                if( player_character.sees( *z ) ) {
+                if( player_character.sees( here, *z ) ) {
                     add_msg( m_warning, _( "The %1$s absorbs the %2$s, growing larger." ), z->name(),
                              current_item.tname() );
                     add_msg_debug( debugmode::DF_MATTACK, "The %1$s now has %2$s out of %3$s hp", z->name(),
@@ -3375,17 +3414,17 @@ bool mattack::lunge( monster *z )
         return false;
     }
 
-    int dist = rl_dist( z->pos_bub(), target->pos_bub() );
+    int dist = rl_dist( z->pos_abs(), target->pos_abs() );
     if( dist > 20 ||
-        !z->sees( *target ) ) {
+        !z->sees( here, *target ) ) {
         return false;
     }
 
-    bool seen = get_player_view().sees( *z );
+    bool seen = get_player_view().sees( here, *z );
     if( dist > 1 ) {
         if( one_in( 5 ) ) {
             // Out of range
-            if( dist > 4 || !z->sees( *target ) ) {
+            if( dist > 4 || !z->sees( here, *target ) ) {
                 return false;
             }
             z->mod_moves( z->get_speed() * 2.0 );
@@ -3441,16 +3480,18 @@ bool mattack::lunge( monster *z )
 
 bool mattack::blow_whistle( monster *z )
 {
+    const map &here = get_map();
+
     if( z->friendly ) {
         // TODO: handle friendly monsters
         return false;
     }
     // Only blow whistle if we can see you!
-    if( !z->sees( get_player_character() ) ) {
+    if( !z->sees( here, get_player_character() ) ) {
         return false;
     }
     add_msg_if_player_sees( *z, m_warning, _( "The %1$s loudly blows their whistle!" ), z->name() );
-    sounds::sound( z->pos_bub(), 40, sounds::sound_t::alarm, _( "FWEEEET!" ), false, "misc",
+    sounds::sound( z->pos_bub( here ), 40, sounds::sound_t::alarm, _( "FWEEEET!" ), false, "misc",
                    "whistle" );
 
     return true;
@@ -3482,18 +3523,21 @@ bool mattack::parrot( monster *z )
 
 bool mattack::parrot_at_danger( monster *parrot )
 {
-    Creature *other = get_creature_tracker().find_reachable( *parrot, [parrot]( Creature * creature ) {
+    const map &here = get_map();
+
+    Creature *other = get_creature_tracker().find_reachable( *parrot, [parrot,
+    &here]( Creature * creature ) {
         if( !creature->is_hallucination() && one_in( 20 ) ) {
             if( creature->is_avatar() || creature->is_npc() ) {
                 Character *character = creature->as_character();
                 return character->attitude_to( *parrot ) == Creature::Attitude::HOSTILE &&
-                       parrot->sees( *character );
+                       parrot->sees( here, *character );
             } else {
                 monster *monster = creature->as_monster();
                 return ( monster->faction->attitude( parrot->faction ) == mf_attitude::MFA_HATE ||
                          ( monster->anger > 0 &&
                            monster->faction->attitude( parrot->faction ) == mf_attitude::MFA_BY_MOOD ) ) &&
-                       parrot->sees( *monster );
+                       parrot->sees( here, *monster );
             }
         }
         return false;
@@ -3509,21 +3553,23 @@ bool mattack::parrot_at_danger( monster *parrot )
 
 bool mattack::darkman( monster *z )
 {
+    const map &here = get_map();
+
     if( z->friendly ) {
         // TODO: handle friendly monsters
         return false;
     }
     Character &player_character = get_player_character();
-    if( rl_dist( z->pos_bub(), player_character.pos_bub() ) > 40 ) {
+    if( rl_dist( z->pos_abs(), player_character.pos_abs() ) > 40 ) {
         return false;
     }
-    if( monster *const shadow = g->place_critter_around( mon_shadow, z->pos_bub(), 1 ) ) {
+    if( monster *const shadow = g->place_critter_around( mon_shadow, z->pos_bub( here ), 1 ) ) {
         z->mod_moves( -to_moves<int>( 1_seconds ) * 0.1 );
         shadow->make_ally( *z );
         add_msg_if_player_sees( *z, m_warning, _( "A shadow splits from the %s!" ), z->name() );
     }
     // Won't do the combat stuff unless it can see you
-    if( !z->sees( player_character ) ) {
+    if( !z->sees( here, player_character ) ) {
         return true;
     }
     // What do we say?
@@ -3557,8 +3603,10 @@ bool mattack::darkman( monster *z )
 
 bool mattack::slimespring( monster *z )
 {
+    const map &here = get_map();
+
     Character &player_character = get_player_character();
-    if( rl_dist( z->pos_bub(), player_character.pos_bub() ) > 30 ) {
+    if( rl_dist( z->pos_abs(), player_character.pos_abs() ) > 30 ) {
         return false;
     }
 
@@ -3572,7 +3620,8 @@ bool mattack::slimespring( monster *z )
         add_msg( m_good, "%s", SNIPPET.random_from_category( "slime_cheers" ).value_or( translation() ) );
         player_character.remove_effect( effect_social_dissatisfied );
     }
-    if( rl_dist( z->pos_bub(), player_character.pos_bub() ) <= 3 && z->sees( player_character ) ) {
+    if( rl_dist( z->pos_abs(), player_character.pos_abs() ) <= 3 &&
+        z->sees( here, player_character ) ) {
         if( player_character.has_effect( effect_bleed ) ||
             player_character.has_effect( effect_bite ) ) {
             //~ Lowercase is intended: they're small voices.
@@ -3809,10 +3858,12 @@ bool mattack::riotbot( monster *z )
 
 bool mattack::evolve_kill_strike( monster *z )
 {
+    map &here = get_map();
+
     Creature *target = z->attack_target();
     if( target == nullptr ||
         !z->is_adjacent( target, false ) ||
-        !z->sees( *target ) ) {
+        !z->sees( here, *target ) ) {
         return false;
     }
     if( !z->can_act() ) {
@@ -3838,7 +3889,7 @@ bool mattack::evolve_kill_strike( monster *z )
                                        z->name() );
         return true;
     }
-    tripoint_bub_ms const target_pos = target->pos_bub();
+    tripoint_abs_ms const target_pos = target->pos_abs();
     const std::string target_name = target->disp_name();
 
     int damage_dealt = target->deal_damage( z, bodypart_id( "torso" ), damage ).total_damage();
@@ -3856,15 +3907,15 @@ bool mattack::evolve_kill_strike( monster *z )
         return true;
     }
     Character &player_character = get_player_character();
-    if( target->is_dead_state() && g->is_empty( target_pos ) &&
+    if( target->is_dead_state() && g->is_empty( &here, target_pos ) &&
         target->made_of_any( Creature::cmat_flesh ) ) {
         const std::string old_name = z->name();
-        const bool could_see_z = player_character.sees( *z );
+        const bool could_see_z = player_character.sees( here, *z );
         z->allow_upgrade();
         z->try_upgrade( false );
         z->setpos( target_pos );
         const std::string upgrade_name = z->name();
-        const bool can_see_z_upgrade = player_character.sees( *z );
+        const bool can_see_z_upgrade = player_character.sees( here, *z );
         if( could_see_z && can_see_z_upgrade ) {
             add_msg( m_warning, _( "The %1$s burrows within %2$s corpse and a %3$s emerges from the remains!" ),
                      old_name,
@@ -3880,7 +3931,9 @@ bool mattack::evolve_kill_strike( monster *z )
 
 bool mattack::leech_spawner( monster *z )
 {
-    const bool u_see = get_player_view().sees( *z );
+    const map &here = get_map();
+
+    const bool u_see = get_player_view().sees( here, *z );
     std::list<monster *> allies;
     for( monster &candidate : g->all_monsters() ) {
         if( candidate.in_species( species_LEECH_PLANT ) && !( candidate.has_flag( mon_flag_IMMOBILE ) ||
@@ -3894,7 +3947,7 @@ bool mattack::leech_spawner( monster *z )
     const int monsters_spawned = rng( 1, 4 );
     const mtype_id monster_type = one_in( 3 ) ? mon_leech_root_runner : mon_leech_root_drone;
     for( int i = 0; i < monsters_spawned; i++ ) {
-        if( monster *const new_mon = g->place_critter_around( monster_type, z->pos_bub(), 1 ) ) {
+        if( monster *const new_mon = g->place_critter_around( monster_type, z->pos_bub( here ), 1 ) ) {
             if( u_see ) {
                 add_msg( m_warning,
                          _( "An egg pod ruptures and a %s crawls out from the remains!" ), new_mon->name() );
@@ -3933,13 +3986,15 @@ bool mattack::mon_leech_evolution( monster *z )
 
 bool mattack::tindalos_teleport( monster *z )
 {
+    map &here = get_map();
+
     Creature *target = z->attack_target();
     if( target == nullptr ) {
         return false;
     }
     if( one_in( 7 ) ) {
         if( monster *const afterimage = g->place_critter_around( mon_hound_tindalos_afterimage,
-                                        z->pos_bub(),
+                                        z->pos_bub( here ),
                                         1 ) ) {
             z->mod_moves( -to_moves<int>( 1_seconds ) * 1.4 );
             afterimage->make_ally( *z );
@@ -3948,16 +4003,15 @@ bool mattack::tindalos_teleport( monster *z )
                                     _( "The hound's movements chaotically rewind as a living afterimage splits from it!" ) );
         }
     }
-    const int distance_to_target = rl_dist( z->pos_bub(), target->pos_bub() );
-    map &here = get_map();
+    const int distance_to_target = rl_dist( z->pos_abs(), target->pos_abs() );
     if( distance_to_target > 5 ) {
-        const tripoint_bub_ms oldpos = z->pos_bub();
-        for( const tripoint_bub_ms &dest : here.points_in_radius( target->pos_bub(), 4 ) ) {
+        const tripoint_bub_ms oldpos = z->pos_bub( here );
+        for( const tripoint_bub_ms &dest : here.points_in_radius( target->pos_bub( here ), 4 ) ) {
             if( here.is_cornerfloor( dest ) ) {
                 if( g->is_empty( dest ) ) {
-                    z->setpos( dest );
+                    z->setpos( here, dest );
                     // Not teleporting if it means losing sight of our current target
-                    if( z->sees( *target ) ) {
+                    if( z->sees( here, *target ) ) {
                         here.add_field( oldpos, fd_tindalos_rift, 2 );
                         here.add_field( dest, fd_tindalos_rift, 2 );
                         add_msg_if_player_sees( *z, m_bad,
@@ -3968,7 +4022,7 @@ bool mattack::tindalos_teleport( monster *z )
             }
         }
         // couldn't teleport without losing sight of target
-        z->setpos( oldpos );
+        z->setpos( here, oldpos );
         return true;
     }
     return true;
@@ -3976,9 +4030,11 @@ bool mattack::tindalos_teleport( monster *z )
 
 bool mattack::flesh_tendril( monster *z )
 {
+    map &here = get_map();
+
     Creature *target = z->attack_target();
 
-    if( target == nullptr || !z->sees( *target ) ) {
+    if( target == nullptr || !z->sees( here, *target ) ) {
         if( one_in( 70 ) ) {
             add_msg( _( "The floor trembles underneath your feet." ) );
             z->mod_moves( -to_moves<int>( 2_seconds ) );
@@ -3989,7 +4045,7 @@ bool mattack::flesh_tendril( monster *z )
         return false;
     }
 
-    const int distance_to_target = rl_dist( z->pos_bub(), target->pos_bub() );
+    const int distance_to_target = rl_dist( z->pos_abs(), target->pos_abs() );
 
     // the monster summons stuff to fight you
     if( distance_to_target > 3 && one_in( 12 ) ) {
@@ -4000,7 +4056,7 @@ bool mattack::flesh_tendril( monster *z )
         if( monster *const summoned = g->place_critter_around( spawned, z->pos_bub(), 1 ) ) {
             z->mod_moves( -to_moves<int>( 1_seconds ) );
             summoned->make_ally( *z );
-            get_map().propagate_field( z->pos_bub(), fd_gibs_flesh, 75, 1 );
+            here.propagate_field( z->pos_bub( here ), fd_gibs_flesh, 75, 1 );
             add_msg_if_player_sees( *z, m_warning, _( "A %s struggles to pull itself free from the %s!" ),
                                     summoned->name(), z->name() );
         }
@@ -4032,6 +4088,8 @@ bool mattack::flesh_tendril( monster *z )
 
 bool mattack::bio_op_random_biojutsu( monster *z )
 {
+    const map &here = get_map();
+
     int choice = 0;
     bool redo = false;
 
@@ -4042,7 +4100,7 @@ bool mattack::bio_op_random_biojutsu( monster *z )
     Creature *target = z->attack_target();
     if( target == nullptr ||
         !z->is_adjacent( target, false ) ||
-        !z->sees( *target ) ) {
+        !z->sees( here, *target ) ) {
         return false;
     }
 
@@ -4086,11 +4144,11 @@ bool mattack::bio_op_takedown( monster *z )
     // TODO: Allow drop-takedown form above
     if( target == nullptr ||
         !z->is_adjacent( target, false ) ||
-        !z->sees( *target ) ) {
+        !z->sees( here, *target ) ) {
         return false;
     }
 
-    bool seen = get_player_view().sees( *z );
+    bool seen = get_player_view().sees( here, *z );
     Character *foe = dynamic_cast< Character * >( target );
     if( seen ) {
         add_msg( _( "The %1$s mechanically grabs at %2$s!" ), z->name(),
@@ -4196,11 +4254,11 @@ bool mattack::bio_op_impale( monster *z )
     Creature *target = z->attack_target();
     if( target == nullptr ||
         !z->is_adjacent( target, false ) ||
-        !z->sees( *target ) ) {
+        !z->sees( here, *target ) ) {
         return false;
     }
 
-    const bool seen = get_player_view().sees( *z );
+    const bool seen = get_player_view().sees( here, *z );
     Character *foe = dynamic_cast< Character * >( target );
     if( seen ) {
         add_msg( _( "The %1$s mechanically lunges at %2$s!" ), z->name(),
@@ -4267,6 +4325,8 @@ bool mattack::bio_op_impale( monster *z )
 
 bool mattack::bio_op_disarm( monster *z )
 {
+    map &here = get_map();
+
     if( !z->can_act() ) {
         return false;
     }
@@ -4274,11 +4334,11 @@ bool mattack::bio_op_disarm( monster *z )
     Creature *target = z->attack_target();
     if( target == nullptr ||
         !z->is_adjacent( target, false ) ||
-        !z->sees( *target ) ) {
+        !z->sees( here, *target ) ) {
         return false;
     }
 
-    const bool seen = get_player_view().sees( *z );
+    const bool seen = get_player_view().sees( here, *z );
     Character *foe = dynamic_cast< Character * >( target );
 
     // disarm doesn't work on creatures or unarmed targets
@@ -4319,11 +4379,11 @@ bool mattack::bio_op_disarm( monster *z )
 
     if( my_roll >= their_roll && !it->has_flag( flag_NO_UNWIELD ) ) {
         target->add_msg_if_player( m_bad, _( "and throws it to the ground!" ) );
-        tripoint_bub_ms tp = foe->pos_bub() + tripoint( rng( -1, 1 ), rng( -1, 1 ), 0 );
-        if( !get_map().can_put_items( tp ) ) {
-            tp = foe->pos_bub();
+        tripoint_bub_ms tp = foe->pos_bub( here ) + tripoint( rng( -1, 1 ), rng( -1, 1 ), 0 );
+        if( !here.can_put_items( tp ) ) {
+            tp = foe->pos_bub( here );
         }
-        get_map().add_item_or_charges( tp, foe->i_rem( &*it ) );
+        here.add_item_or_charges( tp, foe->i_rem( &*it ) );
     } else {
         target->add_msg_if_player( m_good, _( "but you break its grip!" ) );
     }
@@ -4494,6 +4554,8 @@ struct grenade_helper_struct {
 static int grenade_helper( monster *const z, Creature *const target, const int dist,
                            const int moves, std::map<itype_id, grenade_helper_struct> data )
 {
+    const map &here = get_map();
+
     // Can't do anything if we can't act
     if( !z->can_act() ) {
         return 0;
@@ -4533,7 +4595,7 @@ static int grenade_helper( monster *const z, Creature *const target, const int d
     z->ammo[att]--;
 
     // if the player can see it
-    if( get_player_view().sees( *z ) ) {
+    if( get_player_view().sees( here, *z ) ) {
         if( data[att].message.empty() ) {
             add_msg_debug( debugmode::DF_MATTACK, "Invalid ammo message in grenadier special." );
         } else {

--- a/src/mondeath.cpp
+++ b/src/mondeath.cpp
@@ -60,7 +60,7 @@ item_location mdeath::normal( map *here, monster &z )
         const float corpse_damage = 2.5 * overflow_damage / max_hp;
         const bool pulverized = corpse_damage > 5 && overflow_damage > z.get_hp_max();
 
-        z.bleed(); // leave some blood if we have to
+        z.bleed( *here ); // leave some blood if we have to
 
         if( pulverized ) {
             return splatter( here, z );
@@ -85,10 +85,10 @@ static void scatter_chunks( map *here, const itype_id &chunk_name, int chunk_amt
     int placed_chunks = 0;
     while( placed_chunks < chunk_amt ) {
         bool drop_chunks = true;
-        tripoint_bub_ms tarp( z.pos_bub( here ) + point( rng( -distance, distance ),
+        tripoint_bub_ms tarp( z.pos_bub( *here ) + point( rng( -distance, distance ),
                               rng( -distance,
                                    distance ) ) );
-        const std::vector<tripoint_bub_ms> traj = line_to( z.pos_bub( here ), tarp );
+        const std::vector<tripoint_bub_ms> traj = line_to( z.pos_bub( *here ), tarp );
 
         for( size_t j = 0; j < traj.size(); j++ ) {
             tarp = traj[j];
@@ -133,7 +133,7 @@ item_location mdeath::splatter( map *here, monster &z )
     const field_type_id type_gib = z.gibType();
 
     if( gibbable ) {
-        const tripoint_range<tripoint_bub_ms> area = here->points_in_radius( z.pos_bub( here ),
+        const tripoint_range<tripoint_bub_ms> area = here->points_in_radius( z.pos_bub( *here ),
                 1 );
         int number_of_gibs = std::min( std::floor( corpse_damage ) - 1, 1 + max_hp / 5.0f );
 
@@ -192,7 +192,7 @@ item_location mdeath::splatter( map *here, monster &z )
         if( !z.has_eaten_enough() ) {
             corpse.set_flag( STATIC( flag_id( "UNDERFED" ) ) );
         }
-        return here->add_item_ret_loc( z.pos_bub( here ), corpse );
+        return here->add_item_ret_loc( z.pos_bub( *here ), corpse );
     }
     return {};
 }
@@ -224,7 +224,7 @@ void mdeath::broken( map *here, monster &z )
     const float corpse_damage = 2.5 * overflow_damage / max_hp;
     broken_mon.set_damage( static_cast<int>( std::floor( corpse_damage * itype::damage_scale ) ) );
 
-    here->add_item_or_charges( z.pos_bub( here ), broken_mon );
+    here->add_item_or_charges( z.pos_bub( *here ), broken_mon );
 
     if( z.type->has_flag( mon_flag_DROPS_AMMO ) ) {
         for( const std::pair<const itype_id, int> &ammo_entry : z.ammo ) {
@@ -247,14 +247,14 @@ void mdeath::broken( map *here, monster &z )
                                 mags.insert( mags.end(), mag );
                                 ammo_count -= mag.type->magazine->capacity;
                             }
-                            here->spawn_items( z.pos_bub( here ), mags );
+                            here->spawn_items( z.pos_bub( *here ), mags );
                             spawned = true;
                             break;
                         }
                     }
                 }
                 if( !spawned ) {
-                    here->spawn_item( z.pos_bub( here ), ammo_entry.first, ammo_entry.second, 1,
+                    here->spawn_item( z.pos_bub( *here ), ammo_entry.first, ammo_entry.second, 1,
                                       calendar::turn );
                 }
             }
@@ -284,5 +284,5 @@ item_location make_mon_corpse( map *here, monster &z, int damageLvl )
     if( !z.has_eaten_enough() ) {
         corpse.set_flag( STATIC( flag_id( "UNDERFED" ) ) );
     }
-    return here->add_item_ret_loc( z.pos_bub( here ), corpse );
+    return here->add_item_ret_loc( z.pos_bub( *here ), corpse );
 }

--- a/src/mondefense.cpp
+++ b/src/mondefense.cpp
@@ -77,7 +77,7 @@ void mdefense::zapback( monster &m, Creature *const source,
         return;
     }
 
-    if( get_player_view().sees( source->pos_bub() ) ) {
+    if( get_player_view().sees( here, source->pos_bub( here ) ) ) {
         const game_message_type msg_type = source->is_avatar() ? m_bad : m_info;
         add_msg( msg_type, _( "Striking the %1$s shocks %2$s!" ),
                  m.name(), source->disp_name() );
@@ -95,6 +95,8 @@ void mdefense::zapback( monster &m, Creature *const source,
 void mdefense::acidsplash( monster &m, Creature *const source,
                            dealt_projectile_attack const *const proj )
 {
+    const map &here = get_map();
+
     if( source == nullptr ) {
         return;
     }
@@ -127,7 +129,7 @@ void mdefense::acidsplash( monster &m, Creature *const source,
     }
 
     // Don't splatter directly on the `m`, that doesn't work well
-    std::vector<tripoint_bub_ms> pts = closest_points_first( source->pos_bub(), 1 );
+    std::vector<tripoint_bub_ms> pts = closest_points_first( source->pos_bub( here ), 1 );
     pts.erase( std::remove( pts.begin(), pts.end(), m.pos_bub() ), pts.end() );
 
     projectile prj;
@@ -139,16 +141,18 @@ void mdefense::acidsplash( monster &m, Creature *const source,
     dealt_projectile_attack atk;
     for( size_t i = 0; i < num_drops; i++ ) {
         const tripoint_bub_ms &target = random_entry( pts );
-        projectile_attack( atk, prj, m.pos_bub(), target, dispersion_sources{ 1200 }, &m );
+        projectile_attack( atk, prj, m.pos_bub( here ), target, dispersion_sources{ 1200 }, &m );
     }
 
-    if( get_player_view().sees( m.pos_bub() ) ) {
+    if( get_player_view().sees( here, m.pos_bub( here ) ) ) {
         add_msg( m_warning, _( "Acid sprays out of %s as it is hit!" ), m.disp_name() );
     }
 }
 
 void mdefense::return_fire( monster &m, Creature *source, const dealt_projectile_attack *proj )
 {
+    const map &here = get_map();
+
     // No return fire for untargeted projectiles, i.e. from explosions.
     if( source == nullptr ) {
         return;
@@ -177,7 +181,7 @@ void mdefense::return_fire( monster &m, Creature *source, const dealt_projectile
     }
 
     // No return fire if attacker is seen
-    if( m.sees( *source ) ) {
+    if( m.sees( here, *source ) ) {
         return;
     }
 

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -273,8 +273,10 @@ standard_npc::standard_npc( const std::string &name, const tripoint_bub_ms &pos,
                             const std::vector<itype_id> &clothing,
                             int sk_lvl, int s_str, int s_dex, int s_int, int s_per )
 {
+    map &here = get_map();
+
     this->name = name;
-    set_pos_bub_only( pos );
+    set_pos_bub_only( here, pos );
     if( !getID().is_valid() ) {
         setID( g->assign_npc_id() );
     }
@@ -1176,9 +1178,9 @@ void npc::place_on_map( map *here )
         return;
     }
 
-    for( const tripoint_bub_ms &p : closest_points_first( pos_bub(), 1, SEEX + 1 ) ) {
+    for( const tripoint_bub_ms &p : closest_points_first( pos_bub( *here ), 1, SEEX + 1 ) ) {
         if( g->is_empty( p ) ) {
-            setpos( p );
+            setpos( *here, p );
             return;
         }
     }
@@ -1478,6 +1480,8 @@ bool npc::wear_if_wanted( const item &it, std::string &reason )
 
 void npc::stow_item( item &it )
 {
+    map &here = get_map();
+
     bool stow_bionic_weapon = is_using_bionic_weapon()
                               && get_wielded_item().get_item() == &it;
     if( stow_bionic_weapon ) {
@@ -1485,7 +1489,7 @@ void npc::stow_item( item &it )
         return;
     }
 
-    bool avatar_sees = get_player_view().sees( pos_bub() );
+    bool avatar_sees = get_player_view().sees( here, pos_bub( here ) );
     if( wear_item( it, false ) ) {
         // Wearing the item was successful, remove weapon and post message.
         if( avatar_sees ) {
@@ -1505,12 +1509,14 @@ void npc::stow_item( item &it )
         if( avatar_sees ) {
             add_msg_if_npc( m_info, _( "<npcname> drops the %s." ), it.tname() );
         }
-        get_map().add_item_or_charges( pos_bub(), remove_item( it ) );
+        here.add_item_or_charges( pos_bub( here ), remove_item( it ) );
     }
 }
 
 bool npc::wield( item &it )
 {
+    const map &here = get_map();
+
     // sanity check: exit early if we're trying to wield the current weapon
     // needed for ranged_balance_test
     if( is_wielding( it ) ) {
@@ -1549,7 +1555,7 @@ bool npc::wield( item &it )
     cata::event e = cata::event::make<event_type::character_wields_item>( getID(), weapon->typeId() );
     get_event_bus().send_with_talker( this, &weapon, e );
 
-    if( get_player_view().sees( pos_bub() ) ) {
+    if( get_player_view().sees( here, pos_bub( here ) ) ) {
         add_msg_if_npc( m_info, _( "<npcname> wields a %s." ),  weapon->tname() );
     }
     invalidate_range_cache();
@@ -1714,10 +1720,12 @@ npc_opinion npc::get_opinion_values( const Character &you ) const
 
 void npc::mutiny()
 {
+    const map &here = get_map();
+
     if( !my_fac || !is_player_ally() ) {
         return;
     }
-    const bool seen = get_player_view().sees( pos_bub() );
+    const bool seen = get_player_view().sees( here, pos_bub( here ) );
     if( seen ) {
         add_msg( m_bad, _( "%s is tired of your incompetent leadership and abuse!" ), disp_name() );
     }
@@ -1926,16 +1934,18 @@ void npc::say( const std::string &line, const sounds::sound_t spriority ) const
 
 int npc::indoor_voice() const
 {
+    const map &here = get_map();
+
     const int max_volume = get_shout_volume();
     const int min_volume = 1;
     // Actual hearing distance is incredibly dependent on ambient noise and our noise propagation model is... rather binary
     // But we'll assume people normally want to project their voice about 6 meters away.
     int wanted_volume = 6;
     Character &player = get_player_character();
-    const int distance_to_player = rl_dist( pos_bub(), player.pos_bub() );
+    const int distance_to_player = rl_dist( pos_abs(), player.pos_abs() );
     if( is_following() || is_ally( player ) ) {
         wanted_volume = distance_to_player;
-    } else if( is_enemy() && sees( player.pos_bub() ) ) {
+    } else if( is_enemy() && sees( here, player.pos_bub( here ) ) ) {
         // Battle cry! Bandits have no concept of indoor voice, even when not threatened.
         wanted_volume = max_volume;
     }
@@ -2619,6 +2629,8 @@ Creature::Attitude npc::attitude_to( const Creature &other ) const
 
 void npc::npc_dismount()
 {
+    map &here = get_map();
+
     if( !mounted_creature || !has_effect( effect_riding ) ) {
         add_msg_debug( debugmode::DF_NPC,
                        "NPC %s tried to dismount, but they have no mount, or they are not riding",
@@ -2626,7 +2638,7 @@ void npc::npc_dismount()
         return;
     }
     std::optional<tripoint_bub_ms> pnt;
-    for( const tripoint_bub_ms &elem : get_map().points_in_radius( pos_bub(), 1 ) ) {
+    for( const tripoint_bub_ms &elem : here.points_in_radius( pos_bub( here ), 1 ) ) {
         if( g->is_empty( elem ) ) {
             pnt = elem;
             break;
@@ -2644,7 +2656,7 @@ void npc::npc_dismount()
     mounted_creature->remove_effect( effect_ridden );
     mounted_creature->add_effect( effect_controlled, 5_turns );
     mounted_creature = nullptr;
-    setpos( *pnt );
+    setpos( here, *pnt );
     mod_moves( -get_speed() );
 }
 
@@ -2707,7 +2719,7 @@ int npc::follow_distance() const
         return 2;
     }
     // If NPC doesn't see player, change follow distance to 2
-    if( !sees( player_character ) ) {
+    if( !sees( here,  player_character ) ) {
         return 2;
     }
     return 4;
@@ -2731,6 +2743,8 @@ nc_color npc::basic_symbol_color() const
 
 int npc::print_info( const catacurses::window &w, int line, int vLines, int column ) const
 {
+    const map &here = get_map();
+
     const int last_line = line + vLines;
     const int iWidth = getmaxx( w ) - 1 - column;
     // First line of w is the border; the next 4 are terrain info, and after that
@@ -2756,10 +2770,10 @@ int npc::print_info( const catacurses::window &w, int line, int vLines, int colu
     wprintz( w, symbol_color(), " %s", npc_attitude_name( get_attitude() ) );
 
     // Awareness indicator on the third line.
-    std::string senses_str = sees( player_character ) ? _( "Aware of your presence" ) :
+    std::string senses_str = sees( here, player_character ) ? _( "Aware of your presence" ) :
                              _( "Unaware of you" );
     line += fold_and_print( w, point( column, line ), iWidth,
-                            sees( player_character ) ? c_yellow : c_green,
+                            sees( here, player_character ) ? c_yellow : c_green,
                             senses_str );
 
     // Print what item the NPC is holding if any on the fourth line.
@@ -2980,7 +2994,7 @@ void npc::die( map *here, Creature *nkiller )
     // Need to unboard from vehicle before dying, otherwise
     // the vehicle code cannot find us
     if( in_vehicle ) {
-        here->unboard_vehicle( pos_bub( here ), true );
+        here->unboard_vehicle( pos_bub( *here ), true );
     }
     if( is_mounted() ) {
         monster *critter = mounted_creature.get();
@@ -3190,7 +3204,9 @@ void npc::add_msg_player_or_npc( const game_message_params &params,
                                  const std::string &/*player_msg*/,
                                  const std::string &npc_msg ) const
 {
-    if( get_player_view().sees( *this ) ) {
+    const map &here = get_map();
+
+    if( get_player_view().sees( here, *this ) ) {
         add_msg( params, replace_with_npc_name( npc_msg ) );
     }
 }
@@ -3291,14 +3307,14 @@ void npc::on_load( map *here )
 
     // for spawned npcs
     gravity_check( here );
-    if( here->has_flag( ter_furn_flag::TFLAG_UNSTABLE, pos_bub( here ) ) &&
-        !here->has_vehicle_floor( pos_bub( here ) ) ) {
+    if( here->has_flag( ter_furn_flag::TFLAG_UNSTABLE, pos_bub( *here ) ) &&
+        !here->has_vehicle_floor( pos_bub( *here ) ) ) {
         add_effect( effect_bouldering, 1_turns,  true );
     } else if( has_effect( effect_bouldering ) ) {
         remove_effect( effect_bouldering );
     }
     if( here->veh_at( pos_abs() ).part_with_feature( VPFLAG_BOARDABLE, true ) && !in_vehicle ) {
-        here->board_vehicle( pos_bub( here ), this );
+        here->board_vehicle( pos_bub( *here ), this );
     }
     if( has_effect( effect_riding ) && !mounted_creature ) {
         if( const monster *const mon = get_creature_tracker().creature_at<monster>( pos_abs() ) ) {
@@ -3518,6 +3534,8 @@ mfaction_id npc::get_monster_faction() const
 
 std::vector<std::string> npc::extended_description() const
 {
+    const map &here = get_map();
+
     std::vector<std::string> tmp = Character::extended_description();
 
     tmp.emplace_back( "--" );
@@ -3528,7 +3546,8 @@ std::vector<std::string> npc::extended_description() const
     tmp.emplace_back( string_format( "%s; %s", colorize( res.first, res.second ),
                                      colorize( npc_attitude_name( get_attitude() ), symbol_color() ) ) );
 
-    tmp.emplace_back( sees( player_character ) ? colorize( _( "Aware of your presence" ), c_yellow ) :
+    tmp.emplace_back( sees( here, player_character ) ? colorize( _( "Aware of your presence" ),
+                      c_yellow ) :
                       colorize( _( "Unaware of you" ), c_green ) );
 
     if( hit_by_player ) {
@@ -3695,6 +3714,8 @@ npc_attitude npc::get_attitude() const
 
 void npc::set_attitude( npc_attitude new_attitude )
 {
+    const map &here = get_map();
+
     if( new_attitude == attitude ) {
         return;
     }
@@ -3710,7 +3731,7 @@ void npc::set_attitude( npc_attitude new_attitude )
                    get_name(), npc_attitude_id( attitude ), npc_attitude_id( new_attitude ) );
     attitude_group new_group = get_attitude_group( new_attitude );
     attitude_group old_group = get_attitude_group( attitude );
-    if( new_group != old_group && !is_fake() && get_player_view().sees( *this ) ) {
+    if( new_group != old_group && !is_fake() && get_player_view().sees( here, *this ) ) {
         switch( new_group ) {
             case attitude_group::hostile:
                 add_msg_if_npc( m_bad, _( "<npcname> gets angry!" ) );

--- a/src/npc_attack.cpp
+++ b/src/npc_attack.cpp
@@ -189,6 +189,8 @@ int npc_attack_spell::base_time_penalty( const npc &source ) const
 npc_attack_rating npc_attack_spell::evaluate_tripoint(
     const npc &source, const Creature *target, const tripoint_bub_ms &location ) const
 {
+    const map &here = get_map();
+
     const spell &attack_spell = source.magic->get_spell( attack_spell_id );
 
     double total_potential = 0;
@@ -210,7 +212,7 @@ npc_attack_rating npc_attack_spell::evaluate_tripoint(
 
         const Creature::Attitude att = source.attitude_to( *critter );
         int damage = 0;
-        if( source.sees( *critter ) ) {
+        if( source.sees( here, *critter ) ) {
             damage = attack_spell.dps( source, *critter );
         }
         const int distance_to_me = rl_dist( source.pos_bub(), potential_target );

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -727,6 +727,8 @@ std::optional<int> npc_short_term_cache::closest_enemy_to_friendly_distance() co
 
 void npc::assess_danger()
 {
+    const map &here = get_map();
+
     float highest_priority = 1.0f;
     int hostile_count = 0; // for tallying nearby threatening enemies
     int friendly_count = 1; // count yourself as a friendly
@@ -746,7 +748,7 @@ void npc::assess_danger()
     preferred_close_range = std::min( preferred_close_range, preferred_medium_range / 2 );
 
     Character &player_character = get_player_character();
-    bool sees_player = sees( player_character.pos_bub() );
+    bool sees_player = sees( here, player_character.pos_bub( here ) );
     const bool self_defense_only = rules.engagement == combat_engagement::NO_MOVE ||
                                    rules.engagement == combat_engagement::NONE;
     const bool no_fighting = rules.has_flag( ally_rule::forbid_engage );
@@ -796,7 +798,6 @@ void npc::assess_danger()
     for( direction threat_dir : npc_threat_dir ) {
         cur_threat_map[ threat_dir ] = 0.25f * ai_cache.threat_map[ threat_dir ];
     }
-    map &here = get_map();
     // cache string_id -> int_id conversion before hot loop
     const field_type_id fd_fire = ::fd_fire;
     // first, check if we're about to be consumed by fire
@@ -827,13 +828,13 @@ void npc::assess_danger()
 
         if( has_faction_relationship( guy, npc_factions::relationship::watch_your_back ) ) {
             ai_cache.friends.emplace_back( g->shared_from( guy ) );
-        } else if( attitude_to( guy ) != Attitude::NEUTRAL && sees( guy.pos_bub() ) ) {
+        } else if( attitude_to( guy ) != Attitude::NEUTRAL && sees( here, guy.pos_bub( here ) ) ) {
             ai_cache.hostile_guys.emplace_back( g->shared_from( guy ) );
         }
     }
     if( is_friendly( player_character ) && sees_player ) {
         ai_cache.friends.emplace_back( g->shared_from( player_character ) );
-    } else if( sees_player && is_enemy() && sees( player_character ) ) {
+    } else if( sees_player && is_enemy() && sees( here, player_character ) ) {
         // Unlike allies, hostile npcs should not see invisible players
         ai_cache.hostile_guys.emplace_back( g->shared_from( player_character ) );
     }
@@ -852,7 +853,7 @@ void npc::assess_danger()
             ai_cache.neutral_guys.emplace_back( g->shared_from( critter ) );
             continue;
         }
-        if( !sees( critter ) ) {
+        if( !sees( here, critter ) ) {
             continue;
         }
 
@@ -1121,6 +1122,8 @@ void npc::assess_danger()
 
 void npc::act_on_danger_assessment()
 {
+    const map &here = get_map();
+
     bool npc_ranged = get_wielded_item() && get_wielded_item()->is_gun();
     bool failed_reposition = false;
     Character &player_character = get_player_character();
@@ -1175,7 +1178,7 @@ void npc::act_on_danger_assessment()
                 if( !is_player_ally() ) {
                     set_attitude( NPCATT_FLEE_TEMP );
                 }
-                if( mem_combat.panic > 5 && is_player_ally() && sees( player_character.pos_bub() ) ) {
+                if( mem_combat.panic > 5 && is_player_ally() && sees( here, player_character.pos_bub( here ) ) ) {
                     // consider warning player about panic
                     int panic_alert = rl_dist( pos_bub(), player_character.pos_bub() ) - player_character.get_per();
                     if( mem_combat.panic - personality.bravery > panic_alert ) {
@@ -1247,7 +1250,7 @@ void npc::regen_ai_cache()
         }
     }
     while( i != std::end( ai_cache.sound_alerts ) ) {
-        if( sees( here.get_bub( tripoint_abs_ms( i->abs_pos ) ) ) ) {
+        if( sees( here,  here.get_bub( tripoint_abs_ms( i->abs_pos ) ) ) ) {
             // if they were responding to a call for guards because of thievery
             npc *const sound_source = creatures.creature_at<npc>( here.get_bub( tripoint_abs_ms(
                                           i->abs_pos ) ) );
@@ -1325,6 +1328,8 @@ void npc::regen_ai_cache()
 
 void npc::move()
 {
+    const map &here = get_map();
+
     // don't just return from this function without doing something
     // that will eventually subtract moves, or change the NPC to a different type of action.
     // because this will result in an infinite loop
@@ -1354,7 +1359,7 @@ void npc::move()
 
     Character &player_character = get_player_character();
     //faction opinion determines if it should consider you hostile
-    if( !is_enemy() && guaranteed_hostile() && sees( player_character ) ) {
+    if( !is_enemy() && guaranteed_hostile() && sees( here, player_character ) ) {
         if( is_player_ally() ) {
             mutiny();
         }
@@ -1390,7 +1395,6 @@ void npc::move()
      * something nasty is going to happen.
      */
 
-    map &here = get_map();
     if( !ai_cache.dangerous_explosives.empty() ) {
         action = npc_escape_explosion;
     } else if( is_enemy() && vehicle_danger( avoidance_vehicles_radius ) >= 0 ) {
@@ -1758,7 +1762,7 @@ void npc::execute_action( npc_action action )
             if( is_hallucination() ) {
                 pretend_fire( this, mode.qty, *mode );
             } else {
-                fire_gun( &here, tar, mode.qty, *mode );
+                fire_gun( here, tar, mode.qty, *mode );
                 // "discard" the fake bio weapon after shooting it
                 if( is_using_bionic_weapon() ) {
                     discharge_cbm_weapon();
@@ -1769,7 +1773,7 @@ void npc::execute_action( npc_action action )
 
         case npc_look_for_player:
             if( saw_player_recently() && last_player_seen_pos &&
-                sees( here.get_bub( *last_player_seen_pos ) ) ) {
+                sees( here, here.get_bub( *last_player_seen_pos ) ) ) {
                 update_path( here.get_bub( *last_player_seen_pos ) );
                 move_to_next();
             } else {
@@ -2012,6 +2016,9 @@ npc_action npc::method_of_attack()
 
 void npc::evaluate_best_attack( const Creature *target )
 {
+    // Required because evaluation includes electricity via linked cables.
+    const map &here = get_map();
+
     std::shared_ptr<npc_attack> best_attack;
     npc_attack_rating best_evaluated_attack;
     const auto compare = [&best_attack, &best_evaluated_attack, this, &target]
@@ -2025,7 +2032,7 @@ void npc::evaluate_best_attack( const Creature *target )
 
     // punching things is always available
     compare( std::make_shared<npc_attack_melee>( null_item_reference() ) );
-    visit_items( [&compare, this]( item * it, item * ) {
+    visit_items( [&compare, this, &here]( item * it, item * ) {
         if( can_wield( *it ).success() ) {
             // you can theoretically melee with anything.
             compare( std::make_shared<npc_attack_melee>( *it ) );
@@ -2041,7 +2048,7 @@ void npc::evaluate_best_attack( const Creature *target )
                            !can_use( *mode.second.target ) ||
                            ( rules.has_flag( ally_rule::use_silent ) && is_player_ally() &&
                              !mode.second->is_silent() ) ) ) {
-                        if( it->shots_remaining( this ) > 0 || can_reload_current() ) {
+                        if( it->shots_remaining( here, this ) > 0 || can_reload_current() ) {
                             compare( std::make_shared<npc_attack_gun>( *it, mode.second ) );
                         } else {
                             compare( std::make_shared<npc_attack_melee>( *it ) );
@@ -2478,7 +2485,7 @@ npc_action npc::address_needs( float danger )
                 }
             }
             for( const npc &guy : g->all_npcs() ) {
-                if( &guy == this || !guy.is_ally( *this ) || guy.posz() != posz() || !sees( guy ) ) {
+                if( &guy == this || !guy.is_ally( *this ) || guy.posz() != posz() || !sees( here, guy ) ) {
                     continue;
                 }
                 healing_options try_to_fix_other = patient_assessment( guy );
@@ -2600,13 +2607,16 @@ npc_action npc::address_needs( float danger )
 
 npc_action npc::address_player()
 {
+    const map &here = get_map();
+
     Character &player_character = get_player_character();
-    if( ( attitude == NPCATT_TALK || attitude == NPCATT_RECOVER_GOODS ) && sees( player_character ) ) {
+    if( ( attitude == NPCATT_TALK || attitude == NPCATT_RECOVER_GOODS ) &&
+        sees( here, player_character ) ) {
         if( player_character.in_sleep_state() ) {
             // Leave sleeping characters alone.
             return npc_undecided;
         }
-        if( rl_dist( pos_bub(), player_character.pos_bub() ) <= 6 ) {
+        if( rl_dist( pos_abs(), player_character.pos_abs() ) <= 6 ) {
             return npc_talk_to_player;    // Close enough to talk to you
         } else {
             if( one_in( 10 ) ) {
@@ -2616,7 +2626,7 @@ npc_action npc::address_player()
         }
     }
 
-    if( attitude == NPCATT_MUG && sees( player_character ) ) {
+    if( attitude == NPCATT_MUG && sees( here, player_character ) ) {
         if( one_in( 3 ) ) {
             say( chat_snippets().snip_mug_dontmove.translated() );
         }
@@ -2638,7 +2648,7 @@ npc_action npc::address_player()
     }
 
     if( attitude == NPCATT_LEAD ) {
-        if( rl_dist( pos_bub(), player_character.pos_bub() ) >= 12 || !sees( player_character ) ) {
+        if( rl_dist( pos_abs(), player_character.pos_abs() ) >= 12 || !sees( here, player_character ) ) {
             int intense = get_effect_int( effect_catch_up );
             if( intense < 10 ) {
                 say( chat_snippets().snip_keep_up.translated() );
@@ -2793,6 +2803,8 @@ bool npc::wont_hit_friend( const tripoint_bub_ms &tar, const item &it, bool thro
 
 bool npc::enough_time_to_reload( const item &gun ) const
 {
+    const map &here = get_map();
+
     int rltime = item_reload_cost( gun, item( gun.ammo_default() ),
                                    gun.ammo_capacity(
                                        item_controller->find_template( gun.ammo_default() )->ammo->type ) );
@@ -2812,7 +2824,7 @@ bool npc::enough_time_to_reload( const item &gun ) const
         const Character &foe = dynamic_cast<const Character &>( *target );
         const item_location weapon = foe.get_wielded_item();
         // TODO: Allow reloading if the player has a low accuracy gun
-        if( sees( foe ) && weapon && weapon->is_gun() && rltime > 200 &&
+        if( sees( here, foe ) && weapon && weapon->is_gun() && rltime > 200 &&
             weapon->gun_range( true ) > distance + turns_til_reloaded / target_speed ) {
             // Don't take longer than 2 turns if player has a gun
             add_msg_debug( debugmode::DF_NPC_ITEMAI, "%s is shy about reloading with &s standing right there.",
@@ -2978,7 +2990,7 @@ void npc::move_to( const tripoint_bub_ms &pt, bool no_bashing, std::set<tripoint
         }
 
         if( critter->is_avatar() ) {
-            if( sees( *critter ) ) {
+            if( sees( here, *critter ) ) {
                 say( chat_snippets().snip_let_me_pass.translated() );
             } else {
                 stumble_invis( *critter );
@@ -3048,7 +3060,7 @@ void npc::move_to( const tripoint_bub_ms &pt, bool no_bashing, std::set<tripoint
         mod_moves( -get_speed() );
         moved = true;
     } else if( has_effect( effect_stumbled_into_invisible ) &&
-               here.has_field_at( p, field_fd_last_known ) && !sees( player_character ) &&
+               here.has_field_at( p, field_fd_last_known ) && !sees( here, player_character ) &&
                attitude_to( player_character ) == Attitude::HOSTILE ) {
         attack_air( p );
         move_pause();
@@ -3109,30 +3121,30 @@ void npc::move_to( const tripoint_bub_ms &pt, bool no_bashing, std::set<tripoint
 
     if( moved ) {
         make_footstep_noise();
-        const tripoint_bub_ms old_pos = pos_bub();
-        setpos( p );
+        const tripoint_bub_ms old_pos = pos_bub( here );
+        setpos( here, p );
         if( old_pos.x() - p.x() < 0 ) {
             facing = FacingDirection::RIGHT;
         } else {
             facing = FacingDirection::LEFT;
         }
         if( is_mounted() ) {
-            if( mounted_creature->pos_bub() != pos_bub() ) {
-                mounted_creature->setpos( pos_bub() );
+            if( mounted_creature->pos_abs() != pos_abs() ) {
+                mounted_creature->setpos( pos_abs() );
                 mounted_creature->facing = facing;
                 mounted_creature->process_triggers();
                 here.creature_in_field( *mounted_creature );
                 here.creature_on_trap( *mounted_creature );
             }
         }
-        if( here.has_flag( ter_furn_flag::TFLAG_UNSTABLE, pos_bub() ) &&
+        if( here.has_flag( ter_furn_flag::TFLAG_UNSTABLE, pos_bub( here ) ) &&
             !here.has_vehicle_floor( pos_bub() ) ) {
             add_effect( effect_bouldering, 1_turns, true );
         } else if( has_effect( effect_bouldering ) ) {
             remove_effect( effect_bouldering );
         }
 
-        if( here.has_flag_ter_or_furn( ter_furn_flag::TFLAG_NO_SIGHT, pos_bub() ) ) {
+        if( here.has_flag_ter_or_furn( ter_furn_flag::TFLAG_NO_SIGHT, pos_bub( here ) ) ) {
             add_effect( effect_no_sight, 1_turns, true );
         } else if( has_effect( effect_no_sight ) ) {
             remove_effect( effect_no_sight );
@@ -3157,7 +3169,7 @@ void npc::move_to( const tripoint_bub_ms &pt, bool no_bashing, std::set<tripoint
         here.creature_on_trap( *this );
         here.creature_in_field( *this );
 
-        if( will_be_cramped_in_vehicle_tile( here.get_abs( p ) ) ) {
+        if( will_be_cramped_in_vehicle_tile( here, here.get_abs( p ) ) ) {
             if( !has_effect( effect_cramped_space ) ) {
                 add_msg_if_player_sees( *this, m_warning,
                                         string_format( _( "%s has to really cram their huge body to fit." ), disp_name() ) );
@@ -3505,7 +3517,7 @@ void npc::see_item_say_smth( const itype_id &object, const std::string &smth )
 {
     map &here = get_map();
     for( const tripoint_bub_ms &p : closest_points_first( pos_bub(), 6 ) ) {
-        if( here.sees_some_items( p, *this ) && sees( p ) ) {
+        if( here.sees_some_items( p, *this ) && sees( here, p ) ) {
             for( const item &it : here.i_at( p ) ) {
                 if( one_in( 100 ) && ( it.typeId() == object ) ) {
                     say( smth );
@@ -3609,7 +3621,7 @@ void npc::find_item()
             }
         };
         bool can_see = false;
-        if( here.sees_some_items( p, *this ) && sees( p ) ) {
+        if( here.sees_some_items( p, *this ) && sees( here, p ) ) {
             can_see = true;
             for( item &it : m_stack ) {
                 if( consider_item( it, p ) ) {
@@ -3619,12 +3631,12 @@ void npc::find_item()
         }
 
         // Not cached because it gets checked once and isn't expected to change.
-        if( can_see || sees( p ) ) {
+        if( can_see || sees( here, p ) ) {
             can_see = true;
             consider_terrain( p );
         }
 
-        if( !vp || vp->vehicle().is_moving() || !( can_see || sees( p ) ) ) {
+        if( !vp || vp->vehicle().is_moving() || !( can_see || sees( here, p ) ) ) {
             cache_tile();
             continue;
         }
@@ -3698,7 +3710,7 @@ void npc::pick_up_item()
     const bool has_cargo = vp && !vp->has_feature( "LOCKED" );
 
     if( ( !here.has_items( wanted_item_pos ) && !has_cargo &&
-          !here.is_harvestable( wanted_item_pos ) && sees( wanted_item_pos ) ) ||
+          !here.is_harvestable( wanted_item_pos ) && sees( here, wanted_item_pos ) ) ||
         ( is_player_ally() && g->check_zone( zone_type_NO_NPC_PICKUP, wanted_item_pos ) ) ) {
         // Items we wanted no longer exist and we can see it
         // Or player who is leading us doesn't want us to pick it up
@@ -3765,7 +3777,7 @@ void npc::pick_up_item()
     }
     viewer &player_view = get_player_view();
     // Describe the pickup to the player
-    bool u_see = player_view.sees( *this ) || player_view.sees( wanted_item_pos );
+    bool u_see = player_view.sees( here, *this ) || player_view.sees( here, wanted_item_pos );
     if( u_see ) {
         if( picked_up.size() == 1 ) {
             add_msg( _( "%1$s picks up a %2$s." ), get_name(), picked_up.front().tname() );
@@ -3842,6 +3854,8 @@ bool npc::wants_take_that( const item &it )
 
 bool npc::would_take_that( const item &it, const tripoint_bub_ms &p )
 {
+    const map &here = get_map();
+
     const bool is_stealing = !it.is_owned_by( *this, true );
     if( !is_stealing ) {
         return true;
@@ -3871,7 +3885,7 @@ bool npc::would_take_that( const item &it, const tripoint_bub_ms &p )
 
         /*Handle player and follower vision*/
         viewer &player_view = get_player_view();
-        if( player_view.sees( this->pos_bub() ) || player_view.sees( p ) ) {
+        if( player_view.sees( here, this->pos_bub( here ) ) || player_view.sees( here,  p ) ) {
             return false;
         }
         std::vector<npc *> followers;
@@ -3884,7 +3898,7 @@ bool npc::would_take_that( const item &it, const tripoint_bub_ms &p )
             followers.push_back( npc_to_add );
         }
         for( npc *&elem : followers ) {
-            if( elem->sees( this->pos_bub() ) || elem->sees( p ) ) {
+            if( elem->sees( here, this->pos_bub( here ) ) || elem->sees( here,  p ) ) {
                 return false;
             }
         }
@@ -3914,6 +3928,8 @@ std::list<item> npc::pick_up_item_vehicle( vehicle &veh, int part_index )
 
 bool npc::find_corpse_to_pulp()
 {
+    map &here = get_map();
+
     Character &player_character = get_player_character();
     if( is_player_ally() ) {
         if( !rules.has_flag( ally_rule::allow_pulp ) ||
@@ -3926,11 +3942,10 @@ bool npc::find_corpse_to_pulp()
         }
     }
 
-    map &here = get_map();
     // Pathing with overdraw can get expensive, limit it
     int path_counter = 4;
     const auto check_tile = [this, &path_counter, &here]( const tripoint_bub_ms & p ) -> const item * {
-        if( !here.sees_some_items( p, *this ) || !sees( p ) )
+        if( !here.sees_some_items( p, *this ) || !sees( here, p ) )
         {
             return nullptr;
         }
@@ -4070,12 +4085,16 @@ bool npc::do_player_activity()
 
 double npc::evaluate_weapon( item &maybe_weapon, bool can_use_gun, bool use_silent ) const
 {
+    // Needed because evaluation includes electricity via linked cables.
+    const map &here = get_map();
+
     bool allowed = can_use_gun && maybe_weapon.is_gun() && ( !use_silent || maybe_weapon.is_silent() );
     // According to unmodified evaluation score, NPCs almost always prioritize wielding guns if they have one.
     // This is relatively reasonable, as players can issue commands to NPCs when we do not want them to use ranged weapons.
     // Conversely, we cannot directly issue commands when we want NPCs to prioritize ranged weapons.
     // Note that the scoring method here is different from the 'weapon_value' used elsewhere.
-    double val_gun = allowed ? gun_value( maybe_weapon, maybe_weapon.shots_remaining( this ) ) : 0;
+    double val_gun = allowed ? gun_value( maybe_weapon, maybe_weapon.shots_remaining( here,
+                                          this ) ) : 0;
     add_msg_debug( debugmode::DF_NPC_ITEMAI,
                    "%s %s valued at <color_light_cyan>%1.2f as a ranged weapon to wield</color>.",
                    disp_name( true ), maybe_weapon.type->get_id().str(), val_gun );
@@ -4355,12 +4374,14 @@ void npc::activate_item( item &it )
 
 void npc::heal_player( Character &patient )
 {
+    const map &here = get_map();
+
     // Avoid more than one first aid activity at a time.
     if( Character::has_activity( ACT_FIRSTAID ) ) {
         return;
     }
 
-    int dist = rl_dist( pos_bub(), patient.pos_bub() );
+    int dist = rl_dist( pos_abs(), patient.pos_abs() );
 
     if( dist > 1 ) {
         // We need to move to the player
@@ -4371,7 +4392,7 @@ void npc::heal_player( Character &patient )
 
     viewer &player_view = get_player_view();
     // Close enough to heal!
-    bool u_see = player_view.sees( *this ) || player_view.sees( patient );
+    bool u_see = player_view.sees( here, *this ) || player_view.sees( here, patient );
     if( u_see ) {
         add_msg( _( "%1$s starts healing %2$s." ), disp_name(), patient.disp_name() );
     }
@@ -4676,6 +4697,8 @@ bool npc::consume_food()
 
 void npc::mug_player( Character &mark )
 {
+    const map &here = get_map();
+
     if( mark.is_armed() ) {
         make_angry();
     }
@@ -4687,7 +4710,7 @@ void npc::mug_player( Character &mark )
     }
 
     Character &player_character = get_player_character();
-    const bool u_see = player_character.sees( *this ) || player_character.sees( mark );
+    const bool u_see = player_character.sees( here, *this ) || player_character.sees( here, mark );
     if( mark.cash > 0 ) {
         if( !is_hallucination() ) { // hallucinations can't take items
             cash += mark.cash;
@@ -5259,6 +5282,8 @@ bool npc::complain_about( const std::string &issue, const time_duration &dur,
 
 bool npc::complain()
 {
+    const map &here = get_map();
+
     static const std::string infected_string = "infected";
     static const std::string sleepiness_string = "sleepiness";
     static const std::string bite_string = "bite";
@@ -5268,7 +5293,7 @@ bool npc::complain()
     static const std::string hunger_string = "hunger";
     static const std::string thirst_string = "thirst";
 
-    if( !is_player_ally() || !get_player_view().sees( *this ) ) {
+    if( !is_player_ally() || !get_player_view().sees( here, *this ) ) {
         return false;
     }
 
@@ -5367,6 +5392,8 @@ bool npc::complain()
 
 void npc::do_reload( const item_location &it )
 {
+    const map &here = get_map();
+
     if( !it ) {
         debugmsg( "do_reload failed: %s tried to reload a none", name );
         return;
@@ -5398,7 +5425,7 @@ void npc::do_reload( const item_location &it )
     mod_moves( -reload_time );
     recoil = MAX_RECOIL;
 
-    if( get_player_view().sees( *this ) ) {
+    if( get_player_view().sees( here, *this ) ) {
         add_msg( _( "%1$s reloads their %2$s." ), get_name(), it->tname() );
         sfx::play_variant_sound( "reload", it->typeId().str(), sfx::get_heard_volume( pos_bub() ),
                                  sfx::get_heard_angle( pos_bub() ) );

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -968,6 +968,8 @@ static void tell_magic_veh_stop_following()
 
 void game::chat()
 {
+    map &here = get_map();
+
     Character &player_character = get_player_character();
     int volume = player_character.get_shout_volume();
 
@@ -976,8 +978,8 @@ void game::chat()
         return ( guy.is_npc() || ( guy.is_monster() &&
                                    guy.as_monster()->has_flag( mon_flag_CONVERSATION ) &&
                                    !guy.as_monster()->type->chat_topics.empty() ) ) && u.posz() == guy.posz() &&
-               u.sees( guy.pos_bub() ) &&
-               rl_dist( u.pos_bub(), guy.pos_bub() ) <= SEEX * 2;
+               u.sees( here, guy.pos_bub( here ) ) &&
+               rl_dist( u.pos_abs(), guy.pos_abs() ) <= SEEX * 2;
     } );
     const int available_count = available.size();
     const std::vector<npc *> followers = get_npcs_if( [&]( const npc & guy ) {
@@ -1007,7 +1009,7 @@ void game::chat()
     std::vector<vehicle *> following_vehicles;
     std::vector<vehicle *> magic_vehicles;
     std::vector<vehicle *> magic_following_vehicles;
-    for( wrapped_vehicle &veh : get_map().get_vehicles() ) {
+    for( wrapped_vehicle &veh : here.get_vehicles() ) {
         vehicle *&v = veh.v;
         if( v->has_engine_type( fuel_type_animal, false ) &&
             v->is_owned_by( player_character ) ) {
@@ -1235,7 +1237,6 @@ void game::chat()
                 return;
             }
 
-            map &here = get_map();
             std::optional<tripoint_bub_ms> p = look_around();
 
             if( !p ) {
@@ -1450,7 +1451,7 @@ void npc::handle_sound( const sounds::sound_t spriority, const std::string &desc
         say( chat_snippets().snip_acknowledged.translated() );
     }
 
-    if( sees( spos ) || is_hallucination() ) {
+    if( sees( here, spos ) || is_hallucination() ) {
         return;
     }
     // ignore low priority sounds if the NPC "knows" it came from a friend.
@@ -1468,7 +1469,7 @@ void npc::handle_sound( const sounds::sound_t spriority, const std::string &desc
     }
     // discount if sound source is player, or seen by player,
     // and listener is friendly and sound source is combat or alert only.
-    if( spriority < sounds::sound_t::alarm && player_character.sees( spos ) ) {
+    if( spriority < sounds::sound_t::alarm && player_character.sees( here, spos ) ) {
         if( is_player_ally() ) {
             add_msg_debug( debugmode::DF_NPC, "NPC %s ignored low priority noise that player can see",
                            get_name() );
@@ -6093,6 +6094,8 @@ talk_effect_fun_t::func f_run_eoc_selector( const JsonObject &jo, std::string_vi
 talk_effect_fun_t::func f_run_npc_eocs( const JsonObject &jo,
                                         std::string_view member, const std::string_view src, bool is_npc )
 {
+    const map &here = get_map();
+
     std::vector<effect_on_condition_id> eocs = load_eoc_vector( jo, member, src );
     std::vector<str_or_var> unique_ids;
     for( JsonValue jv : jo.get_array( "unique_ids" ) ) {
@@ -6106,7 +6109,7 @@ talk_effect_fun_t::func f_run_npc_eocs( const JsonObject &jo,
     }
     bool npc_must_see = jo.get_bool( "npc_must_see", false );
     if( local ) {
-        return [eocs, unique_ids, npc_must_see, npc_range, is_npc]( dialogue const & d ) {
+        return [eocs, unique_ids, npc_must_see, npc_range, is_npc, &here]( dialogue const & d ) {
             tripoint_bub_ms actor_pos = d.actor( is_npc )->pos_bub();
             std::vector<std::string> ids;
             ids.reserve( unique_ids.size() );
@@ -6114,7 +6117,7 @@ talk_effect_fun_t::func f_run_npc_eocs( const JsonObject &jo,
                 ids.emplace_back( id.evaluate( d ) );
             }
             const std::vector<npc *> available = g->get_npcs_if( [npc_must_see, npc_range, actor_pos,
-                          ids]( const npc & guy ) {
+                          ids, &here]( const npc & guy ) {
                 bool id_valid = ids.empty();
                 for( const std::string &id : ids ) {
                     if( id == guy.get_unique_id() ) {
@@ -6123,7 +6126,7 @@ talk_effect_fun_t::func f_run_npc_eocs( const JsonObject &jo,
                     }
                 }
                 return id_valid && ( !npc_range.has_value() || actor_pos.z() == guy.posz() ) && ( !npc_must_see ||
-                        guy.sees( actor_pos ) ) &&
+                        guy.sees( here, actor_pos ) ) &&
                        ( !npc_range.has_value() || rl_dist( actor_pos, guy.pos_bub() ) <= npc_range.value() );
             } );
             for( npc *target : available ) {
@@ -6155,6 +6158,8 @@ talk_effect_fun_t::func f_run_npc_eocs( const JsonObject &jo,
 talk_effect_fun_t::func f_run_monster_eocs( const JsonObject &jo,
         std::string_view member, const std::string_view src, bool is_npc )
 {
+    const map &here = get_map();
+
     std::vector<effect_on_condition_id> eocs = load_eoc_vector( jo, member, src );
     std::vector<str_or_var> mtype_ids;
     for( JsonValue jv : jo.get_array( "mtype_ids" ) ) {
@@ -6165,7 +6170,7 @@ talk_effect_fun_t::func f_run_monster_eocs( const JsonObject &jo,
         monster_range = jo.get_int( "monster_range" );
     }
     bool monster_must_see = jo.get_bool( "monster_must_see", false );
-    return [eocs, mtype_ids, monster_must_see, monster_range, is_npc]( dialogue const & d ) {
+    return [eocs, mtype_ids, monster_must_see, monster_range, is_npc, &here]( dialogue const & d ) {
         std::vector<mtype_id> ids;
         ids.reserve( mtype_ids.size() );
         for( const str_or_var &id : mtype_ids ) {
@@ -6173,7 +6178,7 @@ talk_effect_fun_t::func f_run_monster_eocs( const JsonObject &jo,
         }
         tripoint_bub_ms actor_pos = d.actor( is_npc )->pos_bub();
         const std::vector<Creature *> available = g->get_creatures_if( [ ids, monster_must_see,
-             monster_range, actor_pos ]( const Creature & critter ) {
+             monster_range, actor_pos, &here ]( const Creature & critter ) {
             bool id_valid = ids.empty();
             bool creature_is_monster = critter.is_monster();
             if( creature_is_monster ) {
@@ -6187,7 +6192,7 @@ talk_effect_fun_t::func f_run_monster_eocs( const JsonObject &jo,
             return creature_is_monster && id_valid && ( !monster_range.has_value() ||
                     actor_pos.z() == critter.posz() ) &&
                    ( !monster_must_see ||
-                     critter.sees( actor_pos ) ) &&
+                     critter.sees( here, actor_pos ) ) &&
                    ( !monster_range.has_value() || rl_dist( actor_pos, critter.pos_bub() ) <= monster_range.value() );
         } );
         for( Creature *target : available ) {
@@ -6754,6 +6759,8 @@ talk_effect_fun_t::func f_deal_damage( const JsonObject &jo, std::string_view me
 talk_effect_fun_t::func f_spawn_monster( const JsonObject &jo, std::string_view member,
         const std::string_view src, bool is_npc )
 {
+    const map &here = get_map();
+
     bool group = jo.get_bool( "group", false );
     bool single_target = jo.get_bool( "single_target", false );
     str_or_var monster_id = get_str_or_var( jo.get_member( member ), member );
@@ -6786,7 +6793,7 @@ talk_effect_fun_t::func f_spawn_monster( const JsonObject &jo, std::string_view 
     return [monster_id, dov_target_range, dov_hallucination_count, dov_real_count, dov_min_radius,
                         dov_max_radius, outdoor_only, indoor_only, group, single_target, dov_lifespan, target_var,
                         spawn_message, spawn_message_plural, true_eocs, false_eocs, open_air_allowed, temporary_drop_items,
-                friendly, is_npc]( dialogue & d ) {
+                friendly, is_npc, &here]( dialogue & d ) {
         monster target_monster;
         std::vector<Creature *> target_monsters;
         mongroup_id target_mongroup;
@@ -6853,7 +6860,7 @@ talk_effect_fun_t::func f_spawn_monster( const JsonObject &jo, std::string_view 
         std::optional<time_duration> lifespan;
         tripoint_bub_ms target_pos = d.actor( is_npc )->pos_bub();
         if( target_var.has_value() ) {
-            target_pos = get_map().get_bub( get_tripoint_ms_from_var( target_var, d, is_npc ) );
+            target_pos = here.get_bub( get_tripoint_ms_from_var( target_var, d, is_npc ) );
         }
         int visible_spawns = 0;
         int spawns = 0;
@@ -6880,7 +6887,7 @@ talk_effect_fun_t::func f_spawn_monster( const JsonObject &jo, std::string_view 
                             critter->as_monster()->friendly = -1;
                         }
                         spawns++;
-                        if( get_avatar().sees( *critter ) ) {
+                        if( get_avatar().sees( here, *critter ) ) {
                             visible_spawns++;
                         }
                     }
@@ -6905,7 +6912,7 @@ talk_effect_fun_t::func f_spawn_monster( const JsonObject &jo, std::string_view 
                         spawned->friendly = -1;
                     }
                     spawns++;
-                    if( get_avatar().sees( *spawned ) ) {
+                    if( get_avatar().sees( here, *spawned ) ) {
                         visible_spawns++;
                     }
                     lifespan = dov_lifespan.evaluate( d );
@@ -6934,6 +6941,8 @@ talk_effect_fun_t::func f_spawn_monster( const JsonObject &jo, std::string_view 
 talk_effect_fun_t::func f_spawn_npc( const JsonObject &jo, std::string_view member,
                                      const std::string_view src, bool is_npc )
 {
+    const map &here = get_map();
+
     str_or_var sov_npc_class = get_str_or_var( jo.get_member( member ), member );
     str_or_var unique_id;
     if( jo.has_member( "unique_id" ) ) {
@@ -6973,7 +6982,7 @@ talk_effect_fun_t::func f_spawn_npc( const JsonObject &jo, std::string_view memb
     return [sov_npc_class, unique_id, traits, dov_hallucination_count, dov_real_count,
                            dov_min_radius,
                            dov_max_radius, outdoor_only, indoor_only, dov_lifespan, target_var, spawn_message,
-                   spawn_message_plural, true_eocs, false_eocs, open_air_allowed, is_npc]( dialogue & d ) {
+                   spawn_message_plural, true_eocs, false_eocs, open_air_allowed, is_npc, &here]( dialogue & d ) {
         int min_radius = dov_min_radius.evaluate( d );
         int max_radius = dov_max_radius.evaluate( d );
         int real_count = dov_real_count.evaluate( d );
@@ -6988,7 +6997,7 @@ talk_effect_fun_t::func f_spawn_npc( const JsonObject &jo, std::string_view memb
         std::optional<time_duration> lifespan;
         tripoint_bub_ms target_pos = d.actor( is_npc )->pos_bub();
         if( target_var.has_value() ) {
-            target_pos = get_map().get_bub( get_tripoint_ms_from_var( target_var, d, is_npc ) );
+            target_pos = here.get_bub( get_tripoint_ms_from_var( target_var, d, is_npc ) );
         }
         int visible_spawns = 0;
         int spawns = 0;
@@ -7004,7 +7013,7 @@ talk_effect_fun_t::func f_spawn_npc( const JsonObject &jo, std::string_view memb
                     Creature *guy = get_creature_tracker().creature_at( spawn_point );
                     if( guy ) {
                         spawns++;
-                        if( get_avatar().sees( *guy ) ) {
+                        if( get_avatar().sees( here, *guy ) ) {
                             visible_spawns++;
                         }
                     }
@@ -7025,7 +7034,7 @@ talk_effect_fun_t::func f_spawn_npc( const JsonObject &jo, std::string_view memb
                     Creature *guy = get_creature_tracker().creature_at( spawn_point );
                     if( guy ) {
                         spawns++;
-                        if( get_avatar().sees( *guy ) ) {
+                        if( get_avatar().sees( here, *guy ) ) {
                             visible_spawns++;
                         }
                     }
@@ -7209,13 +7218,15 @@ talk_effect_fun_t::func f_teleport( const JsonObject &jo, std::string_view membe
 
 talk_effect_fun_t::func f_wants_to_talk( bool is_npc )
 {
-    return [is_npc]( dialogue const & d ) {
+    const map &here = get_map();
+
+    return [is_npc, &here]( dialogue const & d ) {
         npc *p = d.actor( is_npc )->get_npc();
         if( p ) {
             if( p->get_attitude() == NPCATT_TALK ) {
                 return;
             }
-            if( p->sees( get_player_character() ) ) {
+            if( p->sees( here, get_player_character() ) ) {
                 add_msg( _( "%s wants to talk to you." ), p->get_name() );
             }
             p->set_attitude( NPCATT_TALK );

--- a/src/npctalk_funcs.cpp
+++ b/src/npctalk_funcs.cpp
@@ -922,11 +922,13 @@ void talk_function::deny_personal_info( npc &p )
 
 void talk_function::hostile( npc &p )
 {
+    const map &here = get_map();
+
     if( p.get_attitude() == NPCATT_KILL ) {
         return;
     }
 
-    if( p.sees( get_player_character() ) ) {
+    if( p.sees( here, get_player_character() ) ) {
         add_msg( _( "%s turns hostile!" ), p.get_name() );
     }
 
@@ -1076,7 +1078,7 @@ void talk_function::player_weapon_drop( npc &/*p*/ )
     Character &player_character = get_player_character();
     item weap = player_character.remove_weapon();
     drop_on_map( player_character, item_drop_reason::deliberate, {weap}, &here,
-                 player_character.pos_bub( &here ) );
+                 player_character.pos_bub( here ) );
 }
 
 void talk_function::lead_to_safety( npc &p )
@@ -1247,11 +1249,13 @@ void talk_function::start_training_gen( Character &teacher, std::vector<Characte
 
 npc *pick_follower()
 {
+    const map &here = get_map();
+
     std::vector<npc *> followers;
     std::vector<tripoint_bub_ms> locations;
 
     for( npc &guy : g->all_npcs() ) {
-        if( guy.is_player_ally() && get_player_view().sees( guy ) ) {
+        if( guy.is_player_ally() && get_player_view().sees( here, guy ) ) {
             followers.push_back( &guy );
             locations.push_back( guy.pos_bub() );
         }

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -1606,7 +1606,7 @@ void overmapbuffer::spawn_monster( const tripoint_abs_sm &p, bool spawn_nonlocal
     [&]( std::pair<const tripoint_om_sm, monster> &monster_entry ) {
         monster &this_monster = monster_entry.second;
         map &here = get_map();
-        const tripoint_bub_ms local = this_monster.pos_bub( &here );
+        const tripoint_bub_ms local = this_monster.pos_bub( here );
         // The monster position must be local to the main map when added to the game
         if( !spawn_nonlocal ) {
             cata_assert( here.inbounds( local ) );

--- a/src/pixel_minimap.cpp
+++ b/src/pixel_minimap.cpp
@@ -494,6 +494,8 @@ void pixel_minimap::render_cache( const tripoint_bub_ms &center )
 
 void pixel_minimap::render_critters( const tripoint_bub_ms &center )
 {
+    const map &m = get_map();
+
     //handles the enemy faction red highlights
     //this value should be divisible by 200
     const int indicator_length = settings.beacon_blink_interval * 200; //default is 2000 ms, 2 seconds
@@ -509,7 +511,6 @@ void pixel_minimap::render_critters( const tripoint_bub_ms &center )
         mixture = lerp_clamped( 0, 100, std::max( s, 0.0f ) );
     }
 
-    const map &m = get_map();
     const level_cache &access_cache = m.access_cache( center.z() );
 
     const point_rel_ms start( center.x() - total_tiles_count.x / 2,
@@ -535,7 +536,7 @@ void pixel_minimap::render_critters( const tripoint_bub_ms &center )
 
             Creature *critter = creatures.creature_at( p, true );
 
-            if( critter == nullptr || !get_player_view().sees( *critter ) ) {
+            if( critter == nullptr || !get_player_view().sees( m, *critter ) ) {
                 continue;
             }
 

--- a/src/player_hardcoded_effects.cpp
+++ b/src/player_hardcoded_effects.cpp
@@ -324,6 +324,8 @@ static void eff_fun_rat( Character &u, effect &it )
 }
 static void eff_fun_bleed( Character &u, effect &it )
 {
+    map &here = get_map();
+
     if( u.has_flag( json_flag_CANNOT_TAKE_DAMAGE ) ) {
         return;
     }
@@ -374,7 +376,7 @@ static void eff_fun_bleed( Character &u, effect &it )
                 }
                 suffer_string = iter->second;
             }
-            u.bleed();
+            u.bleed( here );
             bodypart_id bp = it.get_bp();
             // piece together the final displayed message here instead of inline, for readability's sake
             // format the chosen string with the relevant variables to make it human-readable, then translate everything we have so far
@@ -676,7 +678,7 @@ static void eff_fun_teleglow( Character &u, effect &it )
                 for( const MonsterGroupResult &mgr : spawn_details ) {
                     g->place_critter_at( mgr.id, dest );
                 }
-                if( uistate.distraction_hostile_spotted && player_character.sees( dest ) ) {
+                if( uistate.distraction_hostile_spotted && player_character.sees( here, dest ) ) {
                     g->cancel_activity_or_ignore_query( distraction_type::hostile_spotted_far,
                                                         _( "A monster appears nearby!" ) );
                     add_msg( m_warning, _( "A portal opens nearby, and a monster crawls through!" ) );
@@ -1330,7 +1332,7 @@ void Character::hardcoded_effects( effect &it )
                 for( const MonsterGroupResult &mgr : spawn_details ) {
                     g->place_critter_at( mgr.id, dest );
                 }
-                if( uistate.distraction_hostile_spotted && player_character.sees( dest ) ) {
+                if( uistate.distraction_hostile_spotted && player_character.sees( here, dest ) ) {
                     g->cancel_activity_or_ignore_query( distraction_type::hostile_spotted_far,
                                                         _( "A monster appears nearby!" ) );
                     add_msg_if_player( m_warning, _( "A portal opens nearby, and a monster crawls through!" ) );

--- a/src/projectile.cpp
+++ b/src/projectile.cpp
@@ -235,7 +235,9 @@ int max_aoe_size( const std::set<ammo_effect_str_id> &tags )
 void multi_projectile_hit_message( Creature *critter, int hit_count, int damage_taken,
                                    const std::string &projectile_name )
 {
-    if( hit_count > 0 && get_player_character().sees( *critter ) ) {
+    const map &here = get_map();
+
+    if( hit_count > 0 && get_player_character().sees( here, *critter ) ) {
         // Building a phrase to summarize the fragment effects.
         // Target, Number of impacts, total amount of damage, proportion of deflected fragments.
         std::map<int, std::string> impact_count_descriptions = {

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -959,10 +959,10 @@ int Character::fire_gun( const tripoint_bub_ms &target, int shots )
         debugmsg( "%s doesn't have a gun to fire", get_name() );
         return 0;
     }
-    return fire_gun( &here, target, shots, *gun, item_location() );
+    return fire_gun( here, target, shots, *gun, item_location() );
 }
 
-int Character::fire_gun( map *here, const tripoint_bub_ms &target, int shots, item &gun,
+int Character::fire_gun( map &here, const tripoint_bub_ms &target, int shots, item &gun,
                          item_location ammo )
 {
     if( !gun.is_gun() ) {
@@ -985,7 +985,7 @@ int Character::fire_gun( map *here, const tripoint_bub_ms &target, int shots, it
 
     // cap our maximum burst size by ammo and energy
     if( !gun.has_flag( flag_VEHICLE ) && !ammo ) {
-        shots = std::min( shots, gun.shots_remaining( this ) );
+        shots = std::min( shots, gun.shots_remaining( here, this ) );
     } else if( gun.ammo_required() ) {
         // This checks ammo only. Vehicle turret energy drain is handled elsewhere.
         const int ammo_left = ammo ? ammo.get_item()->count() : gun.ammo_remaining( );
@@ -998,10 +998,10 @@ int Character::fire_gun( map *here, const tripoint_bub_ms &target, int shots, it
     }
 
     // usage of any attached bipod is dependent upon terrain or on being prone
-    bool bipod = here->has_flag_ter_or_furn( ter_furn_flag::TFLAG_MOUNTABLE, pos_bub( here ) ) ||
+    bool bipod = here.has_flag_ter_or_furn( ter_furn_flag::TFLAG_MOUNTABLE, pos_bub( here ) ) ||
                  is_prone();
     if( !bipod ) {
-        if( const optional_vpart_position vp = here->veh_at( pos_abs( ) ) ) {
+        if( const optional_vpart_position vp = here.veh_at( pos_abs( ) ) ) {
             bipod = vp->vehicle().has_part( pos_abs( ), "MOUNTABLE" );
         }
     }
@@ -1041,7 +1041,7 @@ int Character::fire_gun( map *here, const tripoint_bub_ms &target, int shots, it
         }
 
         // If this is a vehicle mounted turret, which vehicle is it mounted on?
-        const vehicle *in_veh = has_effect( effect_on_roof ) ? veh_pointer_or_null( here->veh_at(
+        const vehicle *in_veh = has_effect( effect_on_roof ) ? veh_pointer_or_null( here.veh_at(
                                     pos_bub( here ) ) ) : nullptr;
 
         // Add gunshot noise
@@ -1061,7 +1061,7 @@ int Character::fire_gun( map *here, const tripoint_bub_ms &target, int shots, it
         dispersion_sources dispersion = total_gun_dispersion( gun, recoil_total(), proj.shot_spread );
 
         dealt_projectile_attack shot;
-        projectile_attack( shot, proj, here, pos_bub( here ), aim, dispersion, this, in_veh, wp_attack );
+        projectile_attack( shot, proj, &here, pos_bub( here ), aim, dispersion, this, in_veh, wp_attack );
         if( !shot.targets_hit.empty() ) {
             hits++;
         }
@@ -1119,7 +1119,7 @@ int Character::fire_gun( map *here, const tripoint_bub_ms &target, int shots, it
         }
 
         const int required = gun.ammo_required();
-        if( gun.ammo_consume( required, here, pos_bub( here ), this ) != required ) {
+        if( gun.ammo_consume( required, &here, pos_bub( here ), this ) != required ) {
             debugmsg( "Unexpected shortage of ammo whilst firing %s", gun.tname() );
             break;
         }
@@ -1127,7 +1127,7 @@ int Character::fire_gun( map *here, const tripoint_bub_ms &target, int shots, it
         // Vehicle turrets drain vehicle battery and do not care about this
         if( !gun.has_flag( flag_VEHICLE ) ) {
             const units::energy energ_req = gun.get_gun_energy_drain();
-            const units::energy drained = gun.energy_consume( energ_req, here, pos_bub( here ), this );
+            const units::energy drained = gun.energy_consume( energ_req, &here, pos_bub( here ), this );
             if( drained < energ_req ) {
                 debugmsg( "Unexpected shortage of energy whilst firing %s. Required: %i J, drained: %i J",
                           gun.tname(), units::to_joule( energ_req ), units::to_joule( drained ) );
@@ -1136,7 +1136,7 @@ int Character::fire_gun( map *here, const tripoint_bub_ms &target, int shots, it
         }
 
         if( !current_ammo.is_null() ) {
-            cycle_action( gun, current_ammo, here, pos_bub( here ) );
+            cycle_action( gun, current_ammo, &here, pos_bub( here ) );
         }
 
         if( gun_skill == skill_launcher ) {
@@ -1237,6 +1237,8 @@ static double calculate_aim_cap_without_target( const Character &you,
 // Handle capping aim level when the player cannot see the target tile or there is nothing to aim at.
 double calculate_aim_cap( const Character &you, const tripoint_bub_ms &target )
 {
+    const map &here = get_map();
+
     const Creature *victim = get_creature_tracker().creature_at( target, true );
     // nothing here, nothing to aim
     if( victim == nullptr ) {
@@ -1247,7 +1249,7 @@ double calculate_aim_cap( const Character &you, const tripoint_bub_ms &target )
     enchant_cache::special_vision sees_with_special = you.enchantment_cache->get_vision( d );
 
     // you do not see it, but your sense it in other ways
-    if( !you.sees( *victim ) && !sees_with_special.is_empty() ) {
+    if( !you.sees( here,  *victim ) && !sees_with_special.is_empty() ) {
         if( sees_with_special.precise ) {
             // your senses are precise enough to aim it with no issues
             return 0.0;
@@ -1714,15 +1716,17 @@ static double target_size_in_moa( int range, double size )
 
 Target_attributes::Target_attributes( tripoint_bub_ms src, tripoint_bub_ms target )
 {
+    const map &here = get_map();
+
     Creature *target_critter = get_creature_tracker().creature_at( target );
     Creature *shooter = get_creature_tracker().creature_at( src );
     range = rl_dist( src, target );
     size = target_critter != nullptr ?
            target_critter->ranged_target_size() :
-           get_map().ranged_target_size( target );
+           here.ranged_target_size( target );
     size_in_moa = target_size_in_moa( range, size ) ;
-    light = get_map().ambient_light_at( target );
-    visible = shooter->sees( target );
+    light = here.ambient_light_at( target );
+    visible = shooter->sees( here, target );
 
 }
 Target_attributes::Target_attributes( int rng, double target_size, float light_target,
@@ -2047,8 +2051,10 @@ static int print_ranged_chance( const catacurses::window &w, int line_number,
 // Whether player character knows creature's position and can roughly track it with the aim cursor
 static bool pl_sees( const Creature &cr )
 {
+    const map &here = get_map();
+
     Character &u = get_player_character();
-    return u.sees( cr ) || u.sees_with_specials( cr );
+    return u.sees( here,  cr ) || u.sees_with_specials( cr );
 }
 
 static int print_aim( const target_ui &ui, Character &you, const catacurses::window &w,
@@ -2084,8 +2090,10 @@ static void draw_throw_aim( const target_ui &ui, const Character &you, const cat
                             int &text_y, input_context &ctxt, const item &weapon, const tripoint_bub_ms &target_pos,
                             bool is_blind_throw )
 {
+    const map &here = get_map();
+
     Creature *target = get_creature_tracker().creature_at( target_pos, true );
-    if( target != nullptr && !you.sees( *target ) ) {
+    if( target != nullptr && !you.sees( here, *target ) ) {
         target = nullptr;
     }
 
@@ -2111,8 +2119,8 @@ static void draw_throw_aim( const target_ui &ui, const Character &you, const cat
             target_ui::TargetMode::ThrowBlind :
             target_ui::TargetMode::Throw;
     Target_attributes attributes( range, target_size,
-                                  get_map().ambient_light_at( target_pos ),
-                                  you.sees( target_pos ) );
+                                  here.ambient_light_at( target_pos ),
+                                  you.sees( here, target_pos ) );
 
     const std::vector<aim_type_prediction> aim_chances = calculate_ranged_chances( ui, you,
             throwing_target_mode, ctxt, weapon, dispersion, confidence_config, attributes, target_pos,
@@ -3151,6 +3159,8 @@ void target_ui::update_target_list()
 
 tripoint_bub_ms target_ui::choose_initial_target()
 {
+    map &here = get_map();
+
     // Try previously targeted creature
     shared_ptr_fast<Creature> cr = you->last_target.lock();
     if( cr && pl_sees( *cr ) && dist_fn( cr->pos_bub() ) <= range ) {
@@ -3163,10 +3173,9 @@ tripoint_bub_ms target_ui::choose_initial_target()
     }
 
     // Try closest practice target
-    map &here = get_map();
     std::optional<tripoint_bub_ms> target_spot = find_point_closest_first( src, 0, range, [this,
     &here]( const tripoint_bub_ms & pt ) {
-        return here.tr_at( pt ).id == tr_practice_target && this->you->sees( pt );
+        return here.tr_at( pt ).id == tr_practice_target && this->you->sees( here, pt );
     } );
 
     if( target_spot != std::nullopt ) {
@@ -3307,6 +3316,8 @@ bool target_ui::prompt_friendlies_in_lof()
 
 std::vector<weak_ptr_fast<Creature>> target_ui::list_friendlies_in_lof()
 {
+    const map &here = get_map();
+
     std::vector<weak_ptr_fast<Creature>> ret;
     if( mode == TargetMode::Turrets || mode == TargetMode::Spell ) {
         debugmsg( "Not implemented" );
@@ -3316,7 +3327,7 @@ std::vector<weak_ptr_fast<Creature>> target_ui::list_friendlies_in_lof()
     for( const tripoint_bub_ms &p : traj ) {
         if( p != dst && p != src ) {
             Creature *cr = creatures.creature_at( p, true );
-            if( cr && you->sees( *cr ) ) {
+            if( cr && you->sees( here, *cr ) ) {
                 Creature::Attitude a = cr->attitude_to( *this->you );
                 if(
                     ( cr->is_npc() && a != Creature::Attitude::HOSTILE ) ||
@@ -4111,9 +4122,11 @@ void target_ui::panel_spell_info( int &text_y )
 
 void target_ui::panel_target_info( int &text_y, bool fill_with_blank_if_no_target )
 {
+    const map &here = get_map();
+
     int max_lines = 6;
     if( dst_critter ) {
-        if( you->sees( *dst_critter ) ) {
+        if( you->sees( here, *dst_critter ) ) {
             // FIXME: print_info doesn't really care about line limit
             //        and can always occupy up to 4 of them (or even more?).
             //        To make things consistent, we ask it for 2 lines

--- a/src/start_location.cpp
+++ b/src/start_location.cpp
@@ -522,7 +522,7 @@ void start_location::place_player( avatar &you, const tripoint_abs_omt &omtstart
         }
     }
 
-    you.setpos( best_spot );
+    you.setpos( here, best_spot );
 
     if( !found_good_spot ) {
         debugmsg( "Could not find a good starting place for character" );

--- a/src/talker_character.cpp
+++ b/src/talker_character.cpp
@@ -162,7 +162,9 @@ dealt_damage_instance talker_character_const::deal_damage( Creature *source, bod
 
 void talker_character::set_pos( tripoint_bub_ms new_pos )
 {
-    me_chr->setpos( new_pos );
+    map &here = get_map();
+
+    me_chr->setpos( here, new_pos );
 }
 
 void talker_character::set_str_max( int value )
@@ -914,7 +916,9 @@ bool talker_character_const::can_see() const
 
 bool talker_character_const::can_see_location( const tripoint_bub_ms &pos ) const
 {
-    return me_chr_const->sees( pos );
+    const map &here = get_map();
+
+    return me_chr_const->sees( here, pos );
 }
 
 void talker_character::set_sleepiness( int amount )

--- a/src/talker_monster.cpp
+++ b/src/talker_monster.cpp
@@ -9,6 +9,8 @@
 #include "damage.h"
 #include "debug.h"
 #include "effect.h"
+#include "game.h"
+#include "map.h"
 #include "messages.h"
 #include "monster.h"
 #include "mtype.h"
@@ -190,7 +192,9 @@ int talker_monster_const::get_grab_strength() const
 
 bool talker_monster_const::can_see_location( const tripoint_bub_ms &pos ) const
 {
-    return me_mon_const->sees( pos );
+    const map &here = get_map();
+
+    return me_mon_const->sees( here, pos );
 }
 
 int talker_monster_const::get_volume() const

--- a/src/talker_monster.cpp
+++ b/src/talker_monster.cpp
@@ -9,7 +9,6 @@
 #include "damage.h"
 #include "debug.h"
 #include "effect.h"
-#include "game.h"
 #include "map.h"
 #include "messages.h"
 #include "monster.h"

--- a/src/teleport.cpp
+++ b/src/teleport.cpp
@@ -171,7 +171,7 @@ bool teleport::teleport_to_point( Creature &critter, tripoint_bub_ms target, boo
             if( tfrag_attempts-- < 1 ) {
                 if( p && display_message ) {
                     p->add_msg_player_or_npc( m_warning, _( "You flicker." ), _( "<npcname> flickers." ) );
-                } else if( get_player_view().sees( critter ) && display_message ) {
+                } else if( get_player_view().sees( here, critter ) && display_message ) {
                     add_msg( _( "%1$s flickers." ), critter.disp_name() );
                 }
                 return false;
@@ -206,7 +206,7 @@ bool teleport::teleport_to_point( Creature &critter, tripoint_bub_ms target, boo
                                                   poor_soul->disp_name() );
                     }
                 } else {
-                    if( get_player_view().sees( *poor_soul ) ) {
+                    if( get_player_view().sees( here, *poor_soul ) ) {
                         if( display_message ) {
                             add_msg( m_warning,
                                      _( "%1$s collides with %2$s mid teleport, and they are both knocked away by a violent explosion of energy!" ),

--- a/src/timed_event.cpp
+++ b/src/timed_event.cpp
@@ -193,7 +193,7 @@ void timed_event::actualize()
             for( const tripoint_bub_ms &p : here.points_on_zlevel() ) {
                 if( here.ter( p ) == ter_t_grate ) {
                     here.ter_set( p, ter_t_stairs_down );
-                    if( !saw_grate && player_character.sees( p ) ) {
+                    if( !saw_grate && player_character.sees( here, p ) ) {
                         saw_grate = true;
                     }
                 }

--- a/src/trapfunc.cpp
+++ b/src/trapfunc.cpp
@@ -428,8 +428,8 @@ bool trapfunc::tripwire( const tripoint_bub_ms &p, Creature *c, item * )
                 }
             }
             if( !valid.empty() ) {
-                player_character.setpos( random_entry( valid ) );
-                z->setpos( player_character.pos_bub() );
+                player_character.setpos( here, random_entry( valid ) );
+                z->setpos( player_character.pos_abs() );
             }
             player_character.mod_moves( -z->get_speed() * 1.5 );
             g->update_map( player_character );
@@ -448,7 +448,7 @@ bool trapfunc::tripwire( const tripoint_bub_ms &p, Creature *c, item * )
             }
         }
         if( !valid.empty() ) {
-            you->setpos( random_entry( valid ) );
+            you->setpos( here, random_entry( valid ) );
         }
         you->mod_moves( -you->get_speed() * 1.5 );
         if( c->is_avatar() ) {
@@ -518,7 +518,7 @@ bool trapfunc::crossbow( const tripoint_bub_ms &p, Creature *c, item * )
                                             _( "<npcname> dodges the shot!" ) );
             }
         } else if( z != nullptr ) {
-            bool seen = get_player_view().sees( *z );
+            bool seen = get_player_view().sees( here, *z );
             int chance = 0;
             // adapted from shotgun code - chance of getting hit depends on size
             switch( z->type->size ) {
@@ -623,7 +623,7 @@ bool trapfunc::shotgun( const tripoint_bub_ms &p, Creature *c, item * )
                                             _( "<npcname> dodges the shot!" ) );
             }
         } else if( z != nullptr ) {
-            bool seen = get_player_view().sees( *z );
+            bool seen = get_player_view().sees( here,  *z );
             int chance = 0;
             switch( z->type->size ) {
                 case creature_size::tiny:
@@ -903,7 +903,7 @@ bool trapfunc::dissector( const tripoint_bub_ms &p, Creature *c, item * )
         return false;
     }
     monster *z = dynamic_cast<monster *>( c );
-    bool player_sees = get_player_view().sees( p );
+    bool player_sees = get_player_view().sees( here, p );
     if( z != nullptr ) {
         if( z->type->in_species( species_ROBOT ) ) {
             //The monster is a robot. So the dissector should not try to dissect the monsters flesh.
@@ -1274,7 +1274,7 @@ static bool sinkhole_safety_roll( Character &you, const itype_id &itemname, cons
     } else {
         you.add_msg_player_or_npc( m_good, _( "You pull yourself to safety!" ),
                                    _( "<npcname> steps on a sinkhole, but manages to pull themselves to safety." ) );
-        you.setpos( random_entry( safe ) );
+        you.setpos( here, random_entry( safe ) );
         if( you.is_avatar() ) {
             g->update_map( you );
         }

--- a/src/turret.cpp
+++ b/src/turret.cpp
@@ -323,7 +323,7 @@ int turret_data::fire( Character &c, map *here, const tripoint_bub_ms &target )
     gun_mode mode = base()->gun_current_mode();
 
     prepare_fire( c );
-    shots = c.fire_gun( here, target, mode.qty, *mode );
+    shots = c.fire_gun( *here, target, mode.qty, *mode );
     post_fire( here, c, shots );
     return shots;
 }
@@ -585,7 +585,7 @@ npc &vehicle_part::get_targeting_npc( vehicle &veh )
         brain.name = string_format( _( "The %s turret" ), get_base().tname( 1 ) );
         brain.set_skill_level( get_base().gun_skill(), 8 );
     }
-    cpu.brain->setpos( veh.bub_part_pos( here, *this ) );
+    cpu.brain->setpos( here, veh.bub_part_pos( here, *this ) );
     cpu.brain->recalc_sight_limits();
     return *cpu.brain;
 }
@@ -631,7 +631,7 @@ int vehicle::automatic_fire_turret( vehicle_part &pt )
     }
 
     Character &player_character = get_player_character();
-    const bool u_see = player_character.sees( pos );
+    const bool u_see = player_character.sees( here, pos );
     const bool u_hear = !player_character.is_deaf();
     // The current target of the turret.
     auto &target = pt.target;

--- a/src/ui_extended_description.cpp
+++ b/src/ui_extended_description.cpp
@@ -38,8 +38,10 @@ static description_target &operator--( description_target &c )
 
 static const Creature *seen_critter( const tripoint_bub_ms &p )
 {
+    const map &here = get_map();
+
     const Creature *critter = get_creature_tracker().creature_at( p, true );
-    if( critter != nullptr && get_player_view().sees( *critter ) ) {
+    if( critter != nullptr && get_player_view().sees( here, *critter ) ) {
         return critter;
     }
 
@@ -85,6 +87,8 @@ extended_description_window::extended_description_window( tripoint_bub_ms &p ) :
                        ImGuiWindowFlags_NoNavInputs ),
     p( p )
 {
+    const map &here = get_map();
+
     ctxt = input_context( "EXTENDED_DESCRIPTION" );
     ctxt.register_action( "NEXT_TAB" );
     ctxt.register_action( "PREV_TAB" );
@@ -101,25 +105,25 @@ extended_description_window::extended_description_window( tripoint_bub_ms &p ) :
     if( critter ) {
         creature_description = critter->extended_description();
     }
-    bool sees = get_player_character().sees( p );
-    const furn_id &furn = get_map().furn( p );
+    bool sees = get_player_character().sees( here, p );
+    const furn_id &furn = here.furn( p );
     if( sees && furn ) {
         furniture_description = furn->extended_description();
     }
-    const ter_id &ter = get_map().ter( p );
+    const ter_id &ter = here.ter( p );
     if( sees && ter ) {
         terrain_description = ter->extended_description();
     }
-    const optional_vpart_position &vp = get_map().veh_at( p );
+    const optional_vpart_position &vp = here.veh_at( p );
     if( sees && vp ) {
         veh_app_description = vp.extended_description();
     }
 
     if( critter ) {
         switch_target = description_target::creature;
-    } else if( get_map().has_furn( p ) ) {
+    } else if( here.has_furn( p ) ) {
         switch_target = description_target::furniture;
-    } else if( get_map().veh_at( p ) ) {
+    } else if( here.veh_at( p ) ) {
         switch_target = description_target::vehicle;
     }
 

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -206,7 +206,7 @@ void orient_part( map &here, vehicle *veh, const vpart_info &vpinfo, int partnum
         point_rel_ms copied_placement = *part_placement;
         offset = offset + copied_placement;
     }
-    player_character.view_offset = offset - player_character.pos_bub( &here );
+    player_character.view_offset = offset - player_character.pos_bub( here );
 
     point_rel_ms delta;
     do {

--- a/src/veh_shape.cpp
+++ b/src/veh_shape.cpp
@@ -53,7 +53,7 @@ player_activity veh_shape::start( const tripoint_bub_ms &pos )
     const auto target_ui_cb = make_shared_fast<game::draw_callback_t>(
     [&]() {
         const avatar &you = get_avatar();
-        g->draw_cursor_unobscuring( you.pos_bub( &here ) + you.view_offset );
+        g->draw_cursor_unobscuring( you.pos_bub( here ) + you.view_offset );
     } );
     g->add_draw_callback( target_ui_cb );
     ui_adaptor ui;

--- a/src/veh_utils.cpp
+++ b/src/veh_utils.cpp
@@ -147,7 +147,7 @@ bool repair_part( map &here, vehicle &veh, vehicle_part &pt, Character &who )
         const point_rel_ms mount = pt.mount;
         const units::angle direction = pt.direction;
         const std::string variant = pt.variant;
-        here.spawn_items( who.pos_bub( &here ), pt.pieces_for_broken_part() );
+        here.spawn_items( who.pos_bub( here ), pt.pieces_for_broken_part() );
         veh.remove_part( pt );
         const int partnum = veh.install_part( here, mount, vpid, std::move( base ) );
         if( partnum >= 0 ) {

--- a/src/vehicle_autodrive.cpp
+++ b/src/vehicle_autodrive.cpp
@@ -731,7 +731,7 @@ bool vehicle::autodrive_controller::check_drivable( map &here, const tripoint_bu
     // we reach them
     if( pt_omt == data.current_omt ) {
         // driver must see the tile or have seen it before in order to plan a route over it
-        if( !driver.sees( pt ) ) {
+        if( !driver.sees( here, pt ) ) {
             if( !driver.is_avatar() ) {
                 return false;
             }
@@ -753,7 +753,7 @@ bool vehicle::autodrive_controller::check_drivable( map &here, const tripoint_bu
     // check for creatures
     // TODO: padding around monsters
     Creature *critter = get_creature_tracker().creature_at( pt, true );
-    if( critter && driver.sees( *critter ) ) {
+    if( critter && driver.sees( here, *critter ) ) {
         return false;
     }
 
@@ -1174,7 +1174,7 @@ collision_check_result vehicle::autodrive_controller::check_collision_zone( map 
     bool blind = true;
     for( const point_rel_ms &p : data.profile( to_orientation( face_dir.dir() ) ).collision_points ) {
         const tripoint_bub_ms next = data.adjust_z( here, veh_pos + forward_offset + p );
-        if( driver.sees( next ) ) {
+        if( driver.sees( here, next ) ) {
             blind = false;
         }
         // Known quirk: the player does not always see points above or below when driving
@@ -1220,7 +1220,7 @@ collision_check_result vehicle::autodrive_controller::check_collision_zone( map 
     }
     for( const point_rel_ms &p : collision_zone ) {
         const tripoint_bub_ms next = data.adjust_z( here, veh_pos + p );
-        if( !data.is_flying && !driver.sees( next ) ) {
+        if( !data.is_flying && !driver.sees( here, next ) ) {
             return collision_check_result::slow_down;
         }
         if( !check_drivable( here, next ) ) {

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -1182,7 +1182,7 @@ veh_collision vehicle::part_collision( map &here, int part, const tripoint_abs_m
             }
 
             if( vpi.has_flag( "SHARP" ) ) {
-                critter->bleed();
+                critter->bleed( here );
             } else {
                 sounds::sound( pos, 20, sounds::sound_t::combat, snd, false, "smash_success", "hit_vehicle" );
             }
@@ -1249,7 +1249,7 @@ void vehicle::handle_trap( map *here, const tripoint_bub_ms &p, vehicle_part &vp
 
     Character &player_character = get_player_character();
     const Character *driver = get_driver( *here );
-    const bool seen = player_character.sees( p );
+    const bool seen = player_character.sees( *here, p );
     const bool known = tr.can_see( p, player_character );
     const bool damage_done = vp_wheel.info().durability <= veh_data.damage;
     if( seen && damage_done ) {

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -1623,7 +1623,7 @@ void vehicle::use_harness( int part, map *here, const tripoint_bub_ms &pos )
 
     // TODO: Make 'choose_adjacent_highlight' map aware.
     const std::optional<tripoint_bub_ms> pnt_ = choose_adjacent_highlight(
-                _( "Where is the creature to harness?" ), _( "There is no creature to harness nearby." ), f,
+                *here, _( "Where is the creature to harness?" ), _( "There is no creature to harness nearby." ), f,
                 false );
     if( !pnt_ ) {
         add_msg( m_info, _( "Never mind." ) );

--- a/src/viewer.h
+++ b/src/viewer.h
@@ -5,14 +5,15 @@
 #include "coords_fwd.h"
 
 class Creature;
+class map;
 
 // This is strictly an interface that provides access to a game entity's Field of View.
 class viewer
 {
     public:
-        virtual bool sees( const tripoint_bub_ms &target, bool is_avatar = false,
+        virtual bool sees( const map &here, const tripoint_bub_ms &target, bool is_avatar = false,
                            int range_mod = 0 ) const = 0;
-        virtual bool sees( const Creature &target ) const = 0;
+        virtual bool sees( const map &here, const Creature &target ) const = 0;
         virtual ~viewer() = default;
 };
 

--- a/tests/act_build_test.cpp
+++ b/tests/act_build_test.cpp
@@ -60,13 +60,15 @@ namespace
 {
 void run_activities( Character &u, int max_moves )
 {
+    map &here = get_map();
+
     u.assign_activity( ACT_MULTIPLE_CONSTRUCTION );
     int turns = 0;
     while( ( !u.activity.is_null() || u.is_auto_moving() ) && turns < max_moves ) {
         u.set_moves( u.get_speed() );
         if( u.is_auto_moving() ) {
-            u.setpos( get_map().get_bub( *u.destination_point ) );
-            get_map().build_map_cache( u.posz() );
+            u.setpos( here, here.get_bub( *u.destination_point ) );
+            here.build_map_cache( u.posz() );
             u.start_destination_activity();
         }
         u.activity.do_turn( u );
@@ -152,12 +154,12 @@ void run_test_case( Character &u )
     u.i_add( item( itype_e_tool ) );
 
     SECTION( "1-step construction activity with pre_terrain" ) {
-        u.setpos( tripoint_bub_ms::zero );
+        u.setpos( here, tripoint_bub_ms::zero );
         here.build_map_cache( u.posz() );
         tripoint_bub_ms const tri_door( tripoint::south );
         construction const build =
             setup_testcase( u, "test_constr_door", tri_door, tripoint_bub_ms() );
-        REQUIRE( u.sees( tri_door ) );
+        REQUIRE( u.sees( here,  tri_door ) );
         here.ter_set( tri_door, ter_id( build.pre_terrain.empty() ? "" : *
                                         build.pre_terrain.begin() ) );
         run_activities( u, build.time * 10 );
@@ -165,7 +167,7 @@ void run_test_case( Character &u )
     }
 
     SECTION( "1-step construction activity with pre_terrain and starting far away" ) {
-        u.setpos( tripoint_bub_ms{ MAX_VIEW_DISTANCE - 1, 0, 0} );
+        u.setpos( here, tripoint_bub_ms{ MAX_VIEW_DISTANCE - 1, 0, 0} );
         here.build_map_cache( u.posz() );
         tripoint_bub_ms const tri_window( tripoint::south );
         construction const build =
@@ -177,7 +179,7 @@ void run_test_case( Character &u )
     }
 
     SECTION( "1-step construction activity with pre_flags" ) {
-        u.setpos( tripoint_bub_ms::zero );
+        u.setpos( here, tripoint_bub_ms::zero );
         here.build_map_cache( u.posz() );
         tripoint_bub_ms const tri_window( tripoint::south );
         construction const build =
@@ -188,7 +190,7 @@ void run_test_case( Character &u )
     }
 
     SECTION( "1-step construction activity with prereq with only pre_special" ) {
-        u.setpos( tripoint_bub_ms::zero );
+        u.setpos( here, tripoint_bub_ms::zero );
         here.build_map_cache( u.posz() );
         tripoint_bub_ms const tri_gravel( tripoint::south );
         construction const pre_build =
@@ -207,7 +209,7 @@ void run_test_case( Character &u )
     }
 
     SECTION( "1-step construction activity - alternative build from same group" ) {
-        u.setpos( tripoint_bub_ms::zero );
+        u.setpos( here, tripoint_bub_ms::zero );
         here.build_map_cache( u.posz() );
         tripoint_bub_ms const tri_window( tripoint::south );
         construction const build =
@@ -219,7 +221,7 @@ void run_test_case( Character &u )
     }
 
     SECTION( "1-step construction activity with existing partial" ) {
-        u.setpos( tripoint_bub_ms::zero );
+        u.setpos( here, tripoint_bub_ms::zero );
         here.build_map_cache( u.posz() );
         tripoint_bub_ms const tri_window( tripoint::south );
         construction const build =
@@ -232,7 +234,7 @@ void run_test_case( Character &u )
     }
 
     SECTION( "1-step construction activity with alternative partial" ) {
-        u.setpos( tripoint_bub_ms::zero );
+        u.setpos( here, tripoint_bub_ms::zero );
         here.build_map_cache( u.posz() );
         tripoint_bub_ms const tri_window( tripoint::south );
         construction const build =
@@ -245,7 +247,7 @@ void run_test_case( Character &u )
     }
 
     SECTION( "1-step construction activity with mismatched partial" ) {
-        u.setpos( tripoint_bub_ms::zero );
+        u.setpos( here, tripoint_bub_ms::zero );
         here.build_map_cache( u.posz() );
         tripoint_bub_ms const tri_window( tripoint::south );
         construction const build =
@@ -259,7 +261,7 @@ void run_test_case( Character &u )
     }
 
     SECTION( "visible but unreachable construction" ) {
-        u.setpos( tripoint_bub_ms::zero );
+        u.setpos( here, tripoint_bub_ms::zero );
         u.path_settings->bash_strength = 0;
         here.build_map_cache( u.posz() );
         tripoint_bub_ms const tri_window = { 0, 5, 0 };
@@ -270,7 +272,7 @@ void run_test_case( Character &u )
             setup_testcase( u, "test_constr_door", tri_window, tripoint_bub_ms() );
         here.ter_set( tri_window, ter_id( build.pre_terrain.empty() ? "" : *
                                           build.pre_terrain.begin() ) );
-        REQUIRE( u.sees( tri_window ) );
+        REQUIRE( u.sees( here, tri_window ) );
         REQUIRE( route_adjacent( u, tri_window ).empty() );
         run_activities( u, build.time * 10 );
         REQUIRE( here.ter( tri_window ) == ter_id( build.pre_terrain.empty() ? "" : *
@@ -278,7 +280,7 @@ void run_test_case( Character &u )
     }
 
     SECTION( "multiple-step construction activity with fetch required" ) {
-        u.setpos( tripoint_bub_ms::zero );
+        u.setpos( here, tripoint_bub_ms::zero );
         here.build_map_cache( u.posz() );
         tripoint_bub_ms const tri_door( tripoint::south );
         construction const build =
@@ -288,7 +290,7 @@ void run_test_case( Character &u )
     }
 
     SECTION( "multiple-step construction activity with prereq from a different group" ) {
-        u.setpos( tripoint_bub_ms::zero );
+        u.setpos( here, tripoint_bub_ms::zero );
         here.build_map_cache( u.posz() );
         tripoint_bub_ms const tri_door( tripoint::south );
         construction const build =
@@ -298,7 +300,7 @@ void run_test_case( Character &u )
     }
 
     SECTION( "multiple-step construction activity with partial of a recursive prerequisite" ) {
-        u.setpos( tripoint_bub_ms::zero );
+        u.setpos( here, tripoint_bub_ms::zero );
         here.build_map_cache( u.posz() );
         tripoint_bub_ms const tri_door( tripoint::south );
         partial_con pc;

--- a/tests/cardio_test.cpp
+++ b/tests/cardio_test.cpp
@@ -124,7 +124,7 @@ static int running_steps( Character &they, const ter_str_id &terrain = ter_t_pav
         last_moves = they.get_moves();
     }
     // Reset to starting position
-    they.setpos( left );
+    they.setpos( here, left );
     return steps;
 }
 

--- a/tests/char_sight_test.cpp
+++ b/tests/char_sight_test.cpp
@@ -101,7 +101,7 @@ TEST_CASE( "light_and_fine_detail_vision_mod", "[character][sight][light][vision
         calendar::turn = calendar::turn_zero;
         tripoint_rel_ms const z_shift = GENERATE( tripoint_rel_ms::above, tripoint_rel_ms::zero );
         // This implicitly rebuilds the light map but in a hacky way so we need to prevent the player falling
-        dummy.setpos( dummy.pos_bub() + z_shift, false );
+        dummy.setpos( dummy.pos_abs() + z_shift, false );
         CAPTURE( z_shift );
         REQUIRE_FALSE( g->is_in_sunlight( dummy.pos_bub() ) );
         REQUIRE( here.ambient_light_at( dummy.pos_bub() ) == Approx( LIGHT_AMBIENT_MINIMAL ) );
@@ -109,7 +109,7 @@ TEST_CASE( "light_and_fine_detail_vision_mod", "[character][sight][light][vision
         // 7.3 is LIGHT_AMBIENT_MINIMAL, a dark cloudy night, unlit indoors
         CHECK( dummy.fine_detail_vision_mod() == Approx( 7.3f ) );
 
-        dummy.setpos( dummy.pos_bub() - z_shift, false );
+        dummy.setpos( dummy.pos_abs() - z_shift, false );
     }
 
     SECTION( "blindfolded" ) {
@@ -135,7 +135,7 @@ TEST_CASE( "npc_light_and_fine_detail_vision_mod", "[character][npc][sight][ligh
     tripoint const u_shift = GENERATE( tripoint::zero, tripoint::above );
     CAPTURE( u_shift );
     // Allow player to float for purpose of purely testing this and not factoring in terrain potentially blocking vision etc
-    u.setpos( u.pos_bub() + u_shift, false );
+    u.setpos( u.pos_abs() + u_shift, false );
     scoped_weather_override weather_clear( WEATHER_CLEAR );
 
     time_point time_dst;
@@ -154,11 +154,11 @@ TEST_CASE( "npc_light_and_fine_detail_vision_mod", "[character][npc][sight][ligh
     REQUIRE( u.fine_detail_vision_mod() == expected_vision );
     SECTION( "NPC on same z-level" ) {
         // Allow NPC to float for purpose of purely testing this and not factoring in terrain potentially blocking vision etc
-        n.setpos( u.pos_bub() + tripoint_rel_ms::east, false );
+        n.setpos( u.pos_abs() + tripoint_rel_ms::east, false );
         CHECK( n.fine_detail_vision_mod() == u.fine_detail_vision_mod() );
     }
     SECTION( "NPC on a different z-level" ) {
-        n.setpos( u.pos_bub() + tripoint_rel_ms::above, false );
+        n.setpos( u.pos_abs() + tripoint_rel_ms::above, false );
         // light map is not calculated outside the player character's z-level
         // even if fov_3d_z_range > 0, and building light map on multiple levels
         // could be expensive, so make NPCs able to see things in this case to

--- a/tests/char_volume_test.cpp
+++ b/tests/char_volume_test.cpp
@@ -74,19 +74,19 @@ TEST_CASE( "character_at_volume_will_be_cramped_in_vehicle", "[volume]" )
 
     clear_vehicles(); // extra safety
     here.add_vehicle( vehicle_prototype_character_volume_test_car, test_pos, 0_degrees, 0, 0 );
-    you.setpos( test_pos );
-    const optional_vpart_position vp_there = here.veh_at( you.pos_bub( &here ) );
+    you.setpos( here, test_pos );
+    const optional_vpart_position vp_there = here.veh_at( you.pos_bub( here ) );
     REQUIRE( vp_there );
     tripoint_abs_ms dest_loc = you.pos_abs();
 
     // Empty aisle
     dest_loc = dest_loc + tripoint::north_west;
-    CHECK( !you.will_be_cramped_in_vehicle_tile( dest_loc ) );
+    CHECK( !you.will_be_cramped_in_vehicle_tile( here, dest_loc ) );
     dest_loc = you.pos_abs(); //reset
 
     // Aisle with 10L rock, a tight fit but not impossible
     dest_loc = dest_loc + tripoint::north;
-    CHECK( you.will_be_cramped_in_vehicle_tile( dest_loc ) );
+    CHECK( you.will_be_cramped_in_vehicle_tile( here, dest_loc ) );
     dest_loc = you.pos_abs(); //reset
 
     // Empty aisle, but we've put on a backpack and a 10L rock in that backpack
@@ -97,24 +97,24 @@ TEST_CASE( "character_at_volume_will_be_cramped_in_vehicle", "[volume]" )
     CHECK( 75_liter <= you.get_total_volume() );
     CHECK( you.get_total_volume() <= 100_liter );
     dest_loc = dest_loc + tripoint::north_west;
-    CHECK( you.will_be_cramped_in_vehicle_tile( dest_loc ) );
+    CHECK( you.will_be_cramped_in_vehicle_tile( here, dest_loc ) );
     dest_loc = you.pos_abs(); //reset
 
     // Try the cramped aisle with a rock again, but now we are tiny, so it is easy.
     CHECK( your_volume_with_trait( trait_SMALL2 ) == 23326_ml );
-    you.setpos( test_pos ); // set our position again, clear_avatar() moved us
+    you.setpos( here, test_pos ); // set our position again, clear_avatar() moved us
     dest_loc = dest_loc + tripoint::north;
-    CHECK( !you.will_be_cramped_in_vehicle_tile( dest_loc ) );
+    CHECK( !you.will_be_cramped_in_vehicle_tile( here, dest_loc ) );
     dest_loc = you.pos_abs(); //reset
 
     // Same aisle, but now we have HUGE GUTS. We will never fit.
     CHECK( your_volume_with_trait( trait_HUGE ) == 156228_ml );
-    you.setpos( test_pos ); // set our position again, clear_avatar() moved us
+    you.setpos( here, test_pos ); // set our position again, clear_avatar() moved us
     dest_loc = dest_loc + tripoint::north;
-    CHECK( you.will_be_cramped_in_vehicle_tile( dest_loc ) );
+    CHECK( you.will_be_cramped_in_vehicle_tile( here, dest_loc ) );
     dest_loc = you.pos_abs(); //reset
 
     // And finally, check that our HUGE body won't fit even into an empty aisle.
     dest_loc = dest_loc + tripoint::north_west;
-    CHECK( you.will_be_cramped_in_vehicle_tile( dest_loc ) );
+    CHECK( you.will_be_cramped_in_vehicle_tile( here, dest_loc ) );
 }

--- a/tests/coverage_test.cpp
+++ b/tests/coverage_test.cpp
@@ -80,6 +80,8 @@ static void check_not_near( const std::string &subject, float actual, const floa
 
 static float get_avg_melee_dmg( const itype_id &clothing_id, bool infect_risk = false )
 {
+    map &here = get_map();
+
     monster zed( mon_manhack, mon_pos );
     standard_npc dude( "TestCharacter", dude_pos, {}, 0, 8, 8, 8, 8 );
     item cloth( clothing_id );
@@ -90,7 +92,7 @@ static float get_avg_melee_dmg( const itype_id &clothing_id, bool infect_risk = 
     int num_hits = 0;
     for( int i = 0; i < num_iters; i++ ) {
         clear_character( dude, true );
-        dude.setpos( dude_pos );
+        dude.setpos( here, dude_pos );
         dude.wear_item( cloth, false );
         dude.add_effect( effect_sleep, 1_hours );
         if( zed.melee_attack( dude, 10000.0f ) ) {
@@ -116,6 +118,8 @@ static float get_avg_melee_dmg( const itype_id &clothing_id, bool infect_risk = 
 
 static float get_avg_melee_dmg( item cloth, bool infect_risk = false )
 {
+    map &here = get_map();
+
     monster zed( mon_manhack, mon_pos );
     standard_npc dude( "TestCharacter", dude_pos, {}, 0, 8, 8, 8, 8 );
     if( infect_risk ) {
@@ -125,7 +129,7 @@ static float get_avg_melee_dmg( item cloth, bool infect_risk = false )
     int num_hits = 0;
     for( int i = 0; i < num_iters; i++ ) {
         clear_character( dude, true );
-        dude.setpos( dude_pos );
+        dude.setpos( here, dude_pos );
         dude.wear_item( cloth, false );
         dude.add_effect( effect_sleep, 1_hours );
         if( zed.melee_attack( dude, 10000.0f ) ) {
@@ -151,6 +155,7 @@ static float get_avg_melee_dmg( item cloth, bool infect_risk = false )
 
 static float get_avg_bullet_dmg( const itype_id &clothing_id )
 {
+    map &here = get_map();
     clear_map();
     std::unique_ptr<standard_npc> badguy = std::make_unique<standard_npc>( "TestBaddie",
                                            badguy_pos, std::vector<itype_id>(), 0, 8, 8, 8, 8 );
@@ -168,13 +173,13 @@ static float get_avg_bullet_dmg( const itype_id &clothing_id )
     int num_hits = 0;
     for( int i = 0; i < num_iters; i++ ) {
         clear_character( *dude, true );
-        dude->setpos( dude_pos );
+        dude->setpos( here, dude_pos );
         dude->wear_item( cloth, false );
         dude->add_effect( effect_sleep, 1_hours );
         dealt_projectile_attack atk;
         projectile_attack( atk, proj, badguy_pos, dude_pos, dispersion_sources(),
                            &*badguy );
-        dude->deal_projectile_attack( &get_map(),  & *badguy, atk, atk.missed_by, false );
+        dude->deal_projectile_attack( &here,  & *badguy, atk, atk.missed_by, false );
         if( atk.missed_by < 1.0 ) {
             num_hits++;
         }

--- a/tests/crafting_test.cpp
+++ b/tests/crafting_test.cpp
@@ -407,7 +407,7 @@ TEST_CASE( "crafting_with_a_companion", "[.]" )
         g->load_npcs();
 
         CHECK( !dummy.in_vehicle );
-        dummy.setpos( who.pos_bub() );
+        dummy.setpos( who.pos_abs() );
         const auto helpers( dummy.get_crafting_helpers() );
 
         REQUIRE( std::find( helpers.begin(), helpers.end(), &who ) != helpers.end() );
@@ -507,7 +507,7 @@ static void prep_craft( const recipe_id &rid, const std::vector<item> &tools,
     const tripoint_bub_ms test_origin( 60, 60, 0 );
     Character &player_character = get_player_character();
     player_character.toggle_trait( trait_DEBUG_CNF );
-    player_character.setpos( test_origin );
+    player_character.setpos( here, test_origin );
     const recipe &r = rid.obj();
     grant_skills_to_character( player_character, r, offset );
     if( grant_profs ) {
@@ -2375,7 +2375,7 @@ TEST_CASE( "pseudo_tools_in_crafting_inventory", "[crafting][tools]" )
     clear_vehicles();
     clear_avatar();
     avatar &player = get_avatar();
-    player.setpos( tripoint_bub_ms( 60, 58, 0 ) );
+    player.setpos( here, tripoint_bub_ms( 60, 58, 0 ) );
     const tripoint_bub_ms veh_pos( 60, 60, 0 );
     const tripoint_bub_ms furn1_pos( 60, 57, 0 );
     const tripoint_bub_ms furn2_pos( 60, 56, 0 );

--- a/tests/eoc_test.cpp
+++ b/tests/eoc_test.cpp
@@ -370,18 +370,19 @@ TEST_CASE( "EOC_transform_radius", "[eoc][timed_event]" )
 
 TEST_CASE( "EOC_transform_line", "[eoc][timed_event]" )
 {
+    map &here = get_map();
     clear_avatar();
     clear_map();
     shared_ptr_fast<npc> guy = make_shared_fast<npc>();
     overmap_buffer.insert_npc( guy );
     npc &npc = *guy;
     clear_character( npc );
-    std::optional<tripoint_bub_ms> const dest = random_point( get_map(), [](
+    std::optional<tripoint_bub_ms> const dest = random_point( here, [](
     tripoint_bub_ms const & p ) {
         return p.xy() != get_avatar().pos_bub().xy();
     } );
     REQUIRE( dest.has_value() );
-    npc.setpos( { dest.value().xy(), get_avatar().posz() } );
+    npc.setpos( here, { dest.value().xy(), get_avatar().posz() } );
 
     tripoint_abs_ms const start = get_avatar().pos_abs();
     tripoint_abs_ms const end = npc.pos_abs();
@@ -1278,7 +1279,7 @@ TEST_CASE( "EOC_combat_event_test", "[eoc]" )
     for( loop = 0; loop < 1000; loop++ ) {
         arm_shooter( get_avatar(), itype_shotgun_s );
         get_avatar().recoil = 0;
-        get_avatar().fire_gun( &here, target_pos, 1, *get_avatar().get_wielded_item() );
+        get_avatar().fire_gun( here, target_pos, 1, *get_avatar().get_wielded_item() );
         if( !npc_dst_ranged.get_value( "test_event_last_event" ).empty() ) {
             break;
         }
@@ -1297,7 +1298,7 @@ TEST_CASE( "EOC_combat_event_test", "[eoc]" )
     for( loop = 0; loop < 1000; loop++ ) {
         arm_shooter( get_avatar(), itype_shotgun_s );
         get_avatar().recoil = 0;
-        get_avatar().fire_gun( &here, mon_dst_ranged.pos_bub(), 1, *get_avatar().get_wielded_item() );
+        get_avatar().fire_gun( here, mon_dst_ranged.pos_bub(), 1, *get_avatar().get_wielded_item() );
         if( !mon_dst_ranged.get_value( "test_event_last_event" ).empty() ) {
             break;
         }

--- a/tests/field_test.cpp
+++ b/tests/field_test.cpp
@@ -417,13 +417,14 @@ TEST_CASE( "fungal_haze_test", "[field]" )
 
 TEST_CASE( "player_in_field_test", "[field][player]" )
 {
+    map &here = get_map();
     fields_test_setup();
     clear_avatar();
     const tripoint_bub_ms p{ 33, 33, 0 };
 
     Character &dummy = get_avatar();
-    const tripoint_bub_ms prev_char_pos = dummy.pos_bub();
-    dummy.setpos( p );
+    const tripoint_bub_ms prev_char_pos = dummy.pos_bub( here );
+    dummy.setpos( here, p );
 
     map &m = get_map();
 
@@ -450,7 +451,7 @@ TEST_CASE( "player_in_field_test", "[field][player]" )
     }
 
     clear_avatar();
-    dummy.setpos( prev_char_pos );
+    dummy.setpos( here, prev_char_pos );
     fields_test_cleanup();
 }
 
@@ -495,7 +496,7 @@ TEST_CASE( "player_double_effect_field_test", "[field][player]" )
     Character &dummy = get_avatar();
     map &m = get_map();
 
-    dummy.setpos( p );
+    dummy.setpos( m, p );
     m.add_field( p, field_fd_test, 1 );
 
     m.creature_in_field( dummy );
@@ -519,7 +520,7 @@ TEST_CASE( "player_single_effect_field_test_head", "[field][player]" )
     item head_armor( itype_test_hazmat_hat );
     dummy.wear_item( head_armor );
 
-    dummy.setpos( p );
+    dummy.setpos( m, p );
     m.add_field( p, field_fd_test, 1 );
 
     m.creature_in_field( dummy );
@@ -543,7 +544,7 @@ TEST_CASE( "player_single_effect_field_test_torso", "[field][player]" )
     item torso_armor( itype_test_hazmat_shirt );
     dummy.wear_item( torso_armor );
 
-    dummy.setpos( p );
+    dummy.setpos( m, p );
     m.add_field( p, field_fd_test, 1 );
 
     m.creature_in_field( dummy );
@@ -569,7 +570,7 @@ TEST_CASE( "player_single_effect_field_test_all", "[field][player]" )
     item head_armor( itype_test_hazmat_hat );
     dummy.wear_item( head_armor );
 
-    dummy.setpos( p );
+    dummy.setpos( m, p );
     m.add_field( p, field_fd_test, 1 );
 
     m.creature_in_field( dummy );

--- a/tests/invlet_test.cpp
+++ b/tests/invlet_test.cpp
@@ -755,12 +755,13 @@ static void merge_invlet_test( avatar &dummy, inventory_location from )
 
 TEST_CASE( "Inventory_letter_test", "[.invlet]" )
 {
+    map &here = get_map();
     avatar &dummy = get_avatar();
     const tripoint_bub_ms spot( 60, 60, 0 );
     clear_map();
-    dummy.setpos( spot );
-    get_map().ter_set( spot, ter_id( "t_dirt" ) );
-    get_map().furn_set( spot, furn_id( "f_null" ) );
+    dummy.setpos( here, spot );
+    here.ter_set( spot, ter_id( "t_dirt" ) );
+    here.furn_set( spot, furn_id( "f_null" ) );
 
     invlet_test_autoletter_off( "Picking up items from the ground", dummy, GROUND, INVENTORY );
     invlet_test_autoletter_off( "Wearing items from the ground", dummy, GROUND, WORN );

--- a/tests/iuse_test.cpp
+++ b/tests/iuse_test.cpp
@@ -781,11 +781,12 @@ static item_location give_water( avatar &dummy, int count, bool in_inventory )
 
 TEST_CASE( "water_purification_tablet_activation", "[iuse][pur_tablets]" )
 {
+    map &here = get_map();
     avatar dummy;
     dummy.normalize();
     build_test_map( ter_t_grass );
     const tripoint_bub_ms test_origin( 20, 20, 0 );
-    dummy.setpos( test_origin );
+    dummy.setpos( here, test_origin );
     // Give the player a backpack to hold the tablets
     dummy.worn.wear_item( dummy, item( itype_backpack ), false, false );
 
@@ -949,10 +950,10 @@ TEST_CASE( "water_purification_tablet_activation", "[iuse][pur_tablets]" )
 
     SECTION( "6 tablets will purify a toilet tank" ) {
         item_location tablet = give_tablets( dummy, 6, true );
-        get_map().furn_set( dummy.pos_bub() + tripoint::north, furn_f_toilet );
+        here.furn_set( dummy.pos_bub( here ) + tripoint::north, furn_f_toilet );
         item water( itype_water );
         water.charges = 24;
-        get_map().add_item( dummy.pos_bub() + tripoint::north, water );
+        here.add_item( dummy.pos_bub( here ) + tripoint::north, water );
         item_location water_location( map_cursor( dummy.pos_bub() + tripoint::north ), &water );
 
         REQUIRE( water_location );
@@ -975,11 +976,12 @@ TEST_CASE( "water_purification_tablet_activation", "[iuse][pur_tablets]" )
 
 TEST_CASE( "water_tablet_purification_test", "[iuse][pur_tablets]" )
 {
+    map &here = get_map();
     avatar dummy;
     dummy.normalize();
     build_test_map( ter_t_grass );
     const tripoint_bub_ms test_origin( 20, 20, 0 );
-    dummy.setpos( test_origin );
+    dummy.setpos( here, test_origin );
 
     SECTION( "Test purifying time" ) {
         item_location tablet = give_tablets( dummy, 1, true );

--- a/tests/magic_spell_effect_test.cpp
+++ b/tests/magic_spell_effect_test.cpp
@@ -40,6 +40,7 @@ static std::set<tripoint_abs_ms> count_fields_near(
 
 TEST_CASE( "line_attack", "[magic]" )
 {
+    map &here = get_map();
     // manually construct a testable spell
     JsonObject obj = json_loader::from_string(
                          "  {\n"
@@ -64,7 +65,7 @@ TEST_CASE( "line_attack", "[magic]" )
     // set up Character to test with, only need position
     npc &c = spawn_npc( point_bub_ms::zero, "test_talker" );
     clear_character( c );
-    c.setpos( tripoint_bub_ms::zero );
+    c.setpos( here, tripoint_bub_ms::zero );
 
     // target point 5 tiles east of zero
     tripoint_bub_ms target = c.pos_bub() + tripoint_rel_ms::east * 5;
@@ -72,11 +73,11 @@ TEST_CASE( "line_attack", "[magic]" )
     // Ensure that AOE=0 spell covers the 5 tiles along vector towards target
     SECTION( "aoe=0" ) {
         const std::set<tripoint_bub_ms> reference( {
-            c.pos_bub() + tripoint_rel_ms::east * 1,
-            c.pos_bub() + tripoint_rel_ms::east * 2,
-            c.pos_bub() + tripoint_rel_ms::east * 3,
-            c.pos_bub() + tripoint_rel_ms::east * 4,
-            c.pos_bub() + tripoint_rel_ms::east * 5,
+            c.pos_bub( here ) + tripoint_rel_ms::east * 1,
+            c.pos_bub( here ) + tripoint_rel_ms::east * 2,
+            c.pos_bub( here ) + tripoint_rel_ms::east * 3,
+            c.pos_bub( here ) + tripoint_rel_ms::east * 4,
+            c.pos_bub( here ) + tripoint_rel_ms::east * 5,
         } );
 
         std::set<tripoint_bub_ms> targets = calculate_spell_effect_area( sp, target, c );

--- a/tests/magic_spell_test.cpp
+++ b/tests/magic_spell_test.cpp
@@ -534,6 +534,7 @@ TEST_CASE( "spell_area_of_effect", "[magic][spell][aoe]" )
 TEST_CASE( "spell_effect_-_target_attack", "[magic][spell][effect][target_attack]" )
 {
     // World setup
+    map &here = get_map();
     clear_map();
 
     // Locations for avatar and monster
@@ -548,7 +549,7 @@ TEST_CASE( "spell_effect_-_target_attack", "[magic][spell][effect][target_attack
     // Avatar/spellcaster
     avatar &dummy = get_avatar();
     clear_character( dummy );
-    dummy.setpos( dummy_loc );
+    dummy.setpos( here, dummy_loc );
     REQUIRE( dummy.pos_bub() == dummy_loc );
     REQUIRE( creatures.creature_at( dummy_loc ) );
     REQUIRE( g->num_creatures() == 1 );
@@ -600,7 +601,7 @@ TEST_CASE( "spell_effect_-_summon", "[magic][spell][effect][summon]" )
     avatar &dummy = get_avatar();
     creature_tracker &creatures = get_creature_tracker();
     clear_character( dummy );
-    dummy.setpos( dummy_loc );
+    dummy.setpos( here, dummy_loc );
     REQUIRE( dummy.pos_bub() == dummy_loc );
     REQUIRE( creatures.creature_at( dummy_loc ) );
     REQUIRE( g->num_creatures() == 1 );

--- a/tests/map_helpers.cpp
+++ b/tests/map_helpers.cpp
@@ -165,9 +165,10 @@ void clear_map( int zmin, int zmax )
 
 void clear_map_and_put_player_underground()
 {
+    map &here = get_map();
     clear_map();
     // Make sure the player doesn't block the path of the monster being tested.
-    get_player_character().setpos( tripoint_bub_ms{ 0, 0, -2 } );
+    get_player_character().setpos( here, tripoint_bub_ms{ 0, 0, -2 } );
 }
 
 monster &spawn_test_monster( const std::string &monster_type, const tripoint_bub_ms &start,

--- a/tests/map_test.cpp
+++ b/tests/map_test.cpp
@@ -92,7 +92,7 @@ TEST_CASE( "destroy_grabbed_furniture" )
     GIVEN( "Furniture grabbed by the player" ) {
         const tripoint_bub_ms test_origin( 60, 60, 0 );
         map &here = get_map();
-        player_character.setpos( test_origin );
+        player_character.setpos( here, test_origin );
         const tripoint_bub_ms grab_point = test_origin + tripoint::east;
         here.furn_set( grab_point, furn_id( "f_chair" ) );
         player_character.grab( object_type::FURNITURE, tripoint_rel_ms::east );
@@ -290,10 +290,10 @@ TEST_CASE( "milk_rotting", "[active_item][map]" )
 
 TEST_CASE( "active_monster_drops", "[active_item][map]" )
 {
-    clear_map();
-    get_avatar().setpos( tripoint_bub_ms::zero );
-    tripoint_bub_ms start_loc = get_avatar().pos_bub() + tripoint::east;
     map &here = get_map();
+    clear_map();
+    get_avatar().setpos( here, tripoint_bub_ms::zero );
+    tripoint_bub_ms start_loc = get_avatar().pos_bub( here ) + tripoint::east;
     restore_on_out_of_scope restore_temp(
         get_weather().forced_temperature );
     get_weather().forced_temperature = units::from_celsius( 21 );

--- a/tests/mapgen_remove_npcs_test.cpp
+++ b/tests/mapgen_remove_npcs_test.cpp
@@ -74,7 +74,7 @@ TEST_CASE( "mapgen_remove_npcs" )
         clear_map();
         clear_avatar();
         tripoint_bub_ms const start_loc( HALF_MAPSIZE_X + SEEX - 2, HALF_MAPSIZE_Y + SEEY - 1, 0 );
-        get_avatar().setpos( start_loc );
+        get_avatar().setpos( here, start_loc );
         clear_npcs();
         set_time( calendar::turn_zero + 12_hours );
 
@@ -90,7 +90,7 @@ TEST_CASE( "mapgen_remove_npcs" )
         place_npc_and_check( here, loc2, update_mapgen_test_update_place_npc,
                              npc_template_test_npc_trader );
         REQUIRE( overmap_buffer.get_npcs_near_omt( omt2, 0 ).size() == 1 );
-        REQUIRE( get_avatar().sees( loc, true ) );
+        REQUIRE( get_avatar().sees( here, loc, true ) );
 
         WHEN( "removing NPC" ) {
             remove_npc_and_check( here, loc, update_mapgen_test_update_remove_npc,

--- a/tests/mapgen_remove_vehicles_test.cpp
+++ b/tests/mapgen_remove_vehicles_test.cpp
@@ -97,7 +97,7 @@ TEST_CASE( "mapgen_remove_vehicles" )
     clear_avatar();
     // this position should prevent pointless mapgen
     tripoint_bub_ms const start_loc( HALF_MAPSIZE_X + SEEX - 2, HALF_MAPSIZE_Y + SEEY - 1, 0 );
-    get_avatar().setpos( start_loc );
+    get_avatar().setpos( here, start_loc );
     clear_map();
     REQUIRE( here.get_vehicles().empty() );
 

--- a/tests/modify_morale_test.cpp
+++ b/tests/modify_morale_test.cpp
@@ -131,7 +131,7 @@ TEST_CASE( "dining_with_table_and_chair", "[food][modify_morale][table][chair]" 
     avatar dummy;
     dummy.set_body();
     const tripoint_bub_ms avatar_pos( 60, 60, 0 );
-    dummy.setpos( avatar_pos );
+    dummy.setpos( here, avatar_pos );
     dummy.worn.wear_item( dummy, item( itype_backpack ), false, false );
 
     // Morale bonus only applies to unspoiled food that is not junk

--- a/tests/monster_attack_test.cpp
+++ b/tests/monster_attack_test.cpp
@@ -74,6 +74,7 @@ static void reset_caches( int a_zlev, int t_zlev )
 static void test_monster_attack( const tripoint &target_offset, bool expect_attack,
                                  bool expect_vision, bool( *special_attack )( monster *x ) = nullptr )
 {
+    map &here = get_map();
     int day_hour = hour_of_day<int>( calendar::turn );
     CAPTURE( day_hour );
     REQUIRE( is_day( calendar::turn ) );
@@ -87,14 +88,14 @@ static void test_monster_attack( const tripoint &target_offset, bool expect_atta
     int t_zlev = target_location.z();
     Character &you = get_player_character();
     clear_avatar();
-    you.setpos( target_location );
+    you.setpos( here, target_location );
     monster &test_monster = spawn_test_monster( monster_type, attacker_location );
     test_monster.set_dest( you.pos_abs() );
     reset_caches( a_zlev, t_zlev );
     // Trigger basic attack.
     CAPTURE( attacker_location );
     CAPTURE( target_location );
-    CHECK( test_monster.sees( target_location ) == expect_vision );
+    CHECK( test_monster.sees( here, target_location ) == expect_vision );
     if( special_attack == nullptr ) {
         CHECK( test_monster.attack_at( target_location ) == expect_attack );
     } else {
@@ -103,10 +104,10 @@ static void test_monster_attack( const tripoint &target_offset, bool expect_atta
     // Then test the reverse.
     clear_creatures();
     clear_avatar();
-    you.setpos( attacker_location );
+    you.setpos( here, attacker_location );
     monster &target_monster = spawn_test_monster( monster_type, target_location );
     reset_caches( a_zlev, t_zlev );
-    CHECK( you.sees( target_monster ) == expect_vision );
+    CHECK( you.sees( here, target_monster ) == expect_vision );
     if( special_attack == nullptr ) {
         CHECK( you.melee_attack( target_monster, false ) == expect_attack );
     }
@@ -204,7 +205,7 @@ TEST_CASE( "monster_throwing_sanity_test", "[throwing],[balance]" )
     clear_avatar();
     you.set_dodges_left( 1 ) ;
     REQUIRE( Approx( you.get_dodge() ) == 4.0 );
-    you.setpos( target_location );
+    you.setpos( here, target_location );
     const tripoint_abs_ms abs_target_location = you.pos_abs();
     reset_caches( target_location.z(), target_location.z() );
     REQUIRE( g->natural_light_level( 0 ) > 50.0 );
@@ -218,11 +219,11 @@ TEST_CASE( "monster_throwing_sanity_test", "[throwing],[balance]" )
         test_monster.set_dest( you.pos_abs() );
         const mtype_special_attack &attack = test_monster.type->special_attacks.at( "gun" );
         REQUIRE( test_monster.get_dest() == abs_target_location );
-        REQUIRE( test_monster.sees( target_location ) );
+        REQUIRE( test_monster.sees( here, target_location ) );
         Creature *target = test_monster.attack_target();
         REQUIRE( target );
-        REQUIRE( test_monster.sees( *target ) );
-        REQUIRE( rl_dist( test_monster.pos_bub(), target->pos_bub() ) <= 5 );
+        REQUIRE( test_monster.sees( here, *target ) );
+        REQUIRE( rl_dist( test_monster.pos_abs(), target->pos_abs() ) <= 5 );
         statistics<int> damage_dealt;
         statistics<bool> hits;
         epsilon_threshold threshold{ expected_damage, 2.5 };
@@ -255,12 +256,13 @@ TEST_CASE( "monster_throwing_sanity_test", "[throwing],[balance]" )
 
 TEST_CASE( "Mattack_dialog_condition_test", "[mattack]" )
 {
+    map &here = get_map();
     clear_map();
     clear_creatures();
     const tripoint_bub_ms target_location = attacker_location + tripoint::east;
     Character &you = get_player_character();
     clear_avatar();
-    you.setpos( target_location );
+    you.setpos( here, target_location );
     const std::string monster_type = "mon_test_mattack_dialog";
     monster &test_monster = spawn_test_monster( monster_type, attacker_location );
     test_monster.set_dest( you.pos_abs() );
@@ -307,7 +309,7 @@ TEST_CASE( "Targeted_grab_removal_test", "[mattack][grab]" )
     clear_creatures();
     Character &you = get_player_character();
     clear_avatar();
-    you.setpos( target_location );
+    you.setpos( here, target_location );
 
     monster &test_monster_left = spawn_test_monster( grabber_left, attacker_location_e );
     monster &test_monster_right = spawn_test_monster( grabber_right, attacker_location );
@@ -338,6 +340,8 @@ TEST_CASE( "Targeted_grab_removal_test", "[mattack][grab]" )
 
 TEST_CASE( "Ranged_pull_tests", "[mattack][grab]" )
 {
+    map &here = get_map();
+
     // Set up further from the target
     const tripoint_bub_ms target_location = attacker_location + tripoint{ 4, 0, 0 };
     clear_map();
@@ -347,14 +351,14 @@ TEST_CASE( "Ranged_pull_tests", "[mattack][grab]" )
     clear_creatures();
     Character &you = get_player_character();
     clear_avatar();
-    you.setpos( target_location );
+    you.setpos( here, target_location );
     REQUIRE( units::to_gram<int>( you.get_weight() ) > 50000 );
 
     SECTION( "Weak puller" ) {
         const std::string monster_type = "mon_debug_puller_weak";
         monster &test_monster = spawn_test_monster( monster_type, attacker_location );
         test_monster.set_dest( you.pos_abs() );
-        REQUIRE( test_monster.sees( you ) );
+        REQUIRE( test_monster.sees( here,  you ) );
         const mattack_actor &attack = test_monster.type->special_attacks.at( "ranged_pull" ).operator * ();
         REQUIRE( units::to_gram<int>( test_monster.get_weight() ) == 100000 );
         // Fail to pull our too-chonky survivor
@@ -372,7 +376,7 @@ TEST_CASE( "Ranged_pull_tests", "[mattack][grab]" )
         const std::string monster_type = "mon_debug_puller_strong";
         monster &test_monster = spawn_test_monster( monster_type, attacker_location );
         test_monster.set_dest( you.pos_abs() );
-        REQUIRE( test_monster.sees( you ) );
+        REQUIRE( test_monster.sees( here,  you ) );
         const mattack_actor &attack = test_monster.type->special_attacks.at( "ranged_pull" ).operator * ();
         REQUIRE( units::to_gram<int>( test_monster.get_weight() ) == 100000 );
         // Pull on the first try
@@ -383,7 +387,7 @@ TEST_CASE( "Ranged_pull_tests", "[mattack][grab]" )
         const std::string monster_type = "mon_debug_puller_incompetent";
         monster &test_monster = spawn_test_monster( monster_type, attacker_location );
         test_monster.set_dest( you.pos_abs() );
-        REQUIRE( test_monster.sees( you ) );
+        REQUIRE( test_monster.sees( here, you ) );
         const mattack_actor &attack = test_monster.type->special_attacks.at( "ranged_pull" ).operator * ();
         // Can't pull, fail silently
         REQUIRE( !attack.call( test_monster ) );
@@ -398,7 +402,7 @@ TEST_CASE( "Ranged_pull_tests", "[mattack][grab]" )
         const mattack_actor &grab = test_grabber.type->special_attacks.at( "grab" ).operator * ();
         test_monster.set_dest( you.pos_abs() );
         test_grabber.set_dest( you.pos_abs() );
-        REQUIRE( test_monster.sees( you ) );
+        REQUIRE( test_monster.sees( here, you ) );
         REQUIRE( grab.call( test_grabber ) );
         int counter = 0;
         // Pull until the grabber lets go, it should eventually do so
@@ -412,12 +416,13 @@ TEST_CASE( "Ranged_pull_tests", "[mattack][grab]" )
 
 TEST_CASE( "Grab_drag_tests", "[mattack][grab][drag]" )
 {
+    map &here = get_map();
     const tripoint_bub_ms target_location = attacker_location + tripoint::east;
     clear_map();
     clear_creatures();
     Character &you = get_player_character();
     clear_avatar();
-    you.setpos( target_location );
+    you.setpos( here, target_location );
 
     const std::string monster_type = "mon_debug_dragger";
     monster &test_monster = spawn_test_monster( monster_type, attacker_location );
@@ -425,7 +430,7 @@ TEST_CASE( "Grab_drag_tests", "[mattack][grab][drag]" )
     const mattack_actor &attack_1 = test_monster.type->special_attacks.at( "grab_drag" ).operator * ();
     const mattack_actor &attack_2 = test_monster.type->special_attacks.at( "drag_followup" ).operator
                                     * ();
-    REQUIRE( test_monster.sees( you ) );
+    REQUIRE( test_monster.sees( here, you ) );
     // We're not too chonk
     REQUIRE( test_monster.get_weight() * 1.5f > you.get_weight() );
     // We fail to get dragged by the followup
@@ -444,6 +449,7 @@ TEST_CASE( "Grab_drag_tests", "[mattack][grab][drag]" )
 
 TEST_CASE( "Unified_grab_break_test", "[mattack][grab]" )
 {
+    map &here = get_map();
     const tripoint_bub_ms target_location = attacker_location + tripoint::east;
     const tripoint_bub_ms attacker_location_2 = target_location + tripoint::north;
     const tripoint_bub_ms attacker_location_3 = target_location + tripoint::east;
@@ -459,7 +465,7 @@ TEST_CASE( "Unified_grab_break_test", "[mattack][grab]" )
     clear_creatures();
     Character &you = get_player_character();
     clear_avatar();
-    you.setpos( target_location );
+    you.setpos( here, target_location );
 
     SECTION( "Fresh character against 1 weak grab" ) {
         monster_type = "mon_debug_grabber";

--- a/tests/monster_vision_test.cpp
+++ b/tests/monster_vision_test.cpp
@@ -23,6 +23,8 @@ static const time_point midday = calendar::turn_zero + 12_hours;
 
 TEST_CASE( "monsters_should_not_see_through_floors", "[vision]" )
 {
+    const map &here = get_map();
+
     calendar::turn = midday;
     clear_map( -2, 1 );
     monster &upper = spawn_and_clear( { 5, 5, 0 }, true );
@@ -34,41 +36,41 @@ TEST_CASE( "monsters_should_not_see_through_floors", "[vision]" )
 
     // First check monsters whose vision should be blocked by floors.
     // One intervening floor between monsters.
-    CHECK( !upper.sees( lower ) );
-    CHECK( !lower.sees( upper ) );
+    CHECK( !upper.sees( here, lower ) );
+    CHECK( !lower.sees( here, upper ) );
     // Two intervening floors between monsters.
-    CHECK( !upper.sees( deep ) );
-    CHECK( !deep.sees( upper ) );
+    CHECK( !upper.sees( here, deep ) );
+    CHECK( !deep.sees( here,  upper ) );
     // One intervening floor and an open space between monsters.
-    CHECK( !sky.sees( lower ) );
-    CHECK( !lower.sees( sky ) );
+    CHECK( !sky.sees( here, lower ) );
+    CHECK( !lower.sees( here, sky ) );
     // One intervening floor between monsters, and offset one tile horizontally.
-    CHECK( !adjacent.sees( lower ) );
-    CHECK( !lower.sees( adjacent ) );
+    CHECK( !adjacent.sees( here, lower ) );
+    CHECK( !lower.sees( here,  adjacent ) );
     // One intervening floor between monsters, and offset two tiles horizontally.
-    CHECK( !distant.sees( lower ) );
-    CHECK( !lower.sees( distant ) );
+    CHECK( !distant.sees( here, lower ) );
+    CHECK( !lower.sees( here, distant ) );
     // Two intervening floors between monsters, and offset one tile horizontally.
-    CHECK( !adjacent.sees( deep ) );
-    CHECK( !deep.sees( adjacent ) );
+    CHECK( !adjacent.sees( here,  deep ) );
+    CHECK( !deep.sees( here, adjacent ) );
     // Two intervening floor between monsters, and offset two tiles horizontally.
-    CHECK( !distant.sees( deep ) );
-    CHECK( !deep.sees( distant ) );
+    CHECK( !distant.sees( here, deep ) );
+    CHECK( !deep.sees( here,  distant ) );
 
     // Then cases where they should be able to see each other.
     // No floor between monsters
-    CHECK( upper.sees( sky ) );
-    CHECK( sky.sees( upper ) );
+    CHECK( upper.sees( here, sky ) );
+    CHECK( sky.sees( here, upper ) );
     // Adjacent monsters.
-    CHECK( upper.sees( adjacent ) );
-    CHECK( adjacent.sees( upper ) );
+    CHECK( upper.sees( here, adjacent ) );
+    CHECK( adjacent.sees( here, upper ) );
     // distant monsters.
-    CHECK( upper.sees( distant ) );
-    CHECK( distant.sees( upper ) );
+    CHECK( upper.sees( here, distant ) );
+    CHECK( distant.sees( here, upper ) );
     // One intervening vertical tile and one intervening horizontal tile.
-    CHECK( sky.sees( adjacent ) );
-    CHECK( adjacent.sees( sky ) );
+    CHECK( sky.sees( here, adjacent ) );
+    CHECK( adjacent.sees( here, sky ) );
     // One intervening vertical tile and two intervening horizontal tiles.
-    CHECK( sky.sees( distant ) );
-    CHECK( distant.sees( sky ) );
+    CHECK( sky.sees( here, distant ) );
+    CHECK( distant.sees( here, sky ) );
 }

--- a/tests/morale_test.cpp
+++ b/tests/morale_test.cpp
@@ -218,6 +218,7 @@ TEST_CASE( "player_morale_killed_innocent_affected_by_prozac", "[player_morale]"
 
 TEST_CASE( "player_morale_murdered_innocent", "[player_morale]" )
 {
+    map &here = get_map();
     clear_avatar();
     Character &player = get_player_character();
     player_morale &m = *player.morale;
@@ -226,7 +227,7 @@ TEST_CASE( "player_morale_murdered_innocent", "[player_morale]" )
     // Innocent as could be.
     faction_id lapin( "lapin" );
     innocent.set_fac( lapin );
-    innocent.setpos( next_to );
+    innocent.setpos( here, next_to );
     innocent.set_all_parts_hp_cur( 1 );
     CHECK( m.get_total_positive_value() == 0 );
     CHECK( m.get_total_negative_value() == 0 );
@@ -242,6 +243,7 @@ TEST_CASE( "player_morale_murdered_innocent", "[player_morale]" )
 
 TEST_CASE( "player_morale_kills_hostile_bandit", "[player_morale]" )
 {
+    map &here = get_map();
     clear_avatar();
     Character &player = get_player_character();
     player_morale &m = *player.morale;
@@ -250,7 +252,7 @@ TEST_CASE( "player_morale_kills_hostile_bandit", "[player_morale]" )
     // Always-hostile
     faction_id hells_raiders( "hells_raiders" );
     badguy.set_fac( hells_raiders );
-    badguy.setpos( next_to );
+    badguy.setpos( here, next_to );
     badguy.set_all_parts_hp_cur( 1 );
     CHECK( m.get_total_positive_value() == 0 );
     CHECK( m.get_total_negative_value() == 0 );
@@ -279,12 +281,12 @@ TEST_CASE( "player_morale_ranged_kill_of_unaware_hostile_bandit", "[player_moral
     CHECK( m.get_total_positive_value() == 0 );
     CHECK( m.get_total_negative_value() == 0 );
     CHECK( badguy.guaranteed_hostile() == true );
-    CHECK( badguy.sees( player.pos_bub() ) == false );
+    CHECK( badguy.sees( here,  player.pos_bub( here ) ) == false );
     for( size_t loop = 0; loop < 1000; loop++ ) {
         player.set_body();
         arm_shooter( player, itype_shotgun_s );
         player.recoil = 0;
-        player.fire_gun( &here, bandit_pos, 1, *player.get_wielded_item() );
+        player.fire_gun( here, bandit_pos, 1, *player.get_wielded_item() );
         if( badguy.is_dead_state() ) {
             break;
         }

--- a/tests/npc_attack_test.cpp
+++ b/tests/npc_attack_test.cpp
@@ -50,14 +50,15 @@ namespace npc_attack_setup
 {
 static npc &spawn_main_npc()
 {
+    map &here = get_map();
     creature_tracker &creatures = get_creature_tracker();
-    get_player_character().setpos( { main_npc_start, -1 } );
+    get_player_character().setpos( here, { main_npc_start, -1 } );
     REQUIRE( creatures.creature_at<Creature>( main_npc_start_tripoint ) == nullptr );
-    const character_id model_id = get_map().place_npc( main_npc_start, npc_template_test_talker );
+    const character_id model_id = here.place_npc( main_npc_start, npc_template_test_talker );
 
     npc &model_npc = *g->find_npc( model_id );
     clear_character( model_npc );
-    model_npc.setpos( main_npc_start_tripoint );
+    model_npc.setpos( here, main_npc_start_tripoint );
 
     g->load_npcs();
 
@@ -83,7 +84,9 @@ static monster *spawn_zombie_at_range( const int range )
 
 TEST_CASE( "NPC_faces_zombies", "[npc_attack]" )
 {
-    get_player_character().setpos( main_npc_start_tripoint );
+    map &here = get_map();
+
+    get_player_character().setpos( here, main_npc_start_tripoint );
     clear_map_and_put_player_underground();
     clear_vehicles();
     scoped_weather_override sunny_weather( weather_sunny );

--- a/tests/npc_behavior_rules_test.cpp
+++ b/tests/npc_behavior_rules_test.cpp
@@ -39,6 +39,7 @@ static const vproto_id vehicle_prototype_locked_as_hell_car( "locked_as_hell_car
 static shared_ptr_fast<npc> setup_generic_rules_test( ally_rule rule_to_test,
         update_mapgen_id update_mapgen_id_to_apply )
 {
+    map &here = get_map();
     clear_map();
     clear_vehicles();
     clear_avatar();
@@ -49,7 +50,7 @@ static shared_ptr_fast<npc> setup_generic_rules_test( ally_rule rule_to_test,
     overmap_buffer.insert_npc( guy );
     g->load_npcs();
     clear_character( *guy );
-    guy->setpos( next_to );
+    guy->setpos( here, next_to );
     talk_function::follow( *guy );
     // rules don't work unless they're an ally.
     REQUIRE( guy->is_player_ally() );
@@ -234,7 +235,7 @@ TEST_CASE( "NPC-rules-avoid-locks", "[npc_rules]" )
     REQUIRE( ( door_lock->is_available() && door_lock->locked ) );
 
 
-    test_subject->setpos( car_door_unlock_pos );
+    test_subject->setpos( here, car_door_unlock_pos );
     here.board_vehicle( car_door_unlock_pos, &*test_subject );
 
     CHECK( doors::can_unlock_door( here, *test_subject, car_door_pos ) );

--- a/tests/npc_talk_test.cpp
+++ b/tests/npc_talk_test.cpp
@@ -143,6 +143,7 @@ static void change_om_type( const std::string &new_type )
 
 static npc &prep_test( dialogue &d, bool shopkeep = false )
 {
+    map &here = get_map();
     clear_avatar();
     clear_vehicles();
     clear_map();
@@ -152,7 +153,7 @@ static npc &prep_test( dialogue &d, bool shopkeep = false )
     REQUIRE_FALSE( player_character.in_vehicle );
 
     const tripoint_bub_ms test_origin( 15, 15, 0 );
-    player_character.setpos( test_origin );
+    player_character.setpos( here, test_origin );
 
     g->faction_manager_ptr->create_if_needed();
 
@@ -1058,6 +1059,8 @@ TEST_CASE( "npc_test_tags", "[npc_talk]" )
 
 TEST_CASE( "npc_compare_int", "[npc_talk]" )
 {
+    map &here = get_map();
+
     calendar::turn = calendar::turn_zero;
     calendar::start_of_cataclysm = calendar::turn_zero;
     calendar::start_of_game = calendar::turn_zero;
@@ -1139,7 +1142,7 @@ TEST_CASE( "npc_compare_int", "[npc_talk]" )
     get_weather().weather_precise->humidity = 16;
     get_weather().weather_precise->pressure = 17;
     get_weather().clear_temp_cache();
-    player_character.setpos( tripoint_bub_ms{ -1, -2, -3 } );
+    player_character.setpos( here, tripoint_bub_ms{ -1, -2, -3 } );
     player_character.set_pain( 21 );
     player_character.add_bionic( bio_power_storage );
     player_character.set_power_level( 22_mJ );

--- a/tests/npc_test.cpp
+++ b/tests/npc_test.cpp
@@ -341,6 +341,8 @@ static void check_npc_movement( const tripoint_bub_ms &origin )
 
 static npc *make_companion( const tripoint_bub_ms &npc_pos )
 {
+    map &here = get_map();
+
     shared_ptr_fast<npc> guy = make_shared_fast<npc>();
     guy->normalize();
     guy->randomize();
@@ -350,7 +352,7 @@ static npc *make_companion( const tripoint_bub_ms &npc_pos )
     guy->companion_mission_role_id.clear();
     guy->guard_pos = std::nullopt;
     clear_character( *guy );
-    guy->setpos( npc_pos );
+    guy->setpos( here, npc_pos );
     talk_function::follow( *guy );
 
     return get_creature_tracker().creature_at<npc>( npc_pos );

--- a/tests/player_activities_test.cpp
+++ b/tests/player_activities_test.cpp
@@ -208,43 +208,43 @@ TEST_CASE( "safecracking", "[activity][safecracking]" )
     }
 
     SECTION( "safecracking tools test" ) {
+        map &here = get_map();
         clear_avatar();
         clear_map();
 
         tripoint_bub_ms safe;
-        dummy.setpos( safe + tripoint::east );
+        dummy.setpos( here, safe + tripoint::east );
 
-        map &mp = get_map();
         dummy.activity = player_activity( safecracking_activity_actor( safe ) );
         dummy.activity.start_or_resume( dummy, false );
 
         GIVEN( "player without the required tools" ) {
-            mp.furn_set( safe, furn_f_safe_l );
+            here.furn_set( safe, furn_f_safe_l );
             REQUIRE( !dummy.cache_has_item_with( flag_SAFECRACK ) );
             REQUIRE( !dummy.has_flag( json_flag_SAFECRACK_NO_TOOL ) );
             REQUIRE( dummy.activity.id() == ACT_CRACKING );
-            REQUIRE( mp.furn( safe ) == furn_f_safe_l );
+            REQUIRE( here.furn( safe ) == furn_f_safe_l );
 
             WHEN( "player tries safecracking" ) {
                 process_activity( dummy );
                 THEN( "activity is canceled" ) {
-                    CHECK( mp.furn( safe ) == furn_f_safe_l );
+                    CHECK( here.furn( safe ) == furn_f_safe_l );
                 }
             }
         }
 
         GIVEN( "player has a stethoscope" ) {
             dummy.i_add( item( itype_stethoscope ) );
-            mp.furn_set( safe, furn_f_safe_l );
+            here.furn_set( safe, furn_f_safe_l );
             REQUIRE( dummy.cache_has_item_with( flag_SAFECRACK ) );
             REQUIRE( !dummy.has_flag( json_flag_SAFECRACK_NO_TOOL ) );
             REQUIRE( dummy.activity.id() == ACT_CRACKING );
-            REQUIRE( mp.furn( safe ) == furn_f_safe_l );
+            REQUIRE( here.furn( safe ) == furn_f_safe_l );
 
             WHEN( "player completes the safecracking activity" ) {
                 process_activity( dummy );
                 THEN( "safe is unlocked" ) {
-                    CHECK( mp.furn( safe ) == furn_f_safe_c );
+                    CHECK( here.furn( safe ) == furn_f_safe_c );
                 }
             }
         }
@@ -253,16 +253,16 @@ TEST_CASE( "safecracking", "[activity][safecracking]" )
             dummy.clear_worn();
             dummy.remove_weapon();
             dummy.add_bionic( bio_ears );
-            mp.furn_set( safe, furn_f_safe_l );
+            here.furn_set( safe, furn_f_safe_l );
             REQUIRE( !dummy.cache_has_item_with( flag_SAFECRACK ) );
             REQUIRE( dummy.has_flag( json_flag_SAFECRACK_NO_TOOL ) );
             REQUIRE( dummy.activity.id() == ACT_CRACKING );
-            REQUIRE( mp.furn( safe ) == furn_f_safe_l );
+            REQUIRE( here.furn( safe ) == furn_f_safe_l );
 
             WHEN( "player completes the safecracking activity" ) {
                 process_activity( dummy );
                 THEN( "safe is unlocked" ) {
-                    CHECK( mp.furn( safe ) == furn_f_safe_c );
+                    CHECK( here.furn( safe ) == furn_f_safe_c );
                 }
             }
         }
@@ -270,11 +270,11 @@ TEST_CASE( "safecracking", "[activity][safecracking]" )
         GIVEN( "player has a stethoscope" ) {
             dummy.clear_bionics();
             dummy.i_add( item( itype_stethoscope ) );
-            mp.furn_set( safe, furn_f_safe_l );
+            here.furn_set( safe, furn_f_safe_l );
             REQUIRE( dummy.cache_has_item_with( flag_SAFECRACK ) );
             REQUIRE( !dummy.has_flag( json_flag_SAFECRACK_NO_TOOL ) );
             REQUIRE( dummy.activity.id() == ACT_CRACKING );
-            REQUIRE( mp.furn( safe ) == furn_f_safe_l );
+            REQUIRE( here.furn( safe ) == furn_f_safe_l );
 
             WHEN( "player is safecracking" ) {
                 dummy.mod_moves( dummy.get_speed() );
@@ -289,7 +289,7 @@ TEST_CASE( "safecracking", "[activity][safecracking]" )
 
                     process_activity( dummy );
                     THEN( "activity is canceled" ) {
-                        CHECK( mp.furn( safe ) == furn_f_safe_l );
+                        CHECK( here.furn( safe ) == furn_f_safe_l );
                     }
                 }
             }
@@ -297,6 +297,7 @@ TEST_CASE( "safecracking", "[activity][safecracking]" )
     }
 
     SECTION( "safecracking proficiency test" ) {
+        map &here = get_map();
 
         auto get_safecracking_time = [&dummy]() -> time_duration {
             const std::vector<display_proficiency> profs = dummy.display_proficiencies();
@@ -315,18 +316,17 @@ TEST_CASE( "safecracking", "[activity][safecracking]" )
         clear_map();
 
         tripoint_bub_ms safe;
-        dummy.setpos( safe + tripoint::east );
+        dummy.setpos( here, safe + tripoint::east );
 
-        map &mp = get_map();
         dummy.activity = player_activity( safecracking_activity_actor( safe ) );
         dummy.activity.start_or_resume( dummy, false );
 
         GIVEN( "player cracks one safe" ) {
             dummy.i_add( item( itype_stethoscope ) );
-            mp.furn_set( safe, furn_f_safe_l );
+            here.furn_set( safe, furn_f_safe_l );
             REQUIRE( dummy.cache_has_item_with( flag_SAFECRACK ) );
             REQUIRE( dummy.activity.id() == ACT_CRACKING );
-            REQUIRE( mp.furn( safe ) == furn_f_safe_l );
+            REQUIRE( here.furn( safe ) == furn_f_safe_l );
 
             REQUIRE( !dummy.has_proficiency( proficiency_prof_safecracking ) );
 
@@ -336,7 +336,7 @@ TEST_CASE( "safecracking", "[activity][safecracking]" )
             const time_duration time_before = get_safecracking_time();
 
             process_activity( dummy );
-            REQUIRE( mp.furn( safe ) == furn_f_safe_c );
+            REQUIRE( here.furn( safe ) == furn_f_safe_c );
             THEN( "proficiency given is less than 90 minutes" ) {
                 const time_duration time_after = get_safecracking_time();
                 REQUIRE( time_after > 0_seconds );
@@ -2061,7 +2061,7 @@ TEST_CASE( "activity_interruption_by_distractions", "[activity][interruption]" )
             monster &zombie = spawn_test_monster( mon_zombie.str(), zombie_pos_far );
             update_cache( m );
 
-            REQUIRE( dummy.sees( zombie ) );
+            REQUIRE( dummy.sees( m, zombie ) );
 
             std::map<distraction_type, std::string> dists = dummy.activity.get_distractions();
 
@@ -2088,7 +2088,7 @@ TEST_CASE( "activity_interruption_by_distractions", "[activity][interruption]" )
             monster &zombie = spawn_test_monster( mon_zombie.str(), zombie_pos_near );
             update_cache( m );
 
-            REQUIRE( !dummy.sees( zombie ) );
+            REQUIRE( !dummy.sees( m, zombie ) );
 
             std::map<distraction_type, std::string> dists = dummy.activity.get_distractions();
 

--- a/tests/player_helpers.cpp
+++ b/tests/player_helpers.cpp
@@ -77,6 +77,8 @@ bool character_has_item_with_var_val( const Character &they, const std::string &
 
 void clear_character( Character &dummy, bool skip_nutrition )
 {
+    map &here = get_map();
+
     dummy.set_body();
     dummy.normalize(); // In particular this clears martial arts style
 
@@ -154,7 +156,7 @@ void clear_character( Character &dummy, bool skip_nutrition )
     dummy.cash = 0;
 
     const tripoint_bub_ms spot( 60, 60, 0 );
-    dummy.setpos( spot );
+    dummy.setpos( here, spot );
     dummy.clear_values();
     dummy.magic = pimpl<known_magic>();
     dummy.forget_all_recipes();

--- a/tests/projectile_test.cpp
+++ b/tests/projectile_test.cpp
@@ -48,7 +48,7 @@ TEST_CASE( "projectiles_through_obstacles", "[projectile]" )
     creature_tracker &creatures = get_creature_tracker();
 
     // Move the player out of the way of the test area
-    get_player_character().setpos( tripoint_bub_ms{ 2, 2, 0 } );
+    get_player_character().setpos( here, tripoint_bub_ms{ 2, 2, 0 } );
 
     // Ensure that a projectile fired from a gun can pass through a chain link fence
     // First, set up a test area - three tiles in a row

--- a/tests/ranged_balance_test.cpp
+++ b/tests/ranged_balance_test.cpp
@@ -510,7 +510,7 @@ static void shoot_monster( const itype_id &gun_type, const std::vector<itype_id>
         shooter->recoil = 0;
         monster &mon = spawn_test_monster( monster_type, monster_pos, false );
         const int prev_HP = mon.get_hp();
-        shooter->fire_gun( &here, monster_pos, 1, *shooter->get_wielded_item() );
+        shooter->fire_gun( here, monster_pos, 1, *shooter->get_wielded_item() );
         damage.add( prev_HP - mon.get_hp() );
         if( other_checks ) {
             other_check_success += other_checks( *shooter, mon );

--- a/tests/reload_time_test.cpp
+++ b/tests/reload_time_test.cpp
@@ -42,7 +42,7 @@ static void check_reload_time( const itype_id &weapon, const itype_id &ammo,
     clear_map();
     avatar &shooter = get_avatar();
     g->place_critter_at( pseudo_debug_mon, spot );
-    shooter.setpos( test_origin );
+    shooter.setpos( here, test_origin );
     shooter.set_wielded_item( item( weapon, calendar::turn_zero, 0 ) );
     if( container.is_null() ) {
         get_map().add_item( test_origin, item( ammo ) );
@@ -64,7 +64,7 @@ static void check_reload_time( const itype_id &weapon, const itype_id &ammo,
     CAPTURE( shooter.used_weapon()->get_reload_time() );
     aim_activity_actor act = aim_activity_actor::use_wielded();
     int moves_before = shooter.get_moves();
-    REQUIRE( shooter.fire_gun( &here, spot, 1, *shooter.used_weapon(), shooter.ammo_location ) );
+    REQUIRE( shooter.fire_gun( here, spot, 1, *shooter.used_weapon(), shooter.ammo_location ) );
     int moves_after = shooter.get_moves();
     int spent_moves = moves_before - moves_after;
     int expected_upper = expected_moves * 1.05;

--- a/tests/reloading_test.cpp
+++ b/tests/reloading_test.cpp
@@ -1171,7 +1171,7 @@ TEST_CASE( "reload_liquid_container", "[reload],[liquid]" )
     SECTION( "liquid reload from map" ) {
         const tripoint_bub_ms test_origin( 60, 60, 0 );
         map &here = get_map();
-        dummy.setpos( test_origin );
+        dummy.setpos( here, test_origin );
         const tripoint_bub_ms near_point = test_origin + tripoint::east;
 
         SECTION( "liquid in container on floor" ) {

--- a/tests/throwing_test.cpp
+++ b/tests/throwing_test.cpp
@@ -13,6 +13,7 @@
 #include "game.h"
 #include "game_constants.h"
 #include "item.h"
+#include "map.h"
 #include "map_helpers.h"
 #include "monster.h"
 #include "npc.h"
@@ -61,9 +62,10 @@ static std::ostream &operator<<( std::ostream &stream, const throw_test_pstats &
 static void reset_player( Character &you, const throw_test_pstats &pstats,
                           const tripoint_bub_ms &pos )
 {
+    map &here = get_map();
     clear_character( you );
     CHECK( !you.in_vehicle );
-    you.setpos( pos );
+    you.setpos( here, pos );
     you.str_max = pstats.str;
     you.dex_max = pstats.dex;
     you.per_max = pstats.per;

--- a/tests/vehicle_drag_test.cpp
+++ b/tests/vehicle_drag_test.cpp
@@ -25,6 +25,7 @@ static const efftype_id effect_blind( "blind" );
 
 static void clear_game_drag( const ter_id &terrain )
 {
+    map &here = get_map();
     // Set to turn 0 to prevent solars from producing power
     calendar::turn = calendar::turn_zero;
     clear_creatures();
@@ -33,7 +34,7 @@ static void clear_game_drag( const ter_id &terrain )
     Character &player_character = get_player_character();
     // Move player somewhere safe
     CHECK( !player_character.in_vehicle );
-    player_character.setpos( tripoint_bub_ms::zero );
+    player_character.setpos( here, tripoint_bub_ms::zero );
     // Blind the player to avoid needless drawing-related overhead
     player_character.add_effect( effect_blind, 1_turns, true );
     // Make sure the ST is 8 so that muscle powered results are consistent
@@ -41,7 +42,6 @@ static void clear_game_drag( const ter_id &terrain )
 
     build_test_map( terrain );
 
-    map &here = get_map();
     // hard force a rebuild of caches
     here.shift( point_rel_sm::south );
     here.shift( point_rel_sm::north );

--- a/tests/vehicle_efficiency_test.cpp
+++ b/tests/vehicle_efficiency_test.cpp
@@ -39,6 +39,7 @@ static const itype_id itype_battery( "battery" );
 
 static void clear_game( const ter_id &terrain )
 {
+    map &here = get_map();
     // Set to turn 0 to prevent solars from producing power
     calendar::turn = calendar::turn_zero;
     clear_creatures();
@@ -48,7 +49,7 @@ static void clear_game( const ter_id &terrain )
     Character &player_character = get_player_character();
     // Move player somewhere safe
     REQUIRE_FALSE( player_character.in_vehicle );
-    player_character.setpos( tripoint_bub_ms::zero );
+    player_character.setpos( here, tripoint_bub_ms::zero );
     // Blind the player to avoid needless drawing-related overhead
     player_character.add_effect( effect_blind, 1_turns, true );
 

--- a/tests/vehicle_fake_part_test.cpp
+++ b/tests/vehicle_fake_part_test.cpp
@@ -357,12 +357,12 @@ TEST_CASE( "fake_parts_are_opaque", "[vehicle][vehicle_fake]" )
     map &here = get_map();
     set_time_to_day();
 
-    REQUIRE( you.sees( you.pos_bub() + point( 10, 10 ) ) );
+    REQUIRE( you.sees( here, you.pos_bub( here ) + point( 10, 10 ) ) );
     vehicle *veh = here.add_vehicle( vehicle_prototype_test_van, test_origin, 315_degrees, 100, 0 );
     REQUIRE( veh != nullptr );
     here.set_seen_cache_dirty( 0 );
     here.build_map_cache( 0 );
-    CHECK( !you.sees( you.pos_bub() + point( 10, 10 ) ) );
+    CHECK( !you.sees( here, you.pos_bub( here ) + point( 10, 10 ) ) );
 }
 
 TEST_CASE( "open_and_close_fake_doors", "[vehicle][vehicle_fake]" )
@@ -388,7 +388,7 @@ TEST_CASE( "open_and_close_fake_doors", "[vehicle][vehicle_fake]" )
         if( vp.info().has_flag( "OPENABLE" ) && vp.part().is_fake ) {
             fakes_tested++;
             REQUIRE( !vp.part().open );
-            CHECK( can_interact_at( ACTION_OPEN, vp.pos_bub( here ) ) );
+            CHECK( can_interact_at( ACTION_OPEN, here, vp.pos_bub( here ) ) );
             int part_to_open = veh->next_part_to_open( vp.part_index() );
             // This should be the same part for this use case since there are no curtains etc.
             REQUIRE( part_to_open == static_cast<int>( vp.part_index() ) );
@@ -414,7 +414,7 @@ TEST_CASE( "open_and_close_fake_doors", "[vehicle][vehicle_fake]" )
             continue;
         }
         CAPTURE( prev_player_pos );
-        CAPTURE( you.pos_bub() );
+        CAPTURE( you.pos_bub( here ) );
         REQUIRE( veh->can_close( vp.part_index(), you ) );
         REQUIRE( veh->can_close( fake_door.part_index(), you ) );
         you.setpos( vp.pos_abs() );
@@ -425,7 +425,7 @@ TEST_CASE( "open_and_close_fake_doors", "[vehicle][vehicle_fake]" )
         you.setpos( fake_door.pos_abs() );
         CHECK( !veh->can_close( vp.part_index(), you ) );
         CHECK( !veh->can_close( fake_door.part_index(), you ) );
-        you.setpos( prev_player_pos );
+        you.setpos( here, prev_player_pos );
     }
 
     // Then scan through all the openables including fakes and assert that we can close them.
@@ -434,7 +434,7 @@ TEST_CASE( "open_and_close_fake_doors", "[vehicle][vehicle_fake]" )
         if( vp.info().has_flag( "OPENABLE" ) && vp.part().is_fake ) {
             fakes_tested++;
             CHECK( vp.part().open );
-            CHECK( can_interact_at( ACTION_CLOSE, vp.pos_bub( here ) ) );
+            CHECK( can_interact_at( ACTION_CLOSE, here, vp.pos_bub( here ) ) );
             int part_to_close = veh->next_part_to_close( vp.part_index() );
             // This should be the same part for this use case since there are no curtains etc.
             REQUIRE( part_to_close == static_cast<int>( vp.part_index() ) );

--- a/tests/vehicle_interact_test.cpp
+++ b/tests/vehicle_interact_test.cpp
@@ -49,7 +49,7 @@ static void test_repair( const std::vector<item> &tools, bool plug_in_tools, boo
 
     const tripoint_bub_ms test_origin( 60, 60, 0 );
     Character &player_character = get_player_character();
-    player_character.setpos( test_origin );
+    player_character.setpos( here, test_origin );
     const item debug_backpack( itype_debug_backpack );
     player_character.wear_item( debug_backpack );
 

--- a/tests/vehicle_power_test.cpp
+++ b/tests/vehicle_power_test.cpp
@@ -36,10 +36,12 @@ static const vproto_id vehicle_prototype_solar_panel_test( "solar_panel_test" );
 // TODO: Move this into player_helpers to avoid character include.
 static void reset_player()
 {
+    map &here = get_map();
+
     Character &player_character = get_player_character();
     // Move player somewhere safe
     REQUIRE( !player_character.in_vehicle );
-    player_character.setpos( tripoint_bub_ms::zero );
+    player_character.setpos( here, tripoint_bub_ms::zero );
     // Blind the player to avoid needless drawing-related overhead
     player_character.add_effect( effect_blind, 1_turns, true );
 }

--- a/tests/vehicle_ramp_test.cpp
+++ b/tests/vehicle_ramp_test.cpp
@@ -109,15 +109,15 @@ static void ramp_transition_angled( const vproto_id &veh_id, const units::angle 
     veh.tags.insert( "IN_CONTROL_OVERRIDE" );
     veh.engine_on = true;
     Character &player_character = get_player_character();
-    player_character.setpos( map_starting_point );
+    player_character.setpos( here, map_starting_point );
 
-    REQUIRE( player_character.pos_bub() == map_starting_point );
-    if( player_character.pos_bub() != map_starting_point ) {
+    REQUIRE( player_character.pos_bub( here ) == map_starting_point );
+    if( player_character.pos_bub( here ) != map_starting_point ) {
         return;
     }
     get_map().board_vehicle( map_starting_point, &player_character );
-    REQUIRE( player_character.pos_bub() == map_starting_point );
-    if( player_character.pos_bub() != map_starting_point ) {
+    REQUIRE( player_character.pos_bub( here ) == map_starting_point );
+    if( player_character.pos_bub( here ) != map_starting_point ) {
         return;
     }
     const int transition_cycle = 3;
@@ -180,7 +180,7 @@ static void ramp_transition_angled( const vproto_id &veh_id, const units::angle 
         const int z_change = map_starting_point.z() - player_character.posz();
         here.unboard_vehicle( *vp, &player_character, false );
         here.ter_set( map_starting_point, ter_id( "t_pavement" ) );
-        player_character.setpos( map_starting_point );
+        player_character.setpos( here, map_starting_point );
         if( z_change ) {
             g->vertical_move( z_change, true );
         }
@@ -245,7 +245,7 @@ static void level_out( const vproto_id &veh_id, const bool drop_pos )
 
     // Make sure the avatar is out of the way
     Character &player_character = get_player_character();
-    player_character.setpos( map_starting_point + point( 5, 5 ) );
+    player_character.setpos( here, map_starting_point + point( 5, 5 ) );
     vehicle *veh_ptr = here.add_vehicle( veh_id, map_starting_point, 180_degrees, 1, 0 );
 
     REQUIRE( veh_ptr != nullptr );

--- a/tests/vehicle_split_test.cpp
+++ b/tests/vehicle_split_test.cpp
@@ -25,7 +25,7 @@ TEST_CASE( "vehicle_split_section", "[vehicle]" )
     for( units::angle dir = 0_degrees; dir < 360_degrees; dir += vehicles::steer_increment ) {
         CHECK( !player_character.in_vehicle );
         const tripoint_bub_ms test_origin( 15, 15, 0 );
-        player_character.setpos( test_origin );
+        player_character.setpos( here, test_origin );
         tripoint_bub_ms vehicle_origin{ 10, 10, 0 };
         VehicleList vehs = here.get_vehicles();
         clear_vehicles();

--- a/tests/vehicle_test.cpp
+++ b/tests/vehicle_test.cpp
@@ -75,7 +75,7 @@ TEST_CASE( "destroy_grabbed_vehicle_section", "[vehicle]" )
         map &here = get_map();
         const tripoint_bub_ms test_origin( 60, 60, 0 );
         avatar &player_character = get_avatar();
-        player_character.setpos( test_origin );
+        player_character.setpos( here, test_origin );
         const tripoint_bub_ms vehicle_origin = test_origin + tripoint::south_east;
         vehicle *veh_ptr = here.add_vehicle( vehicle_prototype_bicycle, vehicle_origin, -90_degrees,
                                              0, 0 );
@@ -762,7 +762,7 @@ static int test_autopilot_moving( const vproto_id &veh_id, const vpart_id &extra
     Character &player_character = get_player_character();
     // Move player somewhere safe
     REQUIRE_FALSE( player_character.in_vehicle );
-    player_character.setpos( tripoint_bub_ms::zero );
+    player_character.setpos( here, tripoint_bub_ms::zero );
 
     const tripoint_bub_ms map_starting_point( 60, 60, 0 );
     vehicle *veh_ptr = here.add_vehicle( veh_id, map_starting_point, -90_degrees, 100, 0, false );

--- a/tests/vehicle_turrets_test.cpp
+++ b/tests/vehicle_turrets_test.cpp
@@ -99,7 +99,7 @@ TEST_CASE( "vehicle_turret", "[vehicle][gun][magazine]" )
             REQUIRE( qry.query() == turret_data::status::ready );
             REQUIRE( qry.range() > 0 );
 
-            player_character.setpos( &here, veh->bub_part_pos( here, vp ) );
+            player_character.setpos( here, veh->bub_part_pos( here, vp ) );
             int shots_fired = 0;
             // 3 attempts to fire, to account for possible misfires
             for( int attempt = 0; shots_fired == 0 && attempt < 3; attempt++ ) {

--- a/tests/vision_test.cpp
+++ b/tests/vision_test.cpp
@@ -559,6 +559,8 @@ TEST_CASE( "vision_single_tile_skylight", "[shadowcasting][vision]" )
 
 TEST_CASE( "vision_junction_reciprocity", "[vision][reciprocity]" )
 {
+    const map &here = get_map();
+
     bool player_in_junction = GENERATE( true, false );
     CAPTURE( player_in_junction );
 
@@ -606,16 +608,18 @@ TEST_CASE( "vision_junction_reciprocity", "[vision][reciprocity]" )
     t.test_all();
 
     if( player_in_junction ) {
-        REQUIRE( !get_avatar().sees( *zombie ) );
-        REQUIRE( !zombie->sees( get_avatar() ) );
+        REQUIRE( !get_avatar().sees( here, *zombie ) );
+        REQUIRE( !zombie->sees( here, get_avatar() ) );
     } else {
-        REQUIRE( get_avatar().sees( *zombie ) );
-        REQUIRE( zombie->sees( get_avatar() ) );
+        REQUIRE( get_avatar().sees( here, *zombie ) );
+        REQUIRE( zombie->sees( here, get_avatar() ) );
     }
 }
 
 TEST_CASE( "vision_blindfold_reciprocity", "[vision][reciprocity]" )
 {
+    const map &here = get_map();
+
     vision_test_case t {
         {
             "U  Z",
@@ -639,13 +643,15 @@ TEST_CASE( "vision_blindfold_reciprocity", "[vision][reciprocity]" )
         t.set_up_tiles;
     t.test_all();
 
-    REQUIRE( !get_avatar().sees( *zombie ) );
+    REQUIRE( !get_avatar().sees( here,  *zombie ) );
     // don't "optimize" lightcasting with player sight range
-    REQUIRE( zombie->sees( get_avatar() ) );
+    REQUIRE( zombie->sees( here, get_avatar() ) );
 }
 
 TEST_CASE( "vision_moncam_basic", "[shadowcasting][vision][moncam]" )
 {
+    const map &here = get_map();
+
     bool add_moncam = GENERATE( true, false );
     bool obstructed = GENERATE( true, false );
 
@@ -731,11 +737,11 @@ TEST_CASE( "vision_moncam_basic", "[shadowcasting][vision][moncam]" )
     t.test_all();
 
     avatar &u = get_avatar();
-    REQUIRE( zombie->sees( u ) == !obstructed );
+    REQUIRE( zombie->sees( here, u ) == !obstructed );
     if( add_moncam ) {
-        REQUIRE( u.sees( zombie->pos_bub(), true ) );
+        REQUIRE( u.sees( here,  zombie->pos_bub( here ), true ) );
     } else {
-        REQUIRE( !u.sees( zombie->pos_bub(), true ) );
+        REQUIRE( !u.sees( here, zombie->pos_bub( here ), true ) );
     }
 }
 
@@ -1170,11 +1176,13 @@ TEST_CASE( "vision_inside_meth_lab", "[shadowcasting][vision][moncam]" )
 
 TEST_CASE( "pl_sees-oob-nocrash", "[vision]" )
 {
+    const map &here = get_map();
+
     // oob crash from game::place_player_overmap() or game::start_game(), simplified
     clear_avatar();
     get_map().load( project_to<coords::sm>( get_avatar().pos_abs() ) + point::south_east, false,
                     false );
-    get_avatar().sees( tripoint_bub_ms::zero ); // CRASH?
+    get_avatar().sees( here, tripoint_bub_ms::zero ); // CRASH?
 
     clear_avatar();
 }

--- a/tests/visitable_remove_test.cpp
+++ b/tests/visitable_remove_test.cpp
@@ -82,11 +82,11 @@ TEST_CASE( "visitable_remove", "[visitable]" )
 
     // move player randomly until we find a suitable position
     constexpr int num_trials = 100;
-    for( int i = 0; i < num_trials && !suitable( p.pos_bub(), 1 ); ++i ) {
+    for( int i = 0; i < num_trials && !suitable( p.pos_bub( here ), 1 ); ++i ) {
         CHECK( !p.in_vehicle );
-        p.setpos( random_entry( closest_points_first( p.pos_bub(), 1 ) ) );
+        p.setpos( here, random_entry( closest_points_first( p.pos_bub( here ), 1 ) ) );
     }
-    REQUIRE( suitable( p.pos_bub(), 1 ) );
+    REQUIRE( suitable( p.pos_bub( here ), 1 ) );
 
     item temp_liquid( liquid_id );
     item obj = temp_liquid.in_container( temp_liquid.type->default_container.value_or( itype_null ) );
@@ -445,7 +445,7 @@ TEST_CASE( "visitable_remove", "[visitable]" )
             v->add_item( here,  vp->part(), obj );
         }
 
-        vehicle_selector sel( here,  p.pos_bub( &here ), 1 );
+        vehicle_selector sel( here,  p.pos_bub( here ), 1 );
 
         REQUIRE( count_items( sel, container_id ) == count );
         REQUIRE( count_items( sel, liquid_id ) == count );

--- a/tests/water_movement_test.cpp
+++ b/tests/water_movement_test.cpp
@@ -66,7 +66,7 @@ TEST_CASE( "avatar_diving", "[diving]" )
 
     GIVEN( "avatar is above water at z0" ) {
         dummy.set_underwater( false );
-        dummy.setpos( test_origin );
+        dummy.setpos( here, test_origin );
         g->vertical_shift( 0 );
 
         WHEN( "avatar dives down" ) {
@@ -92,7 +92,7 @@ TEST_CASE( "avatar_diving", "[diving]" )
 
     GIVEN( "avatar is underwater at z0" ) {
         dummy.set_underwater( true );
-        dummy.setpos( test_origin );
+        dummy.setpos( here, test_origin );
         g->vertical_shift( 0 );
 
         WHEN( "avatar dives down" ) {
@@ -118,7 +118,7 @@ TEST_CASE( "avatar_diving", "[diving]" )
 
     GIVEN( "avatar is underwater at z-1" ) {
         dummy.set_underwater( true );
-        dummy.setpos( test_origin + tripoint::below );
+        dummy.setpos( here, test_origin + tripoint::below );
         g->vertical_shift( -1 );
 
         WHEN( "avatar dives down" ) {
@@ -144,7 +144,7 @@ TEST_CASE( "avatar_diving", "[diving]" )
 
     GIVEN( "avatar is underwater at z-2" ) {
         dummy.set_underwater( true );
-        dummy.setpos( test_origin + tripoint( 0, 0, -2 ) );
+        dummy.setpos( here, test_origin + tripoint( 0, 0, -2 ) );
         g->vertical_shift( -2 );
 
         WHEN( "avatar dives down" ) {
@@ -307,7 +307,7 @@ static int swimming_steps( avatar &swimmer )
         }
         last_moves = swimmer.get_moves();
     }
-    swimmer.setpos( left );
+    swimmer.setpos( here, left );
     return steps;
 }
 

--- a/tests/widget_test.cpp
+++ b/tests/widget_test.cpp
@@ -1699,6 +1699,8 @@ TEST_CASE( "moon_and_lighting_widgets", "[widget]" )
 
 TEST_CASE( "compass_widget", "[widget][compass]" )
 {
+    const map &here = get_map();
+
     const int sidebar_width = 36;
     widget c5s_N = widget_test_compass_N.obj();
     widget c5s_N_nowidth = widget_test_compass_N_nowidth.obj();
@@ -1733,7 +1735,7 @@ TEST_CASE( "compass_widget", "[widget][compass]" )
         set_time( calendar::turn_zero + 12_hours );
         monster &mon1 = spawn_test_monster( "mon_test_CBM", northeast );
         g->mon_info_update();
-        REQUIRE( ava.sees( mon1 ) );
+        REQUIRE( ava.sees( here, mon1 ) );
         REQUIRE( ava.get_mon_visible().unique_mons[static_cast<int>( cardinal_direction::NORTHEAST )].size()
                  == 1 );
         CHECK( c5s_N.layout( ava, sidebar_width ) ==
@@ -1755,7 +1757,7 @@ TEST_CASE( "compass_widget", "[widget][compass]" )
         set_time( calendar::turn_zero + 12_hours );
         monster &mon1 = spawn_test_monster( "mon_test_CBM", north );
         g->mon_info_update();
-        REQUIRE( ava.sees( mon1 ) );
+        REQUIRE( ava.sees( here,  mon1 ) );
         REQUIRE( ava.get_mon_visible().unique_mons[static_cast<int>( cardinal_direction::NORTH )].size() ==
                  1 );
         CHECK( c5s_N.layout( ava, sidebar_width ) ==
@@ -1780,9 +1782,9 @@ TEST_CASE( "compass_widget", "[widget][compass]" )
         monster &mon2 = spawn_test_monster( "mon_test_CBM", north + tripoint( 0, -1, 0 ) );
         monster &mon3 = spawn_test_monster( "mon_test_CBM", north + tripoint( 0, -2, 0 ) );
         g->mon_info_update();
-        REQUIRE( ava.sees( mon1 ) );
-        REQUIRE( ava.sees( mon2 ) );
-        REQUIRE( ava.sees( mon3 ) );
+        REQUIRE( ava.sees( here, mon1 ) );
+        REQUIRE( ava.sees( here, mon2 ) );
+        REQUIRE( ava.sees( here,  mon3 ) );
         REQUIRE( ava.get_mon_visible().unique_mons[static_cast<int>( cardinal_direction::NORTH )].size() ==
                  1 );
         CHECK( c5s_N.layout( ava, sidebar_width ) ==
@@ -1807,9 +1809,9 @@ TEST_CASE( "compass_widget", "[widget][compass]" )
         monster &mon2 = spawn_test_monster( "mon_test_bovine", north + tripoint( 0, -1, 0 ) );
         monster &mon3 = spawn_test_monster( "mon_test_shearable", north + tripoint( 0, -2, 0 ) );
         g->mon_info_update();
-        REQUIRE( ava.sees( mon1 ) );
-        REQUIRE( ava.sees( mon2 ) );
-        REQUIRE( ava.sees( mon3 ) );
+        REQUIRE( ava.sees( here, mon1 ) );
+        REQUIRE( ava.sees( here,  mon2 ) );
+        REQUIRE( ava.sees( here,  mon3 ) );
         REQUIRE( ava.get_mon_visible().unique_mons[static_cast<int>( cardinal_direction::NORTH )].size() ==
                  3 );
         CHECK( c5s_N.layout( ava, sidebar_width ) ==
@@ -1943,6 +1945,7 @@ TEST_CASE( "layout_widgets_in_columns", "[widget][layout][columns]" )
 
 TEST_CASE( "widgets_showing_weather_conditions", "[widget][weather]" )
 {
+    map &here = get_map();
     widget weather_w = widget_test_weather_text.obj();
 
     avatar &ava = get_avatar();
@@ -1976,7 +1979,7 @@ TEST_CASE( "widgets_showing_weather_conditions", "[widget][weather]" )
         }
 
         SECTION( "cannot see weather when underground" ) {
-            ava.setpos( tripoint_bub_ms::zero + tripoint::below );
+            ava.setpos( here, tripoint_bub_ms::zero + tripoint::below );
             CHECK( weather_w.layout( ava ) == "Weather: <color_c_light_gray>Underground</color>" );
         }
     }
@@ -2122,6 +2125,7 @@ static int get_height_from_widget_factory( const widget_id &id )
 // Use the compass legend as a proof-of-concept
 TEST_CASE( "Dynamic_height_for_multiline_widgets", "[widget]" )
 {
+    const map &here = get_map();
     const int sidebar_width = 36;
     widget c5s_legend3 = widget_test_compass_legend_3.obj();
 
@@ -2143,7 +2147,7 @@ TEST_CASE( "Dynamic_height_for_multiline_widgets", "[widget]" )
         set_time( calendar::turn_zero + 12_hours );
         monster &mon1 = spawn_test_monster( "mon_test_CBM", north );
         g->mon_info_update();
-        REQUIRE( ava.sees( mon1 ) );
+        REQUIRE( ava.sees( here, mon1 ) );
         REQUIRE( ava.get_mon_visible().unique_mons[static_cast<int>( cardinal_direction::NORTH )].size() ==
                  1 );
         CHECK( c5s_legend3.layout( ava, sidebar_width ) ==
@@ -2158,8 +2162,8 @@ TEST_CASE( "Dynamic_height_for_multiline_widgets", "[widget]" )
         //NOLINTNEXTLINE(cata-use-named-point-constants)
         monster &mon2 = spawn_test_monster( "mon_test_bovine", north + tripoint( 0, -1, 0 ) );
         g->mon_info_update();
-        REQUIRE( ava.sees( mon1 ) );
-        REQUIRE( ava.sees( mon2 ) );
+        REQUIRE( ava.sees( here, mon1 ) );
+        REQUIRE( ava.sees( here, mon2 ) );
         REQUIRE( ava.get_mon_visible().unique_mons[static_cast<int>( cardinal_direction::NORTH )].size() ==
                  2 );
         CHECK( c5s_legend3.layout( ava, sidebar_width ) ==
@@ -2176,9 +2180,9 @@ TEST_CASE( "Dynamic_height_for_multiline_widgets", "[widget]" )
         monster &mon2 = spawn_test_monster( "mon_test_bovine", north + tripoint( 0, -1, 0 ) );
         monster &mon3 = spawn_test_monster( "mon_test_shearable", north + tripoint( 0, -2, 0 ) );
         g->mon_info_update();
-        REQUIRE( ava.sees( mon1 ) );
-        REQUIRE( ava.sees( mon2 ) );
-        REQUIRE( ava.sees( mon3 ) );
+        REQUIRE( ava.sees( here, mon1 ) );
+        REQUIRE( ava.sees( here, mon2 ) );
+        REQUIRE( ava.sees( here, mon3 ) );
         REQUIRE( ava.get_mon_visible().unique_mons[static_cast<int>( cardinal_direction::NORTH )].size() ==
                  3 );
         CHECK( c5s_legend3.layout( ava, sidebar_width ) ==

--- a/tests/widget_test.cpp
+++ b/tests/widget_test.cpp
@@ -24,6 +24,7 @@
 #include "game_constants.h"
 #include "item.h"
 #include "magic.h"
+#include "map.h"
 #include "map_helpers.h"
 #include "mission.h"
 #include "monster.h"


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Propagate the map used down the call stack rather than assuming it's get_map(). This time the main work was on the `sees` operations of the character etc class hierarchy, but a few other things were done before that.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Get rid of get_map() calls in operations by passing a map parameter into the operation, pushing the map use determination up the chain so all parts use the same map.
Done by changing the profiles and fixing callers (typically by calling get_map() there, for future propagation further upwards).

The changes should not result in any functional changes as long as the the reality bubble is actually the only map in use.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
I would have preferred to make a smaller PR, but the `sees` operations are used in a lot of places, and changing things in a class hierarchy is a pain in itself since you have to find and change all the implementations of them. Retaining the original operations and introduce ones with the current profile in parallel would have been possible, and probably is what I should have done if I had realized how many places they touched.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Load save, walk up ramp, jump into car, drive through hay bales, run over zombie corpse with inventory, run over turkey, smash into vehicle. The oddities seen were skidding on hitting a couple of hay bales and car part destruction on hitting another. Both are things that happen from time to time.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
A reviewer who manages to stay awake may note changes of distance calculations from using bubble coordinates to using absolute ones in a number of places. The reason for this is the the difference is the same regardless of the coordinate system, and since the data is actually stored as absolute, it's cheaper to use those than to convert both parameters before the call. The other reason is that eventually these calls will have to be changed anyway, as a map reference becomes mandatory, so going for the more efficient change now makes some sense.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
