### PR TITLE
Remove unconditional "aim on wait" for NPCs

### DIFF
--- a/src/npc_attack.cpp
+++ b/src/npc_attack.cpp
@@ -16,7 +16,6 @@
 #include "dialogue.h"
 #include "dialogue_helpers.h"
 #include "flag.h"
-#include "game_constants.h"
 #include "inventory.h"
 #include "item.h"
 #include "item_location.h"
@@ -504,14 +503,7 @@ int npc_attack_gun::base_time_penalty( const npc &source ) const
     if( !weapon.ammo_sufficient( &source ) ) {
         time_penalty += npc_attack_constants::base_time_penalty;
     }
-    int recoil_penalty = 0;
-    if( source.is_wielding( weapon ) ) {
-        recoil_penalty = source.recoil;
-    } else {
-        recoil_penalty = MAX_RECOIL;
-    }
-    recoil_penalty /= 100;
-    return time_penalty + recoil_penalty;
+    return time_penalty;
 }
 
 tripoint_range<tripoint_bub_ms> npc_attack_gun::targetable_points( const npc &source ) const

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -3742,10 +3742,13 @@ bool target_ui::action_aim()
     set_last_target();
     apply_aim_turning_penalty();
     const double min_recoil = calculate_aim_cap( *you, dst );
+    double hold_recoil = you->recoil;
     for( int i = 0; i < 10; ++i ) {
         do_aim( *you, *relevant, min_recoil );
     }
-
+    add_msg_debug( debugmode::debug_filter::DF_BALLISTIC,
+                   "you reduced recoil from %f to %f in 10 moves",
+                   hold_recoil, you->recoil );
     // We've changed pc.recoil, update penalty
     recalc_aim_turning_penalty();
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "remove unconditional aim on wait for NPCs"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

In #15506, the following was implemented:

https://github.com/CleverRaven/Cataclysm-DDA/blob/aa4e12398c3aa93f8c4f6bf8a7f52cd90229fec4/src/npcmove.cpp#L3441-L3455

This makes NPCs aim their ranged weapon at any time they aren't doing anything else. That includes without a target, in the dark, before target is in range, etc.

This means that NPCs effectively get a **free first shot on their target at the furthest possible range** as long as they weren't moving beforehand. Given hostile NPCs are often standing still, that means that they nearly always have initiative over the player.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Remove offending line, along with recoil weight for `npc::evaluate_best_attack()` because it isn't necessary now.

Add some debug info for aiming, recoil, `npc::evaluate_best_attack()`

`npc::wont_hit_friend()` ignores allies that aren't seen, because I noticed that they were "seeing" allies through walls when aiming

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Recreated the situation below, noted there was a little more extra time where hostile NPCs have to actually aim.
Verified that NPC allies can still shoot monsters.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

I discovered this when my player turned a flashlight on inside `bandit_camp`'s main building at night and was killed on the next turn by two hostile NPCs. A dumb move for sure, but it seemed off to me, especially because my character was armored and the shots were instant. Part of the issue was that those NPCs start with marksmanship 6 (higher than is probably fair), another was that I was unlucky that they both had high-quality guns.

This will nerf all NPCs, including allies, which is probably okay for now. NPCs need a better way to evaluate danger and then attack while using long-range weapons, though.

For the future, I envision some kind of in-game pause (like "%s points their weapon at you!", or maybe a graphical aim path indicator) for the player seeing themselves getting targeted with a ranged weapon, because not noticing can be a one-turn fatal mistake against a superior opponent.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
