### PR TITLE
[Xedra Evolved] Fix drinking blood with fangs EoC triggering twice on NPCs (+ add dhampir calories)

### DIFF
--- a/data/mods/Xedra_Evolved/mutations/vampire_trait_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/vampire_trait_eocs.json
@@ -219,7 +219,97 @@
       { "u_add_effect": "vampire_virus", "intensity": 1, "duration": "PERMANENT" }
     ]
   },
- 
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_VAMPIRE_DRINK_BLOOD_WITH_FANGS_activated",
+    "condition": {
+      "or": [
+        {
+          "u_has_any_effect": [ "stunned", "dazed", "sleep", "effect_vampire_hypnotism", "effect_vampire_blood_drinking_target" ]
+        },
+        { "test_eoc": "EOC_CONDITIONS_VAMPIRE_DRINK_BLOOD_WITH_FANGS_MOM" }
+      ]
+    },
+    "effect": [
+      {
+        "if": { "and": [ "u_is_npc", { "not": { "u_has_trait": "FAE_CREATURE" } } ] },
+        "then": [
+          { "run_eocs": "EOC_VAMPIRE_DRINK_FROM_HUMAN_IN_COMBAT", "alpha_talker": "npc", "time_in_future": 2 },
+          { "math": [ "u_vitamin('blood')", "-=", "750  + rand(450)" ] },
+          { "math": [ "u_vitamin('redcells')", "-=", "750 + rand(450)" ] },
+          { "u_add_effect": "effect_vampire_blood_drinking_target", "duration": { "math": [ "rng(3,4)" ] } },
+          { "u_add_effect": "dazed", "duration": { "math": [ "rng(3,4)" ] } },
+          { "npc_add_effect": "effect_vampire_blood_drinking", "duration": 4 },
+          { "npc_assign_activity": "ACT_VAMPIRE_DRINKING_BLOOD", "duration": "3 seconds" },
+          { "message": "You are drinking from an NPC.", "type": "debug" }
+        ],
+        "else": [
+          {
+            "if": {
+              "or": [
+                { "and": [ { "u_has_species": "HUMAN" }, { "not": { "u_has_species": "ZOMBIE" } } ] },
+                { "u_has_species": "FERAL" },
+                { "u_has_species": "RENFIELD" },
+                { "and": [ { "u_has_species": "CHANGELING" }, { "not": { "u_has_species": "ZOMBIE" } } ] },
+                { "u_has_species": "HOMULLUS" },
+                { "u_has_trait": "FAE_CREATURE" }
+              ]
+            },
+            "then": [
+              {
+                "if": { "or": [ { "u_has_species": "CHANGELING" }, { "u_has_species": "HOMULLUS" }, { "u_has_trait": "FAE_CREATURE" } ] },
+                "then": [ { "math": [ "n_vampire_just_drank_fae_blood = 1" ] } ]
+              },
+              { "run_eocs": "EOC_VAMPIRE_DRINK_FROM_HUMAN_IN_COMBAT", "alpha_talker": "npc", "time_in_future": 2 },
+              { "u_add_effect": "effect_vampire_drunk_from_in_combat", "duration": "48 hours" },
+              { "u_add_effect": "effect_vampire_blood_drinking_target", "duration": { "math": [ "rng(3,4)" ] } },
+              { "u_add_effect": "dazed", "duration": { "math": [ "rng(3,4)" ] } },
+              { "npc_add_effect": "effect_vampire_blood_drinking", "duration": 4 },
+              { "npc_assign_activity": "ACT_VAMPIRE_DRINKING_BLOOD", "duration": "3 seconds" },
+              { "message": "You are drinking from a human-type monster.", "type": "debug" }
+            ]
+          },
+          {
+            "if": {
+              "and": [
+                { "not": "u_is_npc" },
+                { "or": [ { "not": { "u_has_species": "HUMAN" } }, { "u_has_species": "ZOMBIE" } ] },
+                { "not": { "u_has_species": "FERAL" } },
+                { "not": { "u_has_species": "CHANGELING" } },
+                { "not": { "u_has_species": "RENFIELD" } },
+                { "not": { "u_has_species": "HOMULLUS" } },
+                { "not": { "u_has_trait": "FAE_CREATURE" } }
+              ]
+            },
+            "then": [
+              { "npc_message": "You get a taste of blood but stop drinking when you realize it cannot sustain you.", "type": "bad" },
+              { "message": "You are drinking from an inhuman monster.", "type": "debug" },
+              {
+                "if": {
+                  "or": [
+                    { "u_has_species": "MIGO" },
+                    { "u_has_species": "ZOMBIE" },
+                    { "u_has_species": "HORROR" },
+                    { "u_has_species": "INSECT" },
+                    { "u_has_species": "INSECT_FLYING" },
+                    { "u_has_species": "CENTIPEDE" },
+                    { "u_has_species": "SPIDER" },
+                    { "u_has_species": "MOLLUSK" },
+                    { "u_has_species": "WORM" }
+                  ]
+                },
+                "then": [
+                  { "npc_message": "…and it tastes absolutely disgusting!", "type": "bad" },
+                  { "math": [ "n_vitamin('bad_food')", "+=", "rng(10,15)" ] }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "false_effect": [ { "npc_message": "You can only drink blood from an incapacitated or sleeping target.", "type": "bad" } ]
+  },
   {
     "type": "effect_on_condition",
     "id": "EOC_VAMPIRE_DRINK_FROM_HUMAN_IN_COMBAT",

--- a/data/mods/Xedra_Evolved/mutations/vampire_trait_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/vampire_trait_eocs.json
@@ -87,6 +87,16 @@
   },
   {
     "type": "effect_on_condition",
+    "id": "EOC_DHAMPIR_GAIN_CALORIES_FROM_NON_BAGGED_BLOOD",
+    "condition": { "u_has_trait": "DHAMPIR_TRAIT" },
+    "effect": [
+      { "math": [ "_temp_val = 300 + rand(150)" ] },
+      { "math": [ "u_calories('dont_affect_weariness': true)", "+=", "_temp_val" ] },
+      { "u_message": "You are gaining <context_val:temp_val> calories from the blood you drank.", "type": "debug" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
     "id": "EOC_VAMPIRE_BLOOD_DRINKING_DIRECTLY",
     "eoc_type": "EVENT",
     "required_event": "character_eats_item",
@@ -222,7 +232,7 @@
     },
     "effect": [
       {
-        "if": "u_is_npc",
+        "if": { "and": [ "u_is_npc", { "not": { "u_has_trait": "FAE_CREATURE" } } ] },
         "then": [
           { "run_eocs": "EOC_VAMPIRE_DRINK_FROM_HUMAN_IN_COMBAT", "alpha_talker": "npc", "time_in_future": 2 },
           { "math": [ "u_vitamin('blood')", "-=", "750  + rand(450)" ] },
@@ -230,64 +240,69 @@
           { "u_add_effect": "effect_vampire_blood_drinking_target", "duration": { "math": [ "rng(3,4)" ] } },
           { "u_add_effect": "dazed", "duration": { "math": [ "rng(3,4)" ] } },
           { "npc_add_effect": "effect_vampire_blood_drinking", "duration": 4 },
-          { "npc_assign_activity": "ACT_VAMPIRE_DRINKING_BLOOD", "duration": "3 seconds" }
-        ]
-      },
-      {
-        "if": {
-          "or": [
-            { "and": [ { "u_has_species": "HUMAN" }, { "not": { "u_has_species": "ZOMBIE" } } ] },
-            { "u_has_species": "FERAL" },
-            { "u_has_species": "RENFIELD" },
-            { "and": [ { "u_has_species": "CHANGELING" }, { "not": { "u_has_species": "ZOMBIE" } } ] },
-            { "u_has_species": "HOMULLUS" },
-            { "u_has_trait": "FAE_CREATURE" }
-          ]
-        },
-        "then": [
-          {
-            "if": { "or": [ { "u_has_species": "CHANGELING" }, { "u_has_species": "HOMULLUS" }, { "u_has_trait": "FAE_CREATURE" } ] },
-            "then": [ { "math": [ "n_vampire_just_drank_fae_blood = 1" ] } ]
-          },
-          { "run_eocs": "EOC_VAMPIRE_DRINK_FROM_HUMAN_IN_COMBAT", "alpha_talker": "npc", "time_in_future": 2 },
-          { "u_add_effect": "effect_vampire_drunk_from_in_combat", "duration": "48 hours" },
-          { "u_add_effect": "effect_vampire_blood_drinking_target", "duration": { "math": [ "rng(3,4)" ] } },
-          { "u_add_effect": "dazed", "duration": { "math": [ "rng(3,4)" ] } },
-          { "npc_add_effect": "effect_vampire_blood_drinking", "duration": 4 },
-          { "npc_assign_activity": "ACT_VAMPIRE_DRINKING_BLOOD", "duration": "3 seconds" }
-        ]
-      },
-      {
-        "if": {
-          "and": [
-            { "not": "u_is_npc" },
-            { "or": [ { "not": { "u_has_species": "HUMAN" } }, { "u_has_species": "ZOMBIE" } ] },
-            { "not": { "u_has_species": "FERAL" } },
-            { "not": { "u_has_species": "CHANGELING" } },
-            { "not": { "u_has_species": "RENFIELD" } },
-            { "not": { "u_has_species": "HOMULLUS" } },
-            { "not": { "u_has_trait": "FAE_CREATURE" } }
-          ]
-        },
-        "then": [
-          { "npc_message": "You get a taste of blood but stop drinking when you realize it cannot sustain you.", "type": "bad" },
+          { "npc_assign_activity": "ACT_VAMPIRE_DRINKING_BLOOD", "duration": "3 seconds" },
+          { "message": "You are drinking from an NPC.", "type": "debug" }
+        ],
+        "else": [
           {
             "if": {
               "or": [
-                { "u_has_species": "MIGO" },
-                { "u_has_species": "ZOMBIE" },
-                { "u_has_species": "HORROR" },
-                { "u_has_species": "INSECT" },
-                { "u_has_species": "INSECT_FLYING" },
-                { "u_has_species": "CENTIPEDE" },
-                { "u_has_species": "SPIDER" },
-                { "u_has_species": "MOLLUSK" },
-                { "u_has_species": "WORM" }
+                { "and": [ { "u_has_species": "HUMAN" }, { "not": { "u_has_species": "ZOMBIE" } } ] },
+                { "u_has_species": "FERAL" },
+                { "u_has_species": "RENFIELD" },
+                { "and": [ { "u_has_species": "CHANGELING" }, { "not": { "u_has_species": "ZOMBIE" } } ] },
+                { "u_has_species": "HOMULLUS" },
+                { "u_has_trait": "FAE_CREATURE" }
               ]
             },
             "then": [
-              { "npc_message": "…and it tastes absolutely disgusting!", "type": "bad" },
-              { "math": [ "n_vitamin('bad_food')", "+=", "rng(10,15)" ] }
+              {
+                "if": { "or": [ { "u_has_species": "CHANGELING" }, { "u_has_species": "HOMULLUS" }, { "u_has_trait": "FAE_CREATURE" } ] },
+                "then": [ { "math": [ "n_vampire_just_drank_fae_blood = 1" ] } ]
+              },
+              { "run_eocs": "EOC_VAMPIRE_DRINK_FROM_HUMAN_IN_COMBAT", "alpha_talker": "npc", "time_in_future": 2 },
+              { "u_add_effect": "effect_vampire_drunk_from_in_combat", "duration": "48 hours" },
+              { "u_add_effect": "effect_vampire_blood_drinking_target", "duration": { "math": [ "rng(3,4)" ] } },
+              { "u_add_effect": "dazed", "duration": { "math": [ "rng(3,4)" ] } },
+              { "npc_add_effect": "effect_vampire_blood_drinking", "duration": 4 },
+              { "npc_assign_activity": "ACT_VAMPIRE_DRINKING_BLOOD", "duration": "3 seconds" },
+              { "message": "You are drinking from a human-type monster.", "type": "debug" }
+            ]
+          },
+          {
+            "if": {
+              "and": [
+                { "not": "u_is_npc" },
+                { "or": [ { "not": { "u_has_species": "HUMAN" } }, { "u_has_species": "ZOMBIE" } ] },
+                { "not": { "u_has_species": "FERAL" } },
+                { "not": { "u_has_species": "CHANGELING" } },
+                { "not": { "u_has_species": "RENFIELD" } },
+                { "not": { "u_has_species": "HOMULLUS" } },
+                { "not": { "u_has_trait": "FAE_CREATURE" } }
+              ]
+            },
+            "then": [
+              { "npc_message": "You get a taste of blood but stop drinking when you realize it cannot sustain you.", "type": "bad" },
+              { "message": "You are drinking from an inhuman monster.", "type": "debug" },
+              {
+                "if": {
+                  "or": [
+                    { "u_has_species": "MIGO" },
+                    { "u_has_species": "ZOMBIE" },
+                    { "u_has_species": "HORROR" },
+                    { "u_has_species": "INSECT" },
+                    { "u_has_species": "INSECT_FLYING" },
+                    { "u_has_species": "CENTIPEDE" },
+                    { "u_has_species": "SPIDER" },
+                    { "u_has_species": "MOLLUSK" },
+                    { "u_has_species": "WORM" }
+                  ]
+                },
+                "then": [
+                  { "npc_message": "…and it tastes absolutely disgusting!", "type": "bad" },
+                  { "math": [ "n_vitamin('bad_food')", "+=", "rng(10,15)" ] }
+                ]
+              }
             ]
           }
         ]
@@ -299,7 +314,7 @@
     "type": "effect_on_condition",
     "id": "EOC_VAMPIRE_DRINK_FROM_HUMAN_IN_COMBAT",
     "condition": { "u_has_effect": "effect_vampire_blood_drinking" },
-    "effect": [ { "run_eocs": "EOC_VAMPIRE_GAIN_BLOOD_VITAMIN" } ]
+    "effect": [ { "run_eocs": [ "EOC_VAMPIRE_GAIN_BLOOD_VITAMIN", "EOC_DHAMPIR_GAIN_CALORIES_FROM_NON_BAGGED_BLOOD" ] } ]
   },
   {
     "id": "EOC_VAMPIRE_DRINK_BLOOD_INTERRUPTED_CHECK",

--- a/data/mods/Xedra_Evolved/mutations/vampire_trait_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/vampire_trait_eocs.json
@@ -273,7 +273,9 @@
                 "if": {
                   "and": [
                     { "not": "u_is_npc" },
-                    { "or": [ { "not": { "u_has_species": "HUMAN" } }, { "u_has_species": "ZOMBIE" } ] },
+                    {
+                      "or": [ { "not": { "u_has_species": "HUMAN" } }, { "u_has_species": "ZOMBIE" }, { "u_has_species": "VAMPIRE" } ]
+                    },
                     { "not": { "u_has_species": "FERAL" } },
                     { "not": { "u_has_species": "CHANGELING" } },
                     { "not": { "u_has_species": "RENFIELD" } },

--- a/data/mods/Xedra_Evolved/mutations/vampire_trait_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/vampire_trait_eocs.json
@@ -267,40 +267,49 @@
               { "npc_add_effect": "effect_vampire_blood_drinking", "duration": 4 },
               { "npc_assign_activity": "ACT_VAMPIRE_DRINKING_BLOOD", "duration": "3 seconds" },
               { "message": "You are drinking from a human-type monster.", "type": "debug" }
-            ]
-          },
-          {
-            "if": {
-              "and": [
-                { "not": "u_is_npc" },
-                { "or": [ { "not": { "u_has_species": "HUMAN" } }, { "u_has_species": "ZOMBIE" } ] },
-                { "not": { "u_has_species": "FERAL" } },
-                { "not": { "u_has_species": "CHANGELING" } },
-                { "not": { "u_has_species": "RENFIELD" } },
-                { "not": { "u_has_species": "HOMULLUS" } },
-                { "not": { "u_has_trait": "FAE_CREATURE" } }
-              ]
-            },
-            "then": [
-              { "npc_message": "You get a taste of blood but stop drinking when you realize it cannot sustain you.", "type": "bad" },
-              { "message": "You are drinking from an inhuman monster.", "type": "debug" },
+            ],
+            "else": [
               {
                 "if": {
-                  "or": [
-                    { "u_has_species": "MIGO" },
-                    { "u_has_species": "ZOMBIE" },
-                    { "u_has_species": "HORROR" },
-                    { "u_has_species": "INSECT" },
-                    { "u_has_species": "INSECT_FLYING" },
-                    { "u_has_species": "CENTIPEDE" },
-                    { "u_has_species": "SPIDER" },
-                    { "u_has_species": "MOLLUSK" },
-                    { "u_has_species": "WORM" }
+                  "and": [
+                    { "not": "u_is_npc" },
+                    { "or": [ { "not": { "u_has_species": "HUMAN" } }, { "u_has_species": "ZOMBIE" } ] },
+                    { "not": { "u_has_species": "FERAL" } },
+                    { "not": { "u_has_species": "CHANGELING" } },
+                    { "not": { "u_has_species": "RENFIELD" } },
+                    { "not": { "u_has_species": "HOMULLUS" } },
+                    { "not": { "u_has_trait": "FAE_CREATURE" } }
                   ]
                 },
                 "then": [
-                  { "npc_message": "…and it tastes absolutely disgusting!", "type": "bad" },
-                  { "math": [ "n_vitamin('bad_food')", "+=", "rng(10,15)" ] }
+                  {
+                    "if": { "u_has_species": "VAMPIRE" },
+                    "then": {
+                      "npc_message": "The vampire's blood refuses to leave its veins, no matter how hard you try to drain it.",
+                      "type": "bad"
+                    },
+                    "else": { "npc_message": "You get a taste of blood but stop drinking when you realize it cannot sustain you.", "type": "bad" }
+                  },
+                  { "message": "You are drinking from an inhuman monster.", "type": "debug" },
+                  {
+                    "if": {
+                      "or": [
+                        { "u_has_species": "MIGO" },
+                        { "u_has_species": "ZOMBIE" },
+                        { "u_has_species": "HORROR" },
+                        { "u_has_species": "INSECT" },
+                        { "u_has_species": "INSECT_FLYING" },
+                        { "u_has_species": "CENTIPEDE" },
+                        { "u_has_species": "SPIDER" },
+                        { "u_has_species": "MOLLUSK" },
+                        { "u_has_species": "WORM" }
+                      ]
+                    },
+                    "then": [
+                      { "npc_message": "…and it tastes absolutely disgusting!", "type": "bad" },
+                      { "math": [ "n_vitamin('bad_food')", "+=", "rng(10,15)" ] }
+                    ]
+                  }
                 ]
               }
             ]

--- a/data/mods/Xedra_Evolved/npc/vampire_askblood.json
+++ b/data/mods/Xedra_Evolved/npc/vampire_askblood.json
@@ -216,7 +216,7 @@
         "if": "has_beta",
         "then": { "if": { "npc_has_trait": "FAE_CREATURE" }, "then": { "math": [ "u_vampire_just_drank_fae_blood = 1" ] } }
       },
-      { "run_eocs": "EOC_VAMPIRE_GAIN_BLOOD_VITAMIN" }
+      { "run_eocs": [ "EOC_VAMPIRE_GAIN_BLOOD_VITAMIN", "EOC_DHAMPIR_GAIN_CALORIES_FROM_NON_BAGGED_BLOOD" ] }
     ]
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "[Xedra Evolved] Fix drinking blood with fangs EoC triggering twice on NPCs (+ add dhampir calories)"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Testing something and noticed that drinking from an NPC was getting twice as much blood as intended, so I reworked the EoC so this won't happen again.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add the rest of the `EOC_VAMPIRE_DRINK_BLOOD_WITH_FANGS_activated` EoC as an `else` after the NPC check so it doesn't fire twice. 

Add in the calories for drinking blood directly for dhampirs (the original reason I made this PR)

Add some debug messages to the EoCs.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

EoC now only fires once, blood and calories only granted once.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
