### PR TITLE
Remove how-to instructions on cheating

### DIFF
--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -2896,7 +2896,7 @@
   },
   {
     "type": "keybinding",
-    "name": "Developer debug menu",
+    "name": "Debug menu",
     "category": "DEFAULTMODE",
     "id": "debug"
   },

--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -2896,7 +2896,7 @@
   },
   {
     "type": "keybinding",
-    "name": "Debug menu",
+    "name": "Developer debug menu",
     "category": "DEFAULTMODE",
     "id": "debug"
   },

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -3903,15 +3903,7 @@ void debug()
     const bool should_disable_achievements = action && !is_debug_character() &&
             !non_cheaty_options.count( *action );
     if( should_disable_achievements && achievements.is_enabled() ) {
-        static const std::string query(
-            translate_marker(
-                "Using this will disable achievements.  Proceed?"
-                "\nThey can be reenabled in the 'game' section of the menu." ) );
-        if( query_yn( _( query ) ) ) {
-            achievements.set_enabled( false );
-        } else {
-            action = std::nullopt;
-        }
+        achievements.set_enabled( false );
     }
 
     if( !action ) {

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -3903,6 +3903,7 @@ void debug()
     const bool should_disable_achievements = action && !is_debug_character() &&
             !non_cheaty_options.count( *action );
     if( should_disable_achievements && achievements.is_enabled() ) {
+        add_msg( m_mixed, _( "Achievements have been disabled." ) );
         achievements.set_enabled( false );
     }
 

--- a/src/scores_ui.cpp
+++ b/src/scores_ui.cpp
@@ -191,14 +191,7 @@ void scores_ui_impl::init_data()
 void scores_ui_impl::draw_achievements_text( bool use_conducts ) const
 {
     if( !g->achievements().is_enabled() ) {
-        ImGui::TextWrapped( "%s",
-                            use_conducts
-                            ? _( "Conducts are disabled, probably due to use of the debug menu.  If you only used "
-                                 "the debug menu to work around a game bug, then you can re-enable conducts via the "
-                                 "debug menu (\"Enable achievements\" under the \"Game\" submenu)." )
-                            : _( "Achievements are disabled, probably due to use of the debug menu.  If you only used "
-                                 "the debug menu to work around a game bug, then you can re-enable achievements via the "
-                                 "debug menu (\"Enable achievements\" under the \"Game\" submenu)." ) );
+        ImGui::TextWrapped( "%s", _( "Achievements and conducts are disabled for debug characters." ) );
         return;
     }
     if( use_conducts && conducts_text.empty() ) {


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
I use the debug menu extensively. Because of the nature of debugging, this often involves using it with fresh characters. Each of which must mandatorily accept a bunch of how-to instructions on cheating the game. This is absurd, and gets in the way of debugging.


#### Describe the solution
Remove the instructions on cheating.

This does not prevent players from cheating, or "cheating", or using the debug menu in any way. It just throws away the instructions on how to *cheat* with it. It is 100% not intended for players to use the debug menu, so presenting it as if they should is just plain wrong.

Also renamed the binding from "Debug menu" to "Developer debug menu" to further clarify its use.

#### Describe alternatives you've considered


#### Testing
New character did not receive a query_yn when using the debug menu. Achievements menu showed the updated text, since achievements had been silently disabled.

#### Additional context
