### PR TITLE
Weed snippet fix

### DIFF
--- a/data/json/npcs/snippets/talk_tags_line.json
+++ b/data/json/npcs/snippets/talk_tags_line.json
@@ -514,8 +514,8 @@
     "category": "<weed_smoke>",
     "//": "Complaint when the NPC is near the avatar who is smoking marijuana.",
     "text": [
-      { "text": { "str": "weed_smoke_positive", "//~": "NO_I18N" }, "weight": 77 },
-      { "text": { "str": "weed_smoke_negative", "//~": "NO_I18N" }, "weight": 92 },
+      { "text": { "str": "<weed_smoke_positive>", "//~": "NO_I18N" }, "weight": 77 },
+      { "text": { "str": "<weed_smoke_negative>", "//~": "NO_I18N" }, "weight": 92 },
       "Are you getting stoned right now?",
       "Are you sure it's a good idea to smoke that now?",
       "I can smell that from here.",


### PR DESCRIPTION


#### Summary
None


#### Purpose of change
I found out that <weed_smoke> uses 2 snippets but said snippets don't have <> so the snippet just says "weed_smoke_positive" whenever it is triggered.

#### Describe the solution

give weed_smoke_postive and weed_smoke_negative in <weed_smoke> their <>

#### Describe alternatives you've considered

Not doing so.
#### Testing
changed it in my build and test it by smoking a buncha joints near npc. The first npc message is <weed_smoke_positive> and the second npc message is <weed_smoke_negative>.
![Screenshot_20250320_222155](https://github.com/user-attachments/assets/d610840b-8519-45b6-9192-79f95371443b)


#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
