### PR TITLE
Player Fungal Dusted Apply Message

### DIFF
--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -2723,7 +2723,7 @@
     "desc": [ "You can feel the tiny spores sinking directly into your flesh." ],
     "apply_message": [
       [
-        "You feel your skin prickle with an uncomfortable feeling, and as you try to rub away the specks of dust you realize they've started to embed themselves, sinking into the skin.",
+        "You feel your skin prickle with an uncomfortable feeling, and as you try to rub away the specks of dust you realize they've started to embed themselves, sinking into your skin.",
         "bad"
       ]
     ],

--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -2722,7 +2722,10 @@
     "speed_name": "Spore Covered",
     "desc": [ "You can feel the tiny spores sinking directly into your flesh." ],
     "apply_message": [
-        [ "You feel your skin prickle with an uncomfortable feeling, and as you try to rub away the specks of dust you realize they've started to embed themselves, sinking into the skin.", "bad" ]
+      [
+        "You feel your skin prickle with an uncomfortable feeling, and as you try to rub away the specks of dust you realize they've started to embed themselves, sinking into the skin.",
+        "bad"
+      ]
     ],
     "max_intensity": 3,
     "int_decay_tick": 720,

--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -2721,6 +2721,9 @@
     "name": [ "Spore Dusted", "Spore Covered", "Spore Coated" ],
     "speed_name": "Spore Covered",
     "desc": [ "You can feel the tiny spores sinking directly into your flesh." ],
+    "apply_message": [
+        [ "You feel your skin prickle with an uncomfortable feeling, and as you try to rub away the specks of dust you realize they've started to embed themselves, sinking into the skin.", "bad" ]
+    ],
     "max_intensity": 3,
     "int_decay_tick": 720,
     "int_add_val": 1,


### PR DESCRIPTION

#### Summary
None

#### Purpose of change
I noticed that some folks still thinks that they just only need to not breathe in the spores to not get fungalized, despite the fact that the spores seeps into the exposed skin regardless. So i'm giving it a message when it is applied to them so it is more noticeable.

#### Describe the solution

Give the effect apply_message.

#### Describe alternatives you've considered

Not doing so.

#### Testing

Stand near a fungaloid, log message of the effect came up. I noticed it can pop up more than once at the maximum of 6 (maybe), but i wouldn't really sweat about it.
![Screenshot_20250316_232223](https://github.com/user-attachments/assets/145d14dc-0e57-4524-8110-1376c51527ef)


#### Additional context

Special thanks to @Holli-Git for giving me the message for the apply_message thing.

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
