### PR TITLE
[Bombastic Perks] Below the Belt do not error anymore. Seriously

### DIFF
--- a/data/mods/BombasticPerks/perkdata/belowthebelt.json
+++ b/data/mods/BombasticPerks/perkdata/belowthebelt.json
@@ -10,7 +10,7 @@
         "crit_mult": { "all": 1.1 },
         "armor_mult": { "physical": 0.75 },
         "difficulty": { "melee": 1, "ranged": 5 },
-        "condition": { "and": [ "u_is_character", { "u_has_trait": "perk_belowthebelt" } ] }
+        "condition": { "and": [ "has_alpha", "u_is_character", { "u_has_trait": "perk_belowthebelt" } ] }
       }
     ]
   }

--- a/data/mods/BombasticPerks/perkmenu.json
+++ b/data/mods/BombasticPerks/perkmenu.json
@@ -1162,7 +1162,7 @@
         "topic": "TALK_PERK_MENU_SELECT"
       },
       {
-        "condition": { "and": [ "has_alpha", { "not": { "u_has_trait": "perk_belowthebelt" } } ] },
+        "condition": { "not": { "u_has_trait": "perk_belowthebelt" } },
         "text": "Gain [<trait_name:perk_belowthebelt>]",
         "effect": [
           { "set_string_var": "<trait_name:perk_belowthebelt>", "target_var": { "context_val": "trait_name" } },


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Fix #79809
#### Describe the solution
Place `has_alpha` condition in correct place, remove it from incorrect place