### PR TITLE
Aftershock Damage rebalance VII??:  Actually reblanace the entire game's armor damage formula instead

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -9413,51 +9413,38 @@ item::armor_status item::damage_armor_durability( damage_unit &du, damage_unit &
     }
 
     // We want armor's own resistance to this type, not the resistance it grants
-    const float armors_own_resist = resist( du.type, true, bp );
-    if( armors_own_resist > 1000.0f ) {
+    double armors_own_resist = resist( du.type, true, bp );
+    if( armors_own_resist > 1000.0 ) {
         // This is some weird type that doesn't damage armors
         return armor_status::UNDAMAGED;
     }
-    // Fragile items take damage if they block more than 15% of their armor value, this uses the pre-mitigated damage.
-    if( has_flag( flag_FRAGILE ) &&
-        premitigated.amount / armors_own_resist > ( 0.15f / enchant_multiplier ) ) {
-        return mod_damage( itype::damage_scale * enchant_multiplier ) ? armor_status::DESTROYED :
-               armor_status::DAMAGED;
-    }
+    /*
+    * Armor damage chance is calculated using the logistics function. 
+    *  No matter the damage dealt, an armor piece has at at most 80% chance of being damaged.  
+    *  Chance of damage is 40% when the premitigation damage is equal to armor*1.333
+    *  Sturdy items will not take damage if premitigation damage isn't higher than armor*1.333.
+    * 
+    *  Non fragile items are considered to always have at least 10 points of armor, this is to prevent
+    *  regular clothes from exploding into ribbons whenever you get punched.
+    */
+    armors_own_resist = has_flag( flag_FRAGILE ) ? armors_own_resist * 0.6666 : std::max( 10.0, armors_own_resist*1.3333);
+    double damage_chance = 0.8 / ( 1.0 + std::exp( -( premitigated.amount - armors_own_resist ) ) ) * enchant_multiplier;
 
     // Scale chance of article taking damage based on the number of parts it covers.
     // This represents large articles being able to take more punishment
-    // before becoming ineffective or being destroyed.
-    const int num_parts_covered = get_covered_body_parts().count();
-    if( !one_in( num_parts_covered ) ) {
+    // before becoming ineffective or being destroyed
+    damage_chance = damage_chance/ get_covered_body_parts().count();
+    if (has_flag( flag_STURDY ) && premitigated.amount < armors_own_resist) {
         return armor_status::UNDAMAGED;
     }
-
-    // Don't damage armor as much when bypassed by armor piercing
-    // Most armor piercing damage comes from bypassing armor, not forcing through
-    const float post_mitigated_dmg = du.amount;
-    // more gradual damage chance calc
-    const float damaged_chance = ( 0.11 * ( post_mitigated_dmg / ( armors_own_resist + 2 ) ) + 0.1 ) *
-                                 enchant_multiplier;
-    if( post_mitigated_dmg > armors_own_resist ) {
-        // handle overflow, if you take a lot of damage your armor should be damaged
-        if( damaged_chance >= 1 ) {
-            return armor_status::DAMAGED;
-        }
-        if( one_in( 1 / ( 1 - damaged_chance ) ) ) {
-            return armor_status::UNDAMAGED;
-        }
+    else if( x_in_y( damage_chance, 1.0) ) {
+        return mod_damage( itype::damage_scale * enchant_multiplier ) ? armor_status::DESTROYED :
+        armor_status::DAMAGED;
     } else {
-        // Sturdy items and power armors never take chip damage.
-        // Other armors have 0.5% of getting damaged from hits below their armor value.
-        if( has_flag( flag_STURDY ) || is_power_armor() || !one_in( 200 ) ) {
-            return armor_status::UNDAMAGED;
-        }
-    }
-
-    return mod_damage( itype::damage_scale * enchant_multiplier ) ? armor_status::DESTROYED :
-           armor_status::DAMAGED;
+        return armor_status::UNDAMAGED;
+    }	
 }
+
 
 item::armor_status item::damage_armor_transforms( damage_unit &du, double enchant_multiplier ) const
 {

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -9441,9 +9441,8 @@ item::armor_status item::damage_armor_durability( damage_unit &du, damage_unit &
     } else if( x_in_y( damage_chance, 1.0 ) ) {
         return mod_damage( itype::damage_scale * enchant_multiplier ) ? armor_status::DESTROYED :
                armor_status::DAMAGED;
-    } else {
-        return armor_status::UNDAMAGED;
     }
+    return armor_status::UNDAMAGED;
 }
 
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -9419,30 +9419,31 @@ item::armor_status item::damage_armor_durability( damage_unit &du, damage_unit &
         return armor_status::UNDAMAGED;
     }
     /*
-    * Armor damage chance is calculated using the logistics function. 
-    *  No matter the damage dealt, an armor piece has at at most 80% chance of being damaged.  
+    * Armor damage chance is calculated using the logistics function.
+    *  No matter the damage dealt, an armor piece has at at most 80% chance of being damaged.
     *  Chance of damage is 40% when the premitigation damage is equal to armor*1.333
     *  Sturdy items will not take damage if premitigation damage isn't higher than armor*1.333.
-    * 
+    *
     *  Non fragile items are considered to always have at least 10 points of armor, this is to prevent
     *  regular clothes from exploding into ribbons whenever you get punched.
     */
-    armors_own_resist = has_flag( flag_FRAGILE ) ? armors_own_resist * 0.6666 : std::max( 10.0, armors_own_resist*1.3333);
-    double damage_chance = 0.8 / ( 1.0 + std::exp( -( premitigated.amount - armors_own_resist ) ) ) * enchant_multiplier;
+    armors_own_resist = has_flag( flag_FRAGILE ) ? armors_own_resist * 0.6666 : std::max( 10.0,
+                        armors_own_resist * 1.3333 );
+    double damage_chance = 0.8 / ( 1.0 + std::exp( -( premitigated.amount - armors_own_resist ) ) ) *
+                           enchant_multiplier;
 
     // Scale chance of article taking damage based on the number of parts it covers.
     // This represents large articles being able to take more punishment
     // before becoming ineffective or being destroyed
-    damage_chance = damage_chance/ get_covered_body_parts().count();
-    if (has_flag( flag_STURDY ) && premitigated.amount < armors_own_resist) {
+    damage_chance = damage_chance / get_covered_body_parts().count();
+    if( has_flag( flag_STURDY ) && premitigated.amount < armors_own_resist ) {
         return armor_status::UNDAMAGED;
-    }
-    else if( x_in_y( damage_chance, 1.0) ) {
+    } else if( x_in_y( damage_chance, 1.0 ) ) {
         return mod_damage( itype::damage_scale * enchant_multiplier ) ? armor_status::DESTROYED :
-        armor_status::DAMAGED;
+               armor_status::DAMAGED;
     } else {
         return armor_status::UNDAMAGED;
-    }	
+    }
 }
 
 


