### PR TITLE
[ Xedra Evolved ]  Chronomancy spells no longer gain xp.  Unique level up mechanics.

### DIFF
--- a/data/mods/Xedra_Evolved/dialogue/chronomancer_insight_menu.json
+++ b/data/mods/Xedra_Evolved/dialogue/chronomancer_insight_menu.json
@@ -140,7 +140,7 @@
         "condition": { "math": [ "u_spell_level('xedra_chronomancer_revert_wound') <= 0" ] },
         "text": "Learn [<spell_name:xedra_chronomancer_revert_wound>]",
         "effect": [
-          { "math": [ "u_chronomancer_menu_insight_cost = 10 * u_spell_difficulty('xedra_chronomancer_revert_wound" ] },
+          { "math": [ "u_chronomancer_menu_insight_cost = 10 * u_spell_difficulty('xedra_chronomancer_revert_wound')" ] },
           { "math": [ "_chronomancer_menu_difficulty = 4" ] },
           { "math": [ "_chronomancer_spell_level = u_spell_level('xedra_chronomancer_revert_wound')" ] },
           {
@@ -203,7 +203,7 @@
         "condition": { "math": [ "u_spell_level('xedra_chronomancer_time_loop') <= 0" ] },
         "text": "Learn [<spell_name:xedra_chronomancer_time_loop>]",
         "effect": [
-          { "math": [ "u_chronomancer_menu_insight_cost = 10 * u_spell_difficulty('xedra_chronomancer_time_loop" ] },
+          { "math": [ "u_chronomancer_menu_insight_cost = 10 * u_spell_difficulty('xedra_chronomancer_time_loop')" ] },
           { "math": [ "_chronomancer_menu_difficulty = 5" ] },
           {
             "set_string_var": "<spell_name:xedra_chronomancer_time_loop>",
@@ -266,7 +266,7 @@
         "text": "Learn [<spell_name:xedra_chronomancer_time_stop>]",
         "//": "Difficulty 10 spells will have normal insight costs multiplied by 1.5.",
         "effect": [
-          { "math": [ "u_chronomancer_menu_insight_cost = 15 * u_spell_difficulty('xedra_chronomancer_time_stop" ] },
+          { "math": [ "u_chronomancer_menu_insight_cost = 15 * u_spell_difficulty('xedra_chronomancer_time_stop')" ] },
           { "math": [ "_chronomancer_menu_difficulty = 10" ] },
           {
             "set_string_var": "<spell_name:xedra_chronomancer_time_stop>",
@@ -332,7 +332,7 @@
         "condition": { "math": [ "u_spell_level('xedra_chronomancer_revert_location') <= 0" ] },
         "text": "Learn [<spell_name:xedra_chronomancer_revert_location>]",
         "effect": [
-          { "math": [ "u_chronomancer_menu_insight_cost = 10 * u_spell_difficulty('xedra_chronomancer_revert_location" ] },
+          { "math": [ "u_chronomancer_menu_insight_cost = 10 * u_spell_difficulty('xedra_chronomancer_revert_location')" ] },
           { "math": [ "_chronomancer_menu_difficulty = 8" ] },
           {
             "set_string_var": "<spell_name:xedra_chronomancer_revert_location>",
@@ -402,7 +402,7 @@
         "condition": { "math": [ "u_spell_level('xedra_chronomancer_cement_time') <= 0" ] },
         "text": "Learn [<spell_name:xedra_chronomancer_cement_time>]",
         "effect": [
-          { "math": [ "u_chronomancer_menu_insight_cost = 15 * u_spell_difficulty('xedra_chronomancer_cement_time" ] },
+          { "math": [ "u_chronomancer_menu_insight_cost = 15 * u_spell_difficulty('xedra_chronomancer_cement_time')" ] },
           { "math": [ "_chronomancer_menu_difficulty = 10" ] },
           {
             "set_string_var": "<spell_name:xedra_chronomancer_cement_time>",
@@ -472,7 +472,7 @@
         "condition": { "math": [ "u_spell_level('xedra_chronomancer_chronal_acceleration') <= 0" ] },
         "text": "Learn [<spell_name:xedra_chronomancer_chronal_acceleration>]",
         "effect": [
-          { "math": [ "u_chronomancer_menu_insight_cost = 10 * u_spell_difficulty('xedra_chronomancer_chronal_acceleration" ] },
+          { "math": [ "u_chronomancer_menu_insight_cost = 10 * u_spell_difficulty('xedra_chronomancer_chronal_acceleration')" ] },
           { "math": [ "_chronomancer_menu_difficulty = 8" ] },
           {
             "set_string_var": "<spell_name:xedra_chronomancer_chronal_acceleration>",
@@ -534,7 +534,7 @@
         "condition": { "math": [ "u_spell_level('xedra_chronomancer_stable_loop') <= 0" ] },
         "text": "Learn [<spell_name:xedra_chronomancer_stable_loop>]",
         "effect": [
-          { "math": [ "u_chronomancer_menu_insight_cost = 10 * u_spell_difficulty('xedra_chronomancer_stable_loop" ] },
+          { "math": [ "u_chronomancer_menu_insight_cost = 10 * u_spell_difficulty('xedra_chronomancer_stable_loop')" ] },
           { "math": [ "_chronomancer_menu_difficulty = 5" ] },
           {
             "set_string_var": "<spell_name:xedra_chronomancer_stable_loop>",
@@ -599,7 +599,7 @@
         "condition": { "math": [ "u_spell_level('xedra_chronomancer_destabilizing_strikes') <= 0" ] },
         "text": "Learn [<spell_name:xedra_chronomancer_destabilizing_strikes>]",
         "effect": [
-          { "math": [ "u_chronomancer_menu_insight_cost = 10 * u_spell_difficulty('xedra_chronomancer_destabilizing_strikes" ] },
+          { "math": [ "u_chronomancer_menu_insight_cost = 10 * u_spell_difficulty('xedra_chronomancer_destabilizing_strikes')" ] },
           { "math": [ "_chronomancer_menu_difficulty = 6" ] },
           {
             "set_string_var": "<spell_name:xedra_chronomancer_destabilizing_strikes>",
@@ -661,7 +661,7 @@
         "condition": { "math": [ "u_spell_level('xedra_chronomancer_stabilize_timeline') <= 0" ] },
         "text": "Learn [<spell_name:xedra_chronomancer_stabilize_timeline>]",
         "effect": [
-          { "math": [ "u_chronomancer_menu_insight_cost = 10 * u_spell_difficulty('xedra_chronomancer_stabilize_timeline" ] },
+          { "math": [ "u_chronomancer_menu_insight_cost = 10 * u_spell_difficulty('xedra_chronomancer_stabilize_timeline')" ] },
           { "math": [ "_chronomancer_menu_difficulty = 3" ] },
           {
             "set_string_var": "<spell_name:xedra_chronomancer_stabilize_timeline>",
@@ -723,7 +723,7 @@
         "condition": { "math": [ "u_spell_level('xedra_chronomancer_reverse_entropy') <= 0" ] },
         "text": "Learn [<spell_name:xedra_chronomancer_reverse_entropy>]",
         "effect": [
-          { "math": [ "u_chronomancer_menu_insight_cost = 10 * u_spell_difficulty('xedra_chronomancer_reverse_entropy" ] },
+          { "math": [ "u_chronomancer_menu_insight_cost = 10 * u_spell_difficulty('xedra_chronomancer_reverse_entropy')" ] },
           { "math": [ "_chronomancer_menu_difficulty = 3" ] },
           {
             "set_string_var": "<spell_name:xedra_chronomancer_reverse_entropy>",
@@ -785,7 +785,7 @@
         "condition": { "math": [ "u_spell_level('xedra_chronomancer_rewrite_wound_causality') <= 0" ] },
         "text": "Learn [<spell_name:xedra_chronomancer_rewrite_wound_causality>]",
         "effect": [
-          { "math": [ "u_chronomancer_menu_insight_cost = 10 * u_spell_difficulty('xedra_chronomancer_rewrite_wound_causality" ] },
+          { "math": [ "u_chronomancer_menu_insight_cost = 10 * u_spell_difficulty('xedra_chronomancer_rewrite_wound_causality')" ] },
           { "math": [ "_chronomancer_menu_difficulty = 6" ] },
           {
             "set_string_var": "<spell_name:xedra_chronomancer_rewrite_wound_causality>",
@@ -853,7 +853,7 @@
         "text": "Learn [<spell_name:xedra_chronomancer_rewrite_equipment_causality>]",
         "effect": [
           {
-            "math": [ "u_chronomancer_menu_insight_cost = 10 * u_spell_difficulty('xedra_chronomancer_rewrite_equipment_causality" ]
+            "math": [ "u_chronomancer_menu_insight_cost = 10 * u_spell_difficulty('xedra_chronomancer_rewrite_equipment_causality')" ]
           },
           { "math": [ "_chronomancer_menu_difficulty = 6" ] },
           {

--- a/data/mods/Xedra_Evolved/dialogue/chronomancer_insight_menu.json
+++ b/data/mods/Xedra_Evolved/dialogue/chronomancer_insight_menu.json
@@ -46,6 +46,7 @@
               "u_chronomancer_menu_insight_cost = u_spell_level('xedra_chronomancer_time_bubble') * u_spell_difficulty('xedra_chronomancer_time_bubble')"
             ]
           },
+          { "math": [ "_chronomancer_menu_difficulty = 3" ] },
           { "math": [ "_chronomancer_spell_level = u_spell_level('xedra_chronomancer_time_bubble')" ] },
           {
             "set_string_var": "<spell_name:xedra_chronomancer_time_bubble>",
@@ -73,7 +74,7 @@
         "effect": [
           { "math": [ "u_chronomancer_menu_insight_cost = 80" ] },
           { "math": [ "_chronomancer_menu_difficulty = 8" ] },
-          { "math": [ "_chronomancer_spell_level = u_spell_level('xedra_chronomancer_entropic_burst')" ] },
+          { "math": [ "u_chronomancer_menu_insight_cost = 10 * u_spell_difficulty('xedra_chronomancer_entropic_burst')" ] },
           {
             "set_string_var": "<spell_name:xedra_chronomancer_entropic_burst>",
             "target_var": { "context_val": "chronomancer_menu_choice_name" }
@@ -106,7 +107,12 @@
         },
         "text": "Level [<spell_name:xedra_chronomancer_entropic_burst>]",
         "effect": [
-          { "math": [ "u_chronomancer_menu_insight_cost = u_spell_level('xedra_chronomancer_entropic_burst')*8" ] },
+          {
+            "math": [
+              "u_chronomancer_menu_insight_cost = u_spell_level('xedra_chronomancer_entropic_burst') * u_spell_difficulty('xedra_chronomancer_entropic_burst')"
+            ]
+          },
+          { "math": [ "_chronomancer_menu_difficulty = 8" ] },
           { "math": [ "_chronomancer_spell_level = u_spell_level('xedra_chronomancer_entropic_burst')" ] },
           {
             "set_string_var": "<spell_name:xedra_chronomancer_entropic_burst>",
@@ -132,7 +138,7 @@
         "condition": { "math": [ "u_spell_level('xedra_chronomancer_revert_wound') <= 0" ] },
         "text": "Learn [<spell_name:xedra_chronomancer_revert_wound>]",
         "effect": [
-          { "math": [ "u_chronomancer_menu_insight_cost = 40" ] },
+          { "math": [ "u_chronomancer_menu_insight_cost = 10 * u_spell_difficulty('xedra_chronomancer_revert_wound" ] },
           { "math": [ "_chronomancer_menu_difficulty = 4" ] },
           { "math": [ "_chronomancer_spell_level = u_spell_level('xedra_chronomancer_revert_wound')" ] },
           {
@@ -164,7 +170,12 @@
         },
         "text": "Level [<spell_name:xedra_chronomancer_revert_wound>]",
         "effect": [
-          { "math": [ "u_chronomancer_menu_insight_cost = u_spell_level('xedra_chronomancer_revert_wound')*4" ] },
+          {
+            "math": [
+              "u_chronomancer_menu_insight_cost = u_spell_level('xedra_chronomancer_revert_wound') * u_spell_difficulty('xedra_chronomancer_revert_wound')"
+            ]
+          },
+          { "math": [ "_chronomancer_menu_difficulty = 4" ] },
           { "math": [ "_chronomancer_spell_level = u_spell_level('xedra_chronomancer_revert_wound')" ] },
           {
             "set_string_var": "<spell_name:xedra_chronomancer_revert_wound>",
@@ -190,7 +201,7 @@
         "condition": { "math": [ "u_spell_level('xedra_chronomancer_time_loop') <= 0" ] },
         "text": "Learn [<spell_name:xedra_chronomancer_time_loop>]",
         "effect": [
-          { "math": [ "u_chronomancer_menu_insight_cost = 50" ] },
+          { "math": [ "u_chronomancer_menu_insight_cost = 10 * u_spell_difficulty('xedra_chronomancer_time_loop" ] },
           { "math": [ "_chronomancer_menu_difficulty = 5" ] },
           {
             "set_string_var": "<spell_name:xedra_chronomancer_time_loop>",
@@ -221,7 +232,12 @@
         },
         "text": "Level [<spell_name:xedra_chronomancer_time_loop>]",
         "effect": [
-          { "math": [ "u_chronomancer_menu_insight_cost = u_spell_level('xedra_chronomancer_time_loop')*5" ] },
+          {
+            "math": [
+              "u_chronomancer_menu_insight_cost = u_spell_level('xedra_chronomancer_time_loop') * u_spell_difficulty('xedra_chronomancer_time_lo')"
+            ]
+          },
+          { "math": [ "_chronomancer_menu_difficulty = 5" ] },
           { "math": [ "_chronomancer_spell_level = u_spell_level('xedra_chronomancer_time_loop')" ] },
           {
             "set_string_var": "<spell_name:xedra_chronomancer_time_loop>",
@@ -248,7 +264,7 @@
         "text": "Learn [<spell_name:xedra_chronomancer_time_stop>]",
         "//": "Difficulty 10 spells will have normal insight costs multiplied by 1.5.",
         "effect": [
-          { "math": [ "u_chronomancer_menu_insight_cost = 150" ] },
+          { "math": [ "u_chronomancer_menu_insight_cost = 15 * u_spell_difficulty('xedra_chronomancer_time_stop" ] },
           { "math": [ "_chronomancer_menu_difficulty = 10" ] },
           {
             "set_string_var": "<spell_name:xedra_chronomancer_time_stop>",
@@ -283,7 +299,12 @@
         "text": "Level [<spell_name:xedra_chronomancer_time_stop>]",
         "//": "Difficulty 10 spells will have normal insight costs multiplied by 1.5.",
         "effect": [
-          { "math": [ "u_chronomancer_menu_insight_cost = u_spell_level('xedra_chronomancer_time_stop')*15" ] },
+          {
+            "math": [
+              "u_chronomancer_menu_insight_cost = u_spell_level('xedra_chronomancer_time_stop') * u_spell_difficulty('xedra_chronomancer_time_stop') * 1.5"
+            ]
+          },
+          { "math": [ "_chronomancer_menu_difficulty = 10" ] },
           { "math": [ "_chronomancer_spell_level = u_spell_level('xedra_chronomancer_time_stop')" ] },
           {
             "set_string_var": "<spell_name:xedra_chronomancer_time_stop>",
@@ -309,7 +330,7 @@
         "condition": { "math": [ "u_spell_level('xedra_chronomancer_revert_location') <= 0" ] },
         "text": "Learn [<spell_name:xedra_chronomancer_revert_location>]",
         "effect": [
-          { "math": [ "u_chronomancer_menu_insight_cost = 80" ] },
+          { "math": [ "u_chronomancer_menu_insight_cost = 10 * u_spell_difficulty('xedra_chronomancer_revert_location" ] },
           { "math": [ "_chronomancer_menu_difficulty = 8" ] },
           {
             "set_string_var": "<spell_name:xedra_chronomancer_revert_location>",
@@ -348,7 +369,12 @@
         },
         "text": "Level [<spell_name:xedra_chronomancer_revert_location>]",
         "effect": [
-          { "math": [ "u_chronomancer_menu_insight_cost = u_spell_level('xedra_chronomancer_revert_location')*8" ] },
+          {
+            "math": [
+              "u_chronomancer_menu_insight_cost = u_spell_level('xedra_chronomancer_revert_location') * u_spell_difficulty('xedra_chronomancer_revert_location')"
+            ]
+          },
+          { "math": [ "_chronomancer_menu_difficulty = 8" ] },
           { "math": [ "_chronomancer_spell_level = u_spell_level('xedra_chronomancer_revert_location')" ] },
           {
             "set_string_var": "<spell_name:xedra_chronomancer_revert_location>",
@@ -374,7 +400,7 @@
         "condition": { "math": [ "u_spell_level('xedra_chronomancer_cement_time') <= 0" ] },
         "text": "Learn [<spell_name:xedra_chronomancer_cement_time>]",
         "effect": [
-          { "math": [ "u_chronomancer_menu_insight_cost = 150" ] },
+          { "math": [ "u_chronomancer_menu_insight_cost = 15 * u_spell_difficulty('xedra_chronomancer_cement_time" ] },
           { "math": [ "_chronomancer_menu_difficulty = 10" ] },
           {
             "set_string_var": "<spell_name:xedra_chronomancer_cement_time>",
@@ -413,7 +439,12 @@
         },
         "text": "Level [<spell_name:xedra_chronomancer_cement_time>]",
         "effect": [
-          { "math": [ "u_chronomancer_menu_insight_cost = u_spell_level('xedra_chronomancer_cement_time')*15" ] },
+          {
+            "math": [
+              "u_chronomancer_menu_insight_cost = u_spell_level('xedra_chronomancer_cement_time') * u_spell_difficulty('xedra_chronomancer_cement_time') * 1.5"
+            ]
+          },
+          { "math": [ "_chronomancer_menu_difficulty = 10" ] },
           { "math": [ "_chronomancer_spell_level = u_spell_level('xedra_chronomancer_cement_time')" ] },
           {
             "set_string_var": "<spell_name:xedra_chronomancer_cement_time>",
@@ -439,7 +470,7 @@
         "condition": { "math": [ "u_spell_level('xedra_chronomancer_chronal_acceleration') <= 0" ] },
         "text": "Learn [<spell_name:xedra_chronomancer_chronal_acceleration>]",
         "effect": [
-          { "math": [ "u_chronomancer_menu_insight_cost = 80" ] },
+          { "math": [ "u_chronomancer_menu_insight_cost = 10 * u_spell_difficulty('xedra_chronomancer_chronal_acceleration" ] },
           { "math": [ "_chronomancer_menu_difficulty = 8" ] },
           {
             "set_string_var": "<spell_name:xedra_chronomancer_chronal_acceleration>",
@@ -470,7 +501,12 @@
         },
         "text": "Level [<spell_name:xedra_chronomancer_chronal_acceleration>]",
         "effect": [
-          { "math": [ "u_chronomancer_menu_insight_cost = u_spell_level('xedra_chronomancer_chronal_acceleration')*8" ] },
+          {
+            "math": [
+              "u_chronomancer_menu_insight_cost = u_spell_level('xedra_chronomancer_chronal_acceleration') * u_spell_difficulty('xedra_chronomancer_chronal_acceleration')"
+            ]
+          },
+          { "math": [ "_chronomancer_menu_difficulty = 8" ] },
           { "math": [ "_chronomancer_spell_level = u_spell_level('xedra_chronomancer_chronal_acceleration')" ] },
           {
             "set_string_var": "<spell_name:xedra_chronomancer_chronal_acceleration>",
@@ -496,7 +532,7 @@
         "condition": { "math": [ "u_spell_level('xedra_chronomancer_stable_loop') <= 0" ] },
         "text": "Learn [<spell_name:xedra_chronomancer_stable_loop>]",
         "effect": [
-          { "math": [ "u_chronomancer_menu_insight_cost = 50" ] },
+          { "math": [ "u_chronomancer_menu_insight_cost = 10 * u_spell_difficulty('xedra_chronomancer_stable_loop" ] },
           { "math": [ "_chronomancer_menu_difficulty = 5" ] },
           {
             "set_string_var": "<spell_name:xedra_chronomancer_stable_loop>",
@@ -530,7 +566,12 @@
         },
         "text": "Level [<spell_name:xedra_chronomancer_stable_loop>]",
         "effect": [
-          { "math": [ "u_chronomancer_menu_insight_cost = u_spell_level('xedra_chronomancer_stable_loop')*5" ] },
+          {
+            "math": [
+              "u_chronomancer_menu_insight_cost = u_spell_level('xedra_chronomancer_stable_loop') * u_spell_difficulty('xedra_chronomancer_stable_loop')"
+            ]
+          },
+          { "math": [ "_chronomancer_menu_difficulty = 5" ] },
           { "math": [ "_chronomancer_spell_level = u_spell_level('xedra_chronomancer_stable_loop')" ] },
           {
             "set_string_var": "<spell_name:xedra_chronomancer_stable_loop>",
@@ -556,7 +597,7 @@
         "condition": { "math": [ "u_spell_level('xedra_chronomancer_destabilizing_strikes') <= 0" ] },
         "text": "Learn [<spell_name:xedra_chronomancer_destabilizing_strikes>]",
         "effect": [
-          { "math": [ "u_chronomancer_menu_insight_cost = 60" ] },
+          { "math": [ "u_chronomancer_menu_insight_cost = 10 * u_spell_difficulty('xedra_chronomancer_destabilizing_strikes" ] },
           { "math": [ "_chronomancer_menu_difficulty = 6" ] },
           {
             "set_string_var": "<spell_name:xedra_chronomancer_destabilizing_strikes>",
@@ -587,7 +628,12 @@
         },
         "text": "Level [<spell_name:xedra_chronomancer_destabilizing_strikes>]",
         "effect": [
-          { "math": [ "u_chronomancer_menu_insight_cost = u_spell_level('xedra_chronomancer_destabilizing_strikes')*6" ] },
+          {
+            "math": [
+              "u_chronomancer_menu_insight_cost = u_spell_level('xedra_chronomancer_destabilizing_strikes') * u_spell_difficulty('xedra_chronomancer_destabilizing_strikes')"
+            ]
+          },
+          { "math": [ "_chronomancer_menu_difficulty = 6" ] },
           { "math": [ "_chronomancer_spell_level = u_spell_level('xedra_chronomancer_destabilizing_strikes')" ] },
           {
             "set_string_var": "<spell_name:xedra_chronomancer_destabilizing_strikes>",
@@ -613,7 +659,7 @@
         "condition": { "math": [ "u_spell_level('xedra_chronomancer_stabilize_timeline') <= 0" ] },
         "text": "Learn [<spell_name:xedra_chronomancer_stabilize_timeline>]",
         "effect": [
-          { "math": [ "u_chronomancer_menu_insight_cost = 30" ] },
+          { "math": [ "u_chronomancer_menu_insight_cost = 10 * u_spell_difficulty('xedra_chronomancer_stabilize_timeline" ] },
           { "math": [ "_chronomancer_menu_difficulty = 3" ] },
           {
             "set_string_var": "<spell_name:xedra_chronomancer_stabilize_timeline>",
@@ -644,7 +690,12 @@
         },
         "text": "Level [<spell_name:xedra_chronomancer_stabilize_timeline>]",
         "effect": [
-          { "math": [ "u_chronomancer_menu_insight_cost = u_spell_level('xedra_chronomancer_stabilize_timeline')*3" ] },
+          {
+            "math": [
+              "u_chronomancer_menu_insight_cost = u_spell_level('xedra_chronomancer_stabilize_timeline') * u_spell_difficulty('xedra_chronomancer_stabilize_timeline')"
+            ]
+          },
+          { "math": [ "_chronomancer_menu_difficulty = 3" ] },
           { "math": [ "_chronomancer_spell_level = u_spell_level('xedra_chronomancer_stabilize_timeline')" ] },
           {
             "set_string_var": "<spell_name:xedra_chronomancer_stabilize_timeline>",
@@ -670,7 +721,7 @@
         "condition": { "math": [ "u_spell_level('xedra_chronomancer_reverse_entropy') <= 0" ] },
         "text": "Learn [<spell_name:xedra_chronomancer_reverse_entropy>]",
         "effect": [
-          { "math": [ "u_chronomancer_menu_insight_cost = 30" ] },
+          { "math": [ "u_chronomancer_menu_insight_cost = 10 * u_spell_difficulty('xedra_chronomancer_reverse_entropy" ] },
           { "math": [ "_chronomancer_menu_difficulty = 3" ] },
           {
             "set_string_var": "<spell_name:xedra_chronomancer_reverse_entropy>",
@@ -701,7 +752,12 @@
         },
         "text": "Level [<spell_name:xedra_chronomancer_reverse_entropy>]",
         "effect": [
-          { "math": [ "u_chronomancer_menu_insight_cost = u_spell_level('xedra_chronomancer_reverse_entropy')*3" ] },
+          {
+            "math": [
+              "u_chronomancer_menu_insight_cost = u_spell_level('xedra_chronomancer_reverse_entropy') * u_spell_difficulty('xedra_chronomancer_reverse_entropy')"
+            ]
+          },
+          { "math": [ "_chronomancer_menu_difficulty = 3" ] },
           { "math": [ "_chronomancer_spell_level = u_spell_level('xedra_chronomancer_reverse_entropy')" ] },
           {
             "set_string_var": "<spell_name:xedra_chronomancer_reverse_entropy>",
@@ -727,7 +783,7 @@
         "condition": { "math": [ "u_spell_level('xedra_chronomancer_rewrite_wound_causality') <= 0" ] },
         "text": "Learn [<spell_name:xedra_chronomancer_rewrite_wound_causality>]",
         "effect": [
-          { "math": [ "u_chronomancer_menu_insight_cost = 60" ] },
+          { "math": [ "u_chronomancer_menu_insight_cost = 10 * u_spell_difficulty('xedra_chronomancer_rewrite_wound_causality" ] },
           { "math": [ "_chronomancer_menu_difficulty = 6" ] },
           {
             "set_string_var": "<spell_name:xedra_chronomancer_rewrite_wound_causality>",
@@ -763,7 +819,12 @@
         },
         "text": "Level [<spell_name:xedra_chronomancer_rewrite_wound_causality>]",
         "effect": [
-          { "math": [ "u_chronomancer_menu_insight_cost = u_spell_level('xedra_chronomancer_rewrite_wound_causality')*6" ] },
+          {
+            "math": [
+              "u_chronomancer_menu_insight_cost = u_spell_level('xedra_chronomancer_rewrite_wound_causality') * u_spell_difficulty('xedra_chronomancer_rewrite_wound_causality')"
+            ]
+          },
+          { "math": [ "_chronomancer_menu_difficulty = 6" ] },
           { "math": [ "_chronomancer_spell_level = u_spell_level('xedra_chronomancer_rewrite_wound_causality')" ] },
           {
             "set_string_var": "<spell_name:xedra_chronomancer_rewrite_wound_causality>",
@@ -789,7 +850,7 @@
         "condition": { "math": [ "u_spell_level('xedra_chronomancer_rewrite_equipment_causality') <= 0" ] },
         "text": "Learn [<spell_name:xedra_chronomancer_rewrite_equipment_causality>]",
         "effect": [
-          { "math": [ "u_chronomancer_menu_insight_cost = 60" ] },
+          { "math": [ "u_chronomancer_menu_insight_cost = 10 * u_spell_difficulty('xedra_chronomancer_rewrite_equipment_causality" ] },
           { "math": [ "_chronomancer_menu_difficulty = 6" ] },
           {
             "set_string_var": "<spell_name:xedra_chronomancer_rewrite_equipment_causality>",
@@ -825,7 +886,12 @@
         },
         "text": "Level [<spell_name:xedra_chronomancer_rewrite_equipment_causality>]",
         "effect": [
-          { "math": [ "u_chronomancer_menu_insight_cost = u_spell_level('xedra_chronomancer_rewrite_equipment_causality')*6" ] },
+          {
+            "math": [
+              "u_chronomancer_menu_insight_cost = u_spell_level('xedra_chronomancer_rewrite_equipment_causality') * u_spell_difficulty('xedra_chronomancer_rewrite_equipment_causality')"
+            ]
+          },
+          { "math": [ "_chronomancer_menu_difficulty = 6" ] },
           {
             "math": [ "_chronomancer_spell_level = u_spell_level('xedra_chronomancer_rewrite_equipment_causality')" ]
           },

--- a/data/mods/Xedra_Evolved/dialogue/chronomancer_insight_menu.json
+++ b/data/mods/Xedra_Evolved/dialogue/chronomancer_insight_menu.json
@@ -3,12 +3,13 @@
     "type": "talk_topic",
     "id": "TALK_CHRONOMANCER_INSIGHT_MENU_MAIN",
     "dynamic_line": "Current Insight: <u_val:xedra_chronomancer_insight_count>",
+    "//": "Insight cost is difficulty x 10 for all chronomancy spells.",
     "responses": [
       {
         "condition": { "math": [ "u_spell_level('xedra_chronomancer_time_bubble') <= 0" ] },
         "text": "Learn [<spell_name:xedra_chronomancer_time_bubble>]",
         "effect": [
-          { "math": [ "u_chronomancer_menu_insight_cost = 50" ] },
+          { "math": [ "u_chronomancer_menu_insight_cost = 30" ] },
           { "math": [ "_chronomancer_menu_difficulty = 3" ] },
           {
             "set_string_var": "<spell_name:xedra_chronomancer_time_bubble>",
@@ -38,8 +39,9 @@
           ]
         },
         "text": "Level [<spell_name:xedra_chronomancer_time_bubble>]",
+        "//": "Insight cost is difficulty x spell level for all chronomancy spells.",
         "effect": [
-          { "math": [ "u_chronomancer_menu_insight_cost = u_spell_level('xedra_chronomancer_time_bubble')*5" ] },
+          { "math": [ "u_chronomancer_menu_insight_cost = u_spell_level('xedra_chronomancer_time_bubble')*3" ] },
           { "math": [ "_chronomancer_spell_level = u_spell_level('xedra_chronomancer_time_bubble')" ] },
           {
             "set_string_var": "<spell_name:xedra_chronomancer_time_bubble>",
@@ -65,7 +67,7 @@
         "condition": { "math": [ "u_spell_level('xedra_chronomancer_entropic_burst') <= 0" ] },
         "text": "Learn [<spell_name:xedra_chronomancer_entropic_burst>]",
         "effect": [
-          { "math": [ "u_chronomancer_menu_insight_cost = 100" ] },
+          { "math": [ "u_chronomancer_menu_insight_cost = 80" ] },
           { "math": [ "_chronomancer_menu_difficulty = 8" ] },
           { "math": [ "_chronomancer_spell_level = u_spell_level('xedra_chronomancer_entropic_burst')" ] },
           {
@@ -100,7 +102,7 @@
         },
         "text": "Level [<spell_name:xedra_chronomancer_entropic_burst>]",
         "effect": [
-          { "math": [ "u_chronomancer_menu_insight_cost = u_spell_level('xedra_chronomancer_entropic_burst')*5" ] },
+          { "math": [ "u_chronomancer_menu_insight_cost = u_spell_level('xedra_chronomancer_entropic_burst')*8" ] },
           { "math": [ "_chronomancer_spell_level = u_spell_level('xedra_chronomancer_entropic_burst')" ] },
           {
             "set_string_var": "<spell_name:xedra_chronomancer_entropic_burst>",
@@ -126,7 +128,7 @@
         "condition": { "math": [ "u_spell_level('xedra_chronomancer_revert_wound') <= 0" ] },
         "text": "Learn [<spell_name:xedra_chronomancer_revert_wound>]",
         "effect": [
-          { "math": [ "u_chronomancer_menu_insight_cost = 50" ] },
+          { "math": [ "u_chronomancer_menu_insight_cost = 40" ] },
           { "math": [ "_chronomancer_menu_difficulty = 4" ] },
           { "math": [ "_chronomancer_spell_level = u_spell_level('xedra_chronomancer_revert_wound')" ] },
           {
@@ -158,7 +160,7 @@
         },
         "text": "Level [<spell_name:xedra_chronomancer_revert_wound>]",
         "effect": [
-          { "math": [ "u_chronomancer_menu_insight_cost = u_spell_level('xedra_chronomancer_revert_wound')*5" ] },
+          { "math": [ "u_chronomancer_menu_insight_cost = u_spell_level('xedra_chronomancer_revert_wound')*4" ] },
           { "math": [ "_chronomancer_spell_level = u_spell_level('xedra_chronomancer_revert_wound')" ] },
           {
             "set_string_var": "<spell_name:xedra_chronomancer_revert_wound>",
@@ -240,6 +242,7 @@
       {
         "condition": { "math": [ "u_spell_level('xedra_chronomancer_time_stop') <= 0" ] },
         "text": "Learn [<spell_name:xedra_chronomancer_time_stop>]",
+        "//": "Difficulty 10 spells will have normal insight costs multiplied by 1.5.",
         "effect": [
           { "math": [ "u_chronomancer_menu_insight_cost = 150" ] },
           { "math": [ "_chronomancer_menu_difficulty = 10" ] },
@@ -274,8 +277,9 @@
           ]
         },
         "text": "Level [<spell_name:xedra_chronomancer_time_stop>]",
+        "//": "Difficulty 10 spells will have normal insight costs multiplied by 1.5.",
         "effect": [
-          { "math": [ "u_chronomancer_menu_insight_cost = u_spell_level('xedra_chronomancer_time_stop')*5" ] },
+          { "math": [ "u_chronomancer_menu_insight_cost = u_spell_level('xedra_chronomancer_time_stop')*15" ] },
           { "math": [ "_chronomancer_spell_level = u_spell_level('xedra_chronomancer_time_stop')" ] },
           {
             "set_string_var": "<spell_name:xedra_chronomancer_time_stop>",
@@ -301,7 +305,7 @@
         "condition": { "math": [ "u_spell_level('xedra_chronomancer_revert_location') <= 0" ] },
         "text": "Learn [<spell_name:xedra_chronomancer_revert_location>]",
         "effect": [
-          { "math": [ "u_chronomancer_menu_insight_cost = 100" ] },
+          { "math": [ "u_chronomancer_menu_insight_cost = 80" ] },
           { "math": [ "_chronomancer_menu_difficulty = 8" ] },
           {
             "set_string_var": "<spell_name:xedra_chronomancer_revert_location>",
@@ -340,7 +344,7 @@
         },
         "text": "Level [<spell_name:xedra_chronomancer_revert_location>]",
         "effect": [
-          { "math": [ "u_chronomancer_menu_insight_cost = u_spell_level('xedra_chronomancer_revert_location')*5" ] },
+          { "math": [ "u_chronomancer_menu_insight_cost = u_spell_level('xedra_chronomancer_revert_location')*8" ] },
           { "math": [ "_chronomancer_spell_level = u_spell_level('xedra_chronomancer_revert_location')" ] },
           {
             "set_string_var": "<spell_name:xedra_chronomancer_revert_location>",
@@ -366,7 +370,7 @@
         "condition": { "math": [ "u_spell_level('xedra_chronomancer_cement_time') <= 0" ] },
         "text": "Learn [<spell_name:xedra_chronomancer_cement_time>]",
         "effect": [
-          { "math": [ "u_chronomancer_menu_insight_cost = 100" ] },
+          { "math": [ "u_chronomancer_menu_insight_cost = 150" ] },
           { "math": [ "_chronomancer_menu_difficulty = 10" ] },
           {
             "set_string_var": "<spell_name:xedra_chronomancer_cement_time>",
@@ -405,7 +409,7 @@
         },
         "text": "Level [<spell_name:xedra_chronomancer_cement_time>]",
         "effect": [
-          { "math": [ "u_chronomancer_menu_insight_cost = u_spell_level('xedra_chronomancer_cement_time')*5" ] },
+          { "math": [ "u_chronomancer_menu_insight_cost = u_spell_level('xedra_chronomancer_cement_time')*15" ] },
           { "math": [ "_chronomancer_spell_level = u_spell_level('xedra_chronomancer_cement_time')" ] },
           {
             "set_string_var": "<spell_name:xedra_chronomancer_cement_time>",
@@ -431,7 +435,7 @@
         "condition": { "math": [ "u_spell_level('xedra_chronomancer_chronal_acceleration') <= 0" ] },
         "text": "Learn [<spell_name:xedra_chronomancer_chronal_acceleration>]",
         "effect": [
-          { "math": [ "u_chronomancer_menu_insight_cost = 50" ] },
+          { "math": [ "u_chronomancer_menu_insight_cost = 80" ] },
           { "math": [ "_chronomancer_menu_difficulty = 8" ] },
           {
             "set_string_var": "<spell_name:xedra_chronomancer_chronal_acceleration>",
@@ -462,7 +466,7 @@
         },
         "text": "Level [<spell_name:xedra_chronomancer_chronal_acceleration>]",
         "effect": [
-          { "math": [ "u_chronomancer_menu_insight_cost = u_spell_level('xedra_chronomancer_chronal_acceleration')*5" ] },
+          { "math": [ "u_chronomancer_menu_insight_cost = u_spell_level('xedra_chronomancer_chronal_acceleration')*8" ] },
           { "math": [ "_chronomancer_spell_level = u_spell_level('xedra_chronomancer_chronal_acceleration')" ] },
           {
             "set_string_var": "<spell_name:xedra_chronomancer_chronal_acceleration>",
@@ -488,7 +492,7 @@
         "condition": { "math": [ "u_spell_level('xedra_chronomancer_stable_loop') <= 0" ] },
         "text": "Learn [<spell_name:xedra_chronomancer_stable_loop>]",
         "effect": [
-          { "math": [ "u_chronomancer_menu_insight_cost = 100" ] },
+          { "math": [ "u_chronomancer_menu_insight_cost = 50" ] },
           { "math": [ "_chronomancer_menu_difficulty = 5" ] },
           {
             "set_string_var": "<spell_name:xedra_chronomancer_stable_loop>",
@@ -548,7 +552,7 @@
         "condition": { "math": [ "u_spell_level('xedra_chronomancer_destabilizing_strikes') <= 0" ] },
         "text": "Learn [<spell_name:xedra_chronomancer_destabilizing_strikes>]",
         "effect": [
-          { "math": [ "u_chronomancer_menu_insight_cost = 100" ] },
+          { "math": [ "u_chronomancer_menu_insight_cost = 60" ] },
           { "math": [ "_chronomancer_menu_difficulty = 6" ] },
           {
             "set_string_var": "<spell_name:xedra_chronomancer_destabilizing_strikes>",
@@ -579,7 +583,7 @@
         },
         "text": "Level [<spell_name:xedra_chronomancer_destabilizing_strikes>]",
         "effect": [
-          { "math": [ "u_chronomancer_menu_insight_cost = u_spell_level('xedra_chronomancer_destabilizing_strikes')*5" ] },
+          { "math": [ "u_chronomancer_menu_insight_cost = u_spell_level('xedra_chronomancer_destabilizing_strikes')*6" ] },
           { "math": [ "_chronomancer_spell_level = u_spell_level('xedra_chronomancer_destabilizing_strikes')" ] },
           {
             "set_string_var": "<spell_name:xedra_chronomancer_destabilizing_strikes>",
@@ -605,7 +609,7 @@
         "condition": { "math": [ "u_spell_level('xedra_chronomancer_stabilize_timeline') <= 0" ] },
         "text": "Learn [<spell_name:xedra_chronomancer_stabilize_timeline>]",
         "effect": [
-          { "math": [ "u_chronomancer_menu_insight_cost = 50" ] },
+          { "math": [ "u_chronomancer_menu_insight_cost = 30" ] },
           { "math": [ "_chronomancer_menu_difficulty = 3" ] },
           {
             "set_string_var": "<spell_name:xedra_chronomancer_stabilize_timeline>",
@@ -636,7 +640,7 @@
         },
         "text": "Level [<spell_name:xedra_chronomancer_stabilize_timeline>]",
         "effect": [
-          { "math": [ "u_chronomancer_menu_insight_cost = u_spell_level('xedra_chronomancer_stabilize_timeline')*5" ] },
+          { "math": [ "u_chronomancer_menu_insight_cost = u_spell_level('xedra_chronomancer_stabilize_timeline')*3" ] },
           { "math": [ "_chronomancer_spell_level = u_spell_level('xedra_chronomancer_stabilize_timeline')" ] },
           {
             "set_string_var": "<spell_name:xedra_chronomancer_stabilize_timeline>",
@@ -662,7 +666,7 @@
         "condition": { "math": [ "u_spell_level('xedra_chronomancer_reverse_entropy') <= 0" ] },
         "text": "Learn [<spell_name:xedra_chronomancer_reverse_entropy>]",
         "effect": [
-          { "math": [ "u_chronomancer_menu_insight_cost = 50" ] },
+          { "math": [ "u_chronomancer_menu_insight_cost = 30" ] },
           { "math": [ "_chronomancer_menu_difficulty = 3" ] },
           {
             "set_string_var": "<spell_name:xedra_chronomancer_reverse_entropy>",
@@ -693,7 +697,7 @@
         },
         "text": "Level [<spell_name:xedra_chronomancer_reverse_entropy>]",
         "effect": [
-          { "math": [ "u_chronomancer_menu_insight_cost = u_spell_level('xedra_chronomancer_reverse_entropy')*5" ] },
+          { "math": [ "u_chronomancer_menu_insight_cost = u_spell_level('xedra_chronomancer_reverse_entropy')*3" ] },
           { "math": [ "_chronomancer_spell_level = u_spell_level('xedra_chronomancer_reverse_entropy')" ] },
           {
             "set_string_var": "<spell_name:xedra_chronomancer_reverse_entropy>",
@@ -719,7 +723,7 @@
         "condition": { "math": [ "u_spell_level('xedra_chronomancer_rewrite_wound_causality') <= 0" ] },
         "text": "Learn [<spell_name:xedra_chronomancer_rewrite_wound_causality>]",
         "effect": [
-          { "math": [ "u_chronomancer_menu_insight_cost = 50" ] },
+          { "math": [ "u_chronomancer_menu_insight_cost = 60" ] },
           { "math": [ "_chronomancer_menu_difficulty = 6" ] },
           {
             "set_string_var": "<spell_name:xedra_chronomancer_rewrite_wound_causality>",
@@ -755,7 +759,7 @@
         },
         "text": "Level [<spell_name:xedra_chronomancer_rewrite_wound_causality>]",
         "effect": [
-          { "math": [ "u_chronomancer_menu_insight_cost = u_spell_level('xedra_chronomancer_rewrite_wound_causality')*5" ] },
+          { "math": [ "u_chronomancer_menu_insight_cost = u_spell_level('xedra_chronomancer_rewrite_wound_causality')*6" ] },
           { "math": [ "_chronomancer_spell_level = u_spell_level('xedra_chronomancer_rewrite_wound_causality')" ] },
           {
             "set_string_var": "<spell_name:xedra_chronomancer_rewrite_wound_causality>",
@@ -781,7 +785,7 @@
         "condition": { "math": [ "u_spell_level('xedra_chronomancer_rewrite_equipment_causality') <= 0" ] },
         "text": "Learn [<spell_name:xedra_chronomancer_rewrite_equipment_causality>]",
         "effect": [
-          { "math": [ "u_chronomancer_menu_insight_cost = 50" ] },
+          { "math": [ "u_chronomancer_menu_insight_cost = 60" ] },
           { "math": [ "_chronomancer_menu_difficulty = 6" ] },
           {
             "set_string_var": "<spell_name:xedra_chronomancer_rewrite_equipment_causality>",
@@ -817,7 +821,7 @@
         },
         "text": "Level [<spell_name:xedra_chronomancer_rewrite_equipment_causality>]",
         "effect": [
-          { "math": [ "u_chronomancer_menu_insight_cost = u_spell_level('xedra_chronomancer_rewrite_equipment_causality')*5" ] },
+          { "math": [ "u_chronomancer_menu_insight_cost = u_spell_level('xedra_chronomancer_rewrite_equipment_causality')*6" ] },
           {
             "math": [ "_chronomancer_spell_level = u_spell_level('xedra_chronomancer_rewrite_equipment_causality')" ]
           },

--- a/data/mods/Xedra_Evolved/dialogue/chronomancer_insight_menu.json
+++ b/data/mods/Xedra_Evolved/dialogue/chronomancer_insight_menu.json
@@ -785,7 +785,9 @@
         "condition": { "math": [ "u_spell_level('xedra_chronomancer_rewrite_wound_causality') <= 0" ] },
         "text": "Learn [<spell_name:xedra_chronomancer_rewrite_wound_causality>]",
         "effect": [
-          { "math": [ "u_chronomancer_menu_insight_cost = 10 * u_spell_difficulty('xedra_chronomancer_rewrite_wound_causality')" ] },
+          {
+            "math": [ "u_chronomancer_menu_insight_cost = 10 * u_spell_difficulty('xedra_chronomancer_rewrite_wound_causality')" ]
+          },
           { "math": [ "_chronomancer_menu_difficulty = 6" ] },
           {
             "set_string_var": "<spell_name:xedra_chronomancer_rewrite_wound_causality>",

--- a/data/mods/Xedra_Evolved/dialogue/chronomancer_insight_menu.json
+++ b/data/mods/Xedra_Evolved/dialogue/chronomancer_insight_menu.json
@@ -9,7 +9,7 @@
         "condition": { "math": [ "u_spell_level('xedra_chronomancer_time_bubble') <= 0" ] },
         "text": "Learn [<spell_name:xedra_chronomancer_time_bubble>]",
         "effect": [
-          { "math": [ "u_chronomancer_menu_insight_cost = 30" ] },
+          { "math": [ "u_chronomancer_menu_insight_cost = 10 * u_spell_difficulty('xedra_chronomancer_time_bubble')" ] },
           { "math": [ "_chronomancer_menu_difficulty = 3" ] },
           {
             "set_string_var": "<spell_name:xedra_chronomancer_time_bubble>",
@@ -41,7 +41,7 @@
         "text": "Level [<spell_name:xedra_chronomancer_time_bubble>]",
         "//": "Insight cost is difficulty x spell level for all chronomancy spells.",
         "effect": [
-          { "math": [ "u_chronomancer_menu_insight_cost = u_spell_level('xedra_chronomancer_time_bubble')*3" ] },
+          { "math": [ "u_chronomancer_menu_insight_cost = u_spell_level('xedra_chronomancer_time_bubble') * u_spell_difficulty('xedra_chronomancer_time_bubble')" ] },
           { "math": [ "_chronomancer_spell_level = u_spell_level('xedra_chronomancer_time_bubble')" ] },
           {
             "set_string_var": "<spell_name:xedra_chronomancer_time_bubble>",

--- a/data/mods/Xedra_Evolved/dialogue/chronomancer_insight_menu.json
+++ b/data/mods/Xedra_Evolved/dialogue/chronomancer_insight_menu.json
@@ -41,7 +41,11 @@
         "text": "Level [<spell_name:xedra_chronomancer_time_bubble>]",
         "//": "Insight cost is difficulty x spell level for all chronomancy spells.",
         "effect": [
-          { "math": [ "u_chronomancer_menu_insight_cost = u_spell_level('xedra_chronomancer_time_bubble') * u_spell_difficulty('xedra_chronomancer_time_bubble')" ] },
+          {
+            "math": [
+              "u_chronomancer_menu_insight_cost = u_spell_level('xedra_chronomancer_time_bubble') * u_spell_difficulty('xedra_chronomancer_time_bubble')"
+            ]
+          },
           { "math": [ "_chronomancer_spell_level = u_spell_level('xedra_chronomancer_time_bubble')" ] },
           {
             "set_string_var": "<spell_name:xedra_chronomancer_time_bubble>",

--- a/data/mods/Xedra_Evolved/dialogue/chronomancer_insight_menu.json
+++ b/data/mods/Xedra_Evolved/dialogue/chronomancer_insight_menu.json
@@ -74,7 +74,9 @@
         "effect": [
           { "math": [ "u_chronomancer_menu_insight_cost = 80" ] },
           { "math": [ "_chronomancer_menu_difficulty = 8" ] },
-          { "math": [ "u_chronomancer_menu_insight_cost = 10 * u_spell_difficulty('xedra_chronomancer_entropic_burst')" ] },
+          {
+            "math": [ "u_chronomancer_menu_insight_cost = 10 * u_spell_difficulty('xedra_chronomancer_entropic_burst')" ]
+          },
           {
             "set_string_var": "<spell_name:xedra_chronomancer_entropic_burst>",
             "target_var": { "context_val": "chronomancer_menu_choice_name" }
@@ -850,7 +852,9 @@
         "condition": { "math": [ "u_spell_level('xedra_chronomancer_rewrite_equipment_causality') <= 0" ] },
         "text": "Learn [<spell_name:xedra_chronomancer_rewrite_equipment_causality>]",
         "effect": [
-          { "math": [ "u_chronomancer_menu_insight_cost = 10 * u_spell_difficulty('xedra_chronomancer_rewrite_equipment_causality" ] },
+          {
+            "math": [ "u_chronomancer_menu_insight_cost = 10 * u_spell_difficulty('xedra_chronomancer_rewrite_equipment_causality" ]
+          },
           { "math": [ "_chronomancer_menu_difficulty = 6" ] },
           {
             "set_string_var": "<spell_name:xedra_chronomancer_rewrite_equipment_causality>",

--- a/data/mods/Xedra_Evolved/jmath.json
+++ b/data/mods/Xedra_Evolved/jmath.json
@@ -34,13 +34,13 @@
     "type": "jmath_function",
     "id": "xedra_chronomancer_formula_get_level",
     "num_args": 1,
-    "return": "( sqrt( ( 2 / 375 ) * _0 + 0.25 )  ) - 0.5"
+    "return": "_0 / 1"
   },
   {
     "type": "jmath_function",
     "id": "xedra_chronomancer_formula_exp_for_level",
     "num_args": 1,
-    "return": "375 * 0.5 * _0 * (_0 + 1)"
+    "return": "1 * _0"
   },
   {
     "type": "jmath_function",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "XE Chronomancy Unique XP style"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Every spellcasting school should have unique leveling methods in addition to unique spells.  This is working towards that.  Future PRs may include ending or drastically reducing Eater XP gains and making them gain a unique variable per Nether monster killed that can eventually be spent to level a spell.  Dreamers will of course gain spell xp  while sleeping or in portal storms or reaching certain special Nether locations for the first time.  Inventor and Dreamsmith are actually in a good place.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Changes the insight costs to be variable with spell difficulty.  
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
None
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
