### PR TITLE
[ Xedra Evolved ] Audit blood cutoffs for various vampire powers

### DIFF
--- a/data/mods/Xedra_Evolved/mutations/vampire_trait_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/vampire_trait_eocs.json
@@ -612,7 +612,7 @@
         "run_eocs": [
           {
             "id": "EOC_EYEGLEAM_activated_2",
-            "condition": { "math": [ "u_vitamin('human_blood_vitamin') >= -500" ] },
+            "condition": { "math": [ "u_vitamin('human_blood_vitamin') >= -4500" ] },
             "effect": [
               { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 0.25 },
               { "math": [ "u_vitamin('human_blood_vitamin')", "-=", "100" ] },
@@ -689,7 +689,7 @@
         "run_eocs": [
           {
             "id": "EOC_EYEGLEAM_maintenance_2",
-            "condition": { "math": [ "u_vitamin('human_blood_vitamin') >= -500" ] },
+            "condition": { "math": [ "u_vitamin('human_blood_vitamin') >= -5000" ] },
             "effect": [
               { "math": [ "u_vitamin('human_blood_vitamin')", "-=", "50" ] },
               {
@@ -724,7 +724,7 @@
         "run_eocs": [
           {
             "id": "EOC_VAMPIRIC_STRENGTH_activated_2",
-            "condition": { "math": [ "u_vitamin('human_blood_vitamin') >= -500" ] },
+            "condition": { "math": [ "u_vitamin('human_blood_vitamin') >= -4500" ] },
             "effect": [
               { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 0.25 },
               { "math": [ "u_vitamin('human_blood_vitamin')", "-=", "150" ] },
@@ -777,7 +777,7 @@
         "run_eocs": [
           {
             "id": "EOC_VAMPIRIC_STRENGTH_maintenance_2",
-            "condition": { "math": [ "u_vitamin('human_blood_vitamin') >= -500" ] },
+            "condition": { "math": [ "u_vitamin('human_blood_vitamin') >= -5000" ] },
             "effect": [
               { "math": [ "u_vitamin('human_blood_vitamin')", "-=", "75" ] },
               {
@@ -812,7 +812,7 @@
         "run_eocs": [
           {
             "id": "EOC_VAMPIRIC_RESILIENCE_activated_2",
-            "condition": { "math": [ "u_vitamin('human_blood_vitamin') >= -500" ] },
+            "condition": { "math": [ "u_vitamin('human_blood_vitamin') >= -4500" ] },
             "effect": [
               { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 0.25 },
               { "math": [ "u_vitamin('human_blood_vitamin')", "-=", "150" ] },
@@ -865,7 +865,7 @@
         "run_eocs": [
           {
             "id": "EOC_VAMPIRIC_RESILIENCE_maintenance_2",
-            "condition": { "math": [ "u_vitamin('human_blood_vitamin') >= -500" ] },
+            "condition": { "math": [ "u_vitamin('human_blood_vitamin') >= -5000" ] },
             "effect": [
               { "math": [ "u_vitamin('human_blood_vitamin')", "-=", "75" ] },
               {
@@ -907,7 +907,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_STAMINAFORBLOOD_activated",
-    "condition": { "math": [ "u_vitamin('human_blood_vitamin') >= -500" ] },
+    "condition": { "math": [ "u_vitamin('human_blood_vitamin') >= -2500" ] },
     "effect": [
       { "u_assign_activity": "ACT_GENERIC_EOC", "duration": "1 seconds" },
       { "math": [ "u_vitamin('human_blood_vitamin')", "-=", "100" ] },
@@ -945,7 +945,7 @@
         "run_eocs": [
           {
             "id": "EOC_COAGULANTWEAVE_activated_2",
-            "condition": { "math": [ "u_vitamin('human_blood_vitamin') >= -500" ] },
+            "condition": { "math": [ "u_vitamin('human_blood_vitamin') >= -2500" ] },
             "effect": [
               { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 0.75 },
               { "math": [ "u_vitamin('human_blood_vitamin')", "-=", "500" ] },
@@ -999,7 +999,7 @@
         "run_eocs": [
           {
             "id": "EOC_COAGULANTWEAVE_maintenance_2",
-            "condition": { "math": [ "u_vitamin('human_blood_vitamin') >= -500" ] },
+            "condition": { "math": [ "u_vitamin('human_blood_vitamin') >= -5000" ] },
             "effect": [
               { "math": [ "u_vitamin('human_blood_vitamin')", "-=", "250" ] },
               {
@@ -1028,7 +1028,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_BLOODHEAL_activated",
-    "condition": { "math": [ "u_vitamin('human_blood_vitamin') >= -500" ] },
+    "condition": { "math": [ "u_vitamin('human_blood_vitamin') >= -4500" ] },
     "effect": [
       { "math": [ "u_vitamin('human_blood_vitamin')", "-=", "750" ] },
       { "u_message": "Blood suffuses your flesh, repairing any damage it comes across.", "type": "good" },
@@ -1102,7 +1102,7 @@
         "run_eocs": [
           {
             "id": "EOC_VAMPIRIC_DODGE_activated_2",
-            "condition": { "math": [ "u_vitamin('human_blood_vitamin') >= -500" ] },
+            "condition": { "math": [ "u_vitamin('human_blood_vitamin') >= -4500" ] },
             "effect": [
               { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 0.75 },
               { "math": [ "u_vitamin('human_blood_vitamin')", "-=", "250" ] },
@@ -1155,7 +1155,7 @@
         "run_eocs": [
           {
             "id": "EOC_VAMPIRIC_DODGE_maintenance_2",
-            "condition": { "math": [ "u_vitamin('human_blood_vitamin') >= -500" ] },
+            "condition": { "math": [ "u_vitamin('human_blood_vitamin') >= -5000" ] },
             "effect": [
               { "math": [ "u_vitamin('human_blood_vitamin')", "-=", "125" ] },
               {
@@ -1184,7 +1184,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_VAMPIRE_FEAR_GAZE_activated",
-    "condition": { "math": [ "n_vitamin('human_blood_vitamin') >= -500" ] },
+    "condition": { "math": [ "n_vitamin('human_blood_vitamin') >= -7500" ] },
     "effect": [
       {
         "math": [
@@ -1234,7 +1234,7 @@
         "run_eocs": [
           {
             "id": "EOC_VAMPIRE_BEAST_CLAWS_activated_2",
-            "condition": { "math": [ "u_vitamin('human_blood_vitamin') >= -500" ] },
+            "condition": { "math": [ "u_vitamin('human_blood_vitamin') >= -5500" ] },
             "effect": [
               { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 0.75 },
               { "math": [ "u_vitamin('human_blood_vitamin')", "-=", "125" ] },
@@ -1287,7 +1287,7 @@
         "run_eocs": [
           {
             "id": "EOC_VAMPIRE_BEAST_CLAWS_maintenance_2",
-            "condition": { "math": [ "u_vitamin('human_blood_vitamin') >= -500" ] },
+            "condition": { "math": [ "u_vitamin('human_blood_vitamin') >= -8500" ] },
             "effect": [
               { "math": [ "u_vitamin('human_blood_vitamin')", "-=", "62" ] },
               { "u_message": "You feel a momentary warmth as you maintain your sharp claws.", "type": "mixed" },
@@ -1313,7 +1313,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_MAGICFORBLOOD_activated",
-    "condition": { "math": [ "u_vitamin('human_blood_vitamin') >= -500" ] },
+    "condition": { "math": [ "u_vitamin('human_blood_vitamin') >= -7500" ] },
     "effect": [
       { "u_assign_activity": "ACT_GENERIC_EOC", "duration": "1 seconds" },
       { "math": [ "u_vitamin('human_blood_vitamin')", "-=", "200" ] },
@@ -1334,7 +1334,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_HYPNOTIC_GAZE_activated",
-    "condition": { "math": [ "n_vitamin('human_blood_vitamin') >= -500" ] },
+    "condition": { "math": [ "n_vitamin('human_blood_vitamin') >= -9500" ] },
     "effect": [
       {
         "math": [
@@ -1373,7 +1373,7 @@
         "run_eocs": [
           {
             "id": "EOC_BLOODHASTE_activated_2",
-            "condition": { "math": [ "u_vitamin('human_blood_vitamin') >= -500" ] },
+            "condition": { "math": [ "u_vitamin('human_blood_vitamin') >= -7500" ] },
             "effect": [
               { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 2 },
               { "math": [ "u_vitamin('human_blood_vitamin')", "-=", "750" ] },
@@ -1423,7 +1423,7 @@
         "run_eocs": [
           {
             "id": "EOC_BLOODHASTE_maintenance_2",
-            "condition": { "math": [ "u_vitamin('human_blood_vitamin') >= -500" ] },
+            "condition": { "math": [ "u_vitamin('human_blood_vitamin') >= -9500" ] },
             "effect": [
               { "math": [ "u_vitamin('human_blood_vitamin')", "-=", "375" ] },
               { "u_message": "You feel a momentary warmth as you maintain your superhuman speed.", "type": "mixed" },
@@ -1450,7 +1450,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_VAMPIRE_COMMAND_BEAST_activated",
-    "condition": { "math": [ "n_vitamin('human_blood_vitamin') >= -500" ] },
+    "condition": { "math": [ "n_vitamin('human_blood_vitamin') >= -8500" ] },
     "effect": [
       { "math": [ "n_vitamin('human_blood_vitamin')", "-=", "500" ] },
       { "u_location_variable": { "context_val": "loc" } },
@@ -1571,7 +1571,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_VAMPIRE_DOMINATE_activated",
-    "condition": { "math": [ "n_vitamin('human_blood_vitamin') >= -500" ] },
+    "condition": { "math": [ "n_vitamin('human_blood_vitamin') >= -7500" ] },
     "effect": [
       { "math": [ "n_vitamin('human_blood_vitamin')", "-=", "700" ] },
       { "u_location_variable": { "context_val": "loc" } },
@@ -1601,7 +1601,7 @@
         "run_eocs": [
           {
             "id": "EOC_VAMPIRE_BAT_FORM_activated_2",
-            "condition": { "math": [ "u_vitamin('human_blood_vitamin') >= -500" ] },
+            "condition": { "math": [ "u_vitamin('human_blood_vitamin') >= -7500" ] },
             "effect": [
               { "run_eocs": "EOC_VAMPIRE_CANCEL_WOLF_FORM" },
               { "run_eocs": "EOC_VAMPIRE_CANCEL_MIST_FORM" },
@@ -1663,7 +1663,7 @@
         "run_eocs": [
           {
             "id": "EOC_VAMPIRE_WOLF_FORM_activated_2",
-            "condition": { "math": [ "u_vitamin('human_blood_vitamin') >= -500" ] },
+            "condition": { "math": [ "u_vitamin('human_blood_vitamin') >= -7500" ] },
             "effect": [
               { "run_eocs": "EOC_VAMPIRE_CANCEL_BAT_FORM" },
               { "run_eocs": "EOC_VAMPIRE_CANCEL_MIST_FORM" },
@@ -1718,7 +1718,7 @@
         "run_eocs": [
           {
             "id": "EOC_VAMPIRE_MIST_FORM_activated_2",
-            "condition": { "math": [ "u_vitamin('human_blood_vitamin') >= -500" ] },
+            "condition": { "math": [ "u_vitamin('human_blood_vitamin') >= -7500" ] },
             "effect": [
               { "run_eocs": "EOC_VAMPIRE_CANCEL_BAT_FORM" },
               { "run_eocs": "EOC_VAMPIRE_CANCEL_WOLF_FORM" },
@@ -1777,7 +1777,7 @@
         "run_eocs": [
           {
             "id": "EOC_VAMPIRE_MIST_FORM_BLOOD_COST_2",
-            "condition": { "math": [ "u_vitamin('human_blood_vitamin') >= -500" ] },
+            "condition": { "math": [ "u_vitamin('human_blood_vitamin') >= -10500" ] },
             "effect": { "math": [ "u_vitamin('human_blood_vitamin')", "-=", "2" ] },
             "false_effect": [
               { "u_message": "You don't have enough blood to maintain your mist form.", "type": "bad" },
@@ -1905,7 +1905,7 @@
         "run_eocs": [
           {
             "id": "EOC_VAMPIRE_SHADOW_FORM_activated_2",
-            "condition": { "math": [ "u_vitamin('human_blood_vitamin') >= 500" ] },
+            "condition": { "math": [ "u_vitamin('human_blood_vitamin') >= -4500" ] },
             "effect": [
               { "run_eocs": "EOC_VAMPIRE_CANCEL_BAT_FORM" },
               { "run_eocs": "EOC_VAMPIRE_CANCEL_WOLF_FORM" },
@@ -1959,7 +1959,7 @@
         "run_eocs": [
           {
             "id": "EOC_VAMPIRE_SHADOW_FORM_BLOOD_COST_2",
-            "condition": { "math": [ "u_vitamin('human_blood_vitamin') >= -500" ] },
+            "condition": { "math": [ "u_vitamin('human_blood_vitamin') >= -9500" ] },
             "effect": { "math": [ "u_vitamin('human_blood_vitamin')", "-=", "5" ] },
             "false_effect": [
               { "u_message": "You don't have enough blood to maintain the shadows surrounding you.", "type": "bad" },
@@ -2414,7 +2414,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_VAMPIRE_INVISIBLE_IN_DARK",
-    "condition": { "math": [ "u_vitamin('human_blood_vitamin') >= -500" ] },
+    "condition": { "math": [ "u_vitamin('human_blood_vitamin') >= -3500" ] },
     "effect": [
       {
         "run_eocs": [

--- a/data/mods/Xedra_Evolved/npc/vampire_master_mortal_mind.json
+++ b/data/mods/Xedra_Evolved/npc/vampire_master_mortal_mind.json
@@ -47,7 +47,7 @@
       {
         "text": "[Spend a little blood to make them like you a bit more]",
         "topic": "TALK_NONE",
-        "condition": { "math": [ "u_vitamin('human_blood_vitamin') > -501" ] },
+        "condition": { "math": [ "u_vitamin('human_blood_vitamin') > -5001" ] },
         "effect": [
           {
             "if": { "u_has_trait": "VAMPIRE_MASTER_MORTAL_MIND_UPGRADE" },
@@ -60,7 +60,7 @@
       {
         "text": "[Spend a moderate amount of blood to make them your friend]",
         "topic": "TALK_NONE",
-        "condition": { "math": [ "u_vitamin('human_blood_vitamin') > -501" ] },
+        "condition": { "math": [ "u_vitamin('human_blood_vitamin') > -5001" ] },
         "effect": [
           {
             "if": { "u_has_trait": "VAMPIRE_MASTER_MORTAL_MIND_UPGRADE" },
@@ -73,7 +73,7 @@
       {
         "text": "[Spend a massive amount of blood to make them your renfield]",
         "topic": "TALK_YOUR_NEW_RENFIELD",
-        "condition": { "math": [ "u_vitamin('human_blood_vitamin') > -501" ] },
+        "condition": { "math": [ "u_vitamin('human_blood_vitamin') > -5001" ] },
         "effect": [
           {
             "if": { "u_has_trait": "VAMPIRE_MASTER_MORTAL_MIND_UPGRADE" },
@@ -88,12 +88,12 @@
       {
         "text": "[Don't spend any blood]",
         "topic": "TALK_NONE",
-        "condition": { "math": [ "u_vitamin('human_blood_vitamin') > -501" ] }
+        "condition": { "math": [ "u_vitamin('human_blood_vitamin') > -5001" ] }
       },
       {
         "text": "[You do not have enough blood in you to manipulate someone's mind]",
         "topic": "TALK_NONE",
-        "condition": { "math": [ "u_vitamin('human_blood_vitamin') <= -501" ] }
+        "condition": { "math": [ "u_vitamin('human_blood_vitamin') <= -5001" ] }
       }
     ]
   },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
I saw someone commenting that it was weird they would be content on their blood levels and unable to use most of their powers.  We'd set them at this level to prevent players from starving themselves using their powers.  This kind of handholding doesn't belong in DDA.  They should now let you be much hungrier and still use your powers.  I've pondered going even further.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Lowers the minimum blood levels to cast many powers.  I've probably missed some and they will need editing as well.  
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Going even lower or letting the player power their abilities straight into eternal slumber.    Adding additional penalties and weird circumstances that can occur when your blood levels stay too low.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
