### PR TITLE
Switched usage of m to use get_map()

### DIFF
--- a/src/animation.cpp
+++ b/src/animation.cpp
@@ -498,7 +498,7 @@ void game::draw_bullet( const tripoint_bub_ms &t, const int /*i*/,
         return;
     }
     if( !use_tiles ) {
-        draw_bullet_curses( m, t, bullet, nullptr );
+        draw_bullet_curses( get_map(), t, bullet, nullptr );
         return;
     }
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -874,7 +874,9 @@ special_game_type game::gametype() const
 void game::load_map( const tripoint_abs_sm &pos_sm,
                      const bool pump_events )
 {
-    m.load( pos_sm, true, pump_events );
+    map &here = get_map();
+
+    here.load( pos_sm, true, pump_events );
 }
 
 void game::legacy_migrate_npctalk_var_prefix( std::unordered_map<std::string, std::string>
@@ -979,17 +981,18 @@ bool game::start_game()
     load_map( lev, /*pump_events=*/true );
 
     start_loc.place_player( u, omtstart );
-    int level = m.get_abs_sub().z();
+    map &here = reality_bubble();
+    int level = here.get_abs_sub().z();
     // Rebuild map cache because we want visibility cache to avoid spawning monsters in sight
-    m.invalidate_map_cache( level );
-    m.build_map_cache( level );
+    here.invalidate_map_cache( level );
+    here.build_map_cache( level );
     // Start the overmap with out immediate neighborhood visible, this needs to be after place_player
     overmap_buffer.reveal( u.pos_abs_omt().xy(),
                            get_option<int>( "DISTANCE_INITIAL_VISIBILITY" ), 0 );
 
     const int city_size = get_option<int>( "CITY_SIZE" );
     if( get_scenario()->get_reveal_locale() && city_size > 0 ) {
-        city_reference nearest_city = overmap_buffer.closest_city( m.get_abs_sub() );
+        city_reference nearest_city = overmap_buffer.closest_city( here.get_abs_sub() );
         const tripoint_abs_omt city_center_omt = project_to<coords::omt>( nearest_city.abs_sm_pos );
         // Very necessary little hack: We look for roads around our start, and path from the closest. Because the most common start(evac shelter) cannot be pathed through...
         const tripoint_abs_omt nearest_road = overmap_buffer.find_closest( omtstart, "road", 3, false );
@@ -1034,14 +1037,14 @@ bool game::start_game()
         }
     }
 
