### PR TITLE
Aftershock: Damage rebalance I (Ballistic weapons)

### DIFF
--- a/data/mods/Aftershock/items/ammo/10mm.json
+++ b/data/mods/Aftershock/items/ammo/10mm.json
@@ -1,5 +1,6 @@
 [
   {
+    "//": "10mm ammo is used exclusively in Light weapons.",
     "id": "afs_10mm_caseless_FMJ",
     "type": "AMMO",
     "name": { "str_sp": "10mm FMJ caseless" },
@@ -14,7 +15,7 @@
     "stack_size": 40,
     "ammo_type": "afs_10mm",
     "range": 14,
-    "damage": { "damage_type": "bullet", "amount": 29, "armor_penetration": 4 },
+    "damage": { "damage_type": "bullet", "amount": 21, "armor_penetration": 15 },
     "dispersion": 60,
     "recoil": 650,
     "extend": { "effects": [ "COOKOFF" ], "flags": [ "CASELESS_ROUNDS" ] }
@@ -55,7 +56,7 @@
     "stack_size": 42,
     "ammo_type": "afs_10mm_smart",
     "range": 14,
-    "damage": { "damage_type": "bullet", "amount": 20, "armor_penetration": 10 },
+    "damage": { "damage_type": "bullet", "amount": 20, "armor_penetration": 15 },
     "dispersion": 0,
     "recoil": 600,
     "critical_multiplier": 4,

--- a/data/mods/Aftershock/items/ammo/25mm.json
+++ b/data/mods/Aftershock/items/ammo/25mm.json
@@ -3,7 +3,7 @@
     "id": "afs_25mm_shot",
     "type": "AMMO",
     "name": { "str_sp": "25mm canister shot" },
-    "description": "A 25mm round with a canister shot load, deals devastating damage against moderately armored foes within mid to close range.  Relatively low tech and affordable when compared to other 25mm grenades, these are often fielded by frontier outfits due to their adequate performance in anti-drone and close quarters combat.",
+    "description": "A 25mm round with a canister shot load, deals devastating damage against lightly armored foes within mid to close range.  Relatively low tech and affordable when compared to other 25mm grenades, these are often fielded by frontier outfits due to their adequate performance in anti-drone and close quarters combat.",
     "weight": "130 g",
     "volume": "230 ml",
     "price": "80 USD",
@@ -18,7 +18,7 @@
     "projectile_count": 15,
     "//": "Shot at point blank its about as effective as a 7.50mm rifle round",
     "damage": { "damage_type": "bullet", "amount": 60 },
-    "shot_damage": { "damage_type": "bullet", "amount": 80, "armor_penetration": 30 },
+    "shot_damage": { "damage_type": "bullet", "amount": 16, "armor_penetration": 15 },
     "dispersion": 75,
     "recoil": 2200,
     "effects": [ "NEVER_MISFIRES" ]

--- a/data/mods/Aftershock/items/ammo/25mm.json
+++ b/data/mods/Aftershock/items/ammo/25mm.json
@@ -3,7 +3,7 @@
     "id": "afs_25mm_shot",
     "type": "AMMO",
     "name": { "str_sp": "25mm canister shot" },
-    "description": "A 25mm grenade with a canister shot load, deals devastating damage against moderately armored foes within mid to close range.  Relatively low tech and affordable when compared to other 25mm grenades, these are often fielded by frontier outfits due to their adequate performance in anti-drone and close quarters combat.",
+    "description": "A 25mm round with a canister shot load, deals devastating damage against moderately armored foes within mid to close range.  Relatively low tech and affordable when compared to other 25mm grenades, these are often fielded by frontier outfits due to their adequate performance in anti-drone and close quarters combat.",
     "weight": "130 g",
     "volume": "230 ml",
     "price": "80 USD",
@@ -15,10 +15,30 @@
     "ammo_type": "afs_25mm",
     "casing": "afs_25_casing",
     "range": 24,
-    "damage": { "damage_type": "bullet", "amount": 60, "armor_penetration": 15 },
+    "projectile_count": 15,
+    "//": "Shot at point blank its about as effective as a 7.50mm rifle round",
+    "damage": { "damage_type": "bullet", "amount": 60 },
+    "shot_damage": { "damage_type": "bullet", "amount": 80, "armor_penetration": 30 },
     "dispersion": 75,
     "recoil": 2200,
     "effects": [ "NEVER_MISFIRES" ]
+  },
+  {
+    "id": "afs_25mm_ball",
+    "type": "AMMO",
+    "copy-from": "afs_25mm_shot",
+    "name": { "str_sp": "25mm Ball" },
+    "description": "Standard issue UICA 25mm rounds, loading a single lead-core steel-jacketed projectile.  Suitable for general purpose and anti-personnel use, these are the most common 25mm rounds in circulation.",
+    "//": "expensive illegal ammo",
+    "price": "1350 USD",
+    "material": [ "superalloy", "powder", "plastic" ],
+    "symbol": "=",
+    "color": "pink",
+    "count": 5,
+    "ammo_type": "afs_25mm",
+    "range": 110,
+    "damage": { "damage_type": "bullet", "amount": 80, "armor_penetration": 30 },
+    "dispersion": 15
   },
   {
     "id": "afs_25mm_frag",
@@ -35,7 +55,7 @@
     "ammo_type": "afs_25mm",
     "range": 110,
     "effects": [ "FRAG_25mm", "NEVER_MISFIRES" ],
-    "damage": { "damage_type": "bullet", "amount": 40, "armor_penetration": 7 },
+    "damage": { "damage_type": "bullet", "amount": 70, "armor_penetration": 15 },
     "dispersion": 15
   },
   {
@@ -52,7 +72,7 @@
     "count": 5,
     "ammo_type": "afs_25mm",
     "range": 110,
-    "damage": { "damage_type": "bullet", "amount": 280, "armor_penetration": 70 },
+    "damage": { "damage_type": "bullet", "amount": 70, "armor_penetration": 45 },
     "dispersion": 15
   },
   {
@@ -73,7 +93,7 @@
     "stack_size": 1,
     "recoil": 100,
     "effects": [ "NEVER_MISFIRES", "CASELESS_ROUNDS" ],
-    "damage": { "damage_type": "bullet", "amount": 40, "armor_penetration": 5 },
+    "damage": { "damage_type": "bullet", "amount": 40, "armor_penetration": 30 },
     "critical_multiplier": 10,
     "dispersion": 0
   }

--- a/data/mods/Aftershock/items/ammo/7.50mm.json
+++ b/data/mods/Aftershock/items/ammo/7.50mm.json
@@ -14,7 +14,27 @@
     "stack_size": 47,
     "ammo_type": "afs_7.50mm",
     "range": 36,
-    "damage": { "damage_type": "bullet", "amount": 44, "armor_penetration": 2 },
+    "damage": { "damage_type": "bullet", "amount": 45, "armor_penetration": 15 },
+    "dispersion": 30,
+    "recoil": 1500,
+    "extend": { "effects": [ "COOKOFF" ], "flags": [ "CASELESS_ROUNDS" ] }
+  },
+  {
+    "id": "afs_7.50mm_caseless",
+    "type": "AMMO",
+    "name": { "str_sp": "7.50mm AP caseless" },
+    "description": "Armor piercing 7.50mm ammunition with a tungsten carbide penetrator.  These rounds are designed to defeat body armor and other hard targets, but have reduced stopping power against unarmored targets.",
+    "weight": "12 g",
+    "volume": "194 ml",
+    "price": "2 USD 80 cent",
+    "material": [ "lead" ],
+    "symbol": "=",
+    "color": "yellow",
+    "count": 30,
+    "stack_size": 47,
+    "ammo_type": "afs_7.50mm",
+    "range": 36,
+    "damage": { "damage_type": "bullet", "amount": 35, "armor_penetration": 30 },
     "dispersion": 30,
     "recoil": 1500,
     "extend": { "effects": [ "COOKOFF" ], "flags": [ "CASELESS_ROUNDS" ] }
@@ -57,7 +77,7 @@
     "stack_size": 1,
     "recoil": 100,
     "effects": [ "NEVER_MISFIRES", "CASELESS_ROUNDS" ],
-    "damage": { "damage_type": "bullet", "amount": 35, "armor_penetration": 5 },
+    "damage": { "damage_type": "bullet", "amount": 35, "armor_penetration": 15 },
     "critical_multiplier": 10,
     "dispersion": 0
   }

