### PR TITLE
Add pre_note for fenses with DIGGABLE requirement

### DIFF
--- a/data/json/construction/fences_gates.json
+++ b/data/json/construction/fences_gates.json
@@ -22,6 +22,7 @@
     "qualities": [ [ { "id": "HAMMER", "level": 2 } ] ],
     "components": [ [ [ "pipe", 6 ] ], [ [ "pipe_fittings", 3 ] ], [ [ "scrap", 8 ] ] ],
     "pre_flags": "DIGGABLE",
+    "pre_note": "Requires diggable terrain.",
     "pre_special": "check_empty",
     "post_terrain": "t_chainfence_posts"
   },
@@ -60,6 +61,7 @@
     "qualities": [ [ { "id": "HAMMER", "level": 2 } ] ],
     "components": [ [ [ "2x4", 5 ] ], [ [ "nails", 20, "LIST" ] ] ],
     "pre_flags": "DIGGABLE",
+    "pre_note": "Requires diggable terrain.",
     "pre_special": "check_empty",
     "post_terrain": "t_chickenwire_fence_post"
   },
@@ -102,6 +104,7 @@
       [ [ "hinge", 2 ] ]
     ],
     "pre_flags": "DIGGABLE",
+    "pre_note": "Requires diggable terrain.",
     "pre_special": "check_empty",
     "post_terrain": "t_fencegate_c"
   },
@@ -126,6 +129,7 @@
     "qualities": [ [ { "id": "HAMMER", "level": 2 } ], [ { "id": "DIG", "level": 2 } ] ],
     "components": [ [ [ "pointy_stick", 2 ], [ "spear_wood", 2 ], [ "pointy_stick_long", 2 ] ] ],
     "pre_flags": "DIGGABLE",
+    "pre_note": "Requires diggable terrain.",
     "pre_special": "check_empty",
     "post_terrain": "t_fence_post"
   },
@@ -179,6 +183,7 @@
       [ [ "nails", 20, "LIST" ] ]
     ],
     "pre_flags": "DIGGABLE",
+    "pre_note": "Requires diggable terrain.",
     "pre_special": "check_empty",
     "post_terrain": "t_privacy_fence"
   },
@@ -210,6 +215,7 @@
       [ [ "hinge", 2 ] ]
     ],
     "pre_flags": "DIGGABLE",
+    "pre_note": "Requires diggable terrain.",
     "pre_special": "check_empty",
     "post_terrain": "t_privacy_fencegate_c"
   },
@@ -266,6 +272,7 @@
       [ [ "nails", 20, "LIST" ] ]
     ],
     "pre_flags": "DIGGABLE",
+    "pre_note": "Requires diggable terrain.",
     "pre_special": "check_empty",
     "post_terrain": "t_splitrail_fence"
   },
@@ -297,6 +304,7 @@
       [ [ "hinge", 2 ] ]
     ],
     "pre_flags": "DIGGABLE",
+    "pre_note": "Requires diggable terrain.",
     "pre_special": "check_empty",
     "post_terrain": "t_splitrail_fencegate_c"
   },
@@ -311,6 +319,7 @@
     "qualities": [ [ { "id": "CUT", "level": 2 } ], [ { "id": "HAMMER", "level": 1 } ], [ { "id": "DIG", "level": 1 } ] ],
     "components": [ [ [ "stick", 4 ], [ "pointy_stick", 4 ], [ "stick_long", 2 ] ] ],
     "pre_flags": "DIGGABLE",
+    "pre_note": "Requires diggable terrain.",
     "pre_special": "check_empty",
     "post_terrain": "t_wattle_fence_posts"
   },


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Someone in discord had a problem understanding why they can't build a chicken fence. Turns out they didn't have a diggable terrain around
#### Describe the solution
Add pre_note to fences that require DIGGABLE flag, to note you need a diggable terrain
#### Additional context
I looked over the rest of construction recipes that use pre_flags, but didn't spot anything immediately bad