### PR TITLE
Added separate trait to allow natural growth of beards be switched independently to natural growth of hair

### DIFF
--- a/data/json/effects_on_condition/npc_eocs/appearance_eocs.json
+++ b/data/json/effects_on_condition/npc_eocs/appearance_eocs.json
@@ -123,7 +123,7 @@
     "//2": "Currently beard changes traits every 14 days",
     "recurrence": { "math": [ "time('14 d')" ] },
     "global": false,
-    "condition": { "and": [ { "u_has_trait": "natural_hair_growth" }, "u_male" ] },
+    "condition": { "u_has_trait": "natural_beard_growth" },
     "effect": [
       {
         "if": { "u_has_trait": "FACIAL_HAIR_NONE" },

--- a/data/json/effects_on_condition/npc_eocs/appearance_eocs.json
+++ b/data/json/effects_on_condition/npc_eocs/appearance_eocs.json
@@ -123,7 +123,7 @@
     "//2": "Currently beard changes traits every 14 days",
     "recurrence": { "math": [ "time('14 d')" ] },
     "global": false,
-    "condition": { "u_has_trait": "natural_hair_growth" },
+    "condition": { "and": [ { "u_has_trait": "natural_hair_growth" }, "u_male" ] },
     "effect": [
       {
         "if": { "u_has_trait": "FACIAL_HAIR_NONE" },

--- a/data/json/mutations/appearance_hair_styles.json
+++ b/data/json/mutations/appearance_hair_styles.json
@@ -1955,5 +1955,17 @@
     "purifiable": false,
     "player_display": true,
     "vanity": true
+  },
+  {
+    "type": "mutation",
+    "id": "natural_beard_growth",
+    "name": { "str": "Natural Beard Growth" },
+    "description": "Your beard will naturally grow out into various forms, getting longer over time.  Turning this off will prevent it from growing and changing.",
+    "points": 0,
+    "starting_trait": true,
+    "valid": true,
+    "purifiable": false,
+    "player_display": true,
+    "vanity": true
   }
 ]

--- a/data/json/npcs/EOC_talkers/haircutting.json
+++ b/data/json/npcs/EOC_talkers/haircutting.json
@@ -1284,7 +1284,7 @@
         "text": "Get a clean shave.",
         "condition": {
           "and": [
-            { "u_has_trait": "natural_hair_growth" },
+            { "u_has_trait": "natural_beard_growth" },
             {
               "or": [
                 { "u_has_trait": "FACIAL_HAIR_NECKBEARD" },
@@ -1334,7 +1334,7 @@
         "text": "Get a neck beard.",
         "condition": {
           "and": [
-            { "u_has_trait": "natural_hair_growth" },
+            { "u_has_trait": "natural_beard_growth" },
             {
               "or": [
                 { "u_has_trait": "FACIAL_HAIR_SIDEBURNS" },
@@ -1383,7 +1383,7 @@
         "text": "Get some sideburns.",
         "condition": {
           "and": [
-            { "u_has_trait": "natural_hair_growth" },
+            { "u_has_trait": "natural_beard_growth" },
             {
               "or": [
                 { "u_has_trait": "FACIAL_HAIR_3DAYSTUBBLE" },
@@ -1429,7 +1429,7 @@
         "text": "Get a soul patch.",
         "condition": {
           "and": [
-            { "u_has_trait": "natural_hair_growth" },
+            { "u_has_trait": "natural_beard_growth" },
             {
               "or": [
                 { "u_has_trait": "FACIAL_HAIR_3DAYSTUBBLE" },
@@ -1475,7 +1475,7 @@
         "text": "Get a chin strip.",
         "condition": {
           "and": [
-            { "u_has_trait": "natural_hair_growth" },
+            { "u_has_trait": "natural_beard_growth" },
             {
               "or": [
                 { "u_has_trait": "FACIAL_HAIR_3DAYSTUBBLE" },
@@ -1521,7 +1521,7 @@
         "text": "Get some 3-day stubble.",
         "condition": {
           "and": [
-            { "u_has_trait": "natural_hair_growth" },
+            { "u_has_trait": "natural_beard_growth" },
             {
               "or": [
                 { "u_has_trait": "FACIAL_HAIR_ZAPPA" },
@@ -1561,7 +1561,7 @@
         "text": "Get a toothbrush mustache.",
         "condition": {
           "and": [
-            { "u_has_trait": "natural_hair_growth" },
+            { "u_has_trait": "natural_beard_growth" },
             {
               "or": [
                 { "u_has_trait": "FACIAL_HAIR_ZAPPA" },
@@ -1601,7 +1601,7 @@
         "text": "Get a chin strap.",
         "condition": {
           "and": [
-            { "u_has_trait": "natural_hair_growth" },
+            { "u_has_trait": "natural_beard_growth" },
             {
               "or": [
                 { "u_has_trait": "FACIAL_HAIR_ZAPPA" },
@@ -1641,7 +1641,7 @@
         "text": "Get a mustache.",
         "condition": {
           "and": [
-            { "u_has_trait": "natural_hair_growth" },
+            { "u_has_trait": "natural_beard_growth" },
             {
               "or": [
                 { "u_has_trait": "FACIAL_HAIR_GOATEE" },
@@ -1680,7 +1680,7 @@
         "text": "Get a walrus mustache.",
         "condition": {
           "and": [
-            { "u_has_trait": "natural_hair_growth" },
+            { "u_has_trait": "natural_beard_growth" },
             {
               "or": [
                 { "u_has_trait": "FACIAL_HAIR_GOATEE" },
@@ -1719,7 +1719,7 @@
         "text": "Get a Zappa.",
         "condition": {
           "and": [
-            { "u_has_trait": "natural_hair_growth" },
+            { "u_has_trait": "natural_beard_growth" },
             {
               "or": [
                 { "u_has_trait": "FACIAL_HAIR_GOATEE" },
@@ -1758,7 +1758,7 @@
         "text": "Get a goatee.",
         "condition": {
           "and": [
-            { "u_has_trait": "natural_hair_growth" },
+            { "u_has_trait": "natural_beard_growth" },
             {
               "or": [
                 { "u_has_trait": "FACIAL_HAIR_BEARD" },
@@ -1788,7 +1788,7 @@
         "text": "Get a circle beard.",
         "condition": {
           "and": [
-            { "u_has_trait": "natural_hair_growth" },
+            { "u_has_trait": "natural_beard_growth" },
             {
               "or": [
                 { "u_has_trait": "FACIAL_HAIR_BEARD" },
@@ -1818,7 +1818,7 @@
         "text": "Get a short boxed beard.",
         "condition": {
           "and": [
-            { "u_has_trait": "natural_hair_growth" },
+            { "u_has_trait": "natural_beard_growth" },
             {
               "or": [
                 { "u_has_trait": "FACIAL_HAIR_BEARD" },
@@ -1848,7 +1848,7 @@
         "text": "Get a horseshoe.",
         "condition": {
           "and": [
-            { "u_has_trait": "natural_hair_growth" },
+            { "u_has_trait": "natural_beard_growth" },
             {
               "or": [
                 { "u_has_trait": "FACIAL_HAIR_BEARD" },
@@ -1878,7 +1878,7 @@
         "text": "Get some mutton chops.",
         "condition": {
           "and": [
-            { "u_has_trait": "natural_hair_growth" },
+            { "u_has_trait": "natural_beard_growth" },
             {
               "or": [
                 { "u_has_trait": "FACIAL_HAIR_BEARD" },
@@ -1908,7 +1908,7 @@
         "text": "Get a gunslinger beard.",
         "condition": {
           "and": [
-            { "u_has_trait": "natural_hair_growth" },
+            { "u_has_trait": "natural_beard_growth" },
             {
               "or": [
                 { "u_has_trait": "FACIAL_HAIR_BEARD" },
@@ -1938,7 +1938,7 @@
         "text": "Get a chin curtain.",
         "condition": {
           "and": [
-            { "u_has_trait": "natural_hair_growth" },
+            { "u_has_trait": "natural_beard_growth" },
             {
               "or": [
                 { "u_has_trait": "FACIAL_HAIR_BEARD" },
@@ -1968,7 +1968,7 @@
         "text": "Get a handlebar mustache.",
         "condition": {
           "and": [
-            { "u_has_trait": "natural_hair_growth" },
+            { "u_has_trait": "natural_beard_growth" },
             {
               "or": [
                 { "u_has_trait": "FACIAL_HAIR_BEARD" },
@@ -1998,7 +1998,7 @@
         "text": "Get a Van Dyke.",
         "condition": {
           "and": [
-            { "u_has_trait": "natural_hair_growth" },
+            { "u_has_trait": "natural_beard_growth" },
             {
               "or": [
                 { "u_has_trait": "FACIAL_HAIR_BEARD" },
@@ -2028,7 +2028,7 @@
         "text": "Get a regular beard.",
         "condition": {
           "and": [
-            { "u_has_trait": "natural_hair_growth" },
+            { "u_has_trait": "natural_beard_growth" },
             {
               "or": [
                 { "u_has_trait": "FACIAL_HAIR_SHENANDOAH" },
@@ -2055,7 +2055,7 @@
         "text": "Get a anchor beard.",
         "condition": {
           "and": [
-            { "u_has_trait": "natural_hair_growth" },
+            { "u_has_trait": "natural_beard_growth" },
             {
               "or": [
                 { "u_has_trait": "FACIAL_HAIR_SHENANDOAH" },
@@ -2082,7 +2082,7 @@
         "text": "Get a royale beard.",
         "condition": {
           "and": [
-            { "u_has_trait": "natural_hair_growth" },
+            { "u_has_trait": "natural_beard_growth" },
             {
               "or": [
                 { "u_has_trait": "FACIAL_HAIR_SHENANDOAH" },
@@ -2109,7 +2109,7 @@
         "text": "Get a Shenandoah.",
         "condition": {
           "and": [
-            { "u_has_trait": "natural_hair_growth" },
+            { "u_has_trait": "natural_beard_growth" },
             {
               "or": [ { "u_has_trait": "FACIAL_HAIR_BEARD_LONG" }, { "u_has_trait": "FACIAL_HAIR_BEARD_VERY_LONG" } ]
             }
@@ -2130,7 +2130,7 @@
       },
       {
         "text": "Get a long beard.",
-        "condition": { "and": [ { "u_has_trait": "natural_hair_growth" }, { "u_has_trait": "FACIAL_HAIR_BEARD_VERY_LONG" } ] },
+        "condition": { "and": [ { "u_has_trait": "natural_beard_growth" }, { "u_has_trait": "FACIAL_HAIR_BEARD_VERY_LONG" } ] },
         "effect": [
           { "run_eocs": "reset_all_beard_types" },
           {
@@ -2146,7 +2146,7 @@
       },
       {
         "text": "Get a clean shave.",
-        "condition": { "not": { "u_has_trait": "natural_hair_growth" } },
+        "condition": { "not": { "u_has_trait": "natural_beard_growth" } },
         "effect": [
           { "run_eocs": "reset_all_beard_types" },
           {
@@ -2162,7 +2162,7 @@
       },
       {
         "text": "Get a neck beard.",
-        "condition": { "not": { "u_has_trait": "natural_hair_growth" } },
+        "condition": { "not": { "u_has_trait": "natural_beard_growth" } },
         "effect": [
           { "run_eocs": "reset_all_beard_types" },
           {
@@ -2178,7 +2178,7 @@
       },
       {
         "text": "Get some sideburns.",
-        "condition": { "not": { "u_has_trait": "natural_hair_growth" } },
+        "condition": { "not": { "u_has_trait": "natural_beard_growth" } },
         "effect": [
           { "run_eocs": "reset_all_beard_types" },
           {
@@ -2194,7 +2194,7 @@
       },
       {
         "text": "Get a soul patch.",
-        "condition": { "not": { "u_has_trait": "natural_hair_growth" } },
+        "condition": { "not": { "u_has_trait": "natural_beard_growth" } },
         "effect": [
           { "run_eocs": "reset_all_beard_types" },
           {
@@ -2210,7 +2210,7 @@
       },
       {
         "text": "Get a chin strip.",
-        "condition": { "not": { "u_has_trait": "natural_hair_growth" } },
+        "condition": { "not": { "u_has_trait": "natural_beard_growth" } },
         "effect": [
           { "run_eocs": "reset_all_beard_types" },
           {
@@ -2226,7 +2226,7 @@
       },
       {
         "text": "Get some 3-day stubble.",
-        "condition": { "not": { "u_has_trait": "natural_hair_growth" } },
+        "condition": { "not": { "u_has_trait": "natural_beard_growth" } },
         "effect": [
           { "run_eocs": "reset_all_beard_types" },
           {
@@ -2242,7 +2242,7 @@
       },
       {
         "text": "Get a toothbrush mustache.",
-        "condition": { "not": { "u_has_trait": "natural_hair_growth" } },
+        "condition": { "not": { "u_has_trait": "natural_beard_growth" } },
         "effect": [
           { "run_eocs": "reset_all_beard_types" },
           {
@@ -2258,7 +2258,7 @@
       },
       {
         "text": "Get a chin strap.",
-        "condition": { "not": { "u_has_trait": "natural_hair_growth" } },
+        "condition": { "not": { "u_has_trait": "natural_beard_growth" } },
         "effect": [
           { "run_eocs": "reset_all_beard_types" },
           {
@@ -2274,7 +2274,7 @@
       },
       {
         "text": "Get a mustache.",
-        "condition": { "not": { "u_has_trait": "natural_hair_growth" } },
+        "condition": { "not": { "u_has_trait": "natural_beard_growth" } },
         "effect": [
           { "run_eocs": "reset_all_beard_types" },
           {
@@ -2290,7 +2290,7 @@
       },
       {
         "text": "Get a walrus mustache.",
-        "condition": { "not": { "u_has_trait": "natural_hair_growth" } },
+        "condition": { "not": { "u_has_trait": "natural_beard_growth" } },
         "effect": [
           { "run_eocs": "reset_all_beard_types" },
           {
@@ -2306,7 +2306,7 @@
       },
       {
         "text": "Get a Zappa.",
-        "condition": { "not": { "u_has_trait": "natural_hair_growth" } },
+        "condition": { "not": { "u_has_trait": "natural_beard_growth" } },
         "effect": [
           { "run_eocs": "reset_all_beard_types" },
           {
@@ -2322,7 +2322,7 @@
       },
       {
         "text": "Get a goatee.",
-        "condition": { "not": { "u_has_trait": "natural_hair_growth" } },
+        "condition": { "not": { "u_has_trait": "natural_beard_growth" } },
         "effect": [
           { "run_eocs": "reset_all_beard_types" },
           {
@@ -2338,7 +2338,7 @@
       },
       {
         "text": "Get a circle beard.",
-        "condition": { "not": { "u_has_trait": "natural_hair_growth" } },
+        "condition": { "not": { "u_has_trait": "natural_beard_growth" } },
         "effect": [
           { "run_eocs": "reset_all_beard_types" },
           {
@@ -2354,7 +2354,7 @@
       },
       {
         "text": "Get a short boxed beard.",
-        "condition": { "not": { "u_has_trait": "natural_hair_growth" } },
+        "condition": { "not": { "u_has_trait": "natural_beard_growth" } },
         "effect": [
           { "run_eocs": "reset_all_beard_types" },
           {
@@ -2370,7 +2370,7 @@
       },
       {
         "text": "Get a horseshoe.",
-        "condition": { "not": { "u_has_trait": "natural_hair_growth" } },
+        "condition": { "not": { "u_has_trait": "natural_beard_growth" } },
         "effect": [
           { "run_eocs": "reset_all_beard_types" },
           {
@@ -2386,7 +2386,7 @@
       },
       {
         "text": "Get some mutton chops.",
-        "condition": { "not": { "u_has_trait": "natural_hair_growth" } },
+        "condition": { "not": { "u_has_trait": "natural_beard_growth" } },
         "effect": [
           { "run_eocs": "reset_all_beard_types" },
           {
@@ -2402,7 +2402,7 @@
       },
       {
         "text": "Get a gunslinger beard.",
-        "condition": { "not": { "u_has_trait": "natural_hair_growth" } },
+        "condition": { "not": { "u_has_trait": "natural_beard_growth" } },
         "effect": [
           { "run_eocs": "reset_all_beard_types" },
           {
@@ -2418,7 +2418,7 @@
       },
       {
         "text": "Get a chin curtain.",
-        "condition": { "not": { "u_has_trait": "natural_hair_growth" } },
+        "condition": { "not": { "u_has_trait": "natural_beard_growth" } },
         "effect": [
           { "run_eocs": "reset_all_beard_types" },
           {
@@ -2434,7 +2434,7 @@
       },
       {
         "text": "Get a handlebar mustache.",
-        "condition": { "not": { "u_has_trait": "natural_hair_growth" } },
+        "condition": { "not": { "u_has_trait": "natural_beard_growth" } },
         "effect": [
           { "run_eocs": "reset_all_beard_types" },
           {
@@ -2450,7 +2450,7 @@
       },
       {
         "text": "Get a Van Dyke.",
-        "condition": { "not": { "u_has_trait": "natural_hair_growth" } },
+        "condition": { "not": { "u_has_trait": "natural_beard_growth" } },
         "effect": [
           { "run_eocs": "reset_all_beard_types" },
           {
@@ -2466,7 +2466,7 @@
       },
       {
         "text": "Get a regular beard.",
-        "condition": { "not": { "u_has_trait": "natural_hair_growth" } },
+        "condition": { "not": { "u_has_trait": "natural_beard_growth" } },
         "effect": [
           { "run_eocs": "reset_all_beard_types" },
           {
@@ -2482,7 +2482,7 @@
       },
       {
         "text": "Get a anchor beard.",
-        "condition": { "not": { "u_has_trait": "natural_hair_growth" } },
+        "condition": { "not": { "u_has_trait": "natural_beard_growth" } },
         "effect": [
           { "run_eocs": "reset_all_beard_types" },
           {
@@ -2498,7 +2498,7 @@
       },
       {
         "text": "Get a royale beard.",
-        "condition": { "not": { "u_has_trait": "natural_hair_growth" } },
+        "condition": { "not": { "u_has_trait": "natural_beard_growth" } },
         "effect": [
           { "run_eocs": "reset_all_beard_types" },
           {
@@ -2514,7 +2514,7 @@
       },
       {
         "text": "Get a Shenandoah.",
-        "condition": { "not": { "u_has_trait": "natural_hair_growth" } },
+        "condition": { "not": { "u_has_trait": "natural_beard_growth" } },
         "effect": [
           { "run_eocs": "reset_all_beard_types" },
           {
@@ -2530,7 +2530,7 @@
       },
       {
         "text": "Get a long beard.",
-        "condition": { "not": { "u_has_trait": "natural_hair_growth" } },
+        "condition": { "not": { "u_has_trait": "natural_beard_growth" } },
         "effect": [
           { "run_eocs": "reset_all_beard_types" },
           {
@@ -2546,7 +2546,7 @@
       },
       {
         "text": "Get a very long beard.",
-        "condition": { "not": { "u_has_trait": "natural_hair_growth" } },
+        "condition": { "not": { "u_has_trait": "natural_beard_growth" } },
         "effect": [
           { "run_eocs": "reset_all_beard_types" },
           {

--- a/data/json/npcs/refugee_center/surface_refugees/NPC_Vanessa_Toby.json
+++ b/data/json/npcs/refugee_center/surface_refugees/NPC_Vanessa_Toby.json
@@ -247,6 +247,18 @@
         "condition": { "u_has_trait": "natural_hair_growth" },
         "effect": { "u_lose_trait": "natural_hair_growth" }
       },
+      {
+        "text": "Could you fix it to where I can grow my facial hair out, please?",
+        "topic": "TALK_DONE",
+        "condition": { "not": { "u_has_trait": "natural_beard_growth" } },
+        "effect": { "u_add_trait": "natural_beard_growth" }
+      },
+      {
+        "text": "I'd like it if my facial hair didn't grow out anymore.  Can you help me with that?",
+        "topic": "TALK_DONE",
+        "condition": { "u_has_trait": "natural_beard_growth" },
+        "effect": { "u_lose_trait": "natural_beard_growth" }
+      },
       { "text": "That's a bit rich for my blood.  <done_conversation_section>", "topic": "TALK_NONE" },
       { "text": "That's a bit rich for my blood.  <end_talking_leave>", "topic": "TALK_DONE" }
     ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Natural hair growth trait causes female characters to grow beards."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Previously, "Natural hair growth" trait caused every character to grow facial hair, regardless their gender and this behavior could not be switched by the player.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
~~Add gender condition to "EOC_beard_growth_tracking"~~
Add separate trait for Natural beard growth, in addition to the existing trait switching both mechanics
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Do nothing, i guess?
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Loaded up the game, fired EOC through debug, checked appearance. Changed character gender, fired EOC again.
Gave the character "Natural Beard Growth", repeated the testing.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
