### PR TITLE
[XE] Adds a special boss encounter for tier 5 vampires

### DIFF
--- a/data/mods/Xedra_Evolved/effects/effects.json
+++ b/data/mods/Xedra_Evolved/effects/effects.json
@@ -3287,5 +3287,49 @@
     ],
     "rating": "bad",
     "flags": [ "EFFECT_LIMB_SCORE_MOD" ]
+  },
+  {
+    "type": "effect_type",
+    "id": "effect_anathema_resilience",
+    "//": "As per the vampire power, but includes the fire vulnerability as it is a multiplier, not an absolute.  It also includes the effects of flow like blood.",
+    "blocks_effects": [ "grabbed" ],
+    "name": [ "" ],
+    "desc": [ "" ],
+    "base_mods": { "dodge_mod": [ 15 ] },
+    "enchantments": [
+      {
+        "incoming_damage_mod": [
+          { "type": "bash", "multiply": -0.66 },
+          { "type": "stab", "multiply": -0.25 },
+          { "type": "cut", "multiply": -0.33 },
+          { "type": "bullet", "multiply": -0.85 },
+          { "type": "heat", "multiply": 3 }
+        ]
+      },
+      {
+        "values": [ { "value": "EVASION", "add": 0.7 }, { "value": "DODGE_CHANCE", "add": 15 }, { "value": "BONUS_DODGE", "add": 2 } ]
+      },
+      { "hit_me_effect": [ { "id": "VAMPIRE_ANATHEMA_REACT_TO_HIT", "hit_self": true } ] }
+    ]
+  },
+  {
+    "type": "effect_type",
+    "id": "effect_anathema_battle_started",
+    "//": "From 60 speed to a tier 5's base speed.",
+    "//2": "This isn't a power, just them taking you a little more seriously as you managed to injure them.",
+    "//3": "These two are effects, so they are retained even when the Anathema regains hp unlike the enchantments.",
+    "name": [ "" ],
+    "desc": [ "" ],
+    "enchantments": [ { "values": [ { "value": "SPEED", "add": 125 } ] } ]
+  },
+  {
+    "type": "effect_type",
+    "id": "effect_anathema_final_form",
+    "//": "From a tier 5's base speed to a total of 653 speed, and ensures it can it players benefitting from flow like blood.",
+    "name": [ "Hasted by shadows" ],
+    "desc": [ "The Anathema is much quicker now thanks to vampiric abilities" ],
+    "show_in_info": true,
+    "base_mods": { "hit_mod": [ 50 ], "dodge_mod": [ 20 ] },
+    "enchantments": [ { "values": [ { "value": "SPEED", "add": 468 } ] } ]
   }
 ]

--- a/data/mods/Xedra_Evolved/effects/effects.json
+++ b/data/mods/Xedra_Evolved/effects/effects.json
@@ -3316,8 +3316,7 @@
     "type": "effect_type",
     "id": "effect_anathema_battle_started",
     "//": "From 60 speed to a tier 5's base speed.",
-    "//2": "This isn't a power, just them taking you a little more seriously as you managed to injure them.",
-    "//3": "These two are effects, so they are retained even when the Anathema regains hp unlike the enchantments.",
+    "//2": "This isn't a vampire power, just them taking you a little more seriously as you managed to injure them.",
     "name": [ "" ],
     "desc": [ "" ],
     "enchantments": [ { "values": [ { "value": "SPEED", "add": 125 } ] } ]
@@ -3325,7 +3324,7 @@
   {
     "type": "effect_type",
     "id": "effect_anathema_final_form",
-    "//": "From a tier 5's base speed to a total of 653 speed, and ensures it can it players benefitting from flow like blood.",
+    "//": "From a tier 5's base speed to a total of 653 speed, and ensures it can hit players benefitting from flow like blood.",
     "name": [ "Hasted by shadows" ],
     "desc": [ "The Anathema is much quicker now thanks to vampiric abilities" ],
     "show_in_info": true,

--- a/data/mods/Xedra_Evolved/itemgroups/monster_drops.json
+++ b/data/mods/Xedra_Evolved/itemgroups/monster_drops.json
@@ -593,5 +593,22 @@
       { "item": "dress_shoes" },
       { "item": "union_suit" }
     ]
+  },
+  {
+    "id": "vampire_anathema_death_drops",
+    "type": "item_group",
+    "subtype": "collection",
+    "entries": [
+      { "item": "vampire_anathema_book" },
+      { "item": "blood_camel" },
+      { "item": "salamagman_battleaxe" },
+      { "item": "hc_helm_close", "damage": [ 1, 4 ] },
+      { "item": "armor_hc_plate", "damage": [ 1, 4 ] },
+      { "item": "gloves_plate", "damage": [ 1, 4 ] },
+      { "item": "pants", "variant": "pants_black", "damage": [ 1, 4 ] },
+      { "item": "tshirt", "variant": "generic_tshirt", "damage": [ 1, 4 ] },
+      { "group": "underwear", "damage": [ 1, 4 ] },
+      { "item": "boots_plate", "damage": [ 1, 4 ] }
+    ]
   }
 ]

--- a/data/mods/Xedra_Evolved/items/book_lore.json
+++ b/data/mods/Xedra_Evolved/items/book_lore.json
@@ -262,5 +262,38 @@
     "flags": [ "TRADER_AVOID" ],
     "weight": "30 g",
     "volume": "10 ml"
+  },
+  {
+    "id": "vampire_anathema_book",
+    "type": "TOOL",
+    "name": { "str_sp": "old leather-bound journal" },
+    "description": "This handwritten book contains the detailed yet disorganized notes of a vampire who found how to consume other vampires for power.  Reading it might tell you how to do it, if it is what you want.",
+    "//": "As it is a unique item acquired in violent circumstances, I made it fireproof so the player can use fire without fearing the lost of this item.",
+    "weight": "830 g",
+    "volume": "1320 ml",
+    "price": "1 USD",
+    "material": [ "paper_fireproof" ],
+    "looks_like": "cookbook",
+    "symbol": "?",
+    "color": "dark_gray",
+    "use_action": {
+      "type": "effect_on_conditions",
+      "description": "Read the book.",
+      "effect_on_conditions": [ "TALK_READ_VAMPIRE_ANATHEMA_BOOK" ]
+    }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "TALK_READ_VAMPIRE_ANATHEMA_BOOK",
+    "effect": [
+      { "open_dialogue": { "topic": "TALK_READ_VAMPIRE_ANATHEMA_BOOK" } },
+      { "run_eocs": "EOC_LEARN_FROM_VAMPIRE_ANATHEMA_BOOK" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_LEARN_FROM_VAMPIRE_ANATHEMA_BOOK",
+    "condition": { "not": { "compare_string": [ "yes", { "u_val": "you_know_vampire_anathema_recipe" } ] } },
+    "effect": [  ]
   }
 ]

--- a/data/mods/Xedra_Evolved/material.json
+++ b/data/mods/Xedra_Evolved/material.json
@@ -304,5 +304,23 @@
     "copy-from": "fruit",
     "//": "Identical to regular fruit matter but 10 times as light.",
     "density": 0.11
+  },
+  {
+    "type": "material",
+    "id": "paper_fireproof",
+    "name": "Fireproof Paper",
+    "//": "Identical to regular paper but cannot be burned.  Using delete hasn't worked, so I wrote the entire paper material here.",
+    "density": 1.2,
+    "specific_heat_liquid": 1.34,
+    "specific_heat_solid": 1.34,
+    "latent_heat": 1,
+    "soft": true,
+    "chip_resist": 0,
+    "repaired_with": "paper",
+    "salvaged_into": "paper",
+    "dmg_adj": [ "ripped", "torn", "shredded", "tattered" ],
+    "bash_dmg_verb": "ripped",
+    "cut_dmg_verb": "cut",
+    "resist": { "bash": 1, "cut": 1, "acid": 1, "heat": 999, "bullet": 1 }
   }
 ]

