### PR TITLE
[Xedra Evolved] Vampire traits are now positive

### DIFF
--- a/data/mods/Xedra_Evolved/mutations/mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/mutations.json
@@ -99,7 +99,7 @@
     "id": "EXTEND_LIFE",
     "//": "For now life extenders such as this one grant MEND_ALL.  When the new wound system will be implemented, their function will be to always allow you to fully heal from your wounds (no scars, etc).",
     "name": { "str": "Extended Life" },
-    "points": 0,
+    "points": 10,
     "description": "You swallow the potion and feel younger already.  Though the taste lingers long past when you'd hope it would pass.",
     "valid": false,
     "flags": [ "MEND_ALL" ]
@@ -276,7 +276,7 @@
   {
     "type": "mutation",
     "id": "EYEGLEAM",
-    "points": 0,
+    "points": 2,
     "starting_trait": false,
     "purifiable": false,
     "valid": false,
@@ -290,7 +290,7 @@
   {
     "type": "mutation",
     "id": "BLOOD_FUN",
-    "points": 0,
+    "points": 2,
     "starting_trait": false,
     "purifiable": false,
     "valid": false,
@@ -300,7 +300,7 @@
   {
     "type": "mutation",
     "id": "VAMPIRIC_STRENGTH",
-    "points": 0,
+    "points": 3,
     "starting_trait": false,
     "purifiable": false,
     "valid": false,
@@ -315,7 +315,7 @@
   {
     "type": "mutation",
     "id": "VAMPIRIC_RESILIENCE",
-    "points": 0,
+    "points": 3,
     "starting_trait": false,
     "purifiable": false,
     "valid": false,
@@ -339,7 +339,7 @@
   {
     "type": "mutation",
     "id": "VAMPIRE_HEIGHTENED_SENSES",
-    "points": 0,
+    "points": 2,
     "starting_trait": false,
     "purifiable": false,
     "valid": false,
@@ -351,7 +351,7 @@
   {
     "type": "mutation",
     "id": "VAMPIRE_SILENT_MOVE",
-    "points": 0,
+    "points": 1,
     "starting_trait": false,
     "purifiable": false,
     "valid": false,
@@ -366,14 +366,14 @@
     "starting_trait": false,
     "purifiable": false,
     "valid": false,
-    "points": 0,
+    "points": 1,
     "description": "Your fingers have developed bloodsucking properties, you can now suck up blood through them.  You're not sure where the blood goes but with a thought you can use these deposits.",
     "integrated_armor": [ "integrated_bloodbank" ]
   },
   {
     "type": "mutation",
     "id": "STAMINAFORBLOOD",
-    "points": 0,
+    "points": 2,
     "starting_trait": false,
     "purifiable": false,
     "valid": false,
@@ -384,7 +384,7 @@
   {
     "type": "mutation",
     "id": "COMMUNE_NIGHT",
-    "points": 0,
+    "points": 2,
     "starting_trait": false,
     "purifiable": false,
     "valid": false,
@@ -420,7 +420,7 @@
   {
     "type": "mutation",
     "id": "COAGULANTWEAVE",
-    "points": 0,
+    "points": 3,
     "starting_trait": false,
     "purifiable": false,
     "valid": false,
@@ -434,7 +434,7 @@
   {
     "type": "mutation",
     "id": "BLOODHEAL",
-    "points": 0,
+    "points": 4,
     "starting_trait": false,
     "purifiable": false,
     "valid": false,
@@ -445,7 +445,7 @@
   {
     "type": "mutation",
     "id": "VAMPIRIC_DODGE",
-    "points": 0,
+    "points": 4,
     "starting_trait": false,
     "purifiable": false,
     "valid": false,
@@ -460,7 +460,7 @@
   {
     "type": "mutation",
     "id": "VAMPIRE_FEAR_GAZE",
-    "points": 0,
+    "points": 3,
     "starting_trait": false,
     "purifiable": false,
     "valid": false,
@@ -471,7 +471,7 @@
   {
     "type": "mutation",
     "id": "VAMPIRE_WALK_ON_WALLS",
-    "points": 0,
+    "points": 3,
     "starting_trait": false,
     "purifiable": false,
     "valid": false,
@@ -482,7 +482,7 @@
   {
     "type": "mutation",
     "id": "VAMPIRE_BEAST_CLAWS",
-    "points": 0,
+    "points": 3,
     "starting_trait": false,
     "purifiable": false,
     "valid": false,
@@ -514,7 +514,7 @@
   {
     "type": "mutation",
     "id": "VAMPIRE_SEE_HEAT",
-    "points": 0,
+    "points": 2,
     "starting_trait": false,
     "purifiable": false,
     "valid": false,
@@ -542,7 +542,7 @@
   {
     "type": "mutation",
     "id": "HYPNOTIC_GAZE",
-    "points": 0,
+    "points": 4,
     "starting_trait": false,
     "purifiable": false,
     "valid": false,
@@ -553,7 +553,7 @@
   {
     "type": "mutation",
     "id": "BLOODHASTE",
-    "points": 0,
+    "points": 5,
     "starting_trait": false,
     "purifiable": false,
     "valid": false,
@@ -567,7 +567,7 @@
   {
     "type": "mutation",
     "id": "MAGICFORBLOOD",
-    "points": 0,
+    "points": 3,
     "starting_trait": false,
     "purifiable": false,
     "valid": false,
@@ -578,7 +578,7 @@
   {
     "type": "mutation",
     "id": "VAMPIRE_COMMAND_BEAST",
-    "points": 0,
+    "points": 4,
     "starting_trait": false,
     "purifiable": false,
     "valid": false,
@@ -589,7 +589,7 @@
   {
     "type": "mutation",
     "id": "VAMPIRE_EARTH_SLUMBER",
-    "points": 0,
+    "points": 4,
     "starting_trait": false,
     "purifiable": false,
     "valid": false,
@@ -657,7 +657,7 @@
   {
     "type": "mutation",
     "id": "TRUE_VAMPIRE_POWER",
-    "points": 0,
+    "points": 6,
     "starting_trait": false,
     "purifiable": false,
     "valid": false,
@@ -667,7 +667,7 @@
   {
     "type": "mutation",
     "id": "VAMPIRE_TORPOR",
-    "points": 0,
+    "points": 5,
     "starting_trait": false,
     "purifiable": false,
     "valid": false,
@@ -678,7 +678,7 @@
   {
     "type": "mutation",
     "id": "VAMPIRE_DOMINATE",
-    "points": 0,
+    "points": 7,
     "starting_trait": false,
     "purifiable": false,
     "valid": false,
@@ -689,7 +689,7 @@
   {
     "type": "mutation",
     "id": "VAMPIRE_NO_BREATHE",
-    "points": 0,
+    "points": 6,
     "starting_trait": false,
     "purifiable": false,
     "valid": false,
@@ -702,7 +702,7 @@
   {
     "type": "mutation",
     "id": "VAMPIRE_NO_ILLNESS",
-    "points": 0,
+    "points": 6,
     "starting_trait": false,
     "purifiable": false,
     "valid": false,
@@ -715,7 +715,7 @@
     "type": "mutation",
     "id": "VAMPIRE_BAT_FORM",
     "name": { "str": "Shape of the Night Flier" },
-    "points": 0,
+    "points": 8,
     "description": "You can transform yourself into a bat and take wing on the night air.",
     "starting_trait": false,
     "purifiable": false,
@@ -764,7 +764,7 @@
     "type": "mutation",
     "id": "VAMPIRE_WOLF_FORM",
     "name": { "str": "Shape of the Pack Hunter" },
-    "points": 0,
+    "points": 6,
     "description": "You can transform yourself into a wolf and stalk your enemies.",
     "starting_trait": false,
     "purifiable": false,
@@ -818,7 +818,7 @@
     "type": "mutation",
     "id": "VAMPIRE_MIST_FORM",
     "name": { "str": "Shape of the Billowing Mists" },
-    "points": 0,
+    "points": 8,
     "description": "You can transform yourself into a cloud of mist and flee any dangers.",
     "starting_trait": false,
     "purifiable": false,
@@ -868,7 +868,7 @@
   {
     "type": "mutation",
     "id": "VAMPIRE_MASTER_MORTAL_MIND",
-    "points": 0,
+    "points": 10,
     "starting_trait": false,
     "purifiable": false,
     "valid": false,
@@ -878,7 +878,7 @@
   {
     "type": "mutation",
     "id": "VAMPIRE_DISTILLATE_INNER_BLOOD",
-    "points": 0,
+    "points": 8,
     "starting_trait": false,
     "purifiable": false,
     "valid": false,
@@ -889,7 +889,7 @@
   {
     "type": "mutation",
     "id": "VAMPIRE_SHADOW_FORM",
-    "points": 0,
+    "points": 10,
     "name": { "str": "Shape of the Shadowed Path" },
     "description": "You can shroud your body and what you are carrying with shadows, amplifying your combat ability but preventing communication and using other powers until you return to your normal form.  It also costs blood for every second you spend in that state.",
     "starting_trait": false,
@@ -933,7 +933,7 @@
   {
     "type": "mutation",
     "id": "VAMPIRE_LAST_BREATH_MIST",
-    "points": 0,
+    "points": 11,
     "starting_trait": false,
     "purifiable": false,
     "valid": false,
@@ -943,7 +943,7 @@
   {
     "type": "mutation",
     "id": "VAMPIRE_IRON_MIND",
-    "points": 0,
+    "points": 8,
     "starting_trait": false,
     "purifiable": false,
     "valid": false,
@@ -955,7 +955,7 @@
   {
     "type": "mutation",
     "id": "VAMPIRE_BLIND_THE_SUN",
-    "points": 0,
+    "points": 10,
     "starting_trait": false,
     "purifiable": false,
     "valid": false,


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Xedra Evolved] Vampire traits are now positive"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Most of them were 0 points, which meant they were neutral, which is a bit odd.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Give them point values so they show as positive.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Make all vampire traits negative because you're an inhuman monster who requires the blood of the innocent to sustain your unnatural existence.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

They now show as positive.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
