### PR TITLE
fixed audio (we're done here)

### DIFF
--- a/src/sdlsound.cpp
+++ b/src/sdlsound.cpp
@@ -744,8 +744,9 @@ struct sound_effect_handler {
             // however, we don't want to do that as soon as we finish SENDING audio since the audio device won't be done playing it yet.
             // therefore, we let the sound loop an extra time to finish playing.
 
-            // we still need to update handler->current_sample_index because as previously stated, we
-            handler->current_sample_index += len / bytes_per_sample * playback_speed;
+            // we still need to update handler->current_sample_index so it loops properly
+            int num_samples = len / bytes_per_sample;
+            handler->current_sample_index += num_samples * playback_speed;
             if( handler->current_sample_index >= num_source_samples ) {
                 handler->loops_remaining--;
             }

--- a/src/sdlsound.cpp
+++ b/src/sdlsound.cpp
@@ -729,27 +729,39 @@ struct sound_effect_handler {
         using sample = int16_t; // because AUDIO_S16 is two bytes per ear (signed integer samples)
         constexpr int bytes_per_sample = sizeof( sample ) *
                                          2; // 2 samples per ear (is there a better terminology for this?)
+
+        float playback_speed = is_time_slowed() ? sound_speed_factor : 1; //
+        int num_source_samples = handler->audio_src->alen / bytes_per_sample;
+
         cata_assert( audio_format == AUDIO_S16 );
 
-        // check if the sound effect should end bc we done looping
-        //  (note: we let the sound loop an extra time here because when handler->loops_remaining == -1,
-        //   that means we're done SENDING audio, but that doesn't mean the audio device is done PLAYING it so we don't want the main thread to call).
-        if( !handler->marked_for_termination && handler->loops_remaining < -1 ) {
-            if( channels_to_end_mutex.try_lock() ) { // try_lock(); we do NOT want the audio thread to block.
-                handler->marked_for_termination = true;
-                channels_to_end.push_back( static_cast<sfx::channel>
-                                           ( channel ) ); // the main thread will call Mix_HaltAudio to end the sound effect when make_audio() is next called
-                channels_to_end_mutex.unlock();
-            }
-        }
-
         if( handler->loops_remaining <
-            0 ) { // then we have no more audio to load; the sound effect is over and we're just waiting for SDL to finish playing it and for the main thread to call Mix_HaltAudio()
+            0 ) { // then we have no more audio to load; the sound effect is over and we're just waiting for SDL to finish playing it and for the main thread to call Mix_HaltChannel()
             memset( stream, 0,
-                    len ); // since the sound is over, tell SDL_Mixer to play nothing by setting all the samples to 0
+                    len ); // since the sound is over, tell SDL_Mixer to play nothing by setting all the samples to 0 (faster than iterating through the whole thing)
+
+            // the sound effect won't end on its own, we need to tell the main thread to stop it.
+            // however, we don't want to do that as soon as we finish SENDING audio since the audio device won't be done playing it yet.
+            // therefore, we let the sound loop an extra time to finish playing.
+
+            // we still need to update handler->current_sample_index because as previously stated, we
+            handler->current_sample_index += len / bytes_per_sample * playback_speed;
+            if( handler->current_sample_index >= num_source_samples ) {
+                handler->loops_remaining--;
+            }
+
+            // check if the sound effect should end bc we done looping
+            if( !handler->marked_for_termination && handler->loops_remaining < -1 ) {
+                if( channels_to_end_mutex.try_lock() ) { // try_lock(); we do NOT want the audio thread to block.
+                    handler->marked_for_termination = true;
+                    channels_to_end.push_back( static_cast<sfx::channel>
+                                               ( channel ) ); // the main thread will call Mix_HaltChannel to end the sound effect when make_audio() is next called
+                    channels_to_end_mutex.unlock();
+                }
+            }
+
         } else {
-            float playback_speed = is_time_slowed() ? sound_speed_factor : 1;
-            int num_source_samples = handler->audio_src->alen / bytes_per_sample;
+
 
             // assuming the sound ISN'T over, we need to fill stream with (len/bytes_per_sample) samples from handler->audio_src in this loop.
             for( int dst_index = 0; dst_index < len / bytes_per_sample &&
@@ -814,7 +826,7 @@ struct sound_effect_handler {
                             std::optional<float> fade_in_duration ) {
 
         // tell SDL to halt all sound effects that are done playing
-        if( channels_to_end_mutex.try_lock() ) { // no rush if we can't halt it immediately, we don't want to block
+        if( channels_to_end_mutex.try_lock() ) {  // no rush if we can't halt it immediately, we don't want to block
             for( sfx::channel channel : channels_to_end ) {
                 int success = Mix_HaltChannel( static_cast<int>( channel ) );
                 if( success != 0 ) {

--- a/src/sdlsound.cpp
+++ b/src/sdlsound.cpp
@@ -739,7 +739,7 @@ struct sound_effect_handler {
             0 ) { // then we have no more audio to load; the sound effect is over and we're just waiting for SDL to finish playing it and for the main thread to call Mix_HaltChannel()
             memset( stream, 0,
                     len ); // since the sound is over, tell SDL_Mixer to play nothing by setting all the samples to 0 (faster than iterating through the whole thing)
-
+             
             // the sound effect won't end on its own, we need to tell the main thread to stop it.
             // however, we don't want to do that as soon as we finish SENDING audio since the audio device won't be done playing it yet.
             // therefore, we let the sound loop an extra time to finish playing.

--- a/src/sdlsound.cpp
+++ b/src/sdlsound.cpp
@@ -739,7 +739,7 @@ struct sound_effect_handler {
             0 ) { // then we have no more audio to load; the sound effect is over and we're just waiting for SDL to finish playing it and for the main thread to call Mix_HaltChannel()
             memset( stream, 0,
                     len ); // since the sound is over, tell SDL_Mixer to play nothing by setting all the samples to 0 (faster than iterating through the whole thing)
-             
+
             // the sound effect won't end on its own, we need to tell the main thread to stop it.
             // however, we don't want to do that as soon as we finish SENDING audio since the audio device won't be done playing it yet.
             // therefore, we let the sound loop an extra time to finish playing.


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
While cleaning up the code for PR #80033, I accidentally completely ruined the control flow, causing sound effects to never get halted, so sound effects stopped working after enough sounds had been played to use up all the available channels.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Fixed the control flow, making it so audio loops (silently) until it is halted by the main thread.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
None
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Played a great deal of sound effects over ~10 minutes, some of which were done in slow motion. Seemed okay.
Even when I set it so that only two audio channels were available for sound effects, it still worked correctly (although, as expected in that case it could only play two sounds at a time).
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
It's possible that when I did a bunch of git suffering to get this on its own branch that I messed something up (although I did test it after moving it here).
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