--- a/data/mods/Aftershock/items/ammo/7.50mm.json
+++ b/data/mods/Aftershock/items/ammo/7.50mm.json
@@ -20,7 +20,7 @@
     "extend": { "effects": [ "COOKOFF" ], "flags": [ "CASELESS_ROUNDS" ] }
   },
   {
-    "id": "afs_7.50mm_caseless",
+    "id": "afs_7.50mm_ap_caseless",
     "type": "AMMO",
     "name": { "str_sp": "7.50mm AP caseless" },
     "description": "Armor piercing 7.50mm ammunition with a tungsten carbide penetrator.  These rounds are designed to defeat body armor and other hard targets, but have reduced stopping power against unarmored targets.",

--- a/data/mods/Aftershock/items/ammo/metal_rail.json
+++ b/data/mods/Aftershock/items/ammo/metal_rail.json
@@ -16,7 +16,7 @@
     "count": 10,
     "ammo_type": "metal_rail",
     "range": 40,
-    "damage": { "damage_type": "stab", "amount": 70, "armor_penetration": 25 },
+    "damage": { "damage_type": "bullet", "amount": 90, "armor_penetration": 40 },
     "dispersion": 150,
     "effects": [ "RECYCLED", "NON_FOULING" ],
     "melee_damage": { "bash": 5, "cut": 1 }
@@ -34,8 +34,6 @@
     "material": [ "steel" ],
     "color": "light_gray",
     "dispersion": 0,
-    "effects": [ "NEVER_MISFIRES", "NON_FOULING" ],
-    "relative": { "range": 10, "damage": { "damage_type": "stab", "amount": -5, "armor_penetration": 15 } },
-    "melee_damage": { "bash": 4, "cut": 2 }
+    "effects": [ "NEVER_MISFIRES", "NON_FOULING" ]
   }
 ]

--- a/data/mods/Aftershock/items/ammo/needle.json
+++ b/data/mods/Aftershock/items/ammo/needle.json
@@ -14,7 +14,7 @@
     "stack_size": 75,
     "ammo_type": "3x35",
     "range": 10,
-    "damage": { "damage_type": "bullet", "amount": 8, "armor_penetration": 20 },
+    "damage": { "damage_type": "bullet", "amount": 8, "armor_penetration": 30 },
     "dispersion": 60,
     "recoil": 40,
     "effects": [ "NEVER_MISFIRES" ]
@@ -28,7 +28,7 @@
     "weight": "6 g",
     "price": "16 USD 88 cent",
     "material": [ "ceramic" ],
-    "relative": { "range": -1, "damage": { "damage_type": "bullet", "amount": 14, "armor_penetration": -18 }, "dispersion": 20 },
+    "relative": { "range": -1, "damage": { "damage_type": "bullet", "amount": 20, "armor_penetration": -30 }, "dispersion": 20 },
     "proportional": { "recoil": 0.9 }
   },
   {
@@ -40,7 +40,7 @@
     "weight": "6 g",
     "price": "1600 USD",
     "relative": { "range": -1, "dispersion": 20 },
-    "damage": { "damage_type": "afs_toxin_bullet", "amount": 8, "armor_penetration": 20 },
+    "damage": { "damage_type": "afs_toxin_bullet", "amount": 8, "armor_penetration": 15 },
     "proportional": { "recoil": 0.9 },
     "effects": [ "NEVER_MISFIRES" ]
   }

