### PR TITLE
Rename map::add_item_ret_loc to add_item_or_charges_ret_loc

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -6185,7 +6185,7 @@ void outfit_swap_actor::finish( player_activity &act, Character &who )
     map &here = get_map();
     // First, make a new outfit and shove all our existing clothes into it.
     item new_outfit( outfit_item->typeId() );
-    item_location ground = here.add_item_ret_loc( who.pos_bub(), new_outfit, true );
+    item_location ground = here.add_item_or_charges_ret_loc( who.pos_bub(), new_outfit, true );
     if( !ground ) {
         debugmsg( "Failed to swap outfits during outfit_swap_actor::finish" );
         act.set_to_null();

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -5085,7 +5085,7 @@ units::volume map::free_volume( const tripoint_bub_ms &p )
     return i_at( p ).free_volume();
 }
 
-item_location map::add_item_ret_loc( const tripoint_bub_ms &pos, item obj, bool overflow )
+item_location map::add_item_or_charges_ret_loc( const tripoint_bub_ms &pos, item obj, bool overflow )
 {
     int copies = 1;
     std::pair<item *, tripoint_bub_ms> ret = _add_item_or_charges( pos, std::move( obj ), copies,

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -5085,7 +5085,8 @@ units::volume map::free_volume( const tripoint_bub_ms &p )
     return i_at( p ).free_volume();
 }
 
-item_location map::add_item_or_charges_ret_loc( const tripoint_bub_ms &pos, item obj, bool overflow )
+item_location map::add_item_or_charges_ret_loc( const tripoint_bub_ms &pos, item obj,
+        bool overflow )
 {
     int copies = 1;
     std::pair<item *, tripoint_bub_ms> ret = _add_item_or_charges( pos, std::move( obj ), copies,

--- a/src/map.h
+++ b/src/map.h
@@ -1263,7 +1263,7 @@ class map
          *  @return reference to dropped (and possibly stacked) item or null item on failure
          *  @warning function is relatively expensive and meant for user initiated actions, not mapgen
          */
-        item_location add_item_ret_loc( const tripoint_bub_ms &pos, item obj, bool overflow = true );
+        item_location add_item_or_charges_ret_loc( const tripoint_bub_ms &pos, item obj, bool overflow = true );
         item &add_item_or_charges( const tripoint_bub_ms &pos, item obj, bool overflow = true );
         item &add_item_or_charges( const tripoint_bub_ms &pos, item obj, int &copies_remaining,
                                    bool overflow = true );

--- a/src/map.h
+++ b/src/map.h
@@ -1263,7 +1263,8 @@ class map
          *  @return reference to dropped (and possibly stacked) item or null item on failure
          *  @warning function is relatively expensive and meant for user initiated actions, not mapgen
          */
-        item_location add_item_or_charges_ret_loc( const tripoint_bub_ms &pos, item obj, bool overflow = true );
+        item_location add_item_or_charges_ret_loc( const tripoint_bub_ms &pos, item obj,
+                bool overflow = true );
         item &add_item_or_charges( const tripoint_bub_ms &pos, item obj, bool overflow = true );
         item &add_item_or_charges( const tripoint_bub_ms &pos, item obj, int &copies_remaining,
                                    bool overflow = true );

--- a/src/mondeath.cpp
+++ b/src/mondeath.cpp
@@ -192,7 +192,7 @@ item_location mdeath::splatter( map *here, monster &z )
         if( !z.has_eaten_enough() ) {
             corpse.set_flag( STATIC( flag_id( "UNDERFED" ) ) );
         }
-        return here->add_item_ret_loc( z.pos_bub( *here ), corpse );
+        return here->add_item_or_charges_ret_loc( z.pos_bub( *here ), corpse );
     }
     return {};
 }
@@ -289,5 +289,5 @@ item_location make_mon_corpse( map *here, monster &z, int damageLvl )
     if( !z.has_eaten_enough() ) {
         corpse.set_flag( STATIC( flag_id( "UNDERFED" ) ) );
     }
-    return here->add_item_ret_loc( z.pos_bub( *here ), corpse );
+    return here->add_item_or_charges_ret_loc( z.pos_bub( *here ), corpse );
 }

--- a/tests/iuse_test.cpp
+++ b/tests/iuse_test.cpp
@@ -747,7 +747,8 @@ static item_location give_tablets( avatar &dummy, int count, bool in_inventory )
         for( int i = 0; i < count; ++i ) {
             container.put_in( item( itype_pur_tablets, calendar::turn ), pocket_type::CONTAINER );
         }
-        item_location container_loc = get_map().add_item_or_charges_ret_loc( dummy.pos_bub(), container, true );
+        item_location container_loc = get_map().add_item_or_charges_ret_loc( dummy.pos_bub(), container,
+                                      true );
         REQUIRE( container_loc );
         std::list<item *> all_tablets = container_loc->all_items_top();
         REQUIRE( !all_tablets.empty() );

--- a/tests/iuse_test.cpp
+++ b/tests/iuse_test.cpp
@@ -747,7 +747,7 @@ static item_location give_tablets( avatar &dummy, int count, bool in_inventory )
         for( int i = 0; i < count; ++i ) {
             container.put_in( item( itype_pur_tablets, calendar::turn ), pocket_type::CONTAINER );
         }
-        item_location container_loc = get_map().add_item_ret_loc( dummy.pos_bub(), container, true );
+        item_location container_loc = get_map().add_item_or_charges_ret_loc( dummy.pos_bub(), container, true );
         REQUIRE( container_loc );
         std::list<item *> all_tablets = container_loc->all_items_top();
         REQUIRE( !all_tablets.empty() );
@@ -770,7 +770,7 @@ static item_location give_water( avatar &dummy, int count, bool in_inventory )
     if( in_inventory ) {
         container_loc = dummy.i_add( container );
     } else {
-        container_loc = get_map().add_item_ret_loc( dummy.pos_bub(), container, true );
+        container_loc = get_map().add_item_or_charges_ret_loc( dummy.pos_bub(), container, true );
     }
     REQUIRE( container_loc );
     // Spawning a container of water next to the player does not update the crafting inventory, so force an update


### PR DESCRIPTION
#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
map::add_item_ret_loc(const tripoint_bub_ms &, item, bool) actually calls _add_item_or_charges, and its processing logic is  the same as map::add_item_or_charges(const tripoint_bub_ms &, item, bool) except that return loc. However, there is no _or_charges in its name, which may cause some confusion.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Rename map::add_item_ret_loc to add_item_or_charges_ret_loc. Change the name of all calls.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Don't rename it.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Compilation was successful and the game was launched successfully.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
