### PR TITLE
Update snow shovel, metal rake deconstruction recipe

### DIFF
--- a/data/json/recipes/tools/tools_hand.json
+++ b/data/json/recipes/tools/tools_hand.json
@@ -1612,7 +1612,6 @@
     "skill_used": "fabrication",
     "difficulty": 3,
     "time": "2 h",
-    "reversible": true,
     "autolearn": true,
     "using": [ [ "forging_standard", 8 ] ],
     "qualities": [ { "id": "ANVIL", "level": 3 }, { "id": "HAMMER_FINE", "level": 1 }, { "id": "GRIND", "level": 2 } ],

--- a/data/json/recipes/tools/tools_hand.json
+++ b/data/json/recipes/tools/tools_hand.json
@@ -1578,7 +1578,6 @@
     "skill_used": "fabrication",
     "difficulty": 3,
     "time": "2 h",
-    "reversible": true,
     "autolearn": true,
     "using": [ [ "blacksmithing_standard", 4 ], [ "steel_standard", 1 ] ],
     "qualities": [ { "id": "GRIND", "level": 2 } ],

--- a/data/json/uncraft/recipe_deconstruction.json
+++ b/data/json/uncraft/recipe_deconstruction.json
@@ -7899,6 +7899,6 @@
     "activity_level": "MODERATE_EXERCISE",
     "time": "3 m",
     "qualities": [ { "id": "SAW_W", "level": 1 } ],
-    "components": [ [ [ "plank_short", 1 ] ], [ [ "sheet_metal_small", 1 ], [ [ "splinter", 3 ] ] ]
+    "components": [ [ [ "plank_short", 1 ] ], [ [ "sheet_metal_small", 1 ] ], [ [ "splinter", 3 ] ] ]
   }
 ]

--- a/data/json/uncraft/recipe_deconstruction.json
+++ b/data/json/uncraft/recipe_deconstruction.json
@@ -7899,6 +7899,6 @@
     "activity_level": "MODERATE_EXERCISE",
     "time": "3 m",
     "qualities": [ { "id": "SAW_W", "level": 1 } ],
-    "components": [ [ [ "plank_short", 1 ] ], [ [ "sheet_metal_small", 1 ] ], [ [ "splinter", 3 ] ] ]
+    "components": [ [ [ "plank_short", 1 ] ], [ [ "sheet_metal_small", 1 ] ], [ [ "splinter", 2 ] ], [ [ "scrap", 3 ] ] ]
   }
 ]

--- a/data/json/uncraft/recipe_deconstruction.json
+++ b/data/json/uncraft/recipe_deconstruction.json
@@ -7892,5 +7892,13 @@
     "time": "4 m",
     "qualities": [ { "id": "CUT", "level": 1 } ],
     "components": [ [ [ "meat_tainted", 6 ] ], [ [ "bone_tainted", 3 ] ], [ [ "sinew", 2 ] ] ]
+  },
+  {
+    "result": "shovel_snow",
+    "type": "uncraft",
+    "activity_level": "MODERATE_EXERCISE",
+    "time": "3 m",
+    "qualities": [ { "id": "SAW_W", "level": 1 } ],
+    "components": [ [ [ "plank_short", 1 ] ], [ [ "sheet_metal_small", 1 ], [ [ "splinter", 3 ] ] ]
   }
 ]

--- a/data/json/uncraft/recipe_deconstruction.json
+++ b/data/json/uncraft/recipe_deconstruction.json
@@ -7892,13 +7892,5 @@
     "time": "4 m",
     "qualities": [ { "id": "CUT", "level": 1 } ],
     "components": [ [ [ "meat_tainted", 6 ] ], [ [ "bone_tainted", 3 ] ], [ [ "sinew", 2 ] ] ]
-  },
-  {
-    "result": "shovel_snow",
-    "type": "uncraft",
-    "activity_level": "MODERATE_EXERCISE",
-    "time": "3 m",
-    "qualities": [ { "id": "SAW_W", "level": 1 } ],
-    "components": [ [ [ "plank_short", 1 ] ], [ [ "sheet_metal_small", 1 ] ], [ [ "splinter", 2 ] ], [ [ "scrap", 3 ] ] ]
   }
 ]

--- a/data/json/uncraft/tools.json
+++ b/data/json/uncraft/tools.json
@@ -306,5 +306,13 @@
     "difficulty": 1,
     "time": "2 m",
     "components": [ [ [ "pot_canning_clay", 1 ] ], [ [ "clay_pot", 1 ] ], [ [ "fire_brick", 2 ] ] ]
+  },
+  {
+    "result": "shovel_snow",
+    "type": "uncraft",
+    "activity_level": "MODERATE_EXERCISE",
+    "time": "3 m",
+    "qualities": [ { "id": "SAW_W", "level": 1 } ],
+    "components": [ [ [ "plank_short", 1 ] ], [ [ "sheet_metal_small", 1 ] ], [ [ "splinter", 2 ] ], [ [ "scrap", 3 ] ] ]
   }
 ]

--- a/data/json/uncraft/tools.json
+++ b/data/json/uncraft/tools.json
@@ -314,5 +314,13 @@
     "time": "3 m",
     "qualities": [ { "id": "SAW_W", "level": 1 } ],
     "components": [ [ [ "plank_short", 1 ] ], [ [ "sheet_metal_small", 1 ] ], [ [ "splinter", 2 ] ], [ [ "scrap", 3 ] ] ]
+  },
+  {
+    "result": "rake",
+    "type": "uncraft",
+    "activity_level": "MODERATE_EXERCISE",
+    "time": "3 m",
+    "qualities": [ { "id": "SAW_W", "level": 1 } ],
+    "components": [ [ [ "plank_short", 1 ] ], [ [ "wire", 1 ] ], [ [ "scrap", 2 ] ] ]
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "Updates snow shovel, metal rake deconstruction recipe"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Fix #80120 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Change the deconstruction recipe so that it represents the survivor sawing off the head and handle from the shaft, with some splintered wood (byproduct left inside handle & head) and scrap metal (representing the handle) to justify the weights of byproducts.

Snow shovel: 2kg

Short plank (shaft): 1.22kg
Small metal sheet (head): 0.25kg
2 splintered wood (shaft byproduct from sawing): 0.30kg
3 scrap metal (handle): 0.15kg
= 1.97kg


Rake: 1.5kg

short plank: 1.22kg
wire: 0.15kg
2 scrap: 0.1kg
= 1.47kg

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

A small metal sheet isn't exactly super representative of a snow shovel head, which IRL tend to be larger, heavier and curved, hence the proper solution would be to add a dedicated snow shovel head item (attachable to the shaft via nut/bolt) that can be further deconstructed into two or three small metal sheets, but I don't think that level of realism is necessary for a rare, essentially junk item.

The curve can be explained away as the survivor processing it later when using it for a different recipe, as small metal sheets are generally formed into specific shapes in the recipes that use them.

Modern snow shovels are also mostly made out of aluminum these days, so we could change the recipe to use chunks of aluminum, but as there is currently no aluminum sheet item it seems best to stick with steel.

For the rake, since the wires are all separated and the rake itself is so light, it might be better to not drop wire and instead just drop a bunch of scrap. Realistically, it should be easy enough for the ends of the little wires to be twisted together into a usable length though.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Tested json on a fresh experimental, no issues, was able to deconstruct no issue.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

![image](https://github.com/user-attachments/assets/f55df41f-b103-47c8-a343-56b0efd7e5a7)


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