--- a/data/mods/Aftershock/items/armor/exosuit/exosuit_ammo.json
+++ b/data/mods/Aftershock/items/armor/exosuit/exosuit_ammo.json
@@ -16,6 +16,6 @@
     "color": "light_gray",
     "dispersion": 0,
     "effects": [ "NEVER_MISFIRES", "NON_FOULING", "SEISMIC_MAPPING" ],
-    "damage": { "damage_type": "bullet", "amount": 80, "armor_penetration": 30 }
+    "damage": { "damage_type": "bullet", "amount": 80, "armor_penetration": 40 }
   }
 ]

--- a/data/mods/Aftershock/items/gun/25mm.json
+++ b/data/mods/Aftershock/items/gun/25mm.json
@@ -15,7 +15,6 @@
     "symbol": "(",
     "color": "brown",
     "min_strength": 18,
-    "ranged_damage": { "damage_type": "bullet", "amount": 10 },
     "skill": "rifle",
     "modes": [ [ "DEFAULT", "DOUBLE", 4 ] ],
     "dispersion": 90,

--- a/data/mods/Aftershock/items/gun/7.50mm.json
+++ b/data/mods/Aftershock/items/gun/7.50mm.json
@@ -120,7 +120,7 @@
     "price": "1 kUSD 250 USD",
     "to_hit": -1,
     "material": [ "superalloy", "plastic" ],
-    "ranged_damage": { "damage_type": "bullet", "amount": -7 },
+    "ranged_damage": { "damage_type": "bullet", "amount": -5 },
     "modes": [ [ "DEFAULT", "semi-auto", 1 ], [ "BURST", "burst", 2 ] ],
     "symbol": "(",
     "color": "dark_gray",

--- a/data/mods/Aftershock/items/gun/needle.json
+++ b/data/mods/Aftershock/items/gun/needle.json
@@ -53,7 +53,7 @@
     "material": [ "ceramic" ],
     "symbol": "(",
     "range": 8,
-    "ranged_damage": { "damage_type": "bullet", "amount": 4 },
+    "ranged_damage": { "damage_type": "bullet", "amount": 2 },
     "color": "dark_gray",
     "ammo": [ "3x35" ],
     "skill": "pistol",

--- a/data/mods/Aftershock/items/gun/projectile.json
+++ b/data/mods/Aftershock/items/gun/projectile.json
@@ -37,7 +37,6 @@
     "material": [ "steel", "wood" ],
     "symbol": "(",
     "color": "brown",
-    "ranged_damage": { "damage_type": "heat", "amount": 20 },
     "skill": "rifle",
     "dispersion": 90,
     "durability": 6,

--- a/data/mods/Aftershock/lore/ranged_weapon_balance.md
+++ b/data/mods/Aftershock/lore/ranged_weapon_balance.md
@@ -56,9 +56,7 @@ This table contains every single ranged weapon in the mod and is to be used for 
 
 ## Monster Armor and HP breakpoints 
 
-Monster and player armor should be understood to exist in the following categories: unarmored(0), Light Armor(1), Medium(2), Heavy(5), Vehicle/Structure(7+). Monsters and wearable armor pieces should belong to a single armor category (no mix matching E.X. Light melee armor combined with heavy ballistic armor ), if you desire monsters to be weaker against certain attack types, you should use weakpoint sets to achieve this. Armor pieces for players and NPCs should generally be ablative, either using the energy shield functionality or by having the "FRAGILE" flag.
-
-Armor definitions should have the following defensive ratings, multiplied by the armor factor of the category they belong to:
+Monster and player armor should be understood to exist in the following categories: unarmored, Light Armor, Medium, Heavy, and Vehicle/Structure. Armor definitions should have the following defensive ratings:
 
 | Armor   | Cut | Bash | Ballistic | Laser | Plasma | Electric |
 |---------|-----|------|-----------|-------|--------|----------|
@@ -67,6 +65,7 @@ Armor definitions should have the following defensive ratings, multiplied by the
 | Heavy   | 50  | 37   | 60        | 30    | 20     |    10    |
 | Vehicle | 70  | 50   | 90        | 70    | 50     |    25    |
 
+Monsters and wearable armor pieces should belong to a single armor category (no mix matching E.X. Light melee armor combined with heavy ballistic armor ), if you desire monsters to be weaker against certain attack types, you should use weakpoint sets to achieve this. Armor pieces for players and NPCs should generally be ablative, either using the energy shield functionality or by having the `FRAGILE` flag.
 
 The following should apply based on the monster type:
 

--- a/data/mods/Aftershock/lore/ranged_weapon_balance.md
+++ b/data/mods/Aftershock/lore/ranged_weapon_balance.md
@@ -2,101 +2,121 @@
 
 This table contains every single ranged weapon in the mod and is to be used for balancing weapons, armor and monster armor and hp.  
 
