### PR TITLE
[Xedra Evolved] Fix Magiclysm haste interactions

### DIFF
--- a/data/mods/Xedra_Evolved/effects/effects.json
+++ b/data/mods/Xedra_Evolved/effects/effects.json
@@ -7,9 +7,9 @@
   },
   {
     "type": "effect_type",
-    "id": "haste",
-    "name": [ "Hasted" ],
-    "desc": [ "Your speed is boosted enormously." ],
+    "id": "haste_vampire",
+    "name": [ "Blood Haste" ],
+    "desc": [ "Stolen blood is boosting your speed enormously." ],
     "apply_message": "Your speed is boosted to superhuman levels!",
     "remove_message": "You return to your normal speed.",
     "rating": "good",

--- a/data/mods/Xedra_Evolved/effects/effects.json
+++ b/data/mods/Xedra_Evolved/effects/effects.json
@@ -10,7 +10,7 @@
     "id": "haste_vampire",
     "name": [ "Blood Haste" ],
     "desc": [ "Stolen blood is boosting your speed enormously." ],
-    "apply_message": "Your speed is boosted to superhuman levels!",
+    "apply_message": "",
     "remove_message": "You return to your normal speed.",
     "rating": "good",
     "base_mods": { "dex_mod": [ 4 ], "speed_mod": [ 250 ] }

--- a/data/mods/Xedra_Evolved/mutations/vampire_trait_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/vampire_trait_eocs.json
@@ -1044,7 +1044,7 @@
               { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 2 },
               { "math": [ "u_vitamin('human_blood_vitamin')", "-=", "750" ] },
               { "u_add_effect": "haste_vampire", "duration": "PERMANENT" },
-              { "u_message": "You movements accelerate to superhuman levels.", "type": "good" },
+              { "u_message": "Warmth floods your limbs as you move with inhuman speed.", "type": "good" },
               {
                 "run_eocs": [ "EOC_BLOODHASTE_maintenance" ],
                 "time_in_future": {
@@ -1068,11 +1068,7 @@
           {
             "id": "EOC_BLOODHASTE_deactivated",
             "condition": { "u_has_effect": "haste_vampire" },
-            "effect": [
-              { "u_message": "Your speed returns to normal.", "type": "neutral" },
-              { "u_lose_effect": "haste" },
-              { "u_lose_effect": "haste_vampire" }
-            ]
+            "effect": [ { "u_lose_effect": "haste" }, { "u_lose_effect": "haste_vampire" } ]
           }
         ]
       }

--- a/data/mods/Xedra_Evolved/mutations/vampire_trait_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/vampire_trait_eocs.json
@@ -1033,7 +1033,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_BLOODHASTE_activated",
-    "condition": { "not": { "u_has_effect": "haste" } },
+    "condition": { "not": { "u_has_effect": "haste_vampire" } },
     "effect": [
       {
         "run_eocs": [
@@ -1043,7 +1043,7 @@
             "effect": [
               { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 2 },
               { "math": [ "u_vitamin('human_blood_vitamin')", "-=", "750" ] },
-              { "u_add_effect": "haste", "duration": "PERMANENT" },
+              { "u_add_effect": "haste_vampire", "duration": "PERMANENT" },
               { "u_message": "You movements accelerate to superhuman levels.", "type": "good" },
               {
                 "run_eocs": [ "EOC_BLOODHASTE_maintenance" ],
@@ -1067,8 +1067,12 @@
         "run_eocs": [
           {
             "id": "EOC_BLOODHASTE_deactivated",
-            "condition": { "u_has_effect": "haste" },
-            "effect": [ { "u_message": "Your speed returns to normal.", "type": "neutral" }, { "u_lose_effect": "haste" } ]
+            "condition": { "u_has_effect": "haste_vampire" },
+            "effect": [
+              { "u_message": "Your speed returns to normal.", "type": "neutral" },
+              { "u_lose_effect": "haste" },
+              { "u_lose_effect": "haste_vampire" }
+            ]
           }
         ]
       }
@@ -1083,7 +1087,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_BLOODHASTE_maintenance",
-    "condition": { "u_has_effect": "haste" },
+    "condition": { "u_has_effect": "haste_vampire" },
     "effect": [
       {
         "run_eocs": [
@@ -1104,6 +1108,7 @@
             ],
             "false_effect": [
               { "u_message": "You don't have enough blood to maintain your blood-driven speed.", "type": "bad" },
+              { "u_lose_effect": "haste_vampire" },
               { "u_lose_effect": "haste" },
               { "u_deactivate_trait": "BLOODHASTE" }
             ]

--- a/data/mods/Xedra_Evolved/obsoletion_and_migration/effects.json
+++ b/data/mods/Xedra_Evolved/obsoletion_and_migration/effects.json
@@ -63,5 +63,16 @@
     "apply_message": "",
     "remove_message": "The flames gutter out.",
     "max_duration": "12 hours"
+  },
+  {
+    "type": "effect_type",
+    "id": "haste",
+    "name": [ "Hasted" ],
+    "desc": [ "Your speed is boosted enormously." ],
+    "apply_message": "Your speed is boosted to superhuman levels!",
+    "remove_message": "You return to your normal speed.",
+    "rating": "good",
+    "max_duration": "2 minutes",
+    "enchantments": [ { "values": [ { "value": "MOVE_COST", "multiply": -0.7 }, { "value": "ATTACK_SPEED", "multiply": -0.7 } ] } ]
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "[Xedra Evolved] Fix Magiclysm haste interactions"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

The Japanese discord noticed that XE and Magiclysm both have effects called haste but they work differently. I didn't notice when I modified the Magiclysm haste effect because the XE haste effect is only used by vampires.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Obsolete the XE haste effect, and edit the obsoleted effect to work like the Magiclysm haste effect. Create a new effect, `haste_vampire`, that works like the old XE haste effect, with a straight speed boost instead of move_cost and attack_speed modifiers. Set the vampire Blood Haste ability to mostly work on `haste_vampire` but also turn off the regular `haste` when turned off, to prevent orphan effects (which crash the game). 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Loaded game, gave myself Blood-Driven Speed and manually applied the `haste` effect. Ending Blood-Driven Speed ends `haste`. New `Blood Haste` effect tied to Blood-Driven Speed.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

This does mean if you're a vampire wizard stacking haste, ending Blood Haste will cancel the spell too, but that's unavoidable for the moment. 
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
