### PR TITLE
Modded palette extending

### DIFF
--- a/doc/JSON/JSON_Mapping_Guides/Guide_for_intermediate_mapgen.md
+++ b/doc/JSON/JSON_Mapping_Guides/Guide_for_intermediate_mapgen.md
@@ -116,7 +116,7 @@ Note the ID is now `nested_mapgen_id` and the object uses a new entry `mapgensiz
 
 * `flags`:  More information about mapgen flags can be found in [doc/JSON/MAPGEN.md](https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/JSON/MAPGEN.md#clearing-flags-for-layered-mapgens)
 
-* `terrain` & `furniture`:   Without `fill_ter`, you need to define every floor terrain under furniture.  If you don't it will fall back to the main mapgen's `fill_ter`.  In the above example, there's a green carpet in 1/2 the map and the rest picks up the floor of the mapgen (indoor concrete).  If you need to overwrite existing furniture in the main mapgen you can use a combination of `t_null` and `f_null` to override preexisting mapgen.
+* `terrain` & `furniture`: If you don't want to overwrite existing terrain and furniture from the main mapgen you can use a combination of `t_null` and `f_null`. ` ` is `t_null` and `f_null` by default. For example in the above example, there's a green carpet in 1/2 the map and the rest picks up the floor of the mapgen (indoor concrete). `f_clear` can also be used to remove existing furniture without replacing it.
 
 _Tips:_
 If you're doing interior spaces, pay attention to door placement and access pathways.

--- a/doc/JSON/MAPGEN.md
+++ b/doc/JSON/MAPGEN.md
@@ -1473,6 +1473,8 @@ two or more palettes would have many of the same symbols with the same meanings
 that common part can be pulled out into a new palette which each of them
 includes, so that the definitions need not be repeated.
 
+To extend a vanilla palette in a mod you can add `"extending": true` in a
+palette of the same name, the default behaviour is to override.
 
 ## Palette ids as mapgen values
 

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -4444,6 +4444,7 @@ mapgen_palette mapgen_palette::load_internal( const JsonObject &jo, std::string_
 {
     mapgen_palette new_pal;
     bool extending = src != "DDA" && jo.has_bool( "extending" ) && jo.get_bool( "extending" );
+    require_id |= extending;
     mapgen_palette::placing_map &format_placings = new_pal.format_placings;
     auto &keys_with_terrain = new_pal.keys_with_terrain;
     if( require_id ) {
@@ -4456,7 +4457,7 @@ mapgen_palette mapgen_palette::load_internal( const JsonObject &jo, std::string_
 
     if( jo.has_array( "palettes" ) ) {
         jo.read( "palettes", new_pal.palettes_used );
-        if( allow_recur || extending ) {
+        if( allow_recur ) {
             // allow_recur means that it's safe to assume all the palettes have
             // been defined and we can inline now.  Otherwise we just leave the
             // list in our palettes_used array and it will be consumed
@@ -4467,6 +4468,11 @@ mapgen_palette mapgen_palette::load_internal( const JsonObject &jo, std::string_
             }
             new_pal.palettes_used.clear();
         }
+    }
+
+    if( extending ) {
+        add_palette_context add_context{ context, &new_pal.parameters };
+        new_pal.add( new_pal.id, add_context );
     }
 
     // mandatory: every character in rows must have matching entry, unless fill_ter is set

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -4439,21 +4439,24 @@ void mapgen_palette::add( const mapgen_palette &rh, const add_palette_context &c
     parameters.check_and_merge( rh.parameters, actual_context );
 }
 
-mapgen_palette mapgen_palette::load_internal( const JsonObject &jo, const std::string_view,
+mapgen_palette mapgen_palette::load_internal( const JsonObject &jo, std::string_view src,
         const std::string &context, bool require_id, bool allow_recur )
 {
     mapgen_palette new_pal;
+    bool extending = src != "DDA" && jo.has_bool( "extending" ) && jo.get_bool( "extending" );
     mapgen_palette::placing_map &format_placings = new_pal.format_placings;
     auto &keys_with_terrain = new_pal.keys_with_terrain;
     if( require_id ) {
         new_pal.id = palette_id( jo.get_string( "id" ) );
+        const auto iter = palettes.find( new_pal.id );
+        extending &= iter != palettes.end();
     }
 
     jo.read( "parameters", new_pal.parameters.map );
 
     if( jo.has_array( "palettes" ) ) {
         jo.read( "palettes", new_pal.palettes_used );
-        if( allow_recur ) {
+        if( allow_recur || extending ) {
             // allow_recur means that it's safe to assume all the palettes have
             // been defined and we can inline now.  Otherwise we just leave the
             // list in our palettes_used array and it will be consumed
@@ -4504,7 +4507,6 @@ mapgen_palette mapgen_palette::load_internal( const JsonObject &jo, const std::s
     new_pal.load_place_mapings<jmapgen_zone>( jo, "zones", format_placings, c );
     new_pal.load_place_mapings<jmapgen_ter_furn_transform>( jo, "ter_furn_transforms",
             format_placings, c );
-    new_pal.load_place_mapings<jmapgen_faction>( jo, "faction_owner_character", format_placings, c );
 
     for( mapgen_palette::placing_map::value_type &p : format_placings ) {
         p.second.erase(


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Closes #73299
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
If you want to extend a palette in a mod you can now add a `"extending": true` field to a same id version of the palette in your mod. This isn't needed for vanilla copy-fromesque behaviour as you can just do `"palettes": [ "palette_to_include" ]`.
Adds documentation for this and f_clear bc I randomly noticed that wasn't documented
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Making this the default behaviour and having an `"override"` bool instead but that would require adding the feild to existing modded same id palettes which seems silly.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Checked with this extended fabric store palette in No Hope, replacing the vanilla palette's terrains while keeping the rest
```
[
  {
    "type": "palette",
    "id": "fabric_store_pallete",
    "extending": true,
    "terrain": { ";": "t_water_sh", "i": "t_water_sh", "0": "t_water_sh", "z": "t_water_sh", "p": "t_water_sh" }
  }
]
```
![image](https://github.com/user-attachments/assets/63f8ae4e-e9db-4a46-9fd9-786bb521af66)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
