### PR TITLE
Configure skip-duplicates jobs to not skip duplicates (yes, really)

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -27,6 +27,7 @@ jobs:
         uses: fkirc/skip-duplicate-actions@master
         with:
           cancel_others: 'true'
+          skip_after_successful_duplicate: 'false'
           paths: '[ "**.cpp", "**.h", "**.c", "**/CMakeLists.txt", "**/Makefile", "**.hpp", "**.cmake", "build-scripts/clang-tidy-build.sh", "build-scripts/clang-tidy-run.sh", "build-scripts/clang-tidy-wrapper.sh", "build-scripts/get_affected_files.py", ".github/workflows/clang-tidy.yml" ]'
 
 
@@ -80,9 +81,9 @@ jobs:
         TILES: 1
         SOUND: 1
         LOCALIZE: 1
+    if: ${{ needs.skip-duplicates.outputs.should_skip != 'true' && github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     steps:
     - name: install dependencies
-      if: ${{ needs.skip-duplicates.outputs.should_skip != 'true' && github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
       run: |
           sudo apt-get update
           sudo apt install clang-18 clang-tidy-18 cmake ccache jq
@@ -90,7 +91,6 @@ jobs:
     - name: checkout repository
       uses: actions/checkout@v4
     - name: download plugin from the previous job in this workflow run
-      if: ${{ needs.skip-duplicates.outputs.should_skip != 'true' && github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
       uses: actions/download-artifact@v4
       with:
         name: cata-analyzer-plugin
@@ -115,7 +115,6 @@ jobs:
           fs.writeFileSync("files_changed", files.join('\n') + '\n');
     - uses: ammaraskar/gcc-problem-matcher@master
     - name: run clang-tidy
-      if: ${{ needs.skip-duplicates.outputs.should_skip != 'true' && github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
       run: bash ./build-scripts/clang-tidy-run.sh
     - name: show most time consuming checks
       if: always()

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -63,6 +63,7 @@ jobs:
       - id: skip_check
         uses: fkirc/skip-duplicate-actions@master
         with:
+          skip_after_successful_duplicate: 'false'
           paths_ignore: '["android/**", "build-data/osx/**", "doc/**", "doxygen_doc/**", "lgtm/**", "msvc-**", "object_creator/**", "tools/**", "utilities/**", "data/**", "lang/**"]'
   skip-duplicates-data:
     continue-on-error: true
@@ -74,6 +75,7 @@ jobs:
       - id: skip_check
         uses: fkirc/skip-duplicate-actions@master
         with:
+          skip_after_successful_duplicate: 'false'
           paths_ignore: '["android/**", "build-data/osx/**", "doc/**", "doxygen_doc/**", "lgtm/**", "msvc-**", "object_creator/**", "tools/**", "utilities/**"]'
   matrix-variables:
     permissions:


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Partially addresses https://github.com/CleverRaven/Cataclysm-DDA/issues/79241
Patches the exploit that allowed skipping CI checks but still getting a passing ✔️  checkmark

#### Describe the solution
We are using skip-duplicates job as a glorified path filter since regular path filter does not play nicely with required checks (see #49923).
Out of the box we also get the "skip duplicate" functionality i.e. "don't run the same check again if there is already a successful CI run of the same code". It's very nice, but as described in #79241 it runs into issues when we also conditionally disable checks on draft prs.

The CI exploit looks something like this:
- create a draft PR
- let the CI run. skip-duplicates would report that "there're no exiting duplicate runs, go ahead", then later we would decide "you know what, it's draft, let's not waste CPU cycles on this" and skip the checks.
- CI run succeeds ✔️ 
- Undraft the pr
- Let the CI run again. skip-duplicate would look and find an already successful previous run *on the exact same code*(!), and say "you know, there's no need to run this thing again - we've done it already. Let's not waste CPU cycles here" and skip the checks. 
- CI run succeeds ✔️ 
- checks were never run

These two redundancy checks are seemingly in conflict, and I couldn't find a better way to resolve it than removing one of the checks.
Even though both are somewhat rare, my hunch is that "duplicates" check triggers less often under normal conditions than "draft" check, so I disabled the "duplicates" one to save more CPU-time, but I don't have a strong opinion here. (Disabling the "draft" check makes the code cleaner. Tradeoffs...). 


#### Describe alternatives you've considered
- Leave duplicates checking be, but remove the draft pr special casing
- remove the duplicates check from other jobs (astyle, json style) for consistency. They can't trigger the exploit since they have no "is in draft?" checks, and they run turbo-fast already, so i decided not to bother.

#### Testing
None other than ensuring the workflow is valid.

#### Additional context
