### PR TITLE
'None'-skill crafting counts as max level, not level 0

### DIFF
--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -1098,9 +1098,13 @@ float Character::get_recipe_weighted_skill_average( const recipe &making ) const
                    secondary_skill_total, secondary_difficulty );
     // The primary required skill counts extra compared to the secondary skills, before factoring in the
     // weight added by the required level.
+    float primary_skill_level = get_skill_level( making.skill_used );
+    if( making.skill_used.is_null() ) {
+        primary_skill_level = static_cast<float>( MAX_SKILL );
+    }
     const float weighted_skill_average =
         ( ( 2.0f * std::max( making.difficulty,
-                             1 ) * get_skill_level( making.skill_used ) ) + secondary_skill_total ) /
+                             1 ) * primary_skill_level ) + secondary_skill_total ) /
         // No DBZ
         std::max( 1.f, ( 2.0f * std::max( making.difficulty, 1 ) + secondary_difficulty ) );
     add_msg_debug( debugmode::DF_CRAFTING, "Weighted skill average: %g", weighted_skill_average );


### PR DESCRIPTION
#### Summary
Bugfixes "'None'-skill crafting counts as max level, not level 0"

#### Purpose of change
We have a variety of crafting tasks which are so trivial that they should not even be assigned a skill, because even with a difficulty of 0 they can level that skill up to 1.

Unfortunately since they have no skill assigned, the character could never have levels in the (non-existent) skill, which meant that crafting these recipes always counted as if the skill level was 0.

Related to #65433 though I couldn't think of a way to accomplish this at the time.

#### Describe the solution
If there is no skill defined, count our skill level as if it was MAX_SKILL (10).

#### Describe alternatives you've considered
These recipes can still have fail chance due to encumbrance, limb scores, etc. Perhaps they should not be able to fail even in those circumstances?

#### Testing
All images with default 8/8/8/8 character with all skills at maximum, no proficiencies other than default ones.

Before:
![image](https://github.com/user-attachments/assets/26727224-bfb0-4ebf-8b66-52c80b0494d2)

After:
![image](https://github.com/user-attachments/assets/d4d2ebdb-8da8-4d6f-804d-8c18a440b824)


#### Additional context
