### PR TITLE
NPCs can go down stairs

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2432,7 +2432,7 @@ bool map::passable( const tripoint_bub_ms &p ) const
 
 bool map::passable_through( const tripoint_bub_ms &p ) const
 {
-    return passable( p ) && has_floor_or_support( p );
+    return passable( p ) && ( has_floor( p ) || has_floor_or_support( p ) );
 }
 
 bool map::passable_skip_fields( const tripoint_bub_ms &p ) const


### PR DESCRIPTION
#### Summary
Bugfixes "NPCs can go down stairs"

#### Purpose of change
closes #80286

#### Describe the solution
The introduction of #80186 added a bug where the NPCs will not go down stairs because the logic in `passable_through` only checks if there is a valid tile down the one that the NPC want to move. Since stairs usually don't have a solid tile below the check on `passable_through` prevents them of moving into it. So I added the additional check `has_floor` to resolve he issue.

#### Describe alternatives you've considered
- removing the `has_floor_or_support` check and only using the `has_floor` but since I been unable of reproducing #80131 I cannot check if only adding the check `has_floor` on `passable_through` is enough to prevent the previous bug .

#### Testing

- Start the a game with `Play now (Default scenario)`
- Befriend the starting NPC 
- Check if it can go down the stairs

#### Additional context
