### PR TITLE
460 s&w casings can be used for the pistol cartridge necklaces

### DIFF
--- a/data/json/items/armor/jewelry.json
+++ b/data/json/items/armor/jewelry.json
@@ -4509,6 +4509,7 @@
       { "type": "COMPONENT_ID", "condition": "357mag_casing", "name": { "str_sp": "Big Iron" } },
       { "type": "COMPONENT_ID", "condition": "45colt_casing", "name": { "str_sp": "Peacemaker's" } },
       { "type": "COMPONENT_ID", "condition": "454_casing", "name": { "str_sp": "Judge's Wrath" } },
+      { "type": "COMPONENT_ID", "condition": "460sw_casing", "name": { "str_sp": "Moose Killer" } },
       { "type": "COMPONENT_ID", "condition": "45_casing", "name": { "str_sp": "God's Caliber" } },
       { "type": "COMPONENT_ID", "condition": "46mm_casing", "name": { "str_sp": "Heckler's Screamer" } },
       { "type": "COMPONENT_ID", "condition": "57mm_casing", "name": { "str_sp": "Needle Rain" } },

--- a/data/json/items/armor/jewelry.json
+++ b/data/json/items/armor/jewelry.json
@@ -4509,7 +4509,7 @@
       { "type": "COMPONENT_ID", "condition": "357mag_casing", "name": { "str_sp": "Big Iron" } },
       { "type": "COMPONENT_ID", "condition": "45colt_casing", "name": { "str_sp": "Peacemaker's" } },
       { "type": "COMPONENT_ID", "condition": "454_casing", "name": { "str_sp": "Judge's Wrath" } },
-      { "type": "COMPONENT_ID", "condition": "460sw_casing", "name": { "str_sp": "Moose Killer" } },
+      { "type": "COMPONENT_ID", "condition": "460sw_casing", "name": { "str_sp": "Hyper Velocity" } },
       { "type": "COMPONENT_ID", "condition": "45_casing", "name": { "str_sp": "God's Caliber" } },
       { "type": "COMPONENT_ID", "condition": "46mm_casing", "name": { "str_sp": "Heckler's Screamer" } },
       { "type": "COMPONENT_ID", "condition": "57mm_casing", "name": { "str_sp": "Needle Rain" } },

--- a/data/json/requirements/ammo.json
+++ b/data/json/requirements/ammo.json
@@ -323,6 +323,7 @@
         [ "10mm_casing", 1 ],
         [ "44_casing", 1 ],
         [ "454_casing", 1 ],
+        [ "460sw_casing", 1 ],
         [ "45_casing", 1 ],
         [ "45colt_casing", 1 ],
         [ "46mm_casing", 1 ],


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

I like these necklaces, I make one every run for the unique names they have.

#### Describe the solution

Add 460 s&w casings to the craft requirements group `pistol_cartridges` and give the necklace a unique `conditional_name` for having it in its components. Holli suggested "high velocity" since it's reportedly the highest velocity handgun cartridge and I went with "hyper velocity" because it has more zing.

#### Describe alternatives you've considered

I will take other name suggestions

#### Testing

It works

#### Additional context

none