### PR TITLE
Expose emp_blast and scrambler_blast to eoc

### DIFF
--- a/doc/JSON/EFFECT_ON_CONDITION.md
+++ b/doc/JSON/EFFECT_ON_CONDITION.md
@@ -4281,8 +4281,10 @@ Creates an explosion at talker position or at passed coordinate
 
 | Syntax | Optionality | Value  | Info |
 | --- | --- | --- | --- | 
-| "u_explosion", / "npc_explosion" | **mandatory** | explosion_data | copies the `explosion` field from `"type": "ammo_effect"`, but allows to use variables; defines what type of explosion is occuring |
+| "u_explosion", / "npc_explosion" | **mandatory** | explosion_data | copies the `explosion` field from `"type": "ammo_effect"`, but allows to use variables; defines what type of explosion is occuring. |
 | "target_var" | optional | [variable object](#variable-object) | if used, explosion will occur where the variable point to | 
+| "emp_blast" | optional | bool | if used, the emp blast would appear at the center of the explosion (only at the center, no matter the size of explosion.  If you want the explosion to have an area, see examples below) | 
+| "scrambler_blast" | optional | bool | if used, the scrambler blast would appear at the center of the explosion (only at the center, no matter the size of explosion) |
 
 ##### Valid talkers:
 
@@ -4307,6 +4309,28 @@ You pick a tile using u_query_omt, then the explosion is caused at this position
     ]
   }
 ```
+
+`u_map_run_eocs` runs 5 tiles around alpha talker, applying EMP effect on all the tiles
+```json
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_AOE_EMP",
+    "effect": [
+      {
+        "u_map_run_eocs": [ "EOC_EMP" ],
+        "range": 5,
+        "store_coordinates_in": { "context_val": "loc" },
+        "stop_at_first": false
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_EMP",
+    "effect": [ { "u_explosion": { }, "emp_blast": true, "target_var": { "context_val": "loc" } } ]
+  },
+```
+
 
 #### `u_knockback`, `npc_knockback`
 Pushes the creature on the tile in specific direction

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -4470,7 +4470,7 @@ talk_effect_fun_t::func f_explosion( const JsonObject &jo, std::string_view memb
     }
 
     JsonObject jo_explosion = jo.get_object( member );
-    dov_power = get_dbl_or_var( jo_explosion, "power", true );
+    dov_power = get_dbl_or_var( jo_explosion, "power", false, 0 );
     dov_distance_factor = get_dbl_or_var( jo_explosion, "distance_factor", false, 0.75f );
     dov_max_noise = get_dbl_or_var( jo_explosion, "max_noise", false, 90000000 );
     fire = jo_explosion.get_bool( "fire", false );
@@ -4484,8 +4484,11 @@ talk_effect_fun_t::func f_explosion( const JsonObject &jo, std::string_view memb
         dov_shrapnel_drop = get_str_or_var( jo_shr.get_member( "drop" ), "drop", false, "null" );
     }
 
+    bool emp_blast = jo.get_bool( "emp_blast", false );
+    bool scrambler_blast = jo.get_bool( "scrambler_blast", false );
+
     return [target_var, dov_power, dov_distance_factor, dov_max_noise, fire, dov_shrapnel_casing_mass,
-                        dov_shrapnel_fragment_mass, dov_shrapnel_recovery, dov_shrapnel_drop,
+                        dov_shrapnel_fragment_mass, dov_shrapnel_recovery, dov_shrapnel_drop, emp_blast, scrambler_blast,
                 is_npc, &here]( dialogue const & d ) {
         tripoint_bub_ms target_pos;
         if( target_var.has_value() ) {
@@ -4507,6 +4510,13 @@ talk_effect_fun_t::func f_explosion( const JsonObject &jo, std::string_view memb
         expl_data.shrapnel.drop = itype_id( dov_shrapnel_drop.evaluate( d ) );
 
         explosion_handler::explosion( &guy, target_pos, expl_data );
+
+        if( emp_blast ) {
+            explosion_handler::emp_blast( target_pos );
+        }
+        if( scrambler_blast ) {
+            explosion_handler::scrambler_blast( target_pos );
+        }
     };
 }
 


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Request from Storm
#### Describe the solution
Expose emp_blast as a sub-effect for u_explosion effect
Also expose scrambler because i could
Make power of explosion optional, since now user may want to just apply emp/scramble effect without actual damage
#### Testing
![image](https://github.com/user-attachments/assets/56281c9b-bff6-444c-ba53-a397b8365cb7)
![image](https://github.com/user-attachments/assets/7fed1883-5e7b-49f1-8b8f-94a83cda9bad)
![image](https://github.com/user-attachments/assets/3212e77f-9740-4399-9182-ed74bfa812ed)