### PR TITLE
Fix aim query charges not considering pocket limitations

### DIFF
--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -2252,15 +2252,7 @@ bool advanced_inventory::query_charges( aim_location destarea, const advanced_in
     // Check how many items you can stash. extra check because free_volume() doesn't account for pockets the item would not fit .
     if( destarea == AIM_INVENTORY ) {
         int copies_remaining = amount;
-
-        // absolutely cursed, if I just feed copies_remaining, ignore_pkt_settings gets optimized out and copies remaining gets interpreted as bool for
-        // bool can_stash_partial( const item &it, bool ignore_pkt_settings = false ); overload, meaning I never get into
-        // the correct overload:
-        // bool can_stash_partial( const item &it, int &copies_remaining, bool ignore_pkt_settings = false );
-        // negating the whole reason I overload it (no need to do copy item tomfoolery here), by forcing me to do timfoolery with int references
-        int &tmp = copies_remaining;
-        player_character.can_stash_partial( it, tmp, /*ignore_pkt_settings=*/false );
-
+        player_character.can_stash_partial( it, copies_remaining, /*ignore_pkt_settings=*/false );
         amount -= copies_remaining;
         if( amount <= 0 ) {
             popup_getkey( _( "No pocket can contain the %s." ), it.tname() );

--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -19,6 +19,7 @@
 #include <vector>
 
 #include "activity_actor_definitions.h"
+#include "advanced_inv_area.h"
 #include "advanced_inv_listitem.h"
 #include "advanced_inv_pagination.h"
 #include "auto_pickup.h"
@@ -2247,19 +2248,26 @@ bool advanced_inventory::query_charges( aim_location destarea, const advanced_in
         popup_getkey( _( "Spilt gasses cannot be picked up.  They will disappear over time." ) );
         return false;
     }
-
-    // Check volume, this should work the same for inventory, map and vehicles, but not for worn
-    if( destarea != AIM_WORN && destarea != AIM_WIELD ) {
+    Character &player_character = get_player_character();
+    // Check how many items you can stash. extra check because free_volume() doesn't account for pockets the item would not fit .
+    if( destarea == AIM_INVENTORY ) {
+        int copies_remaining = input_amount;
+        player_character.can_stash( it, copies_remaining );
+        amount -= copies_remaining;
+        popup_getkey( _( "input_amount : %i, amount remaining: %i." ), input_amount, copies_remaining );
+        if( amount <= 0 ) {
+            popup_getkey( _( "No pocket can contain the %s." ), it.tname() );
+            return false;
+        }
+    }
+    // Check volume, this should work the same map and vehicles, but not for worn
+    else if( destarea != AIM_WIELD && destarea != AIM_WORN ) {
         const units::volume free_volume = panes[dest].free_volume( squares[destarea] );
         const units::mass free_mass = panes[dest].free_weight_capacity();
         const int room_for = std::min( it.charges_per_volume( free_volume ),
                                        it.charges_per_weight( free_mass ) );
         if( room_for <= 0 ) {
-            if( destarea == AIM_INVENTORY ) {
-                popup_getkey( _( "You have no space for the %s." ), it.tname() );
-            } else {
-                popup_getkey( _( "Destination area is full.  Remove some items first." ) );
-            }
+            popup_getkey( _( "Destination area is full.  Remove some items first." ) );
             return false;
         }
         amount = std::min( room_for, amount );
@@ -2287,7 +2295,7 @@ bool advanced_inventory::query_charges( aim_location destarea, const advanced_in
             amount = std::min( cntmax, amount );
         }
     }
-    Character &player_character = get_player_character();
+
     // Inventory has a weight capacity, map and vehicle don't have that
     if( destarea == AIM_INVENTORY || destarea == AIM_WORN || destarea == AIM_WIELD ) {
         const units::mass unitweight = it.weight() / ( by_charges ? it.charges : 1 );

--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -2251,10 +2251,15 @@ bool advanced_inventory::query_charges( aim_location destarea, const advanced_in
     Character &player_character = get_player_character();
     // Check how many items you can stash. extra check because free_volume() doesn't account for pockets the item would not fit .
     if( destarea == AIM_INVENTORY ) {
-        int copies_remaining = input_amount;
-        player_character.can_stash( it, copies_remaining );
+        item it_copy = it;
+        if( by_charges ) {
+            it_copy.charges = 1;
+        }
+
+        int copies_remaining = amount;
+        player_character.can_stash( it_copy, copies_remaining );
+
         amount -= copies_remaining;
-        popup_getkey( _( "input_amount : %i, amount remaining: %i." ), input_amount, copies_remaining );
         if( amount <= 0 ) {
             popup_getkey( _( "No pocket can contain the %s." ), it.tname() );
             return false;

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1576,6 +1576,16 @@ bool Character::can_stash( const item &it, int &copies_remaining, bool ignore_pk
     return stashed_any;
 }
 
+bool Character::can_stash_partial( const item &it, int &copies_remaining, bool ignore_pkt_settings )
+{
+    item copy = it;
+    if( it.count_by_charges() ) {
+        copy.charges = 1;
+    }
+
+    return can_stash( copy, copies_remaining, ignore_pkt_settings );
+}
+
 bool Character::can_stash_partial( const item &it, bool ignore_pkt_settings )
 {
     item copy = it;

--- a/src/character.h
+++ b/src/character.h
@@ -3045,6 +3045,7 @@ class Character : public Creature, public visitable
         bool can_stash( const item &it, bool ignore_pkt_settings = false );
         bool can_stash( const item &it, int &copies_remaining, bool ignore_pkt_settings = false );
         bool can_stash_partial( const item &it, bool ignore_pkt_settings = false );
+        bool can_stash_partial( const item &it, int &copies_remaining, bool ignore_pkt_settings = false );
         void initialize_stomach_contents();
 
         /** Stable base metabolic rate due to traits */

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -10708,6 +10708,16 @@ ret_val<void> item::can_contain_partial( const item &it ) const
     return can_contain( i_copy );
 }
 
+ret_val<void> item::can_contain_partial( const item &it, int &copies_remaining,
+        bool nested ) const
+{
+    item i_copy = it;
+    if( i_copy.count_by_charges() ) {
+        i_copy.charges = 1;
+    }
+    return can_contain( i_copy, copies_remaining, nested );
+}
+
 ret_val<void> item::can_contain_partial_directly( const item &it ) const
 {
     item i_copy = it;

--- a/src/item.h
+++ b/src/item.h
@@ -1769,6 +1769,8 @@ class item : public visitable
                                    bool allow_nested = true ) const;
         ret_val<void> can_contain( const itype &tp ) const;
         ret_val<void> can_contain_partial( const item &it ) const;
+        ret_val<void> can_contain_partial( const item &it, int &copies_remaining,
+                                           bool nested = false ) const;
         ret_val<void> can_contain_directly( const item &it ) const;
         ret_val<void> can_contain_partial_directly( const item &it ) const;
         /*@}*/


### PR DESCRIPTION
#### Summary
Bugfixes "Fix aim query charges not considering pocket limitations"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
While working on #80000 I ran into an issue, where trying to move items into your inventory when not all fit, the query charges would display the wrong number. ("Destination can only fit 2500") When trying to transfer the amount you would get a message that the item doesnt fit, as it only looked how many would fit into the total volume.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Check how many can fit with can_stash( it_copy, copies_remaining ), there copies_remaining is the amount that dont fit into any pockets.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
can insert max amount. When trying to insert more I cant, indicating it truly was the max amount.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
~~I hate that character::can_stash(it, copies remaining) doesnt work with charge items. usually copies remaining will have the amount, that cannot fit, but with charges is just sais "nope, i cant fit the 10k stack, so copies remaining is still 10k", requiring the hac with making a copy and setting its charges to 1~~
I overloaded Character::can_stash_partial, so it can take &copies_remaining arg
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
