### PR TITLE
bump runner to ubuntu-22.04

### DIFF
--- a/.github/workflows/check-translation.yml
+++ b/.github/workflows/check-translation.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   check-po-printf:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: "Install dependencies"
         run: |

--- a/.github/workflows/text-changes-analyzer.yml
+++ b/.github/workflows/text-changes-analyzer.yml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   analyze-text-changes:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: "Install dependencies"
         run: |


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Partially addresses #80436 
Ubuntu 20.04 runner is EOL

#### Describe the solution
Bump these workflow to next runner version. 

#### Describe alternatives you've considered
Could probably just use latest, I don't think anything here is version sensitive. 
Could have folded this into #80524 but I think this one is much more straightforward so prefer handling it seperately.

#### Testing
No easy alternative other than merge it and see if it breaks.