### PR TITLE
adjusted splattering

### DIFF
--- a/data/mods/TEST_DATA/pulping_test.json
+++ b/data/mods/TEST_DATA/pulping_test.json
@@ -630,7 +630,7 @@
       },
       {
         "name": "058: fresh character with a pocket knife vs skeletal zombie",
-        "pulp_time": 742,
+        "pulp_time": 743,
         "items": [ "knife_folding" ],
         "corpse": "mon_skeleton"
       },
@@ -642,13 +642,13 @@
       },
       {
         "name": "060: fresh character with pipe mace and pocket knife vs skeletal zombie",
-        "pulp_time": 504,
+        "pulp_time": 505,
         "items": [ "mace_pipe", "knife_folding" ],
         "corpse": "mon_skeleton"
       },
       {
         "name": "061: moderate character with a pipe mace vs skeletal zombie",
-        "pulp_time": 419,
+        "pulp_time": 420,
         "skills": [
           { "skill": "swimming", "level": 2 },
           { "skill": "survival", "level": 2 },
@@ -660,7 +660,7 @@
       },
       {
         "name": "062: moderate character with pipe mace and folding knife vs skeletal zombie",
-        "pulp_time": 357,
+        "pulp_time": 356,
         "skills": [
           { "skill": "swimming", "level": 2 },
           { "skill": "survival", "level": 2 },
@@ -672,7 +672,7 @@
       },
       {
         "name": "063: moderate character with folding knife and a pipe mace vs skeletal zombie with all weakpoints learned",
-        "pulp_time": 214,
+        "pulp_time": 213,
         "skills": [
           { "skill": "swimming", "level": 2 },
           { "skill": "survival", "level": 2 },
@@ -685,7 +685,7 @@
       },
       {
         "name": "064: moderate character with National Guard bayonet vs skeletal zombie",
-        "pulp_time": 418,
+        "pulp_time": 417,
         "skills": [
           { "skill": "swimming", "level": 2 },
           { "skill": "survival", "level": 2 },
@@ -709,7 +709,7 @@
       },
       {
         "name": "066: moderate character with fire axe vs skeletal zombie with all weakpoints learned",
-        "pulp_time": 78,
+        "pulp_time": 79,
         "skills": [
           { "skill": "swimming", "level": 2 },
           { "skill": "survival", "level": 2 },
@@ -722,7 +722,7 @@
       },
       {
         "name": "067: experienced character with National Guard bayonet vs skeletal zombie",
-        "pulp_time": 232,
+        "pulp_time": 233,
         "skills": [
           { "skill": "swimming", "level": 5 },
           { "skill": "survival", "level": 5 },
@@ -746,7 +746,7 @@
       },
       {
         "name": "069: experienced character with National Guard bayonet and mace vs skeletal zombie with all weakpoints learned",
-        "pulp_time": 56,
+        "pulp_time": 57,
         "skills": [
           { "skill": "swimming", "level": 5 },
           { "skill": "survival", "level": 5 },
@@ -785,7 +785,7 @@
       },
       {
         "name": "072: fresh character with a pocket knife vs skeletal juggernaut",
-        "pulp_time": 40468,
+        "pulp_time": 40467,
         "items": [ "knife_folding" ],
         "corpse": "mon_skeleton_hulk"
       },
@@ -815,7 +815,7 @@
       },
       {
         "name": "076: moderate character with pipe mace and folding knife vs skeletal juggernaut",
-        "pulp_time": 19434,
+        "pulp_time": 19435,
         "skills": [
           { "skill": "swimming", "level": 2 },
           { "skill": "survival", "level": 2 },
@@ -827,7 +827,7 @@
       },
       {
         "name": "077: moderate character with folding knife and a pipe mace vs skeletal juggernaut with all weakpoints learned",
-        "pulp_time": 11660,
+        "pulp_time": 11661,
         "skills": [
           { "skill": "swimming", "level": 2 },
           { "skill": "survival", "level": 2 },
@@ -864,7 +864,7 @@
       },
       {
         "name": "080: moderate character with fire axe vs skeletal juggernaut with all weakpoints learned",
-        "pulp_time": 4323,
+        "pulp_time": 4324,
         "skills": [
           { "skill": "swimming", "level": 2 },
           { "skill": "survival", "level": 2 },
@@ -877,7 +877,7 @@
       },
       {
         "name": "081: experienced character with National Guard bayonet vs skeletal juggernaut",
-        "pulp_time": 12761,
+        "pulp_time": 12762,
         "skills": [
           { "skill": "swimming", "level": 5 },
           { "skill": "survival", "level": 5 },

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -8560,9 +8560,8 @@ bool pulp_activity_actor::punch_corpse_once( item &corpse, Character &you,
         corpse.set_flag( flag_PULPED );
     }
 
-    const float corpse_volume = units::to_liter( corpse_mtype->volume );
-
-    if( one_in( corpse_volume / pd.pulp_power ) ) {
+    // Magic number to adjust splatter density to subjective balance.
+    if( one_in( 15000 / pd.pulp_power ) ) {
         // Splatter some blood around
         // Splatter a bit more randomly, so that it looks cooler
         const int radius = pd.mess_radius + x_in_y( pd.pulp_power, 500 ) + x_in_y( pd.pulp_power, 1000 );
@@ -8700,6 +8699,7 @@ void pulp_activity_actor::serialize( JsonOut &jsout ) const
 
     jsout.member( "num_corpses", num_corpses );
     jsout.member( "placement", placement );
+    jsout.member( "nominal_pulp_power", pd.nominal_pulp_power );
     jsout.member( "pulp_power", pd.pulp_power );
     jsout.member( "pulp_effort", pd.pulp_effort );
     jsout.member( "mess_radius", pd.mess_radius );
@@ -8730,6 +8730,10 @@ std::unique_ptr<activity_actor> pulp_activity_actor::deserialize( JsonValue &jsi
     data.read( "num_corpses", actor.num_corpses );
     data.read( "placement", actor.placement );
     data.read( "pulp_power", actor.pd.pulp_power );
+    // Backward compatibility introduced 2025-04-09
+    if( !data.read( "nominal_pulp_power", actor.pd.nominal_pulp_power ) ) {
+        actor.pd.nominal_pulp_power = actor.pd.pulp_power;
+    }
     data.read( "pulp_effort", actor.pd.pulp_effort );
     data.read( "mess_radius", actor.pd.mess_radius );
     data.read( "unpulped_corpses_qty", actor.unpulped_corpses_qty );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -14445,9 +14445,9 @@ pulp_data game::calculate_character_ability_to_pulp( const Character &you )
             you.get_skill_level( skill_survival ),
             you.get_skill_level( skill_firstaid ) ) );
 
-    pd.pulp_power = bash_factor * skill_factor * ( pd.can_cut_precisely ? 1 : 0.85 );
+    pd.nominal_pulp_power = bash_factor * skill_factor * ( pd.can_cut_precisely ? 1 : 0.85 );
 
-    add_msg_debug( debugmode::DF_ACTIVITY, "final pulp_power: %s", pd.pulp_power );
+    add_msg_debug( debugmode::DF_ACTIVITY, "final pulp_power: %s", pd.nominal_pulp_power );
 
     // since we are trying to depict pulping as more involved than you Isaac Clarke the corpse 100% of time,
     // we would assume there is some time between attacks, where you try to reach some sweet spot,
@@ -14481,11 +14481,22 @@ pulp_data game::calculate_pulpability( const Character &you, const mtype &corpse
 
     float corpse_volume = units::to_liter( corpse_mtype.volume );
     // in seconds
-    int time_to_pulp = ( std::pow( corpse_volume, pow_factor ) * 1000 ) / pd.pulp_power;
-
+    int time_to_pulp = ( std::pow( corpse_volume, pow_factor ) * 1000 ) / pd.nominal_pulp_power;
     // in seconds also
     // 30 seconds for human body volume of 62.5L, scale from this
     int min_time_to_pulp = 30 * corpse_volume / 62.5;
+
+    // you have a hard time pulling armor to reach important parts of this monster
+    if( corpse_mtype.has_flag( mon_flag_PULP_PRYING ) ) {
+        if( pd.can_pry_armor ) {
+            time_to_pulp *= 1.25;
+        } else {
+            time_to_pulp *= 1.7;
+        }
+    }
+
+    // Adjust pulp_power to match the time taken.
+    pd.pulp_power = ( std::pow( corpse_volume, pow_factor ) * 1000 ) / time_to_pulp;
 
     // +25% to pulp time if char knows no weakpoints of monster
     // -25% if knows all of them
@@ -14498,19 +14509,19 @@ pulp_data game::calculate_pulpability( const Character &you, const mtype &corpse
                 pd.unknown_prof = wf.proficiency;
             }
         }
+        // We're not adjusting pulp_power here, so no proficiency will result in more
+        // splatter and full proficiency will result in less, as no needless bashes
+        // resulting in splatter are made.
         time_to_pulp *= 1.25 - 0.5 * wp_known / corpse_mtype.families.families.size();
     }
 
-    // you have a hard time pulling armor to reach important parts of this monster
-    if( corpse_mtype.has_flag( mon_flag_PULP_PRYING ) ) {
-        if( pd.can_pry_armor ) {
-            time_to_pulp *= 1.25;
-        } else {
-            time_to_pulp *= 1.7;
-        }
+    if( time_to_pulp < min_time_to_pulp ) {
+        pd.time_to_pulp = min_time_to_pulp;
+        // Reducing the power to match the time in order to get the same amount of splatter.
+        pd.pulp_power = pd.time_to_pulp / ( std::pow( corpse_volume, pow_factor ) * 1000 );
+    } else {
+        pd.time_to_pulp = time_to_pulp;
     }
-
-    pd.time_to_pulp = std::max( min_time_to_pulp, time_to_pulp );
 
     return pd;
 }

--- a/src/game.h
+++ b/src/game.h
@@ -134,6 +134,8 @@ struct pulp_data {
     // how far the splatter goes
     int mess_radius = 1;
     // how much damage you deal to corpse every second, average of multiple values
+    float nominal_pulp_power;
+    // The actual power produced, adjusted based on time adjustments.
     float pulp_power;
     // how much stamina is consumed after each punch
     float pulp_effort;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fix #80371, i.e. pulping corpses resulting in excessive amounts of splatter.
Also adjust splattering to account for time extensions, i.e. keep the splatter from the same corpse size about the same when the time taken to do the job is changed:
- Spending time to get through armor is time not spent causing splatter.
- Extending the time to a minimum time shouldn't increase the amount of splatter.
- Adjusting time due to proficiency knowledge should not compensate the splattering, as the changed time reflects needless bashing that would result in additional splattering.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
- Calculate a nominal pulp power based on tools etc.
- Use the nominal pulp power as the basis for the (effective) pulp power through adjustments based on time adjustments.
- Change the splatter chance logic to use an arbitrarily set number rather than the corpse volume as the nominator. The corpse volume has already been used to determine the number of bashes needed to pulp the corpse, so it shouldn't be used again. The number selected is based on subjective testing of what looks like a good amount of splatter.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
- Ignore it: it's not really important that the world is subjected to excessive blood covers. Someone else might eventually take it up anyway.
- Don't adjust the pulp power. That was the issue first addressed before homing in on the broken 100% splatter probability, and I didn't want to throw that effort away.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
- Load the bug report save.
- Debug spawn a border collie, a zombie, a kevlar zombie, and a moose.
- Debug kill them all.
- Pulp them all.
- Decide the results look reasonable.
- Creature selection: Border collie: The smallest mammal found to rise, zombie as the standard critter, kevlar zombie as a version of the previous one that should require some armor handling, moose as being a really large critter (the tusked one didn't result in a rising corpse, for some reason).
![Screenshot (659)](https://github.com/user-attachments/assets/6b141c94-ccb8-431b-b17b-530dac138a1a)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
No comments on the findings left in the bug report and nobody producing a PR resulting in this PR being produced.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