--- a/data/mods/Xedra_Evolved/monsters/anathema.json
+++ b/data/mods/Xedra_Evolved/monsters/anathema.json
@@ -542,7 +542,7 @@
       "You have a passing thought about standing in unblocked sunlight, and how you would be safer in it than you currently are here.",
       "Someone is coming to kill you.  You can feel them knowing where you are, waiting for the right moment to strike.",
       "You are filled with the fear that a vampire will soon drink you dry.  You know that vampire blood is inedible to vampires, but you're still unsettled.",
-      "For a moment, the darkness doesn't feel like home.  It feels like a slautherhouse, and you're next in line to be killed."
+      "For a moment, the darkness doesn't feel like home.  It feels like a slaughterhouse, and you're next in line to be killed."
     ]
   }
 ]

--- a/data/mods/Xedra_Evolved/monsters/anathema.json
+++ b/data/mods/Xedra_Evolved/monsters/anathema.json
@@ -1,0 +1,548 @@
+[
+  {
+    "id": "mon_vampire_anathema",
+    "//": "A special encounter for tier 5 vampires, dropping the means to become more vampire than vampires.",
+    "//2": "They start slow, as they are too arrogant to go for a quick kill.  This is why they only have the resilience and anti-bleed powers active until hit and that they are this slow.",
+    "//3": "When hit, their speed increases for the rest of the encounter.  They mainly use their axe to fight, but they also have healing abilities and will activate blood haste and shape of the shadowed path when below half health.",
+    "//4": "Intended to be incredibly hard to fight head-on, but manageable with proper planning.",
+    "//5": "An anathema to both vampires and hunters, they will attack or be attacked by mostly everything.",
+    "//6": "They are considered as having every single regular vampire weaknesses except for the need for living blood and picky feeding.",
+    "//7": "They do not appear for non-tier-5 vampires, as their focus is gaining power through vampire blood to be better at killing vampires.  Only tier 5 vampires can encounter them.  Should enough vampire hunter content be added, hunting it down as a non-vampire could be a possibility.  Doing such will only need a description rewrite to remove the mentions about the player being a vampire.",
+    "type": "MONSTER",
+    "name": { "str_sp": "Vampiric Anathema" },
+    "description": "Your instincts are telling you three things about this armored, axe-wielding humanoid foe: they are a vampire far more powerful than you, they thirst for your blood, and they are a vampire hunter wanting all vampires dead.  You know for certain that you will be quickly killed if you attack them without a proper plan.",
+    "default_faction": "vampire_anathema",
+    "bodytype": "human",
+    "species": [ "VAMPIRE_ANATHEMA" ],
+    "material": [ "flesh" ],
+    "harvest": "vampire",
+    "diff": 500,
+    "volume": "108500 ml",
+    "weight": "100 kg",
+    "hp": 200,
+    "speed": 60,
+    "symbol": "@",
+    "color": "red",
+    "scents_tracked": [ "sc_human", "sc_vampire" ],
+    "regenerates_in_dark": true,
+    "aggression": 100,
+    "morale": 300,
+    "melee_skill": 10,
+    "melee_dice": 7,
+    "melee_dice_sides": 9,
+    "dodge": 5,
+    "bleed_rate": 0,
+    "vision_day": 5,
+    "vision_night": 85,
+    "melee_training_cap": 0,
+    "path_settings": {
+      "max_dist": 45,
+      "allow_open_doors": true,
+      "avoid_traps": true,
+      "avoid_dangerous_fields": true,
+      "avoid_sharp": true,
+      "allow_climb_stairs": true
+    },
+    "special_attacks": [
+      { "id": "salamagman_battleaxe", "cooldown": 1 },
+      { "id": "BIO_OP_BIOJUTSU", "cooldown": 2 },
+      { "id": "PARROT", "cooldown": 100 },
+      {
+        "type": "spell",
+        "id": "VAMPIRE_ANATHEMA_SETUP",
+        "//8": "This applies the protective effect.  If monsters can someday spawn with an enchantment, remove this attack.",
+        "condition": { "not": { "u_has_effect": "effect_anathema_resilience" } },
+        "spell_data": { "id": "VAMPIRE_ANATHEMA_SETUP", "min_level": 1, "hit_self": true },
+        "cooldown": 1,
+        "allow_no_target": true
+      },
+      {
+        "type": "spell",
+        "id": "VAMPIRE_ANATHEMA_HEAL",
+        "//9": "Stops working during the final form as they are running out of blood when reaching that point.  This also is why they cannot activate Last Breath's Mist.",
+        "condition": { "and": [ { "not": { "u_has_effect": "effect_anathema_final_form" } }, { "math": [ "u_hp('ALL') < 200" ] } ] },
+        "spell_data": { "id": "VAMPIRE_ANATHEMA_HEAL", "max_level": 1, "hit_self": true },
+        "allow_no_target": true,
+        "monster_message": "%1$s's wounds are closing at a rapid pace!",
+        "cooldown": 20
+      },
+      {
+        "type": "spell",
+        "id": "VAMPIRE_ANATHEMA_STARTS_BATTLE",
+        "//10": "These two are in case the player manages to injure them without triggering the hit_me.",
+        "condition": { "and": [ { "not": { "u_has_effect": "effect_anathema_battle_started" } }, { "math": [ "u_hp('ALL') < 200" ] } ] },
+        "spell_data": { "id": "VAMPIRE_ANATHEMA_STARTS_BATTLE", "min_level": 1, "hit_self": true },
+        "allow_no_target": true,
+        "monster_message": "%1$s's movements are much quicker now!",
+        "cooldown": 20
+      },
+      {
+        "type": "spell",
+        "id": "VAMPIRE_ANATHEMA_FINAL_FORM",
+        "condition": { "and": [ { "not": { "u_has_effect": "effect_anathema_final_form" } }, { "math": [ "u_hp('ALL') < 100" ] } ] },
+        "spell_data": { "id": "VAMPIRE_ANATHEMA_FINAL_FORM", "min_level": 1, "hit_self": true },
+        "allow_no_target": true,
+        "monster_message": "%1$s accelerates to the point your eyes struggle to follow and heal their wounds as shadows surround their body!",
+        "cooldown": 20
+      }
+    ],
+    "anger_triggers": [ "HURT", "PLAYER_CLOSE", "PLAYER_WEAK" ],
+    "flags": [
+      "SEES",
+      "HEARS",
+      "SMELLS",
+      "BASHES",
+      "NO_BREATHE",
+      "CAN_OPEN_DOORS",
+      "CLIMBS",
+      "DESTROYS",
+      "ALWAYS_SEES_YOU",
+      "NEVER_WANDER",
+      "QUIETMOVES",
+      "HAS_MIND",
+      "NO_FUNG_DMG",
+      "NOT_HALLUCINATION",
+      "REVIVES",
+      "PATH_AVOID_DANGER",
+      "PATH_AVOID_FIRE",
+      "PATH_AVOID_FALL",
+      "SUNDEATH"
+    ],
+    "//11": "Armor equivalent to a full set of high steel plate armor.",
+    "armor": { "cut": 40, "stab": 32, "bash": 40, "bullet": 26 },
+    "zombify_into": "mon_vampire_strigoi",
+    "death_drops": "vampire_anathema_death_drops",
+    "families": [ "prof_wp_demihuman" ],
+    "weakpoint_sets": [ "wps_humanoid_body_armor", "wps_humanoid_open_helmet" ]
+  },
+  {
+    "id": "VAMPIRE_ANATHEMA_SETUP",
+    "type": "SPELL",
+    "name": { "str": "Anathema Setup", "//~": "NO_I18N" },
+    "description": {
+      "str": "This gives the protective effect to the Anathema when it spawns, as monsters cannot spawn with enchantments as of writting this.",
+      "//~": "NO_I18N"
+    },
+    "flags": [ "NO_EXPLOSION_SFX", "SILENT", "NO_FAIL", "NO_LEGS", "NO_HANDS" ],
+    "valid_targets": [ "self" ],
+    "shape": "blast",
+    "effect": "attack",
+    "effect_str": "effect_anathema_resilience",
+    "spell_class": "NONE",
+    "energy_source": "NONE",
+    "max_level": 1,
+    "min_duration": 3000000,
+    "max_duration": 3000000
+  },
+  {
+    "id": "VAMPIRE_ANATHEMA_REACT_TO_HIT",
+    "type": "SPELL",
+    "name": { "str": "Anathema reacts", "//~": "NO_I18N" },
+    "description": { "str": "This gives the Anathema their buff effects without needing to wait for their turn.", "//~": "NO_I18N" },
+    "flags": [ "NO_EXPLOSION_SFX", "SILENT", "NO_FAIL", "NO_LEGS", "NO_HANDS" ],
+    "valid_targets": [ "self" ],
+    "shape": "blast",
+    "effect": "effect_on_condition",
+    "effect_str": "EOC_ANATHEMA_BUFF_ON_HIT",
+    "spell_class": "NONE",
+    "energy_source": "NONE",
+    "max_level": 1
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_ANATHEMA_BUFF_ON_HIT",
+    "effect": [
+      {
+        "run_eocs": [
+          {
+            "id": "EOC_ANATHEMA_CHECK_FOR_START",
+            "condition": { "and": [ { "not": { "u_has_effect": "effect_anathema_battle_started" } }, { "math": [ "u_hp('ALL') < 200" ] } ] },
+            "effect": [
+              { "u_cast_spell": { "id": "VAMPIRE_ANATHEMA_STARTS_BATTLE" } },
+              { "message": "The vampiric anathema's movements are much quicker now!", "type": "bad" }
+            ]
+          },
+          {
+            "id": "EOC_ANATHEMA_CHECK_FOR_LATER",
+            "condition": { "and": [ { "not": { "u_has_effect": "effect_anathema_final_form" } }, { "math": [ "u_hp('ALL') < 100" ] } ] },
+            "effect": [
+              { "u_cast_spell": { "id": "VAMPIRE_ANATHEMA_FINAL_FORM" } },
+              {
+                "message": "The vampiric anathema accelerates to the point your eyes struggle to follow and heal their wounds as shadows surround their body!",
+                "type": "bad"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "VAMPIRE_ANATHEMA_STARTS_BATTLE",
+    "type": "SPELL",
+    "name": { "str": "Anathema Start Battle", "//~": "NO_I18N" },
+    "description": {
+      "str": "This accelerates and empowers the Anathema after they get injured, as they decide to mess around a little less.",
+      "//~": "NO_I18N"
+    },
+    "flags": [ "NO_EXPLOSION_SFX", "SILENT", "NO_FAIL", "NO_LEGS", "NO_HANDS" ],
+    "valid_targets": [ "self" ],
+    "shape": "blast",
+    "effect": "attack",
+    "effect_str": "effect_anathema_battle_started",
+    "spell_class": "NONE",
+    "energy_source": "NONE",
+    "max_level": 1,
+    "min_duration": 3000000,
+    "max_duration": 3000000
+  },
+  {
+    "id": "VAMPIRE_ANATHEMA_HEAL",
+    "type": "SPELL",
+    "name": { "str": "Cure Anathema Wounds", "//~": "NO_I18N" },
+    "description": { "str": "Heals a little bit of damage on the Anathema.  For Anathema use only.", "//~": "NO_I18N" },
+    "valid_targets": [ "self" ],
+    "min_damage": -25,
+    "max_damage": -250,
+    "effect": "attack",
+    "shape": "blast",
+    "base_casting_time": 0,
+    "flags": [ "NO_EXPLOSION_SFX", "SILENT", "NO_FAIL", "NO_LEGS", "NO_HANDS" ],
+    "max_level": 10,
+    "damage_increment": -25,
+    "spell_class": "NONE",
+    "energy_source": "NONE"
+  },
+  {
+    "id": "VAMPIRE_ANATHEMA_FINAL_FORM",
+    "type": "SPELL",
+    "name": { "str": "Anathema Final Form", "//~": "NO_I18N" },
+    "description": {
+      "str": "This accelerates and empowers the Anathema as per blood haste and shadow form, as they decide to stop messing around.  It also heals them fully, so they can benefit from that form longer.  At this point the Anathema has almost ran out of blood, preventing the use of more powers.",
+      "//~": "NO_I18N"
+    },
+    "flags": [ "NO_EXPLOSION_SFX", "SILENT", "NO_FAIL", "NO_LEGS", "NO_HANDS" ],
+    "valid_targets": [ "self" ],
+    "shape": "blast",
+    "effect": "attack",
+    "effect_str": "effect_anathema_final_form",
+    "spell_class": "NONE",
+    "energy_source": "NONE",
+    "max_level": 1,
+    "min_duration": 3000000,
+    "max_duration": 3000000,
+    "extra_effects": [ { "id": "VAMPIRE_ANATHEMA_HEAL", "hit_self": true, "min_level": 10 } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_ACTIVATE_ANATHEMA",
+    "recurrence": "1 day",
+    "global": true,
+    "run_for_npcs": false,
+    "condition": { "and": [ { "u_has_trait": "BLOOD_DRINKER" }, { "math": [ "Anathema_Activated < 1" ] } ] },
+    "effect": [ { "math": [ "Anathema_Ready = 1" ] }, { "math": [ "Anathema_Activated = 1" ] } ],
+    "deactivate_condition": { "math": [ "Anathema_Activated == 1" ] }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_SPAWN_ANATHEMA",
+    "recurrence": [ "15 minutes", "9 hours" ],
+    "global": true,
+    "run_for_npcs": false,
+    "//1": "Night time, Anathema is active, you are outdoors, not sleeping nor in torpor, and you are away from vast water and holy ground.",
+    "//2": "Requires at least one warning to have been given before spawning can succeed. The warnings are global, not character-unique.",
+    "condition": {
+      "and": [
+        { "one_in_chance": 6 },
+        { "not": "is_day" },
+        { "not": { "u_has_effect": "sleep" } },
+        { "not": { "u_has_effect": "effect_vampire_torpor" } },
+        { "math": [ "Anathema_Ready > 0" ] },
+        { "math": [ "Anathema_Warnings >= 1" ] },
+        "u_is_outside",
+        {
+          "not": {
+            "or": [
+              { "u_near_om_location": "church_1", "range": 5 },
+              { "u_near_om_location": "church_2ndfloor_1", "range": 5 },
+              { "u_near_om_location": "church_3rdfloor_1", "range": 5 },
+              { "u_near_om_location": "church_roof_1", "range": 5 },
+              { "u_near_om_location": "rural_church_parking", "range": 5 },
+              { "u_near_om_location": "rural_church", "range": 5 },
+              { "u_near_om_location": "rural_church_basement", "range": 5 },
+              { "u_near_om_location": "rural_church_steeple", "range": 5 },
+              { "u_near_om_location": "rural_church_steeple_roof", "range": 5 },
+              { "u_near_om_location": "cathedral_7_NW", "range": 5 },
+              { "u_near_om_location": "cathedral_7_NE", "range": 5 },
+              { "u_near_om_location": "cathedral_6_NW", "range": 5 },
+              { "u_near_om_location": "cathedral_6_NE", "range": 5 },
+              { "u_near_om_location": "cathedral_5_NW", "range": 5 },
+              { "u_near_om_location": "cathedral_5_NE", "range": 5 },
+              { "u_near_om_location": "cathedral_4_NW", "range": 5 },
+              { "u_near_om_location": "cathedral_4_NE", "range": 5 },
+              { "u_near_om_location": "cathedral_7_NW", "range": 5 },
+              { "u_near_om_location": "cathedral_7_NE", "range": 5 },
+              { "u_near_om_location": "cathedral_6_NW", "range": 5 },
+              { "u_near_om_location": "cathedral_6_NE", "range": 5 },
+              { "u_near_om_location": "cathedral_5_NW", "range": 5 },
+              { "u_near_om_location": "cathedral_5_NE", "range": 5 },
+              { "u_near_om_location": "cathedral_4_NW", "range": 5 },
+              { "u_near_om_location": "cathedral_4_NE", "range": 5 },
+              { "u_near_om_location": "cathedral_3_NW", "range": 5 },
+              { "u_near_om_location": "cathedral_3_NE", "range": 5 },
+              { "u_near_om_location": "cathedral_3_SW", "range": 5 },
+              { "u_near_om_location": "cathedral_3_SE", "range": 5 },
+              { "u_near_om_location": "cathedral_2_NW", "range": 5 },
+              { "u_near_om_location": "cathedral_2_NE", "range": 5 },
+              { "u_near_om_location": "cathedral_2_SW", "range": 5 },
+              { "u_near_om_location": "cathedral_2_SE", "range": 5 },
+              { "u_near_om_location": "cathedral_1_NW", "range": 5 },
+              { "u_near_om_location": "cathedral_1_NE", "range": 5 },
+              { "u_near_om_location": "cathedral_1_SW", "range": 5 },
+              { "u_near_om_location": "cathedral_1_SE", "range": 5 },
+              { "u_near_om_location": "cathedral_b_NW", "range": 5 },
+              { "u_near_om_location": "cathedral_b_NE", "range": 5 },
+              { "u_near_om_location": "cathedral_b_SW", "range": 5 },
+              { "u_near_om_location": "cathedral_b_SE", "range": 5 },
+              { "u_near_om_location": "synagogue", "range": 5 },
+              { "u_near_om_location": "synagogue_roof", "range": 5 },
+              { "u_near_om_location": "synagogue_upper_roof", "range": 5 },
+              { "u_near_om_location": "generic_river_bank", "range": 3 },
+              { "u_near_om_location": "generic_river", "range": 3 },
+              { "u_near_om_location": "river_center", "range": 3 },
+              { "u_near_om_location": "river", "range": 3 },
+              { "u_near_om_location": "river_c_not_ne", "range": 3 },
+              { "u_near_om_location": "river_c_not_nw", "range": 3 },
+              { "u_near_om_location": "river_c_not_se", "range": 3 },
+              { "u_near_om_location": "river_c_not_sw", "range": 3 },
+              { "u_near_om_location": "lake_shore", "range": 3 },
+              { "u_near_om_location": "lake_surface", "range": 3 },
+              { "u_near_om_location": "ocean", "range": 3 },
+              { "u_near_om_location": "ocean_shore", "range": 3 },
+              { "u_near_om_location": "ocean_surface", "range": 3 },
+              { "u_near_om_location": "ocean_bed", "range": 3 },
+              { "u_near_om_location": "ocean_water_cube", "range": 3 },
+              { "u_near_om_location": "ocean_surface", "range": 3 }
+            ]
+          }
+        }
+      ]
+    },
+    "effect": [
+      { "math": [ "Anathema_Ready", "=", "0" ] },
+      { "u_spawn_monster": "mon_vampire_anathema", "real_count": 1, "min_radius": 40, "max_radius": 50 },
+      { "run_eocs": "EOC_ANATHEMA_SPAWN_MESSAGE", "time_in_future": 1 }
+    ],
+    "false_effect": [ { "run_eocs": [ "EOC_ANATHEMA_WARN" ] } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_ANATHEMA_WARN",
+    "eoc_type": "ACTIVATION",
+    "//1": "Same conditions as the above, minus the RNG check and the warnings check.",
+    "condition": {
+      "and": [
+        { "not": "is_day" },
+        { "not": { "u_has_effect": "sleep" } },
+        { "not": { "u_has_effect": "effect_vampire_torpor" } },
+        { "math": [ "Anathema_Ready > 0" ] },
+        "u_is_outside",
+        {
+          "not": {
+            "or": [
+              { "u_near_om_location": "church_1", "range": 5 },
+              { "u_near_om_location": "church_2ndfloor_1", "range": 5 },
+              { "u_near_om_location": "church_3rdfloor_1", "range": 5 },
+              { "u_near_om_location": "church_roof_1", "range": 5 },
+              { "u_near_om_location": "rural_church_parking", "range": 5 },
+              { "u_near_om_location": "rural_church", "range": 5 },
+              { "u_near_om_location": "rural_church_basement", "range": 5 },
+              { "u_near_om_location": "rural_church_steeple", "range": 5 },
+              { "u_near_om_location": "rural_church_steeple_roof", "range": 5 },
+              { "u_near_om_location": "cathedral_7_NW", "range": 5 },
+              { "u_near_om_location": "cathedral_7_NE", "range": 5 },
+              { "u_near_om_location": "cathedral_6_NW", "range": 5 },
+              { "u_near_om_location": "cathedral_6_NE", "range": 5 },
+              { "u_near_om_location": "cathedral_5_NW", "range": 5 },
+              { "u_near_om_location": "cathedral_5_NE", "range": 5 },
+              { "u_near_om_location": "cathedral_4_NW", "range": 5 },
+              { "u_near_om_location": "cathedral_4_NE", "range": 5 },
+              { "u_near_om_location": "cathedral_7_NW", "range": 5 },
+              { "u_near_om_location": "cathedral_7_NE", "range": 5 },
+              { "u_near_om_location": "cathedral_6_NW", "range": 5 },
+              { "u_near_om_location": "cathedral_6_NE", "range": 5 },
+              { "u_near_om_location": "cathedral_5_NW", "range": 5 },
+              { "u_near_om_location": "cathedral_5_NE", "range": 5 },
+              { "u_near_om_location": "cathedral_4_NW", "range": 5 },
+              { "u_near_om_location": "cathedral_4_NE", "range": 5 },
+              { "u_near_om_location": "cathedral_3_NW", "range": 5 },
+              { "u_near_om_location": "cathedral_3_NE", "range": 5 },
+              { "u_near_om_location": "cathedral_3_SW", "range": 5 },
+              { "u_near_om_location": "cathedral_3_SE", "range": 5 },
+              { "u_near_om_location": "cathedral_2_NW", "range": 5 },
+              { "u_near_om_location": "cathedral_2_NE", "range": 5 },
+              { "u_near_om_location": "cathedral_2_SW", "range": 5 },
+              { "u_near_om_location": "cathedral_2_SE", "range": 5 },
+              { "u_near_om_location": "cathedral_1_NW", "range": 5 },
+              { "u_near_om_location": "cathedral_1_NE", "range": 5 },
+              { "u_near_om_location": "cathedral_1_SW", "range": 5 },
+              { "u_near_om_location": "cathedral_1_SE", "range": 5 },
+              { "u_near_om_location": "cathedral_b_NW", "range": 5 },
+              { "u_near_om_location": "cathedral_b_NE", "range": 5 },
+              { "u_near_om_location": "cathedral_b_SW", "range": 5 },
+              { "u_near_om_location": "cathedral_b_SE", "range": 5 },
+              { "u_near_om_location": "synagogue", "range": 5 },
+              { "u_near_om_location": "synagogue_roof", "range": 5 },
+              { "u_near_om_location": "synagogue_upper_roof", "range": 5 },
+              { "u_near_om_location": "generic_river_bank", "range": 3 },
+              { "u_near_om_location": "generic_river", "range": 3 },
+              { "u_near_om_location": "river_center", "range": 3 },
+              { "u_near_om_location": "river", "range": 3 },
+              { "u_near_om_location": "river_c_not_ne", "range": 3 },
+              { "u_near_om_location": "river_c_not_nw", "range": 3 },
+              { "u_near_om_location": "river_c_not_se", "range": 3 },
+              { "u_near_om_location": "river_c_not_sw", "range": 3 },
+              { "u_near_om_location": "lake_shore", "range": 3 },
+              { "u_near_om_location": "lake_surface", "range": 3 },
+              { "u_near_om_location": "ocean", "range": 3 },
+              { "u_near_om_location": "ocean_shore", "range": 3 },
+              { "u_near_om_location": "ocean_surface", "range": 3 },
+              { "u_near_om_location": "ocean_bed", "range": 3 },
+              { "u_near_om_location": "ocean_water_cube", "range": 3 },
+              { "u_near_om_location": "ocean_surface", "range": 3 }
+            ]
+          }
+        }
+      ]
+    },
+    "effect": [
+      { "math": [ "Anathema_Warnings", "+=", "1" ] },
+      {
+        "if": { "math": [ "Anathema_Warnings < 2" ] },
+        "then": { "u_message": "Anathema_Warnings_Snippets", "snippet": true, "popup": true },
+        "else": { "u_message": "Anathema_Warnings_Snippets", "snippet": true, "popup": false }
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_ANATHEMA_SPAWN_MESSAGE",
+    "effect": [
+      {
+        "u_message": "You feel a threat closing in, more dangerous than anything you've ever faced.  Your vampiric instincts urge you to flee, as fighting them is certain to cause your death.\nRUN.",
+        "type": "bad",
+        "popup": true,
+        "popup_w_interrupt_query": true,
+        "interrupt_type": "eoc"
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_ANATHEMA_WITHDRAWS_FOR_NOW",
+    "recurrence": "1 second",
+    "global": true,
+    "run_for_npcs": false,
+    "//1": "Near holy ground, near vast water, the sun has risen, or you've run far enough away from where it spawned (7.5 OMTs).",
+    "condition": {
+      "and": [
+        {
+          "or": [
+            { "u_near_om_location": "church_1", "range": 5 },
+            { "u_near_om_location": "church_2ndfloor_1", "range": 5 },
+            { "u_near_om_location": "church_3rdfloor_1", "range": 5 },
+            { "u_near_om_location": "church_roof_1", "range": 5 },
+            { "u_near_om_location": "rural_church_parking", "range": 5 },
+            { "u_near_om_location": "rural_church", "range": 5 },
+            { "u_near_om_location": "rural_church_basement", "range": 5 },
+            { "u_near_om_location": "rural_church_steeple", "range": 5 },
+            { "u_near_om_location": "rural_church_steeple_roof", "range": 5 },
+            { "u_near_om_location": "cathedral_7_NW", "range": 5 },
+            { "u_near_om_location": "cathedral_7_NE", "range": 5 },
+            { "u_near_om_location": "cathedral_6_NW", "range": 5 },
+            { "u_near_om_location": "cathedral_6_NE", "range": 5 },
+            { "u_near_om_location": "cathedral_5_NW", "range": 5 },
+            { "u_near_om_location": "cathedral_5_NE", "range": 5 },
+            { "u_near_om_location": "cathedral_4_NW", "range": 5 },
+            { "u_near_om_location": "cathedral_4_NE", "range": 5 },
+            { "u_near_om_location": "cathedral_7_NW", "range": 5 },
+            { "u_near_om_location": "cathedral_7_NE", "range": 5 },
+            { "u_near_om_location": "cathedral_6_NW", "range": 5 },
+            { "u_near_om_location": "cathedral_6_NE", "range": 5 },
+            { "u_near_om_location": "cathedral_5_NW", "range": 5 },
+            { "u_near_om_location": "cathedral_5_NE", "range": 5 },
+            { "u_near_om_location": "cathedral_4_NW", "range": 5 },
+            { "u_near_om_location": "cathedral_4_NE", "range": 5 },
+            { "u_near_om_location": "cathedral_3_NW", "range": 5 },
+            { "u_near_om_location": "cathedral_3_NE", "range": 5 },
+            { "u_near_om_location": "cathedral_3_SW", "range": 5 },
+            { "u_near_om_location": "cathedral_3_SE", "range": 5 },
+            { "u_near_om_location": "cathedral_2_NW", "range": 5 },
+            { "u_near_om_location": "cathedral_2_NE", "range": 5 },
+            { "u_near_om_location": "cathedral_2_SW", "range": 5 },
+            { "u_near_om_location": "cathedral_2_SE", "range": 5 },
+            { "u_near_om_location": "cathedral_1_NW", "range": 5 },
+            { "u_near_om_location": "cathedral_1_NE", "range": 5 },
+            { "u_near_om_location": "cathedral_1_SW", "range": 5 },
+            { "u_near_om_location": "cathedral_1_SE", "range": 5 },
+            { "u_near_om_location": "cathedral_b_NW", "range": 5 },
+            { "u_near_om_location": "cathedral_b_NE", "range": 5 },
+            { "u_near_om_location": "cathedral_b_SW", "range": 5 },
+            { "u_near_om_location": "cathedral_b_SE", "range": 5 },
+            { "u_near_om_location": "synagogue", "range": 5 },
+            { "u_near_om_location": "synagogue_roof", "range": 5 },
+            { "u_near_om_location": "synagogue_upper_roof", "range": 5 },
+            { "u_near_om_location": "generic_river_bank", "range": 3 },
+            { "u_near_om_location": "generic_river", "range": 3 },
+            { "u_near_om_location": "river_center", "range": 3 },
+            { "u_near_om_location": "river", "range": 3 },
+            { "u_near_om_location": "river_c_not_ne", "range": 3 },
+            { "u_near_om_location": "river_c_not_nw", "range": 3 },
+            { "u_near_om_location": "river_c_not_se", "range": 3 },
+            { "u_near_om_location": "river_c_not_sw", "range": 3 },
+            { "u_near_om_location": "lake_shore", "range": 3 },
+            { "u_near_om_location": "lake_surface", "range": 3 },
+            { "u_near_om_location": "ocean", "range": 3 },
+            { "u_near_om_location": "ocean_shore", "range": 3 },
+            { "u_near_om_location": "ocean_surface", "range": 3 },
+            { "u_near_om_location": "ocean_bed", "range": 3 },
+            { "u_near_om_location": "ocean_water_cube", "range": 3 },
+            { "u_near_om_location": "ocean_surface", "range": 3 },
+            "is_day"
+          ]
+        },
+        { "math": [ "u_monsters_nearby('mon_vampire_anathema', 'radius': 60) > 0" ] }
+      ]
+    },
+    "//2": "Despawn the Anathema, adjust var for later to bring them back.",
+    "//3": "Reuses the Shadow's EOC as they are identical in effect.",
+    "effect": [
+      { "math": [ "Anathema_Ready = 1" ] },
+      { "u_add_effect": "blind_no_msg", "duration": "0 second" },
+      { "u_message": "The Anathema vanishes in a fine mist", "type": "good" },
+      {
+        "u_location_variable": { "global_val": "Vampire_Anathema" },
+        "monster": "mon_vampire_anathema",
+        "target_min_radius": 0,
+        "target_max_radius": 60
+      },
+      { "run_eocs": "EOC_KILL_SHADOW", "beta_loc": { "global_val": "Vampire_Anathema" } },
+      { "u_message": "…but they will come back.", "type": "bad" }
+    ]
+  },
+  {
+    "type": "snippet",
+    "category": "Anathema_Warnings_Snippets",
+    "text": [
+      "You shudder at the thought of vampire hunters.  Knowing your luck, one is probably tracking you as this very moment.",
+      "You long for the safety of a warm uncontrolled blaze, burning away the thing stalking you from the shadows.",
+      "Your instincts warn you about something far more dangerous than you are, wandering the shadows to find you.",
+      "You long for proximity to vast waters and holy ground, no matter how uneasy you might be about them.",
+      "You feel a threatening presence.  Someone who desires nothing but killing vampires has their sights on you.",
+      "You have a passing thought about standing in unblocked sunlight, and how you would be safer in it than you currently are here.",
+      "Someone is coming to kill you.  You can feel them knowing where you are, waiting for the right moment to strike.",
+      "You are filled with the fear that a vampire will soon drink you dry.  You know that vampire blood is inedible to vampires, but you're still unsettled.",
+      "For a moment, the darkness doesn't feel like home.  It feels like a slautherhouse, and you're next in line to be killed."
+    ]
+  }
+]

--- a/data/mods/Xedra_Evolved/monsters/anathema.json
+++ b/data/mods/Xedra_Evolved/monsters/anathema.json
@@ -330,7 +330,7 @@
     },
     "effect": [
       { "math": [ "Anathema_Ready", "=", "0" ] },
-      { "u_spawn_monster": "mon_vampire_anathema", "real_count": 1, "min_radius": 40, "max_radius": 50 },
+      { "u_spawn_monster": "mon_vampire_anathema", "real_count": 1, "min_radius": 30, "max_radius": 40 },
       { "run_eocs": "EOC_ANATHEMA_SPAWN_MESSAGE", "time_in_future": 1 }
     ],
     "false_effect": [ { "run_eocs": [ "EOC_ANATHEMA_WARN" ] } ]
@@ -443,7 +443,7 @@
     "recurrence": "1 second",
     "global": true,
     "run_for_npcs": false,
-    "//1": "Near holy ground, near vast water, the sun has risen, or you've run far enough away from where it spawned (7.5 OMTs).",
+    "//1": "Near holy ground, near vast water, the sun has risen, or you're about to outrun it (55 tiles away).",
     "condition": {
       "and": [
         {
@@ -508,7 +508,8 @@
             { "u_near_om_location": "ocean_bed", "range": 3 },
             { "u_near_om_location": "ocean_water_cube", "range": 3 },
             { "u_near_om_location": "ocean_surface", "range": 3 },
-            "is_day"
+            "is_day",
+            { "math": [ "u_monsters_nearby('mon_vampire_anathema', 'radius': 55) == 0" ] }
           ]
         },
         { "math": [ "u_monsters_nearby('mon_vampire_anathema', 'radius': 60) > 0" ] }

--- a/data/mods/Xedra_Evolved/monsters/monfaction.json
+++ b/data/mods/Xedra_Evolved/monsters/monfaction.json
@@ -17,6 +17,13 @@
   },
   {
     "type": "MONSTER_FACTION",
+    "name": "vampire_anathema",
+    "copy-from": "vampire",
+    "//": "Like the mentors, they are human enough to be attacked by zombies.  Luring them into other hostiles is a valid strategy.",
+    "extend": { "hate": [ "changeling", "nether", "nightmares", "vampire", "zombie" ] }
+  },
+  {
+    "type": "MONSTER_FACTION",
     "name": "arvore",
     "base_faction": "changeling",
     "neutral": [ "small_animal", "fish" ],
@@ -92,7 +99,7 @@
     "type": "MONSTER_FACTION",
     "name": "zombie",
     "copy-from": "zombie",
-    "extend": { "hate": [ "changeling" ], "neutral": [ "vampire" ] }
+    "extend": { "hate": [ "changeling", "vampire_anathema" ], "neutral": [ "vampire" ] }
   },
   {
     "type": "MONSTER_FACTION",
@@ -110,13 +117,13 @@
     "type": "MONSTER_FACTION",
     "name": "exodii",
     "copy-from": "exodii",
-    "extend": { "hate": [ "changeling", "vampire" ] }
+    "extend": { "hate": [ "changeling", "vampire", "vampire_anathema" ] }
   },
   {
     "type": "MONSTER_FACTION",
     "name": "isolated_artisans",
     "copy-from": "isolated_artisans",
-    "extend": { "hate": [ "changeling", "vampire", "nightmares" ] }
+    "extend": { "hate": [ "changeling", "vampire", "nightmares", "vampire_anathema" ] }
   },
   {
     "type": "MONSTER_FACTION",

--- a/data/mods/Xedra_Evolved/monsters/species.json
+++ b/data/mods/Xedra_Evolved/monsters/species.json
@@ -70,6 +70,12 @@
   },
   {
     "type": "SPECIES",
+    "id": "VAMPIRE_ANATHEMA",
+    "description": "a being who devoured vampires to become better at killing them.",
+    "flags": [ "NO_NECRO", "VAMP_VIRUS", "DRACULIN_IMMUNE" ]
+  },
+  {
+    "type": "SPECIES",
     "id": "NIGHTMARE",
     "description": "creatures made from dreams, technically not alive",
     "flags": [ "DRACULIN_IMMUNE" ]

--- a/data/mods/Xedra_Evolved/npc/talk_read_vampire_anathema_book.json
+++ b/data/mods/Xedra_Evolved/npc/talk_read_vampire_anathema_book.json
@@ -27,7 +27,7 @@
   {
     "type": "talk_topic",
     "id": "TALK_ANATHEMA_RECIPE",
-    "dynamic_line": "After so long spent experimenting on vampire blood, I found a way to push vampirism beyond its absolute limits.  By taking vampire blood, a drop of my own blood, some blood no human nor vampire could ever want to drink and an assortment of poisons and toxins, it is possible to apply the process of an ancient poison-making method to vampire blood, forcing it to devour itself to become stronger.  When the process was over and I drank the remaining blood, I could now drink vampire blood to become more of a vampire than they are, with all the power this brings.",
+    "dynamic_line": "After so long spent experimenting on vampire blood, I found a way to push vampirism beyond its absolute limits.\nBy taking vampire blood, a drop of my own blood, some blood no human nor vampire could ever want to drink and an assortment of poisons and toxins, it is possible to apply the process of an ancient poison-making method to vampire blood, forcing it to devour itself to become stronger.\nWhen the process was over and I drank the remaining blood, I could now drink vampire blood to become more of a vampire than they are, with all the power this brings.",
     "responses": [
       { "text": "[Read about their history]", "topic": "TALK_ANATHEMA_HISTORY" },
       { "text": "[Read about the recipe's benefits]", "topic": "TALK_ANATHEMA_BENEFITS" },
@@ -51,7 +51,7 @@
   {
     "type": "talk_topic",
     "id": "TALK_ANATHEMA_DRAWBACKS",
-    "dynamic_line": "In addition to manifesting more of the vampires' classical weaknesses, some time after beginning to consume vampires for power I started to burn away under the sun even while fully covered.  Only being indoors or underground protected me if I didn't block the sun with shadows.  I did felt a passing impulse to drink more vampire blood and the first few doses made me think my mind would unravel, but that passed.  It might be that this path gives a single weakness not seen in other vampires to those far enough on it, but testing this would require creating vampires and I won't ever tolerate this.",
+    "dynamic_line": "In addition to manifesting more of the vampires' classical weaknesses, some time after beginning to consume vampires for power I started to burn away under the sun even while fully covered.\nOnly being indoors or underground protected me if I didn't block the sun with shadows.\nI did felt a passing impulse to drink more vampire blood and the first few doses made me think my mind would unravel, but that passed.  It might be that this path gives a single weakness not seen in other vampires to those far enough on it, but testing this would require creating vampires and I won't ever tolerate this.",
     "responses": [
       { "text": "[Read about their history]", "topic": "TALK_ANATHEMA_HISTORY" },
       { "text": "[Read about their recipe]", "topic": "TALK_ANATHEMA_RECIPE" },
@@ -63,7 +63,7 @@
   {
     "type": "talk_topic",
     "id": "TALK_ANATHEMA_HUNTERS",
-    "dynamic_line": "There are other hunters, but they are traitors to the cause.  All of them.  How can they attack me?  How can some of them team up with vampires to attack me?  It is worse than I thought.  I am the last true hunter.  The duty of purging the world of vampires is mine and mine alone now.  I still let my past allies decide between running away or dying, but so many refuse to flee.  They force my hand over and over, I hope they will remember that.",
+    "dynamic_line": "There are other hunters, but they are traitors to the cause.  All of them.\nHow can they attack me?  How can some of them team up with vampires to attack me?\nIt is worse than I thought.  I am the last true hunter.  The duty of purging the world of vampires is mine and mine alone now.  I still let my past allies decide between running away or dying, but so many refuse to flee.\nThey force my hand over and over, I hope they will remember that.",
     "responses": [
       { "text": "[Read about their history]", "topic": "TALK_ANATHEMA_HISTORY" },
       { "text": "[Read about their recipe]", "topic": "TALK_ANATHEMA_RECIPE" },

--- a/data/mods/Xedra_Evolved/npc/talk_read_vampire_anathema_book.json
+++ b/data/mods/Xedra_Evolved/npc/talk_read_vampire_anathema_book.json
@@ -15,7 +15,7 @@
   {
     "type": "talk_topic",
     "id": "TALK_ANATHEMA_HISTORY",
-    "dynamic_line": "I've been a vampire hunter since as far as I can remember.  I spent my entire life killing all the vampires I could find but I recently realized that doing so was futile with my current power.   I need more power.  No matter how many vampires I kill, there's always more.\nI became a vampire so I could kill them all, but even that wasn't enough.  I've followed the mentor's instructions until they had nothing more to tell me but that wasn't enough.\nI need to find a way to reach power undreamt of.  To protect everyone from the vampire threat, I must become the strongest vampire ever seen.",
+    "dynamic_line": "I've been a vampire hunter since as far as I can remember.  I spent my entire life killing all the vampires I could find but I recently realized that doing so was futile with my current power.  I need more power.  No matter how many vampires I kill, there's always more.\nI became a vampire so I could kill them all, but even that wasn't enough.  I've followed the mentor's instructions until they had nothing more to tell me but that wasn't enough.\nI need to find a way to reach power undreamt of.  To protect everyone from the vampire threat, I must become the strongest vampire ever seen.",
     "responses": [
       { "text": "[Read about their recipe]", "topic": "TALK_ANATHEMA_RECIPE" },
       { "text": "[Read about the recipe's benefits]", "topic": "TALK_ANATHEMA_BENEFITS" },

--- a/data/mods/Xedra_Evolved/npc/talk_read_vampire_anathema_book.json
+++ b/data/mods/Xedra_Evolved/npc/talk_read_vampire_anathema_book.json
@@ -1,0 +1,75 @@
+[
+  {
+    "type": "talk_topic",
+    "id": "TALK_READ_VAMPIRE_ANATHEMA_BOOK",
+    "dynamic_line": "[You skim through the book, searching for useful information.  Most pages are filled with trivial notes and long rants, but there's a few that attract your attention.]",
+    "responses": [
+      { "text": "[Read about their history]", "topic": "TALK_ANATHEMA_HISTORY" },
+      { "text": "[Read about their recipe]", "topic": "TALK_ANATHEMA_RECIPE" },
+      { "text": "[Read about the recipe's benefits]", "topic": "TALK_ANATHEMA_BENEFITS" },
+      { "text": "[Read about the recipe's drawbacks]", "topic": "TALK_ANATHEMA_DRAWBACKS" },
+      { "text": "[Read about other hunters]", "topic": "TALK_ANATHEMA_HUNTERS" },
+      { "text": "[Close the book]", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_ANATHEMA_HISTORY",
+    "dynamic_line": "I've been a vampire hunter since as far as I can remember.  I spent my entire life killing all the vampires I could find but I recently realized that doing so was futile with my current power.   I need more power.  No matter how many vampires I kill, there's always more.\nI became a vampire so I could kill them all, but even that wasn't enough.  I've followed the mentor's instructions until they had nothing more to tell me but that wasn't enough.\nI need to find a way to reach power undreamt of.  To protect everyone from the vampire threat, I must become the strongest vampire ever seen.",
+    "responses": [
+      { "text": "[Read about their recipe]", "topic": "TALK_ANATHEMA_RECIPE" },
+      { "text": "[Read about the recipe's benefits]", "topic": "TALK_ANATHEMA_BENEFITS" },
+      { "text": "[Read about the recipe's drawbacks]", "topic": "TALK_ANATHEMA_DRAWBACKS" },
+      { "text": "[Read about other hunters]", "topic": "TALK_ANATHEMA_HUNTERS" },
+      { "text": "[Close the book]", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_ANATHEMA_RECIPE",
+    "dynamic_line": "After so long spent experimenting on vampire blood, I found a way to push vampirism beyond its absolute limits.  By taking vampire blood, a drop of my own blood, some blood no human nor vampire could ever want to drink and an assortment of poisons and toxins, it is possible to apply the process of an ancient poison-making method to vampire blood, forcing it to devour itself to become stronger.  When the process was over and I drank the remaining blood, I could now drink vampire blood to become more of a vampire than they are, with all the power this brings.",
+    "responses": [
+      { "text": "[Read about their history]", "topic": "TALK_ANATHEMA_HISTORY" },
+      { "text": "[Read about the recipe's benefits]", "topic": "TALK_ANATHEMA_BENEFITS" },
+      { "text": "[Read about the recipe's drawbacks]", "topic": "TALK_ANATHEMA_DRAWBACKS" },
+      { "text": "[Read about other hunters]", "topic": "TALK_ANATHEMA_HUNTERS" },
+      { "text": "[Close the book]", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_ANATHEMA_BENEFITS",
+    "dynamic_line": "After drinking enough vampire blood, I gained new abilities.  I could store more blood inside me, my vampiric abilities all became stronger, I could feed from vampire blood, my wounds closed at incredible speeds in the dark and more.  At the point I now am, every time I drink vampire blood my vampiric abilities grow stronger.",
+    "responses": [
+      { "text": "[Read about their history]", "topic": "TALK_ANATHEMA_HISTORY" },
+      { "text": "[Read about their recipe]", "topic": "TALK_ANATHEMA_RECIPE" },
+      { "text": "[Read about the recipe's drawbacks]", "topic": "TALK_ANATHEMA_DRAWBACKS" },
+      { "text": "[Read about other hunters]", "topic": "TALK_ANATHEMA_HUNTERS" },
+      { "text": "[Close the book]", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_ANATHEMA_DRAWBACKS",
+    "dynamic_line": "In addition to manifesting more of the vampires' classical weaknesses, some time after beginning to consume vampires for power I started to burn away under the sun even while fully covered.  Only being indoors or underground protected me if I didn't block the sun with shadows.  I did felt a passing impulse to drink more vampire blood and the first few doses made me think my mind would unravel, but that passed.  It might be that this path gives a single weakness not seen in other vampires to those far enough on it, but testing this would require creating vampires and I won't ever tolerate this.",
+    "responses": [
+      { "text": "[Read about their history]", "topic": "TALK_ANATHEMA_HISTORY" },
+      { "text": "[Read about their recipe]", "topic": "TALK_ANATHEMA_RECIPE" },
+      { "text": "[Read about the recipe's benefits]", "topic": "TALK_ANATHEMA_BENEFITS" },
+      { "text": "[Read about other hunters]", "topic": "TALK_ANATHEMA_HUNTERS" },
+      { "text": "[Close the book]", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_ANATHEMA_HUNTERS",
+    "dynamic_line": "There are other hunters, but they are traitors to the cause.  All of them.  How can they attack me?  How can some of them team up with vampires to attack me?  It is worse than I thought.  I am the last true hunter.  The duty of purging the world of vampires is mine and mine alone now.  I still let my past allies decide between running away or dying, but so many refuse to flee.  They force my hand over and over, I hope they will remember that.",
+    "responses": [
+      { "text": "[Read about their history]", "topic": "TALK_ANATHEMA_HISTORY" },
+      { "text": "[Read about their recipe]", "topic": "TALK_ANATHEMA_RECIPE" },
+      { "text": "[Read about the recipe's benefits]", "topic": "TALK_ANATHEMA_BENEFITS" },
+      { "text": "[Read about the recipe's drawbacks]", "topic": "TALK_ANATHEMA_DRAWBACKS" },
+      { "text": "[Close the book]", "topic": "TALK_DONE" }
+    ]
+  }
+]

--- a/data/mods/Xedra_Evolved/snippets/anathema_snippets.json
+++ b/data/mods/Xedra_Evolved/snippets/anathema_snippets.json
@@ -1,0 +1,123 @@
+[
+  {
+    "type": "speech",
+    "//": "The Anathema is both vampire and vampire hunter.  This contradiction result in them speaking about both as they cannot doubt that they did the right thing.",
+    "speaker": [ "mon_vampire_anathema" ],
+    "sound": "\"One more to kill.\"",
+    "volume": 20
+  },
+  {
+    "type": "speech",
+    "speaker": [ "mon_vampire_anathema" ],
+    "sound": "\"Your blood will contribute to a great cause, the end of all vampires.\"",
+    "volume": 20
+  },
+  {
+    "type": "speech",
+    "speaker": [ "mon_vampire_anathema" ],
+    "sound": "\"I've slain thousands, each stronger than you.  Do not believe that you can kill me.\"",
+    "volume": 20
+  },
+  {
+    "type": "speech",
+    "speaker": [ "mon_vampire_anathema" ],
+    "sound": "\"It is all necessary, yet they all failed to understand.\"",
+    "volume": 20
+  },
+  {
+    "type": "speech",
+    "speaker": [ "mon_vampire_anathema" ],
+    "sound": "\"They tried to stop me, so I killed them all.\"",
+    "volume": 20
+  },
+  {
+    "type": "speech",
+    "speaker": [ "mon_vampire_anathema" ],
+    "sound": "\"Most hunters are siding with the vampires.  I know as they tried to kill me, calling me a vampire.\"",
+    "volume": 20
+  },
+  {
+    "type": "speech",
+    "speaker": [ "mon_vampire_anathema" ],
+    "sound": "\"Standing against me is standing against humanity.\"",
+    "volume": 20
+  },
+  {
+    "type": "speech",
+    "speaker": [ "mon_vampire_anathema" ],
+    "sound": "\"So thirsty… Need to drink…\"",
+    "volume": 10
+  },
+  {
+    "type": "speech",
+    "speaker": [ "mon_vampire_anathema" ],
+    "sound": "\"I'll send you where you belong!\"",
+    "volume": 35
+  },
+  {
+    "type": "speech",
+    "speaker": [ "mon_vampire_anathema" ],
+    "sound": "\"The mentors still elude me.  You however, do not.\"",
+    "volume": 20
+  },
+  {
+    "type": "speech",
+    "speaker": [ "mon_vampire_anathema" ],
+    "sound": "\"Vampires cannot truly be bargained with.  They must all die.\"",
+    "volume": 20
+  },
+  {
+    "type": "speech",
+    "speaker": [ "mon_vampire_anathema" ],
+    "sound": "\"Never trust a vampire.  It will leave you open to their mind control.\"",
+    "volume": 20
+  },
+  {
+    "type": "speech",
+    "speaker": [ "mon_vampire_anathema" ],
+    "sound": "\"Why did they hated me?  I only wanted to help them!\"",
+    "volume": 35
+  },
+  {
+    "type": "speech",
+    "speaker": [ "mon_vampire_anathema" ],
+    "sound": "\"Their blood was so delicious.\"",
+    "volume": 20
+  },
+  {
+    "type": "speech",
+    "speaker": [ "mon_vampire_anathema" ],
+    "sound": "\"I need your blood!\"",
+    "volume": 35
+  },
+  {
+    "type": "speech",
+    "speaker": [ "mon_vampire_anathema" ],
+    "sound": "\"They aren't uniting against me aren't they?\"",
+    "volume": 20
+  },
+  {
+    "type": "speech",
+    "speaker": [ "mon_vampire_anathema" ],
+    "sound": "\"I'm just trying to kill all the vampires, and everyone trying to oppose me in this goal.\"",
+    "volume": 20
+  },
+  {
+    "type": "speech",
+    "speaker": [ "mon_vampire_anathema" ],
+    "sound": "\"I can't understand why vampire hunters could want me dead.  I'm one of them!\"",
+    "volume": 20
+  },
+  {
+    "type": "speech",
+    "speaker": [ "mon_vampire_anathema" ],
+    "sound": "\"They have started to attack me with the vampires' help!  Traitors, all of them!\"",
+    "volume": 35
+  },
+  {
+    "type": "speech",
+    "speaker": [ "mon_vampire_anathema" ],
+    "sound": "\"Every other vampire will die, then I'll get rid of the last one.\"",
+    "volume": 20
+  }
+]


### PR DESCRIPTION
#### Summary
Mods "[XE] Adds a special boss encounter for tier 5 vampires."

#### Purpose of change

I'm planning a vampire-exclusive mutation path, so vampires can decide to become even more of a vampire through consuming vampires instead of using regular mutations.
However, how would the player learn the procedure? The mentors wouldn't ever share anything that would make vampires kill each other, and the non-mentors do not want more powerful vampires.

Turns out there's someone who wants to be a powerful vampire through killing vampires.

#### Describe the solution

Adds the vampiric anathema boss encounter. A vampire hunter who decided to become the strongest vampire ever to be the strongest vampire killer ever, they are looking for vampire-blooded to kill and drain to get more power. 

Their power is only equaled by their arrogance, which is why they are so slow until the battle begins. Why hurry, when that vampire cannot hope to defeat you?

Only tier 5 vampire players can encounter them, as lesser vampires still have regular blood and do not interest the anathema.

They are intended to easily kill even full-power vampires in melee, but to be manageable through proper planning and to be easy to flee from until the player attacks.

As per the Shadow singularity, once you kill the anathema it will never come back.

<details> 
  <summary>Encounter details</summary>
After becoming tier 5, a check starts. If the player is at night, outside and far from holy ground & vast water, there's a chance for the boss to appear, causing a popup.  

The anathema has a plate armor and the combined effects of flow like blood and sanguine resilience including a great dodge ability. They are very tough to kill through mundane damage but lack non-mundane armor. On top of that, they regenerate in the dark and can use the vampire heal spell .

It also has every single vampire weakness except for the need for living blood and non-human only feeding half as much. In gameplay terns, it means a big vulnerability to fire and retreating should the player approaches holy ground or vast water.

They also retreat when day comes. Any retreat allows them to return, as per the Shadow.

Their attacks are BIO_OP_BIOJUSTU and a weapon attack using a salamagman battle axe. When hit, they reach the speed of a regular tier 5 vampire for the rest of the encounter. When hit when under half hp, they get the equivalent of blood haste and shape of the shadowed path (massive speed, dodge and melee hit chance boost) for the rest of the encounter. They also fully heal when reaching that point but lose access to the vampire heal spell.

They do not activate last breath's mist when killed, as at this point they do not have enough inner blood to do so.

</details>

#### Describe alternatives you've considered

Not needing the recipe, which is far too simple.

Making the anathema a target for a vampire hunter mission. This can happen, when vampire hunter content will be added. For now, that encounter is for tier 5 only.

#### Testing

Anathema spawns and despawns according to the conditions.

They drop their loot when killed, including a fireproof book.
The book can be used to read it.

Attacked them in melee with 10 in all skills, a frostrimed estoc, a riot armor and all vampire buffs active: I got killed over and over.

Hasted and spammed flamethrower shots at them at close range: they died but I got damaged by them and by the heat.
Hasted and spammed precise Ree 3.3 shots: they died after 4 shots fired by a rifles 10 character.
Took them on a trip at Rubik's: they managed to kill a quad but they died.

Like the mentors, they are attacked by the undead.

If they rise as a strigoi, killing the strigoi drops their stuff.

#### Additional context

The mutations will be part of another PR. This one only implements the boss that drops the recipe-holding book.