### PR TITLE
Wounds, Major Changes and Additions

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -3186,7 +3186,7 @@ void activity_handlers::operation_do_turn( player_activity *act, Character *you 
             if( !bps.empty() ) {
                 for( const bodypart_id &bp : bps ) {
                     you->add_effect( effect_bleed,  1_minutes * difficulty, bp, true, 1 );
-                    you->apply_damage( nullptr, bp, 20 * difficulty );
+                    you->apply_damage( nullptr, bp, damage_instance( damage_type::CUT, 20 * difficulty ) );
 
                     if( u_see ) {
                         you->add_msg_player_or_npc( m_bad, _( "Your %s is ripped open." ),
@@ -3199,7 +3199,8 @@ void activity_handlers::operation_do_turn( player_activity *act, Character *you 
                 }
             } else {
                 you->add_effect( effect_bleed,  1_minutes * difficulty, bodypart_str_id::NULL_ID(), true, 1 );
-                you->apply_damage( nullptr, bodypart_id( "torso" ), 20 * difficulty );
+                you->apply_damage( nullptr, bodypart_id( "torso" ), damage_instance( damage_type::CUT,
+                                   20 * difficulty ) );
             }
         }
     }

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -1785,7 +1785,7 @@ void Character::bionics_uninstall_failure( int difficulty, int success, float ad
                         continue;
                     }
                     bp_hurt.emplace( bp->main_part );
-                    apply_damage( this, bp, rng( 5, 10 ), true );
+                    apply_damage( this, bp, damage_instance( damage_type::CUT, rng( 5, 10 ) ), true );
                     add_msg_player_or_npc( m_bad, _( "Your %s is damaged." ), _( "<npcname>'s %s is damaged." ),
                                            body_part_name_accusative( bp ) );
                 }
@@ -1801,7 +1801,7 @@ void Character::bionics_uninstall_failure( int difficulty, int success, float ad
                     }
                     bp_hurt.emplace( bp->main_part );
 
-                    apply_damage( this, bp, rng( 25, 50 ), true );
+                    apply_damage( this, bp, damage_instance( damage_type::CUT, rng( 25, 50 ) ), true );
                     roll_critical_bionics_failure( bp );
 
                     add_msg_player_or_npc( m_bad, _( "Your %s is severely damaged." ),
@@ -1873,7 +1873,8 @@ void Character::bionics_uninstall_failure( monster &installer, Character &patien
                         continue;
                     }
                     bp_hurt.emplace( bp->main_part );
-                    patient.apply_damage( this, bp, rng( failure_level, failure_level * 2 ), true );
+                    patient.apply_damage( this, bp, damage_instance( damage_type::CUT, rng( failure_level,
+                                          failure_level * 2 ) ), true );
                     if( u_see ) {
                         patient.add_msg_player_or_npc( m_bad, _( "Your %s is damaged." ), _( "<npcname>'s %s is damaged." ),
                                                        body_part_name_accusative( bp ) );
@@ -1891,7 +1892,7 @@ void Character::bionics_uninstall_failure( monster &installer, Character &patien
                     }
                     bp_hurt.emplace( bp->main_part );
 
-                    patient.apply_damage( this, bp, rng( 25, 50 ), true );
+                    patient.apply_damage( this, bp, damage_instance( damage_type::CUT, rng( 25, 50 ) ), true );
                     roll_critical_bionics_failure( bp );
 
                     if( u_see ) {
@@ -2609,7 +2610,7 @@ void Character::bionics_install_failure( const bionic_id &bid, const std::string
                         }
                         bp_hurt.emplace( bp->main_part );
 
-                        apply_damage( this, bp, rng( 25, 50 ), true );
+                        apply_damage( this, bp, damage_instance( damage_type::CUT, rng( 25, 50 ) ), true );
                         roll_critical_bionics_failure( bp );
 
                         add_msg_player_or_npc( m_bad, _( "Your %s is damaged." ), _( "<npcname>'s %s is damaged." ),

--- a/src/bodypart.cpp
+++ b/src/bodypart.cpp
@@ -1186,6 +1186,16 @@ void bodypart::mod_frostbite_timer( int mod )
     frostbite_timer += mod;
 }
 
+void bodypart::apply_wound( const damage_instance &dam )
+{
+    wounds.add_wound( dam, rng( 0, 100 ) );
+}
+
+const std::vector<wound> &bodypart::get_all_wounds() const
+{
+    return wounds.get_all_wounds();
+}
+
 void bodypart::serialize( JsonOut &json ) const
 {
     json.start_object();

--- a/src/bodypart.h
+++ b/src/bodypart.h
@@ -20,6 +20,7 @@
 #include "type_id.h"
 #include "units.h"
 #include "weather.h"
+#include "wound.h"
 
 class JsonObject;
 class JsonOut;
@@ -449,6 +450,8 @@ class bodypart
         int damage_bandaged = 0;
         int damage_disinfected = 0;
 
+        limb_wounds wounds;
+
         encumbrance_data encumb_data; // NOLINT(cata-serialize)
 
         std::array<int, NUM_WATER_TOLERANCE> mut_drench; // NOLINT(cata-serialize)
@@ -507,6 +510,8 @@ class bodypart
         int get_bmi_encumbrance_threshold() const;
         float get_bmi_encumbrance_scalar() const;
         int get_power_efficiency() const;
+        void apply_wound( const damage_instance &dam );
+        const std::vector<wound> &get_all_wounds() const;
 
         std::array<int, NUM_WATER_TOLERANCE> get_mut_drench() const;
 

--- a/src/character.h
+++ b/src/character.h
@@ -97,6 +97,7 @@ enum class steed_type : int;
 enum npc_attitude : int;
 struct bionic;
 struct construction;
+struct damage_instance;
 struct dealt_projectile_attack;
 struct display_proficiency;
 /// @brief Item slot used to apply modifications from food and meds
@@ -1271,8 +1272,10 @@ class Character : public Creature, public visitable
         // any side effects that might happen when the Character hits a Creature
         void did_hit( Creature &target );
 
+        // add a wound to the limb
+        void wound_limb( bodypart_id hurt, const damage_instance &dam );
         /** Actually hurt the player, hurts a body_part directly, no armor reduction */
-        void apply_damage( Creature *source, bodypart_id hurt, int dam,
+        void apply_damage( Creature *source, bodypart_id hurt, const damage_instance &dam,
                            bool bypass_med = false ) override;
         /** Calls Creature::deal_damage and handles damaged effects (waking up, etc.) */
         dealt_damage_instance deal_damage( Creature *source, bodypart_id bp,

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -1443,7 +1443,7 @@ dealt_damage_instance Creature::deal_damage( Creature *source, bodypart_id bp,
         mod_pain( total_pain );
     }
 
-    apply_damage( source, bp, total_damage );
+    apply_damage( source, bp, d );
 
     if( wkpt != nullptr ) {
         wkpt->apply_effects( *this, total_damage, attack );

--- a/src/creature.h
+++ b/src/creature.h
@@ -502,7 +502,7 @@ class Creature : public viewer
 
         // directly decrements the damage. ONLY handles damage, doesn't
         // increase pain, apply effects, etc
-        virtual void apply_damage( Creature *source, bodypart_id bp, int amount,
+        virtual void apply_damage( Creature *source, bodypart_id bp, const damage_instance &dam,
                                    bool bypass_med = false ) = 0;
 
         virtual void heal_bp( bodypart_id bp, int dam );

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -3414,7 +3414,7 @@ static void damage_self()
         part = parts[smenu.ret];
     }
     if( query_int( dbg_damage, _( "Damage self for how much?  HP: %s" ), part.id().c_str() ) ) {
-        player_character.apply_damage( nullptr, part, dbg_damage );
+        player_character.apply_damage( nullptr, part, damage_instance( damage_type::CUT, dbg_damage ) );
         if( player_character.is_dead_state() ) {
             player_character.die( &get_map(), nullptr );
         }

--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -347,7 +347,8 @@ static void do_blast( map *m, const Creature *source, const tripoint_bub_ms &p, 
             const double dmg = std::max( force - critter->get_armor_type( damage_bash,
                                          bodypart_id( "torso" ) ) / 2.0, 0.0 );
             const int actual_dmg = rng_float( dmg * 2, dmg * 3 );
-            critter->apply_damage( mutable_source, bodypart_id( "torso" ), actual_dmg );
+            critter->apply_damage( mutable_source, bodypart_id( "torso" ), damage_instance( damage_type::BASH,
+                                    actual_dmg ) );
             critter->check_dead_state( m );
             add_msg_debug( debugmode::DF_EXPLOSION, "Blast hits %s for %d damage", critter->disp_name(),
                            actual_dmg );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -13025,7 +13025,7 @@ std::optional<tripoint_bub_ms> game::find_or_make_stairs( map &mp, const int z_a
                     rope_ladder = true;
                     add_msg( m_bad, _( "You descend on your vines, though leaving a part of you behind stings." ) );
                     u.mod_pain( 5 );
-                    u.apply_damage( nullptr, bodypart_id( "torso" ), 5 );
+                    u.apply_damage( nullptr, bodypart_id( "torso" ), damage_instance( damage_type::BIOLOGICAL, 5 ) );
                     u.mod_stored_kcal( -87 );
                     u.mod_thirst( 10 );
                 } else {

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -2531,8 +2531,8 @@ void iexamine::flower_poppy( Character &you, const tripoint_bub_ms &examp )
         add_msg( m_bad, _( "The flower's fragrance makes you extremely drowsy…" ) );
         you.fall_asleep( 2_hours );
         add_msg( m_bad, _( "Your legs are covered in the poppy's roots!" ) );
-        you.apply_damage( nullptr, bodypart_id( "leg_l" ), 4 );
-        you.apply_damage( nullptr, bodypart_id( "leg_r" ), 4 );
+        you.apply_damage( nullptr, bodypart_id( "leg_l" ), damage_instance( damage_type::STAB, 4 ) );
+        you.apply_damage( nullptr, bodypart_id( "leg_r" ), damage_instance( damage_type::STAB, 4 ) );
         you.mod_moves( -to_moves<int>( 1_seconds ) * 0.5 );
     }
 
@@ -2559,8 +2559,8 @@ void iexamine::flower_cactus( Character &you, const tripoint_bub_ms &examp )
 
     if( one_in( 6 ) ) {
         add_msg( m_bad, _( "The cactus' nettles sting you!" ) );
-        you.apply_damage( nullptr, bodypart_id( "arm_l" ), 4 );
-        you.apply_damage( nullptr, bodypart_id( "arm_r" ), 4 );
+        you.apply_damage( nullptr, bodypart_id( "arm_l" ), damage_instance( damage_type::STAB, 4 ) );
+        you.apply_damage( nullptr, bodypart_id( "arm_r" ), damage_instance( damage_type::STAB, 4 ) );
     }
 
     here.furn_set( examp, furn_str_id::NULL_ID() );

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -110,6 +110,7 @@
 #include "weather_type.h"
 #include "widget.h"
 #include "worldfactory.h"
+#include "wound.h"
 
 DynamicDataLoader::DynamicDataLoader()
 {
@@ -493,6 +494,7 @@ void DynamicDataLoader::initialize()
     add( "conduct", &achievement::load_achievement );
     add( "widget", &widget::load_widget );
     add( "weakpoint_set", &weakpoints::load_weakpoint_sets );
+    add( "wound", &wound_type::load_wound );
     add( "damage_type", &damage_type::load_damage_types );
     add( "damage_info_order", &damage_info_order::load_damage_info_orders );
 #if defined(TILES)
@@ -836,6 +838,7 @@ void DynamicDataLoader::finalize_loaded_data()
             { _( "Anatomies" ), &anatomy::finalize_all },
             { _( "Mutations" ), &mutation_branch::finalize_all },
             { _( "Achievements" ), &achievement::finalize },
+            { _( "Wounds" ), &wound_type::finalize },
             { _( "Damage info orders" ), &damage_info_order::finalize_all },
             { _( "Widgets" ), &widget::finalize },
             { _( "Faults" ), &faults::finalize },

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -1134,7 +1134,8 @@ std::optional<int> iuse::blech( Character *p, item *it, const tripoint_bub_ms & 
         p->add_msg_if_player( m_bad, _( "Blech, that burns your throat!" ) );
         p->mod_pain( rng( 32, 64 ) );
         p->add_effect( effect_poison, 1_hours );
-        p->apply_damage( nullptr, bodypart_id( "torso" ), rng( 4, 12 ) );
+        p->apply_damage( nullptr, bodypart_id( "torso" ), damage_instance( damage_type::ACID, rng( 4,
+                         12 ) ) );
         p->vomit();
     } else {
         p->add_msg_if_player( m_bad, _( "Blech, you don't feel you can stomach much of that." ) );
@@ -1993,7 +1994,8 @@ std::optional<int> iuse::extinguisher( Character *p, item *it, const tripoint_bu
             if( player_view.sees( here, critter ) ) {
                 p->add_msg_if_player( _( "The %s is frozen!" ), critter.name() );
             }
-            critter.apply_damage( p, bodypart_id( "torso" ), rng( 20, 60 ) );
+            p->apply_damage( nullptr, bodypart_id( "torso" ), damage_instance( damage_type::BIOLOGICAL, rng( 60,
+                                     20 ) ) );
             critter.set_speed_base( critter.get_speed_base() / 2 );
         }
     }
@@ -6947,8 +6949,10 @@ std::optional<int> iuse::ehandcuffs_tick( Character *p, item *it, const tripoint
         } else {
             add_msg( m_bad, _( "Ouch, the cuffs shock you!" ) );
 
-            p->apply_damage( nullptr, bodypart_id( "arm_l" ), rng( 0, 2 ) );
-            p->apply_damage( nullptr, bodypart_id( "arm_r" ), rng( 0, 2 ) );
+            p->apply_damage( nullptr, bodypart_id( "arm_l" ), damage_instance( damage_type::ELECTRIC, rng( 0,
+                                     2 ) ) );
+            p->apply_damage( nullptr, bodypart_id( "arm_r" ), damage_instance( damage_type::ELECTRIC, rng( 0,
+                                     2 ) ) );
             p->mod_pain( rng( 2, 5 ) );
 
         }

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -3864,11 +3864,8 @@ int heal_actor::finish_using( Character &healer, Character &patient, item &it,
     const int dam = get_heal_value( healer, healed );
     const int cur_hp = patient.get_part_hp_cur( healed );
 
-    if( ( cur_hp >= 1 ) && ( dam > 0 ) ) { // Prevent first-aid from mending limbs
-        patient.heal( healed, dam );
-    } else if( ( cur_hp >= 1 ) && ( dam < 0 ) ) {
-        patient.apply_damage( nullptr, healed, -dam ); //hurt takes + damage
-    }
+    if( cur_hp >= 1 ) { // Prevent first-aid from mending limbs
+        patient.heal( healed, std::abs( dam ) );
 
     Character &player_character = get_player_character();
     const bool u_see = healer.is_avatar() || patient.is_avatar() ||

--- a/src/map_field.cpp
+++ b/src/map_field.cpp
@@ -1668,8 +1668,7 @@ void map::player_in_field( Character &you )
             if( cur.get_field_intensity() > 0 && !you.is_elec_immune() && !you.in_vehicle ) {
                 const bodypart_id &main_part = bodypart_id( "torso" );
                 const int dmg = std::max( 1, rng( cur.get_field_intensity() / 2, cur.get_field_intensity() ) );
-                const int main_part_damage = you.deal_damage( nullptr, main_part,
-                                             damage_instance( damage_electric, dmg ) ).total_damage();
+                const int main_part_damage = you.apply_damage( nullptr, bp, damage_instance( damage_type::ELECTRIC, dmg ), true );
 
                 if( main_part_damage > 0 ) {
                     for( const bodypart_id &bp :

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -2350,6 +2350,12 @@ void monster::set_hp( const int hp )
     this->hp = hp;
 }
 
+void monster::apply_damage( Creature *source, bodypart_id hurt, const damage_instance &dam,
+                            const bool bypass_med )
+{
+    apply_damage( source, hurt, dam.total_damage(), bypass_med );
+}
+
 void monster::apply_damage( Creature *source, bodypart_id /*bp*/, int dam,
                             const bool /*bypass_med*/ )
 {

--- a/src/monster.h
+++ b/src/monster.h
@@ -36,6 +36,7 @@ class item;
 class map;
 enum class mon_trigger : int;
 enum class phase_id : int;
+struct damage_instance;
 struct monster_plan;
 struct mtype;
 
@@ -367,7 +368,8 @@ class monster : public Creature
                                      const weakpoint_attack &wp_attack = weakpoint_attack() ) override;
         void deal_damage_handle_type( const effect_source &source, const damage_unit &du, bodypart_id bp,
                                       int &damage, int &pain ) override;
-        void apply_damage( Creature *source, bodypart_id bp, int dam,
+        void apply_damage( Creature *source, bodypart_id bp, int dam, bool bypass_med = false );
+        void apply_damage( Creature *source, bodypart_id bp, const damage_instance &dam,
                            bool bypass_med = false ) override;
         // create gibs/meat chunks/blood etc all over the place, does not kill, can be called on a dead monster.
         void explode();

--- a/src/player_hardcoded_effects.cpp
+++ b/src/player_hardcoded_effects.cpp
@@ -175,7 +175,7 @@ static void eff_fun_antifungal( Character &u, effect & )
         // not using u.get_random_body_part() as it is weighted & not fully random
         std::vector<bodypart_id> bparts = u.get_all_body_parts( get_body_part_flags::only_main );
         bodypart_id random_bpart = bparts[ rng( 0, bparts.size() - 1 ) ];
-        u.apply_damage( nullptr, random_bpart, 1 );
+        u.apply_damage( nullptr, random_bpart, damage_instance( damage_type::BIOLOGICAL, 1 ) );
     }
 }
 static void eff_fun_fake_common_cold( Character &u, effect & )
@@ -232,7 +232,8 @@ static void eff_fun_fungus( Character &u, effect &it )
             if( one_in( 3600 + bonus * 18 ) ) {
                 u.add_msg_if_player( m_bad,  _( "You spasm suddenly!" ) );
                 u.mod_moves( -to_moves<int>( 1_seconds ) );
-                u.apply_damage( nullptr, bodypart_id( "torso" ), resists ? rng( 1, 5 ) : 5 );
+                u.apply_damage( nullptr, bodypart_id( "torso" ), damage_instance( damage_type::BIOLOGICAL,
+                                resists ? rng( 1, 5 ) : 5 ) );
             }
             if( x_in_y( u.vomit_mod(), ( 4800 + bonus * 24 ) ) || one_in( 12000 + bonus * 60 ) ) {
                 u.add_msg_player_or_npc( m_bad, _( "You vomit a thick, gray goop." ),
@@ -243,8 +244,9 @@ static void eff_fun_fungus( Character &u, effect &it )
                 u.mod_hunger( awfulness );
                 u.mod_thirst( awfulness );
                 ///\EFFECT_STR decreases damage taken by fungus effect
-                u.apply_damage( nullptr, bodypart_id( "torso" ), awfulness / std::max( u.str_cur,
-                                1 ) ); // can't be healthy
+                // can't be healthy
+                u.apply_damage( nullptr, bodypart_id( "torso" ), damage_instance( damage_type::BIOLOGICAL,
+                                awfulness / std::max( u.str_cur, 1 ) ) );
             }
             break;
         case 3:
@@ -286,9 +288,9 @@ static void eff_fun_fungus( Character &u, effect &it )
                         u.add_msg_player_or_npc( m_bad, _( "Your hands bulge.  Fungus stalks burst through the bulge!" ),
                                                  _( "<npcname>'s hands bulge.  Fungus stalks burst through the bulge!" ) );
                     }
-                    u.apply_damage( nullptr, bodypart_id( "arm_l" ), 999 );
-                    u.apply_damage( nullptr, bodypart_id( "arm_r" ), 999 );
-                } else {
+                    // TODO Replace with a specific wound for flavour
+                    u.apply_damage( nullptr, bodypart_id( "arm_l" ), damage_instance( damage_type::STAB, 999 ) );
+                    u.apply_damage( nullptr, bodypart_id( "arm_r" ), damage_instance( damage_type::STAB, 999 ) );
                     // we don't have viable arms, so the fungus does a little chestbursting
                     u.add_msg_player_or_npc( m_bad,
                                              _( "Your chest bulges, and fungal stalks burst out of your skin!" ),
@@ -1303,7 +1305,7 @@ void Character::hardcoded_effects( effect &it )
             }
             mod_moves( -to_moves<int>( 1_seconds ) * 1.5 );
             mod_pain( 1 );
-            apply_damage( nullptr, bp, 1 );
+            apply_damage( nullptr, bp, damage_instance( damage_type::CUT, 1 ) );
         }
     } else if( id == effect_evil ) {
         // Major effects, all bad.
@@ -1347,6 +1349,7 @@ void Character::hardcoded_effects( effect &it )
                 add_msg_if_player( m_bad, _( "You feel paranoid.  They're watching you." ) );
                 mod_pain( 1 );
                 mod_sleepiness( dice( 1, 6 ) );
+            // These need wounds if we keep them
             } else if( one_in( 3000 ) ) {
                 add_msg_if_player( m_bad,
                                    _( "You feel like you need less teeth.  You pull one out, and it is rotten to the core." ) );
@@ -1392,7 +1395,8 @@ void Character::hardcoded_effects( effect &it )
         }
         if( one_in( 6144 ) ) {
             mod_daily_health( -10, -100 );
-            apply_damage( nullptr, bodypart_id( "head" ), rng( 0, 1 ) );
+            apply_damage( nullptr, bodypart_id( "head" ), damage_instance( damage_type::BIOLOGICAL, rng( 0,
+                          1 ) ) );
             if( !has_effect( effect_visuals ) ) {
                 add_msg_if_player( m_bad, _( "Your vision is getting fuzzy." ) );
                 schedule_effect( effect_visuals, rng( 1_minutes, 60_minutes ) );
@@ -1400,7 +1404,8 @@ void Character::hardcoded_effects( effect &it )
         }
         if( one_in( 24576 ) ) {
             mod_daily_health( -10, -100 );
-            apply_damage( nullptr, bodypart_id( "head" ), rng( 1, 2 ) );
+            apply_damage( nullptr, bodypart_id( "head" ), damage_instance( damage_type::BIOLOGICAL, rng( 1,
+                          2 ) ) );
             if( !is_blind() && !sleeping ) {
                 add_msg_if_player( m_bad, _( "Your vision goes black!" ) );
                 schedule_effect( effect_blind, rng( 5_turns, 20_turns ) );

--- a/src/start_location.cpp
+++ b/src/start_location.cpp
@@ -588,7 +588,7 @@ void start_location::handle_heli_crash( avatar &you ) const
                 const int maxHp = you.get_hp_max( bp );
                 // Body part health will range from 33% to 66% with occasional bleed
                 const int dmg = static_cast<int>( rng( maxHp / 3, maxHp * 2 / 3 ) );
-                you.apply_damage( nullptr, bp, dmg );
+                you.apply_damage( nullptr, bp, damage_instance( damage_type::BASH, dmg ) );
                 break;
             }
             // No damage

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -230,7 +230,7 @@ void suffer::water_damage( Character &you )
                           0 ) * wetness_percentage / 100;
         const int dmg = roll_remainder( dmg_float );
         if( dmg > 0 ) {
-            you.apply_damage( nullptr, elem.first, dmg );
+            you.apply_damage( nullptr, elem.first, damage_instance( damage_type::PURE, dmg ) );
             you.add_msg_player_or_npc( m_bad, _( "Your %s is damaged by the water." ),
                                        _( "<npcname>'s %s is damaged by the water." ),
                                        body_part_name( elem.first ) );
@@ -325,7 +325,8 @@ void suffer::while_underwater( Character &you )
             you.mod_power_level( -bio_gills->power_trigger );
         } else {
             you.add_msg_if_player( m_bad, _( "You're drowning!" ) );
-            you.apply_damage( nullptr, bodypart_id( "torso" ), rng( 1, 4 ) );
+            you.apply_damage( nullptr, bodypart_id( "head" ), damage_instance( damage_type::BIOLOGICAL, rng( 1,
+                              4 ) ) );
         }
     }
     if( you.has_trait( trait_FRESHWATEROSMOSIS ) &&
@@ -393,12 +394,8 @@ void suffer::while_grabbed( Character &you )
     // a few warnings before starting to take damage
     if( you.oxygen <= 5 ) {
         you.add_msg_if_player( m_bad, _( "You're suffocating!" ) );
-        if( uistate.distraction_oxygen && you.is_avatar() ) {
-            g->cancel_activity_or_ignore_query( distraction_type::oxygen, _( "You're suffocating!" ) );
-        }
-        // your characters chest is being crushed and you are dying
-        you.apply_damage( nullptr, you.get_random_body_part_of_type( body_part_type::type::torso ), rng( 1,
-                          4 ) );
+        // Sleep effect change is from KorGgenT, don't know if it was intentional
+        you.add_effect( efftype_id( "sleep" ), 1_seconds );
     } else if( you.oxygen <= 15 ) {
         you.add_msg_if_player( m_bad, _( "You can't breathe with all this weight!" ) );
     } else if( you.oxygen <= 25 ) {
@@ -826,9 +823,9 @@ void suffer::from_sunburn( Character &you, bool severe )
             // an HP pool with the head, those parts take an unfair share of damage in relation
             // to the torso, which only has one part.  Increase torso damage to balance this.
             if( bp == bodypart_id( "torso" ) ) {
-                you.apply_damage( nullptr, bp, 2 );
+                you.apply_damage( nullptr, bp, damage_instance( damage_type::HEAT, 2 ) );
             } else {
-                you.apply_damage( nullptr, bp, 1 );
+                you.apply_damage( nullptr, bp, damage_instance( damage_type::HEAT, 1 ) );
             }
             return Damage;
         } else {
@@ -1549,7 +1546,7 @@ void suffer::from_tourniquet( Character &you )
     for( const bodypart_id &bp : you.get_all_body_parts( get_body_part_flags::only_main ) ) {
         if( you.worn_with_flag( flag_TOURNIQUET, bp ) && one_turn_in( 30_seconds ) ) {
             you.mod_pain( 1 );
-            you.apply_damage( nullptr, bp, 1, true );
+            you.apply_damage( nullptr, bp, damage_instance( damage_type::BIOLOGICAL, 1 ), true );
             you.add_msg_player_or_npc( m_bad, _( "Your tourniquet hurts you." ),
                                        _( "<npcname> is hurting from the tourniquet." ) );
         }

--- a/src/teleport.cpp
+++ b/src/teleport.cpp
@@ -116,7 +116,7 @@ bool teleport::teleport_to_point( Creature &critter, tripoint_bub_ms target, boo
                 }
                 return false;
             }
-            critter.apply_damage( nullptr, bodypart_id( "torso" ), 9999 );
+            critter.apply_damage( nullptr, bodypart_id( "torso" ), damage_instance( damage_type::BASH, 9999 ) );
             if( c_is_u ) {
                 get_event_bus().send<event_type::teleports_into_wall>( p->getID(),
                         dest->obstacle_name( dest_target ) );
@@ -183,9 +183,40 @@ bool teleport::teleport_to_point( Creature &critter, tripoint_bub_ms target, boo
                 poor_soul->as_character()->add_msg_if_player( m_warning, _( "You feel disjointed." ) );
                 return false;
             }
+            if( collision ) {
+                        critter.setpos( target );
+                        g->fling_creature( &critter, units::from_degrees( collision_angle - 180 ), 50 );
+                        critter.apply_damage( nullptr, bodypart_id( "arm_l" ), damage_instance( damage_type::BASH, rng( 5,
+                                              10 ) ) );
+                        critter.apply_damage( nullptr, bodypart_id( "arm_r" ), damage_instance( damage_type::BASH, rng( 5,
+                                              10 ) ) );
+                        critter.apply_damage( nullptr, bodypart_id( "leg_l" ), damage_instance( damage_type::BASH, rng( 7,
+                                              12 ) ) );
+                        critter.apply_damage( nullptr, bodypart_id( "leg_r" ), damage_instance( damage_type::BASH, rng( 7,
+                                              12 ) ) );
+                        critter.apply_damage( nullptr, bodypart_id( "torso" ), damage_instance( damage_type::BASH, rng( 5,
+                                              15 ) ) );
+                        critter.apply_damage( nullptr, bodypart_id( "head" ), damage_instance( damage_type::BASH, rng( 2,
+                                              8 ) ) );
+                        critter.check_dead_state();
+                        //player and npc exclusive teleporting effects
+                        if( p ) {
+                            g->place_player( p->pos() );
+                            if( add_teleglow ) {
+                                p->add_effect( effect_teleglow, 30_minutes );
+                            }
+                        }
+                        if( c_is_u ) {
+                            g->update_map( *p );
+                        }
+                critter.remove_effect( effect_grabbed );
+            return true;
+        }
+        //Character *const poor_player = dynamic_cast<Character *>( poor_soul );
+
             if( force ) {
-                //this should only happen through debug menu, so this won't affect the player.
-                poor_soul->apply_damage( nullptr, bodypart_id( "torso" ), 9999 );
+                poor_soul->apply_damage( nullptr, bodypart_id( "torso" ), damage_instance( damage_type::BASH,
+                            9999 ) );
                 poor_soul->check_dead_state( &here );
             } else if( safe ) {
                 if( c_is_u && display_message ) {

--- a/src/wound.cpp
+++ b/src/wound.cpp
@@ -1,0 +1,226 @@
+#include "wound.h"
+
+#include "damage.h"
+#include "generic_factory.h"
+
+std::map<damage_type, std::vector<wound_id>> wound_type::wound_lookup;
+
+namespace
+{
+generic_factory<wound_type> wound_factory( "wound" );
+} // namespace
+
+const std::vector<wound_type> &wound_type::get_all()
+{
+    return wound_factory.get_all();
+}
+
+template<>
+const wound_type &string_id<wound_type>::obj() const
+{
+    return wound_factory.obj( *this );
+}
+
+template<>
+bool string_id<wound_type>::is_valid() const
+{
+    return wound_factory.is_valid( *this );
+}
+
+void wound_type::load_wound( const JsonObject &jo, const std::string &src )
+{
+    wound_factory.load( jo, src );
+}
+
+void wound_type::finalize()
+{
+    wound_type::wound_lookup.clear();
+    for( const wound_type &cur_wound : get_all() ) {
+        wound_lookup[cur_wound.dmg_type].push_back( cur_wound.id );
+    }
+}
+
+void wound_type::load( const JsonObject &jo, const std::string & )
+{
+    optional( jo, was_loaded, "name", name );
+    optional( jo, was_loaded, "description", description );
+    optional( jo, was_loaded, "size", size, 0 );
+    optional( jo, was_loaded, "sunder", sunder, 0 );
+    optional( jo, was_loaded, "pain", pain );
+    optional( jo, was_loaded, "min_damage", min_damage, 1 );
+    optional( jo, was_loaded, "max_damage", max_damage, INT_MAX );
+    mandatory( jo, was_loaded, "damage_type", dmg_type );
+    mandatory( jo, was_loaded, "limbs", limbs );
+    optional( jo, was_loaded, "bleed", bleed, volume_reader{}, 0_ml );
+    optional( jo, was_loaded, "heal_time", heal_time );
+    optional( jo, was_loaded, "heals_into", heals_into );
+    optional( jo, was_loaded, "infects_into", infects_into );
+}
+
+wound::wound( const damage_unit &damage )
+{
+    const auto lookup_iter = wound_type::wound_lookup.find( damage.type );
+
+    if( lookup_iter == wound_type::wound_lookup.cend() ) {
+        debugmsg( string_format( "Error: No wound found that has damage type %s",
+                                 io::enum_to_string( damage.type ) ) );
+        // no point looking through empty vectors
+        return;
+    }
+
+    // damage unit lookup here
+    std::vector<wound_id> potential_hurt;
+    for( const wound_id &wnd : lookup_iter->second ) {
+        if( wnd->min_damage <= damage.amount && wnd->max_damage >= damage.amount ) {
+            potential_hurt.push_back( wnd );
+        }
+    }
+    int pick_random = rng( 0, static_cast<int>( potential_hurt.size() ) - 1 );
+    id = potential_hurt[pick_random];
+    intensity_multiplier = 1.0 + static_cast<double>( damage.amount - id->min_damage ) /
+                           static_cast<double>( id->max_damage - id->min_damage );
+}
+
+std::string wound::name() const
+{
+    return id->name.translated();
+}
+
+std::string wound::description() const
+{
+    return id->description.translated();
+}
+
+wound wound::wound_healed() const
+{
+    if( !heals_into() ) {
+        debugmsg( "Error: wound trying to heal into nonexistent wound" );
+    }
+    wound healed_wound;
+    healed_wound.id = *heals_into();
+    healed_wound.intensity_multiplier = intensity_multiplier;
+    healed_wound.contamination = contamination;
+
+    return healed_wound;
+}
+
+wound wound::wound_infected() const
+{
+    if( !infects_into() ) {
+        debugmsg( "Error: wound trying to infect into nonexistent wound" );
+    }
+    wound infected_wound;
+    infected_wound.id = *infects_into();
+    infected_wound.intensity_multiplier = intensity_multiplier;
+    infected_wound.contamination = contamination;
+
+    return infected_wound;
+}
+
+bool wound::process( const time_duration &t, double healing_factor )
+{
+    age += t * healing_factor * ( 1 - infection );
+    // stand-in sentinel value
+    infection += 0.01 * contamination * to_seconds<double>( t );
+
+    return id->heal_time && age >= *id->heal_time || is_infected();
+}
+
+std::optional<wound_id> wound::heals_into() const
+{
+    return id->heals_into;
+}
+
+std::optional<wound_id> wound::infects_into() const
+{
+    return id->infects_into;
+}
+
+double wound::wound_progression() const
+{
+    if( !id->heal_time ) {
+        // this is a permanent wound
+        return 0.0;
+    }
+    return to_turns<double>( age ) / to_turns<double>( *id->heal_time );
+}
+
+double wound::infection_progression() const
+{
+    return infection;
+}
+
+bool wound::is_infected() const
+{
+    return infection_progression() >= 1.0;
+}
+
+bool wound::overlaps( int target ) const
+{
+    if( location + id->size <= 100 ) {
+        return location >= target && location + id->size <= target;
+    } else {
+        return location >= target || location + id->size - 100 <= target;
+    }
+}
+
+int wound::sunder() const
+{
+    return id->sunder;
+}
+
+damage_type wound::damage_type() const
+{
+    return id->dmg_type;
+}
+
+const std::vector<wound> &limb_wounds::get_all_wounds() const
+{
+    return wounds;
+}
+
+int limb_wounds::sunder( damage_type dmg_type, int location ) const
+{
+    int total = 0;
+    for( const wound &wnd : wounds ) {
+        if( dmg_type == wnd.damage_type() && wnd.overlaps( location ) ) {
+            total += wnd.sunder();
+        }
+    }
+    return total;
+}
+
+void limb_wounds::add_wound( const damage_instance &damage, int location )
+{
+    for( damage_unit du : damage.damage_units ) {
+        du.amount += sunder( du.type, location );
+        add_wound( wound( du ) );
+    }
+}
+
+void limb_wounds::add_wound( const wound &wnd )
+{
+    wounds.push_back( wnd );
+}
+
+// for this function, the bulk of it is actually the loop with the iterators.
+// the actual processing is wound::process and any special rules should be put into there.
+void limb_wounds::process( const time_duration &t, double healing_factor )
+{
+    // start at the ending because we'll be adding more to the real end as we go along
+    for( auto wound_iter = wounds.rbegin(); wound_iter != wounds.rend(); ) {
+        if( wound_iter->process( t, healing_factor ) ) {
+            // the wound's age renews when it transforms
+            if( wound_iter->is_infected() ) {
+                // "infects" the wound
+                add_wound( wound_iter->wound_infected() );
+            } else if( wound_iter->heals_into() ) {
+                // "heals" the wound
+                add_wound( wound_iter->wound_healed() );
+            }
+            wound_iter = decltype( wound_iter )( wounds.erase( std::next( wound_iter ).base() ) );
+        } else {
+            ++wound_iter;
+        }
+    }
+}

--- a/src/wound.h
+++ b/src/wound.h
@@ -1,0 +1,125 @@
+#pragma once
+#ifndef CATA_SRC_WOUND_H
+#define CATA_SRC_WOUND_H
+
+#include <optional>
+#include <vector>
+
+#include "body_part_set.h"
+#include "calendar.h"
+#include "damage.h"
+#include "string_id.h"
+#include "translation.h"
+#include "units.h"
+
+class body_part_set;
+class damage_instance;
+class JsonObject;
+class wound_type;
+
+enum class damage_type;
+
+using wound_id = string_id<wound_type>;
+
+// this is the json object, so it needs to all be public
+class wound_type
+{
+    public:
+        wound_type() = default;
+
+        void load( const JsonObject &jo, const std::string & );
+        static void load_wound( const JsonObject &jo, const std::string &src );
+
+        static const std::vector<wound_type> &get_all();
+        static void finalize();
+        static std::map<damage_type, std::vector<wound_id>> wound_lookup;
+
+        wound_id id;
+        bool was_loaded;
+
+        translation name;
+        translation description;
+
+        // this is a representation of how often this wound would be damaged by attacks, and how they overlap
+        // 0-100
+        int size;
+        int pain;
+        // this is basically negative armor, effectively giving you worse wounds with the same amount of damage
+        int sunder;
+        int min_damage = 1;
+        int max_damage = INT_MAX;
+        damage_type dmg_type;
+
+        body_part_set limbs;
+        // the amount of bleeding per second
+        units::volume bleed;
+        // how long it takes for this wound to heal.
+        std::optional<time_duration> heal_time;
+        // transforms into this wound once age has reached heal_time
+        std::optional<wound_id> heals_into;
+        // transforms into this wound once infection reaches 1.0 (100%)
+        std::optional<wound_id> infects_into;
+};
+
+// this is the mutable object in code that points to the wound_type
+class wound
+{
+    private:
+        wound_id id;
+        // represents the location of the wound and how they overlap
+        // 0-100
+        int location;
+        // multiplies various wound effects
+        double intensity_multiplier;
+        // how old the wound is. if older than heal_time, turns this wound into the next one.
+        time_duration age;
+        // the percentage to full infection this wound is at. ticks up based on how dirty it is and perhaps other factors.
+        double infection;
+        // the multiplier for normal infection rate
+        double contamination = 1.0;
+    public:
+        wound() = default;
+        wound( const damage_unit &damage );
+        // if true, this wound is ready to be removed.
+        bool process( const time_duration &t, double healing_factor );
+        // value that represents the wound progression to healed status. the wound is healed at 1.0
+        double wound_progression() const;
+        // value that represents infection progression. the wound is infected at 1.0
+        double infection_progression() const;
+
+        bool is_infected() const;
+        bool overlaps( int location ) const;
+
+        std::optional<wound_id> heals_into() const;
+        std::optional<wound_id> infects_into() const;
+
+        // creates a new version of this wound, with inherited values
+        // will error if there is no healed version. make sure to check first.
+        wound wound_healed() const;
+        wound wound_infected() const;
+
+        int sunder() const;
+        damage_type damage_type() const;
+
+        std::string name() const;
+        std::string description() const;
+};
+
+// this is all of the wounds that are attached to a limb.
+// essentially a wrapper object for a list of wounds
+class limb_wounds
+{
+    private:
+        std::vector<wound> wounds;
+    public:
+        limb_wounds() = default;
+        void add_wound( const damage_instance &damage, int location );
+        void add_wound( const wound &wnd );
+        // healing factor is a multiple to duration for age so the wound heals faster.
+        void process( const time_duration &t, double healing_factor );
+        // the effective negative armor at the location / damage type
+        int sunder( damage_type dmg_type, int location ) const;
+        const std::vector<wound> &get_all_wounds() const;
+};
+
+#endif // CATA_SRC_WOUND_H

--- a/tests/character_modifier_test.cpp
+++ b/tests/character_modifier_test.cpp
@@ -97,13 +97,6 @@ TEST_CASE( "Basic_limb_score_test", "[character][encumbrance][limb]" )
                 CHECK( dude.get_limb_score( limb_score_test ) == Approx( 0.8 ).epsilon( 0.001 ) );
             }
         }
-        WHEN( "limb is wounded" ) {
-            dude.apply_damage( nullptr, test_bp->get_id(), test_bp->get_hp_max() / 2, true );
-            THEN( "modified limb score is less than unmodified limb score" ) {
-                CHECK( test_bp->get_id()->get_limb_score( limb_score_test ) == Approx( 0.8 ).epsilon( 0.001 ) );
-                CHECK( dude.get_limb_score( limb_score_test ) == Approx( 0.53333 ).epsilon( 0.001 ) );
-            }
-        }
     }
 
     GIVEN( "limb is encumbered" ) {
@@ -113,13 +106,6 @@ TEST_CASE( "Basic_limb_score_test", "[character][encumbrance][limb]" )
             THEN( "modified limb score is less than unmodified limb score" ) {
                 CHECK( test_bp->get_id()->get_limb_score( limb_score_test ) == Approx( 0.8 ).epsilon( 0.001 ) );
                 CHECK( dude.get_limb_score( limb_score_test ) == Approx( 0.4701 ).epsilon( 0.001 ) );
-            }
-        }
-        WHEN( "limb is wounded" ) {
-            dude.apply_damage( nullptr, test_bp->get_id(), test_bp->get_hp_max() / 2, true );
-            THEN( "modified limb score is less than unmodified limb score" ) {
-                CHECK( test_bp->get_id()->get_limb_score( limb_score_test ) == Approx( 0.8 ).epsilon( 0.001 ) );
-                CHECK( dude.get_limb_score( limb_score_test ) == Approx( 0.3134 ).epsilon( 0.001 ) );
             }
         }
     }
@@ -141,13 +127,6 @@ TEST_CASE( "Basic_character_modifier_test", "[character][encumbrance][limb]" )
                            0.001 ) );
             }
         }
-        WHEN( "limb is wounded" ) {
-            dude.apply_damage( nullptr, test_bp->get_id(), test_bp->get_hp_max() / 2, true );
-            THEN( "modified limb score is less than unmodified limb score" ) {
-                CHECK( dude.get_modifier( character_modifier_test_char_cost_mod ) == Approx( 26.25 ).epsilon(
-                           0.001 ) );
-            }
-        }
     }
 
     GIVEN( "limb is encumbered" ) {
@@ -156,13 +135,6 @@ TEST_CASE( "Basic_character_modifier_test", "[character][encumbrance][limb]" )
         WHEN( "limb is not wounded" ) {
             THEN( "modified limb score is less than unmodified limb score" ) {
                 CHECK( dude.get_modifier( character_modifier_test_char_cost_mod ) == Approx( 33.81579 ).epsilon(
-                           0.001 ) );
-            }
-        }
-        WHEN( "limb is wounded" ) {
-            dude.apply_damage( nullptr, test_bp->get_id(), test_bp->get_hp_max() / 2, true );
-            THEN( "modified limb score is less than unmodified limb score" ) {
-                CHECK( dude.get_modifier( character_modifier_test_char_cost_mod ) == Approx( 65.72368 ).epsilon(
                            0.001 ) );
             }
         }

--- a/tests/firstaid_test.cpp
+++ b/tests/firstaid_test.cpp
@@ -62,7 +62,7 @@ TEST_CASE( "avatar_does_healing", "[activity][firstaid][avatar]" )
     int start_bandage_count = dummy.items_with( bandages_filter ).size();
     REQUIRE( dummy.has_item( *bandages ) );
     GIVEN( "avatar has a damaged right arm" ) {
-        dummy.apply_damage( nullptr, right_arm, 20 );
+        dummy.apply_damage( nullptr, right_arm, damage_instance( damage_type::CUT, 20 ) );
         WHEN( "avatar bandages self" ) {
             dummy.assign_activity( firstaid_activity_actor( moves, bandages->tname(), dummy.getID() ) );
             dummy.activity.targets.emplace_back( bandages );
@@ -75,7 +75,7 @@ TEST_CASE( "avatar_does_healing", "[activity][firstaid][avatar]" )
         }
     }
     GIVEN( "avatar has a damaged right arm" ) {
-        dummy.apply_damage( nullptr, right_arm, 20 );
+        dummy.apply_damage( nullptr, right_arm, damage_instance( damage_type::CUT, 20 ) );
         WHEN( "avatar bandages self and is interrupted before finishing" ) {
             dummy.assign_activity( firstaid_activity_actor( moves, bandages->tname(), dummy.getID() ) );
             dummy.activity.targets.emplace_back( bandages );
@@ -88,7 +88,7 @@ TEST_CASE( "avatar_does_healing", "[activity][firstaid][avatar]" )
         }
     }
     GIVEN( "npc has a damaged right arm" ) {
-        dunsel.apply_damage( nullptr, right_arm, 20 );
+        dunsel.apply_damage( nullptr, right_arm, damage_instance( damage_type::CUT, 20 ) );
         WHEN( "avatar bandages npc" ) {
             dummy.assign_activity( firstaid_activity_actor( moves, bandages->tname(), dunsel.getID() ) );
             dummy.activity.targets.emplace_back( bandages );
@@ -117,7 +117,7 @@ TEST_CASE( "npc_does_healing", "[activity][firstaid][npc]" )
     int start_bandage_count = dunsel.items_with( bandages_filter ).size();
     REQUIRE( dunsel.has_item( *bandages ) );
     GIVEN( "npc has a damaged right arm" ) {
-        dunsel.apply_damage( nullptr, right_arm, 20 );
+        dunsel.apply_damage( nullptr, right_arm, damage_instance( damage_type::CUT, 20 ) );
         WHEN( "npc bandages self" ) {
             // See npc::heal_self()
             bandages->type->invoke( &dunsel, *bandages, dunsel.pos_bub(), "heal" );
@@ -129,7 +129,7 @@ TEST_CASE( "npc_does_healing", "[activity][firstaid][npc]" )
         }
     }
     GIVEN( "npc has a damaged right arm" ) {
-        dunsel.apply_damage( nullptr, right_arm, 20 );
+        dunsel.apply_damage( nullptr, right_arm, damage_instance( damage_type::CUT, 20 ) );
         WHEN( "npc bandages self and is interrupted before finishing" ) {
             // See npc::heal_self()
             bandages->type->invoke( &dunsel, *bandages, dunsel.pos_bub(), "heal" );
@@ -141,7 +141,7 @@ TEST_CASE( "npc_does_healing", "[activity][firstaid][npc]" )
         }
     }
     GIVEN( "avatar has a damaged right arm" ) {
-        dummy.apply_damage( nullptr, right_arm, 20 );
+        dummy.apply_damage( nullptr, right_arm, damage_instance( damage_type::CUT, 20 ) );
         WHEN( "npc bandages avatar" ) {
             // See npc::heal_player
             bandages->type->invoke( &dunsel, *bandages, dummy.pos_bub(), "heal" );


### PR DESCRIPTION
# Summary
The Wounds system has been on the backburner for a while, and the design document is thorough enough to work with. This is going to change hitpoints and combat drastically, and thus will be tested and tweaked as I work on it.

What Doesn’t Kill You…
The way you “die” is being massively changed. With my very limited medical knowledge, oxygen is the primary reason the body shuts down. This will be game-ified and abstracted heavily, but will affect the way the player is hurt.

Other elements like blood pressure are coming, but will mainly be extensions of current effects like hypovolemia (following the example) and used for symptoms. Most elements will affect oxygen in some way, followed by circulation (hypovolemia > loss of blood pressure > loss of circulation > loss of oxygen in essential organs). This won’t be micromanaged, but will come into play mainly with tourniquets and similar.

Symptoms will assist in diagnosis by the player, as a sort of notification system to help identify major issues.

This also lets writers expand how diseases and injuries work, defining how exactly the player is being hurt beyond “+10 damage”.

How much this expands should be under _a lot_ of scrutiny by the head devs, so I don’t bog down the game or performance. It should ideally be a few core counters, like oxygen is presently.

Effects Replaced
A good deal of effects are being moved to the medical menu, and their effects on the player handled by medical code. You inject Adrenaline (or activate it via your mutations/bionics) and create a tiny wound on your body, with the Adrenaline contaminant, which enters your bloodstream and triggers the effect. Poison and venom are similar.

Assist Innovative Devices
A new pre-cataclysm company which developed AI-assisted medical tools for the homes and the hospitals of New England. Han-DY-alysis (Product DY), SECIL (Product SC), and ERIC (Product ER) will be there to help the player with their more dire ailments.

(A.I.D. products fill the role of a tutorial on more complex medical treatments, going further than Medical Menu tooltips, and providing assistance with treatments. Traditional medical machines are also found more consistently but provide no assistance and require medical knowledge to use. Usually they’re found as vehicle modules on wheels, unable to be removed. SECIL is furniture.)

Han-DY-alysis hosts a (relatively) compact dialysis machine with blood-testing capabilities. Its onboard AI (basically a combined chatbot and medical robot) makes it simple to use for anyone, just connect the machine to your body and let it handle the rest! Han-DY-alysis is commercially available and often found in homes and doctors offices alike—or in hospitals alongside traditional machines of course.

(AI is named “Heba al-Assist”, came up with the name when I was still trying to fit the naming scheme into puns. Like ‘dialysis’, alysis, al-assist, of the family Assist. Thought it might be interesting for characterization, so I kept it. If anybody with more experience in Middle Eastern culture would like to contribute more to her that would be amazing!)

[WIP note: Provides medical tools related to blood, and gives a slight boost to treatment successes. Thinking about adding the potential for user error, if your character makes a mistake while setting everything up. “Oh s#!t I forgot to plug the intake into the machine, my blood is pouring out!”]

SECIL is an evolution of the famous (and recalled) Mr. Stem Cell. Now with the same AI and medical capabilities of his sister, the Stem-cell Enhanced Care for Intensive Liabilities is present in hospitals and medical centers for use by medical professionals. SECIL hosts a wider variety of medical tools and is capable of providing a stem-cell treatment (with appropriate resources).

[WIP note: “SECIL! I NEED YOU SECIL!!”. Jokes aside, SECIL provides almost every medical tool you’d find in an emergency room, greatly boosts your treatment successes, plus the return of Stem Cell Treatment. In the real world, stem cell treatment is only cleared for use in blood-loss, but research has been done on healing wounds and treating ordinarily untreatable conditions which involve currently irreparable cells. 

If we ever make nerve damage more common, or add brain damage or spinal-damage paralysis—both of which I say are terrible ideas—this could be a good option.]

ERIC is an experimental compact AI-assistant installed on a few select ambulances for trials in the field. Emergency Response Intervention - Compact is equipped with medical tools for trauma which require emergency medical services, designed to assist first responders. ERIC was developed quickly as a response to the rioting and chaos leading up to the Cataclysm, and was never refined or distributed—even within New England.

[WIP note: Found with ambulances, slotted in where another module would be similar to a stretcher. Thinking about cutting this and replacing it with another assistant. Where Han-DY-alysis provides information and help with contaminants and blood loss, ERIC helps with trauma in the field that the player would likely encounter. It’s meant to be a step close to Han-DY-alysis, but short of SECIL.

A separate Assist product to take care of this found in similar circumstances might be better.]

[General WIP notes: An Assist product for fire departments focused on burns (acid or otherwise) would be good. Not sure how necessary it may be, but I don’t think it should be relegated to SECIL, especially with how dangerous acid is becoming.]


I’m using a lot of ideas from various sources, all of which will be attributed.
-Original Wound Design Doc (Issue #64424)
KorGgenT, I-am-Erk, Shiubiha, Venera3 and zachary-kaelan contributed the framework for the implementation of wounds and contamination.
-"Flinch", a mechanic for making speed penalties less deadly and annoying (Issue #73050)
I-am-Erk laid out a mechanic for flinching, rather than pain universally slowing the player. It’s been waiting for the wounds system for a while.

## Combat Changes
These are WIP and will need to be extensively tested and changed.

If things across the board are far too deadly, the JSON values for injury depth and thresholds can be adjusted (eg. “Small Cut” will only become a different wound at 20 damage rather than 10)

If a specific encounter is deadlier than intended, the damage values of that specific monster/attack can be adjusted (eg. A zombie variant can cause extremely deep wounds on specific vitals, only countered by armour not available at this point in the game)

Pain changes, limb loss WIP, new Exodii merchant for prosthetics, repairs and regrowth, all are WIP

### Bifurcation, Decapitation, Etc
Without insane mutations (more than likely restricted to the undead or hostile mutants) this would definitely be fatal, or at the very least put an end to your adventuring without exotic repair and replacement.

However, seeing (or even being) someone get their head chopped off, and watching crab legs sprout from the stump as it scurries off like The Thing, would be freaky as all hell.

# Purpose of change
As great as Hitpoints are, they’ve had their issues in the past with balance and “realism”---our ever-present lofty ideal. In the real world, stubbing your toe a hundred times doesn’t break your femur; and this isn’t fun in-game either.

This will also make changes to pain and the player’s body, as combat changes made by wounds will require rebalancing and the associated changes along with it.

# Describe the solution
## Wounds:

Rather than hitpoints, your main limbs will accumulate wounds.

When attacked, you will accumulate wounds. If these wounds overlap, they are merged, increasing the surface area and potentially severity. Each wound is affected by its depth, type, and surface area.

This is done by a “layers” system, from your skin to your bones to the skin on the other side. Attributes affect the resilience of these layers, similar to the interaction between armour and hitpoints as it is now.

For example: Bones are pretty damn strong, slicing through them isn’t easy by normal means. However, having weakened bones from some preexisting condition or deficiency might make your bones a bit less resistant to damage.

On the more extreme end, having hollow bones from mutation will make your bones much easier to shatter—exposing you to more unique wounds due to your new biology. While hollow bones may have the same material and strength, they aren’t solid, and you’re at risk for injuries that wouldn’t happen with solid bones (like getting shards of bone stuck inside your healing bone)

### **Layers**:
As recommended by IdleSol, the body is made up of layers.

[Layer 0] Anything outside your body, eg armour and clothing. This is just your clothing layers.
[**Sub-Clothing**]
Damage absorbed by your outer layers will still affect what’s under it. Your plate carrier stopping a rifle round is fantastic, the bruises and broken ribs aren't.
Different parts of the body hold different vitals. Say ~3% of the surface area of your leg is above a vital area, if an attack hits this area, it will affect your vitals. Say your femoral artery is after the muscle (Layer 3) but before the bone (Layer 4). If damage is deep enough to affect Layer 3, on this 3% area, you’ll have a chance of striking the vital. This is increased if the second threshold Layer 4 is reached.
Bionics will have a defined depth layer and coverage, acting similar to vitals
[Layer 1] Hair/Wool/Etc, this is your main source of cushioning (reducing blunt force from attacks stopped by your other layers)
[Layer 2] Skin, or equivalent. 
[Layer 3] Tissue, muscle, etc
[Layer 4] Bone
[Layer 5] Deepest tissue and organs
[**Other Side**]
Wounds deep enough will reach the other side of your body.
[Layer 6] Other Side’s Bone
[Layer 7] Other Side’s Tissue
[Layer 8] Other Side’s Skin
[Layer 9] Other Side’s Hair
[**Clothing**]
[Layer 10] Other side’s outer area

### Example
For some examples of what wounds will look like:

#### **ID**:
The source of the wound affects its behaviour, healing method, etc. A third degree burn is much different than a burn from acidic material. Various injuries are assigned an ID in JSON, with the information for their healing and attributes. This makes it easier to create new wounds from unique sources (even if just a copy-from variant)

#### **Depth**:
The deeper the wound, the closer it is to your major blood vessels, organs, bones, and vital areas. A small through-and-through wound that doesn’t hit your vitals is lucky and fantastic, and certainly may happen. Just the same, you might be struck in the thigh wrong and burst your femoral artery.

In-game, this will have to be balanced extremely carefully.

##### **Bionics and Mutations**:
Additionally, your mutations and bionics may be in the way of different attacks and such. 

A subdermal armour bionic situated just below your skin is designed to take and slow down the force of attacks, and won’t do anything too terrible if it breaks (relatively speaking. Only a small hole or crack in the armour that sprayed particles of material into your body, like minor shrapnel)

Conversely, an arm shotgun may have its hammer knocked out of place, or the deployment mechanism gets jammed, causing it to not function. On the higher end, a portion of your cloaking system bionic being damaged may send sparks into your body or uncontrollably power on/off occasionally. Or even your time dilation bionic occasionally malfunctioning and making parts of your body react slower/faster, causing friction and frying your reaction time and nerves.

For mutations, having a huge rack (ANTLERS, damn it! Get your mind out of the gutter!) would add surface area on your head composed of only a single layer: bone, slightly different to your other bones. Different resistances and less painful to break and grow back. Unless of course these antlers are just growths of normal human bone, but that’s not relevant here.

This also gives a place for Issue #79031; getting half your antler knocked off and having it grow back means losing an ear/mutated ear would have it heal over in some way—still recognizable as a scar or mutated clump of flesh. The body horror of your system healing towards your mutation rather than your body is interesting; you’ve changed irreparably (unless you find some purifier…)

#### **Surface Area**:
An abrasion across your forearm would accumulate dirt and filth faster than a cut on your knee, and would need more material to cover. Burns are extremely dangerous for this reason, as they are in real life.

## Contamination
Having foreign substances in your open injuries is bad. Depending on what causes the wounds, different contaminants will find their way into your wounds, causing different infections. In general, uncovered wounds accumulate generic "filth", causing a variety of your mundane, earthly infections and diseases.

-Contaminants drain into your system, depending on their "spread factor". This doesn't cause the contamination to disappear, this only delays how quickly contamination sets in. If the system contamination level reaches its threshold in the wound, the wound becomes infected with the specified infection.
-Infections have a "severity", similar to effects having multiple levels. Deeper wounds will be more likely to begin more severe, especially if close to vitals. Some infections may have a single level, others may get worse over time unless combated, some progress regardless.
-Infection makes healing much harder, sometimes outright

This means older effects getting a revamp; take tetanus for example:

1. Initial contamination. For filth, this is caused by leaving a wound uncovered in general, and starts higher if the wound is caused by something like mounting a broken window. For rust monsters, tetanus is the only infection caused by the specific contaminant
2. Contaminants in the wound are left uncleaned and drain into the system. If more contaminants of the same type enter the wound, and the system contamination for this wound crosses the threshold
3. The threshold is crossed, and a delay is started. At the end of the delay, a percentage chance is calculated by the difference in the contamination value and its upper limit. When that delay is reached, the chance is rolled and the delay begins again **as long as there is still contamination in your system**
(ie, System Contamination has a risk of infection at 10, and will always infect at 110. 20 contamination enters your system before you wash your wound. 10 points past the initial limit _out of_ 100 points between risk and guaranteed infection. 10% chance.)
4. The system contamination constantly lowers based on its "decay", which represents your system trying to filter out and defeat the infection. When the infection chance is rolled, if the infection strikes, system contamination is reduced and the infection severity increases (if you are infected currently)
5. Initial severity is affected by depth, and infection chance is affected by depth.

EQUATION WIP: Calculations will be added
Contamination > System Contamination > Delay > Roll based on factors > Roll for infection type (if multiple) > Repeat until no system contamination present

As far as I know, tetanus has historically only triggered from mounting broken windows or rusty objects, more recently through certain monsters. In the real world, tetanus is a bacterial infection caused by a bacterium commonly found in soil worldwide.

Tetanus will be one of the infections possible when you leave your wounds uncovered and accumulating the filth contaminant.

### Notes on Contamination
Filth will be the generically used contaminant for general contamination while out and about, Zombie Filth will be the specific contaminant which causes "infection" as it currently is. Where filth has a chance of causing this infection (due to XE-037 presence worldwide), Zombie Filth specifically causes "infection", and accumulates from attacks by zombie monsters.

WIP

## Describe alternatives you've considered

### **Misc Notes**

#### **Bionics and Mutations**
Bionics may be changed or JSON-ified, moving the specific changes to a generic damage function for future use may be more reasonable.

Medical and Chimera mutations are getting huge bonuses. Ultra-fast healing and morphing can make lethal wounds a minor setback, and give you effective recovery methods mid/post-combat. Bleeding isn’t a problem when your wounds are instantly covered with reactive bone growths and clots form in seconds.

Lizards and such get this to a much lesser degree, but limb regrowth is nothing to scoff at.

#### **Organ Damage**
A collapsed lung or a punctured heart would be invariably fatal to the average survivor. Not to mention brain damage from being knocked around. I assume instant deaths and common permanent debuffs are not intended, barring extreme circumstances. Unless I'm given a greenlight for some makeshift medical equipment similar to what you'd find in a staffed ambulance, the initial implementation will only trigger insta-death if the heart, lungs, or brain sustain immense damage. Other vitals and organs can be added with long-term damage changes.

#### **Sticks and Stones**
In the real world, XE-037 healing factor or not, you're not repairing a shattered jaw on your own, nor can you reasonably recover with a broken spine. We can explain away healing as XE-037 kicking into high gear, but it still has a limit. For the initial implementation I'm limiting damage to "cracked" bones, a step below breaking or shattering. A cracked jaw might make eating painful and difficult, but it can be reasonably handled on your own; later on, we can figure out a solution attainable through challenge or faction debts (maybe even incorporating the "super-soldier serums")

#### **Assist Innovative Devices**
This is a huge new corporation with new lore and might not be the best approach for their purpose, or might not fit with lore. They aren’t very involved with top secret organizations like XEDRA, maybe at most giving them first-dibs on ERIC or similar technology.

They’re meant to be the mundane step below Super Soldier Serums, only guaranteeing you can recover on your own.

#### **Moddability**

##### Old HP System
This is meant to be heavily moddable and compatible. So what if your mod hinges on using the old HP system?

I’m including a generic “damage” wound which fills this purpose, and will work as the old hp system does, even excluding organs and arteries and such. This doesn’t catch everything, but I’ll do my best and will remain very open to the concerns of modders.

WIP

### Testing
WIP

# Additional context

### Contaminants System
This is **extremely rough** and **convoluted**, any suggestions are very welcome!

### Suggestions...
...are **extremely welcome** and **appreciated**! This is all rough, and I'm putting together multiple ideas from the design document and scenarios brought up previously. Credit will be given to those whose ideas were used to build this system.

Suggestions from this PR:

"Layers system for body, giving resistance for each layer individually and helping with calculations" _HIGHLY ABBREVIATED_
-IdleSol

_This is genius, and can solve the issue of mutations/bionics altering resistances; simply applying armour bonuses to certain damage sources on specific layers_

“Resetting bones and certain injuries, losing teeth, and similar” _HIGHLY ABBREVIATED_
-ADekema

_Like cauterization, resetting bones will be_  a  _option for injury treatment, but not without drawbacks and risks. And with the recent additions of a dentistry office, I could definitely add a medical machine found there and the needed items. But I don’t think it would be needed in general, and would bog down gameplay a bit without much effect outside niche problems._

WIP
