### PR TITLE
[XEDRA Evolved] The Noon

### DIFF
--- a/data/mods/Xedra_Evolved/itemgroups/itemgroups.json
+++ b/data/mods/Xedra_Evolved/itemgroups/itemgroups.json
@@ -161,13 +161,26 @@
     "type": "item_group",
     "subtype": "distribution",
     "copy-from": "homebooks",
-    "extend": { "entries": [ { "item": "manual_deduction", "prob": 1 }, { "item": "mag_deduction", "prob": 10 } ] }
+    "extend": {
+      "entries": [
+        { "item": "manual_deduction", "prob": 1 },
+        { "item": "mag_deduction", "prob": 10 },
+        { "item": "mag_deduction_tabloid", "prob": 40 }
+      ]
+    }
   },
   {
     "id": "book_mag_gen",
     "type": "item_group",
     "subtype": "distribution",
     "copy-from": "book_mag_gen",
+    "extend": { "entries": [ { "item": "mag_deduction_tabloid", "prob": 40 } ] }
+  },
+  {
+    "id": "newspaper",
+    "type": "item_group",
+    "subtype": "distribution",
+    "copy-from": "newspaper",
     "extend": { "entries": [ { "item": "mag_deduction_tabloid", "prob": 40 } ] }
   },
   {

--- a/data/mods/Xedra_Evolved/itemgroups/itemgroups.json
+++ b/data/mods/Xedra_Evolved/itemgroups/itemgroups.json
@@ -164,6 +164,13 @@
     "extend": { "entries": [ { "item": "manual_deduction", "prob": 1 }, { "item": "mag_deduction", "prob": 10 } ] }
   },
   {
+    "id": "book_mag_gen",
+    "type": "item_group",
+    "subtype": "distribution",
+    "copy-from": "book_mag_gen",
+    "extend": { "entries": [ { "item": "mag_deduction_tabloid", "prob": 40 } ] }
+  },
+  {
     "id": "religious_books",
     "type": "item_group",
     "subtype": "distribution",

--- a/data/mods/Xedra_Evolved/items/books_deduction.json
+++ b/data/mods/Xedra_Evolved/items/books_deduction.json
@@ -20,6 +20,20 @@
     "fun": 1
   },
   {
+    "id": "mag_deduction_tabloid",
+    "type": "BOOK",
+    "category": "manuals",
+    "copy-from": "mag_deduction",
+    "name": { "str": "The Noon", "str_pl": "issues of The Noon" },
+    "description": "A tabloid paper with a rather unusually out-of-this-world articles even for tabloids' standard, ranging from something like an article about morticians selling the deceased's 'dreams' to the government to a sensational headline about a half-bat half-human boy causing 40-car pileup in the highway while driving away from police pursuit.  While most thought of The Noon as an amusing but otherwise mostly fake news paper in the past, the Cataclysm might bring the articles' presumably fake facts to light.",
+    "color": "red",
+    "skill": "deduction",
+    "max_level": 1,
+    "intelligence": 5,
+    "time": "15 m",
+    "fun": 2
+  },
+  {
     "id": "manual_deduction",
     "type": "BOOK",
     "category": "manuals",


### PR DESCRIPTION


#### Summary
Mods "[XE] The Noon tabloid paper"


#### Purpose of change
I thought it would be fitting for there to be a tabloid paper that really have outlandish articles that folks dont believe it pre-cataclysm but turns out to be true post-cataclysm, and also i already referenced it in the loading screen image for XE,  so might as well add it to the mod as an item you can find.


#### Describe the solution

Add "The Noon" paper tabloid and its itemgroup spawns.

#### Describe alternatives you've considered

Not adding it and miss out the chance to read about Bat Boy and his shenanigans.

#### Testing

I added it to my build, i go around the town looking for The Noon. i did found it though i was expecting it to be more common, but it does spawn in the world nonetheless.

![Screenshot_20250322_092800](https://github.com/user-attachments/assets/e95704ac-5fa2-4e54-b144-103cbb89eb57)


#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