-    m.spawn_monsters( !spawn_near ); // Static monsters
+    here.spawn_monsters( !spawn_near ); // Static monsters
 
     // Make sure that no monsters are near the player
     // This can happen in lab starts
     if( !spawn_near ) {
         for( monster &critter : all_monsters() ) {
             if( rl_dist( critter.pos_bub(), u.pos_bub() ) <= 5 ||
-                m.clear_path( critter.pos_bub(), u.pos_bub(), 40, 1, 100 ) ) {
+                here.clear_path( critter.pos_bub(), u.pos_bub(), 40, 1, 100 ) ) {
                 remove_zombie( critter );
             }
         }
@@ -1057,7 +1060,7 @@ bool game::start_game()
     if( scen->has_flag( "HELI_CRASH" ) ) {
         start_loc.handle_heli_crash( u );
         bool success = false;
-        for( wrapped_vehicle v : m.get_vehicles() ) {
+        for( wrapped_vehicle v : here.get_vehicles() ) {
             std::string name = v.v->type.str();
             std::string search = std::string( "helicopter" );
             if( name.find( search ) != std::string::npos ) {
@@ -1280,7 +1283,7 @@ void game::load_npcs()
         add_msg_debug( debugmode::DF_NPC, "game::load_npcs: Spawning static NPC, %s %s",
                        abs_sub.to_string_writable(), sm_loc.to_string_writable() );
         temp->place_on_map( &here );
-        if( !m.inbounds( temp->pos_bub() ) ) {
+        if( !reality_bubble().inbounds( temp->pos_bub() ) ) {
             continue;
         }
         // In the rare case the npc was marked for death while
@@ -1574,8 +1577,8 @@ void game::catch_a_monster( monster *fish, const tripoint_bub_ms &pos, Character
     map &here = get_map();
 
     //spawn the corpse, rotten by a part of the duration
-    m.add_item_or_charges( pos, item::make_corpse( fish->type->id, calendar::turn + rng( 0_turns,
-                           catch_duration ) ) );
+    here.add_item_or_charges( pos, item::make_corpse( fish->type->id, calendar::turn + rng( 0_turns,
+                              catch_duration ) ) );
     if( u.sees( here, pos ) ) {
         u.add_msg_if_player( m_good, _( "You caught a %s." ), fish->type->nname() );
     }
@@ -1897,10 +1900,12 @@ static void update_faction_api( npc *guy )
 
 void game::validate_linked_vehicles()
 {
-    for( wrapped_vehicle &veh : m.get_vehicles() ) {
+    map &here = get_map();
+
+    for( wrapped_vehicle &veh : here.get_vehicles() ) {
         vehicle *v = veh.v;
         if( v->tow_data.other_towing_point != tripoint_bub_ms::zero ) {
-            vehicle *other_v = veh_pointer_or_null( m.veh_at( v->tow_data.other_towing_point ) );
+            vehicle *other_v = veh_pointer_or_null( here.veh_at( v->tow_data.other_towing_point ) );
             if( other_v ) {
                 // the other vehicle is towing us.
                 v->tow_data.set_towing( other_v, v );
@@ -1955,15 +1960,17 @@ void game::validate_npc_followers()
 
 void game::validate_camps()
 {
-    basecamp camp = m.hoist_submap_camp( u.pos_bub() );
+    map &here = get_map();
+
+    basecamp camp = here.hoist_submap_camp( u.pos_bub() );
     if( camp.is_valid() ) {
         overmap_buffer.add_camp( camp );
-        m.remove_submap_camp( u.pos_bub() );
+        here.remove_submap_camp( u.pos_bub() );
     } else if( camp.camp_omt_pos() != tripoint_abs_omt() ) {
         std::string camp_name = _( "Faction Camp" );
         camp.set_name( camp_name );
         overmap_buffer.add_camp( camp );
-        m.remove_submap_camp( u.pos_bub() );
+        here.remove_submap_camp( u.pos_bub() );
     }
 }
 
@@ -2832,7 +2839,7 @@ vehicle *game::remoteveh()
     } else {
         tripoint_bub_ms vp;
         remote_veh_string >> vp.x() >> vp.y() >> vp.z();
-        vehicle *veh = veh_pointer_or_null( m.veh_at( vp ) );
+        vehicle *veh = veh_pointer_or_null( here.veh_at( vp ) );
         if( veh && veh->fuel_left( here, itype_battery ) > 0 ) {
             remoteveh_cache = veh;
         } else {
@@ -2901,7 +2908,7 @@ bool game::try_get_left_click_action( action_id &act, const tripoint_bub_ms &mou
 
 bool game::try_get_right_click_action( action_id &act, const tripoint_bub_ms &mouse_target )
 {
-    const map &here = get_map();
+    map &here = get_map();
 
     const bool cleared_destination = !destination_preview.empty();
     u.clear_destination();
@@ -2931,8 +2938,8 @@ bool game::try_get_right_click_action( action_id &act, const tripoint_bub_ms &mo
 
         act = ACTION_FIRE;
     } else if( is_adjacent &&
-               m.close_door( tripoint_bub_ms( mouse_target.xy(), u.posz() ),
-                             !m.is_outside( u.pos_bub() ), true ) ) {
+               here.close_door( tripoint_bub_ms( mouse_target.xy(), u.posz() ),
+                                !here.is_outside( u.pos_bub() ), true ) ) {
         act = ACTION_CLOSE;
     } else if( is_self ) {
         act = ACTION_PICKUP;
@@ -2970,7 +2977,7 @@ bool game::is_game_over()
     }
     if( uquit == QUIT_DIED ) {
         if( u.in_vehicle ) {
-            m.unboard_vehicle( u.pos_bub() );
+            here.unboard_vehicle( u.pos_bub() );
         }
         u.place_corpse( &here );
         return true;
@@ -2978,7 +2985,7 @@ bool game::is_game_over()
     if( uquit == QUIT_SUICIDE ) {
         bury_screen();
         if( u.in_vehicle ) {
-            m.unboard_vehicle( u.pos_bub() );
+            here.unboard_vehicle( u.pos_bub() );
         }
         return true;
     }
@@ -3213,6 +3220,8 @@ bool game::load( const std::string &world )
 
 bool game::load( const save_t &name )
 {
+    map &here = get_map();
+
     const cata_path worldpath = PATH_INFO::world_base_save_path();
     const cata_path save_file_path = PATH_INFO::world_base_save_path() /
                                      ( name.base_path() + SAVE_EXTENSION );
@@ -3315,7 +3324,7 @@ bool game::load( const save_t &name )
                         u.setID( assign_npc_id() );
                         // The vehicle stores the IDs of the boarded players, so update it, too.
                         if( u.in_vehicle ) {
-                            if( const std::optional<vpart_reference> vp = m.veh_at(
+                            if( const std::optional<vpart_reference> vp = here.veh_at(
                                         u.pos_bub() ).part_with_feature( "BOARDABLE", true ) ) {
                                 vp->part().passenger_id = u.getID();
                             }
@@ -3352,7 +3361,7 @@ bool game::load( const save_t &name )
 
                     effect_on_conditions::load_existing_character( u );
                     // recalculate light level for correctly resuming crafting and disassembly
-                    m.build_map_cache( m.get_abs_sub().z() );
+                    here.build_map_cache( here.get_abs_sub().z() );
                 }
             },
         }
@@ -3496,8 +3505,10 @@ bool game::save_factions_missions_npcs()
 
 bool game::save_maps()
 {
+    map &here = get_map();
+
     try {
-        m.save();
+        here.save();
         overmap_buffer.save(); // can throw
         MAPBUFFER.save(); // can throw
         return true;
@@ -4160,13 +4171,15 @@ bool game::has_blink_curses()
 
 void game::draw( ui_adaptor &ui )
 {
+    map &here = get_map();
+
     if( test_mode ) {
         return;
     }
 
     ter_view_p.z() = ( u.pos_bub() + u.view_offset ).z();
-    m.build_map_cache( ter_view_p.z() );
-    m.update_visibility_cache( ter_view_p.z() );
+    here.build_map_cache( ter_view_p.z() );
+    here.update_visibility_cache( ter_view_p.z() );
 
     werase( w_terrain );
     void_blink_curses();
@@ -4290,7 +4303,7 @@ void game::draw_critter( const Creature &critter, const tripoint_bub_ms &center 
     if( critter_pos.z() != center.z() ) {
         if( critter_pos.z() == center.z() - 1 &&
             ( debug_mode || u.sees( here, critter ) ) &&
-            m.valid_move( critter_pos, critter_pos + tripoint::above, false, true ) ) {
+            here.valid_move( critter_pos, critter_pos + tripoint::above, false, true ) ) {
             // Monster is below
             // TODO: Make this show something more informative than just green 'v'
             // TODO: Allow looking at this mon with look command
@@ -4298,7 +4311,7 @@ void game::draw_critter( const Creature &critter, const tripoint_bub_ms &center 
         }
         if( critter_pos.z() == center.z() + 1 &&
             ( debug_mode || u.sees( here, critter ) ) &&
-            m.valid_move( critter_pos, critter_pos + tripoint::below, false, true ) ) {
+            here.valid_move( critter_pos, critter_pos + tripoint::below, false, true ) ) {
             // Monster is above
             init_draw_blink_curses( { critter_pos.xy(), center.z() }, "^", c_green_cyan );
         }
@@ -4338,11 +4351,11 @@ void game::draw_ter( const bool draw_sounds )
 void game::draw_ter( const tripoint_bub_ms &center, const bool looking, const bool draw_sounds )
 {
     map &here = get_map();
-    const tripoint_bub_ms pos = u.pos_bub( here );
+    const tripoint_bub_ms pos = u.pos_bub( );
 
     ter_view_p = center;
 
-    m.draw( w_terrain, tripoint_bub_ms( center ) );
+    here.draw( w_terrain, tripoint_bub_ms( center ) );
 
     if( draw_sounds ) {
         draw_footsteps( w_terrain, tripoint_rel_ms( -center.x(), -center.y(), center.z() ) + point( POSX,
@@ -4372,10 +4385,12 @@ void game::draw_ter( const tripoint_bub_ms &center, const bool looking, const bo
 
 std::optional<tripoint_rel_ms> game::get_veh_dir_indicator_location( bool next ) const
 {
+    map &here = get_map();
+
     if( !get_option<bool>( "VEHICLE_DIR_INDICATOR" ) ) {
         return std::nullopt;
     }
-    const optional_vpart_position vp = m.veh_at( u.pos_bub() );
+    const optional_vpart_position vp = here.veh_at( u.pos_bub() );
     if( !vp ) {
         return std::nullopt;
     }
@@ -4546,6 +4561,8 @@ std::unordered_set<tripoint_abs_ms> game::get_fishable_locations_abs( int distan
 std::unordered_set<tripoint_bub_ms> game::get_fishable_locations_bub( int distance,
         const tripoint_bub_ms &fish_pos )
 {
+    map &here = get_map();
+
     // We're going to get the contiguous fishable terrain starting at
     // the provided fishing location (e.g. where a line was cast or a fish
     // trap was set), and then check whether or not fishable monsters are
@@ -4582,7 +4599,7 @@ std::unordered_set<tripoint_bub_ms> game::get_fishable_locations_bub( int distan
             // Mark this point as visited.
             visited.emplace( current_point );
 
-            if( m.has_flag( ter_furn_flag::TFLAG_FISHABLE, current_point ) ) {
+            if( here.has_flag( ter_furn_flag::TFLAG_FISHABLE, current_point ) ) {
                 fishable_terrain.emplace( current_point );
                 to_check.push( current_point + point::south );
                 to_check.push( current_point + point::north );
@@ -4938,8 +4955,8 @@ void game::knockback( std::vector<tripoint_bub_ms> &traj, int stun, int dam_mult
             add_msg( _( "%s was stunned!" ), targ->name() );
         }
         for( size_t i = 1; i < traj.size(); i++ ) {
-            if( m.impassable( traj[i].xy() ) ) {
-                targ->setpos( m, traj[i - 1] );
+            if( here.impassable( traj[i].xy() ) ) {
+                targ->setpos( here, traj[i - 1] );
                 force_remaining = traj.size() - i;
                 if( stun != 0 ) {
                     targ->add_effect( effect_stunned, 1_turns * force_remaining );
@@ -4948,10 +4965,10 @@ void game::knockback( std::vector<tripoint_bub_ms> &traj, int stun, int dam_mult
                     targ->apply_damage( nullptr, bodypart_id( "torso" ), dam_mult * force_remaining );
                     targ->check_dead_state( &here );
                 }
-                m.bash( traj[i], 2 * dam_mult * force_remaining );
+                here.bash( traj[i], 2 * dam_mult * force_remaining );
                 break;
             } else if( creatures.creature_at( traj[i] ) ) {
-                targ->setpos( m, traj[i - 1] );
+                targ->setpos( here, traj[i - 1] );
                 force_remaining = traj.size() - i;
                 if( stun != 0 ) {
                     targ->add_effect( effect_stunned, 1_turns * force_remaining );
@@ -4975,15 +4992,15 @@ void game::knockback( std::vector<tripoint_bub_ms> &traj, int stun, int dam_mult
                 knockback( traj, stun, dam_mult );
                 break;
             }
-            targ->setpos( m, traj[i] );
-            if( m.has_flag( ter_furn_flag::TFLAG_LIQUID, targ_pos ) && !targ->can_drown() &&
+            targ->setpos( here, traj[i] );
+            if( here.has_flag( ter_furn_flag::TFLAG_LIQUID, targ_pos ) && !targ->can_drown() &&
                 !targ->is_dead() ) {
                 targ->die( &here, nullptr );
                 if( u.sees( here, *targ ) ) {
                     add_msg( _( "The %s drowns!" ), targ->name() );
                 }
             }
-            if( !m.has_flag( ter_furn_flag::TFLAG_LIQUID, targ_pos ) &&
+            if( !here.has_flag( ter_furn_flag::TFLAG_LIQUID, targ_pos ) &&
                 targ->has_flag( mon_flag_AQUATIC ) &&
                 !targ->is_dead() ) {
                 targ->die( &here, nullptr );
@@ -4998,8 +5015,8 @@ void game::knockback( std::vector<tripoint_bub_ms> &traj, int stun, int dam_mult
             add_msg( _( "%s was stunned!" ), targ->get_name() );
         }
         for( size_t i = 1; i < traj.size(); i++ ) {
-            if( m.impassable( traj[i].xy() ) ) { // oops, we hit a wall!
-                targ->setpos( m, traj[i - 1] );
+            if( here.impassable( traj[i].xy() ) ) { // oops, we hit a wall!
+                targ->setpos( here, traj[i - 1] );
                 force_remaining = traj.size() - i;
                 if( stun != 0 ) {
                     targ->add_effect( effect_stunned, 1_turns * force_remaining );
@@ -5022,10 +5039,10 @@ void game::knockback( std::vector<tripoint_bub_ms> &traj, int stun, int dam_mult
                     }
                     targ->check_dead_state( &here );
                 }
-                m.bash( traj[i], 2 * dam_mult * force_remaining );
+                here.bash( traj[i], 2 * dam_mult * force_remaining );
                 break;
             } else if( creatures.creature_at( traj[i] ) ) {
-                targ->setpos( m, traj[i - 1] );
+                targ->setpos( here, traj[i - 1] );
                 force_remaining = traj.size() - i;
                 if( stun != 0 ) {
                     add_msg( _( "%s was stunned!" ), targ->get_name() );
@@ -5053,7 +5070,7 @@ void game::knockback( std::vector<tripoint_bub_ms> &traj, int stun, int dam_mult
                 knockback( traj, stun, dam_mult );
                 break;
             }
-            targ->setpos( m, traj[i] );
+            targ->setpos( here, traj[i] );
         }
     } else if( pos == tp ) {
         if( stun > 0 ) {
@@ -5064,8 +5081,8 @@ void game::knockback( std::vector<tripoint_bub_ms> &traj, int stun, int dam_mult
                      stun );
         }
         for( size_t i = 1; i < traj.size(); i++ ) {
-            if( m.impassable( traj[i] ) ) { // oops, we hit a wall!
-                u.setpos( m, traj[i - 1] );
+            if( here.impassable( traj[i] ) ) { // oops, we hit a wall!
+                u.setpos( here, traj[i - 1] );
                 force_remaining = traj.size() - i;
                 if( stun != 0 ) {
                     if( u.has_effect( effect_stunned ) ) {
@@ -5095,10 +5112,10 @@ void game::knockback( std::vector<tripoint_bub_ms> &traj, int stun, int dam_mult
                     }
                     u.check_dead_state( &here );
                 }
-                m.bash( traj[i], 2 * dam_mult * force_remaining );
+                here.bash( traj[i], 2 * dam_mult * force_remaining );
                 break;
             } else if( creatures.creature_at( traj[i] ) ) {
-                u.setpos( m, traj[i - 1] );
+                u.setpos( here, traj[i - 1] );
                 force_remaining = traj.size() - i;
                 if( stun != 0 ) {
                     if( u.has_effect( effect_stunned ) ) {
@@ -5127,10 +5144,10 @@ void game::knockback( std::vector<tripoint_bub_ms> &traj, int stun, int dam_mult
                 knockback( traj, stun, dam_mult );
                 break;
             }
-            if( m.has_flag( ter_furn_flag::TFLAG_LIQUID, pos ) && force_remaining == 0 ) {
-                avatar_action::swim( m, u, pos );
+            if( here.has_flag( ter_furn_flag::TFLAG_LIQUID, pos ) && force_remaining == 0 ) {
+                avatar_action::swim( here, u, pos );
             } else {
-                u.setpos( m,  traj[i] );
+                u.setpos( here,  traj[i] );
             }
         }
     }
@@ -5138,6 +5155,8 @@ void game::knockback( std::vector<tripoint_bub_ms> &traj, int stun, int dam_mult
 
 void game::use_computer( const tripoint_bub_ms &p )
 {
+    map &here = get_map();
+
     if( u.has_trait( trait_ILLITERATE ) ) {
         add_msg( m_info, _( "You can not read a computer screen!" ) );
         return;
@@ -5154,10 +5173,10 @@ void game::use_computer( const tripoint_bub_ms &p )
         return;
     }
 
-    computer *used = m.computer_at( p );
+    computer *used = here.computer_at( p );
 
     if( used == nullptr ) {
-        if( m.has_flag( ter_furn_flag::TFLAG_CONSOLE, p ) ) { //Console without map data
+        if( here.has_flag( ter_furn_flag::TFLAG_CONSOLE, p ) ) { //Console without map data
             add_msg( m_bad, _( "The console doesn't display anything coherent." ) );
         } else {
             dbg( D_ERROR ) << "game:use_computer: Tried to use computer at (" <<
@@ -5314,6 +5333,8 @@ monster *game::place_critter_around( const shared_ptr_fast<monster> &mon,
                                      const int radius,
                                      bool forced )
 {
+    map &here = get_map();
+
     std::optional<tripoint_bub_ms> where;
     if( forced || can_place_monster( *mon, center ) ) {
         where = center;
@@ -5322,7 +5343,7 @@ monster *game::place_critter_around( const shared_ptr_fast<monster> &mon,
     // This loop ensures the monster is placed as close to the center as possible,
     // but all places that equally far from the center have the same probability.
     for( int r = 1; r <= radius && !where; ++r ) {
-        where = choose_where_to_place_monster( *mon, m.points_in_radius( center, r ) );
+        where = choose_where_to_place_monster( *mon, here.points_in_radius( center, r ) );
     }
 
     if( !where ) {
@@ -5550,8 +5571,10 @@ bool game::spawn_npc( const tripoint_bub_ms &p, const string_id<npc_template> &n
 
 bool game::swap_critters( Creature &a, Creature &b )
 {
-    const tripoint_bub_ms a_pos = a.pos_bub( m );
-    const tripoint_bub_ms b_pos = b.pos_bub( m );
+    map &here = get_map();
+
+    const tripoint_bub_ms a_pos = a.pos_bub( );
+    const tripoint_bub_ms b_pos = b.pos_bub( );
 
     if( &a == &b ) {
         // No need to do anything, but print a debugmsg anyway
@@ -5607,38 +5630,40 @@ bool game::swap_critters( Creature &a, Creature &b )
     // Issue https://github.com/CleverRaven/Cataclysm-DDA/issues/80245
     // second can be a monster, in that case other_npc will be NULL
     Character *other_npc = dynamic_cast< Character * >( &second );
-    const tripoint_bub_ms u_or_npc_pos = u_or_npc->pos_bub( m );
-    const tripoint_bub_ms other_npc_pos = second.pos_bub( m );
+    const tripoint_bub_ms u_or_npc_pos = u_or_npc->pos_bub( );
+    const tripoint_bub_ms other_npc_pos = second.pos_bub( );
 
     if( u_or_npc->in_vehicle ) {
-        m.unboard_vehicle( u_or_npc_pos );
+        here.unboard_vehicle( u_or_npc_pos );
     }
 
     if( other_npc && other_npc->in_vehicle ) {
-        m.unboard_vehicle( other_npc_pos );
+        here.unboard_vehicle( other_npc_pos );
     }
 
-    tripoint_bub_ms temp = second.pos_bub( m );
-    second.setpos( m, first.pos_bub( m ) );
+    tripoint_bub_ms temp = second.pos_bub( );
+    second.setpos( here, first.pos_bub( ) );
 
     if( first.is_avatar() ) {
         walk_move( temp );
     } else {
-        first.setpos( m, temp );
-        if( m.veh_at( u_or_npc_pos ).part_with_feature( VPFLAG_BOARDABLE, true ) ) {
-            m.board_vehicle( u_or_npc_pos, u_or_npc );
+        first.setpos( here, temp );
+        if( here.veh_at( u_or_npc_pos ).part_with_feature( VPFLAG_BOARDABLE, true ) ) {
+            here.board_vehicle( u_or_npc_pos, u_or_npc );
         }
     }
 
-    if( other_npc && m.veh_at( other_npc_pos ).part_with_feature( VPFLAG_BOARDABLE, true ) ) {
-        m.board_vehicle( other_npc_pos, other_npc );
+    if( other_npc && here.veh_at( other_npc_pos ).part_with_feature( VPFLAG_BOARDABLE, true ) ) {
+        here.board_vehicle( other_npc_pos, other_npc );
     }
     return true;
 }
 
 bool game::is_empty( const tripoint_bub_ms &p )
 {
-    return ( m.passable( p ) || m.has_flag( ter_furn_flag::TFLAG_LIQUID, p ) ) &&
+    map &here = get_map();
+
+    return ( here.passable( p ) || here.has_flag( ter_furn_flag::TFLAG_LIQUID, p ) ) &&
            get_creature_tracker().creature_at( p ) == nullptr;
 }
 
@@ -5664,7 +5689,9 @@ bool game::is_in_sunlight( map *here, const tripoint_bub_ms &p )
 
 bool game::is_sheltered( const tripoint_bub_ms &p )
 {
-    return game::is_sheltered( &m, p );
+    map &here = get_map();
+
+    return game::is_sheltered( &here, p );
 }
 
 bool game::is_sheltered( map *here, const tripoint_bub_ms &p )
@@ -5752,6 +5779,8 @@ void game::assing_revive_form( item &it, tripoint_bub_ms p )
 
 void game::save_cyborg( item *cyborg, const tripoint_bub_ms &couch_pos, Character &installer )
 {
+    map &here = get_map();
+
     int damage = cyborg->damage();
     int dmg_lvl = cyborg->damage_level();
     int difficulty = 12;
@@ -5778,7 +5807,7 @@ void game::save_cyborg( item *cyborg, const tripoint_bub_ms &couch_pos, Characte
         add_msg( m_good, _( "Successfully removed Personality override." ) );
         add_msg( m_bad, _( "Autodoc immediately destroys the CBM upon removal." ) );
 
-        m.i_rem( couch_pos, cyborg );
+        here.i_rem( couch_pos, cyborg );
 
         shared_ptr_fast<npc> tmp = make_shared_fast<npc>();
         tmp->normalize();
@@ -5809,7 +5838,7 @@ void game::save_cyborg( item *cyborg, const tripoint_bub_ms &couch_pos, Characte
             case 5:
                 add_msg( m_info, _( "The removal is a catastrophe." ) );
                 add_msg( m_bad, _( "The body is destroyed!" ) );
-                m.i_rem( couch_pos, cyborg );
+                here.i_rem( couch_pos, cyborg );
                 break;
             default:
                 break;
@@ -5852,9 +5881,11 @@ void game::open_gate( const tripoint_bub_ms &p )
 
 void game::moving_vehicle_dismount( const tripoint_bub_ms &dest_loc )
 {
-    const tripoint_bub_ms pos = u.pos_bub( m );
+    map &here = get_map();
 
-    const optional_vpart_position vp = m.veh_at( pos );
+    const tripoint_bub_ms pos = u.pos_bub( );
+
+    const optional_vpart_position vp = here.veh_at( pos );
     if( !vp ) {
         debugmsg( "Tried to exit non-existent vehicle." );
         return;
@@ -5868,12 +5899,12 @@ void game::moving_vehicle_dismount( const tripoint_bub_ms &dest_loc )
     // TODO:: make dir() const correct!
     const units::angle d = ray.dir();
     add_msg( _( "You dive from the %s." ), veh->name );
-    m.unboard_vehicle( pos );
+    here.unboard_vehicle( pos );
     u.mod_moves( -to_moves<int>( 2_seconds ) );
     // Dive three tiles in the direction of tox and toy
     fling_creature( &u, d, 30, true, true );
     // Hit the ground according to vehicle speed
-    if( !m.has_flag( ter_furn_flag::TFLAG_SWIMMABLE, pos ) ) {
+    if( !here.has_flag( ter_furn_flag::TFLAG_SWIMMABLE, pos ) ) {
         if( veh->velocity > 0 ) {
             fling_creature( &u, veh->face.dir(), veh->velocity / static_cast<float>( 100 ), false, true );
         } else {
@@ -5894,7 +5925,7 @@ void game::control_vehicle()
         }
     }
     vehicle *veh = nullptr;
-    if( const optional_vpart_position vp = m.veh_at( u.pos_bub() ) ) {
+    if( const optional_vpart_position vp = here.veh_at( u.pos_bub() ) ) {
         veh = &vp->vehicle();
         const int controls_idx = veh->avail_part_with_feature( vp->mount_pos(), "CONTROLS" );
         const int reins_idx = veh->avail_part_with_feature( vp->mount_pos(), "CONTROL_ANIMAL" );
@@ -5959,8 +5990,8 @@ void game::control_vehicle()
         int num_valid_controls = 0;
         std::optional<tripoint_bub_ms> vehicle_position;
         std::optional<vpart_reference> vehicle_controls;
-        for( const tripoint_bub_ms &elem : m.points_in_radius( get_player_character().pos_bub(), 1 ) ) {
-            if( const optional_vpart_position vp = m.veh_at( elem ) ) {
+        for( const tripoint_bub_ms &elem : here.points_in_radius( get_player_character().pos_bub(), 1 ) ) {
+            if( const optional_vpart_position vp = here.veh_at( elem ) ) {
                 const std::optional<vpart_reference> controls = vp.value().part_with_feature( "CONTROLS", true );
                 if( controls ) {
                     num_valid_controls++;
@@ -5979,7 +6010,7 @@ void game::control_vehicle()
             } else {
                 vehicle_position.value() = temp.value();
             }
-            const optional_vpart_position vp = m.veh_at( *vehicle_position );
+            const optional_vpart_position vp = here.veh_at( *vehicle_position );
             if( vp ) {
                 vehicle_controls = vp.value().part_with_feature( "CONTROLS", true );
                 if( !vehicle_controls ) {
@@ -6005,7 +6036,7 @@ void game::control_vehicle()
         // Clear the map memory for the area covered by the vehicle to eliminate ghost vehicles.
         for( const tripoint_abs_ms &target : veh->get_points() ) {
             u.memorize_clear_decoration( target, "vp_" );
-            m.memory_cache_dec_set_dirty( m.get_bub( target ), true );
+            here.memory_cache_dec_set_dirty( here.get_bub( target ), true );
         }
         veh->is_following = false;
         veh->is_patrolling = false;
@@ -6180,7 +6211,7 @@ void game::examine( bool with_pickup )
 
     // if we are driving a vehicle, examine the
     // current tile without asking.
-    const optional_vpart_position vp = m.veh_at( u.pos_bub() );
+    const optional_vpart_position vp = here.veh_at( u.pos_bub() );
     if( vp && vp->vehicle().player_in_control( here, u ) ) {
         examine( u.pos_bub(), with_pickup );
         return;
@@ -6276,6 +6307,8 @@ static std::string get_fire_fuel_string( const tripoint_bub_ms &examp )
 
 void game::examine( const tripoint_bub_ms &examp, bool with_pickup )
 {
+    map &here = get_map();
+
     if( disable_robot( examp ) ) {
         return;
     }
@@ -6315,11 +6348,11 @@ void game::examine( const tripoint_bub_ms &examp, bool with_pickup )
         }
     }
 
-    const optional_vpart_position vp = m.veh_at( examp );
+    const optional_vpart_position vp = here.veh_at( examp );
     if( vp ) {
         if( !u.is_mounted() || u.mounted_creature->has_flag( mon_flag_RIDEABLE_MECH ) ) {
             if( !vp->vehicle().is_appliance() ) {
-                vp->vehicle().interact_with( &m, examp, with_pickup );
+                vp->vehicle().interact_with( &here, examp, with_pickup );
             } else {
                 g->exam_appliance( vp->vehicle(), vp->mount_pos() );
             }
@@ -6331,22 +6364,22 @@ void game::examine( const tripoint_bub_ms &examp, bool with_pickup )
 
     iexamine::part_con( get_avatar(), examp );
     // trap::iexamine will handle the invisible traps.
-    m.tr_at( examp ).examine( examp );
+    here.tr_at( examp ).examine( examp );
 
-    if( m.has_flag( ter_furn_flag::TFLAG_CONSOLE, examp ) && !u.is_mounted() ) {
+    if( here.has_flag( ter_furn_flag::TFLAG_CONSOLE, examp ) && !u.is_mounted() ) {
         use_computer( examp );
         return;
-    } else if( m.has_flag( ter_furn_flag::TFLAG_CONSOLE, examp ) && u.is_mounted() ) {
+    } else if( here.has_flag( ter_furn_flag::TFLAG_CONSOLE, examp ) && u.is_mounted() ) {
         add_msg( m_warning, _( "You cannot use a console while mounted." ) );
     }
-    const furn_t &xfurn_t = m.furn( examp ).obj();
-    const ter_t &xter_t = m.ter( examp ).obj();
+    const furn_t &xfurn_t = here.furn( examp ).obj();
+    const ter_t &xter_t = here.ter( examp ).obj();
 
     const tripoint_bub_ms player_pos = u.pos_bub();
 
-    if( m.has_furn( examp ) ) {
+    if( here.has_furn( examp ) ) {
         if( !u.cant_do_mounted() ) {
-            if( !m.has_flag( "FREE_TO_EXAMINE", examp ) &&
+            if( !here.has_flag( "FREE_TO_EXAMINE", examp ) &&
                 !warn_player_maybe_anger_local_faction( false, true ) ) {
                 return; // player declined to mess with faction's stuff
             }
@@ -6354,7 +6387,7 @@ void game::examine( const tripoint_bub_ms &examp, bool with_pickup )
         }
     } else {
         if( xter_t.can_examine( examp ) && !u.is_mounted() ) {
-            if( !m.has_flag( "FREE_TO_EXAMINE", examp ) &&
+            if( !here.has_flag( "FREE_TO_EXAMINE", examp ) &&
                 !warn_player_maybe_anger_local_faction( false, true ) ) {
                 return; // player declined to mess with faction's stuff
             }
@@ -6384,29 +6417,29 @@ void game::examine( const tripoint_bub_ms &examp, bool with_pickup )
         add_msg( fire_fuel );
     }
 
-    if( m.has_flag( ter_furn_flag::TFLAG_SEALED, examp ) ) {
+    if( here.has_flag( ter_furn_flag::TFLAG_SEALED, examp ) ) {
         if( none ) {
-            if( m.has_flag( ter_furn_flag::TFLAG_UNSTABLE, examp ) ) {
-                add_msg( _( "The %s is too unstable to remove anything." ), m.name( examp ) );
+            if( here.has_flag( ter_furn_flag::TFLAG_UNSTABLE, examp ) ) {
+                add_msg( _( "The %s is too unstable to remove anything." ), here.name( examp ) );
             } else {
-                add_msg( _( "The %s is firmly sealed." ), m.name( examp ) );
+                add_msg( _( "The %s is firmly sealed." ), here.name( examp ) );
             }
         }
     } else {
         //examp has no traps, is a container and doesn't have a special examination function
-        if( m.tr_at( examp ).is_null() && m.i_at( examp ).empty() &&
-            m.has_flag( ter_furn_flag::TFLAG_CONTAINER, examp ) && none ) {
+        if( here.tr_at( examp ).is_null() && here.i_at( examp ).empty() &&
+            here.has_flag( ter_furn_flag::TFLAG_CONTAINER, examp ) && none ) {
             add_msg( _( "It is empty." ) );
-        } else if( ( m.has_flag( ter_furn_flag::TFLAG_FIRE_CONTAINER, examp ) &&
+        } else if( ( here.has_flag( ter_furn_flag::TFLAG_FIRE_CONTAINER, examp ) &&
                      xfurn_t.has_examine( iexamine::fireplace ) ) ||
                    xfurn_t.has_examine( iexamine::workbench ) ) {
             return;
         } else {
             sounds::process_sound_markers( &u );
             // Pick up items, if there are any, unless there is reason to not to
-            if( with_pickup && m.has_items( examp ) && !u.is_mounted() &&
-                !m.has_flag( ter_furn_flag::TFLAG_NO_PICKUP_ON_EXAMINE, examp ) &&
-                !m.only_liquid_in_liquidcont( examp ) ) {
+            if( with_pickup && here.has_items( examp ) && !u.is_mounted() &&
+                !here.has_flag( ter_furn_flag::TFLAG_NO_PICKUP_ON_EXAMINE, examp ) &&
+                !here.only_liquid_in_liquidcont( examp ) ) {
                 pickup( examp );
             }
         }
@@ -6476,9 +6509,11 @@ void game::pickup_all()
 
 void game::pickup( const tripoint_bub_ms &p )
 {
+    map &here = get_map();
+
     // Highlight target
     shared_ptr_fast<game::draw_callback_t> hilite_cb = make_shared_fast<game::draw_callback_t>( [&]() {
-        m.drawsq( w_terrain, p, drawsq_params().highlight( true ) );
+        here.drawsq( w_terrain, p, drawsq_params().highlight( true ) );
     } );
     add_draw_callback( hilite_cb );
 
@@ -6490,6 +6525,8 @@ void game::pickup( const tripoint_bub_ms &p )
 //represents carefully peeking around a corner, hence the large move cost.
 void game::peek()
 {
+    map &here = get_map();
+
     const std::optional<tripoint_rel_ms> p = choose_direction( _( "Peek where?" ), true );
     if( !p ) {
         return;
@@ -6503,13 +6540,13 @@ void game::peek()
         if( old_loc != u.pos_abs() ) {
             new_pos = u.pos_bub();
             u.move_to( old_loc );
-            m.vertical_shift( old_loc.z() );
+            here.vertical_shift( old_loc.z() );
         } else {
             return;
         }
     }
 
-    if( m.impassable( new_pos ) ) {
+    if( here.impassable( new_pos ) ) {
         return;
     }
 
@@ -6518,14 +6555,16 @@ void game::peek()
 
 void game::peek( const tripoint_bub_ms &p )
 {
+    map &here = get_map();
+
     u.mod_moves( -u.get_speed() * 2 );
     tripoint_bub_ms prev = u.pos_bub();
-    u.setpos( m, p, false );
+    u.setpos( here, p, false );
     const bool is_same_pos = u.pos_bub() == prev;
     const bool is_standup_peek = is_same_pos && u.is_crouching();
     tripoint_bub_ms center = p;
-    m.build_map_cache( p.z() );
-    m.update_visibility_cache( p.z() );
+    here.build_map_cache( p.z() );
+    here.update_visibility_cache( p.z() );
 
     look_around_result result;
     const look_around_params looka_params = { true, center, center, false, false, true, true};
@@ -6535,7 +6574,7 @@ void game::peek( const tripoint_bub_ms &p )
         u.activate_crouch_mode();
     } else {                // Else is normal peek
         result = look_around( looka_params );
-        u.setpos( m, prev, false );
+        u.setpos( here, prev, false );
     }
 
     if( result.peek_action ) {
@@ -6546,8 +6585,8 @@ void game::peek( const tripoint_bub_ms &p )
             avatar_action::plthrow_wielded( u, p );
         }
     }
-    m.invalidate_map_cache( p.z() );
-    m.invalidate_visibility_cache();
+    here.invalidate_map_cache( p.z() );
+    here.invalidate_visibility_cache();
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////
@@ -6571,16 +6610,16 @@ void game::draw_look_around_cursor( const tripoint_bub_ms &lp, const visibility_
 #endif
         const tripoint_bub_ms view_center = u.pos_bub() + u.view_offset;
         visibility_type visibility = visibility_type::HIDDEN;
-        const bool inbounds = m.inbounds( lp );
+        const bool inbounds = here.inbounds( lp );
         if( inbounds ) {
-            visibility = m.get_visibility( m.apparent_light_at( lp, cache ), cache );
+            visibility = here.get_visibility( here.apparent_light_at( lp, cache ), cache );
         }
         if( visibility == visibility_type::CLEAR ) {
             const Creature *const creature = get_creature_tracker().creature_at( lp, true );
             if( creature != nullptr && u.sees( here, *creature ) ) {
                 creature->draw( w_terrain, view_center, true );
             } else {
-                m.drawsq( w_terrain, lp, drawsq_params().highlight( true ).center( view_center ) );
+                here.drawsq( w_terrain, lp, drawsq_params().highlight( true ).center( view_center ) );
             }
         } else {
             std::string visibility_indicator;
@@ -6620,15 +6659,17 @@ void game::print_all_tile_info( const tripoint_bub_ms &lp, const catacurses::win
                                 const int last_line,
                                 const visibility_variables &cache )
 {
+    map &here = get_map();
+
     visibility_type visibility = visibility_type::HIDDEN;
-    const bool inbounds = m.inbounds( lp );
+    const bool inbounds = here.inbounds( lp );
     if( inbounds ) {
-        visibility = m.get_visibility( m.apparent_light_at( lp, cache ), cache );
+        visibility = here.get_visibility( here.apparent_light_at( lp, cache ), cache );
     }
     const Creature *creature = get_creature_tracker().creature_at( lp, true );
     switch( visibility ) {
         case visibility_type::CLEAR: {
-            const optional_vpart_position vp = m.veh_at( lp );
+            const optional_vpart_position vp = here.veh_at( lp );
             print_terrain_info( lp, w_look, area_name, column, line );
             print_fields_info( lp, w_look, column, line );
             print_trap_info( lp, w_look, column, line );
@@ -6731,18 +6772,20 @@ void game::print_visibility_info( const catacurses::window &w_look, int column, 
 void game::print_terrain_info( const tripoint_bub_ms &lp, const catacurses::window &w_look,
                                const std::string &area_name, int column, int &line )
 {
+    map &here = get_map();
+
     const int max_width = getmaxx( w_look ) - column - 1;
 
     // Print OMT type and terrain type on first two lines
     // if can't fit in one line.
-    std::string tile = uppercase_first_letter( m.tername( lp ) );
+    std::string tile = uppercase_first_letter( here.tername( lp ) );
     std::string area = uppercase_first_letter( area_name );
     if( const timed_event *e = get_timed_events().get( timed_event_type::OVERRIDE_PLACE ) ) {
         area = e->string_id;
     }
     mvwprintz( w_look, point( column, line++ ), c_yellow, area );
     mvwprintz( w_look, point( column, line++ ), c_white, tile );
-    std::string desc = string_format( m.ter( lp ).obj().description );
+    std::string desc = string_format( here.ter( lp ).obj().description );
     std::vector<std::string> lines = foldstring( desc, max_width );
     int numlines = lines.size();
     wattron( w_look, c_light_gray );
@@ -6756,9 +6799,9 @@ void game::print_terrain_info( const tripoint_bub_ms &lp, const catacurses::wind
 
     // Cover percentage from terrain and furniture next.
     fold_and_print( w_look, point( column, ++line ), max_width, c_light_gray, _( "Concealment: %d%%" ),
-                    m.coverage( lp ) );
+                    here.coverage( lp ) );
 
-    if( m.has_flag( ter_furn_flag::TFLAG_TREE, lp ) ) {
+    if( here.has_flag( ter_furn_flag::TFLAG_TREE, lp ) ) {
         const int lines = fold_and_print( w_look, point( column, ++line ), max_width, c_light_gray,
                                           _( "Can be <color_green>cut down</color> with the right tools." ) );
         line += lines - 1;
@@ -6766,7 +6809,7 @@ void game::print_terrain_info( const tripoint_bub_ms &lp, const catacurses::wind
 
     // Terrain and furniture flags next. These can be several lines for some combinations of
     // furnitures and terrains.
-    lines = foldstring( m.features( lp ), max_width );
+    lines = foldstring( here.features( lp ), max_width );
     numlines = lines.size();
     wattron( w_look, c_light_gray );
     for( int i = 0; i < numlines; i++ ) {
@@ -6776,15 +6819,15 @@ void game::print_terrain_info( const tripoint_bub_ms &lp, const catacurses::wind
 
     // Move cost from terrain and furniture and vehicle parts.
     // Vehicle part information is printed in a different function.
-    if( m.impassable( lp ) ) {
+    if( here.impassable( lp ) ) {
         mvwprintz( w_look, point( column, ++line ), c_light_red, _( "Impassable" ) );
     } else {
         mvwprintz( w_look, point( column, ++line ), c_light_gray, _( "Move cost: %d" ),
-                   m.move_cost( lp ) * 50 );
+                   here.move_cost( lp ) * 50 );
     }
 
     // Next print the string on any SIGN flagged furniture if any.
-    std::string signage = m.get_signage( lp );
+    std::string signage = here.get_signage( lp );
     if( !signage.empty() ) {
         std::string sign_string = u.has_trait( trait_ILLITERATE ) ? "???" : signage;
         const int lines = fold_and_print( w_look, point( column, ++line ), max_width, c_light_gray,
@@ -6794,19 +6837,19 @@ void game::print_terrain_info( const tripoint_bub_ms &lp, const catacurses::wind
 
     // Print light level on the selected tile.
     std::pair<std::string, nc_color> ll = get_light_level( std::max( 1.0,
-                                          LIGHT_AMBIENT_LIT - m.ambient_light_at( lp ) + 1.0 ) );
+                                          LIGHT_AMBIENT_LIT - here.ambient_light_at( lp ) + 1.0 ) );
     mvwprintz( w_look, point( column, ++line ), c_light_gray, _( "Lighting: " ) );
     mvwprintz( w_look, point( column + utf8_width( _( "Lighting: " ) ), line ), ll.second, ll.first );
 
     // Print the terrain and any furntiure on the tile below and whether it is walkable.
-    if( lp.z() > -OVERMAP_DEPTH && !m.has_floor( lp ) ) {
+    if( lp.z() > -OVERMAP_DEPTH && !here.has_floor( lp ) ) {
         tripoint_bub_ms below( lp + tripoint::below );
-        std::string tile_below = m.tername( below );
-        if( m.has_furn( below ) ) {
-            tile_below += ", " + m.furnname( below );
+        std::string tile_below = here.tername( below );
+        if( here.has_furn( below ) ) {
+            tile_below += ", " + here.furnname( below );
         }
 
-        if( !m.has_floor_or_support( lp ) ) {
+        if( !here.has_floor_or_support( lp ) ) {
             fold_and_print( w_look, point( column, ++line ), max_width, c_dark_gray,
                             _( "Below: %s; No support" ), tile_below );
         } else {
@@ -6822,18 +6865,20 @@ void game::print_furniture_info( const tripoint_bub_ms &lp, const catacurses::wi
                                  int column,
                                  int &line )
 {
+    map &here = get_map();
+
     // Do nothing if there is no furniture here
-    if( !m.has_furn( lp ) ) {
+    if( !here.has_furn( lp ) ) {
         return;
     }
     const int max_width = getmaxx( w_look ) - column - 1;
 
     // Print furniture name in white
-    std::string desc = uppercase_first_letter( m.furnname( lp ) );
+    std::string desc = uppercase_first_letter( here.furnname( lp ) );
     mvwprintz( w_look, point( column, line++ ), c_white, desc );
 
     // Print each line of furniture description in gray
-    const furn_id &f = m.furn( lp );
+    const furn_id &f = here.furn( lp );
     desc = string_format( f.obj().description );
     std::vector<std::string> lines = foldstring( desc, max_width );
     int numlines = lines.size();
@@ -6869,11 +6914,13 @@ void game::print_fields_info( const tripoint_bub_ms &lp, const catacurses::windo
                               int column,
                               int &line )
 {
-    const field &tmpfield = m.field_at( lp );
+    map &here = get_map();
+
+    const field &tmpfield = here.field_at( lp );
     for( const auto &fld : tmpfield ) {
         const field_entry &cur = fld.second;
-        if( fld.first.obj().has_fire && ( m.has_flag( ter_furn_flag::TFLAG_FIRE_CONTAINER, lp ) ||
-                                          m.ter( lp ) == ter_t_pit_shallow || m.ter( lp ) == ter_t_pit ) ) {
+        if( fld.first.obj().has_fire && ( here.has_flag( ter_furn_flag::TFLAG_FIRE_CONTAINER, lp ) ||
+                                          here.ter( lp ) == ter_t_pit_shallow || here.ter( lp ) == ter_t_pit ) ) {
             const int max_width = getmaxx( w_look ) - column - 2;
             int lines = fold_and_print( w_look, point( column, ++line ), max_width, cur.color(),
                                         get_fire_fuel_string( lp ) ) - 1;
@@ -6893,7 +6940,9 @@ void game::print_trap_info( const tripoint_bub_ms &lp, const catacurses::window 
                             const int column,
                             int &line )
 {
-    const trap &tr = m.tr_at( lp );
+    map &here = get_map();
+
+    const trap &tr = here.tr_at( lp );
     if( tr.can_see( lp, u ) ) {
         std::string tr_name = tr.name();
         mvwprintz( w_look, point( column, ++line ), tr.color, tr_name );
@@ -6906,7 +6955,9 @@ void game::print_part_con_info( const tripoint_bub_ms &lp, const catacurses::win
                                 const int column,
                                 int &line )
 {
-    partial_con *pc = m.partial_con_at( lp );
+    map &here = get_map();
+
+    partial_con *pc = here.partial_con_at( lp );
     std::string tr_name;
     if( pc != nullptr ) {
         const construction &built = pc->id.obj();
@@ -6960,9 +7011,11 @@ void game::print_items_info( const tripoint_bub_ms &lp, const catacurses::window
                              int &line,
                              const int last_line )
 {
-    if( !m.sees_some_items( lp, u ) ) {
+    map &here = get_map();
+
+    if( !here.sees_some_items( lp, u ) ) {
         return;
-    } else if( m.has_flag( ter_furn_flag::TFLAG_CONTAINER, lp ) && !m.could_see_items( lp, u ) ) {
+    } else if( here.has_flag( ter_furn_flag::TFLAG_CONTAINER, lp ) && !here.could_see_items( lp, u ) ) {
         mvwprintw( w_look, point( column, ++line ), _( "You cannot see what is inside of it." ) );
     } else if( u.has_effect( effect_blind ) || u.worn_with_flag( flag_BLIND ) ) {
         mvwprintz( w_look, point( column, ++line ), c_yellow,
@@ -6970,7 +7023,7 @@ void game::print_items_info( const tripoint_bub_ms &lp, const catacurses::window
         return;
     } else {
         std::map<std::string, std::pair<int, nc_color>> item_names;
-        for( const item &it : m.i_at( lp ) ) {
+        for( const item &it : here.i_at( lp ) ) {
             add_visible_items_recursive( item_names, it );
         }
 
@@ -6997,15 +7050,17 @@ void game::print_graffiti_info( const tripoint_bub_ms &lp, const catacurses::win
                                 const int column, int &line,
                                 const int last_line )
 {
+    map &here = get_map();
+
     if( line > last_line ) {
         return;
     }
 
     const int max_width = getmaxx( w_look ) - column - 2;
-    if( m.has_graffiti_at( lp ) ) {
+    if( here.has_graffiti_at( lp ) ) {
         const int lines = fold_and_print( w_look, point( column, ++line ), max_width, c_light_gray,
-                                          m.ter( lp ) == ter_t_grave_new ? _( "Graffiti: %s" ) : _( "Inscription: %s" ),
-                                          m.graffiti_at( lp ) );
+                                          here.ter( lp ) == ter_t_grave_new ? _( "Graffiti: %s" ) : _( "Inscription: %s" ),
+                                          here.graffiti_at( lp ) );
         line += lines - 1;
     }
 }
@@ -7025,12 +7080,16 @@ void game::print_debug_info( const tripoint_bub_ms &lp, const catacurses::window
 
 bool game::check_zone( const zone_type_id &type, const tripoint_bub_ms &where ) const
 {
-    return zone_manager::get_manager().has( type, m.get_abs( where ) );
+    map &here = get_map();
+
+    return zone_manager::get_manager().has( type, here.get_abs( where ) );
 }
 
 bool game::check_near_zone( const zone_type_id &type, const tripoint_bub_ms &where ) const
 {
-    return zone_manager::get_manager().has_near( type, m.get_abs( where ) );
+    map &here = get_map();
+
+    return zone_manager::get_manager().has_near( type, here.get_abs( where ) );
 }
 
 bool game::is_zones_manager_open() const
@@ -7115,7 +7174,9 @@ static void zones_manager_draw_borders( const catacurses::window &w_border,
 
 void game::zones_manager()
 {
-    const tripoint_bub_ms pos = u.pos_bub( m );
+    map &here = get_map();
+
+    const tripoint_bub_ms pos = u.pos_bub( );
 
     const tripoint_rel_ms stored_view_offset = u.view_offset;
 
@@ -7303,13 +7364,13 @@ void game::zones_manager()
                     true, true, false );
             if( second.position ) {
                 tripoint_abs_ms first_abs =
-                m.get_abs(
+                here.get_abs(
                     tripoint_bub_ms(
                         std::min( first.position->x(), second.position->x() ),
                         std::min( first.position->y(), second.position->y() ),
                         std::min( first.position->z(), second.position->z() ) ) );
                 tripoint_abs_ms second_abs =
-                m.get_abs(
+                here.get_abs(
                     tripoint_bub_ms(
                         std::max( first.position->x(), second.position->x() ),
                         std::max( first.position->y(), second.position->y() ),
@@ -7439,8 +7500,8 @@ void game::zones_manager()
         if( zone_cnt > 0 ) {
             blink = !blink;
             const zone_data &zone = zones[active_index].get();
-            zone_start = m.get_bub( zone.get_start_point() );
-            zone_end = m.get_bub( zone.get_end_point() );
+            zone_start = here.get_bub( zone.get_start_point() );
+            zone_end = here.get_bub( zone.get_end_point() );
             ctxt.set_timeout( get_option<int>( "BLINK_SPEED" ) );
         } else {
             blink = false;
@@ -7676,16 +7737,16 @@ void game::zones_manager()
                         static_popup message_pop;
                         message_pop.on_top( true );
                         message_pop.message( "%s", _( "Moving zone." ) );
-                        const tripoint_bub_ms zone_local_start_point = m.get_bub( zone.get_start_point() );
-                        const tripoint_bub_ms zone_local_end_point = m.get_bub( zone.get_end_point() );
+                        const tripoint_bub_ms zone_local_start_point = here.get_bub( zone.get_start_point() );
+                        const tripoint_bub_ms zone_local_end_point = here.get_bub( zone.get_end_point() );
                         // local position of the zone center, used to calculate the u.view_offset,
                         // could center the screen to the position it represents
-                        tripoint_bub_ms view_center = m.get_bub( zone.get_center_point() );
+                        tripoint_bub_ms view_center = here.get_bub( zone.get_center_point() );
                         const look_around_result result_local = look_around( false, view_center,
                                                                 zone_local_start_point, false, false,
                                                                 false, true, zone_local_end_point );
                         if( result_local.position ) {
-                            const tripoint_abs_ms new_start_point = m.get_abs( *result_local.position );
+                            const tripoint_abs_ms new_start_point = here.get_abs( *result_local.position );
                             const tripoint_abs_ms new_end_point = zone.get_end_point() - zone.get_start_point() +
                                                                   new_start_point;
                             if( new_start_point == zone.get_start_point() ) {
@@ -7799,8 +7860,10 @@ void game::pre_print_all_tile_info( const tripoint_bub_ms &lp, const catacurses:
                                     int &first_line, const int last_line,
                                     const visibility_variables &cache )
 {
+    map &here = get_map();
+
     // get global area info according to look_around caret position
-    tripoint_abs_omt omp( coords::project_to<coords::omt>( m.get_abs( lp ) ) );
+    tripoint_abs_omt omp( coords::project_to<coords::omt>( here.get_abs( lp ) ) );
     const oter_id &cur_ter_m = overmap_buffer.ter( omp );
     om_vision_level vision = overmap_buffer.seen( omp );
     // we only need the area name and then pass it to print_all_tile_info() function below
@@ -7870,7 +7933,7 @@ look_around_result game::look_around(
     bool select_zone, bool peeking, bool is_moving_zone, const tripoint_bub_ms &end_point,
     bool change_lv )
 {
-    const map &here = get_map();
+    map &here = get_map();
 
     bVMonsterLookFire = false;
 
@@ -7962,12 +8025,12 @@ look_around_result game::look_around(
     ctxt.register_action( "zoom_in" );
     ctxt.register_action( "toggle_pixel_minimap" );
 
-    const int old_levz = m.get_abs_sub().z();
+    const int old_levz = here.get_abs_sub().z();
     const int min_levz = std::max( old_levz - fov_3d_z_range, -OVERMAP_DEPTH );
     const int max_levz = std::min( old_levz + fov_3d_z_range, OVERMAP_HEIGHT );
 
-    m.update_visibility_cache( old_levz );
-    const visibility_variables &cache = m.get_visibility_variables_cache();
+    here.update_visibility_cache( old_levz );
+    const visibility_variables &cache = here.get_visibility_variables_cache();
 
     bool blink = true;
     look_around_result result;
@@ -8115,10 +8178,10 @@ look_around_result game::look_around(
             add_msg_debug( debugmode::DF_GAME, "levx: %d, levy: %d, levz: %d",
                            here.get_abs_sub().x(), here.get_abs_sub().y(), center.z() );
             u.view_offset.z() = center.z() - u.posz();
-            m.invalidate_map_cache( center.z() );
+            here.invalidate_map_cache( center.z() );
             // Fix player character not visible from above
-            m.build_map_cache( u.posz() );
-            m.invalidate_visibility_cache();
+            here.build_map_cache( u.posz() );
+            here.invalidate_visibility_cache();
         } else if( action == "TRAVEL_TO" ) {
             const std::optional<std::vector<tripoint_bub_ms>> try_route = safe_route_to( u, lp,
             0,  []( const std::string & msg ) {
@@ -8211,8 +8274,8 @@ look_around_result game::look_around(
              action != "throw_blind" && action != "throw_blind_wielded" );
 
     if( center.z() != old_levz ) {
-        m.invalidate_map_cache( old_levz );
-        m.build_map_cache( old_levz );
+        here.invalidate_map_cache( old_levz );
+        here.build_map_cache( old_levz );
         u.view_offset.z() = 0;
     }
 
@@ -8267,7 +8330,7 @@ static void add_item_recursive( std::vector<std::string> &item_order,
 
 std::vector<map_item_stack> game::find_nearby_items( int iRadius )
 {
-    const map &here = get_map();
+    map &here = get_map();
     const tripoint_bub_ms pos = u.pos_bub( here );
 
     std::map<std::string, map_item_stack> temp_items;
@@ -8281,9 +8344,9 @@ std::vector<map_item_stack> game::find_nearby_items( int iRadius )
     for( tripoint_bub_ms &points_p_it : closest_points_first( pos, iRadius ) ) {
         if( points_p_it.y() >= pos.y() - iRadius && points_p_it.y() <= pos.y() + iRadius &&
             u.sees( here, points_p_it ) &&
-            m.sees_some_items( points_p_it, u ) ) {
+            here.sees_some_items( points_p_it, u ) ) {
 
-            for( item &elem : m.i_at( points_p_it ) ) {
+            for( item &elem : here.i_at( points_p_it ) ) {
                 const tripoint_rel_ms relative_pos = points_p_it - pos;
 
                 add_item_recursive( item_order, temp_items, &elem, relative_pos );
@@ -10013,6 +10076,8 @@ static void butcher_submenu( const std::vector<map_stack::iterator> &corpses, in
 
 void game::butcher()
 {
+    map &here = get_map();
+
     static const std::string salvage_string = "salvage";
     if( u.controlling_vehicle ) {
         add_msg( m_info, _( "You can't butcher while driving!" ) );
@@ -10025,8 +10090,8 @@ void game::butcher()
     const std::string no_corpse_msg = _( "There are no corpses here to butcher." );
 
     //You can't butcher on sealed terrain- you have to smash/shovel/etc it open first
-    if( m.has_flag( ter_furn_flag::TFLAG_SEALED, u.pos_bub() ) ) {
-        if( m.sees_some_items( u.pos_bub(), u ) ) {
+    if( here.has_flag( ter_furn_flag::TFLAG_SEALED, u.pos_bub() ) ) {
+        if( here.sees_some_items( u.pos_bub(), u ) ) {
             add_msg( m_info, _( "You can't access the items here." ) );
         } else if( factor > INT_MIN || factorD > INT_MIN ) {
             add_msg( m_info, no_corpse_msg );
@@ -10041,7 +10106,7 @@ void game::butcher()
     std::vector<map_stack::iterator> corpses;
     std::vector<map_stack::iterator> disassembles;
     std::vector<map_stack::iterator> salvageables;
-    map_stack items = m.i_at( u.pos_bub() );
+    map_stack items = here.i_at( u.pos_bub() );
     const inventory &crafting_inv = u.crafting_inventory();
 
     // TODO: Properly handle different material whitelists
@@ -10413,6 +10478,8 @@ void game::reload_wielded( bool prompt )
 
 void game::reload_weapon( bool try_everything )
 {
+    map &here = get_map();
+
     // As a special streamlined activity, hitting reload repeatedly should:
     // Reload wielded gun
     // First reload a magazine if necessary.
@@ -10467,7 +10534,7 @@ void game::reload_weapon( bool try_everything )
         return;
     }
     // If we make it here and haven't found anything to reload, start looking elsewhere.
-    const optional_vpart_position ovp = m.veh_at( u.pos_abs() );
+    const optional_vpart_position ovp = here.veh_at( u.pos_abs() );
     if( ovp ) {
         const turret_data turret = ovp->vehicle().turret_query( ovp->pos_abs( ) );
         if( turret.can_reload() ) {
@@ -10678,6 +10745,8 @@ bool game::is_dangerous_tile( const tripoint_bub_ms &dest_loc ) const
 bool game::prompt_dangerous_tile( const tripoint_bub_ms &dest_loc,
                                   std::vector<std::string> *harmful_stuff ) const
 {
+    map &here = get_map();
+
     if( u.has_effect( effect_stunned ) || u.has_effect( effect_psi_stunned ) ) {
         return true;
     }
@@ -10691,7 +10760,7 @@ bool game::prompt_dangerous_tile( const tripoint_bub_ms &dest_loc,
         !query_yn( _( "Really step into %s?" ), enumerate_as_string( *harmful_stuff ) ) ) {
         return false;
     }
-    if( !harmful_stuff->empty() && u.is_mounted() && m.is_open_air( dest_loc ) ) {
+    if( !harmful_stuff->empty() && u.is_mounted() && here.is_open_air( dest_loc ) ) {
         add_msg( m_warning, _( "Your %s refuses to move over that ledge!" ),
                  u.mounted_creature->get_name() );
         return false;
@@ -10702,18 +10771,20 @@ bool game::prompt_dangerous_tile( const tripoint_bub_ms &dest_loc,
 std::vector<std::string> game::get_dangerous_tile( const tripoint_bub_ms &dest_loc,
         const size_t max ) const
 {
+    map &here = get_map();
+
     if( u.is_blind() ) {
         return {}; // blinded players don't see dangerous tiles
     }
 
     std::vector<std::string> harmful_stuff;
-    const field fields_here = m.field_at( u.pos_bub() );
-    const auto veh_here = m.veh_at( u.pos_bub() ).part_with_feature( "BOARDABLE", true );
-    const auto veh_dest = m.veh_at( dest_loc ).part_with_feature( "BOARDABLE", true );
+    const field fields_here = here.field_at( u.pos_bub() );
+    const auto veh_here = here.veh_at( u.pos_bub() ).part_with_feature( "BOARDABLE", true );
+    const auto veh_dest = here.veh_at( dest_loc ).part_with_feature( "BOARDABLE", true );
     const bool veh_here_inside = veh_here && veh_here->is_inside();
     const bool veh_dest_inside = veh_dest && veh_dest->is_inside();
 
-    for( const std::pair<const field_type_id, field_entry> &e : m.field_at( dest_loc ) ) {
+    for( const std::pair<const field_type_id, field_entry> &e : here.field_at( dest_loc ) ) {
         if( !u.is_dangerous_field( e.second ) ) {
             continue;
         }
@@ -10763,7 +10834,7 @@ std::vector<std::string> game::get_dangerous_tile( const tripoint_bub_ms &dest_l
         }
     }
 
-    if( m.is_open_air( dest_loc ) ) {
+    if( here.is_open_air( dest_loc ) ) {
         if( !veh_dest && !u.has_effect_with_flag( json_flag_LEVITATION ) ) {
             harmful_stuff.emplace_back( "ledge" );
             if( harmful_stuff.size() == max ) {
@@ -10772,7 +10843,7 @@ std::vector<std::string> game::get_dangerous_tile( const tripoint_bub_ms &dest_l
         }
     }
 
-    const trap &tr = m.tr_at( dest_loc );
+    const trap &tr = here.tr_at( dest_loc );
 
     if( tr.can_see( dest_loc, u ) && !tr.is_benign() && !veh_dest ) {
         harmful_stuff.push_back( tr.name() );
@@ -10792,22 +10863,22 @@ std::vector<std::string> game::get_dangerous_tile( const tripoint_bub_ms &dest_l
         return u.immune_to( bp, { damage_cut, 10 } );
     };
 
-    if( m.has_flag( ter_furn_flag::TFLAG_ROUGH, dest_loc ) &&
-        !m.has_flag( ter_furn_flag::TFLAG_ROUGH, u.pos_bub() ) &&
+    if( here.has_flag( ter_furn_flag::TFLAG_ROUGH, dest_loc ) &&
+        !here.has_flag( ter_furn_flag::TFLAG_ROUGH, u.pos_bub() ) &&
         !u.has_flag( json_flag_ALL_TERRAIN_NAVIGATION ) &&
         !veh_dest &&
         ( u.get_armor_type( damage_bash, bodypart_id( "foot_l" ) ) < 5 ||
           u.get_armor_type( damage_bash, bodypart_id( "foot_r" ) ) < 5 ) ) { // NOLINT(bugprone-branch-clone)
-        harmful_stuff.emplace_back( m.name( dest_loc ) );
-    } else if( m.has_flag( ter_furn_flag::TFLAG_SHARP, dest_loc ) &&
-               !m.has_flag( ter_furn_flag::TFLAG_SHARP, u.pos_bub() ) &&
+        harmful_stuff.emplace_back( here.name( dest_loc ) );
+    } else if( here.has_flag( ter_furn_flag::TFLAG_SHARP, dest_loc ) &&
+               !here.has_flag( ter_furn_flag::TFLAG_SHARP, u.pos_bub() ) &&
                !u.has_flag( json_flag_ALL_TERRAIN_NAVIGATION ) &&
-               !( u.in_vehicle || m.veh_at( dest_loc ) ) &&
+               !( u.in_vehicle || here.veh_at( dest_loc ) ) &&
                u.dex_cur < 78 &&
                !( u.is_mounted() &&
                   u.mounted_creature->get_armor_type( damage_cut, bodypart_id( "torso" ) ) >= 10 ) &&
                !std::all_of( sharp_bps.begin(), sharp_bps.end(), sharp_bp_check ) ) {
-        harmful_stuff.push_back( m.name( dest_loc ) );
+        harmful_stuff.push_back( here.name( dest_loc ) );
     }
 
     return harmful_stuff;
@@ -11106,7 +11177,7 @@ bool game::walk_move( const tripoint_bub_ms &dest_loc, const bool via_ramp,
     oldpos = oldpos - ms_shift.raw();
 
     if( moving ) {
-        cata_event_dispatch::avatar_moves( old_abs_pos, u, m );
+        cata_event_dispatch::avatar_moves( old_abs_pos, u, here );
 
         // Add trail animation when sprinting
         if( get_option<bool>( "ANIMATIONS" ) && u.is_running() ) {
@@ -11160,7 +11231,7 @@ bool game::walk_move( const tripoint_bub_ms &dest_loc, const bool via_ramp,
         start_hauling( oldpos );
     }
 
-    if( u.will_be_cramped_in_vehicle_tile( m, dest_loc_abs ) ) {
+    if( u.will_be_cramped_in_vehicle_tile( here, dest_loc_abs ) ) {
         if( u.get_size() == creature_size::huge ) {
             add_msg( m_warning, _( "You barely fit in this tiny human vehicle." ) );
         } else if( u.get_total_volume() > u.get_base_volume() ) {
@@ -11178,11 +11249,11 @@ bool game::walk_move( const tripoint_bub_ms &dest_loc, const bool via_ramp,
 point_rel_sm game::place_player( const tripoint_bub_ms &dest_loc, bool quick )
 {
     map &here = get_map();
-    const optional_vpart_position vp1 = m.veh_at( dest_loc );
+    const optional_vpart_position vp1 = here.veh_at( dest_loc );
     if( const std::optional<std::string> label = vp1.get_label() ) {
         add_msg( m_info, _( "Label here: %s" ), *label );
     }
-    std::string signage = m.get_signage( dest_loc );
+    std::string signage = here.get_signage( dest_loc );
     if( !signage.empty() ) {
         if( !u.has_trait( trait_ILLITERATE ) ) {
             add_msg( m_info, _( "The sign says: %s" ), signage );
@@ -11190,34 +11261,36 @@ point_rel_sm game::place_player( const tripoint_bub_ms &dest_loc, bool quick )
             add_msg( m_info, _( "There is a sign here, but you are unable to read it." ) );
         }
     }
-    if( m.has_graffiti_at( dest_loc ) ) {
+    if( here.has_graffiti_at( dest_loc ) ) {
         if( !u.has_trait( trait_ILLITERATE ) ) {
-            add_msg( m_info, _( "Written here: %s" ), m.graffiti_at( dest_loc ) );
+            add_msg( m_info, _( "Written here: %s" ), here.graffiti_at( dest_loc ) );
         } else {
             add_msg( m_info, _( "Something is written here, but you are unable to read it." ) );
         }
     }
     // TODO: Move the stuff below to a Character method so that NPCs can reuse it
-    if( m.has_flag( ter_furn_flag::TFLAG_ROUGH, dest_loc ) && ( !u.in_vehicle ) &&
+    if( here.has_flag( ter_furn_flag::TFLAG_ROUGH, dest_loc ) && ( !u.in_vehicle ) &&
         ( !u.is_mounted() ) && !u.has_flag( json_flag_ALL_TERRAIN_NAVIGATION ) ) {
         if( one_in( 5 ) && u.get_armor_type( damage_bash, bodypart_id( "foot_l" ) ) < rng( 2, 5 ) ) {
             add_msg( m_bad, _( "You hurt your left foot on the %s!" ),
-                     m.has_flag_ter( ter_furn_flag::TFLAG_ROUGH, dest_loc ) ? m.tername( dest_loc ) : m.furnname(
+                     here.has_flag_ter( ter_furn_flag::TFLAG_ROUGH,
+                                        dest_loc ) ? here.tername( dest_loc ) : here.furnname(
                          dest_loc ) );
             u.deal_damage( nullptr, bodypart_id( "foot_l" ), damage_instance( damage_cut, 1 ) );
         }
         if( one_in( 5 ) && u.get_armor_type( damage_bash, bodypart_id( "foot_r" ) ) < rng( 2, 5 ) ) {
             add_msg( m_bad, _( "You hurt your right foot on the %s!" ),
-                     m.has_flag_ter( ter_furn_flag::TFLAG_ROUGH, dest_loc ) ? m.tername( dest_loc ) : m.furnname(
+                     here.has_flag_ter( ter_furn_flag::TFLAG_ROUGH,
+                                        dest_loc ) ? here.tername( dest_loc ) : here.furnname(
                          dest_loc ) );
             u.deal_damage( nullptr, bodypart_id( "foot_l" ), damage_instance( damage_cut, 1 ) );
         }
     }
     ///\EFFECT_DEX increases chance of avoiding cuts on sharp terrain
-    if( m.has_flag( ter_furn_flag::TFLAG_SHARP, dest_loc ) && !one_in( 3 ) &&
+    if( here.has_flag( ter_furn_flag::TFLAG_SHARP, dest_loc ) && !one_in( 3 ) &&
         !u.has_flag( json_flag_ALL_TERRAIN_NAVIGATION ) &&
         !x_in_y( 1 + u.dex_cur / 2.0, 40 ) &&
-        ( !u.in_vehicle && !m.veh_at( dest_loc ) ) && ( !u.has_proficiency( proficiency_prof_parkour ) ||
+        ( !u.in_vehicle && !here.veh_at( dest_loc ) ) && ( !u.has_proficiency( proficiency_prof_parkour ) ||
                 one_in( 4 ) ) && ( u.has_trait( trait_THICKSKIN ) ? !one_in( 8 ) : true ) ) {
         const int sharp_damage = rng( 1, 10 );
         if( u.is_mounted() ) {
@@ -11234,7 +11307,8 @@ point_rel_sm game::place_player( const tripoint_bub_ms &dest_loc, bool quick )
                     //~ 1$s - bodypart name in accusative, 2$s is terrain name.
                     add_msg( m_bad, _( "You cut your %1$s on the %2$s!" ),
                              body_part_name_accusative( bp ),
-                             m.has_flag_ter( ter_furn_flag::TFLAG_SHARP, dest_loc ) ? m.tername( dest_loc ) : m.furnname(
+                             here.has_flag_ter( ter_furn_flag::TFLAG_SHARP,
+                                                dest_loc ) ? here.tername( dest_loc ) : here.furnname(
                                  dest_loc ) );
                     if( !u.has_flag( json_flag_INFECTION_IMMUNE ) ) {
                         const int chance_in = u.has_trait( trait_INFRESIST ) ? 1024 : 256;
@@ -11246,20 +11320,20 @@ point_rel_sm game::place_player( const tripoint_bub_ms &dest_loc, bool quick )
             }
         }
     }
-    if( m.has_flag( ter_furn_flag::TFLAG_UNSTABLE, dest_loc ) &&
-        !u.is_mounted() && !m.has_vehicle_floor( dest_loc ) ) {
+    if( here.has_flag( ter_furn_flag::TFLAG_UNSTABLE, dest_loc ) &&
+        !u.is_mounted() && !here.has_vehicle_floor( dest_loc ) ) {
         u.add_effect( effect_bouldering, 1_turns, true );
     } else if( u.has_effect( effect_bouldering ) ) {
         u.remove_effect( effect_bouldering );
     }
-    if( m.has_flag_ter_or_furn( ter_furn_flag::TFLAG_NO_SIGHT, dest_loc ) ) {
+    if( here.has_flag_ter_or_furn( ter_furn_flag::TFLAG_NO_SIGHT, dest_loc ) ) {
         u.add_effect( effect_no_sight, 1_turns, true );
     } else if( u.has_effect( effect_no_sight ) ) {
         u.remove_effect( effect_no_sight );
     }
 
     // If we moved out of the nonant, we need update our map data
-    if( m.has_flag( ter_furn_flag::TFLAG_SWIMMABLE, dest_loc ) && u.has_effect( effect_onfire ) ) {
+    if( here.has_flag( ter_furn_flag::TFLAG_SWIMMABLE, dest_loc ) && u.has_effect( effect_onfire ) ) {
         add_msg( _( "The water puts out the flames!" ) );
         u.remove_effect( effect_onfire );
         if( u.is_mounted() ) {
@@ -11278,7 +11352,7 @@ point_rel_sm game::place_player( const tripoint_bub_ms &dest_loc, bool quick )
         if( !critter.has_effect( effect_ridden ) ) {
             if( u.is_mounted() ) {
                 std::vector<tripoint_bub_ms> maybe_valid;
-                for( const tripoint_bub_ms &jk : m.points_in_radius( critter.pos_bub(), 1 ) ) {
+                for( const tripoint_bub_ms &jk : here.points_in_radius( critter.pos_bub(), 1 ) ) {
                     if( is_empty( jk ) ) {
                         maybe_valid.push_back( jk );
                     }
@@ -11316,27 +11390,27 @@ point_rel_sm game::place_player( const tripoint_bub_ms &dest_loc, bool quick )
         if( u.pos_bub() == dest_loc ) {
             was_in_control_same_pos = true;
         } else {
-            m.unboard_vehicle( u.pos_bub() );
+            here.unboard_vehicle( u.pos_bub() );
         }
     }
     // Move the player
     // Start with z-level, to make it less likely that old functions (2D ones) freak out
     bool z_level_changed = false;
-    if( dest_loc.z() != m.get_abs_sub().z() ) {
+    if( dest_loc.z() != here.get_abs_sub().z() ) {
         z_level_changed = vertical_shift( dest_loc.z() );
     }
 
-    if( u.is_hauling() && ( !m.can_put_items( dest_loc ) ||
-                            m.has_flag( ter_furn_flag::TFLAG_DEEP_WATER, dest_loc ) ||
+    if( u.is_hauling() && ( !here.can_put_items( dest_loc ) ||
+                            here.has_flag( ter_furn_flag::TFLAG_DEEP_WATER, dest_loc ) ||
                             vp1 ) ) {
         u.stop_hauling();
     }
-    u.setpos( m, dest_loc );
+    u.setpos( here, dest_loc );
     if( u.is_mounted() ) {
         monster *mon = u.mounted_creature.get();
-        mon->setpos( m, dest_loc );
+        mon->setpos( here, dest_loc );
         mon->process_triggers();
-        m.creature_in_field( *mon );
+        here.creature_in_field( *mon );
     }
     point_rel_sm submap_shift = update_map( u, z_level_changed );
     // Important: don't use dest_loc after this line. `update_map` may have shifted the map
@@ -11354,8 +11428,8 @@ point_rel_sm game::place_player( const tripoint_bub_ms &dest_loc, bool quick )
         const std::string forage_type = get_option<std::string>( "AUTO_FORAGING" );
         if( forage_type != "off" ) {
             const auto forage = [&]( const tripoint_bub_ms & pos ) {
-                const ter_t &xter_t = *m.ter( pos );
-                const furn_t &xfurn_t = *m.furn( pos );
+                const ter_t &xter_t = *here.ter( pos );
+                const furn_t &xfurn_t = *here.furn( pos );
                 const bool forage_everything = forage_type == "all";
                 const bool forage_bushes = forage_everything || forage_type == "bushes";
                 const bool forage_trees = forage_everything || forage_type == "trees";
@@ -11389,7 +11463,7 @@ point_rel_sm game::place_player( const tripoint_bub_ms &dest_loc, bool quick )
             u.max_quality( qual_BUTCHER, PICKUP_RANGE ) > INT_MIN ) {
             std::vector<item *> corpses;
 
-            for( item &it : m.i_at( u.pos_bub() ) ) {
+            for( item &it : here.i_at( u.pos_bub() ) ) {
                 corpses.push_back( &it );
             }
 
@@ -11403,7 +11477,7 @@ point_rel_sm game::place_player( const tripoint_bub_ms &dest_loc, bool quick )
                    pulp_butcher == "pulp_zombie_only" || pulp_butcher == "pulp_adjacent_zombie_only" ) {
             const bool acid_immune = u.is_immune_damage( damage_acid ) || u.is_immune_field( fd_acid );
             const auto corpse_available = [&]( const tripoint_bub_ms & pos ) {
-                for( const item &maybe_corpse : m.i_at( pos ) ) {
+                for( const item &maybe_corpse : here.i_at( pos ) ) {
                     if( maybe_corpse.is_corpse() && maybe_corpse.can_revive() &&
                         ( !maybe_corpse.get_mtype()->bloodType().obj().has_acid || acid_immune ) ) {
                         if( pulp_butcher == "pulp_zombie_only" || pulp_butcher == "pulp_adjacent_zombie_only" ) {
@@ -11423,7 +11497,7 @@ point_rel_sm game::place_player( const tripoint_bub_ms &dest_loc, bool quick )
                 std::set<tripoint_abs_ms> places;
                 for( const direction &elem : adjacentDir ) {
                     if( corpse_available( u.pos_bub() + displace_XY( elem ) ) ) {
-                        places.emplace( m.get_abs( u.pos_bub() + displace_XY( elem ) ) );
+                        places.emplace( here.get_abs( u.pos_bub() + displace_XY( elem ) ) );
                     }
                 }
                 if( !places.empty() ) {
@@ -11431,7 +11505,7 @@ point_rel_sm game::place_player( const tripoint_bub_ms &dest_loc, bool quick )
                 }
             } else {
                 if( corpse_available( u.pos_bub() ) ) {
-                    u.assign_activity( pulp_activity_actor( m.get_abs( u.pos_bub() ) ) );
+                    u.assign_activity( pulp_activity_actor( here.get_abs( u.pos_bub() ) ) );
                 }
             }
         }
@@ -11441,26 +11515,26 @@ point_rel_sm game::place_player( const tripoint_bub_ms &dest_loc, bool quick )
     if( !quick && !u.is_mounted() && get_option<bool>( "AUTO_PICKUP" ) && !u.is_hauling() &&
         ( !get_option<bool>( "AUTO_PICKUP_SAFEMODE" ) ||
           !u.get_mon_visible().has_dangerous_creature_in_proximity ) &&
-        ( m.has_items( u.pos_bub() ) || get_option<bool>( "AUTO_PICKUP_ADJACENT" ) ) ) {
+        ( here.has_items( u.pos_bub() ) || get_option<bool>( "AUTO_PICKUP_ADJACENT" ) ) ) {
         Pickup::autopickup( u.pos_bub() );
     }
 
     // If the new tile is a boardable part, board it
     if( !was_in_control_same_pos && vp1.part_with_feature( "BOARDABLE", true ) && !u.is_mounted() ) {
-        m.board_vehicle( u.pos_bub(), &u );
+        here.board_vehicle( u.pos_bub(), &u );
     }
 
     // Traps!
     // Try to detect.
     u.search_surroundings();
     if( u.is_mounted() ) {
-        m.creature_on_trap( *u.mounted_creature );
+        here.creature_on_trap( *u.mounted_creature );
     } else {
-        m.creature_on_trap( u );
+        here.creature_on_trap( u );
     }
     // Drench the player if swimmable
-    if( m.has_flag( ter_furn_flag::TFLAG_SWIMMABLE, u.pos_bub() ) &&
-        !m.has_flag_furn( "BRIDGE", u.pos_bub() ) &&
+    if( here.has_flag( ter_furn_flag::TFLAG_SWIMMABLE, u.pos_bub() ) &&
+        !here.has_flag_furn( "BRIDGE", u.pos_bub() ) &&
         !( u.is_mounted() || ( u.in_vehicle && vp1->vehicle().can_float( here ) ) ) &&
         !u.has_flag( json_flag_WATERWALKING ) ) {
         u.drench( 80, u.get_drenching_body_parts( false, false ),
@@ -11468,13 +11542,13 @@ point_rel_sm game::place_player( const tripoint_bub_ms &dest_loc, bool quick )
     }
 
     // List items here
-    if( !quick && !m.has_flag( ter_furn_flag::TFLAG_SEALED, u.pos_bub() ) ) {
+    if( !quick && !here.has_flag( ter_furn_flag::TFLAG_SEALED, u.pos_bub() ) ) {
         if( get_option<bool>( "NO_AUTO_PICKUP_ZONES_LIST_ITEMS" ) ||
             !check_zone( zone_type_NO_AUTO_PICKUP, u.pos_bub() ) ) {
-            const map_stack &ms = m.i_at( u.pos_bub() );
+            const map_stack &ms = here.i_at( u.pos_bub() );
             if( u.is_blind() && !ms.empty() ) {
                 add_msg( _( "There's something here, but you can't see what it is." ) );
-            } else if( m.has_items( u.pos_bub() ) ) {
+            } else if( here.has_items( u.pos_bub() ) ) {
                 std::vector<std::string> names;
                 std::vector<size_t> counts;
                 std::vector<item> items;
@@ -11563,6 +11637,8 @@ point_rel_sm game::place_player( const tripoint_bub_ms &dest_loc, bool quick )
 
 void game::place_player_overmap( const tripoint_abs_omt &om_dest, bool move_player )
 {
+    map &here = get_map();
+
     // if player is teleporting around, they don't bring their horse with them
     if( u.is_mounted() ) {
         u.remove_effect( effect_riding );
@@ -11575,14 +11651,14 @@ void game::place_player_overmap( const tripoint_abs_omt &om_dest, bool move_play
         despawn_monster( critter );
     }
     if( u.in_vehicle ) {
-        m.unboard_vehicle( u.pos_bub() );
+        here.unboard_vehicle( u.pos_bub() );
     }
     for( int z = -OVERMAP_DEPTH; z <= OVERMAP_HEIGHT; z++ ) {
-        m.clear_vehicle_list( z );
+        here.clear_vehicle_list( z );
     }
-    m.rebuild_vehicle_level_caches();
-    m.access_cache( m.get_abs_sub().z() ).map_memory_cache_dec.reset();
-    m.access_cache( m.get_abs_sub().z() ).map_memory_cache_ter.reset();
+    here.rebuild_vehicle_level_caches();
+    here.access_cache( here.get_abs_sub().z() ).map_memory_cache_dec.reset();
+    here.access_cache( here.get_abs_sub().z() ).map_memory_cache_ter.reset();
     // offset because load_map expects the coordinates of the top left corner, but the
     // player will be centered in the middle of the map.
     const tripoint_abs_sm map_sm_pos =
@@ -11590,7 +11666,7 @@ void game::place_player_overmap( const tripoint_abs_omt &om_dest, bool move_play
     const tripoint_bub_ms player_pos( u.pos_bub().xy(), map_sm_pos.z() );
     load_map( map_sm_pos );
     load_npcs();
-    m.spawn_monsters( true ); // Static monsters
+    here.spawn_monsters( true ); // Static monsters
     update_overmap_seen();
     // update weather now as it could be different on the new location
     weather.nextweather = calendar::turn;
@@ -11656,7 +11732,7 @@ bool game::phasing_move( const tripoint_bub_ms &dest_loc, const bool via_ramp )
         //tunneling costs 250 bionic power per impassable tile
         u.mod_power_level( -( tunneldist * trigger_cost ) );
         u.mod_moves( -to_moves<int>( 1_seconds ) ); //tunneling takes exactly one second
-        u.setpos( m, dest );
+        u.setpos( here, dest );
 
         if( here.veh_at( pos ).part_with_feature( "BOARDABLE", true ) ) {
             here.board_vehicle( pos, &u );
@@ -11733,38 +11809,42 @@ bool game::phasing_move_enchant( const tripoint_bub_ms &dest_loc, const int phas
 
 bool game::can_move_furniture( tripoint_bub_ms fdest, const tripoint_rel_ms &dp )
 {
+    map &here = get_map();
+
     const bool pulling_furniture = dp.xy() == -u.grab_point.xy();
-    const bool has_floor = m.has_floor_or_water( fdest );
+    const bool has_floor = here.has_floor_or_water( fdest );
     creature_tracker &creatures = get_creature_tracker();
-    bool is_ramp_or_road = m.has_flag( ter_furn_flag::TFLAG_RAMP_DOWN, fdest ) ||
-                           m.has_flag( ter_furn_flag::TFLAG_RAMP_UP, fdest ) ||
-                           m.has_flag( ter_furn_flag::TFLAG_ROAD, fdest );
-    return  m.passable( fdest ) &&
+    bool is_ramp_or_road = here.has_flag( ter_furn_flag::TFLAG_RAMP_DOWN, fdest ) ||
+                           here.has_flag( ter_furn_flag::TFLAG_RAMP_UP, fdest ) ||
+                           here.has_flag( ter_furn_flag::TFLAG_ROAD, fdest );
+    return  here.passable( fdest ) &&
             creatures.creature_at<npc>( fdest ) == nullptr &&
             creatures.creature_at<monster>( fdest ) == nullptr &&
             ( !pulling_furniture || is_empty( u.pos_bub() + dp ) ) &&
-            ( !has_floor || m.has_flag( ter_furn_flag::TFLAG_FLAT, fdest ) ||
+            ( !has_floor || here.has_flag( ter_furn_flag::TFLAG_FLAT, fdest ) ||
               is_ramp_or_road ) &&
-            !m.has_furn( fdest ) &&
-            !m.veh_at( fdest ) &&
-            ( !has_floor || m.tr_at( fdest ).is_null() );
+            !here.has_furn( fdest ) &&
+            !here.veh_at( fdest ) &&
+            ( !has_floor || here.tr_at( fdest ).is_null() );
 }
 
 int game::grabbed_furn_move_time( const tripoint_rel_ms &dp )
 {
+    map &here = get_map();
+
     // Furniture: pull, push, or standing still and nudging object around.
     // Can push furniture out of reach.
     tripoint_bub_ms fpos = u.pos_bub() + u.grab_point;
     // supposed position of grabbed furniture
-    if( !m.has_furn( fpos ) ) {
+    if( !here.has_furn( fpos ) ) {
         return 0;
     }
 
     tripoint_bub_ms fdest = fpos + tripoint_rel_ms( dp.xy(), 0 ); // intended destination of furniture.
 
     const bool canmove = can_move_furniture( fdest, dp );
-    const furn_t &furntype = m.furn( fpos ).obj();
-    const map_stack &ms = m.i_at( fdest );
+    const furn_t &furntype = here.furn( fpos ).obj();
+    const map_stack &ms = here.i_at( fdest );
     const int dst_items = ms.size();
 
     const bool only_liquid_items = std::all_of( ms.begin(), ms.end(),
@@ -11772,11 +11852,11 @@ int game::grabbed_furn_move_time( const tripoint_rel_ms &dp )
         return liquid_item.made_of_from_type( phase_id::LIQUID );
     } );
 
-    const bool dst_item_ok = !m.has_flag( ter_furn_flag::TFLAG_NOITEM, fdest ) &&
-                             !m.has_flag( ter_furn_flag::TFLAG_SWIMMABLE, fdest ) &&
-                             !m.has_flag( ter_furn_flag::TFLAG_DESTROY_ITEM, fdest ) &&
+    const bool dst_item_ok = !here.has_flag( ter_furn_flag::TFLAG_NOITEM, fdest ) &&
+                             !here.has_flag( ter_furn_flag::TFLAG_SWIMMABLE, fdest ) &&
+                             !here.has_flag( ter_furn_flag::TFLAG_DESTROY_ITEM, fdest ) &&
                              only_liquid_items;
-    const furn_t &fo = m.furn( fpos ).obj();
+    const furn_t &fo = here.furn( fpos ).obj();
     const bool src_item_ok = fo.has_flag( ter_furn_flag::TFLAG_CONTAINER ) ||
                              fo.has_flag( ter_furn_flag::TFLAG_FIRE_CONTAINER ) ||
                              fo.has_flag( ter_furn_flag::TFLAG_SEALED );
@@ -11784,7 +11864,7 @@ int game::grabbed_furn_move_time( const tripoint_rel_ms &dp )
     int str_req = furntype.move_str_req;
     // Factor in weight of items contained in the furniture.
     units::mass furniture_contents_weight = 0_gram;
-    for( item &contained_item : m.i_at( fpos ) ) {
+    for( item &contained_item : here.i_at( fpos ) ) {
         furniture_contents_weight += contained_item.weight();
     }
     str_req += furniture_contents_weight / 4_kilogram;
@@ -11820,11 +11900,12 @@ int game::grabbed_furn_move_time( const tripoint_rel_ms &dp )
 
 bool game::grabbed_furn_move( const tripoint_rel_ms &dp )
 {
+    map &here = get_map();
     // Furniture: pull, push, or standing still and nudging object around.
     // Can push furniture out of reach.
     tripoint_bub_ms fpos = ( u.pos_bub() + u.grab_point );
     // supposed position of grabbed furniture
-    if( !m.has_furn( fpos ) ) {
+    if( !here.has_furn( fpos ) ) {
         // Where did it go? We're grabbing thin air so reset.
         add_msg( m_info, _( "No furniture at grabbed point." ) );
         u.grab( object_type::NONE );
@@ -11833,9 +11914,9 @@ bool game::grabbed_furn_move( const tripoint_rel_ms &dp )
 
     int ramp_z_offset = 0;
     // Furniture could be on a ramp at different time than player so adjust for that.
-    if( m.has_flag( ter_furn_flag::TFLAG_RAMP_UP, fpos + dp.xy() ) ) {
+    if( here.has_flag( ter_furn_flag::TFLAG_RAMP_UP, fpos + dp.xy() ) ) {
         ramp_z_offset = 1;
-    } else if( m.has_flag( ter_furn_flag::TFLAG_RAMP_DOWN, fpos + dp.xy() ) ) {
+    } else if( here.has_flag( ter_furn_flag::TFLAG_RAMP_DOWN, fpos + dp.xy() ) ) {
         ramp_z_offset = -1;
     }
 
@@ -11854,9 +11935,9 @@ bool game::grabbed_furn_move( const tripoint_rel_ms &dp )
     // The current check (no move if trap) allows a player to detect invisible traps by
     // attempting to move stuff onto it.
 
-    const furn_t furntype = m.furn( fpos ).obj();
-    const int src_items = m.i_at( fpos ).size();
-    const map_stack &dst_ms = m.i_at( fdest );
+    const furn_t furntype = here.furn( fpos ).obj();
+    const int src_items = here.i_at( fpos ).size();
+    const map_stack &dst_ms = here.i_at( fdest );
     const int dst_items = dst_ms.size();
 
     const bool only_liquid_items = std::all_of( dst_ms.begin(), dst_ms.end(),
@@ -11864,22 +11945,22 @@ bool game::grabbed_furn_move( const tripoint_rel_ms &dp )
         return liquid_item.made_of_from_type( phase_id::LIQUID );
     } );
 
-    const bool dst_item_ok = !m.has_flag( ter_furn_flag::TFLAG_NOITEM, fdest ) &&
-                             !m.has_flag( ter_furn_flag::TFLAG_SWIMMABLE, fdest ) &&
-                             !m.has_flag( ter_furn_flag::TFLAG_DESTROY_ITEM, fdest );
+    const bool dst_item_ok = !here.has_flag( ter_furn_flag::TFLAG_NOITEM, fdest ) &&
+                             !here.has_flag( ter_furn_flag::TFLAG_SWIMMABLE, fdest ) &&
+                             !here.has_flag( ter_furn_flag::TFLAG_DESTROY_ITEM, fdest );
 
-    const furn_t &fo = m.furn( fpos ).obj();
+    const furn_t &fo = here.furn( fpos ).obj();
     const bool src_item_ok = fo.has_flag( ter_furn_flag::TFLAG_CONTAINER ) ||
                              fo.has_flag( ter_furn_flag::TFLAG_FIRE_CONTAINER ) ||
                              fo.has_flag( ter_furn_flag::TFLAG_SEALED );
 
-    const int fire_intensity = m.get_field_intensity( fpos, fd_fire );
-    time_duration fire_age = m.get_field_age( fpos, fd_fire );
+    const int fire_intensity = here.get_field_intensity( fpos, fd_fire );
+    time_duration fire_age = here.get_field_age( fpos, fd_fire );
 
     int str_req = furntype.move_str_req;
     // Factor in weight of items contained in the furniture.
     units::mass furniture_contents_weight = 0_gram;
-    for( item &contained_item : m.i_at( fpos ) ) {
+    for( item &contained_item : here.i_at( fpos ) ) {
         furniture_contents_weight += contained_item.weight();
     }
     str_req += furniture_contents_weight / 4_kilogram;
@@ -11944,33 +12025,33 @@ bool game::grabbed_furn_move( const tripoint_rel_ms &dp )
                    _( "a scraping noise." ), true, "misc", "scraping" );
 
     // Actually move the furniture.
-    m.furn_set( fdest, m.furn( fpos ), false, false, true );
-    m.furn_set( fpos, furn_str_id::NULL_ID(), true );
+    here.furn_set( fdest, here.furn( fpos ), false, false, true );
+    here.furn_set( fpos, furn_str_id::NULL_ID(), true );
 
     if( fire_intensity == 1 && !pulling_furniture ) {
-        m.remove_field( fpos, fd_fire );
-        m.set_field_intensity( fdest, fd_fire, fire_intensity );
-        m.set_field_age( fdest, fd_fire, fire_age );
+        here.remove_field( fpos, fd_fire );
+        here.set_field_intensity( fdest, fd_fire, fire_intensity );
+        here.set_field_age( fdest, fd_fire, fire_age );
     }
 
     // Is there is only liquids on the ground, remove them after moving furniture.
     if( dst_items > 0 && only_liquid_items ) {
-        m.i_clear( fdest );
+        here.i_clear( fdest );
     }
 
     if( src_items > 0 ) { // Move the stuff inside.
         if( dst_item_ok && src_item_ok ) {
             // Assume contents of both cells are legal, so we can just swap contents.
             std::list<item> temp;
-            map_stack ms = m.i_at( fpos );
+            map_stack ms = here.i_at( fpos );
             std::move( ms.begin(), ms.end(),
                        std::back_inserter( temp ) );
-            m.i_clear( fpos );
+            here.i_clear( fpos );
             for( auto item_iter = ms.begin();
                  item_iter != ms.end(); ++item_iter ) {
                 ms.insert( *item_iter );
             }
-            m.i_clear( fdest );
+            here.i_clear( fdest );
             for( item &cur_item : temp ) {
                 ms.insert( cur_item );
             }
@@ -11979,7 +12060,7 @@ bool game::grabbed_furn_move( const tripoint_rel_ms &dp )
         }
     }
 
-    if( !m.has_floor_or_water( fdest ) && !m.has_flag( ter_furn_flag::TFLAG_FLAT, fdest ) ) {
+    if( !here.has_floor_or_water( fdest ) && !here.has_flag( ter_furn_flag::TFLAG_FLAT, fdest ) ) {
         std::string danger_tile = enumerate_as_string( get_dangerous_tile( fdest ) );
         add_msg( _( "You let go of the %1$s as it falls down the %2$s." ), furntype.name(), danger_tile );
         u.grab( object_type::NONE );
@@ -12000,10 +12081,10 @@ bool game::grabbed_furn_move( const tripoint_rel_ms &dp )
         return true; // We moved furniture but stayed still.
     }
 
-    if( pushing_furniture && m.impassable( fpos ) ) {
+    if( pushing_furniture && here.impassable( fpos ) ) {
         // Not sure how that chair got into a wall, but don't let player follow.
         add_msg( _( "You let go of the %1$s as it slides past %2$s." ),
-                 furntype.name(), m.tername( fdest ) );
+                 furntype.name(), here.tername( fdest ) );
         u.grab( object_type::NONE );
         return true;
     }
@@ -12628,7 +12709,7 @@ void game::vertical_move( int movez, bool force, bool peeking )
     bool rope_ladder = false;
     // TODO: Remove the stairfinding, make the mapgen gen aligned maps
     if( !force && !climbing && !swimming ) {
-        const std::optional<tripoint_bub_ms> pnt = find_or_make_stairs( m, z_after, rope_ladder, peeking,
+        const std::optional<tripoint_bub_ms> pnt = find_or_make_stairs( here, z_after, rope_ladder, peeking,
                 pos );
         if( !pnt ) {
             return;
@@ -12726,7 +12807,7 @@ void game::vertical_move( int movez, bool force, bool peeking )
 
     // Now that we know the player's destination position, we can move their mount as well
     if( u.is_mounted() ) {
-        u.mounted_creature->setpos( m, pos );
+        u.mounted_creature->setpos( here, pos );
     }
 
     // This ugly check is here because of stair teleport bullshit
@@ -12764,12 +12845,14 @@ void game::vertical_move( int movez, bool force, bool peeking )
 
     u.recoil = MAX_RECOIL;
 
-    cata_event_dispatch::avatar_moves( old_abs_pos, u, m );
+    cata_event_dispatch::avatar_moves( old_abs_pos, u, here );
 }
 
 void game::start_hauling( const tripoint_bub_ms &pos )
 {
-    std::vector<item_location> candidate_items = m.get_haulable_items( pos );
+    map &here = get_map();
+
+    std::vector<item_location> candidate_items = here.get_haulable_items( pos );
     // Find target items and quantities thereof for the new activity
     u.trim_haul_list( candidate_items );
     std::vector<item_location> target_items = u.haul_list;
@@ -13024,6 +13107,8 @@ std::optional<tripoint_bub_ms> game::find_or_make_stairs( map &mp, const int z_a
 
 bool game::vertical_shift( const int z_after )
 {
+    map &here = get_map();
+
     if( z_after < -OVERMAP_DEPTH || z_after > OVERMAP_HEIGHT ) {
         debugmsg( "Tried to get z-level %d outside allowed range of %d-%d",
                   z_after, -OVERMAP_DEPTH, OVERMAP_HEIGHT );
@@ -13036,7 +13121,7 @@ bool game::vertical_shift( const int z_after )
     u.move_to( tripoint_abs_ms( u.pos_abs().xy(), z_after ) );
 
     // Shift the map itself
-    m.vertical_shift( z_after );
+    here.vertical_shift( z_after );
 
     vertical_notes( z_before, z_after );
 
@@ -13045,12 +13130,14 @@ bool game::vertical_shift( const int z_after )
 
 void game::vertical_notes( int z_before, int z_after )
 {
+    map &here = get_map();
+
     if( z_before == z_after || !get_option<bool>( "AUTO_NOTES" ) ||
         !get_option<bool>( "AUTO_NOTES_STAIRS" ) ) {
         return;
     }
 
-    if( !m.inbounds_z( z_before ) || !m.inbounds_z( z_after ) ) {
+    if( !here.inbounds_z( z_before ) || !here.inbounds_z( z_after ) ) {
         debugmsg( "game::vertical_notes invalid arguments: z_before == %d, z_after == %d",
                   z_before, z_after );
         return;
@@ -13114,7 +13201,7 @@ point_rel_sm game::update_map( int &x, int &y, bool z_level_changed )
 
     if( shift == point_rel_sm::zero ) {
         // adjust player position
-        u.setpos( m, tripoint_bub_ms( x, y, here.get_abs_sub().z() ) );
+        u.setpos( here, tripoint_bub_ms( x, y, here.get_abs_sub().z() ) );
         if( z_level_changed ) {
             // Update what parts of the world map we can see
             // We may be able to see farther now that the z-level has changed.
@@ -13160,7 +13247,7 @@ point_rel_sm game::update_map( int &x, int &y, bool z_level_changed )
     // Also ensure the player is on current z-level
     // m.get_abs_sub().z should later be removed, when there is no longer such a thing
     // as "current z-level"
-    u.setpos( m, tripoint_bub_ms( x, y, here.get_abs_sub().z() ) );
+    u.setpos( here, tripoint_bub_ms( x, y, here.get_abs_sub().z() ) );
 
     // Only do the loading after all coordinates have been shifted.
 
@@ -13276,7 +13363,7 @@ void game::shift_monsters( const tripoint_rel_sm &shift )
             critter.shift( shift.xy() );
         }
 
-        if( m.inbounds( critter.pos_bub() ) ) {
+        if( reality_bubble().inbounds( critter.pos_bub() ) ) {
             // We're inbounds, so don't despawn after all.
             continue;
         }
@@ -13607,8 +13694,10 @@ void game::start_calendar()
 
 overmap &game::get_cur_om() const
 {
+    map &here = get_map();
+
     // The player is located in the middle submap of the map.
-    const tripoint_abs_sm sm = m.get_abs_sub() + tripoint( HALF_MAPSIZE, HALF_MAPSIZE, 0 );
+    const tripoint_abs_sm sm = here.get_abs_sub() + tripoint( HALF_MAPSIZE, HALF_MAPSIZE, 0 );
     const tripoint_abs_om pos_om = project_to<coords::om>( sm );
     return overmap_buffer.get( pos_om.xy() );
 }
@@ -13919,6 +14008,8 @@ float game::slip_down_chance( climb_maneuver, climbing_aid_id aid_id,
 bool game::slip_down( climb_maneuver maneuver, climbing_aid_id aid_id,
                       bool show_chance_messages )
 {
+    map &here = get_map();
+
     float slip = slip_down_chance( maneuver, aid_id, show_chance_messages );
 
     if( x_in_y( slip, 100 ) ) {
@@ -13928,7 +14019,7 @@ bool game::slip_down( climb_maneuver maneuver, climbing_aid_id aid_id,
         }
         // Check for traps and gravity if climbing up or down.
         if( maneuver != climb_maneuver::over_obstacle ) {
-            m.creature_on_trap( u );
+            here.creature_on_trap( u );
             u.gravity_check();
         }
         return true;
@@ -13974,7 +14065,7 @@ void game::climb_down_menu_gen( const tripoint_bub_ms &examp, uilist &cmenu )
     }
 
     // This is used to mention object names.  TODO make this more flexible.
-    std::string target_disp_name = m.disp_name( fall.pos_furniture_or_floor() );
+    std::string target_disp_name = here.disp_name( fall.pos_furniture_or_floor() );
 
     climbing_aid::condition_list conditions = climbing_aid::detect_conditions( you, examp );
 
@@ -14187,7 +14278,7 @@ void game::climb_down_using( const tripoint_bub_ms &examp, climbing_aid_id aid_i
     if( !levitating && ( !seems_perfectly_safe || !easy_climb_back_up ) ) {
 
         // This is used to mention object names.  TODO make this more flexible.
-        std::string target_disp_name = m.disp_name( fall.pos_furniture_or_floor() );
+        std::string target_disp_name = here.disp_name( fall.pos_furniture_or_floor() );
 
         // Show the risk prompt.
         if( !query_yn( query.c_str(), target_disp_name ) ) {
@@ -14510,6 +14601,11 @@ avatar &get_avatar()
 }
 
 map &get_map()
+{
+    return g->m;
+}
+
+map &reality_bubble()
 {
     return g->m;
 }

--- a/src/game.h
+++ b/src/game.h
@@ -1123,7 +1123,7 @@ class game
         pimpl<spell_events> spell_events_ptr; // NOLINT(cata-serialize)
         pimpl<eoc_events> eoc_events_ptr; // NOLINT(cata-serialize)
 
-        map &m;
+        map &m; // NOLINT(cata-serialize)
         avatar &u;
         scent_map &scent;
         // scenario is saved in avatar::store

--- a/src/game.h
+++ b/src/game.h
@@ -172,6 +172,7 @@ class game
         friend achievements_tracker &get_achievements();
         friend event_bus &get_event_bus();
         friend map &get_map();
+        friend map &reality_bubble();
         friend creature_tracker &get_creature_tracker();
         friend Character &get_player_character();
         friend avatar &get_avatar();

--- a/src/grab.cpp
+++ b/src/grab.cpp
@@ -24,7 +24,7 @@ bool game::grabbed_veh_move( const tripoint_rel_ms &dp )
 {
     map &here = get_map();
 
-    const optional_vpart_position grabbed_vehicle_vp = m.veh_at( u.pos_bub( here ) + u.grab_point );
+    const optional_vpart_position grabbed_vehicle_vp = here.veh_at( u.pos_bub( here ) + u.grab_point );
     if( !grabbed_vehicle_vp ) {
         add_msg( m_info, _( "No vehicle at grabbed point." ) );
         u.grab( object_type::NONE );
@@ -42,7 +42,7 @@ bool game::grabbed_veh_move( const tripoint_rel_ms &dp )
         u.grab( object_type::NONE );
         return false;
     }
-    const vehicle *veh_under_player = veh_pointer_or_null( m.veh_at( u.pos_bub( here ) ) );
+    const vehicle *veh_under_player = veh_pointer_or_null( here.veh_at( u.pos_bub( here ) ) );
     if( grabbed_vehicle == veh_under_player ) {
         u.grab_point = - dp;
         return false;
@@ -128,7 +128,7 @@ bool game::grabbed_veh_move( const tripoint_rel_ms &dp )
             const tripoint_bub_ms vehpos = grabbed_vehicle->pos_bub( here );
             for( int p : wheel_indices ) {
                 const tripoint_bub_ms wheel_pos = vehpos + grabbed_vehicle->part( p ).precalc[0];
-                const int mapcost = m.move_cost( wheel_pos, grabbed_vehicle );
+                const int mapcost = here.move_cost( wheel_pos, grabbed_vehicle );
                 mc += str_req * mapcost / wheel_indices.size();
             }
             //set strength check threshold
@@ -291,17 +291,17 @@ bool game::grabbed_veh_move( const tripoint_rel_ms &dp )
         u.grab_point = next_grab;
     }
 
-    m.displace_vehicle( *grabbed_vehicle, final_dp_veh );
-    m.rebuild_vehicle_level_caches();
+    here.displace_vehicle( *grabbed_vehicle, final_dp_veh );
+    here.rebuild_vehicle_level_caches();
 
     if( grabbed_vehicle ) {
-        m.level_vehicle( *grabbed_vehicle );
+        here.level_vehicle( *grabbed_vehicle );
         grabbed_vehicle->check_falling_or_floating();
         if( grabbed_vehicle->is_falling ) {
             add_msg( _( "You let go of the %1$s as it starts to fall." ), grabbed_vehicle->disp_name() );
             u.grab( object_type::NONE );
             u.grab_point = tripoint_rel_ms::zero;
-            m.set_seen_cache_dirty( grabbed_vehicle->pos_bub( here ) );
+            here.set_seen_cache_dirty( grabbed_vehicle->pos_bub( here ) );
             return true;
         }
     } else {
@@ -313,7 +313,7 @@ bool game::grabbed_veh_move( const tripoint_rel_ms &dp )
         if( one_in( 2 ) ) {
             vehicle_part &vp_wheel = grabbed_vehicle->part( p );
             tripoint_bub_ms wheel_p = grabbed_vehicle->bub_part_pos( here, vp_wheel );
-            grabbed_vehicle->handle_trap( &m, wheel_p, vp_wheel );
+            grabbed_vehicle->handle_trap( &here, wheel_p, vp_wheel );
         }
     }
 

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -239,7 +239,7 @@ class user_turn
 
 input_context game::get_player_input( std::string &action )
 {
-    const map &here = get_map();
+    map &here = get_map();
 
     const tripoint_bub_ms pos = u.pos_bub( here );
 
@@ -271,9 +271,9 @@ input_context game::get_player_input( std::string &action )
         ctxt = get_default_mode_input_context();
     }
 
-    m.update_visibility_cache( pos.z() );
-    const visibility_variables &cache = m.get_visibility_variables_cache();
-    const level_cache &map_cache = m.get_cache_ref( pos.z() );
+    here.update_visibility_cache( pos.z() );
+    const visibility_variables &cache = here.get_visibility_variables_cache();
+    const level_cache &map_cache = here.get_cache_ref( pos.z() );
     const auto &visibility_cache = map_cache.visibility_cache;
 #if defined(TILES)
     // Mark cata_tiles draw caches as dirty
@@ -358,8 +358,8 @@ input_context game::get_player_input( std::string &action )
 
                     const tripoint_bub_ms mapp( map.x, map.y, pos.z() );
 
-                    if( m.inbounds( mapp ) && m.is_outside( mapp ) &&
-                        m.get_visibility( visibility_cache[mapp.x()][mapp.y()], cache ) ==
+                    if( here.inbounds( mapp ) && here.is_outside( mapp ) &&
+                        here.get_visibility( visibility_cache[mapp.x()][mapp.y()], cache ) ==
                         visibility_type::CLEAR &&
                         !creatures.creature_at( mapp, true ) ) {
                         // Suppress if a critter is there
@@ -2342,9 +2342,9 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
                         tripoint_bub_ms auto_travel_destination =
                             player_character.pos_bub() + dest_delta * ( SEEX - i );
                         destination_preview =
-                            m.route( player_character.pos_bub(), auto_travel_destination,
-                                     player_character.get_pathfinding_settings(),
-                                     player_character.get_path_avoid() );
+                            here.route( player_character.pos_bub(), auto_travel_destination,
+                                        player_character.get_pathfinding_settings(),
+                                        player_character.get_path_avoid() );
                         if( !destination_preview.empty() ) {
                             destination_preview.erase(
                                 destination_preview.begin() + 1, destination_preview.end() );
@@ -2359,7 +2359,7 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
                     }
                     dest_delta = dest_next;
                 }
-                if( !avatar_action::move( player_character, m, tripoint_rel_ms( dest_delta, 0 ) ) ) {
+                if( !avatar_action::move( player_character, here, tripoint_rel_ms( dest_delta, 0 ) ) ) {
                     // auto-move should be canceled due to a failed move or obstacle
                     player_character.abort_automove();
                 }
@@ -2406,19 +2406,19 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
 
             if( !player_character.in_vehicle ) {
                 // We're NOT standing on tiles with stairs, ropes, ladders etc
-                if( !m.has_flag( ter_furn_flag::TFLAG_GOES_DOWN, player_character.pos_bub() ) ) {
+                if( !here.has_flag( ter_furn_flag::TFLAG_GOES_DOWN, player_character.pos_bub() ) ) {
                     std::vector<tripoint_bub_ms> pts;
 
                     // If levitating, just move straight down if possible.
                     if( player_character.has_flag( json_flag_LEVITATION ) &&
-                        m.has_flag( ter_furn_flag::TFLAG_NO_FLOOR, player_character.pos_bub() ) ) {
+                        here.has_flag( ter_furn_flag::TFLAG_NO_FLOOR, player_character.pos_bub() ) ) {
                         pts.push_back( player_character.pos_bub() );
                     }
 
                     if( pts.empty() ) {
                         // Check tiles around player character for open air
-                        for( const tripoint_bub_ms &p : m.points_in_radius( player_character.pos_bub(), 1 ) ) {
-                            if( m.has_flag( ter_furn_flag::TFLAG_NO_FLOOR, p ) ) {
+                        for( const tripoint_bub_ms &p : here.points_in_radius( player_character.pos_bub(), 1 ) ) {
+                            if( here.has_flag( ter_furn_flag::TFLAG_NO_FLOOR, p ) ) {
                                 pts.push_back( p );
                             }
                         }
@@ -2473,7 +2473,7 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
                     add_msg( m_info, _( "You can't close things while you're riding." ) );
                 }
             } else if( mouse_target ) {
-                doors::close_door( m, player_character, *mouse_target );
+                doors::close_door( here, player_character, *mouse_target );
             } else {
                 close();
             }
@@ -2866,7 +2866,7 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
             break;
 
         case ACTION_MAP:
-            if( !m.is_outside( player_character.pos_bub() ) ) {
+            if( !here.is_outside( player_character.pos_bub() ) ) {
                 uistate.overmap_visible_weather = false;
             }
             if( !get_timed_events().get( timed_event_type::OVERRIDE_PLACE ) ) {
@@ -2877,7 +2877,7 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
             break;
 
         case ACTION_SKY:
-            if( m.is_outside( player_character.pos_bub() ) ) {
+            if( here.is_outside( player_character.pos_bub() ) ) {
                 ui::omap::display_visible_weather();
             } else {
                 add_msg( m_info, _( "You can't see the sky from here." ) );
@@ -3096,7 +3096,7 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
             break;
 
         case ACTION_AUTOATTACK:
-            avatar_action::autoattack( player_character, m );
+            avatar_action::autoattack( player_character, here );
             break;
 
         default:

--- a/src/map.h
+++ b/src/map.h
@@ -2238,7 +2238,21 @@ class map
 #endif
 };
 
+// The map the code is currently processing. It is currently (incorrectly) fixed at the
+// reality bubble, but will will have to be constantly adjusted to match the map that's
+// actually processed (so reality bubble coordinates on a mapgen map are actually referring
+// to that map rather than the reality bubble).
 map &get_map();
+
+// The reality bubble map, for when you need it to e.g. determine whether the map
+// you're operating on is the reality bubble. This can be to process things differently
+// between mapgen and the reality bubble, determine whether to carry over map cache info,
+// determine whether to produce a sound, etc.
+// Note that if the game will support more than one reality bubble map for a longer period
+// than a single tick, this operation will have to be split into one for the active bubble
+// for sound etc. processing, and another one for accessing all bubbles for cache
+// synchronization purposes.
+map &reality_bubble();
 
 template<int SIZE, int MULTIPLIER>
 void shift_bitset_cache( std::bitset<SIZE *SIZE> &cache, const point_rel_sm &s );

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -102,7 +102,7 @@ void game::serialize( std::ostream &fout )
     json.member( "run_mode", static_cast<int>( safe_mode ) );
     json.member( "mostseen", mostseen );
     // current map coordinates
-    tripoint_abs_sm pos_abs_sm = m.get_abs_sub();
+    tripoint_abs_sm pos_abs_sm = get_map().get_abs_sub();
     point_abs_om pos_om;
     tripoint_om_sm pos_sm;
     std::tie( pos_om, pos_sm ) = project_remain<coords::om>( pos_abs_sm );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
- Switch usage of g->m to usage of get_map() to separate the reality bubble map from the current map.
- Introduce reality_bubble() to allow code to perform checks explicitly against the reality bubble.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
- Introduce reality_bubble()
- Replace usages of g->m with usages of a local map variable containing the fetched get_map().

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
The changes should have no functional effects currently, as get_map() is still hard coded to return g->m.
Load save, walk up ramp, jump into car, drive through hay bales, run over zombie corpse with inventory, run over turkey, smash into stationary vehicle. Nothing odd seen.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
The long term goal is to change get_map() to return whatever map the code is currently working with and thus have all code downstream in the call chain use the same map, rather than the current bizarre (and erroneous) mixture between the actual map and the reality bubble, depending on how the map reference is gotten in individual operations.

Before that can be achieved the current anarchy has to be tamed at least a little. This is the first step. The next intended step is to go through every blasted usage of get_map() to find those that are actually looking for the reality bubble map and switch those usages to use the new reality_bubble() operation. That will still not make any functional difference, as the operations are currently identical, but will once a separation is made.
There are currently 1588 usages of get_map(), and you can only examine so many before the eyes glaze over and the brain freezes, so it may be a slow process.

The actual functional changes would appear once means to redirect get_map() to refer to the proper map have been introduced. It would then be a matter of applying those means to get the appropriate map processed in the appropriate call chains. It's not unlikely this will uncover lots of existing bugs that are plastered over by just doing nothing rather than doing what the code intended it to do because mapgen positions are no longer outside of the reality bubble, and possibly ones where they ARE inside the reality bubble, but not the mapgen smallmap actually being processed.

I dumped a few pos_bub() map parameters as being pointless when get_map() is used as the reference by the caller (and thus being the same as the call done by the parameter less version) and probably to be removed eventually (although I won't do that: I'll leave that cleanup to somebody else).

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
