### PR TITLE
Speed up big zone construction of `Turn forest floor into dirt` by 166% (from 96 sec to 36 sec)

### DIFF
--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -848,7 +848,7 @@ bool already_done( construction const &build, tripoint_bub_ms const &loc )
 
 static activity_reason_info find_base_construction(
     Character &you,
-    const inventory &inv,
+    const tripoint_bub_ms &inv_from_loc,
     const tripoint_bub_ms &loc,
     const std::optional<construction_id> &part_con_idx,
     const construction_id &idx )
@@ -895,6 +895,7 @@ static activity_reason_info find_base_construction(
     if( !cc ) {
         return activity_reason_info::build( do_activity_reason::BLOCKING_TILE, false, idx );
     }
+    const inventory &inv = you.crafting_inventory( inv_from_loc, PICKUP_RANGE );
     if( !player_can_build( you, inv, build, true ) ) {
         //can't build with current inventory, do not look for pre-req
         return activity_reason_info::build( do_activity_reason::NO_COMPONENTS, false, build.id );
@@ -1289,12 +1290,11 @@ static activity_reason_info can_do_activity_there( const activity_id &act, Chara
             }
             nearest_src_loc = route.back();
         }
-        const inventory pre_inv = you.crafting_inventory( nearest_src_loc, PICKUP_RANGE );
         if( !zones.empty() ) {
             const blueprint_options &options = dynamic_cast<const blueprint_options &>
                                                ( zones.front().get_options() );
             const construction_id index = options.get_index();
-            return find_base_construction( you, pre_inv, src_loc, part_con_idx,
+            return find_base_construction( you, nearest_src_loc, src_loc, part_con_idx,
                                            index );
         }
     } else if( act == ACT_MULTIPLE_FARM ) {

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -878,14 +878,10 @@ static activity_reason_info find_base_construction(
     }
 
     const construction &build = con == nullptr ? idx.obj() : *con;
-    bool pcb = player_can_build( you, inv, build, true );
-    //already done?
     if( already_done( build, loc ) ) {
         return activity_reason_info::build( do_activity_reason::ALREADY_DONE, false, build.id );
     }
-
-    const bool has_skill = you.meets_skill_requirements( build );
-    if( !has_skill ) {
+    if( !you.meets_skill_requirements( build ) ) {
         return activity_reason_info::build( do_activity_reason::DONT_HAVE_SKILL, false, build.id );
     }
     //if there's an appropriate partial construction on the tile, then we can work on it, no need to check inventories.
@@ -896,16 +892,14 @@ static activity_reason_info find_base_construction(
         }
         return activity_reason_info::build( do_activity_reason::CAN_DO_CONSTRUCTION, true, build.id );
     }
-    //can build?
-    if( cc ) {
-        if( pcb ) {
-            return activity_reason_info::build( do_activity_reason::CAN_DO_CONSTRUCTION, true, build.id );
-        }
+    if( !cc ) {
+        return activity_reason_info::build( do_activity_reason::BLOCKING_TILE, false, idx );
+    }
+    if( !player_can_build( you, inv, build, true ) ) {
         //can't build with current inventory, do not look for pre-req
         return activity_reason_info::build( do_activity_reason::NO_COMPONENTS, false, build.id );
     }
-
-    return activity_reason_info::build( do_activity_reason::BLOCKING_TILE, false, idx );
+    return activity_reason_info::build( do_activity_reason::CAN_DO_CONSTRUCTION, true, build.id );
 }
 
 static bool are_requirements_nearby(


### PR DESCRIPTION
#### Summary
Performance "Speed up big zone construction of `Turn forest floor into dirt` by 266% (from 96s to 36s)"

#### Purpose of change

 - Fix #79936.
 - The game could lag for 10 seconds in some cases when construction in a big zone is ordered.

#### Describe the solution

 - Pass a reference instead of copying the inventory. Flashback to #77914.
   - I don't see adding the reference in #78957 (unmerged as of writing this).
 - Ask for the inventory as late as possible in case we early return earlier.

#### Describe alternatives you've considered


#### Testing

Profiled using Visual Studio.

1. Profiling on this map: [TEST Winter Beach-trimmed.tar.gz](https://github.com/user-attachments/files/19044369/TEST.Winter.Beach-trimmed.tar.gz)
   - ![image](https://github.com/user-attachments/assets/b3a3d088-cfce-4541-a8dc-3b07c40a39a6)
2. Added this commit (before testing) to standardize the start and end of profiling:
<details>

```patch
From 41eb5a52d2d2e2d9637562ab7d031caddf964265 Mon Sep 17 00:00:00 2001
From: Brambor <tondadrd@seznam.cz>
Date: Sun, 2 Mar 2025 16:05:52 +0100
Subject: [PATCH] LOCAL TESTING CALENDAR TURN

---
 src/crafting.cpp | 3 +++
 1 file changed, 3 insertions(+)

diff --git a/src/crafting.cpp b/src/crafting.cpp
index 078b9efbf0..3e35d937ad 100644
--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -697,6 +697,9 @@ const inventory &Character::crafting_inventory( map *here, const tripoint_bub_ms
     crafting_cache.time = calendar::turn;
     crafting_cache.position = inv_pos;
     crafting_cache.radius = radius;
+    if ( calendar::turn > time_point( 8012578 ) ) {
+        printf("/n");
+    }
     return *crafting_cache.crafting_inventory;
 }
 
-- 
2.48.1.windows.1
```
</details>

3. Put breakpoints at `if ( calendar::turn > time_point( 8012578 ) ) {` and `printf("/n");`. Activate both.
5. Load the game.
6. `O` Zone activities.
7. `c`onstruct plots.
8. Observe: first breakpoint is hit.
9. Make sure you have CPU profiling on. Remove the first breakpoint. Continue execution.
8. (Wait 36 to 104 seconds.)
10. Observe: The second breakpoint is hit.
11. Look at the results.
12. _If you are profiling again, don't forget to reactivate the breakpoint in step 3._

#### Results

<details>

<summary>Profiling pictures</summary>

First up, after the refactor:
![image](https://github.com/user-attachments/assets/6f007f3f-cf0b-4a00-adcc-96fdf8001e93)

Second, after just changing `const inventory pre_rev` to `const inventory &pre_rev`. Note that `inventory::inventory` is completely gone, took 15 seconds.
![image](https://github.com/user-attachments/assets/9981f878-202e-4ff8-adaa-a0d89a7bfe86)

Third (final) only ask for `inv` when it is needed:
![image](https://github.com/user-attachments/assets/c2dbff0f-767a-4112-850c-24f57d95be32)

</details>

I ran each profiling 3 times. I noted the time the whole thing took and the time `can_do_activity_there` took, here are the results:

What changed | Entire thing: median (measurements) | `can_do_activity_there`: median (measurements) | Total median improvement
--- | --- | --- | ---
refactor (no change) | 96.1 sec (96.1, 95.8, 104.6) | 61 sec (60.9, 61, 68.2) | -
reference (don't copy) | 77.6 sec (77.6, 77.1, 76.2) | 41.3 sec (41.6, 41.3, 40.8) | 24% or 18.5s faster
inv only when needed | 36.1 sec (36.1, 36.1, 38.5) | 1.6 sec (1.6, 1.6, 1.7) | 166% or 60s faster

<!--
total time - can_do_activity_there time

LOCAL TESTING CALENDAR TURN
96066 ms - 60897 ms
95770 ms - 60960 ms
104590 ms - 68162 ms

Constr: ref
77555 ms - 41641 ms
77057 ms - 41281 ms
76235 ms - 40819 ms

Constr: build inv only when needed
36145 ms - 1611 ms
36109 ms - 1611 ms
38547 ms - 1734 ms
-->

#### Additional context

 - It takes a different approach than suggested in #79936. Since inventory things now take less than 5% time, the more complicated suggested improvements are no longer needed. Which is why I am closing that issue with this.