### PR TITLE
[MoM] Wary Sleeper Fix

### DIFF
--- a/data/json/bionics.json
+++ b/data/json/bionics.json
@@ -26,7 +26,7 @@
     "name": { "str": "Alarm System" },
     "description": "A motion-detecting alarm system will notice almost all movement within a fifteen-foot radius, and will silently alert you.  This is very useful during sleep, or if you suspect a cloaked pursuer.",
     "occupied_bodyparts": [ [ "torso", 2 ], [ "head", 1 ] ],
-    "enchantments": [ { "condition": "ALWAYS", "values": [ { "value": "MOTION_ALARM", "add": 5 } ] } ],
+    "enchantments": [ { "condition": "ACTIVE", "values": [ { "value": "MOTION_ALARM", "add": 5 } ] } ],
     "flags": [ "BIONIC_TOGGLED", "BIONIC_SLEEP_FRIENDLY" ],
     "act_cost": "1 J",
     "react_cost": "1 J",


### PR DESCRIPTION
#### Summary
Bugfixes "[MoM] Wary Sleeper. Change bio_alarm enchantments from `"ALWAYS"` to `"ACTIVE"` "

#### Purpose of change

`"ALWAYS"` condition in bio_alarm (Alarm System) enchantment somehow (magic of hardcoded code), make work Wary Sleeper perk even if it was in turn off condition.

#### Describe the solution

Change `ALWAYS` to` ACTIVE`

#### Describe alternatives you've considered

None, my PR, my bug, my fix.

#### Testing

Changed that line in my version of DDA, runned test world. No more annoying messages, perk and CBM works as planned.

#### Additional context


