### PR TITLE
Debug option to view used palette symbols

### DIFF
--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -210,6 +210,7 @@ std::string enum_to_string<debug_menu::debug_menu_index>( debug_menu::debug_menu
         case debug_menu::debug_menu_index::SPAWN_CLAIRVOYANCE: return "SPAWN_CLAIRVOYANCE";
         case debug_menu::debug_menu_index::SPAWN_HORDE: return "SPAWN_HORDE";
         case debug_menu::debug_menu_index::MAP_EDITOR: return "MAP_EDITOR";
+        case debug_menu::debug_menu_index::PALETTE_VIEWER: return "PALETTE_VIEWER";
         case debug_menu::debug_menu_index::CHANGE_WEATHER: return "CHANGE_WEATHER";
         case debug_menu::debug_menu_index::WIND_DIRECTION: return "WIND_DIRECTION";
         case debug_menu::debug_menu_index::WIND_SPEED: return "WIND_SPEED";
@@ -985,6 +986,7 @@ static int map_uilist()
         { uilist_entry( debug_menu_index::KILL_AREA, true, 'a', _( "Kill in Area" ) ) },
         { uilist_entry( debug_menu_index::KILL_NPCS, true, 'k', _( "Kill NPCs" ) ) },
         { uilist_entry( debug_menu_index::MAP_EDITOR, true, 'M', _( "Map editor" ) ) },
+        { uilist_entry( debug_menu_index::PALETTE_VIEWER, true, 'P', _( "Palette viewer" ) ) },
         { uilist_entry( debug_menu_index::CHANGE_WEATHER, true, 'w', _( "Change weather" ) ) },
         { uilist_entry( debug_menu_index::WIND_DIRECTION, true, 'd', _( "Change wind direction" ) ) },
         { uilist_entry( debug_menu_index::WIND_SPEED, true, 's', _( "Change wind speed" ) ) },
@@ -4060,6 +4062,10 @@ void debug()
 
         case debug_menu_index::MAP_EDITOR:
             g->look_debug();
+            break;
+
+        case debug_menu_index::PALETTE_VIEWER:
+            debug_palettes::debug_view_all_palettes();
             break;
 
         case debug_menu_index::CHANGE_WEATHER:

--- a/src/debug_menu.h
+++ b/src/debug_menu.h
@@ -46,6 +46,7 @@ enum class debug_menu_index : int {
     SPAWN_CLAIRVOYANCE,
     SPAWN_HORDE,
     MAP_EDITOR,
+    PALETTE_VIEWER,
     CHANGE_WEATHER,
     WIND_DIRECTION,
     WIND_SPEED,

--- a/src/mapgen.h
+++ b/src/mapgen.h
@@ -321,6 +321,12 @@ struct mapgen_constraint {
     T value;
 };
 
+namespace debug_palettes
+{
+
+void debug_view_all_palettes();
+} // namespace debug_palettes
+
 class mapgen_palette
 {
     public:


### PR DESCRIPTION
#### Summary
Interface "Debug option to view used palette symbols"

#### Purpose of change
It's very difficult to tell what symbols are used in a palette, especially when palettes can inherit other palettes.

#### Describe the solution
Make a tool for it. Debug menu > Palette viewer > select the palette you want. Because this is uilist, it supports string searching.

The symbols are sorted into alphabetical order to make it easier to glance through them.

#### Describe alternatives you've considered
An out of game tool?

#### Testing
![image](https://github.com/user-attachments/assets/f0f19c70-b31b-4707-9000-3306b52908ba)


#### Additional context
This does not tell you **what the symbol actually places**. I can't find how we currently do that. This is not my area of experience.

CC @Milopetilo 