### PR TITLE
Warn on load if files have been modified

### DIFF
--- a/src/flexbuffer_cache.cpp
+++ b/src/flexbuffer_cache.cpp
@@ -23,6 +23,7 @@
 #include "filesystem.h"
 #include "json.h"
 #include "mmap_file.h"
+#include "options.h"
 
 namespace
 {
@@ -325,6 +326,21 @@ class flexbuffer_disk_cache
 
             // Does the source file's mtime match what we cached previously
             if( source_mtime != disk_entry->second.mtime ) {
+                std::string filepath_and_name = disk_entry->first;
+                // we use this as an exclusion condition. Configuration options can be changed all the time, we don't want to warn over those.
+                // FIXME: Arcane bullshit handling to make sure both windows and unix filepaths are recognized. On windows the filepath comes back as e.g. config\\options.json
+                bool stale_game_data = filepath_and_name.find( "config/" ) == std::string::npos &&
+                                       filepath_and_name.find( "config\\" ) == std::string::npos;
+                if( stale_game_data ) {
+                    if( get_option<bool>( "WARN_ON_MODIFIED" ) ) {
+                        debugmsg( "Stale game data detected at %s, did you overwrite old files?  When updating the game you must install to a fresh folder, overwriting old files will cause errors.",
+                                  filepath_and_name );
+                    } else {
+                        // we still log the modification warning even if the option is disabled, for sifting bug reports
+                        DebugLog( D_WARNING, D_MAIN ) << "Stale game data detected (error disabled by user): " <<
+                                                      filepath_and_name;
+                    }
+                }
                 // Cached flexbuffer on disk is out of date, remove it.
                 remove_file( disk_entry->second.flexbuffer_path.u8string() );
                 cached_flexbuffers_.erase( disk_entry );

--- a/src/flexbuffer_cache.cpp
+++ b/src/flexbuffer_cache.cpp
@@ -328,9 +328,7 @@ class flexbuffer_disk_cache
             if( source_mtime != disk_entry->second.mtime ) {
                 std::string filepath_and_name = disk_entry->first;
                 // we use this as an exclusion condition. Configuration options can be changed all the time, we don't want to warn over those.
-                // FIXME: Arcane bullshit handling to make sure both windows and unix filepaths are recognized. On windows the filepath comes back as e.g. config\\options.json
-                bool stale_game_data = filepath_and_name.find( "config/" ) == std::string::npos &&
-                                       filepath_and_name.find( "config\\" ) == std::string::npos;
+                bool stale_game_data = *root_relative_source_path.begin() != std::filesystem::u8path( "config" );
                 if( stale_game_data ) {
                     if( get_option<bool>( "WARN_ON_MODIFIED" ) ) {
                         debugmsg( "Stale game data detected at %s, did you overwrite old files?  When updating the game you must install to a fresh folder, overwriting old files will cause errors.",

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2974,6 +2974,12 @@ void options_manager::add_options_debug()
 
     add_empty_line();
 
+    add( "WARN_ON_MODIFIED", "debug", to_translation( "Warn if file integrity check fails" ),
+         to_translation( "This option controls whether the game will warn when it detects that the game's data has been modified." ),
+         true );
+
+    add_empty_line();
+
     add( "SKIP_VERIFICATION", "debug", to_translation( "Skip verification step during loading" ),
          to_translation( "If enabled, this skips the JSON verification step during loading.  This may give a faster loading time, but risks JSON errors not being caught until runtime." ),
 #if defined(EMSCRIPTEN)


### PR DESCRIPTION
#### Summary
Infrastructure "Warn on load if files have been modified"

#### Purpose of change
I have seen a number of occasions where people install new versions incorrectly, or (more often) their launcher screws up. This can produce totally wild errors which are impossible to reproduce and waste valuable bug-squashing time and effort.

I am not the only one to have noticed this pattern, here's a select quote from discord:
"Having data/ folder (or individual subfolders) be archives would have a nice side-effect of preventing nonsense bugreports from people who like to update their game by unpacking it over the old installation."

#### Describe the solution
Hijack the flexbuffers cache. While it CAN update the cache for file changes, it should not be doing that in regular operation. If the game's data has changed this indicates a failure of some sort, so it should warn. Therefore we throw a warning.

This does not prevent the game from loading and the warning does not reoccur unless further modifications happen.

#### Describe alternatives you've considered
I originally thought about doing some wild homegrown checksum implementation:
![image](https://github.com/user-attachments/assets/5d7b022b-3511-46ea-8620-848bf2a91e5d)


...but then I realized the flexbuffers cache already does that, so hijacking it was 100x easier.

#### Testing
Modify game json locally, game throws warning on load. Can be ignored, does not reoccur.

Game does not throw warnings when game json has not been modified.


#### Additional context

@akrieger since this is your baby and I'm sure you may have an opinion on any changes to it, courtesy notification

Known issues: **Several.** I'll type them up in a reply so they don't clog up the summary.