### PR TITLE
Allow more charges to be placed with add_item_or_charges

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -5146,9 +5146,8 @@ std::pair<item *, tripoint_bub_ms> map::_add_item_or_charges( const tripoint_bub
                     return e;
                 }
             }
-            support_dirty( tile );
-
             // if its charges and not already present, add them as a single item with the amount of charges
+            support_dirty( tile );
             obj.charges = copies;
             return add_item( tile, obj );
         }


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
map::add_item_or_charges would only place MAX_ITEM_IN_SQUARE charges, even though charges dont count towards item count in square. This allows placing an item with item::INFINITE_CHARGES.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
If the item count_by_charges, make an item with x charges.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
There is already a function for calculating charges per volume, use that.
another step towards #80308
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
