### PR TITLE
Cache item factory all to speed up `d:` filter by ~2s or ~10%

### DIFF
--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -5316,17 +5316,6 @@ const std::vector<const itype *> &Item_factory::all() const
     return templates_all_cache;
 }
 
-std::vector<const itype *> Item_factory::get_runtime_types() const
-{
-    std::vector<const itype *> res;
-    res.reserve( m_runtimes.size() );
-    for( const auto &e : m_runtimes ) {
-        res.push_back( e.second.get() );
-    }
-
-    return res;
-}
-
 /** Find all templates matching the UnaryPredicate function */
 std::vector<const itype *> Item_factory::find( const std::function<bool( const itype & )> &func )
 {

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -2570,6 +2570,17 @@ void Item_factory::check_definitions() const
     }
 }
 
+const itype *Item_factory::add_runtime( const itype_id &id, translation name,
+                                        translation description ) const
+{
+    itype *def = new itype();
+    def->id = id;
+    def->name = std::move( name );
+    def->description = std::move( description );
+    m_runtimes[ id ].reset( def );
+    return def;
+}
+
 //Returns the template with the given identification tag
 const itype *Item_factory::find_template( const itype_id &id ) const
 {
@@ -2589,23 +2600,13 @@ const itype *Item_factory::find_template( const itype_id &id ) const
     const recipe_id &making_id = recipe_id( id.c_str() );
     if( oter_str_id( id.c_str() ).is_valid() ||
         ( making_id.is_valid() && making_id.obj().is_blueprint() ) ) {
-        itype *def = new itype();
-        def->id = id;
-        def->name = no_translation( string_format( "DEBUG: %s", id.c_str() ) );
-        def->description = making_id.obj().description;
-        m_runtimes[ id ].reset( def );
-        return def;
+        return add_runtime( id, no_translation( string_format( "DEBUG: %s", id.c_str() ) ),
+                            making_id.obj().description );
     }
 
     debugmsg( "Missing item definition: %s", id.c_str() );
-
-    itype *def = new itype();
-    def->id = id;
-    def->name = no_translation( string_format( "undefined-%s", id.c_str() ) );
-    def->description = no_translation( string_format( "Missing item definition for %s.", id.c_str() ) );
-
-    m_runtimes[ id ].reset( def );
-    return def;
+    return add_runtime( id, no_translation( string_format( "undefined-%s", id.c_str() ) ),
+                        no_translation( string_format( "Missing item definition for %s.", id.c_str() ) ) );
 }
 
 Item_spawn_data *Item_factory::get_group( const item_group_id &group_tag )

--- a/src/item_factory.h
+++ b/src/item_factory.h
@@ -263,9 +263,6 @@ class Item_factory
         /** Get all item templates (both static and runtime) */
         const std::vector<const itype *> &all() const;
 
-        /** Get item types created at runtime. */
-        std::vector<const itype *> get_runtime_types() const;
-
         /** Find all item templates (both static and runtime) matching UnaryPredicate function */
         static std::vector<const itype *> find( const std::function<bool( const itype & )> &func );
 

--- a/src/item_factory.h
+++ b/src/item_factory.h
@@ -261,7 +261,7 @@ class Item_factory
         void load_item_blacklist( const JsonObject &json );
 
         /** Get all item templates (both static and runtime) */
-        std::vector<const itype *> all() const;
+        const std::vector<const itype *> &all() const;
 
         /** Get item types created at runtime. */
         std::vector<const itype *> get_runtime_types() const;
@@ -280,6 +280,9 @@ class Item_factory
         std::unordered_map<itype_id, itype> m_templates;
 
         mutable std::map<itype_id, std::unique_ptr<itype>> m_runtimes;
+        /** Runtimes rarely change. Used for cache templates_all_cache for the all() method. */
+        mutable bool m_runtimes_dirty = true;
+        mutable std::vector<const itype *> templates_all_cache;
 
         using GroupMap = std::map<item_group_id, std::unique_ptr<Item_spawn_data>>;
         GroupMap m_template_groups;

--- a/src/item_factory.h
+++ b/src/item_factory.h
@@ -229,6 +229,14 @@ class Item_factory
         void migrate_item_from_variant( item &obj, const std::string &from_variant );
 
         /**
+         * Add itype_id to m_runtimes.
+         *
+         * If the itype overrides an existing itype, the existing itype is deleted first.
+         * Return the newly created itype.
+         */
+        const itype *add_runtime( const itype_id &id, translation name, translation description ) const;
+
+        /**
          * Check if an item type is known to the Item_factory.
          * @param id Item type id (@ref itype::id).
          */


### PR DESCRIPTION
#### Summary
Performance "speed up `d:` filter by ~2s or ~10%"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Speed up the search.

#### Describe the solution

Cache the result of `item_factory->all()` used in `find()`.

`m_runtimes` almost never change (like not ever for some games). AFAIK they are used only for camp stuff. The cache needs to be dirtied only when those change.

#### Describe alternatives you've considered

Finish #78950 first.

#### Testing

If #78950 was merged, a new hot path for search appears. This removes it:

before (with #78950):
![image](https://github.com/user-attachments/assets/487dbbf7-a5e9-46ad-895a-abb301821c31)

after:
![image](https://github.com/user-attachments/assets/bbc01216-5271-4284-aea7-52ccee2a4c35)

I am lazy to evaluate this properly now. My git history is bit of a mess:

<details>

![image](https://github.com/user-attachments/assets/13eef944-8aea-4020-944d-a6b71f47771a)

</details>

#### Additional context

