### PR TITLE
Add a dump palette & increase amount of trash

### DIFF
--- a/data/json/mapgen/cs_city_dump_small.json
+++ b/data/json/mapgen/cs_city_dump_small.json
@@ -1,19 +1,5 @@
 [
   {
-    "type": "item_group",
-    "id": "custom_trash",
-    "items": [
-      [ "mag_porn", 10 ],
-      { "group": "ammo_pocket_batteries", "prob": 10 },
-      [ "television", 20 ],
-      [ "two_way_radio", 10 ],
-      [ "eyedrops", 10 ],
-      [ "cotton_patchwork", 20 ],
-      { "item": "cotton_patchwork", "prob": 20, "custom-flags": [ "FILTHY" ] },
-      [ "microwave", 20 ]
-    ]
-  },
-  {
     "type": "mapgen",
     "om_terrain": [ "cs_city_dump_small" ],
     "method": "json",
@@ -23,28 +9,29 @@
         "          oooo          ",
         "          oooo XX XX    ",
         "  --------++++--------  ",
-        "  |*^^,,,,oooo,,,,**,|  ",
-        "  |*** ^,,oooo^X,,,**|  ",
-        "  |*,v*,^,oooo,,*^,*,|  ",
-        "  |,,**,v,oooo^,**,,,|  ",
-        "  |^,**,*,oooo,,,**^,|  ",
-        "  |^,*,*,,oooo1,*^*,,|  ",
-        "  |,1**,SSoooo,****,,|  ",
-        "  |,**,*,*====*,***,,|  ",
-        "  |,2*,^**1*,*,,*,,,^|  ",
-        "  |^,*,****,,,***^*v1|  ",
-        "  |,*,,***,*,v*****,*|  ",
-        "  |,,*,*****,*,*,**,*|  ",
-        "  |vv***,*****,^**B**|  ",
-        "  |,^********33***B1,|  ",
-        "  |*,BB^**,*s v**^**,|  ",
-        "  |*,,,***,******,**,|  ",
-        "  |,*^****^,,21**3***|  ",
-        "  |***,2,,,^,,*,*3*,*|  ",
+        "  |*^^&&&&oooo&&&&**&|  ",
+        "  |*** ^&&oooo^X&&&**|  ",
+        "  |*&v*&^&oooo&&*^&*&|  ",
+        "  |&&**&v&oooo^&**&&&|  ",
+        "  |^&**&*&oooo&&&**^&|  ",
+        "  |^&*&*&&oooo&&*^*&&|  ",
+        "  |&&**&SSoooo&****&&|  ",
+        "  |&**&*&*====*&***&&|  ",
+        "  |&^*&^**&*&*&&*&&&^|  ",
+        "  |^&*&****&&&***^*v&|  ",
+        "  |&*&&***&*&v*****&*|  ",
+        "  |&&*&*****&*&*&**&*|  ",
+        "  |vv***&*****&^**B**|  ",
+        "  |&^********PP***B&&|  ",
+        "  |*&BB^**&*s v**^**&|  ",
+        "  |*&&&***&******&**&|  ",
+        "  |&*^****^&&^&**P***|  ",
+        "  |***&^&&&^&&*&*P*&*|  ",
         "  --------------------  ",
         "                        ",
         "                        "
       ],
+      "palettes": [ "dump_palette" ],
       "terrain": {
         " ": "t_region_groundcover",
         ",": "t_region_soil",
@@ -86,11 +73,6 @@
         { "vehicle": "pickup", "x": 11, "y": 5, "rotation": 270, "chance": 30 },
         { "vehicle": "bicycle", "x": 5, "y": 3, "rotation": 0, "chance": 40 }
       ],
-      "items": {
-        "1": { "item": "custom_trash", "chance": 70 },
-        "2": { "item": "SUS_trash_floor", "chance": 80 },
-        "3": { "item": "SUS_trash_forest_manmade", "chance": 80 }
-      },
       "place_signs": [ { "signage": "Municipal City Dump", "x": 8, "y": 1 } ]
     }
   }

--- a/data/json/mapgen/cs_city_dump_small.json
+++ b/data/json/mapgen/cs_city_dump_small.json
@@ -69,6 +69,7 @@
           "f_crate_o"
         ]
       },
