### PR TITLE
Auto Pickup menu: fix crash on removing last, add hint, remove artefact after switch from `False`

### DIFF
--- a/src/auto_pickup.cpp
+++ b/src/auto_pickup.cpp
@@ -13,7 +13,6 @@
 
 #include "cata_path.h"
 #include "cata_utility.h"
-#include "catacharset.h"
 #include "character.h"
 #include "color.h"
 #include "coordinates.h"
@@ -372,17 +371,18 @@ void user_interface::show()
         wnoutrefresh( w_border );
 
         // Redraw the header
-        int locx = 0;
-        const std::string autopickup_enabled_text = _( "Auto pickup enabled:" );
-        mvwprintz( w_header, point( locx, 0 ), c_white, autopickup_enabled_text );
-        locx += utf8_width( autopickup_enabled_text );
-        locx += shortcut_print( w_header, point( locx + 1, 0 ),
-                                ( get_option<bool>( "AUTO_PICKUP" ) ? c_light_green : c_light_red ), c_white,
-                                ( get_option<bool>( "AUTO_PICKUP" ) ? _( "True" ) : _( "False" ) ) );
-        std::string desc_2 = string_format( "%s", ctxt.get_desc( "HELP_KEYBINDINGS",
-                                            _( "Display keybindings" ) ) );
         // NOLINTNEXTLINE(cata-use-named-point-constants)
-        fold_and_print( w_header, point( 0, 1 ), 0, c_white, desc_2 );
+        mvwhline( w_header, point( 0, 0 ), ' ', FULL_SCREEN_WIDTH - 2 );  // clear the line
+        const bool enabled = get_option<bool>( "AUTO_PICKUP" );
+        nc_color color = c_white;
+        // NOLINTNEXTLINE(cata-use-named-point-constants)
+        print_colored_text( w_header, point( 1, 0 ), color, c_white, string_format( "%s %s",
+                            ctxt.get_desc( "SWITCH_AUTO_PICKUP_OPTION", _( "Auto pickup enabled:" ) ),
+                            colorize( enabled ? _( "True" ) : _( "False" ),
+                                      enabled ? c_light_green : c_light_red ) ) );
+        // NOLINTNEXTLINE(cata-use-named-point-constants)
+        print_colored_text( w_header, point( 1, 1 ), color, c_white,
+                            ctxt.get_desc( "HELP_KEYBINDINGS", _( "Display keybindings" ) ) );
 
         wattron( w_header, c_light_gray );
         mvwhline( w_header, point( 0,  2 ), LINE_OXOX, 78 );
@@ -398,7 +398,7 @@ void user_interface::show()
         mvwprintz( w_header, point( 52, 3 ), c_white, _( "Inc/Exc" ) );
 
         rule_list &cur_rules = tabs[iTab].new_rules;
