### PR TITLE
handle empty travel path

### DIFF
--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -25,6 +25,7 @@
 #include "cata_variant.h"
 #include "character_id.h"
 #include "debug.h"
+#include "enums.h"
 #include "enum_conversions.h"
 #include "input_enums.h"
 #include "mapdata.h"

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -25,7 +25,6 @@
 #include "cata_variant.h"
 #include "character_id.h"
 #include "debug.h"
-#include "enums.h"
 #include "enum_conversions.h"
 #include "input_enums.h"
 #include "mapdata.h"
@@ -1850,12 +1849,20 @@ static bool try_travel_to_destination( avatar &player_character, const tripoint_
     std::vector<tripoint_abs_omt> path = get_overmap_path_to( dest, driving );
 
     if( path.empty() ) {
+        std::string popupmsg;
         if( dest.z() == player_character.posz() ) {
-            add_msg( m_warning, _( "Unable to find a path from the current location." ) );
+            popupmsg = _( "Unable to find a path from the current location:" );
         } else {
-            add_msg( m_warning,
-                     _( "Auto travel can only be used with the source and destination on the same Z level." ) );
+            popupmsg = _( "Auto travel requires source and destination on same Z level:" );
         }
+        string_input_popup pop;
+        const std::string ok = _( "OK" );
+        pop
+        .title( popupmsg )
+        .width( ok.length() )
+        .text( ok )
+        .only_digits( false )
+        .query();
         return false;
     }
 

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -1847,6 +1847,11 @@ static bool try_travel_to_destination( avatar &player_character, const tripoint_
                                        const tripoint_abs_omt dest, const bool driving )
 {
     std::vector<tripoint_abs_omt> path = get_overmap_path_to( dest, driving );
+
+    if( path.empty() ) {
+        return false;
+    }
+
     bool dest_is_curs = curs == dest;
     bool path_changed = false;
     if( path.front() == player_character.omt_path.front() && path != player_character.omt_path ) {

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -1849,6 +1849,12 @@ static bool try_travel_to_destination( avatar &player_character, const tripoint_
     std::vector<tripoint_abs_omt> path = get_overmap_path_to( dest, driving );
 
     if( path.empty() ) {
+        if( dest.z() == player_character.posz() ) {
+            add_msg( m_warning, _( "Unable to find a path from the current location." ) );
+        } else {
+            add_msg( m_warning,
+                     _( "Auto travel only can only be used with the source and destination on the same Z level." ) );
+        }
         return false;
     }
 

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -1854,7 +1854,7 @@ static bool try_travel_to_destination( avatar &player_character, const tripoint_
             add_msg( m_warning, _( "Unable to find a path from the current location." ) );
         } else {
             add_msg( m_warning,
-                     _( "Auto travel only can only be used with the source and destination on the same Z level." ) );
+                     _( "Auto travel can only be used with the source and destination on the same Z level." ) );
         }
         return false;
     }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fix #80279, i.e. crash when trying to auto travel while on different Z level.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Check whether the path is empty and return false if it is, rather than attempt to get the first element of the empty path and blow up.

Added popup to inform player about the failure. Doesn't exit the overmap, though.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Change the pathing logic to be able to handle Z levels. That seems difficult.

Try to figure out how to automatically escape from the overmap.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Repeat the error.
Change the code.
- Repeat the error situation without the game crashing.
- Get the popup.
- Accept or reject the popup.
- Escape from the overmap.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
As indicated, the game ought to be able to handle travel between Z levels (although the bug report save doesn't allow that from the ground level either, presumably due to the need to deal with fences).

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
