### PR TITLE
Spreading dogbane is now harvestable

### DIFF
--- a/data/json/furniture_and_terrain/furniture-flora.json
+++ b/data/json/furniture_and_terrain/furniture-flora.json
@@ -473,6 +473,7 @@
     "required_str": -1,
     "move_cost_mod": 0,
     "flags": [ "TRANSPARENT", "SHORT", "SHRUB", "FLAMMABLE_ASH", "NOCOLLIDE", "ORGANIC" ],
+    "examine_action": "harvest_furn",
     "harvest_by_season": [ { "seasons": [ "spring", "summer", "autumn" ], "id": "dogbane_harv" } ],
     "bash": {
       "str_min": 2,


### PR DESCRIPTION
#### Summary
Bugfixes "Spreading dogbane is now harvestable"

#### Purpose of change
* Closes #80052.

#### Describe the solution
Added missing `examine_action` to json definition.

#### Describe alternatives you've considered
None.

#### Testing
Found spreading dogbane in the forest. `e`xamined it. Got dogbane from harvest.

#### Additional context
None.