### PR TITLE
fix both AIM-panels selected

### DIFF
--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -1998,6 +1998,8 @@ void advanced_inventory::process_action( const std::string &input_action )
             popup_getkey( _( "There's no vehicle storage space there." ) );
         }
     }
+    dest = src == advanced_inventory::side::left ? advanced_inventory::side::right :
+           advanced_inventory::side::left;
 }
 
 void advanced_inventory::display()
@@ -2086,9 +2088,6 @@ void advanced_inventory::display()
             do_return_entry();
             return;
         }
-
-        dest = src == advanced_inventory::side::left ? advanced_inventory::side::right :
-               advanced_inventory::side::left;
 
         if( ui ) {
             ui->invalidate_ui();

--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -1839,8 +1839,6 @@ bool advanced_inventory::action_unload( advanced_inv_listitem *sitem,
 
 void advanced_inventory::process_action( const std::string &input_action )
 {
-    dest = src == advanced_inventory::side::left ? advanced_inventory::side::right :
-           advanced_inventory::side::left;
     recalc = false;
     // source and destination pane
     advanced_inventory_pane &spane = panes[src];
@@ -2089,6 +2087,8 @@ void advanced_inventory::display()
             return;
         }
 
+        dest = src == advanced_inventory::side::left ? advanced_inventory::side::right :
+               advanced_inventory::side::left;
 
         if( ui ) {
             ui->invalidate_ui();

--- a/src/advanced_inv.h
+++ b/src/advanced_inv.h
@@ -64,6 +64,10 @@ class advanced_inventory
         side get_src() {
             return src;
         }
+        side get_dest() {
+            return dest;
+        }
+
         advanced_inventory_pane get_pane( side side ) {
             return panes[side];
         }

--- a/tests/advanced_inventory_test.cpp
+++ b/tests/advanced_inventory_test.cpp
@@ -87,7 +87,6 @@ TEST_CASE( "advanced_inventory_navigation" )
     clear_map();
     advanced_inventory advinv;
 
-    avatar &u = get_avatar();
     advinv.init();
     advanced_inventory::side init_src = advinv.get_src();
     advanced_inventory::side init_dest = advinv.get_dest();

--- a/tests/advanced_inventory_test.cpp
+++ b/tests/advanced_inventory_test.cpp
@@ -81,6 +81,42 @@ static void do_activity( advanced_inventory &advinv, const std::string &activity
     recalc_panes( advinv );
 }
 
+TEST_CASE( "advanced_inventory_navigation" )
+{
+    clear_avatar();
+    clear_map();
+    advanced_inventory advinv;
+
+    avatar &u = get_avatar();
+    advinv.init();
+    advanced_inventory::side init_src = advinv.get_src();
+    advanced_inventory::side init_dest = advinv.get_dest();
+    advanced_inventory_pane init_src_pane = advinv.get_pane( init_src );
+    advanced_inventory_pane init_dest_pane = advinv.get_pane( init_dest );
+
+    GIVEN( "Areas are not the same" ) {
+        REQUIRE( init_src_pane.get_area() != init_dest_pane.get_area() );
+
+        WHEN( "Switching sides" ) {
+            advinv.process_action( "TOGGLE_TAB" );
+
+            advanced_inventory::side src = advinv.get_src();
+            advanced_inventory::side dest = advinv.get_dest();
+            advanced_inventory_pane src_pane = advinv.get_pane( src );
+            advanced_inventory_pane dest_pane = advinv.get_pane( dest );
+
+            THEN( "sides got switched" ) {
+                REQUIRE( src == init_dest );
+                REQUIRE( dest == init_src );
+            }
+            AND_THEN( "pane areas got switched" ) {
+                REQUIRE( src_pane.get_area() == init_dest_pane.get_area() );
+                REQUIRE( dest_pane.get_area() == init_src_pane.get_area() );
+
+            }
+        }
+    }
+}
 
 TEST_CASE( "advanced_inventory_actions" )
 {


### PR DESCRIPTION
#### Summary
Bugfixes "fix both AIM-panels selected"

#### Purpose of change
fix #80244
in #79976 I messed up when dest gets updated. Im pretty sure I didnt experience this until now, so I dont know how it ever worked.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
update dest before redrawing ui.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
make dest be a method defined as always being opposite of src. It would be easy in python (`@property`) and c# (getter) but I'm not aware of a way in cpp where you can treat a method as an attribute.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
swapping panes correctly de-selects previous src pane
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
