### PR TITLE
Candy Butchery update

### DIFF
--- a/data/mods/My_Sweet_Cataclysm/sweet_comestibles.json
+++ b/data/mods/My_Sweet_Cataclysm/sweet_comestibles.json
@@ -209,5 +209,27 @@
     "container": "null",
     "color": "red",
     "description": "A swirly confectionary treat in strings of sweet tasting candy.  You think you've seen them wriggle a bit.  How strange…"
+  },
+  {
+    "type": "COMESTIBLE",
+    "id": "blood_chocolate",
+    "name": { "str_sp": "chocolate ichor" },
+    "comestible_type": "DRINK",
+    "spoils_in": "1 day",
+    "symbol": "~",
+    "color": "brown",
+    "quench": 50,
+    "healthy": -1,
+    "calories": 200,
+    "description": "Ichor harvested from the corpse of a chocolate cow. Quite sweet and... oddly warm?",
+    "price": "20 cent",
+    "price_postapoc": "50 cent",
+    "material": [ "junk" ],
+    "volume": "250 ml",
+    "weight": "260 g",
+    "charges": 1,
+    "phase": "liquid",
+    "fun": -1,
+    "//": "will be used for chocolate-branched additions later on. currently only from cows, will be added from additional chocolate monsters."
   }
 ]

--- a/data/mods/My_Sweet_Cataclysm/sweet_comestibles.json
+++ b/data/mods/My_Sweet_Cataclysm/sweet_comestibles.json
@@ -221,7 +221,7 @@
     "quench": 50,
     "healthy": -1,
     "calories": 200,
-    "description": "Ichor harvested from the corpse of a chocolate cow. Quite sweet and… oddly warm?",
+    "description": "Ichor harvested from the corpse of a chocolate cow.  Quite sweet and… oddly warm?",
     "price": "20 cent",
     "price_postapoc": "50 cent",
     "material": [ "junk" ],

--- a/data/mods/My_Sweet_Cataclysm/sweet_comestibles.json
+++ b/data/mods/My_Sweet_Cataclysm/sweet_comestibles.json
@@ -221,7 +221,7 @@
     "quench": 50,
     "healthy": -1,
     "calories": 200,
-    "description": "Ichor harvested from the corpse of a chocolate cow. Quite sweet and... oddly warm?",
+    "description": "Ichor harvested from the corpse of a chocolate cow. Quite sweet and… oddly warm?",
     "price": "20 cent",
     "price_postapoc": "50 cent",
     "material": [ "junk" ],

--- a/data/mods/My_Sweet_Cataclysm/sweet_comestibles.json
+++ b/data/mods/My_Sweet_Cataclysm/sweet_comestibles.json
@@ -209,27 +209,5 @@
     "container": "null",
     "color": "red",
     "description": "A swirly confectionary treat in strings of sweet tasting candy.  You think you've seen them wriggle a bit.  How strange…"
-  },
-  {
-    "type": "COMESTIBLE",
-    "id": "blood_chocolate",
-    "name": { "str_sp": "chocolate ichor" },
-    "comestible_type": "DRINK",
-    "spoils_in": "1 day",
-    "symbol": "~",
-    "color": "brown",
-    "quench": 50,
-    "healthy": -1,
-    "calories": 200,
-    "description": "Ichor harvested from the corpse of a chocolate cow. Quite sweet and… oddly warm?",
-    "price": "20 cent",
-    "price_postapoc": "50 cent",
-    "material": [ "junk" ],
-    "volume": "250 ml",
-    "weight": "260 g",
-    "charges": 1,
-    "phase": "liquid",
-    "fun": -1,
-    "//": "will be used for chocolate-branched additions later on. currently only from cows, will be added from additional chocolate monsters."
   }
 ]

--- a/data/mods/My_Sweet_Cataclysm/sweet_flesh.json
+++ b/data/mods/My_Sweet_Cataclysm/sweet_flesh.json
@@ -157,7 +157,7 @@
     "comestible_type": "FOOD",
     "symbol": "%",
     "calories": 287,
-    "description": "A chunk chocolate meat, still dripping with liquid chocolate.",
+    "description": "A chunk of chocolate meat, still dripping with liquid chocolate.",
     "price_postapoc": "4 USD",
     "material": [ "junk" ],
     "volume": "250 ml",

--- a/data/mods/My_Sweet_Cataclysm/sweet_flesh.json
+++ b/data/mods/My_Sweet_Cataclysm/sweet_flesh.json
@@ -197,7 +197,7 @@
     "quench": 50,
     "healthy": -1,
     "calories": 200,
-    "description": "Ichor harvested from the corpse of a chocolate cow. Quite bitter and… oddly warm?",
+    "description": "Ichor harvested from the corpse of a chocolate cow.  Quite bitter and… oddly warm?",
     "price": "20 cent",
     "price_postapoc": "50 cent",
     "material": [ "junk" ],

