### PR TITLE
[Magiclysm] Replace `Hoarder` for Ravenfolk with `Chrysophilia`

### DIFF
--- a/data/mods/Magiclysm/effect_on_conditions/mutation_eocs.json
+++ b/data/mods/Magiclysm/effect_on_conditions/mutation_eocs.json
@@ -235,6 +235,7 @@
         "then": {
           "u_add_morale": "morale_need_shiny_objects",
           "bonus": { "math": [ "-30 +( _shiny_count * 5)" ] },
+          "max_bonus": -30,
           "duration": "168 hours"
         }
       }

--- a/data/mods/Magiclysm/effect_on_conditions/mutation_eocs.json
+++ b/data/mods/Magiclysm/effect_on_conditions/mutation_eocs.json
@@ -228,7 +228,7 @@
       {
         "u_run_inv_eocs": "all",
         "search_data": [ { "material": "silver", "worn_only": true }, { "material": "gold", "worn_only": true } ],
-        "true_eocs": [ { "id": "EOC_LOVES_SHINY_OBJECTS_FOLLOWUP_TRUE", "effect": [ { "math": [ "_shiny_count == 1" ] } ] } ]
+        "true_eocs": [ { "id": "EOC_LOVES_SHINY_OBJECTS_FOLLOWUP_TRUE", "effect": [ { "math": [ "_shiny_count += 1" ] } ] } ]
       },
       {
         "if": { "math": [ "_shiny_count < 6" ] },

--- a/data/mods/Magiclysm/effect_on_conditions/mutation_eocs.json
+++ b/data/mods/Magiclysm/effect_on_conditions/mutation_eocs.json
@@ -194,5 +194,47 @@
         }
       }
     ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_LOVES_SHINY_OBJECTS_WEARING",
+    "eoc_type": "EVENT",
+    "required_event": "character_wears_item",
+    "condition": { "u_has_trait": "LOVES_SHINY_OBJECTS" },
+    "effect": [ { "run_eocs": "EOC_LOVES_SHINY_OBJECTS_FOLLOWUP" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_LOVES_SHINY_OBJECTS_UNWEARING",
+    "eoc_type": "EVENT",
+    "required_event": "character_takeoff_item",
+    "condition": { "u_has_trait": "LOVES_SHINY_OBJECTS" },
+    "effect": [ { "run_eocs": "EOC_LOVES_SHINY_OBJECTS_FOLLOWUP", "time_in_future": 1 } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_LOVES_SHINY_OBJECTS_WIELDING",
+    "eoc_type": "EVENT",
+    "required_event": "character_wields_item",
+    "condition": { "u_has_trait": "LOVES_SHINY_OBJECTS" },
+    "effect": [ { "run_eocs": "EOC_LOVES_SHINY_OBJECTS_FOLLOWUP" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_LOVES_SHINY_OBJECTS_FOLLOWUP",
+    "effect": [
+      { "math": [ "_shiny_count = 0" ] },
+      { "u_lose_morale": "morale_need_shiny_objects" },
+      {
+        "u_run_inv_eocs": "all",
+        "search_data": [ { "material": "silver", "worn_only": true }, { "material": "gold", "worn_only": true } ],
+        "true_eocs": [ { "id": "EOC_LOVES_SHINY_OBJECTS_FOLLOWUP_TRUE", "effect": [ { "math": [ "_shiny_count == 1" ] } ] } ]
+      },
+      {
+        "u_add_morale": "morale_need_shiny_objects",
+        "bonus": { "math": [ "-30 + min( (_shiny_count * 5), 30)" ] },
+        "duration": "168 hours"
+      }
+    ]
   }
 ]

--- a/data/mods/Magiclysm/effect_on_conditions/mutation_eocs.json
+++ b/data/mods/Magiclysm/effect_on_conditions/mutation_eocs.json
@@ -231,9 +231,12 @@
         "true_eocs": [ { "id": "EOC_LOVES_SHINY_OBJECTS_FOLLOWUP_TRUE", "effect": [ { "math": [ "_shiny_count == 1" ] } ] } ]
       },
       {
-        "u_add_morale": "morale_need_shiny_objects",
-        "bonus": { "math": [ "-30 + min( (_shiny_count * 5), 30)" ] },
-        "duration": "168 hours"
+        "if": { "math": [ "_shiny_count < 6" ] },
+        "then": {
+          "u_add_morale": "morale_need_shiny_objects",
+          "bonus": { "math": [ "-30 +( _shiny_count * 5)" ] },
+          "duration": "168 hours"
+        }
       }
     ]
   }

