### PR TITLE
fix #80035 and maybe other crash/segfault on quit

### DIFF
--- a/src/sdlsound.cpp
+++ b/src/sdlsound.cpp
@@ -41,6 +41,7 @@
 #include "sounds.h"
 #include "units.h"
 #include "avatar.h"
+#include "game.h"
 
 #define dbg(x) DebugLog((x),D_SDL) << __FILE__ << ":" << __LINE__ << ": "
 
@@ -676,6 +677,9 @@ bool sfx::has_variant_sound( const std::string &id, const std::string &variant,
 
 static bool is_time_slowed()
 {
+    if( g == nullptr || g->uquit != QUIT_NO ) {
+        return false;
+    }
     // if the player have significantly more moves than their speed, they probably used an artifact/CBM to slow time.
     // I checked; the only things that increase a player's # of moves is spells/cbms that slow down time (and also unit tests) so this should work.
     // Would get_speed_base() be better?


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Fix sound related error/segfault on quit"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

I like to play with sound, but since a while I get random crash or even segfault on "save and quit" and also on the main menu "quit". I opened an issue about this #80035
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

First, I may be wrong here, I am not a good C++ dev, but I think this issue may be related to a use after free/mutate. The SDL Mixer thread (via the registered `slowed_time_effect` effect) is accessing the `game` object to compule his `is_time_slowed()`.

So my fix is more of a plaster: I ensure at least we have a game object alive (is was not reset during shutdown) `g == nullptr`, and also that the `g->uquit` flag is set to `QUIT_NO`, which means we are still playing, otherwise I return instead of messing with the `game` object.

So yeah, this does not address the root cause. Honestly the `sdlsound.cpp` is a kind of a mess. I still wonder why we cant just modify the pitch (even the function already exists!) to simulate sounds when time is slowdown. I am pretty sure we dont need all this complex infinitly looping thread only to change the pitch. Anways, this will be for an aother time, it not directly related to this issue.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

I did not really try to address the root cause, that would need a kind of refactor of the way we handle data in the SDL Mixer thread.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

I was able to consistently reproduce the "invalid body part id `arm_l`" message. With my fix I dont see it. And also gdb report the program exiting correctly on quit, instead of segfaulting.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
