### PR TITLE
Some Profession Worn Item Fix

### DIFF
--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -5651,8 +5651,6 @@
     "items": {
       "both": {
         "entries": [
-          { "item": "hoodie" },
-          { "item": "hoodie_cropped" },
           { "item": "jeans" },
           { "item": "socks" },
           { "item": "elbow_pads" },
@@ -5663,13 +5661,11 @@
           { "item": "wristwatch" },
           { "item": "sports_drink" },
           { "group": "charged_smart_phone" },
-          { "group": "starter_wallet_full" },
-          { "item": "tshirt", "variant": "generic_tshirt" },
-          { "item": "tshirt_cropped" }
+          { "group": "starter_wallet_full" }
         ]
       },
-      "male": { "entries": [ { "item": "briefs" } ] },
-      "female": { "entries": [ { "item": "boy_shorts" } ] }
+      "male": { "entries": [ { "item": "briefs" }, { "item": "hoodie" }, { "item": "tshirt" } ] },
+      "female": { "entries": [ { "item": "boy_shorts" }, { "item": "hoodie_cropped" }, { "item": "tshirt_cropped" } ] }
     },
     "age_lower": 16,
     "age_upper": 21
@@ -5687,8 +5683,6 @@
     "items": {
       "both": {
         "entries": [
-          { "item": "hoodie" },
-          { "item": "hoodie_cropped" },
           { "item": "jeans" },
           { "item": "socks" },
           { "item": "elbow_pads" },
@@ -5700,13 +5694,11 @@
           { "item": "wristwatch" },
           { "item": "sports_drink" },
           { "group": "charged_smart_phone" },
-          { "group": "starter_wallet_full" },
-          { "item": "tshirt", "variant": "generic_tshirt" },
-          { "item": "tshirt_cropped" }
+          { "group": "starter_wallet_full" }
         ]
       },
-      "male": { "entries": [ { "item": "briefs" } ] },
-      "female": { "entries": [ { "item": "boy_shorts" } ] }
+      "male": { "entries": [ { "item": "briefs" }, { "item": "hoodie" }, { "item": "tshirt" } ] },
+      "female": { "entries": [ { "item": "boy_shorts" }, { "item": "hoodie_cropped" }, { "item": "tshirt_cropped" } ] }
     },
     "age_lower": 16,
     "age_upper": 21
@@ -5729,8 +5721,6 @@
     "items": {
       "both": {
         "entries": [
-          { "item": "hoodie" },
-          { "item": "hoodie_cropped" },
           { "item": "jeans" },
           { "item": "socks" },
           { "item": "sneakers" },
@@ -5745,13 +5735,11 @@
           { "item": "slingshot" },
           { "group": "charged_smart_phone" },
           { "group": "starter_wallet_full" },
-          { "group": "charged_matches" },
-          { "item": "tshirt", "variant": "generic_tshirt" },
-          { "item": "tshirt_cropped" }
+          { "group": "charged_matches" }
         ]
       },
-      "male": { "entries": [ { "item": "briefs" } ] },
-      "female": { "entries": [ { "item": "boy_shorts" } ] }
+      "male": { "entries": [ { "item": "briefs" }, { "item": "hoodie" }, { "item": "tshirt" } ] },
+      "female": { "entries": [ { "item": "boy_shorts" }, { "item": "hoodie_cropped" }, { "item": "tshirt_cropped" } ] }
     },
     "age_lower": 16,
     "age_upper": 18
@@ -6058,21 +6046,19 @@
     "items": {
       "both": {
         "entries": [
-          { "item": "hoodie" },
-          { "item": "hoodie_cropped" },
           { "item": "pants_cargo" },
           { "item": "socks_ankle" },
           { "item": "sneakers" },
           { "item": "runner_bag" },
           { "item": "wristwatch" },
           { "group": "charged_smart_phone" },
-          { "group": "starter_wallet_full" },
-          { "item": "tshirt", "variant": "generic_tshirt" },
-          { "item": "tshirt_cropped" }
+          { "group": "starter_wallet_full" }
         ]
       },
-      "male": { "entries": [ { "item": "briefs" } ] },
-      "female": { "entries": [ { "item": "sports_bra" }, { "item": "boy_shorts" } ] }
+      "male": { "entries": [ { "item": "briefs" }, { "item": "tshirt" }, { "item": "hoodie" } ] },
+      "female": {
+        "entries": [ { "item": "sports_bra" }, { "item": "boy_shorts" }, { "item": "hoodie_cropped" }, { "item": "tshirt_cropped" } ]
+      }
     },
     "age_lower": 18
   },
@@ -6099,13 +6085,11 @@
           { "group": "charged_smart_phone" },
           { "group": "starter_rich_wallet_full" },
           { "item": "camera", "charges": 300 },
-          { "item": "tshirt", "variant": "generic_tshirt" },
-          { "item": "tshirt_cropped" },
           { "item": "pants", "variant": "pants_black" }
         ]
       },
-      "male": { "entries": [ { "item": "boxer_shorts" } ] },
-      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
+      "male": { "entries": [ { "item": "boxer_shorts" }, { "item": "tshirt" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "tshirt_cropped" }, { "item": "panties" } ] }
     }
   },
   {


### PR DESCRIPTION


#### Summary
None

#### Purpose of change
I noticed some profession like skaterkid, juvenile delinquent, traceur, and tourist wears both cropped tshirt/hoodie and regular tshirt/hoodie regardless of which kind of outfit is selected. This fixes it.

#### Describe the solution

Move the cropped tshirt and hoodie to the female side of things and non-cropped tshirt and hoodie to the male side.

#### Describe alternatives you've considered

Not doing so. 
Made them pocket the tshirt/hoodie?

#### Testing
 Ive checked the professions mentioned above in the profession screen to see if it works. It is working as expected.
![Screenshot_20250313_015625](https://github.com/user-attachments/assets/bd927175-9966-41dc-9d9d-254d802ffdf3)
![Screenshot_20250313_015609](https://github.com/user-attachments/assets/fbda99cf-231a-4f61-ab94-f86fb7b4726c)


#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
