### PR TITLE
Another gunmod audit

### DIFF
--- a/data/json/items/gunmod/rail.json
+++ b/data/json/items/gunmod/rail.json
@@ -6,18 +6,10 @@
     "name": { "str_sp": "offset iron sights" },
     "description": "An alternative set of iron sights mounted at 45° for use when a scope or other modification prevents use of the primary sights.",
     "location": "rail",
-    "mod_targets": [ "smg", "rifle", "shotgun" ],
+    "mod_targets": [ "pistol", "smg", "rifle", "shotgun", "launcher" ],
     "min_skills": [ [ "weapon", 3 ], [ "gun", 4 ] ],
     "proportional": { "sight_dispersion": 1.25 },
     "delete": { "flags": [ "DISABLE_SIGHTS" ] }
-  },
-  {
-    "id": "offset_sights_mod",
-    "copy-from": "offset_sights",
-    "type": "GUNMOD",
-    "name": { "str_sp": "modified offset iron sights" },
-    "description": "An alternative set of iron sights mounted at 45° for use when a scope or other modification prevents use of the primary sights.  This one was modified and customized to mount on pretty much any weapon, if you so want.",
-    "mod_targets": [ "pistol", "smg", "rifle", "shotgun", "launcher", "crossbow" ]
   },
   {
     "id": "offset_sight_rail",
@@ -33,17 +25,9 @@
     "symbol": ":",
     "color": "light_gray",
     "location": "rail",
-    "mod_targets": [ "shotgun", "smg", "rifle" ],
+    "mod_targets": [ "shotgun", "smg", "rifle", "launcher" ],
     "min_skills": [ [ "gun", 1 ] ],
     "add_mod": [ [ "sights", 1 ] ]
-  },
-  {
-    "id": "offset_sight_rail_mod",
-    "copy-from": "offset_sight_rail",
-    "type": "GUNMOD",
-    "name": { "str": "modified offset sight rail" },
-    "description": "An additional rail set at 45° for attaching a secondary optic.  This one was modified and customized to mount on pretty much any weapon, if you so want.",
-    "mod_targets": [ "pistol", "smg", "rifle", "shotgun", "launcher", "crossbow" ]
   },
   {
     "id": "rail_laser_sight",

--- a/data/json/items/gunmod/sights.json
+++ b/data/json/items/gunmod/sights.json
@@ -162,7 +162,7 @@
     "symbol": ":",
     "color": "dark_gray",
     "location": "sights",
-    "mod_targets": [ "rifle", "crossbow", "launcher" ],
+    "mod_targets": [ "rifle", "crossbow", "launcher", "shotgun" ],
     "install_time": "5 m",
     "sight_dispersion": 0,
     "aim_speed_modifier": -1,
@@ -184,7 +184,7 @@
     "symbol": ":",
     "color": "dark_gray",
     "location": "sights",
-    "mod_targets": [ "rifle", "crossbow", "launcher" ],
+    "mod_targets": [ "rifle", "crossbow", "launcher", "shotgun" ],
     "install_time": "5 m",
     "sight_dispersion": 0,
     "aim_speed_modifier": -1,
@@ -192,14 +192,6 @@
     "min_skills": [ [ "weapon", 2 ], [ "gun", 4 ] ],
     "flags": [ "DISABLE_SIGHTS", "ZOOM" ],
     "add_mod": [ [ "sights", 1 ] ]
-  },
-  {
-    "id": "rifle_scope_mod",
-    "copy-from": "rifle_scope",
-    "type": "GUNMOD",
-    "name": { "str": "modified rifle scope" },
-    "description": "A 3-18x44 rifle scope.  It is adjustable for windage and elevation in 1/10th mrad increments and is remarkably small and light for its magnification.  This one was modified and customized to mount on pretty much any weapon other than pistols and SMGs, if you so want.",
-    "mod_targets": [ "rifle", "shotgun", "launcher", "crossbow" ]
   },
   {
     "id": "acog_scope",
@@ -214,7 +206,7 @@
     "symbol": ":",
     "color": "dark_gray",
     "location": "sights",
-    "mod_targets": [ "rifle", "crossbow", "launcher" ],
+    "mod_targets": [ "rifle", "crossbow", "launcher", "shotgun", "smg" ],
     "install_time": "5 m",
     "sight_dispersion": 8,
     "field_of_view": 270,
@@ -251,14 +243,6 @@
     "description": "A high end 4x32 military grade ACOG scope.  This one has additional mounting brackets on top for another sight.",
     "flags": [ "DISABLE_SIGHTS", "ZOOM" ],
     "add_mod": [ [ "sights", 1 ] ]
-  },
-  {
-    "id": "acog_scope_mod",
-    "copy-from": "acog_scope",
-    "type": "GUNMOD",
-    "name": { "str": "modified ACOG scope" },
-    "description": "A 4x32 TA01 Advanced Combat Optical Gunsight with a tritium illuminated crosshair.  This one was modified and customized to mount on pretty much any weapon other than pistols, if you so want.",
-    "mod_targets": [ "smg", "rifle", "shotgun", "launcher", "crossbow" ]
   },
   {
     "id": "riv_scope",

--- a/data/json/items/gunmod/sling.json
+++ b/data/json/items/gunmod/sling.json
@@ -14,7 +14,7 @@
     "symbol": ":",
     "color": "green",
     "location": "sling",
-    "mod_targets": [ "rifle", "shotgun", "smg", "crossbow", "launcher" ],
+    "mod_targets": [ "rifle", "shotgun", "smg", "crossbow", "launcher", "pistol" ],
     "flags": [ "IS_ARMOR", "BELTED", "OVERSIZE", "WATER_FRIENDLY" ],
     "armor_data": {
       "armor": [

--- a/data/json/items/gunmod/underbarrel.json
+++ b/data/json/items/gunmod/underbarrel.json
@@ -14,20 +14,11 @@
     "symbol": ":",
     "color": "brown",
     "location": "underbarrel",
-    "mod_targets": [ "rifle", "launcher" ],
+    "mod_targets": [ "rifle", "launcher", "smg", "shotgun", "crossbow" ],
     "handling_modifier": 18,
     "min_skills": [ [ "weapon", 2 ] ],
     "flags": [ "BIPOD", "SLOW_WIELD" ],
     "melee_damage": { "bash": 10 }
-  },
-  {
-    "id": "bipod_mod",
-    "copy-from": "bipod",
-    "type": "GUNMOD",
-    "name": { "str": "modified bipod" },
-    "description": "Bipods are commonly used on rifles and machine guns to provide a forward rest and reduce motion.  Although they greatly improve handling of recoil, they are usable only on certain surfaces (or from the prone position), and are slow to equip.  This one was modified and customized to mount on pretty much any weapon, if you so want.",
-    "mod_targets": [ "pistol", "smg", "rifle", "shotgun", "launcher", "crossbow" ],
-    "extend": { "flags": [ "PUMP_RAIL_COMPATIBLE" ] }
   },
   {
     "id": "bipod_handguard",
@@ -467,7 +458,7 @@
     "color": "light_red",
     "location": "underbarrel",
     "blacklist_mod": [ "knife_combat_army", "knife_combat", "enfield_bayonet", "knife_combat_marine", "sword_bayonet" ],
-    "mod_targets": [ "rifle", "crossbow" ],
+    "mod_targets": [ "smg", "rifle", "shotgun", "launcher", "crossbow" ],
     "gun_data": {
       "barrel_length": "419 mm",
       "ammo": [ "shot" ],
@@ -479,14 +470,6 @@
     "min_skills": [ [ "weapon", 1 ], [ "shotgun", 1 ] ],
     "flags": [ "RELOAD_ONE" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "ammo_restriction": { "shot": 2 } } ]
-  },
-  {
-    "id": "u_shotgun_mod",
-    "copy-from": "u_shotgun",
-    "type": "GUNMOD",
-    "name": { "str": "modified underslung shotgun" },
-    "description": "A short shotgun with 2 barrels, which can be mounted under the barrel of many rifles.  It allows two shotgun shells to be loaded and fired.  This one was modified and customized to mount on pretty much any weapon other than pistols, if you so want.",
-    "mod_targets": [ "smg", "rifle", "shotgun", "launcher", "crossbow" ]
   },
   {
     "id": "arisaka_monopod",

--- a/data/json/obsoletion_and_migration_0.I/migration_items.json
+++ b/data/json/obsoletion_and_migration_0.I/migration_items.json
@@ -2463,5 +2463,35 @@
     "id": "muzzle_brake_mod",
     "type": "MIGRATION",
     "replace": "muzzle_brake"
+  },
+  {
+    "id": "offset_sights_mod",
+    "type": "MIGRATION",
+    "replace": "offset_sights"
+  },
+  {
+    "id": "offset_sight_rail_mod",
+    "type": "MIGRATION",
+    "replace": "offset_sight_rail"
+  },
+  {
+    "id": "rifle_scope_mod",
+    "type": "MIGRATION",
+    "replace": "rifle_scope"
+  },
+  {
+    "id": "acog_scope_mod",
+    "type": "MIGRATION",
+    "replace": "acog_scope"
+  },
+  {
+    "id": "bipod_mod",
+    "type": "MIGRATION",
+    "replace": "bipod"
+  },
+  {
+    "id": "u_shotgun_mod",
+    "type": "MIGRATION",
+    "replace": "u_shotgun"
   }
 ]

--- a/data/json/recipes/nested.json
+++ b/data/json/recipes/nested.json
@@ -4103,7 +4103,7 @@
     "name": "modified attachments",
     "description": "Recipes related to modifying weapon accessories to attach to a wider variety of guns and crossbows.",
     "skill_used": "fabrication",
-    "nested_category_data": [ "bipod_mod", "grip_mod", "nested_modified_gunmods_weapons", "nested_modified_gunmods_sights" ]
+    "nested_category_data": [ "grip_mod", "nested_modified_gunmods_weapons" ]
   },
   {
     "id": "nested_modified_gunmods_weapons",
@@ -4122,20 +4122,8 @@
       "m203_mod",
       "m320_mod_mod",
       "masterkey_mod",
-      "sword_bayonet_mod",
-      "u_shotgun_mod"
+      "sword_bayonet_mod"
     ]
