### PR TITLE
[MSC] My sweet mutation overlay fix

### DIFF
--- a/data/mods/My_Sweet_Cataclysm/sweet_mutations.json
+++ b/data/mods/My_Sweet_Cataclysm/sweet_mutations.json
@@ -64,5 +64,9 @@
       }
     ],
     "flags": [ "NO_THIRST", "NO_DISEASE", "NO_RADIATION", "BLEED_IMMUNE", "INFECTION_IMMUNE" ]
+  },
+  {
+    "type": "overlay_order",
+    "overlay_ordering": [ { "id": [ "SUGAR" ], "order": 1500 } ]
   }
 ]


### PR DESCRIPTION


#### Summary
None

#### Purpose of change
I noticed MSC's Made of Sugar trait sprite looks wrong, so i give it its own overlay_order.

#### Describe the solution

give the trait their own overlay_order.

#### Describe alternatives you've considered

Not doing so

#### Testing
Tileset used: MSXotto+

Before
![Screenshot_20250411_073108](https://github.com/user-attachments/assets/1c28f38f-3395-43f9-bff5-daa54919fabc)

After
![Screenshot_20250411_072051](https://github.com/user-attachments/assets/c3c53943-9a97-471f-bbb1-078be4d702fb)

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
