### PR TITLE
Generic factory: bound_reader

### DIFF
--- a/data/mods/CrazyCataclysm/crazy_comestibles.json
+++ b/data/mods/CrazyCataclysm/crazy_comestibles.json
@@ -5,7 +5,6 @@
     "id": "sporeos",
     "name": { "str_sp": "SpOreos" },
     "color": "dark_gray",
-    "spoils_in": 0,
     "symbol": "%",
     "quench": 25,
     "calories": 217,

--- a/data/mods/TEST_DATA/items.json
+++ b/data/mods/TEST_DATA/items.json
@@ -5032,7 +5032,6 @@
     "name": { "str": "TEST 500kcal" },
     "description": "This one's 500kcal, and some vitamins.",
     "price": "0 cent",
-    "spoils_in": 0,
     "calories": 500,
     "material": [ "stone" ],
     "weight": "100 g",

--- a/data/mods/Xedra_Evolved/items/comestibles/goblin_fruits.json
+++ b/data/mods/Xedra_Evolved/items/comestibles/goblin_fruits.json
@@ -760,8 +760,7 @@
     "comestible_type": "FOOD",
     "color": "yellow_cyan",
     "weight": "222 g",
-    "volume": "202 ml",
-    "spoils_in": 0
+    "volume": "202 ml"
   },
   {
     "type": "COMESTIBLE",

--- a/src/advanced_inv_pane.cpp
+++ b/src/advanced_inv_pane.cpp
@@ -475,7 +475,7 @@ units::mass advanced_inventory_pane::free_weight_capacity() const
     } else if( area == AIM_INVENTORY || area == AIM_WORN ) {
         return get_player_character().free_weight_capacity();
     } else {
-        return units::mass_max;
+        return units::mass::max();
     }
 }
 

