### PR TITLE
Aggressively whitelist terrain for overmap_terrain_coverage test

### DIFF
--- a/data/mods/TEST_DATA/overmap_terrain_coverage_test/overmap_terrain_coverage_whitelist.json
+++ b/data/mods/TEST_DATA/overmap_terrain_coverage_test/overmap_terrain_coverage_whitelist.json
@@ -28,7 +28,19 @@
       "roadstop",
       "roadstop_roof",
       "roadstop_a",
-      "roadstop_a_roof"
+      "roadstop_a_roof",
+      "chemical_lab(_roof)?_ocu",
+      "homelesscamp_npc",
+      "ranch_camp_77",
+      "prison_island_1_.*",
+      "prison_alcatraz_.*",
+      "cabin_lakeside\\d?(_roof)?",
+      "boat_rental(_[12])?(_roof)?",
+      "nursing_home_(b.*|lab\\d)",
+      "farm_isherwood_.*",
+      "corpse_head_neck_(l|r|center)_decap",
+      "abandoned_textile_mill(_b)?_\\d_\\d",
+      "hotel_tower(_flr2)_1_5B?"
     ]
   }
 ]

--- a/src/test_data.cpp
+++ b/src/test_data.cpp
@@ -4,9 +4,10 @@
 #include "generic_factory.h"
 #include "pocket_type.h"  // IWYU pragma: keep // need full type to read from json
 
+// Define the static class varaibles
 std::set<itype_id> test_data::legacy_to_hit;
 std::set<itype_id> test_data::known_bad;
-std::unordered_set<oter_type_id> test_data::overmap_terrain_coverage_whitelist;
+std::vector<std::regex> test_data::overmap_terrain_coverage_whitelist;
 std::map<vproto_id, std::vector<double>> test_data::drag_data;
 std::map<vproto_id, efficiency_data> test_data::eff_data;
 std::map<itype_id, double> test_data::expected_dps;
@@ -126,10 +127,10 @@ void test_data::load( const JsonObject &jo )
     }
 
     if( jo.has_array( "overmap_terrain_coverage_whitelist" ) ) {
-        std::unordered_set<oter_type_str_id> new_overmap_terrain_coverage_whitelist;
+        std::vector<std::string> new_overmap_terrain_coverage_whitelist;
         jo.read( "overmap_terrain_coverage_whitelist", new_overmap_terrain_coverage_whitelist );
-        for( const oter_type_str_id &o : new_overmap_terrain_coverage_whitelist ) {
-            overmap_terrain_coverage_whitelist.insert( o.id() );
+        for( const std::string &o : new_overmap_terrain_coverage_whitelist ) {
+            overmap_terrain_coverage_whitelist.push_back( std::regex( o ) );
         }
     }
 

--- a/src/test_data.cpp
+++ b/src/test_data.cpp
@@ -130,7 +130,7 @@ void test_data::load( const JsonObject &jo )
         std::vector<std::string> new_overmap_terrain_coverage_whitelist;
         jo.read( "overmap_terrain_coverage_whitelist", new_overmap_terrain_coverage_whitelist );
         for( const std::string &o : new_overmap_terrain_coverage_whitelist ) {
-            overmap_terrain_coverage_whitelist.push_back( std::regex( o ) );
+            overmap_terrain_coverage_whitelist.emplace_back( o );
         }
     }
 

--- a/src/test_data.h
+++ b/src/test_data.h
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <map>
 #include <optional>
+#include <regex>
 #include <set>
 #include <string>
 #include <unordered_set>
@@ -108,7 +109,7 @@ class test_data
         static std::set<itype_id> legacy_to_hit;
         // TODO: remove when all known bad items got fixed
         static std::set<itype_id> known_bad;
-        static std::unordered_set<oter_type_id> overmap_terrain_coverage_whitelist;
+        static std::vector<std::regex> overmap_terrain_coverage_whitelist;
         static std::map<vproto_id, std::vector<double>> drag_data;
         static std::map<vproto_id, efficiency_data> eff_data;
         static std::map<itype_id, double> expected_dps;

