### PR TITLE
[Magiclysm] Add `Morphogenic Mastery` Biomancer spell

### DIFF
--- a/data/mods/Magiclysm/Spells/biomancer.json
+++ b/data/mods/Magiclysm/Spells/biomancer.json
@@ -818,5 +818,26 @@
         "then": { "math": [ "u_vitamin('redcells')", "+=", "300 + (u_spell_level('biomancer_get_more_blood') * 150)" ] }
       }
     ]
+  },
+  {
+    "id": "biomancer_control_mutations",
+    "type": "SPELL",
+    "name": "Morphogenic Mastery",
+    "description": "The scroll said that this spell is for \"Exerting deliberate control over morphogenic alterations\", which sounds ominous.",
+    "valid_targets": [ "self" ],
+    "spell_class": "BIOMANCER",
+    "flags": [ "ENHANCEMENT_SPELL", "CONCENTRATE", "VERBAL", "SOMATIC" ],
+    "effect": "attack",
+    "effect_str": "effect_biomancer_control_mutations",
+    "shape": "blast",
+    "difficulty": 12,
+    "max_level": 15,
+    "magic_type": "magiclysm_generic_magic",
+    "min_duration": 360000,
+    "max_durationg": 3060000,
+    "duration_increment": 180000,
+    "base_energy_cost": 1200,
+    "extra_effects": [ { "id": "eoc_enhancement_setup", "hit_self": true }, { "id": "biomantic_pain_caused_light", "hit_self": true } ],
+    "base_casting_time": 6000
   }
 ]

--- a/data/mods/Magiclysm/Spells/biomancer.json
+++ b/data/mods/Magiclysm/Spells/biomancer.json
@@ -834,7 +834,7 @@
     "max_level": 15,
     "magic_type": "magiclysm_generic_magic",
     "min_duration": 360000,
-    "max_durationg": 3060000,
+    "max_duration": 3060000,
     "duration_increment": 180000,
     "base_energy_cost": 1200,
     "extra_effects": [ { "id": "eoc_enhancement_setup", "hit_self": true }, { "id": "biomantic_pain_caused_light", "hit_self": true } ],

--- a/data/mods/Magiclysm/effects/effects.json
+++ b/data/mods/Magiclysm/effects/effects.json
@@ -1397,7 +1397,7 @@
     "enchantments": [
       {
         "values": [
-          { "value": "MUT_ADDITIONAL_OPTIONS", "add": { "math": [ "1 + ( u_spell_level('biomancer_remove_instability') / 5)" ] } }
+          { "value": "MUT_ADDITIONAL_OPTIONS", "add": { "math": [ "1 + ( u_spell_level('biomancer_control_mutations') / 5)" ] } }
         ]
       }
     ]

--- a/data/mods/Magiclysm/effects/effects.json
+++ b/data/mods/Magiclysm/effects/effects.json
@@ -1390,7 +1390,7 @@
     "id": "effect_biomancer_control_mutations",
     "type": "effect_type",
     "name": [ "Morphogenic Mastery" ],
-    "desc": [ "You are able to extert conscious control over any mutations to your body." ],
+    "desc": [ "You are able to exert conscious control over any mutations to your body." ],
     "apply_message": "You feel…strange.",
     "remove_message": "The strange feeling passes and you feel more like yourself.",
     "rating": "good",

