### PR TITLE
Return radiation back to NPP

### DIFF
--- a/data/json/mapgen/nuclear_plant/nuclear_plant_z0.json
+++ b/data/json/mapgen/nuclear_plant/nuclear_plant_z0.json
@@ -347,6 +347,7 @@
       "terrain": {  },
       "furniture": {  },
       "palettes": [ "nuclear_plant_palette" ],
+      "set": [ { "square": "radiation", "amount": [ 1, 10 ], "x": 0, "y": 0, "x2": 23, "y2": 23 } ],
       "place_furniture": [
         { "furn": "f_diesel_generator", "x": 233, "y": 60 },
         { "furn": "f_diesel_generator", "x": 130, "y": 116 },

--- a/data/json/mapgen/nuclear_plant/nuclear_plant_z1.json
+++ b/data/json/mapgen/nuclear_plant/nuclear_plant_z1.json
@@ -346,6 +346,7 @@
       ],
       "terrain": {  },
       "furniture": {  },
+      "set": [ { "square": "radiation", "amount": [ 1, 10 ], "x": 0, "y": 0, "x2": 23, "y2": 23 } ],
       "palettes": [ "nuclear_plant_palette" ],
       "place_furniture": [ { "furn": "f_diesel_generator", "x": 116, "y": 117 }, { "furn": "f_diesel_generator", "x": 235, "y": 91 } ],
       "place_vehicles": [

--- a/data/json/mapgen/nuclear_plant/nuclear_plant_z2.json
+++ b/data/json/mapgen/nuclear_plant/nuclear_plant_z2.json
@@ -346,6 +346,7 @@
       ],
       "terrain": {  },
       "furniture": {  },
+      "set": [ { "square": "radiation", "amount": [ 1, 10 ], "x": 0, "y": 0, "x2": 23, "y2": 23 } ],
       "palettes": [ "nuclear_plant_palette" ],
       "place_furniture": [
         { "furn": "f_diesel_generator", "x": 147, "y": 76 },

--- a/data/json/mapgen/nuclear_plant/nuclear_plant_z3.json
+++ b/data/json/mapgen/nuclear_plant/nuclear_plant_z3.json
@@ -262,6 +262,7 @@
       ],
       "terrain": {  },
       "furniture": {  },
+      "set": [ { "square": "radiation", "amount": [ 1, 10 ], "x": 0, "y": 0, "x2": 23, "y2": 23 } ],
       "palettes": [ "nuclear_plant_palette" ]
     }
   }

--- a/data/json/mapgen/nuclear_plant/nuclear_plant_z4.json
+++ b/data/json/mapgen/nuclear_plant/nuclear_plant_z4.json
@@ -109,6 +109,7 @@
       ],
       "terrain": {  },
       "furniture": {  },
+      "set": [ { "square": "radiation", "amount": [ 1, 10 ], "x": 0, "y": 0, "x2": 23, "y2": 23 } ],
       "palettes": [ "nuclear_plant_palette" ]
     }
   }

--- a/data/json/mapgen/nuclear_plant/nuclear_plant_z5.json
+++ b/data/json/mapgen/nuclear_plant/nuclear_plant_z5.json
@@ -57,6 +57,7 @@
       ],
       "terrain": {  },
       "furniture": {  },
+      "set": [ { "square": "radiation", "amount": [ 1, 10 ], "x": 0, "y": 0, "x2": 23, "y2": 23 } ],
       "palettes": [ "nuclear_plant_palette" ]
     }
   }

--- a/data/json/mapgen/nuclear_plant/nuclear_plant_z6.json
+++ b/data/json/mapgen/nuclear_plant/nuclear_plant_z6.json
@@ -33,6 +33,7 @@
       ],
       "terrain": {  },
       "furniture": {  },
+      "set": [ { "square": "radiation", "amount": [ 1, 10 ], "x": 0, "y": 0, "x2": 23, "y2": 23 } ],
       "palettes": [ "nuclear_plant_palette" ]
     }
   }

--- a/data/json/mapgen/nuclear_plant/nuclear_plant_z7.json
+++ b/data/json/mapgen/nuclear_plant/nuclear_plant_z7.json
@@ -33,6 +33,7 @@
       ],
       "terrain": {  },
       "furniture": {  },
+      "set": [ { "square": "radiation", "amount": [ 1, 10 ], "x": 0, "y": 0, "x2": 23, "y2": 23 } ],
       "palettes": [ "nuclear_plant_palette" ]
     }
   }


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
https://discord.com/channels/598523535169945603/598523535169945607/1076663128848351233
`This I think is a decent source outlining what CAN happen with a non-catastrophic reactor failure https://en.m.wikipedia.org/wiki/Radiation_effects_from_the_Fukushima_Daiichi_nuclear_disaster
Tl;dr ~10mSv/hr at the fukishima front gate, so basically anywhere in the plant is worse`
`If the power is gone and the local power fails (it WILL), that's pretty much your best case outcome`
`Plus, there would be no large scale cleanup or impact mitigation because the world is ending`
`To be clear,  it's a big grey area,  my point is these reactors are not as safe as is being claimed in a massive disaster scenario`
`Honestly ending up around 10mSv/h is a very interesting outcome because you can visit but you can NOT live there`
#### Describe the solution
Partially revert #79676 by adding radiation back to the location
#### Additional context
I'm very curious why defining radiation once in a single square proparated it across entire special