-|Name                           |Archetype  |Type               |Ammo        |Ballistic|Heat Damage|Plasma|Electric|Pure|AP (MAX)|BURST|NOTES                                     |
-|-------------------------------|-----------|-------------------|------------|---------|-----------|------|--------|----|--------|-----|------------------------------------------|
-|10mm Pistol                    |BALLISTIC  |Pistol             |10mm        |26       |           |      |        |    |4       |1    |                                          |
-|MarSec. 4                      |BALLISTIC  |Pistol             |10mm        |35       |           |      |        |    |4       |2    |                                          |
-|W1011 Silvergram               |BALLISTIC  |Smartgun           |10mm SMART  |20       |           |      |        |    |10      |2    |                                          |
-|Gibson S86                     |BALLISTIC  |AR/Grenade Launcher|25mm        |60, 290  |           |      |        |    |70      |4    |                                          |
-|1025 Goa                       |BALLISTIC  |AT  Sniper         |25mm        |60, 280  |           |      |        |    |        |1    |Single shot                               |
-|Wraitheon Armory 2519          |BALLISTIC  |Smart Sniper       |25mm SMART  |40       |           |      |        |    |5       |1    |Single shot                               |
-|eidolon derringer              |Obsolete   |                   |            |         |           |      |        |    |        |1    |                                          |
-|RM216 SPIW                     |Obsolete   |                   |            |         |           |      |        |    |        |     |                                          |
-|RM232 IDW                      |Obsolete   |                   |            |         |           |      |        |    |        |     |                                          |
-|MarSec. T72                    |BALLISTIC  |Handcannon         |7.5mm       |40       |           |      |        |    |2       |1    |                                          |
-|landfall survival gun          |BALLISTIC  |Hunting Gun        |7.5mm       |44       |           |      |        |    |2       |1    |                                          |
-|Accipiter Hawk-00              |BALLISTIC  |LMG                |7.5mm       |44       |           |      |        |    |2       |4    |                                          |
-|Vahagn 10XR                    |BALLISTIC  |Smart LMG          |7.5mm SMART |35       |           |      |        |    |5       |4    |                                          |
-|G&W SR-P9                      |BALLISTIC  |AR                 |7.5mm       |47       |           |      |        |    |        |2    |                                          |
-|G&W SR-P77                     |BALLISTIC  |AR                 |7.5mm       |34       |           |      |        |    |        |15   |                                          |
-|RM99 revolver                  |Obsolete   |                   |            |         |           |      |        |    |        |     |                                          |
-|wrist-stunner                  |Obsolete   |                   |UPS         |         |           |      |        |    |        |     |                                          |
-|wrist-trilaser                 |Obsolete   |                   |UPS         |         |           |      |        |    |        |     |                                          |
-|handheld x-ray cannon          |Obsolete   |                   |            |         |           |      |        |    |        |     |                                          |
-|shoddy laser rifle             |Obsolete   |                   |LASER CELL  |         |           |      |        |    |        |     |                                          |
-|av-22                          |LASER      |Pistol             |LASER CELL  |         |5, 8       |      |        |    |        |3    |                                          |
-|E-150b                         |LASER      |Pistol             |LASER CELL  |         |20, 30     |      |        |5   |        |2    |                                          |
-|Izhevsk PLC-75                 |LASER      |Recoiless Rifle    |LASER CELL  |         |220        |      |        |15  |        |1    |Single shot                               |
-|Shikishma A-82 tactical laser  |LASER      |AT  Sniper         |LASER CELL  |         |35, 53     |      |        |    |        |3    |                                          |
-|V14 laser pistol               |LASER      |Pistol             |LASER CELL  |         |4, 6       |      |        |    |        |1    |                                          |
-|A7 laser rifle                 |Obsolete   |AR                 |LASER CELL  |         |           |      |        |    |4       |2    |                                          |
-|Makeshift Scrambler Rifle      |LASER      |Anti Drone         |LASER CELL  |         |           |      |        |    |1       |1    |                                          |
-|xm34 EMP projector             |Obsolete   |                   |LASER CELL  |         |           |      |        |    |        |1    |                                          |
-|makeshift rail rifle           |SOV-RAILGUN|Sniper             |ROD         |65, 80   |20         |      |        |    |25      |1    |Single shot                               |
-|mining rod launcher            |SOV-RAILGUN|Sniper             |ROD         |65, 80   |           |      |        |    |25      |1    |Single shot                               |
-|GG-860 Wasp Rifle              |RAILGUN    |AR                 |3X35        |14       |           |      |        |    |20      |8    |                                          |
-|3x35mm automatic Coilpistol    |RAILGUN    |Pistol             |3X35        |10       |           |      |        |    |20      |5    |                                          |
-|Magnadrive 230K                |PLASMA     |AR                 |MIL PLASMA  |         |           |80    |        |    |        |1    |                                          |
-|PAM-41 2g                      |PLASMA     |Handcannon         |MIL PLASMA  |         |           |50    |        |    |        |1    |                                          |
-|direct fusion gun              |PLASMA     |Flamethrower       |CIV PLASMA  |         |           |45    |        |    |        |5    |                                          |
-|377-UASTA                      |PLASMA     |Handcannon         |CIV PLASMA  |         |           |45    |        |    |        |1    |                                          |
-|bionic skullgun                |BALLISTIC  |Meme               |7.5mm       |34       |           |      |        |    |        |1    |                                          |
-|Benelli 315                    |SHOT       |Shotgun            |0           |15*9     |           |      |        |    |        |1    |                                          |
-|Accipiter Magnastorm-12        |SHOT       |AP Shotgun         |0           |15*9     |           |      |        |    |3*9     |1    |                                          |
-|Raketa                         |SHOT       |Assault Shotgun    |0           |15*9     |           |      |        |    |        |2    |                                          |
-|Drotik Shotpistol              |SHOT       |Pistol             |0           |15*9     |           |      |        |    |        |1    |                                          |
-|R-PROTON ENR                   |VOLTAIC    |Anti Drone         |VOLTAIC CELL|         |           |      |10      |25  |        |1    |                                          |
-|W3310 Archangel ENR            |VOLTAIC    |Anti Drone         |VOLTAIC CELL|         |           |      |30      |    |        |1    |Chains 3 times for 15 electric damage each|
-|W3100 Volt                     |VOLTAIC    |Anti Drone         |VOLTAIC CELL|         |           |      |7       |    |        |1    |                                          |
-|Alien lune                     |EXPLOSIVE  |Launcher           |ALIEN CELL  |         |50         |      |        |    |50      |1    |Explosion: 2500dmg                        |
-|vatforged grenade launcher     |EXPLOSIVE  |Launcher           |Grenades    |         |           |      |        |    |        |1    |                                          |
-|Aztlani bow                    |BOW        |Bow                |ARROW       |64       |           |      |        |    |        |1    |                                          |
-|salvage bow                    |BOW        |Bow                |ARROW       |45       |           |      |        |    |        |1    |                                          |
-|salvage crossbow               |BOW        |Bow                |ARROW       |60       |           |      |        |    |        |1    |                                          |
+|Name                           |Archetype  |Type               |Ammo        |Ballistic | Laser |Plasma|Electric|Pure|AP  |BURST|NOTES                                     |
+|-------------------------------|-----------|-------------------|------------|----------|-------|------|--------|----|----|-----|------------------------------------------|
+|10mm Pistol                    |BALLISTIC  |Pistol             |10mm        |26        |       |      |        |    |0   |1    |                                          |
+|MarSec. 4                      |BALLISTIC  |Pistol             |10mm        |35        |       |      |        |    |0   |2    |                                          |
+|W1011 Silvergram               |BALLISTIC  |Smartgun           |10mm SMART  |20        |       |      |        |    |10  |2    |                                          |
+|Gibson S86                     |BALLISTIC  |AR/Grenade Launcher|25mm        |80        |       |      |        |    |30  |4    |                                          |
+|1025 Goa                       |BALLISTIC  |AT  Sniper         |25mm        |80        |       |      |        |    |30  |1    |Single shot                               |
+|Wraitheon Armory 2519          |BALLISTIC  |Smart Sniper       |25mm SMART  |40        |       |      |        |    |30  |1    |Single shot                               |
+|eidolon derringer              |Obsolete   |                   |            |          |       |      |        |    |    |1    |                                          |
+|RM216 SPIW                     |Obsolete   |                   |            |          |       |      |        |    |    |     |                                          |
+|RM232 IDW                      |Obsolete   |                   |            |          |       |      |        |    |    |     |                                          |
+|MarSec. T72                    |BALLISTIC  |Handcannon         |7.5mm       |41        |       |      |        |    |15  |1    |                                          |
+|landfall survival gun          |BALLISTIC  |Hunting Rifle      |7.5mm       |45        |       |      |        |    |15  |1    |                                          |
+|Accipiter Hawk-00              |BALLISTIC  |LMG                |7.5mm       |45        |       |      |        |    |15  |4    |                                          |
+|G&W SR-P9                      |BALLISTIC  |AR                 |7.5mm       |40        |       |      |        |    |15  |2    |                                          |
+|G&W SR-P77                     |BALLISTIC  |AR                 |7.5mm       |35        |       |      |        |    |15  |15   |                                          |
+|Vahagn 10XR                    |BALLISTIC  |Smart LMG          |7.5mm SMART |35        |       |      |        |    |15  |4    |                                          |
+|RM99 revolver                  |Obsolete   |                   |            |          |       |      |        |    |    |     |                                          |
+|wrist-stunner                  |Obsolete   |                   |UPS         |          |       |      |        |    |    |     |                                          |
+|wrist-trilaser                 |Obsolete   |                   |UPS         |          |       |      |        |    |    |     |                                          |
+|handheld x-ray cannon          |Obsolete   |                   |            |          |       |      |        |    |    |     |                                          |
+|shoddy laser rifle             |Obsolete   |                   |LASER CELL  |          |       |      |        |    |    |     |                                          |
+|av-22                          |LASER      |Pistol             |LASER CELL  |          |5, 8   |      |        |    |    |3    |                                          |
+|E-150b                         |LASER      |Pistol             |LASER CELL  |          |20, 30 |      |        |5   |    |2    |                                          |
+|Izhevsk PLC-75                 |LASER      |Recoiless Rifle    |LASER CELL  |          |220    |      |        |15  |    |1    |Single shot                               |
+|Shikishma A-82 tactical laser  |LASER      |AT  Sniper         |LASER CELL  |          |35, 53 |      |        |    |    |3    |                                          |
+|V14 laser pistol               |LASER      |Pistol             |LASER CELL  |          |4, 6   |      |        |    |    |1    |                                          |
+|A7 laser rifle                 |Obsolete   |AR                 |LASER CELL  |          |       |      |        |    |4   |2    |                                          |
+|Makeshift Scrambler Rifle      |LASER      |Anti Drone         |LASER CELL  |          |       |      |        |    |1   |1    |                                          |
+|xm34 EMP projector             |Obsolete   |                   |LASER CELL  |          |       |      |        |    |    |1    |                                          |
+|makeshift rail rifle           |SOV-RAILGUN|Sniper             |ROD         |65, 80    |20     |      |        |    |40  |1    |Single shot                               |
+|mining rod launcher            |SOV-RAILGUN|Sniper             |ROD         |90        |       |      |        |    |40  |1    |Single shot                               |
+|GG-860 Wasp Rifle              |RAILGUN    |AR                 |3X35        |14        |       |      |        |    |30  |8    |                                          |
+|3x35mm automatic Coilpistol    |RAILGUN    |Pistol             |3X35        |10        |       |      |        |    |30  |5    |                                          |
+|Magnadrive 230K                |PLASMA     |AR                 |MIL PLASMA  |          |       |80    |        |    |    |1    |                                          |
+|PAM-41 2g                      |PLASMA     |Handcannon         |MIL PLASMA  |          |       |50    |        |    |    |1    |                                          |
+|direct fusion gun              |PLASMA     |Flamethrower       |CIV PLASMA  |          |       |45    |        |    |    |5    |                                          |
+|377-UASTA                      |PLASMA     |Handcannon         |CIV PLASMA  |          |       |45    |        |    |    |1    |                                          |
+|bionic skullgun                |BALLISTIC  |Meme               |7.5mm       |34        |       |      |        |    |    |1    |                                          |
+|Benelli 315                    |SHOT       |Shotgun            |0           |15*9      |       |      |        |    |    |1    |                                          |
+|Accipiter Magnastorm-12        |SHOT       |AP Shotgun         |0           |15*9      |       |      |        |    |3*9 |1    |                                          |
+|Raketa                         |SHOT       |Assault Shotgun    |0           |15*9      |       |      |        |    |    |2    |                                          |
+|Drotik Shotpistol              |SHOT       |Pistol             |0           |15*9      |       |      |        |    |    |1    |                                          |
+|R-PROTON ENR                   |VOLTAIC    |Anti Drone         |VOLTAIC CELL|          |       |      |10      |25  |    |1    |                                          |
+|W3310 Archangel ENR            |VOLTAIC    |Anti Drone         |VOLTAIC CELL|          |       |      |30      |    |    |1    |Chains 3 times for 15 electric damage each|
+|W3100 Volt                     |VOLTAIC    |Anti Drone         |VOLTAIC CELL|          |       |      |7       |    |    |1    |                                          |
+|Alien lune                     |EXPLOSIVE  |Launcher           |ALIEN CELL  |          |50     |      |        |    |50  |1    |Explosion: 2500dmg                        |
+|vatforged grenade launcher     |EXPLOSIVE  |Launcher           |Grenades    |          |       |      |        |    |    |1    |                                          |
+|Aztlani bow                    |BOW        |Bow                |ARROW       |64        |       |      |        |    |    |1    |                                          |
+|salvage bow                    |BOW        |Bow                |ARROW       |45        |       |      |        |    |    |1    |                                          |
+|salvage crossbow               |BOW        |Bow                |ARROW       |60        |       |      |        |    |    |1    |                                          |
 
 ## Monster Armor and HP breakpoints 
