### PR TITLE
to-hit reader, other remaining changes for item subtypes split

### DIFF
--- a/data/mods/Generic_Guns/magazines/gg_magazines_migration.json
+++ b/data/mods/Generic_Guns/magazines/gg_magazines_migration.json
@@ -182,6 +182,7 @@
       "40_speedloader6",
       "44_speedloader6",
       "454_speedloader5",
+      "454_speedloader6",
       "500_speedloader5",
       "8x40_speedloader5",
       "9mm_speedloader7",

--- a/data/mods/Generic_Guns/magazines/rifle.json
+++ b/data/mods/Generic_Guns/magazines/rifle.json
@@ -90,6 +90,7 @@
     "type": "MAGAZINE",
     "name": { "str": "rifle clip" },
     "description": "A tiny piece of grooved metal designed to allow a shooter to quickly load ten rifle rounds into a magazine.",
+    "ammo_type": [ "ammo_rifle" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "ammo_rifle": 10 } } ]
   }
 ]

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -722,6 +722,13 @@ void Item_factory::finalize_pre( itype &obj )
         obj.drop_action.get_actor_ptr()->finalize( obj.id );
     }
 
+    if( obj.book ) {
+        if( obj.ememory_size == 0_KB ) {
+            //PDF size varies wildly depending on page:image ratio
+            obj.ememory_size = 20_KB * item::pages_in_book( obj );
+        }
+    }
+
     if( obj.can_use( "MA_MANUAL" ) && obj.book && obj.book->martial_art.is_null() &&
         string_starts_with( obj.get_id().str(), "manual_" ) ) {
         // HACK: Legacy martial arts books rely on a hack whereby the name of the
@@ -3459,18 +3466,6 @@ void Item_factory::load_book( const JsonObject &jo, const std::string &src )
     }
 }
 
-void Item_factory::load_ememory_size( const JsonObject &jo, itype &def )
-{
-    if( def.book ) {
-        if( def.ememory_size == 0_KB ) {
-            //PDF size varies wildly depending on page:image ratio
-            def.ememory_size = 20_KB * item::pages_in_book( def );
-            return;
-        }
-    }
-    assign( jo, "ememory_size", def.ememory_size );
-}
-
 /**
  * Loads vitamin JSON for generic_factory
  * Format must be an array of array-pairs: [[a,b],[c,d]]
@@ -4274,7 +4269,7 @@ void Item_factory::load_basic_info( const JsonObject &jo, itype &def, const std:
     optional( jo, false, "fall_damage_reduction", def.fall_damage_reduction, 0 );
     assign( jo, "ascii_picture", def.picture_id );
     assign( jo, "repairs_with", def.repairs_with );
-    load_ememory_size( jo, def );
+    assign( jo, "ememory_size", def.ememory_size );
 
     optional( jo, def.was_loaded, "color", def.color, color_reader{} );
 

--- a/src/item_factory.h
+++ b/src/item_factory.h
@@ -344,10 +344,6 @@ class Item_factory
                         const std::string &src );
 
         /**
-        * Load ememory_size, which is automatically calculated for books
-        */
-        void load_ememory_size( const JsonObject &jo, itype &def );
-        /**
          * Load item the item slot if present in json.
          * Checks whether the json object has a member of the given name and if so, loads the item
          * slot from that object. If the member does not exists, nothing is done.

--- a/src/relic.cpp
+++ b/src/relic.cpp
@@ -366,7 +366,7 @@ void relic::load( const JsonObject &jo )
     if( jo.has_member( "charges_per_activation" ) ) {
         charge.charges_per_use = jo.get_int( "charges_per_activation", 1 );
     }
-    jo.read( "name", item_name_override );
+    jo.read( "artifact_name", item_name_override );
     moves = jo.get_int( "moves", 100 );
 }
 

--- a/src/relic.h
+++ b/src/relic.h
@@ -236,6 +236,7 @@ class relic
         void finalize();
 
         void serialize( JsonOut &jsout ) const;
+        bool was_loaded = false;
         void deserialize( const JsonObject &jobj );
 
         void add_passive_effect( const enchant_cache &ench );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Infrastructure "to-hit reader, other remaining changes for item subtypes split"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Splitting up https://github.com/CleverRaven/Cataclysm-DDA/pull/80283 as much as possible

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

The remaining non-`Item_factory` changes, including:
- to-hit reader, which will be removed once legacy to-hit is removed
- renaming the unused artifact "name" JSON field to avoid duplicates
- moving magazine functions to `finalize_pre()`
- moves my poorly-written load_ememory_size() function to `finalize_pre()` where it belongs

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Passes all tests locally (important for to-hit)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

I don't like how I reordered fields in `itype::load()` so I'm going to redo those changes to just reflect converting assign -> optional

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
