### PR TITLE
Spices, sugar and lemonade mixes is now dissolved in water

### DIFF
--- a/data/json/items/classes/comestible.json
+++ b/data/json/items/classes/comestible.json
@@ -5,7 +5,7 @@
     "comestible_type": "FOOD",
     "name": { "str_sp": "spice", "//~": "NO_I18N" },
     "//": "Spices are inedible in their base form but useful in crafting",
-    "flags": [ "NUTRIENT_OVERRIDE", "INEDIBLE" ],
+    "flags": [ "NUTRIENT_OVERRIDE", "INEDIBLE", "WATER_DISSOLVE" ],
     "weight": "3500 mg",
     "volume": "5 ml",
     "price": "2 cent",

--- a/data/json/items/comestibles/fruit_dishes.json
+++ b/data/json/items/comestibles/fruit_dishes.json
@@ -159,7 +159,7 @@
     "material": [ "powder", "fruit" ],
     "primary_material": "powder",
     "volume": "25 ml",
-    "flags": [ "EDIBLE_FROZEN", "SOFT" ],
+    "flags": [ "EDIBLE_FROZEN", "SOFT", "WATER_DISSOLVE" ],
     "vitamins": [ [ "vitC", 7 ], [ "fruit_allergen", 1 ] ],
     "fun": 1
   },

--- a/data/json/items/comestibles/spice.json
+++ b/data/json/items/comestibles/spice.json
@@ -120,7 +120,7 @@
     "material": [ "sugar" ],
     "volume": "6 ml",
     "calories": 19,
-    "flags": [ "EDIBLE_FROZEN", "NUTRIENT_OVERRIDE" ]
+    "flags": [ "EDIBLE_FROZEN", "NUTRIENT_OVERRIDE", "WATER_DISSOLVE" ]
   },
   {
     "type": "COMESTIBLE",


### PR DESCRIPTION

#### Summary

Bugfixes "Spices, sugar, salt, lemonade mixes"

#### Purpose of change

Spices should dissolve in water.

#### Describe the solution

Added `"WATER_DISSOLVE"` flag to sugar, salt("abstract": "spice",) and to lemonade mix 

#### Describe alternatives you've considered
Do nothing

#### Testing

Tried to jump in deep swamp have spices salt, sugar, mix in warning list

![зображення](https://github.com/user-attachments/assets/48c93b8e-b199-4d0e-bd74-0d2391cf17ac)


#### Additional context