+      "items": { "X": { "item": "SUS_trash_dumpster", "chance": 100 } },
       "place_vehicles": [
         { "vehicle": "pickup", "x": 11, "y": 5, "rotation": 270, "chance": 30 },
         { "vehicle": "bicycle", "x": 5, "y": 3, "rotation": 0, "chance": 40 }

--- a/data/json/mapgen/dump.json
+++ b/data/json/mapgen/dump.json
@@ -31,51 +31,7 @@
         " |||||||||||||||||||||| ",
         "                        "
       ],
-      "terrain": {
-        ".": "t_region_groundcover_barren",
-        "&": "t_region_soil",
-        "^": "t_region_soil",
-        " ": "t_region_groundcover_urban",
-        "|": "t_chainfence"
-      },
-      "furniture": {
-        "^": [ [ "f_rubble", 3 ], "f_null", "f_rubble_rock", "f_wreckage" ],
-        "&": [ [ "f_rubble", 3 ], [ "f_null", 6 ], "f_rubble_rock", "f_wreckage" ]
-      },
-      "items": {
-        "^": [
-          { "item": "SUS_trash_floor", "chance": 25, "repeat": 2 },
-          { "item": "road", "chance": 2 },
-          { "item": "allclothes_damaged", "chance": 3 },
-          { "item": "stoner", "chance": 1 },
-          { "item": "oven", "chance": 2 },
-          { "item": "garden_shed", "chance": 2 },
-          { "item": "homebooks", "chance": 2 },
-          { "item": "wheels", "chance": 2 },
-          { "item": "electronics", "chance": 2 },
-          { "item": "creepy", "chance": 1 },
-          { "item": "chem_home", "chance": 1 },
-          { "item": "hardware", "chance": 2 },
-          { "item": "misc_smoking", "chance": 1 },
-          { "item": "tools_home", "chance": 1 }
-        ],
-        "&": [
-          { "item": "SUS_trash_floor", "chance": 35 },
-          { "item": "road", "chance": 1 },
-          { "item": "allclothes_damaged", "chance": 2 },
-          { "item": "stoner", "chance": 1 },
-          { "item": "oven", "chance": 1 },
-          { "item": "garden_shed", "chance": 1 },
-          { "item": "homebooks", "chance": 1 },
-          { "item": "wheels", "chance": 1 },
-          { "item": "electronics", "chance": 1 },
-          { "item": "creepy", "chance": 1 },
-          { "item": "chem_home", "chance": 1 },
-          { "item": "hardware", "chance": 1 },
-          { "item": "misc_smoking", "chance": 1 },
-          { "item": "tools_home", "chance": 1 }
-        ]
-      },
+      "palettes": [ "dump_palette" ],
       "place_signs": [ { "signage": "<city> Dump", "x": 9, "y": 2 }, { "signage": "<city> Dump", "x": 14, "y": 2 } ]
     }
   },
@@ -111,51 +67,7 @@
         " |||||||||||||||||||||| ",
         "                        "
       ],
-      "terrain": {
-        ".": "t_region_groundcover_barren",
-        "&": "t_region_soil",
-        "^": "t_region_soil",
-        " ": "t_region_groundcover_urban",
-        "|": "t_chainfence"
-      },
-      "furniture": {
-        "^": [ [ "f_rubble", 3 ], "f_null", "f_rubble_rock", "f_wreckage" ],
-        "&": [ [ "f_rubble", 3 ], [ "f_null", 6 ], "f_rubble_rock", "f_wreckage" ]
-      },
-      "items": {
-        "^": [
-          { "item": "SUS_trash_floor", "chance": 25, "repeat": 2 },
-          { "item": "road", "chance": 2 },
-          { "item": "allclothes_damaged", "chance": 3 },
-          { "item": "stoner", "chance": 1 },
-          { "item": "oven", "chance": 2 },
-          { "item": "garden_shed", "chance": 2 },
-          { "item": "homebooks", "chance": 2 },
-          { "item": "wheels", "chance": 2 },
-          { "item": "electronics", "chance": 2 },
-          { "item": "creepy", "chance": 1 },
-          { "item": "chem_home", "chance": 1 },
-          { "item": "hardware", "chance": 2 },
-          { "item": "misc_smoking", "chance": 1 },
-          { "item": "tools_home", "chance": 1 }
-        ],
-        "&": [
-          { "item": "SUS_trash_floor", "chance": 35 },
-          { "item": "road", "chance": 1 },
-          { "item": "allclothes_damaged", "chance": 2 },
-          { "item": "stoner", "chance": 1 },
-          { "item": "oven", "chance": 1 },
-          { "item": "garden_shed", "chance": 1 },
-          { "item": "homebooks", "chance": 1 },
-          { "item": "wheels", "chance": 1 },
-          { "item": "electronics", "chance": 1 },
-          { "item": "creepy", "chance": 1 },
-          { "item": "chem_home", "chance": 1 },
-          { "item": "hardware", "chance": 1 },
-          { "item": "misc_smoking", "chance": 1 },
-          { "item": "tools_home", "chance": 1 }
-        ]
-      },
+      "palettes": [ "dump_palette" ],
       "place_signs": [ { "signage": "<city> Dump", "x": 8, "y": 2 }, { "signage": "<city> Dump", "x": 15, "y": 2 } ]
     }
   },
