### PR TITLE
sanify ebooksave energy consumptions

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -2857,7 +2857,7 @@ void ebooksave_activity_actor::start( player_activity &act, Character &/*who*/ )
 
 void ebooksave_activity_actor::do_turn( player_activity &act, Character &who )
 {
-    // only consume charges every 25 pages
+    // only consume charges every pages_per_charge pages
     if( calendar::once_every( pages_per_charge * time_per_page ) ) {
         if( !ereader->ammo_sufficient( &who ) ) {
             add_msg_if_player_sees(

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -715,8 +715,8 @@ class ebooksave_activity_actor : public activity_actor
         int turns_left_on_current_book = 0;
 
         static constexpr time_duration time_per_page = 5_seconds;
-        // Every 25 pages requires one charge of the ereader
-        static constexpr int pages_per_charge = 25;
+        // Every 120 pages requires one charge of the ereader (equivalent of 1500 mWh, so roughly 6 charges per hour )
+        static constexpr int pages_per_charge = 120;
 
         void start_scanning_next_book( player_activity &act );
         void completed_scanning_current_book( player_activity &act, Character &who );


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Previous calculations assumed character spend 5 seconds scanning a single page, and spend 1 charge every 25 pages, which is roughly 8 watt - ludicrious amount at this point
#### Describe the solution
Since right now phone (not the only tool that can make photos, but average one for our purposes) uses 1500 mW, which is 5.4 kj per hour, which is roughly 6 charges per hour, we should consume 1 charge every 10 minutes, which is, if we spend 5 seconds for 1 page, result in 120 pages scanned before a charge is consumed
#### Describe alternatives you've considered
- to perfectly match phone power consumption it should be 133 pages per chrage, but that's too detailed imo
- instead of using the same charge value for all tools, calculate the power consumption dynamically for each tool from it's power_draw