-The following should apply based on the monster type. Values can vary +/-25% depending on desired monster balance 
 
-| Monster Archetype         | Example   | Estimate HP | Armor (Cut/Bash) | Armor (Ballistic/Heat/Plasma/Electric) | Melee Damage Die | Speed | Notes                              |
-|---------------------------|-----------|-------------|------------------|----------------------------------------|------------------|-------|------------------------------------|
-| Small Alien Fauna         | Hevel     | <30         | 0/0              |      0/0/0/0                           |                  |       |                                    |
-| Alien Herbivore           | Venandi   | 100         | 0/0              |      0/0/0/0                           |                  |       |                                    |
-| Alien Predator            | Boatman   | 300         | 12/5             |     10/0/0/0                           |                  |       |                                    |
-| Alien Fauna Bossfight     | none yet  | 700+        | 30/20            |     30/5/5/5                           |                  |       |                                    |
-| Moxphore Grunt            | Scavenger | 80          | 5/3              |      5/0/0/0                           |                  |       | Regens ~10hp                       |
-| Moxphore Specialized      | Elder     | 250         | 30/20            |     22/5/0/0                           |                  |       | Regens ~15hp                       |
-| Moxphore Armored          | Spartan   | 160         | 20/15            |     30/5/5/5                           |                  |       | Regens ~15hp                       |
-| Moxphore Bossfight        | none yet  | 1500+       | 30/20            |     40/5/10/10                         |                  |       | Regens ~30hp                       |
-| Small Utility Drone       | Eyebot    | 30          | 10/10            |     15/10/0/0                          |                  |       |                                    |
-| Flying Utility Drone      | eyebot    | 30          | 40               |     15/5/0/0                           |                  |       |                                    |
-| Human/Medium Utility Robot| seneschal | 150         | 12/8             |     20/5/0/0                           |                  |       |                                    |
-| Large Utility Robot       | Udarnik   | 600         | 30/12            |     20/5/0/0                           |                  |       |                                    |
-| Small Combat Drone        | Kaburaya  | 80          | 15/10            |     30/5/0/0                           |                  |       | Armor is up to X3 the base rating  |
-| Human/Medium Combat Drone | Isohypsa  | 600         | 20/15            |     35/15/8/0                          |                  |       | Armor is up to X3 the base rating  |
-| Large Combat Drone        | Zenit     | 1500        | 30/20            |     25/10/5/5                          |                  |       | Armor is up to X3 the base rating  |
-| Robot Bossfight           | none yet  | 4500+       | 30/20            |     50/50/10/15                        |                  |       | Armor is up to X3 the base rating  |
-| UICA/Mercenary Grunt      | UICA NPC  | 80          | 55/25            |     60/30/30/15                        |                  |       | Armor is blative and wont last     |
-| UICA specops/Solos        | SOLO NPC  | 120+shield  | 55/25            |     60/60/60/immune + shield           |                  |       | Armor is blative and wont last     |
+Monster and player armor should be understood to exist in the following categories: unarmored(0), Light Armor(1), Medium(2), Heavy(5), Vehicle/Structure(7+). Monsters and wearable armor pieces should belong to a single armor category (no mix matching E.X. Light melee armor combined with heavy ballistic armor ), if you desire monsters to be weaker against certain attack types, you should use weakpoint sets to achieve this. Armor pieces for players and NPCs should generally be ablative, either using the energy shield functionality or by having the "FRAGILE" flag.
+
+Armor definitions should have the following defensive ratings, multiplied by the armor factor of the category they belong to:
+
+| Armor   | Cut | Bash | Ballistic | Laser | Plasma | Electric |
+|---------|-----|------|-----------|-------|--------|----------|
+| Light   | 10  | 7.5  | 15        |  0    |  0     |     0    |
+| Medium  | 20  | 15   | 30        | 10    |  0     |     0    |
+| Heavy   | 50  | 37   | 60        | 30    | 20     |    10    |
+| Vehicle | 70  | 50   | 90        | 70    | 50     |    25    |
+
+
+The following should apply based on the monster type:
+
+| Monster Archetype         | Example   | Estimate HP | Armor                    | Melee Damage Die | Speed | Notes                              |
+|---------------------------|-----------|-------------|--------------------------|------------------|-------|------------------------------------|
+| Small Alien Fauna         | Hevel     | <30         | unarmored                |                  |       |                                    |
+| Alien Herbivore           | Venandi   | 100         | unarmored                |                  |       |                                    |
+| Alien Predator            | Boatman   | 300         | light armor              |                  |       |                                    |
+| Alien Fauna Bossfight     | none yet  | 700+        | heavy armor              |                  |       |                                    |
+| Moxphore Grunt            | Scavenger | 80          | unarmored                |                  |       | Regens ~10hp                       |
+| Moxphore Specialized      | Elder     | 140         | light armor or medium    |                  |       | Regens ~15hp                       |
+| Moxphore Armored          | Spartan   | 200         | medium armor             |                  |       | Regens ~15hp                       |
+| Moxphore Bossfight        | none yet  | 1500+       | heavy armor              |                  |       | Regens ~30hp                       |
+| Small Utility Drone       | Eyebot    | 30          | light armor              |                  |       |                                    |
+| Flying Utility Drone      | eyebot    | 30          | unarmored                |                  |       |                                    |
+| Human/Medium Utility Robot| seneschal | 150         | medium armor             |                  |       |                                    |
+| Large Utility Robot       | Udarnik   | 600         | medium armor             |                  |       |                                    |
+| Small Combat Drone        | none yet  | 80          | light armor              |                  |       | Armor is up to X3 the base rating  |
+| Human/Medium Combat Drone | Isohypsa  | 600         | heavy armor              |                  |       | Armor is up to X3 the base rating  |
+| Large Combat Drone        | Zenit     | 1500        | vehicle                  |                  |       | Armor is up to X3 the base rating  |
+| Robot Bossfight           | none yet  | 4500+       | vehicle + omnishield     |                  |       | Armor is up to X3 the base rating  |
+| Salvor                    | SALVOR NPC| 80          | light armor              |                  |       |                                    |
+| UICA/Mercenary Grunt      | UICA NPC  | 80          | heavy armor              |                  |       | Armor is blative and wont last     |
+| UICA specops/Solos        | SOLO NPC  | 120+shield  | heavy armor + omnishield |                  |       | Armor is blative and wont last     |
 
 # Weapon Categorization
 