@@ -171,82 +83,27 @@
         "    __PPPPPPPPPPPP__    ",
         "   _PPPPPPPPPPPPPPPP_   ",
         "  _PPPPPPPPPPPPPPPPPP_  ",
-        "  _PPPPPPPP##PPPPPPPP__ ",
-        " _PPPPPPP######PPPPPPP_ ",
-        " _PPPPP##########PPPPP_ ",
-        " _PPPPP##########PPPPP_ ",
-        "_PPPPP#####&&#####PPPPP_",
-        "_PPPPP####&&&&####PPPPP_",
-        "_PPPP####&&&&&&####PPPP_",
-        "_PPPP####&&&&&&####PPPP_",
-        "_PPPPP####&&&&####PPPPP_",
-        "_PPPPP#####&&#####PPPPP_",
-        " _PPPPP##########PPPPP_ ",
-        " _PPPPP##########PPPPP_ ",
-        " _PPPPPPP######PPPPPPP_ ",
-        "  _PPPPPPPP##PPPPPPPP_  ",
+        "  _PPPPPPPP&&PPPPPPPP__ ",
+        " _PPPPPPP&&&&&&PPPPPPP_ ",
+        " _PPPPP&&&&&&&&&&PPPPP_ ",
+        " _PPPPP&&&&&&&&&&PPPPP_ ",
+        "_PPPPP&&&&&^^&&&&&PPPPP_",
+        "_PPPPP&&&&^^^^&&&&PPPPP_",
+        "_PPPP&&&&^^^^^^&&&&PPPP_",
+        "_PPPP&&&&^^^^^^&&&&PPPP_",
+        "_PPPPP&&&&^^^^&&&&PPPPP_",
+        "_PPPPP&&&&&^^&&&&&PPPPP_",
+        " _PPPPP&&&&&&&&&&PPPPP_ ",
+        " _PPPPP&&&&&&&&&&PPPPP_ ",
+        " _PPPPPPP&&&&&&PPPPPPP_ ",
+        "  _PPPPPPPP&&PPPPPPPP_  ",
         "  _PPPPPPPPPPPPPPPPPP_  ",
         "   _PPPPPPPPPPPPPPPP_   ",
         "    __PPPPPPPPPPPP__    ",
         "      ___PPPPPP___      ",
         "         ______         "
       ],
