### PR TITLE
[CR][WIP] Adds 2,4-Dinitrophenol

### DIFF
--- a/data/json/items/chemicals_and_resources.json
+++ b/data/json/items/chemicals_and_resources.json
@@ -1102,6 +1102,23 @@
   },
   {
     "type": "AMMO",
+    "id": "chem_dnp",
+    "category": "chems",
+    "price": "75 USD",
+    "price_postapoc": "25 USD",
+    "name": { "str_sp": "DNP" },
+    "symbol": "=",
+    "color": "white",
+    "description": "2,4-Dinitrophenol: a yellow powder that in the past was used as an herbicide, pesticide, and even as a niche weight-loss drug. It was banned from human consumption many decades ago, but lived on as a drug for fitness enthusiasts, and after the Cataclysm as an easy to manufacture and safe explosive.",
+    "material": [ "powder" ],
+    "//": "1.683 g/cc at 24 °C",
+    "volume": "297 ml",
+    "weight": "1 g",
+    "ammo_type": "components",
+    "count": 500
+  },
+  {
+    "type": "AMMO",
     "id": "chem_compositionb",
     "category": "chems",
     "price": "75 USD",

--- a/data/json/items/chemicals_and_resources.json
+++ b/data/json/items/chemicals_and_resources.json
@@ -1108,7 +1108,7 @@
     "price_postapoc": "25 USD",
     "name": { "str_sp": "DNP" },
     "symbol": "=",
-    "color": "white",
+    "color": "yellow",
     "description": "2,4-Dinitrophenol: a yellow powder that in the past was used as an herbicide, pesticide, and even as a niche weight-loss drug. It was banned from human consumption many decades ago, but lived on as a drug for fitness enthusiasts, and after the Cataclysm as an easy to manufacture and safe explosive.",
     "material": [ "powder" ],
     "//": "1.683 g/cc at 24 °C",

--- a/data/json/recipes/recipe_medsandchemicals.json
+++ b/data/json/recipes/recipe_medsandchemicals.json
@@ -1669,6 +1669,25 @@
   {
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",
+    "result": "chem_dnp",
+    "category": "CC_CHEM",
+    "subcategory": "CSC_CHEM_CHEMICALS",
+    "skill_used": "chemistry",
+    "difficulty": 5,
+    "time": "1 h",
+    "book_learn": [ [ "recipe_labchem", 8 ], [ "textbook_anarch", 10 ] ],
+    "proficiencies": [
+      { "proficiency": "prof_intro_chemistry" },
+      { "proficiency": "prof_inorganic_chemistry" },
+      { "proficiency": "prof_organic_chemistry" }
+    ],
+    "qualities": [ { "id": "BOIL", "level": 2 }, { "id": "CHEM", "level": 3 }, { "id": "DISTILL", "level": 1 } ],
+    "tools": [ [ [ "surface_heat", 20, "LIST" ] ] ],
+    "components": [ [ [ "chem_nitric_acid", 1 ] ],  [ [ "chem_ethanol", 1000 ] ], [ [ "chem_phenol", 50 ] ] , [ [ "water_clean", 1 ] ] ]
+  },
+  {
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
     "result": "chem_thermite",
     "category": "CC_CHEM",
     "subcategory": "CSC_CHEM_CHEMICALS",

--- a/data/json/recipes/recipe_medsandchemicals.json
+++ b/data/json/recipes/recipe_medsandchemicals.json
@@ -1683,7 +1683,8 @@
     ],
     "qualities": [ { "id": "BOIL", "level": 2 }, { "id": "CHEM", "level": 3 }, { "id": "DISTILL", "level": 1 } ],
     "tools": [ [ [ "surface_heat", 20, "LIST" ] ] ],
-    "components": [ [ [ "chem_nitric_acid", 1 ] ],  [ [ "chem_ethanol", 1000 ] ], [ [ "chem_phenol", 50 ] ] , [ [ "water_clean", 1 ] ] ]
+    "components": [ [ [ "chem_nitric_acid", 1 ] ],  [ [ "chem_ethanol", 1000 ] ], [ [ "chem_phenol", 50 ] ] , [ [ "water_clean", 1 ] ] ],
+    "charges": 96
   },
   {
     "type": "recipe",

--- a/data/json/requirements/explosives.json
+++ b/data/json/requirements/explosives.json
@@ -69,7 +69,7 @@
     "id": "stable_explosive",
     "type": "requirement",
     "//": "This should contain all the explosives you need to set off with an explosive primer, but can be used without casting in a crucible. 10g tnt equivalent.",
-    "components": [ [ [ "chem_ammonium_nitrate", 24 ], [ "chem_ammonium_nitrate_pellets", 24 ], [ "chem_anfo", 14 ], [ "chem_rdx", 6 ], [ "chem_dnp", 17 ] ] ]
+    "components": [ [ [ "chem_ammonium_nitrate", 24 ], [ "chem_ammonium_nitrate_pellets", 24 ], [ "chem_anfo", 14 ], [ "chem_rdx", 6 ], [ "chem_dnp", 13 ] ] ]
   },
   {
     "id": "military_explosive",

--- a/data/json/requirements/explosives.json
+++ b/data/json/requirements/explosives.json
@@ -69,7 +69,7 @@
     "id": "stable_explosive",
     "type": "requirement",
     "//": "This should contain all the explosives you need to set off with an explosive primer, but can be used without casting in a crucible. 10g tnt equivalent.",
-    "components": [ [ [ "chem_ammonium_nitrate", 24 ], [ "chem_ammonium_nitrate_pellets", 24 ], [ "chem_anfo", 14 ], [ "chem_rdx", 6 ] ] ]
+    "components": [ [ [ "chem_ammonium_nitrate", 24 ], [ "chem_ammonium_nitrate_pellets", 24 ], [ "chem_anfo", 14 ], [ "chem_rdx", 6 ], [ "chem_dnp", 17 ] ] ]
   },
   {
     "id": "military_explosive",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
1. Content "Adds 2,4-Dinitrophenol as a craftable explosive"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
5. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
6. Interface "Show crafting failure chances in the crafting interface"
7. Infrastructure "JSON-ize slot machines"
8. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

My intention with this addition is to allow the player to craft simpler explosives for innawoods and long-term survival playthroughs. I stumbled over an old PR (#37179) with interesting content that was left unfinished, so I was going to try to revive it myself piecemeal. This is also going to add a purpose to phenol to the game, which has been a useless chemical for a while.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

In this PR I am adding 2,4-Dinitrophenol, or DNP, to the game, a safe and simple high explosive made out of nitrated phenol. It adds the item, a corresponding crafting recipe, and adds it to high explosive requirements so it can be used to make grenades and other bombs.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Not adding it. Using mercury fulminate and black powder for my innawoods bombs instead.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

I launched the game, used the debug menu to spawn myself the materials and ingredients, and crafted it. Then I crafted a grenade out of it to blow up the NPC in the evac shelter.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

I based the crafting recipe off of a Russian chemistry paper from 2012 which has been cited on Wikipedia and other places online.
https://www.researchgate.net/publication/257861451_Synthesis_of_24-dinitrophenol
Wikipedia claims that it's got 80% relative strength to TNT, but the sources are behind paywalls so I cannot confirm it.
I am personally not a chemist, I hacked this recipe together based on layman's research and citations online, so I could use some comments from chemists to help me out with this.
The requirements and proficiencies are currently based off of RDX, with an added distillation requirement.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
