### PR TITLE
fix crash on wielding nullitem and restore old npc behavior

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -13126,14 +13126,12 @@ bool Character::wield( item &it, std::optional<int> obtain_cost )
         wielded->on_wield( *this );
         inv->update_invlet( *wielded );
         inv->update_cache_with_item( *wielded );
+        cata::event e = cata::event::make<event_type::character_wields_item>( getID(), last_item );
+        get_event_bus().send_with_talker( this, &wielded, e );
     } else {
         last_item = to_wield.typeId();
+        get_event_bus().send<event_type::character_wields_item>( getID(), item().typeId() );
     }
-
-
-    cata::event e = cata::event::make<event_type::character_wields_item>( getID(), last_item );
-    get_event_bus().send_with_talker( this, &wielded, e );
-
     return true;
 }
 

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -13102,8 +13102,6 @@ bool Character::wield( item &it, std::optional<int> obtain_cost )
     add_msg_debug( debugmode::DF_AVATAR, "wielding took %d moves", mv );
     mod_moves( -mv );
 
-
-
     item to_wield;
     if( has_item( it ) ) {
         to_wield = i_rem( &it );

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -13102,29 +13102,39 @@ bool Character::wield( item &it, std::optional<int> obtain_cost )
     add_msg_debug( debugmode::DF_AVATAR, "wielding took %d moves", mv );
     mod_moves( -mv );
 
-    bool had_item = has_item( it );
-    if( combine_stacks ) {
-        wielded->combine( it );
+
+
+    item to_wield;
+    if( has_item( it ) ) {
+        to_wield = i_rem( &it );
     } else {
-        set_wielded_item( it );
+        // is_null means fists
+        to_wield = it.is_null() ? item() : it;
     }
 
-    if( had_item ) {
-        i_rem( &it );
+    if( combine_stacks ) {
+        wielded->combine( to_wield );
+    } else {
+        set_wielded_item( to_wield );
     }
 
     // set_wielded_item invalidates the weapon item_location, so get it again
     wielded = get_wielded_item();
-    last_item = wielded->typeId();
     recoil = MAX_RECOIL;
 
-    wielded->on_wield( *this );
+    // if fists are wielded get_wielded_item returns item_location::nowhere, which is a nullptr
+    if( wielded ) {
+        last_item = wielded->typeId();
+        wielded->on_wield( *this );
+        inv->update_invlet( *wielded );
+        inv->update_cache_with_item( *wielded );
+    } else {
+        to_wield.typeId();
+    }
+
 
     cata::event e = cata::event::make<event_type::character_wields_item>( getID(), last_item );
     get_event_bus().send_with_talker( this, &wielded, e );
-
-    inv->update_invlet( *wielded );
-    inv->update_cache_with_item( *wielded );
 
     return true;
 }

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -13129,7 +13129,7 @@ bool Character::wield( item &it, std::optional<int> obtain_cost )
         inv->update_invlet( *wielded );
         inv->update_cache_with_item( *wielded );
     } else {
-        to_wield.typeId();
+        last_item = to_wield.typeId();
     }
 
 

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1517,11 +1517,17 @@ void npc::stow_item( item &it )
 
 bool npc::wield( item &it )
 {
+    if( is_wielding( it ) ) {
+        return true;
+    }
     if( !Character::wield( it ) ) {
         return false;
     }
-    add_msg_if_player_sees( *this, m_info, _( "<npcname> wields a %s." ),
-                            get_wielded_item()->tname() );
+    if( get_wielded_item() ) {
+        add_msg_if_player_sees( *this, m_info, _( "<npcname> wields a %s." ),
+                                get_wielded_item()->tname() );
+    }
+
 
     invalidate_range_cache();
     return true;


### PR DESCRIPTION
#### Summary
Bugfixes "fix crash on wielding nullitem"

#### Purpose of change
continuation from #80098
fixes #80025, fixes #80028, fixes #80045, ~~probably #80090 (cant load savefile and dont want to re-compile with newer version)~~ call stack looks different, fixes #80100, fixes #80154
When I refactored wield in #79719 I forgot to implement some NPC specific behaviours, causing a segfault.
namely not unwielding when trying to wield the same item:
https://github.com/CleverRaven/Cataclysm-DDA/blob/27152a95375f796ffaa06faf0a133a98a75d2634/src/npc.cpp#L1522-L1524
and handling wielding nullitem (fists)
https://github.com/CleverRaven/Cataclysm-DDA/blob/27152a95375f796ffaa06faf0a133a98a75d2634/src/npc.cpp#L1541-L1545

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Exiting early when npc wields same item,

add a few more checks for nullitem.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Implementing nullitem the exact same, but only wielding and sending the event misses a lot of updates (last_item update, movement cost, on_wield)
make if fists are optimal, make npc::wield_better_weapon unwield, instad of trying to wield a null_item
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
No crash for save from #80025
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
most of the issue was that get_wielded_item would return item_location::nowhere. If it returned a location with a nullitem, We could get its default typeId, which would dramatically cut down on the number of checks. But that would open up a whole other can of worms I don't want to deal with right now.
also, what is character::last_item even for? The od code didnt update it when wielding fists, so it cant be that important?

also apologies to @jankyd, as I pointed him to the wrong part of the missing implementation in my [comment](https://github.com/CleverRaven/Cataclysm-DDA/pull/80098#issuecomment-2710216416) and to everyone affected for the oversight in my original PR
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