-      "terrain": {
-        "#": "t_region_soil",
-        "&": "t_region_soil",
-        " ": "t_region_groundcover_urban",
-        "P": "t_region_soil",
-        "_": "t_region_soil"
-      },
-      "furniture": {
-        "#": [ [ "f_rubble", 6 ], [ "f_rubble_rock", 2 ], "f_wreckage", [ "f_null", 4 ] ],
-        "&": [ [ "f_rubble", 6 ], [ "f_rubble_rock", 2 ], "f_wreckage" ],
-        "P": [ [ "f_rubble", 6 ], [ "f_rubble_rock", 2 ], "f_wreckage", [ "f_null", 12 ] ]
-      },
-      "items": {
-        "&": [
-          { "item": "SUS_trash_floor", "chance": 25, "repeat": 2 },
-          { "item": "road", "chance": 2 },
-          { "item": "allclothes_damaged", "chance": 3 },
-          { "item": "stoner", "chance": 1 },
-          { "item": "oven", "chance": 2 },
-          { "item": "garden_shed", "chance": 2 },
-          { "item": "homebooks", "chance": 2 },
-          { "item": "wheels", "chance": 2 },
-          { "item": "electronics", "chance": 2 },
-          { "item": "creepy", "chance": 1 },
-          { "item": "chem_home", "chance": 1 },
-          { "item": "hardware", "chance": 2 },
-          { "item": "misc_smoking", "chance": 1 },
-          { "item": "tools_home", "chance": 1 }
-        ],
-        "#": [
-          { "item": "SUS_trash_floor", "chance": 35 },
-          { "item": "road", "chance": 1 },
-          { "item": "allclothes_damaged", "chance": 2 },
-          { "item": "stoner", "chance": 1 },
-          { "item": "oven", "chance": 1 },
-          { "item": "garden_shed", "chance": 1 },
-          { "item": "homebooks", "chance": 1 },
-          { "item": "wheels", "chance": 1 },
-          { "item": "electronics", "chance": 2 },
-          { "item": "creepy", "chance": 1 },
-          { "item": "chem_home", "chance": 1 },
-          { "item": "hardware", "chance": 1 },
-          { "item": "misc_smoking", "chance": 1 },
-          { "item": "tools_home", "chance": 1 }
-        ],
-        "P": [
-          { "item": "SUS_trash_floor", "chance": 15 },
-          { "item": "road", "chance": 1 },
-          { "item": "allclothes_damaged", "chance": 1 },
-          { "item": "oven", "chance": 1 },
-          { "item": "wheels", "chance": 1 },
-          { "item": "garden_shed", "chance": 1 },
-          { "item": "hardware", "chance": 1 },
-          { "item": "misc_smoking", "chance": 1 }
-        ]
-      },
+      "palettes": [ "dump_palette" ],
       "place_signs": [ { "signage": "DUMP", "x": 1, "y": 1 }, { "signage": "DUMP", "x": 22, "y": 1 } ]
     }
   },
@@ -267,11 +124,11 @@
         "   __________________   ",
         "  ____________________  ",
         "  ____________________  ",
-        "  _______rrrrrr_______  ",
-        "  ____rrrrrrrrrrrr____  ",
-        "  __rrrrrrrrrrrrrrrr__  ",
-        "  __rrrrrrr^^rrrrrrr__  ",
-        "  _rrrr^^^^^^^^^^rrrr_  ",
+        "  _______&&&&&&_______  ",
+        "  ____&&&&&&&&&&&&____  ",
+        "  __&&&&&&&&&&&&&&&&__  ",
+        "  __&&&&&&&^^&&&&&&&__  ",
+        "  _&&&&^^^^^^^^^^&&&&_  ",
         "  ^^^^^^^^^^^^^^^^^^^^  ",
         "  ^^^^^^^^^^^^^^^^^^^^  ",
         "  |^^^^^^^^^^^^^^^^^^|  ",
@@ -282,54 +139,7 @@
         "                        ",
         "                        "
       ],
-      "terrain": {
-        " ": "t_region_groundcover_urban",
-        "7": "t_region_tree",
-        "^": "t_region_groundcover_barren",
-        "_": "t_region_groundcover_barren",
-        "r": "t_region_groundcover_barren",
-        "|": "t_concrete_wall"
-      },
-      "furniture": {
-        "^": [ [ "f_rubble", 3 ], "f_null", "f_rubble_rock", "f_wreckage" ],
-        "r": [ [ "f_rubble", 3 ], [ "f_null", 6 ], "f_rubble_rock", "f_wreckage" ]
-      },
-      "items": {
-        "^": [
-          { "item": "SUS_trash_floor", "chance": 25, "repeat": 2 },
-          { "item": "road", "chance": 2 },
-          { "item": "allclothes_damaged", "chance": 3 },
-          { "item": "stoner", "chance": 1 },
-          { "item": "oven", "chance": 2 },
-          { "item": "garden_shed", "chance": 2 },
-          { "item": "homebooks", "chance": 2 },
-          { "item": "electronics", "chance": 2 },
-          { "item": "creepy", "chance": 1 },
-          { "item": "chem_home", "chance": 1 },
-          { "item": "barrels", "chance": 1 },
-          { "item": "hardware", "chance": 2 },
-          { "item": "wheels", "chance": 1 },
-          { "item": "misc_smoking", "chance": 1 },
-          { "item": "tools_home", "chance": 1 }
-        ],
-        "r": [
-          { "item": "SUS_trash_floor", "chance": 35 },
-          { "item": "road", "chance": 1 },
-          { "item": "allclothes_damaged", "chance": 2 },
-          { "item": "stoner", "chance": 1 },
-          { "item": "oven", "chance": 1 },
-          { "item": "garden_shed", "chance": 1 },
-          { "item": "homebooks", "chance": 1 },
-          { "item": "wheels", "chance": 1 },
-          { "item": "electronics", "chance": 1 },
-          { "item": "creepy", "chance": 1 },
-          { "item": "barrels", "chance": 1 },
-          { "item": "chem_home", "chance": 1 },
-          { "item": "hardware", "chance": 1 },
-          { "item": "misc_smoking", "chance": 1 },
-          { "item": "tools_home", "chance": 1 }
-        ]
-      },
+      "palettes": [ "dump_palette" ],
       "place_signs": [ { "signage": "<city> Area Dump", "x": 17, "y": 2 } ]
     }
   },