--- a/data/mods/Magiclysm/effect_on_conditions/mutation_eocs.json
+++ b/data/mods/Magiclysm/effect_on_conditions/mutation_eocs.json
@@ -223,19 +223,20 @@
     "type": "effect_on_condition",
     "id": "EOC_LOVES_SHINY_OBJECTS_FOLLOWUP",
     "effect": [
-      { "math": [ "_shiny_count = 0" ] },
+      { "math": [ "u_shiny_count = 0" ] },
       { "u_lose_morale": "morale_need_shiny_objects" },
       {
         "u_run_inv_eocs": "all",
         "search_data": [ { "material": "silver", "worn_only": true }, { "material": "gold", "worn_only": true } ],
-        "true_eocs": [ { "id": "EOC_LOVES_SHINY_OBJECTS_FOLLOWUP_TRUE", "effect": [ { "math": [ "_shiny_count += 1" ] } ] } ]
+        "true_eocs": [ { "id": "EOC_LOVES_SHINY_OBJECTS_FOLLOWUP_TRUE", "effect": [ { "math": [ "u_shiny_count += 1" ] } ] } ]
       },
+      { "u_message": "You have <u_val:shiny_count> shiny objects.", "type": "debug" },
       {
-        "if": { "math": [ "_shiny_count < 6" ] },
+        "if": { "math": [ "u_shiny_count < 6" ] },
         "then": {
           "u_add_morale": "morale_need_shiny_objects",
-          "bonus": { "math": [ "-30 +( _shiny_count * 5)" ] },
-          "max_bonus": -30,
+          "bonus": { "math": [ "-30 + ( u_shiny_count * 5)" ] },
+          "max_bonus": { "math": [ "-30 + ( u_shiny_count * 5)" ] },
           "duration": "168 hours"
         }
       }

--- a/data/mods/Magiclysm/hobbies_fantasy_species.json
+++ b/data/mods/Magiclysm/hobbies_fantasy_species.json
@@ -132,7 +132,7 @@
       "LIGHT_BONES",
       "RAVEN_BONES",
       "NOMAD",
-      "HOARDER"
+      "LOVES_SHINY_OBJECTS"
     ]
   }
 ]

--- a/data/mods/Magiclysm/migration_and_obsoletion/eocs.json
+++ b/data/mods/Magiclysm/migration_and_obsoletion/eocs.json
@@ -138,5 +138,18 @@
       { "u_lose_trait": "ACIDBLOOD" },
       { "u_lose_trait": "ACIDPROOF" }
     ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_MAGICLYSM_RAVENFOLK_HOARDER_UPDATE",
+    "eoc_type": "EVENT",
+    "required_event": "game_begin",
+    "condition": { "and": [ { "u_has_trait": "RAVENFOLK_BUILD" }, { "math": [ "u_has_ravenfolk_loves_gold_update != 1" ] } ] },
+    "effect": [
+      { "u_add_trait": "LOVES_SHINY_OBJECTS" },
+      { "u_lose_trait": "HOARDER" },
+      { "math": [ "u_has_ravenfolk_loves_gold_update = 1" ] },
+      { "u_message": "Your ravenfolk traits have been updated.", "type": "mixed" }
+    ]
   }
 ]

--- a/data/mods/Magiclysm/morale_types.json
+++ b/data/mods/Magiclysm/morale_types.json
@@ -8,5 +8,10 @@
     "id": "morale_forest_unity",
     "type": "morale_type",
     "text": "Peace of the Forest"
