### PR TITLE
remove --reporter cata-ci-reporter

### DIFF
--- a/.github/workflows/msvc-full-features.yml
+++ b/.github/workflows/msvc-full-features.yml
@@ -196,7 +196,7 @@ jobs:
     - name: Run tests
       if: ${{ github.ref_name != 'master' }}
       run: |
-          .\Cataclysm-test-vcpkg-static-Release-x64.exe --min-duration 20 --rng-seed time --order lex --reporter cata-ci-reporter --wait-for-keypress exit
+          .\Cataclysm-test-vcpkg-static-Release-x64.exe --min-duration 20 --rng-seed time --order lex --wait-for-keypress exit
 
     - name: Dump disk usage logs if job failed
       if: failure()

--- a/build-scripts/gha_test_only.sh
+++ b/build-scripts/gha_test_only.sh
@@ -7,7 +7,7 @@ set -exo pipefail
 
 num_jobs=3
 parallel_opts="--verbose --linebuffer"
-cata_test_opts="--min-duration 20 --use-colour yes --rng-seed time --order lex --reporter cata-ci-reporter ${EXTRA_TEST_OPTS}"
+cata_test_opts="--min-duration 20 --use-colour yes --rng-seed time --order lex ${EXTRA_TEST_OPTS}"
 [ -z $NUM_TEST_JOBS ] && num_test_jobs=3 || num_test_jobs=$NUM_TEST_JOBS
 
 # We might need binaries installed via pip, so ensure that our personal bin dir is on the PATH


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
#79681 is a nice change, but it made our CI logs absolutely unreadable, i spend two to three times more time to find what the actual error is, scrolling a ton of successful tests
#### Describe the solution
Partially revert #79681 by removing `--reporter cata-ci-reporter`
#### Testing
CI