### PR TITLE
Generic factory: islot_ammo, islot_bionic, islot_magazine; general islot cleanup

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -16043,15 +16043,10 @@ void disp_mod_by_barrel::deserialize( const JsonObject &jo )
     mandatory( jo, false, "dispersion", dispersion_modifier );
 }
 
-void rot_spawn_data::load( const JsonObject &jo )
+void rot_spawn_data::deserialize( const JsonObject &jo )
 {
     optional( jo, false, "monster", rot_spawn_monster, mtype_id::NULL_ID() );
     optional( jo, false, "group", rot_spawn_group, mongroup_id::NULL_ID() );
     optional( jo, false, "chance", rot_spawn_chance );
     optional( jo, false, "amount", rot_spawn_monster_amount, {1, 1} );
-}
-
-void rot_spawn_data::deserialize( const JsonObject &jo )
-{
-    load( jo );
 }

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -2734,16 +2734,14 @@ void Item_factory::load_ammo( const JsonObject &jo, const std::string &src )
     itype def;
     if( load_definition( jo, src, def ) ) {
         if( def.was_loaded ) {
-            if( def.ammo ) {
-                def.ammo->was_loaded = true;
-            } else {
+            if( !def.ammo ) {
                 def.ammo = cata::make_value<islot_ammo>();
-                def.ammo->was_loaded = true;
             }
         } else {
             def.ammo = cata::make_value<islot_ammo>();
         }
         def.ammo->deserialize( jo );
+        def.ammo->was_loaded = true;
         load_basic_info( jo, def, src );
     }
 }
@@ -2758,16 +2756,14 @@ void Item_factory::load_engine( const JsonObject &jo, const std::string &src )
     itype def;
     if( load_definition( jo, src, def ) ) {
         if( def.was_loaded ) {
-            if( def.engine ) {
-                def.engine->was_loaded = true;
-            } else {
+            if( !def.engine ) {
                 def.engine = cata::make_value<islot_engine>();
-                def.engine->was_loaded = true;
             }
         } else {
             def.engine = cata::make_value<islot_engine>();
         }
         def.engine->deserialize( jo );
+        def.engine->was_loaded = true;
         load_basic_info( jo, def, src );
     }
 }
@@ -2783,16 +2779,14 @@ void Item_factory::load_wheel( const JsonObject &jo, const std::string &src )
     itype def;
     if( load_definition( jo, src, def ) ) {
         if( def.was_loaded ) {
-            if( def.wheel ) {
-                def.wheel->was_loaded = true;
-            } else {
+            if( !def.wheel ) {
                 def.wheel = cata::make_value<islot_wheel>();
-                def.wheel->was_loaded = true;
             }
         } else {
             def.wheel = cata::make_value<islot_wheel>();
         }
         def.wheel->deserialize( jo );
+        def.wheel->was_loaded = true;
         load_basic_info( jo, def, src );
     }
 }
