### PR TITLE
New England Community Church fixes 1

### DIFF
--- a/data/json/effects_on_condition/npc_eocs/godco_npc_eocs.json
+++ b/data/json/effects_on_condition/npc_eocs/godco_npc_eocs.json
@@ -100,7 +100,7 @@
     "id": "GODCO_TRADER_MISSION_DEATHFAIL",
     "eoc_type": "NPC_DEATH",
     "effect": [
-      { "math": [ "godco_freemerch_representative_dead = 0" ] },
+      { "math": [ "godco_freemerch_representative_dead = 1" ] },
       { "u_lose_var": "general_trade_u_think_suspicious_price" },
       { "finish_mission": "MISSION_INVESTIGATE_TRADER", "success": false }
     ]

--- a/data/json/npcs/godco/members/NPC_Zachary_Montes.json
+++ b/data/json/npcs/godco/members/NPC_Zachary_Montes.json
@@ -158,7 +158,7 @@
       {
         "text": "I'll see what I can do.",
         "topic": "TALK_NONE",
-        "effect": { "assign_mission": "MISSION_GODCO_ZACHARY_KILL_NIGHTMARE" }
+        "effect": { "add_mission": "MISSION_GODCO_ZACHARY_KILL_NIGHTMARE" }
       },
       { "text": "I'm sorry to hear that <name_g>, but I don't feel like facing it either.", "topic": "TALK_DONE" }
     ]

--- a/data/json/npcs/refugee_center/surface_staff/NPC_free_merchant_teamster.json
+++ b/data/json/npcs/refugee_center/surface_staff/NPC_free_merchant_teamster.json
@@ -84,7 +84,7 @@
         "text": "Do you know anything about a trader near the New England Church Community, claims to be from here?",
         "condition": {
           "and": [
-            { "math": [ "godco_freemerch_representative_dead != 0" ] },
+            { "math": [ "godco_freemerch_representative_dead != 1" ] },
             { "compare_string": [ "yes", { "u_val": "general_trade_u_think_suspicious_price" } ] },
             { "not": { "u_has_mission": "MISSION_INVESTIGATE_TRADER" } }
           ]
@@ -95,7 +95,7 @@
         "text": "I think I've got the evidence you were looking for.",
         "condition": {
           "and": [
-            { "math": [ "godco_freemerch_representative_dead != 0" ] },
+            { "math": [ "godco_freemerch_representative_dead != 1" ] },
             { "u_has_mission": "MISSION_INVESTIGATE_TRADER" },
             { "u_has_item": "godcotrader_accounting_records_dirty" }
           ]
@@ -106,7 +106,7 @@
         "text": "I think I've got the evidence you were looking for.",
         "condition": {
           "and": [
-            { "not": { "math": [ "godco_freemerch_representative_dead == 0" ] } },
+            { "math": [ "godco_freemerch_representative_dead != 1" ] },
             { "u_has_mission": "MISSION_INVESTIGATE_TRADER" },
             { "u_has_item": "godcotrader_accounting_records_clean" }
           ]


### PR DESCRIPTION
#### Summary
Bugfixes "Fixes some problems with the New England Church missions"

#### Purpose of change
Predator merchant and Nightmare (Zachary) missions were bugged, the predator one because you were unable to start/finish the mission since the variable was calling for a value other than 0, when the only possible value was always 0... And the Nightmare mission had the same problem that is being fixed in #80287, you as the mission giver, so the mission was completed as soon as you killed the monster, the reward appeared out of thin air and you never managed to tell the quest giver that you fixed their problem.

#### Describe the solution
A simple change of assigned/compared values for the first mission, and a simple change to a different way to give missions for the second one.

#### Describe alternatives you've considered


#### Testing
Tested both missions in a build from a month ago, they work! You can now start and finish the merchant mission, and when you kill the nightmare of the second mission you have to actually return and tell the guy to receive your reward.

#### Additional context
Some other missions from this faction seem to be unused, so I want to fix that later and give the player a way to receive them.
