### PR TITLE
Fix charcoal kilns producing no charcoal

### DIFF
--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -3263,7 +3263,7 @@ void iexamine::kiln_empty( Character &you, const tripoint_bub_ms &examp )
     pick_firestarter_and_fire( you, examp, firestarter_actor::start_type::KILN );
 }
 
-bool iexamine::kiln_prep( Character &you, const tripoint_bub_ms &examp )
+bool iexamine::kiln_prep( Character &, const tripoint_bub_ms &examp )
 {
     map &here = get_map();
     const furn_id &cur_kiln_type = here.furn( examp );

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -3263,14 +3263,14 @@ void iexamine::kiln_empty( Character &you, const tripoint_bub_ms &examp )
     pick_firestarter_and_fire( you, examp, firestarter_actor::start_type::KILN );
 }
 
-bool iexamine::kiln_prep( Character& you, const tripoint_bub_ms& examp )
+bool iexamine::kiln_prep( Character &you, const tripoint_bub_ms &examp )
 {
     map &here = get_map();
     const furn_id &cur_kiln_type = here.furn( examp );
     if( cur_kiln_type != furn_f_kiln_empty && cur_kiln_type != furn_f_kiln_metal_empty &&
         cur_kiln_type != furn_f_kiln_portable_empty ) {
         debugmsg( "Examined furniture has action kiln_empty, but is of type %s",
-            cur_kiln_type.id().c_str() );
+                  cur_kiln_type.id().c_str() );
         return false;
     }
 
@@ -3282,13 +3282,11 @@ bool iexamine::kiln_prep( Character& you, const tripoint_bub_ms& examp )
             add_msg( _( "This kiln already contains charcoal." ) );
             add_msg( _( "Remove it before firing the kiln again." ) );
             return false;
-        }
-        else if( i.made_of_any( kilnable ) ) {
+        } else if( i.made_of_any( kilnable ) ) {
             fuel_present = true;
-        }
-        else {
+        } else {
             add_msg( m_bad, _( "This kiln contains %s, which can't be made into charcoal!" ), i.tname( 1,
-                false ) );
+                     false ) );
             return false;
         }
     }
@@ -3313,11 +3311,9 @@ bool iexamine::kiln_fire( Character &you, const tripoint_bub_ms &examp )
     furn_id next_kiln_type = furn_str_id::NULL_ID();
     if( cur_kiln_type == furn_f_kiln_empty ) {
         next_kiln_type = furn_f_kiln_full;
-    }
-    else if( cur_kiln_type == furn_f_kiln_metal_empty ) {
+    } else if( cur_kiln_type == furn_f_kiln_metal_empty ) {
         next_kiln_type = furn_f_kiln_metal_full;
-    }
-    else if( cur_kiln_type == furn_f_kiln_portable_empty ) {
+    } else if( cur_kiln_type == furn_f_kiln_portable_empty ) {
         next_kiln_type = furn_f_kiln_portable_full;
     }
 
@@ -3329,27 +3325,25 @@ bool iexamine::kiln_fire( Character &you, const tripoint_bub_ms &examp )
     // For a cruddy kiln (a pit with a rock chimney) assume 10-15% efficiency, depending on fabrication (40-60% wastage)
     // For a well made kiln (industrial-style metal kiln) assume 20-25% efficiency, depending on fabrication (0-20% wastage)
     ///\EFFECT_FABRICATION decreases loss when firing a kiln
-    const float skill = you.get_skill_level(skill_fabrication);
+    const float skill = you.get_skill_level( skill_fabrication );
     int loss = 0;
     // if the current kiln is a metal one, use a more efficient conversion rate otherwise default to assuming it is a rock pit kiln