@@ -347,14 +157,14 @@
         "    ________________    ",
         "   __________________   ",
         "   __________________   ",
-        "  _____rrrrrrrrrr_____  ",
-        "  ___rrrrrrrrrrrrrr___  ",
-        "  __rrrrrrrrrrrrrrrr__  ",
-        "  _rrrrrrrrrrrrrrrrrr_  ",
-        "  _rrrrrrrrrrrrrrrrrr_  ",
-        "  _rrrrrrrrrrrrrrrrrr_  ",
-        "  _rrr^^^^^^^^^^^^rrr_  ",
-        "  _r^^^^^^^^^^^^^^^^r_  ",
+        "  _____&&&&&&&&&&_____  ",
+        "  ___&&&&&&&&&&&&&&___  ",
+        "  __&&&&&&&&&&&&&&&&__  ",
+        "  _&&&&&&&&&&&&&&&&&&_  ",
+        "  _&&&&&&&&&&&&&&&&&&_  ",
+        "  _&&&&&&&&&&&&&&&&&&_  ",
+        "  _&&&^^^^^^^^^^^^&&&_  ",
+        "  _&^^^^^^^^^^^^^^^^&_  ",
         "  _^^^^^^^^^^^^^^^^^^_  ",
         "  _^^^^^^^^^^^^^^^^^^_  ",
         "  _^^^^^^^^^^^^^^^^^^_  ",
@@ -365,46 +175,10 @@
         "                        ",
         "                        "
       ],
-      "terrain": { " ": "t_region_groundcover_urban", "^": "t_region_soil", "_": "t_region_groundcover_barren", "r": "t_region_soil" },
+      "palettes": [ "dump_palette" ],
       "furniture": {
         "^": [ [ "f_rubble", 3 ], "f_null", "f_rubble_rock", "f_wreckage" ],
         "r": [ [ "f_rubble", 3 ], [ "f_null", 6 ], "f_rubble_rock", "f_wreckage" ]
-      },
-      "items": {
-        "^": [
-          { "item": "SUS_trash_floor", "chance": 25, "repeat": 2 },
-          { "item": "road", "chance": 2 },
-          { "item": "allclothes_damaged", "chance": 3 },
-          { "item": "stoner", "chance": 1 },
-          { "item": "oven", "chance": 2 },
-          { "item": "garden_shed", "chance": 2 },
-          { "item": "homebooks", "chance": 2 },
-          { "item": "electronics", "chance": 2 },
-          { "item": "wheels", "chance": 2 },
-          { "item": "creepy", "chance": 1 },
-          { "item": "chem_home", "chance": 1 },
-          { "item": "barrels", "chance": 1 },
-          { "item": "hardware", "chance": 2 },
-          { "item": "misc_smoking", "chance": 1 },
-          { "item": "tools_home", "chance": 1 }
-        ],
-        "r": [
-          { "item": "SUS_trash_floor", "chance": 35 },
-          { "item": "road", "chance": 1 },
-          { "item": "allclothes_damaged", "chance": 2 },
-          { "item": "stoner", "chance": 1 },
-          { "item": "oven", "chance": 1 },
-          { "item": "wheels", "chance": 1 },
-          { "item": "garden_shed", "chance": 1 },
-          { "item": "homebooks", "chance": 1 },
-          { "item": "electronics", "chance": 1 },
-          { "item": "creepy", "chance": 1 },
-          { "item": "chem_home", "chance": 1 },
-          { "item": "barrels", "chance": 1 },
-          { "item": "hardware", "chance": 1 },
-          { "item": "misc_smoking", "chance": 1 },
-          { "item": "tools_home", "chance": 1 }
-        ]
       }
     }
   }

