### PR TITLE
Climbing down from a roof does not anger locals

### DIFF
--- a/data/json/furniture_and_terrain/terrain-roofs.json
+++ b/data/json/furniture_and_terrain/terrain-roofs.json
@@ -8,7 +8,7 @@
     "color": "i_cyan",
     "move_cost": 2,
     "roof": "t_flat_roof",
-    "flags": [ "TRANSPARENT", "NO_FLOOR", "EMPTY_SPACE" ],
+    "flags": [ "TRANSPARENT", "NO_FLOOR", "EMPTY_SPACE", "FREE_TO_EXAMINE" ],
     "examine_action": "ledge"
   },
   {
@@ -22,7 +22,7 @@
     "roof": "t_flat_roof",
     "examine_action": "ledge",
     "connect_groups": "INDOORFLOOR",
-    "flags": [ "TRANSPARENT", "NO_FLOOR", "INDOORS", "EMPTY_SPACE" ]
+    "flags": [ "TRANSPARENT", "NO_FLOOR", "INDOORS", "EMPTY_SPACE", "FREE_TO_EXAMINE" ]
   },
   {
     "type": "terrain",
@@ -32,7 +32,7 @@
     "symbol": " ",
     "color": "i_cyan",
     "move_cost": 2,
-    "flags": [ "TRANSPARENT", "NO_FLOOR", "EMPTY_SPACE" ],
+    "flags": [ "TRANSPARENT", "NO_FLOOR", "EMPTY_SPACE", "FREE_TO_EXAMINE" ],
     "examine_action": "ledge"
   },
   {


### PR DESCRIPTION
#### Summary
Bugfixes "Climbing down from a roof does not anger locals"

#### Purpose of change
Climbing down from a roof calls an examine_action ever since the ledge trap hack got removed. This means it triggers anger for the local faction. Oops

#### Describe the solution
Make it a free action. Nobody will get upset if you climb down off the roof.

#### Describe alternatives you've considered
Nobody gets upset that you're climbing *onto* the roof either, although they probably should. That can be dealt with in another PR.

#### Testing
Teleport onto refugee center roof, try to climb down. Notice that you do not upset them.

#### Additional context
