### PR TITLE
converted item_location and computer to use absolute coordinates

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -1430,6 +1430,8 @@ static void butchery_quarter( item *corpse_item, const Character &you )
 
 void activity_handlers::butcher_finish( player_activity *act, Character *you )
 {
+    map &here = get_map();
+
     // No targets means we are done
     if( act->targets.empty() ) {
         act->set_to_null();
@@ -1461,7 +1463,7 @@ void activity_handlers::butcher_finish( player_activity *act, Character *you )
 
     // Dump items from the "container" before destroying it.
     // Presumably, the character would be doing this while setting up for butchering.
-    corpse_item.spill_contents( target.pos_bub() );
+    corpse_item.spill_contents( &here, target.pos_bub( here ) );
     corpse_item.erase_var( butcher_progress_var( action ) );
 
     if( action == butcher_type::QUARTER ) {
@@ -1470,7 +1472,6 @@ void activity_handlers::butcher_finish( player_activity *act, Character *you )
         return;
     }
 
-    map &here = get_map();
     if( action == butcher_type::DISMEMBER ) {
         here.add_splatter( type_gib, you->pos_bub(), rng( corpse->size + 2, ( corpse->size + 1 ) * 2 ) );
     }
@@ -2533,7 +2534,7 @@ void repair_item_finish( player_activity *act, Character *you, bool no_menu )
 
         if( attempt != repair_item_actor::AS_CANT ) {
             if( ploc && ploc->where() == item_location::type::map ) {
-                used_tool->ammo_consume( used_tool->ammo_required(), ploc->pos_bub(), you );
+                used_tool->ammo_consume( used_tool->ammo_required(), ploc->pos_bub( here ), you );
             } else {
                 you->consume_charges( *used_tool, used_tool->ammo_required() );
             }

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -3788,8 +3788,8 @@ int get_auto_consume_moves( Character &you, const bool food )
 
     if( best_comestible ) {
         //The moves it takes you to walk there and back.
-        int consume_moves = 2 * you.run_cost( 100, false ) * std::max( rl_dist( you.pos_bub(),
-                            best_comestible.pos_bub() ), 1 );
+        int consume_moves = 2 * you.run_cost( 100, false ) * std::max( rl_dist( you.pos_abs(),
+                            best_comestible.pos_abs() ), 1 );
         consume_moves += to_moves<int>( you.get_consume_time( *best_comestible ) );
 
         you.consume( best_comestible );

--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -749,11 +749,11 @@ void advanced_inventory::recalc_pane( side p )
     if( pane.container &&
         pane.container_base_loc >= AIM_SOUTHWEST && pane.container_base_loc <= AIM_ALL ) {
 
-        const tripoint_rel_ms offset = player_character.pos_bub() - pane.container.pos_bub();
+        const tripoint_rel_ms offset = player_character.pos_abs() - pane.container.pos_abs();
 
         // If container is no longer adjacent or on the player's z-level, nullify it.
         if( std::abs( offset.x() ) > 1 || std::abs( offset.y() ) > 1 ||
-            player_character.posz() != pane.container.pos_bub().z() ) {
+            player_character.posz() != pane.container.pos_abs().z() ) {
 
             pane.container = item_location::nowhere;
             pane.container_base_loc = NUM_AIM_LOCATIONS;

--- a/src/auto_pickup.cpp
+++ b/src/auto_pickup.cpp
@@ -151,6 +151,8 @@ static void empty_autopickup_target( item *what, tripoint_bub_ms where )
  */
 static std::vector<item_location> get_autopickup_items( item_location &from )
 {
+    map &here = get_map();
+
     item *container_item = from.get_item();
     // items sealed in containers should never be unsealed by auto pickup
     bool force_pick_container = container_item->any_pockets_sealed();
@@ -179,7 +181,7 @@ static std::vector<item_location> get_autopickup_items( item_location &from )
             if( !force_pick_container ) {
                 if( item_entry->is_container() ) {
                     // whitelisted containers should exclude contained blacklisted items
-                    empty_autopickup_target( item_entry, from.pos_bub() );
+                    empty_autopickup_target( item_entry, from.pos_bub( here ) );
                 } else if( item_entry->made_of_from_type( phase_id::LIQUID ) ) {
                     // liquid items should never be picked up without container
                     force_pick_container = true;

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -948,12 +948,14 @@ void avatar_action::eat( avatar &you, item_location &loc,
                          const std::string &consume_menu_filter,
                          activity_id type )
 {
+    map &here = get_map();
+
     if( !loc ) {
         you.cancel_activity();
         add_msg( _( "Never mind." ) );
         return;
     }
-    loc.overflow();
+    loc.overflow( here );
     you.assign_activity( consume_activity_actor( loc, consume_menu_selections,
                          consume_menu_selected_items, consume_menu_filter, type ) );
     you.last_item = item( *loc ).typeId();
@@ -1127,6 +1129,8 @@ void avatar_action::use_item( avatar &you )
 
 void avatar_action::use_item( avatar &you, item_location &loc, std::string const &method )
 {
+    map &here = get_map();
+
     if( you.has_effect( effect_incorporeal ) ) {
         you.add_msg_if_player( m_bad, _( "You can't use anything while incorporeal." ) );
         return;
@@ -1148,7 +1152,7 @@ void avatar_action::use_item( avatar &you, item_location &loc, std::string const
         return;
     }
 
-    loc.overflow();
+    loc.overflow( here );
 
     if( loc->is_comestible() && loc->is_frozen_liquid() ) {
         add_msg( _( "Try as you might, you can't consume frozen liquids." ) );

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -10178,6 +10178,8 @@ ret_val<crush_tool_type> Character::can_crush_frozen_liquid( item_location const
 
 bool Character::crush_frozen_liquid( item_location loc )
 {
+    map &here = get_map();
+
     ret_val<crush_tool_type> can_crush = can_crush_frozen_liquid( loc );
     bool done_crush = false;
     if( can_crush.success() ) {
@@ -10195,7 +10197,7 @@ bool Character::crush_frozen_liquid( item_location loc )
                                        hammering_item.tname() );
                     // FIXME: Hardcoded damage type
                     const int smashskill = get_arm_str() + hammering_item.damage_melee( damage_bash );
-                    get_map().bash( loc.pos_bub(), smashskill );
+                    here.bash( loc.pos_bub( here ), smashskill );
                 }
             } else {
                 done_crush = false;
@@ -13108,6 +13110,8 @@ void Character::use( int inventory_position )
 
 void Character::use( item_location loc, int pre_obtain_moves, std::string const &method )
 {
+    map &here = get_map();
+
     if( has_effect( effect_incorporeal ) ) {
         add_msg_if_player( m_bad, _( "You can't use anything while incorporeal." ) );
         return;
@@ -13132,10 +13136,10 @@ void Character::use( item_location loc, int pre_obtain_moves, std::string const 
             set_moves( pre_obtain_moves );
             return;
         }
-        invoke_item( &used, method, loc.pos_bub(), pre_obtain_moves );
+        invoke_item( &used, method, loc.pos_bub( here ), pre_obtain_moves );
 
     } else if( used.type->can_use( "PETFOOD" ) ) { // NOLINT(bugprone-branch-clone)
-        invoke_item( &used, method, loc.pos_bub(), pre_obtain_moves );
+        invoke_item( &used, method, loc.pos_bub( here ), pre_obtain_moves );
 
     } else if( !used.is_craft() && ( used.is_medication() || ( !used.type->has_use() &&
                                      used.is_food() ) ) ) {
@@ -13168,7 +13172,7 @@ void Character::use( item_location loc, int pre_obtain_moves, std::string const 
             }
         }
     } else if( used.type->has_use() ) {
-        invoke_item( &used, method, loc.pos_bub(), pre_obtain_moves );
+        invoke_item( &used, method, loc.pos_bub( here ), pre_obtain_moves );
     } else if( used.has_flag( flag_SPLINT ) ) {
         ret_val<void> need_splint = can_wear( *loc );
         if( need_splint.success() ) {
@@ -13178,7 +13182,7 @@ void Character::use( item_location loc, int pre_obtain_moves, std::string const 
             add_msg( m_info, need_splint.str() );
         }
     } else if( used.is_relic() ) {
-        invoke_item( &used, method, loc.pos_bub(), pre_obtain_moves );
+        invoke_item( &used, method, loc.pos_bub( here ), pre_obtain_moves );
     } else {
         if( !is_armed() ) {
             add_msg( m_info, _( "You are not wielding anything you could use." ) );

--- a/src/character_attire.cpp
+++ b/src/character_attire.cpp
@@ -2123,8 +2123,10 @@ void outfit::best_pocket( Character &guy, const item &it, const item *avoid,
 
 void outfit::overflow( Character &guy )
 {
+    map &here = get_map();
+
     for( item_location &clothing : top_items_loc( guy ) ) {
-        clothing.overflow();
+        clothing.overflow( here );
     }
 }
 

--- a/src/character_inventory.cpp
+++ b/src/character_inventory.cpp
@@ -670,6 +670,8 @@ ret_val<void> Character::can_drop( const item &it ) const
 
 void Character::drop_invalid_inventory()
 {
+    map &here = get_map();
+
     if( cache_inventory_is_valid ) {
         return;
     }
@@ -678,7 +680,7 @@ void Character::drop_invalid_inventory()
         const item &it = stack->front();
         if( it.made_of( phase_id::LIQUID ) ) {
             dropped_liquid = true;
-            get_map().add_item_or_charges( pos_bub(), it );
+            here.add_item_or_charges( pos_bub( here ), it );
             // must be last
             i_rem( &it );
         }
@@ -689,7 +691,7 @@ void Character::drop_invalid_inventory()
 
     item_location weap = get_wielded_item();
     if( weap ) {
-        weap.overflow();
+        weap.overflow( here );
     }
     worn.overflow( *this );
     cache_inventory_is_valid = true;

--- a/src/computer.cpp
+++ b/src/computer.cpp
@@ -7,7 +7,6 @@
 #include "debug.h"
 #include "enum_conversions.h"
 #include "flexbuffer_json.h"
-#include "game.h"
 #include "json.h"
 #include "map.h"
 #include "output.h"

--- a/src/computer.cpp
+++ b/src/computer.cpp
@@ -7,7 +7,9 @@
 #include "debug.h"
 #include "enum_conversions.h"
 #include "flexbuffer_json.h"
+#include "game.h"
 #include "json.h"
+#include "map.h"
 #include "output.h"
 #include "point.h"
 #include "talker.h"
@@ -62,7 +64,16 @@ void computer_failure::deserialize( const JsonObject &jo )
     type = jo.get_enum_value<computer_failure_type>( "action" );
 }
 
-computer::computer( const std::string &new_name, int new_security, tripoint_bub_ms new_loc )
+computer::computer( const std::string &new_name, int new_security, map &here,
+                    tripoint_bub_ms new_loc )
+    : name( new_name ), mission_id( -1 ), security( new_security ), alerts( 0 ),
+      next_attempt( calendar::before_time_starts ),
+      access_denied( _( "ERROR!  Access denied!" ) )
+{
+    loc = here.get_abs( new_loc );
+}
+
+computer::computer( const std::string &new_name, int new_security, tripoint_abs_ms new_loc )
     : name( new_name ), mission_id( -1 ), security( new_security ), alerts( 0 ),
       next_attempt( calendar::before_time_starts ),
       access_denied( _( "ERROR!  Access denied!" ) )
@@ -202,7 +213,7 @@ void computer::serialize( JsonOut &jout ) const
     jout.member( "eocs", eocs );
     jout.member( "chat_topics", chat_topics );
     jout.member( "values", values );
-    jout.member( "loc", loc );
+    jout.member( "location", loc );
     jout.end_object();
 }
 
@@ -223,7 +234,12 @@ void computer::deserialize( const JsonValue &jv )
         jo.read( "eocs", eocs );
         jo.read( "chat_topics", chat_topics );
         jo.read( "values", values );
-        jo.read( "loc", loc );
+        if( !jo.read( "location", loc ) ) {
+            // Backward compatibility code for change made 2025-02-19.
+            tripoint_bub_ms temp;
+            jo.read( "loc", temp );
+            loc = get_map().get_abs( temp );
+        }
     }
 }
 

--- a/src/computer.h
+++ b/src/computer.h
@@ -15,6 +15,7 @@
 class JsonObject;
 class JsonOut;
 class JsonValue;
+class map;
 class talker;
 
 enum computer_action {
@@ -119,7 +120,8 @@ struct computer_failure {
 class computer
 {
     public:
-        computer( const std::string &new_name, int new_security, tripoint_bub_ms new_loc );
+        computer( const std::string &new_name, int new_security, map &here, tripoint_bub_ms new_loc );
+        computer( const std::string &new_name, int new_security, tripoint_abs_ms new_loc );
 
         // Initialization
         void set_security( int Security );
@@ -137,7 +139,7 @@ class computer
         void deserialize( const JsonValue &jv );
 
         friend class computer_session;
-        tripoint_bub_ms loc;
+        tripoint_abs_ms loc;
         // "Jon's Computer", "Lab 6E77-B Terminal Omega"
         std::string name;
         // Linked to a mission?

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -2157,7 +2157,7 @@ std::list<item> Character::consume_items( map &m, const comp_selection<item_comp
             it.spill_contents( *this );
         }
         // todo: make a proper solution that overflows with the proper item_location
-        it.overflow( pos_bub() );
+        it.overflow( m, pos_bub( m ) );
     }
     empty_buckets( *this );
     return ret;
@@ -2809,7 +2809,7 @@ void Character::complete_disassemble( item_location &target, const recipe &dis )
 
     // Get the proper recipe - the one for disassembly, not assembly
     const requirement_data dis_requirements = dis.disassembly_requirements();
-    const tripoint_bub_ms loc = target.pos_bub();
+    const tripoint_bub_ms loc = target.pos_bub( here );
 
     // Get the item to disassemble, and make a copy to keep its data (damage/components)
     // after the original has been removed.

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -3778,6 +3778,8 @@ std::pair<size_t, std::string> basecamp::farm_action( const point_rel_omt &dir, 
 void basecamp::start_farm_op( const point_rel_omt &dir, const mission_id &miss_id,
                               float exertion_level )
 {
+    map &here = get_map();
+
     farm_ops op = farm_ops::plow;
     if( miss_id.id == Camp_Plow ) {
         op = farm_ops::plow;
@@ -3818,7 +3820,7 @@ void basecamp::start_farm_op( const point_rel_omt &dir, const mission_id &miss_i
             for( std::pair<item_location, int> &seeds : seed_selection ) {
                 size_t num_seeds = seeds.second;
                 item_location seed = seeds.first;
-                seed.overflow();
+                seed.overflow( here );
                 if( seed->count_by_charges() ) {
                     seed->charges = num_seeds;
                 }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -10470,7 +10470,7 @@ void game::wield( item_location loc )
     // Can't use loc.obtain() here because that would cause things to spill.
     item to_wield = *loc.get_item();
     item_location::type location_type = loc.where();
-    tripoint_bub_ms pos = loc.pos_bub();
+    tripoint_bub_ms pos = loc.pos_bub( here );
     const int obtain_cost = loc.obtain_cost( u );
     int worn_index = INT_MIN;
 

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -589,7 +589,7 @@ class pickup_inventory_preset : public inventory_selector_preset
             if( ignore_liquidcont && loc.where() == item_location::type::map &&
                 !loc->made_of( phase_id::SOLID ) ) {
                 map &here = get_map();
-                if( here.has_flag( ter_furn_flag::TFLAG_LIQUIDCONT, loc.pos_bub() ) ) {
+                if( here.has_flag( ter_furn_flag::TFLAG_LIQUIDCONT, loc.pos_bub( here ) ) ) {
                     return false;
                 }
             }
@@ -791,12 +791,14 @@ class comestible_inventory_preset : public inventory_selector_preset
         }
 
         std::string get_denial( const item_location &loc ) const override {
+            map &here = get_map();
+
             const item &med = *loc;
 
             if(
                 ( loc->made_of_from_type( phase_id::LIQUID ) &&
                   loc.where() != item_location::type::container ) &&
-                !get_map().has_flag_furn( ter_furn_flag::TFLAG_LIQUIDCONT, loc.pos_bub() ) ) {
+                !here.has_flag_furn( ter_furn_flag::TFLAG_LIQUIDCONT, loc.pos_bub( here ) ) ) {
                 return _( "Can't drink spilt liquids." );
             }
             if(
@@ -1680,7 +1682,7 @@ drop_locations game_menus::inv::edevice_select( Character &who, item_location &u
 
     const inventory_filter_preset preset( [&]( const item_location & loc ) {
         //make sure this is an edevice before we make edevice calls
-        if( loc->is_estorage() && loc->is_owned_by( who, true ) && who.sees( here, loc.pos_bub() ) ) {
+        if( loc->is_estorage() && loc->is_owned_by( who, true ) && who.sees( here, loc.pos_bub( here ) ) ) {
             efile_activity_actor::edevice_compatible compat =
                 efile_activity_actor::edevices_compatible( used_edevice, loc );
             bool is_tool_has_charge = !loc->is_tool() || loc->ammo_sufficient( &who );
@@ -3063,7 +3065,7 @@ class select_ammo_inventory_preset : public inventory_selector_preset
             }
 
             if( loc->made_of( phase_id::LIQUID ) && loc.where() == item_location::type::map ) {
-                if( !here.has_flag_ter_or_furn( ter_furn_flag::TFLAG_LIQUIDCONT, loc.pos_bub() ) ) {
+                if( !here.has_flag_ter_or_furn( ter_furn_flag::TFLAG_LIQUIDCONT, loc.pos_bub( here ) ) ) {
                     return false;
                 }
             }

--- a/src/handle_liquid.cpp
+++ b/src/handle_liquid.cpp
@@ -326,6 +326,8 @@ static bool get_liquid_target( item &liquid, const item *const source, const int
 static bool get_liquid_target( item_location &liquid, const item *const source, const int radius,
                                liquid_dest_opt &target )
 {
+    const map &here = get_map();
+
     const tripoint_bub_ms *source_pos = nullptr;
     const vehicle *source_veh = nullptr;
     const monster *source_mon = nullptr;
@@ -336,7 +338,7 @@ static bool get_liquid_target( item_location &liquid, const item *const source, 
             // intentionally empty
             break;
         case item_location::type::map:
-            pos = liquid.pos_bub();
+            pos = liquid.pos_bub( here );
             source_pos = &pos;
             break;
         case item_location::type::vehicle:
@@ -430,6 +432,8 @@ static bool check_liquid( item &liquid )
 
 bool perform_liquid_transfer( item_location &liquid, liquid_dest_opt &target )
 {
+    map &here = get_map();
+
     if( !check_liquid( *liquid ) ) {
         // "canceled by the user" because we *can* not handle it.
         return false;
@@ -445,7 +449,7 @@ bool perform_liquid_transfer( item_location &liquid, liquid_dest_opt &target )
             return true;
         } else if( liquid.where() == item_location::type::map ) {
             player_character.assign_activity( ACT_FILL_LIQUID );
-            serialize_liquid_source( player_character.activity, liquid.pos_bub(), *liquid );
+            serialize_liquid_source( player_character.activity, liquid.pos_bub( here ), *liquid );
             return true;
         } else {
             return false;

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -1615,11 +1615,13 @@ bool iexamine::can_hack( Character &you )
 
 bool iexamine::try_start_hacking( Character &you, const tripoint_bub_ms &examp )
 {
+    map &here = get_map();
+
     if( !can_hack( you ) ) {
         return false;
     } else {
         item_location hacking_tool = item_location{you, &you.best_item_with_quality( qual_HACK )};
-        hacking_tool->ammo_consume( hacking_tool->ammo_required(), hacking_tool.pos_bub(), &you );
+        hacking_tool->ammo_consume( hacking_tool->ammo_required(), hacking_tool.pos_bub( here ), &you );
         you.assign_activity( hacking_activity_actor( hacking_tool ) );
         you.activity.placement = get_map().get_abs( examp );
         return true;
@@ -4616,7 +4618,7 @@ void iexamine::tree_maple( Character &you, const tripoint_bub_ms &examp )
     map &here = get_map();
     item_location spile_loc = g->inv_map_splice( [&here]( const item_location & it ) {
         return it->get_quality_nonrecursive( qual_TREE_TAP ) > 0 &&
-               !( here.ter( it.pos_bub() ) == ter_t_tree_maple_tapped );
+               !( here.ter( it.pos_bub( here ) ) == ter_t_tree_maple_tapped );
     }, _( "Use which tapping tool?" ), PICKUP_RANGE, _( "You don't have a tapping tool at hand." ) );
 
     item *spile = spile_loc.get_item();
@@ -5121,7 +5123,7 @@ static void reload_furniture( Character &you, const tripoint_bub_ms &examp, bool
     you.mod_moves( -you.item_handling_cost( moved ) );
     std::list<item>used;
     if( opt.ammo.get_item()->use_charges( opt_type->get_id(), amount, used,
-                                          opt.ammo.pos_bub() ) ) {
+                                          opt.ammo.pos_bub( here ) ) ) {
         opt.ammo.remove_item();
     }
 
@@ -6823,7 +6825,7 @@ static void smoker_load_food( Character &you, const tripoint_bub_ms &examp,
     units::volume vol = remaining_capacity;
     for( const drop_location &dloc : locs ) {
         item_location original = dloc.first;
-        original.overflow();
+        original.overflow( here );
         item copy( *original );
         if( copy.count_by_charges() ) {
             copy.charges = clamp( copy.charges_per_volume( vol ), 1, dloc.second );

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -1308,7 +1308,7 @@ inventory_entry *inventory_column::add_entry( const inventory_entry &entry )
             return !e.is_collated() &&
                    e.get_category_ptr() == entry.get_category_ptr() &&
                    entry_item.where() == found_entry_item.where() &&
-                   entry_item.pos_bub() == found_entry_item.pos_bub() &&
+                   entry_item.pos_abs() == found_entry_item.pos_abs() &&
                    entry_item.parent_item() == found_entry_item.parent_item() &&
                    entry_item->is_collapsed() == found_entry_item->is_collapsed() &&
                    entry_item->link_length() == found_entry_item->link_length() &&
@@ -3204,6 +3204,8 @@ void inventory_selector::_categorize( inventory_column &col )
 
 void inventory_selector::_uncategorize( inventory_column &col )
 {
+    const map &here = get_map();
+
     for( inventory_entry *entry : col.get_entries( return_item, true ) ) {
         // find the topmost parent of the entry's item and categorize it by that
         // to form the hierarchy
@@ -3216,7 +3218,7 @@ void inventory_selector::_uncategorize( inventory_column &col )
         if( ancestor.where() != item_location::type::character ) {
             const std::string name = to_upper_case( remove_color_tags( ancestor.describe() ) );
             const item_category map_cat( name, no_translation( name ), translation(), 100 );
-            custom_category = naturalize_category( map_cat, ancestor.pos_bub() );
+            custom_category = naturalize_category( map_cat, ancestor.pos_bub( here ) );
         } else {
             custom_category = wielded_worn_category( ancestor, u );
         }

--- a/src/item.h
+++ b/src/item.h
@@ -1881,7 +1881,8 @@ class item : public visitable
         bool spill_contents( map *here, const tripoint_bub_ms &pos );
         bool spill_open_pockets( Character &guy, const item *avoid = nullptr );
         /** Spill items that don't fit in the container. */
-        void overflow( const tripoint_bub_ms &pos, const item_location &loc = item_location::nowhere );
+        void overflow( map &here, const tripoint_bub_ms &pos,
+                       const item_location &loc = item_location::nowhere );
 
         /**
          * Check if item is a holster and currently capable of storing obj.
@@ -2600,7 +2601,7 @@ class item : public visitable
          * @return amount of ammo consumed which will be between 0 and qty
          */
         int ammo_consume( int qty, const tripoint_bub_ms &pos, Character *carrier );
-        int ammo_consume( int qty, map *here, const tripoint_bub_ms &pos, Character *carrier );
+        int ammo_consume( int qty, map &here, const tripoint_bub_ms &pos, Character *carrier );
 
         /**
          * Consume energy (if available) and return the amount of energy that was consumed

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -1241,10 +1241,10 @@ bool item_contents::spill_contents( map *here, const tripoint_bub_ms &pos )
     return spilled;
 }
 
-void item_contents::overflow( const tripoint_bub_ms &pos, const item_location &loc )
+void item_contents::overflow( map &here, const tripoint_bub_ms &pos, const item_location &loc )
 {
     for( item_pocket &pocket : contents ) {
-        pocket.overflow( pos, loc );
+        pocket.overflow( here, pos, loc );
     }
 }
 
@@ -1275,7 +1275,7 @@ int item_contents::ammo_consume( int qty, map *here, const tripoint_bub_ms &pos,
             }
             // assuming only one mag
             item &mag = pocket.front();
-            const int res = mag.ammo_consume( qty, here, pos, nullptr );
+            const int res = mag.ammo_consume( qty, *here, pos, nullptr );
             if( res && mag.ammo_remaining( ) == 0 ) {
                 if( mag.has_flag( STATIC( flag_id( "MAG_DESTROY" ) ) ) ) {
                     pocket.remove_item( mag );

--- a/src/item_contents.h
+++ b/src/item_contents.h
@@ -313,7 +313,7 @@ class item_contents
         bool spill_contents( const tripoint_bub_ms &pos );
         bool spill_contents( map *here, const tripoint_bub_ms &pos );
         /** Spill items that don't fit in the container. */
-        void overflow( const tripoint_bub_ms &pos, const item_location &loc );
+        void overflow( map &here, const tripoint_bub_ms &pos, const item_location &loc );
         void clear_items();
         /** Clear all items from magazine type pockets. */
         void clear_magazines();

--- a/src/item_location.cpp
+++ b/src/item_location.cpp
@@ -95,7 +95,8 @@ class item_location::impl
         virtual item_pocket *parent_pocket() const {
             return nullptr;
         }
-        virtual tripoint_bub_ms pos_bub() const = 0;
+        virtual tripoint_bub_ms pos_bub( const map &here ) const = 0;
+        virtual tripoint_abs_ms pos_abs() const = 0;
         virtual Character *carrier() const = 0;
         virtual const vehicle_cursor *veh_cursor() const {
             return nullptr;
@@ -149,9 +150,14 @@ class item_location::impl::nowhere : public item_location::impl
             return type::invalid;
         }
 
-        tripoint_bub_ms pos_bub() const override {
+        tripoint_bub_ms pos_bub( const map &here ) const override {
             debugmsg( "invalid use of nowhere item_location" );
             return tripoint_bub_ms::min;
+        }
+
+        tripoint_abs_ms pos_abs() const override {
+            debugmsg( "invalid use of nowhere item_location" );
+            return tripoint_abs_ms::min;
         }
 
         Character *carrier() const override {
@@ -216,7 +222,7 @@ class item_location::impl::item_on_map : public item_location::impl
         void serialize( JsonOut &js ) const override {
             js.start_object();
             js.member( "type", "map" );
-            js.member( "pos", pos_bub() );
+            js.member( "position", pos_abs() );
             js.member( "idx", find_index( cur, target() ) );
             js.end_object();
         }
@@ -229,8 +235,12 @@ class item_location::impl::item_on_map : public item_location::impl
             return type::map;
         }
 
-        tripoint_bub_ms pos_bub() const override {
-            return cur.pos_bub();
+        tripoint_bub_ms pos_bub( const map &here ) const override {
+            return cur.pos_bub( here );
+        }
+
+        tripoint_abs_ms pos_abs() const override {
+            return cur.pos_abs();
         }
 
         Character *carrier() const override {
@@ -355,11 +365,18 @@ class item_location::impl::item_on_person : public item_location::impl
             return type::character;
         }
 
-        tripoint_bub_ms pos_bub() const override {
+        tripoint_bub_ms pos_bub( const map &here ) const override {
             if( !ensure_who_unpacked() ) {
                 return tripoint_bub_ms::zero;
             }
-            return who->pos_bub();
+            return who->pos_bub( here );
+        }
+
+        tripoint_abs_ms pos_abs() const override {
+            if( !ensure_who_unpacked() ) {
+                return tripoint_abs_ms::invalid;
+            }
+            return who->pos_abs();
         }
 
         Character *carrier() const override {
@@ -475,7 +492,7 @@ class item_location::impl::item_on_vehicle : public item_location::impl
         void serialize( JsonOut &js ) const override {
             js.start_object();
             js.member( "type", "vehicle" );
-            js.member( "pos", pos_bub() );
+            js.member( "position", pos_abs() );
             js.member( "part", cur.part );
             if( target() != &cur.veh.part( cur.part ).base ) {
                 js.member( "idx", find_index( cur, target() ) );
@@ -491,9 +508,12 @@ class item_location::impl::item_on_vehicle : public item_location::impl
             return type::vehicle;
         }
 
-        tripoint_bub_ms pos_bub() const override {
-            map &here = get_map();
+        tripoint_bub_ms pos_bub( const map &here ) const override {
             return cur.veh.bub_part_pos( here, cur.part );
+        }
+
+        tripoint_abs_ms pos_abs() const override {
+            return cur.veh.abs_part_pos( cur.part );
         }
 
         Character *carrier() const override {
@@ -567,7 +587,7 @@ class item_location::impl::item_on_vehicle : public item_location::impl
         }
 
         void make_active( item_location &head ) {
-            cur.veh.make_active( get_map(), head );
+            cur.veh.make_active( head );
         }
 
         units::volume volume_capacity() const override {
@@ -668,8 +688,12 @@ class item_location::impl::item_in_container : public item_location::impl
             return container.where_recursive();
         }
 
-        tripoint_bub_ms pos_bub() const override {
-            return container.pos_bub();
+        tripoint_bub_ms pos_bub( const map &here ) const override {
+            return container.pos_bub( here );
+        }
+
+        tripoint_abs_ms pos_abs() const override {
+            return container.pos_abs();
         }
 
         void remove_item() override {
@@ -825,13 +849,20 @@ void item_location::serialize( JsonOut &js ) const
 
 void item_location::deserialize( const JsonObject &obj )
 {
+    const map &here = get_map();
+
     std::string type = obj.get_string( "type" );
 
     int idx = -1;
-    tripoint_bub_ms pos = tripoint_bub_ms::invalid;
+    tripoint_bub_ms pos_ = tripoint_bub_ms::invalid;
+    tripoint_abs_ms position = tripoint_abs_ms::invalid;
 
     obj.read( "idx", idx );
-    obj.read( "pos", pos );
+    if( !obj.read( "position", position ) ) {
+        // Save compatibility for change made 2025-02-19
+        obj.read( "pos", pos_ );
+        position = here.get_abs( pos_ );
+    }
 
     if( type == "character" ) {
         character_id who_id;
@@ -845,10 +876,10 @@ void item_location::deserialize( const JsonObject &obj )
         ptr = std::make_shared<impl::item_on_person>( who_id, idx );
 
     } else if( type == "map" ) {
-        ptr = std::make_shared<impl::item_on_map>( map_cursor( pos ), idx );
+        ptr = std::make_shared<impl::item_on_map>( map_cursor( position ), idx );
 
     } else if( type == "vehicle" ) {
-        vehicle *const veh = veh_pointer_or_null( get_map().veh_at( pos ) );
+        vehicle *const veh = veh_pointer_or_null( here.veh_at( position ) );
         int part = obj.get_int( "part" );
         if( veh && part >= 0 && part < veh->part_count() ) {
             ptr = std::make_shared<impl::item_on_vehicle>( vehicle_cursor( *veh, part ), idx );
@@ -863,7 +894,7 @@ void item_location::deserialize( const JsonObject &obj )
                 return;
             }
             debugmsg( "parent location does not point to valid item" );
-            ptr = std::make_shared<impl::item_on_map>( map_cursor( parent.pos_bub() ), idx ); // drop on ground
+            ptr = std::make_shared<impl::item_on_map>( map_cursor( parent.pos_abs() ), idx ); // drop on ground
             return;
         }
         const std::list<item *> parent_contents = parent->all_items_container_top();
@@ -1014,9 +1045,9 @@ bool item_location::eventually_contains( item_location loc ) const
     return false;
 }
 
-void item_location::overflow()
+void item_location::overflow( map &here )
 {
-    get_item()->overflow( pos_bub(), *this );
+    get_item()->overflow( here, pos_bub( here ), *this );
 }
 
 item_location::type item_location::where() const
@@ -1029,9 +1060,14 @@ item_location::type item_location::where_recursive() const
     return ptr->where_recursive();
 }
 
-tripoint_bub_ms item_location::pos_bub() const
+tripoint_bub_ms item_location::pos_bub( const map &here ) const
 {
-    return ptr->pos_bub();
+    return ptr->pos_bub( here );
+}
+
+tripoint_abs_ms item_location::pos_abs() const
+{
+    return ptr->pos_abs();
 }
 
 std::string item_location::describe( const Character *ch ) const

--- a/src/item_location.cpp
+++ b/src/item_location.cpp
@@ -150,7 +150,7 @@ class item_location::impl::nowhere : public item_location::impl
             return type::invalid;
         }
 
-        tripoint_bub_ms pos_bub( const map &here ) const override {
+        tripoint_bub_ms pos_bub( const map & ) const override {
             debugmsg( "invalid use of nowhere item_location" );
             return tripoint_bub_ms::min;
         }

--- a/src/item_location.h
+++ b/src/item_location.h
@@ -16,6 +16,7 @@ class JsonOut;
 class const_talker;
 class item;
 class item_pocket;
+class map;
 class map_cursor;
 class talker;
 class vehicle_cursor;
@@ -69,7 +70,8 @@ class item_location
         type where_recursive() const;
 
         /** Returns the position where the item is found */
-        tripoint_bub_ms pos_bub() const;
+        tripoint_bub_ms pos_bub( const map &here ) const;
+        tripoint_abs_ms pos_abs() const;
 
         /** Describes the item location
          *  @param ch if set description is relative to character location */
@@ -155,7 +157,7 @@ class item_location
         /**
          * Overflow items into parent pockets recursively
          */
-        void overflow();
+        void overflow( map &here );
 
         /**
          * returns whether the item can be reloaded with the specified item.

--- a/src/item_pocket.h
+++ b/src/item_pocket.h
@@ -292,7 +292,7 @@ class item_pocket
         std::optional<item> remove_item( const item &it );
         std::optional<item> remove_item( const item_location &it );
         // spills any contents that can't fit into the pocket, largest items first
-        void overflow( const tripoint_bub_ms &pos, const item_location &loc );
+        void overflow( map &here, const tripoint_bub_ms &pos, const item_location &loc );
         bool spill_contents( const tripoint_bub_ms &pos );
         bool spill_contents( map *here, const tripoint_bub_ms &pos );
         void on_pickup( Character &guy, item *avoid = nullptr );

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -2555,15 +2555,17 @@ std::optional<int> iuse::purify_water( Character *p, item *purifier, item_locati
 
 std::optional<int> iuse::water_tablets( Character *p, item *it, const tripoint_bub_ms & )
 {
+    map &here = get_map();
+
     if( p->cant_do_mounted() ) {
         return std::nullopt;
     }
 
-    item_location obj = g->inv_map_splice( []( const item_location & e ) {
+    item_location obj = g->inv_map_splice( [&here]( const item_location & e ) {
         return ( !e->empty() && e->has_item_with( []( const item & it ) {
             return it.typeId() == itype_water;
         } ) ) || ( e->typeId() == itype_water &&
-                   get_map().has_flag_furn( ter_furn_flag::TFLAG_LIQUIDCONT, e.pos_bub() ) );
+                   here.has_flag_furn( ter_furn_flag::TFLAG_LIQUIDCONT, e.pos_bub( here ) ) );
     }, _( "Purify what?" ), 1, _( "You don't have water to purify." ) );
 
     if( !obj ) {
@@ -5015,11 +5017,13 @@ std::optional<int> iuse::handle_ground_graffiti( Character &p, item *it, const s
  */
 static bool heat_item( Character &p )
 {
-    item_location loc = g->inv_map_splice( []( const item_location & itm ) {
+    map &here = get_map();
+
+    item_location loc = g->inv_map_splice( [&here]( const item_location & itm ) {
         return itm->has_temperature() && !itm->has_own_flag( flag_HOT ) &&
                ( !itm->made_of_from_type( phase_id::LIQUID ) ||
                  itm.where() == item_location::type::container ||
-                 get_map().has_flag_furn( ter_furn_flag::TFLAG_LIQUIDCONT, itm.pos_bub() ) );
+                 here.has_flag_furn( ter_furn_flag::TFLAG_LIQUIDCONT, itm.pos_bub( here ) ) );
     }, _( "Heat up what?" ), 1, _( "You don't have any appropriate food to heat up." ) );
 
     item *heat = loc.get_item();
@@ -8333,6 +8337,8 @@ heater find_heater( Character *p, item *it )
 
 static bool heat_items( Character *p, item *it, bool liquid_items, bool solid_items )
 {
+    map &here = get_map();
+
     p->inv->restack( *p );
     heater h = find_heater( p, it );
     if( h.available_heater == -1 ) {
@@ -8347,11 +8353,11 @@ static bool heat_items( Character *p, item *it, bool liquid_items, bool solid_it
     units::mass frozen_weight = 0_gram;
     units::mass not_frozen_weight = 0_gram;
     if( multiple == false ) {
-        item_location loc = g->inv_map_splice( []( const item_location & itm ) {
+        item_location loc = g->inv_map_splice( [&here]( const item_location & itm ) {
             return itm->has_temperature() && !itm->has_own_flag( flag_HOT ) &&
                    ( !itm->made_of_from_type( phase_id::LIQUID ) ||
                      itm.where() == item_location::type::container ||
-                     get_map().has_flag_furn( ter_furn_flag::TFLAG_LIQUIDCONT, itm.pos_bub() ) );
+                     here.has_flag_furn( ter_furn_flag::TFLAG_LIQUIDCONT, itm.pos_bub( here ) ) );
         }, _( "Heat up what?" ), 1, _( "You don't have any appropriate food to heat up." ) );
         if( !loc ) {
             return false;

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -1967,7 +1967,7 @@ void salvage_actor::cut_up( Character &p, item_location &cut ) const
              cut.get_item()->tname() );
 
     const item_location::type cut_type = cut.where();
-    const tripoint_bub_ms pos = cut.pos_bub();
+    const tripoint_bub_ms pos = cut.pos_bub( here );
     const bool filthy = cut.get_item()->is_filthy();
 
     // Clean up before removing the item.
@@ -3447,7 +3447,7 @@ static bool damage_item( Character &pl, item_location &fix )
                 if( it->has_flag( flag_NO_DROP ) ) {
                     continue;
                 }
-                put_into_vehicle_or_drop( pl, item_drop_reason::tumbling, { *it }, &here, fix.pos_bub() );
+                put_into_vehicle_or_drop( pl, item_drop_reason::tumbling, { *it }, &here, fix.pos_bub( here ) );
             }
             fix.remove_item();
         }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -5338,7 +5338,7 @@ void map::make_active( item_location &loc )
     item *target = loc.get_item();
 
     point_sm_ms l;
-    submap *const current_submap = get_submap_at( loc.pos_bub(), l );
+    submap *const current_submap = get_submap_at( loc.pos_bub( *this ), l );
     if( current_submap == nullptr ) {
         debugmsg( "Tried to make active at (%d,%d) but the submap is not loaded", l.x(), l.y() );
         return;
@@ -5347,8 +5347,8 @@ void map::make_active( item_location &loc )
     cata::colony<item>::iterator iter = item_stack.get_iterator_from_pointer( target );
 
     if( current_submap->active_items.add( *iter, l ) ) {
-        tripoint_abs_sm const smloc( abs_sub.x() + loc.pos_bub().x() / SEEX,
-                                     abs_sub.y() + loc.pos_bub().y() / SEEY, loc.pos_bub().z() );
+        tripoint_abs_sm const smloc( abs_sub.x() + loc.pos_bub( *this ).x() / SEEX,
+                                     abs_sub.y() + loc.pos_bub( *this ).y() / SEEY, loc.pos_abs().z() );
         submaps_with_active_items_dirty.insert( smloc );
         if( this != &get_map() && get_map().inbounds( smloc ) ) {
             get_map().make_active( smloc );
@@ -5371,7 +5371,7 @@ void map::update_lum( item_location &loc, bool add )
     }
 
     point_sm_ms l;
-    submap *const current_submap = get_submap_at( loc.pos_bub(), l );
+    submap *const current_submap = get_submap_at( loc.pos_bub( *this ), l );
     if( current_submap == nullptr ) {
         debugmsg( "Tried to update lum at (%d,%d) but the submap is not loaded", l.x(), l.y() );
         return;
@@ -8601,7 +8601,7 @@ void map::actualize( const tripoint_rel_sm &grid )
         // spill out items too large, MIGRATION pockets etc from vehicle parts
         for( const vpart_reference &vp : veh->get_all_parts() ) {
             const item &base_const = vp.part().get_base();
-            const_cast<item &>( base_const ).overflow( vp.pos_bub( *this ) );
+            const_cast<item &>( base_const ).overflow( *this, vp.pos_bub( *this ) );
         }
         veh->refresh( );
     }

--- a/src/map_selector.cpp
+++ b/src/map_selector.cpp
@@ -92,9 +92,9 @@ tripoint_bub_ms map_cursor::pos_bub() const
     return g ? get_map().get_bub( pos_abs_ ) : pos_bub_;
 }
 
-tripoint_bub_ms map_cursor::pos_bub( map *here ) const
+tripoint_bub_ms map_cursor::pos_bub( const map &here ) const
 {
-    return g ? here->get_bub( pos_abs_ ) : pos_bub_;
+    return g ? here.get_bub( pos_abs_ ) : pos_bub_;
 }
 
 tripoint_abs_ms map_cursor::pos_abs() const

--- a/src/map_selector.h
+++ b/src/map_selector.h
@@ -23,7 +23,7 @@ class map_cursor : public visitable
         // Marginally faster than the previous operation if you have the absolute coordinates at hand.
         explicit map_cursor( const tripoint_abs_ms &pos );
         tripoint_bub_ms pos_bub() const;
-        tripoint_bub_ms pos_bub( map *here ) const;
+        tripoint_bub_ms pos_bub( const map &here ) const;
         // Will return tripoint_abs_ms::invalid if g hasn't been defined.
         tripoint_abs_ms pos_abs() const;
 

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -7399,10 +7399,10 @@ computer *map::add_computer( const tripoint_bub_ms &p, const std::string &name, 
     submap *const place_on_submap = get_submap_at( p, l );
     if( place_on_submap == nullptr ) {
         debugmsg( "Tried to add computer at (%d,%d) but the submap is not loaded", l.x(), l.y() );
-        static computer null_computer = computer( name, security, p );
+        static computer null_computer = computer( name, security, *this, p );
         return &null_computer;
     }
-    place_on_submap->set_computer( l, computer( name, security, p ) );
+    place_on_submap->set_computer( l, computer( name, security, *this, p ) );
     return place_on_submap->get_computer( l );
 }
 

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -1127,7 +1127,7 @@ bool mattack::resurrect( monster *z )
     };
     for( item_location &location : here.get_active_items_in_radius( z->pos_bub(), range,
             special_item_type::corpse ) ) {
-        const tripoint_bub_ms &p = location.pos_bub();
+        const tripoint_bub_ms &p = location.pos_bub( here );
         item &i = *location;
         const mtype *mt = i.get_mtype();
         if( !( i.can_revive() && i.active && mt->has_flag( mon_flag_REVIVES ) &&

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -3122,7 +3122,7 @@ void monster::die( map *here, Creature *nkiller )
         }
     }
     if( corpse ) {
-        corpse->process( *here, nullptr, corpse.pos_bub() );
+        corpse->process( *here, nullptr, corpse.pos_bub( *here ) );
         if( get_map().inbounds( pos_abs() ) ) {
             corpse.make_active();
         }

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -453,6 +453,8 @@ bool npc::could_move_onto( const tripoint_bub_ms &p ) const
 
 std::vector<sphere> npc::find_dangerous_explosives() const
 {
+    const map &here = get_map();
+
     std::vector<sphere> result;
 
     const auto active_items = get_map().get_active_items_in_radius( pos_bub(), MAX_VIEW_DISTANCE,
@@ -468,7 +470,7 @@ std::vector<sphere> npc::find_dangerous_explosives() const
         const explosion_iuse *actor = dynamic_cast<const explosion_iuse *>( use->get_actor_ptr() );
         const int safe_range = actor->explosion.safe_range();
 
-        if( rl_dist( pos_bub(), elem.pos_bub() ) >= safe_range ) {
+        if( rl_dist( pos_abs(), elem.pos_abs() ) >= safe_range ) {
             continue;   // Far enough.
         }
 
@@ -478,7 +480,7 @@ std::vector<sphere> npc::find_dangerous_explosives() const
             continue;   // Consider only imminent dangers.
         }
 
-        result.emplace_back( elem.pos_bub().raw(), safe_range );
+        result.emplace_back( elem.pos_bub( here ).raw(), safe_range );
     }
 
     return result;
@@ -3990,13 +3992,14 @@ bool npc::find_corpse_to_pulp()
 
     if( corpse == nullptr ) {
         // If we're following the player, don't wander off to pulp corpses
-        const tripoint_bub_ms around = is_walking_with() ? player_character.pos_bub() : pos_bub();
+        const tripoint_bub_ms around = is_walking_with() ? player_character.pos_bub( here ) : pos_bub(
+                                           here );
         for( const item_location &location : here.get_active_items_in_radius( around, range,
                 special_item_type::corpse ) ) {
-            corpse = check_tile( location.pos_bub() );
+            corpse = check_tile( location.pos_bub( here ) );
 
             if( corpse != nullptr ) {
-                pulp_location = here.get_abs( location.pos_bub() );
+                pulp_location = location.pos_abs();
                 break;
             }
 

--- a/src/pickup.cpp
+++ b/src/pickup.cpp
@@ -493,8 +493,9 @@ void Pickup::pick_info::deserialize( const JsonObject &jsobj )
 
 void Pickup::pick_info::set_src( const item_location &src_ )
 {
+    const map &here = get_map(); // TODO: Change src_pos to absolute?
     // item_location of source may become invalid after the item is moved, so save the information separately.
-    src_pos = src_.pos_bub();
+    src_pos = src_.pos_bub( here );
     src_container = src_.parent_item();
     src_type = src_.where();
 }

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -1119,7 +1119,7 @@ int Character::fire_gun( map &here, const tripoint_bub_ms &target, int shots, it
         }
 
         const int required = gun.ammo_required();
-        if( gun.ammo_consume( required, &here, pos_bub( here ), this ) != required ) {
+        if( gun.ammo_consume( required, here, pos_bub( here ), this ) != required ) {
             debugmsg( "Unexpected shortage of ammo whilst firing %s", gun.tname() );
             break;
         }

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -5300,7 +5300,7 @@ void submap::load( const JsonValue &jv, const std::string &member_name, int vers
                 point_sm_ms loc;
                 computers_json.next_value().read( loc );
                 auto new_comp_it = computers.emplace( loc, computer( "BUGGED_COMPUTER", -100,
-                                                      tripoint_bub_ms::zero ) ).first;
+                                                      tripoint_abs_ms::invalid ) ).first;
                 computers_json.next_value().read( new_comp_it->second );
             }
         }

--- a/src/talker_furniture.cpp
+++ b/src/talker_furniture.cpp
@@ -16,12 +16,12 @@ std::string talker_furniture_const::disp_name() const
 
 int talker_furniture_const::posx() const
 {
-    return me_comp->loc.x();
+    return get_map().get_bub( me_comp->loc ).x();
 }
 
 int talker_furniture_const::posy() const
 {
-    return me_comp->loc.y();
+    return get_map().get_bub( me_comp->loc ).y();
 }
 
 int talker_furniture_const::posz() const
@@ -31,12 +31,12 @@ int talker_furniture_const::posz() const
 
 tripoint_bub_ms talker_furniture_const::pos_bub() const
 {
-    return me_comp->loc;
+    return get_map().get_bub( me_comp->loc );
 }
 
 tripoint_abs_ms talker_furniture_const::pos_abs() const
 {
-    return get_map().get_abs( me_comp->loc );
+    return me_comp->loc;
 }
 
 tripoint_abs_omt talker_furniture_const::pos_abs_omt() const

--- a/src/talker_item.cpp
+++ b/src/talker_item.cpp
@@ -31,27 +31,33 @@ std::string talker_item_const::get_name() const
 
 int talker_item_const::posx() const
 {
-    return me_it_const->pos_bub().x();
+    const map &here = get_map();
+
+    return me_it_const->pos_bub( here ).x();
 }
 
 int talker_item_const::posy() const
 {
-    return me_it_const->pos_bub().y();
+    const map &here = get_map();
+
+    return me_it_const->pos_bub( here ).y();
 }
 
 int talker_item_const::posz() const
 {
-    return me_it_const->pos_bub().z();
+    return me_it_const->pos_abs().z();
 }
 
 tripoint_bub_ms talker_item_const::pos_bub() const
 {
-    return me_it_const->pos_bub();
+    const map &here = get_map();
+
+    return me_it_const->pos_bub( here );
 }
 
 tripoint_abs_ms talker_item_const::pos_abs() const
 {
-    return get_map().get_abs( me_it_const->pos_bub() );
+    return me_it_const->pos_abs();
 }
 
 tripoint_abs_omt talker_item_const::pos_abs_omt() const

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -5902,10 +5902,10 @@ void vehicle::idle( map &here, bool on_map )
     for( vehicle_part *turret : turrets() ) {
         item_location base = turret_query( *turret ).base();
         // Notify player about status of a turret if they're on the same tile
-        if( player_at_controls || player_character.pos_bub( here ) == base.pos_bub() ) {
-            base->process( here, &player_character, base.pos_bub() );
+        if( player_at_controls || player_character.pos_abs( ) == base.pos_abs() ) {
+            base->process( here, &player_character, base.pos_bub( here ) );
         } else {
-            base->process( here, nullptr, base.pos_bub() );
+            base->process( here, nullptr, base.pos_bub( here ) );
         }
     }
 }
@@ -6010,10 +6010,10 @@ void vehicle::disable_smart_controller_if_needed()
     }
 }
 
-void vehicle::make_active( map &here, item_location &loc )
+void vehicle::make_active( item_location &loc )
 {
     item &target = *loc;
-    auto cargo_parts = get_parts_at( &here, loc.pos_bub(), "CARGO", part_status_flag::any );
+    auto cargo_parts = get_parts_at( loc.pos_abs(), "CARGO", part_status_flag::any );
     if( cargo_parts.empty() ) {
         return;
     }

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -1867,7 +1867,7 @@ class vehicle
          * Update an item's active status, for example when adding
          * hot or perishable liquid to a container.
          */
-        void make_active( map &here, item_location &loc );
+        void make_active( item_location &loc );
         /**
          * Try to add an item to part's cargo.
          * @return iterator to added item or std::nullopt if it can't be put here (not a cargo part, adding

--- a/src/vehicle_part.cpp
+++ b/src/vehicle_part.cpp
@@ -367,7 +367,7 @@ int vehicle_part::ammo_consume( int qty, map *here, const tripoint_bub_ms &pos )
         }
         return res;
     }
-    return base.ammo_consume( qty, here, pos, nullptr );
+    return base.ammo_consume( qty, *here, pos, nullptr );
 }
 
 units::energy vehicle_part::consume_energy( const itype_id &ftype, units::energy wanted_energy )

--- a/tests/eoc_test.cpp
+++ b/tests/eoc_test.cpp
@@ -793,6 +793,8 @@ TEST_CASE( "EOC_stored_condition_test", "[eoc]" )
 
 TEST_CASE( "dialogue_copy", "[eoc]" )
 {
+    map &here = get_map();
+
     standard_npc dude;
     dialogue d( get_talker_for( get_avatar() ), get_talker_for( &dude ) );
     dialogue d_copy( d );
@@ -802,7 +804,7 @@ TEST_CASE( "dialogue_copy", "[eoc]" )
 
     item hammer( itype_hammer );
     item_location hloc( map_cursor( tripoint_bub_ms::zero ), &hammer );
-    computer comp( "test_computer", 0, tripoint_bub_ms::zero );
+    computer comp( "test_computer", 0, here, tripoint_bub_ms::zero );
     dialogue d2( get_talker_for( hloc ), get_talker_for( comp ) );
     dialogue d2_copy( d2 );
     d2_copy.set_value( "suppress", "1" );
@@ -819,6 +821,8 @@ TEST_CASE( "dialogue_copy", "[eoc]" )
 
 TEST_CASE( "EOC_meta_test", "[eoc]" )
 {
+    map &here = get_map();
+
     global_variables &globvars = get_globals();
     globvars.clear_global_values();
 
@@ -826,7 +830,7 @@ TEST_CASE( "EOC_meta_test", "[eoc]" )
     monster zombie( mon_zombie );
     item hammer( itype_hammer );
     item_location hloc( map_cursor( tripoint_bub_ms::zero ), &hammer );
-    computer comp( "test_computer", 0, tripoint_bub_ms::zero );
+    computer comp( "test_computer", 0, here, tripoint_bub_ms::zero );
 
     dialogue d_empty( std::make_unique<talker>(), std::make_unique<talker>() );
     dialogue d_avatar( get_talker_for( get_avatar() ), std::make_unique<talker>() );

--- a/tests/item_contents_test.cpp
+++ b/tests/item_contents_test.cpp
@@ -30,6 +30,8 @@ static const itype_id itype_wrench_pocket_test( "wrench_pocket_test" );
 
 TEST_CASE( "item_contents" )
 {
+    map &here = get_map();
+
     clear_map();
     item tool_belt( itype_test_tool_belt );
 
@@ -83,9 +85,9 @@ TEST_CASE( "item_contents" )
     tool_belt.force_insert_item( crowbar, pocket_type::CONTAINER );
     CHECK( tool_belt.num_item_stacks() == 5 );
     tool_belt.force_insert_item( crowbar, pocket_type::CONTAINER );
-    tool_belt.overflow( tripoint_bub_ms::zero );
+    tool_belt.overflow( here, tripoint_bub_ms::zero );
     CHECK( tool_belt.num_item_stacks() == 4 );
-    tool_belt.overflow( tripoint_bub_ms::zero );
+    tool_belt.overflow( here, tripoint_bub_ms::zero );
     // overflow should only spill items if they can't fit
     CHECK( tool_belt.num_item_stacks() == 4 );
 
@@ -111,7 +113,7 @@ TEST_CASE( "overflow_on_combine", "[item]" )
     } );
     map &here = get_map();
     here.i_clear( origin );
-    purse.overflow( origin );
+    purse.overflow( here, origin );
     CHECK( here.i_at( origin ).size() == 1 );
 }
 
@@ -123,12 +125,14 @@ TEST_CASE( "overflow_test", "[item]" )
     item log( itype_log );
     purse.force_insert_item( log, pocket_type::MIGRATION );
     map &here = get_map();
-    purse.overflow( origin );
+    purse.overflow( here, origin );
     CHECK( here.i_at( origin ).size() == 1 );
 }
 
 TEST_CASE( "overflow_test_into_parent_item", "[item]" )
 {
+    map &here = get_map();
+
     clear_map();
     tripoint_bub_ms origin{ 60, 60, 0 };
     item jar( itype_jar_glass_sealed );
@@ -142,8 +146,7 @@ TEST_CASE( "overflow_test_into_parent_item", "[item]" )
     REQUIRE( contents_pre == 1 );
 
     item_location jar_loc( map_cursor( origin ), &jar );
-    jar_loc.overflow();
-    map &here = get_map();
+    jar_loc.overflow( here );
     CHECK( here.i_at( origin ).empty() );
 
     int contents_count = 0;

--- a/tests/item_pocket_test.cpp
+++ b/tests/item_pocket_test.cpp
@@ -2334,7 +2334,7 @@ TEST_CASE( "multipocket_liquid_transfer_test", "[pocket][item][liquid]" )
             REQUIRE( jug_w_water->all_items_top().size() == 1 );
             REQUIRE( jug_w_water->all_items_top().front()->charges == 15 );
             struct liquid_dest_opt liquid_target;
-            liquid_target.pos = jug_w_water.pos_bub();
+            liquid_target.pos = jug_w_water.pos_bub( m );
             liquid_target.dest_opt = LD_ITEM;
             liquid_target.item_loc = suit;
             u.set_moves( 100 );
@@ -2362,7 +2362,7 @@ TEST_CASE( "multipocket_liquid_transfer_test", "[pocket][item][liquid]" )
             REQUIRE( jug_w_water->all_items_top().size() == 1 );
             REQUIRE( jug_w_water->all_items_top().front()->charges == 15 );
             struct liquid_dest_opt liquid_target;
-            liquid_target.pos = jug_w_water.pos_bub();
+            liquid_target.pos = jug_w_water.pos_bub( m );
             liquid_target.dest_opt = LD_ITEM;
             liquid_target.item_loc = suit;
             u.set_moves( 100 );
@@ -2388,7 +2388,7 @@ TEST_CASE( "multipocket_liquid_transfer_test", "[pocket][item][liquid]" )
             REQUIRE( jug_w_water->all_items_top().size() == 1 );
             REQUIRE( jug_w_water->all_items_top().front()->charges == 2 );
             struct liquid_dest_opt liquid_target;
-            liquid_target.pos = jug_w_water.pos_bub();
+            liquid_target.pos = jug_w_water.pos_bub( m );
             liquid_target.dest_opt = LD_ITEM;
             liquid_target.item_loc = suit;
             u.set_moves( 100 );
@@ -2412,7 +2412,7 @@ TEST_CASE( "multipocket_liquid_transfer_test", "[pocket][item][liquid]" )
             REQUIRE( jug_w_water->all_items_top().size() == 1 );
             REQUIRE( jug_w_water->all_items_top().front()->charges == 2 );
             struct liquid_dest_opt liquid_target;
-            liquid_target.pos = jug_w_water.pos_bub();
+            liquid_target.pos = jug_w_water.pos_bub( m );
             liquid_target.dest_opt = LD_ITEM;
             liquid_target.item_loc = suit;
             u.set_moves( 100 );
@@ -2440,7 +2440,7 @@ TEST_CASE( "multipocket_liquid_transfer_test", "[pocket][item][liquid]" )
             suit->fill_with( water );
             REQUIRE( suit->all_items_top().size() == 2 );
             struct liquid_dest_opt liquid_target;
-            liquid_target.pos = suit.pos_bub();
+            liquid_target.pos = suit.pos_bub( m );
             liquid_target.dest_opt = LD_ITEM;
             liquid_target.item_loc = jug_w_water;
             for( item *&it : suit->all_items_top() ) {
@@ -2465,7 +2465,7 @@ TEST_CASE( "multipocket_liquid_transfer_test", "[pocket][item][liquid]" )
             REQUIRE( suit->all_items_top().size() == 2 );
             REQUIRE( jug_w_water->only_item().charges == 8 );
             struct liquid_dest_opt liquid_target;
-            liquid_target.pos = suit.pos_bub();
+            liquid_target.pos = suit.pos_bub( m );
             liquid_target.dest_opt = LD_ITEM;
             liquid_target.item_loc = jug_w_water;
             for( item *&it : suit->all_items_top() ) {
@@ -2827,6 +2827,8 @@ void check_whitelist( item const &it, bool should, itype_id const &id )
 
 TEST_CASE( "auto_whitelist", "[item][pocket][item_spawn]" )
 {
+    map &here = get_map();
+
     clear_avatar();
     clear_map();
     tripoint_abs_omt const this_omt =
@@ -2867,8 +2869,8 @@ TEST_CASE( "auto_whitelist", "[item][pocket][item_spawn]" )
 
     SECTION( "container emptied by processing" ) {
         itype_id const id = spawned_w_modifier->get_contents().first_item().typeId();
-        get_map().i_clear( spawned_w_custom_container.pos_bub() );
-        get_map().i_clear( spawned_in_def_container.pos_bub() );
+        get_map().i_clear( spawned_w_custom_container.pos_bub( here ) );
+        get_map().i_clear( spawned_in_def_container.pos_bub( here ) );
         restore_on_out_of_scope restore_temp(
             get_weather().forced_temperature );
         get_weather().forced_temperature = units::from_celsius( 21 );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Convert item_location and computer to use absolute coordinates internally in order to remove map dependencies where they aren't needed.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Change the type of the position element stored and adjust the usage of it accordingly, including some operations.

Storage of the coordinates uses a different name than previously, and compatibility code was added to process the old element.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
I started elsewhere, but ran into issues with the computer location requiring a map to be properly resolved. Backed out of that and tackles these two file storage issues I've avoided previously.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
- Loaded a save having breakpoints at the reading of the location and computer data.
- Verified the backward compatibility code for item_location was called on load and that get_map() produced a valid map at that time.
- Teleported to a shelter and verified that the backward compatibility code for the computer triggered.
- Teleported away from the shelter to a distant field.
- Saved and quit.
- Loaded the save.
- Noted the new code for item_location was triggered once and the compatibility code twice.
- Teleported back to the shelter and verified the new format was read.
- Verified the computer in the shelter worked normally.

I'm not sure why some item_locations were using the old format on the second load, but guess it may be a matter of files that haven't been overwritten. I haven't investigated it further, as I don't think that's relevant to the PR.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Scratched my head for a while trying to figure out what the submap computer loading was up to before realizing it created a dummy computer object that was then updated with the real data read from file. Creating the computer with an absolute dummy parameter allowed me to avoid a map dependency in this awkward location (submaps do not have any knowledge of maps).

Will get back to what I intended to address in the next PR, namely to get the talker class hierarchy pos_bub(), posx(), and posy() operations to be map aware (posz() doesn't need it, as `z` is the same for both bub and abs). However, this has a rather nasty propagation, so I don't want to add that to this PR (and I don't think the spread is half as bad as the previous PR).

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