--- a/data/json/mapgen_palettes/dump.json
+++ b/data/json/mapgen_palettes/dump.json
@@ -1,0 +1,68 @@
+[
+  {
+    "type": "palette",
+    "id": "dump_palette",
+    "terrain": {
+      ".": "t_region_groundcover_barren",
+      "&": "t_region_soil",
+      "^": "t_region_soil",
+      " ": "t_region_groundcover_urban",
+      "P": "t_region_soil",
+      "7": "t_region_tree",
+      "|": "t_chainfence",
+      "_": "t_region_groundcover_barren"
+    },
+    "furniture": {
+      "^": [ [ "f_rubble", 3 ], "f_null", "f_rubble_rock", "f_wreckage" ],
+      "&": [ [ "f_rubble", 3 ], [ "f_null", 6 ], "f_rubble_rock", "f_wreckage" ],
+      "P": [ [ "f_rubble", 6 ], [ "f_rubble_rock", 2 ], "f_wreckage", [ "f_null", 12 ] ]
+    },
+    "items": {
+      "^": [
+        { "item": "SUS_trash_floor", "chance": 75, "repeat": [ 4, 20 ] },
+        { "item": "SUS_trash_dumpster", "chance": 50, "repeat": [ 1, 3 ] },
+        { "item": "road", "chance": 20 },
+        { "item": "allclothes_damaged", "chance": 30 },
+        { "item": "stoner", "chance": 10 },
+        { "item": "oven", "chance": 20 },
+        { "item": "garden_shed", "chance": 20 },
+        { "item": "homebooks", "chance": 20 },
+        { "item": "wheels", "chance": 5 },
+        { "item": "electronics", "chance": 20 },
+        { "item": "creepy", "chance": 1 },
+        { "item": "chem_home", "chance": 5 },
+        { "item": "SUS_trash_hardware", "chance": 10 },
+        { "item": "misc_smoking", "chance": 10 },
+        { "item": "tools_home", "chance": 10 }
+      ],
+      "&": [
+        { "item": "SUS_trash_floor", "chance": 50, "repeat": [ 2, 10 ] },
+        { "item": "SUS_trash_dumpster", "chance": 50, "repeat": [ 0, 2 ] },
+        { "item": "road", "chance": 10 },
+        { "item": "allclothes_damaged", "chance": 20 },
+        { "item": "stoner", "chance": 5 },
+        { "item": "oven", "chance": 10 },
+        { "item": "garden_shed", "chance": 10 },
+        { "item": "homebooks", "chance": 10 },
+        { "item": "wheels", "chance": 2 },
+        { "item": "electronics", "chance": 10 },
+        { "item": "creepy", "chance": 1 },
+        { "item": "chem_home", "chance": 1 },
+        { "item": "SUS_trash_hardware", "chance": 5 },
+        { "item": "misc_smoking", "chance": 5 },
+        { "item": "tools_home", "chance": 5 }
+      ],
+      "P": [
+        { "item": "SUS_trash_floor", "chance": 25, "repeat": [ 0, 5 ] },
+        { "item": "SUS_trash_dumpster", "chance": 50, "repeat": [ 0, 1 ] },
+        { "item": "road", "chance": 5 },
+        { "item": "allclothes_damaged", "chance": 10 },
+        { "item": "oven", "chance": 5 },
+        { "item": "wheels", "chance": 1 },
+        { "item": "garden_shed", "chance": 3 },
+        { "item": "SUS_trash_hardware", "chance": 1 },
+        { "item": "misc_smoking", "chance": 5 }
+      ]
+    }
+  }
+]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Closes #80423
I made a palette for all the dump variants since they mostly used the same definitions. I also increased the types and amount of trash that would spawn.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add a palette, adjust all variants to use the palette and make them use it. Add some more itemgroups to the items that spawn and increase their repeats and chances.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
I originally had it spawn even more trash but it froze the game when loading the OMT in so I dialed it down a little.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Game loads, dumps have a lot of trash now.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