-  },
-  {
-    "id": "nested_modified_gunmods_sights",
-    "type": "nested_category",
-    "activity_level": "MODERATE_EXERCISE",
-    "category": "CC_*",
-    "subcategory": "CSC_*_NESTED",
-    "name": "sights",
-    "description": "Recipes related to modifying sights to attach to a wider variety of guns and crossbows.",
-    "skill_used": "fabrication",
-    "nested_category_data": [ "acog_scope_mod", "offset_sights_mod", "offset_sight_rail_mod", "rifle_scope_mod" ]
   },
   {
     "id": "nested_ammo_flamethrower",

--- a/data/json/recipes/weapon/mods.json
+++ b/data/json/recipes/weapon/mods.json
@@ -175,20 +175,6 @@
     "components": [ [ [ "arredondo_chute", 1 ] ] ]
   },
   {
-    "result": "bipod_mod",
-    "type": "recipe",
-    "activity_level": "MODERATE_EXERCISE",
-    "category": "CC_*",
-    "subcategory": "CSC_*_NESTED",
-    "skill_used": "fabrication",
-    "difficulty": 4,
-    "skills_required": [ [ "gun", 2 ] ],
-    "time": "30 m",
-    "autolearn": true,
-    "tools": [ [ [ "large_repairkit", 25 ], [ "small_repairkit", 45 ] ] ],
-    "components": [ [ [ "bipod", 1 ] ], [ [ "scrap", 1 ] ], [ [ "plastic_chunk", 1 ] ] ]
-  },
-  {
     "result": "grip_mod",
     "type": "recipe",
     "activity_level": "MODERATE_EXERCISE",
@@ -259,62 +245,6 @@
     "components": [ [ [ "m26_mass", 1 ] ], [ [ "scrap", 3 ] ], [ [ "plastic_chunk", 1 ] ] ]
   },
   {
-    "result": "u_shotgun_mod",
-    "type": "recipe",
-    "activity_level": "MODERATE_EXERCISE",
-    "category": "CC_*",
-    "subcategory": "CSC_*_NESTED",
-    "skill_used": "fabrication",
-    "difficulty": 7,
-    "skills_required": [ [ "gun", 2 ], [ "shotgun", 1 ] ],
-    "time": "90 m",
-    "autolearn": true,
-    "tools": [ [ [ "large_repairkit", 50 ], [ "small_repairkit", 100 ] ] ],
-    "components": [ [ [ "u_shotgun", 1 ] ], [ [ "scrap", 3 ] ], [ [ "plastic_chunk", 1 ] ] ]
-  },
-  {
-    "result": "offset_sight_rail_mod",
-    "type": "recipe",
-    "activity_level": "MODERATE_EXERCISE",
-    "category": "CC_*",
-    "subcategory": "CSC_*_NESTED",
-    "skill_used": "fabrication",
-    "difficulty": 4,
-    "skills_required": [ [ "gun", 4 ] ],
-    "time": "30 m",
-    "autolearn": true,
-    "tools": [ [ [ "large_repairkit", 25 ], [ "small_repairkit", 45 ] ] ],
-    "components": [ [ [ "offset_sight_rail", 1 ] ], [ [ "scrap", 1 ] ], [ [ "plastic_chunk", 1 ] ] ]
-  },
-  {
-    "result": "rifle_scope_mod",
-    "type": "recipe",
-    "activity_level": "MODERATE_EXERCISE",
-    "category": "CC_*",
-    "subcategory": "CSC_*_NESTED",
-    "skill_used": "fabrication",
-    "difficulty": 4,
-    "skills_required": [ [ "gun", 4 ] ],
-    "time": "30 m",
-    "autolearn": true,
-    "tools": [ [ [ "large_repairkit", 25 ], [ "small_repairkit", 45 ] ] ],
-    "components": [ [ [ "rifle_scope", 1 ] ], [ [ "scrap", 1 ] ], [ [ "plastic_chunk", 1 ] ] ]
-  },
-  {
-    "result": "acog_scope_mod",
-    "type": "recipe",
-    "activity_level": "MODERATE_EXERCISE",
-    "category": "CC_*",
-    "subcategory": "CSC_*_NESTED",
-    "skill_used": "fabrication",
-    "difficulty": 4,
-    "skills_required": [ [ "gun", 4 ] ],
-    "time": "30 m",
-    "autolearn": true,
-    "tools": [ [ [ "large_repairkit", 25 ], [ "small_repairkit", 45 ] ] ],
-    "components": [ [ [ "acog_scope", 1 ] ], [ [ "scrap", 1 ] ], [ [ "plastic_chunk", 1 ] ] ]
-  },
-  {
     "result": "improve_sights",
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",
@@ -367,20 +297,6 @@
     "qualities": [ { "id": "HAMMER_FINE", "level": 1 }, { "id": "SAW_M_FINE", "level": 1 } ],
     "tools": [ [ [ "large_repairkit", 10 ], [ "small_repairkit", 30 ] ] ],
     "components": [ [ [ "scrap", 1 ] ], [ [ "plastic_chunk", 1 ] ] ]
-  },
-  {
-    "result": "offset_sights_mod",
-    "type": "recipe",
-    "activity_level": "MODERATE_EXERCISE",
-    "category": "CC_*",
-    "subcategory": "CSC_*_NESTED",
-    "skill_used": "fabrication",
-    "difficulty": 4,
-    "skills_required": [ [ "gun", 2 ], [ "rifle", 1 ] ],
-    "time": "30 m",
-    "autolearn": true,
-    "tools": [ [ [ "large_repairkit", 25 ], [ "small_repairkit", 45 ] ] ],
-    "components": [ [ [ "offset_sights", 1 ] ], [ [ "scrap", 1 ] ], [ [ "plastic_chunk", 1 ] ] ]
   },
   {
     "result": "sights_mount",

--- a/data/mods/TEST_DATA/expected_dps_data/junk_dps.json
+++ b/data/mods/TEST_DATA/expected_dps_data/junk_dps.json
@@ -55,7 +55,6 @@
       "torch_lit": 5.4,
       "pipe_quiver_large": 5.83,
       "bipod_handguard": 7.69,
-      "bipod_mod": 7.69,
       "bipod": 7.69,
       "bipod_handguard_deployed": 7.69,
       "wizard_cane": 7.86,


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
We have a few more stinkers with our gunmods. Some of the locations were nonsense, some of the gunmods themselves were nonsense. With #80360 merged, there's more sense in where gunmods can be attached, and so instead of flatout saying "No, you can't attach a gunmod to pistols even if the pistol has the mounting bracket" we can instead say "Sure, you can attach it to pistols, but only a select few" like with the P50 and slings. 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Remove a lot of the "modified" gunmods and just change what guns the default mod attaches to. Either a gun will have the rail/mount/whatever for the gunmod to fit, or it doesn't. Whether it's a handgun or a rocket launcher is irrelevant. 

Changed a few gunmods to be attachable to more guns, as an example the sling or rifle scope. There is nothing preventing you from attaching a rifle scope to a shotgun besides common sense, and some pistols such as the P50 do have sling swivels. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Loads fine
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
