### PR TITLE
Adding WASP and SPIDER flags to appropriate overmap specials

### DIFF
--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -1126,7 +1126,7 @@
     "city_distance": [ 5, 25 ],
     "occurrences": [ 80, 100 ],
     "spawns": { "group": "GROUP_WASP_FORAGER", "population": [ 50, 80 ], "radius": [ 6, 20 ] },
-    "flags": [ "OVERMAP_UNIQUE", "MAN_MADE" ]
+    "flags": [ "WASP", "OVERMAP_UNIQUE", "MAN_MADE" ]
   },
   {
     "type": "overmap_special",
@@ -1147,7 +1147,7 @@
     "city_distance": [ 5, 25 ],
     "occurrences": [ 80, 100 ],
     "spawns": { "group": "GROUP_WASP_FORAGER", "population": [ 50, 100 ], "radius": [ 6, 20 ] },
-    "flags": [ "OVERMAP_UNIQUE", "MAN_MADE" ]
+    "flags": [ "WASP", "OVERMAP_UNIQUE", "MAN_MADE" ]
   },
   {
     "type": "overmap_special",

--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -1541,7 +1541,7 @@
     "city_sizes": [ 0, 12 ],
     "occurrences": [ 33, 100 ],
     "rotate": false,
-    "flags": [ "WILDERNESS", "OVERMAP_UNIQUE" ]
+    "flags": [ "SPIDER", "WILDERNESS", "OVERMAP_UNIQUE" ]
   },
   {
     "type": "overmap_special",


### PR DESCRIPTION
#### Summary
Content "Added WASP and SPIDER flags to wasp towers and spider pits."

Purpose of change
They didn't have flags on them for such things, which results in attempts to blacklist them missing these overmap specials.

Describe the solution
I added flags.

Describe alternatives you've considered
Not doing this, I guess? Maybe adding the SPIDER flag to the void spider lair as well.

Testing
Haven't tested yet, don't really see a way this could go wrong though.

Additional context
I really hate wasps.