+  },
+  {
+    "id": "morale_need_shiny_objects",
+    "type": "morale_type",
+    "text": "Lacking shiny objects"
   }
 ]

--- a/data/mods/Magiclysm/mutations/mutation_paths/fantasy_species.json
+++ b/data/mods/Magiclysm/mutations/mutation_paths/fantasy_species.json
@@ -808,6 +808,7 @@
     "type": "mutation",
     "id": "LOVES_SHINY_OBJECTS",
     "name": { "str": "Chrysophilia" },
+    "points": -3,
     "//": "Name just means 'lover of gold' but at least it fits the format of other negative traits",
     "description": "You need to have shiny objects on your person or you just can't concentrate very well.  You suffer a morale penalty unless you're wearing at least six items made of gold or silver.",
     "purifiable": false,

--- a/data/mods/Magiclysm/mutations/mutation_paths/fantasy_species.json
+++ b/data/mods/Magiclysm/mutations/mutation_paths/fantasy_species.json
@@ -809,7 +809,7 @@
     "id": "LOVES_SHINY_OBJECTS",
     "name": { "str": "Chrysophilia" },
     "//": "Name just means 'lover of gold' but at least it fits the format of other negative traits",
-    "description": "You need to have shiny objects on your person or you just can't concentrate very well.  You suffer a morale penalty unless you're wearing at least five items made of gold or silver.",
+    "description": "You need to have shiny objects on your person or you just can't concentrate very well.  You suffer a morale penalty unless you're wearing at least six items made of gold or silver.",
     "purifiable": false,
     "category": [ "SPECIES_RAVENFOLK" ]
   },

--- a/data/mods/Magiclysm/mutations/mutation_paths/fantasy_species.json
+++ b/data/mods/Magiclysm/mutations/mutation_paths/fantasy_species.json
@@ -738,6 +738,7 @@
     "purifiable": false,
     "extend": { "prereqs": [ "RAVEN_BONES" ] },
     "threshreq": [ "THRESH_SPECIES_RAVENFOLK" ],
+    "restricts_gear": [ "foot_l", "foot_r" ],
     "activation_msg": ""
   },
   {
@@ -802,6 +803,15 @@
     "id": "FLEET",
     "copy-from": "FLEET",
     "extend": { "category": [ "SPECIES_RAVENFOLK" ] }
+  },
+  {
+    "type": "mutation",
+    "id": "LOVES_SHINY_OBJECTS",
+    "name": { "str": "Chrysophilia" },
+    "//": "Name just means 'lover of gold' but at least it fits the format of other negative traits",
+    "description": "You need to have shiny objects on your person or you just can't concentrate very well.  You suffer a morale penalty unless you're wearing at least five items made of gold or silver.",
+    "purifiable": false,
+    "category": [ "SPECIES_RAVENFOLK" ]
   },
   {
     "type": "mutation",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Magiclysm] Replace `Hoarder` for Ravenfolk with `Chrysophilia`"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Technically in boring real life, corvids are no more likely to gravitate toward shiny objects than anyone else. But this is Magiclysm and mythology matters here.

Also, Hoarder was always a stop-gap until we could have something specifically for valuable things. 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Replace Hoarder for Ravenfolk with `Chrysophilia`, which technically means "love of gold" but at least matches the naming format of the other negative traits. Like Hoarder, it provides a mood penalty, in proportion to the amount of gold and silver jewelry you're wearing, with more items reducing the penalty (due to the way `u_run_inv_eocs` works, I can't include gemstones because they'd be double-counted with gold/silver). The max penalty is -30, because that was the previous max penalty they had with Hoarder. 

The morale lasts 1 week by itself and updates every time you wear, take off, or wield anything, so it's highly unlikely you'll ever be in a situation where it's not up to date. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Loaded in game, put on and took off items. Morale changed appropriately.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Maybe black dragon mutants should also have Chrysophilia?

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
