### PR TITLE
Fix android build

### DIFF
--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -2785,30 +2785,30 @@ static void CheckMessages()
 
                         if( dx != 0 || dy != 0 ) {
                             // Check for actions that work on nearby tiles
-                            //if( can_interact_at( ACTION_OPEN, pos ) ) {
+                            //if( can_interact_at( ACTION_OPEN, here, pos ) ) {
                             // don't bother with open since user can just walk into target
                             //}
-                            if( can_interact_at( ACTION_CLOSE, bub_pos ) ) {
+                            if( can_interact_at( ACTION_CLOSE, here, bub_pos ) ) {
                                 actions.insert( ACTION_CLOSE );
                             }
-                            if( can_interact_at( ACTION_EXAMINE, bub_pos ) ) {
+                            if( can_interact_at( ACTION_EXAMINE, here, bub_pos ) ) {
                                 actions.insert( ACTION_EXAMINE );
                             }
                         } else {
                             // Check for actions that work on own tile only
-                            if( can_interact_at( ACTION_BUTCHER, bub_pos ) ) {
+                            if( can_interact_at( ACTION_BUTCHER, here, bub_pos ) ) {
                                 actions.insert( ACTION_BUTCHER );
                             } else {
                                 actions_remove.insert( ACTION_BUTCHER );
                             }
 
-                            if( can_interact_at( ACTION_MOVE_UP, bub_pos ) ) {
+                            if( can_interact_at( ACTION_MOVE_UP, here, bub_pos ) ) {
                                 actions.insert( ACTION_MOVE_UP );
                             } else {
                                 actions_remove.insert( ACTION_MOVE_UP );
                             }
 
-                            if( can_interact_at( ACTION_MOVE_DOWN, bub_pos ) ) {
+                            if( can_interact_at( ACTION_MOVE_DOWN, here, bub_pos ) ) {
                                 actions.insert( ACTION_MOVE_DOWN );
                             } else {
                                 actions_remove.insert( ACTION_MOVE_DOWN );
@@ -2816,7 +2816,7 @@ static void CheckMessages()
                         }
 
                         // Check for actions that work on nearby tiles and own tile
-                        if( can_interact_at( ACTION_PICKUP, bub_pos ) ) {
+                        if( can_interact_at( ACTION_PICKUP, here, bub_pos ) ) {
                             actions.insert( ACTION_PICKUP );
                         }
                     }


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Fixes #79754 

#### Describe the solution
Find the logs https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/13394176790/job/37408928756#step:26:3740
Read the error message
```
  /home/runner/work/Cataclysm-DDA/Cataclysm-DDA/android/app/jni/src/../../../../src/sdltiles.cpp:2791:33: error: no matching function for call to 'can_interact_at'
                              if( can_interact_at( ACTION_CLOSE, bub_pos ) ) {
                                  ^~~~~~~~~~~~~~~
  /home/runner/work/Cataclysm-DDA/Cataclysm-DDA/android/app/jni/src/../../../../src/action.h:628:6: note: candidate function not viable: requires 3 arguments, but 2 were provided
  bool can_interact_at( action_id action, map &here, const tripoint_bub_ms &p );
       ^
```
Fix it.

The #79699 broke it because automated refactoring missed the calls behind `#if defined(__ANDROID__)`, and we don't check android builds in CI

#### Describe alternatives you've considered

#### Testing
None. I was unable to set up android build env locally

#### Additional context
Maybe we should add android build (without tests) to CI suite...