### PR TITLE
Add dormant map extra

### DIFF
--- a/data/json/mapgen/map_extras/dormants.json
+++ b/data/json/mapgen/map_extras/dormants.json
@@ -1,0 +1,8 @@
+[
+  {
+    "type": "mapgen",
+    "method": "json",
+    "update_mapgen_id": "mx_dormant",
+    "object": { "monsters": { " ": { "monster": "GROUP_VANILLA_DORMANT", "chance": 10, "density": 0.02 } } }
+  }
+]

--- a/data/json/overmap/map_extras.json
+++ b/data/json/overmap/map_extras.json
@@ -24,6 +24,17 @@
     "flags": [ "MAN_MADE", "CLASSIC" ]
   },
   {
+    "id": "mx_dormant",
+    "type": "map_extra",
+    "name": { "str": "Corpses" },
+    "description": "There are a lot of dead corpses here.",
+    "generator": { "generator_method": "update_mapgen", "generator_id": "mx_dormant" },
+    "min_max_zlevel": [ -7, 7 ],
+    "sym": "d",
+    "color": "light_red",
+    "flags": [ "MAN_MADE", "CLASSIC" ]
+  },
+  {
     "id": "mx_drugdeal",
     "type": "map_extra",
     "name": { "str": "Drug Deal" },

--- a/data/json/regional_map_settings.json
+++ b/data/json/regional_map_settings.json
@@ -723,6 +723,7 @@
           "mx_military": 5,
           "mx_science": 7,
           "mx_collegekids": 15,
+          "mx_dormant": 30,
           "mx_portal": 5,
           "mx_portal_in": 3,
           "mx_point_burned_ground": 5,
@@ -732,7 +733,10 @@
         }
       },
       "marloss": { "chance": 20, "extras": { "mx_marloss_pilgrimage": 100 } },
-      "subway": { "chance": 100, "extras": { "mx_military": 5, "mx_science": 12, "mx_drugdeal": 5, "mx_casings": 10 } },
+      "subway": {
+        "chance": 100,
+        "extras": { "mx_military": 5, "mx_science": 12, "mx_drugdeal": 5, "mx_casings": 10, "mx_dormant": 10 }
+      },
       "lab_subway": { "chance": 25, "extras": { "mx_military": 5, "mx_science": 15, "mx_portal": 3, "mx_portal_in": 3 } },
       "research_facility_lot": {
         "chance": 3,

--- a/src/trapfunc.cpp
+++ b/src/trapfunc.cpp
@@ -1573,17 +1573,6 @@ bool trapfunc::cast_spell( const tripoint_bub_ms &p, Creature *critter, item * )
         if( !tr.has_flag( json_flag_UNCONSUMED ) ) {
             here.remove_trap( p );
         }
-        if( tr.has_flag( json_flag_PROXIMITY ) ) {
-            // remove all traps in 3-3 area area
-            for( int x = p.x() - 1; x <= p.x() + 1; x++ ) {
-                for( int y = p.y() - 1; y <= p.y() + 1; y++ ) {
-                    tripoint_bub_ms pt( x, y, p.z() );
-                    if( here.tr_at( pt ).loadid == tr.loadid ) {
-                        here.remove_trap( pt );
-                    }
-                }
-            }
-        }
         // we remove the trap before casting the spell because otherwise if we teleport we might be elsewhere at the end and p is no longer valid
         trap_spell.cast_all_effects( dummy, p );
         trap_spell.make_sound( p, get_player_character() );


### PR DESCRIPTION
#### Summary
Content "Dormant map extra"
#### Purpose of change
Dormant zeds are here, but spawn randomly by one. Not dormant enough
Dormant enough = spawn in groups, and wake up all at once
How to make? spawn them all in a single map extra
#### Describe the solution
Add map extra, that can occupy some buildings, meaning one need to be extra quiet near such building
Also remove specific handling for PROXIMITY traps, that made dormants somewhat broken
#### Testing
(actual monster quantities were reduced, and correct amount is depicted only on the last image)
![image](https://github.com/user-attachments/assets/1788c990-69ae-42f3-95b6-ccf1d7787de3)
![image](https://github.com/user-attachments/assets/338059fa-80fe-4ccd-9191-0919a4d0618c)
![image](https://github.com/user-attachments/assets/c442e9ba-9bce-45b1-bbcf-ca45212842ba)
![image](https://github.com/user-attachments/assets/e43dbb5a-fcb6-4454-8b5c-d52f6fb707f8)