### PR TITLE
De-bash the Sheathes

### DIFF
--- a/data/json/items/armor/sheath.json
+++ b/data/json/items/armor/sheath.json
@@ -106,8 +106,7 @@
     ],
     "use_action": { "type": "holster", "holster_prompt": "Sheath sword", "holster_msg": "You sheath your %s" },
     "flags": [ "BELTED", "OVERSIZE", "WATER_FRIENDLY", "STURDY" ],
-    "armor": [ { "encumbrance": 2, "coverage": 100, "covers": [ "torso" ], "specifically_covers": [ "torso_waist" ] } ],
-    "melee_damage": { "bash": 4 }
+    "armor": [ { "encumbrance": 2, "coverage": 100, "covers": [ "torso" ], "specifically_covers": [ "torso_waist" ] } ]
   },
   {
     "id": "leg_sheath6",
@@ -382,8 +381,7 @@
     ],
     "use_action": { "type": "holster", "holster_prompt": "Sheath sword", "holster_msg": "You sheath your %s" },
     "flags": [ "BELTED", "OVERSIZE", "WATER_FRIENDLY" ],
-    "armor": [ { "encumbrance": [ 6, 10 ], "coverage": 20, "covers": [ "torso" ], "specifically_covers": [ "torso_hanging_back" ] } ],
-    "melee_damage": { "bash": 4 }
+    "armor": [ { "encumbrance": [ 6, 10 ], "coverage": 20, "covers": [ "torso" ], "specifically_covers": [ "torso_hanging_back" ] } ]
   },
   {
     "id": "scabbard",
@@ -420,8 +418,7 @@
         "covers": [ "leg_l", "leg_r" ],
         "specifically_covers": [ "leg_hip_r", "leg_hip_l" ]
       }
-    ],
-    "melee_damage": { "bash": 4 }
+    ]
   },
   {
     "id": "nylon_scabbard",
@@ -495,8 +492,7 @@
         "encumbrance": [ 0, 1 ],
         "specifically_covers": [ "leg_hip_r", "leg_hip_l" ]
       }
-    ],
-    "melee_damage": { "bash": 4 }
+    ]
   },
   {
     "id": "sheath_birchbark",


### PR DESCRIPTION


#### Summary
None

#### Purpose of change

I found out that 4 sheath-type items; `sheath`, `scabbard`, `back scabbard`, and `longsword scabbard` has a melee damage stat of bash 4, despite the fact that the other sheathes dont have such stat. This changes it for consistency's sake and the fact that sheathes aren't a good weapon to use.

#### Describe the solution

Delete the melee damage stat on the offending item's json.
#### Describe alternatives you've considered

Not doing so.
#### Testing

There was a melee damage section down in the descriptions. Now there isnt any.
![Screenshot_20250223_031901](https://github.com/user-attachments/assets/bbe77693-081b-4a68-ba53-9da1cd26ee9e)
![Screenshot_20250223_031849](https://github.com/user-attachments/assets/9729183e-2d3f-4b6d-9736-94f8cf2b1177)
![Screenshot_20250223_031837](https://github.com/user-attachments/assets/2eb94e8e-afbe-44bb-a9a6-aeeab19c5142)
![Screenshot_20250223_031824](https://github.com/user-attachments/assets/23722e75-ff35-4119-9a1a-535cdded3fea)


#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
