### PR TITLE
[Draft] Allow mutation encumbrance modifiers to take math

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -329,7 +329,7 @@
     "points": -1,
     "vitamin_cost": 60,
     "description": "A photophore has grown from your head.  You can't consciously control it, and it might start to shine in response to your emotions or your physiological state.",
-    "encumbrance_covered": [ [ "head", 5 ] ],
+    "encumbrance_covered": { "head": 5 },
     "changes_to": [ "BIOLUM1" ],
     "types": [ "BIOLUM" ],
     "category": [ "ELFA", "INSECT", "FISH" ],
@@ -347,7 +347,7 @@
     "cost": 9,
     "time": "225 h",
     "kcal": true,
-    "encumbrance_covered": [ [ "head", 5 ] ],
+    "encumbrance_covered": { "head": 5 },
     "types": [ "BIOLUM" ],
     "prereqs": [ "BIOLUM0" ],
     "changes_to": [ "BIOLUM2" ],
@@ -375,7 +375,7 @@
     "cost": 9,
     "time": "112 h 30 m",
     "kcal": true,
-    "encumbrance_covered": [ [ "head", 5 ] ],
+    "encumbrance_covered": { "head": 5 },
     "types": [ "BIOLUM" ],
     "prereqs": [ "BIOLUM1" ],
     "leads_to": [ "BIOLUM3" ],
@@ -399,7 +399,7 @@
     "points": 6,
     "vitamin_cost": 210,
     "description": "You can spit a wad of bioluminescent goo several meters away.  There it will light up its surroundings until it dissipates.",
-    "encumbrance_covered": [ [ "head", 5 ] ],
+    "encumbrance_covered": { "head": 5 },
     "types": [ "BIOLUM" ],
     "prereqs": [ "BIOLUM2" ],
     "category": [ "INSECT" ],
@@ -3616,7 +3616,8 @@
     "changes_to": [ "LEAVES3" ],
     "category": [ "PLANT" ],
     "wet_protection": [ { "part": "head", "ignored": 4 }, { "part": "arm_l", "ignored": 5 }, { "part": "arm_r", "ignored": 5 } ],
