### PR TITLE
tests: add roadstop_b to coverage whitelist

### DIFF
--- a/data/mods/TEST_DATA/overmap_terrain_coverage_test/overmap_terrain_coverage_whitelist.json
+++ b/data/mods/TEST_DATA/overmap_terrain_coverage_test/overmap_terrain_coverage_whitelist.json
@@ -29,6 +29,8 @@
       "roadstop_roof",
       "roadstop_a",
       "roadstop_a_roof",
+      "roadstop_b",
+      "roadstop_b_roof",
       "chemical_lab(_roof)?_ocu",
       "homelesscamp_npc",
       "ranch_camp_77",


### PR DESCRIPTION

#### Summary
None

#### Purpose of change
The overmap coverage tests identifies `roadstop_b` as a special that spawns extremely rarely. `roadstop_b` has an identical definition to `roadstop_a`, which was added to the test whitelist in #79034.

#### Describe the solution
Add `roadstop_b` to the test whitelist

#### Describe alternatives you've considered
Tracking down the PRs that broke it

#### Testing
CI

#### Additional context
IMO this is the wrong solution, but `roadstop_a` is already there and this should unblock a lot of PRs.
