### PR TITLE
Aftershock: Thermos & Cookers

### DIFF
--- a/data/mods/aftershock_exoplanet/items/containers.json
+++ b/data/mods/aftershock_exoplanet/items/containers.json
@@ -31,6 +31,34 @@
     "flags": [ "NO_UNLOAD", "MAG_BULKY" ]
   },
   {
+    "id": "afs_thermos",
+    "type": "GENERIC",
+    "category": "container",
+    "name": { "str": "radio thermos", "str_pl": "radio thermoses" },
+    "looks_like": "thermos",
+    "description": "A small radioactive source is used to safely(?) heat the contents of this vacuum flask.  Its not powerful enough to melt already frozen liquids.\n\n Frontier rated only.",
+    "ascii_picture": "thermos",
+    "weight": "530 g",
+    "volume": "1250 ml",
+    "longest_side": "32 cm",
+    "price": "15 USD 95 cent",
+    "price_postapoc": "1 USD",
+    "material": [ "steel" ],
+    "symbol": "I",
+    "color": "green",
+    "pocket_data": [
+      {
+        "pocket_type": "CONTAINER",
+        "rigid": true,
+        "watertight": true,
+        "max_contains_volume": "1 L",
+        "max_contains_weight": "4 kg"
+      }
+    ],
+    "insulation": 1600,
+    "flags": [ "COLLAPSE_CONTENTS" ]
+  },
+  {
     "id": "afs_mre_package",
     "copy-from": "mre_package",
     "type": "GENERIC",

--- a/data/mods/aftershock_exoplanet/items/tools.json
+++ b/data/mods/aftershock_exoplanet/items/tools.json
@@ -787,7 +787,7 @@
     "power_draw": "100 W",
     "qualities": [ [ "CONTAIN", 1 ] ],
     "tick_action": "MULTICOOKER_TICK",
-    "use_action": [ "MULTICOOKER", { "type": "link_up", "cable_length": 2, "charge_rate": "1000 W" } ],
+    "use_action": [ "MULTICOOKER", "HOTPLATE", { "type": "link_up", "cable_length": 2, "charge_rate": "1000 W" } ],
     "pocket_data": [
       {
         "pocket_type": "MAGAZINE_WELL",

--- a/data/mods/aftershock_exoplanet/npcs/Augustmoon_Salvors/augustmoon_tool_trader.json
+++ b/data/mods/aftershock_exoplanet/npcs/Augustmoon_Salvors/augustmoon_tool_trader.json
@@ -35,6 +35,8 @@
       { "group": "afs_tools_programing", "count": [ 1, 1 ] },
       { "group": "afs_tools_scavenging", "count": [ 6, 12 ] },
       { "group": "afs_tools_pocket", "count": [ 5, 10 ] },
+      { "item": "afs_thermos", "count": [ 2, 3 ] },
+      { "item": "multi_cooker", "count": [ 1, 1 ] },
       { "item": "afs_40g_plasma_civ", "count": [ 2, 5 ] },
       { "item": "afs_heavy_suit_battery_cell", "count": [ 2, 5 ] },
       { "group": "afs_tools_welding_consumable", "count": [ 6, 8 ] },


### PR DESCRIPTION
#### Summary
Mods "Aftershock: Add thermos & cookers for sale at port Augustmoon"

#### Purpose of change
Will partially solve the issues of #80331.  The nutritional value of the other liquids mentioned there is still worth an audit.

#### Describe the solution
Simple tweaks to let the multicooker heat food like a hotplate and a new super thermos for the mod. The items are guaranteed to be on sale at the station.

#### Testing
Verified functionality in game.
