### PR TITLE
Add some debug plumbing to NPC query_yn

### DIFF
--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -3335,8 +3335,11 @@ void npc::on_load( map *here )
     shop_restock();
 }
 
-bool npc::query_yn( const std::string &/*msg*/ ) const
+bool npc::query_yn( const std::string &msg ) const
 {
+    add_msg_debug( debugmode::DF_NPC,
+                   "%s declines this query_yn because they are a npc (automatic, always declines).\n %s",
+                   disp_name(), msg );
     // NPCs don't like queries - most of them are in the form of "Do you want to get hurt?".
     return false;
 }

--- a/src/npc.h
+++ b/src/npc.h
@@ -1275,7 +1275,7 @@ class npc : public Character
 
         // The preceding are in npcmove.cpp
 
-        bool query_yn( const std::string &mes ) const override;
+        bool query_yn( const std::string &msg ) const override;
 
         std::vector<std::string> extended_description() const override;
         std::string get_epilogue() const;


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
During #77986 I was confused for quite a while when examining the crafting window's behavior of calling a specific query_yn. The query_yn overload *for the player* contained the actual logic which instructed the crafting window how to proceed. For NPCs, query_yn is always declined and it "did nothing", but that was not obvious or intuitive!

#### Describe the solution
Add a debug mode message when this happens in the future, which can help contributors to troubleshoot why a NPC does or does not do something. It's fine that they always decline, but there must be some way for contributors to know aside from personally chasing down every avenue of code.

#### Describe alternatives you've considered
Make them say yes sometimes, and print reasoning to log even outside of debug mode?

#### Testing
No testing was performed but this is a simple debug-only change. If it compiles in CI it's good to go.

#### Additional context
