### PR TITLE
Report vehicle out of map bound + fix bounding_box bug

### DIFF
--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -7307,6 +7307,18 @@ vehicle *map::add_vehicle( const vproto_id &type, const tripoint_bub_ms &p, cons
             return placed_vehicle;
         }
         place_on_submap->ensure_nonuniform();
+        bounding_box box = placed_vehicle->get_bounding_box( false );
+        if( !inbounds( p + box.p1 ) ) {
+            const tripoint_abs_omt omt = project_to<coords::omt>( get_abs_sub() );
+            const oter_id &oid = overmap_buffer.ter( omt );
+            debugmsg( "Placed %s vehicle at %s causing its edge to be out of bounds at %s on terrain %s",
+                      placed_vehicle->disp_name().c_str(), p.to_string(), ( p + box.p1 ).to_string(), oid.id().c_str() );
+        } else if( !inbounds( p + box.p2 ) ) {
+            const tripoint_abs_omt omt = project_to<coords::omt>( get_abs_sub() );
+            const oter_id &oid = overmap_buffer.ter( omt );
+            debugmsg( "Placed %s vehicle at %s causing its edge to be out of bounds at %s on terrain %s",
+                      placed_vehicle->disp_name().c_str(), p.to_string(), ( p + box.p2 ).to_string(), oid.id().c_str() );
+        }
         place_on_submap->vehicles.push_back( std::move( placed_vehicle_up ) );
         invalidate_max_populated_zlev( p.z() );
 

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -7311,13 +7311,17 @@ vehicle *map::add_vehicle( const vproto_id &type, const tripoint_bub_ms &p, cons
         if( !inbounds( p + box.p1 ) ) {
             const tripoint_abs_omt omt = project_to<coords::omt>( get_abs_sub() );
             const oter_id &oid = overmap_buffer.ter( omt );
-            debugmsg( "Placed %s vehicle at %s causing its edge to be out of bounds at %s on terrain %s",
-                      placed_vehicle->disp_name().c_str(), p.to_string(), ( p + box.p1 ).to_string(), oid.id().c_str() );
+            const tripoint_rel_ms vel_pos = get_player_character().pos_abs() - get_abs( p );
+            debugmsg( "Placed %s vehicle at %s causing its edge to be out of bounds at %s on terrain %s.  Vehicle at %s relative to PC.",
+                      placed_vehicle->disp_name().c_str(), p.to_string(), ( p + box.p1 ).to_string(), oid.id().c_str(),
+                      vel_pos.to_string() );
         } else if( !inbounds( p + box.p2 ) ) {
             const tripoint_abs_omt omt = project_to<coords::omt>( get_abs_sub() );
             const oter_id &oid = overmap_buffer.ter( omt );
-            debugmsg( "Placed %s vehicle at %s causing its edge to be out of bounds at %s on terrain %s",
-                      placed_vehicle->disp_name().c_str(), p.to_string(), ( p + box.p2 ).to_string(), oid.id().c_str() );
+            const tripoint_rel_ms vel_pos = get_player_character().pos_abs() - get_abs( p );
+            debugmsg( "Placed %s vehicle at %s causing its edge to be out of bounds at %s on terrain %s.  Vehicle at %s relative to PC.",
+                      placed_vehicle->disp_name().c_str(), p.to_string(), ( p + box.p2 ).to_string(), oid.id().c_str(),
+                      vel_pos.to_string() );
         }
         place_on_submap->vehicles.push_back( std::move( placed_vehicle_up ) );
         invalidate_max_populated_zlev( p.z() );

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -24,6 +24,7 @@
 #include "cata_assert.h"
 #include "cata_utility.h"
 #include "catacharset.h"
+#include "character.h"
 #include "character_id.h"
 #include "city.h"
 #include "clzones.h"

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -8405,6 +8405,14 @@ bounding_box vehicle::get_bounding_box( bool use_precalc, bool no_fake )
             max_y = pt.y();
         }
     }
+
+    if( relative_parts.size() == 0 ) {
+        min_x = 0;
+        min_y = 0;
+        max_x = 0;
+        max_y = 0;
+    }
+
     bounding_box b;
     b.p1 = point_rel_ms( min_x, min_y );
     b.p2 = point_rel_ms( max_x, max_y );

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -8406,7 +8406,7 @@ bounding_box vehicle::get_bounding_box( bool use_precalc, bool no_fake )
         }
     }
 
-    if( relative_parts.size() == 0 ) {
+    if( relative_parts.empty() ) {
         min_x = 0;
         min_y = 0;
         max_x = 0;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
- Report cases where vehicles are placed partially outside their OMTs.
- Fixed bounding_box logic for single tile vehicles as a by-catch.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
- Check whether the mapgen placement of a vehicle will cause its bounding box to fall outside of the OMT and report the issue.
- Check if a vehicle doesn't perform any bounding box checks due to an empty relative parts list (single tile vehicles and prototype vehicles).
 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Teleport around in unexplored cities until the report is generated (I thought I took a screen shot of it, but apparently not).

Edit:
Tested again after adding relative position.
Error report (the relative distance doesn't make sense because I'm teleporting. It will be 1 tile off when moving normally, and possibly a bit more if moving in a fast vehicle):
![Screenshot (661)](https://github.com/user-attachments/assets/8146ac24-3568-4433-8d30-c7653fb762b7)

Located the location:
![Screenshot (662)](https://github.com/user-attachments/assets/364baf4c-cf36-44b0-9a34-2168557b0f67)
And yes. The flatbed truck should have wing mirrors. I failed to find the offending one on the neighboring OMT, and the one colliding with the building seems to be missing as well. Didn't think to examine the vehicle and look for the wing mirrors there, though.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
The bounding box error was discovered when the report claimed out of bound positions were near MIN_INT. Rather than working around that in the report, the operation was fixed instead.

Related to #80556 in that these errors will be reported, but it's not limited to that set. Unfortunately the report location doesn't have access to the mapgen context, which would otherwise have been helpful to track down the exact mapgen chain that needs to be fixed.

Edit:
It was hinted at above, but another issue discovered was that for some reason the game tries to place prototype vehicles during mapgen. This is probably not intended.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
