### PR TITLE
Expose uilist hilight_disabled to run_eoc_selector, use in locked smartpone recovery EoC

### DIFF
--- a/data/json/effects_on_condition/computer_eocs.json
+++ b/data/json/effects_on_condition/computer_eocs.json
@@ -69,6 +69,7 @@
       {
         "run_eoc_selector": [ "EOC_SMARTPHONE_RECOVERY_BASIC", "EOC_SMARTPHONE_RECOVERY_ADVANCED" ],
         "allow_cancel": true,
+        "hilight_disabled": true,
         "names": [ "Simple recovery", "Advanced recovery" ],
         "title": "Pick the recovery type",
         "descriptions": [

--- a/doc/JSON/EFFECT_ON_CONDITION.md
+++ b/doc/JSON/EFFECT_ON_CONDITION.md
@@ -2891,6 +2891,7 @@ Open a menu, that allow to select one of multiple options
 | "title" | optional | string | Text, that would be shown as the name of the list; Default `Select an option.` | 
 | "hide_failing" | optional | boolean | if true, the options, that fail their check, would be completely removed from the list, instead of being grayed out | 
 | "allow_cancel" | optional | boolean | if true, you can quit the menu without selecting an option, no effect will occur | 
+| "hilight_disabled" | optional | boolean | if true, the option, that fail their check, would still be navigateable, meaning you can highlight it and read it's description. If `allow_cancel` is true, picking it would be considered same as quitting | 
 | "variables" | optional | pair of `"variable_name": "variable"` | variables, that would be passed to the EoCs; numeric values should be specified as strings; when a variable is an object and has the `i18n` member set to true, the variable will be localized; `expects_vars` condition can be used to ensure every variable exist before the EoC is run | 
 ##### Valid talkers:
 

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -6319,11 +6319,16 @@ talk_effect_fun_t::func f_run_eoc_selector( const JsonObject &jo, std::string_vi
         allow_cancel = jo.get_bool( "allow_cancel" );
     }
 
+    bool hilight_disabled = false;
+    if( jo.has_bool( "hilight_disabled" ) ) {
+        hilight_disabled = jo.get_bool( "hilight_disabled" );
+    }
+
     translation title = to_translation( "Select an option." );
     jo.read( "title", title );
 
     return [eocs, context, title, eoc_names, eoc_keys, eoc_descriptions,
-          hide_failing, allow_cancel]( dialogue & d ) {
+          hide_failing, allow_cancel, hilight_disabled]( dialogue & d ) {
         uilist eoc_list;
 
         std::unique_ptr<talker> default_talker = get_talker_for( get_player_character() );
@@ -6334,6 +6339,7 @@ talk_effect_fun_t::func f_run_eoc_selector( const JsonObject &jo, std::string_vi
         eoc_list.text = title.translated();
         eoc_list.allow_cancel = allow_cancel;
         eoc_list.desc_enabled = !eoc_descriptions.empty();
+        eoc_list.hilight_disabled = hilight_disabled;
         parse_tags( eoc_list.text, alpha, beta, d );
 
         for( size_t i = 0; i < eocs.size(); i++ ) {


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
I thought that it would happen, just didn't know it would happen so fast
Folks open the recovery menu on locked phones, but are unable to read the requirements for advanced recovery
#### Describe the solution
Now they can
#### Testing
![image](https://github.com/user-attachments/assets/2805f3c7-15f3-4330-abe6-fcbbc08eb416)