### PR TITLE
[Bombastic Perks] Below the Belt do not error anymore

### DIFF
--- a/data/mods/BombasticPerks/perkmenu.json
+++ b/data/mods/BombasticPerks/perkmenu.json
@@ -1162,7 +1162,7 @@
         "topic": "TALK_PERK_MENU_SELECT"
       },
       {
-        "condition": { "not": { "u_has_trait": "perk_belowthebelt" } },
+        "condition": { "and": [ "has_alpha", { "not": { "u_has_trait": "perk_belowthebelt" } } ] },
         "text": "Gain [<trait_name:perk_belowthebelt>]",
         "effect": [
           { "set_string_var": "<trait_name:perk_belowthebelt>", "target_var": { "context_val": "trait_name" } },


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Fix #79809
#### Describe the solution
Add `has_alpha` check
#### Additional context
i initially thought to also add a callstack to an error, so it is easier to track when such error happens, but apparenly it was already here. the issue is that there is no eocs, so there was no callstack to print