### PR TITLE
Underground Temperature now depends on Region Settings

### DIFF
--- a/src/game_constants.h
+++ b/src/game_constants.h
@@ -111,12 +111,6 @@ constexpr int HORDE_VISIBILITY_SIZE = 3;
 constexpr time_duration time_between_npc_OM_moves = 5_minutes;
 
 /**
- * Average annual temperature in Kelvin used for climate, weather and temperature calculation.
- * Average New England temperature = 43F/6C rounded to int.
-*/
-constexpr units::temperature AVERAGE_ANNUAL_TEMPERATURE = units::from_fahrenheit( 43 );
-
-/**
  * Base starting spring temperature in Kelvin used for climate, weather and temperature calculation.
  * New England base spring temperature = 65F/18C rounded to int.
 */

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -13435,7 +13435,7 @@ bool item::process_temperature_rot( float insulation, const tripoint_bub_ms &pos
             temp = std::max( temp, temperatures::normal );
             break;
         case temperature_flag::ROOT_CELLAR:
-            temp = AVERAGE_ANNUAL_TEMPERATURE;
+            temp = units::from_celsius( get_weather().get_cur_weather_gen().base_temperature );
             break;
         default:
             debugmsg( "Temperature flag enum not valid.  Using current temperature." );
@@ -13488,7 +13488,7 @@ bool item::process_temperature_rot( float insulation, const tripoint_bub_ms &pos
             if( pos.z() >= 0 && flag != temperature_flag::ROOT_CELLAR ) {
                 env_temperature = wgen.get_weather_temperature( get_map().get_abs( pos ), time, seed );
             } else {
-                env_temperature = AVERAGE_ANNUAL_TEMPERATURE;
+                env_temperature = units::from_celsius( get_weather().get_cur_weather_gen().base_temperature );
             }
             env_temperature += temp_mod;
 
@@ -13506,7 +13506,7 @@ bool item::process_temperature_rot( float insulation, const tripoint_bub_ms &pos
                     env_temperature = std::max( env_temperature, temperatures::normal );
                     break;
                 case temperature_flag::ROOT_CELLAR:
-                    env_temperature = AVERAGE_ANNUAL_TEMPERATURE;
+                    env_temperature =  units::from_celsius( get_weather().get_cur_weather_gen().base_temperature );
                     break;
                 default:
                     debugmsg( "Temperature flag enum not valid.  Using normal temperature." );

--- a/src/weather.cpp
+++ b/src/weather.cpp
@@ -966,7 +966,7 @@ units::temperature weather_manager::get_temperature( const tripoint_bub_ms &loca
     }
 
     //underground temperature = average New England temperature = 43F/6C
-    units::temperature temp = location.z() < 0 ? AVERAGE_ANNUAL_TEMPERATURE : temperature;
+    units::temperature temp = location.z() < 0 ? units::from_celsius(get_cur_weather_gen().base_temperature) : temperature;
 
     if( !g->new_game ) {
         units::temperature_delta temp_mod;
@@ -983,7 +983,7 @@ units::temperature weather_manager::get_temperature( const tripoint_bub_ms &loca
 
 units::temperature weather_manager::get_temperature( const tripoint_abs_omt &location ) const
 {
-    return location.z() < 0 ? AVERAGE_ANNUAL_TEMPERATURE : temperature;
+    return location.z() < 0 ? units::from_celsius( get_weather().get_cur_weather_gen().base_temperature ) : temperature;
 }
 
 void weather_manager::clear_temp_cache()

--- a/src/weather.cpp
+++ b/src/weather.cpp
@@ -21,7 +21,6 @@
 #include "effect_on_condition.h"
 #include "enums.h"
 #include "game.h"
-#include "game_constants.h"
 #include "item.h"
 #include "item_contents.h"
 #include "item_location.h"

--- a/src/weather.cpp
+++ b/src/weather.cpp
@@ -966,7 +966,8 @@ units::temperature weather_manager::get_temperature( const tripoint_bub_ms &loca
     }
 
     //underground temperature = average New England temperature = 43F/6C
-    units::temperature temp = location.z() < 0 ? units::from_celsius(get_cur_weather_gen().base_temperature) : temperature;
+    units::temperature temp = location.z() < 0 ? units::from_celsius(
+                                  get_cur_weather_gen().base_temperature ) : temperature;
 
     if( !g->new_game ) {
         units::temperature_delta temp_mod;
@@ -983,7 +984,8 @@ units::temperature weather_manager::get_temperature( const tripoint_bub_ms &loca
 
 units::temperature weather_manager::get_temperature( const tripoint_abs_omt &location ) const
 {
-    return location.z() < 0 ? units::from_celsius( get_weather().get_cur_weather_gen().base_temperature ) : temperature;
+    return location.z() < 0 ? units::from_celsius(
+               get_weather().get_cur_weather_gen().base_temperature ) : temperature;
 }
 
 void weather_manager::clear_temp_cache()


### PR DESCRIPTION


#### Summary
Features "Underground Temperature now depends on Region Settings"

#### Purpose of change
Needed for aftershock.

#### Describe the solution
Underground temperature is now the same as the "base_temperature" defined in region settings, which if you are using it properly should be the average yearly temperature anyhow.

No change for vanilla besides the value no longer being hardcoded.

#### Testing
Loaded and went underground to check the temps.