@@ -2802,16 +2796,14 @@ void Item_factory::load_comestible( const JsonObject &jo, const std::string &src
     itype def;
     if( load_definition( jo, src, def ) ) {
         if( def.was_loaded ) {
-            if( def.comestible ) {
-                def.comestible->was_loaded = true;
-            } else {
+            if( !def.comestible ) {
                 def.comestible = cata::make_value<islot_comestible>();
-                def.comestible->was_loaded = true;
             }
         } else {
             def.comestible = cata::make_value<islot_comestible>();
         }
         def.comestible->deserialize( jo );
+        def.comestible->was_loaded = true;
         load_basic_info( jo, def, src );
     }
 }
@@ -2921,16 +2913,14 @@ void Item_factory::load_gun( const JsonObject &jo, const std::string &src )
     itype def;
     if( load_definition( jo, src, def ) ) {
         if( def.was_loaded ) {
-            if( def.gun ) {
-                def.gun->was_loaded = true;
-            } else {
+            if( !def.gun ) {
                 def.gun = cata::make_value<islot_gun>();
-                def.gun->was_loaded = true;
             }
         } else {
             def.gun = cata::make_value<islot_gun>();
         }
         def.gun->deserialize( jo );
+        def.gun->was_loaded = true;
         load_basic_info( jo, def, src );
     }
 }
@@ -2960,16 +2950,14 @@ void Item_factory::load_pet_armor( const JsonObject &jo, const std::string &src 
     itype def;
     if( load_definition( jo, src, def ) ) {
         if( def.was_loaded ) {
-            if( def.pet_armor ) {
-                def.pet_armor->was_loaded = true;
-            } else {
+            if( !def.pet_armor ) {
                 def.pet_armor = cata::make_value<islot_pet_armor>();
-                def.pet_armor->was_loaded = true;
             }
         } else {
             def.pet_armor = cata::make_value<islot_pet_armor>();
         }
         def.pet_armor->deserialize( jo );
+        def.pet_armor->was_loaded = true;
         load_basic_info( jo, def, src );
     }
 }
@@ -3334,16 +3322,14 @@ void Item_factory::load_book( const JsonObject &jo, const std::string &src )
     itype def;
     if( load_definition( jo, src, def ) ) {
         if( def.was_loaded ) {
-            if( def.book ) {
-                def.book->was_loaded = true;
-            } else {
+            if( !def.book ) {
                 def.book = cata::make_value<islot_book>();
-                def.book->was_loaded = true;
             }
         } else {
             def.book = cata::make_value<islot_book>();
         }
         def.book->deserialize( jo );
+        def.book->was_loaded = true;
         load_basic_info( jo, def, src );
     }
 }
@@ -3562,16 +3548,14 @@ void Item_factory::load_magazine( const JsonObject &jo, const std::string &src )
     itype def;
     if( load_definition( jo, src, def ) ) {
         if( def.was_loaded ) {
-            if( def.magazine ) {
-                def.magazine->was_loaded = true;
-            } else {
+            if( !def.magazine ) {
                 def.magazine = cata::make_value<islot_magazine>();
-                def.magazine->was_loaded = true;
             }
         } else {
             def.magazine = cata::make_value<islot_magazine>();
         }
         def.magazine->deserialize( jo );
+        def.magazine->was_loaded = true;
         load_basic_info( jo, def, src );
     }
 }
@@ -3586,16 +3570,14 @@ void Item_factory::load_battery( const JsonObject &jo, const std::string &src )
     itype def;
     if( load_definition( jo, src, def ) ) {
         if( def.was_loaded ) {
-            if( def.battery ) {
-                def.battery->was_loaded = true;
-            } else {
+            if( !def.battery ) {
                 def.battery = cata::make_value<islot_battery>();
-                def.battery->was_loaded = true;
             }
         } else {
             def.battery = cata::make_value<islot_battery>();
         }
         def.battery->deserialize( jo );
+        def.battery->was_loaded = true;
         load_basic_info( jo, def, src );
     }
 }
@@ -3612,16 +3594,14 @@ void Item_factory::load_bionic( const JsonObject &jo, const std::string &src )
     itype def;
     if( load_definition( jo, src, def ) ) {
         if( def.was_loaded ) {
-            if( def.bionic ) {
-                def.bionic->was_loaded = true;
-            } else {
+            if( !def.bionic ) {
                 def.bionic = cata::make_value<islot_bionic>();
-                def.bionic->was_loaded = true;
             }
         } else {
             def.bionic = cata::make_value<islot_bionic>();
         }
         def.bionic->deserialize( jo );
+        def.bionic->was_loaded = true;
         load_basic_info( jo, def, src );
     }
 }

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -2664,15 +2664,10 @@ bool Item_factory::load_definition( const JsonObject &jo, const std::string &src
     return false;
 }
 
-void islot_milling::load( const JsonObject &jo )
+void islot_milling::deserialize( const JsonObject &jo )
 {
     optional( jo, was_loaded, "into", into_ );
     optional( jo, was_loaded, "recipe", recipe_ );
-}
-
-void islot_milling::deserialize( const JsonObject &jo )
-{
-    load( jo );
 }
 
 static void load_memory_card_data( memory_card_info &mcd, const JsonObject &jo )
@@ -2703,9 +2698,8 @@ static void load_memory_card_data( memory_card_info &mcd, const JsonObject &jo )
     }
 }
 
