### PR TITLE
[MoM] Allow Force Shove to hurl the target in different directions

### DIFF
--- a/data/mods/Aftershock/spells/psionics/telekinesis_eocs.json
+++ b/data/mods/Aftershock/spells/psionics/telekinesis_eocs.json
@@ -59,11 +59,44 @@
         "then": { "run_eocs": "EOC_AFS_TELEKINETIC_PUSH_DOWN_CHECKER" },
         "else": [
           {
-            "npc_cast_spell": { "id": "afs_telekinetic_force_shove_away", "min_level": { "math": [ "u_afs_telekinesis_shove_spell_level" ] } },
-            "loc": { "context_val": "loc" }
-          },
-          { "npc_message": "You hurl your target away.", "type": "good" },
-          { "run_eocs": "EOC_AFS_TELEKINETIC_PUSH_DOWN_CHECKER" }
+            "if": "npc_is_avatar",
+            "then": [
+              { "npc_message": "You hurl your target.", "type": "good" },
+              {
+                "run_eocs": [
+                  {
+                    "id": "EOC_AFS_TELEKINETIC_PUSH_DIRECTION_PICKER",
+                    "effect": [
+                      { "set_string_var": { "mutator": "u_loc_relative", "target": "(0,0,0)" }, "target_var": { "context_val": "u_pos" } },
+                      {
+                        "npc_choose_adjacent_highlight": { "context_val": "push_direction_incorrect" },
+                        "target_var": { "context_val": "u_pos" },
+                        "message": "Select direction."
+                      },
+                      {
+                        "mirror_coordinates": { "context_val": "push_direction_correct" },
+                        "center_var": { "context_val": "u_pos" },
+                        "relative_var": { "context_val": "push_direction_incorrect" }
+                      },
+                      {
+                        "u_knockback": { "math": [ "u_afs_telekinesis_shove_spell_level" ] },
+                        "stun": 1,
+                        "dam_mult": 2,
+                        "direction_var": { "context_val": "push_direction_correct" }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "else": [
+              {
+                "npc_cast_spell": { "id": "telekinetic_force_shove_away", "min_level": { "math": [ "u_telekinesis_shove_spell_level" ] } },
+                "loc": { "context_val": "loc" }
+              },
+              { "run_eocs": "EOC_TELEKINETIC_PUSH_DOWN_CHECKER" }
+            ]
+          }
         ]
       }
     ]

--- a/data/mods/MindOverMatter/PowerDescriptionSpoilers.md
+++ b/data/mods/MindOverMatter/PowerDescriptionSpoilers.md
@@ -987,7 +987,7 @@ Powers causing telekinetic damage have a 40% chance to stagger the target for 2 
 *Duration*: Instant<br />
 *Stamina Cost*: 1750, minus 80 per level to a minimum of 750<br />
 *Channeling Time*: 50 moves, minus 4 moves per level to a minimum of 10<br />
-*Effects*: The psion attempts to shove a single target either toward or away from them. The distance is based on the ratio of the target's weight to the psion's power level (modified by Intelligence and Nether Attunement as usual).  By default, the formula is (power level * 25 kg) * Intelligence modifier * Nether Attunement modifier, divided by the target's weight in kg. If this is 1 or higher, the target is hurled back 1 square for every 0.5 above 1 the ratio is. If it is below one, there is still a chance to knock the target over (chance is weight ratio * 100 in percentage; a weight ratio of 0.678 has a 67.8% chance of causing knockdown).<br />
+*Effects*: The psion attempts to shove a single target either to them or in a chosen direction. The distance is based on the ratio of the target's weight to the psion's power level (modified by Intelligence and Nether Attunement as usual).  By default, the formula is (power level * 25 kg) * Intelligence modifier * Nether Attunement modifier, divided by the target's weight in kg. If this is 1 or higher, the target is hurled 1 square for every 0.5 above 1 the ratio is. If it is below one, there is still a chance to knock the target over (chance is weight ratio * 100 in percentage; a weight ratio of 0.678 has a 67.8% chance of causing knockdown).<br />
 *Prerequisites*: Starting power<br />
 </details>
 <details>
@@ -1141,7 +1141,7 @@ Powers causing telekinetic damage have a 40% chance to stagger the target for 2 
 *Duration*: Instant<br />
 *Stamina Cost*: 9500, minus 175 per level to a minimum of 5000<br />
 *Channeling Time*: 80 moves, minus 5 moves per level to a minimum of 25<br />/>
-*Effects*: Like Force Shove, but on a much greater scale, the psion hurls a single target either toward or away from them. The distance is based on the ratio of the target's weight to the psion's power level (modified by Intelligence and Nether Attunement as usual).  By default, the formula is (power level * 150 kg) * Intelligence modifier * Nether Attunement modifier, plus 100 kg, divided by the target's weight in kg. If this is 1 or higher, the target is hurled back 1 square for every 0.5 above 1 the ratio is. If it is below one, there is still a chance to knock the target over (chance is weight ratio * 1000 in percentage; a weight ratio of 0.952 has a 95.2% chance of causing knockdown).<br />
+*Effects*: Like Force Shove, but on a much greater scale, the psion hurls a single target either to them or in a chosen direction. The distance is based on the ratio of the target's weight to the psion's power level (modified by Intelligence and Nether Attunement as usual).  By default, the formula is (power level * 150 kg) * Intelligence modifier * Nether Attunement modifier, plus 100 kg, divided by the target's weight in kg. If this is 1 or higher, the target is hurled 1 square for every 0.5 above 1 the ratio is. If it is below one, there is still a chance to knock the target over (chance is weight ratio * 1000 in percentage; a weight ratio of 0.952 has a 95.2% chance of causing knockdown).<br />
 *Prerequisites*: Force Shove 15 *or* Far Hand 15, Momentum Alteration 10, Lift Vehicle 6<br />
 </details>
 <details>

--- a/data/mods/MindOverMatter/powers/telekinesis_eoc.json
+++ b/data/mods/MindOverMatter/powers/telekinesis_eoc.json
@@ -62,14 +62,12 @@
         "then": { "run_eocs": "EOC_TELEKINETIC_PUSH_DOWN_CHECKER" },
         "else": [
           {
-            "if": "u_is_avatar",
+            "if": "npc_is_avatar",
             "then": [
               { "npc_message": "You hurl your target.", "type": "good" },
-              { "run_eocs": "EOC_TELEKINETIC_PUSH_DOWN_CHECKER" },
               {
                 "run_eocs": [
                   {
-                    "type": "effect_on_condition",
                     "id": "EOC_TELEKINETIC_PUSH_DIRECTION_PICKER",
                     "effect": [
                       { "set_string_var": { "mutator": "u_loc_relative", "target": "(0,0,0)" }, "target_var": { "context_val": "u_pos" } },
@@ -189,11 +187,44 @@
         "then": { "run_eocs": "EOC_TELEKINETIC_PUSH_DOWN_CHECKER" },
         "else": [
           {
-            "npc_cast_spell": { "id": "telekinetic_force_shove_away", "min_level": { "math": [ "u_telekinesis_shove_spell_level" ] } },
-            "loc": { "context_val": "loc" }
-          },
-          { "npc_message": "You hurl your target away.", "type": "good" },
-          { "run_eocs": "EOC_TELEKINETIC_PUSH_DOWN_CHECKER" }
+            "if": "npc_is_avatar",
+            "then": [
+              { "npc_message": "You hurl your target.", "type": "good" },
+              {
+                "run_eocs": [
+                  {
+                    "id": "EOC_TELEKINETIC_PUSH_DIRECTION_PICKER_2",
+                    "effect": [
+                      { "set_string_var": { "mutator": "u_loc_relative", "target": "(0,0,0)" }, "target_var": { "context_val": "u_pos" } },
+                      {
+                        "npc_choose_adjacent_highlight": { "context_val": "push_direction_incorrect" },
+                        "target_var": { "context_val": "u_pos" },
+                        "message": "Select direction."
+                      },
+                      {
+                        "mirror_coordinates": { "context_val": "push_direction_correct" },
+                        "center_var": { "context_val": "u_pos" },
+                        "relative_var": { "context_val": "push_direction_incorrect" }
+                      },
+                      {
+                        "u_knockback": { "math": [ "u_telekinesis_shove_spell_level" ] },
+                        "stun": 1,
+                        "dam_mult": 2,
+                        "direction_var": { "context_val": "push_direction_correct" }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "else": [
+              {
+                "npc_cast_spell": { "id": "telekinetic_force_shove_away", "min_level": { "math": [ "u_telekinesis_shove_spell_level" ] } },
+                "loc": { "context_val": "loc" }
+              },
+              { "run_eocs": "EOC_TELEKINETIC_PUSH_DOWN_CHECKER" }
+            ]
+          }
         ]
       }
     ]

--- a/data/mods/MindOverMatter/powers/telekinesis_eoc.json
+++ b/data/mods/MindOverMatter/powers/telekinesis_eoc.json
@@ -150,9 +150,9 @@
     "effect": [
       {
         "run_eoc_selector": [ "EOC_TELEKINETIC_MOVE_LARGE_WEIGHT_SELECTOR_PUSH", "EOC_TELEKINETIC_MOVE_LARGE_WEIGHT_SELECTOR_PULL" ],
-        "names": [ "Push", "Pull" ],
+        "names": [ "Shove", "Pull" ],
         "keys": [ "1", "2" ],
-        "descriptions": [ "Push something away from you.", "Pull something toward you." ]
+        "descriptions": [ "Shove a target in particular direction.", "Pull something toward you." ]
       }
     ]
   },

--- a/data/mods/MindOverMatter/powers/telekinesis_eoc.json
+++ b/data/mods/MindOverMatter/powers/telekinesis_eoc.json
@@ -65,6 +65,7 @@
             "if": "u_is_avatar",
             "then": [
               { "npc_message": "You hurl your target.", "type": "good" },
+              { "run_eocs": "EOC_TELEKINETIC_PUSH_DOWN_CHECKER" },
               {
                 "run_eocs": [
                   {

--- a/data/mods/MindOverMatter/powers/telekinesis_eoc.json
+++ b/data/mods/MindOverMatter/powers/telekinesis_eoc.json
@@ -209,7 +209,7 @@
                       {
                         "u_knockback": { "math": [ "u_telekinesis_shove_spell_level" ] },
                         "stun": 1,
-                        "dam_mult": 2,
+                        "dam_mult": 5,
                         "direction_var": { "context_val": "push_direction_correct" }
                       }
                     ]

--- a/data/mods/MindOverMatter/powers/telekinesis_eoc.json
+++ b/data/mods/MindOverMatter/powers/telekinesis_eoc.json
@@ -25,9 +25,9 @@
     "condition": "u_is_avatar",
     "effect": {
       "run_eoc_selector": [ "EOC_TELEKINETIC_FORCE_SHOVE_SELECTOR_PUSH", "EOC_TELEKINETIC_FORCE_SHOVE_SELECTOR_PULL" ],
-      "names": [ "Push", "Pull" ],
+      "names": [ "Shove", "Pull" ],
       "keys": [ "1", "2" ],
-      "descriptions": [ "Shove a target away from you.", "Grab a target and pull them towards you." ]
+      "descriptions": [ "Shove a target in a particular direction.", "Grab a target and pull them towards you." ]
     },
     "false_effect": { "u_cast_spell": { "id": "telekinetic_force_shove_away_target" }, "targeted": true }
   },
@@ -62,11 +62,45 @@
         "then": { "run_eocs": "EOC_TELEKINETIC_PUSH_DOWN_CHECKER" },
         "else": [
           {
-            "npc_cast_spell": { "id": "telekinetic_force_shove_away", "min_level": { "math": [ "u_telekinesis_shove_spell_level" ] } },
-            "loc": { "context_val": "loc" }
-          },
-          { "npc_message": "You hurl your target away.", "type": "good" },
-          { "run_eocs": "EOC_TELEKINETIC_PUSH_DOWN_CHECKER" }
+            "if": "u_is_avatar",
+            "then": [
+              { "npc_message": "You hurl your target.", "type": "good" },
+              {
+                "run_eocs": [
+                  {
+                    "type": "effect_on_condition",
+                    "id": "EOC_TELEKINETIC_PUSH_DIRECTION_PICKER",
+                    "effect": [
+                      { "set_string_var": { "mutator": "u_loc_relative", "target": "(0,0,0)" }, "target_var": { "context_val": "u_pos" } },
+                      {
+                        "npc_choose_adjacent_highlight": { "context_val": "push_direction_incorrect" },
+                        "target_var": { "context_val": "u_pos" },
+                        "message": "Select direction."
+                      },
+                      {
+                        "mirror_coordinates": { "context_val": "push_direction_correct" },
+                        "center_var": { "context_val": "u_pos" },
+                        "relative_var": { "context_val": "push_direction_incorrect" }
+                      },
+                      {
+                        "u_knockback": { "math": [ "u_telekinesis_shove_spell_level" ] },
+                        "stun": 1,
+                        "dam_mult": 2,
+                        "direction_var": { "context_val": "push_direction_correct" }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "else": [
+              {
+                "npc_cast_spell": { "id": "telekinetic_force_shove_away", "min_level": { "math": [ "u_telekinesis_shove_spell_level" ] } },
+                "loc": { "context_val": "loc" }
+              },
+              { "run_eocs": "EOC_TELEKINETIC_PUSH_DOWN_CHECKER" }
+            ]
+          }
         ]
       }
     ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[MoM] Allow Force Shove to hurl the target in different directions"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

I knew that Guardian was working on this functionality, but I hadn't realized that it had already been finished over a week ago. Oops.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Implement `u_knockback` in Force Shove and Megakinesis. The knockback distance is equal to the effective spell level that `telekinetic_force_shove_away` would be cast at in the original calculations.  Since NPCs have no functionality for choosing where to throw their targets, at the moment they maintain the old way Force Shove works. 

I borrowed the EoC in the docs, which Guardian mentioned was tailor-made for this purpose.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Threw some monsters around for a while.

- [X] Extend to Megakinesis
- [X] Extend to Aftershock's Force Shove

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

I bet I could get a better Wave of Force with this function too. 
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
