### PR TITLE
Add ``character_takeoff_item`` event

### DIFF
--- a/doc/JSON/EFFECT_ON_CONDITION.md
+++ b/doc/JSON/EFFECT_ON_CONDITION.md
@@ -1621,115 +1621,115 @@ Every event EOC passes context vars with each of their key value pairs that the 
 
 ## Event EOC Types:
 
-| EVENT                                | Description | Context Variables | Talker(alpha/beta)                                                   |
-|--------------------------------------| ----------- | ----------------- |----------------------------------------------------------------------|
-| activates_artifact                   | Triggers when the player activates an artifact | { "character", `character_id` },<br/> { "item_name", `string` }, | character / NONE                                                     |
-| activates_mininuke                   | Triggers when any character arms a mininuke | { "character", `character_id` } | character / NONE                                                     |
-| administers_mutagen                  |  | { "character", `character_id` },<br/> { "technique", `mutagen_technique` }, | character / NONE                                                     |
-| angers_amigara_horrors               | Triggers when amigara horrors are spawned as part of a mine finale | NONE | avatar / NONE                                                        |
-| avatar_enters_omt                    | Triggers when player crosses the overmap boundary, including when player spawns | { "pos", `tripoint` },<br/> { "oter_id", `oter_id` }, | avatar / NONE                                                        |
-| avatar_moves                         |  | { "mount", `mtype_id` },<br/> { "terrain", `ter_id` },<br/> { "movement_mode", `move_mode_id` },<br/> { "underwater", `bool` },<br/> { "z", `int` }, | avatar / NONE                                                        |
-| avatar_dies                          |  | NONE | avatar / NONE                                                        |
-| awakes_dark_wyrms                    | Triggers when `pedestal_wyrm` examine action is used | NONE | avatar / NONE                                                        |
-| becomes_wanted                       | Triggered when copbots/riot bots are spawned as part of a timed event after mon/char is photo'd by eyebot | { "character", `character_id` } | character / NONE                                                     |
-| broken_bone                          | Triggered when any body part reaches 0 hp | { "character", `character_id` },<br/> { "part", `body_part` }, | character / NONE                                                     |
-| broken_bone_mends                    | Triggered when `mending` effect is removed by expiry (Character::mend) | { "character", `character_id` },<br/> { "part", `body_part` }, | character / NONE                                                     |
-| buries_corpse                        | Triggers when item with flag CORPSE is located on same tile as construction with post-special `done_grave` is completed | { "character", `character_id` },<br/> { "corpse_type", `mtype_id` },<br/> { "corpse_name", `string` }, | character / NONE                                                     |
-| camp_taken_over                      | Triggers any faction's camp is taken over | { "old_owner", `faction_id` }, <br/> { "new_Owner", `faction_id` }, <br/> { "camp_name", `string` }, <br/> { "was_violent", `bool` }, | avatar / NONE                                                        |
-| causes_resonance_cascade             | Triggers when resonance cascade option is activated via "old lab" finale's computer | NONE | avatar / NONE                                                        |
-| character_butchered_corpse           | Triggers after succesful butchering action. Possible values of butcher_type are `ACT_BLEED`, `ACT_BUTCHER`, `ACT_BUTCHER_FULL`, `ACT_FIELD_DRESS`, `ACT_SKIN`, `ACT_QUARTER`, `ACT_DISMEMBER`, `ACT_DISSECT` | { "character", `character_id` }, { "monster_id", `mtype_id` }, { "butcher_type", `string` }, | character / NONE                                                     |
-| character_casts_spell                | Triggers when a character casts spells. When a spell with multiple effects is cast, the number of effects will be triggered | { "character", `character_id` },<br/> { "spell", `spell_id` },<br/> { "school", `trait_id` },<br/> { "difficulty", `int` },<br/> { "cost", `int` },<br/> { "cast_time", `int` },<br/> { "damage", `int` }, | character / NONE                                                     |
-| character_consumes_item              |  | { "character", `character_id` },<br/> { "itype", `itype_id` }, | character / NONE                                                     |
-| character_dies                       |  | { "character", `character_id` }, | character / NONE                                                     |
-| character_eats_item                  |  | { "character", `character_id` },<br/> { "itype", `itype_id` }, | character / NONE                                                     |
-| character_finished_activity          | Triggered when character finished or canceled activity | { "character", `character_id` },<br/> { "activity", `activity_id` },<br/> { "canceled", `bool` } | character / NONE                                                     |
-| character_forgets_spell              |  | { "character", `character_id` },<br/> { "spell", `spell_id` } | character / NONE                                                     |
-| character_gains_effect               |  | { "character", `character_id` },<br/> { "effect", `efftype_id` },<br/> { "bodypart", `bodypart_id` }, { "intensity", `int` }</br> | character / NONE                                                     |
-| character_gets_headshot              |  | { "character", `character_id` } | character / NONE                                                     |
-| character_heals_damage               |  | { "character", `character_id` },<br/> { "damage", `int` }, | character / NONE                                                     |
-| character_kills_character            |  | { "killer", `character_id` },<br/> { "victim", `character_id` },<br/> { "victim_name", `string` }, | character / NONE                                                     |
-| character_kills_monster              |  | { "killer", `character_id` },<br/> { "victim_type", `mtype_id` },<br/> { "exp", `int` }, | character / monster                                                  |
-| character_learns_spell               |  | { "character", `character_id` },<br/> { "spell", `spell_id` } | character / NONE                                                     |
-| character_loses_effect               |  | { "character", `character_id` },<br/> { "effect", `efftype_id` },<br/> { "bodypart", `bodypart_id` } | character / NONE                                                     |
-| character_melee_attacks_character    |  | { "attacker", `character_id` },<br/> { "weapon", `itype_id` },<br/> { "hits", `bool` },<br/> { "victim", `character_id` },<br/> { "victim_name", `string` }, | character (attacker) / character (victim)                            |
-| character_melee_attacks_monster      | | { "attacker", `character_id` },<br/> { "weapon", `itype_id` },<br/> { "hits", `bool` },<br/> { "victim_type", `mtype_id` },| character / monster                                                  |
-| character_radioactively_mutates      | triggered when a character mutates due to being irradiated | { "character", `character_id` }, | character / NONE                                                     |
-| character_ranged_attacks_character   | |  { "attacker", `character_id` },<br/> { "weapon", `itype_id` },<br/> { "victim", `character_id` },<br/> { "victim_name", `string` }, | character (attacker) / character (victim)                            |
-| character_ranged_attacks_monster     | | { "attacker", `character_id` },<br/> { "weapon", `itype_id` },<br/> { "victim_type", `mtype_id` }, | character / monster                                                  |
-| character_smashes_tile               | | { "character", `character_id` },<br/> { "terrain", `ter_str_id` },  { "furniture", `furn_str_id` }, | character / NONE                                                     |
-| character_starts_activity            | Triggered when character starts or resumes activity | { "character", `character_id` },<br/> { "activity", `activity_id` },<br/> { "resume", `bool` } | character / NONE                                                     |
-| character_takes_damage               | triggers when character gets any damage from any creature | { "character", `character_id` },<br/> { "damage", `int` },<br/> { "bodypart", `bodypart_id` },<br/> { "pain", `int` }, | character / attacker if exists, otherwise NONE(character or monster) | use `has_beta` conditon before interacting with beta talker
-| monster_takes_damage                 | triggers when monster gets any damage from any creature. Includes damages from effects like bleeding | { "damage", `int` },<br/> { "dies", `bool` }, | monster / attacker if exists, otherwise NONE(character or monster)   | use `has_beta` conditon before interacting with beta talker
-| character_triggers_trap              | | { "character", `character_id` },<br/> { "trap", `trap_str_id` }, | character / NONE                                                     |
-| character_wakes_up                   | triggers in the moment player lost it's sleep effect and wakes up | { "character", `character_id` }, | character / NONE                                                     |
-| character_attempt_to_fall_asleep     | triggers in the moment character tries to fall asleep, after confirming and setting an alarm, but before "you lie down" | { "character", `character_id` }, | character / NONE                                                     |
-| character_falls_asleep               | triggers in the moment character actually falls asleep; trigger includes cases where character sleep for a short time because of sleepiness or drugs; duration of the sleep can be changed mid sleep because of hurt/noise/light/pain thresholds and another factors | { "character", `character_id` }, { "duration", `int_` (in seconds) } | character / NONE                                                     |
-| character_wields_item                | | { "character", `character_id` },<br/> { "itype", `itype_id` }, | character / item to wield                                            |
-| character_wears_item                 | | { "character", `character_id` },<br/> { "itype", `itype_id` }, | character / item to wear                                             |
-| character_takeoff_item               | | { "character", `character_id` },<br/> { "itype", `itype_id` }, | character / item to take off                                         |
-| character_armor_destroyed            | triggers when a worn armor is set to be destroyed from damage. The armor still exists but will be destroyed immediately after the EOCs finish running. | { "character", `character_id` },<br/> { "itype", `itype_id` }, | character / item to wear                                             |
-| consumes_marloss_item                | | { "character", `character_id` },<br/> { "itype", `itype_id` }, | character / NONE                                                     |
-| crosses_marloss_threshold            | | { "character", `character_id` } | character / NONE                                                     |
-| crosses_mutation_threshold           | | { "character", `character_id` },<br/> { "category", `mutation_category_id` }, | character / NONE                                                     |
-| crosses_mycus_threshold              | | { "character", `character_id` } | character / NONE                                                     |
-| cuts_tree                            | | { "character", `character_id` } | character / NONE                                                     |
-| dermatik_eggs_hatch                  | | { "character", `character_id` } | character / NONE                                                     |
-| dermatik_eggs_injected               | | { "character", `character_id` } | character / NONE                                                     |
-| destroys_triffid_grove               | Triggered *only* via spell with effect_str `ROOTS_DIE` (currently via death spell of triffid heart) | NONE | avatar / NONE                                                        |
-| dies_from_asthma_attack              | | { "character", `character_id` } | character / NONE                                                     |
-| dies_from_drug_overdose              | | { "character", `character_id` },<br/> { "effect", `efftype_id` }, | character / NONE                                                     |
-| dies_from_bleeding                   | | { "character", `character_id` }  | character / NONE                                                     |
-| dies_from_hypovolemia                | | { "character", `character_id` }  | character / NONE                                                     |
-| dies_from_redcells_loss              | | { "character", `character_id` }  | character / NONE                                                     |
-| dies_of_infection                    | | { "character", `character_id` }  | character / NONE                                                     |
-| dies_of_starvation                   | | { "character", `character_id` }  | character / NONE                                                     |
-| dies_of_thirst                       | | { "character", `character_id` }  | character / NONE                                                     |
-| digs_into_lava                       | | NONE  | avatar / NONE                                                        |
-| disarms_nuke                         | Triggered via disarm missile computer action in missile silo special | NONE  | avatar / NONE                                                        |
-| eats_sewage                          | Triggered via use action `SEWAGE` | NONE  | avatar / NONE                                                        |
-| evolves_mutation                     | | { "character", `character_id` },<br/> { "from_trait", `trait_id` },<br/> { "to_trait", `trait_id` }, | character / NONE                                                     |
-| exhumes_grave                        | Triggers when construction with post-special `done_dig_grave` or `done_dig_grave_nospawn` is completed | { "character", `character_id` } | character / NONE                                                     |
-| fails_to_install_cbm                 | | { "character", `character_id` },<br/> { "bionic", `bionic_id` }, | character / NONE                                                     |
-| fails_to_remove_cbm                  | | { "character", `character_id` },<br/> { "bionic", `bionic_id` }, | character / NONE                                                     |
-| falls_asleep_from_exhaustion         | | { "character", `character_id` } | character / NONE                                                     |
-| fuel_tank_explodes                   | Triggers when vehicle part (that is watertight container/magazine with magazine pocket/or is a reactor) is sufficiently damaged | { "vehicle_name", `string` }, | avatar / NONE                                                        |
-| gains_addiction                      | |  { "character", `character_id` },<br/> { "add_type", `addiction_id` }, | character / NONE                                                     |
-| gains_mutation                       | |  { "character", `character_id` },<br/> { "trait", `trait_id` }, | character / NONE                                                     |
-| gains_proficiency                    | | { "character", `character_id` },<br/> { "proficiency", `proficiency_id` }, | character / NONE                                                     |
-| gains_skill_level                    | | { "character", `character_id` },<br/> { "skill", `skill_id` },<br/> { "new_level", `int` }, | character / NONE                                                     |
-| game_avatar_death                    | Triggers during bury screen with ASCII grave art is displayed (when avatar dies, obviously) | { "avatar_id", `character_id` },<br/> { "avatar_name", `string` },<br/> { "avatar_is_male", `bool` },<br/> { "is_suicide", `bool` },<br/> { "last_words", `string` }, | avatar / NONE                                                        |
-| game_avatar_new                      | Triggers when new character is controlled and during new game character initialization  | { "is_new_game", `bool` },<br/> { "is_debug", `bool` },<br/> { "avatar_id", `character_id` },<br/> { "avatar_name", `string` },<br/> { "avatar_is_male", `bool` },<br/> { "avatar_profession", `profession_id` },<br/> { "avatar_custom_profession", `string` }, | avatar / NONE                                                        |
-| game_load                            | Triggers only when loading a saved game (not a new game!) | { "cdda_version", `string` }, | avatar / NONE                                                        |
-| game_begin                           | Triggered during game load and new game start | { "cdda_version", `string` }, | avatar / NONE                                                        |
-| game_over                            | Triggers after fully accepting death, epilogues etc. have played (probably not useable for eoc purposes?) | { "total_time_played", `chrono_seconds` }, | avatar / NONE                                                        |
-| game_save                            | | { "time_since_load", `chrono_seconds` },<br/> { "total_time_played", `chrono_seconds` }, | avatar / NONE                                                        |
-| game_start                           | Triggered only during new game character initialization | { "game_version", `string` }, | avatar / NONE                                                        |
-| installs_cbm                         | | { "character", `character_id` },<br/> { "bionic", `bionic_id` }, | character / NONE                                                     |
-| installs_faulty_cbm                  | | { "character", `character_id` },<br/> { "bionic", `bionic_id` }, | character / NONE                                                     |
-| learns_martial_art                   | |  { "character", `character_id` },<br/> { "martial_art", `matype_id` }, | character / NONE                                                     |
-| loses_addiction                      | | { "character", `character_id` },<br/> { "add_type", `addiction_id` }, | character / NONE                                                     |
-| loses_mutation                       | |  { "character", `character_id` },<br/> { "trait", `trait_id` }, | character / NONE                                                     |
-| npc_becomes_hostile                  | Triggers when NPC's attitude is set to `NPCATT_KILL` via dialogue effect `hostile` | { "npc", `character_id` },<br/> { "npc_name", `string` }, | NPC / NONE                                                           |
-| opens_portal                         | Triggers when TOGGLE PORTAL option is activated via ("old lab" finale's?) computer | NONE | avatar / NONE                                                        |
-| opens_spellbook                      | Triggers when player opens the spell menu OR when NPC evaluates spell as best weapon(in preparation to use it) | { "character", `character_id` } | character / NONE                                                     |
-| opens_temple                         | Triggers when `pedestal_temple` examine action is used to consume a petrified eye | NONE | avatar / NONE                                                        |
-| player_fails_conduct                 | | { "conduct", `achievement_id` },<br/> { "achievements_enabled", `bool` }, | avatar / NONE                                                        |
-| player_gets_achievement              | | { "achievement", `achievement_id` },<br/> { "achievements_enabled", `bool` }, | avatar / NONE                                                        |
-| player_levels_spell                  | triggers when player changes it's spell level, either by casting a spell, reading spell book, or using EoC. Spawning a new character with spells defined by using `spells` in chargen option will also run an event | { "character", `character_id` },<br/>{ "spell", `spell_id` },<br/>{ "new_level", `int` },{ "spell_class", `trait_id` } | character / NONE                                                     |
-| reads_book                           | | { "character", `character_id` } | character / NONE                                                     |
-| releases_subspace_specimens          | Triggers when Release Specimens option is activated via ("old lab" finale's?) computer | NONE | avatar / NONE                                                        |
-| removes_cbm                          | |  { "character", `character_id` },<br/> { "bionic", `bionic_id` }, | character / NONE                                                     |
-| seals_hazardous_material_sarcophagus | Triggers via `srcf_seal_order` computer action | NONE | avatar / NONE                                                        |
-| spellcasting_finish                  | Triggers only once when a character finishes casting a spell | { "character", `character_id` },<br/> { "success", `bool` },<br/>  { "spell", `spell_id` },<br/> { "school", `trait_id` },<br/> { "difficulty", `int` },<br/> { "cost", `int` },<br/> { "cast_time", `int` },<br/> { "damage", `int` }, | character / NONE                                                     |
-| telefrags_creature                   | (Unimplemented) | { "character", `character_id` },<br/> { "victim_name", `string` }, | character / NONE                                                     |
-| teleglow_teleports                   | Triggers when character(only avatar is actually eligible) is teleported due to teleglow effect | { "character", `character_id` } | character / NONE                                                     |
-| teleports_into_wall                  | Triggers when character(only avatar is actually eligible) is teleported into wall | { "character", `character_id` },<br/> { "obstacle_name", `string` }, | character / NONE                                                     |
-| terminates_subspace_specimens        | Triggers when Terminate Specimens option is activated via ("old lab" finale's?) computer | NONE | avatar / NONE                                                        |
-| throws_up                            | | { "character", `character_id` } | character / NONE                                                     |
-| triggers_alarm                       | Triggers when alarm is sounded as a failure state of hacking, prying, using a computer, or (if player is sufficiently close)damaged terrain with ALARMED flag | { "character", `character_id` } | character / NONE                                                     |
-| uses_debug_menu                      | | { "debug_menu_option", `debug_menu_index` }, | avatar / NONE                                                        |
-| u_var_changed                        | | { "var", `string` },<br/> { "value", `string` }, | avatar / NONE                                                        |
-| vehicle_moves                        | | { "avatar_on_board", `bool` },<br/> { "avatar_is_driving", `bool` },<br/> { "avatar_remote_control", `bool` },<br/> { "is_flying_aircraft", `bool` },<br/> { "is_floating_watercraft", `bool` },<br/> { "is_on_rails", `bool` },<br/> { "is_falling", `bool` },<br/> { "is_sinking", `bool` },<br/> { "is_skidding", `bool` },<br/> { "velocity", `int` }, // vehicle current velocity, mph * 100<br/> { "z", `int` }, | vehicle / avatar                                                     |
+| EVENT              | Description | Context Variables | Talker(alpha/beta) |
+| ------------------ | ----------- | ----------------- | ------------------ |
+| activates_artifact | Triggers when the player activates an artifact | { "character", `character_id` },<br/> { "item_name", `string` }, | character / NONE |
+| activates_mininuke | Triggers when any character arms a mininuke | { "character", `character_id` } | character / NONE |
+| administers_mutagen |  | { "character", `character_id` },<br/> { "technique", `mutagen_technique` }, | character / NONE |
+| angers_amigara_horrors | Triggers when amigara horrors are spawned as part of a mine finale | NONE | avatar / NONE |
+| avatar_enters_omt | Triggers when player crosses the overmap boundary, including when player spawns | { "pos", `tripoint` },<br/> { "oter_id", `oter_id` }, | avatar / NONE |
+| avatar_moves |  | { "mount", `mtype_id` },<br/> { "terrain", `ter_id` },<br/> { "movement_mode", `move_mode_id` },<br/> { "underwater", `bool` },<br/> { "z", `int` }, | avatar / NONE |
+| avatar_dies |  | NONE | avatar / NONE |
+| awakes_dark_wyrms | Triggers when `pedestal_wyrm` examine action is used | NONE | avatar / NONE |
+| becomes_wanted | Triggered when copbots/riot bots are spawned as part of a timed event after mon/char is photo'd by eyebot | { "character", `character_id` } | character / NONE |
+| broken_bone | Triggered when any body part reaches 0 hp | { "character", `character_id` },<br/> { "part", `body_part` }, | character / NONE |
+| broken_bone_mends | Triggered when `mending` effect is removed by expiry (Character::mend) | { "character", `character_id` },<br/> { "part", `body_part` }, | character / NONE |
+| buries_corpse | Triggers when item with flag CORPSE is located on same tile as construction with post-special `done_grave` is completed | { "character", `character_id` },<br/> { "corpse_type", `mtype_id` },<br/> { "corpse_name", `string` }, | character / NONE |
+| camp_taken_over | Triggers any faction's camp is taken over | { "old_owner", `faction_id` }, <br/> { "new_Owner", `faction_id` }, <br/> { "camp_name", `string` }, <br/> { "was_violent", `bool` }, | avatar / NONE |
+| causes_resonance_cascade | Triggers when resonance cascade option is activated via "old lab" finale's computer | NONE | avatar / NONE |
+| character_butchered_corpse | Triggers after succesful butchering action. Possible values of butcher_type are `ACT_BLEED`, `ACT_BUTCHER`, `ACT_BUTCHER_FULL`, `ACT_FIELD_DRESS`, `ACT_SKIN`, `ACT_QUARTER`, `ACT_DISMEMBER`, `ACT_DISSECT` | { "character", `character_id` }, { "monster_id", `mtype_id` }, { "butcher_type", `string` }, | character / NONE |
+| character_casts_spell | Triggers when a character casts spells. When a spell with multiple effects is cast, the number of effects will be triggered | { "character", `character_id` },<br/> { "spell", `spell_id` },<br/> { "school", `trait_id` },<br/> { "difficulty", `int` },<br/> { "cost", `int` },<br/> { "cast_time", `int` },<br/> { "damage", `int` }, | character / NONE |
+| character_consumes_item |  | { "character", `character_id` },<br/> { "itype", `itype_id` }, | character / NONE |
+| character_dies |  | { "character", `character_id` }, | character / NONE |
+| character_eats_item |  | { "character", `character_id` },<br/> { "itype", `itype_id` }, | character / NONE |
+| character_finished_activity | Triggered when character finished or canceled activity | { "character", `character_id` },<br/> { "activity", `activity_id` },<br/> { "canceled", `bool` } | character / NONE |
+| character_forgets_spell |  | { "character", `character_id` },<br/> { "spell", `spell_id` } | character / NONE |
+| character_gains_effect |  | { "character", `character_id` },<br/> { "effect", `efftype_id` },<br/> { "bodypart", `bodypart_id` }, { "intensity", `int` }</br> | character / NONE |
+| character_gets_headshot |  | { "character", `character_id` } | character / NONE |
+| character_heals_damage |  | { "character", `character_id` },<br/> { "damage", `int` }, | character / NONE |
+| character_kills_character |  | { "killer", `character_id` },<br/> { "victim", `character_id` },<br/> { "victim_name", `string` }, | character / NONE |
+| character_kills_monster |  | { "killer", `character_id` },<br/> { "victim_type", `mtype_id` },<br/> { "exp", `int` }, | character / monster |
+| character_learns_spell |  | { "character", `character_id` },<br/> { "spell", `spell_id` } | character / NONE |
+| character_loses_effect |  | { "character", `character_id` },<br/> { "effect", `efftype_id` },<br/> { "bodypart", `bodypart_id` } | character / NONE |
+| character_melee_attacks_character |  | { "attacker", `character_id` },<br/> { "weapon", `itype_id` },<br/> { "hits", `bool` },<br/> { "victim", `character_id` },<br/> { "victim_name", `string` }, | character (attacker) / character (victim) |
+| character_melee_attacks_monster | | { "attacker", `character_id` },<br/> { "weapon", `itype_id` },<br/> { "hits", `bool` },<br/> { "victim_type", `mtype_id` },| character / monster |
+| character_radioactively_mutates | triggered when a character mutates due to being irradiated | { "character", `character_id` }, | character / NONE |
+| character_ranged_attacks_character | |  { "attacker", `character_id` },<br/> { "weapon", `itype_id` },<br/> { "victim", `character_id` },<br/> { "victim_name", `string` }, | character (attacker) / character (victim) |
+| character_ranged_attacks_monster | | { "attacker", `character_id` },<br/> { "weapon", `itype_id` },<br/> { "victim_type", `mtype_id` }, | character / monster |
+| character_smashes_tile | | { "character", `character_id` },<br/> { "terrain", `ter_str_id` },  { "furniture", `furn_str_id` }, | character / NONE |
+| character_starts_activity | Triggered when character starts or resumes activity | { "character", `character_id` },<br/> { "activity", `activity_id` },<br/> { "resume", `bool` } | character / NONE |
+| character_takes_damage | triggers when character gets any damage from any creature | { "character", `character_id` },<br/> { "damage", `int` },<br/> { "bodypart", `bodypart_id` },<br/> { "pain", `int` }, | character / attacker if exists, otherwise NONE(character or monster) | use `has_beta` conditon before interacting with beta talker
+| monster_takes_damage | triggers when monster gets any damage from any creature. Includes damages from effects like bleeding | { "damage", `int` },<br/> { "dies", `bool` }, | monster / attacker if exists, otherwise NONE(character or monster) | use `has_beta` conditon before interacting with beta talker
+| character_triggers_trap | | { "character", `character_id` },<br/> { "trap", `trap_str_id` }, | character / NONE |
+| character_wakes_up | triggers in the moment player lost it's sleep effect and wakes up | { "character", `character_id` }, | character / NONE |
+| character_attempt_to_fall_asleep | triggers in the moment character tries to fall asleep, after confirming and setting an alarm, but before "you lie down" | { "character", `character_id` }, | character / NONE |
+| character_falls_asleep | triggers in the moment character actually falls asleep; trigger includes cases where character sleep for a short time because of sleepiness or drugs; duration of the sleep can be changed mid sleep because of hurt/noise/light/pain thresholds and another factors | { "character", `character_id` }, { "duration", `int_` (in seconds) } | character / NONE |
+| character_wields_item | | { "character", `character_id` },<br/> { "itype", `itype_id` }, | character / item to wield |
+| character_wears_item | | { "character", `character_id` },<br/> { "itype", `itype_id` }, | character / item to wear |
+| character_takeoff_item | | { "character", `character_id` },<br/> { "itype", `itype_id` }, | character / item to take off |
+| character_armor_destroyed | triggers when a worn armor is set to be destroyed from damage. The armor still exists but will be destroyed immediately after the EOCs finish running. | { "character", `character_id` },<br/> { "itype", `itype_id` }, | character / item to wear |
+| consumes_marloss_item | | { "character", `character_id` },<br/> { "itype", `itype_id` }, | character / NONE |
+| crosses_marloss_threshold | | { "character", `character_id` } | character / NONE |
+| crosses_mutation_threshold | | { "character", `character_id` },<br/> { "category", `mutation_category_id` }, | character / NONE |
+| crosses_mycus_threshold | | { "character", `character_id` } | character / NONE |
+| cuts_tree | | { "character", `character_id` } | character / NONE |
+| dermatik_eggs_hatch | | { "character", `character_id` } | character / NONE |
+| dermatik_eggs_injected | | { "character", `character_id` } | character / NONE |
+| destroys_triffid_grove | Triggered *only* via spell with effect_str `ROOTS_DIE` (currently via death spell of triffid heart) | NONE | avatar / NONE |
+| dies_from_asthma_attack | | { "character", `character_id` } | character / NONE |
+| dies_from_drug_overdose | | { "character", `character_id` },<br/> { "effect", `efftype_id` }, | character / NONE |
+| dies_from_bleeding | | { "character", `character_id` }  | character / NONE |
+| dies_from_hypovolemia | | { "character", `character_id` }  | character / NONE |
+| dies_from_redcells_loss | | { "character", `character_id` }  | character / NONE |
+| dies_of_infection | | { "character", `character_id` }  | character / NONE |
+| dies_of_starvation | | { "character", `character_id` }  | character / NONE |
+| dies_of_thirst | | { "character", `character_id` }  | character / NONE |
+| digs_into_lava | | NONE  | avatar / NONE |
+| disarms_nuke | Triggered via disarm missile computer action in missile silo special | NONE  | avatar / NONE |
+| eats_sewage | Triggered via use action `SEWAGE` | NONE  | avatar / NONE |
+| evolves_mutation | | { "character", `character_id` },<br/> { "from_trait", `trait_id` },<br/> { "to_trait", `trait_id` }, | character / NONE |
+| exhumes_grave | Triggers when construction with post-special `done_dig_grave` or `done_dig_grave_nospawn` is completed | { "character", `character_id` } | character / NONE |
+| fails_to_install_cbm | | { "character", `character_id` },<br/> { "bionic", `bionic_id` }, | character / NONE |
+| fails_to_remove_cbm | | { "character", `character_id` },<br/> { "bionic", `bionic_id` }, | character / NONE |
+| falls_asleep_from_exhaustion | | { "character", `character_id` } | character / NONE |
+| fuel_tank_explodes | Triggers when vehicle part (that is watertight container/magazine with magazine pocket/or is a reactor) is sufficiently damaged | { "vehicle_name", `string` }, | avatar / NONE |
+| gains_addiction | |  { "character", `character_id` },<br/> { "add_type", `addiction_id` }, | character / NONE |
+| gains_mutation | |  { "character", `character_id` },<br/> { "trait", `trait_id` }, | character / NONE |
+| gains_proficiency | | { "character", `character_id` },<br/> { "proficiency", `proficiency_id` }, | character / NONE |
+| gains_skill_level | | { "character", `character_id` },<br/> { "skill", `skill_id` },<br/> { "new_level", `int` }, | character / NONE |
+| game_avatar_death | Triggers during bury screen with ASCII grave art is displayed (when avatar dies, obviously) | { "avatar_id", `character_id` },<br/> { "avatar_name", `string` },<br/> { "avatar_is_male", `bool` },<br/> { "is_suicide", `bool` },<br/> { "last_words", `string` }, | avatar / NONE |
+| game_avatar_new | Triggers when new character is controlled and during new game character initialization  | { "is_new_game", `bool` },<br/> { "is_debug", `bool` },<br/> { "avatar_id", `character_id` },<br/> { "avatar_name", `string` },<br/> { "avatar_is_male", `bool` },<br/> { "avatar_profession", `profession_id` },<br/> { "avatar_custom_profession", `string` }, | avatar / NONE |
+| game_load | Triggers only when loading a saved game (not a new game!) | { "cdda_version", `string` }, | avatar / NONE |
+| game_begin | Triggered during game load and new game start | { "cdda_version", `string` }, | avatar / NONE |
+| game_over | Triggers after fully accepting death, epilogues etc. have played (probably not useable for eoc purposes?) | { "total_time_played", `chrono_seconds` }, | avatar / NONE |
+| game_save | | { "time_since_load", `chrono_seconds` },<br/> { "total_time_played", `chrono_seconds` }, | avatar / NONE |
+| game_start | Triggered only during new game character initialization | { "game_version", `string` }, | avatar / NONE |
+| installs_cbm | | { "character", `character_id` },<br/> { "bionic", `bionic_id` }, | character / NONE |
+| installs_faulty_cbm | | { "character", `character_id` },<br/> { "bionic", `bionic_id` }, | character / NONE |
+| learns_martial_art | |  { "character", `character_id` },<br/> { "martial_art", `matype_id` }, | character / NONE |
+| loses_addiction | | { "character", `character_id` },<br/> { "add_type", `addiction_id` }, | character / NONE |
+| loses_mutation | |  { "character", `character_id` },<br/> { "trait", `trait_id` }, | character / NONE |
+| npc_becomes_hostile | Triggers when NPC's attitude is set to `NPCATT_KILL` via dialogue effect `hostile` | { "npc", `character_id` },<br/> { "npc_name", `string` }, | NPC / NONE |
+| opens_portal | Triggers when TOGGLE PORTAL option is activated via ("old lab" finale's?) computer | NONE | avatar / NONE |
+| opens_spellbook | Triggers when player opens the spell menu OR when NPC evaluates spell as best weapon(in preparation to use it) | { "character", `character_id` } | character / NONE |
+| opens_temple | Triggers when `pedestal_temple` examine action is used to consume a petrified eye | NONE | avatar / NONE |
+| player_fails_conduct | | { "conduct", `achievement_id` },<br/> { "achievements_enabled", `bool` }, | avatar / NONE |
+| player_gets_achievement | | { "achievement", `achievement_id` },<br/> { "achievements_enabled", `bool` }, | avatar / NONE |
+| player_levels_spell | triggers when player changes it's spell level, either by casting a spell, reading spell book, or using EoC. Spawning a new character with spells defined by using `spells` in chargen option will also run an event | { "character", `character_id` },<br/>{ "spell", `spell_id` },<br/>{ "new_level", `int` },{ "spell_class", `trait_id` } | character / NONE |
+| reads_book | | { "character", `character_id` } | character / NONE |
+| releases_subspace_specimens | Triggers when Release Specimens option is activated via ("old lab" finale's?) computer | NONE | avatar / NONE |
+| removes_cbm | |  { "character", `character_id` },<br/> { "bionic", `bionic_id` }, | character / NONE |
+| seals_hazardous_material_sarcophagus | Triggers via `srcf_seal_order` computer action | NONE | avatar / NONE |
+| spellcasting_finish | Triggers only once when a character finishes casting a spell | { "character", `character_id` },<br/> { "success", `bool` },<br/>  { "spell", `spell_id` },<br/> { "school", `trait_id` },<br/> { "difficulty", `int` },<br/> { "cost", `int` },<br/> { "cast_time", `int` },<br/> { "damage", `int` }, | character / NONE |
+| telefrags_creature | (Unimplemented) | { "character", `character_id` },<br/> { "victim_name", `string` }, | character / NONE |
+| teleglow_teleports | Triggers when character(only avatar is actually eligible) is teleported due to teleglow effect | { "character", `character_id` } | character / NONE |
+| teleports_into_wall | Triggers when character(only avatar is actually eligible) is teleported into wall | { "character", `character_id` },<br/> { "obstacle_name", `string` }, | character / NONE |
+| terminates_subspace_specimens | Triggers when Terminate Specimens option is activated via ("old lab" finale's?) computer | NONE | avatar / NONE |
+| throws_up | | { "character", `character_id` } | character / NONE |
+| triggers_alarm | Triggers when alarm is sounded as a failure state of hacking, prying, using a computer, or (if player is sufficiently close)damaged terrain with ALARMED flag | { "character", `character_id` } | character / NONE |
+| uses_debug_menu | | { "debug_menu_option", `debug_menu_index` }, | avatar / NONE |
+| u_var_changed | | { "var", `string` },<br/> { "value", `string` }, | avatar / NONE |
+| vehicle_moves | | { "avatar_on_board", `bool` },<br/> { "avatar_is_driving", `bool` },<br/> { "avatar_remote_control", `bool` },<br/> { "is_flying_aircraft", `bool` },<br/> { "is_floating_watercraft", `bool` },<br/> { "is_on_rails", `bool` },<br/> { "is_falling", `bool` },<br/> { "is_sinking", `bool` },<br/> { "is_skidding", `bool` },<br/> { "velocity", `int` }, // vehicle current velocity, mph * 100<br/> { "z", `int` }, | vehicle / avatar |
 
 ## Context Variables For Other EOCs
 Other EOCs have some variables as well that they have access to, they are as follows:

--- a/doc/JSON/EFFECT_ON_CONDITION.md
+++ b/doc/JSON/EFFECT_ON_CONDITION.md
@@ -1621,114 +1621,115 @@ Every event EOC passes context vars with each of their key value pairs that the 
 
 ## Event EOC Types:
 
-| EVENT              | Description | Context Variables | Talker(alpha/beta) |
-| ------------------ | ----------- | ----------------- | ------------------ |
-| activates_artifact | Triggers when the player activates an artifact | { "character", `character_id` },<br/> { "item_name", `string` }, | character / NONE |
-| activates_mininuke | Triggers when any character arms a mininuke | { "character", `character_id` } | character / NONE |
-| administers_mutagen |  | { "character", `character_id` },<br/> { "technique", `mutagen_technique` }, | character / NONE |
-| angers_amigara_horrors | Triggers when amigara horrors are spawned as part of a mine finale | NONE | avatar / NONE |
-| avatar_enters_omt | Triggers when player crosses the overmap boundary, including when player spawns | { "pos", `tripoint` },<br/> { "oter_id", `oter_id` }, | avatar / NONE |
-| avatar_moves |  | { "mount", `mtype_id` },<br/> { "terrain", `ter_id` },<br/> { "movement_mode", `move_mode_id` },<br/> { "underwater", `bool` },<br/> { "z", `int` }, | avatar / NONE |
-| avatar_dies |  | NONE | avatar / NONE |
-| awakes_dark_wyrms | Triggers when `pedestal_wyrm` examine action is used | NONE | avatar / NONE |
-| becomes_wanted | Triggered when copbots/riot bots are spawned as part of a timed event after mon/char is photo'd by eyebot | { "character", `character_id` } | character / NONE |
-| broken_bone | Triggered when any body part reaches 0 hp | { "character", `character_id` },<br/> { "part", `body_part` }, | character / NONE |
-| broken_bone_mends | Triggered when `mending` effect is removed by expiry (Character::mend) | { "character", `character_id` },<br/> { "part", `body_part` }, | character / NONE |
-| buries_corpse | Triggers when item with flag CORPSE is located on same tile as construction with post-special `done_grave` is completed | { "character", `character_id` },<br/> { "corpse_type", `mtype_id` },<br/> { "corpse_name", `string` }, | character / NONE |
-| camp_taken_over | Triggers any faction's camp is taken over | { "old_owner", `faction_id` }, <br/> { "new_Owner", `faction_id` }, <br/> { "camp_name", `string` }, <br/> { "was_violent", `bool` }, | avatar / NONE |
-| causes_resonance_cascade | Triggers when resonance cascade option is activated via "old lab" finale's computer | NONE | avatar / NONE |
-| character_butchered_corpse | Triggers after succesful butchering action. Possible values of butcher_type are `ACT_BLEED`, `ACT_BUTCHER`, `ACT_BUTCHER_FULL`, `ACT_FIELD_DRESS`, `ACT_SKIN`, `ACT_QUARTER`, `ACT_DISMEMBER`, `ACT_DISSECT` | { "character", `character_id` }, { "monster_id", `mtype_id` }, { "butcher_type", `string` }, | character / NONE |
-| character_casts_spell | Triggers when a character casts spells. When a spell with multiple effects is cast, the number of effects will be triggered | { "character", `character_id` },<br/> { "spell", `spell_id` },<br/> { "school", `trait_id` },<br/> { "difficulty", `int` },<br/> { "cost", `int` },<br/> { "cast_time", `int` },<br/> { "damage", `int` }, | character / NONE |
-| character_consumes_item |  | { "character", `character_id` },<br/> { "itype", `itype_id` }, | character / NONE |
-| character_dies |  | { "character", `character_id` }, | character / NONE |
-| character_eats_item |  | { "character", `character_id` },<br/> { "itype", `itype_id` }, | character / NONE |
-| character_finished_activity | Triggered when character finished or canceled activity | { "character", `character_id` },<br/> { "activity", `activity_id` },<br/> { "canceled", `bool` } | character / NONE |
-| character_forgets_spell |  | { "character", `character_id` },<br/> { "spell", `spell_id` } | character / NONE |
-| character_gains_effect |  | { "character", `character_id` },<br/> { "effect", `efftype_id` },<br/> { "bodypart", `bodypart_id` }, { "intensity", `int` }</br> | character / NONE |
-| character_gets_headshot |  | { "character", `character_id` } | character / NONE |
-| character_heals_damage |  | { "character", `character_id` },<br/> { "damage", `int` }, | character / NONE |
-| character_kills_character |  | { "killer", `character_id` },<br/> { "victim", `character_id` },<br/> { "victim_name", `string` }, | character / NONE |
-| character_kills_monster |  | { "killer", `character_id` },<br/> { "victim_type", `mtype_id` },<br/> { "exp", `int` }, | character / monster |
-| character_learns_spell |  | { "character", `character_id` },<br/> { "spell", `spell_id` } | character / NONE |
-| character_loses_effect |  | { "character", `character_id` },<br/> { "effect", `efftype_id` },<br/> { "bodypart", `bodypart_id` } | character / NONE |
-| character_melee_attacks_character |  | { "attacker", `character_id` },<br/> { "weapon", `itype_id` },<br/> { "hits", `bool` },<br/> { "victim", `character_id` },<br/> { "victim_name", `string` }, | character (attacker) / character (victim) |
-| character_melee_attacks_monster | | { "attacker", `character_id` },<br/> { "weapon", `itype_id` },<br/> { "hits", `bool` },<br/> { "victim_type", `mtype_id` },| character / monster |
-| character_radioactively_mutates | triggered when a character mutates due to being irradiated | { "character", `character_id` }, | character / NONE |
-| character_ranged_attacks_character | |  { "attacker", `character_id` },<br/> { "weapon", `itype_id` },<br/> { "victim", `character_id` },<br/> { "victim_name", `string` }, | character (attacker) / character (victim) |
-| character_ranged_attacks_monster | | { "attacker", `character_id` },<br/> { "weapon", `itype_id` },<br/> { "victim_type", `mtype_id` }, | character / monster |
-| character_smashes_tile | | { "character", `character_id` },<br/> { "terrain", `ter_str_id` },  { "furniture", `furn_str_id` }, | character / NONE |
-| character_starts_activity | Triggered when character starts or resumes activity | { "character", `character_id` },<br/> { "activity", `activity_id` },<br/> { "resume", `bool` } | character / NONE |
-| character_takes_damage | triggers when character gets any damage from any creature | { "character", `character_id` },<br/> { "damage", `int` },<br/> { "bodypart", `bodypart_id` },<br/> { "pain", `int` }, | character / attacker if exists, otherwise NONE(character or monster) | use `has_beta` conditon before interacting with beta talker
-| monster_takes_damage | triggers when monster gets any damage from any creature. Includes damages from effects like bleeding | { "damage", `int` },<br/> { "dies", `bool` }, | monster / attacker if exists, otherwise NONE(character or monster) | use `has_beta` conditon before interacting with beta talker
-| character_triggers_trap | | { "character", `character_id` },<br/> { "trap", `trap_str_id` }, | character / NONE |
-| character_wakes_up | triggers in the moment player lost it's sleep effect and wakes up | { "character", `character_id` }, | character / NONE |
-| character_attempt_to_fall_asleep | triggers in the moment character tries to fall asleep, after confirming and setting an alarm, but before "you lie down" | { "character", `character_id` }, | character / NONE |
-| character_falls_asleep | triggers in the moment character actually falls asleep; trigger includes cases where character sleep for a short time because of sleepiness or drugs; duration of the sleep can be changed mid sleep because of hurt/noise/light/pain thresholds and another factors | { "character", `character_id` }, { "duration", `int_` (in seconds) } | character / NONE |
-| character_wields_item | | { "character", `character_id` },<br/> { "itype", `itype_id` }, | character / item to wield |
-| character_wears_item | | { "character", `character_id` },<br/> { "itype", `itype_id` }, | character / item to wear |
-| character_armor_destroyed | triggers when a worn armor is set to be destroyed from damage. The armor still exists but will be destroyed immediately after the EOCs finish running. | { "character", `character_id` },<br/> { "itype", `itype_id` }, | character / item to wear |
-| consumes_marloss_item | | { "character", `character_id` },<br/> { "itype", `itype_id` }, | character / NONE |
-| crosses_marloss_threshold | | { "character", `character_id` } | character / NONE |
-| crosses_mutation_threshold | | { "character", `character_id` },<br/> { "category", `mutation_category_id` }, | character / NONE |
-| crosses_mycus_threshold | | { "character", `character_id` } | character / NONE |
-| cuts_tree | | { "character", `character_id` } | character / NONE |
-| dermatik_eggs_hatch | | { "character", `character_id` } | character / NONE |
-| dermatik_eggs_injected | | { "character", `character_id` } | character / NONE |
-| destroys_triffid_grove | Triggered *only* via spell with effect_str `ROOTS_DIE` (currently via death spell of triffid heart) | NONE | avatar / NONE |
-| dies_from_asthma_attack | | { "character", `character_id` } | character / NONE |
-| dies_from_drug_overdose | | { "character", `character_id` },<br/> { "effect", `efftype_id` }, | character / NONE |
-| dies_from_bleeding | | { "character", `character_id` }  | character / NONE |
-| dies_from_hypovolemia | | { "character", `character_id` }  | character / NONE |
-| dies_from_redcells_loss | | { "character", `character_id` }  | character / NONE |
-| dies_of_infection | | { "character", `character_id` }  | character / NONE |
-| dies_of_starvation | | { "character", `character_id` }  | character / NONE |
-| dies_of_thirst | | { "character", `character_id` }  | character / NONE |
-| digs_into_lava | | NONE  | avatar / NONE |
-| disarms_nuke | Triggered via disarm missile computer action in missile silo special | NONE  | avatar / NONE |
-| eats_sewage | Triggered via use action `SEWAGE` | NONE  | avatar / NONE |
-| evolves_mutation | | { "character", `character_id` },<br/> { "from_trait", `trait_id` },<br/> { "to_trait", `trait_id` }, | character / NONE |
-| exhumes_grave | Triggers when construction with post-special `done_dig_grave` or `done_dig_grave_nospawn` is completed | { "character", `character_id` } | character / NONE |
-| fails_to_install_cbm | | { "character", `character_id` },<br/> { "bionic", `bionic_id` }, | character / NONE |
-| fails_to_remove_cbm | | { "character", `character_id` },<br/> { "bionic", `bionic_id` }, | character / NONE |
-| falls_asleep_from_exhaustion | | { "character", `character_id` } | character / NONE |
-| fuel_tank_explodes | Triggers when vehicle part (that is watertight container/magazine with magazine pocket/or is a reactor) is sufficiently damaged | { "vehicle_name", `string` }, | avatar / NONE |
-| gains_addiction | |  { "character", `character_id` },<br/> { "add_type", `addiction_id` }, | character / NONE |
-| gains_mutation | |  { "character", `character_id` },<br/> { "trait", `trait_id` }, | character / NONE |
-| gains_proficiency | | { "character", `character_id` },<br/> { "proficiency", `proficiency_id` }, | character / NONE |
-| gains_skill_level | | { "character", `character_id` },<br/> { "skill", `skill_id` },<br/> { "new_level", `int` }, | character / NONE |
-| game_avatar_death | Triggers during bury screen with ASCII grave art is displayed (when avatar dies, obviously) | { "avatar_id", `character_id` },<br/> { "avatar_name", `string` },<br/> { "avatar_is_male", `bool` },<br/> { "is_suicide", `bool` },<br/> { "last_words", `string` }, | avatar / NONE |
-| game_avatar_new | Triggers when new character is controlled and during new game character initialization  | { "is_new_game", `bool` },<br/> { "is_debug", `bool` },<br/> { "avatar_id", `character_id` },<br/> { "avatar_name", `string` },<br/> { "avatar_is_male", `bool` },<br/> { "avatar_profession", `profession_id` },<br/> { "avatar_custom_profession", `string` }, | avatar / NONE |
-| game_load | Triggers only when loading a saved game (not a new game!) | { "cdda_version", `string` }, | avatar / NONE |
-| game_begin | Triggered during game load and new game start | { "cdda_version", `string` }, | avatar / NONE |
-| game_over | Triggers after fully accepting death, epilogues etc. have played (probably not useable for eoc purposes?) | { "total_time_played", `chrono_seconds` }, | avatar / NONE |
-| game_save | | { "time_since_load", `chrono_seconds` },<br/> { "total_time_played", `chrono_seconds` }, | avatar / NONE |
-| game_start | Triggered only during new game character initialization | { "game_version", `string` }, | avatar / NONE |
-| installs_cbm | | { "character", `character_id` },<br/> { "bionic", `bionic_id` }, | character / NONE |
-| installs_faulty_cbm | | { "character", `character_id` },<br/> { "bionic", `bionic_id` }, | character / NONE |
-| learns_martial_art | |  { "character", `character_id` },<br/> { "martial_art", `matype_id` }, | character / NONE |
-| loses_addiction | | { "character", `character_id` },<br/> { "add_type", `addiction_id` }, | character / NONE |
-| loses_mutation | |  { "character", `character_id` },<br/> { "trait", `trait_id` }, | character / NONE |
-| npc_becomes_hostile | Triggers when NPC's attitude is set to `NPCATT_KILL` via dialogue effect `hostile` | { "npc", `character_id` },<br/> { "npc_name", `string` }, | NPC / NONE |
-| opens_portal | Triggers when TOGGLE PORTAL option is activated via ("old lab" finale's?) computer | NONE | avatar / NONE |
-| opens_spellbook | Triggers when player opens the spell menu OR when NPC evaluates spell as best weapon(in preparation to use it) | { "character", `character_id` } | character / NONE |
-| opens_temple | Triggers when `pedestal_temple` examine action is used to consume a petrified eye | NONE | avatar / NONE |
-| player_fails_conduct | | { "conduct", `achievement_id` },<br/> { "achievements_enabled", `bool` }, | avatar / NONE |
-| player_gets_achievement | | { "achievement", `achievement_id` },<br/> { "achievements_enabled", `bool` }, | avatar / NONE |
-| player_levels_spell | triggers when player changes it's spell level, either by casting a spell, reading spell book, or using EoC. Spawning a new character with spells defined by using `spells` in chargen option will also run an event | { "character", `character_id` },<br/>{ "spell", `spell_id` },<br/>{ "new_level", `int` },{ "spell_class", `trait_id` } | character / NONE |
-| reads_book | | { "character", `character_id` } | character / NONE |
-| releases_subspace_specimens | Triggers when Release Specimens option is activated via ("old lab" finale's?) computer | NONE | avatar / NONE |
-| removes_cbm | |  { "character", `character_id` },<br/> { "bionic", `bionic_id` }, | character / NONE |
-| seals_hazardous_material_sarcophagus | Triggers via `srcf_seal_order` computer action | NONE | avatar / NONE |
-| spellcasting_finish | Triggers only once when a character finishes casting a spell | { "character", `character_id` },<br/> { "success", `bool` },<br/>  { "spell", `spell_id` },<br/> { "school", `trait_id` },<br/> { "difficulty", `int` },<br/> { "cost", `int` },<br/> { "cast_time", `int` },<br/> { "damage", `int` }, | character / NONE |
-| telefrags_creature | (Unimplemented) | { "character", `character_id` },<br/> { "victim_name", `string` }, | character / NONE |
-| teleglow_teleports | Triggers when character(only avatar is actually eligible) is teleported due to teleglow effect | { "character", `character_id` } | character / NONE |
-| teleports_into_wall | Triggers when character(only avatar is actually eligible) is teleported into wall | { "character", `character_id` },<br/> { "obstacle_name", `string` }, | character / NONE |
-| terminates_subspace_specimens | Triggers when Terminate Specimens option is activated via ("old lab" finale's?) computer | NONE | avatar / NONE |
-| throws_up | | { "character", `character_id` } | character / NONE |
-| triggers_alarm | Triggers when alarm is sounded as a failure state of hacking, prying, using a computer, or (if player is sufficiently close)damaged terrain with ALARMED flag | { "character", `character_id` } | character / NONE |
-| uses_debug_menu | | { "debug_menu_option", `debug_menu_index` }, | avatar / NONE |
-| u_var_changed | | { "var", `string` },<br/> { "value", `string` }, | avatar / NONE |
-| vehicle_moves | | { "avatar_on_board", `bool` },<br/> { "avatar_is_driving", `bool` },<br/> { "avatar_remote_control", `bool` },<br/> { "is_flying_aircraft", `bool` },<br/> { "is_floating_watercraft", `bool` },<br/> { "is_on_rails", `bool` },<br/> { "is_falling", `bool` },<br/> { "is_sinking", `bool` },<br/> { "is_skidding", `bool` },<br/> { "velocity", `int` }, // vehicle current velocity, mph * 100<br/> { "z", `int` }, | vehicle / avatar |
+| EVENT                                | Description | Context Variables | Talker(alpha/beta)                                                   |
+|--------------------------------------| ----------- | ----------------- |----------------------------------------------------------------------|
+| activates_artifact                   | Triggers when the player activates an artifact | { "character", `character_id` },<br/> { "item_name", `string` }, | character / NONE                                                     |
+| activates_mininuke                   | Triggers when any character arms a mininuke | { "character", `character_id` } | character / NONE                                                     |
+| administers_mutagen                  |  | { "character", `character_id` },<br/> { "technique", `mutagen_technique` }, | character / NONE                                                     |
+| angers_amigara_horrors               | Triggers when amigara horrors are spawned as part of a mine finale | NONE | avatar / NONE                                                        |
+| avatar_enters_omt                    | Triggers when player crosses the overmap boundary, including when player spawns | { "pos", `tripoint` },<br/> { "oter_id", `oter_id` }, | avatar / NONE                                                        |
+| avatar_moves                         |  | { "mount", `mtype_id` },<br/> { "terrain", `ter_id` },<br/> { "movement_mode", `move_mode_id` },<br/> { "underwater", `bool` },<br/> { "z", `int` }, | avatar / NONE                                                        |
+| avatar_dies                          |  | NONE | avatar / NONE                                                        |
+| awakes_dark_wyrms                    | Triggers when `pedestal_wyrm` examine action is used | NONE | avatar / NONE                                                        |
+| becomes_wanted                       | Triggered when copbots/riot bots are spawned as part of a timed event after mon/char is photo'd by eyebot | { "character", `character_id` } | character / NONE                                                     |
+| broken_bone                          | Triggered when any body part reaches 0 hp | { "character", `character_id` },<br/> { "part", `body_part` }, | character / NONE                                                     |
+| broken_bone_mends                    | Triggered when `mending` effect is removed by expiry (Character::mend) | { "character", `character_id` },<br/> { "part", `body_part` }, | character / NONE                                                     |
+| buries_corpse                        | Triggers when item with flag CORPSE is located on same tile as construction with post-special `done_grave` is completed | { "character", `character_id` },<br/> { "corpse_type", `mtype_id` },<br/> { "corpse_name", `string` }, | character / NONE                                                     |
+| camp_taken_over                      | Triggers any faction's camp is taken over | { "old_owner", `faction_id` }, <br/> { "new_Owner", `faction_id` }, <br/> { "camp_name", `string` }, <br/> { "was_violent", `bool` }, | avatar / NONE                                                        |
+| causes_resonance_cascade             | Triggers when resonance cascade option is activated via "old lab" finale's computer | NONE | avatar / NONE                                                        |
+| character_butchered_corpse           | Triggers after succesful butchering action. Possible values of butcher_type are `ACT_BLEED`, `ACT_BUTCHER`, `ACT_BUTCHER_FULL`, `ACT_FIELD_DRESS`, `ACT_SKIN`, `ACT_QUARTER`, `ACT_DISMEMBER`, `ACT_DISSECT` | { "character", `character_id` }, { "monster_id", `mtype_id` }, { "butcher_type", `string` }, | character / NONE                                                     |
+| character_casts_spell                | Triggers when a character casts spells. When a spell with multiple effects is cast, the number of effects will be triggered | { "character", `character_id` },<br/> { "spell", `spell_id` },<br/> { "school", `trait_id` },<br/> { "difficulty", `int` },<br/> { "cost", `int` },<br/> { "cast_time", `int` },<br/> { "damage", `int` }, | character / NONE                                                     |
+| character_consumes_item              |  | { "character", `character_id` },<br/> { "itype", `itype_id` }, | character / NONE                                                     |
+| character_dies                       |  | { "character", `character_id` }, | character / NONE                                                     |
+| character_eats_item                  |  | { "character", `character_id` },<br/> { "itype", `itype_id` }, | character / NONE                                                     |
+| character_finished_activity          | Triggered when character finished or canceled activity | { "character", `character_id` },<br/> { "activity", `activity_id` },<br/> { "canceled", `bool` } | character / NONE                                                     |
+| character_forgets_spell              |  | { "character", `character_id` },<br/> { "spell", `spell_id` } | character / NONE                                                     |
+| character_gains_effect               |  | { "character", `character_id` },<br/> { "effect", `efftype_id` },<br/> { "bodypart", `bodypart_id` }, { "intensity", `int` }</br> | character / NONE                                                     |
+| character_gets_headshot              |  | { "character", `character_id` } | character / NONE                                                     |
+| character_heals_damage               |  | { "character", `character_id` },<br/> { "damage", `int` }, | character / NONE                                                     |
+| character_kills_character            |  | { "killer", `character_id` },<br/> { "victim", `character_id` },<br/> { "victim_name", `string` }, | character / NONE                                                     |
+| character_kills_monster              |  | { "killer", `character_id` },<br/> { "victim_type", `mtype_id` },<br/> { "exp", `int` }, | character / monster                                                  |
+| character_learns_spell               |  | { "character", `character_id` },<br/> { "spell", `spell_id` } | character / NONE                                                     |
+| character_loses_effect               |  | { "character", `character_id` },<br/> { "effect", `efftype_id` },<br/> { "bodypart", `bodypart_id` } | character / NONE                                                     |
+| character_melee_attacks_character    |  | { "attacker", `character_id` },<br/> { "weapon", `itype_id` },<br/> { "hits", `bool` },<br/> { "victim", `character_id` },<br/> { "victim_name", `string` }, | character (attacker) / character (victim)                            |
+| character_melee_attacks_monster      | | { "attacker", `character_id` },<br/> { "weapon", `itype_id` },<br/> { "hits", `bool` },<br/> { "victim_type", `mtype_id` },| character / monster                                                  |
+| character_radioactively_mutates      | triggered when a character mutates due to being irradiated | { "character", `character_id` }, | character / NONE                                                     |
+| character_ranged_attacks_character   | |  { "attacker", `character_id` },<br/> { "weapon", `itype_id` },<br/> { "victim", `character_id` },<br/> { "victim_name", `string` }, | character (attacker) / character (victim)                            |
+| character_ranged_attacks_monster     | | { "attacker", `character_id` },<br/> { "weapon", `itype_id` },<br/> { "victim_type", `mtype_id` }, | character / monster                                                  |
+| character_smashes_tile               | | { "character", `character_id` },<br/> { "terrain", `ter_str_id` },  { "furniture", `furn_str_id` }, | character / NONE                                                     |
+| character_starts_activity            | Triggered when character starts or resumes activity | { "character", `character_id` },<br/> { "activity", `activity_id` },<br/> { "resume", `bool` } | character / NONE                                                     |
+| character_takes_damage               | triggers when character gets any damage from any creature | { "character", `character_id` },<br/> { "damage", `int` },<br/> { "bodypart", `bodypart_id` },<br/> { "pain", `int` }, | character / attacker if exists, otherwise NONE(character or monster) | use `has_beta` conditon before interacting with beta talker
+| monster_takes_damage                 | triggers when monster gets any damage from any creature. Includes damages from effects like bleeding | { "damage", `int` },<br/> { "dies", `bool` }, | monster / attacker if exists, otherwise NONE(character or monster)   | use `has_beta` conditon before interacting with beta talker
+| character_triggers_trap              | | { "character", `character_id` },<br/> { "trap", `trap_str_id` }, | character / NONE                                                     |
+| character_wakes_up                   | triggers in the moment player lost it's sleep effect and wakes up | { "character", `character_id` }, | character / NONE                                                     |
+| character_attempt_to_fall_asleep     | triggers in the moment character tries to fall asleep, after confirming and setting an alarm, but before "you lie down" | { "character", `character_id` }, | character / NONE                                                     |
+| character_falls_asleep               | triggers in the moment character actually falls asleep; trigger includes cases where character sleep for a short time because of sleepiness or drugs; duration of the sleep can be changed mid sleep because of hurt/noise/light/pain thresholds and another factors | { "character", `character_id` }, { "duration", `int_` (in seconds) } | character / NONE                                                     |
+| character_wields_item                | | { "character", `character_id` },<br/> { "itype", `itype_id` }, | character / item to wield                                            |
+| character_wears_item                 | | { "character", `character_id` },<br/> { "itype", `itype_id` }, | character / item to wear                                             |
+| character_takeoff_item               | | { "character", `character_id` },<br/> { "itype", `itype_id` }, | character / item to take off                                         |
+| character_armor_destroyed            | triggers when a worn armor is set to be destroyed from damage. The armor still exists but will be destroyed immediately after the EOCs finish running. | { "character", `character_id` },<br/> { "itype", `itype_id` }, | character / item to wear                                             |
+| consumes_marloss_item                | | { "character", `character_id` },<br/> { "itype", `itype_id` }, | character / NONE                                                     |
+| crosses_marloss_threshold            | | { "character", `character_id` } | character / NONE                                                     |
+| crosses_mutation_threshold           | | { "character", `character_id` },<br/> { "category", `mutation_category_id` }, | character / NONE                                                     |
+| crosses_mycus_threshold              | | { "character", `character_id` } | character / NONE                                                     |
+| cuts_tree                            | | { "character", `character_id` } | character / NONE                                                     |
+| dermatik_eggs_hatch                  | | { "character", `character_id` } | character / NONE                                                     |
+| dermatik_eggs_injected               | | { "character", `character_id` } | character / NONE                                                     |
+| destroys_triffid_grove               | Triggered *only* via spell with effect_str `ROOTS_DIE` (currently via death spell of triffid heart) | NONE | avatar / NONE                                                        |
+| dies_from_asthma_attack              | | { "character", `character_id` } | character / NONE                                                     |
+| dies_from_drug_overdose              | | { "character", `character_id` },<br/> { "effect", `efftype_id` }, | character / NONE                                                     |
+| dies_from_bleeding                   | | { "character", `character_id` }  | character / NONE                                                     |
+| dies_from_hypovolemia                | | { "character", `character_id` }  | character / NONE                                                     |
+| dies_from_redcells_loss              | | { "character", `character_id` }  | character / NONE                                                     |
+| dies_of_infection                    | | { "character", `character_id` }  | character / NONE                                                     |
+| dies_of_starvation                   | | { "character", `character_id` }  | character / NONE                                                     |
+| dies_of_thirst                       | | { "character", `character_id` }  | character / NONE                                                     |
+| digs_into_lava                       | | NONE  | avatar / NONE                                                        |
+| disarms_nuke                         | Triggered via disarm missile computer action in missile silo special | NONE  | avatar / NONE                                                        |
+| eats_sewage                          | Triggered via use action `SEWAGE` | NONE  | avatar / NONE                                                        |
+| evolves_mutation                     | | { "character", `character_id` },<br/> { "from_trait", `trait_id` },<br/> { "to_trait", `trait_id` }, | character / NONE                                                     |
+| exhumes_grave                        | Triggers when construction with post-special `done_dig_grave` or `done_dig_grave_nospawn` is completed | { "character", `character_id` } | character / NONE                                                     |
+| fails_to_install_cbm                 | | { "character", `character_id` },<br/> { "bionic", `bionic_id` }, | character / NONE                                                     |
+| fails_to_remove_cbm                  | | { "character", `character_id` },<br/> { "bionic", `bionic_id` }, | character / NONE                                                     |
+| falls_asleep_from_exhaustion         | | { "character", `character_id` } | character / NONE                                                     |
+| fuel_tank_explodes                   | Triggers when vehicle part (that is watertight container/magazine with magazine pocket/or is a reactor) is sufficiently damaged | { "vehicle_name", `string` }, | avatar / NONE                                                        |
+| gains_addiction                      | |  { "character", `character_id` },<br/> { "add_type", `addiction_id` }, | character / NONE                                                     |
+| gains_mutation                       | |  { "character", `character_id` },<br/> { "trait", `trait_id` }, | character / NONE                                                     |
+| gains_proficiency                    | | { "character", `character_id` },<br/> { "proficiency", `proficiency_id` }, | character / NONE                                                     |
+| gains_skill_level                    | | { "character", `character_id` },<br/> { "skill", `skill_id` },<br/> { "new_level", `int` }, | character / NONE                                                     |
+| game_avatar_death                    | Triggers during bury screen with ASCII grave art is displayed (when avatar dies, obviously) | { "avatar_id", `character_id` },<br/> { "avatar_name", `string` },<br/> { "avatar_is_male", `bool` },<br/> { "is_suicide", `bool` },<br/> { "last_words", `string` }, | avatar / NONE                                                        |
+| game_avatar_new                      | Triggers when new character is controlled and during new game character initialization  | { "is_new_game", `bool` },<br/> { "is_debug", `bool` },<br/> { "avatar_id", `character_id` },<br/> { "avatar_name", `string` },<br/> { "avatar_is_male", `bool` },<br/> { "avatar_profession", `profession_id` },<br/> { "avatar_custom_profession", `string` }, | avatar / NONE                                                        |
+| game_load                            | Triggers only when loading a saved game (not a new game!) | { "cdda_version", `string` }, | avatar / NONE                                                        |
+| game_begin                           | Triggered during game load and new game start | { "cdda_version", `string` }, | avatar / NONE                                                        |
+| game_over                            | Triggers after fully accepting death, epilogues etc. have played (probably not useable for eoc purposes?) | { "total_time_played", `chrono_seconds` }, | avatar / NONE                                                        |
+| game_save                            | | { "time_since_load", `chrono_seconds` },<br/> { "total_time_played", `chrono_seconds` }, | avatar / NONE                                                        |
+| game_start                           | Triggered only during new game character initialization | { "game_version", `string` }, | avatar / NONE                                                        |
+| installs_cbm                         | | { "character", `character_id` },<br/> { "bionic", `bionic_id` }, | character / NONE                                                     |
+| installs_faulty_cbm                  | | { "character", `character_id` },<br/> { "bionic", `bionic_id` }, | character / NONE                                                     |
+| learns_martial_art                   | |  { "character", `character_id` },<br/> { "martial_art", `matype_id` }, | character / NONE                                                     |
+| loses_addiction                      | | { "character", `character_id` },<br/> { "add_type", `addiction_id` }, | character / NONE                                                     |
+| loses_mutation                       | |  { "character", `character_id` },<br/> { "trait", `trait_id` }, | character / NONE                                                     |
+| npc_becomes_hostile                  | Triggers when NPC's attitude is set to `NPCATT_KILL` via dialogue effect `hostile` | { "npc", `character_id` },<br/> { "npc_name", `string` }, | NPC / NONE                                                           |
+| opens_portal                         | Triggers when TOGGLE PORTAL option is activated via ("old lab" finale's?) computer | NONE | avatar / NONE                                                        |
+| opens_spellbook                      | Triggers when player opens the spell menu OR when NPC evaluates spell as best weapon(in preparation to use it) | { "character", `character_id` } | character / NONE                                                     |
+| opens_temple                         | Triggers when `pedestal_temple` examine action is used to consume a petrified eye | NONE | avatar / NONE                                                        |
+| player_fails_conduct                 | | { "conduct", `achievement_id` },<br/> { "achievements_enabled", `bool` }, | avatar / NONE                                                        |
+| player_gets_achievement              | | { "achievement", `achievement_id` },<br/> { "achievements_enabled", `bool` }, | avatar / NONE                                                        |
+| player_levels_spell                  | triggers when player changes it's spell level, either by casting a spell, reading spell book, or using EoC. Spawning a new character with spells defined by using `spells` in chargen option will also run an event | { "character", `character_id` },<br/>{ "spell", `spell_id` },<br/>{ "new_level", `int` },{ "spell_class", `trait_id` } | character / NONE                                                     |
+| reads_book                           | | { "character", `character_id` } | character / NONE                                                     |
+| releases_subspace_specimens          | Triggers when Release Specimens option is activated via ("old lab" finale's?) computer | NONE | avatar / NONE                                                        |
+| removes_cbm                          | |  { "character", `character_id` },<br/> { "bionic", `bionic_id` }, | character / NONE                                                     |
+| seals_hazardous_material_sarcophagus | Triggers via `srcf_seal_order` computer action | NONE | avatar / NONE                                                        |
+| spellcasting_finish                  | Triggers only once when a character finishes casting a spell | { "character", `character_id` },<br/> { "success", `bool` },<br/>  { "spell", `spell_id` },<br/> { "school", `trait_id` },<br/> { "difficulty", `int` },<br/> { "cost", `int` },<br/> { "cast_time", `int` },<br/> { "damage", `int` }, | character / NONE                                                     |
+| telefrags_creature                   | (Unimplemented) | { "character", `character_id` },<br/> { "victim_name", `string` }, | character / NONE                                                     |
+| teleglow_teleports                   | Triggers when character(only avatar is actually eligible) is teleported due to teleglow effect | { "character", `character_id` } | character / NONE                                                     |
+| teleports_into_wall                  | Triggers when character(only avatar is actually eligible) is teleported into wall | { "character", `character_id` },<br/> { "obstacle_name", `string` }, | character / NONE                                                     |
+| terminates_subspace_specimens        | Triggers when Terminate Specimens option is activated via ("old lab" finale's?) computer | NONE | avatar / NONE                                                        |
+| throws_up                            | | { "character", `character_id` } | character / NONE                                                     |
+| triggers_alarm                       | Triggers when alarm is sounded as a failure state of hacking, prying, using a computer, or (if player is sufficiently close)damaged terrain with ALARMED flag | { "character", `character_id` } | character / NONE                                                     |
+| uses_debug_menu                      | | { "debug_menu_option", `debug_menu_index` }, | avatar / NONE                                                        |
+| u_var_changed                        | | { "var", `string` },<br/> { "value", `string` }, | avatar / NONE                                                        |
+| vehicle_moves                        | | { "avatar_on_board", `bool` },<br/> { "avatar_is_driving", `bool` },<br/> { "avatar_remote_control", `bool` },<br/> { "is_flying_aircraft", `bool` },<br/> { "is_floating_watercraft", `bool` },<br/> { "is_on_rails", `bool` },<br/> { "is_falling", `bool` },<br/> { "is_sinking", `bool` },<br/> { "is_skidding", `bool` },<br/> { "velocity", `int` }, // vehicle current velocity, mph * 100<br/> { "z", `int` }, | vehicle / avatar                                                     |
 
 ## Context Variables For Other EOCs
 Other EOCs have some variables as well that they have access to, they are as follows:

--- a/src/character_attire.cpp
+++ b/src/character_attire.cpp
@@ -1505,7 +1505,6 @@ int outfit::amount_worn( const itype_id &clothing ) const
 bool outfit::takeoff( item_location loc, std::list<item> *res, Character &guy )
 {
     item &it = *loc;
-    //@todo may here
     const auto ret = guy.can_takeoff( it, res );
     if( !ret.success() ) {
         add_msg( m_info, "%s", ret.c_str() );

--- a/src/character_attire.cpp
+++ b/src/character_attire.cpp
@@ -1505,7 +1505,7 @@ int outfit::amount_worn( const itype_id &clothing ) const
 bool outfit::takeoff( item_location loc, std::list<item> *res, Character &guy )
 {
     item &it = *loc;
-
+    //@todo may here
     const auto ret = guy.can_takeoff( it, res );
     if( !ret.success() ) {
         add_msg( m_info, "%s", ret.c_str() );
@@ -1517,6 +1517,9 @@ bool outfit::takeoff( item_location loc, std::list<item> *res, Character &guy )
     } );
 
     it.on_takeoff( guy );
+    cata::event e = cata::event::make<event_type::character_takeoff_item>( guy.getID(),
+                    it.typeId() );
+    get_event_bus().send_with_talker( &guy, &loc, e );
     item takeoff_copy( it );
     worn.erase( iter );
     if( res == nullptr ) {

--- a/src/event.cpp
+++ b/src/event.cpp
@@ -57,6 +57,7 @@ std::string enum_to_string<event_type>( event_type data )
         case event_type::character_attempt_to_fall_asleep: return "character_attempt_to_fall_asleep";
         case event_type::character_wakes_up: return "character_wakes_up";
         case event_type::character_wears_item: return "character_wears_item";
+        case event_type::character_takeoff_item: return "character_takeoff_item";
          case event_type::character_armor_destroyed: return "character_armor_destroyed";
         case event_type::character_wields_item: return "character_wields_item";
         case event_type::consumes_marloss_item: return "consumes_marloss_item";
@@ -145,7 +146,7 @@ DEFINE_EVENT_HELPER_FIELDS( event_spec_empty )
 DEFINE_EVENT_HELPER_FIELDS( event_spec_character )
 DEFINE_EVENT_HELPER_FIELDS( event_spec_character_item )
 
-static_assert( static_cast<int>( event_type::num_event_types ) == 106,
+static_assert( static_cast<int>( event_type::num_event_types ) == 107,
                "This static_assert is a reminder to add a definition below when you add a new "
                "event_type.  If your event_spec specialization inherits from another struct for "
                "its fields definition then you probably don't need a definition here." );

--- a/src/event.h
+++ b/src/event.h
@@ -66,6 +66,7 @@ enum class event_type : int {
     character_wakes_up,
     character_wields_item,
     character_wears_item,
+    character_takeoff_item,
     character_armor_destroyed,
     consumes_marloss_item,
     crosses_marloss_threshold,
@@ -190,7 +191,7 @@ struct event_spec_character_item {
     };
 };
 
-static_assert( static_cast<int>( event_type::num_event_types ) == 106,
+static_assert( static_cast<int>( event_type::num_event_types ) == 107,
                "This static_assert is to remind you to add a specialization for your new "
                "event_type below" );
 
@@ -533,6 +534,8 @@ struct event_spec<event_type::character_butchered_corpse> {
 template<>
 struct event_spec<event_type::character_wears_item> : event_spec_character_item {};
 
+template<>
+struct event_spec<event_type::character_takeoff_item> : event_spec_character_item {};
 template<>
 struct event_spec<event_type::character_armor_destroyed> : event_spec_character_item {};
 

--- a/src/memorial_logger.cpp
+++ b/src/memorial_logger.cpp
@@ -1144,6 +1144,7 @@ void memorial_logger::notify( const cata::event &e )
         case event_type::character_falls_asleep:
         case event_type::character_radioactively_mutates:
         case event_type::character_wears_item:
+        case event_type::character_takeoff_item:
         case event_type::character_wields_item:
         case event_type::character_armor_destroyed:
         case event_type::character_casts_spell:


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "Add ``character_takeoff_item`` event"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Add an event that is triggered when the character takes off an item.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add a new  event called ``character_takeoff_item``, which has two argument character id and item type id. It is  triggered between ``it.on_takeoff( guy )`` and ``worn.erase( iter )``.
Add relevant documentation.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Test the player character and NPC taking off items, and no errors occurred.
Add the following eoc for testing, eoc is successfully triggered and prints out the correct character id and item type id:
`
  {
    "type": "effect_on_condition",
    "id": "test_character_takeoff_item",
    "eoc_type": "EVENT",
    "required_event": "character_takeoff_item",
    "effect": [
      {"message": "<context_val:character> take_off <context_val:itype>"}
    ]
  }
`
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
