### PR TITLE
sanitized get_map use

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -541,7 +541,8 @@ void aim_activity_actor::restore_view() const
     bool changed_z = player_character.view_offset.z() != initial_view_offset.z();
     player_character.view_offset = initial_view_offset;
     if( changed_z ) {
-        get_map().invalidate_map_cache( player_character.view_offset.z() );
+        // reality_bubble to indicate need to adjust when/if remote operation is implemented.
+        reality_bubble().invalidate_map_cache( player_character.view_offset.z() );
         g->invalidate_main_ui_adaptor();
     }
 }
@@ -2743,9 +2744,8 @@ std::optional<tripoint_bub_ms> lockpick_activity_actor::select_location( avatar 
         return std::nullopt;
     }
 
-    const std::function<bool( const tripoint_bub_ms & )> is_pickable = [&you](
+    const std::function<bool( const tripoint_bub_ms & )> is_pickable = [&you, &here](
     const tripoint_bub_ms & p ) {
-        const map &here = get_map();
         const optional_vpart_position vpart = here.veh_at( p );
         if( p == you.pos_bub() ) {
             return false;
@@ -2765,7 +2765,7 @@ std::optional<tripoint_bub_ms> lockpick_activity_actor::select_location( avatar 
         return target;
     }
 
-    const ter_id &terr_type = get_map().ter( *target );
+    const ter_id &terr_type = here.ter( *target );
     if( *target == you.pos_bub() ) {
         you.add_msg_if_player( m_info, _( "You pick your nose and your sinuses swing open." ) );
     } else if( get_creature_tracker().creature_at<npc>( *target ) ) {
@@ -4944,6 +4944,8 @@ void disable_activity_actor::do_turn( player_activity &, Character &who )
 
 void disable_activity_actor::finish( player_activity &act, Character &/*who*/ )
 {
+    map &here = get_map();
+
     // Should never be null as we just checked in do_turn
     monster &critter = *get_creature_tracker().creature_at<monster>( target );
 
@@ -4962,11 +4964,11 @@ void disable_activity_actor::finish( player_activity &act, Character &/*who*/ )
             }
         }
     } else {
-        get_map().add_item_or_charges( target, critter.to_item() );
+        here.add_item_or_charges( target, critter.to_item() );
         if( !critter.has_flag( mon_flag_INTERIOR_AMMO ) ) {
             for( std::pair<const itype_id, int> &ammodef : critter.ammo ) {
                 if( ammodef.second > 0 ) {
-                    get_map().spawn_item( target.xy(), ammodef.first, 1, ammodef.second, calendar::turn );
+                    here.spawn_item( target.xy(), ammodef.first, 1, ammodef.second, calendar::turn );
                 }
             }
         }

--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -244,12 +244,12 @@ bool avatar::should_show_map_memory() const
 
 bool avatar::save_map_memory()
 {
-    return player_map_memory->save( get_map().get_abs( pos_bub() ) );
+    return player_map_memory->save( pos_abs() );
 }
 
 void avatar::load_map_memory()
 {
-    player_map_memory->load( get_map().get_abs( pos_bub() ) );
+    player_map_memory->load( pos_abs() );
 }
 
 void avatar::prepare_map_memory_region( const tripoint_abs_ms &p1, const tripoint_abs_ms &p2 )
@@ -1283,6 +1283,8 @@ void avatar::rebuild_aim_cache() const
 
 void avatar::set_movement_mode( const move_mode_id &new_mode )
 {
+    map &here = get_map();
+
     if( can_switch_to( new_mode ) ) {
         if( is_hauling() && new_mode->stop_hauling() ) {
             stop_hauling();
@@ -1293,8 +1295,8 @@ void avatar::set_movement_mode( const move_mode_id &new_mode )
         recalculate_enchantment_cache();
         // crouching affects visibility
         //TODO: Replace with dirtying vision_transparency_cache
-        get_map().set_transparency_cache_dirty( pos_bub() );
-        get_map().set_seen_cache_dirty( posz() );
+        here.set_transparency_cache_dirty( pos_bub() );
+        here.set_seen_cache_dirty( posz() );
         recoil = MAX_RECOIL;
     } else {
         add_msg( new_mode->change_message( false, get_steed_type() ) );

--- a/src/ballistics.cpp
+++ b/src/ballistics.cpp
@@ -87,7 +87,7 @@ static void drop_or_embed_projectile( map *here, const dealt_projectile_attack &
         // TODO: Non-glass breaking
         // TODO: Wine glass breaking vs. entire sheet of glass breaking
         // TODO: Refine logic to allow for overlapping maps.
-        if( here == &get_map() ) {
+        if( here == &reality_bubble() ) {
             sounds::sound( pt, 16, sounds::sound_t::combat, _( "glass breaking!" ), false, "bullet_hit",
                            "hit_glass" );
         }
@@ -111,7 +111,7 @@ static void drop_or_embed_projectile( map *here, const dealt_projectile_attack &
 
     if( effects.count( ammo_effect_BURST ) ) {
         // Drop the contents, not the thrown item
-        add_msg_if_player_sees( get_map().get_bub( here->get_abs( pt ) ), _( "The %s bursts!" ),
+        add_msg_if_player_sees( reality_bubble().get_bub( here->get_abs( pt ) ), _( "The %s bursts!" ),
                                 drop_item.tname() );
 
         // copies the drop item to spill the contents
@@ -343,8 +343,8 @@ void projectile_attack( dealt_projectile_attack &attack, const projectile &proj_
         range = rl_dist( source, target );
         extend_to_range = range;
 
-        if( get_map().inbounds( here->get_abs( target ) ) ) {
-            const tripoint_bub_ms bub_target = get_map().get_bub( here->get_abs( target ) );
+        if( reality_bubble().inbounds( here->get_abs( target ) ) ) {
+            const tripoint_bub_ms bub_target = reality_bubble().get_bub( here->get_abs( target ) );
             sfx::play_variant_sound( "bullet_hit", "hit_wall", sfx::get_heard_volume( bub_target ),
                                      sfx::get_heard_angle( bub_target ) );
         }
@@ -476,7 +476,7 @@ void projectile_attack( dealt_projectile_attack &attack, const projectile &proj_
                 // TODO: Make this draw thrown item/launched grenade/arrow
                 if( projectile_skip_current_frame >= projectile_skip_calculation ) {
                     // TODO: Refine so overlapping maps are handled.
-                    if( here == &get_map() ) {
+                    if( here == &reality_bubble() ) {
                         g->draw_bullet( tp, static_cast<int>( i ), trajectory, bullet );
                     }
                     projectile_skip_current_frame = 0;
@@ -566,7 +566,7 @@ void projectile_attack( dealt_projectile_attack &attack, const projectile &proj_
                         }
                     }
                     // TODO: Refine to account for overlapping maps
-                    if( here == &get_map() ) {
+                    if( here == &reality_bubble() ) {
                         sfx::do_projectile_hit( *attack.last_hit_critter );
                     }
                     has_momentum = false;
@@ -657,7 +657,7 @@ void projectile_attack( dealt_projectile_attack &attack, const projectile &proj_
             add_msg( _( "The attack bounced to %s!" ), z.get_name() );
             projectile_attack( attack, proj, here, tp, z.pos_bub(), dispersion, origin, in_veh );
             // TODO: Refine to handle overlapping maps
-            if( here == &get_map() ) {
+            if( here == &reality_bubble() ) {
                 sfx::play_variant_sound( "fire_gun", "bio_lightning_tail",
                                          sfx::get_heard_volume( z.pos_bub() ), sfx::get_heard_angle( z.pos_bub() ) );
             }

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -2222,7 +2222,7 @@ void Character::perform_uninstall( const bionic &bio, int difficulty, int succes
 bool Character::uninstall_bionic( const bionic &bio, monster &installer, Character &patient,
                                   float adjusted_skill )
 {
-    const map &here = get_map();
+    map &here = get_map();
 
     viewer &player_view = get_player_view();
     if( installer.ammo[itype_anesthetic] <= 0 ) {
@@ -2283,7 +2283,7 @@ bool Character::uninstall_bionic( const bionic &bio, monster &installer, Charact
         cbm.set_flag( flag_NO_STERILE );
         cbm.set_flag( flag_NO_PACKED );
         cbm.faults.emplace( fault_bionic_salvaged );
-        get_map().add_item( patient.pos_bub(), cbm );
+        here.add_item( patient.pos_bub(), cbm );
     } else {
         bionics_uninstall_failure( installer, patient, difficulty, success, adjusted_skill );
     }

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -5093,7 +5093,7 @@ void cata_tiles::get_terrain_orientation( const tripoint_bub_ms &p, int &rota, i
         }
     }
 
-    uint8_t rotation_targets = get_map().get_known_rotates_to( p, rotate_group, {} );
+    uint8_t rotation_targets = here.get_known_rotates_to( p, rotate_group, {} );
     get_rotation_and_subtile( val, rotation_targets, rota, subtile );
 }
 
@@ -5338,8 +5338,10 @@ void cata_tiles::get_connect_values( const tripoint_bub_ms &p, int &subtile, int
                                      const std::bitset<NUM_TERCONN> &rotate_to_group,
                                      const std::map<tripoint_bub_ms, ter_id> &ter_override )
 {
-    uint8_t connections = get_map().get_known_connections( p, connect_group, ter_override );
-    uint8_t rotation_targets = get_map().get_known_rotates_to( p, rotate_to_group, ter_override );
+    map &here = get_map();
+
+    uint8_t connections = here.get_known_connections( p, connect_group, ter_override );
+    uint8_t rotation_targets = here.get_known_rotates_to( p, rotate_to_group, ter_override );
     get_rotation_and_subtile( connections, rotation_targets, rotation, subtile );
 }
 
@@ -5347,8 +5349,10 @@ void cata_tiles::get_furn_connect_values( const tripoint_bub_ms &p, int &subtile
         const std::bitset<NUM_TERCONN> &connect_group, const std::bitset<NUM_TERCONN> &rotate_to_group,
         const std::map<tripoint_bub_ms, furn_id> &furn_override )
 {
-    uint8_t connections = get_map().get_known_connections_f( p, connect_group, furn_override );
-    uint8_t rotation_targets = get_map().get_known_rotates_to_f( p, rotate_to_group, {}, {} );
+    map &here = get_map();
+
+    uint8_t connections = here.get_known_connections_f( p, connect_group, furn_override );
+    uint8_t rotation_targets = here.get_known_rotates_to_f( p, rotate_to_group, {}, {} );
     get_rotation_and_subtile( connections, rotation_targets, rotation, subtile );
 }
 
@@ -5371,7 +5375,7 @@ void cata_tiles::get_tile_values_with_ter(
     const std::bitset<NUM_TERCONN> &rotate_to_group )
 {
     map &here = get_map();
-    uint8_t rotation_targets = get_map().get_known_rotates_to_f( p, rotate_to_group, {} );
+    uint8_t rotation_targets = here.get_known_rotates_to_f( p, rotate_to_group, {} );
     //check if furniture should connect to itself
     if( here.has_flag( ter_furn_flag::TFLAG_NO_SELF_CONNECT, p ) ||
         here.has_flag( ter_furn_flag::TFLAG_ALIGN_WORKBENCH, p ) ) {

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -11527,7 +11527,7 @@ npc_attitude Character::get_attitude() const
 bool Character::sees( const map &here, const tripoint_bub_ms &t, bool, int ) const
 {
     const int wanted_range = rl_dist( pos_bub( here ), t );
-    bool can_see = this->is_avatar() ? get_map().pl_sees( t, std::min( sight_max, wanted_range ) ) :
+    bool can_see = this->is_avatar() ? here.pl_sees( t, std::min( sight_max, wanted_range ) ) :
                    Creature::sees( here, t );
     // Clairvoyance is now pretty cheap, so we can check it early
     if( wanted_range < MAX_CLAIRVOYANCE && wanted_range < clairvoyance() ) {
@@ -13026,14 +13026,16 @@ void Character::on_worn_item_transform( const item &old_it, const item &new_it )
 
 void Character::leak_items()
 {
+    map &here = get_map();
+
     std::vector<item_location> removed_items;
     if( weapon.is_container() ) {
-        if( weapon.leak( get_map(), this, pos_bub() ) ) {
+        if( weapon.leak( here, this, pos_bub() ) ) {
             weapon.spill_contents( pos_bub() );
         }
     } else if( weapon.made_of( phase_id::LIQUID ) ) {
-        if( weapon.leak( get_map(), this, pos_bub() ) ) {
-            get_map().add_item_or_charges( pos_bub(), weapon );
+        if( weapon.leak( here, this, pos_bub() ) ) {
+            here.add_item_or_charges( pos_bub(), weapon );
             removed_items.emplace_back( *this, &weapon );
             add_msg_if_player( m_warning, _( "%s spilled from your hand." ), weapon.tname() );
         }
@@ -13043,7 +13045,7 @@ void Character::leak_items()
         if( !it || ( !it->is_container() && !it->made_of( phase_id::LIQUID ) ) ) {
             continue;
         }
-        if( it->leak( get_map(), this, pos_bub() ) ) {
+        if( it->leak( here, this, pos_bub() ) ) {
             it->spill_contents( pos_bub() );
             removed_items.push_back( it );
         }
@@ -13559,7 +13561,7 @@ void Character::pause()
     map &here = get_map();
 
     // effects of being partially/fully underwater
-    if( !in_vehicle && !get_map().has_flag_furn( "BRIDGE", pos_bub( ) ) ) {
+    if( !in_vehicle && !here.has_flag_furn( "BRIDGE", pos_bub( ) ) ) {
         if( underwater ) {
             // TODO: gain "swimming" proficiency but not "athletics" skill
             drench( 100, get_drenching_body_parts(), false );

--- a/src/character_escape.cpp
+++ b/src/character_escape.cpp
@@ -90,6 +90,8 @@ void Character::try_remove_downed()
 
 void Character::try_remove_bear_trap()
 {
+    map &here = get_map();
+
     /* Real bear traps can't be removed without the proper tools or immense strength; eventually this should
        allow normal players two options: removal of the limb or removal of the trap from the ground
        (at which point the player could later remove it from the leg with the right tools).
@@ -102,7 +104,7 @@ void Character::try_remove_bear_trap()
             if( x_in_y( mon->type->melee_dice * mon->type->melee_sides, 200 ) ) {
                 mon->remove_effect( effect_beartrap );
                 remove_effect( effect_beartrap );
-                get_map().spawn_item( pos_bub(), itype_beartrap );
+                here.spawn_item( pos_bub(), itype_beartrap );
                 add_msg( _( "The %s escapes the bear trap!" ), mon->get_name() );
             } else {
                 add_msg_if_player( m_bad,
@@ -112,7 +114,7 @@ void Character::try_remove_bear_trap()
     } else {
         if( can_escape_trap( 100 ) ) {
             remove_effect( effect_beartrap );
-            get_map().spawn_item( pos_bub(), itype_beartrap );
+            here.spawn_item( pos_bub(), itype_beartrap );
             add_msg_player_or_npc( m_good, _( "You free yourself from the bear trap!" ),
                                    _( "<npcname> frees themselves from the bear trap!" ) );
         } else {

--- a/src/character_inventory.cpp
+++ b/src/character_inventory.cpp
@@ -589,12 +589,14 @@ void Character::drop( item_location loc, const tripoint_bub_ms &where )
 void Character::drop( const drop_locations &what, const tripoint_bub_ms &target,
                       bool stash )
 {
+    map &here = get_map();
+
     if( what.empty() ) {
         return;
     }
     invalidate_leak_level_cache();
-    const std::optional<vpart_reference> vp = get_map().veh_at( target ).cargo();
-    if( rl_dist( pos_bub(), target ) > 1 || !( stash || get_map().can_put_items( target ) )
+    const std::optional<vpart_reference> vp = here.veh_at( target ).cargo();
+    if( rl_dist( pos_bub(), target ) > 1 || !( stash || here.can_put_items( target ) )
         || ( vp.has_value() && vp->part().is_cleaner_on() ) ) {
         add_msg_player_or_npc( m_info, _( "You can't place items here!" ),
                                _( "<npcname> can't place items here!" ) );

--- a/src/clzones.cpp
+++ b/src/clzones.cpp
@@ -1359,6 +1359,8 @@ std::vector<zone_data> zone_manager::get_zones( const zone_type_id &type,
 const zone_data *zone_manager::get_zone_at( const tripoint_abs_ms &where, bool loot_only,
         const faction_id &fac ) const
 {
+    map &here = get_map();
+
     auto const check = [&fac, loot_only, &where]( zone_data const & z ) {
         return z.get_faction() == fac &&
                ( !loot_only || z.get_type().str().substr( 0, 4 ) == "LOOT" ) &&
@@ -1369,7 +1371,7 @@ const zone_data *zone_manager::get_zone_at( const tripoint_abs_ms &where, bool l
             return &*it;
         }
     }
-    auto const vzones = get_map().get_vehicle_zones( get_map().get_abs_sub().z() );
+    auto const vzones = here.get_vehicle_zones( here.get_abs_sub().z() );
     for( zone_data *it : vzones ) {
         if( check( *it ) ) {
             return &*it;

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -3561,7 +3561,7 @@ static void kill_area()
         return;
     }
 
-    const tripoint_range<tripoint_bub_ms> points = get_map().points_in_rectangle(
+    const tripoint_range<tripoint_bub_ms> points = here.points_in_rectangle(
                 tripoint_bub_ms( first.position.value() ), tripoint_bub_ms( second.position.value() ) );
 
     std::vector<Creature *> creatures = g->get_creatures_if(

--- a/src/editmap.cpp
+++ b/src/editmap.cpp
@@ -480,7 +480,7 @@ void editmap::uber_draw_ter( const catacurses::window &w, map *m )
         bool draw_veh=true;
     */
 
-    bool game_map = m == &get_map() || w == g->w_terrain;
+    bool game_map = m == &reality_bubble() || w == g->w_terrain;
     const int msize = MAPSIZE_X;
     if( refresh_mplans ) {
         hilights["mplan"].points.clear();
@@ -2079,8 +2079,10 @@ void editmap::mapgen_retarget()
         if( const std::optional<tripoint_rel_omt> vec = ctxt.get_direction_rel_omt( action ) ) {
             point_rel_ms vec_ms = coords::project_to<coords::ms>( vec->xy() );
             tripoint_bub_ms ptarget = target + vec_ms;
-            if( get_map().inbounds( ptarget ) &&
-                get_map().inbounds( ptarget + point( SEEX, SEEY ) ) ) {
+            map &here = get_map();
+
+            if( here.inbounds( ptarget ) &&
+                here.inbounds( ptarget + point( SEEX, SEEY ) ) ) {
                 target = ptarget;
 
                 target_list.clear();

--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -291,7 +291,7 @@ static void do_blast( map *m, const Creature *source, const tripoint_bub_ms &p, 
     }
 
     // Draw the explosion, but only if the explosion center is within the reality bubble
-    map &bubble_map = get_map();
+    map &bubble_map = reality_bubble();
     if( bubble_map.inbounds( m->get_abs( p ) ) ) {
         std::map<tripoint_bub_ms, nc_color> explosion_colors;
         for( const tripoint_bub_ms &pt : closed ) {
@@ -486,7 +486,7 @@ static std::vector<tripoint_bub_ms> shrapnel( map *m, const Creature *source,
                 }
             }
             auto it = frag.targets_hit[critter];
-            if( get_map().inbounds(
+            if( reality_bubble().inbounds(
                     abs_target ) ) { // Only report on critters in the reality bubble. Should probably be only for visible critters...
                 multi_projectile_hit_message( critter, it.first, it.second, n_gettext( "bomb fragment",
                                               "bomb fragments", it.first ) );
@@ -542,8 +542,10 @@ void explosion( const Creature *source, map *here, const tripoint_bub_ms &p,
 void _make_explosion( map *m, const Creature *source, const tripoint_bub_ms &p,
                       const explosion_data &ex )
 {
-    if( get_map().inbounds( m->get_abs( p ) ) ) {
-        tripoint_bub_ms bubble_pos = get_map().get_bub( m->get_abs( p ) );
+    map &bubble_map = reality_bubble();
+
+    if( bubble_map.inbounds( m->get_abs( p ) ) ) {
+        tripoint_bub_ms bubble_pos = bubble_map.get_bub( m->get_abs( p ) );
         int noise = ex.power * ( ex.fire ? 2 : 10 );
         noise = ( noise > ex.max_noise ) ? ex.max_noise : noise;
 
@@ -955,7 +957,7 @@ void process_explosions()
 
     for( const queued_explosion &ex : explosions_copy ) {
         const int safe_range = ex.data.safe_range();
-        map  *bubble_map = &get_map();
+        map  *bubble_map = &reality_bubble();
         const tripoint_bub_ms bubble_pos( bubble_map->get_bub( ex.pos ) );
 
         if( bubble_pos.x() - safe_range < 0 || bubble_pos.x() + safe_range > MAPSIZE_X ||

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5432,6 +5432,8 @@ bool game::find_nearby_spawn_point( const tripoint_bub_ms &target, const mtype_i
                                     int min_radius,
                                     int max_radius, tripoint_bub_ms &point, bool outdoor_only, bool indoor_only, bool open_air_allowed )
 {
+    map &here = get_map();
+
     tripoint_bub_ms target_point;
     //find a legal outdoor place to spawn based on the specified radius,
     //we just try a bunch of random points and use the first one that works, it none do then no spawn
@@ -5439,9 +5441,9 @@ bool game::find_nearby_spawn_point( const tripoint_bub_ms &target, const mtype_i
         target_point = target + tripoint( rng( -max_radius, max_radius ),
                                           rng( -max_radius, max_radius ), 0 );
         if( can_place_monster( monster( mt->id ), target_point ) &&
-            ( open_air_allowed || get_map().has_floor_or_water( target_point ) ) &&
-            ( !outdoor_only || get_map().is_outside( target_point ) ) &&
-            ( !indoor_only || !get_map().is_outside( target_point ) ) &&
+            ( open_air_allowed || here.has_floor_or_water( target_point ) ) &&
+            ( !outdoor_only || here.is_outside( target_point ) ) &&
+            ( !indoor_only || !here.is_outside( target_point ) ) &&
             rl_dist( target_point, target ) >= min_radius ) {
             point = target_point;
             return true;
@@ -5453,6 +5455,8 @@ bool game::find_nearby_spawn_point( const tripoint_bub_ms &target, const mtype_i
 bool game::find_nearby_spawn_point( const tripoint_bub_ms &target, int min_radius,
                                     int max_radius, tripoint_bub_ms &point, bool outdoor_only, bool indoor_only, bool open_air_allowed )
 {
+    map &here = get_map();
+
     tripoint_bub_ms target_point;
     //find a legal outdoor place to spawn based on the specified radius,
     //we just try a bunch of random points and use the first one that works, it none do then no spawn
@@ -5460,9 +5464,9 @@ bool game::find_nearby_spawn_point( const tripoint_bub_ms &target, int min_radiu
         target_point = target + tripoint( rng( -max_radius, max_radius ),
                                           rng( -max_radius, max_radius ), 0 );
         if( can_place_npc( target_point ) &&
-            ( open_air_allowed || get_map().has_floor_or_water( target_point ) ) &&
-            ( !outdoor_only || get_map().is_outside( target_point ) ) &&
-            ( !indoor_only || !get_map().is_outside( target_point ) ) &&
+            ( open_air_allowed || here.has_floor_or_water( target_point ) ) &&
+            ( !outdoor_only || here.is_outside( target_point ) ) &&
+            ( !indoor_only || !here.is_outside( target_point ) ) &&
             rl_dist( target_point, target ) >= min_radius ) {
             point = target_point;
             return true;
@@ -5479,8 +5483,10 @@ bool game::find_nearby_spawn_point( const tripoint_bub_ms &target, int min_radiu
  */
 bool game::spawn_hallucination( const tripoint_bub_ms &p )
 {
+    map &here = get_map();
+
     //Don't spawn hallucinations on open air
-    if( get_map().has_flag( ter_furn_flag::TFLAG_NO_FLOOR, p ) ) {
+    if( here.has_flag( ter_furn_flag::TFLAG_NO_FLOOR, p ) ) {
         return false;
     }
 
@@ -5488,7 +5494,7 @@ bool game::spawn_hallucination( const tripoint_bub_ms &p )
         shared_ptr_fast<npc> tmp = make_shared_fast<npc>();
         tmp->normalize();
         tmp->randomize( NC_HALLU );
-        tmp->spawn_at_precise( get_map().get_abs( p ) );
+        tmp->spawn_at_precise( here.get_abs( p ) );
         if( !get_creature_tracker().creature_at( p, true ) ) {
             overmap_buffer.insert_npc( tmp );
             load_npcs();
@@ -5812,7 +5818,7 @@ void game::save_cyborg( item *cyborg, const tripoint_bub_ms &couch_pos, Characte
         shared_ptr_fast<npc> tmp = make_shared_fast<npc>();
         tmp->normalize();
         tmp->load_npc_template( npc_template_cyborg_rescued );
-        tmp->spawn_at_precise( get_map().get_abs( couch_pos ) );
+        tmp->spawn_at_precise( here.get_abs( couch_pos ) );
         overmap_buffer.insert_npc( tmp );
         tmp->hurtall( dmg_lvl * 10, nullptr );
         tmp->add_effect( effect_downed, rng( 1_turns, 4_turns ), false, 0, true );
@@ -12923,16 +12929,16 @@ std::optional<tripoint_bub_ms> game::find_stairs( const map &mp, int z_after,
                                         z_after ) ) );
     tripoint_bub_ms omtile_align_end( omtile_align_start + point( omtilesz, omtilesz ) );
 
-    if( !get_map().is_open_air( u.pos_bub() ) ) {
+    if( !mp.is_open_air( u.pos_bub( mp ) ) ) {
         for( const tripoint_bub_ms &dest : mp.points_in_rectangle( omtile_align_start,
                 omtile_align_end ) ) {
-            if( rl_dist( u.pos_bub(), dest ) <= best &&
+            if( rl_dist( u.pos_bub( mp ), dest ) <= best &&
                 ( ( going_down_1 && mp.has_flag( ter_furn_flag::TFLAG_GOES_UP, dest ) ) ||
                   ( going_up_1 && ( mp.has_flag( ter_furn_flag::TFLAG_GOES_DOWN, dest ) ||
                                     mp.ter( dest ) == ter_t_manhole_cover ) ) ||
                   ( ( movez == 2 || movez == -2 ) && mp.ter( dest ) == ter_t_elevator ) ) ) {
                 stairs.emplace( dest );
-                best = rl_dist( u.pos_bub(), dest );
+                best = rl_dist( u.pos_bub( mp ), dest );
             }
         }
     }
@@ -12944,7 +12950,7 @@ std::optional<tripoint_bub_ms> game::find_or_make_stairs( map &mp, const int z_a
         bool &rope_ladder,
         bool peeking, const tripoint_bub_ms &pos )
 {
-    const bool is_avatar = u.pos_bub() == pos;
+    const bool is_avatar = u.pos_bub( mp ) == pos;
     const int movez = z_after - pos.z();
 
     // Try to find the stairs.
@@ -13003,7 +13009,7 @@ std::optional<tripoint_bub_ms> game::find_or_make_stairs( map &mp, const int z_a
         return stairs;
     }
 
-    if( u.has_effect( effect_gliding ) && get_map().is_open_air( u.pos_bub() ) ) {
+    if( u.has_effect( effect_gliding ) && mp.is_open_air( u.pos_bub( mp ) ) ) {
         return stairs;
     }
 

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -674,7 +674,7 @@ static void close()
                 here, _( "Close where?" ),
                 pgettext( "no door, gate, etc.", "There is nothing that can be closed nearby." ),
                 ACTION_CLOSE, false ) ) {
-        doors::close_door( get_map(), get_player_character(), *pnt );
+        doors::close_door( here, get_player_character(), *pnt );
     }
 }
 

--- a/src/handle_liquid.cpp
+++ b/src/handle_liquid.cpp
@@ -65,7 +65,9 @@ static void serialize_liquid_source( player_activity &act, const vehicle &veh, c
 static void serialize_liquid_source( player_activity &act, const tripoint_bub_ms &pos,
                                      const item &liquid )
 {
-    const map_stack stack = get_map().i_at( pos );
+    map &here = get_map();
+
+    const map_stack stack = here.i_at( pos );
     // Need to store the *index* of the item on the ground, but it may be a virtual item from
     // an infinite liquid source.
     const auto iter = std::find_if( stack.begin(), stack.end(), [&]( const item & i ) {
@@ -78,7 +80,7 @@ static void serialize_liquid_source( player_activity &act, const tripoint_bub_ms
         act.values.push_back( static_cast<int>( liquid_source_type::MAP_ITEM ) );
         act.values.push_back( std::distance( stack.begin(), iter ) );
     }
-    act.coords.push_back( get_map().get_abs( pos ) );
+    act.coords.push_back( here.get_abs( pos ) );
     act.str_values.push_back( serialize( liquid ) );
 }
 

--- a/src/iexamine_actors.cpp
+++ b/src/iexamine_actors.cpp
@@ -294,9 +294,11 @@ std::unique_ptr<iexamine_actor> cardreader_examine_actor::clone() const
 
 void eoc_examine_actor::call( Character &you, const tripoint_bub_ms &examp ) const
 {
+    map &here = get_map();
+
     dialogue d( get_talker_for( you ), nullptr );
-    d.set_value( "this", get_map().furn( examp ).id().str() );
-    d.set_value( "pos", get_map().get_abs( examp ).to_string() );
+    d.set_value( "this", here.furn( examp ).id().str() );
+    d.set_value( "pos", here.get_abs( examp ).to_string() );
     for( const effect_on_condition_id &eoc : eocs ) {
         eoc->activate( d );
     }
@@ -325,6 +327,8 @@ std::unique_ptr<iexamine_actor> eoc_examine_actor::clone() const
 
 void mortar_examine_actor::call( Character &you, const tripoint_bub_ms &examp ) const
 {
+    map &here = get_map();
+
     dialogue d( get_talker_for( you ), nullptr );
 
     if( has_condition && !condition( d ) ) {
@@ -366,7 +370,7 @@ void mortar_examine_actor::call( Character &you, const tripoint_bub_ms &examp ) 
     }
 
     const int aim_range = range / 24;
-    const tripoint_abs_omt pos_omt = project_to<coords::omt>( get_map().get_abs( examp ) );
+    const tripoint_abs_omt pos_omt = project_to<coords::omt>( here.get_abs( examp ) );
     tripoint_abs_omt target = ui::omap::choose_point( "Pick a target.", pos_omt, false, aim_range );
 
     if( target == tripoint_abs_omt::invalid ) {
@@ -405,8 +409,8 @@ void mortar_examine_actor::call( Character &you, const tripoint_bub_ms &examp ) 
         loc.remove_item();
     }
 
-    d.set_value( "this", get_map().furn( examp ).id().str() );
-    d.set_value( "pos", get_map().get_abs( examp ).to_string() );
+    d.set_value( "this", here.furn( examp ).id().str() );
+    d.set_value( "pos", here.get_abs( examp ).to_string() );
     d.set_value( "target", target_abs_ms.to_string() );
     for( const effect_on_condition_id &eoc : eocs ) {
         eoc->activate( d );

--- a/src/item_pocket.cpp
+++ b/src/item_pocket.cpp
@@ -1780,7 +1780,7 @@ static void move_to_parent_pocket_recursive( map &here, const tripoint_bub_ms &p
                                         _( "<npcname>'s %s falls to the ground." ), it.display_name() );
     } else {
         // TODO: Make operation map aware.
-        add_msg_if_player_sees( get_map().get_bub( here.get_abs( pos ) ), m_bad,
+        add_msg_if_player_sees( reality_bubble().get_bub( here.get_abs( pos ) ), m_bad,
                                 _( "The %s falls to the ground." ),
                                 it.display_name() );
     }

--- a/src/item_tname.cpp
+++ b/src/item_tname.cpp
@@ -305,8 +305,8 @@ std::string location_hint( item const &it, unsigned int /* quantity */,
     if( it.has_flag( json_flag_HINT_THE_LOCATION ) && it.has_var( "spawn_location" ) ) {
         tripoint_abs_omt loc( coords::project_to<coords::omt>(
                                   it.get_var( "spawn_location", tripoint_abs_ms::zero ) ) );
-        tripoint_abs_omt player_loc( coords::project_to<coords::omt>( get_map().get_abs(
-                                         get_avatar().pos_bub() ) ) );
+        tripoint_abs_omt player_loc( coords::project_to<coords::omt>(
+                                         get_avatar().pos_abs() ) );
         int dist = rl_dist( player_loc, loc );
         if( dist < 1 ) {
             return _( " (from here)" );

--- a/src/item_tname.cpp
+++ b/src/item_tname.cpp
@@ -26,7 +26,6 @@
 #include "item_contents.h"
 #include "item_pocket.h"
 #include "itype.h"
-#include "map.h"
 #include "mutation.h"
 #include "options.h"
 #include "recipe.h"

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -3273,7 +3273,7 @@ std::optional<int> iuse::geiger( Character *p, item *it, const tripoint_bub_ms &
         }
         case 1:
             p->add_msg_if_player( m_info, _( "The ground's radiation level: %d mSv/h" ),
-                                  get_map().get_radiation( p->pos_bub() ) );
+                                  here.get_radiation( p->pos_bub() ) );
             break;
         case 2:
             p->add_msg_if_player( _( "The geiger counter's scan LED turns on." ) );
@@ -3698,7 +3698,7 @@ std::optional<int> iuse::portal( Character *p, item *it, const tripoint_bub_ms &
         return std::nullopt;
     }
     tripoint_bub_ms t( pos.x() + rng( -2, 2 ), pos.y() + rng( -2, 2 ), pos.z() );
-    get_map().trap_set( t, tr_portal );
+    here.trap_set( t, tr_portal );
     return 1;
 }
 
@@ -6458,7 +6458,7 @@ static item::extended_photo_def photo_def_for_camera_point( const tripoint_bub_m
     }
     photo_text += "\n" + overmap_desc + ".";
 
-    if( get_map().get_abs_sub().z() >= 0 && need_store_weather ) {
+    if( here.get_abs_sub().z() >= 0 && need_store_weather ) {
         photo_text += "\n\n";
         if( is_dawn( calendar::turn ) ) {
             photo_text += _( "It is <color_yellow>sunrise</color>. " );
@@ -7888,6 +7888,8 @@ std::optional<int> iuse::multicooker_tick( Character *p, item *it, const tripoin
 
 std::optional<int> iuse::weather_tool( Character *p, item *it, const tripoint_bub_ms & )
 {
+    map &here = get_map();
+
     weather_manager &weather = get_weather();
     const w_point weatherPoint = *weather.weather_precise;
 
@@ -7900,8 +7902,8 @@ std::optional<int> iuse::weather_tool( Character *p, item *it, const tripoint_bu
     }
     if( it->has_flag( flag_THERMOMETER ) ) {
         std::string temperature_str;
-        if( get_map().has_flag_ter( ter_furn_flag::TFLAG_DEEP_WATER, p->pos_bub() ) ||
-            get_map().has_flag_ter( ter_furn_flag::TFLAG_SHALLOW_WATER, p->pos_bub() ) ) {
+        if( here.has_flag_ter( ter_furn_flag::TFLAG_DEEP_WATER, p->pos_bub() ) ||
+            here.has_flag_ter( ter_furn_flag::TFLAG_SHALLOW_WATER, p->pos_bub() ) ) {
             temperature_str = print_temperature( get_weather().get_cur_weather_gen().get_water_temperature() );
         } else {
             temperature_str = print_temperature( player_local_temp );
@@ -7935,7 +7937,7 @@ std::optional<int> iuse::weather_tool( Character *p, item *it, const tripoint_bu
 
     if( it->typeId() == itype_weather_reader ) {
         int vehwindspeed = 0;
-        if( optional_vpart_position vp = get_map().veh_at( p->pos_bub() ) ) {
+        if( optional_vpart_position vp = here.veh_at( p->pos_bub() ) ) {
             vehwindspeed = std::abs( vp->vehicle().velocity / 100 ); // For mph
         }
         const oter_id &cur_om_ter = overmap_buffer.ter( p->pos_abs_omt() );

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -2362,7 +2362,7 @@ std::optional<int> manualnoise_actor::use( Character *p, item &it,
     return manualnoise_actor::use( p, it, &get_map(), pos );
 }
 
-std::optional<int> manualnoise_actor::use( Character *p, item &, map *here,
+std::optional<int> manualnoise_actor::use( Character *p, item &, map *,
         const tripoint_bub_ms & ) const
 {
     map &bubble_map = reality_bubble();

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -2237,7 +2237,7 @@ std::optional<int> fireweapon_off_actor::use( Character *p, item &it,
 }
 
 std::optional<int> fireweapon_off_actor::use( Character *p, item &it,
-        map *here, const tripoint_bub_ms & ) const
+        map *, const tripoint_bub_ms & ) const
 {
     if( !p ) {
         debugmsg( "%s called action fireweapon_off that requires character but no character is present",

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -659,8 +659,10 @@ std::optional<int> sound_iuse::use( Character *, item &,
 std::optional<int> sound_iuse::use( Character *, item &,
                                     map *here, const tripoint_bub_ms &pos ) const
 {
-    if( get_map().inbounds( here->get_abs( pos ) ) ) {
-        sounds::sound( get_map().get_bub( here->get_abs( pos ) ), sound_volume, sounds::sound_t::alarm,
+    map &bubble_map = reality_bubble();
+
+    if( bubble_map.inbounds( here->get_abs( pos ) ) ) {
+        sounds::sound( bubble_map.get_bub( here->get_abs( pos ) ), sound_volume, sounds::sound_t::alarm,
                        sound_message.translated(), true,
                        sound_id, sound_variant );
     }
@@ -751,8 +753,11 @@ std::optional<int> explosion_iuse::use( Character *p, item &it, map *here,
         explosion_handler::explosion( source, here, pos, explosion );
     }
 
-    if( draw_explosion_radius >= 0 && get_map().inbounds( here->get_abs( pos ) ) ) {
-        explosion_handler::draw_explosion( pos, draw_explosion_radius, draw_explosion_color );
+    map &bubble_map = reality_bubble();
+
+    if( draw_explosion_radius >= 0 && bubble_map.inbounds( here->get_abs( pos ) ) ) {
+        explosion_handler::draw_explosion( bubble_map.get_bub( here->get_abs( pos ) ),
+                                           draw_explosion_radius, draw_explosion_color );
     }
     if( do_flashbang ) {
         // TODO: Use map aware 'flashbang' operation when available.
@@ -1019,7 +1024,7 @@ std::optional<int> place_monster_iuse::use( Character *p, item &it,
 std::optional<int> place_monster_iuse::use( Character *p, item &it, map *here,
         const tripoint_bub_ms & ) const
 {
-    if( here != &get_map() ) { // Because of the g usage below
+    if( here != &reality_bubble() ) { // Because of the g usage below
         debugmsg( "Not supported for maps other than the reality bubble" );
         return std::nullopt;
     }
@@ -1300,7 +1305,7 @@ std::optional<int> deploy_furn_actor::use( Character *p, item &it,
         return std::nullopt;
     }
 
-    get_map().furn_set( suitable.value(), furn_type, false, false, true );
+    here->furn_set( suitable.value(), furn_type, false, false, true );
     it.spill_contents( suitable.value() );
     p->mod_moves( -to_moves<int>( 2_seconds ) );
     return 1;
@@ -1439,7 +1444,7 @@ std::unique_ptr<iuse_actor> firestarter_actor::clone() const
 firestarter_actor::start_type firestarter_actor::prep_firestarter_use( Character &p,
         map *here, tripoint_bub_ms &pos )
 {
-    if( here != &get_map() ) { // Unless 'choose_adjacent' gets map aware.
+    if( here != &reality_bubble() ) { // Unless 'choose_adjacent' gets map aware.
         debugmsg( "Usage outside reality bubble is not supported" );
         return start_type::NONE;
     }
@@ -1587,7 +1592,7 @@ ret_val<void> firestarter_actor::can_use( const Character &p, const item &it,
 
 float firestarter_actor::light_mod( map *here, const tripoint_bub_ms &pos ) const
 {
-    if( here != &get_map() ) {
+    if( here != &reality_bubble() ) {
         debugmsg( "not supported outside the reality bubble" );
         return 0.0f;
     }
@@ -2152,7 +2157,7 @@ std::optional<int> inscribe_actor::use( Character *p, item &it, const tripoint_b
 std::optional<int> inscribe_actor::use( Character *p, item &it, map *here,
                                         const tripoint_bub_ms & ) const
 {
-    if( here != &get_map() ) { // or make 'choose_adjacent' map aware.
+    if( here != &reality_bubble() ) { // or make 'choose_adjacent' map aware.
         debugmsg( "%s called action inscribe that can only be performed in the reality bubble",
                   it.typeId().str() );
         return std::nullopt;
@@ -2244,8 +2249,11 @@ std::optional<int> fireweapon_off_actor::use( Character *p, item &it,
     p->mod_moves( -moves );
     if( rng( 0, 10 ) - it.damage_level() > success_chance && !p->is_underwater() ) {
         if( noise > 0 ) {
-            if( here == &get_map() ) { // or make 'sound' map aware
-                sounds::sound( p->pos_bub( *here ), noise, sounds::sound_t::combat, success_message );
+            map &bubble_map = reality_bubble();
+
+            if( bubble_map.inbounds( p->pos_abs() ) ) {
+                sounds::sound( bubble_map.get_bub( p->pos_abs( ) ), noise, sounds::sound_t::combat,
+                               success_message );
             }
         } else {
             p->add_msg_if_player( "%s", success_message );
@@ -2357,16 +2365,12 @@ std::optional<int> manualnoise_actor::use( Character *p, item &it,
 std::optional<int> manualnoise_actor::use( Character *p, item &, map *here,
         const tripoint_bub_ms & ) const
 {
-    if( here !=
-        &get_map() ) { // or make 'sound' work outside the reality bubble, or translate position to bubble
-        debugmsg( "manualnoise action can only be performed in the reality bubble" );
-        return std::nullopt;
-    }
+    map &bubble_map = reality_bubble();
 
     // Uses the moves specified by iuse_actor's definition
     p->mod_moves( -moves );
-    if( noise > 0 ) {
-        sounds::sound( p->pos_bub( *here ), noise, sounds::sound_t::activity,
+    if( noise > 0 && bubble_map.inbounds( p->pos_abs() ) ) {
+        sounds::sound( bubble_map.get_bub( p->pos_abs( ) ), noise, sounds::sound_t::activity,
                        noise_message.empty() ? _( "Hsss" ) : noise_message.translated(), true, noise_id, noise_variant );
     }
     p->add_msg_if_player( "%s", use_message );
@@ -2482,7 +2486,9 @@ std::optional<int> musical_instrument_actor::use( Character *p, item &it,
 std::optional<int> musical_instrument_actor::use( Character *p, item &it,
         map *here, const tripoint_bub_ms & ) const
 {
-    if( here != &get_map() ) { // Or change 'sound', 'can_hear', and 'play' below
+    map &bubble_map = reality_bubble();
+
+    if( here != &bubble_map ) { // Or change 'sound', 'can_hear', and 'play' below
         debugmsg( "musical instrument used outside of the reality bubble" );
         return std::nullopt;
     }
@@ -4295,7 +4301,9 @@ std::optional<int> place_trap_actor::use( Character *p, item &it, const tripoint
 std::optional<int> place_trap_actor::use( Character *p, item &it, map *here,
         const tripoint_bub_ms & ) const
 {
-    if( here != &get_map() ) { // Or make 'choose_adjacent' and 'is_allowed' map aware.
+    map &bubble_map = reality_bubble();
+
+    if( here != &bubble_map ) { // Or make 'choose_adjacent' and 'is_allowed' map aware.
         debugmsg( "place_trap_actor::use cannot act on non reality bubble map." );
         return std::nullopt;
     }
@@ -5686,7 +5694,9 @@ std::optional<int> deploy_tent_actor::use( Character *p, item &it,
 std::optional<int> deploy_tent_actor::use( Character *p, item &it, map *here,
         const tripoint_bub_ms & ) const
 {
-    if( here != &get_map() ) { // Or make 'choose_direction' map aware.
+    map &bubble_map = reality_bubble();
+
+    if( here != &bubble_map ) { // Or make 'choose_direction' map aware.
         debugmsg( "deply_tent_actor::use can only be called from the reality bubble" );
         return std::nullopt;
     }

--- a/src/live_view.cpp
+++ b/src/live_view.cpp
@@ -39,17 +39,19 @@ void live_view::hide()
 
 void live_view::show( const tripoint &p )
 {
+    map &here = get_map();
+
     mouse_position = p;
     if( !ui ) {
         ui = std::make_unique<ui_adaptor>();
-        ui->on_screen_resize( [this]( ui_adaptor & ui ) {
+        ui->on_screen_resize( [this, &here]( ui_adaptor & ui ) {
             panel_manager &mgr = panel_manager::get_manager();
             const bool sidebar_right = get_option<std::string>( "SIDEBAR_POSITION" ) == "right";
             const int width = sidebar_right ? mgr.get_width_right() : mgr.get_width_left();
 
             const int max_height = pixel_minimap_option ? TERMY / 2 : TERMY;
             const int line_limit = max_height - 2;
-            const visibility_variables &cache = get_map().get_visibility_variables_cache();
+            const visibility_variables &cache = here.get_visibility_variables_cache();
             int line_out = START_LINE;
             // HACK: using dummy window to get the window height without refreshing.
             win = catacurses::newwin( 1, width, point::zero );
@@ -60,9 +62,9 @@ void live_view::show( const tripoint &p )
                                       point( sidebar_right ? TERMX - width : 0, 0 ) );
             ui.position_from_window( win );
         } );
-        ui->on_redraw( [this]( const ui_adaptor & ) {
+        ui->on_redraw( [this, &here]( const ui_adaptor & ) {
             werase( win );
-            const visibility_variables &cache = get_map().get_visibility_variables_cache();
+            const visibility_variables &cache = here.get_visibility_variables_cache();
             int line_out = START_LINE;
             g->pre_print_all_tile_info( tripoint_bub_ms( mouse_position ), win, line_out, getmaxy( win ) - 2,
                                         cache );

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -278,8 +278,10 @@ map::~map()
 {
     if( ( _main_requires_cleanup && !_main_cleanup_override ) ||
         ( _main_cleanup_override && *_main_cleanup_override ) ) {
-        get_map().reset_vehicles_sm_pos();
-        get_map().rebuild_vehicle_level_caches();
+        map &bubble_map = reality_bubble();
+
+        bubble_map.reset_vehicles_sm_pos();
+        bubble_map.rebuild_vehicle_level_caches();
         g->load_npcs();
     }
 }
@@ -3863,20 +3865,23 @@ void map::smash_items( const tripoint_bub_ms &p, int power, const std::string &c
     }
 
     // Let the player know that the item was damaged if they can see it.
+    map &bubble_map = reality_bubble();
+
     if( items_destroyed > 1 ) {
-        add_msg_if_player_sees( get_map().get_bub( get_abs( p ) ), m_bad,
+        add_msg_if_player_sees( bubble_map.get_bub( get_abs( p ) ), m_bad,
                                 _( "The %s destroys several items!" ), cause_message );
     } else if( items_destroyed == 1 && items_damaged == 1 ) {
-        add_msg_if_player_sees( get_map().get_bub( get_abs( p ) ), m_bad,
+        add_msg_if_player_sees( bubble_map.get_bub( get_abs( p ) ), m_bad,
                                 //~ %1$s: the cause of destruction, %2$s: destroyed item name
                                 _( "The %1$s destroys the %2$s!" ), cause_message,
                                 damaged_item_name );
     } else if( items_damaged > 1 ) {
-        add_msg_if_player_sees( get_map().get_bub( get_abs( p ) ), m_bad,
+        add_msg_if_player_sees( bubble_map.get_bub( get_abs( p ) ), m_bad,
                                 _( "The %s damages several items." ), cause_message );
     } else if( items_damaged == 1 ) {
         //~ %1$s: the cause of damage, %2$s: damaged item name
-        add_msg_if_player_sees( get_map().get_bub( get_abs( p ) ), m_bad, _( "The %1$s damages the %2$s." ),
+        add_msg_if_player_sees( bubble_map.get_bub( get_abs( p ) ), m_bad,
+                                _( "The %1$s damages the %2$s." ),
                                 cause_message,
                                 damaged_item_name );
     }
@@ -5318,8 +5323,11 @@ item &map::add_item( const tripoint_bub_ms &p, item new_item, int copies )
         // TODO: fix point types
         tripoint_abs_sm const loc( abs_sub.x() + p.x() / SEEX, abs_sub.y() + p.y() / SEEY, p.z() );
         submaps_with_active_items_dirty.insert( loc );
-        if( this != &get_map() && get_map().inbounds( loc ) ) {
-            get_map().make_active( loc );
+
+        map &bubble_map = reality_bubble();
+
+        if( this != &bubble_map && bubble_map.inbounds( loc ) ) {
+            bubble_map.make_active( loc );
         }
     }
 
@@ -5359,8 +5367,11 @@ void map::make_active( item_location &loc )
         tripoint_abs_sm const smloc( abs_sub.x() + loc.pos_bub( *this ).x() / SEEX,
                                      abs_sub.y() + loc.pos_bub( *this ).y() / SEEY, loc.pos_abs().z() );
         submaps_with_active_items_dirty.insert( smloc );
-        if( this != &get_map() && get_map().inbounds( smloc ) ) {
-            get_map().make_active( smloc );
+
+        map &bubble_map = reality_bubble();
+
+        if( this != &bubble_map && bubble_map.inbounds( smloc ) ) {
+            bubble_map.make_active( smloc );
         }
     }
 }
@@ -6268,7 +6279,7 @@ void map::remove_trap( const tripoint_bub_ms &p )
 
     trap_id tid = current_submap->get_trap( l );
     if( tid != tr_null ) {
-        if( g != nullptr && this == &get_map() ) {
+        if( g != nullptr && this == &reality_bubble() ) {
             memory_cache_dec_set_dirty( p, true );
             avatar &player_character = get_avatar();
             if( player_character.sees( *this,  p ) ) {
@@ -6529,7 +6540,7 @@ bool map::add_field( const tripoint_bub_ms &p, const field_type_id &type_id, int
 
     if( hit_player ) {
         Character &player_character = get_player_character();
-        if( g != nullptr && this == &get_map() && p == player_character.pos_bub() ) {
+        if( g != nullptr && this == &reality_bubble() && p == player_character.pos_bub() ) {
             //Hit the player with the field if it spawned on top of them.
             creature_in_field( player_character );
         }
@@ -8131,8 +8142,10 @@ void map::loadn( const point_bub_sm &grid, bool update_vehicles )
     const tripoint_abs_sm grid_sm_base = project_to<coords::sm>( grid_abs_omt );
     bool map_incomplete = false;
 
+    map &bubble_map = reality_bubble();
+
     bool const main_inbounds =
-        this != &get_map() && get_map().inbounds( project_to<coords::ms>( grid_abs_sub ) );
+        this != &bubble_map && bubble_map.inbounds( project_to<coords::ms>( grid_abs_sub ) );
 
     // It might be possible to just check the (0, 0) submap as we should never have
     // a case where only one submap is missing from an OMT level.
@@ -8872,7 +8885,7 @@ void map::spawn_monsters_submap_group( const tripoint_rel_sm &gp, mongroup &grou
             // This usage of get_map() rather than the actual map used is due to the called operation's hidden usage of
             // the reality bubble map, so the reference has to be adjusted to match that.
             monster *const placed = g->place_critter_at( make_shared_fast<monster>( tmp ),
-                                    get_map().get_bub( abs_pos ) );
+                                    reality_bubble().get_bub( abs_pos ) );
             if( placed ) {
                 placed->on_load();
             }
@@ -9460,8 +9473,10 @@ void map::build_floor_caches()
 
 static void vehicle_caching_internal( level_cache &zch, const vpart_reference &vp, vehicle *v )
 {
+    // TODO: Check if this is actually reasonable. Probably need to feed the map in.
+    // The guess is that the reality bubble should be affected, but that needs to be checked as well.
     map &here =
-        get_map(); // TODO: Check is this is actually reasonable. Probably need to feed the map in.
+        reality_bubble();
     auto &outside_cache = zch.outside_cache;
     auto &transparency_cache = zch.transparency_cache;
     auto &floor_cache = zch.floor_cache;
@@ -9492,8 +9507,10 @@ static void vehicle_caching_internal( level_cache &zch, const vpart_reference &v
 static void vehicle_caching_internal_above( level_cache &zch_above, const vpart_reference &vp,
         vehicle *v )
 {
+    // TODO: Check if this is actually reasonable. Probably need to feed the map in.
+    // The guess is that the reality bubble should be affected, but that needs to be checked as well.
     map &here =
-        get_map(); // TODO: Check is this is actually reasonable. Probably need to feed the map in.
+        reality_bubble();
     if( vp.has_feature( VPFLAG_ROOF ) || vp.has_feature( VPFLAG_OPAQUE ) ) {
         const tripoint_bub_ms part_pos = v->bub_part_pos( here, vp.part() );
         zch_above.floor_cache[part_pos.x()][part_pos.y()] = true;
@@ -9989,7 +10006,7 @@ bool map::try_fall( const tripoint_bub_ms &p, Creature *c )
         return true;
     }
 
-    if( you->has_flag( json_flag_WALL_CLING ) &&  get_map().is_wall_adjacent( p ) ) {
+    if( you->has_flag( json_flag_WALL_CLING ) &&  this->is_wall_adjacent( p ) ) {
         you->add_msg_player_or_npc( _( "You attach yourself to the nearby wall." ),
                                     _( "<npcname> clings to the wall." ) );
         return false;
@@ -10382,7 +10399,7 @@ void map::set_pathfinding_cache_dirty( const tripoint_bub_ms &p )
 
 void map::queue_main_cleanup()
 {
-    if( this != &get_map() ) {
+    if( this != &reality_bubble() ) {
         _main_requires_cleanup = true;
     }
 }
@@ -10424,7 +10441,6 @@ void map::update_pathfinding_cache( const tripoint_bub_ms &p ) const
     const ter_t &terrain = tile.get_ter_t();
     const furn_t &furniture = tile.get_furn_t();
     const field &field = tile.get_field();
-    const map &here = get_map();
     int part;
     const vehicle *veh = veh_at_internal( p, part );
 
@@ -10451,7 +10467,7 @@ void map::update_pathfinding_cache( const tripoint_bub_ms &p ) const
     }
 
     if( ( !tile.get_trap_t().is_benign() || !terrain.trap.obj().is_benign() ) &&
-        !here.has_vehicle_floor( p ) ) {
+        !this->has_vehicle_floor( p ) ) {
         cur_value |= PathfindingFlag::DangerousTrap;
     }
 
@@ -10472,7 +10488,7 @@ void map::update_pathfinding_cache( const tripoint_bub_ms &p ) const
         cur_value |= PathfindingFlag::GoesDown | PathfindingFlag::RampDown;
     }
 
-    if( terrain.has_flag( ter_furn_flag::TFLAG_SHARP ) && !here.has_vehicle_floor( p ) ) {
+    if( terrain.has_flag( ter_furn_flag::TFLAG_SHARP ) && !this->has_vehicle_floor( p ) ) {
         cur_value |= PathfindingFlag::Sharp;
     }
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -3879,8 +3879,8 @@ void map::smash_items( const tripoint_bub_ms &p, int power, const std::string &c
         add_msg_if_player_sees( bubble_map.get_bub( get_abs( p ) ), m_bad,
                                 _( "The %s damages several items." ), cause_message );
     } else if( items_damaged == 1 ) {
-        //~ %1$s: the cause of damage, %2$s: damaged item name
         add_msg_if_player_sees( bubble_map.get_bub( get_abs( p ) ), m_bad,
+                                //~ %1$s: the cause of damage, %2$s: damaged item name
                                 _( "The %1$s damages the %2$s." ),
                                 cause_message,
                                 damaged_item_name );

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -259,7 +259,7 @@ static Creature *sting_get_target( monster *z, float range = 5.0f )
 
     // Can't see/reach target, no attack
     if( !z->sees( here,  *target ) ||
-        !get_map().clear_path( z->pos_bub(), target->pos_bub(), range, 1, 100 ) ) {
+        !here.clear_path( z->pos_bub(), target->pos_bub(), range, 1, 100 ) ) {
         return nullptr;
     }
 
@@ -785,7 +785,7 @@ bool mattack::acid_barf( monster *z )
 
     z->mod_moves( -to_moves<int>( 1_seconds ) * 0.8 );
     // Make sure it happens before uncanny dodge
-    get_map().add_field( target->pos_bub(), fd_acid, 1 );
+    here.add_field( target->pos_bub(), fd_acid, 1 );
 
     bodypart_id hit = target->get_random_body_part();
     damage_instance dam_inst = damage_instance( damage_acid, rng( 5, 12 ) );
@@ -1711,13 +1711,13 @@ bool mattack::fungus( monster *z )
 
 bool mattack::fungus_corporate( monster *z )
 {
-    const map &here = get_map();
+    map &here = get_map();
 
     if( x_in_y( 1, 20 ) ) {
         sounds::sound( z->pos_bub(), 10, sounds::sound_t::speech, _( "\"Buy SpOreos™ now!\"" ) );
         if( get_player_view().sees( here, *z ) ) {
             add_msg( m_warning, _( "Delicious snacks are released from the %s!" ), z->name() );
-            get_map().add_item( z->pos_bub(), item( itype_sporeos ) );
+            here.add_item( z->pos_bub(), item( itype_sporeos ) );
         } // only spawns SpOreos if the player is near; can't have the COMMONERS stealing our product from good customers
         return true;
     } else {
@@ -4466,7 +4466,7 @@ bool mattack::kamikaze( monster *z )
             item i_explodes( act_bomb_type, calendar::turn );
             i_explodes.active = true;
             i_explodes.countdown_point = calendar::turn_zero;
-            i_explodes.process( get_map(), nullptr, z->pos_bub() );
+            i_explodes.process( here, nullptr, z->pos_bub() );
             return false;
         }
         return false;

--- a/src/mondeath.cpp
+++ b/src/mondeath.cpp
@@ -139,7 +139,7 @@ item_location mdeath::splatter( map *here, monster &z )
 
         if( z.type->size >= creature_size::medium ) {
             number_of_gibs += rng( 1, 6 );
-            if( get_map().inbounds( z.pos_abs() ) ) {
+            if( reality_bubble().inbounds( z.pos_abs() ) ) {
                 sfx::play_variant_sound( "mon_death", "zombie_gibbed", sfx::get_heard_volume( z.pos_bub() ) );
             }
         }

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -1133,7 +1133,7 @@ void monster::move()
                 rampPos += 1;
                 candidate += tripoint_rel_ms::below;
             }
-            const tripoint_abs_ms candidate_abs = get_map().get_abs( candidate );
+            const tripoint_abs_ms candidate_abs = here.get_abs( candidate );
 
             if( candidate.z() != pos.z() ) {
                 bool can_z_move = true;
@@ -1432,8 +1432,9 @@ void monster::footsteps( const tripoint_bub_ms &p )
 
 tripoint_bub_ms monster::scent_move()
 {
+    map &here = get_map();
     // TODO: Remove when scentmap is 3D
-    if( std::abs( posz() - get_map().get_abs_sub().z() ) > SCENT_MAP_Z_REACH ) {
+    if( std::abs( posz() - here.get_abs_sub().z() ) > SCENT_MAP_Z_REACH ) {
         return { -1, -1, INT_MIN };
     }
     scent_map &scents = get_scent();
@@ -1494,7 +1495,6 @@ tripoint_bub_ms monster::scent_move()
     }
 
     const bool can_bash = bash_skill() > 0;
-    map &here = get_map();
     if( !fleeing && scent_here > smell_threshold ) {
         // Smell too strong to track, wander around
         sdirection.push_back( pos_bub() );
@@ -1793,7 +1793,7 @@ bool monster::attack_at( const tripoint_bub_ms &p )
 
     // Attack last known position despite empty
     if( has_effect( effect_stumbled_into_invisible ) &&
-        get_map().has_field_at( p, field_fd_last_known ) && !sees_player &&
+        here.has_field_at( p, field_fd_last_known ) && !sees_player &&
         attitude_to( player_character ) == Attitude::HOSTILE ) {
         return attack_air( tripoint_bub_ms( p ) );
     }

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -3128,7 +3128,7 @@ void monster::die( map *here, Creature *nkiller )
     }
     if( corpse ) {
         corpse->process( *here, nullptr, corpse.pos_bub( *here ) );
-        if( get_map().inbounds( pos_abs() ) ) {
+        if( reality_bubble().inbounds( pos_abs() ) ) {
             corpse.make_active();
         }
     }
@@ -3465,7 +3465,7 @@ void monster::process_effects()
     }
 
     if( type->regenerates_in_dark && !g->is_in_sunlight( pos_bub() ) ) {
-        const float light = get_map().ambient_light_at( pos_bub() );
+        const float light = here.ambient_light_at( pos_bub() );
         // Magic number 10000 was chosen so that a floodlight prevents regeneration in a range of 20 tiles
         const float dHP = 50.0 * std::exp( - light * light / 10000 );
         if( heal( static_cast<int>( dHP ) ) > 0 && one_in( 2 ) ) {
@@ -3497,7 +3497,6 @@ void monster::process_effects()
     }
 
     if( has_flag( mon_flag_CORNERED_FIGHTER ) ) {
-        map &here = get_map();
         creature_tracker &creatures = get_creature_tracker();
         for( const tripoint_bub_ms &p : here.points_in_radius( pos_bub(), 2 ) ) {
             const monster *const mon = creatures.creature_at<monster>( p );
@@ -3536,7 +3535,7 @@ void monster::process_effects()
         add_effect( effect_nemesis_buff, 1000_turns, true );
     }
 
-    if( has_flag( mon_flag_PHOTOPHOBIC ) && get_map().ambient_light_at( pos_bub() ) >= 30.0f ) {
+    if( has_flag( mon_flag_PHOTOPHOBIC ) && here.ambient_light_at( pos_bub() ) >= 30.0f ) {
         add_msg_if_player_sees( *this, m_good, _( "The shadow withers in the light!" ), name() );
         add_effect( effect_photophobia, 5_turns, true );
     }

--- a/src/monster_oracle.cpp
+++ b/src/monster_oracle.cpp
@@ -32,8 +32,10 @@ status_t monster_oracle_t::split_possible( const std::string_view ) const
 
 status_t monster_oracle_t::items_available( const std::string_view ) const
 {
-    if( !get_map().has_flag( ter_furn_flag::TFLAG_SEALED, subject->pos_bub() ) &&
-        get_map().has_items( subject->pos_bub() ) ) {
+    map &here = get_map();
+
+    if( !here.has_flag( ter_furn_flag::TFLAG_SEALED, subject->pos_bub() ) &&
+        here.has_items( subject->pos_bub() ) ) {
         std::vector<material_id> absorb_material = subject->get_absorb_material();
         std::vector<material_id> no_absorb_material = subject->get_no_absorb_material();
 
@@ -44,7 +46,7 @@ status_t monster_oracle_t::items_available( const std::string_view ) const
         // case 2: no whitelist specified (it is approved for everything) but a blacklist specified
         if( absorb_material.empty() && !no_absorb_material.empty() ) {
             bool found = false;
-            for( item &it : get_map().i_at( subject->pos_bub() ) ) {
+            for( item &it : here.i_at( subject->pos_bub() ) ) {
                 for( const material_type *mat_type : it.made_of_types() ) {
                     if( !( std::find( no_absorb_material.begin(), no_absorb_material.end(),
                                       mat_type->id ) != no_absorb_material.end() ) ) {
@@ -61,7 +63,7 @@ status_t monster_oracle_t::items_available( const std::string_view ) const
         }
         // Case 3: there is a whitelist but no blacklist, so only allow the whitelisted ones
         if( !absorb_material.empty() && no_absorb_material.empty() ) {
-            for( item &it : get_map().i_at( subject->pos_bub() ) ) {
+            for( item &it : here.i_at( subject->pos_bub() ) ) {
                 for( const material_type *mat_type : it.made_of_types() ) {
                     if( std::find( absorb_material.begin(), absorb_material.end(),
                                    mat_type->id ) != absorb_material.end() ) {
@@ -72,7 +74,7 @@ status_t monster_oracle_t::items_available( const std::string_view ) const
         }
         // case 4: no whitelist specified (it is approved for everything) but a blacklist specified
         if( !absorb_material.empty() && !no_absorb_material.empty() ) {
-            for( item &it : get_map().i_at( subject->pos_bub() ) ) {
+            for( item &it : here.i_at( subject->pos_bub() ) ) {
                 for( const material_type *mat_type : it.made_of_types() ) {
                     if( !( std::find( no_absorb_material.begin(), no_absorb_material.end(),
                                       mat_type->id ) != no_absorb_material.end() ) ) {
@@ -92,8 +94,10 @@ status_t monster_oracle_t::items_available( const std::string_view ) const
 // TODO: Have it select a target and stash it somewhere.
 status_t monster_oracle_t::adjacent_plants( const std::string_view ) const
 {
-    for( const tripoint_bub_ms &p : get_map().points_in_radius( subject->pos_bub(), 1 ) ) {
-        if( get_map().has_flag( ter_furn_flag::TFLAG_PLANT, p ) ) {
+    map &here = get_map();
+
+    for( const tripoint_bub_ms &p : here.points_in_radius( subject->pos_bub(), 1 ) ) {
+        if( here.has_flag( ter_furn_flag::TFLAG_PLANT, p ) ) {
             return status_t::running;
         }
     }

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -567,6 +567,8 @@ void Character::recalculate_size()
 
 void Character::mutation_effect( const trait_id &mut, const bool worn_destroyed_override )
 {
+    map &here = get_map();
+
     if( mut.obj().vanity ) {
         return;
     }
@@ -597,7 +599,7 @@ void Character::mutation_effect( const trait_id &mut, const bool worn_destroyed_
                                    _( "Your %s is pushed off!" ),
                                    _( "<npcname>'s %s is pushed off!" ),
                                    armor.tname() );
-            get_map().add_item_or_charges( pos_bub(), armor );
+            here.add_item_or_charges( pos_bub(), armor );
             return true;
         }
         if( !branch.conflicts_with_item( armor ) ) {
@@ -631,7 +633,7 @@ void Character::mutation_effect( const trait_id &mut, const bool worn_destroyed_
                                    _( "Your %s is pushed off!" ),
                                    _( "<npcname>'s %s is pushed off!" ),
                                    armor.tname() );
-            get_map().add_item_or_charges( pos_bub(), armor );
+            here.add_item_or_charges( pos_bub(), armor );
         }
         return true;
     } );
@@ -817,6 +819,8 @@ void Character::activate_mutation( const trait_id &mut )
 
 void Character::activate_cached_mutation( const trait_id &mut )
 {
+    map &here = get_map();
+
     const mutation_branch &mdata = mut.obj();
     trait_data &tdata = cached_mutations[mut];
     int cost = mdata.cost;
@@ -885,7 +889,7 @@ void Character::activate_cached_mutation( const trait_id &mut )
     }
 
     if( mut == trait_WEB_WEAVER ) {
-        get_map().add_field( pos_bub(), fd_web, 1 );
+        here.add_field( pos_bub(), fd_web, 1 );
         add_msg_if_player( _( "You start spinning web with your spinnerets!" ) );
     } else if( mut == trait_LONG_TONGUE2 ||
                mut == trait_GASTROPOD_EXTREMITY2 ||
@@ -894,7 +898,7 @@ void Character::activate_cached_mutation( const trait_id &mut )
         assign_activity( ACT_PULL_CREATURE, to_moves<int>( 1_seconds ), 0, 0, mutation_name( mut ) );
         return;
     } else if( mut == trait_SNAIL_TRAIL ) {
-        get_map().add_field( pos_bub(), fd_sludge, 1 );
+        here.add_field( pos_bub(), fd_sludge, 1 );
         add_msg_if_player( _( "You start leaving a trail of sludge as you go." ) );
     } else if( mut == trait_BURROW || mut == trait_BURROWLARGE ) {
         tdata.powered = false;
@@ -943,7 +947,6 @@ void Character::activate_cached_mutation( const trait_id &mut )
             return;
         }        // Check for adjacent trees.
         bool adjacent_tree = false;
-        map &here = get_map();
         for( const tripoint_bub_ms &p2 : here.points_in_radius( pos_bub(), 1 ) ) {
             if( here.has_flag( ter_furn_flag::TFLAG_TREE, p2 ) ) {
                 adjacent_tree = true;

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -456,11 +456,11 @@ bool npc::could_move_onto( const tripoint_bub_ms &p ) const
 
 std::vector<sphere> npc::find_dangerous_explosives() const
 {
-    const map &here = get_map();
+    map &here = get_map();
 
     std::vector<sphere> result;
 
-    const auto active_items = get_map().get_active_items_in_radius( pos_bub(), MAX_VIEW_DISTANCE,
+    const auto active_items = here.get_active_items_in_radius( pos_bub(), MAX_VIEW_DISTANCE,
                               special_item_type::explosive );
 
     for( const item_location &elem : active_items ) {
@@ -1944,7 +1944,7 @@ void npc::execute_action( npc_action action )
             break;
 
         case npc_goto_to_this_pos: {
-            update_path( get_map().get_bub( *goto_to_this_pos ) );
+            update_path( here.get_bub( *goto_to_this_pos ) );
             move_to_next();
 
             if( pos_abs() == *goto_to_this_pos ) {

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -3630,8 +3630,10 @@ talk_effect_fun_t::func f_remove_var( const JsonObject &jo, std::string_view mem
 
 void map_add_item( item &it, tripoint_abs_ms target_pos )
 {
-    if( get_map().inbounds( target_pos ) ) {
-        get_map().add_item_or_charges( get_map().get_bub( target_pos ), it );
+    map &here = get_map();
+
+    if( here.inbounds( target_pos ) ) {
+        here.add_item_or_charges( here.get_bub( target_pos ), it );
     } else {
         tinymap target_bay;
         target_bay.load( project_to<coords::omt>( target_pos ), false );
@@ -4229,14 +4231,14 @@ talk_effect_fun_t::func f_location_variable( const JsonObject &jo, std::string_v
         }
         const tripoint_abs_ms abs_ms( target_pos );
         map *here_ptr = &get_map();
+        map &here = *here_ptr;
         std::unique_ptr<map> distant_map = std::make_unique<map>();
-        if( !get_map().inbounds( abs_ms ) ) {
+        if( !here.inbounds( abs_ms ) ) {
             distant_map->load( project_to<coords::sm>( abs_ms ), false );
             here_ptr = distant_map.get();
         }
-        map &here = *here_ptr;
         if( search_target.has_value() ) {
-            if( search_type.value() == "monster" && !get_map().inbounds( abs_ms ) ) {
+            if( search_type.value() == "monster" && !here.inbounds( abs_ms ) ) {
                 here.spawn_monsters( true, true );
             }
             int min_target_dist = dov_target_min_radius.evaluate( d );
@@ -4263,7 +4265,7 @@ talk_effect_fun_t::func f_location_variable( const JsonObject &jo, std::string_v
                         break;
                     }
                 } else if( search_type.value() == "field" ) {
-                    field &fields_here = get_map().field_at( search_loc );
+                    field &fields_here = here.field_at( search_loc );
                     if( fields_here.find_field( field_type_id( cur_search_target ) ) || cur_search_target.empty() ) {
                         target_pos = here.get_abs( search_loc );
                         found = true;
@@ -4436,10 +4438,11 @@ talk_effect_fun_t::func f_transform_radius( const JsonObject &jo, std::string_vi
                                     //Timed events happen before the player turn and eocs are during so we add a second here to sync them up using the same variable
                                     -1, target_pos, radius, transform.evaluate( d ), key.evaluate( d ) );
         } else {
+            map &bubble_map = reality_bubble();
             // Use the main map when possible to reduce performance overhead.
-            if( get_map().inbounds( target_pos - point{ radius, radius} ) &&
-                get_map().inbounds( target_pos + point{ radius, radius} ) ) {
-                get_map().transform_radius( ter_furn_transform_id( transform.evaluate( d ) ), radius, target_pos );
+            if( bubble_map.inbounds( target_pos - point{ radius, radius} ) &&
+                bubble_map.inbounds( target_pos + point{ radius, radius} ) ) {
+                bubble_map.transform_radius( ter_furn_transform_id( transform.evaluate( d ) ), radius, target_pos );
             } else {
                 map tm;
                 tm.load( project_to<coords::sm>( target_pos - point{ radius, radius} ), false );
@@ -4578,7 +4581,7 @@ talk_effect_fun_t::func f_query_tile( const JsonObject &jo, std::string_view mem
 
         }
         if( loc.has_value() ) {
-            tripoint_abs_ms pos_global = get_map().get_abs( *loc );
+            tripoint_abs_ms pos_global = here.get_abs( *loc );
             write_var_value( target_var.type, target_var.name, &d,
                              pos_global.to_string() );
         }
@@ -4635,6 +4638,7 @@ talk_effect_fun_t::func f_query_omt( const JsonObject &jo, std::string_view memb
 talk_effect_fun_t::func f_choose_adjacent_highlight( const JsonObject &jo, std::string_view member,
         const std::string_view src, bool is_npc )
 {
+    map &here = get_map();
 
     var_info output_var = read_var_info( jo.get_object( member ) );
 
@@ -4668,29 +4672,27 @@ talk_effect_fun_t::func f_choose_adjacent_highlight( const JsonObject &jo, std::
     read_condition( jo, "condition", cond, true );
 
     return [output_var, target_var, message, failure_message, allow_vertical, allow_autoselect, cond,
-                false_eocs, is_npc]( dialogue & d ) {
-        map &here = get_map();
-
+                false_eocs, is_npc, &here]( dialogue & d ) {
         tripoint_bub_ms target_pos;
         if( target_var.has_value() ) {
             tripoint_abs_ms abs_ms = get_tripoint_ms_from_var( target_var, d, is_npc );
-            target_pos = get_map().get_bub( abs_ms );
+            target_pos = here.get_bub( abs_ms );
         } else {
             target_pos = d.actor( is_npc )->pos_bub( here );
         }
 
-        const std::function<bool( const tripoint_bub_ms & )> f = [cond, &d](
+        const std::function<bool( const tripoint_bub_ms & )> f = [cond, &d, &here](
         const tripoint_bub_ms & pnt ) {
-            write_var_value( var_type::context, "loc", &d, get_map().get_abs( pnt ).to_string_writable() );
+            write_var_value( var_type::context, "loc", &d, here.get_abs( pnt ).to_string_writable() );
             return cond( d );
         };
 
-        std::optional<tripoint_bub_ms> picked_coord = choose_adjacent_highlight( get_map(), target_pos,
+        std::optional<tripoint_bub_ms> picked_coord = choose_adjacent_highlight( here, target_pos,
                 message.evaluate( d ), failure_message.evaluate( d ), f, allow_vertical, allow_autoselect );
 
         if( picked_coord.has_value() ) {
             write_var_value( output_var.type, output_var.name, &d,
-                             get_map().get_abs( picked_coord.value() ).to_string_writable() );
+                             here.get_abs( picked_coord.value() ).to_string_writable() );
         } else {
             run_eoc_vector( false_eocs, d );
         }
@@ -4813,7 +4815,7 @@ talk_effect_fun_t::func f_mapgen_update( const JsonObject &jo, std::string_view 
                                         d.actor( d.has_beta )->selected_mission() );
                 set_queued_points();
             }
-            get_map().invalidate_map_cache( omt_pos.z() );
+            reality_bubble().invalidate_map_cache( omt_pos.z() );
         }
     };
 }
@@ -4865,7 +4867,7 @@ talk_effect_fun_t::func f_revert_location( const JsonObject &jo, std::string_vie
             }
         }
 
-        get_map().invalidate_map_cache( omt_pos.z() );
+        reality_bubble().invalidate_map_cache( omt_pos.z() );
     };
 }
 
@@ -5941,13 +5943,15 @@ talk_effect_fun_t::func f_unset_flag( const JsonObject &jo, std::string_view mem
 talk_effect_fun_t::func f_activate( const JsonObject &jo, std::string_view member,
                                     const std::string_view, bool is_npc )
 {
+    map &here = get_map();
+
     str_or_var method = get_str_or_var( jo.get_member( member ), member, true );
     std::optional<var_info> target_var;
     if( jo.has_member( "target_var" ) ) {
         target_var = read_var_info( jo.get_object( "target_var" ) );
     }
 
-    return [is_npc, method, target_var]( dialogue & d ) {
+    return [is_npc, method, target_var, &here]( dialogue & d ) {
         Character *guy = d.actor( is_npc )->get_character();
         item_location *it = d.actor( !is_npc )->get_item();
 
@@ -5960,8 +5964,8 @@ talk_effect_fun_t::func f_activate( const JsonObject &jo, std::string_view membe
                 }
                 if( target_var.has_value() ) {
                     tripoint_abs_ms target_pos = get_tripoint_ms_from_var( target_var, d, is_npc );
-                    if( get_map().inbounds( target_pos ) ) {
-                        guy->invoke_item( it->get_item(), method_str, get_map().get_bub( target_pos ) );
+                    if( here.inbounds( target_pos ) ) {
+                        guy->invoke_item( it->get_item(), method_str, here.get_bub( target_pos ) );
                         return;
                     }
                 }
@@ -6074,7 +6078,8 @@ talk_effect_fun_t::func f_make_sound( const JsonObject &jo, std::string_view mem
         } else {
             translated_message = message.evaluate( d );
         }
-        sounds::sound( get_map().get_bub( target_pos ), volume.evaluate( d ), type, translated_message,
+        sounds::sound( reality_bubble().get_bub( target_pos ), volume.evaluate( d ), type,
+                       translated_message,
                        ambient );
     };
 }
@@ -6634,13 +6639,13 @@ talk_effect_fun_t::func f_map_run_item_eocs( const JsonObject &jo, std::string_v
         Character *guy = d.actor( is_npc )->get_character();
         guy = guy ? guy : &get_player_character();
         const auto f = [d, guy, title, center, min_radius,
-           max_radius]( const item_location_filter & filter ) {
+           max_radius, &here]( const item_location_filter & filter ) {
             inventory_filter_preset preset( filter );
             inventory_pick_selector inv_s( *guy, preset );
             inv_s.set_title( title.evaluate( d ) );
             inv_s.set_display_stats( false );
             inv_s.clear_items();
-            for( const tripoint_bub_ms &pos : get_map().points_in_radius( center, max_radius ) ) {
+            for( const tripoint_bub_ms &pos : here.points_in_radius( center, max_radius ) ) {
                 if( rl_dist( center, pos ) >= min_radius ) {
                     inv_s.add_map_items( pos );
                 }
@@ -6652,13 +6657,13 @@ talk_effect_fun_t::func f_map_run_item_eocs( const JsonObject &jo, std::string_v
             return inv_s.execute();
         };
         const item_menu_mul f_mul = [d, guy, title, center, min_radius,
-           max_radius]( const item_location_filter & filter ) {
+           max_radius, &here]( const item_location_filter & filter ) {
             inventory_filter_preset preset( filter );
             inventory_multiselector inv_s( *guy, preset );
             inv_s.set_title( title.evaluate( d ) );
             inv_s.set_display_stats( false );
             inv_s.clear_items();
-            for( const tripoint_bub_ms &pos : get_map().points_in_radius( center, max_radius ) ) {
+            for( const tripoint_bub_ms &pos : here.points_in_radius( center, max_radius ) ) {
                 if( rl_dist( center, pos ) >= min_radius ) {
                     inv_s.add_map_items( pos );
                 }
@@ -7497,6 +7502,8 @@ talk_effect_fun_t::func f_field( const JsonObject &jo, std::string_view member,
     }
     return [new_field, dov_intensity, dov_age, dov_radius, outdoor_only,
                hit_player, target_var, is_npc, indoor_only]( dialogue & d ) {
+        map &here = get_map();
+
         int radius = dov_radius.evaluate( d );
         int intensity = dov_intensity.evaluate( d );
 
@@ -7504,13 +7511,13 @@ talk_effect_fun_t::func f_field( const JsonObject &jo, std::string_view member,
         if( target_var.has_value() ) {
             target_pos = get_tripoint_ms_from_var( target_var, d, is_npc );
         }
-        for( const tripoint_bub_ms &dest : get_map().points_in_radius( get_map().get_bub( target_pos ),
+        for( const tripoint_bub_ms &dest : here.points_in_radius( here.get_bub( target_pos ),
                 radius ) ) {
-            if( ( !outdoor_only || get_map().is_outside( dest ) ) && ( !indoor_only ||
-                    !get_map().is_outside( dest ) ) ) {
-                get_map().add_field( dest, field_type_str_id( new_field.evaluate( d ) ), intensity,
-                                     dov_age.evaluate( d ),
-                                     hit_player );
+            if( ( !outdoor_only || here.is_outside( dest ) ) && ( !indoor_only ||
+                    !here.is_outside( dest ) ) ) {
+                here.add_field( dest, field_type_str_id( new_field.evaluate( d ) ), intensity,
+                                dov_age.evaluate( d ),
+                                hit_player );
             }
         }
     };
@@ -7527,12 +7534,14 @@ talk_effect_fun_t::func f_emit( const JsonObject &jo, std::string_view member,
         target_var = read_var_info( jo.get_object( "target_var" ) );
     }
     return [emit, target_var, chance_mult, is_npc ]( dialogue & d ) {
+        map &here = get_map();
+
         tripoint_abs_ms target_pos = d.actor( is_npc )->pos_abs();
         if( target_var.has_value() ) {
             target_pos = get_tripoint_ms_from_var( target_var, d, is_npc );
         }
-        tripoint_bub_ms target = get_map().get_bub( target_pos );
-        get_map().emit_field( target, emit_id( emit.evaluate( d ) ), chance_mult.evaluate( d ) );
+        tripoint_bub_ms target = here.get_bub( target_pos );
+        here.emit_field( target, emit_id( emit.evaluate( d ) ), chance_mult.evaluate( d ) );
     };
 }
 

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -1912,6 +1912,8 @@ static bool try_travel_to_destination( avatar &player_character, const tripoint_
 
 static tripoint_abs_omt display()
 {
+    map &here = get_map();
+
     overmap_draw_data_t &data = g->overmap_data;
     tripoint_abs_omt &orig = data.origin_pos;
     std::vector<tripoint_abs_omt> &display_path = data.display_path;
@@ -2066,7 +2068,7 @@ static tripoint_abs_omt display()
             curs += mouse_pos->xy().raw();
         } else if( action == "look" ) {
             tripoint_abs_ms pos = project_combine( curs, g->overmap_data.origin_remainder );
-            tripoint_bub_ms pos_rel = get_map().get_bub( pos );
+            tripoint_bub_ms pos_rel = here.get_bub( pos );
             uistate.open_menu = [pos_rel]() {
                 tripoint_bub_ms pos_cpy = pos_rel;
                 g->look_around( true, pos_cpy, pos_rel, false, false, false, false, pos_rel );
@@ -2195,7 +2197,7 @@ static tripoint_abs_omt display()
         } else if( action == "TOGGLE_EXPLORED" ) {
             overmap_buffer.toggle_explored( curs );
         } else if( action == "TOGGLE_OVERMAP_WEATHER" ) {
-            if( get_map().is_outside( get_player_character().pos_bub() ) ) {
+            if( here.is_outside( get_player_character().pos_bub() ) ) {
                 uistate.overmap_visible_weather = !uistate.overmap_visible_weather;
             }
         } else if( action == "TOGGLE_FAST_SCROLL" ) {

--- a/src/player_activity.cpp
+++ b/src/player_activity.cpp
@@ -192,8 +192,10 @@ std::optional<std::string> player_activity::get_progress_message( const avatar &
         }
 
         if( type == ACT_BUILD ) {
+            map &here = get_map();
+
             partial_con *pc =
-                get_map().partial_con_at( get_map().get_bub( u.activity.placement ) );
+                here.partial_con_at( here.get_bub( u.activity.placement ) );
             if( pc ) {
                 int counter = std::min( pc->counter, 10000000 );
                 const int percentage = counter / 100000;

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -2356,7 +2356,7 @@ static void cycle_action( item &weap, const itype_id &ammo, map *here, const tri
             }
 
             // TODO: Refine critera to handle overlapping maps.
-            if( here == &get_map() ) {
+            if( here == &reality_bubble() ) {
                 sfx::play_variant_sound( "fire_gun", "brass_eject", sfx::get_heard_volume( eject ),
                                          sfx::get_heard_angle( eject ) );
             }
@@ -3364,11 +3364,13 @@ int target_ui::dist_fn( const tripoint_bub_ms &p )
 
 void target_ui::set_last_target()
 {
+    map &here = get_map();
+
     if( !you->last_target_pos.has_value() ||
-        you->last_target_pos.value() != get_map().get_abs( dst ) ) {
+        you->last_target_pos.value() != here.get_abs( dst ) ) {
         you->aim_cache_dirty = true;
     }
-    you->last_target_pos = get_map().get_abs( dst );
+    you->last_target_pos = here.get_abs( dst );
     if( dst_critter ) {
         you->last_target = g->shared_from( *dst_critter );
     } else {

--- a/src/scent_map.cpp
+++ b/src/scent_map.cpp
@@ -141,13 +141,15 @@ scenttype_id scent_map::get_type( const tripoint_bub_ms &p ) const
 
 bool scent_map::inbounds( const tripoint_bub_ms &p ) const
 {
+    map &here = get_map();
+
     // HACK: This weird long check here is a hack around the fact that scentmap is 2D
     // A z-level can access scentmap if it is within SCENT_MAP_Z_REACH flying z-level move from player's z-level
     // That is, if a flying critter could move directly up or down (or stand still) and be on same z-level as player
-    const int levz = get_map().get_abs_sub().z();
+    const int levz = here.get_abs_sub().z();
     const bool scent_map_z_level_inbounds = ( p.z() == levz ) ||
                                             ( std::abs( p.z() - levz ) == SCENT_MAP_Z_REACH &&
-                                                    get_map().valid_move( p, tripoint_bub_ms( p.xy(), levz ), false, true ) );
+                                                    here.valid_move( p, tripoint_bub_ms( p.xy(), levz ), false, true ) );
     if( !scent_map_z_level_inbounds ) {
         return false;
     }

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -459,6 +459,8 @@ static int get_signal_for_hordes( const centroid &centr )
 
 void sounds::process_sounds()
 {
+    map &here = get_map();
+
     std::vector<centroid> sound_clusters = cluster_sounds( recent_sounds );
     const int weather_vol = get_weather().weather_id->sound_attn;
     for( const centroid &this_centroid : sound_clusters ) {
@@ -472,7 +474,7 @@ void sounds::process_sounds()
         int sig_power = get_signal_for_hordes( this_centroid );
         if( sig_power > 0 ) {
 
-            const point_abs_ms abs_ms = get_map().get_abs( source ).xy();
+            const point_abs_ms abs_ms = here.get_abs( source ).xy();
             const point_abs_sm abs_sm( coords::project_to<coords::sm>( abs_ms ) );
             const tripoint_abs_sm target( abs_sm, source.z() );
             overmap_buffer.signal_hordes( target, sig_power );
@@ -488,9 +490,9 @@ void sounds::process_sounds()
         }
         // Trigger sound-triggered traps and ensure they are still valid
         for( const trap *trapType : trap::get_sound_triggered_traps() ) {
-            for( const tripoint_bub_ms &tp : get_map().trap_locations( trapType->id ) ) {
+            for( const tripoint_bub_ms &tp : here.trap_locations( trapType->id ) ) {
                 const int dist = sound_distance( source, tp );
-                const trap &tr = get_map().tr_at( tp );
+                const trap &tr = here.tr_at( tp );
                 // Exclude traps that certainly won't hear the sound
                 if( vol * 2 > dist ) {
                     if( tr.triggered_by_sound( vol, dist ) ) {
@@ -1728,6 +1730,8 @@ void sfx::remove_hearing_loss()
 
 void sfx::do_footstep()
 {
+    map &here = get_map();
+
     if( test_mode ) {
         return;
     }
@@ -1737,7 +1741,7 @@ void sfx::do_footstep()
     if( std::chrono::duration_cast<std::chrono::milliseconds> ( sfx_time ).count() > 400 ) {
         const Character &player_character = get_player_character();
         int heard_volume = sfx::get_heard_volume( player_character.pos_bub() );
-        const auto terrain = get_map().ter( player_character.pos_bub() ).id();
+        const auto terrain = here.ter( player_character.pos_bub() ).id();
         static const std::set<ter_str_id> grass = {
             ter_t_grass,
             ter_t_shrub,
@@ -1829,7 +1833,7 @@ void sfx::do_footstep()
             start_sfx_timestamp = std::chrono::high_resolution_clock::now();
         };
 
-        auto veh_displayed_part = get_map().veh_at( player_character.pos_bub() ).part_displayed();
+        auto veh_displayed_part = here.veh_at( player_character.pos_bub() ).part_displayed();
 
         const season_type seas = season_of_year( calendar::turn );
         const std::string seas_str = season_str( seas );

--- a/src/timed_event.cpp
+++ b/src/timed_event.cpp
@@ -296,7 +296,7 @@ void timed_event::actualize()
         break;
 
         case timed_event_type::EXPLOSION: {
-            explosion_handler::explosion( player_character.as_avatar(), get_map().get_bub( map_square ),
+            explosion_handler::explosion( player_character.as_avatar(), here.get_bub( map_square ),
                                           expl_data );
         }
         break;
@@ -330,13 +330,13 @@ void timed_event::actualize()
             run_mapgen_update_func(
                 update_mapgen_id( string_id ), project_to<coords::omt>( map_point ), {}, nullptr );
             set_queued_points();
-            get_map().invalidate_map_cache( map_point.z() );
+            reality_bubble().invalidate_map_cache( map_point.z() );
             break;
 
         case timed_event_type::REVERT_SUBMAP: {
             submap *sm = MAPBUFFER.lookup_submap( map_point );
             sm->revert_submap( revert );
-            get_map().invalidate_map_cache( map_point.z() );
+            reality_bubble().invalidate_map_cache( map_point.z() );
             break;
         }
 

--- a/src/trapfunc.cpp
+++ b/src/trapfunc.cpp
@@ -169,7 +169,7 @@ bool trapfunc::glass( const tripoint_bub_ms &p, Creature *c, item * )
                         damage_instance( damage_cut, dmg ) );
     }
     sounds::sound( p, 8, sounds::sound_t::combat, _( "glass cracking!" ), false, "trap", "glass" );
-    get_map().remove_trap( p );
+    here.remove_trap( p );
     c->check_dead_state( &here );
     return true;
 }
@@ -387,7 +387,7 @@ bool trapfunc::eocs( const tripoint_bub_ms &p, Creature *critter, item * )
     }
     map &here = get_map();
     trap tr = here.tr_at( p );
-    const tripoint_abs_ms trap_location = get_map().get_abs( p );
+    const tripoint_abs_ms trap_location = here.get_abs( p );
     for( const effect_on_condition_id &eoc : tr.eocs ) {
         dialogue d( get_talker_for( critter ), nullptr );
         write_var_value( var_type::context, "trap_location", &d, trap_location.to_string() );
@@ -833,6 +833,8 @@ bool trapfunc::landmine( const tripoint_bub_ms &p, Creature *c, item * )
 
 bool trapfunc::boobytrap( const tripoint_bub_ms &p, Creature *c, item * )
 {
+    map &here = get_map();
+
     if( c != nullptr ) {
         c->add_msg_player_or_npc( m_bad, _( "You trigger a booby trap!" ),
                                   _( "<npcname> triggers a booby trap!" ) );
@@ -840,9 +842,9 @@ bool trapfunc::boobytrap( const tripoint_bub_ms &p, Creature *c, item * )
 
     item grenade( itype_grenade_act );
     grenade.active = true;
-    get_map().add_item( p, grenade );
+    here.add_item( p, grenade );
 
-    get_map().remove_trap( p );
+    here.remove_trap( p );
     return true;
 }
 
@@ -1193,7 +1195,7 @@ bool trapfunc::lava( const tripoint_bub_ms &p, Creature *c, item * )
         return false;
     }
     c->add_msg_player_or_npc( m_bad, _( "The %s burns you horribly!" ), _( "The %s burns <npcname>!" ),
-                              get_map().tername( p ) );
+                              here.tername( p ) );
     monster *z = dynamic_cast<monster *>( c );
     Character *you = dynamic_cast<Character *>( c );
     if( you != nullptr ) {

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -756,7 +756,7 @@ void vehicle::drive_to_local_target( map *here, const tripoint_abs_ms &target,
 {
     Character &player_character = get_player_character();
     if( follow_protocol && player_character.in_vehicle ) {
-        if( here == &get_map() ) { // TODO: Make sound handling map aware
+        if( here == &reality_bubble() ) { // TODO: Make sound handling map aware
             sounds::sound( pos_bub( *here ), 30, sounds::sound_t::alert,
                            string_format( _( "the %s emitting a beep and saying \"Autonomous driving protocols suspended!\"" ),
                                           name ) );
@@ -771,7 +771,7 @@ void vehicle::drive_to_local_target( map *here, const tripoint_abs_ms &target,
     bool stop = precollision_check( angle, *here, follow_protocol );
     if( stop ) {
         if( autopilot_on ) {
-            if( here == &get_map() ) { // TODO: Make sound handling map aware
+            if( here == &reality_bubble() ) { // TODO: Make sound handling map aware
                 sounds::sound( pos_bub( *here ), 30, sounds::sound_t::alert,
                                string_format( _( "the %s emitting a beep and saying \"Obstacle detected!\"" ),
                                               name ) );
@@ -958,7 +958,7 @@ void vehicle::smash( map &m, float hp_percent_loss_min, float hp_percent_loss_ma
                     // on the main game map. And assume that we run from some mapgen code if called on
                     // another instance.
                     // TODO: Make this capable of distinguishing between mapgen and non bubble active maps.
-                    if( g && &get_map() == &m ) {
+                    if( g && &reality_bubble() == &m ) {
                         handler_ptr = std::make_unique<DefaultRemovePartHandler>();
                     } else {
                         handler_ptr = std::make_unique<MapgenRemovePartHandler>( m );
@@ -1099,7 +1099,7 @@ void vehicle::backfire( map *here, const vehicle_part &vp ) const
     const std::string text = _( "a loud BANG! from the %s" ); // NOLINT(cata-text-style);
     const tripoint_bub_ms pos = bub_part_pos( *here, vp );
     const int volume = 40 + units::to_watt( part_vpower_w( *here, vp, true ) ) / 10000;
-    if( here == &get_map() ) { // TODO: Make sound handling map aware.
+    if( here == &reality_bubble() ) { // TODO: Make sound handling map aware.
         sounds::sound( pos, volume, sounds::sound_t::movement,
                        string_format( text, vp.name() ), true, "vehicle", "engine_backfire" );
     }
@@ -7590,7 +7590,7 @@ int vehicle::break_off( map &here, vehicle_part &vp, int dmg )
         }
     };
     std::unique_ptr<RemovePartHandler> handler_ptr;
-    if( g && &get_map() ==
+    if( g && &reality_bubble() ==
         &here ) { // TODO: Refine logic to determine whether it's mapgen or game play.
         handler_ptr = std::make_unique<DefaultRemovePartHandler>();
     } else {
@@ -7800,7 +7800,8 @@ int vehicle::damage_direct( map &here, vehicle_part &vp, int dmg, const damage_t
             if( !magic ) {
                 here.add_item_or_charges( vppos, part_as_item );
             }
-            if( !g || &get_map() != &here ) { // TODO: Refine logic to determine if this is mapgen or gameplay.
+            if( !g || &reality_bubble() !=
+                &here ) { // TODO: Refine logic to determine if this is mapgen or gameplay.
                 MapgenRemovePartHandler handler( here );
                 remove_part( vp, handler );
             } else {

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -954,7 +954,7 @@ void vehicle::play_chimes( map &here ) const
     }
 
     for( const vpart_reference &vp : get_enabled_parts( "CHIMES" ) ) {
-        if( &here == &get_map() ) { // TODO: Make sound handling map aware
+        if( &here == &reality_bubble() ) { // TODO: Make sound handling map aware
             sounds::sound( vp.pos_bub( here ), 40, sounds::sound_t::music,
                            _( "a simple melody blaring from the loudspeakers." ), false, "vehicle", "chimes" );
         }
@@ -989,7 +989,7 @@ void vehicle::crash_terrain_around( map &here )
             velocity = 0;
             cruise_velocity = 0;
             here.destroy( crush_target );
-            if( &here == &get_map() ) { // TODO: Make sound handling map aware
+            if( &here == &reality_bubble() ) { // TODO: Make sound handling map aware
                 sounds::sound( crush_target, 500, sounds::sound_t::combat, _( "Clanggggg!" ), false,
                                "smash_success", "hit_vehicle" );
             }
@@ -1023,7 +1023,7 @@ void vehicle::transform_terrain( map &here )
             const int speed = std::abs( velocity );
             int v_damage = rng( 3, speed );
             damage( here, vp.part_index(), v_damage, damage_bash, false );
-            if( &here == &get_map() ) { // TODO: Make sound handling map aware.
+            if( &here == &reality_bubble() ) { // TODO: Make sound handling map aware.
                 sounds::sound( start_pos, v_damage, sounds::sound_t::combat, _( "Clanggggg!" ), false,
                                "smash_success", "hit_vehicle" );
             }
@@ -1059,7 +1059,7 @@ void vehicle::operate_reaper( map &here )
                  seed_type, plant_produced, seed_produced, false ) ) {
             here.add_item_or_charges( reaper_pos, i );
         }
-        if( &here == &get_map() ) { // TODO: Make sound handling map aware.
+        if( &here == &reality_bubble() ) { // TODO: Make sound handling map aware.
             sounds::sound( reaper_pos, rng( 10, 25 ), sounds::sound_t::combat, _( "Swish" ), false, "vehicle",
                            "reaper" );
         }
@@ -1094,7 +1094,7 @@ void vehicle::operate_planter( map &here )
                 } else if( !here.has_flag( ter_furn_flag::TFLAG_PLOWABLE, loc ) ) {
                     //If it isn't plowable terrain, then it will most likely be damaged.
                     damage( here, planter_id, rng( 1, 10 ), damage_bash, false );
-                    if( &here == &get_map() ) { // TODO: Make sound handling map aware
+                    if( &here == &reality_bubble() ) { // TODO: Make sound handling map aware
                         sounds::sound( loc, rng( 10, 20 ), sounds::sound_t::combat, _( "Clink" ), false, "smash_success",
                                        "hit_vehicle" );
                     }
@@ -1126,7 +1126,7 @@ void vehicle::operate_scoop( map &here )
                 _( "Whirrrr" ), _( "Ker-chunk" ), _( "Swish" ), _( "Cugugugugug" )
             }
         };
-        if( &here == &get_map() ) { // TODO: Make sound handling map aware.
+        if( &here == &reality_bubble() ) { // TODO: Make sound handling map aware.
             sounds::sound( bub_part_pos( here, scoop ), rng( 20, 35 ), sounds::sound_t::combat,
                            random_entry_ref( sound_msgs ), false, "vehicle", "scoop" );
         }
@@ -1160,7 +1160,7 @@ void vehicle::operate_scoop( map &here )
                 //The scoop will not destroy the item, but it may damage it a bit.
                 that_item_there->inc_damage();
                 //The scoop gets a lot louder when breaking an item.
-                if( &here == &get_map() ) { // TODO: Make sound handling map aware.
+                if( &here == &reality_bubble() ) { // TODO: Make sound handling map aware.
                     sounds::sound( position, rng( 10,
                                                   that_item_there->volume() * 2 / 250_ml + 10 ),
                                    sounds::sound_t::combat, _( "BEEEThump" ), false, "vehicle", "scoop_thump" );
@@ -1184,7 +1184,7 @@ void vehicle::alarm( map &here )
 
         //if alarm found, make noise, else set alarm disabled
         if( found_alarm ) {
-            if( &here == &get_map() ) { // TODO: Make sound handling map aware.
+            if( &here == &reality_bubble() ) { // TODO: Make sound handling map aware.
                 const std::array<std::string, 4> sound_msgs = { {
                         _( "WHOOP WHOOP" ), _( "NEEeu NEEeu NEEeu" ), _( "BLEEEEEEP" ), _( "WREEP" )
                     }
@@ -1591,7 +1591,7 @@ void vehicle::use_monster_capture( int part, map */*here*/, const tripoint_bub_m
 void vehicle::use_harness( int part, map *here, const tripoint_bub_ms &pos )
 {
     if( here !=
-        &get_map() ) { // TODO: Work needed on used operations for this to be possible to remove.
+        &reality_bubble() ) { // TODO: Work needed on used operations for this to be possible to remove.
         debugmsg( "vehicle::use_harness can only be used with the reality bubble." );
         return;
     }

--- a/tests/advanced_inventory_test.cpp
+++ b/tests/advanced_inventory_test.cpp
@@ -142,7 +142,7 @@ TEST_CASE( "AIM_basic_move_items", "[items][advanced_inv]" )
         advanced_inventory_pane &spane = advinv.get_pane( src );
 
         GIVEN( "a single item on the ground" ) {
-            item &knife_combat_map = get_map().add_item_or_charges( pos, knife_combat );
+            item &knife_combat_map = here.add_item_or_charges( pos, knife_combat );
 
             recalc_panes( advinv );
             REQUIRE_FALSE( here.i_at( pos ).empty() );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
- Evaluate usages of get_map() to change them into reality_bubble() where that's what the operation looked for.
- Clean up usages of get_map into fetching get_map into a local variable and then use the variable throughout, rather than a lot of get_map calls, or a mixture of variable and calls.
- Sort out a few sound calls that sort of checked for the reality bubble into actually doing it properly.
- Fix a few bugs encountered.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
As the compiler for all usages of get_map() and then go through them, essentially doing what the purpose section said.

Bugs encountered:
- game::find_stairs didn't handle the mp !=get_map() case correctly (still using reality bubble data).
- game::find_or_make_stairs: Essentially the same.
- map::try_fall: get_map() -> this->. Using the reality bubble map for a map operation's bubble coordinate makes no sense (but it isn't visible as long as that map happens to be identical to get_map()).
- map::update_pathfinding_cache: Ditto.

I couldn't be bothered with consolidating the test code: it's still littered with get_map() calls, but I didn't find any usages of get_map() that should be reality_bubble().
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Process all of the sound on non reality bubble map cases properly. I only did a few, while the rest were just converted to checking against reality_bubble() rather than get_map().

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
I don't think the bug corrections are testable, i.e. that there are actual call chain cases where the calling map isn't the reality bubble one. Thus, I don't expect there to be any functional changes with the current code.

Load save, walk up ramp, jump into car, drive through hay bales, run over zombie corpse with inventory, run over turkeys, smash into stationary vehicle. Nothing odd seen.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

This ought to set the stage for any attempts to make get_map() return the map currently used, rather than the reality bubble (so mapgen call chains actually use the same map with its bubble coordinates throughout, rather that the tinymap/smallmap at some times and the reality bubble at others), and similarly for explosion handling.
There will probably be issues beyond coordinate ones, such as implicit assumptions that the PC is on the map, hidden within some call chains.

Any work to implement an additional reality bubble(s) for scrying/remote operation purposes would need this to have stabilized, but would also require additional infrastructure to manage more than one concurrent bubble. Transient bubbles, such as the explosion one that doesn't require any processing beyond the call creating and destroying it (like the explosion one) should work about as well the explosion one does (i.e. probably still subject to bugs).
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