### PR DESCRIPTION
#### Summary
Features "Rebalance the chance for armor to be damaged by attacks."

#### Purpose of change
While rebalancing Aftershock I noticed that the old equation #55271 wasn't properly implemented, and after I implemented it I noticed it actually lead to pretty terrible game play, with your clothes exploding into ribbons like a weird-ass anime every time you got into a fight.

It was also based on over damage, and the chance for your actual armor being degraded didnt really ramp up until the point where you were taking 20+ over damage in a single attack, which meant that armor would almost never break without your character finding themselves in the start of a death spiral.

Here I'm trying to setup a formula that wont cause normal clothing to explode into ribbons with every attack but will also allow for proper armor to take damage when hit.

#### Describe the solution
The new formula is a modification of the logistics curve:
```math
\left(\frac{0.8}{1+e^{-\left(Premitigation Damage- 1.33*Armor\right)\ }}\right)
```
With the value `Armor` given a floor value of `10`. Which ensures that normall zombie punches will only rarely damage your clothes.


- For fragile items: The minimum armor is not given the floor of `10` and the Armor value is multiplied by `0.66` instead of `1.33`

- For sturdy items: Wont take any damage if the pre-mitigation damage of the attack is less than ` Armor*1.33`. If the pre-mitigation damage is larger than this, they have the same chance of taking damage as a regular item.

Heres a comparison of the percentage chance of an item taking damage in the old system (that never worked) and the new:

| Scenario                                                       | Old Chance | New Chance |
|------------------------------------------------|--------------|---------------|
| 2 raw damage 0 armor (weakest zombie attack)   | 20%        | 0.02%      |
| 6 raw damage 0 armor (strongest zombie attack) | 43%        | 1.5%       |
| 5 raw damage 10 armor                          | 5%         | 0.02%      |
| 10 raw damage 10 armor                         | 10%        | 2.8%       |
| 20 raw damage 20 armor                         | 10%        | 0.02%      |
| 25 raw damage 20 armor                         | 12.5$      | 13.4%      |
| 30 raw damage 20armor                          | 15%        | 77%        |
| 50 raw damage 20 armor                         | 25%        | 80%        |

End result: Attacks with low base damage very rarely if ever damage your gear, but if you are using your armor to protect against game ending blows, it will much more consistently take damage if it blocks more damage than its armor rating.

#### Describe alternatives you've considered
Theres other formulas that could be implemented, but I opted for the logistics curve because its easier to understand and tweak if you graph it.

#### Testing
I played with it for a bit to ensure it worked (and it did). I think the balance itself is ok of course, but this is the sort of thing that is more balance than realism and is hard to actually nail down.