### PR TITLE
Up the max_item_lengths of rope_loop, bigframe_pack

### DIFF
--- a/data/json/items/armor/storage.json
+++ b/data/json/items/armor/storage.json
@@ -3249,7 +3249,7 @@
         "max_contains_volume": "50 L",
         "max_contains_weight": "80 kg",
         "min_item_length": "60 cm",
-        "max_item_length": "250 cm",
+        "max_item_length": "260 cm",
         "moves": 1000,
         "ripoff": 5,
         "activity_noise": { "volume": 9, "chance": 15 },
@@ -3370,7 +3370,7 @@
         "max_contains_weight": "150 kg",
         "moves": 300,
         "min_item_volume": "1 L",
-        "max_item_length": "180 cm"
+        "max_item_length": "260 cm"
       }
     ],
     "warmth": 5,


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "Up the max_item_lengths of loop of rope and big frame pack"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

For rope_loop, as mentioned in  #54630, 250cm was chosen arbitrarily. This number is 10cm shy of the long stick's 260cm, an item which thematically and realistically should be able to be bundled up and dragged behind the survivor with the rope loop.

For bigframe_pack, it's a similar vein - it's purpose is to allow the survivor to carry around an oversized thing at a massive encumbrance hit, an example given in the original PR (#65588) was a household fridge. Upping the length to 260cm allows our fridges to actually be hauled around, as well as the later-added oversized boxes.

#### Describe the solution

Up the max lengths to 260cm. This allows for long sticks, fridges, long boxes, etc. while still preventing pikes from being hauled.

#### Describe alternatives you've considered

Adding a new rope harness item designed to haul massive things, like in the last image.

#### Testing

See screenshots, tested numbers in active game in latest experimental.

#### Additional context

Encumbrance enschumbrance.
![image](https://github.com/user-attachments/assets/2dd3d129-b125-4d02-80d2-1d7c3813b884)

Can hardly feel a thing!
![image](https://github.com/user-attachments/assets/6bc327b5-2c6a-45d3-b285-95b013b2812a)

![fridge](https://github.com/user-attachments/assets/d74b03d7-23e0-4de0-8d74-1fa84a207ce9)



<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
