### PR TITLE
New cigarette variants

### DIFF
--- a/data/json/itemgroups/Drugs_Tobacco_Alcohol/tobacco.json
+++ b/data/json/itemgroups/Drugs_Tobacco_Alcohol/tobacco.json
@@ -19,11 +19,11 @@
     "items": [
       {
         "distribution": [
-          { "item": "cig", "probability": 50 },
-          { "item": "cig_light", "probability": 20 },
-          { "item": "cig_menthol", "probability": 20 },
-          { "item": "cig_gold", "probability": 7 },
-          { "item": "cigar_small", "probability": 3 }
+          { "item": "cig", "prob": 50 },
+          { "item": "cig_light", "prob": 20 },
+          { "item": "cig_menthol", "prob": 20 },
+          { "item": "cig_gold", "prob": 7 },
+          { "item": "cigar_small", "prob": 3 }
         ]
       }
     ]

--- a/data/json/itemgroups/Drugs_Tobacco_Alcohol/tobacco.json
+++ b/data/json/itemgroups/Drugs_Tobacco_Alcohol/tobacco.json
@@ -15,13 +15,24 @@
   },
   {
     "type": "item_group",
-    "id": "cigarettes",
+    "id": "cigarettes_opened",
     "items": [
-      { "item": "cig", "prob": 50, "container-item": "null" },
-      { "item": "cig_light", "prob": 20, "container-item": "null" },
-      { "item": "cig_menthol", "prob": 20, "container-item": "null" },
-      { "item": "cig_gold", "prob": 7, "container-item": "null" },
-      { "item": "cigar_small", "prob": 3, "container-item": "null" }
+      { "item": "cig", "prob": 50, "count": [ 1, 20 ], "container-item": "null" },
+      { "item": "cig_light", "prob": 20, "count": [ 1, 20 ], "container-item": "null" },
+      { "item": "cig_menthol", "prob": 20, "count": [ 1, 20 ], "container-item": "null" },
+      { "item": "cig_gold", "prob": 7, "count": [ 1, 20 ], "container-item": "null" },
+      { "item": "cigar_small", "prob": 3, "count": [ 1, 20 ], "container-item": "null" }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "cigarettes_new",
+    "items": [
+      { "item": "cig", "prob": 50, "count": [ 20, 20 ], "container-item": "null" },
+      { "item": "cig_light", "prob": 20, "count": [ 20, 20 ], "container-item": "null" },
+      { "item": "cig_menthol", "prob": 20, "count": [ 20, 20 ], "container-item": "null" },
+      { "item": "cig_gold", "prob": 7, "count": [ 20, 20 ], "container-item": "null" },
+      { "item": "cigar_small", "prob": 3, "count": [ 20, 20 ], "container-item": "null" }
     ]
   },
   {
@@ -66,7 +77,7 @@
     "entries": [
       {
         "distribution": [
-          { "group": "cigarettes", "prob": 75, "count": [ 1, 10 ], "container-item": "null", "entry-wrapper": "box_cigarette" },
+          { "group": "cigarettes_opened", "prob": 75, "entry-wrapper": "box_cigarette" },
           {
             "collection": [
               { "item": "tobacco", "count": [ 1, 20 ], "container-item": "null", "entry-wrapper": "bag_plastic" },
@@ -102,6 +113,6 @@
     "subtype": "collection",
     "//": "This group was created automatically and may contain errors.",
     "container-item": "box_cigarette",
-    "entries": [ { "group": "cigarettes", "container-item": "null", "count": 20 } ]
+    "entries": [ { "group": "cigarettes_new" } ]
   }
 ]

--- a/data/json/itemgroups/Drugs_Tobacco_Alcohol/tobacco.json
+++ b/data/json/itemgroups/Drugs_Tobacco_Alcohol/tobacco.json
@@ -17,15 +17,11 @@
     "type": "item_group",
     "id": "cigarettes",
     "items": [
-      {
-        "distribution": [
-          { "item": "cig", "prob": 50, "container-item": "null" },
-          { "item": "cig_light", "prob": 20, "container-item": "null" },
-          { "item": "cig_menthol", "prob": 20, "container-item": "null" },
-          { "item": "cig_gold", "prob": 7, "container-item": "null" },
-          { "item": "cigar_small", "prob": 3, "container-item": "null" }
-        ]
-      }
+      { "item": "cig", "prob": 50, "container-item": "null" },
+      { "item": "cig_light", "prob": 20, "container-item": "null" },
+      { "item": "cig_menthol", "prob": 20, "container-item": "null" },
+      { "item": "cig_gold", "prob": 7, "container-item": "null" },
+      { "item": "cigar_small", "prob": 3, "container-item": "null" }
     ]
   },
   {

--- a/data/json/itemgroups/Drugs_Tobacco_Alcohol/tobacco.json
+++ b/data/json/itemgroups/Drugs_Tobacco_Alcohol/tobacco.json
@@ -14,6 +14,21 @@
     ]
   },
   {
+    "type": "item_group",
+    "id": "cigarettes",
+    "items": [
+      {
+        "distribution": [
+          { "item": "cig", "probability": 50 },
+          { "item": "cig_light", "probability": 20 },
+          { "item": "cig_menthol", "probability": 20 },
+          { "item": "cig_gold", "probability": 7 },
+          { "item": "cigar_small", "probability": 3 }
+        ]
+      }
+    ]
+  },
+  {
     "id": "pocket_cigar",
     "type": "item_group",
     "subtype": "collection",
@@ -55,7 +70,7 @@
     "entries": [
       {
         "distribution": [
-          { "item": "cig", "prob": 75, "count": [ 1, 10 ], "container-item": "null", "entry-wrapper": "box_cigarette" },
+          { "group": "cigarettes", "prob": 75, "count": [ 1, 10 ], "container-item": "null", "entry-wrapper": "box_cigarette" },
           {
             "collection": [
               { "item": "tobacco", "count": [ 1, 20 ], "container-item": "null", "entry-wrapper": "bag_plastic" },
@@ -91,6 +106,6 @@
     "subtype": "collection",
     "//": "This group was created automatically and may contain errors.",
     "container-item": "box_cigarette",
-    "entries": [ { "item": "cig", "container-item": "null", "count": 20 } ]
+    "entries": [ { "group": "cigarettes", "container-item": "null", "count": 20 } ]
   }
 ]

--- a/data/json/itemgroups/Drugs_Tobacco_Alcohol/tobacco.json
+++ b/data/json/itemgroups/Drugs_Tobacco_Alcohol/tobacco.json
@@ -19,11 +19,11 @@
     "items": [
       {
         "distribution": [
-          { "item": "cig", "prob": 50 },
-          { "item": "cig_light", "prob": 20 },
-          { "item": "cig_menthol", "prob": 20 },
-          { "item": "cig_gold", "prob": 7 },
-          { "item": "cigar_small", "prob": 3 }
+          { "item": "cig", "prob": 50, "container-item": "null" },
+          { "item": "cig_light", "prob": 20, "container-item": "null" },
+          { "item": "cig_menthol", "prob": 20, "container-item": "null" },
+          { "item": "cig_gold", "prob": 7, "container-item": "null" },
+          { "item": "cigar_small", "prob": 3, "container-item": "null" }
         ]
       }
     ]

--- a/data/json/itemgroups/Drugs_Tobacco_Alcohol/tobacco.json
+++ b/data/json/itemgroups/Drugs_Tobacco_Alcohol/tobacco.json
@@ -17,22 +17,22 @@
     "type": "item_group",
     "id": "cigarettes_opened",
     "items": [
-      { "item": "cig", "prob": 50, "count": [ 1, 20 ], "container-item": "null" },
-      { "item": "cig_light", "prob": 20, "count": [ 1, 20 ], "container-item": "null" },
-      { "item": "cig_menthol", "prob": 20, "count": [ 1, 20 ], "container-item": "null" },
-      { "item": "cig_gold", "prob": 7, "count": [ 1, 20 ], "container-item": "null" },
-      { "item": "cigar_small", "prob": 3, "count": [ 1, 20 ], "container-item": "null" }
+      { "item": "cig", "variant": "cig_basic", "prob": 40, "count": [ 1, 20 ], "container-item": "null" },
+      { "item": "cig", "variant": "cig_light", "prob": 25, "count": [ 1, 20 ], "container-item": "null" },
+      { "item": "cig", "variant": "cig_menthol", "prob": 25, "count": [ 1, 20 ], "container-item": "null" },
+      { "item": "cig", "variant": "cig_gold", "prob": 7, "count": [ 1, 20 ], "container-item": "null" },
+      { "item": "cig", "variant": "cig_little_cigar", "prob": 3, "count": [ 1, 20 ], "container-item": "null" }
     ]
   },
   {
     "type": "item_group",
     "id": "cigarettes_new",
     "items": [
-      { "item": "cig", "prob": 50, "count": [ 20, 20 ], "container-item": "null" },
-      { "item": "cig_light", "prob": 20, "count": [ 20, 20 ], "container-item": "null" },
-      { "item": "cig_menthol", "prob": 20, "count": [ 20, 20 ], "container-item": "null" },
-      { "item": "cig_gold", "prob": 7, "count": [ 20, 20 ], "container-item": "null" },
-      { "item": "cigar_small", "prob": 3, "count": [ 20, 20 ], "container-item": "null" }
+      { "item": "cig", "variant": "cig_basic", "prob": 40, "count": [ 20, 20 ], "container-item": "null" },
+      { "item": "cig", "variant": "cig_light", "prob": 25, "count": [ 20, 20 ], "container-item": "null" },
+      { "item": "cig", "variant": "cig_menthol", "prob": 25, "count": [ 20, 20 ], "container-item": "null" },
+      { "item": "cig", "variant": "cig_gold", "prob": 7, "count": [ 20, 20 ], "container-item": "null" },
+      { "item": "cig", "variant": "cig_little_cigar", "prob": 3, "count": [ 20, 20 ], "container-item": "null" }
     ]
   },
   {

--- a/data/json/itemgroups/collections_domestic.json
+++ b/data/json/itemgroups/collections_domestic.json
@@ -1639,7 +1639,7 @@
     "subtype": "collection",
     "//": "This group was created automatically and may contain errors.",
     "container-item": "box_cigarette",
-    "entries": [ { "item": "cig", "container-item": "null", "count": [ 1, 20 ] } ]
+    "entries": [ { "group": "cigarettes", "container-item": "null", "count": [ 1, 20 ] } ]
   },
   {
     "type": "item_group",

--- a/data/json/itemgroups/collections_domestic.json
+++ b/data/json/itemgroups/collections_domestic.json
@@ -1639,7 +1639,7 @@
     "subtype": "collection",
     "//": "This group was created automatically and may contain errors.",
     "container-item": "box_cigarette",
-    "entries": [ { "group": "cigarettes", "container-item": "null", "count": [ 1, 20 ] } ]
+    "entries": [ { "group": "cigarettes_opened" } ]
   },
   {
     "type": "item_group",

--- a/data/json/itemgroups/misc.json
+++ b/data/json/itemgroups/misc.json
@@ -7,7 +7,7 @@
     "entries": [
       {
         "distribution": [
-          { "item": "cig", "prob": 70, "count": [ 1, 10 ], "container-item": "null", "entry-wrapper": "box_cigarette" },
+          { "group": "cigarettes", "prob": 70, "count": [ 1, 10 ], "container-item": "null", "entry-wrapper": "box_cigarette" },
           {
             "collection": [
               { "item": "tobacco", "count": [ 1, 20 ], "container-item": "null", "entry-wrapper": "bag_plastic" },

--- a/data/json/itemgroups/misc.json
+++ b/data/json/itemgroups/misc.json
@@ -7,7 +7,7 @@
     "entries": [
       {
         "distribution": [
-          { "group": "cigarettes", "prob": 70, "count": [ 1, 10 ], "container-item": "null", "entry-wrapper": "box_cigarette" },
+          { "group": "cigarettes_opened", "prob": 70, "entry-wrapper": "box_cigarette" },
           {
             "collection": [
               { "item": "tobacco", "count": [ 1, 20 ], "container-item": "null", "entry-wrapper": "bag_plastic" },

--- a/data/json/items/comestibles/med.json
+++ b/data/json/items/comestibles/med.json
@@ -372,55 +372,39 @@
     "addiction_potential": 50,
     "addiction_type": "nicotine",
     "flags": [ "NO_INGEST", "IRREPLACEABLE_CONSUMABLE", "EDIBLE_FROZEN" ],
-    "use_action": [ "SMOKING" ]
-  },
-  {
-    "id": "cig_menthol",
-    "type": "COMESTIBLE",
-    "comestible_type": "MED",
-    "copy-from": "cig",
-    "name": { "str": "menthol cigarette" },
-    "description": "A cigarette with a menthol flavor, the only type of flavored cigarette permitted for sale in the US. The FDA had previously proposed a ban on them, but the world ended before the plan could be implemented. It feels somewhat better to smoke than a regular cigarette.",
-    "color": "cyan",
-    "fun": 7
-  },
-  {
-    "id": "cig_light",
-    "type": "COMESTIBLE",
-    "comestible_type": "MED",
-    "copy-from": "cig",
-    "name": { "str": "\"light\" cigarette" },
-    "description": "A cigarette with reduced tar and nicotine content, designed to appeal to quitters and health-conscious smokers. While not actually less harmful than regular cigarettes, the amount of nicotine absorbed per cigarette is indeed lower. Marketing cigarettes as 'light' has been illegal since 2007, but the term has persisted in common usage.",
-    "color": "white",
-    "fun": 3
-  },
-  {
-    "id": "cig_gold",
-    "type": "COMESTIBLE",
-    "comestible_type": "MED",
-    "copy-from": "cig",
-    "name": { "str": "quality cigarette" },
-    "description": "A premium brand cigarette crafted from strong, high-quality tobacco. While discerning smokers may appreciate its superior flavor compared to average cigarettes, the higher tar and nicotine content won't do you any favors. Then again, you probably have bigger concerns than lung cancer.",
-    "price": "25 cent",
-    "price_postapoc": "50 cent",
-    "color": "yellow",
-    "healthy": -3,
-    "fun": 10,
-    "addiction_potential": 55
-  },
-  {
-    "id": "cigar_small",
-    "type": "COMESTIBLE",
-    "comestible_type": "MED",
-    "copy-from": "cig",
-    "name": { "str": "little cigar" },
-    "description": "A compact, slim cigar in the shape of a cigarette. It’s a popular choice for those who want a taste of luxury without the time commitment of a full-sized cigar. Addictive and hazardous to health.",
-    "price": "1 USD",
-    "price_postapoc": "2 USD 50 cent",
-    "color": "brown",
-    "healthy": -3,
-    "fun": 12,
-    "addiction_potential": 60
+    "use_action": [ "SMOKING" ],
+    "variants": [
+      {
+        "id": "cig_basic",
+        "name": { "str": "cigarette" },
+        "description": "A mixture of dried tobacco leaf, pesticides, and chemical additives, rolled into a filtered paper tube.  Stimulates mental acuity and reduces appetite.  Highly addictive and hazardous to health, but lung cancer is kind of the least of your concerns at this point.",
+        "color": "dark_gray"
+      },
+      {
+        "id": "cig_menthol",
+        "name": { "str": "menthol cigarette" },
+        "description": "A cigarette with a menthol flavor, the only type of flavored cigarette permitted for sale in the US. The FDA had previously proposed a ban on them, but the world ended before the plan could be implemented. It feels somewhat better to smoke than a regular cigarette.",
+        "color": "cyan"
+      },
+      {
+        "id": "cig_light",
+        "name": { "str": "\"light\" cigarette" },
+        "description": "A cigarette with reduced tar and nicotine content, designed to appeal to quitters and health-conscious smokers. While not actually less harmful than regular cigarettes, the amount of nicotine absorbed per cigarette is indeed lower. Marketing cigarettes as 'light' has been illegal since 2007, but the term has persisted in common usage.",
+        "color": "white"
+      },
+      {
+        "id": "cig_gold",
+        "name": { "str": "quality cigarette" },
+        "description": "A premium brand cigarette crafted from strong, high-quality tobacco. While discerning smokers may appreciate its superior flavor compared to average cigarettes, the higher tar and nicotine content won't do you any favors. Then again, you probably have bigger concerns than lung cancer.",
+        "color": "yellow"
+      },
+      {
+        "id": "cig_little_cigar",
+        "name": { "str": "little cigar" },
+        "description": "A compact, slim cigar in the shape of a cigarette. It’s a popular choice for those who want a taste of luxury without the time commitment of a full-sized cigar. Addictive and hazardous to health.",
+        "color": "brown"
+      }
+    ]
   },
   {
     "id": "cigar",

--- a/data/json/items/comestibles/med.json
+++ b/data/json/items/comestibles/med.json
@@ -383,7 +383,7 @@
       {
         "id": "cig_menthol",
         "name": { "str": "menthol cigarette" },
-        "description": "A cigarette with a menthol flavor, the only type of flavored cigarette permitted for sale in the US.  The FDA had previously proposed a ban on them, but the world ended before the plan could be implemented.  It feels somewhat nicer to smoke than a regular cigarette.",
+        "description": "A cigarette with a menthol flavor, the only type of flavored cigarette permitted for sale in the US.  The FDA had previously proposed a ban on them, but the world ended before it could be implemented.  It feels somewhat nicer to smoke than a regular cigarette.",
         "color": "cyan"
       },
       {
@@ -395,13 +395,13 @@
       {
         "id": "cig_gold",
         "name": { "str": "quality cigarette" },
-        "description": "A premium brand cigarette rolled from strong, high-quality tobacco.  While discerning smokers may appreciate its flavor to average cigarettes, the higher tar and nicotine content won't do you any favors.  Then again, you probably have bigger concerns than lung cancer.",
+        "description": "A premium brand cigarette rolled from strong, high-quality tobacco.  While discerning smokers may prefer its flavor to that of average cigarettes, the higher tar and nicotine content won't do you any favors.  Then again, you probably have bigger concerns than lung cancer.",
         "color": "yellow"
       },
       {
         "id": "cig_little_cigar",
         "name": { "str": "little cigar" },
-        "description": "A compact, slim cigar in the shape of a cigarette.  It's a popular choice for those who want a taste of luxury without the time commitment of a full-sized cigar.  Addictive and hazardous to health.",
+        "description": "A compact, slim cigar in the form of a cigarette.  It's a popular choice for those who want a taste of luxury without the time commitment of a full-sized cigar.  Addictive and hazardous to health.",
         "color": "brown"
       }
     ]

--- a/data/json/items/comestibles/med.json
+++ b/data/json/items/comestibles/med.json
@@ -401,7 +401,7 @@
       {
         "id": "cig_little_cigar",
         "name": { "str": "little cigar" },
-        "description": "A compact, slim cigar in the shape of a cigarette. It’s a popular choice for those who want a taste of luxury without the time commitment of a full-sized cigar. Addictive and hazardous to health.",
+        "description": "A compact, slim cigar in the shape of a cigarette. It's a popular choice for those who want a taste of luxury without the time commitment of a full-sized cigar. Addictive and hazardous to health.",
         "color": "brown"
       }
     ]

--- a/data/json/items/comestibles/med.json
+++ b/data/json/items/comestibles/med.json
@@ -389,7 +389,7 @@
       {
         "id": "cig_light",
         "name": { "str": "\"light\" cigarette" },
-        "description": "A cigarette with reduced tar and nicotine content, designed to appeal to quitters and health-conscious smokers.  While not actually less harmful than regular cigarettes, the amount of nicotine absorbed per cigarette is indeed lower.  Marketing cigarettes as 'light' has been illegal since 2007, but the term has persisted as a shorthand.",
+        "description": "A cigarette with reduced tar and nicotine content, designed to appeal to quitters and health-conscious smokers.  While not actually less harmful than regular cigarettes, the amount of nicotine absorbed per cigarette is indeed lower.  Marketing cigarettes as \"light\" has been illegal since 2007, but the term has persisted as a shorthand.",
         "color": "white"
       },
       {

--- a/data/json/items/comestibles/med.json
+++ b/data/json/items/comestibles/med.json
@@ -375,6 +375,54 @@
     "use_action": [ "SMOKING" ]
   },
   {
+    "id": "cig_menthol",
+    "type": "COMESTIBLE",
+    "comestible_type": "MED",
+    "copy-from": "cig",
+    "name": { "str": "menthol cigarette" },
+    "description": "A cigarette with a menthol flavor, the only type of flavored cigarette permitted for sale in the US. The FDA had previously proposed a ban on them, but the world ended before the plan could be implemented. It feels somewhat better to smoke than a regular cigarette.",
+    "color": "cyan",
+    "fun": 7
+  },
+  {
+    "id": "cig_light",
+    "type": "COMESTIBLE",
+    "comestible_type": "MED",
+    "copy-from": "cig",
+    "name": { "str": "\"light\" cigarette" },
+    "description": "A cigarette with reduced tar and nicotine content, designed to appeal to quitters and health-conscious smokers. While not actually less harmful than regular cigarettes, the amount of nicotine absorbed per cigarette is indeed lower. Marketing cigarettes as 'light' has been illegal since 2007, but the term has persisted in common usage.",
+    "color": "white",
+    "fun": 3
+  },
+  {
+    "id": "cig_gold",
+    "type": "COMESTIBLE",
+    "comestible_type": "MED",
+    "copy-from": "cig",
+    "name": { "str": "quality cigarette" },
+    "description": "A premium brand cigarette crafted from strong, high-quality tobacco. While discerning smokers may appreciate its superior flavor compared to average cigarettes, the higher tar and nicotine content won't do you any favors. Then again, you probably have bigger concerns than lung cancer.",
+    "price": "25 cent",
+    "price_postapoc": "50 cent",
+    "color": "yellow",
+    "healthy": -3,
+    "fun": 10,
+    "addiction_potential": 55
+  },
+  {
+    "id": "cigar_small",
+    "type": "COMESTIBLE",
+    "comestible_type": "MED",
+    "copy-from": "cig",
+    "name": { "str": "little cigar" },
+    "descirption": "A compact, slim cigar in the shape of a cigarette. It’s a popular choice for those who want a taste of luxury without the time commitment of a full-sized cigar. Addictive and hazardous to health.",
+    "price": "1 USD",
+    "price_postapoc": "2 USD 50 cent",
+    "color": "brown",
+    "healthy": -3,
+    "fun": 12,
+    "addiction_potential": 60
+  },
+  {
     "id": "cigar",
     "type": "COMESTIBLE",
     "comestible_type": "MED",

--- a/data/json/items/comestibles/med.json
+++ b/data/json/items/comestibles/med.json
@@ -414,7 +414,7 @@
     "comestible_type": "MED",
     "copy-from": "cig",
     "name": { "str": "little cigar" },
-    "descirption": "A compact, slim cigar in the shape of a cigarette. It’s a popular choice for those who want a taste of luxury without the time commitment of a full-sized cigar. Addictive and hazardous to health.",
+    "description": "A compact, slim cigar in the shape of a cigarette. It’s a popular choice for those who want a taste of luxury without the time commitment of a full-sized cigar. Addictive and hazardous to health.",
     "price": "1 USD",
     "price_postapoc": "2 USD 50 cent",
     "color": "brown",

--- a/data/json/items/comestibles/med.json
+++ b/data/json/items/comestibles/med.json
@@ -383,25 +383,25 @@
       {
         "id": "cig_menthol",
         "name": { "str": "menthol cigarette" },
-        "description": "A cigarette with a menthol flavor, the only type of flavored cigarette permitted for sale in the US. The FDA had previously proposed a ban on them, but the world ended before the plan could be implemented. It feels somewhat better to smoke than a regular cigarette.",
+        "description": "A cigarette with a menthol flavor, the only type of flavored cigarette permitted for sale in the US.  The FDA had previously proposed a ban on them, but the world ended before the plan could be implemented.  It feels somewhat nicer to smoke than a regular cigarette.",
         "color": "cyan"
       },
       {
         "id": "cig_light",
         "name": { "str": "\"light\" cigarette" },
-        "description": "A cigarette with reduced tar and nicotine content, designed to appeal to quitters and health-conscious smokers. While not actually less harmful than regular cigarettes, the amount of nicotine absorbed per cigarette is indeed lower. Marketing cigarettes as 'light' has been illegal since 2007, but the term has persisted in common usage.",
+        "description": "A cigarette with reduced tar and nicotine content, designed to appeal to quitters and health-conscious smokers.  While not actually less harmful than regular cigarettes, the amount of nicotine absorbed per cigarette is indeed lower.  Marketing cigarettes as 'light' has been illegal since 2007, but the term has persisted as a shorthand.",
         "color": "white"
       },
       {
         "id": "cig_gold",
         "name": { "str": "quality cigarette" },
-        "description": "A premium brand cigarette crafted from strong, high-quality tobacco. While discerning smokers may appreciate its superior flavor compared to average cigarettes, the higher tar and nicotine content won't do you any favors. Then again, you probably have bigger concerns than lung cancer.",
+        "description": "A premium brand cigarette rolled from strong, high-quality tobacco.  While discerning smokers may appreciate its flavor to average cigarettes, the higher tar and nicotine content won't do you any favors.  Then again, you probably have bigger concerns than lung cancer.",
         "color": "yellow"
       },
       {
         "id": "cig_little_cigar",
         "name": { "str": "little cigar" },
-        "description": "A compact, slim cigar in the shape of a cigarette. It's a popular choice for those who want a taste of luxury without the time commitment of a full-sized cigar. Addictive and hazardous to health.",
+        "description": "A compact, slim cigar in the shape of a cigarette.  It's a popular choice for those who want a taste of luxury without the time commitment of a full-sized cigar.  Addictive and hazardous to health.",
         "color": "brown"
       }
     ]

--- a/data/json/monsterdrops/zombie_default.json
+++ b/data/json/monsterdrops/zombie_default.json
@@ -210,7 +210,7 @@
       },
       {
         "distribution": [
-          { "item": "cig", "prob": 65, "count": [ 0, 20 ], "container-item": "null", "entry-wrapper": "box_cigarette" },
+          { "group": "cigarettes", "prob": 65, "count": [ 0, 20 ], "container-item": "null", "entry-wrapper": "box_cigarette" },
           { "item": "chaw", "prob": 5 },
           { "item": "cigar", "prob": 5 },
           { "group": "pocket_cigar", "prob": 1 },

--- a/data/json/monsterdrops/zombie_default.json
+++ b/data/json/monsterdrops/zombie_default.json
@@ -210,7 +210,7 @@
       },
       {
         "distribution": [
-          { "group": "cigarettes", "prob": 65, "count": [ 0, 20 ], "container-item": "null", "entry-wrapper": "box_cigarette" },
+          { "group": "cigarettes_opened", "prob": 65, "entry-wrapper": "box_cigarette" },
           { "item": "chaw", "prob": 5 },
           { "item": "cigar", "prob": 5 },
           { "group": "pocket_cigar", "prob": 1 },


### PR DESCRIPTION
#### Summary
Content "Add cigarette variants"

#### Purpose of change

adds new cigarette types for gameplay flavor purposes

#### Describe the solution

add a few variants to the cigarette item. create groups for unopened and opened cigarette packs so that all cigarettes that spawn in a pack are of the same variant. replace "cig" items with "cigarette" groups in itemgroups.

#### Describe alternatives you've considered

i tried to make it work by creating distinct items for each type so i could modify the stats but i ran into some issues and its not worth the trouble anyway imo

#### Testing

load into the game. kill some zombies and look at the packs they drop as well as find some natural spawns in the world. in both cases only one type of cigarettes spawns in a single pack. smoke the cigarettes, they smoke fine.

#### Additional context

n/a
