### PR TITLE
Allow generic-factory loaded objects to defer load

### DIFF
--- a/src/mission.h
+++ b/src/mission.h
@@ -260,7 +260,7 @@ struct mission_type {
 
         bool parse_funcs( const JsonObject &jo, std::string_view src,
                           std::function<void( mission * )> &phase_func );
-        void load( const JsonObject &jo, const std::string &src );
+        bool load( const JsonObject &jo, const std::string &src );
 
         /**
          * Returns the translated name

--- a/src/missiondef.cpp
+++ b/src/missiondef.cpp
@@ -1,7 +1,6 @@
 #include "mission.h" // IWYU pragma: associated
 
 #include <algorithm>
-#include <list>
 #include <set>
 
 #include "assign.h"
@@ -11,7 +10,6 @@
 #include "enum_conversions.h"
 #include "flexbuffer_json.h"
 #include "generic_factory.h"
-#include "init.h"
 #include "item.h"
 #include "rng.h"
 

--- a/src/missiondef.cpp
+++ b/src/missiondef.cpp
@@ -287,15 +287,9 @@ void mission_type::load_mission_type( const JsonObject &jo, const std::string &s
     mission_type_factory.load( jo, src );
 }
 
-static DynamicDataLoader::deferred_json deferred;
-
 void mission_type::reset()
 {
     mission_type_factory.reset();
-    for( std::pair<JsonObject, std::string> &deferred_json : deferred ) {
-        deferred_json.first.allow_omitted_members();
-    }
-    deferred.clear();
 }
 
 template <typename Fun>
@@ -312,7 +306,7 @@ void assign_function( const JsonObject &jo, const std::string &id, Fun &target,
     }
 }
 
-void mission_type::load( const JsonObject &jo, const std::string &src )
+bool mission_type::load( const JsonObject &jo, const std::string &src )
 {
     const bool strict = src == "dda";
 
@@ -365,8 +359,6 @@ void mission_type::load( const JsonObject &jo, const std::string &src )
         } else if( jo.has_member( phase ) ) {
             JsonObject j_start = jo.get_object( phase );
             if( !parse_funcs( j_start, src, phase_func ) ) {
-                deferred.emplace_back( jo, src );
-                jo.allow_omitted_members();
                 j_start.allow_omitted_members();
                 return false;
             }
@@ -374,13 +366,13 @@ void mission_type::load( const JsonObject &jo, const std::string &src )
         return true;
     };
     if( !parse_phase( "start", start ) ) {
-        return;
+        return false;
     }
     if( !parse_phase( "end", end ) ) {
-        return;
+        return false;
     }
     if( !parse_phase( "fail", fail ) ) {
-        return;
+        return false;
     }
 
     deadline = get_duration_or_var( jo, "deadline", false );
@@ -407,6 +399,8 @@ void mission_type::load( const JsonObject &jo, const std::string &src )
     }
 
     optional( jo, was_loaded, "invisible_on_complete", invisible_on_complete, false );
+
+    return true;
 }
 
 bool mission_type::test_goal_condition( struct dialogue &d ) const
@@ -419,7 +413,6 @@ bool mission_type::test_goal_condition( struct dialogue &d ) const
 
 void mission_type::finalize()
 {
-    DynamicDataLoader::get_instance().load_deferred( deferred );
 }
 
 void mission_type::check_consistency()


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Mapgen updates used by mission defs decide to defer loading when they run into something that is not defined. This is not a good pattern (they should just load whatever and then later be checked or finalized later), but it's too deep to untangle easily.

This causes any issue in a mapgen update in a mission def to result in the half-formed mission def being inserted into the factory, and then the deferred JSON trying to insert it again, triggering the 'duplicate object from same source' check.

#### Describe the solution
Allow instead those mission definitions request that generic factory defer them, instead of hand-rolling their own deferral.

#### Describe alternatives you've considered
I think this is hack, but I don't have time to untangle the deeper mess and I think it's worth fixing the issue.

#### Additional Context

Astyle made some interesting choices here.