### PR TITLE
[Xedra Evolved] Remove obsolete homullus-specific jmath statement

### DIFF
--- a/data/mods/Xedra_Evolved/jmath.json
+++ b/data/mods/Xedra_Evolved/jmath.json
@@ -195,13 +195,6 @@
   },
   {
     "type": "jmath_function",
-    "id": "paraclesian_homullus_total_mutations",
-    "//": "Yes, this is horrible, but there's apparently no way to check the total number of mutations in a category otherwise.",
-    "num_args": 1,
-    "return": "_0 + u_has_trait('HOMULLUS_DURABILITY_MULT_1') + u_has_trait('HOMULLUS_DURABILITY_MULT_2') + u_has_trait('HOMULLUS_SKIN_1') + u_has_trait('HOMULLUS_SKIN_2') + u_has_trait('HOMULLUS_SKIN_3') + u_has_trait('HOMULLUS_EYES') + u_has_trait('HOMULLUS_BETTER_AT_LYING') + u_has_trait('HOMULLUS_DREAMWALKER') + u_has_trait('HOMULLUS_CHARM_FERALS') + u_has_trait('HOMULLUS_SUMMON_FERALS') + u_has_trait('HOMULLUS_SELF_DECEPTION') + u_has_trait('HOMULLUS_INVISIBLE_TO_HUMANS') + u_has_trait('HOMULLUS_REDUCED_VISIBILITY_ALLY') + u_has_trait('HOMULLUS_RESTORE_POWER') + u_has_trait('HOMULLUS_ADD_LEARNING_FOCUS') + u_has_trait('HOMULLUS_CULTIVATE_GOBLIN_FRUIT') + u_has_trait('NO_TRACE_YET_I_WISH') + u_has_trait('HOMULLUS_BACKSTAGE') + u_has_trait('HOMULLUS_CBM_INSTALL') + u_has_trait('HOMULLUS_CBM_MANA_1') + u_has_trait('HOMULLUS_CBM_MANA_2') + u_has_trait('HOMULLUS_PASSIVE_BIONIC_POWER') + u_has_trait('HOMULLUS_ARMOR_MULT_1') + u_has_trait('HOMULLUS_ARMOR_MULT_2') + u_has_trait('HOMULLUS_GAIN_BIONIC_POWER') + u_has_trait('HOMULLUS_GAIN_BIONIC_POWER_AND_MANA') + u_has_trait('HOMULLUS_CITY_STRIDER') + u_has_trait('HOMULLUS_THE_HUNTER') + u_has_trait('HOMULLUS_EAT_DEMIHUMANS') + u_has_trait('HOMULLUS_TEMPERATURE_TOLERANCE') + u_has_trait('HOMULLUS_CRAFTING_BONUS_1') + u_has_trait('HOMULLUS_CRAFTING_BONUS_2') + u_has_trait('HOMULLUS_CRAFTING_BONUS_3') + u_has_trait('HOMULLUS_GAIN_INTEGRATED_TOOLS') + u_has_trait('HOMULLUS_GAIN_INTEGRATED_HACKER') + u_has_trait('HOMULLUS_EXPANDED_MUTATIONS') + u_has_trait('HOMULLUS_THE_HUNTER2') + u_has_trait('HOMULLUS_DOLL_FORM') + u_has_trait('SOCIAL1') + u_has_trait('SOCIAL2') + u_has_trait('PRETTY') + u_has_trait('BEAUTIFUL') + u_has_trait('BEAUTIFUL2') + u_has_trait('BEAUTIFUL3') + u_has_trait('STR_UP') + u_has_trait('STR_UP_2') + u_has_trait('STR_ALPHA') + u_has_trait('DEX_UP')+ u_has_trait('DEX_UP_2') + u_has_trait('DEX_ALPHA') + u_has_trait('INT_UP') + u_has_trait('INT_UP_2') + u_has_trait('INT_ALPHA') + u_has_trait('PER_UP') + u_has_trait('PER_UP_2') + u_has_trait('PER_ALPHA')"
-  },
-  {
-    "type": "jmath_function",
     "id": "vampire_total_tier_one_traits",
     "num_args": 0,
     "return": "u_has_trait('EYEGLEAM') + u_has_trait('BLOOD_FUN') + u_has_trait('STAMINAFORBLOOD') + u_has_trait('COMMUNE_NIGHT') + u_has_trait('VAMPIRIC_STRENGTH') + u_has_trait('VAMPIRIC_RESILIENCE') + u_has_trait('VAMPIRE_HEIGHTENED_SENSES') + u_has_trait('VAMPIRE_SILENT_MOVE')"

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_mutations.json
@@ -1,6 +1,5 @@
 [
   {
-    "//": "When any new mutation is added, make sure to add it to the jmath statement paraclesian_homullus_total_mutations",
     "type": "mutation",
     "id": "HOMULLUS_SKIN_1",
     "name": { "str": "Mannequin Skin" },
@@ -322,7 +321,7 @@
     "prereqs": [ "HOMULLUS_CBM_MANA_1", "HOMULLUS_CBM_MANA_2" ],
     "enchantments": [
       {
-        "values": [ { "value": "BIONIC_POWER", "add": { "math": [ "paraclesian_homullus_total_mutations(1) * 50000000" ] } } ]
+        "values": [ { "value": "BIONIC_POWER", "add": { "math": [ "u_sum_traits_of_category_char_has('HOMULLUS') * 50000000" ] } } ]
       }
     ]
   },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Xedra Evolved] Remove obsolete homullus-specific jmath statement"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

A while back I wrote a jmath statement that had every homullus trait in it, to empower homullus the more traits they had. It was clunky, prone to breakage if I'm not around to check on it, and now that we have `u_sum_traits_of_category_char_has`, entirely unnecessary.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Replace the invocation of the jmath statement with `u_sum_traits_of_category_char_has` and delete the statement.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Functionality is maintained.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
