### PR TITLE
eoc: replace u_loc_relative with u_location_variable

### DIFF
--- a/data/json/effects_on_condition/example_eocs.json
+++ b/data/json/effects_on_condition/example_eocs.json
@@ -186,7 +186,7 @@
     "type": "effect_on_condition",
     "id": "EOC_map_item_test2",
     "effect": [
-      { "set_string_var": { "mutator": "u_loc_relative", "target": "(0,1,0)" }, "target_var": { "context_val": "loc" } },
+      { "u_location_variable": { "context_val": "loc" }, "y_adjust": 1 },
       { "map_spawn_item": "bottle_plastic", "loc": { "context_val": "loc" } }
     ]
   },
@@ -194,15 +194,13 @@
     "type": "effect_on_condition",
     "id": "EOC_map_condition_test",
     "effect": [
+      { "u_location_variable": { "context_val": "check_loc" } },
       {
-        "if": { "map_in_city": { "mutator": "u_loc_relative", "target": "(0,0,0)" } },
+        "if": { "map_in_city": { "context_val": "check_loc" } },
         "then": { "u_message": "Inside city" },
         "else": { "u_message": "Outside city" }
       },
-      {
-        "set_string_var": { "mutator": "u_loc_relative", "target": "(0,-1,0)" },
-        "target_var": { "context_val": "loc" }
-      },
+      { "u_location_variable": { "context_val": "loc" }, "y_adjust": -1 },
       {
         "if": { "map_terrain_with_flag": "TRANSPARENT", "loc": { "context_val": "loc" } },
         "then": { "u_message": "North terrain: TRANSPARENT" },
@@ -213,10 +211,7 @@
         "then": { "u_message": "North furniture: TRANSPARENT" },
         "else": { "u_message": "North furniture: Not TRANSPARENT" }
       },
-      {
-        "set_string_var": { "mutator": "u_loc_relative", "target": "(1,0,0)" },
-        "target_var": { "context_val": "loc" }
-      },
+      { "u_location_variable": { "context_val": "loc" }, "x_adjust": 1 },
       {
         "if": { "map_terrain_with_flag": "TRANSPARENT", "loc": { "context_val": "loc" } },
         "then": { "u_message": "East terrain: TRANSPARENT" },
@@ -227,10 +222,7 @@
         "then": { "u_message": "East furniture: TRANSPARENT" },
         "else": { "u_message": "East furniture: Not TRANSPARENT" }
       },
-      {
-        "set_string_var": { "mutator": "u_loc_relative", "target": "(0,1,0)" },
-        "target_var": { "context_val": "loc" }
-      },
+      { "u_location_variable": { "context_val": "loc" }, "y_adjust": 1 },
       {
         "if": { "map_terrain_with_flag": "TRANSPARENT", "loc": { "context_val": "loc" } },
         "then": { "u_message": "South terrain: TRANSPARENT" },
@@ -241,10 +233,7 @@
         "then": { "u_message": "South furniture: TRANSPARENT" },
         "else": { "u_message": "South furniture: Not TRANSPARENT" }
       },
-      {
-        "set_string_var": { "mutator": "u_loc_relative", "target": "(-1,0,0)" },
-        "target_var": { "context_val": "loc" }
-      },
+      { "u_location_variable": { "context_val": "loc" }, "x_adjust": -1 },
       {
         "if": { "map_terrain_with_flag": "TRANSPARENT", "loc": { "context_val": "loc" } },
         "then": { "u_message": "West terrain: TRANSPARENT" },

--- a/data/mods/Aftershock/spells/psionics/telekinesis_eocs.json
+++ b/data/mods/Aftershock/spells/psionics/telekinesis_eocs.json
@@ -67,7 +67,7 @@
                   {
                     "id": "EOC_AFS_TELEKINETIC_PUSH_DIRECTION_PICKER",
                     "effect": [
-                      { "set_string_var": { "mutator": "u_loc_relative", "target": "(0,0,0)" }, "target_var": { "context_val": "u_pos" } },
+                      { "u_location_variable": { "context_val": "u_pos" } },
                       {
                         "npc_choose_adjacent_highlight": { "context_val": "push_direction_incorrect" },
                         "target_var": { "context_val": "u_pos" },

--- a/data/mods/MindOverMatter/powers/telekinesis_eoc.json
+++ b/data/mods/MindOverMatter/powers/telekinesis_eoc.json
@@ -41,7 +41,7 @@
                     {
                       "id": "EOC_TELEKINETIC_PUSH_DIRECTION_PICKER",
                       "effect": [
-                        { "set_string_var": { "mutator": "u_loc_relative", "target": "(0,0,0)" }, "target_var": { "context_val": "u_pos" } },
+                        { "u_location_variable": { "context_val": "u_pos" } },
                         {
                           "npc_choose_adjacent_highlight": { "context_val": "push_direction_incorrect" },
                           "target_var": { "context_val": "u_pos" },

--- a/data/mods/TEST_DATA/EOC.json
+++ b/data/mods/TEST_DATA/EOC.json
@@ -285,7 +285,7 @@
     "type": "effect_on_condition",
     "id": "EOC_try_kill",
     "effect": [
-      { "set_string_var": { "mutator": "u_loc_relative", "target": "(0,1,0)" }, "target_var": { "context_val": "kill_loc" } },
+      { "u_location_variable": { "context_val": "kill_loc" }, "y_adjust": 1 },
       { "run_eocs": "EOC_kill", "beta_loc": { "context_val": "kill_loc" } }
     ]
   },
@@ -330,10 +330,7 @@
     "effect": [
       { "set_string_var": "fd_blood", "target_var": { "global_val": "field_id_1" } },
       { "set_string_var": "fd_blood_insect", "target_var": { "global_val": "field_id_2" } },
-      {
-        "set_string_var": { "mutator": "u_loc_relative", "target": "(0,1,0)" },
-        "target_var": { "global_val": "loc" }
-      },
+      { "u_location_variable": { "global_val": "loc" }, "y_adjust": 1 },
       { "math": [ "key_field_strength = u_field_strength(field_id_1)" ] },
       { "math": [ "key_field_strength_north = field_strength(field_id_2, 'location': loc)" ] }
     ]
@@ -818,23 +815,9 @@
     "type": "effect_on_condition",
     "id": "EOC_map_test",
     "effect": [
-      { "set_string_var": { "mutator": "u_loc_relative", "target": "(10,10,0)" }, "target_var": { "context_val": "loc" } },
+      { "u_location_variable": { "context_val": "loc" }, "x_adjust": 10, "y_adjust": 10 },
       { "math": [ "key_distance_loc = distance('u', _loc)" ] },
       { "math": [ "key_distance_npc = distance('u', 'npc')" ] }
-    ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "EOC_loc_relative_test",
-    "effect": [
-      {
-        "set_string_var": { "mutator": "u_loc_relative", "target": "(10,10,0)" },
-        "target_var": { "global_val": "map_test_loc_a" }
-      },
-      {
-        "set_string_var": { "mutator": "npc_loc_relative", "target": "(0,0,0)" },
-        "target_var": { "global_val": "map_test_loc_b" }
-      }
     ]
   },
   {

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_eocs.json
@@ -6,6 +6,7 @@
     "required_event": "avatar_enters_omt",
     "condition": { "u_has_trait": "HOMULLUS" },
     "effect": [
+      { "u_location_variable": { "context_val": "check_loc" } },
       {
         "run_eocs": [
           {
@@ -14,7 +15,7 @@
               "or": [
                 { "test_eoc": "EOC_CONDITION_HOMULLUS_NEAR_FACTION" },
                 { "u_near_om_location": "FACTION_CAMP_ANY", "range": 2 },
-                { "map_in_city": { "mutator": "u_loc_relative", "target": "(0,0,0)" } }
+                { "map_in_city": { "context_val": "check_loc" } }
               ]
             },
             "effect": [ { "math": [ "u_homullus_is_in_civilization = 1" ] } ],

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_spell_learning_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_spell_learning_eocs.json
@@ -25,6 +25,7 @@
     },
     "deactivate_condition": { "not": { "u_has_trait": "HOMULLUS" } },
     "effect": [
+      { "u_location_variable": { "context_val": "check_loc" } },
       {
         "run_eocs": [
           {
@@ -34,7 +35,7 @@
                 { "test_eoc": "EOC_CONDITION_HOMULLUS_NEAR_FACTION" },
                 { "test_eoc": "EOC_CONDITION_SKY_ISLAND_ON_THE_ISLAND" },
                 { "u_near_om_location": "FACTION_CAMP_ANY", "range": 2 },
-                { "map_in_city": { "mutator": "u_loc_relative", "target": "(0,0,0)" } }
+                { "map_in_city": { "context_val": "check_loc" } }
               ]
             },
             "effect": [ { "run_eocs": "EOC_HOMULLUS_SPELL_EXPERIENCE_INCREASER_SELECTOR" } ]

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/paraclesian_fae_bans.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/paraclesian_fae_bans.json
@@ -71,24 +71,26 @@
     "id": "EOC_ARVORE_FAE_BAN_SLEPT_IN_CITY",
     "eoc_type": "EVENT",
     "required_event": "character_wakes_up",
-    "condition": {
-      "and": [
-        { "or": [ { "u_has_trait": "THRESH_ARVORE" }, { "u_has_trait": "ARVORE_MOSS" } ] },
-        {
-          "or": [
-            { "test_eoc": "EOC_CONDITION_HOMULLUS_NEAR_FACTION" },
-            { "map_in_city": { "mutator": "u_loc_relative", "target": "(0,0,0)" } }
-          ]
-        }
-      ]
-    },
     "effect": [
-      { "run_eocs": "EOC_PARACLESIAN_BROKE_FAE_BAN" },
-      { "run_eocs": "EOC_PARACLESIAN_BROKE_FAE_BAN_PAIN", "time_in_future": 1 },
-      { "math": [ "u_val('sleepiness')", "+=", "150" ] },
+      { "u_location_variable": { "context_val": "check_loc" } },
       {
-        "u_message": "You awaken with a groggy head, blinking bleary eyes.  Sleeping near the remnants of civilization away from the bounty of nature, your sleep was not as restful as it should have been.",
-        "type": "bad"
+        "if": {
+          "and": [
+            { "or": [ { "u_has_trait": "THRESH_ARVORE" }, { "u_has_trait": "ARVORE_MOSS" } ] },
+            {
+              "or": [ { "test_eoc": "EOC_CONDITION_HOMULLUS_NEAR_FACTION" }, { "map_in_city": { "context_val": "check_loc" } } ]
+            }
+          ]
+        },
+        "then": [
+          { "run_eocs": "EOC_PARACLESIAN_BROKE_FAE_BAN" },
+          { "run_eocs": "EOC_PARACLESIAN_BROKE_FAE_BAN_PAIN", "time_in_future": 1 },
+          { "math": [ "u_val('sleepiness') += 150" ] },
+          {
+            "u_message": "You awaken with a groggy head, blinking bleary eyes.  Sleeping near the remnants of civilization away from the bounty of nature, your sleep was not as restful as it should have been.",
+            "type": "bad"
+          }
+        ]
       }
     ]
   },

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/paraclesian_passive_trait_gain_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/paraclesian_passive_trait_gain_eocs.json
@@ -61,12 +61,13 @@
     "condition": { "u_has_trait": "HOMULLUS" },
     "deactivate_condition": { "not": { "u_has_trait": "HOMULLUS" } },
     "effect": [
+      { "u_location_variable": { "context_val": "check_loc" } },
       {
         "if": {
           "or": [
             { "test_eoc": "EOC_CONDITION_HOMULLUS_NEAR_FACTION" },
             { "u_near_om_location": "FACTION_CAMP_ANY", "range": 2 },
-            { "map_in_city": { "mutator": "u_loc_relative", "target": "(0,0,0)" } }
+            { "map_in_city": { "context_val": "check_loc" } }
           ]
         },
         "then": { "math": [ "u_paraclesian_passive_mutation_value", "+=", "1 " ] },

--- a/data/mods/Xedra_Evolved/mutations/xe_lilin_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/xe_lilin_eocs.json
@@ -286,8 +286,9 @@
     "required_event": "avatar_enters_omt",
     "condition": { "u_has_trait": "LILIN_TRAITS" },
     "effect": [
+      { "u_location_variable": { "context_val": "check_loc" } },
       {
-        "if": { "map_in_city": { "mutator": "u_loc_relative", "target": "(0,0,0)" } },
+        "if": { "map_in_city": { "context_val": "check_loc" } },
         "then": { "math": [ "u_lilit_is_in_civilization = 1" ] },
         "else": { "math": [ "u_lilit_is_in_civilization = 0" ] }
       }

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -2251,14 +2251,6 @@ static std::function<T( const_dialogue const & )> get_get_str_( const JsonObject
                                  true )->get_const_creature(),
                              crit, dodge_counter, block_counter, bl ).str() );
         };
-    } else if( mutator == "u_loc_relative" || mutator == "npc_loc_relative" ) {
-        str_or_var target = get_str_or_var( jo.get_member( "target" ), "target" );
-        bool use_beta_talker = mutator == "npc_loc_relative";
-        return [target, use_beta_talker, ret_func]( const_dialogue const & d ) {
-            tripoint_abs_ms char_pos = d.const_actor( use_beta_talker )->pos_abs();
-            tripoint_abs_ms target_pos = char_pos + tripoint::from_string( target.evaluate( d ) );
-            return ret_func( target_pos.to_string() );
-        };
     } else if( mutator == "topic_item" ) {
         return [ret_func]( const_dialogue const & d ) {
             return ret_func( d.cur_item.str() );

--- a/tests/eoc_test.cpp
+++ b/tests/eoc_test.cpp
@@ -87,8 +87,6 @@ static const effect_on_condition_id
 effect_on_condition_EOC_item_teleport_test( "EOC_item_teleport_test" );
 static const effect_on_condition_id
 effect_on_condition_EOC_jmath_test( "EOC_jmath_test" );
-static const effect_on_condition_id
-effect_on_condition_EOC_loc_relative_test( "EOC_loc_relative_test" );
 static const effect_on_condition_id effect_on_condition_EOC_map_test( "EOC_map_test" );
 static const effect_on_condition_id
 effect_on_condition_EOC_martial_art_test_1( "EOC_martial_art_test_1" );
@@ -1386,38 +1384,6 @@ TEST_CASE( "EOC_map_test", "[eoc]" )
     CHECK( effect_on_condition_EOC_map_test->activate( d ) );
     CHECK( globvars.get_global_value( "key_distance_loc" ) == "14" );
     CHECK( globvars.get_global_value( "key_distance_npc" ) == "10" );
-}
-
-TEST_CASE( "EOC_loc_relative_test", "[eoc]" )
-{
-    global_variables &globvars = get_globals();
-    globvars.clear_global_values();
-    clear_avatar();
-    clear_map();
-
-    map &m = get_map();
-    g->place_player( tripoint_bub_ms::zero );
-
-    const tripoint_abs_ms start = get_avatar().pos_abs();
-    const tripoint_bub_ms tgt = m.get_bub( start + tripoint::north );
-    m.furn_set( tgt, furn_test_f_eoc );
-    m.furn( tgt )->examine( get_avatar(), tgt );
-
-    const tripoint_bub_ms target_pos = get_avatar().pos_bub() + point::east * 10;
-    npc &npc_dst = spawn_npc( target_pos.xy(), "thug" );
-    dialogue d( get_talker_for( get_avatar() ), get_talker_for( npc_dst ) );
-
-    CHECK( effect_on_condition_EOC_loc_relative_test->activate( d ) );
-    tripoint_abs_ms tmp_abs_a = tripoint_abs_ms( tripoint::from_string(
-                                    globvars.get_global_value( "map_test_loc_a" ) ) );
-    tripoint_abs_ms tmp_abs_b = tripoint_abs_ms( tripoint::from_string(
-                                    globvars.get_global_value( "map_test_loc_b" ) ) );
-    CHECK( m.get_bub( tmp_abs_a ) == tripoint_bub_ms( 70, 70, 0 ) );
-    CHECK( m.get_bub( tmp_abs_b ) == tripoint_bub_ms( 70, 60, 0 ) );
-
-    globvars.clear_global_values();
-    clear_avatar();
-    clear_map();
 }
 
 TEST_CASE( "EOC_martial_art_test", "[eoc]" )


### PR DESCRIPTION

#### Summary
None

#### Purpose of change
The EOC mutator `u_loc_relative` does the same thing as x/y/z`_adjust` from `u_location_variable`, but relies on all variables being strings. I am trying to change variable types so this needs to go too.

#### Describe the solution
Replace all uses of `u_loc_relative` with `u_location_variable`, then pass that variable as an object.

#### Describe alternatives you've considered
N/A

#### Testing
One test unit?

#### Additional context