--- a/data/mods/Magiclysm/effects/effects.json
+++ b/data/mods/Magiclysm/effects/effects.json
@@ -1387,6 +1387,22 @@
     "flags": [ "EFFECT_LIMB_SCORE_MOD" ]
   },
   {
+    "id": "effect_biomancer_control_mutations",
+    "type": "effect_type",
+    "name": [ "Morphogenic Mastery" ],
+    "desc": [ "You are able to extert conscious control over any mutations to your body." ],
+    "apply_message": "You feel…strange.",
+    "remove_message": "The strange feeling passes and you feel more like yourself.",
+    "rating": "good",
+    "enchantments": [
+      {
+        "values": [
+          { "value": "MUT_ADDITIONAL_OPTIONS", "add": { "math": [ "1 + ( u_spell_level('biomancer_remove_instability') / 5)" ] } }
+        ]
+      }
+    ]
+  },
+  {
     "id": "effect_biomancer_carrion_feast",
     "type": "effect_type",
     "name": [ "Carrion Feast" ],

--- a/data/mods/Magiclysm/itemgroups/itemgroups.json
+++ b/data/mods/Magiclysm/itemgroups/itemgroups.json
@@ -1967,5 +1967,14 @@
       { "item": "mana_leech_shackle_unlocked", "count": [ 3, 8 ], "prob": 100 },
       { "item": "mana_leech_unlock_scroll", "count": [ 3, 8 ], "prob": 100 }
     ]
+  },
+  {
+    "type": "item_group",
+    "id": "xedra_thaumaturgical_lab_secret_spells",
+    "subtype": "distribution",
+    "items": [
+      { "item": "spell_scroll_biomancer_control_mutations", "prob": 1 },
+      { "item": "spell_scroll_biomancer_remove_instability", "prob": 1 }
+    ]
   }
 ]

--- a/data/mods/Magiclysm/items/spell_scrolls.json
+++ b/data/mods/Magiclysm/items/spell_scrolls.json
@@ -2193,5 +2193,14 @@
     "name": { "str": "Scroll of Witchsight", "str_pl": "Scrolls of Witchsight" },
     "description": "Open up your senses to detect the brighter ley lines of those who habitually use their magic.",
     "use_action": { "type": "learn_spell", "spells": [ "animist_detect_wizards" ] }
+  },
+  {
+    "type": "BOOK",
+    "copy-from": "spell_scroll",
+    "id": "spell_scroll_biomancer_control_mutations",
+    "//": "Biomancer spell",
+    "name": { "str": "Formula of Morphogenic Mastery", "str_pl": "Formulae of Morphogenic Mastery" },
+    "description": "This research paper has an extremely complicated series of formulae with various genetic code diagrams interspersed.  It claims that the spell will allow conscious control over any \"morphogenic alterations\".",
+    "use_action": { "type": "learn_spell", "spells": [ "biomancer_control_mutations" ] }
   }
 ]

--- a/data/mods/Magiclysm/worldgen/labs/microlab.json
+++ b/data/mods/Magiclysm/worldgen/labs/microlab.json
@@ -37,12 +37,12 @@
       "terrain": { "G": "t_card_science", "Ø": "t_rock_floor", "¢": "t_rock_floor" },
       "furniture": { "☿": "f_alembic", "β": "f_magic_bench", "Ø": "f_magic_circle" },
       "place_item": [
-        { "item": "spell_scroll_biomancer_remove_instability", "x": 12, "y": 9, "chance": 100 },
         { "item": "candle", "x": 15, "y": 5, "chance": 100 },
         { "item": "candle", "x": 15, "y": 8, "chance": 100 },
         { "item": "candle", "x": 18, "y": 5, "chance": 100 },
         { "item": "candle", "x": 18, "y": 8, "chance": 100 }
       ],
+      "place_loot": [ { "group": "xedra_thaumaturgical_lab_secret_spells", "x": 12, "y": 9, "chance": 100 } ],
       "items": {
         "B": [
           { "item": "magic_shop_books", "chance": 33, "repeat": [ 1, 3 ] },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Magiclysm] Add `Morphogenic Mastery` Biomancer spell"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Another fine spell from the eggheads at the XEDRA Thaumaturgical Research Division, based on #79814
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add the Morphogenic Mastery spell, which allows you to exert conscious control over your mutations if you mutate while it's in effect. It's found the same place the Preserve Genetic Stability scroll is.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Scroll spawns, scroll teaches spell, spell works. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Found out while working on this that Yugg attacks bypass the `MUT_ADDITIONAL_OPTIONS` enchant.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
