### PR TITLE
Possibly maybe try and fix pulping crash on android (unlikely)

### DIFF
--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -2431,9 +2431,7 @@ class pulp_activity_actor : public activity_actor
         void send_final_message( Character &you ) const;
 
         std::unique_ptr<activity_actor> clone() const override {
-            auto plp = std::make_unique<pulp_activity_actor>( *this );
-            plp.get()->current_pos_iter = plp.get()->placement.begin();
-            return plp;
+            return std::make_unique<pulp_activity_actor>( *this );
         }
 
         void serialize( JsonOut &jsout ) const override;
@@ -2458,9 +2456,6 @@ class pulp_activity_actor : public activity_actor
         int num_corpses = 0;
 
         pulp_data pd;
-
-        // what `placement` we are currently at
-        std::set<tripoint_abs_ms>::const_iterator current_pos_iter; // NOLINT(cata-serialize)
 };
 
 class wait_stamina_activity_actor : public activity_actor

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -14294,7 +14294,7 @@ void game::climb_down_using( const tripoint_bub_ms &examp, climbing_aid_id aid_i
 
 pulp_data game::calculate_character_ability_to_pulp( const Character &you )
 {
-    pulp_data pd;
+    pulp_data pd{};
 
     double pulp_power_bash = 1;
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Tags #79784  but i'm not sure it fixes it

#### Describe the solution
I cannot test android build locally (neither the crashing one nor the "fixed"), so this is shooting in the dark.

Look at the backtrace (rather sparse on details), look at the code, try to find places to add safeguards to.
-Don't store the `std::set` iterator, and instead recreate it each time it's needed (so as categorically avoid iterator invalidation issues. Not that we should trigger those, but just in case)
-Check the corpse pointer for nullptr'ness (not that we should get nullptr corpse mtypes, but just in case)
-Default-initialize `pulp_data` when starting the activity instead of leaving it uninitialized and (I think) undefined (this might be it, actually, but i'm not quite confident)

I am not remotely confident this works, but I'm not seeing anything else obviously wrong with the code, sadly.

#### Describe alternatives you've considered
Craft a test and run it with ASan/UBSan to know better where isolate the problem. There is in-flight #79804 that would definitely help. I'll try to do it locally too, but no promises

#### Testing
None.
Am unable to create a local android build. 
CI's experimental release workflow doesn't work for android builds in forks either, turns out (there are probably legitimate reasons for that).

Checked windows build - pulping in that one (still) works.

#### Additional context
