### PR TITLE
Show appropriate message when trying to pulp acid corpses without protection or immunity

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -8615,7 +8615,7 @@ void pulp_activity_actor::send_final_message( Character &you ) const
 
     if( acid_corpse ) {
         you.add_msg_if_player( m_bad,
-                               _( "You cannot pulp this corpse since it's filled with acid, and you have no protection against it." ) );
+                               _( "You cannot pulp acid-filled corpses without appropriate protection." ) );
         return;
     }
 

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -8712,6 +8712,7 @@ void pulp_activity_actor::serialize( JsonOut &jsout ) const
     jsout.member( "too_long_to_pulp", too_long_to_pulp );
     jsout.member( "too_long_to_pulp_interrupted", too_long_to_pulp_interrupted );
     jsout.member( "way_too_long_to_pulp", way_too_long_to_pulp );
+    jsout.member( "acid_corpse", acid_corpse );
     jsout.member( "stomps_only", pd.stomps_only );
     jsout.member( "weapon_only", pd.weapon_only );
     jsout.member( "can_cut_precisely", pd.can_cut_precisely );
@@ -8740,6 +8741,7 @@ std::unique_ptr<activity_actor> pulp_activity_actor::deserialize( JsonValue &jsi
     data.read( "too_long_to_pulp", actor.too_long_to_pulp );
     data.read( "too_long_to_pulp_interrupted", actor.too_long_to_pulp_interrupted );
     data.read( "way_too_long_to_pulp", actor.way_too_long_to_pulp );
+    data.read( "acid_corpse", actor.acid_corpse );
     data.read( "stomps_only", actor.pd.stomps_only );
     data.read( "weapon_only", actor.pd.weapon_only );
     data.read( "can_cut_precisely", actor.pd.can_cut_precisely );

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -8529,9 +8529,14 @@ bool pulp_activity_actor::punch_corpse_once( item &corpse, Character &you,
         return false;
     }
 
+    if( !g->can_pulp_acid_corpse( you, *corpse_mtype ) ) {
+        acid_corpse = true;
+        return false;
+    }
+
     pd = g->calculate_pulpability( you, *corpse_mtype, pd );
 
-    if( !g->can_pulp_corpse( you, *corpse_mtype, pd ) ) {
+    if( !g->can_pulp_corpse( pd ) ) {
         way_too_long_to_pulp = true;
         return false;
     }
@@ -8607,6 +8612,12 @@ void pulp_activity_actor::finish( player_activity &act, Character &you )
 
 void pulp_activity_actor::send_final_message( Character &you ) const
 {
+
+    if( acid_corpse ) {
+        you.add_msg_if_player( m_bad,
+                               _( "You cannot pulp this corpse since it's filled with acid, and you have no protection against it." ) );
+        return;
+    }
 
     if( way_too_long_to_pulp && num_corpses == 0 ) {
         you.add_msg_player_or_npc( n_gettext(

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -2456,6 +2456,8 @@ class pulp_activity_actor : public activity_actor
         // if corpse cost more than hour to pulp, drop it
         bool way_too_long_to_pulp = false;
 
+        bool acid_corpse = false;
+
         // how many corpses we pulped
         int num_corpses = 0;
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -14416,16 +14416,6 @@ pulp_data game::calculate_pulpability( const Character &you, const mtype &corpse
 
 bool game::can_pulp_corpse( const Character &you, const mtype &corpse_mtype )
 {
-
-    const bool acid_immune = you.is_immune_damage( damage_acid ) ||
-                             you.is_immune_field( fd_acid );
-    // this corpse is acid, and you are not immune to it
-    const bool acid_corpse = corpse_mtype.bloodType().obj().has_acid && !acid_immune;
-
-    if( acid_corpse ) {
-        return false;
-    }
-
     pulp_data pd = calculate_pulpability( you, corpse_mtype );
 
     return can_pulp_corpse( pd );
@@ -14437,7 +14427,7 @@ bool game::can_pulp_corpse( const pulp_data &pd )
     return pd.time_to_pulp < 3600;
 }
 
-bool game::can_pulp_corpse( Character &you, const mtype &corpse_mtype, const pulp_data &pd )
+bool game::can_pulp_acid_corpse( const Character &you, const mtype &corpse_mtype )
 {
     const bool acid_immune = you.is_immune_damage( damage_acid ) ||
                              you.is_immune_field( fd_acid );
@@ -14448,8 +14438,7 @@ bool game::can_pulp_corpse( Character &you, const mtype &corpse_mtype, const pul
         return false;
     }
 
-    // if pulping is longer than an hour, this is a hard no
-    return pd.time_to_pulp < 3600;
+    return true;
 }
 
 namespace cata_event_dispatch

--- a/src/game.h
+++ b/src/game.h
@@ -1339,7 +1339,7 @@ class game
         pulp_data calculate_pulpability( const Character &you, const mtype &corpse_mtype, pulp_data pd );
         bool can_pulp_corpse( const Character &you, const mtype &corpse_mtype );
         bool can_pulp_corpse( const pulp_data &pd );
-        bool can_pulp_corpse( Character &you, const mtype &corpse_mtype, const pulp_data &pd );
+        bool can_pulp_acid_corpse( const Character &you, const mtype &corpse_mtype );
 };
 
 // Returns temperature modifier from direct heat radiation of nearby sources


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
While investigating #79452, in my tests I noticed that game shows `You cannot pulp this corpse, for you have no tool heavy enough to deal with it quickly.` message even if you have the appropriate tool for pulping (like the sledgehammer) when trying to pulp acid corpse. This happens because game combines checks for pulping acid corpse and time required to pulp a corpse in single `can_pulp_corpse` function.

#### Describe the solution
- Extracted check for pulping acid corpses from `can_pulp_corpse` function and created a new `can_pulp_acid_corpse` function.
- Used this new check in pulp activity actor.

#### Describe alternatives you've considered
None.

#### Testing
Spawned acid zombie and killed it. Got sledgehammer. Tried to `s`mash the corpse. Got correct message about acid.
Also, just in case, got `Acidproof` mutation and tried to pulp that corpse. No fail messages, successful pulping.
Also, just in case, tried to pulp corpse of a zombie hulk without any tools. Got correct message about absence of tools.

#### Additional context
None.