### PR TITLE
[MoM] Gateway now has a volume limit

### DIFF
--- a/data/mods/MindOverMatter/PowerDescriptionSpoilers.md
+++ b/data/mods/MindOverMatter/PowerDescriptionSpoilers.md
@@ -1516,7 +1516,7 @@ Powers causing telepathic damage have a 5% chance to down the target, a 33% chan
 *Duration*: Instant<br />
 *Stamina Cost*: 10000, minus 200 per level to a minimum of 6000<br />
 *Channeling Time*: 200 moves, minus 5.5 moves per level to a minimum of 75. Attunement takes 8 hours, minus 20 minutes per power level of Gateway to a minimum of 30 minutes<br />
-*Effects*: Transport yourself through the Nether to an attuned location. This power works at any distance.  You may have a number of destinations simultaneously equal to 1 + 1 per 3 levels of Gateway (2.5 levels if you have the Good Memory trait, 4 levels if you have the Forgetful trait).<br />
+*Effects*: Transport yourself through the Nether to an attuned location. This power works at any distance.  You may have a number of destinations simultaneously equal to 1 + 1 per 3 levels of Gateway (2.5 levels if you have the Good Memory trait, 4 levels if you have the Forgetful trait).  You can always teleport yourself, and can carry 10L of gear, plus 7.5L per power level.<br />
 *Prerequisites*: Farstep 10, Loci Establishment 6 <br />
 </details>
 <details>

