### PR TITLE
Clarify that infection is always a case of sepsis, not "zombie virus"

### DIFF
--- a/src/character_body.cpp
+++ b/src/character_body.cpp
@@ -1301,8 +1301,9 @@ bodypart_id Character::body_window( const std::string &menu_header,
                                                  static_cast<int>( infect * 100 ) ), c_light_green ) + "\n";
                 treatment_rank += 60 + infect * 10;
             } else {
-                desc += colorize( _( "It has a deep wound that looks infected.  Antibiotics might be required." ),
-                                  c_red );
+                desc += colorize(
+                            _( "It has a deep wound that looks to have a septic infection.  Antibiotics might be required." ),
+                            c_red );
             }
             desc += "\n";
         }

--- a/src/medical_ui.cpp
+++ b/src/medical_ui.cpp
@@ -431,7 +431,7 @@ static medical_column draw_health_summary( const int column_count, Character &yo
         // INFECTED block
         if( infected ) {
             const effect infected_effect = you.get_effect( effect_infected, part );
-            detail += string_format( _( "[ %s ]" ), colorize( _( "INFECTED" ), c_pink ) );
+            detail += string_format( _( "[ %s ]" ), colorize( _( "SEPTIC" ), c_pink ) );
             description += string_format( "[ %s ] - %s\n",
                                           colorize( infected_effect.get_speed_name(), c_pink ),
                                           infected_effect.disp_short_desc() );

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -278,7 +278,7 @@ std::string enum_to_string<bodypart_status>( bodypart_status stat )
         case bodypart_status::BITTEN:
             return "bitten";
         case bodypart_status::INFECTED:
-            return "infected";
+            return "septic";
         case bodypart_status::BROKEN:
             return "broken";
         case bodypart_status::SPLINTED:


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
It has often been confused by newer players that they get an infected wound and think they have the "zombie virus". That's not how our zombies work.

#### Describe the solution
Replace the "INFECTED" notice with "SEPTIC" in the treatment UI and sidebar. Replace a description with the (somewhat redundant) specifier "septic".

#### Describe alternatives you've considered
I considered also changing the messages/names of the Infected effect. But I think players most commonly come to this belief from log messages/the treatment window.

#### Testing
I'm unable to find which of the sidebars displays limb statuses.

#### Additional context