-void islot_ammo::load( const JsonObject &jo )
+void islot_ammo::deserialize( const JsonObject &jo )
 {
-    bool strict = false;
     numeric_bound_reader not_negative{ 0 };
     numeric_bound_reader positive{ 1 };
     numeric_bound_reader positive_float{ 1.0f };
@@ -2735,11 +2729,6 @@ void islot_ammo::load( const JsonObject &jo )
     optional( jo, was_loaded, "show_stats", force_stat_display, false );
 }
 
-void islot_ammo::deserialize( const JsonObject &jo )
-{
-    load( jo );
-}
-
 void Item_factory::load_ammo( const JsonObject &jo, const std::string &src )
 {
     itype def;
@@ -2754,19 +2743,14 @@ void Item_factory::load_ammo( const JsonObject &jo, const std::string &src )
         } else {
             def.ammo = cata::make_value<islot_ammo>();
         }
-        def.ammo->load( jo );
+        def.ammo->deserialize( jo );
         load_basic_info( jo, def, src );
     }
 }
 
-void islot_engine::load( const JsonObject &jo )
-{
-    optional( jo, was_loaded, "displacement", displacement );
-}
-
 void islot_engine::deserialize( const JsonObject &jo )
 {
-    load( jo );
+    optional( jo, was_loaded, "displacement", displacement );
 }
 
 void Item_factory::load_engine( const JsonObject &jo, const std::string &src )
@@ -2783,20 +2767,15 @@ void Item_factory::load_engine( const JsonObject &jo, const std::string &src )
         } else {
             def.engine = cata::make_value<islot_engine>();
         }
-        def.engine->load( jo );
+        def.engine->deserialize( jo );
         load_basic_info( jo, def, src );
     }
 }
 
-void islot_wheel::load( const JsonObject &jo )
+void islot_wheel::deserialize( const JsonObject &jo )
 {
     optional( jo, was_loaded, "diameter", diameter );
     optional( jo, was_loaded, "width", width );
-}
-
-void islot_wheel::deserialize( const JsonObject &jo )
-{
-    load( jo );
 }
 
 void Item_factory::load_wheel( const JsonObject &jo, const std::string &src )
@@ -2813,7 +2792,7 @@ void Item_factory::load_wheel( const JsonObject &jo, const std::string &src )
         } else {
             def.wheel = cata::make_value<islot_wheel>();
         }
-        def.wheel->load( jo );
+        def.wheel->deserialize( jo );
         load_basic_info( jo, def, src );
     }
 }
@@ -2832,7 +2811,7 @@ void Item_factory::load_comestible( const JsonObject &jo, const std::string &src
         } else {
             def.comestible = cata::make_value<islot_comestible>();
         }
-        def.comestible->load( jo );
+        def.comestible->deserialize( jo );
         load_basic_info( jo, def, src );
     }
 }
@@ -2896,7 +2875,7 @@ class gun_modes_reader : public generic_typed_reader<gun_modes_reader>
         }
 };
 
-void islot_gun::load( const JsonObject &jo )
+void islot_gun::deserialize( const JsonObject &jo )
 {
     numeric_bound_reader<int> not_negative = numeric_bound_reader<int> { 0 };
     numeric_bound_reader<double> not_negative_float = numeric_bound_reader<double> { 0 };
@@ -2937,11 +2916,6 @@ void islot_gun::load( const JsonObject &jo )
     optional( jo, was_loaded, "hurt_part_when_fired", hurt_part_when_fired );
 }
 
-void islot_gun::deserialize( const JsonObject &jo )
-{
-    load( jo );
-}
-
 void Item_factory::load_gun( const JsonObject &jo, const std::string &src )
 {
     itype def;
@@ -2956,7 +2930,7 @@ void Item_factory::load_gun( const JsonObject &jo, const std::string &src )
         } else {
             def.gun = cata::make_value<islot_gun>();
         }
-        def.gun->load( jo );
+        def.gun->deserialize( jo );
         load_basic_info( jo, def, src );
     }
 }
@@ -2976,7 +2950,7 @@ void Item_factory::load_armor( const JsonObject &jo, const std::string &src )
         } else {
             def.armor = cata::make_value<islot_armor>();
         }