--- a/data/mods/MindOverMatter/powers/teleportation_eoc.json
+++ b/data/mods/MindOverMatter/powers/teleportation_eoc.json
@@ -255,7 +255,7 @@
       {
         "if": {
           "math": [
-            "u_teleport_total_carried_volume <= ( ( ( u_spell_level('teleport_gateway') * 7500 ) + 15000 ) * scaling_factor( u_val('intelligence') ) * u_nether_attunement_power_scaling )"
+            "u_teleport_total_carried_volume <= ( ( ( u_spell_level('teleport_gateway') * 7500 ) + 10000 ) * scaling_factor( u_val('intelligence') ) * u_nether_attunement_power_scaling )"
           ]
         },
         "then": [ { "math": [ "u_teleport_total_carried_volume = 1" ] } ],

--- a/data/mods/MindOverMatter/powers/teleportation_eoc.json
+++ b/data/mods/MindOverMatter/powers/teleportation_eoc.json
@@ -1,6 +1,23 @@
 [
   {
     "type": "effect_on_condition",
+    "id": "EOC_TELEPORT_SELF_CARRIED_VOLUME_CHECKER",
+    "effect": [
+      { "math": [ "u_teleport_total_carried_volume = 0" ] },
+      {
+        "u_run_inv_eocs": "all",
+        "search_data": [ { "condition": { "math": [ "n_volume() > 0" ] } } ],
+        "true_eocs": [
+          {
+            "id": "EOC_TELEPORT_SELF_CARRIED_VOLUME_CHECKER_ADD_VOLUME",
+            "effect": [ { "math": [ "u_teleport_total_carried_volume", "+=", "n_volume()" ] } ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
     "id": "EOC_TELEPORT_ITEM_APPORT",
     "effect": [
       {
@@ -197,6 +214,16 @@
   },
   {
     "type": "effect_on_condition",
+    "id": "EOC_TELEPORTER_GATEWAY_MESSAGE_CARRYING_TOO_MUCH",
+    "effect": [
+      {
+        "u_message": "You attempt to teleport to your destination, but your skin merely tingles and nothing happens.  You're carrying too much.",
+        "type": "bad"
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
     "id": "EOC_TELEPORTER_ATTUNING_MESSAGE",
     "effect": [
       { "u_message": "You concentrate and begin memorizing every detail of the current area you are in.", "type": "neutral" }
@@ -216,7 +243,24 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_TELEPORT_GATEWAY_SELECTOR",
+    "condition": {
+      "and": [
+        { "not": { "u_has_worn_with_flag": "DIMENSIONAL_ANCHOR" } },
+        { "not": { "u_has_flag": "DIMENSIONAL_ANCHOR" } },
+        { "not": { "u_has_flag": "TELEPORT_LOCK" } }
+      ]
+    },
     "effect": [
+      { "run_eocs": "EOC_TELEPORT_SELF_CARRIED_VOLUME_CHECKER" },
+      {
+        "if": {
+          "math": [
+            "u_teleport_total_carried_volume <= ( ( ( u_spell_level('teleport_gateway') * 7500 ) + 15000 ) * scaling_factor( u_val('intelligence') ) * u_nether_attunement_power_scaling )"
+          ]
+        },
+        "then": [ { "math": [ "u_teleport_total_carried_volume = 1" ] } ],
+        "else": [ { "math": [ "u_teleport_total_carried_volume = -1" ] } ]
+      },
       {
         "run_eoc_selector": [
           "EOC_TELEPORT_GATEWAY_SELECTOR_01",
@@ -258,7 +302,8 @@
         "hide_failing": true,
         "allow_cancel": true
       }
-    ]
+    ],
+    "false_effect": [ { "u_message": "You feel a strange, inward force.", "type": "bad" } ]
   },
   {
     "type": "effect_on_condition",
@@ -291,7 +336,13 @@
     "type": "effect_on_condition",
     "id": "EOC_TELEPORT_GATEWAY_TELEPORT_01",
     "condition": { "math": [ "has_var(u_gateway_destination_1)" ] },
-    "effect": [ { "u_teleport": { "u_val": "gateway_destination_1" } }, { "run_eocs": "EOC_TELEPORTER_GATEWAY_MESSAGE" } ]
+    "effect": [
+      {
+        "if": { "math": [ "u_teleport_total_carried_volume >= 0" ] },
+        "then": [ { "u_teleport": { "u_val": "gateway_destination_1" } }, { "run_eocs": "EOC_TELEPORTER_GATEWAY_MESSAGE" } ],
+        "else": [ { "run_eocs": "EOC_TELEPORTER_GATEWAY_MESSAGE_CARRYING_TOO_MUCH" } ]
+      }
+    ]
   },
   {
     "type": "effect_on_condition",
@@ -350,7 +401,13 @@
     "type": "effect_on_condition",
     "id": "EOC_TELEPORT_GATEWAY_TELEPORT_02",
     "condition": { "math": [ "has_var(u_gateway_destination_2)" ] },
-    "effect": [ { "u_teleport": { "u_val": "gateway_destination_2" } }, { "run_eocs": "EOC_TELEPORTER_GATEWAY_MESSAGE" } ]
+    "effect": [
+      {
+        "if": { "math": [ "u_teleport_total_carried_volume >= 0" ] },
+        "then": [ { "u_teleport": { "u_val": "gateway_destination_2" } }, { "run_eocs": "EOC_TELEPORTER_GATEWAY_MESSAGE" } ],
+        "else": [ { "run_eocs": "EOC_TELEPORTER_GATEWAY_MESSAGE_CARRYING_TOO_MUCH" } ]
+      }
+    ]
   },
   {
     "type": "effect_on_condition",
@@ -409,7 +466,13 @@
     "type": "effect_on_condition",
     "id": "EOC_TELEPORT_GATEWAY_TELEPORT_03",
     "condition": { "math": [ "has_var(u_gateway_destination_3)" ] },
-    "effect": [ { "u_teleport": { "u_val": "gateway_destination_3" } }, { "run_eocs": "EOC_TELEPORTER_GATEWAY_MESSAGE" } ]
+    "effect": [
+      {
+        "if": { "math": [ "u_teleport_total_carried_volume >= 0" ] },
+        "then": [ { "u_teleport": { "u_val": "gateway_destination_3" } }, { "run_eocs": "EOC_TELEPORTER_GATEWAY_MESSAGE" } ],
+        "else": [ { "run_eocs": "EOC_TELEPORTER_GATEWAY_MESSAGE_CARRYING_TOO_MUCH" } ]
+      }
+    ]
   },
   {
     "type": "effect_on_condition",
@@ -468,7 +531,13 @@
     "type": "effect_on_condition",
     "id": "EOC_TELEPORT_GATEWAY_TELEPORT_04",
     "condition": { "math": [ "has_var(u_gateway_destination_4)" ] },
-    "effect": [ { "u_teleport": { "u_val": "gateway_destination_4" } }, { "run_eocs": "EOC_TELEPORTER_GATEWAY_MESSAGE" } ]
+    "effect": [
+      {
+        "if": { "math": [ "u_teleport_total_carried_volume >= 0" ] },
+        "then": [ { "u_teleport": { "u_val": "gateway_destination_4" } }, { "run_eocs": "EOC_TELEPORTER_GATEWAY_MESSAGE" } ],
+        "else": [ { "run_eocs": "EOC_TELEPORTER_GATEWAY_MESSAGE_CARRYING_TOO_MUCH" } ]
+      }
+    ]
   },
   {
     "type": "effect_on_condition",
@@ -527,7 +596,13 @@
     "type": "effect_on_condition",
     "id": "EOC_TELEPORT_GATEWAY_TELEPORT_05",
     "condition": { "math": [ "has_var(u_gateway_destination_5)" ] },
-    "effect": [ { "u_teleport": { "u_val": "gateway_destination_5" } }, { "run_eocs": "EOC_TELEPORTER_GATEWAY_MESSAGE" } ]
+    "effect": [
+      {
+        "if": { "math": [ "u_teleport_total_carried_volume >= 0" ] },
+        "then": [ { "u_teleport": { "u_val": "gateway_destination_5" } }, { "run_eocs": "EOC_TELEPORTER_GATEWAY_MESSAGE" } ],
+        "else": [ { "run_eocs": "EOC_TELEPORTER_GATEWAY_MESSAGE_CARRYING_TOO_MUCH" } ]
+      }
+    ]
   },
   {
     "type": "effect_on_condition",
@@ -586,7 +661,13 @@
     "type": "effect_on_condition",
     "id": "EOC_TELEPORT_GATEWAY_TELEPORT_06",
     "condition": { "math": [ "has_var(u_gateway_destination_6)" ] },
-    "effect": [ { "u_teleport": { "u_val": "gateway_destination_6" } }, { "run_eocs": "EOC_TELEPORTER_GATEWAY_MESSAGE" } ]
+    "effect": [
+      {
+        "if": { "math": [ "u_teleport_total_carried_volume >= 0" ] },
+        "then": [ { "u_teleport": { "u_val": "gateway_destination_6" } }, { "run_eocs": "EOC_TELEPORTER_GATEWAY_MESSAGE" } ],
+        "else": [ { "run_eocs": "EOC_TELEPORTER_GATEWAY_MESSAGE_CARRYING_TOO_MUCH" } ]
+      }
+    ]
   },
   {
     "type": "effect_on_condition",
@@ -645,7 +726,13 @@
     "type": "effect_on_condition",
     "id": "EOC_TELEPORT_GATEWAY_TELEPORT_07",
     "condition": { "math": [ "has_var(u_gateway_destination_7)" ] },
-    "effect": [ { "u_teleport": { "u_val": "gateway_destination_7" } }, { "run_eocs": "EOC_TELEPORTER_GATEWAY_MESSAGE" } ]
+    "effect": [
+      {
+        "if": { "math": [ "u_teleport_total_carried_volume >= 0" ] },
+        "then": [ { "u_teleport": { "u_val": "gateway_destination_7" } }, { "run_eocs": "EOC_TELEPORTER_GATEWAY_MESSAGE" } ],
+        "else": [ { "run_eocs": "EOC_TELEPORTER_GATEWAY_MESSAGE_CARRYING_TOO_MUCH" } ]
+      }
+    ]
   },
   {
     "type": "effect_on_condition",
@@ -704,7 +791,13 @@
     "type": "effect_on_condition",
     "id": "EOC_TELEPORT_GATEWAY_TELEPORT_08",
     "condition": { "math": [ "has_var(u_gateway_destination_8)" ] },
-    "effect": [ { "u_teleport": { "u_val": "gateway_destination_8" } }, { "run_eocs": "EOC_TELEPORTER_GATEWAY_MESSAGE" } ]
+    "effect": [
+      {
+        "if": { "math": [ "u_teleport_total_carried_volume >= 0" ] },
+        "then": [ { "u_teleport": { "u_val": "gateway_destination_8" } }, { "run_eocs": "EOC_TELEPORTER_GATEWAY_MESSAGE" } ],
+        "else": [ { "run_eocs": "EOC_TELEPORTER_GATEWAY_MESSAGE_CARRYING_TOO_MUCH" } ]
+      }
+    ]
   },
   {
     "type": "effect_on_condition",
@@ -763,7 +856,13 @@
     "type": "effect_on_condition",
     "id": "EOC_TELEPORT_GATEWAY_TELEPORT_09",
     "condition": { "math": [ "has_var(u_gateway_destination_9)" ] },
-    "effect": [ { "u_teleport": { "u_val": "gateway_destination_9" } }, { "run_eocs": "EOC_TELEPORTER_GATEWAY_MESSAGE" } ]
+    "effect": [
+      {
+        "if": { "math": [ "u_teleport_total_carried_volume >= 0" ] },
+        "then": [ { "u_teleport": { "u_val": "gateway_destination_9" } }, { "run_eocs": "EOC_TELEPORTER_GATEWAY_MESSAGE" } ],
+        "else": [ { "run_eocs": "EOC_TELEPORTER_GATEWAY_MESSAGE_CARRYING_TOO_MUCH" } ]
+      }
+    ]
   },
   {
     "type": "effect_on_condition",
@@ -822,7 +921,13 @@
     "type": "effect_on_condition",
     "id": "EOC_TELEPORT_GATEWAY_TELEPORT_10",
     "condition": { "math": [ "has_var(u_gateway_destination_10)" ] },
-    "effect": [ { "u_teleport": { "u_val": "gateway_destination_10" } }, { "run_eocs": "EOC_TELEPORTER_GATEWAY_MESSAGE" } ]
+    "effect": [
+      {
+        "if": { "math": [ "u_teleport_total_carried_volume >= 0" ] },
+        "then": [ { "u_teleport": { "u_val": "gateway_destination_10" } }, { "run_eocs": "EOC_TELEPORTER_GATEWAY_MESSAGE" } ],
+        "else": [ { "run_eocs": "EOC_TELEPORTER_GATEWAY_MESSAGE_CARRYING_TOO_MUCH" } ]
+      }
+    ]
   },
   {
     "type": "effect_on_condition",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[MoM] Gateway now has a volume limit"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Continuation of volume limits on Teleportation.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Implement a check on Gateway that runs and determines the total volume of all your carried, worn, and wielded items. If it's below 10L + 7.5L per power level, everything works fine. If you're above that, you get a message that you're carrying too much.

You can always teleport yourself. It wouldn't be much use otherwise. If there's ever some kind of gradual growth or adjustment period on size-changing mutations, I'll look into messing with your teleportation during that period. 

I also noticed that Gateway's new EoC-based implementation didn't account for anti-teleport flags like `DIMENSIONAL_ANCHOR`, so I included handling for that too.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

![image](https://github.com/user-attachments/assets/111b2a33-1e3a-4cee-8d84-e5724095f8b7)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Did this one before Oubliette, that and Blink next, then Farstep. Then Dilated Gateway.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