-For ease of balancing, all aftershock weapons are separated into three abstract and gamified categories: light weapons, medium weapons and heavy weapons. Where a weapon belongs among these three categories depends on its raw damage output  as defined on the weapon/ammo json definitions.
+For ease of balancing, all aftershock weapons are separated into three abstract and gamified categories: light weapons, medium weapons and heavy weapons. Where a weapon belongs among these three categories depends on its damage output and AP rating as defined on the weapon/ammo json definitions.
 
-Ideally the mod shouldn't have weapons that exist merely as stat block variations of each other, if you have a weapon idea and you can't get it to play differently from others, its better if you convert it into a variant and spawn it with some integrated mods.
+Ideally the mod shouldn't have weapons that exist merely as stat block variations of each other, if you have a weapon idea and you can't get it to play differently from others, its better if you convert it into a variant and spawn it with some integrated gun mods.
 
 ##  Weapon types
 
 ### Ballistic/Railguns
 Ballistic weapons are the most common. They offer the highest maximum range of all weapons, above average damage per projectile and are also the lightest. Compared to energy weapons they are more straightforward to use, with no marked weaknesses or strengths that should be worked around.
+ 
+The current ballistic ammo calibres currently exist in the mod:
 
-#### Expected ballistic stats
-For light medium and heavy categories
+|Type        | Default ammo   | Damage of default | AP of default | Design intent                                                                                                             |
+|------------|----------------|-------------------|---------------|---------------------------------------------------------------------------------------------------------------------------|
+| 00 shot    | 12 g buckshot  |            9x15   |             0 | Deals with lightly armored foes at a disadvantage and deals little to no damage to medium armor. Many specialty variants. |
+| 10mm       | 10mm JHP       |              31   |             0 | Deals with lightly armored foes at a disadvantage and deals little to no damage to medium armor.                          |
+| 7.5mm      | 7.5mm caseless |              40   |            15 | Cleanly defeats light armor, deals with medium armor at a disadvantage and deals little to no heavy to medium armor.      |
+| 25mm       | 25mm ball      |              80   |            30 | Cleanly defeats medium armor, deals with heavy armor at a strong disadvantage.                                            |
+| 3x35mm     | GG Stinger     |               8   |            30 | Cleanly defeats medium armor, deals very low damage. Default ammo is considered the AP variant.                           |
+| Rail Rod   | Steel rail     |              90   |            40 | Cleanly defeats heavy armor, deals with vehicle armor at a  disadvantage.                                                 |
 
