### PR TITLE
[MoM] Give feral teleporters Warped Strikes

### DIFF
--- a/data/mods/MindOverMatter/effects/effects_monster.json
+++ b/data/mods/MindOverMatter/effects/effects_monster.json
@@ -332,6 +332,14 @@
   },
   {
     "type": "effect_type",
+    "id": "effect_monster_warped_strikes",
+    "name": [ "Warped Strikes" ],
+    "desc": [ "Your melee attacks travel further than the range of your weapons makes it seem like they should." ],
+    "show_in_info": true,
+    "rating": "good"
+  },
+  {
+    "type": "effect_type",
     "id": "effect_riftwalker_teleport",
     "name": [ "Dimensionally Unstable" ],
     "desc": [ "You feel like you're barely part of the world." ],

--- a/data/mods/MindOverMatter/monsters/feral_psychics.json
+++ b/data/mods/MindOverMatter/monsters/feral_psychics.json
@@ -1180,7 +1180,7 @@
     "id": "mon_feral_human_porter",
     "type": "MONSTER",
     "name": "feral jumper",
-    "description": "What was once empty air suddenly contains this feral human.  They have the same crazed expression as their fellows, but their gaze is focused on more distant locations.",
+    "description": "What was once empty air suddenly contains this feral human.  They have the same crazed expression as their fellows, but their gaze is focused on more distant locations.  A sturdy piece of debris from some ruin dangles from one of their hands.",
     "copy-from": "mon_feral_psion_default",
     "relative": { "dodge": 2 },
     "color": "blue",
@@ -1191,6 +1191,15 @@
     "upgrades": { "half_life": 45, "into": "mon_feral_human_porter2" },
     "extend": {
       "special_attacks": [
+        {
+          "id": "feral_weapon_pipe",
+          "hit_dmg_u": "%1$s hits your %2$s with their weapon!",
+          "hit_dmg_npc": "%1$s hits <npcname>'s %2$s with their weapon!",
+          "miss_msg_u": "%1$s tries to hit you, but you dodge!",
+          "miss_msg_npc": "%1$s tries to hit <npcname>, but they dodge!",
+          "no_dmg_msg_u": "%1$s hits your %2$s without penetrating your armor.",
+          "no_dmg_msg_npc": "%1$s hits <npcname>'s %2$s without penetrating their armor."
+        },
         {
           "id": "psi_teleport1_slow",
           "type": "spell",
@@ -1208,14 +1217,14 @@
           "message": "%1$s vanishes and reappears elsewhere!"
         }
       ],
-      "flags": [ "CLIMBS", "HARDTOSHOOT", "TELEPORT_IMMUNE" ]
+      "flags": [ "CLIMBS", "HARDTOSHOOT", "TELEPORT_IMMUNE", "WIELDED_WEAPON" ]
     }
   },
   {
     "id": "mon_feral_human_porter2",
     "type": "MONSTER",
     "name": "feral slider",
-    "description": "Every time you blink, this feral human is in a different place.  They are always in motion without actually crossing the intervening space.",
+    "description": "Every time you blink, this debris-wielding feral is in a different place.  They are always in motion without actually crossing the intervening space.",
     "copy-from": "mon_feral_psion_default",
     "relative": { "dodge": 4 },
     "color": "blue",
@@ -1226,6 +1235,41 @@
     "upgrades": { "half_life": 45, "into": "mon_feral_human_porter3" },
     "extend": {
       "special_attacks": [
+        {
+          "id": "feral_weapon_pipe",
+          "hit_dmg_u": "%1$s hits your %2$s with their weapon!",
+          "hit_dmg_npc": "%1$s hits <npcname>'s %2$s with their weapon!",
+          "miss_msg_u": "%1$s tries to hit you, but you dodge!",
+          "miss_msg_npc": "%1$s tries to hit <npcname>, but they dodge!",
+          "no_dmg_msg_u": "%1$s hits your %2$s without penetrating your armor.",
+          "no_dmg_msg_npc": "%1$s hits <npcname>'s %2$s without penetrating their armor."
+        },
+        {
+          "type": "monster_attack",
+          "attack_type": "melee",
+          "id": "psi_teleport3_pipe_warped",
+          "cooldown": 1,
+          "move_cost": 80,
+          "accuracy": 5,
+          "range": 3,
+          "//": "Feral melee skill + weapon's to hit, so 3+0=3, +2 for being harder to predict because of space warping",
+          "//2": "all melee damage is decreased by 10% with assumption it is at least `|/` broken",
+          "damage_max_instance": [ { "damage_type": "bash", "amount": 9 } ],
+          "condition": {
+            "and": [
+              { "test_eoc": "is_disarmed" },
+              { "not": { "u_has_flag": "NO_PSIONICS" } },
+              { "u_has_effect": "effect_monster_warped_strikes" },
+              { "math": [ "distance('u', 'npc') > 1" ] }
+            ]
+          },
+          "hit_dmg_u": "The air around %1$s's hands distorts and they hit your %2$s with their weapon!",
+          "hit_dmg_npc": "The air around %1$s's hands distorts and they hit <npcname>'s %2$s with their weapon!",
+          "miss_msg_u": "%1$s tries to hit you as the air around their hands warps, but you dodge!",
+          "miss_msg_npc": "%1$s tries to hit <npcname> as the air around their hands warps, but they dodge!",
+          "no_dmg_msg_u": "The air around %1$s's hands distorts and they hit your %2$s without penetrating your armor.",
+          "no_dmg_msg_npc": "The air around %1$s's hands distorts and they hit <npcname>'s %2$s without penetrating their armor."
+        },
         {
           "id": "psi_teleport2_slow",
           "type": "spell",
@@ -1241,8 +1285,9 @@
           "move_cost": 80,
           "cooldown": { "math": [ "7 + rand(14)" ] },
           "accuracy": 5,
-          "damage_max_instance": [ { "damage_type": "psi_teleporter_teleporting_damage", "amount": 2, "armor_penetration": 10 } ],
+          "damage_max_instance": [ { "damage_type": "bash", "amount": 0 } ],
           "blockable": false,
+          "eoc": [ "EOC_FERAL_TELEPORTER_TELEPORTION_TOUCH" ],
           "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
           "hit_dmg_u": "%1$s touches you and the world shifts around you!",
           "hit_dmg_npc": "%1$s touches <npcname> and the world shifts around them!",
@@ -1263,6 +1308,16 @@
           "monster_message": "The space around %1$s distorts."
         },
         {
+          "id": "psi_porter3_warped_strikes",
+          "type": "spell",
+          "spell_data": { "id": "teleporter_warped_strikes_monster" },
+          "cooldown": 1,
+          "condition": {
+            "and": [ { "not": { "u_has_flag": "NO_PSIONICS" } }, { "not": { "u_has_effect": "effect_monster_warped_strikes" } } ]
+          },
+          "monster_message": "The air around %1$s's hands wavers."
+        },
+        {
           "type": "leap",
           "cooldown": { "math": [ "1 + rand(2)" ] },
           "move_cost": 50,
@@ -1272,7 +1327,7 @@
           "condition": { "not": { "u_has_flag": "NO_PSIONICS" } }
         }
       ],
-      "flags": [ "CLIMBS", "HARDTOSHOOT", "TELEPORT_IMMUNE" ]
+      "flags": [ "CLIMBS", "HARDTOSHOOT", "TELEPORT_IMMUNE", "WIELDED_WEAPON" ]
     }
   },
   {
@@ -1293,9 +1348,33 @@
     },
     "zombify_into": "mon_zombie_survivor",
     "luminance": 25,
