### PR TITLE
Fix Pneumatic mission

### DIFF
--- a/data/json/npcs/refugee_center/surface_refugees/NPC_Jenny_Forcette.json
+++ b/data/json/npcs/refugee_center/surface_refugees/NPC_Jenny_Forcette.json
@@ -375,7 +375,7 @@
       {
         "text": "If I see anything, I'll let you know.  Can you tell me more about your project?",
         "topic": "TALK_REFUGEE_JENNY_Project2",
-        "effect": { "assign_mission": "MISSION_REFUGEE_Jenny_GET_PNEUMATICS" },
+        "effect": { "add_mission": "MISSION_REFUGEE_Jenny_GET_PNEUMATICS" },
         "condition": {
           "and": [
             { "not": { "u_has_mission": "MISSION_REFUGEE_Jenny_GET_PNEUMATICS" } },


### PR DESCRIPTION
#### Summary
Bugfixes "Fixes quest item of pneumatic mission disappearing into thin air"

#### Purpose of change
Fixes #78603, fixes #74731, and fixes #69079 (closed as stale).

#### Describe the solution
A simple change to "add_mission" rather than "assign_mission" which seems to automatically assigns you the mission without a quest giver (You are the quest giver), "add_mission" does not seems to be documented... But I found another instance of it working for what I wanted, so I used it.

#### Describe alternatives you've considered

#### Testing
Tested the changes in a build from a month ago, worked like a charm, the book did not disappear until I returned with it to the quest giver (Jenny) and delivered it like any normal "find item" mission, the rewards were given upon delivery too.

#### Additional context
I think there should be other instances of this problem, I found one that I will fix after this along with another bug, but there are probably others in the wild.
