### PR TITLE
Fix emscripten build

### DIFF
--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CCACHE: 1
+      CMAKE_POLICY_VERSION_MINIMUM: 3.5
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Fixes(?) emscripten build

#### Describe the solution
Since ~today, the emscripten build is spuriously failing the install-ccache step with logs like this <https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/14225908812/job/39882122905>:

```
Run emsdk install ccache-git-emscripten-64bit
  emsdk install ccache-git-emscripten-64bit
  emsdk activate ccache-git-emscripten-64bit
  shell: /usr/bin/bash -e {0}
  env:
    CCACHE: 1
    PATH: /home/runner/work/_temp/b313e2f5-47b0-41d6-adf4-b04386910322/emsdk-main:/home/runner/work/_temp/b313e2f5-47b0-41d6-adf4-b04386910322/emsdk-main/upstream/emscripten:/snap/bin:/home/runner/.local/bin:/opt/pipx_bin:/home/runner/.cargo/bin:/home/runner/.config/composer/vendor/bin:/usr/local/.ghcup/bin:/home/runner/.dotnet/tools:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games
    EMSDK: /home/runner/work/_temp/b313e2f5-47b0-41d6-adf4-b04386910322/emsdk-main
    EMSDK_NODE: /home/runner/work/_temp/b313e2f5-47b0-41d6-adf4-b04386910322/emsdk-main/node/20.18.0_64bit/bin/node
Cloning into '/home/runner/work/_temp/b313e2f5-47b0-41d6-adf4-b04386910322/emsdk-main/ccache/git-emscripten_64bit/src'...
CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.


-- Configuring incomplete, errors occurred!
CMake invocation failed due to exception!
Working directory: /home/runner/work/_temp/b313e2f5-47b0-41d6-adf4-b04386910322/emsdk-main/ccache/git-emscripten_64bit/build_emscripten_64
Command '['cmake', '-G', 'Unix Makefiles', '-DCMAKE_BUILD_TYPE=Release', '-DPYTHON_EXECUTABLE=/usr/bin/python3', '-DCMAKE_OSX_DEPLOYMENT_TARGET=10.14', '-DZSTD_FROM_INTERNET=ON', '/home/runner/work/_temp/b313e2f5-47b0-41d6-adf4-b04386910322/emsdk-main/ccache/git-emscripten_64bit/src']' returned non-zero exit status 1.
error: installation failed!
Installing tool 'ccache-git-emscripten-64bit'..
Cloning from https://github.com/juj/ccache.git...
Running CMake: ['cmake', '-G', 'Unix Makefiles', '-DCMAKE_BUILD_TYPE=Release', '-DPYTHON_EXECUTABLE=/usr/bin/python3', '-DCMAKE_OSX_DEPLOYMENT_TARGET=10.14', '-DZSTD_FROM_INTERNET=ON', '/home/runner/work/_temp/b313e2f5-47b0-41d6-adf4-b04386910322/emsdk-main/ccache/git-emscripten_64bit/src']
Error: Process completed with exit code 1.
```

Apparently that's because github is rolling out a new runner image which bumps cmake version from 3.31.6 to 4.0.0 https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20250330.1

And cmake 4.0.0 is rejecting CMakeLists.txt written for the older versions. Not that they don't neccessarily *work* with 4.0.0, but cmake looks at the header, sees `cmake_minimum_required(VERSION 3.4.3)` and immediately gives up.

This PR heeds the error message advice and "adds -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway". (Well, can't add the -D flag, but we can add it as an env var which should do the same thing. Docs: https://cmake.org/cmake/help/latest/variable/CMAKE_POLICY_VERSION_MINIMUM.html )

I'm not convinced 3.5 is the correct value, it might need to be set to 3.4, since that's what emscripten's fork of ccache (https://github.com/juj/ccache) uses. We'll see.


#### Describe alternatives you've considered

Instead of trying to work around cmake quirks, we could just pin github action runner to 22.04 (which is really unlikely to upgrade cmake, ever) and ignore this problem for a good while.
Edit: jokes on me. All of the images getting cmake 4.0.0 not just the latest:
https://github.com/actions/runner-images/releases/tag/ubuntu22%2F20250330.1
https://github.com/actions/runner-images/releases/tag/ubuntu20%2F20250330.1

#### Testing
None. CI should self-test.
Although that might be tricky with flaky tests, and we *also* need to get lucky and have the new runner pick up the job (otherwise it won't be truly tested)

#### Additional context