-        def.armor->load( jo );
+        def.armor->deserialize( jo );
         load_basic_info( jo, def, src );
     }
 }
@@ -2995,7 +2969,7 @@ void Item_factory::load_pet_armor( const JsonObject &jo, const std::string &src 
         } else {
             def.pet_armor = cata::make_value<islot_pet_armor>();
         }
-        def.pet_armor->load( jo );
+        def.pet_armor->deserialize( jo );
         load_basic_info( jo, def, src );
     }
 }
@@ -3132,7 +3106,7 @@ static void get_proportional( const JsonObject &jo, const std::string_view membe
     }
 }
 
-void islot_armor::load( const JsonObject &jo )
+void islot_armor::deserialize( const JsonObject &jo )
 {
     optional( jo, was_loaded, "armor", sub_data );
 
@@ -3198,12 +3172,7 @@ void islot_armor::load( const JsonObject &jo )
     optional( jo, was_loaded, "valid_mods", valid_mods );
 }
 
-void islot_armor::deserialize( const JsonObject &jo )
-{
-    load( jo );
-}
-
-void islot_pet_armor::load( const JsonObject &jo )
+void islot_pet_armor::deserialize( const JsonObject &jo )
 {
     optional( jo, was_loaded, "material_thickness", thickness, 0 );
     optional( jo, was_loaded, "max_pet_vol", max_vol, volume_reader{}, 0_ml );
@@ -3212,11 +3181,6 @@ void islot_pet_armor::load( const JsonObject &jo )
     optional( jo, was_loaded, "environmental_protection", env_resist, 0 );
     optional( jo, was_loaded, "environmental_protection_with_filter", env_resist_w_filter, 0 );
     optional( jo, was_loaded, "power_armor", power_armor, false );
-}
-
-void islot_pet_armor::deserialize( const JsonObject &jo )
-{
-    load( jo );
 }
 
 void Item_factory::load( islot_tool &slot, const JsonObject &jo, const std::string &src )
@@ -3343,12 +3307,12 @@ void Item_factory::load_tool_armor( const JsonObject &jo, const std::string &src
         } else {
             def.armor = cata::make_value<islot_armor>();
         }
-        def.armor->load( jo );
+        def.armor->deserialize( jo );
         load_basic_info( jo, def, src );
     }
 }
 
-void islot_book::load( const JsonObject &jo )
+void islot_book::deserialize( const JsonObject &jo )
 {
     optional( jo, was_loaded, "max_level", level, 0 );
     optional( jo, was_loaded, "required_level", req, 0 );
@@ -3365,11 +3329,6 @@ void islot_book::load( const JsonObject &jo )
     optional( jo, was_loaded, "scannable", is_scannable, true );
 }
 
-void islot_book::deserialize( const JsonObject &jo )
-{
-    load( jo );
-}
-
 void Item_factory::load_book( const JsonObject &jo, const std::string &src )
 {
     itype def;
@@ -3384,7 +3343,7 @@ void Item_factory::load_book( const JsonObject &jo, const std::string &src )
         } else {
             def.book = cata::make_value<islot_book>();
         }
-        def.book->load( jo );
+        def.book->deserialize( jo );
         load_basic_info( jo, def, src );
     }
 }
@@ -3429,7 +3388,7 @@ class vitamins_reader : public generic_typed_reader<vitamins_reader>
         }
 };
 
-void islot_comestible::load( const JsonObject &jo )
+void islot_comestible::deserialize( const JsonObject &jo )
 {
     std::string src = "dda";
 
@@ -3467,29 +3426,7 @@ void islot_comestible::load( const JsonObject &jo )
     optional( jo, was_loaded, "rot_spawn", rot_spawn );
 }
 
-void islot_comestible::deserialize( const JsonObject &jo )
-{
-    load( jo );
-}
-
-void islot_brewable::load( const JsonObject &jo )
-{
-    optional( jo, was_loaded, "time", time, 1_turns );
-    if( jo.has_array( "results" ) ) {
-        for( std::string entry : jo.get_string_array( "results" ) ) {
-            results[itype_id( entry )] = 1;
-        }
-    } else {
-        mandatory( jo, was_loaded, "results", results );
-    }
-}
-
 void islot_brewable::deserialize( const JsonObject &jo )
