### PR TITLE
Fix #80290 Riot damage's random moving of items for SEALED CONTAINER

### DIFF
--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -447,17 +447,15 @@ static void GENERATOR_riot_damage( map &md, const tripoint_abs_omt &p )
             continue;
         }
         // Bash stuff at random!
-        bash_params rnd_bash_result;
         if( x_in_y( 20, 100 ) ) {
-            rnd_bash_result = md.bash( current_tile, rng( 6, 60 ) );
+            md.bash( current_tile, rng( 6, 60 ) );
         }
         // Move stuff at random!
         auto item_iterator = md.i_at( current_tile.xy() ).begin();
         while( item_iterator != md.i_at( current_tile.xy() ).end() ) {
-            // do not move seed out of the not destroyed planter
-            if( item_iterator->is_seed() &&
-                md.has_flag_ter_or_furn( ter_furn_flag::TFLAG_PLANT, current_tile ) &&
-                !rnd_bash_result.success ) {
+            // do not move items out of SEALED CONTAINER
+            if( md.has_flag_ter_or_furn( ter_furn_flag::TFLAG_SEALED, current_tile ) &&
+                md.has_flag_ter_or_furn( ter_furn_flag::TFLAG_CONTAINER, current_tile ) ) {
                 item_iterator++;
                 continue;
             }

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -447,12 +447,20 @@ static void GENERATOR_riot_damage( map &md, const tripoint_abs_omt &p )
             continue;
         }
         // Bash stuff at random!
+        bash_params rnd_bash_result;
         if( x_in_y( 20, 100 ) ) {
-            md.bash( current_tile, rng( 6, 60 ) );
+            rnd_bash_result = md.bash( current_tile, rng( 6, 60 ) );
         }
         // Move stuff at random!
         auto item_iterator = md.i_at( current_tile.xy() ).begin();
         while( item_iterator != md.i_at( current_tile.xy() ).end() ) {
+            // do not move seed out of the not destroyed planter
+            if( item_iterator->is_seed() &&
+                md.has_flag_ter_or_furn( ter_furn_flag::TFLAG_PLANT, current_tile ) &&
+                !rnd_bash_result.success ) {
+                item_iterator++;
+                continue;
+            }
             if( x_in_y( 10, 100 ) ) {
                 // pick a new spot...
                 tripoint_bub_ms destination_tile( current_tile.x() + rng( -3, 3 ),

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -453,11 +453,15 @@ static void GENERATOR_riot_damage( map &md, const tripoint_abs_omt &p )
         // Move stuff at random!
         auto item_iterator = md.i_at( current_tile.xy() ).begin();
         while( item_iterator != md.i_at( current_tile.xy() ).end() ) {
-            // do not move items out of SEALED CONTAINER
+            // Some items must not be moved out of SEALED CONTAINER
             if( md.has_flag_ter_or_furn( ter_furn_flag::TFLAG_SEALED, current_tile ) &&
                 md.has_flag_ter_or_furn( ter_furn_flag::TFLAG_CONTAINER, current_tile ) ) {
-                item_iterator++;
-                continue;
+                // Seed should stay in their planter for map::grow_plant to grow them
+                if( md.has_flag_ter_or_furn( ter_furn_flag::TFLAG_PLANT, current_tile ) &&
+                    item_iterator->is_seed() ) {
+                    item_iterator++;
+                    continue;
+                }
             }
             if( x_in_y( 10, 100 ) ) {
                 // pick a new spot...


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Fix the riot damage's random moving of items for SEALED CONTAINER"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Fix #80290
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

This was really not obvious to me. I was searching in the bash code. But the problem was in the `GENERATOR_riot_damage` when we randomly move items. 

When the current tile we damage has a `TFLAG_PLANT` furniture and was not completely destroyed by a random bashing, the random moving of items displaced the seed. So the seed was not in its place when `map::grow_plant` executes.

So the solution was to put a condition to NOT move a seed out of a not destroyed planter.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

I wrongly considered at least [two alternatives here](https://github.com/CleverRaven/Cataclysm-DDA/issues/80290#issuecomment-2746417100) but I was wrong because I assumed the random bashing on a planter was destroying the seed on purpose.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

This one is kind of hard to test because we need the `GENERATOR_riot_damage` to pass on a `TFLAG_PLANT` furniture AND bash it AND not destroy it AND randomly moving stuff around.

So, I put a break point in my new `if`, teleport around big city a lot, hit the breakpoint, correctly assert that I had the correct objects in hand and saw that the original error message (Plant furniture has no seed item) did not happen.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

This bug gave me a lot of insight on the code. Its been a while since a contributed and many things changed since.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
