### PR TITLE
fix not being able to unwield

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -13088,7 +13088,7 @@ bool Character::wield( item &it, std::optional<int> obtain_cost )
             return false;
         }
 
-        if( wielded->has_item( it ) ) {
+        if( !is_unwielding && wielded->has_item( it ) ) {
             add_msg_if_player( m_info,
                                _( "You need to put the bag away before trying to wield something from it." ) );
             return false;


### PR DESCRIPTION
#### Summary
Bugfixes "fix not being able to unwield"

#### Purpose of change
fix #80220
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
For some reason wielded->has_item( it ) returned true if both are the same item. add !is_wielding( it ) check.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
can unwield
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
I should really take a look at those tests. This should have been covered
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