-{
-    load( jo );
-}
-
-void islot_compostable::load( const JsonObject &jo )
 {
     optional( jo, was_loaded, "time", time, 1_turns );
     if( jo.has_array( "results" ) ) {
@@ -3503,10 +3440,17 @@ void islot_compostable::load( const JsonObject &jo )
 
 void islot_compostable::deserialize( const JsonObject &jo )
 {
-    load( jo );
+    optional( jo, was_loaded, "time", time, 1_turns );
+    if( jo.has_array( "results" ) ) {
+        for( std::string entry : jo.get_string_array( "results" ) ) {
+            results[itype_id( entry )] = 1;
+        }
+    } else {
+        mandatory( jo, was_loaded, "results", results );
+    }
 }
 
-void islot_seed::load( const JsonObject &jo )
+void islot_seed::deserialize( const JsonObject &jo )
 {
     assign( jo, "grow", grow, false, 1_days );
     optional( jo, was_loaded, "fruit_div", fruit_div, 1 );
@@ -3516,11 +3460,6 @@ void islot_seed::load( const JsonObject &jo )
     optional( jo, was_loaded, "byproducts", byproducts );
     optional( jo, was_loaded, "required_terrain_flag", required_terrain_flag,
               ter_furn_flag::TFLAG_PLANTABLE );
-}
-
-void islot_seed::deserialize( const JsonObject &jo )
-{
-    load( jo );
 }
 
 void Item_factory::load( islot_gunmod &slot, const JsonObject &jo, const std::string &src )
@@ -3605,7 +3544,7 @@ void Item_factory::load_gunmod( const JsonObject &jo, const std::string &src )
     }
 }
 
-void islot_magazine::load( const JsonObject &jo )
+void islot_magazine::deserialize( const JsonObject &jo )
 {
     numeric_bound_reader not_negative{ 0 };
 
@@ -3632,19 +3571,14 @@ void Item_factory::load_magazine( const JsonObject &jo, const std::string &src )
         } else {
             def.magazine = cata::make_value<islot_magazine>();
         }
-        def.magazine->load( jo );
+        def.magazine->deserialize( jo );
         load_basic_info( jo, def, src );
     }
 }
 
-void islot_battery::load( const JsonObject &jo )
-{
-    mandatory( jo, was_loaded, "max_capacity", max_capacity );
-}
-
 void islot_battery::deserialize( const JsonObject &jo )
 {
-    load( jo );
+    mandatory( jo, was_loaded, "max_capacity", max_capacity );
 }
 
 void Item_factory::load_battery( const JsonObject &jo, const std::string &src )
@@ -3661,12 +3595,12 @@ void Item_factory::load_battery( const JsonObject &jo, const std::string &src )
         } else {
             def.battery = cata::make_value<islot_battery>();
         }
-        def.battery->load( jo );
+        def.battery->deserialize( jo );
         load_basic_info( jo, def, src );
     }
 }
 
-void islot_bionic::load( const JsonObject &jo )
+void islot_bionic::deserialize( const JsonObject &jo )
 {
     optional( jo, was_loaded, "difficulty", difficulty, numeric_bound_reader{0} );
     optional( jo, was_loaded, "is_upgrade", is_upgrade );
@@ -3687,7 +3621,7 @@ void Item_factory::load_bionic( const JsonObject &jo, const std::string &src )
         } else {
             def.bionic = cata::make_value<islot_bionic>();
         }
-        def.bionic->load( jo );
+        def.bionic->deserialize( jo );
         load_basic_info( jo, def, src );
     }
 }

--- a/src/item_factory.h
+++ b/src/item_factory.h
@@ -317,8 +317,6 @@ class Item_factory
         void load( islot_tool &slot, const JsonObject &jo, const std::string &src );
         void load( islot_mod &slot, const JsonObject &jo, const std::string &src );
         void load( islot_gunmod &slot, const JsonObject &jo, const std::string &src );
