### PR TITLE
Pin cmake version in windows build

### DIFF
--- a/.github/workflows/msvc-full-features.yml
+++ b/.github/workflows/msvc-full-features.yml
@@ -80,6 +80,9 @@ jobs:
 
     - name: Install stable CMake
       uses: lukka/get-cmake@latest
+      with:
+        # 4.0.0 has issues compiling old packages
+        cmakeVersion: 3.31.6
 
     - name: Install vcpkg
       uses: lukka/run-vcpkg@v11

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,6 +164,8 @@ jobs:
       - name: Install dependencies (windows msvc) (0/4)
         if: runner.os == 'Windows'
         uses: lukka/get-cmake@latest
+          # 4.0.0 has issues compiling old packages in vcpkg
+          cmakeVersion: 3.31.6
       - name: Install dependencies (windows msvc) (1/4)
         if: runner.os == 'Windows'
         uses: microsoft/setup-msbuild@v2


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
* Fixes #80358

#### Describe the solution
Pin cmake version to 3.31.6 (that's the latest 3.X.X that is currently released).

#### Describe alternatives you've considered
Update the versions of our deps *once* vcpkg makes that route viable (presently there is no `yasm` version that can be compiled with cmake 4.0.0)

#### Testing
CI only (make sure windows build passes)

#### Additional context
Whoever added `Dump vcpkg logs if build failed` step to CI (*cough* @ akrieger *cough*), you're the best! 