-* Max damage per turn: `30 / 70 / 150` 
-* Maximum range `30/  50 /  60`.
-* Average volume `1.5l / 5l / 30l`.
-* Average Weight `2kg / 4kg / 12kg`. 
-* Minimum reload time ` 100 / 200 / 300` moves.
+To balance specialty rounds use the following rule:
+- AP ammo recieves +15 ballistic armor piercing at the cost of -10 damage.
+- Specialty ammo has the damage of AP ammo and the armor piercing capability of the default round + whatever special effect is granted. If the specialty effect is a strong AOE AP might be reduced further.
 
 ### Lasers
 Lasers are accurate mid-range weapons whose reduced projectile damage is compensated by their fast fire rates, lack of recoil and the ability to set foes on fire. Lasers are the most common type of energy weapon and also the most versatile. Their magazines are heavier than their ballistic equivalents, but are fully interchangeable between weapons. They excel at dispatching isolated foes, which they can do in the most resource efficient ways.


### PR DESCRIPTION
#### Summary
Mods "Aftershock:Rebalance Ballistic Weapons"

#### Purpose of change
I was adding a turbolaser turret for one of Quill's map and I noticed that assigning armor values to monster was hard and needed you to test combat with many different weapons to judge balance. This is cubersome and can easy lead to balancing mistakes, so in here I'm trying to conceptualize a more standarized system based on armor and HP breakpoints  that is simpler to test,