--- a/data/mods/My_Sweet_Cataclysm/sweet_flesh.json
+++ b/data/mods/My_Sweet_Cataclysm/sweet_flesh.json
@@ -185,5 +185,27 @@
     "fun": 7,
     "flags": [ "EDIBLE_FROZEN" ],
     "vitamins": [ [ "junk_allergen", 1 ] ]
+  },
+  {
+    "type": "COMESTIBLE",
+    "id": "blood_chocolate",
+    "name": { "str_sp": "chocolate ichor" },
+    "comestible_type": "DRINK",
+    "spoils_in": "1 day",
+    "symbol": "~",
+    "color": "brown",
+    "quench": 50,
+    "healthy": -1,
+    "calories": 200,
+    "description": "Ichor harvested from the corpse of a chocolate cow. Quite sweet and… oddly warm?",
+    "price": "20 cent",
+    "price_postapoc": "50 cent",
+    "material": [ "junk" ],
+    "volume": "250 ml",
+    "weight": "260 g",
+    "charges": 1,
+    "phase": "liquid",
+    "fun": -1,
+    "//": "will be used for chocolate-branched additions later on. currently only from cows, will be added from additional chocolate monsters."
   }
 ]

--- a/data/mods/My_Sweet_Cataclysm/sweet_flesh.json
+++ b/data/mods/My_Sweet_Cataclysm/sweet_flesh.json
@@ -197,7 +197,7 @@
     "quench": 50,
     "healthy": -1,
     "calories": 200,
-    "description": "Ichor harvested from the corpse of a chocolate cow. Quite sweet and… oddly warm?",
+    "description": "Ichor harvested from the corpse of a chocolate cow. Quite bitter and… oddly warm?",
     "price": "20 cent",
     "price_postapoc": "50 cent",
     "material": [ "junk" ],

--- a/data/mods/My_Sweet_Cataclysm/sweet_harvest.json
+++ b/data/mods/My_Sweet_Cataclysm/sweet_harvest.json
@@ -3,19 +3,32 @@
     "id": "marshmallow_boy",
     "type": "harvest",
     "leftovers": "ruined_candy",
-    "entries": [ { "drop": "marshmallow_flesh", "type": "flesh", "mass_ratio": 0.7 } ]
+    "entries": [
+      { "drop": "marshmallow_flesh", "type": "flesh", "mass_ratio": 0.7 },
+      { "drop": "bone_sugar", "type": "bone", "mass_ratio": 0.15 },
+      { "drop": "syrup_corn", "type": "blood", "mass_ratio": 0.05 }
+    ]
   },
   {
     "id": "armored_marshmallow_boy",
     "type": "harvest",
     "leftovers": "ruined_candy",
-    "entries": [ { "drop": "smores_flesh", "type": "flesh", "mass_ratio": 0.7 } ]
+    "entries": [
+      { "drop": "smores_flesh", "type": "flesh", "mass_ratio": 0.65 },
+      { "drop": "bone_sugar", "type": "bone", "mass_ratio": 0.15 },
+      { "drop": "syrup_corn", "type": "blood", "mass_ratio": 0.05 },
+      { "drop": "grahmcrackers_shell", "type": "skin", "mass_ratio": 0.05 }
+    ]
   },
   {
     "id": "gummy_bear",
     "type": "harvest",
     "leftovers": "ruined_candy",
-    "entries": [ { "drop": "candy3_flesh", "type": "flesh", "mass_ratio": 0.7 } ]
+    "entries": [
+      { "drop": "candy3_flesh", "type": "flesh", "mass_ratio": 0.7 },
+      { "drop": "bone_sugar", "type": "bone", "mass_ratio": 0.15 },
+      { "drop": "syrup_corn", "type": "blood", "mass_ratio": 0.05 }
+    ]
   },
   {
     "id": "cracker_boy",
@@ -45,13 +58,21 @@
     "id": "choc_cows",
     "type": "harvest",
     "message": "As you butcher the chocolate corpse, you break the large pieces of flesh down into more manageable chunks.",
-    "entries": [ { "drop": "cow_candy_flesh", "type": "flesh", "mass_ratio": 0.7 } ]
+    "entries": [
+      { "drop": "cow_candy_flesh", "type": "flesh", "mass_ratio": 0.7 },
+      { "drop": "bone_sugar", "type": "bone", "mass_ratio": 0.15 },
+      { "drop": "blood_chocolate", "type": "blood", "mass_ratio": 0.05 }
+    ]
   },
   {
     "id": "licorice_snake",
     "type": "harvest",
     "leftovers": "ruined_candy",
     "message": "You carefully open the snake to extract the sweet fillets.",
-    "entries": [ { "drop": "licorice_flesh", "type": "flesh", "mass_ratio": 0.7 } ]
+    "entries": [
+      { "drop": "licorice_flesh", "type": "flesh", "mass_ratio": 0.7 },
+      { "drop": "bone_sugar", "type": "bone", "mass_ratio": 0.05 },
+      { "drop": "syrup_corn", "type": "blood", "mass_ratio": 0.05 }
+    ]
   }
 ]