--- a/src/assign.cpp
+++ b/src/assign.cpp
@@ -305,8 +305,8 @@ bool assign( const JsonObject &jo, const std::string_view name, units::energy &v
     const auto parse = [&name]( const JsonObject & obj, units::energy & out ) {
         if( obj.has_int( name ) ) {
             const std::int64_t tmp = obj.get_int( name );
-            if( tmp > units::to_kilojoule( units::energy_max ) ) {
-                out = units::energy_max;
+            if( tmp > units::to_kilojoule( units::energy::max() ) ) {
+                out = units::energy::max();
             } else {
                 out = units::from_kilojoule( tmp );
             }
@@ -374,8 +374,8 @@ bool assign( const JsonObject &jo, const std::string_view name, units::power &va
     const auto parse = [&name]( const JsonObject & obj, units::power & out ) {
         if( obj.has_int( name ) ) {
             const std::int64_t tmp = obj.get_int( name );
-            if( tmp > units::to_kilowatt( units::power_max ) ) {
-                out = units::power_max;
+            if( tmp > units::to_kilowatt( units::power::max() ) ) {
+                out = units::power::max();
             } else {
                 out = units::from_kilowatt( tmp );
             }

--- a/src/assign.h
+++ b/src/assign.h
@@ -200,35 +200,36 @@ std::enable_if_t<std::is_constructible_v<T, std::string>, bool>assign(
     return details::assign_set<T, cata::flat_set<T>>( jo, name, val );
 }
 
+//TO-DO: remove specifically-typed bounded assigns
 bool assign( const JsonObject &jo, std::string_view name, units::volume &val,
              bool strict = false,
-             units::volume lo = units::volume_min,
-             units::volume hi = units::volume_max );
+             units::volume lo = units::volume::min(),
+             units::volume hi = units::volume::max() );
 
 bool assign( const JsonObject &jo, std::string_view name, units::mass &val,
              bool strict = false,
-             units::mass lo = units::mass_min,
-             units::mass hi = units::mass_max );
+             units::mass lo = units::mass::min(),
+             units::mass hi = units::mass::max() );
 
 bool assign( const JsonObject &jo, std::string_view name, units::length &val,
              bool strict = false,
-             units::length lo = units::length_min,
-             units::length hi = units::length_max );
+             units::length lo = units::length::min(),
+             units::length hi = units::length::max() );
 
 bool assign( const JsonObject &jo, std::string_view name, units::money &val,
              bool strict = false,
-             units::money lo = units::money_min,
-             units::money hi = units::money_max );
+             units::money lo = units::money::min(),
+             units::money hi = units::money::max() );
 
 bool assign( const JsonObject &jo, std::string_view name, units::energy &val,
              bool strict = false,
-             units::energy lo = units::energy_min,
-             units::energy hi = units::energy_max );
+             units::energy lo = units::energy::min(),
+             units::energy hi = units::energy::max() );
 
 bool assign( const JsonObject &jo, std::string_view name, units::power &val,
              bool strict = false,
-             units::power lo = units::power_min,
-             units::power hi = units::power_max );
+             units::power lo = units::power::min(),
+             units::power hi = units::power::max() );
 
 bool assign( const JsonObject &jo, const std::string &name, nc_color &val,
              bool strict = false );

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -3467,7 +3467,7 @@ void Character::update_bionic_power_capacity()
     for( const bionic_id &bid : get_bionics() ) {
         max_power_level_cached += bid->capacity;
     }
-    max_power_level_cached = clamp( max_power_level_cached, 0_kJ, units::energy_max );
+    max_power_level_cached = clamp( max_power_level_cached, 0_kJ, units::energy::max() );
 
     set_power_level( get_power_level() );
 }

--- a/src/calendar.cpp
+++ b/src/calendar.cpp
@@ -24,8 +24,6 @@ static constexpr float moonlight_per_quarter = 1.5f;
 
 // Divided by 100 to prevent overflowing when converted to moves
 const int calendar::INDEFINITELY_LONG( std::numeric_limits<int>::max() / 100 );
-const time_duration calendar::INDEFINITELY_LONG_DURATION(
-    time_duration::from_turns( std::numeric_limits<int>::max() ) );
 static bool is_eternal_season = false;
 static bool is_eternal_night = false;
 static bool is_eternal_day = false;

--- a/src/calendar.h
+++ b/src/calendar.h
@@ -2,6 +2,7 @@
 #ifndef CATA_SRC_CALENDAR_H
 #define CATA_SRC_CALENDAR_H
 
+#include <limits>
 #include <optional>
 #include <string>
 #include <utility>
@@ -90,16 +91,6 @@ bool once_every( const time_duration &event_frequency );
  * represent a larger unit (hours/days/years), then this will result in integer overflow.
  */
 extern const int INDEFINITELY_LONG;
-
-/**
- * The expected duration of the cataclysm
- *
- * Large duration that can be used to approximate infinite amounts of time.
- *
- * This number can't be safely converted to a number of moves without causing
- * an integer overflow.
- */
-extern const time_duration INDEFINITELY_LONG_DURATION;
 
 /// @returns Whether the eternal season is enabled.
 bool eternal_season();
@@ -525,6 +516,17 @@ class time_point
 
 namespace calendar
 {
+
+/**
+ * The expected duration of the cataclysm
+ *
+ * Large duration that can be used to approximate infinite amounts of time.
+ *
+ * This number can't be safely converted to a number of moves without causing
+ * an integer overflow.
+ */
+inline constexpr time_duration INDEFINITELY_LONG_DURATION(
+    time_duration::from_turns( std::numeric_limits<int>::max() ) );
 
 /**
  * A time point that is always before the current turn, even when the game has

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -2916,7 +2916,7 @@ units::energy Character::get_max_power_level() const
 {
     units::energy val = enchantment_cache->modify_value( enchant_vals::mod::BIONIC_POWER,
                         max_power_level_cached + max_power_level_modifier );
-    return clamp( val, 0_kJ, units::energy_max );
+    return clamp( val, 0_kJ, units::energy::max() );
 }
 
 void Character::set_power_level( const units::energy &npower )
@@ -2926,13 +2926,13 @@ void Character::set_power_level( const units::energy &npower )
 
 void Character::set_max_power_level_modifier( const units::energy &capacity )
 {
-    max_power_level_modifier = clamp( capacity, units::energy_min, units::energy_max );
+    max_power_level_modifier = clamp( capacity, units::energy::min(), units::energy::max() );
 }
 
 void Character::set_max_power_level( const units::energy &capacity )
 {
-    max_power_level_modifier = clamp( capacity - max_power_level_cached, units::energy_min,
-                                      units::energy_max );
+    max_power_level_modifier = clamp( capacity - max_power_level_cached, units::energy::min(),
+                                      units::energy::max() );
 }
 
 void Character::mod_power_level( const units::energy &npower )
@@ -2949,8 +2949,8 @@ void Character::mod_power_level( const units::energy &npower )
 
 void Character::mod_max_power_level_modifier( const units::energy &npower )
 {
-    max_power_level_modifier = clamp( max_power_level_modifier + npower, units::energy_min,
-                                      units::energy_max );
+    max_power_level_modifier = clamp( max_power_level_modifier + npower, units::energy::min(),
+                                      units::energy::max() );
 }
 
 bool Character::is_max_power() const

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -7310,7 +7310,7 @@ units::mass item::weight( bool include_contents, bool integral ) const
 
     }
 
-    // prevent units::mass_max * 1.0, which results in -units::mass_max
+    // prevent units::mass::max() * 1.0, which results in -units::mass::max()
     if( ret_mul != 1 ) {
         ret *= ret_mul;
     }

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -2888,6 +2888,9 @@ class gun_modes_reader : public generic_typed_reader<gun_modes_reader>
 
 void islot_gun::load( const JsonObject &jo )
 {
+    numeric_bound_reader<int> not_negative = numeric_bound_reader<int> { 0 };
+    numeric_bound_reader<double> not_negative_float = numeric_bound_reader<double> { 0 };
+
     optional( jo, was_loaded, "skill", skill_used, skill_id::NULL_ID() );
     optional( jo, was_loaded, "ammo", ammo, auto_flags_reader<ammotype> {} );
     optional( jo, was_loaded, "range", range );
@@ -2895,27 +2898,29 @@ void islot_gun::load( const JsonObject &jo )
     optional( jo, was_loaded, "ranged_damage", damage );
     optional( jo, was_loaded, "dispersion", dispersion );
     optional( jo, was_loaded, "sight_dispersion", sight_dispersion, 30 );
-    optional( jo, was_loaded, "recoil", recoil );
+    optional( jo, was_loaded, "recoil", recoil, not_negative );
     optional( jo, was_loaded, "handling", handling, -1 );
-    optional( jo, was_loaded, "durability", durability );
+    optional( jo, was_loaded, "durability", durability, numeric_bound_reader<int> {0, 10} );
     optional( jo, was_loaded, "loudness", loudness );
-    optional( jo, was_loaded, "clip_size", clip );
-    optional( jo, was_loaded, "reload", reload_time, 100 );
+    optional( jo, was_loaded, "clip_size", clip, not_negative );
+    optional( jo, was_loaded, "reload", reload_time, not_negative, 100 );
     optional( jo, was_loaded, "reload_noise", reload_noise, to_translation( "click." ) );
-    optional( jo, was_loaded, "reload_noise_volume", reload_noise_volume );
-    optional( jo, was_loaded, "barrel_volume", barrel_volume );
-    optional( jo, was_loaded, "barrel_length", barrel_length );
+    optional( jo, was_loaded, "reload_noise_volume", reload_noise_volume, not_negative );
+    optional( jo, was_loaded, "barrel_volume", barrel_volume, units_bound_reader<units::volume> {0_ml} );
+    optional( jo, was_loaded, "barrel_length", barrel_length, units_bound_reader<units::length> {0_mm} );
     optional( jo, was_loaded, "built_in_mods", built_in_mods, auto_flags_reader<itype_id> {} );
     optional( jo, was_loaded, "default_mods", default_mods, auto_flags_reader<itype_id> {} );
-    optional( jo, was_loaded, "energy_drain", energy_drain );
-    optional( jo, was_loaded, "blackpowder_tolerance", blackpowder_tolerance, 8 );
-    optional( jo, was_loaded, "min_cycle_recoil", min_cycle_recoil );
+    optional( jo, was_loaded, "energy_drain", energy_drain, units_bound_reader<units::energy> {0_kJ} );
+    optional( jo, was_loaded, "blackpowder_tolerance", blackpowder_tolerance, not_negative, 8 );
+    optional( jo, was_loaded, "min_cycle_recoil", min_cycle_recoil, not_negative );
     optional( jo, was_loaded, "ammo_effects", ammo_effects, auto_flags_reader<ammo_effect_str_id> {} );
-    optional( jo, was_loaded, "ammo_to_fire", ammo_to_fire, 1 );
-    optional( jo, was_loaded, "heat_per_shot", heat_per_shot );
-    optional( jo, was_loaded, "cooling_value", cooling_value, 100.0 );
-    optional( jo, was_loaded, "overheat_threshold", overheat_threshold, -1.0 );
-    optional( jo, was_loaded, "gun_jam_mult", gun_jam_mult, 1 );
+    optional( jo, was_loaded, "ammo_to_fire", ammo_to_fire, not_negative, 1 );
+    optional( jo, was_loaded, "heat_per_shot", heat_per_shot, not_negative_float );
+    optional( jo, was_loaded, "cooling_value", cooling_value, not_negative_float,
+              100.0 );
+    optional( jo, was_loaded, "overheat_threshold", overheat_threshold, numeric_bound_reader<double> {-1.0},
+              -1.0 );
+    optional( jo, was_loaded, "gun_jam_mult", gun_jam_mult, not_negative_float, 1.0 );
     optional( jo, was_loaded, "valid_mod_locations", valid_mod_locations,
               weighted_string_id_reader<gunmod_location, int> {0} );
     optional( jo, was_loaded, "modes", modes, gun_modes_reader {} );
@@ -3420,16 +3425,16 @@ void islot_comestible::load( const JsonObject &jo )
 
     mandatory( jo, was_loaded, "comestible_type", comesttype );
     optional( jo, was_loaded, "tool", tool, itype_id::NULL_ID() );
-    optional( jo, was_loaded, "charges", def_charges, 0 );
+    optional( jo, was_loaded, "charges", def_charges, numeric_bound_reader<int> {1}, 0 );
     optional( jo, was_loaded, "stack_size", stack_size );
     optional( jo, was_loaded, "quench", quench );
     optional( jo, was_loaded, "fun", fun );
     optional( jo, was_loaded, "stim", stim );
     optional( jo, was_loaded, "sleepiness_mod", sleepiness_mod );
     optional( jo, was_loaded, "healthy", healthy );
-    optional( jo, was_loaded, "parasites", parasites );
+    optional( jo, was_loaded, "parasites", parasites, numeric_bound_reader<int> {0} );
     optional( jo, was_loaded, "freezing_point", freeze_point );
-    optional( jo, was_loaded, "spoils_in", spoils );
+    optional( jo, was_loaded, "spoils_in", spoils, time_bound_reader{1_hours} );
     optional( jo, was_loaded, "cooks_like", cooks_like );
     optional( jo, was_loaded, "smoking_result", smoking_result );
     optional( jo, was_loaded, "petfood", petfood );

--- a/src/item_location.cpp
+++ b/src/item_location.cpp
@@ -305,7 +305,7 @@ class item_location::impl::item_on_map : public item_location::impl
         }
 
         units::mass weight_capacity() const override {
-            return units::mass_max;
+            return units::mass::max();
         }
 
         bool check_parent_capacity_recursive() const override {
@@ -468,11 +468,11 @@ class item_location::impl::item_on_person : public item_location::impl
         }
 
         units::volume volume_capacity() const override {
-            return units::volume_max;
+            return units::volume::max();
         }
 
         units::mass weight_capacity() const override {
-            return units::mass_max;
+            return units::mass::max();
         }
 
         bool check_parent_capacity_recursive() const override {
@@ -595,7 +595,7 @@ class item_location::impl::item_on_vehicle : public item_location::impl
         }
 
         units::mass weight_capacity() const override {
-            return units::mass_max;
+            return units::mass::max();
         }
 
         bool check_parent_capacity_recursive() const override {

--- a/src/item_search.cpp
+++ b/src/item_search.cpp
@@ -133,7 +133,7 @@ std::function<bool( const item & )> basic_item_filter( std::string filter )
         // by can contain length
         case 'L': {
             return can_contain_filter<units::length>( "Failed to convert '%s' to length.\nValid examples:\n122 cm\n1101mm\n2   meter",
-            filter, units::length_max, units::length_units, []( itype * typ, units::length len ) {
+            filter, units::length::max(), units::length_units, []( itype * typ, units::length len ) {
                 typ->longest_side = len;
                 item itm( typ );
                 itm.set_flag( flag_HARD );
@@ -143,7 +143,7 @@ std::function<bool( const item & )> basic_item_filter( std::string filter )
         // by can contain volume
         case 'V': {
             return can_contain_filter<units::volume>( "Failed to convert '%s' to volume.\nValid examples:\n750 ml\n4L",
-            filter, units::volume_max, units::volume_units, []( itype * typ, units::volume vol ) {
+            filter, units::volume::max(), units::volume_units, []( itype * typ, units::volume vol ) {
                 typ->volume = vol;
                 return item( typ );
             } );
@@ -151,7 +151,7 @@ std::function<bool( const item & )> basic_item_filter( std::string filter )
         // by can contain mass
         case 'M': {
             return can_contain_filter<units::mass>( "Failed to convert '%s' to mass.\nValid examples:\n12 mg\n400g\n25  kg",
-            filter, units::mass_max, units::mass_units, []( itype * typ, units::mass mas ) {
+            filter, units::mass::max(), units::mass_units, []( itype * typ, units::mass mas ) {
                 typ->weight = mas;
                 return item( typ );
             } );

--- a/src/itype.h
+++ b/src/itype.h
@@ -847,7 +847,7 @@ struct islot_gun : common_ranged_data {
     /**
     *  Multiplier of the chance for the gun to jam.
     */
-    double gun_jam_mult = 1;
+    double gun_jam_mult = 1.0;
 
     std::map<ammotype, std::set<itype_id>> cached_ammos;
 

--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -464,8 +464,8 @@ bool map_shoot_info::load( const JsonObject &jsobj, const std::string_view membe
     return true;
 }
 
-furn_workbench_info::furn_workbench_info() : multiplier( 1.0f ), allowed_mass( units::mass_max ),
-    allowed_volume( units::volume_max ) {}
+furn_workbench_info::furn_workbench_info() : multiplier( 1.0f ), allowed_mass( units::mass::max() ),
+    allowed_volume( units::volume::max() ) {}
 
 bool furn_workbench_info::load( const JsonObject &jsobj, const std::string_view member )
 {

--- a/src/recipe_dictionary.cpp
+++ b/src/recipe_dictionary.cpp
@@ -374,7 +374,7 @@ std::vector<const recipe *> recipe_subset::search(
         case search_type::length: {
             units::length len = can_contain_filter(
                                     "Failed to convert '%s' to length.\nValid examples:\n122 cm\n1101mm\n2   meter",
-                                    txt, units::length_max, units::length_units );
+                                    txt, units::length::max(), units::length_units );
 
             filtered_fake_itype.longest_side = len;
             filtered_fake_item = item( &filtered_fake_itype );
@@ -385,7 +385,7 @@ std::vector<const recipe *> recipe_subset::search(
         case search_type::volume: {
             units::volume vol = can_contain_filter(
                                     "Failed to convert '%s' to volume.\nValid examples:\n750 ml\n4L",
-                                    txt, units::volume_max, units::volume_units );
+                                    txt, units::volume::max(), units::volume_units );
 
             filtered_fake_itype.volume = vol;
             filtered_fake_item = item( &filtered_fake_itype );
@@ -394,7 +394,7 @@ std::vector<const recipe *> recipe_subset::search(
         case search_type::mass: {
             units::mass mas = can_contain_filter(
                                   "Failed to convert '%s' to mass.\nValid examples:\n12 mg\n400g\n25  kg",
-                                  txt, units::mass_max, units::mass_units );
+                                  txt, units::mass::max(), units::mass_units );
 
             filtered_fake_itype.weight = mas;
             filtered_fake_item = item( &filtered_fake_itype );

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -1076,7 +1076,7 @@ void Character::load( const JsonObject &data )
     calc_encumbrance();
 
     assign( data, "power_level", power_level, false, 0_kJ );
-    assign( data, "max_power_level_modifier", max_power_level_modifier, false, units::energy_min );
+    assign( data, "max_power_level_modifier", max_power_level_modifier, false, units::energy::min() );
 
     // Bionic power should not be negative!
     if( power_level < 0_mJ ) {

--- a/src/units.h
+++ b/src/units.h
@@ -55,6 +55,15 @@ class quantity
             value_( other.value() ) {
         }
 
+        //returns the smallest possible value for this unit
+        static constexpr this_type min() {
+            return this_type( std::numeric_limits<value_type>::min(), unit_type{} );
+        }
+        //returns the largest possible value for this unit
+        static constexpr this_type max() {
+            return this_type( std::numeric_limits<value_type>::max(), unit_type{} );
+        }
+
         /**
          * Access the raw dimensionless value. Use it in a properly named wrapper function only.
          */
@@ -294,12 +303,6 @@ operator%=( quantity<lvt, ut> &lhs, const quantity<rvt, ut> &rhs )
 }
 /**@}*/
 
-const volume volume_min = units::volume( std::numeric_limits<units::volume::value_type>::min(),
-                          units::volume::unit_type{} );
-
-const volume volume_max = units::volume( std::numeric_limits<units::volume::value_type>::max(),
-                          units::volume::unit_type{} );
-
 template<typename value_type>
 inline constexpr quantity<value_type, volume_in_milliliter_tag> from_milliliter(
     const value_type v )
@@ -323,12 +326,6 @@ inline constexpr double to_liter( const volume &v )
 {
     return v.value() / 1000.0;
 }
-
-const mass mass_min = units::mass( std::numeric_limits<units::mass::value_type>::min(),
-                                   units::mass::unit_type{} );
-
-const mass mass_max = units::mass( std::numeric_limits<units::mass::value_type>::max(),
-                                   units::mass::unit_type{} );
 
 template<typename value_type>
 inline constexpr quantity<value_type, mass_in_milligram_tag> from_milligram(
@@ -368,13 +365,6 @@ inline constexpr double to_kilogram( const mass &v )
     return v.value() / 1000000.0;
 }
 
-// Specific energy
-const specific_energy specific_energy_min = units::specific_energy(
-            std::numeric_limits<units::specific_energy::value_type>::min(), units::specific_energy::unit_type{} );
-
-const specific_energy specific_energy_max = units::specific_energy(
-            std::numeric_limits<units::specific_energy::value_type>::max(), units::specific_energy::unit_type{} );
-
 template<typename value_type>
 inline constexpr quantity<value_type, specific_energy_in_joule_per_gram_tag>
 from_joule_per_gram( const value_type v )
@@ -389,13 +379,6 @@ inline constexpr value_type to_joule_per_gram( const
 {
     return v.value();
 }
-
-// Temperature
-// Absolute zero - possibly should just be INT_MIN
-const temperature temperature_min = units::temperature( 0, units::temperature::unit_type{} );
-
-const temperature temperature_max = units::temperature(
-                                        std::numeric_limits<units::temperature::value_type>::max(), units::temperature::unit_type{} );
 
 template<typename value_type>
 inline constexpr quantity<units::temperature::value_type, temperature_in_kelvin_tag> from_kelvin(
@@ -454,15 +437,6 @@ inline constexpr int to_legacy_bodypart_temp( const
     const auto c = units::to_celsius( v );
     return static_cast<int>( ( c - 37.0 ) * 500.0 + 5000.0 );
 }
-
-// Temperature delta
-// Absolute zero - possibly should just be INT_MIN
-const temperature_delta temperature_delta_min = units::temperature_delta( 0,
-        units::temperature_delta::unit_type{} );
-
-const temperature_delta temperature_delta_max = units::temperature_delta(
-            std::numeric_limits<units::temperature_delta::value_type>::max(),
-            units::temperature_delta::unit_type{} );
 
 template<typename value_type>
 inline constexpr quantity<units::temperature_delta::value_type, temperature_delta_in_kelvin_tag>
@@ -524,13 +498,6 @@ inline constexpr int to_legacy_bodypart_temp_delta( const
 }
 
 // Energy
-
-const energy energy_min = units::energy( std::numeric_limits<units::energy::value_type>::min(),
-                          units::energy::unit_type{} );
-
-const energy energy_max = units::energy( std::numeric_limits<units::energy::value_type>::max(),
-                          units::energy::unit_type{} );
-
 template<typename value_type>
 inline constexpr quantity<value_type, energy_in_millijoule_tag> from_millijoule(
     const value_type v )
@@ -578,13 +545,6 @@ inline constexpr value_type to_kilojoule( const quantity<value_type, energy_in_m
 }
 
 // Power (watts)
-
-const power power_min = units::power( std::numeric_limits<units::power::value_type>::min(),
-                                      units::power::unit_type{} );
-
-const power power_max = units::power( std::numeric_limits<units::power::value_type>::max(),
-                                      units::power::unit_type{} );
-
 template<typename value_type>
 inline constexpr quantity<value_type, power_in_milliwatt_tag> from_milliwatt(
     const value_type v )
@@ -632,13 +592,6 @@ inline constexpr value_type to_kilowatt( const quantity<value_type, power_in_mil
 }
 
 // Money(cents)
-
-const money money_min = units::money( std::numeric_limits<units::money::value_type>::min(),
-                                      units::money::unit_type{} );
-
-const money money_max = units::money( std::numeric_limits<units::money::value_type>::max(),
-                                      units::money::unit_type{} );
-
 template<typename value_type>
 inline constexpr quantity<value_type, money_in_cent_tag> from_cent(
     const value_type v )
@@ -675,12 +628,6 @@ inline constexpr value_type to_kusd( const quantity<value_type, money_in_cent_ta
 {
     return to_usd( v ) / 1000.0;
 }
-
-const length length_min = units::length( std::numeric_limits<units::length::value_type>::min(),
-                          units::length::unit_type{} );
-
-const length length_max = units::length( std::numeric_limits<units::length::value_type>::max(),
-                          units::length::unit_type{} );
 
 template<typename value_type>
 inline constexpr quantity<value_type, length_in_millimeter_tag> from_millimeter(

--- a/tests/iuse_actor_test.cpp
+++ b/tests/iuse_actor_test.cpp
@@ -176,14 +176,14 @@ static void cut_up_yields( const itype_id &target )
     const std::map<material_id, int> &target_materials = cut_up_target.made_of();
     const float mat_total = cut_up_target.type->mat_portion_total == 0 ? 1 :
                             cut_up_target.type->mat_portion_total;
-    units::mass smallest_yield_mass = units::mass_max;
+    units::mass smallest_yield_mass = units::mass::max();
     for( const auto &mater : target_materials ) {
         if( const std::optional<itype_id> item_id = mater.first->salvaged_into() ) {
             units::mass portioned_weight = item_id->obj().weight * ( mater.second / mat_total );
             smallest_yield_mass = std::min( smallest_yield_mass, portioned_weight );
         }
     }
-    REQUIRE( smallest_yield_mass != units::mass_max );
+    REQUIRE( smallest_yield_mass != units::mass::max() );
 
     units::mass cut_up_target_mass = cut_up_target.weight();
     item &spawned_item = here.add_item_or_charges( guy.pos_bub(), cut_up_target );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Infrastructure "generic factory bound_reader"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

`generic_factory`'s reading functions don't handle providing bounds for JSON fields like some overloads of `assign()` do.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

`bound_reader` takes a low and (optionally) a high bound as parameters. If the read value is outside those bounds, the JsonValue throws an error and the value is set to the closest bound. `bound_reader` is extended to primitive numbers, time_duration, and the units:: namespace.

Implemented where bounds were removed for the changes in #79830 and #79590

Also deduplicates `units::X_min/max` code and makes `calendar::INDEFINITELY_LONG_DURATION` an inline header-only constant because it functionally was anyways.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

1. Implementing the bounds into optional/mandatory directly. This would be a template nightmare, and I think it's very easy to confuse a single low bound with a single default value, especially while assign and optional/mandatory currently coexist in the same load function.
2. Just bounding every necessary field in its respective `finalize()`, which is difficult to locate in any given case.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Tested bounds for all three `bound_reader` classes.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

islot_ammo next, probably

It is an existing bug that you can provide a number to a JSON field larger than its type supports (e.g. `int`) and it'll wrap because it's getting cast, and this happens before `bound_reader` gets to it. It's an issue with our basic JSON functions.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
