### PR TITLE
attempt to make "ages_into"

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -70,6 +70,7 @@
 #include "item_factory.h"
 #include "item_group.h"
 #include "item_tname.h"
+#include "item_location.h"
 #include "iteminfo_query.h"
 #include "itype.h"
 #include "iuse.h"
@@ -14945,6 +14946,15 @@ bool item::process_internal( map &here, Character *carrier, const tripoint_bub_m
         if( is_tool() ) {
             return process_tool( carrier, pos );
         }
+
+        if( calendar::once_every( 10_minutes )
+            && ( !type->ages_into.item.is_null() && !type->ages_into.group.is_null() )
+            && carrier != nullptr ) {
+            // i absolutely do not trust this function
+            item_location item_loc = item_location::form_loc( *carrier, &here, pos, *this );
+            item_loc.ages_into();
+        }
+
         // All foods that go bad have temperature
         if( has_temperature() &&
             process_temperature_rot( insulation, pos, here, carrier, flag, spoil_modifier,

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -4404,6 +4404,25 @@ void Item_factory::load_basic_info( const JsonObject &jo, itype &def, const std:
 
     optional( jo, def.was_loaded, "max_worn", def.max_worn, MAX_WORN_PER_TYPE );
 
+    if( jo.has_member( "ages_into" ) ) {
+        JsonObject job = jo.get_member( "ages_into" );
+        optional( job, def.was_loaded, "item", def.ages_into.item, itype_id::NULL_ID() );
+        optional( job, def.was_loaded, "item_group", def.ages_into.group, item_group_id::NULL_ID() );
+        if( job.has_string( "time" ) ) {
+            time_duration time;
+            mandatory( job, def.was_loaded, "time", time );
+            def.ages_into.time = std::make_pair( time, time );
+        } else if( job.has_array( "time" ) ) {
+            mandatory( job, def.was_loaded, "time", def.ages_into.time );
+        }
+        optional( job, def.was_loaded, "amount", def.ages_into.amount );
+        optional( job, def.was_loaded, "displace_by_volume", def.ages_into.displace_by_volume, true );
+        optional( job, def.was_loaded, "use_rotting", def.ages_into.use_rotting, false );
+        if( !def.ages_into.item.is_null() && !def.ages_into.group.is_null() ) {
+            debugmsg( "%s cannot age both into item and in itemgroup", def.id.str() );
+        }
+    }
+
     if( jo.has_member( "techniques" ) ) {
         def.techniques.clear();
         set_techniques_from_json( jo, "techniques", def );

--- a/src/item_location.h
+++ b/src/item_location.h
@@ -146,6 +146,17 @@ class item_location
         **/
         bool protected_from_liquids() const;
 
+        /**
+        * very ugly function that construct potential item_location
+        * it is desired to replace it with visit_items using item_location instead of item
+        **/
+        static item_location form_loc( Character &you, map *here, const tripoint_bub_ms &p, item &it );
+
+        /**
+        * checks if item can and should transform into another item over time, and if yes, transform it
+        **/
+        void ages_into();
+
         ret_val<void> parents_can_contain_recursive( item *it ) const;
         ret_val<int> max_charges_by_parent_recursive( const item &it ) const;
 

--- a/src/itype.h
+++ b/src/itype.h
@@ -1253,6 +1253,15 @@ struct memory_card_info {
     bool secret_recipes;
 };
 
+struct ages_into {
+    itype_id item;
+    item_group_id group;
+    std::pair<time_duration, time_duration> time;
+    int amount;
+    bool displace_by_volume;
+    bool use_rotting;
+};
+
 struct itype {
         friend class Item_factory;
         friend struct mod_tracker;
@@ -1534,6 +1543,11 @@ struct itype {
 
         // Expand snippets in the description and save the description on the object
         bool expand_snippets = false;
+
+        /**
+        * Information what this item should be transformed into some time in the future
+        */
+        ages_into ages_into;
 
     private:
         // load-only, for applying proportional melee values at load time

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -2904,39 +2904,6 @@ bool holster_actor::store( Character &you, item &holster, item &obj ) const
     return true;
 }
 
-template<typename T>
-static item_location form_loc_recursive( T &loc, item &it )
-{
-    item *parent = loc.find_parent( it );
-    if( parent != nullptr ) {
-        return item_location( form_loc_recursive( loc, *parent ), &it );
-    }
-
-    return item_location( loc, &it );
-}
-
-static item_location form_loc( Character &you, map *here, const tripoint_bub_ms &p, item &it )
-{
-    if( you.has_item( it ) ) {
-        return form_loc_recursive( you, it );
-    }
-    map_cursor mc( here, p );
-    if( mc.has_item( it ) ) {
-        return form_loc_recursive( mc, it );
-    }
-    const optional_vpart_position vp = here->veh_at( p );
-    if( vp ) {
-        vehicle_cursor vc( vp->vehicle(), vp->part_index() );
-        if( vc.has_item( it ) ) {
-            return form_loc_recursive( vc, it );
-        }
-    }
-
-    debugmsg( "Couldn't find item %s to form item_location, forming dummy location to ensure minimum functionality",
-              it.display_name() );
-    return item_location( you, &it );
-}
-
 std::optional<int> holster_actor::use( Character *you, item &it, const tripoint_bub_ms &p ) const
 {
     return holster_actor::use( you, it, &get_map(), p );
@@ -3009,7 +2976,7 @@ std::optional<int> holster_actor::use( Character *you, item &it, map *here,
         }
 
         // iuse_actor really needs to work with item_location
-        item_location item_loc = form_loc( *you, here, p, it );
+        item_location item_loc = item_location::form_loc( *you, here, p, it );
         game_menus::inv::insert_items( item_loc );
     }
 
@@ -5548,8 +5515,8 @@ std::optional<int> link_up_actor::link_extend_cable( Character *p, item &it,
         return std::nullopt;
     }
 
-    item_location extension = is_cable_item ? form_loc( *p, here, pnt, it ) : selected;
-    item_location extended = is_cable_item ? selected : form_loc( *p, here, pnt, it );
+    item_location extension = is_cable_item ? item_location::form_loc( *p, here, pnt, it ) : selected;
+    item_location extended = is_cable_item ? selected : item_location::form_loc( *p, here, pnt, it );
     std::optional<item> extended_copy;
 
     // We'll make a copy of the extended item and check pocket weight/volume capacity if:


### PR DESCRIPTION
#### Summary
Features "Framework for items 'rotting' into another items over time"
#### Purpose of change
Attempt to close #37054
#### Describe the solution
Function, that transform items into another items over time
#### Problems
- every item processing is build around `item` type, which is okay-ish if we want to transform one item into another item with 1:1 ratio (see `item::convert()`) or outright delete item (see rot); it is absolutely invalid approach if you try to replace item with multiple items - for this item_location type is needed, which is, eeh, i honestly don't know in which way i can create without transforming entire `visit_items()` to use item_location instead of item (which i can, because it's like three thousand interlinked functions and overloads). There was a (very fishy) form_loc() function that i moved to item_location.cpp, but i honestly do not trust it fully
- for the same reason it cannot be unified with rotting properly, because rot uses `item`, and ages_into uses `item_location`
- potentially perfomance tanking 
- at this moment it plain doesn't work, duh
#### Testing
TBD
#### Additional context
hold your expectations, i don't know if i can finish it; 
If i make it work, i can at least try to expand it to also support transforming from material definition

***any help is appreciated**