### PR TITLE
Move is_efile, fix not able to read from e-device with full inventory

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -13430,7 +13430,7 @@ void Character::use( item_location loc, int pre_obtain_moves, std::string const 
     } else if( used.is_book() ) {
         // TODO: Handle this with dynamic dispatch.
         if( avatar *u = as_avatar() ) {
-            if( item::is_efile( loc ) ) {
+            if( loc.is_efile() ) {
                 u->read( loc, loc.parent_item() );
             } else {
                 u->read( loc );

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -1479,9 +1479,12 @@ class read_inventory_preset: public pickup_inventory_preset
 
         std::string get_denial( const item_location &loc ) const override {
             std::vector<std::string> denials;
-            if( you.get_book_reader( *loc, denials ) == nullptr && !denials.empty() &&
-                !loc->type->can_use( "learn_spell" ) ) {
+            if( ( you.get_book_reader( *loc, denials ) == nullptr &&
+                  !denials.empty() &&
+                  !loc->type->can_use( "learn_spell" ) ) ) {
                 return denials.front();
+            } else if( loc.is_efile() ) {
+                return std::string();
             }
             return pickup_inventory_preset::get_denial( loc );
         }
@@ -1774,7 +1777,7 @@ drop_locations game_menus::inv::efile_select( Character &who, item_location &use
     bool wiping = action == EF_WIPE;
 
     const inventory_filter_preset preset( [&copying]( const item_location & loc ) {
-        return item::is_efile( loc ) && ( !copying || loc->is_ecopiable() );
+        return loc.is_efile() && ( !copying || loc->is_ecopiable() );
     } );
 
     const int available_charges = to_edevice->ammo_remaining( );

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -1483,10 +1483,8 @@ class read_inventory_preset: public pickup_inventory_preset
                   !denials.empty() &&
                   !loc->type->can_use( "learn_spell" ) ) ) {
                 return denials.front();
-            } else if( loc.is_efile() ) {
-                return std::string();
             }
-            return pickup_inventory_preset::get_denial( loc );
+            return pickup_inventory_preset::get_denial( loc.is_efile() ? loc.parent_item() : loc );
         }
 
         std::function<bool( const inventory_entry & )> get_filter( const std::string &filter ) const

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -1712,7 +1712,7 @@ static void read()
             } else {
                 loc = loc.obtain( player_character );
                 item_location parent_loc = loc.parent_item();
-                ( parent_loc && parent_loc->is_estorage() ) ?
+                loc.is_efile() ?
                 player_character.read( loc, parent_loc ) : player_character.read( loc );
             }
         }

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -8949,11 +8949,6 @@ units::ememory item::remaining_ememory() const
     return total_ememory() - occupied_ememory();
 }
 
-bool item::is_efile( const item_location &loc )
-{
-    return loc.parent_item() && loc.parent_item()->is_estorage();
-}
-
 item *item::get_recipe_catalog()
 {
     const std::function<bool( const item &i )> filter = []( const item & i ) {

--- a/src/item.h
+++ b/src/item.h
@@ -370,8 +370,6 @@ class item : public visitable
         units::ememory occupied_ememory() const;
         /** @return remaining electronic memory on this e-device */
         units::ememory remaining_ememory() const;
-        /** Returns whether the given item location is inside an e-device) */
-        static bool is_efile( const item_location &loc );
         /** Returns the recipe catalog for this item if it exists, otherwise returns nullptr */
         item *get_recipe_catalog();
         const item *get_recipe_catalog() const;

--- a/src/item_location.cpp
+++ b/src/item_location.cpp
@@ -933,6 +933,11 @@ bool item_location::has_parent() const
     return false;
 }
 
+bool item_location::is_efile() const
+{
+    return parent_item() && parent_item()->is_estorage();
+}
+
 ret_val<void> item_location::parents_can_contain_recursive( item *it ) const
 {
     item_pocket *parent_pocket;

--- a/src/item_location.h
+++ b/src/item_location.h
@@ -127,6 +127,11 @@ class item_location
         bool has_parent() const;
 
         /**
+        * Returns whether the item location is inside an e-device)
+        */
+        bool is_efile() const;
+
+        /**
         * Returns available volume capacity where this item is located.
         */
         units::volume volume_capacity() const;


### PR DESCRIPTION
#### Summary
Bugfixes "fix not able to read with full inventory"

#### Purpose of change
fix #80470, fix #80427
While fixing them I found that the implementation of item::is_efile is increadibly wierd.
https://github.com/CleverRaven/Cataclysm-DDA/blob/6819531d550b27676c14bc86a438b1b4afc2d9c3/src/item.h#L373-L374

it is a static method, takes its own `item_location` to get its parent. Why not just move it to item_location::is_efile without being static?

#### Describe the solution
make is_efile a method of item_location.
provide the parent location (estorage) if its an e_item to check for denials.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
This PR changes two only loosely connected things. If that is a problem, I'll split it up.
Also if there is a reason the old is_efile method is the way it is for a reason ill drop that part and only implement the fix.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
can read if storage is in the inventory. Books are not listed if e-storage is on the ground, which, I believe, is not intended.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
