### PR TITLE
Add android build to the CI matrix

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -127,6 +127,10 @@ jobs:
             ccache_limit: 10G
             ccache_key: macos-llvm-15-universal
 
+          - title: Android x64 (build only)
+            os: ubuntu-latest
+            android: arm64
+
           - compiler: g++-9
             os: ubuntu-22.04
             cmake: 0
@@ -190,6 +194,7 @@ jobs:
         COMPILER: ${{ matrix.compiler }}
         MXE_TARGET: ${{ matrix.mxe_target }}
         WINE: ${{ matrix.wine }}
+        ANDROID: ${{ matrix.android }}
         OS: ${{ matrix.os }}
         TILES: ${{ matrix.tiles }}
         SOUND: ${{ matrix.sound }}
@@ -218,13 +223,13 @@ jobs:
           ( matrix.dont_skip_data_only_changes == 0 && needs.skip-duplicates.outputs.should_skip_code == 'true' ) ||
           ( matrix.dont_skip_data_only_changes != 0 && needs.skip-duplicates-mods.outputs.should_skip_data == 'true' )
           }}
-        SKIP_TESTS: ${{ needs.matrix-variables.outputs.skip_tests }}
+        SKIP_TESTS: ${{ fromJSON(needs.matrix-variables.outputs.skip_tests) || (matrix.android != '') }}
     steps:
     - name: Maximize build space
       if: ${{ runner.os == 'Linux' }}
       uses: AdityaGarg8/remove-unwanted-software@v4.1
       with:
-        remove-android: 'true'
+        remove-android: ${{ matrix.android == '' }}
     - name: checkout repository
       if: ${{ env.SKIP == 'false' }}
       uses: actions/checkout@v4
@@ -274,7 +279,7 @@ jobs:
         echo "ccache-path=$([ "$RUNNER_OS" = "macOS" ] && echo '/Users/runner/Library/Caches/ccache' || echo '~/.cache/ccache')" >> $GITHUB_OUTPUT
       shell: bash
     - name: ccache cache files
-      if: ${{ env.SKIP == 'false' && ( runner.os == 'Linux' || runner.os == 'macOS' ) }}
+      if: ${{ env.SKIP == 'false' && ( runner.os == 'Linux' || runner.os == 'macOS' ) && matrix.ccache_key != '' }}
       uses: actions/cache@v4
       with:
         path: ${{ steps.get-vars.outputs.ccache-path }}
@@ -283,11 +288,18 @@ jobs:
         restore-keys: |
           ccache-master-${{ matrix.ccache_key }}--
     - uses: ammaraskar/gcc-problem-matcher@master
-    - name: build
+
+    - name: Set up JDK 8 (android)
+      if: runner.os == 'Linux' && matrix.android != 'none'
+      uses: actions/setup-java@v4
+      with:
+        java-version: '11'
+        distribution: 'adopt'
+    - name: Build CDDA
       if: ${{ env.SKIP == 'false' }}
       run: bash ./build-scripts/gha_compile_only.sh
     - name: post-build ccache manipulation
-      if: ${{ env.SKIP == 'false' && !failure() && (runner.os == 'Linux' || runner.os == 'macOS') }}
+      if: ${{ env.SKIP == 'false' && !failure() && (runner.os == 'Linux' || runner.os == 'macOS') && matrix.ccache_key != '' }}
       run: |
         ccache --show-stats --verbose
         NOW=`/bin/date +%s`

--- a/build-scripts/gha_compile_only.sh
+++ b/build-scripts/gha_compile_only.sh
@@ -5,6 +5,27 @@
 echo "Using bash version $BASH_VERSION"
 set -exo pipefail
 
+# Android build is its own separate thing, only bundled here for invocation convenience
+if [ -n "$ANDROID" ]
+then
+    cd ./android
+    chmod +x gradlew
+    if [ ${ANDROID} = "arm64" ]
+    then
+        ./gradlew -Pj=$((`nproc`+0)) -Pabi_arm_32=false assembleExperimentalRelease
+    elif [ ${ANDROID} = "arm32" ]
+    then
+        ./gradlew -Pj=$((`nproc`+0)) -Pabi_arm_64=false assembleExperimentalRelease
+    elif [ ${ANDROID} = "bundle" ]
+    then
+        ./gradlew -Pj=$((`nproc`+0)) bundleExperimentalRelease
+    else
+        echo "Unexpected value of ANDROID env var - '${ANDROID}'"
+        exit 1
+    fi
+    exit 0  # no fallthrough
+fi
+
 num_jobs=3
 
 # We might need binaries installed via pip, so ensure that our personal bin dir is on the PATH


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Catching android build issues earlier.
See #79182 #79760 #79834 for examples

#### Describe the solution

Add an extra entry to the matrix ci job, adjust `gha_compile_only.sh` launcher to handle said extra entry
The build invocation taken from `release.yml` sans signing.

No tests are being run for this android build, because, well, github action hosts are not running android.
ccache is not being set up because gradle build is not using ccache, apparently?

The build is deliberately placed after BBT/macos but before the santizers in hope that it is more likely to catch errors than sanitizers would. (But perhaps the hope is misplaced)

#### Describe alternatives you've considered

None that are particularly good.

Perhaps it's better to build 32-bit android instead of 64-bit, in order to... test more obscure corner cases? I dunno.

#### Testing
https://github.com/moxian/Cataclysm-DDA/actions/runs/13934570891/job/38999587495?pr=36

#### Additional context
