### PR TITLE
Inhaler and Antibiotics Mission Audit

### DIFF
--- a/data/json/npcs/missiondef.json
+++ b/data/json/npcs/missiondef.json
@@ -34,7 +34,7 @@
     "value": 150000,
     "urgent": true,
     "origins": [ "ORIGIN_OPENER_NPC", "ORIGIN_ANY_NPC" ],
-    "deadline": [ "30 days", "48 days" ],
+    "deadline": [ "2 days", "3 days" ],
     "dialogue": {
       "describe": "I'm… short… of breath…",
       "offer": "I'm asthmatic.  I need you to get an inhaler for me…",
@@ -67,7 +67,7 @@
     "urgent": true,
     "goal_condition": { "or": [ { "u_has_item": "antibiotics" }, { "u_has_item": "strong_antibiotic" }, { "u_has_item": "panacea" } ] },
     "origins": [ "ORIGIN_OPENER_NPC" ],
-    "deadline": [ "24 days", "48 days" ],
+    "deadline": "1 day",
     "dialogue": {
       "describe": "This infection is bad, totally bad…",
       "offer": "I'm infected.  Badly.  I need you to get some good antibiotics for me…",


### PR DESCRIPTION


#### Summary
None

#### Purpose of change
I noticed that the deadlines for both the inhaler mission and antibiotic mission goes on for far too long than expected from the missions, so i'm fixing that.

#### Describe the solution

- Reduce the Inhaler mission deadline to 2-3 days.
- Reduce the Antibiotic mission to 1 day.

#### Describe alternatives you've considered

Not doing so?

#### Testing

I give the npcs both mission, accept their missions, and then change the time to 2-3 days later. They died as expected.
![Screenshot_20250311_032518](https://github.com/user-attachments/assets/dedb1864-91ea-4fdc-a715-87b8a619128c)
![Screenshot_20250311_031505](https://github.com/user-attachments/assets/030b1952-9f9c-4210-b203-accc8a3eefac)


#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
