### PR TITLE
General IWYU CI improvements

### DIFF
--- a/.github/workflows/iwyu.yml
+++ b/.github/workflows/iwyu.yml
@@ -26,8 +26,8 @@ jobs:
     steps:
     - name: install LLVM 19
       run: |
-          sudo apt install llvm-19 llvm-19-dev llvm-19-tools clang-19 clang-tidy-19 clang-tools-19 libclang-19-dev
-          sudo apt install python3-pip ninja-build cmake
+          sudo apt install llvm-19-dev clang-19 libclang-19-dev
+          sudo apt install cmake
     - name: checkout IWYU repository
       uses: actions/checkout@v4
       with:
@@ -65,8 +65,9 @@ jobs:
           }
           fs.writeFileSync("Cataclysm-DDA/files_changed", files.join('\n') + '\n');
     - name: create CDDA compilation database
+      working-directory: Cataclysm-DDA
       run: |
-        cd Cataclysm-DDA
+        set -x
         cmake -B build \
             -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
             -DCMAKE_CXX_COMPILER=$COMPILER \
@@ -78,16 +79,17 @@ jobs:
         # and include database too, for get_affected_files.py
         make includes -j4 --silent TILES=${TILES:-0} SOUND=${SOUND:-0} LOCALIZE=${LOCALIZE:-0}
     - name: run the thing
+      working-directory: Cataclysm-DDA
       env:
         IWYU_SRC_DIR: ${{ steps.build-iwyu.outputs.IWYU_SRC_DIR }}
         IWYU_BIN_DIR: ${{ steps.build-iwyu.outputs.IWYU_BIN_DIR }}
       run: |
         PATH="${PATH}:${IWYU_BIN_DIR}"
-        cd Cataclysm-DDA
+        mkdir -p out
 
         CHECK_ALL=no
         if [[ -f ./files_changed ]]; then
-            CHECK_ALL=$( cat ./files_changed | grep -E -i 'tools/iwyu|github/iwyu.yml|CMakeLists.txt|build-scripts/get_affected_files.py' && echo yes || echo no )
+            CHECK_ALL=$( cat ./files_changed | grep -E -i 'tools/iwyu|github/workflows/iwyu.yml|CMakeLists.txt|build-scripts/get_affected_files.py' && echo yes || echo no )
         fi
         if [[ "${CHECK_ALL}" = "no" ]] && [[ -f ./files_changed ]]; then
             FILES_LIST=$( python3 build-scripts/get_affected_files.py --changed-files-list ./files_changed )
@@ -96,5 +98,32 @@ jobs:
         fi
         FILES_LIST=$( printf "%s\n" ${FILES_LIST[@]} | grep -v -f tools/iwyu/bad_files.txt )
 
-        python ${IWYU_SRC_DIR}/iwyu_tool.py ${FILES_LIST} -p build --output-format clang --jobs 4  -- -Xiwyu "--mapping_file=${PWD}/tools/iwyu/cata.imp" -Xiwyu --cxx17ns -Xiwyu --comment_style=long -Xiwyu --max_line_length=1000 -Xiwyu --error=1
+        if [[ "${CHECK_ALL}" = "no" ]] && [[ "${FILES_LIST}" == "" ]]; then
+          echo "Nothing to check, exiting"
+          exit 0
+        fi
 
+        # actually run it, store output in a log file, display only errors to the user
+        python ${IWYU_SRC_DIR}/iwyu_tool.py ${FILES_LIST} -p build \
+            --output-format clang --jobs 4  -- \
+            -Xiwyu "--mapping_file=${PWD}/tools/iwyu/cata.imp" \
+            -Xiwyu --cxx17ns -Xiwyu --comment_style=long -Xiwyu --max_line_length=1000 \
+            -Xiwyu --error=1 \
+          | tee out/iwyu-output.log \
+          |  grep -v ' note: #includes/fwd-decls are correct' \
+          || true
+
+        # scan the log file to determine the exit code
+        if grep --quiet -v ' note: #includes/fwd-decls are correct' out/iwyu-output.log ; then
+          exit 1
+        else
+          exit 0
+        fi
+
+    - name: show full logs
+      if: always()
+      working-directory: Cataclysm-DDA
+      run: |
+        # uninstall problem matcher to prevent duplicate annotations
+        echo "::remove-matcher owner=gcc-problem-matcher::"
+        cat out/iwyu-output.log || true


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
- Make it so that we don't list all the correct files to stdout, making it easier to read (suggested by @GuardianDll https://github.com/CleverRaven/Cataclysm-DDA/pull/79767#issuecomment-2673935931)
- Fix a bug where touching only files excluded from iwyu check would result in a failed job (https://github.com/CleverRaven/Cataclysm-DDA/pull/79760#issuecomment-2672556029)
- Audit the libraries being installed, and trim down the list, making the process a tiny bit faster
- minor stylistic tweaks to the workflow

#### Describe the solution
see above

#### Testing
- touched src/lightmap.cpp (excluded from checks) and ran the thing - check passed with "Nothing to check"
- touched src/achievement.cpp and ran the thing - check passed, silently (and provided logs with "includes are correct" for inspection)
- added some bogus includes to src/achievement.cpp and ran the thing - check failed, annotations were added.
- didn't touch any files at all except the workflow (this PR) - iwyu runs on the entire codebse

#### Additional context