### PR TITLE
Audit of Wood Panel Recipes to use Result Multi instead of Byproduct

### DIFF
--- a/data/json/recipes/other/parts_construction.json
+++ b/data/json/recipes/other/parts_construction.json
@@ -119,7 +119,8 @@
     "skill_used": "fabrication",
     "time": "2 h",
     "autolearn": true,
-    "byproducts": [ [ "splinter", 7 ], [ "wood_panel", 3 ] ],
+    "result_mult": 4,
+    "byproducts": [ [ "splinter", 7 ] ],
     "qualities": [ { "id": "SAW_W", "level": 2 } ],
     "components": [ [ [ "wood_beam", 1 ] ] ],
     "//": "I am assuming here that you actually get more than 4 smaller-than-represented wood panels, but any application that requires panels means you'll be putting these side by side to get the effect of a single panel."

--- a/data/json/recipes/other/parts_construction.json
+++ b/data/json/recipes/other/parts_construction.json
@@ -135,7 +135,7 @@
     "skill_used": "fabrication",
     "time": "10 m",
     "autolearn": true,
-    "byproducts": [ [ "wood_panel", 1 ] ],
+    "result_mult": 2,
     "qualities": [ { "id": "SAW_W", "level": 2 } ],
     "components": [ [ [ "wood_sheet", 1 ] ] ]
   },


### PR DESCRIPTION
…"Byproduct"


#### Summary
Bugfixes "Audit of Wood panel from Beam and Sheet to replace Byproduct with Result Multi"

#### Purpose of change

Bring the Crafting Recipes in-line with other Crafting Recipes.

#### Describe the solution

Simple Json Edit to add "Result Multi" and Remove Wood_panel from the Byproduct list

#### Describe alternatives you've considered

this Appears to be the Simplest Solution

#### Testing

I have Tested the Recipes in Debug Mode on a Default World and the Recipe Worked Perfectly without Error

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