--- a/tests/overmap_test.cpp
+++ b/tests/overmap_test.cpp
@@ -526,7 +526,7 @@ TEST_CASE( "overmap_terrain_coverage", "[overmap][slow]" )
                                          std::regex_match( id_s.c_str(), m, wl ) && m.prefix().length() == 0 && m.suffix().length() == 0 );
                 }
                 if( !is_whitelisted ) {
-                    missing.push_back( id_s );
+                    missing.emplace_back( id_s );
                 }
             }
         }

--- a/tests/overmap_test.cpp
+++ b/tests/overmap_test.cpp
@@ -6,6 +6,7 @@
 #include <map>
 #include <memory>
 #include <optional>
+#include <regex>
 #include <set>
 #include <string>
 #include <unordered_map>
@@ -409,7 +410,7 @@ TEST_CASE( "overmap_terrain_coverage", "[overmap][slow]" )
     g->place_player_overmap( { project_to<coords::omt>( overmap_origin + ( 6 * point::north_west ) ), 0 } );
     // Don't inherit overmap state from initialization or previous tests.
     overmap_buffer.clear();
-    for( int i = 0; i < 7; ++i ) {
+    for( int attempt_no = 0; attempt_no < 3; ++attempt_no ) {
         // First we just touch all the overmaps in an area to cause them to generate.
         for( const point_abs_om &om_cur : closest_points_first( overmap_origin, 0, 3 ) ) {
             point_abs_omt omt_start = project_to<coords::omt>( om_cur );
@@ -516,9 +517,17 @@ TEST_CASE( "overmap_terrain_coverage", "[overmap][slow]" )
 
             if( found ) {
                 FAIL( "oter_type_id was found in map but had SHOULD_NOT_SPAWN flag" );
-            } else if( !test_data::overmap_terrain_coverage_whitelist.count( id ) &&
-                       !id->has_flag( oter_flags::ocean ) ) {
-                missing.push_back( id );
+            } else {
+                bool is_whitelisted = id->has_flag( oter_flags::ocean );
+                for( const std::regex &wl : test_data::overmap_terrain_coverage_whitelist ) {
+                    std::cmatch m;
+                    is_whitelisted = is_whitelisted || (
+                                         // ensure the full string matches. Don't accept substrings.
+                                         std::regex_match( id_s.c_str(), m, wl ) && m.prefix().length() == 0 && m.suffix().length() == 0 );
+                }
+                if( !is_whitelisted ) {
+                    missing.push_back( id_s );
+                }
             }
         }
     }


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Making the tests less flaky

#### Describe the solution
Grab logs of flaky CI test runs since 2025-01-01
Classify them based on the test they tripped over
Go over all the `overmap_terrain_coverage` failures and add them to the whitelist.
Run the test with low iteration count locally, and add the newly discovered failures to whitelist as well (if it can fail on my local PC with the few runs i have done - then surely it can also fail on CI).
Make `overmap_terrain_coverage_whitelist` hold regex instead of raw ids, because adding 50 (literally) omts for prison island is neither fun to do, nor easy to read.
YOLO reduce the iteration count on CI from 7 down to 3 in an attempt to reduce run time. This might turn out counterproductive and bite us back.

<details>
<summary>logs grabber</summary>

```js
//const github = require('@actions/github');

import { Octokit, App } from "octokit";
import { restEndpointMethods } from "@octokit/plugin-rest-endpoint-methods";

import fs from 'node:fs';
import { writeFile } from 'node:fs/promises';
import path from 'node:path';

const token = "ghp_REDACTED"
const token2 = "github_pat_REDACTED"

async function fileExists(fn) {
    try {
        const x = fs.statSync(fn);
        return true;
    } catch {
        return false
    }
}

function read_dir_deep(root) {
    let out = [];
    const files_here = fs.readdirSync(root);
    for (const file of files_here) {
        console.log(file)
        const fn = path.join(root, file);
        const stat = fs.statSync(fn);

        if (stat.isDirectory()) {
            out = out.concat(read_dir_deep(fn))
        } else {
            out.push(fn)
        }
    }
    return out
}


async function main() {
    const MyOctokit = Octokit.plugin(restEndpointMethods);
    const octokit = new MyOctokit({ auth: token2 });
    const owner = 'CleverRaven';
    const repo = 'Cataclysm-DDA';

    const dl_dir = "out/untriaged";
    // const other_dirs = ["out/bad", "out/maybe", "out/good"];
    // console.log(data);
    fs.mkdirSync(dl_dir, { recursive: true });

    const iterator = octokit.paginate.iterator(octokit.rest.actions.listWorkflowRuns, {
        owner, repo: repo,
        workflow_id: 'matrix.yml',
        event: 'pull_request', status: 'failure'
    });

    const known_logs = new Map();
    for (const fn of read_dir_deep('out') ){
        known_logs.set(path.basename(fn), fn)
    }

    const cutoff_date = "2025-01-01T00:00:00";

    const pr_num_extractor = new RegExp("\\d+");;

    let all_runs = new Map();
    let stop = false;
    for await (const { data: workflows_data } of iterator) {
        console.log("fetching...")
        if (stop) {
            break
        }
        for (const run of workflows_data) {
            if (run.created_at < cutoff_date) {
                stop = true;
                break
            }
            const pr_num = pr_num_extractor.exec(run.referenced_workflows[0].ref)[0];
            const key = `pr-${pr_num}-${run.referenced_workflows[0].sha.substring(0,8)}`
            let here = all_runs.get(key) || []
            here.push(run)
            all_runs.set(key, here)
        }
    }
    for (const [runs_key, runs] of all_runs.entries()) {
        console.log(runs_key)
        let interesting_jobs = [];
        for (const run of runs) {
            console.log(`  run ${run.id}`)
            for (let attempt = 1; attempt <= run.run_attempt; attempt++) {
                const { data: jobs_data } = await octokit.rest.actions.listJobsForWorkflowRunAttempt({
                    owner, repo: repo,
                    run_id: run.id,
                    attempt_number: attempt,
                });

                for (const job of jobs_data.jobs) {
                    if (['matrix-variables', 'skip-duplicates-data', 'skip-duplicates-code'].includes(job.name)) {
                        continue
                    }
                    if (['skipped', 'cancelled'].includes(job.conclusion)) {
                        continue
                    }
                    interesting_jobs.push(job)
                }
            }
        }
        let any_success = false;
        for (const job of interesting_jobs){
            if (job.conclusion == "success"){
                any_success = true;
                break
            }
        }
        if (!any_success){
            continue
        }
        for (const job of interesting_jobs) {
            console.log(job.conclusion, job.name);
            if (job.conclusion == 'success') {
                continue
            }
            const fn = `${runs_key}-${job.id}.log`;
            const found = known_logs.get(fn)
            if (found){
                console.log(`  .. skipping - ${found} exists`);
                continue
            }
            console.log(`  job ${job.id}`);
            const { data } = await octokit.rest.actions.downloadJobLogsForWorkflowRun({
                owner,
                repo,
                job_id: job.id,
            });
            // const content = `${data}`;
            // console.log('hi');
            const out_fp = path.join(dl_dir, fn)
            await fs.writeFile(out_fp, data, (err) => { if (err) throw err; });
            // return
        }
        // break;
    }
}

main().catch((e) => {
    console.error(`Failed generating release notes with error: ${e}`);
    process.exit(0);
});
```

</details>

<details>
<summary>logs classifier</summary>

```py
import os
import os.path
from pathlib import Path
import re

def main():
    root = Path("out")
    untriaged_dir = root
    nice_tests = {
        "overmap_terrain_coverage": "mapgen/coverage",
        "vehicle_split_section": "fixed/vehicle_split_test",
        "shooting_at_terrain": "rng/map_bash_test",
        "Unified_grab_break_test": "rng/other",
        "x_in_y_distribution": "rng/other",
        "bleed_effect_attribution": "fixed/bleed",
        "uncraft_from_a_damaged_item": "rng/other",
        "Ranged_coverage_vs_bullet": "rng/other",
        "npc_prefers_guns": "other",
        "firebugs": "rng/other",
        "EOC_combat_event_test": "other",
        "player_morale_ranged_kill_of_unaware_hostile_bandit": "fixed/other",
        "grenade_lethality": "rng/other",
        "unskilled_shooter_accuracy": "rng/other",
        "Damage_type_effectiveness_vs_monster_resistance": "rng/other",
        "weakpoint_basic": "rng/other",
    }
    raw_matches = {
        "FAILED to match on terrain solid_earth with neighbours ": "mapgen/mines",
        "Spawn of mutable special .* had unresolved joins": "mapgen/mines",
        "ERROR: AddressSanitizer: stack-use-after-scope on address ": "fixed/asan",
        "tried to put an item \\(survnote\\) count": "fixed/other",
        "Tried to .* but the submap is not loaded": "other",
        "Bad tag.  '<freaking>'": "fixed/other",
        r"##\[error\]The operation was canceled.": "bad",
        "error: no matching member function for call to ": "bad",
        "Error: Port freetype not found": "bad",
        "Setting furniture f_fireweed at .* where terrain is t_open_air": "mapgen/other",
        "vehicle::remove_part part .* is out of map bounds on vehicle": "other",
    }
    fancy_break = "-------------------------------------------------------------------------------"

    destinations = []
    destinations.extend(
        (re.compile("%s\n.*%s\n.*%s\n" %(fancy_break, k, fancy_break), flags=re.DOTALL),
            v)
        for k,v in nice_tests.items()
    )
    destinations.extend(
        (re.compile(k), v) for k,v in raw_matches.items()
    )
    destinations = [(k, root/v) for k, v in destinations]
    
    for (dirname, nextdir, files) in os.walk(root):
        dirname = Path(dirname)
        if not files and not nextdir and dirname != untriaged_dir:
            os.rmdir(dirname)    

    for _, td in destinations:
        os.makedirs(td, exist_ok=True)
    for (dirname, _nextdir, files) in os.walk(untriaged_dir):
        dirname = Path(dirname)
        should_skip = False
        for _, x in destinations:
            if (dirname == x) or (x in dirname.parents):
                should_skip = True
                break
        if should_skip:
            continue
        for base_fn in files:
            fn = dirname  / base_fn
            content = None
            with open(fn, 'r') as fd:
                content = fd.read()
            for matcher, target_dir in destinations:
                if re.search(matcher, content) is not None:
                    target_fn = target_dir / base_fn
                    print(f"{fn} -> {target_fn}")
                    if fn != target_fn and os.path.exists(target_fn):
                        os.remove(target_fn)
                    os.rename(fn, target_fn)
                    break

        
if __name__ == '__main__':
    main()
```

</details>

#### Describe alternatives you've considered

- Bother people to look closer into why the failures are the way they are, and tweak the spawning constraints to make the thigns spawn more reliably?
- Do not reduce the retry count
- Do something clever with the dynamic retry count (decided against it because the code became a bit too ugly that way)

#### Testing

`overmap_terrain_coverage` tends to pass locally, but that doesn't say much

#### Additional context

Did you know that `--rng-seed` does not really work for reprocuing `overmap_terrain_coverage` failures? Not only is the test extremely sensitive to all of the json (which is understandable - different items mean different amount of rng calls), but also to the local environment! Running the test with a different `--user-dir` or with a `--user-dir` that already has things in it produces compeltely different results!


It might be worth mentioning the distribution of failed tests:
- `overmap_terrain_coverage` - 47
- `shooting_at_terrain`- 25
- other rng-based tests - 19 combined
- `Spawn of mutable special .* had unresolved joins` (not exactly a test, but a failure mode) - 12
- other failures - 14 combined

So this PR aims to reduce flakiness by ~40%