-    "encumbrance_covered": [ [ "arm_l", 5 ], [ "arm_r", 5 ] ]
+    "encumbrance_multiplier_always": { "arm_l": 0.4, "arm_r": 0.4, "hand_l": 0.4, "hand_r": 0.4, "leg_l": 0.4, "leg_r": 0.4, "mouth": 0.4 },
+    "encumbrance_covered": { "arm_l": 5, "arm_r": 5 }
   },
   {
     "type": "mutation",
@@ -3633,7 +3634,7 @@
     "threshreq": [ "THRESH_PLANT" ],
     "category": [ "PLANT" ],
     "wet_protection": [ { "part": "head", "ignored": 5 }, { "part": "arm_l", "ignored": 8 }, { "part": "arm_r", "ignored": 8 } ],
-    "encumbrance_covered": [ [ "arm_l", 10 ], [ "arm_r", 10 ] ]
+    "encumbrance_covered": { "arm_l": 10, "arm_r": 10 }
   },
   {
     "type": "mutation",
@@ -3871,7 +3872,7 @@
     "mixed_effect": true,
     "//": "Didn't integrate-ize tentacle rakes because they are hardcoded, waiting for limb rework.",
     "description": "Your upper tentacles have grown large, hook-barbed rakes on the ends.  They're quite vicious, but really aren't suited for fine manipulation.",
-    "encumbrance_always": [ [ "hand_l", 20 ], [ "hand_r", 20 ] ],
+    "encumbrance_always": { "hand_l": 20, "hand_r": 20 },
     "flags": [ "PSEUDOPOD_GRASP" ],
     "prereqs": [ "ARM_TENTACLES", "ARM_TENTACLES_4", "ARM_TENTACLES_8" ],
     "threshreq": [ "THRESH_CEPHALOPOD" ],
@@ -5644,7 +5645,7 @@
     "flags": [ "SLUDGE_IMMUNE" ],
     "visibility": 8,
     "ugliness": 9,
-    "encumbrance_always": [ [ "leg_l", 10 ], [ "leg_r", 10 ], [ "foot_l", 10 ], [ "foot_r", 10 ] ],
+    "encumbrance_always": { "leg_l": 10, "leg_r": 10, "foot_l": 10, "foot_r": 10 },
     "enchantments": [
       {
         "values": [ { "value": "MOVECOST_FLATGROUND_MOD", "multiply": 0.25 }, { "value": "FOOTSTEP_NOISE", "multiply": -0.75 } ]
@@ -5971,7 +5972,7 @@
     "visibility": 1,
     "ugliness": 1,
     "mixed_effect": true,
-    "encumbrance_always": [ [ "torso", 10 ], [ "arm_l", 10 ], [ "arm_r", 10 ] ],
+    "encumbrance_always": { "torso": 10, "arm_l": 10, "arm_r": 10 },
     "description": "You have grown noticeably taller and broader.  Much of it is useful muscle mass (Strength +2), but you find it throws off your balance and you get in your own way (+10 torso and arm encumbrance).",
     "types": [ "SIZE" ],
     "prereqs": [ "STR_UP", "STR_UP_2", "STR_UP_3", "STR_UP_4", "MASOCHIST_MED" ],
@@ -6646,7 +6647,7 @@
     "visibility": 7,
     "ugliness": 4,
     "description": "You have a flattened nose and thin slits for nostrils, giving you a lizard-like appearance.  This makes breathing slightly difficult and increases mouth encumbrance by 10.",
-    "encumbrance_always": [ [ "mouth", 10 ] ],
+    "encumbrance_always": { "mouth": 10 },
     "changes_to": [ "LEAFNOSE" ],
     "category": [ "LIZARD", "CEPHALOPOD", "RAPTOR", "CHIROPTERAN" ]
   },
@@ -6797,7 +6798,7 @@
     "description": "Most of your fingers have grown to tremendous length, becoming a broad pair of leathery wings.  This allows you to arrest a fall or glide from a ledge if you aren't too weighed down, but naturally impedes your fine motor skills.  They even keep you warm when you sleep.",
     "types": [ "ARMS", "HANDS" ],
     "flags": [ "WING_GLIDE", "WINGS_2" ],
-    "encumbrance_always": [ [ "arm_r", 20 ], [ "arm_l", 20 ], [ "hand_r", 40 ], [ "hand_l", 40 ] ],
+    "encumbrance_always": { "arm_r": 20, "arm_l": 20, "hand_r": 40, "hand_l": 40 },
     "prereqs": [ "WEBBED" ],
     "strict_threshreq": true,
     "category": [ "CHIROPTERAN" ],
@@ -6814,7 +6815,7 @@
     "ugliness": -2,
     "description": "You have a very large pair of brightly-colored, very beautiful wings.  They can't lift you, and they make balancing tricky, but they certainly catch air and attention!",
     "purifiable": false,
-    "encumbrance_always": [ [ "torso", 10 ] ],
+    "encumbrance_always": { "torso": 10 },
     "types": [ "WINGS" ],
     "prereqs": [ "WINGS_STUB" ],
     "threshreq": [ "THRESH_INSECT" ],
@@ -7520,7 +7521,7 @@
     "flags": [ "WEBBED_HANDS" ],
     "changes_to": [ "WINGS_BAT" ],
     "wet_protection": [ { "part": "hand_l", "good": 3 }, { "part": "hand_r", "good": 3 } ],
-    "encumbrance_covered": [ [ "hand_l", 50 ], [ "hand_r", 50 ] ],
+    "encumbrance_covered": { "hand_l": 50, "hand_r": 50 },
     "enchantments": [ { "values": [ { "value": "DEXTERITY", "add": -1 } ] } ]
   },
   {
@@ -7546,7 +7547,7 @@
     "ugliness": 2,
     "mixed_effect": true,
     "description": "Your hands have fused into quasi-paws.  Fine manipulation is a challenge: permanent hand encumbrance of 10, difficulty with delicate craftwork, and your gloves don't fit.  But they handle water better and bear weight well, allowing you to move on all fours when crouching and unarmed.",
-    "encumbrance_always": [ [ "hand_l", 10 ], [ "hand_r", 10 ] ],
+    "encumbrance_always": { "hand_l": 10, "hand_r": 10 },
     "restricts_gear": [ "hand_l", "hand_r" ],
     "craft_skill_bonus": [ [ "electronics", -2 ], [ "tailor", -2 ], [ "mechanics", -2 ] ],
     "types": [ "HANDS" ],
@@ -7594,7 +7595,7 @@
       [ "cooking", -2 ],
       [ "survival", -2 ]
     ],
-    "encumbrance_always": [ [ "hand_l", 20 ], [ "hand_r", 20 ] ],
+    "encumbrance_always": { "hand_l": 20, "hand_r": 20 },
     "restricts_gear": [ "hand_l", "hand_r" ],
     "types": [ "HANDS" ],
     "prereqs": [ "PAWS" ],
@@ -7975,7 +7976,7 @@
     "prereqs": [ "PLANTSKIN", "BARK", "BARK2_a", "BARK2_b", "BARK2_c" ],
     "changes_to": [ "VINES2" ],
     "category": [ "PLANT" ],
-    "encumbrance_always": [ [ "torso", 10 ] ]
+    "encumbrance_always": { "torso": 10 }
   },
   {
     "type": "mutation",
@@ -8000,7 +8001,7 @@
         "hardcoded_effect": true
       }
     ],