-        void load( islot_magazine &slot, const JsonObject &jo, const std::string &src );
-        void load( islot_bionic &slot, const JsonObject &jo, const std::string &src );
         void load( relic &slot, const JsonObject &jo, std::string_view src );
 
         //json data handlers

--- a/src/itype.h
+++ b/src/itype.h
@@ -137,7 +137,6 @@ struct rot_spawn_data {
     /** Range of monsters spawned */
     std::pair<int, int> rot_spawn_monster_amount;
 
-    void load( const JsonObject &jo );
     void deserialize( const JsonObject &jo );
 };
 
@@ -147,7 +146,6 @@ struct islot_comestible {
         friend item;
 
         bool was_loaded = false;
-        void load( const JsonObject &jo );
         void deserialize( const JsonObject &jo );
 
         /** subtype, e.g. FOOD, DRINK, MED */
@@ -218,9 +216,9 @@ struct islot_comestible {
         material_id primary_material =
             material_id::NULL_ID(); //TO-DO: this overrides materials and shouldn't be necessary
         //** specific heats in J/(g K) and latent heat in J/g */
-        float specific_heat_liquid = 4.186f;
-        float specific_heat_solid = 2.108f;
-        float latent_heat = 333.0f;
+        float specific_heat_liquid = 4.186f; // NOLINT(cata-serialize)
+        float specific_heat_solid = 2.108f; // NOLINT(cata-serialize)
+        float latent_heat = 333.0f; // NOLINT(cata-serialize)
 
         /** A penalty applied to fun for every time this food has been eaten in the last 48 hours */
         int monotony_penalty = -1;
@@ -259,8 +257,6 @@ struct islot_brewable {
     time_duration time = 0_turns;
 
     bool was_loaded = false;
-
-    void load( const JsonObject &jo );
     void deserialize( const JsonObject &jo );
 };
 
@@ -272,8 +268,6 @@ struct islot_compostable {
     time_duration time = 0_turns;
 
     bool was_loaded = false;
-
-    void load( const JsonObject &jo );
     void deserialize( const JsonObject &jo );
 };
 
@@ -454,30 +448,30 @@ struct islot_armor {
         /**
          * Whether this item has ablative pockets
          */
-        bool ablative = false;
+        bool ablative = false; // NOLINT(cata-serialize)
         /**
          * Whether this item has pockets that generate additional encumbrance
          */
-        bool additional_pocket_enc = false;
+        bool additional_pocket_enc = false; // NOLINT(cata-serialize)
         /**
          * Whether this item has pockets that can be ripped off
          */
-        bool ripoff_chance = false;
+        bool ripoff_chance = false; // NOLINT(cata-serialize)
 
         /**
          * If the entire item is rigid
          */
-        bool rigid = false;
+        bool rigid = false; // NOLINT(cata-serialize)
 
         /**
          * If the entire item is comfortable
          */
-        bool comfortable = true;
+        bool comfortable = true; // NOLINT(cata-serialize)
 
         /**
          * Whether this item has pockets that are noisy
          */
-        bool noisy = false;
+        bool noisy = false; // NOLINT(cata-serialize)
         /**
          * Whitelisted clothing mods.
          * Restricted clothing mods must be listed here by id to be compatible.
@@ -487,27 +481,25 @@ struct islot_armor {
         /**
          * If the item in question has any sub coverage when testing for encumbrance
          */
-        bool has_sub_coverage = false;
+        bool has_sub_coverage = false; // NOLINT(cata-serialize)
 
         // Layer, encumbrance and coverage information for each body part.
         // This isn't directly loaded in but is instead generated from the loaded in
         // sub_data vector
-        std::vector<armor_portion_data> data;
+        std::vector<armor_portion_data> data; // NOLINT(cata-serialize)
 
         // Layer, encumbrance and coverage information for each sub body part.
         // This vector can have duplicates for body parts themselves.
         std::vector<armor_portion_data> sub_data;
 
         // all of the layers this item is involved in
-        std::vector<layer_level> all_layers;
-
-        bool was_loaded = false;
+        std::vector<layer_level> all_layers; // NOLINT(cata-serialize)
 
         int avg_env_resist() const;
         int avg_env_resist_w_filter() const;
         float avg_thickness() const;
 
-        void load( const JsonObject &jo );
+        bool was_loaded = false;
         void deserialize( const JsonObject &jo );
 
     private:
@@ -548,8 +540,6 @@ struct islot_pet_armor {
     bool power_armor = false;
 
     bool was_loaded = false;
-
-    void load( const JsonObject &jo );
     void deserialize( const JsonObject &jo );
 };
 
@@ -621,13 +611,12 @@ struct islot_book {
         std::string name() const;
     };
     using recipe_list_t = std::set<recipe_with_description_t>;
-    recipe_list_t recipes;
+    recipe_list_t recipes; // NOLINT(cata-serialize)
     std::vector<book_proficiency_bonus> proficiencies;
 
-    bool was_loaded = false;
     bool is_scannable = false;
 
-    void load( const JsonObject &jo );
+    bool was_loaded = false;
     void deserialize( const JsonObject &jo );
 };
 
@@ -687,8 +676,6 @@ struct islot_engine {
         int displacement = 0;
 
         bool was_loaded = false;
-
-        void load( const JsonObject &jo );
         void deserialize( const JsonObject &jo );
 };
 
@@ -701,8 +688,6 @@ struct islot_wheel {
         int width = 0;
 
         bool was_loaded = false;
-
-        void load( const JsonObject &jo );
         void deserialize( const JsonObject &jo );
 };
 
@@ -739,7 +724,6 @@ struct itype_variant_data {
 // TODO: this shares a lot with the ammo item type, merge into a separate slot type?
 struct islot_gun : common_ranged_data {
     bool was_loaded = false;
-    void load( const JsonObject &jo );
     void deserialize( const JsonObject &jo );
     /**
      * What skill this gun uses.
@@ -849,7 +833,7 @@ struct islot_gun : common_ranged_data {
     */
     double gun_jam_mult = 1.0;
 
-    std::map<ammotype, std::set<itype_id>> cached_ammos;
+    std::map<ammotype, std::set<itype_id>> cached_ammos; // NOLINT(cata-serialize)
 
     /**
      * Used for the skullgun cbm. Hurts the bodypart by that much when fired
@@ -999,7 +983,6 @@ struct islot_gunmod : common_ranged_data {
 
 struct islot_magazine {
     bool was_loaded = false;
-    void load( const JsonObject &jo );
     void deserialize( const JsonObject &jo );
 
     /** What type of ammo this magazine can be loaded with */
@@ -1023,7 +1006,7 @@ struct islot_magazine {
     /** For ammo belts one linkage (of given type) is dropped for each unit of ammo consumed */
     std::optional<itype_id> linkage;
 
-    std::map<ammotype, std::set<itype_id>> cached_ammos;
+    std::map<ammotype, std::set<itype_id>> cached_ammos; // NOLINT(cata-serialize)
     /** Map of [magazine type id] -> [set of gun itype_ids that accept the mag type ] */
     static std::map<itype_id, std::set<itype_id>> compatible_guns;
 };
@@ -1033,8 +1016,6 @@ struct islot_battery {
     units::energy max_capacity;
 
     bool was_loaded = false;
-
-    void load( const JsonObject &jo );
     void deserialize( const JsonObject &jo );
 };
 
@@ -1103,14 +1084,14 @@ struct islot_ammo : common_ranged_data {
      * This value is cached by item_factory based on ammo_effects and item material.
      * @warning It is not read from the json directly.
      */
-    bool cookoff = false;
+    bool cookoff = false; // NOLINT(cata-serialize)
 
     /**
      * Should this ammo apply a special explosion effect when in fire?
      * This value is cached by item_factory based on ammo_effects and item material.
      * @warning It is not read from the json directly.
      * */
-    bool special_cookoff = false;
+    bool special_cookoff = false; // NOLINT(cata-serialize)
 
     /**
      * The damage multiplier to apply after a critical hit.
@@ -1131,13 +1112,11 @@ struct islot_ammo : common_ranged_data {
     bool was_loaded = false;
 
     int dispersion_considering_length( units::length barrel_length ) const;
-    void load( const JsonObject &jo );
     void deserialize( const JsonObject &jo );
 };
 
 struct islot_bionic {
     bool was_loaded = false;
-    void load( const JsonObject &jo );
     void deserialize( const JsonObject &jo );
     /**
      * Arbitrary difficulty scale, see bionics.cpp for its usage.
@@ -1146,7 +1125,7 @@ struct islot_bionic {
     /**
      * Id of the bionic, see bionics.cpp for its usage.
      */
-    bionic_id id;
+    bionic_id id; // NOLINT(cata-serialize)
     /**
      * Whether this CBM is an upgrade of another.
      */
@@ -1161,8 +1140,6 @@ struct islot_bionic {
 struct islot_seed {
     // Generic factory stuff
     bool was_loaded = false;
-
-    void load( const JsonObject &jo );
     void deserialize( const JsonObject &jo );
 
     /**
@@ -1180,15 +1157,15 @@ struct islot_seed {
     /**
      * What the plant sprouts into. Defaults to f_plant_seedling.
      */
-    furn_str_id seedling_form;
+    furn_str_id seedling_form; // NOLINT(cata-serialize)
     /**
      * What the plant grows into. Defaults to f_plant_mature.
      */
-    furn_str_id mature_form;
+    furn_str_id mature_form; // NOLINT(cata-serialize)
     /**
      * The plant's final growth stage. Defaults to f_plant_harvest.
      */
-    furn_str_id harvestable_form;
+    furn_str_id harvestable_form; // NOLINT(cata-serialize)
     /**
      * Type id of the fruit item.
      */
@@ -1243,8 +1220,6 @@ class islot_milling
         recipe_id recipe_;
 
         bool was_loaded = false;
-
-        void load( const JsonObject &jo );
         void deserialize( const JsonObject &jo );
 };
 

--- a/src/itype.h
+++ b/src/itype.h
@@ -1136,6 +1136,9 @@ struct islot_ammo : common_ranged_data {
 };
 
 struct islot_bionic {
+    bool was_loaded = false;
+    void load( const JsonObject &jo );
+    void deserialize( const JsonObject &jo );
     /**
      * Arbitrary difficulty scale, see bionics.cpp for its usage.
      */

--- a/src/itype.h
+++ b/src/itype.h
@@ -1060,6 +1060,12 @@ struct islot_ammo : common_ranged_data {
     int def_charges = 1;
 
     /**
+    * Number of items per above volume for @ref count_by_charges items;
+    * Overwrites generic item stack_size in finalize_pre()
+    */
+    int stack_size = 0;
+
+    /**
      * Number of projectiles fired per round, e.g. shotgun shot.
      */
     int count = 1;

--- a/src/itype.h
+++ b/src/itype.h
@@ -998,6 +998,10 @@ struct islot_gunmod : common_ranged_data {
 };
 
 struct islot_magazine {
+    bool was_loaded = false;
+    void load( const JsonObject &jo );
+    void deserialize( const JsonObject &jo );
+
     /** What type of ammo this magazine can be loaded with */
     std::set<ammotype> type;
 
@@ -1014,7 +1018,7 @@ struct islot_magazine {
     int reload_time = 100;
 
     /** Multiplier for the gun jamming from physical damage */
-    double mag_jam_mult = 1 ;
+    double mag_jam_mult = 1.0 ;
 
     /** For ammo belts one linkage (of given type) is dropped for each unit of ammo consumed */
     std::optional<itype_id> linkage;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Infrastructure "generic factory: islot_ammo, islot_bionic, islot_magazine; general islot cleanup"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

The now-not-quite-as-long road to completing #36851.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Converts islot_ammo, islot_bionic, islot_magazine to `generic_factory`-friendly formats

Removes unused "bionic_id", "bionic_data" fields

Refactor redundant `islot::load()` functions based on a Discord comment correctly pointing out that they are cargo-culted. Specifically, these functions are only called from `Item_factory::load_X()`, and they're just clones of `deserialize()`.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Compiled and successfully ran tests for each islot converted, tested basic functionality for each.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

There weren't many huge changes here, so this should be relatively safe to merge.

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
