### PR TITLE
Monsters now stop grabbing if grabbed monster was killed while grabbing the first monster

### DIFF
--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -2539,6 +2539,11 @@ bool monster::move_effects( bool )
             // Is our grabber around?
             monster *grabber = nullptr;
             for( const tripoint_bub_ms loc : surrounding ) {
+                // In an edge case when two monsters grab each other
+                // Don't consider grabbed monster to be its own grabber
+                if( loc == pos_bub() ) {
+                    continue;
+                }
                 monster *mon = creatures.creature_at<monster>( loc );
                 if( mon && mon->has_effect_with_flag( json_flag_GRAB_FILTER ) ) {
                     add_msg_debug( debugmode::DF_MATTACK, "Grabber %s found", mon->name() );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Previously when two monsters were grabbing each other, one of the grabbed monsters was considered as its own grabber:
![изображение](https://github.com/user-attachments/assets/050fa21f-58bc-4f4f-b54e-de70559b7c06)

As such, if you kill one of the grabbed monsters while they were grabbing each other, the other monster will break free from itself:
![изображение](https://github.com/user-attachments/assets/1d38184e-561f-4940-a932-b67733f7398d)

* Closes #79992.

#### Describe the solution
Skip searching the tile the monster is located on when calculating who is the grabber in this edge case.

#### Describe alternatives you've considered
None.

#### Testing
Spawned vine beast and zombie, waited for them to grab each other. 
- Vine beast kills the zombie during the mutual grab - postmortem grab was removed.
- I killed the zombie with my Barrett during the mutual grab - postmortem grab was removed.

Also I checked for case when only one monster grabs the other one (zombie versus cow). The postmortem grab was also removed as it should.

#### Additional context
None.