### PR TITLE
Fix furniture tool pocket error and segfault error

### DIFF
--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -30,7 +30,6 @@
 #include "pocket_type.h"
 #include "point.h"
 #include "proficiency.h"
-#include "ret_val.h"
 #include "rng.h"
 #include "translations.h"
 #include "type_id.h"

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -556,7 +556,7 @@ void inventory::form_from_map( map &m, std::vector<tripoint_bub_ms> pts, const C
                     }
                     if( amount > 0 ) {
                         item furn_ammo( ammo_id, calendar::turn, amount );
-                        furn_item->put_in( furn_ammo, pocket_type::MAGAZINE );
+                        furn_item->force_insert_item( furn_ammo, pocket_type::MAGAZINE );
                     }
                 }
             }


### PR DESCRIPTION
#### Summary
Bugfixes "Fix furniture tool pocket error and segfault error"

#### Purpose of change
Fixes #79840 #76008 #59189 

Furniture used for crafting such as forges, kilns, and smoking racks were causing a pocket error when trying to form an inventory for crafting or construction. The pseudo item formed during this process would encounter an error if there were multiple of the same furniture type nearby (ex: Forge 1 and 2 both have 2000 charges for a total of 4000 charges, but the pseudo forge can only hold 2000 charges). This would also cause a segmentation fault when using the debug menu to spawn in items when near these furniture types for the same reason.

#### Describe the solution

This resolves the issue by bypassing the pocket checks for loading charges into the pseudo crafting furniture.

#### Describe alternatives you've considered

I considered adjusting how much "ammo" furniture can contain, but this value is used by the reload_furniture function to set the capacity for reloading forges and smoking racks.

#### Testing

Spawned in multiple forges, kilns, and smoking racks. After checking to see furniture still has the proper capacity as per basecamp.json I filled them all with charcoal and tested opening the crafting menu and spawning in items through the debug menu. Lastly, I spawned in forging equipment and made a few metal weapons to ensure charges were still being utilized properly.

#### Additional context

