### PR TITLE
fix typo in labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -256,7 +256,7 @@
 "Mods: Magiclysm":
   - data/mods/Magiclysm/**/*
 
-"My Sweet Cataclysm 🍬"
+"My Sweet Cataclysm 🍬":
   - data/mods/My_Sweet_Cataclysm/**/*
 
 "Mods: Innawood 🌲":


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Labeler is borked because of a typo in #80324
#### Describe the solution
fix the typo