-    if (cur_kiln_type == furn_f_kiln_metal_empty) {
+    if( cur_kiln_type == furn_f_kiln_metal_empty ) {
         loss = 20 - 2 * skill;
-    }
-    else if (cur_kiln_type == furn_f_kiln_portable_empty) {
+    } else if( cur_kiln_type == furn_f_kiln_portable_empty ) {
         loss = 25 - 2 * skill;
-    }
-    else {
+    } else {
         loss = 60 - 2 * skill;
     }
 
     // Burn stuff that should get charred, leave out the rest
     map_stack items = here.i_at( examp );
     units::volume total_volume = 0_ml;
-    for ( const item& i : items ) {
+    for( const item &i : items ) {
         total_volume += i.volume();
     }
 
-    const itype* char_type = item::find_type( itype_unfinished_charcoal );
+    const itype *char_type = item::find_type( itype_unfinished_charcoal );
     int char_charges = char_type->charges_per_volume( ( 100 - loss ) * total_volume / 100 );
     if( char_charges < 1 ) {
         add_msg( _( "The batch in this kiln is too small to yield any charcoal." ) );
@@ -3372,16 +3366,13 @@ void iexamine::kiln_full( Character &, const tripoint_bub_ms &examp )
     furn_id next_kiln_type = furn_str_id::NULL_ID();
     if( cur_kiln_type == furn_f_kiln_metal_full ) {
         next_kiln_type = furn_f_kiln_metal_empty;
-    }
-    else if( cur_kiln_type == furn_f_kiln_portable_full ) {
+    } else if( cur_kiln_type == furn_f_kiln_portable_full ) {
         next_kiln_type = furn_f_kiln_portable_empty;
-    }
-    else if( cur_kiln_type == furn_f_kiln_full ) {
+    } else if( cur_kiln_type == furn_f_kiln_full ) {
         next_kiln_type = furn_f_kiln_empty;
-    }
-    else {
+    } else {
         debugmsg( "Examined furniture has action kiln_full, but is of type %s",
-            here.furn( examp ).id().c_str() );
+                  here.furn( examp ).id().c_str() );
         return;
     }
     map_stack items = here.i_at( examp );
@@ -3400,16 +3391,14 @@ void iexamine::kiln_full( Character &, const tripoint_bub_ms &examp )
         int minutes = to_minutes<int>( time_left ) + 1;
         if( minutes > 60 ) {
             add_msg( n_gettext( "It will finish burning in about %d hour.",
-                "It will finish burning in about %d hours.",
-                hours ), hours );
-        }
-        else if( minutes > 30 ) {
+                                "It will finish burning in about %d hours.",
+                                hours ), hours );
+        } else if( minutes > 30 ) {
             add_msg( _( "It will finish burning in less than an hour." ) );
-        }
-        else {
+        } else {
             add_msg( n_gettext( "It should take about %d minute to finish burning.",
-                "It should take about %d minutes to finish burning.",
-                minutes ), minutes );
+                                "It should take about %d minutes to finish burning.",
+                                minutes ), minutes );
         }
         return;
     }
@@ -3420,8 +3409,7 @@ void iexamine::kiln_full( Character &, const tripoint_bub_ms &examp )
         if( item_it->typeId() == itype_unfinished_charcoal || item_it->typeId() == itype_charcoal ) {
             total_volume += item_it->volume();
             item_it = items.erase( item_it );
-        }
-        else {
+        } else {
             item_it++;
         }
     }

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -3256,7 +3256,7 @@ static void pick_firestarter_and_fire( Character &you, const tripoint_bub_ms &ex
 // Highly modified fermenting vat functions
 void iexamine::kiln_empty( Character &you, const tripoint_bub_ms &examp )
 {
-    if(!kiln_prep( you, examp ) ) {
+    if( !kiln_prep( you, examp ) ) {
         return;
     }
 


### PR DESCRIPTION
#### Summary

Bugfixes "Fix charcoal kilns producing no charcoal"

#### Purpose of change

Charcoal kilns were still intermittently producing either no or very low amounts of charcoal(60~200charges from a fully loaded kiln) [#79838](https://github.com/CleverRaven/Cataclysm-DDA/issues/79838). This issue occurs due to improper calculations of the "unfinished charcoal" item which is necessary to determine the end amount of charcoal produced.

To reproduce this issue you must start a new world then place and fire any charcoal kiln variant. If you then smash or deconstruct the kiln the amount of unfinished charcoal will always be 0.

#### Describe the solution

This resolves the issue by moving the calculation of unfinished charcoal to occur in the same function instead of being split between two functions.

#### Describe alternatives you've considered

Could also try figuring out why kiln_prep_internal was not properly returning a value for the unfinished charcoal equation in the original code.

#### Testing

Started new game, spawned in two of each charcoal kiln variant, filled with logs and fired them. Deconstructed one of each variant to ensure the unfinished charcoal was spawning in properly, then waited in game until remaining charcoal kilns were finished to ensure charcoal spawned properly.

#### Additional context

Do note opening the crafting/construction menu will active an older bug [59189](https://github.com/CleverRaven/Cataclysm-DDA/issues/59189) with charcoal amounts exceeding a total of 50000 charges in the local area. I plan to look at this later as it relates to a pseudo crafting items for basecamps.