-        locx = 17;
+        int locx = 17;
         for( size_t i = 0; i < tabs.size(); i++ ) {
             const nc_color color = iTab == i ? hilite( c_white ) : c_white;
             locx += shortcut_print( w_header, point( locx, 2 ), c_white, color, tabs[i].title ) + 1;

--- a/src/auto_pickup.cpp
+++ b/src/auto_pickup.cpp
@@ -475,12 +475,8 @@ void user_interface::show()
         } else if( action == "REMOVE_RULE" && currentPageNonEmpty ) {
             bStuffChanged = true;
             cur_rules.erase( cur_rules.begin() + iLine );
-            if( iLine > recmax - 1 ) {
-                iLine--;
-            }
-            if( iLine < 0 ) {
-                iLine = 0;
-            }
+            // after erase, recmax - 2 is the last valid index
+            iLine = std::clamp( iLine, 0, recmax - 2 );
         } else if( action == "COPY_RULE" && currentPageNonEmpty ) {
             bStuffChanged = true;
             cur_rules.push_back( cur_rules[iLine] );

--- a/src/auto_pickup.cpp
+++ b/src/auto_pickup.cpp
@@ -338,6 +338,7 @@ void user_interface::show()
     ctxt.register_action( "QUIT" );
     if( tabs.size() > 1 ) {
         ctxt.register_action( "NEXT_TAB" );
+        ctxt.register_action( "PREV_TAB" );
     }
     ctxt.register_action( "ADD_RULE" );
     ctxt.register_action( "REMOVE_RULE" );
@@ -456,18 +457,8 @@ void user_interface::show()
         const int scroll_rate = recmax > 20 ? 10 : 3;
         const std::string action = ctxt.handle_input();
 
-        if( action == "NEXT_TAB" ) {
-            iTab++;
-            if( iTab >= tabs.size() ) {
-                iTab = 0;
-            }
-            iLine = 0;
-        } else if( action == "PREV_TAB" ) {
-            if( iTab > 0 ) {
-                iTab--;
-            } else {
-                iTab = tabs.size() - 1;
-            }
+        if( action == "NEXT_TAB" || action == "PREV_TAB" ) {
+            iTab = inc_clamp_wrap( iTab, action == "NEXT_TAB", tabs.size() );
             iLine = 0;
         } else if( action == "QUIT" ) {
             break;


### PR DESCRIPTION
#### Summary
Bugfixes "Auto Pickup menu: fix crash on removing last, add hint, remove artefact after switch from False"

#### Purpose of changes and solutions

Picture before (as broken as possible):
![image](https://github.com/user-attachments/assets/18f1a55c-4c45-439f-8d97-78577438762b)

Picture after:
![image](https://github.com/user-attachments/assets/4c43d0da-bee2-4150-9dfc-ebbc0fe554fe)


---

Crash:
1. Open Auto Pickup with at least one entry.
2. Move to the last entry.
   - ![image](https://github.com/user-attachments/assets/d6a5583d-eb64-4543-9d80-faed115d46da)
3. `r`emove it.
4. Observe: the cursor disappeared.
   - ![image](https://github.com/user-attachments/assets/ded7911c-be8a-4cc0-bbd4-eb097f73d322)
6. `r`emove again.
7. Observe: the game crashes.
   - It tries to access rule N in a vector with N-1 entries.

**Solution:** When the last entry is removed, select the new last entry.
![image](https://github.com/user-attachments/assets/fb7823e2-50d0-45f2-bf45-6c37a07274a1)


---

Text artefact:
1. Switch enable auto pickup to `False`, if it wasn't already.
2. Switch to `True`.
3. Observe: red `e` from False is still there.
   - ![image](https://github.com/user-attachments/assets/9bd66550-b062-4527-bc8a-e74dbff73e40)


**Solution:** Clear the line. This way, it will work for any length difference.

---

**Problem:** How do I switch enabled?
![image](https://github.com/user-attachments/assets/5971afd6-85be-46c8-8c79-43402fd7f96e)


**Solution:** Add hint.
![image](https://github.com/user-attachments/assets/c25dc2ef-cd85-4dd5-8fd2-c41bf67535ad)


---

**Problem:** There is usually space between border and text, but not in this menu.
![image](https://github.com/user-attachments/assets/0e0015f8-e883-40d8-bb74-c4faea3a1c05)

**Solution:** Add the space.
![image](https://github.com/user-attachments/assets/26d2aa4a-5aad-41e8-addd-921821acced2)


---

**Problem:** You could TAB but not BACKTAB. (Cycle tabs in reverse).

**Solution:** The code was there, BACKTAB action was just not registered in context. Register it.

---

#### Describe alternatives you've considered

Less refactoring.

#### Testing

Went through the menus. Didn't reproduce the problems. Tried most of the available keybindings.

Open Auto Pickup in game and in main menu.

#### Additional context

The crash fix was on my PC since Sep 2 16:22:15 2021 +0200. I am finally cleaning up.

- Note the super recent #79564 this builds upon.