### PR TITLE
Spells can parse tags now

### DIFF
--- a/doc/JSON/EFFECT_ON_CONDITION.md
+++ b/doc/JSON/EFFECT_ON_CONDITION.md
@@ -66,7 +66,8 @@ For example, `{ "npc_has_effect": "Shadow_Reveal" }`, used by shadow lieutenant,
 | Use computer                                     | player (Avatar)             | computer (Furniture)        |
 | furniture: "examine_action"                      | player (Avatar)             | NONE                        | `this`, string, furniture id; `pos`; string, coordinates of the furniture
 | furniture: "mortar"                              | player (Avatar)             | NONE                        | `this`, string, furniture id; `pos`; string, coordinates of the furniture; `target`, string, coordinates of picked tile
-| SPELL: "effect": "effect_on_condition"           | target (Character, Monster) | spell caster (Character, Monster) | `spell_location`, location variable, location of target for use primarily when the target isn't a creature
+| spell: "effect": "effect_on_condition"           | target (Character, Monster) | spell caster (Character, Monster) | `spell_location`, location variable, location of target for use primarily when the target isn't a creature
+| spell: "description"                             | avatar                      | avatar                      | Used for tags
 | trap: "action": "eocs"                           | triggerer (Creature, item not supported yet) | NONE | `trap_location`, location variable, location of the trap to use primarily with ranged traps
 | monster_attack: "eoc"                            | attacker ( Monster)         | victim (Creature)           | `damage`, int, damage dealt by attack
 | use_action: "type": "effect_on_conditions"       | user (Character)            | item (item)                 | `id`, string, stores item id

--- a/doc/JSON/MAGIC.md
+++ b/doc/JSON/MAGIC.md
@@ -49,7 +49,7 @@ In `data/mods/Magiclysm` there is a template spell, copied here for your perusal
     "id": "example_template",                                 // id of the spell, used internally. not translated
     "type": "SPELL",
     "name": "Template Spell",                                 // name of the spell that shows in game
-    "description": "This is a template to show off all the available values",
+    "description": "This is a template to show off all the available values", // Description of the spell. Supports color tags and dialogue variables (both alpha and beta are evaluated as avatar)
     "valid_targets": [ "hostile", "ground", "self", "ally" ], // if a valid target is not included, you cannot cast the spell on that target.
     "effect": "shallow_pit",                                  // effects are coded in C++. A list will be provided below of possible effects that have been coded.
     "effect_str": "template",                                 // special. see below

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -2873,7 +2873,9 @@ void spellcasting_callback::display_spell_info( size_t index )
     cataimgui::set_scroll( spell_info_scroll );
     ImGui::TextColored( c_yellow, "%s", sp.spell_class() == trait_NONE ? _( "Classless" ) :
                         sp.spell_class()->name().c_str() );
-    std::vector<std::string> lines = string_split( sp.description(), '\n' );
+    std::string desc = sp.description();
+    parse_tags( desc, *get_avatar().as_character(), *get_avatar().as_character() );
+    std::vector<std::string> lines = string_split( desc, '\n' );
     for( std::string &l : lines ) {
         cataimgui::TextColoredParagraph( c_white, l );
         ImGui::NewLine();


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Json variables power
#### Describe the solution
Instead of using string directly, parse it's tags first
#### Testing
Before:
![image](https://github.com/user-attachments/assets/7acc85e5-ab5e-4614-8585-8a66536bb2e6)
After:
![image](https://github.com/user-attachments/assets/626f0b58-4e59-4905-8aee-a338464b049c)
![image](https://github.com/user-attachments/assets/b2b607e2-8552-4000-81f4-8e1dfb155e59)
#### Additional context
It's nice to have a feature made in 3 lines