### PR TITLE
expand _die eoc function

### DIFF
--- a/doc/JSON/EFFECT_ON_CONDITION.md
+++ b/doc/JSON/EFFECT_ON_CONDITION.md
@@ -4526,8 +4526,14 @@ You pick `first` and `center` locations and store it, then mirror them to create
 ```
 
 #### `u_die`, `npc_die`
-You or an NPC will instantly die.
+Alpha or beta talker will instantly die.
 If the target is an item, it will be deleted.
+
+| Syntax | Optionality | Value  | Info |
+| --- | --- | --- | --- | 
+| "remove_corpse" | optional | bool | default false; if true, the corpse and all inside of it won't be spawned on death | 
+| "supress_message" | optional | bool | default false; if true, death would omit death message | 
+| "remove_from_creature_tracker" | optional | bool | default false; if true, and talker is monster, the monster instead removed from creature tracker, resulting not only in monster disappearing without message and corpse, but also bypasses any death effect they could fire before their death | 
 
 ##### Valid talkers:
 
@@ -4537,7 +4543,7 @@ If the target is an item, it will be deleted.
 
 ##### Examples
 
-You and NPC both die
+Alpha and beta both die
 ```json
 {
   "type": "effect_on_condition",
@@ -4546,33 +4552,14 @@ You and NPC both die
 }
 ```
 
-Removes a corpse around you (corpses are handled as items)
-
+beta talker dies without a message and without a corpse
 ```json
   {
-    "id": "EOC_CORPSE_REMOVAL",
     "type": "effect_on_condition",
-    "effect": [
-      { "message": "Select target", "u_query_tile": "around", "target_var": { "context_val": "delete_this_corpse" } },
-      {
-        "if": { "math": [ "has_var(_delete_this_corpse)" ] },
-        "then": [
-          {
-            "u_map_run_item_eocs": "all",
-            "search_data": [ { "id": "corpse" } ],
-            "loc": { "context_val": "delete_this_corpse" },
-            "min_radius": 0,
-            "max_radius": 0,
-            "true_eocs": [ { "id": "EOC_CORPSE_REMOVAL_SUCCESS", "effect": [ "npc_die", { "u_message": "*poof*", "type": "good" } ] } ],
-            "false_eocs": [ { "id": "EOC_CORPSE_REMOVAL_FAIL", "effect": [ { "u_message": "There is no corpse there.", "type": "bad" } ] } ]
-          }
-        ],
-        "else": [ { "u_message": "Canceled" } ]
-      }
-    ]
-  }
+    "id": "ded_no_corpse",
+    "effect": [ { "npc_die": { "remove_corpse": true, "supress_message": true } } ]
+  },
 ```
-
 
 #### `u_prevent_death`, `npc_prevent_death`
 You or NPC will be prevented from death. Intended for use in EoCs has `NPC_DEATH` or `EVENT(character_dies)` type (Take care that u will be the dying npc in these events).

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -2384,7 +2384,7 @@ static void character_edit_menu()
         D_DESC, D_SKILLS, D_THEORY, D_PROF, D_STATS, D_SPELLS, D_ITEMS, D_DELETE_ITEMS, D_DROP_ITEMS, D_ITEM_WORN, D_RADS,
         D_HP, D_STAMINA, D_MORALE, D_PAIN, D_NEEDS, D_NORMALIZE_BODY, D_HEALTHY, D_STATUS, D_MISSION_ADD, D_MISSION_EDIT,
         D_TELE, D_MUTATE, D_BIONICS, D_CLASS, D_ATTITUDE, D_OPINION, D_PERSONALITY, D_ADD_EFFECT, D_ASTHMA, D_PRINT_VARS,
-        D_WRITE_EOCS, D_KILL_XP, D_CHECK_TEMP, D_EDIT_VARS, D_FACTION
+        D_WRITE_EOCS, D_KILL_XP, D_CHECK_TEMP, D_EDIT_VARS, D_FACTION, D_ALPHA_EOC, D_BETA_EOC
     };
     nmenu.addentry( D_DESC, true, 'D', "%s",
                     _( "Edit description - name, age, height or blood type" ) );
@@ -2430,6 +2430,10 @@ static void character_edit_menu()
         nmenu.addentry( D_OPINION, true, 'O', "%s", _( "Set opinions" ) );
         nmenu.addentry( D_PERSONALITY, true, 'P', "%s", _( "Set personality" ) );
         nmenu.addentry( D_FACTION, true, 'F', "%s", _( "Set faction" ) );
+        nmenu.addentry( D_ALPHA_EOC, true, 'r', "%s",
+                        _( "Run EOC with character as alpha talker (avatar as beta)" ) );
+        nmenu.addentry( D_BETA_EOC, true, 't', "%s",
+                        _( "Run EOC with character as beta talker (avatar as alpha)" ) );
     }
     nmenu.query();
     switch( nmenu.ret ) {
@@ -2733,6 +2737,13 @@ static void character_edit_menu()
             }
             break;
         }
+        case D_ALPHA_EOC:
+            run_eoc_menu( &you, true );
+            break;
+        case D_BETA_EOC:
+            run_eoc_menu( &you );
+            break;
+
     }
 }
 

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -2996,12 +2996,14 @@ void npc::die( map *here, Creature *nkiller )
     dead = true;
     Character::die( here, nkiller );
 
-    if( is_hallucination() || lifespan_end ) {
-        add_msg_if_player_sees( *this, _( "%s disappears." ), get_name().c_str() );
-        return;
-    }
+    if( !quiet_death ) {
+        if( is_hallucination() || lifespan_end ) {
+            add_msg_if_player_sees( *this, _( "%s disappears." ), get_name().c_str() );
+            return;
+        }
 
-    add_msg_if_player_sees( *this, _( "%s dies!" ), get_name() );
+        add_msg_if_player_sees( *this, _( "%s dies!" ), get_name() );
+    }
 
     if( Character *ch = dynamic_cast<Character *>( killer ) ) {
         get_event_bus().send<event_type::character_kills_character>( ch->getID(), getID(), get_name() );
@@ -3054,7 +3056,9 @@ void npc::die( map *here, Creature *nkiller )
         }
     }
 
-    place_corpse( here );
+    if( spawn_corpse ) {
+        place_corpse( here );
+    }
 }
 
 void npc::prevent_death()

--- a/src/npc.h
+++ b/src/npc.h
@@ -1398,6 +1398,8 @@ class npc : public Character
         bool marked_for_death = false; // If true, we die as soon as we respawn!
         bool hit_by_player = false;
         bool hallucination = false; // If true, NPC is an hallucination
+        bool spawn_corpse = true;
+        bool quiet_death = false; // supress messages about death
         std::vector<npc_need> needs;
         std::optional<int> confident_range_cache;
         // Dummy point that indicates that the goal is invalid.

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -5573,6 +5573,36 @@ talk_effect_fun_t::func f_die( bool is_npc )
     };
 }
 
+talk_effect_fun_t::func f_die_advanced( const JsonObject &jo, std::string_view member,
+                                        const std::string_view, bool is_npc )
+{
+    JsonObject job = jo.get_object( member );
+    std::optional<bool> remove_corpse = job.get_bool( "remove_corpse" );
+    std::optional<bool> supress_message = job.get_bool( "supress_message" );
+    std::optional<bool> remove_from_creature_tracker = job.get_bool( "remove_from_creature_tracker" );
+
+    return [remove_corpse, supress_message, remove_from_creature_tracker,
+                   is_npc]( dialogue const & d ) {
+        map &here = get_map();
+
+        if( d.actor( is_npc )->get_monster() ) {
+            monster &mon = *d.actor( is_npc )->get_monster();
+            if( remove_from_creature_tracker ) {
+                get_creature_tracker().remove( mon );
+                return;
+            }
+            mon.death_drops = remove_corpse.has_value() ? !remove_corpse.value() : mon.death_drops;
+            mon.quiet_death = supress_message.has_value() ? supress_message.value() : mon.quiet_death;
+        } else if( d.actor( is_npc )->get_npc() ) {
+            npc &guy_npc = *d.actor( is_npc )->get_npc();
+            guy_npc.spawn_corpse = remove_corpse.has_value() ? !remove_corpse.value() : guy_npc.spawn_corpse;
+            guy_npc.quiet_death = supress_message.has_value() ? supress_message.value() : guy_npc.quiet_death;
+        }
+
+        d.actor( is_npc )->die( &here );
+    };
+}
+
 talk_effect_fun_t::func f_cancel_activity( bool is_npc )
 {
     return [is_npc]( dialogue const & d ) {
@@ -7719,6 +7749,7 @@ parsers = {
     { "u_add_bionic", "npc_add_bionic", jarg::member, &talk_effect_fun::f_add_bionic },
     { "u_lose_bionic", "npc_lose_bionic", jarg::member, &talk_effect_fun::f_lose_bionic },
     { "u_attack", "npc_attack", jarg::member, &talk_effect_fun::f_attack },
+    { "u_die", "npc_die", jarg::object, &talk_effect_fun::f_die_advanced},
     { "u_spawn_monster", "npc_spawn_monster", jarg::member, &talk_effect_fun::f_spawn_monster },
     { "u_spawn_npc", "npc_spawn_npc", jarg::member, &talk_effect_fun::f_spawn_npc },
     { "u_set_field", "npc_set_field", jarg::member, &talk_effect_fun::f_field },


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Request from discord
#### Describe the solution
Expand effect with a few fields, that support removing death message, corpse, and even death effects
also adds a bit of code that support npcs running eocs
#### Testing
All effects works as expected with monsters and NPCs