-    "encumbrance_always": [ [ "torso", 10 ] ]
+    "encumbrance_always": { "torso": 10 }
   },
   {
     "type": "mutation",
@@ -8059,7 +8060,7 @@
     "cancels": [ "LEG_TENTACLES", "HOOVES" ],
     "category": [ "PLANT" ],
     "restricts_gear": [ "leg_stub_r", "leg_stub_l" ],
-    "encumbrance_covered": [ [ "foot_l", 10 ], [ "foot_r", 10 ] ]
+    "encumbrance_covered": { "foot_l": 10, "foot_r": 10 }
   },
   {
     "type": "mutation",
@@ -8078,7 +8079,7 @@
     "threshreq": [ "THRESH_PLANT" ],
     "changes_to": [ "ROOTS3" ],
     "category": [ "PLANT" ],
-    "encumbrance_covered": [ [ "foot_l", 10 ], [ "foot_r", 10 ] ],
+    "encumbrance_covered": { "foot_l": 10, "foot_r": 10 },
     "flags": [ "TOUGH_FEET", "ROOTS2" ]
   },
   {
@@ -8096,7 +8097,7 @@
     "threshreq": [ "THRESH_PLANT" ],
     "changes_to": [ "CHLOROMORPH" ],
     "category": [ "PLANT" ],
-    "encumbrance_covered": [ [ "foot_l", 10 ], [ "foot_r", 10 ] ],
+    "encumbrance_covered": { "foot_l": 10, "foot_r": 10 },
     "flags": [ "TOUGH_FEET", "ROOTS3" ]
   },
   {
@@ -8116,7 +8117,7 @@
     "cancels": [ "SMELLY", "SMELLY2" ],
     "category": [ "PLANT" ],
     "scent_type": "sc_flower",
-    "encumbrance_covered": [ [ "foot_l", 10 ], [ "foot_r", 10 ] ],
+    "encumbrance_covered": { "foot_l": 10, "foot_r": 10 },
     "flags": [ "TOUGH_FEET", "ROOTS3" ],
     "comfort": [
       {
@@ -8372,7 +8373,7 @@
       { "part": "hand_l", "neutral": 10 },
       { "part": "hand_r", "neutral": 10 }
     ],
-    "encumbrance_always": [ [ "arm_l", 8 ], [ "arm_r", 8 ] ],
+    "encumbrance_always": { "arm_l": 8, "arm_r": 8 },
     "armor": [ { "parts": [ "arm_l", "arm_r" ], "bash": 1, "cut": 1 } ]
   },
   {
@@ -8385,7 +8386,7 @@
     "ugliness": 5,
     "description": "You've *finally* sprouted a pair of arms from your midsection.  They flail more or less uncontrollably, making you feel rather larval.",
     "purifiable": false,
-    "encumbrance_always": [ [ "arm_l", 30 ], [ "arm_r", 30 ] ],
+    "encumbrance_always": { "arm_l": 30, "arm_r": 30 },
     "types": [ "HANDS" ],
     "changes_to": [ "INSECT_ARMS_OK", "ARACHNID_ARMS" ],
     "prereqs": [ "CHITIN", "CHITIN2", "CHITIN3", "CHITIN_FUR2", "CHITIN_FUR3" ],
@@ -8420,7 +8421,7 @@
     "ugliness": 10,
     "description": "There's the last two limbs you were expecting.  Unfortunately, you still can't coordinate them, so you're getting in your own way.  A lot.",
     "purifiable": false,
-    "encumbrance_always": [ [ "arm_l", 40 ], [ "arm_r", 40 ] ],
+    "encumbrance_always": { "arm_l": 40, "arm_r": 40 },
     "types": [ "HANDS" ],
     "changes_to": [ "ARACHNID_ARMS_OK" ],
     "prereqs": [ "INSECT_ARMS" ],
@@ -8456,7 +8457,7 @@
     "ugliness": 4,
     "mixed_effect": true,
     "description": "Your arms have transformed into tentacles, resulting in a +1 bonus to Dexterity, permanent hand encumbrance of 30, and an inability to wear gloves.  Reduces penalties for attacking while prone and somewhat decreases wet penalties.",
-    "encumbrance_always": [ [ "hand_l", 30 ], [ "hand_r", 30 ] ],
+    "encumbrance_always": { "hand_l": 30, "hand_r": 30 },
     "restricts_gear": [ "hand_l", "hand_r" ],
     "types": [ "HANDS", "CLAWS" ],
     "leads_to": [ "CLAWS_TENTACLE" ],
@@ -8496,7 +8497,7 @@
     "visibility": 8,
     "ugliness": 5,
     "description": "Your arms have transformed into four tentacles, resulting in a +1 bonus to Dexterity, permanent hand encumbrance of 30, and an inability to wear gloves.  You can make up to 3 extra attacks with them, and you suffer reduced penalties to attacking while prone.  Somewhat decreases wet penalties.",
-    "encumbrance_always": [ [ "hand_l", 30 ], [ "hand_r", 30 ] ],
+    "encumbrance_always": { "hand_l": 30, "hand_r": 30 },
     "restricts_gear": [ "hand_l", "hand_r" ],
     "types": [ "HANDS", "CLAWS" ],
     "prereqs": [ "ARM_TENTACLES" ],
@@ -8536,7 +8537,7 @@
     "visibility": 9,
     "ugliness": 6,
     "description": "Your arms have transformed into eight tentacles, resulting in a +1 bonus to Dexterity, permanent hand encumbrance of 30, and an inability to wear gloves.  You can make up to 7 extra attacks with them, and suffer reduced penalties to attacking while prone.  Somewhat decreases wet penalties.",
-    "encumbrance_always": [ [ "hand_l", 30 ], [ "hand_r", 30 ] ],
+    "encumbrance_always": { "hand_l": 30, "hand_r": 30 },
     "restricts_gear": [ "hand_l", "hand_r" ],
     "types": [ "HANDS", "CLAWS" ],
     "prereqs": [ "ARM_TENTACLES_4" ],
@@ -10141,7 +10142,7 @@
     "visibility": 2,
     "ugliness": 1,
     "description": "Your hands have elongated and look a bit more like paws.  It makes fine manipulation a little more difficult, but you can still probably manage.  Plus, they allow you to move on all fours when crouching and unarmed.",
-    "encumbrance_always": [ [ "hand_l", 5 ], [ "hand_r", 5 ] ],
+    "encumbrance_always": { "hand_l": 5, "hand_r": 5 },
     "craft_skill_bonus": [ [ "electronics", -1 ], [ "tailor", -1 ], [ "mechanics", -1 ] ],
     "types": [ "HANDS" ],
     "prereqs": [ "NAILS" ],

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -632,6 +632,18 @@ Character::Character() :
         recalc_sight_limits();
         trait_flag_cache.clear();
         bio_flag_cache.clear();
+        // if(get_name() == "" ) {
+        //     debugmsg("character init: invalid character");
+        // }
+        // if(is_npc() || is_avatar()) {
+        //     debugmsg("is npc");
+        // }
+        // if (is_avatar()) {
+        //     debugmsg("is avatar");
+        // }
+        // if (!is_npc() || !is_avatar() ) {
+        //     debugmsg("isn't npc or avatar");
+        // }
         calc_encumbrance();
         worn.recalc_ablative_blocking(this);
     }
@@ -4187,20 +4199,22 @@ void Character::apply_mut_encumbrance( std::map<bodypart_id, encumbrance_data> &
     // (calculation is costly, most of players and npcs are don't have encumbering mutations)
 
     for( const trait_id &mut : all_muts ) {
-        for( const std::pair<const bodypart_str_id, int> &enc : mut->encumbrance_always ) {
-            total_enc[enc.first] += enc.second;
+        const_dialogue d( get_const_talker_for( *this ), nullptr );
+        for( const std::pair<const bodypart_str_id, dbl_or_var> &enc : mut->encumbrance_always ) {
+            total_enc[enc.first] += enc.second.evaluate( d );
         }
-        for( const std::pair<const bodypart_str_id, int> &enc : mut->encumbrance_covered ) {
+        for( const std::pair<const bodypart_str_id, dbl_or_var> &enc : mut->encumbrance_covered ) {
             if( wearing_fitting_on( enc.first ) ) {
-                total_enc[enc.first] += enc.second;
+                total_enc[enc.first] += enc.second.evaluate( d );
             }
         }
     }
 
     for( const trait_id &mut : all_muts ) {
-        for( const std::pair<const bodypart_str_id, float> &enc : mut->encumbrance_multiplier_always ) {
+        const_dialogue d( get_const_talker_for( *this ), nullptr );
+        for( const std::pair<const bodypart_str_id, dbl_or_var> &enc : mut->encumbrance_multiplier_always ) {
             if( total_enc[enc.first] > 0 ) {
-                total_enc[enc.first] *= enc.second;
+                total_enc[enc.first] *= enc.second.evaluate( d );
             }
         }
     }

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -4192,14 +4192,19 @@ int Character::encumb( const bodypart_id &bp ) const
 void Character::apply_mut_encumbrance( std::map<bodypart_id, encumbrance_data> &vals ) const
 {
     const std::vector<trait_id> all_muts = get_functioning_mutations();
+
+    if( all_muts.empty() ) {
+        return;
+    }
+
     std::map<bodypart_str_id, float> total_enc;
+    const_dialogue d( get_const_talker_for( *this ), nullptr );
 
     // Lower penalty for bps covered only by XL or unrestricted armor
     // Initialized on demand for performance reasons:
     // (calculation is costly, most of players and npcs are don't have encumbering mutations)
 
     for( const trait_id &mut : all_muts ) {
-        const_dialogue d( get_const_talker_for( *this ), nullptr );
         for( const std::pair<const bodypart_str_id, dbl_or_var> &enc : mut->encumbrance_always ) {
             total_enc[enc.first] += enc.second.evaluate( d );
         }
@@ -4211,7 +4216,6 @@ void Character::apply_mut_encumbrance( std::map<bodypart_id, encumbrance_data> &
     }
 
     for( const trait_id &mut : all_muts ) {
-        const_dialogue d( get_const_talker_for( *this ), nullptr );
         for( const std::pair<const bodypart_str_id, dbl_or_var> &enc : mut->encumbrance_multiplier_always ) {
             if( total_enc[enc.first] > 0 ) {
                 total_enc[enc.first] *= enc.second.evaluate( d );

--- a/src/mutation.h
+++ b/src/mutation.h
@@ -13,6 +13,7 @@
 
 #include "bodypart.h"
 #include "calendar.h"
+#include "condition.h"
 #include "damage.h"
 #include "enums.h"
 #include "memory_fast.h"
@@ -337,11 +338,11 @@ struct mutation_branch {
         std::set<json_character_flag> active_flags; // Mutation flags only when active
         std::set<json_character_flag> inactive_flags; // Mutation flags only when inactive
         std::map<bodypart_str_id, tripoint> protection; // Mutation wet effects
-        std::map<bodypart_str_id, int> encumbrance_always; // Mutation encumbrance that always applies
+        std::map<bodypart_str_id, dbl_or_var> encumbrance_always; // Mutation encumbrance that always applies
         // Mutation encumbrance that applies when covered with unfitting item
-        std::map<bodypart_str_id, int> encumbrance_covered;
+        std::map<bodypart_str_id, dbl_or_var> encumbrance_covered;
         // a multiplier to encumbrance that is already modified by mutations
-        std::map<bodypart_str_id, float> encumbrance_multiplier_always;
+        std::map<bodypart_str_id, dbl_or_var> encumbrance_multiplier_always;
         // Body parts that now need OVERSIZE gear
         std::set<bodypart_str_id> restricts_gear;
         std::set<sub_bodypart_str_id> restricts_gear_subparts;

--- a/src/mutation_data.cpp
+++ b/src/mutation_data.cpp
@@ -482,22 +482,60 @@ void mutation_branch::load( const JsonObject &jo, const std::string_view src )
         protection[bodypart_str_id( wp.get_string( "part" ) )] = protect;
     }
 
-    for( JsonArray ea : jo.get_array( "encumbrance_always" ) ) {
-        const bodypart_str_id bp = bodypart_str_id( ea.next_string() );
-        const int enc = ea.next_int();
-        encumbrance_always[bp] = enc;
+    // for( JsonObject ea: jo.get_object( "encumbrance_always" ) ) {
+    //     const bodypart_str_id bp = bodypart_str_id( ea. );
+    // }
+
+    JsonObject eaObj = jo.get_object( "encumbrance_always" );
+    for( JsonMember ea : jo.get_object( "encumbrance_always" ) ) {
+        const bodypart_str_id bp = bodypart_str_id( ea.name() );
+        int val = ea.get_int();
+        encumbrance_always[bp] = get_dbl_or_var( eaObj, bp.str(), false, val );
+        // encumbrance_always[bp] = get_dbl_or_var( jo.get_object( "encumbrance_always" ), bp.str(), false, 0 );
     }
 
-    for( JsonArray ec : jo.get_array( "encumbrance_covered" ) ) {
-        const bodypart_str_id bp = bodypart_str_id( ec.next_string() );
-        int enc = ec.next_int();
-        encumbrance_covered[bp] = enc;
+    JsonObject ecObj = jo.get_object( "encumbrance_covered" );
+    for( JsonMember ec : jo.get_object( "encumbrance_covered" ) ) {
+        const bodypart_str_id bp = bodypart_str_id( ec.name() );
+        int val = ec.get_int();
+        encumbrance_covered[bp] = get_dbl_or_var( ecObj, bp.str(), false, val );
+        // encumbrance_covered[bp] = get_dbl_or_var( jo.get_object( "encumbrance_covered" ), bp.str(), false, 0 );
     }
 
+    JsonObject emaObj = jo.get_object( "encumbrance_multiplier_always" );
     for( JsonMember ema : jo.get_object( "encumbrance_multiplier_always" ) ) {
-        const bodypart_str_id &bp = bodypart_str_id( ema.name() );
-        encumbrance_multiplier_always[bp] = ema.get_float();
+        const bodypart_str_id bp = bodypart_str_id( ema.name() );
+        float val = ema.get_float();
+        encumbrance_multiplier_always[bp] = get_dbl_or_var( emaObj, bp.str(), false, val );
+        // encumbrance_multiplier_always[bp] = get_dbl_or_var( jo.get_object( "encumbrance_multiplier_always" ), bp.str(), false, 0 );
     }
+
+    // for( JsonArray ea : jo.get_array( "encumbrance_always" ) ) {
+    //     const bodypart_str_id bp = bodypart_str_id( ea.next_string() );
+    //     // if( ea.test_int() ) {
+    //     //     // encumbrance_always[bp] = ea.next_int();
+    //     //     encumbrance_always[bp] = get_dbl_or_var( ea, bp.str(), false, 0 );
+    //     // }
+    //     // const int enc = ea.next_int();
+    //     const JsonObject encObj = ea.next_object();
+    //     encumbrance_always[bp] = get_dbl_or_var( encObj, bp.str(), false, 0 );
+    //     // encumbrance_always[bp] = enc;
+    // }
+
+    // for( JsonArray ec : jo.get_array( "encumbrance_covered" ) ) {
+    //     const bodypart_str_id bp = bodypart_str_id( ec.next_string() );
+    //     // int enc = ec.next_int();
+    //     const JsonObject encObj = ec.next_object();
+    //     encumbrance_covered[bp] = get_dbl_or_var( encObj, bp.str(), false, 0 );
+    //     // encumbrance_covered[bp] = enc;
+    // }
+
+    // for( JsonMember ema : jo.get_object( "encumbrance_multiplier_always" ) ) {
+    //     const bodypart_str_id &bp = bodypart_str_id( ema.name() );
+    //     const JsonObject encObj = ema.get_object();
+    //     // encumbrance_multiplier_always[bp] = ema.get_float();
+    //     encumbrance_multiplier_always[bp] = get_dbl_or_var( encObj, bp.str(), false, 0 );
+    // }
 
     for( const std::string line : jo.get_array( "restricts_gear" ) ) {
         bodypart_str_id bp( line );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Infrastructure "Allow mutation encumbrance modifiers to take math"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Reduce the need for multiple separate mutations with different encumbrance definitions if a developer wants scaling encumbrance on their mutation
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Use dlb_or_var to store encumbrance modifiers
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
