### PR TITLE
Remove road vehicles from mine field

### DIFF
--- a/src/map_extras.cpp
+++ b/src/map_extras.cpp
@@ -481,7 +481,11 @@ static bool mx_minefield( map &, const tripoint_abs_sm &abs_sub )
 
     tinymap m;
     if( bridge_at_north && road_at_south ) {
-        m.load( abs_omt + point::south, false );
+        // Remove vehicles. They don't make sense here, and may cause collision crashes.
+        m.load( abs_omt + point::south, true );
+        for( wrapped_vehicle &veh : m.get_vehicles() ) {
+            m.cast_to_map()->detach_vehicle( veh.v );
+        }
 
         //Sandbag block at the left edge
         line_furn( &m, furn_f_sandbag_half, point_omt_ms( 3, 4 ), point_omt_ms( 3, 7 ) );
@@ -588,7 +592,12 @@ static bool mx_minefield( map &, const tripoint_abs_sm &abs_sub )
     }
 
     if( bridge_at_south && road_at_north ) {
-        m.load( abs_omt + point::north, false );
+        // Remove vehicles. They don't make sense here, and may cause collision crashes.
+        m.load( abs_omt + point::north, true );
+        for( wrapped_vehicle &veh : m.get_vehicles() ) {
+            m.cast_to_map()->detach_vehicle( veh.v );
+        }
+
         //Two horizontal lines of sandbags
         line_furn( &m, furn_f_sandbag_half, point_omt_ms( 5, 15 ), point_omt_ms( 10, 15 ) );
         line_furn( &m, furn_f_sandbag_half, point_omt_ms( 13, 15 ), point_omt_ms( 18, 15 ) );
@@ -697,7 +706,12 @@ static bool mx_minefield( map &, const tripoint_abs_sm &abs_sub )
     }
 
     if( bridge_at_west && road_at_east ) {
-        m.load( abs_omt + point::east, false );
+        // Remove vehicles. They don't make sense here, and may cause collision crashes.
+        m.load( abs_omt + point::east, true );
+        for( wrapped_vehicle &veh : m.get_vehicles() ) {
+            m.cast_to_map()->detach_vehicle( veh.v );
+        }
+
         //Draw walls of first tent
         square_furn( &m, furn_f_canvas_wall, point_omt_ms( 0, 3 ), point_omt_ms( 4, 13 ) );
 
@@ -851,7 +865,12 @@ static bool mx_minefield( map &, const tripoint_abs_sm &abs_sub )
     }
 
     if( bridge_at_east && road_at_west ) {
-        m.load( abs_omt + point::west, false );
+        // Remove vehicles. They don't make sense here, and may cause collision crashes.
+        m.load( abs_omt + point::west, true );
+        for( wrapped_vehicle &veh : m.get_vehicles() ) {
+            m.cast_to_map()->detach_vehicle( veh.v );
+        }
+
         //Spawn military cargo truck blocking the entry
         m.add_vehicle( vehicle_prototype_military_cargo_truck, tripoint_omt_ms( 15, 11, abs_sub.z() ),
                        270_degrees, 70, 1 );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fix #79889, i.e. minefield placement generating errors due to collision with road generated vehicles.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Remove all vehicles that may have been generated by the road generation before placing the mine field stuff.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Only remove vehicles that overlap with placed vehicles. Decided against it as it doesn't make sense to have both sets of vehicles at the OMT (and it can presumably cause other problems as well).

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Created a new coded map extra placed on roads with a southern road connection (to match the double humvee minefield orientation) and added the JSON for it with a weight of 1000000.
Created a test for this map extra based on the one for the mine field.
Added log output in the map extra code to print what vehicles were present before the code got to work.
Ran the new test and saw similar symptoms as for the failed minefield test.
Changed the code to remove the pre generated vehicles.
Saw there were still weird errors generated.
Changed the map load to load vehicles properly.
Only saw the logs stating vehicles were detected (line before they were removed), but no errors.

Changed the minefield code as per this PR based on the above.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
This problem may occur with other map extras that spawn on top of a base that can spawn vehicles on the base OMT. I have made no attempt to investigate this.

I haven't tracked down why the vehicle placement on top of other vehicles resulted in out of bounds errors. There may still be a bug hiding there. My debug output didn't report any vehicles placements that seemed dangerous as far as I noted.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