--- a/data/mods/My_Sweet_Cataclysm/sweet_items.json
+++ b/data/mods/My_Sweet_Cataclysm/sweet_items.json
@@ -74,7 +74,7 @@
     "comestible_type": "FOOD",
     "id": "bone_sugar",
     "name": { "str_sp": "sugar bone" },
-    "description": "A large bone, made entirely up of super-compressed sugar. Way too hard to be eaten directly, but it can be broken down into sugar.",
+    "description": "A large bone, made entirely up of super-compressed sugar.  Way too hard to be eaten directly, but it can be broken down into sugar.",
     "weight": "508 g",
     "volume": "320 ml",
     "//": "values based off of sucrose's density and our 'bone' item",

--- a/data/mods/My_Sweet_Cataclysm/sweet_items.json
+++ b/data/mods/My_Sweet_Cataclysm/sweet_items.json
@@ -74,7 +74,7 @@
     "comestible_type": "FOOD",
     "id": "bone_sugar",
     "name": { "str_sp": "sugar bone" },
-    "description": "A large bone, made entirely up of super-compressed sugar.  Way too hard to be eaten directly, but it can be broken down into sugar.",
+    "description": "A large bone, made entirely of super-compressed sugar.  Way too hard to be eaten directly, but it can be broken down into sugar.",
     "weight": "508 g",
     "volume": "320 ml",
     "//": "values based off of sucrose's density and our 'bone' item",

--- a/data/mods/My_Sweet_Cataclysm/sweet_items.json
+++ b/data/mods/My_Sweet_Cataclysm/sweet_items.json
@@ -68,5 +68,21 @@
     "description": "Sweet, sweet sugar.  Bad for your teeth and surprisingly not very tasty on its own.",
     "material": [ "junk" ],
     "vitamins": [ [ "junk_allergen", 1 ] ]
+  },
+  {
+    "type": "COMESTIBLE",
+    "comestible_type": "FOOD",
+    "id": "bone_sugar",
+    "name": { "str_sp": "sugar bone" },
+    "description": "A large bone, made entirely up of super-compressed sugar. Way too hard to be eaten directly, but it can be broken down into sugar.",
+    "weight": "508 g",
+    "volume": "320 ml",
+    "//": "values based off of sucrose's density and our 'bone' item",
+    "symbol": "I",
+    "price": "0 cent",
+    "price_postapoc": "20 cent",
+    "color": "white",
+    "material": [ "rock_candy" ],
+    "flags": [ "INEDIBLE" ]
   }
 ]

--- a/data/mods/My_Sweet_Cataclysm/sweet_monsters.json
+++ b/data/mods/My_Sweet_Cataclysm/sweet_monsters.json
@@ -184,6 +184,7 @@
     "copy-from": "mon_marshmallow_goliath",
     "symbol": "M",
     "color": "brown_magenta",
+    "harvest": "armored_marshmallow_boy",
     "reproduction": { "baby_type": { "baby_egg": "smores" }, "baby_count": 10, "baby_timer": 10 },
     "armor": { "bash": 9, "cut": 11, "bullet": 9 }
   },

--- a/data/mods/My_Sweet_Cataclysm/sweet_recipe.json
+++ b/data/mods/My_Sweet_Cataclysm/sweet_recipe.json
@@ -43,5 +43,22 @@
     "tools": [ [ [ "dehydrator", 25 ], [ "char_smoker", 25 ] ] ],
     "components": [ [ [ "milk_choc", 1 ] ] ],
     "charges": 4
+  },
+  {
+    "type": "recipe",
+    "result": "sugar",
+    "id_suffix": "bone_smash",
+    "activity_level": "MODERATE_EXERCISE",
+    "charges": 100,
+    "//": "quite a lot of sugar is scattered when you bash the bones apart",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_OTHER",
+    "skill_used": "cooking",
+    "difficulty": 0,
+    "time": "30 m",
+    "autolearn": true,
+    "batch_time_factors": [ 95, 2 ],
+    "qualities": [ { "id": "HAMMER", "level": 1 } ],
+    "components": [ [ [ "bone_sugar", 1 ] ] ]
   }
 ]


### PR DESCRIPTION


<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "Updates candy butchery from MSC"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

I want to do some work with My Sweet Cataclysm: here's the start.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

This adds sugar bones & chocolate ichor. This adds these items to the appropriate butchering group - marshmallows, gummies, licorice and chocolates get bones, chocolates get ichor. Marshmallows and gummies now have corn syrup as a "blood" butchery result. Chocolate cows use the resulting chocolate ichor as their "blood" for butchery. Sugar bones can be broken down - 1 bone gives you 100 pieces of sugar. Armored marshmallows now also include graham cracker shells as a part of their butchery, under the "skin" field.

I also want to add more breakdown recipes - the flesh into their smaller parts (smores, marshmallows, chocolate bars etc) so they can interact with other recipes that involve them. 

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

not touch MSC

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

Spawn in a marshmallow, a gummy bear, a chocolate cow and obliterate them. Butcher them, see expected butchery products, cheer. Use a candy bone to make sugar. Sugar is made, cheer. 
#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
