### PR TITLE
passable -> passable_through

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -7786,7 +7786,7 @@ void unload_loot_activity_actor::do_turn( player_activity &act, Character &you )
 
                 // get either direct route or route to nearest adjacent tile if
                 // source tile is impassable
-                if( here.passable( src_loc ) ) {
+                if( here.passable_through( src_loc ) ) {
                     route = here.route( you.pos_bub(), src_loc, you.get_pathfinding_settings(),
                                         you.get_path_avoid() );
                 } else {

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -2916,10 +2916,10 @@ void activity_handlers::travel_do_turn( player_activity *act, Character *you )
         }
         map &here = get_map();
         tripoint_bub_ms centre_sub = here.get_bub( waypoint );
-        if( !here.passable( centre_sub ) ) {
+        if( !here.passable_through( centre_sub ) ) {
             tripoint_range<tripoint_bub_ms> candidates = here.points_in_radius( centre_sub, 2 );
             for( const tripoint_bub_ms &elem : candidates ) {
-                if( here.passable( elem ) ) {
+                if( here.passable_through( elem ) ) {
                     centre_sub = elem;
                     break;
                 }

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -345,7 +345,7 @@ std::vector<item_location> drop_on_map( Character &you, item_drop_reason reason,
         return {};
     }
     const std::string ter_name = here->name( where );
-    const bool can_move_there = here->passable( where );
+    const bool can_move_there = here->passable_through( where );
 
     if( same_type( items ) ) {
         const item &it = items.front();
@@ -666,7 +666,7 @@ std::vector<tripoint_bub_ms> route_adjacent( const Character &you, const tripoin
     map &here = get_map();
 
     for( const tripoint_bub_ms &tp : here.points_in_radius( dest, 1 ) ) {
-        if( tp != you.pos_bub() && here.passable( tp ) ) {
+        if( tp != you.pos_bub() && here.passable_through( tp ) ) {
             passable_tiles.emplace( tp );
         }
     }
@@ -694,7 +694,7 @@ static std::vector<tripoint_bub_ms> route_best_workbench(
     map &here = get_map();
     creature_tracker &creatures = get_creature_tracker();
     for( const tripoint_bub_ms &tp : here.points_in_radius( dest, 1 ) ) {
-        if( tp == you.pos_bub() || ( here.passable( tp ) && !creatures.creature_at( tp ) ) ) {
+        if( tp == you.pos_bub() || ( here.passable_through( tp ) && !creatures.creature_at( tp ) ) ) {
             passable_tiles.insert( tp );
         }
     }
@@ -2243,7 +2243,7 @@ void activity_on_turn_move_loot( player_activity &act, Character &you )
 
                 // get either direct route or route to nearest adjacent tile if
                 // source tile is impassable
-                if( here.passable( src_loc ) ) {
+                if( here.passable_through( src_loc ) ) {
                     route = here.route( you.pos_bub(), src_loc, you.get_pathfinding_settings(),
                                         you.get_path_avoid() );
                 } else {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -12439,8 +12439,7 @@ void game::vertical_move( int movez, bool force, bool peeking )
             pts.push_back( stairs );
         } else {
             for( const tripoint_bub_ms &pt : here.points_in_radius( stairs, 1 ) ) {
-                if( here.passable( pt ) &&
-                    here.has_floor_or_support( pt ) ) {
+                if( here.passable_through( pt ) ) {
                     pts.push_back( pt );
                 }
             }
@@ -12934,8 +12933,7 @@ std::optional<tripoint_bub_ms> game::find_or_make_stairs( map &mp, const int z_a
                 std::vector<tripoint_bub_ms> pts;
 
                 for( const tripoint_bub_ms &pt : mp.points_in_radius( *stairs, 1 ) ) {
-                    if( mp.passable( pt ) &&
-                        mp.has_floor_or_support( pt ) ) {
+                    if( mp.passable_through( pt ) ) {
                         pts.push_back( pt );
                     }
                 }

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -1535,7 +1535,7 @@ void iexamine::elevator( Character &you, const tripoint_bub_ms &examp )
         if( eit != that_elevator.cend() ) {
             for( const tripoint_bub_ms &candidate : closest_points_first( *eit, 10 ) ) {
                 if( !here.has_flag( ter_furn_flag::TFLAG_ELEVATOR, candidate ) &&
-                    here.passable( candidate ) &&
+                    here.passable_through( candidate ) &&
                     creatures.creature_at( candidate ) == nullptr ) {
                     critter.setpos( here, candidate );
                     break;

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -1130,7 +1130,7 @@ std::optional<int> place_npc_iuse::use( Character *p, item &, map *here,
 
     const std::optional<tripoint_bub_ms> target_pos =
     random_point( target_range, [here]( const tripoint_bub_ms & t ) {
-        return here->passable( t ) && here->has_floor_or_support( t ) &&
+        return here->passable_through( t ) &&
                !get_creature_tracker().creature_at( t );
     } );
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2430,6 +2430,11 @@ bool map::passable( const tripoint_bub_ms &p ) const
     return move_cost( p ) != 0;
 }
 
+bool map::passable_through( const tripoint_bub_ms &p ) const
+{
+    return passable( p ) && has_floor_or_support( p );
+}
+
 bool map::passable_skip_fields( const tripoint_bub_ms &p ) const
 {
     return move_cost( p, static_cast<const vehicle *>( nullptr ), true ) != 0;

--- a/src/map.h
+++ b/src/map.h
@@ -587,6 +587,12 @@ class map
         bool passable( const point_bub_ms &p ) const {
             return passable( tripoint_bub_ms( p, abs_sub.z() ) );
         }
+        // Doesn't only check if it's possible to move to the tile as "passable" does, but also
+        // that it has a floor or other support, so it's possible to remain there without extra effort,
+        // and thus is a reasonable target for normal movement. Note that effortless levitation,
+        // swimming, etc. by a particular creature is not checked for.
+        bool passable_through( const tripoint_bub_ms &p ) const;
+
         bool passable_skip_fields( const tripoint_bub_ms &p ) const;
         bool is_wall_adjacent( const tripoint_bub_ms &center ) const;
 

--- a/src/map_extras.cpp
+++ b/src/map_extras.cpp
@@ -1805,7 +1805,7 @@ static bool mx_looters( map &m, const tripoint_abs_sm &abs_sub )
 {
     const tripoint_bub_ms center( rng( 5, SEEX * 2 - 5 ), rng( 5, SEEY * 2 - 5 ), abs_sub.z() );
     //25% chance to spawn a corpse with some blood around it
-    if( one_in( 4 ) && m.passable( center ) ) {
+    if( one_in( 4 ) && m.passable_through( center ) ) {
         m.add_corpse( center );
         for( int i = 0; i < rng( 1, 3 ); i++ ) {
             m.add_field( random_entry( m.points_in_radius( center, 1 ) ), fd_blood, rng( 1, 3 ) );
@@ -1817,7 +1817,7 @@ static bool mx_looters( map &m, const tripoint_abs_sm &abs_sub )
     for( int i = 0; i < num_looters; i++ ) {
         if( const std::optional<tripoint_bub_ms> pos_ = random_point( m.points_in_radius( center, rng( 1,
         4 ) ), [&]( const tripoint_bub_ms & p ) {
-        return m.passable( p );
+        return m.passable_through( p );
         } ) ) {
             m.place_npc( pos_->xy(), string_id<npc_template>( one_in( 2 ) ? "thug" : "bandit" ) );
             m.place_npc( pos_->xy(), string_id<npc_template>( one_in( 2 ) ? "thug" : "bandit" ) );
@@ -1833,7 +1833,7 @@ static bool mx_corpses( map &m, const tripoint_abs_sm &abs_sub )
     //Spawn up to 5 human corpses in random places
     for( int i = 0; i < num_corpses; i++ ) {
         const tripoint_bub_ms corpse_location = { rng( 1, SEEX * 2 - 1 ), rng( 1, SEEY * 2 - 1 ), abs_sub.z()};
-        if( m.passable( corpse_location ) ) {
+        if( m.passable_through( corpse_location ) ) {
             m.add_field( corpse_location, fd_blood, rng( 1, 3 ) );
             m.put_items_from_loc( Item_spawn_data_everyday_corpse, corpse_location );
             //50% chance to spawn blood in every tile around every corpse in 1-tile radius

--- a/src/map_field.cpp
+++ b/src/map_field.cpp
@@ -777,7 +777,7 @@ static void field_processor_monster_spawn( const tripoint_bub_ms &p, field_entry
                 if( const std::optional<tripoint_bub_ms> spawn_point =
                         random_point( points_in_radius( p, int_level.monster_spawn_radius ),
                 [&pd]( const tripoint_bub_ms & n ) {
-                return pd.here.passable( n );
+                return pd.here.passable_through( n );
                 } ) ) {
                     const tripoint_bub_ms pt = spawn_point.value();
                     pd.here.add_spawn( mgr, pt );

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -668,7 +668,7 @@ void map::generate( const tripoint_abs_omt &p, const time_point &when, bool save
                         }
                         if( const std::optional<tripoint_bub_ms> pt =
                         random_point_on_level( *this, gridz, [this]( const tripoint_bub_ms & n ) {
-                        return passable( n );
+                        return passable_through( n );
                         } ) ) {
                             const tripoint_bub_ms pnt = pt.value();
                             add_spawn( mgr, pnt );

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -431,7 +431,7 @@ bool npc::sees_dangerous_field( const tripoint_bub_ms &p ) const
 bool npc::could_move_onto( const tripoint_bub_ms &p ) const
 {
     map &here = get_map();
-    if( !here.passable( p ) ) {
+    if( !here.passable_through( p ) ) {
         return false;
     }
 
@@ -2930,8 +2930,8 @@ bool npc::can_move_to( const tripoint_bub_ms &p, bool no_bashing ) const
     // Doors are not passable for hallucinations
     return( rl_dist( pos_bub(), p ) <= 1 && here.has_floor_or_water( p ) &&
             !g->is_dangerous_tile( p ) &&
-            ( here.passable( p ) || ( can_open_door( p, !here.is_outside( pos_bub() ) ) &&
-                                      !is_hallucination() ) ||
+            ( here.passable_through( p ) || ( can_open_door( p, !here.is_outside( pos_bub() ) ) &&
+                    !is_hallucination() ) ||
               ( !no_bashing && here.bash_rating( smash_ability(), p ) > 0 ) )
           );
 }
@@ -3085,7 +3085,7 @@ void npc::move_to( const tripoint_bub_ms &pt, bool no_bashing, std::set<tripoint
                attitude_to( player_character ) == Attitude::HOSTILE ) {
         attack_air( p );
         move_pause();
-    } else if( here.passable( p ) && !here.has_flag( ter_furn_flag::TFLAG_DOOR, p ) ) {
+    } else if( here.passable_through( p ) && !here.has_flag( ter_furn_flag::TFLAG_DOOR, p ) ) {
         bool diag = trigdist && pos.x() != p.x() && pos.y() != p.y();
         if( is_mounted() ) {
             const double base_moves = run_cost( here.combined_movecost( pos, p ),
@@ -3458,7 +3458,7 @@ static std::optional<tripoint_bub_ms> nearest_passable( const tripoint_bub_ms &p
         const tripoint_bub_ms &closest_to )
 {
     map &here = get_map();
-    if( here.passable( p ) ) {
+    if( here.passable_through( p ) ) {
         return p;
     }
 
@@ -3471,7 +3471,7 @@ static std::optional<tripoint_bub_ms> nearest_passable( const tripoint_bub_ms &p
     } );
     auto iter = std::find_if( candidates.begin(), candidates.end(),
     [&here]( const tripoint_bub_ms & pt ) {
-        return here.passable( pt );
+        return here.passable_through( pt );
     } );
     if( iter != candidates.end() ) {
         return *iter;
@@ -5052,10 +5052,10 @@ void npc::go_to_omt_destination()
     }
     tripoint_bub_ms sm_tri = here.get_bub( project_to<coords::ms>( omt_path.back() ) );
     tripoint_bub_ms centre_sub = sm_tri + point( SEEX, SEEY );
-    if( !here.passable( centre_sub ) ) {
+    if( !here.passable_through( centre_sub ) ) {
         auto candidates = here.points_in_radius( centre_sub, 2 );
         for( const tripoint_bub_ms &elem : candidates ) {
-            if( here.passable( elem ) ) {
+            if( here.passable_through( elem ) ) {
                 centre_sub = elem;
                 break;
             }

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -4338,7 +4338,7 @@ talk_effect_fun_t::func f_location_variable( const JsonObject &jo, std::string_v
                              max_radius ),
                              0 );
                 if( ( !outdoor_only || here.is_outside( here.get_bub( target_pos ) ) ) &&
-                    ( !passable_only || here.passable( here.get_bub( target_pos ) ) ) &&
+                    ( !passable_only || here.passable_through( here.get_bub( target_pos ) ) ) &&
                     rl_dist( target_pos, talker_pos ) >= min_radius ) {
                     found = true;
                     break;

--- a/src/start_location.cpp
+++ b/src/start_location.cpp
@@ -415,7 +415,7 @@ static int rate_location( map &m, const tripoint_bub_ms &p,
         }
 
         const tripoint_bub_ms pt( add_p, p.z() );
-        if( m.passable( pt ) ||
+        if( m.passable_through( pt ) ||
             m.bash_resistance( pt ) <= bash_str ||
             m.open_door( get_avatar(), pt, !m.is_outside( from ), true ) ) {
             st.push_back( pt );

--- a/src/teleport.cpp
+++ b/src/teleport.cpp
@@ -216,7 +216,7 @@ bool teleport::teleport_to_point( Creature &critter, tripoint_bub_ms target, boo
             //TODO: Swap for this once #75961 merges
             //std::vector<tripoint_bub_ms> nearest_points = closest_points_first( dest_target, 1, 5 );
             for( tripoint_bub_ms p : nearest_points ) {
-                if( dest->passable( p ) ) {
+                if( dest->passable_through( p ) ) {
                     dest_target = p;
                     break;
                 }
@@ -261,7 +261,7 @@ bool teleport::teleport_to_point( Creature &critter, tripoint_bub_ms target, boo
             for( tripoint_abs_ms p : nearest_points ) {
                 // If point is not inbounds, ignore if spot is passible or not.  Creatures in impassable terrain will be automatically teleported out in their turn.
                 // some way of validating terrain passability out of bounds would be superior, however.
-                if( ( !dest->inbounds( here.get_bub( p ) ) || dest->passable( here.get_bub( p ) ) ) &&
+                if( ( !dest->inbounds( here.get_bub( p ) ) || dest->passable_through( here.get_bub( p ) ) ) &&
                     get_creature_tracker().creature_at<Creature>( p ) == nullptr ) {
                     found_new_spot = true;
                     abs_ms = p;

--- a/src/trapfunc.cpp
+++ b/src/trapfunc.cpp
@@ -1262,7 +1262,7 @@ static bool sinkhole_safety_roll( Character &you, const itype_id &itemname, cons
 
     std::vector<tripoint_bub_ms> safe;
     for( const tripoint_bub_ms &tmp : here.points_in_radius( you.pos_bub(), 1 ) ) {
-        if( here.passable( tmp ) && here.tr_at( tmp ) != tr_pit ) {
+        if( here.passable_through( tmp ) && here.tr_at( tmp ) != tr_pit ) {
             safe.push_back( tmp );
         }
     }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fix #80131 and the underlying misconception that "passable" means you can actually use the tile to pass through it, rather than just that it's possible to pass to it (and then potentially fall, have to swim, etc.).

It's really surprising how many cases there are where the code just checks whether a tile is "passable", and then continues to place critters, NPCs, the PC, corpses, etc. on that tile. It doesn't exactly help that the map.h file appears to claim that movement cost would be a suitable check for whether you can actually pass a tile.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Introduce a new map operation "passable_through" that checks both whether it's possible to pass to the tile and whether it has floor or support.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
- Just deal with the bug reported and leave the other cases unchanged.
- Check for absence of empty space.
- Check for something else.
- Deal with a larger or smaller set of cases.
- Rename the "passable" operations to something less misleading.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Tested only the bug report situation, not anything else.
Using the bug report save, I let go of the grabbed coffin and ordered the PC to perform construction. The PC then proceeded to deconstruct gutters (asking for each one) until I gave up when a zombie interrupted the party (presumably the deceased companion).
I've previously done the same thing prior to the code change and verified the PC tries to step over the edge of the roof to try to deconstruct gutter tiles.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
I ended up with the logic used based on finding it used in game.cpp, and considering it to be a reasonable check.

This PR ought to be checked by people who understand what they're doing so they can assess whether the change of operations make sense in each case (and probably also check the cases not changed, e.g. by searing for usage of "passable").

This PR was made because people more suitable to the task than me haven't picked up the bug report.

I don't actually know what happens if you spread fire or acid at an open air tile. It ought to fall, but I don't know if it does. Those were a couple of usages I didn't change.

I don't know what led to these recent bugs. Has ledge handling been changed so trap checks used to prevent falls?

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
