### PR TITLE
Load vehicles before explosion + leaks at right map

### DIFF
--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -972,6 +972,7 @@ void process_explosions()
             g->load_npcs( &m );
             process_explosions_in_progress = false;
             _make_explosion( &m, ex.source, m.get_bub( ex.pos ), ex.data );
+            m.process_falling();
         } else {
             _make_explosion( bubble_map, ex.source, bubble_map->get_bub( ex.pos ), ex.data );
         }

--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -967,7 +967,7 @@ void process_explosions()
             // to actually overlap the reality bubble, so a large explosion can be detonated without blowing up the PC
             // or have a vehicle run into a crater suddenly appearing just in front of it.
             process_explosions_in_progress = true;
-            m.load( origo, false, false );
+            m.load( origo, true, false );
             m.spawn_monsters( true, true );
             g->load_npcs( &m );
             process_explosions_in_progress = false;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -15472,7 +15472,7 @@ bool item::on_drop( const tripoint_bub_ms &pos, map &m )
 
     avatar &player_character = get_avatar();
 
-    return type->drop_action && type->drop_action.call( &player_character, *this, pos );
+    return type->drop_action && type->drop_action.call( &player_character, *this, &m, pos );
 }
 
 time_duration item::age() const

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -8293,12 +8293,12 @@ void vehicle::calc_mass_center( map &here, bool use_precalc ) const
     if( use_precalc ) {
         mass_center_precalc.x() = std::round( x );
         mass_center_precalc.y() = std::round( y );
-        mass_center_precalc_dirty = false;
     } else {
         mass_center_no_precalc.x() = std::round( x );
         mass_center_no_precalc.y() = std::round( y );
-        mass_center_no_precalc_dirty = false;
     }
+
+    mass_center_no_precalc_dirty = false;
 }
 
 bounding_box vehicle::get_bounding_box( bool use_precalc, bool no_fake )

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -8287,8 +8287,9 @@ void vehicle::calc_mass_center( map &here, bool use_precalc ) const
     mass_cache = m_total;
     mass_dirty = false;
 
-    const float x = xf / mass_cache;
-    const float y = yf / mass_cache;
+    // If no reall parts remain the weight is zero, and we'd end up with division by zero.
+    const float x = mass_cache == 0_gram ? 0 : xf / mass_cache;
+    const float y = mass_cache == 0_gram ? 0 : yf / mass_cache;
     if( use_precalc ) {
         mass_center_precalc.x() = std::round( x );
         mass_center_precalc.y() = std::round( y );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
- Make separate map explosions affect vehicles.
- Make leaks from explosion touched vehicles spill on the correct map.
- Handle division by zero when vehicle has no real parts left (all removed or fake)
- Cause items to fall after explosions have generated them.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
- Enable vehicle loading in "load".
- Use the map aware version of spillage in the call chain used by explosions.
- Check for total weight of vehicle being zero, indicating no parts contributed to the weight and set the mass center to zero.
- add call to `process_falling()` after an explosion has generated them in the non reality bubble explosion case.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Continue to try to find why pivot_anchor[1] contains garbage. I will do that, but would appreciate help.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Prior to the `load` call change vehicles randomly weren't subjected to the effect of the explosion, while afterwards they are badly damaged.
Prior to the change to the spillage code acid from batteries occasionally (20%?) appeared in front of the PC rather than on the explosion site.
Tested until a zero vehicle failure occurred and looked through the debug output added to verify zero vehicle parts were processed. This code adjusted the generated position to (0, 0).
The code was then revised to the committed one, but I'm not going to test that due to the number of attempts it takes for this failure case to occur. 

The explosion results:
![Screenshot (653)](https://github.com/user-attachments/assets/e11e669b-2f05-4a6c-b7cc-c928997c6161)

Done after the screenshot above:
Set off a barrel bomb, move away from it outside the reality bubble, return after the timer has expired so it explodes when entering the reality bubble, move to the crater, observe the debris is no longer hovering, but has fallen to the bottom of the crater.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
I've removed the text placed here during the draft phase as it no longer serves a purpose.

~~It can be noted that levitating explosion products still exist after the explosion. This was the case before these changes as well, so it's not a regression, but something that will have to be tracked down and fixed in a future PR.~~ Now included in this PR, as it's another one liner.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
