### PR TITLE
Dreamforged Vehicle Parts

### DIFF
--- a/data/mods/Xedra_Evolved/items/dreamforged_vehicle_items.json
+++ b/data/mods/Xedra_Evolved/items/dreamforged_vehicle_items.json
@@ -1,0 +1,25 @@
+[
+    {
+        "type": "GENERIC",
+        "id": "plate_dreamforged",
+        "name": {"str_sp": "dreamforged plating"},
+        "copy_from": "steel_plate",
+        "weight": "3220 g",
+        "description": "A piece of vehicle armor plating made of forged dreamstuff.",
+        "color": "light_pink",
+        "material": "forged_dreamstuff",
+        "price": "20 USD",
+        "price_postapoc": "50 USD"
+    },
+    {
+        "type": "GENERIC",
+        "id": "frame_dreamforged",
+        "copy-from": "frame",
+        "description": "A large frame made of forged dreamstuff. Useful for vehicle construction.",
+        "weight": "5000 g",
+        "color": "light_pink",
+        "material": "forged_dreamstuff",
+        "price": "20 USD",
+        "price_postapoc": "50 USD"
+    }
+]

--- a/data/mods/Xedra_Evolved/items/vehicle_parts.json
+++ b/data/mods/Xedra_Evolved/items/vehicle_parts.json
@@ -22,5 +22,47 @@
     "color": "green",
     "material": [ "veggy" ],
     "price": "8 kUSD"
-  }
+  },
+  {
+    "//": "Dreamforged parts are supposed to be really freaking quick to work on.",
+    "type": "vehicle_part",
+    "id": "frame_dreamforged",
+    "copy-from": "frame",
+    "name": "dreamforged frame",
+    "requirements": {
+      "install":{"time": "31m", "skills": [["deduction", 1]], "qualities": [{ "id": "DREAM_HAMMER", "level": 1}]},
+      "repair": {"time": "10m", "skills": [["deduction", 1]], "qualities": [{"id": "DREAM_HAMMER", "level": 1}], "using": [["dreamdross_lump", 2]]},
+      "removal": {"time": "5m", "skills": [["deduction", 1]], "qualities": [{"id": "DREAM_HAMMER", "level": 1}]}
+    },
+    "item": "frame_dreamforged"
+  },
+  {
+    "type": "vehicle_part",
+    "id": "plate_dreamforged",
+    "name": "dreamforged armor plating",
+    "color": "magenta",
+    "durability": 1000,
+    "item": "plate_dreamforged",
+    "location": "armor",
+    "requirements": {
+      "install":{"time": "10m", "skills": [["deduction", 1]], "qualities": [{ "id": "DREAM_HAMMER", "level": 1}]},
+      "repair": {"time": "10m", "skills": [["deduction", 1]], "qualities": [{"id": "DREAM_HAMMER", "level": 1}], "using": [["dreamdross_lump", 10]]},
+      "removal": {"time": "5m", "skills": [["deduction", 1]], "qualities": [{"id": "DREAM_HAMMER", "level": 1}]}
+    },
+    "flags": ["ARMOR"],
+    "damage_reduction": {"all": 80}
+  },
+  {
+    "type": "vehicle_part",
+    "id": "ram_dreamforged",
+    "color": "magenta",
+    "copy-from": "ram_blaze",
+    "requirements": {
+      "install":{"time": "10m", "skills": [["deduction", 1]], "qualities": [{ "id": "DREAM_HAMMER", "level": 1}]},
+      "repair": {"time": "10m", "skills": [["deduction", 1]], "qualities": [{"id": "DREAM_HAMMER", "level": 1}], "using": [["dreamdross_lump", 5]]},
+      "removal": {"time": "5m", "skills": [["deduction", 1]], "qualities": [{"id": "DREAM_HAMMER", "level": 1}]}
+  },
+  "item":"plate_dreamforged",
+  "damage_reduction": {"all": 60}
+}
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "Adds dreamforged vehicle parts."


#### Purpose of change
I'll keep it real - I think Dreamsmith is pretty boring in comparison to Mad Genius. Dreamsmiths feel to be Vanilla+ whereas Mad Genius expands options/capabilities. Does this change that? Not really, but it does give Dreamsmiths a cool option in very quickly assembled vehicles.
#### Describe the solution

Allows Dreamsmiths to make vehicle parts. These are naturally lighter than their steel counterparts. This means (i think) they're worse for ramming, but they're very good at going fast. 

A list of parts being worked on are listed below. As additional suggestions are added, the list will expand.

- [x] Dreamforged Armor Plating
- [x] Dreamforged Frame
- [x] Dreamforged Ram
- [x] Dreamforged Wheels
- [ ] Dreamforged Yoke & Harness

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternative solutions

keep dreamsmith SUPER BORING!!!

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

This is a draft. Before I complete this, I would absolutely love any additional suggestions as to additional parts I should include in this PR.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
