### PR TITLE
fix Segfault when adding gunmod

### DIFF
--- a/src/character_guns.cpp
+++ b/src/character_guns.cpp
@@ -184,7 +184,7 @@ void Character::gunmod_add( item &gun, item &mod )
     itype_id mod_type = mod.typeId();
     std::string mod_name = mod.tname();
 
-    if( !wield( gun ) ) {
+    if( !is_wielding( gun ) && !wield( gun ) ) {
         add_msg_if_player( _( "You can't wield the %1$s." ), gun.tname() );
         return;
     }

--- a/src/sdlsound.cpp
+++ b/src/sdlsound.cpp
@@ -759,7 +759,7 @@ struct sound_effect_handler {
             if( handler->loops_remaining >= 0 &&
                 handler->current_sample_index >= num_source_samples ) {
                 handler->loops_remaining--;
-                handler->current_sample_index = std::fmodf( handler->current_sample_index, num_source_samples );
+                handler->current_sample_index = fmodf( handler->current_sample_index, num_source_samples );
             }
         }
 


### PR DESCRIPTION
#### Summary
Bugfixes "Segfault when adding gunmod"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
fix #79950

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Character::gunmod_add made use of a difference in avatar::wield and game::wield that #79719 eliminated, namely avatar::wield would remove and wield the item again, whereas game::wield would query to unequipt it. I dont think it is intended when calling wield to unwield and rewield the item, so check is_wielding( gun ) before calling wield.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
can attach mods to wielded gun
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Mac test error seems unrelated

Are there other functions that always wield , no matter if its already wielded?
for some reason I had a compile error at src/sdlsound.cpp:762
Incorparates linux build fix from  #79979
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
