### PR TITLE
checkwielded->has_item BEFORE unwielding

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -13077,12 +13077,20 @@ bool Character::wield( item &it, std::optional<int> obtain_cost )
     invalidate_inventory_validity_cache();
     invalidate_leak_level_cache();
 
+    item_location wielded = get_wielded_item();
+
     if( has_wield_conflicts( it ) ) {
         const bool is_unwielding = is_wielding( it );
         const auto ret = can_unwield( it );
 
         if( !ret.success() ) {
             add_msg_if_player( m_info, "%s", ret.c_str() );
+            return false;
+        }
+
+        if( wielded->has_item( it ) ) {
+            add_msg_if_player( m_info,
+                               _( "You need to put the bag away before trying to wield something from it." ) );
             return false;
         }
 
@@ -13096,13 +13104,6 @@ bool Character::wield( item &it, std::optional<int> obtain_cost )
             }
             return true;
         }
-    }
-
-    item_location wielded = get_wielded_item();
-    if( wielded && wielded->has_item( it ) ) {
-        add_msg_if_player( m_info,
-                           _( "You need to put the bag away before trying to wield something from it." ) );
-        return false;
     }
 
     if( !can_wield( it ).success() ) {

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1517,8 +1517,13 @@ void npc::stow_item( item &it )
 
 bool npc::wield( item &it )
 {
+    // dont unwield if you already wield the item
     if( is_wielding( it ) ) {
         return true;
+    }
+    // instead of unwield(), call stow_item, allowing to wear it and check it is not inside wielded itm
+    if( has_wield_conflicts( it ) && !get_wielded_item()->has_item( it ) ) {
+        stow_item( *get_wielded_item() );
     }
     if( !Character::wield( it ) ) {
         return false;


### PR DESCRIPTION
#### Summary
Bugfixes "disallow wielding item contained in wielded item"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
fix #80167
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
I accidentally checked wielded->has_item only AFTER already unwielding the wielded item. that means all contained items got deleted and if the item we want to wield is inside that container, it points to some garbage data. (For some reason it pointed to a broken item with the item_id of the scabbard, making me chase completely unrelated rabbit-holes)
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
somehow reacquiring the correct item after unwielding
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
save works now, 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
"guneet singh" is wielding a scabbard with a sword, he should probably wear it. 
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
