### PR TITLE
Prevent characters from lowering movecost below 1

### DIFF
--- a/data/mods/TEST_DATA/mutations.json
+++ b/data/mods/TEST_DATA/mutations.json
@@ -443,5 +443,18 @@
     "points": 1,
     "description": "You see exactly 3 overmap afar (smallest value).",
     "enchantments": [ { "values": [ { "value": "OVERMAP_SIGHT", "add": -10 } ] } ]
+  },
+  {
+    "type": "mutation",
+    "id": "200_MOVE_COST_REDUCTION",
+    "name": { "str": "Debug 200% move cost reduction" },
+    "points": 0,
+    "vitamin_cost": 210,
+    "visibility": 8,
+    "ugliness": 4,
+    "mixed_effect": true,
+    "description": "",
+    "types": [ "LEGS", "FEET", "SOLES" ],
+    "enchantments": [ { "values": [ { "value": "MOVE_COST", "multiply": -2.0 } ] } ]
   }
 ]

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -10501,6 +10501,9 @@ std::vector<run_cost_effect> Character::run_cost_effects( float &movecost ) cons
                              _( "Downed" ) );
     }
 
+    // minimum possible movecost is 1, no infinispeed
+    movecost = std::max( 1.0f, movecost );
+
     return effects;
 }
 

--- a/tests/move_cost_test.cpp
+++ b/tests/move_cost_test.cpp
@@ -52,6 +52,7 @@ static const move_mode_id move_mode_walk( "walk" );
 static const ter_str_id ter_t_grass( "t_grass" );
 static const ter_str_id ter_t_pavement( "t_pavement" );
 
+static const trait_id trait_200_MOVE_COST_REDUCTION( "200_MOVE_COST_REDUCTION" );
 static const trait_id trait_HOOVES( "HOOVES" );
 static const trait_id trait_LEG_TENTACLES( "LEG_TENTACLES" );
 static const trait_id trait_TOUGH_FEET( "TOUGH_FEET" );
@@ -188,6 +189,14 @@ TEST_CASE( "mutations_may_affect_movement_cost", "[move_cost][mutation]" )
         THEN( "being barefoot gives a +16 movement cost penalty" ) {
             ava.clear_worn();
             CHECK( ava.run_cost( 100 ) == Approx( base_cost + 16 ) );
+        }
+    }
+
+    GIVEN( "infinite movecost reduction from enchantments" ) {
+        ava.toggle_trait( trait_200_MOVE_COST_REDUCTION );
+        THEN( "there is still a minimum cost" ) {
+            ava.clear_worn();
+            CHECK( ava.run_cost( 100 ) > 0 );
         }
     }
 


### PR DESCRIPTION
#### Summary
Bugfixes "Movecost can never be 0 or negative"

#### Purpose of change
MoM is once again stress testing the game and has managed to get people with -1 move cost. This absolutely breaks many of the game's core assumptions.

#### Describe the solution
Lock it down. Cap move cost at 1 and add a section to our tests to make sure this stays working.

#### Describe alternatives you've considered


#### Testing
I am relying on CI runs here. I have not tried this ingame.

I am unsure how the UI handles it, if it properly reports the movecost as being locked at 1 or if it would continue to show negative move costs.

#### Additional context
