### PR TITLE
Remove "Slowdown Fungal Growth" mod

### DIFF
--- a/data/json/monsters/fungus.json
+++ b/data/json/monsters/fungus.json
@@ -367,9 +367,11 @@
       "prof_wp_fungaloid_advanced"
     ],
     "harvest": "exempt",
-    "special_attacks": [ [ "PLANT", 100 ] ],
+    "//COMMENT": "This monster is meant to have the 'PLANT' special attack, allowing the fungus to spread incredibly rapidly. However with that attack their growth becomes *quadratic*, far outside of any reasonable means. There have been various proposals to balance to the faction, but none successfully implemented. If and when it can be balanced it is hoped that one day they can get the attack back. But definitely not before then.",
+    "special_attacks": [ [ "DISAPPEAR", 10 ] ],
     "death_function": { "message": "The %s disintegrates!", "corpse_type": "NO_CORPSE" },
-    "upgrades": { "age_grow": 21, "into": "mon_fungaloid" },
+    "//COMMENT2": "Same deal as the first comment this is meant to upgrade into mon_fungaloid when the faction has been properly balanced for it.",
+    "upgrades": false,
     "flags": [ "STUMBLES", "FLIES", "POISON", "NO_BREATHE", "NOHEAD", "NOGIB" ]
   },
   {

--- a/data/mods/no_fungal_growth/modinfo.json
+++ b/data/mods/no_fungal_growth/modinfo.json
@@ -6,15 +6,7 @@
     "authors": [ "eltank" ],
     "description": "Removes the exponential growth ability of fungaloids.",
     "category": "rebalance",
+    "obsolete": true,
     "dependencies": [ "dda" ]
-  },
-  {
-    "id": "mon_spore",
-    "copy-from": "mon_spore",
-    "type": "MONSTER",
-    "name": { "str": "spore cloud" },
-    "upgrades": false,
-    "special_attacks": [ [ "DISAPPEAR", 10 ] ],
-    "delete": { "special_attacks": [ "PLANT" ] }
   }
 ]


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
The mod "Slowdown Fungal Growth" does not meet the criteria for our in-repo mods. It is a simple balance mod which changes one(1) creature in the game. 

Its existence impairs development and whenever newer players ask about fungals growing raises questions about "Did you disable the default mod?" etc. 

It clogs up the mod list. We have lots of really impactful, beautiful mods which offer entirely different gameplay and settings. This isn't one of them.

There's simply no reason for the mod to exist.

#### Describe the solution
Nix it. Obsolete the mod itself and mainline its effects. Add notes to the only content it changed explaining why things are the way they are, to carry us into a future with hopefully rebalanced fungals.

#### Describe alternatives you've considered
Well we could just delete the mod without mainlining it...

#### Testing
CI might need to be adjusted to account for it being obsolete. We'll see.

#### Additional context
