### PR TITLE
Don't spawn blacklisted items from `container-item` entries in item groups

### DIFF
--- a/src/item_group.cpp
+++ b/src/item_group.cpp
@@ -920,6 +920,10 @@ bool Item_group::remove_item( const itype_id &itemid )
             ++a;
         }
     }
+    if( container_item && ( *container_item == itemid ) ) {
+        container_item = std::nullopt;
+        on_overflow = overflow_behaviour::none;
+    }
     return items.empty();
 }
 


### PR DESCRIPTION
#### Summary
Bugfixes "Don't spawn blacklisted items from `container-item` entries in item groups"

#### Purpose of change

They're blacklisted, so don't spawn them.

#### Describe the solution

Add removing container-item to `Item_group::remove_item`.

#### Describe alternatives you've considered



#### Testing

Ran `force_load_game` test with this fix applied to #79794 and it fixed most of the errors listed here: https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/13488383665/job/37682641195?pr=79794#step:17:3109

#### Additional context

`container-item` is also not migrated currently. I made another branch for that [here](https://github.com/mqrause/Cataclysm-DDA/tree/migrate_group_container), but it adds more errors (with Generic Guns) that need some json fixes that I'm not willing to sort through. Anyone can feel free to grab that.

There's also the additional issue of ammo/item restrictions not being migrated. But since this fix supercedes that issue for the mentioned PR, I left it alone for now. I may or may not return to that at a later time, if no one else gets to it.