### PR TITLE
Fixed explosion leaving roofless soil, cleaned up repair

### DIFF
--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -97,6 +97,7 @@ static const ter_str_id ter_t_card_reader_broken( "t_card_reader_broken" );
 static const ter_str_id ter_t_card_science( "t_card_science" );
 static const ter_str_id ter_t_door_metal_locked( "t_door_metal_locked" );
 static const ter_str_id ter_t_floor( "t_floor" );
+static const ter_str_id ter_t_open_air( "t_open_air" );
 
 static const trait_id trait_LEG_TENT_BRACE( "LEG_TENT_BRACE" );
 static const trait_id trait_PER_SLIME( "PER_SLIME" );
@@ -250,14 +251,14 @@ static void do_blast( map *m, const Creature *source, const tripoint_bub_ms &p, 
                                          force / 2;
                 if( z_offset[i] == 0 ) {
                     // Horizontal - no floor bashing
-                    m->bash( dest, bash_force, true, false, false );
+                    m->bash( dest, bash_force, true, false, false, nullptr, false );
                 } else if( z_offset[i] > 0 ) {
                     // Should actually bash through the floor first, but that's not really possible yet
-                    m->bash( dest, bash_force, true, false, true );
+                    m->bash( dest, bash_force, true, false, true, nullptr, false );
                 } else if( !m->valid_move( pt, dest, false, true ) ) {
                     // Only bash through floor if it doesn't exist
                     // Bash the current tile's floor, not the one's below
-                    m->bash( pt, bash_force, true, false, true );
+                    m->bash( pt, bash_force, true, false, true, nullptr, false );
                 }
             }
 
@@ -274,6 +275,17 @@ static void do_blast( map *m, const Creature *source, const tripoint_bub_ms &p, 
             if( dist_map.count( dest ) == 0 || dist_map[dest] > next_dist ) {
                 open.emplace( next_dist, dest );
                 dist_map[dest] = next_dist;
+            }
+        }
+    }
+
+    for( const tripoint_bub_ms &pos : bashed ) {
+        const tripoint_bub_ms below = pos + tripoint::below;
+        const ter_t ter_below = m->ter( below ).obj();
+
+        if( m->ter( pos ).id() == ter_t_open_air ) {
+            if( ter_below.has_flag( "NATURAL_UNDERGROUND" ) ) {
+                m->ter_set( pos, ter_below.roof );
             }
         }
     }

--- a/src/map.h
+++ b/src/map.h
@@ -1147,7 +1147,8 @@ class map
          */
         bash_params bash( const tripoint_bub_ms &p, int str, bool silent = false,
                           bool destroy = false, bool bash_floor = false,
-                          const vehicle *bashing_vehicle = nullptr );
+                          const vehicle *bashing_vehicle = nullptr,
+                          bool repair_missing_ground = true );
 
         // Effects of attacks/items
         bool hit_with_acid( const tripoint_bub_ms &p );
@@ -2044,7 +2045,8 @@ class map
 
         // Internal methods used to bash just the selected features
         // Information on what to bash/what was bashed is read from/written to the bash_params struct
-        void bash_ter_furn( const tripoint_bub_ms &p, bash_params &params );
+        void bash_ter_furn( const tripoint_bub_ms &p, bash_params &params,
+                            bool repair_missing_ground = true );
         void bash_items( const tripoint_bub_ms &p, bash_params &params );
         void bash_vehicle( const tripoint_bub_ms &p, bash_params &params );
         void bash_field( const tripoint_bub_ms &p, bash_params &params );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
I've noticed barrel bomb explosion pits have soil terrain without "floor" above them. That shouldn't be the case.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Changed the bash and bash_ter_furn operations to take an additional parameter to suppress terrain "repair" on bash operations and defer that repair in the explosion handling code to when all the bashing is done.

When doing that, it was realized there is an existing flag that distinguishes natural solid terrain from everything else, so that flag, together with the terrain "roof" element was used for the repair rather than the ugly listing of all currently existing cases and their assumed "roof" terrain.

This logic was then propagated to the two other places where the logic was used.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Reuse the add_tree_tops operation. Doesn't work well, as it takes a single submap grid coordinate, and since explosions affect a lot of terrain, it's more efficient to only examine the tiles actually affected (and it helped this info was already collected by the explosion code in order to not affect the same tile multiple times).

Use the new parameter for mapgen bashing? It may affect the behavior if bashing is somehow propagated during mapgen, and add_tree_tops is called to repair things afterwards anyway. This has not been explored, but I suspect it would only affect odd edge cases which probably aren't present.

Factor out the repair logic to a new operation. I'm not too keen on that due to the large number of tiles processed both in the explosion case and the add_tree_tops one.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Barrel bomb pit before the changes (note the tiles of soil with no "roof", e.g. directly south of the PC):
![Screenshot (649)](https://github.com/user-attachments/assets/27c09e52-9ca9-42bf-805e-cad0fabf74e2)

Barrel bomb pit after the changes:
![Screenshot (650)](https://github.com/user-attachments/assets/21cdbdaa-e2e3-4e75-b3d7-e51c04c3b5aa)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
I think the explosion pit gets a litter wider and deeper after the changes. This should be a reversion back to the original shape, before repair was introduced to handle mapgen bashing (and the same repair was also introduced into the bashing itself).

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
