### PR TITLE
Tainted human skulls can be broken down into tainted bones.

### DIFF
--- a/data/json/uncraft/generic.json
+++ b/data/json/uncraft/generic.json
@@ -599,6 +599,17 @@
     "components": [ [ [ "bone_human", 4 ] ] ],
     "flags": [ "BLIND_EASY" ]
   },
+  },
+  {
+    "result": "skull_human_tainted",
+    "type": "uncraft",
+    "activity_level": "MODERATE_EXERCISE",
+    "skill_used": "fabrication",
+    "time": "10 s",
+    "qualities": [ { "id": "HAMMER", "level": 1 } ],
+    "components": [ [ [ "bone_tainted", 4 ] ] ],
+    "flags": [ "BLIND_EASY" ]
+  },
   {
     "result": "skull_canis",
     "type": "uncraft",

--- a/data/json/uncraft/generic.json
+++ b/data/json/uncraft/generic.json
@@ -599,7 +599,6 @@
     "components": [ [ [ "bone_human", 4 ] ] ],
     "flags": [ "BLIND_EASY" ]
   },
-  },
   {
     "result": "skull_human_tainted",
     "type": "uncraft",


### PR DESCRIPTION

#### Summary
None

#### Purpose of change

I made #60402 years ago so this seems like a good followup. Same reasons as last time, lets you use the bones.

#### Describe the solution

quite literally just a copypaste and a couple name changes.

#### Describe alternatives you've considered

Same as #60402.

#### Testing

it hasn't been, but it's small and I doubt anything will happen

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
