### PR TITLE
update clang-tidy docs to reflect our switch to llvm-18 and clang++-18

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -196,6 +196,7 @@ cataclysm.a
 # clang tooling
 compile_commands.json
 .clangd
+clang-tidy-trace/
 
 # IDA database
 Cataclysm.i64

--- a/doc/c++/DEVELOPER_TOOLING.md
+++ b/doc/c++/DEVELOPER_TOOLING.md
@@ -113,12 +113,7 @@ here](https://apt.llvm.org/) to your `sources.list`, install the needed packages
 libclang-18-dev llvm-18-dev llvm-18-tools`), and build Cataclysm with CMake,
 adding `-DCATA_CLANG_TIDY_PLUGIN=ON`.
 
-You can use the automated install script instead:
-```bash
-wget https://apt.llvm.org/llvm.sh
-chmod +x llvm.sh
-sudo ./llvm.sh 18
-```
+[apt.llvm.org](apt.llvm.org) also has an automated install script.
 
 #### Other Linux distributions
 

--- a/doc/c++/DEVELOPER_TOOLING.md
+++ b/doc/c++/DEVELOPER_TOOLING.md
@@ -68,7 +68,7 @@ In addition to the usual means of creating a `tags` file via e.g. [`ctags`](http
 
 Cataclysm has a [clang-tidy configuration file](../.clang-tidy) and if you have
 `clang-tidy` available you can run it to perform static analysis of the
-codebase.  We test with `clang-tidy` from LLVM 12.0.0 with CI, so for the most
+codebase.  We test with `clang-tidy` from LLVM 18.0.0 with CI, so for the most
 consistent results, you might want to use that version.
 
 To run it, you have a few options.
@@ -97,29 +97,36 @@ work requires some extra steps.
 #### Extreme tl;dr for Ubuntu Focal (including WSL)
 The following set of commands should take you from zero to running clang-tidy equivalent to the CI job. This will lint all sources in a random order.
 ```sh
-sudo apt install build-essential cmake clang-12 libclang-12-dev llvm-12 llvm-12-dev llvm-12-tools pip
+sudo apt install build-essential cmake clang-18 libclang-18-dev llvm-18 llvm-18-dev llvm-18-tools pip
 sudo pip install compiledb lit
 test -f /usr/bin/python || sudo ln -s /usr/bin/python3 /usr/bin/python
 # The following command invokes clang-tidy exactly like CI does
-COMPILER=clang++-12 CLANG=clang++-12 CMAKE=1 CATA_CLANG_TIDY=plugin TILES=1 LOCALIZE=0 ./build-scripts/clang-tidy-build.sh
-COMPILER=clang++-12 CLANG=clang++-12 CMAKE=1 CATA_CLANG_TIDY=plugin TILES=1 LOCALIZE=0 ./build-scripts/clang-tidy-run.sh
+COMPILER=clang++-18 CLANG=clang++-18 CMAKE=1 CATA_CLANG_TIDY=plugin TILES=1 LOCALIZE=0 ./build-scripts/clang-tidy-build.sh
+COMPILER=clang++-18 CLANG=clang++-18 CMAKE=1 CATA_CLANG_TIDY=plugin TILES=1 LOCALIZE=0 ./build-scripts/clang-tidy-run.sh
 ```
 
 #### Ubuntu Focal
 
 If you are on Ubuntu Focal then you might be able to get it working the same
-way our CI does.  Add the LLVM 12 Focal source [listed
-here](https://apt.llvm.org/) to your `sources.list`, install the needed packages (`clang-12
-libclang-12-dev llvm-12-dev llvm-12-tools`), and build Cataclysm with CMake,
+way our CI does.  Add the LLVM 18 Focal source [listed
+here](https://apt.llvm.org/) to your `sources.list`, install the needed packages (`clang-18
+libclang-18-dev llvm-18-dev llvm-18-tools`), and build Cataclysm with CMake,
 adding `-DCATA_CLANG_TIDY_PLUGIN=ON`.
+
+You can use the automated install script instead:
+```bash
+wget https://apt.llvm.org/llvm.sh
+chmod +x llvm.sh
+sudo ./llvm.sh 18
+```
 
 #### Other Linux distributions
 
 On other distributions you will probably need to build `clang-tidy` yourself.
 * Expect this process to take about 80GB of disk space.
-* Check out the `llvm` project, release 12 branch, with e.g.
-  `git clone --branch release/12.x --depth 1 https://github.com/llvm/llvm-project.git llvm-12`.
-* Enter the newly cloned repo `cd llvm-12`.
+* Check out the `llvm` project, release 18 branch, with e.g.
+  `git clone --branch release/18.x --depth 1 https://github.com/llvm/llvm-project.git llvm-18`.
+* Enter the newly cloned repo `cd llvm-18`.
 * Patch in plugin support for `clang-tidy` using [this
   patch](https://github.com/jbytheway/clang-tidy-plugin-support/blob/master/plugin-support.patch).
   `curl https://raw.githubusercontent.com/jbytheway/clang-tidy-plugin-support/master/plugin-support.patch | patch -p1`
@@ -421,7 +428,7 @@ After the tools are installed, a patch still needs to be applied before building
 LLVM, since `clang-tidy` as distributed by LLVM doesn't support plugins.
 
 First, clone the LLVM repo from, for example, [the official github repo](https://github.com/llvm/llvm-project.git).
-Checkout the `release/12.x` branch, since that's what our patch was based on.
+Checkout the `release/18.x` branch, since that's what our patch was based on.
 
 On Windows, in addition to applying `plugin-support.patch` mentioned in the previous section, you
 should also apply


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
I tried installing and running clang-tidy on my local machine using our [docs](https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/c%2B%2B/DEVELOPER_TOOLING.md#clang-tidy), which are outdated. Our plugin no longer compiles with clang-tidy-12

#### Describe the solution
update docs to version 18, which we use in our CI
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
also added clang-tidy-trace/, which is created when running clang-tidy, to .gitignore.
also added the automated install script from llvm.org for easier installation.

I would like to mark the build and run script as executable, but I'm not sure if it has any consequences
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
