### PR TITLE
[Bombastic Perk] Below the belt

### DIFF
--- a/data/mods/BombasticPerks/perkdata/belowthebelt.json
+++ b/data/mods/BombasticPerks/perkdata/belowthebelt.json
@@ -1,0 +1,17 @@
+[
+  {
+    "type": "weakpoint_set",
+    "id": "wps_humanoid_body",
+    "weakpoints": [
+      {
+        "id": "groin",
+        "name": "the groin",
+        "coverage": 5,
+        "crit_mult": { "all": 1.1 },
+        "armor_mult": { "physical": 0.75 },
+        "difficulty": { "melee": 1, "ranged": 5 },
+        "condition": { "and": [ "u_is_character", { "u_has_trait": "perk_belowthebelt" } ] }
+      }
+    ]
+  }
+]

--- a/data/mods/BombasticPerks/perkmenu.json
+++ b/data/mods/BombasticPerks/perkmenu.json
@@ -1162,6 +1162,25 @@
         "topic": "TALK_PERK_MENU_SELECT"
       },
       {
+        "condition": { "not": { "u_has_trait": "perk_belowthebelt" } },
+        "text": "Gain [<trait_name:perk_belowthebelt>]",
+        "effect": [
+          { "set_string_var": "<trait_name:perk_belowthebelt>", "target_var": { "context_val": "trait_name" } },
+          {
+            "set_string_var": "<trait_description:perk_belowthebelt>",
+            "target_var": { "context_val": "trait_description" }
+          },
+          { "set_string_var": "perk_belowthebelt", "target_var": { "context_val": "trait_id" } },
+          {
+            "set_string_var": "Requires Melee 1",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
+          { "set_condition": "perk_condition", "condition": { "math": [ "u_skill('melee') >= 1" ] } }
+        ],
+        "topic": "TALK_PERK_MENU_SELECT"
+      },
+      {
         "condition": { "not": { "u_has_trait": "perk_thickblood" } },
         "text": "Gain [<trait_name:perk_thickblood>]",
         "effect": [

--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -811,6 +811,16 @@
   },
   {
     "type": "mutation",
+    "id": "perk_belowthebelt",
+    "name": { "str": "Below the Belt" },
+    "points": 0,
+    "purifiable": false,
+    "valid": false,
+    "description": "After some time surviving in the apocalypse, you realized that you don't have to fight fair in melee combat.  Now you can hit below the belt on most humanoid monsters.",
+    "category": [ "perk" ]
+  },
+  {
+    "type": "mutation",
     "id": "perk_empath",
     "name": { "str": "Empath" },
     "points": 0,


### PR DESCRIPTION


#### Summary
Mods "Below the Belt perk"

#### Purpose of change
Add a perk that lets ya hit the groin of most humanoid monsters, mainly because seeing a message log about hitting a zombie groin is funny.

#### Describe the solution

Adds the perk's data and such.

#### Describe alternatives you've considered

Not adding it.

Make it hits harder for feral humans?

#### Testing
After putting it to my build of the game, i made a new world with only the bombasticperk mod. Got into said world, run the eoc that gives a perk point and train my melee to 1, then summon some zombie and hit it with a cudgel. I got the groin weakpoint message after some zombies.
![Screenshot_20250221_202057](https://github.com/user-attachments/assets/1250b1b0-ab89-4d62-99f3-403570934476)
![Screenshot_20250221_202830](https://github.com/user-attachments/assets/41cb9328-baff-4df0-8548-b4519d9026e0)



#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