+    "//": "No wielded pipe on this one because they're too dimensionally unstable for it.",
     "extend": {
       "special_attacks": [
         [ "PARROT_AT_DANGER", 10 ],
+        {
+          "type": "monster_attack",
+          "attack_type": "melee",
+          "id": "psi_teleport3_warped",
+          "cooldown": 1,
+          "move_cost": 80,
+          "accuracy": 6,
+          "range": 5,
+          "damage_max_instance": [ { "damage_type": "bash", "amount": 9 } ],
+          "condition": {
+            "and": [
+              { "not": { "u_has_flag": "NO_PSIONICS" } },
+              { "u_has_effect": "effect_monster_warped_strikes" },
+              { "math": [ "distance('u', 'npc') > 1" ] }
+            ]
+          },
+          "hit_dmg_u": "The air around %1$s's hands distorts and they hit your %2$s seemingly out of nowhere!",
+          "hit_dmg_npc": "The air around %1$s's hands distorts and they hit <npcname>'s %2$s seemingly out of nowhere!",
+          "miss_msg_u": "%1$s tries to hit you as the air around their hands warps, but you dodge!",
+          "miss_msg_npc": "%1$s tries to hit <npcname> as the air around their hands warps, but they dodge!",
+          "no_dmg_msg_u": "The air around %1$s's hands distorts and they hit your %2$s without penetrating your armor.",
+          "no_dmg_msg_npc": "The air around %1$s's hands distorts and they hit <npcname>'s %2$s without penetrating their armor."
+        },
         {
           "type": "monster_attack",
           "attack_type": "melee",
@@ -1303,8 +1382,9 @@
           "move_cost": 65,
           "cooldown": { "math": [ "5 + rand(10)" ] },
           "accuracy": 6,
-          "damage_max_instance": [ { "damage_type": "psi_teleporter_teleporting_damage", "amount": 2, "armor_penetration": 10 } ],
+          "damage_max_instance": [ { "damage_type": "bash", "amount": 0 } ],
           "blockable": false,
+          "eoc": [ "EOC_FERAL_TELEPORTER_TELEPORTION_TOUCH" ],
           "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
           "hit_dmg_u": "%1$s touches you and the world warps around you!",
           "hit_dmg_npc": "%1$s touches <npcname> and the world warps around them!",
@@ -1339,6 +1419,16 @@
             ]
           },
           "monster_message": "The space around %1$s distorts."
+        },
+        {
+          "id": "psi_porter3_warped_strikes",
+          "type": "spell",
+          "spell_data": { "id": "teleporter_warped_strikes_monster" },
+          "cooldown": 1,
+          "condition": {
+            "and": [ { "not": { "u_has_flag": "NO_PSIONICS" } }, { "not": { "u_has_effect": "effect_monster_warped_strikes" } } ]
+          },
+          "monster_message": "The air around %1$s's hands wavers."
         },
         {
           "type": "leap",

--- a/data/mods/MindOverMatter/monsters/monster_eoc_attacks.json
+++ b/data/mods/MindOverMatter/monsters/monster_eoc_attacks.json
@@ -1,6 +1,12 @@
 [
   {
     "type": "effect_on_condition",
+    "id": "EOC_FERAL_TELEPORTER_TELEPORTION_TOUCH",
+    "condition": { "and": [ { "not": { "u_has_worn_with_flag": "DIMENSIONAL_ANCHOR" } }, { "not": { "u_has_flag": "TELESTOP" } } ] },
+    "effect": [ { "npc_cast_spell": { "id": "teleport_blink_monster", "min_level": 5 } } ]
+  },
+  {
+    "type": "effect_on_condition",
     "id": "EOC_FERAL_VITAKIN1_ENERVATING_TOUCH",
     "condition": "npc_is_character",
     "effect": [

--- a/data/mods/MindOverMatter/monsters/monsters_spells.json
+++ b/data/mods/MindOverMatter/monsters/monsters_spells.json
@@ -1222,6 +1222,34 @@
     "ignored_monster_species": [ "PSI_NULL" ]
   },
   {
+    "type": "SPELL",
+    "id": "teleporter_warped_strikes_monster",
+    "name": { "str": "Warped Strikes Monster enemy check", "//~": "NO_I18N" },
+    "description": { "str": "Preps for using Warped Strikes when a hostile target is detected.", "//~": "NO_I18N" },
+    "flags": [ "SILENT", "NO_HANDS", "NO_LEGS", "MUST_HAVE_CLASS_TO_LEARN" ],
+    "valid_targets": [ "hostile" ],
+    "max_level": 1,
+    "effect": "attack",
+    "extra_effects": [ { "id": "teleporter_warped_strikes_monster_self", "hit_self": true } ],
+    "shape": "blast",
+    "min_range": 60,
+    "max_range": 60
+  },
+  {
+    "type": "SPELL",
+    "id": "teleporter_warped_strikes_monster_self",
+    "name": { "str": "Warped Strikes Monster Effect", "//~": "NO_I18N" },
+    "description": { "str": "Grants the Warped Strikes effect to a monster.", "//~": "NO_I18N" },
+    "flags": [ "NO_HANDS", "NO_LEGS", "MUST_HAVE_CLASS_TO_LEARN", "RANDOM_DURATION" ],
+    "valid_targets": [ "self" ],
+    "max_level": 1,
+    "effect": "attack",
+    "effect_str": "effect_monster_warped_strikes",
+    "shape": "blast",
+    "min_duration": 6000,
+    "max_duration": 24000
+  },
+  {
     "id": "teleporter_breach_monster",
     "type": "SPELL",
     "name": { "str": "[Ψ]Breach Monster", "//~": "NO_I18N" },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[MoM] Give feral teleporters Warped Strikes"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Fair's fair.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Give the feral slider and ephemeral riftwalker Warped Strikes. Also give the feral jumper and feral slider improvised weapons.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Feral slider is now pointless to fight in melee as you'll constantly be teleporting around while they do the same, unless you have teleport immunity, and they can hit you at (short) range. 

Ephemeral Riftwalker is mostly too busy channeling Breach and causing massive problems by spamming Nether creatures everywhere to actually melee you, but that's an unchanged status quo.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