#### Describe the solution

Monster and player armor should be understood to exist in the following categories: unarmored, light armor, medium, Heavy, Vehicle/Structure. These categories should have the following defensive ratings:

| Armor   | Cut | Bash | Ballistic | Laser | Plasma | Electric |
|---------|-----|------|-----------|-------|--------|----------|
| Light   | 10  | 7.5  | 15        |  0    |  0     |     0    |
| Medium  | 20  | 15   | 30        | 10    |  0     |     0    |
| Heavy   | 50  | 37   | 60        | 30    | 20     |    10    |
| Vehicle | 70  | 50   | 90        | 70    | 50     |    25    |

According to this armor breakpoints the current ammo types have been balanced as follows:


|Type        | Default ammo   | Damage of default | AP of default | Design intent                                                                                                             |
|------------|----------------|-------------------|---------------|---------------------------------------------------------------------------------------------------------------------------|
| 00 shot    | 12 g buckshot  |            9x15   |             0 | Deals with lightly armored foes at a disadvantage and deals little to no damage to medium armor. Many specialty variants. |
| 10mm       | 10mm JHP       |              31   |             0 | Deals with lightly armored foes at a disadvantage and deals little to no damage to medium armor.                          |
| 7.5mm      | 7.5mm caseless |              40   |            15 | Cleanly defeats light armor, deals with medium armor at a disadvantage and deals little to no heavy to medium armor.      |
| 25mm       | 25mm ball      |              80   |            30 | Cleanly defeats medium armor, deals with heavy armor at a strong disadvantage.                                            |
| 3x35mm     | GG Stinger     |               8   |            30 | Cleanly defeats medium armor, deals very low damage. Default ammo is considered the AP variant.                           |
| Rail Rod   | Steel rail     |              90   |            40 | Cleanly defeats heavy armor, deals with vehicle armor at a  disadvantage.                                                 |

To balance specialty rounds use the following rule:
- AP ammo recieves +15 ballistic armor piercing at the cost of -10 damage.
- Specialty ammo has the damage of AP ammo and the armor piercing capability of the default round + whatever special effect is granted. If the specialty effect is a strong AOE AP might be reduced further.


Aditionally monsters should have the following stats depending on their `monster archetype`
| Monster Archetype         | Example   | Estimate HP | Armor                    | Melee Damage Die | Speed | Notes                              |
|---------------------------|-----------|-------------|--------------------------|------------------|-------|------------------------------------|
| Small Alien Fauna         | Hevel     | <30         | unarmored                |                  |       |                                    |
| Alien Herbivore           | Venandi   | 100         | unarmored                |                  |       |                                    |
| Alien Predator            | Boatman   | 300         | light armor              |                  |       |                                    |
| Alien Fauna Bossfight     | none yet  | 700+        | heavy armor              |                  |       |                                    |
| Moxphore Grunt            | Scavenger | 80          | unarmored                |                  |       | Regens ~10hp                       |
| Moxphore Specialized      | Elder     | 140         | light armor or medium    |                  |       | Regens ~15hp                       |
| Moxphore Armored          | Spartan   | 200         | medium armor             |                  |       | Regens ~15hp                       |
| Moxphore Bossfight        | none yet  | 1500+       | heavy armor              |                  |       | Regens ~30hp                       |
| Small Utility Drone       | Eyebot    | 30          | light armor              |                  |       |                                    |
| Flying Utility Drone      | eyebot    | 30          | unarmored                |                  |       |                                    |
| Human/Medium Utility Robot| seneschal | 150         | medium armor             |                  |       |                                    |
| Large Utility Robot       | Udarnik   | 600         | medium armor             |                  |       |                                    |
| Small Combat Drone        | none yet  | 80          | light armor              |                  |       | Armor is up to X3 the base rating  |
| Human/Medium Combat Drone | Isohypsa  | 600         | heavy armor              |                  |       | Armor is up to X3 the base rating  |
| Large Combat Drone        | Zenit     | 1500        | vehicle                  |                  |       | Armor is up to X3 the base rating  |
| Robot Bossfight           | none yet  | 4500+       | vehicle + omnishield     |                  |       | Armor is up to X3 the base rating  |
| Salvor                    | SALVOR NPC| 80          | light armor              |                  |       |                                    |
| UICA/Mercenary Grunt      | UICA NPC  | 80          | heavy armor              |                  |       | Armor is blative and wont last     |
| UICA specops/Solos        | SOLO NPC  | 120+shield  | heavy armor + omnishield |                  |       | Armor is blative and wont last     |

#### Testing
Needs changes to the monster themselves to make sure it plays properly, but the math checks out.