### PR TITLE
fix can_contain copies_remaining amount for sheaths

### DIFF
--- a/src/item_pocket.cpp
+++ b/src/item_pocket.cpp
@@ -1597,7 +1597,7 @@ ret_val<item_pocket::contain_code> item_pocket::_can_contain( const item &it,
     }
 
     if( copies_remaining > 1 ) {
-        int how_many_copies_fit = std::min( { copies_remaining, copy_weight_capacity, copy_volume_capacity } );
+        int how_many_copies_fit = std::min( { data->holster ? 1 : copies_remaining, copy_weight_capacity, copy_volume_capacity } );
         copies_remaining -= how_many_copies_fit;
     } else {
         copies_remaining = 0;


### PR DESCRIPTION
#### Summary
Bugfixes "Show correct amount from can_contain"

#### Purpose of change
fix #80336
Wen checking how many items an item can fit it would count how many it would fit by volume/mass and not the fact that sheaths can only hold 1 item.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
only count 1 if its a sheath
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
there might be a better place to put it.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
AIM move now shows the right amount.
If the holster contains a container, it will show the amount that can be put into it.
![image](https://github.com/user-attachments/assets/cc362c51-8ea4-4ab8-b558-ff41d5913db6)
![image](https://github.com/user-attachments/assets/04955008-aaee-42b9-84d0-b6412cc37092)
![image](https://github.com/user-attachments/assets/1b53ebd2-cb61-4b53-aa2b-8052e3eb2acd)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
One step closer to #80308
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
