### PR TITLE
Helicopters don't fall out of the sky on z-level 0

### DIFF
--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -1352,10 +1352,7 @@ void vehicle::selfdrive( map &here, const int trn, const int acceleration )
 
 bool vehicle::check_is_heli_landed( map &here )
 {
-    // @TODO - when there are chasms that extend below z-level 0 - perhaps the heli
-    // will be able to descend into them but for now, assume z-level-0 == the ground.
-    if( pos_abs().z() == 0 ||
-        !here.has_flag_ter_or_furn( ter_furn_flag::TFLAG_NO_FLOOR, pos_bub( here ) ) ) {
+    if( !here.has_flag_ter_or_furn( ter_furn_flag::TFLAG_NO_FLOOR, pos_bub( here ) ) ) {
         is_flying = false;
         return true;
     }


### PR DESCRIPTION
#### Summary
Bugfixes "Helicopters can fly through open air on z-level 0 and below"

#### Purpose of change
Helicopters set `is_flying` to false when they reached z-0, even if it was open air. This caused them to immediately plummet out of the sky and crash into the ground, regardless of what was actually on z-0.

#### Describe the solution
Simply stop doing that. Helicopters only count as landed if they're actually landed on something.

#### Describe alternatives you've considered
Some sort of ground effect simulation, but that doesn't exist on Z>0, so why should it exist on Z<=0? That's too arbitrary...

#### Testing
Flying on z-0 without crashing
![image](https://github.com/user-attachments/assets/e17812c2-09d2-430e-8917-fe49b907abb1)

Landing on z-level -1 without crashing
![image](https://github.com/user-attachments/assets/721870ef-cf1b-4403-a436-c765ca576e85)


#### Additional context
Save used for testing:
[HELI_DESCENT-trimmed.tar.gz](https://github.com/user-attachments/files/19150504/HELI_DESCENT-trimmed.tar.gz)

