### PR TITLE
Make bag_durasack_cement teach recipe like an actual book

### DIFF
--- a/data/json/items/containers/containers.json
+++ b/data/json/items/containers/containers.json
@@ -150,20 +150,10 @@
     "type": "GENERIC",
     "name": { "str": "durable plastic sack, cement" },
     "looks_like": "bag_plastic",
-    "description": "A large and sturdy sack, made out plastic material.  Stores cement and has instructions on how to use it to make mortar.  Activate the bag to learn the recipe.",
-    "//": "durasack woven polypropylene bags",
+    "description": "A large and sturdy sack, made out plastic material.  Stores cement and has instructions on how to use it to make mortar.",
+    "//": "book data is used so item can work as book and provide recipes",
     "copy-from": "bag_durasack",
-    "use_action": {
-      "type": "effect_on_conditions",
-      "description": "Instructions on what to do with the contents of the bag.",
-      "effect_on_conditions": [ "EOC_CEMENT_INSTRUCTIONS" ]
-    }
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "EOC_CEMENT_INSTRUCTIONS",
-    "condition": { "and": [ { "not": { "u_has_trait": "ILLITERATE" } }, { "not": "u_driving" } ] },
-    "effect": [ { "u_message": "You learn the recipe to make cement mortar.", "type": "good" }, { "u_learn_recipe": "mortar_build" } ]
+    "book_data": { "max_level": 0, "skill": "fabrication" }
   },
   {
     "id": "bag_canvas",

--- a/data/json/recipes/other/parts_construction.json
+++ b/data/json/recipes/other/parts_construction.json
@@ -675,10 +675,10 @@
     "category": "CC_OTHER",
     "subcategory": "CSC_OTHER_OTHER",
     "skill_used": "fabrication",
-    "difficulty": 2,
+    "difficulty": 0,
     "time": "10 m",
     "autolearn": false,
-    "book_learn": [ [ "concrete_book", 2 ] ],
+    "book_learn": [ [ "concrete_book", 2 ], [ "bag_durasack_cement", 1 ] ],
     "tools": [ [ [ "concrete_mix_tool", 50 ] ] ],
     "components": [ [ [ "material_cement", 50 ] ], [ [ "material_sand", 150 ] ] ]
   },

--- a/data/json/recipes/other/parts_construction.json
+++ b/data/json/recipes/other/parts_construction.json
@@ -675,7 +675,6 @@
     "category": "CC_OTHER",
     "subcategory": "CSC_OTHER_OTHER",
     "skill_used": "fabrication",
-    "difficulty": 0,
     "time": "10 m",
     "autolearn": false,
     "book_learn": [ [ "concrete_book", 2 ], [ "bag_durasack_cement", 1 ] ],


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
after #80016 i digged more, and found that you actually can use any item as book, if you give it minimal amount of book_data
I don't like you still need to "read" a sack to obtain the recipe, and that you need to add "book can train your skill to level 0", but that's fine
#### Describe the solution
Remove learning EoC, add some fake book data to sack, make mortar_build recipe be learned from sack, make recipe level 0 so you can actually learn it (note, i don't think you need a particularly high skill to mix two powders)
#### Testing
I tested it, it provided me a recipe, but i forgot to make a screenshots :/