### PR TITLE
Fix typo within design-balance.md

### DIFF
--- a/doc/design-balance-lore/design-balance.md
+++ b/doc/design-balance-lore/design-balance.md
@@ -2,7 +2,7 @@
 
 **Summary**
 
-The driving goal of balance in DDA is to support **versimilitude in the scenario**.  In other words we want the right *things* to be present to match reality, but also when those things are used to accomplish goals, they should be appoximately as effective at doing so as their real-world counterparts.  Of note, this is not the same as pursuing all aspects of realism.  New features added should have the goal of improving verissimilitude rather than complexity for complexity's sake.
+The driving goal of balance in DDA is to support **verisimilitude in the scenario**.  In other words we want the right *things* to be present to match reality, but also when those things are used to accomplish goals, they should be appoximately as effective at doing so as their real-world counterparts.  Of note, this is not the same as pursuing all aspects of realism.  New features added should have the goal of improving verissimilitude rather than complexity for complexity's sake.
 
 This means that *solutions to problems* should come from the same angle.  If something is not working as it should, the answer is to assess how it should work in reality, and figure out a way to better simulate that.  We find that reality tends to be quite balanced, and having things work as one would expect makes for a fun game.  
 


### PR DESCRIPTION
#### Summary

Bugfixes "Fixed a spelling error within design-balance.md"

#### Purpose of change

Spelling errors are an abomination and an affront to humanity. They should be terminated on sight.

#### Describe the solution

Changed versimilitude to verisimilitude. As far as I'm aware, this is the correct spelling and the other word is a misspelling, I've looked through a small handful of dictionaries and they all seem to agree verisimilitude is the most correct spelling.

#### Describe alternatives you've considered

Don't change the spelling.

#### Testing

It is a simple text change in a markdown file, there should be no issues pushing this change. I've looked at the Merriam-Webster dictionary, Dictionary.com and the Oxford dictionary to see the spelling of versimilitude/verisimilitude. They all spelt the word like verisimilitude.

#### Additional context