### PR TITLE
Final mission giver fix in vainilla

### DIFF
--- a/data/json/npcs/isherwood_farm/NPC_Chris_Isherwood.json
+++ b/data/json/npcs/isherwood_farm/NPC_Chris_Isherwood.json
@@ -303,7 +303,7 @@
         "condition": {
           "and": [ { "math": [ "isherwood_barry_rescued != 1" ] }, { "not": { "u_has_mission": "MISSION_ISHERWOOD_CHRIS_1" } } ]
         },
-        "effect": { "assign_mission": "MISSION_ISHERWOOD_CHRIS_1" },
+        "effect": { "add_mission": "MISSION_ISHERWOOD_CHRIS_1" },
         "topic": "TALK_ISHERWOOD_CHRIS_RESCUE_BARRY"
       },
       { "text": "<done_conversation_section>", "topic": "TALK_ISHERWOOD_CHRIS_TOPICS" },

--- a/data/json/npcs/tacoma_ranch/Nunez/NPC_Pablo_Tacoma.json
+++ b/data/json/npcs/tacoma_ranch/Nunez/NPC_Pablo_Tacoma.json
@@ -175,10 +175,7 @@
     "id": "TALK_TACOMA_Pablo_Bakery-Firebricks1",
     "dynamic_line": { "gendered_line": "Seriously?  You've already done so much.  I won't say no, though.", "relevant_genders": [ "u" ] },
     "speaker_effect": {
-      "effect": [
-        { "add_mission": "MISSION_TACOMA_Pablo_Firebricks" },
-        { "u_add_var": "firebricks_tacoma_bakery", "value": "helped" }
-      ]
+      "effect": [ { "add_mission": "MISSION_TACOMA_Pablo_Firebricks" }, { "u_add_var": "firebricks_tacoma_bakery", "value": "helped" } ]
     },
     "responses": [
       { "text": "No problem.  <done_conversation_section>", "topic": "TALK_NONE" },

--- a/data/json/npcs/tacoma_ranch/Nunez/NPC_Pablo_Tacoma.json
+++ b/data/json/npcs/tacoma_ranch/Nunez/NPC_Pablo_Tacoma.json
@@ -176,7 +176,7 @@
     "dynamic_line": { "gendered_line": "Seriously?  You've already done so much.  I won't say no, though.", "relevant_genders": [ "u" ] },
     "speaker_effect": {
       "effect": [
-        { "assign_mission": "MISSION_TACOMA_Pablo_Firebricks" },
+        { "add_mission": "MISSION_TACOMA_Pablo_Firebricks" },
         { "u_add_var": "firebricks_tacoma_bakery", "value": "helped" }
       ]
     },


### PR DESCRIPTION
#### Summary
Bugfixes "Small almost insignificant fix to the first Chris mission, and preventive fix to an unused Pablo mission"

#### Purpose of change
The first mission from Chris Isherwood had a little problem in not giving its rewards properly (trust) because "nobody" gave you the mission, and the Pablo Nunez bricks mission (Unused for now, part or the Tacoma missions) would have the same problem as the others that I fixed, items disappearing into thin air as soon as you get close, rewards appearing suddenly too.

#### Describe the solution
Simple fix to an undocumented function that actually correctly assigns the missions from the NPC giving them.

#### Describe alternatives you've considered
There are a couple of other missions where, since you actually receive the mission from yourself, you are unable to see the unique dialogue of the quest giver inquiring about the mission, I did not touch them since they lacked any material item/reward that would cause bugs, just in case, since I'm not quite sure if what I'm doing has any unforeseen changes.

I also did not touch mods missions, did not check if there was a problem in those since I'm not used to playing with most mission givers mods, so I wouldn't be sure how they are supposed to work, please report any such missions that suddenly get completed and should not, items disappearing as soon as you get close and what not.

#### Testing
It works! The Pablo mission is just preventive since you can't actually receive it.

#### Additional context

