### PR TITLE
define magic number for max (unsafe) weight capacity

### DIFF
--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -2298,7 +2298,7 @@ bool advanced_inventory::query_charges( aim_location destarea, const advanced_in
     // Inventory has a weight capacity, map and vehicle don't have that
     if( destarea == AIM_INVENTORY || destarea == AIM_WORN || destarea == AIM_WIELD ) {
         const units::mass unitweight = it.weight() / ( by_charges ? it.charges : 1 );
-        const units::mass max_weight = player_character.safe_weight_capacity() -
+        const units::mass max_weight = player_character.safe_carry_capacity() -
                                        player_character.weight_carried();
         if( unitweight > 0_gram && unitweight * amount > max_weight ) {
             const int weightmax = max_weight / unitweight;

--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -2298,7 +2298,7 @@ bool advanced_inventory::query_charges( aim_location destarea, const advanced_in
     // Inventory has a weight capacity, map and vehicle don't have that
     if( destarea == AIM_INVENTORY || destarea == AIM_WORN || destarea == AIM_WIELD ) {
         const units::mass unitweight = it.weight() / ( by_charges ? it.charges : 1 );
-        const units::mass max_weight = player_character.weight_capacity() * 4 -
+        const units::mass max_weight = player_character.safe_weight_capacity() -
                                        player_character.weight_carried();
         if( unitweight > 0_gram && unitweight * amount > max_weight ) {
             const int weightmax = max_weight / unitweight;

--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -2298,7 +2298,7 @@ bool advanced_inventory::query_charges( aim_location destarea, const advanced_in
     // Inventory has a weight capacity, map and vehicle don't have that
     if( destarea == AIM_INVENTORY || destarea == AIM_WORN || destarea == AIM_WIELD ) {
         const units::mass unitweight = it.weight() / ( by_charges ? it.charges : 1 );
-        const units::mass max_weight = player_character.safe_carry_capacity() -
+        const units::mass max_weight = player_character.max_pickup_capacity() -
                                        player_character.weight_carried();
         if( unitweight > 0_gram && unitweight * amount > max_weight ) {
             const int weightmax = max_weight / unitweight;

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -3377,7 +3377,7 @@ units::mass Character::weight_capacity() const
     return ret;
 }
 
-/* maximum you should ever be able to pick up ( e.g. with DANGEROUS_PICKUPS enabled) */
+/* maximum you should ever be able to pick up ( i.e. with DANGEROUS_PICKUPS enabled) */
 units::mass Character::max_pickup_capacity() const
 {
     return weight_capacity() * 4;

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -3377,7 +3377,6 @@ units::mass Character::weight_capacity() const
     return ret;
 }
 
-/* maximum you should ever be able to pick up ( i.e. with DANGEROUS_PICKUPS enabled) */
 units::mass Character::max_pickup_capacity() const
 {
     return weight_capacity() * 4;

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -3378,7 +3378,7 @@ units::mass Character::weight_capacity() const
 }
 
 /* Character can safely carry up to four times their maximum weight */
-units::mass Character::safe_weight_capacity() const
+units::mass Character::safe_carry_capacity() const
 {
     return weight_capacity() * 4;
 }
@@ -3416,7 +3416,7 @@ bool Character::can_pickVolume_partial( const item &it, bool, const item *avoid,
 bool Character::can_pickWeight( const item &it, bool safe ) const
 {
     if( !safe ) {
-        return ( weight_carried() + it.weight() <= safe_weight_capacity() );
+        return ( weight_carried() + it.weight() <= safe_carry_capacity() );
     } else {
         return ( weight_carried() + it.weight() <= weight_capacity() );
     }

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -3377,7 +3377,7 @@ units::mass Character::weight_capacity() const
     return ret;
 }
 
-/* Character can safely carry up to four times their maximum weight */
+/* maximum you should ever be able to pick up ( e.g. with DANGEROUS_PICKUPS enabled) */
 units::mass Character::max_pickup_capacity() const
 {
     return weight_capacity() * 4;
@@ -3420,11 +3420,6 @@ bool Character::can_pickWeight( const item &it, bool safe ) const
     } else {
         return ( weight_carried() + it.weight() <= weight_capacity() );
     }
-}
-
-bool Character::can_pickWeight( const item &it ) const
-{
-    return can_pickWeight( it, !who.is_avatar() || !get_option<bool>( "DANGEROUS_PICKUPS" ) );
 }
 
 bool Character::can_pickWeight_partial( const item &it, bool safe ) const

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -3377,6 +3377,12 @@ units::mass Character::weight_capacity() const
     return ret;
 }
 
+/* Character can safely carry up to four times their maximum weight */
+units::mass Character::safe_weight_capacity() const
+{
+    return weight_capacity() * 4;
+}
+
 bool Character::can_pickVolume( const item &it, bool, const item *avoid,
                                 const bool ignore_pkt_settings ) const
 {
@@ -3410,8 +3416,7 @@ bool Character::can_pickVolume_partial( const item &it, bool, const item *avoid,
 bool Character::can_pickWeight( const item &it, bool safe ) const
 {
     if( !safe ) {
-        // Character can carry up to four times their maximum weight
-        return ( weight_carried() + it.weight() <= weight_capacity() * 4 );
+        return ( weight_carried() + it.weight() <= safe_weight_capacity() );
     } else {
         return ( weight_carried() + it.weight() <= weight_capacity() );
     }

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -3378,7 +3378,7 @@ units::mass Character::weight_capacity() const
 }
 
 /* Character can safely carry up to four times their maximum weight */
-units::mass Character::safe_carry_capacity() const
+units::mass Character::max_pickup_capacity() const
 {
     return weight_capacity() * 4;
 }
@@ -3416,10 +3416,15 @@ bool Character::can_pickVolume_partial( const item &it, bool, const item *avoid,
 bool Character::can_pickWeight( const item &it, bool safe ) const
 {
     if( !safe ) {
-        return ( weight_carried() + it.weight() <= safe_carry_capacity() );
+        return ( weight_carried() + it.weight() <= max_pickup_capacity() );
     } else {
         return ( weight_carried() + it.weight() <= weight_capacity() );
     }
+}
+
+bool Character::can_pickWeight( const item &it ) const
+{
+    return can_pickWeight( it, !who.is_avatar() || !get_option<bool>( "DANGEROUS_PICKUPS" ) );
 }
 
 bool Character::can_pickWeight_partial( const item &it, bool safe ) const

--- a/src/character.h
+++ b/src/character.h
@@ -2277,6 +2277,8 @@ class Character : public Creature, public visitable
         units::volume volume_carried_with_tweaks( const std::vector<std::pair<item_location, int>>
                 &locations ) const;
         units::mass weight_capacity() const override;
+
+        /* maximum you should ever be able to pick up ( i.e. with DANGEROUS_PICKUPS enabled) */
         units::mass max_pickup_capacity() const;
         units::volume volume_capacity() const;
         units::volume volume_capacity_with_tweaks( const item_tweaks &tweaks ) const;

--- a/src/character.h
+++ b/src/character.h
@@ -2277,6 +2277,7 @@ class Character : public Creature, public visitable
         units::volume volume_carried_with_tweaks( const std::vector<std::pair<item_location, int>>
                 &locations ) const;
         units::mass weight_capacity() const override;
+        units::mass safe_weight_capacity() const;
         units::volume volume_capacity() const;
         units::volume volume_capacity_with_tweaks( const item_tweaks &tweaks ) const;
         units::volume volume_capacity_with_tweaks( const std::vector<std::pair<item_location, int>>

--- a/src/character.h
+++ b/src/character.h
@@ -2277,7 +2277,7 @@ class Character : public Creature, public visitable
         units::volume volume_carried_with_tweaks( const std::vector<std::pair<item_location, int>>
                 &locations ) const;
         units::mass weight_capacity() const override;
-        units::mass safe_weight_capacity() const;
+        units::mass safe_carry_capacity() const;
         units::volume volume_capacity() const;
         units::volume volume_capacity_with_tweaks( const item_tweaks &tweaks ) const;
         units::volume volume_capacity_with_tweaks( const std::vector<std::pair<item_location, int>>

--- a/src/character.h
+++ b/src/character.h
@@ -2277,7 +2277,7 @@ class Character : public Creature, public visitable
         units::volume volume_carried_with_tweaks( const std::vector<std::pair<item_location, int>>
                 &locations ) const;
         units::mass weight_capacity() const override;
-        units::mass safe_carry_capacity() const;
+        units::mass max_pickup_capacity() const;
         units::volume volume_capacity() const;
         units::volume volume_capacity_with_tweaks( const item_tweaks &tweaks ) const;
         units::volume volume_capacity_with_tweaks( const std::vector<std::pair<item_location, int>>

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -439,7 +439,7 @@ void suffer::from_addictions( Character &you )
 
 void suffer::while_awake( Character &you, const int current_stim )
 {
-    if( you.weight_carried() > 4 * you.weight_capacity() ) {
+    if( you.weight_carried() > you.safe_carry_capacity() ) {
         if( you.has_effect( effect_downed ) ) {
             you.add_effect( effect_downed, 1_turns, false, 0, true );
         } else {

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -439,7 +439,7 @@ void suffer::from_addictions( Character &you )
 
 void suffer::while_awake( Character &you, const int current_stim )
 {
-    if( you.weight_carried() > you.safe_carry_capacity() ) {
+    if( you.weight_carried() > you.max_pickup_capacity() ) {
         if( you.has_effect( effect_downed ) ) {
             you.add_effect( effect_downed, 1_turns, false, 0, true );
         } else {


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
While working on #8000 I found a magic number that was not explained. if you have more then `4 * carry_capacity()`, you cannot pick up any more items (with dangerous pickups turned on).
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
make a function explaining it.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
is there a particular reason for it to be 4 * carry capacity? should there be other factors?
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Im very tempted to slightly rework Character::can_pickWeight
https://github.com/CleverRaven/Cataclysm-DDA/blob/54063aabc6387898f00745e03c7b8a7ad0151f16/src/character.cpp#L3410-L3418
as the only reason safe is ever false, is when get_option<bool>( "DANGEROUS_PICKUPS" ) is enabled. Only exception being 
https://github.com/CleverRaven/Cataclysm-DDA/blob/54063aabc6387898f00745e03c7b8a7ad0151f16/src/pickup.cpp#L247 
where it ignores it for some reason and some cases where it checks the option, even for character (potential npc) pickups where i believe it doesnt belong.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
