### PR TITLE
Used/unused names for map cache + lore files

### DIFF
--- a/src/item_tname.cpp
+++ b/src/item_tname.cpp
@@ -32,6 +32,7 @@
 #include "recipe.h"
 #include "relic.h"
 #include "string_formatter.h"
+#include "text_snippets.h"
 #include "translation.h"
 #include "translation_cache.h"
 #include "translations.h"
@@ -445,6 +446,26 @@ std::string vars( item const &it, unsigned int /* quantity */,
                                   item::nname( itype_id( it.get_var( "NANOFAB_ITEM_ID" ) ) ) );
         }
         ret += string_format( " (%s)", item::nname( itype_id( it.get_var( "NANOFAB_ITEM_ID" ) ) ) );
+    }
+
+    if( it.has_var( "snippet_file" ) ) {
+        std::string has_snippet = it.get_var( "snippet_file" );
+        if( has_snippet == "has" ) {
+            std::optional<translation> snippet_name =
+                SNIPPET.get_name_by_id( snippet_id( it.get_var( "local_files_simple_snippet_id" ) ) );
+            if( snippet_name ) {
+                ret += string_format( " (%s)", snippet_name->translated() );
+            }
+        } else {
+            ret += _( " (uninteresting)" );
+        }
+    }
+
+    if( it.has_var( "map_cache" ) ) {
+        std::string has_map_cache = it.get_var( "map_cache" );
+        if( has_map_cache == "read" ) {
+            ret += _( " (read)" );
+        }
     }
 
     if( it.already_used_by_player( get_avatar() ) ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Interface "used/unused names for map cache + lore files"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

From #79097, I hadn't gotten around to it yet

If you can't tell which `map cache`s and `questionable media file`s you have and haven't used, it's guesswork to actually use them

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

The affected items display after they've been used, like so:
![efile_vars](https://github.com/user-attachments/assets/53299248-4085-43cd-b2b1-c852c15173e8)

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Destroying the items after they've been used, but they could plausibly be sold or kept for later use

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Loaded game, used some of the affected items, noted correct display names

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Thanks to @Uwuewsky (EDIT: @GuardianDll, looked at wrong PR ) for giving snippets names, makes this very easy

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
