### PR TITLE
Fix - Allow healing items that only do instant healing

### DIFF
--- a/data/mods/Sky_Island/items.json
+++ b/data/mods/Sky_Island/items.json
@@ -455,7 +455,7 @@
     "material": [ "alien_resin" ],
     "symbol": ",",
     "color": "magenta",
-    "use_action": { "type": "heal", "bite": 0.01, "move_cost": 2500, "limb_power": 21, "head_power": 21, "torso_power": 21 }
+    "use_action": { "type": "heal", "move_cost": 2500, "limb_power": 21, "head_power": 21, "torso_power": 21 }
   },
   {
     "id": "warp_waterwalking_stone",

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -3671,9 +3671,9 @@ void heal_actor::load( const JsonObject &obj, const std::string & )
 {
     // Mandatory
     move_cost = obj.get_int( "move_cost" );
-    limb_power = obj.get_float( "limb_power", 0 );
 
     // Optional
+    limb_power = obj.get_float( "limb_power", 0 );
     bandages_power = obj.get_float( "bandages_power", 0 );
     bandages_scaling = obj.get_float( "bandages_scaling", 0.25f * bandages_power );
     disinfectant_power = obj.get_float( "disinfectant_power", 0 );
@@ -3698,8 +3698,13 @@ void heal_actor::load( const JsonObject &obj, const std::string & )
         }
     }
 
-    if( !bandages_power && !disinfectant_power && !bleed && !bite && !infect &&
-        !obj.has_array( "effects" ) ) {
+    const bool does_instant_healing = limb_power || head_power || torso_power;
+    const bool heal_over_time = bandages_power;
+    const bool stops_bleed = bleed;
+    const bool has_any_disinfect = disinfectant_power || bite || infect;
+    const bool has_scripted_effect = obj.has_array( "effects" );
+    if( !does_instant_healing && !heal_over_time && !stops_bleed
+        && !has_any_disinfect && !has_scripted_effect ) {
         obj.throw_error( _( "Heal actor is missing any valid healing effect" ) );
     }
 


### PR DESCRIPTION
#### Summary
Bugfixes "Fix - Allow healing items that only do instant healing"

#### Purpose of change
@Standing-Storm in #80345 found an issue with the loading check I introduced in #77354. Namely an item that does instant healing but has no other healing effects is considered to have no healing effects.

#### Describe the solution
Grug fix. Also remove the bite healing chance from the warp salve, since it is no longer necessary.

Grug take [notes from other grug on expression complexity](https://grugbrain.dev/#grug-on-expression-complexity). Use boolean to understand what big if block is doing. Easier to debug.

Also moved the limb_power loading to under the `optional` comment, since it is optional.

#### Describe alternatives you've considered
Grug make even bigger if block, no boolean.

#### Testing
Game loads without errors.

#### Additional context

