### PR TITLE
Handle conflicts field when generating mod combinations for CI

### DIFF
--- a/build-scripts/get_all_mods.py
+++ b/build-scripts/get_all_mods.py
@@ -13,13 +13,16 @@ mods_this_time = []
 
 exclusions = [
     # Tuple of (mod_id, mod_id) - these two mods will be incompatible
-    ("isolation_protocol", "generic_guns")
+    # Note that mod_id is case sensitive
 ]
 
 
 def compatible_with(mod, existing_mods):
     if mod in total_conversions and total_conversions & set(existing_mods):
         return False
+    for entry in existing_mods:
+        if mod in all_mod_conflicts[entry] or entry in all_mod_conflicts[mod]:
+            return False
     for entry in exclusions:
         if entry[0] == mod and entry[1] in existing_mods:
             return False
@@ -52,6 +55,7 @@ def print_modlist(modlist, master_list):
 
 
 all_mod_dependencies = {}
+all_mod_conflicts = {}
 total_conversions = set()
 
 for info in glob.glob('data/mods/*/modinfo.json'):
@@ -61,6 +65,7 @@ for info in glob.glob('data/mods/*/modinfo.json'):
                 ("obsolete" not in e or not e["obsolete"])):
             ident = e["id"]
             all_mod_dependencies[ident] = e.get("dependencies", [])
+            all_mod_conflicts[ident] = e.get("conflicts", [])
             if e["category"] == "total_conversion":
                 total_conversions.add(ident)
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

#80465 added the `conflicts` field to modinfo, but it wasn't directly handled in `get_all_mods.py`. Instead an exclusion tuple was added for the offending mods, but didn't actually work because mod ids are case sensitive.

#### Describe the solution

- read the conflicts field and exclude those combinations
- add a note about case sensitivity for the exclusion tuples

#### Describe alternatives you've considered

- just fix mod id case
- also make mod id case insensitive

#### Testing

Ran the script a couple times to make sure GG is pushed out of the group when Isolation Protocol is already in it.

#### Additional context

