### PR TITLE
Bump basic build and release runner and compiler version

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -111,7 +111,7 @@ jobs:
             archive-success: basic-build
             dont_skip_data_only_changes: 1
             mods: --mods=magiclysm
-            title: Basic Build and Test (Clang 13, Ubuntu, Curses)
+            title: Basic Build and Test (Clang oldest supported, Ubuntu, Curses)
             ccache_limit: 4.5G
             ccache_key: linux-llvm-13
 

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -113,7 +113,7 @@ jobs:
             mods: --mods=magiclysm
             title: Basic Build and Test (Clang 13, Ubuntu, Curses)
             ccache_limit: 4.5G
-            ccache_key: linux-llvm-13-break1
+            ccache_key: linux-llvm-13
 
           - compiler: clang++
             os: macos-13

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -41,7 +41,7 @@ concurrency:
 # At the time of writing (Jan 2025), the feature matrix for the above criteria looks like this:
 # | name                                 | OS       | compiler | newest/ oldest | tiles | sound | localize | cmake | backtrace | lto | sanitize | mods |
 # | ------------------------------------ | -------- | -------- | -------------- | ----- | ----- | -------- | ----- | --------- | --- | -------- | ---- |
-# | Basic Build and Test                 | ubuntu   | clang-10 | oldest (clang) |       |       | yes      |       |           |     |          | yes  |
+# | Basic Build and Test                 | ubuntu   | clang-13 | oldest (clang) |       |       | yes      |       |           |     |          | yes  |
 # | Clang 18, Ubuntu, Tiles, ASan        | ubuntu   | clang-18 | newest (clang) | yes   |       | yes      |       | yes       |     | address  |      |
 # | GCC 9, Curses, LTO                   | ubuntu   | gcc-9    | oldest   (gcc) |       |       | yes      |       | yes       | yes |          |      |
 # | GCC 12, Ubuntu, Curses, ASan         | ubuntu   | gcc-12   | newest*  (gcc) |       |       | yes      |       |           |     | address  |      |
@@ -99,8 +99,8 @@ jobs:
       max-parallel: ${{ fromJSON(needs.matrix-variables.outputs.max_parallel) }}
       matrix:
         include:
-          - compiler: clang++-10
-            os: ubuntu-20.04
+          - compiler: clang++-13
+            os: ubuntu-22.04
             tiles: 0
             sound: 0
             cmake: 0
@@ -111,9 +111,9 @@ jobs:
             archive-success: basic-build
             dont_skip_data_only_changes: 1
             mods: --mods=magiclysm
-            title: Basic Build and Test (Clang 10, Ubuntu, Curses)
+            title: Basic Build and Test (Clang 13, Ubuntu, Curses)
             ccache_limit: 4.5G
-            ccache_key: linux-llvm-10-break1
+            ccache_key: linux-llvm-13-break1
 
           - compiler: clang++
             os: macos-13
@@ -219,7 +219,7 @@ jobs:
         CCACHE_NOCOMPRESS: true
         SKIP: >-
           ${{
-          ( github.event.pull_request.draft == true && matrix.title != 'Basic Build and Test (Clang 10, Ubuntu, Curses)' ) ||
+          ( github.event.pull_request.draft == true && matrix.title != 'Basic Build and Test (Clang 13, Ubuntu, Curses)' ) ||
           ( matrix.dont_skip_data_only_changes == 0 && needs.skip-duplicates.outputs.should_skip_code == 'true' ) ||
           ( matrix.dont_skip_data_only_changes != 0 && needs.skip-duplicates-mods.outputs.should_skip_data == 'true' )
           }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
             content: application/zip
             sound: 1
           - name: Linux Tiles x64
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             mxe: none
             android: none
             libbacktrace: 1
@@ -83,7 +83,7 @@ jobs:
             ext: tar.gz
             content: application/gzip
           - name: Linux Tiles Sounds x64
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             mxe: none
             android: none
             libbacktrace: 1
@@ -93,7 +93,7 @@ jobs:
             ext: tar.gz
             content: application/gzip
           - name: Linux Curses x64
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             mxe: none
             android: none
             libbacktrace: 1

--- a/doc/c++/COMPILER_SUPPORT.md
+++ b/doc/c++/COMPILER_SUPPORT.md
@@ -3,7 +3,7 @@
 | Compiler                                             | Oldest Version |
 | :---                                                 | ---: |
 | [GCC](https://gcc.gnu.org)                           | [9.3](https://gcc.gnu.org/onlinedocs/gcc-9.3.0/gcc/) |
-| [clang](https://clang.llvm.org)                      | [10.0](https://releases.llvm.org/10.0.0/docs/index.html) |
+| [clang](https://clang.llvm.org)                      | [13.0](https://releases.llvm.org/13.0.0/docs/index.html) |
 | [MinGW-w64](https://www.mingw-w64.org)               | [UCRT 14.2.0](https://www.mingw-w64.org/downloads/)  |
 | [Visual Studio](https://visualstudio.microsoft.com/) | [2019](COMPILING-VS-VCPKG.md) |
 | [XCode](https://developer.apple.com/xcode)           | [11.4](https://developer.apple.com/documentation/xcode-release-notes/xcode-11_4-release-notes) <br/> [macOS 10.15](https://en.wikipedia.org/wiki/MacOS_Catalina) |
@@ -22,12 +22,12 @@ automated testing[^1].
 [^1]: [GitHub Actions Runner Images](https://github.com/actions/runner-images?tab=readme-ov-file#available-images)
 
 At the time of writing:
-* Bionic is about to end general support, so we aim to support the next oldest
-  Ubuntu LTS (Focal).  Focal [defaults to g++
-  9.3](https://packages.ubuntu.com/focal/g++) and [clang
-  10](https://packages.ubuntu.com/focal/clang).
-* Debian stable is Bullseye, and [defaults to g++
-  10.2](https://packages.debian.org/bullseye/g++).
+* Focal is about to end general support, so we aim to support the next oldest
+  Ubuntu LTS (Jammy).  Jammy [defaults to g++
+  11.2](https://packages.ubuntu.com/jammy/g++) and [clang
+  14](https://packages.ubuntu.com/jammy/clang).
+* Debian stable is Bookworm, and [defaults to g++
+  12.2](https://packages.debian.org/bookworm/g++).
 * Oldest [supported Fedora](https://fedoraproject.org/wiki/Releases) is 40,
   which uses [gcc
   14.0](https://fedoraproject.org/wiki/Changes/GNUToolchainF40).


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Fixes #80436 
The oldest ubuntu runner is EOL, have to migrate to a newer one.

#### Describe the solution
Changed basic build runner image to ubuntu-22.04 since ubuntu-20.04 is being EOL.
Bumping compiler version to clang++13 as the oldest clang on that image.
Changed release builds to use Ubuntu 22.04 as well, why are we using the oldest image for release builds?
Updated compiler support doc to reflect shifting supported versions. Ubuntu and Debian versions have both changed.

#### Describe alternatives you've considered
None really, builds would break.

#### Testing
Merge and test is the test.

#### Additional context
This effectively bumps minimum clang version to 13 since we are no longer testing on it and can't really commit to keeping the build working there without testing.
We'll need to turn of the basic build branch protection to allow this to merge and keep it off until "enough" of the outstanding PRs are merged.
I think I'm going to rename the test to "Basic Build and Test (Clang oldest version, Ubuntu, Curses)" so we're not continuing to be subject to this problem.