### PR TITLE
Scopes attached to weapon will double overmap sight range

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1334,7 +1334,7 @@ bool Character::overmap_los( const tripoint_abs_omt &omt, int sight_points ) con
 
 int Character::overmap_sight_range( float light_level ) const
 {
-    // How many map tiles I can given the light??
+    // How many map tiles I can see given the light??
     int sight = sight_range( light_level );
     // What are these doing???
     if( sight < SEEX ) {
@@ -1380,7 +1380,16 @@ int Character::overmap_modified_sight_range( float light_level ) const
                            ( is_mounted() && mounted_creature->has_flag( mon_flag_MECH_RECON_VISION ) ) ||
                            get_map().veh_at( pos_bub() ).avail_part_with_feature( "ENHANCED_VISION" ).has_value();
 
-    if( has_optic ) {
+    const bool has_scoped_gun = cache_has_item_with( "is_gun", &item::is_gun, [&]( const item & gun ) {
+        for( const item *mod : gun.gunmods() ) {
+            if( mod->has_flag( flag_ZOOM ) ) {
+                return true;
+            }
+        }
+        return false;
+    } );
+
+    if( has_optic || has_scoped_gun ) {
         sight *= 2;
     }
 


### PR DESCRIPTION
#### Summary
Features "Scopes attached to weapon will double overmap sight range"

#### Purpose of change
* Closes #79744.

#### Describe the solution
Added check for gunmods with `ZOOM` flag attached to weapon to `Character::overmap_modified_sight_range`.

#### Describe alternatives you've considered
None.

#### Testing
Teleported to the top of radio tower. Opened overmap, checked the range of my overmap sight. Spawned a Barrett M107A1, which comes with a pre-attached rifle scope. Wielded the rifle. Opened overmap once again, checked that overmap sight range is doubled as is should.

#### Additional context
None.