### PR TITLE
Remove "slowdown fungal growth" from being a default mod

### DIFF
--- a/data/mods/default.json
+++ b/data/mods/default.json
@@ -4,6 +4,6 @@
     "id": "dev:default",
     "name": "default",
     "description": "contains all the mods recommended by the developers",
-    "dependencies": [ "dda", "no_npc_food", "personal_portal_storms", "no_fungal_growth", "No_Rail_Stations" ]
+    "dependencies": [ "dda", "no_npc_food", "personal_portal_storms", "No_Rail_Stations" ]
   }
 ]


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Oops - this is still around.

#### Describe the solution
Get rid of it.

#### Describe alternatives you've considered
Maybe the mod list should have already checked for this?

#### Testing


#### Additional context
Fun fact: Obsolete mods in the world's settings menu are colored *grey*, despite it not normally being possible to add an obsolete mod to the mod list.
