### PR TITLE
[Xedra Evolved] Rescale blood vitamin 

### DIFF
--- a/data/mods/Xedra_Evolved/effects/effects.json
+++ b/data/mods/Xedra_Evolved/effects/effects.json
@@ -599,14 +599,6 @@
   },
   {
     "type": "effect_type",
-    "id": "effect_dhampir_immune_to_withering",
-    "//": "Hidden--prevents dhampirs from suffering from the withering",
-    "name": [ "" ],
-    "desc": [ "" ],
-    "removes_effects": [ "withering" ]
-  },
-  {
-    "type": "effect_type",
     "id": "effect_dhampir_empowered_blood_indicator",
     "name": [ "Empowered Blood" ],
     "desc": [ "Your blood hums with power, allowing you to access more of your vampiric abilities." ]

--- a/data/mods/Xedra_Evolved/effects/effects.json
+++ b/data/mods/Xedra_Evolved/effects/effects.json
@@ -599,6 +599,14 @@
   },
   {
     "type": "effect_type",
+    "id": "effect_dhampir_immune_to_withering",
+    "//": "Hidden--prevents dhampirs from suffering from the withering",
+    "name": [ "" ],
+    "desc": [ "" ],
+    "removes_effects": [ "withering" ]
+  },
+  {
+    "type": "effect_type",
     "id": "effect_dhampir_empowered_blood_indicator",
     "name": [ "Empowered Blood" ],
     "desc": [ "Your blood hums with power, allowing you to access more of your vampiric abilities." ]

--- a/data/mods/Xedra_Evolved/mutations/mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/mutations.json
@@ -177,7 +177,7 @@
         "condition": {
           "and": [
             { "not": { "u_has_trait": "DHAMPIR_WEAKNESS_SLOWER_BLOOD_GAIN" } },
-            { "math": [ "u_vitamin('human_blood_vitamin')", "<", "6599" ] }
+            { "math": [ "u_vitamin('human_blood_vitamin')", "<", "1799" ] }
           ]
         },
         "ench_effects": [ { "effect": "effect_dhampir_slow_blood_gain", "intensity": 1 } ]
@@ -186,26 +186,20 @@
         "condition": {
           "and": [
             { "u_has_trait": "DHAMPIR_WEAKNESS_SLOWER_BLOOD_GAIN" },
-            { "math": [ "u_vitamin('human_blood_vitamin')", "<", "6599" ] }
+            { "math": [ "u_vitamin('human_blood_vitamin')", "<", "1799" ] }
           ]
         },
         "ench_effects": [ { "effect": "effect_dhampir_slow_blood_gain_with_weakness", "intensity": 1 } ]
       },
       {
-        "condition": { "math": [ "u_vitamin('human_blood_vitamin')", ">=", "6600" ] },
+        "condition": { "math": [ "u_vitamin('human_blood_vitamin')", ">=", "1800" ] },
         "ench_effects": [ { "effect": "effect_dhampir_slow_blood_loss", "intensity": 1 } ]
       },
       {
-        "condition": { "math": [ "u_vitamin('human_blood_vitamin')", ">", "3600" ] },
+        "condition": { "math": [ "u_vitamin('human_blood_vitamin')", ">", "0" ] },
         "ench_effects": [ { "effect": "effect_dhampir_empowered_blood_indicator", "intensity": 1 } ]
       },
-      {
-        "condition": "ALWAYS",
-        "ench_effects": [
-          { "effect": "effect_lilin_vampire_immune", "intensity": 1 },
-          { "effect": "effect_dhampir_immune_to_withering", "intensity": 1 }
-        ]
-      }
+      { "condition": "ALWAYS", "ench_effects": [ { "effect": "effect_lilin_vampire_immune", "intensity": 1 } ] }
     ],
     "//": "Dhampirs not getting Cannibal is deliberate.  The struggle over their own humanity is a core part of the dhampir theme.",
     "flags": [ "HEMOVORE" ],
@@ -507,7 +501,7 @@
     "starting_trait": false,
     "purifiable": false,
     "valid": false,
-    "vitamin_rates": [ [ "human_blood_vitamin", 180 ] ],
+    "vitamin_rates": [ [ "human_blood_vitamin", 720 ] ],
     "no_empathize_with": [ "HUMAN" ],
     "flags": [ "CANNIBAL", "HEMOVORE" ],
     "cancels": [ "DREAMER", "DREAMSMITH", "EATER", "INVENTOR" ]
@@ -642,7 +636,7 @@
     "purifiable": false,
     "types": [ "TEETH" ],
     "valid": false,
-    "vitamin_rates": [ [ "human_blood_vitamin", 180 ] ],
+    "vitamin_rates": [ [ "human_blood_vitamin", 720 ] ],
     "flags": [ "CANNIBAL", "ALBINO", "HEMOVORE" ],
     "attacks": [
       {
@@ -781,7 +775,7 @@
     "purifiable": false,
     "valid": false,
     "vitamins_absorb_multi": [ [ "all", [ [ "human_blood_vitamin", 1.25 ] ] ] ],
-    "vitamin_rates": [ [ "human_blood_vitamin", 180 ] ],
+    "vitamin_rates": [ [ "human_blood_vitamin", 720 ] ],
     "flags": [ "CANNIBAL", "ALBINO", "DAYFEAR", "HEMOVORE" ],
     "enchantments": [
       { "condition": { "not": "is_day" }, "values": [ { "value": "OVERMAP_SIGHT", "add": 1 } ] },

--- a/data/mods/Xedra_Evolved/mutations/mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/mutations.json
@@ -361,7 +361,7 @@
     "description": "You are only half-alive now, sustained as much by the energy in your blood as by biological processes.  You age far slower than a mortal, and when your limbs break, they heal more quickly in proportion to how much empowered blood you have.",
     "enchantments": [
       {
-        "values": [ { "value": "MENDING_MODIFIER", "multiply": { "math": [ "max( (u_vitamin('human_blood_vitamin') / 750), 0)" ] } } ]
+        "values": [ { "value": "MENDING_MODIFIER", "multiply": { "math": [ "max( (u_vitamin('human_blood_vitamin') / 250), 0)" ] } } ]
       }
     ],
     "flags": [ "MEND_ALL" ]

--- a/data/mods/Xedra_Evolved/mutations/mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/mutations.json
@@ -196,7 +196,7 @@
         "ench_effects": [ { "effect": "effect_dhampir_slow_blood_loss", "intensity": 1 } ]
       },
       {
-        "condition": { "math": [ "u_vitamin('human_blood_vitamin')", ">", "3200" ] },
+        "condition": { "math": [ "u_vitamin('human_blood_vitamin')", ">", "3600" ] },
         "ench_effects": [ { "effect": "effect_dhampir_empowered_blood_indicator", "intensity": 1 } ]
       },
       {

--- a/data/mods/Xedra_Evolved/mutations/mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/mutations.json
@@ -289,7 +289,7 @@
     "description": "Your half-dead flesh is inured to winter's chill.  As long as you have empowered blood in your body, you suffer much less from colder temperatures.",
     "enchantments": [
       {
-        "condition": { "u_has_effecf": "effect_dhampir_empowered_blood_indicator" },
+        "condition": { "u_has_effect": "effect_dhampir_empowered_blood_indicator" },
         "values": [ { "value": "CLIMATE_CONTROL_CHILL", "add": 25 } ]
       }
     ]
@@ -305,7 +305,7 @@
     "description": "The deathly energies that course through your veins are inimical to mundane poisons and diseases.  As long as you have empowered blood in your body, you are more resistant to disease, poison, and infection.",
     "enchantments": [
       {
-        "condition": { "math": [ "u_vitamin('human_blood_vitamin')", ">", "0" ] },
+        "condition": { "u_has_effect": "effect_dhampir_empowered_blood_indicator" },
         "ench_effects": [ { "effect": "effect_dhampir_resist_disease_poison_infection", "intensity": 1 } ]
       }
     ]
@@ -321,7 +321,7 @@
     "description": "While unable to ignore gravity like a true vampire, it has less of a hold on you.  You take greatly-reduced fall damage as long as you have empowered blood in your body.",
     "enchantments": [
       {
-        "condition": { "math": [ "u_vitamin('human_blood_vitamin')", ">", "0" ] },
+        "condition": { "u_has_effect": "effect_dhampir_empowered_blood_indicator" },
         "values": [ { "value": "FALL_DAMAGE", "multiply": -0.8 } ],
         "ench_effects": [ { "effect": "effect_dhampir_fall_one_story", "intensity": 1 } ]
       }
@@ -361,7 +361,7 @@
     "description": "You are only half-alive now, sustained as much by the energy in your blood as by biological processes.  You age far slower than a mortal, and when your limbs break, they heal more quickly in proportion to how much empowered blood you have.",
     "enchantments": [
       {
-        "values": [ { "value": "MENDING_MODIFIER", "multiply": { "math": [ "max( (u_vitamin('human_blood_vitamin') / 250), 0)" ] } } ]
+        "values": [ { "value": "MENDING_MODIFIER", "multiply": { "math": [ "max( (u_vitamin('human_blood_vitamin') / 750), 0)" ] } } ]
       }
     ],
     "flags": [ "MEND_ALL" ]

--- a/data/mods/Xedra_Evolved/mutations/mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/mutations.json
@@ -177,7 +177,7 @@
         "condition": {
           "and": [
             { "not": { "u_has_trait": "DHAMPIR_WEAKNESS_SLOWER_BLOOD_GAIN" } },
-            { "math": [ "u_vitamin('human_blood_vitamin')", "<", "1799" ] }
+            { "math": [ "u_vitamin('human_blood_vitamin')", "<", "6599" ] }
           ]
         },
         "ench_effects": [ { "effect": "effect_dhampir_slow_blood_gain", "intensity": 1 } ]
@@ -186,17 +186,17 @@
         "condition": {
           "and": [
             { "u_has_trait": "DHAMPIR_WEAKNESS_SLOWER_BLOOD_GAIN" },
-            { "math": [ "u_vitamin('human_blood_vitamin')", "<", "1799" ] }
+            { "math": [ "u_vitamin('human_blood_vitamin')", "<", "6599" ] }
           ]
         },
         "ench_effects": [ { "effect": "effect_dhampir_slow_blood_gain_with_weakness", "intensity": 1 } ]
       },
       {
-        "condition": { "math": [ "u_vitamin('human_blood_vitamin')", ">=", "1800" ] },
+        "condition": { "math": [ "u_vitamin('human_blood_vitamin')", ">=", "6600" ] },
         "ench_effects": [ { "effect": "effect_dhampir_slow_blood_loss", "intensity": 1 } ]
       },
       {
-        "condition": { "math": [ "u_vitamin('human_blood_vitamin')", ">", "0" ] },
+        "condition": { "math": [ "u_vitamin('human_blood_vitamin')", ">", "3200" ] },
         "ench_effects": [ { "effect": "effect_dhampir_empowered_blood_indicator", "intensity": 1 } ]
       },
       { "condition": "ALWAYS", "ench_effects": [ { "effect": "effect_lilin_vampire_immune", "intensity": 1 } ] }
@@ -289,7 +289,7 @@
     "description": "Your half-dead flesh is inured to winter's chill.  As long as you have empowered blood in your body, you suffer much less from colder temperatures.",
     "enchantments": [
       {
-        "condition": { "math": [ "u_vitamin('human_blood_vitamin')", ">", "0" ] },
+        "condition": { "u_has_effecf": "effect_dhampir_empowered_blood_indicator" },
         "values": [ { "value": "CLIMATE_CONTROL_CHILL", "add": 25 } ]
       }
     ]

--- a/data/mods/Xedra_Evolved/mutations/mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/mutations.json
@@ -199,7 +199,13 @@
         "condition": { "math": [ "u_vitamin('human_blood_vitamin')", ">", "3200" ] },
         "ench_effects": [ { "effect": "effect_dhampir_empowered_blood_indicator", "intensity": 1 } ]
       },
-      { "condition": "ALWAYS", "ench_effects": [ { "effect": "effect_lilin_vampire_immune", "intensity": 1 } ] }
+      {
+        "condition": "ALWAYS",
+        "ench_effects": [
+          { "effect": "effect_lilin_vampire_immune", "intensity": 1 },
+          { "effect": "effect_dhampir_immune_to_withering", "intensity": 1 }
+        ]
+      }
     ],
     "//": "Dhampirs not getting Cannibal is deliberate.  The struggle over their own humanity is a core part of the dhampir theme.",
     "flags": [ "HEMOVORE" ],

--- a/data/mods/Xedra_Evolved/mutations/vampire_trait_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/vampire_trait_eocs.json
@@ -377,7 +377,7 @@
         "math": [
           "u_max_blood_amount_for_graph",
           "=",
-          "5600 + (u_has_trait('VAMPIRE_STORE_MORE_BLOOD') * 9000) + (u_has_trait('VAMPIRE_STORE_MORE_BLOOD_UPGRADE') * 18000)"
+          "10400 + (u_has_trait('VAMPIRE_STORE_MORE_BLOOD') * 9000) + (u_has_trait('VAMPIRE_STORE_MORE_BLOOD_UPGRADE') * 18000)"
         ]
       },
       { "run_eocs": "EOC_VAMPIRE_BLOOD_MAX_LIMIT" }
@@ -390,17 +390,17 @@
       "math": [
         "u_vitamin('human_blood_vitamin')",
         ">=",
-        "5600 + (u_has_trait('VAMPIRE_STORE_MORE_BLOOD') * 9000) + (u_has_trait('VAMPIRE_STORE_MORE_BLOOD_UPGRADE') * 18000)"
+        "10400 + (u_has_trait('VAMPIRE_STORE_MORE_BLOOD') * 9000) + (u_has_trait('VAMPIRE_STORE_MORE_BLOOD_UPGRADE') * 18000)"
       ]
     },
     "effect": [
       {
         "if": { "u_has_trait": "VAMPIRE_STORE_MORE_BLOOD_UPGRADE" },
-        "then": { "math": [ "u_vitamin('human_blood_vitamin') = 32600" ] },
+        "then": { "math": [ "u_vitamin('human_blood_vitamin') = 37400" ] },
         "else": {
           "if": { "u_has_trait": "VAMPIRE_STORE_MORE_BLOOD" },
-          "then": { "math": [ "u_vitamin('human_blood_vitamin') = 14600" ] },
-          "else": { "math": [ "u_vitamin('human_blood_vitamin') = 5600" ] }
+          "then": { "math": [ "u_vitamin('human_blood_vitamin') = 19400" ] },
+          "else": { "math": [ "u_vitamin('human_blood_vitamin') = 10400" ] }
         }
       }
     ]
@@ -602,6 +602,15 @@
       { "math": [ "u_vampire_total_tier_four_traits = vampire_total_tier_four_traits_plus_potence()" ] },
       { "math": [ "u_vampire_total_tier_five_traits = vampire_total_tier_five_traits_plus_cauldron()" ] }
     ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_GAIN_BLOOD_BECOME_A_VAMPIRE",
+    "eoc_type": "EVENT",
+    "required_event": "character_gains_effect",
+    "condition": { "compare_string": [ "vampire_virus", { "context_val": "effect" } ] },
+    "//": "Adds blood on becoming a vampire so you don't instantly start withering",
+    "effect": [ { "math": [ "u_vitamin('human_blood_vitamin') += 2500" ] } ]
   },
   {
     "type": "effect_on_condition",

--- a/data/mods/Xedra_Evolved/mutations/vampire_trait_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/vampire_trait_eocs.json
@@ -377,7 +377,7 @@
         "math": [
           "u_max_blood_amount_for_graph",
           "=",
-          "10400 + (u_has_trait('VAMPIRE_STORE_MORE_BLOOD') * 9000) + (u_has_trait('VAMPIRE_STORE_MORE_BLOOD_UPGRADE') * 18000)"
+          "5400 + (u_has_trait('VAMPIRE_STORE_MORE_BLOOD') * 9000) + (u_has_trait('VAMPIRE_STORE_MORE_BLOOD_UPGRADE') * 18000)"
         ]
       },
       { "run_eocs": "EOC_VAMPIRE_BLOOD_MAX_LIMIT" }
@@ -390,17 +390,17 @@
       "math": [
         "u_vitamin('human_blood_vitamin')",
         ">=",
-        "10400 + (u_has_trait('VAMPIRE_STORE_MORE_BLOOD') * 9000) + (u_has_trait('VAMPIRE_STORE_MORE_BLOOD_UPGRADE') * 18000)"
+        "5600 + (u_has_trait('VAMPIRE_STORE_MORE_BLOOD') * 9000) + (u_has_trait('VAMPIRE_STORE_MORE_BLOOD_UPGRADE') * 18000)"
       ]
     },
     "effect": [
       {
         "if": { "u_has_trait": "VAMPIRE_STORE_MORE_BLOOD_UPGRADE" },
-        "then": { "math": [ "u_vitamin('human_blood_vitamin') = 37400" ] },
+        "then": { "math": [ "u_vitamin('human_blood_vitamin') = 32600" ] },
         "else": {
           "if": { "u_has_trait": "VAMPIRE_STORE_MORE_BLOOD" },
-          "then": { "math": [ "u_vitamin('human_blood_vitamin') = 19400" ] },
-          "else": { "math": [ "u_vitamin('human_blood_vitamin') = 10400" ] }
+          "then": { "math": [ "u_vitamin('human_blood_vitamin') = 14600" ] },
+          "else": { "math": [ "u_vitamin('human_blood_vitamin') = 5600" ] }
         }
       }
     ]

--- a/data/mods/Xedra_Evolved/mutations/vampire_trait_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/vampire_trait_eocs.json
@@ -610,7 +610,7 @@
     "required_event": "character_gains_effect",
     "condition": { "compare_string": [ "vampire_virus", { "context_val": "effect" } ] },
     "//": "Adds blood on becoming a vampire so you don't instantly start withering",
-    "effect": [ { "math": [ "u_vitamin('human_blood_vitamin') += 2500" ] } ]
+    "effect": [ { "math": [ "u_vitamin('human_blood_vitamin') += 1200" ] } ]
   },
   {
     "type": "effect_on_condition",

--- a/data/mods/Xedra_Evolved/obsoletion_and_migration/eocs.json
+++ b/data/mods/Xedra_Evolved/obsoletion_and_migration/eocs.json
@@ -73,8 +73,10 @@
     "condition": { "math": [ "u_vampire_blood_scale_updated != 1" ] },
     "effect": [
       {
-        "if": { "and": [ { "u_has_any_trait": [ "VAMPIRE", "DHAMPIR_TRAIT" ] } ] },
-        "then": { "math": [ "u_vitamin('human_blood_vitamin') += 4800" ] }
+        "if": {
+          "and": [ { "u_has_any_trait": [ "VAMPIRE", "DHAMPIR_TRAIT" ] }, { "math": [ "u_vitamin('human_blood_vitamin') <= 0" ] } ]
+        },
+        "then": { "math": [ "u_vitamin('human_blood_vitamin') = 500" ] }
       },
       { "math": [ "u_vampire_blood_scale_updated = 1" ] }
     ]

--- a/data/mods/Xedra_Evolved/obsoletion_and_migration/eocs.json
+++ b/data/mods/Xedra_Evolved/obsoletion_and_migration/eocs.json
@@ -74,7 +74,10 @@
     "effect": [
       {
         "if": {
-          "and": [ { "u_has_any_trait": [ "VAMPIRE", "DHAMPIR_TRAIT" ] }, { "math": [ "u_vitamin('human_blood_vitamin') <= 0" ] } ]
+          "and": [
+            { "or": [ { "u_has_any_trait": [ "VAMPIRE", "DHAMPIR_TRAIT" ] }, { "u_has_effect": "vampire_virus" } ] },
+            { "math": [ "u_vitamin('human_blood_vitamin') <= 0" ] }
+          ]
         },
         "then": { "math": [ "u_vitamin('human_blood_vitamin') = 500" ] }
       },

--- a/data/mods/Xedra_Evolved/obsoletion_and_migration/eocs.json
+++ b/data/mods/Xedra_Evolved/obsoletion_and_migration/eocs.json
@@ -64,5 +64,19 @@
         ]
       }
     ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_VAMPIRE_BLOOD_UPDATE_GAME_BEGIN",
+    "eoc_type": "EVENT",
+    "required_event": "game_begin",
+    "condition": { "math": [ "u_vampire_blood_scale_updated != 1" ] },
+    "effect": [
+      {
+        "if": { "and": [ { "u_has_any_trait": [ "VAMPIRE", "DHAMPIR_TRAIT" ] } ] },
+        "then": { "math": [ "u_vitamin('human_blood_vitamin') += 4800" ] }
+      },
+      { "math": [ "u_vampire_blood_scale_updated = 1" ] }
+    ]
   }
 ]

--- a/data/mods/Xedra_Evolved/ui/vamp_blood_levels.json
+++ b/data/mods/Xedra_Evolved/ui/vamp_blood_levels.json
@@ -10,12 +10,7 @@
         "id": "slumber",
         "text": "Eternal Slumber",
         "color": "dark_gray_red",
-        "condition": {
-          "and": [
-            { "or": [ { "u_has_trait": "DHAMPIR_TRAIT" }, { "u_has_effect": "vampire_virus" } ] },
-            { "math": [ "u_vitamin('human_blood_vitamin') <= -7199" ] }
-          ]
-        }
+        "condition": { "and": [ { "u_has_effect": "vampire_virus" }, { "math": [ "u_vitamin('human_blood_vitamin') <= -1501" ] } ] }
       },
       {
         "id": "near_death",
@@ -23,9 +18,9 @@
         "color": "light_gray",
         "condition": {
           "and": [
-            { "or": [ { "u_has_trait": "DHAMPIR_TRAIT" }, { "u_has_effect": "vampire_virus" } ] },
-            { "math": [ "u_vitamin('human_blood_vitamin') <= -1601" ] },
-            { "math": [ "u_vitamin('human_blood_vitamin') > -7199" ] }
+            { "u_has_effect": "vampire_virus" },
+            { "math": [ "u_vitamin('human_blood_vitamin') <= -751" ] },
+            { "math": [ "u_vitamin('human_blood_vitamin') > -1500" ] }
           ]
         }
       },
@@ -35,9 +30,9 @@
         "color": "yellow",
         "condition": {
           "and": [
-            { "or": [ { "u_has_trait": "DHAMPIR_TRAIT" }, { "u_has_effect": "vampire_virus" } ] },
-            { "math": [ "u_vitamin('human_blood_vitamin') <= -801" ] },
-            { "math": [ "u_vitamin('human_blood_vitamin') > -2601" ] }
+            { "u_has_effect": "vampire_virus" },
+            { "math": [ "u_vitamin('human_blood_vitamin') <= -301" ] },
+            { "math": [ "u_vitamin('human_blood_vitamin') > -751" ] }
           ]
         }
       },
@@ -47,11 +42,17 @@
         "color": "light_green",
         "condition": {
           "and": [
-            { "or": [ { "u_has_trait": "DHAMPIR_TRAIT" }, { "u_has_effect": "vampire_virus" } ] },
+            { "u_has_effect": "vampire_virus" },
             { "math": [ "u_vitamin('human_blood_vitamin') <= -1" ] },
-            { "math": [ "u_vitamin('human_blood_vitamin') > -801" ] }
+            { "math": [ "u_vitamin('human_blood_vitamin') > -301" ] }
           ]
         }
+      },
+      {
+        "id": "hungry",
+        "text": "Enervated",
+        "color": "yellow",
+        "condition": { "and": [ { "u_has_trait": "DHAMPIR_TRAIT" }, { "math": [ "u_vitamin('human_blood_vitamin') <= -1" ] } ] }
       },
       {
         "id": "content",
@@ -60,7 +61,7 @@
         "condition": {
           "and": [
             { "or": [ { "u_has_trait": "DHAMPIR_TRAIT" }, { "u_has_effect": "vampire_virus" } ] },
-            { "math": [ "u_vitamin('human_blood_vitamin') <= 6599" ] },
+            { "math": [ "u_vitamin('human_blood_vitamin') <= 1800" ] },
             { "math": [ "u_vitamin('human_blood_vitamin') > -1" ] }
           ]
         }
@@ -73,8 +74,8 @@
           "and": [
             { "or": [ { "u_has_trait": "DHAMPIR_TRAIT" }, { "u_has_effect": "vampire_virus" } ] },
             { "not": { "u_has_trait": "VAMPIRE_DISTILLATE_INNER_BLOOD" } },
-            { "math": [ "u_vitamin('human_blood_vitamin') <= 7200" ] },
-            { "math": [ "u_vitamin('human_blood_vitamin') > 6599" ] }
+            { "math": [ "u_vitamin('human_blood_vitamin') <= 2401" ] },
+            { "math": [ "u_vitamin('human_blood_vitamin') > 1800" ] }
           ]
         }
       },
@@ -86,8 +87,8 @@
           "and": [
             { "or": [ { "u_has_trait": "DHAMPIR_TRAIT" }, { "u_has_effect": "vampire_virus" } ] },
             { "not": { "u_has_trait": "VAMPIRE_DISTILLATE_INNER_BLOOD" } },
-            { "math": [ "u_vitamin('human_blood_vitamin') <= 9200" ] },
-            { "math": [ "u_vitamin('human_blood_vitamin') > 7200" ] }
+            { "math": [ "u_vitamin('human_blood_vitamin') <= 4401" ] },
+            { "math": [ "u_vitamin('human_blood_vitamin') > 2401" ] }
           ]
         }
       },
@@ -99,7 +100,7 @@
           "and": [
             { "or": [ { "u_has_trait": "DHAMPIR_TRAIT" }, { "u_has_effect": "vampire_virus" } ] },
             { "not": { "u_has_trait": "VAMPIRE_DISTILLATE_INNER_BLOOD" } },
-            { "math": [ "u_vitamin('human_blood_vitamin') > 9200" ] }
+            { "math": [ "u_vitamin('human_blood_vitamin') > 4401" ] }
           ]
         }
       },
@@ -111,8 +112,8 @@
           "and": [
             { "or": [ { "u_has_trait": "DHAMPIR_TRAIT" }, { "u_has_effect": "vampire_virus" } ] },
             { "u_has_trait": "VAMPIRE_DISTILLATE_INNER_BLOOD" },
-            { "math": [ "u_vitamin('human_blood_vitamin') <= 7200" ] },
-            { "math": [ "u_vitamin('human_blood_vitamin') > 6599" ] }
+            { "math": [ "u_vitamin('human_blood_vitamin') <= 2401" ] },
+            { "math": [ "u_vitamin('human_blood_vitamin') > 1800" ] }
           ]
         }
       },
@@ -124,8 +125,8 @@
           "and": [
             { "or": [ { "u_has_trait": "DHAMPIR_TRAIT" }, { "u_has_effect": "vampire_virus" } ] },
             { "u_has_trait": "VAMPIRE_DISTILLATE_INNER_BLOOD" },
-            { "math": [ "u_vitamin('human_blood_vitamin') <= 9200" ] },
-            { "math": [ "u_vitamin('human_blood_vitamin') > 7199" ] }
+            { "math": [ "u_vitamin('human_blood_vitamin') <= 4401" ] },
+            { "math": [ "u_vitamin('human_blood_vitamin') > 2401" ] }
           ]
         }
       },
@@ -137,8 +138,8 @@
           "and": [
             { "or": [ { "u_has_trait": "DHAMPIR_TRAIT" }, { "u_has_effect": "vampire_virus" } ] },
             { "u_has_trait": "VAMPIRE_DISTILLATE_INNER_BLOOD" },
-            { "math": [ "u_vitamin('human_blood_vitamin') <= 13200" ] },
-            { "math": [ "u_vitamin('human_blood_vitamin') > 9200" ] }
+            { "math": [ "u_vitamin('human_blood_vitamin') > 4401" ] },
+            { "math": [ "u_vitamin('human_blood_vitamin') < 8401" ] }
           ]
         }
       },
@@ -150,8 +151,8 @@
           "and": [
             { "u_has_effect": "vampire_virus" },
             { "u_has_trait": "VAMPIRE_DISTILLATE_INNER_BLOOD" },
-            { "math": [ "u_vitamin('human_blood_vitamin') >= 13201" ] },
-            { "math": [ "u_vitamin('human_blood_vitamin') < 19200" ] }
+            { "math": [ "u_vitamin('human_blood_vitamin') >= 8401" ] },
+            { "math": [ "u_vitamin('human_blood_vitamin') < 14401" ] }
           ]
         }
       },
@@ -163,8 +164,8 @@
           "and": [
             { "u_has_effect": "vampire_virus" },
             { "u_has_trait": "VAMPIRE_DISTILLATE_INNER_BLOOD" },
-            { "math": [ "u_vitamin('human_blood_vitamin') >= 19201" ] },
-            { "math": [ "u_vitamin('human_blood_vitamin') < 29200" ] }
+            { "math": [ "u_vitamin('human_blood_vitamin') >= 14401" ] },
+            { "math": [ "u_vitamin('human_blood_vitamin') < 24401" ] }
           ]
         }
       },
@@ -176,7 +177,7 @@
           "and": [
             { "u_has_effect": "vampire_virus" },
             { "u_has_trait": "VAMPIRE_DISTILLATE_INNER_BLOOD" },
-            { "math": [ "u_vitamin('human_blood_vitamin') >= 29200" ] }
+            { "math": [ "u_vitamin('human_blood_vitamin') >= 24401" ] }
           ]
         }
       }
@@ -209,7 +210,7 @@
             { "or": [ { "u_has_trait": "DHAMPIR_TRAIT" }, { "u_has_effect": "vampire_virus" } ] },
             { "not": { "u_has_trait": "VAMPIRE_DISTILLATE_INNER_BLOOD" } },
             { "math": [ "u_vitamin('human_blood_vitamin') > 0" ] },
-            { "math": [ "u_vitamin('human_blood_vitamin') < 6600" ] }
+            { "math": [ "u_vitamin('human_blood_vitamin') < 1800" ] }
           ]
         }
       },
@@ -221,7 +222,7 @@
           "and": [
             { "or": [ { "u_has_trait": "DHAMPIR_TRAIT" }, { "u_has_effect": "vampire_virus" } ] },
             { "not": { "u_has_trait": "VAMPIRE_DISTILLATE_INNER_BLOOD" } },
-            { "math": [ "u_vitamin('human_blood_vitamin') > 6599" ] }
+            { "math": [ "u_vitamin('human_blood_vitamin') > 1799" ] }
           ]
         }
       },
@@ -249,17 +250,17 @@
         0,
         {
           "math": [
-            "(10400 + (u_has_trait('VAMPIRE_STORE_MORE_BLOOD') * 9000) + (u_has_trait('VAMPIRE_STORE_MORE_BLOOD_UPGRADE') * 18000) + (u_has_trait('VAMPIRE_DISTILLATE_INNER_BLOOD') * 11200)) * 0.3333333"
+            "(5600 + (u_has_trait('VAMPIRE_STORE_MORE_BLOOD') * 9000) + (u_has_trait('VAMPIRE_STORE_MORE_BLOOD_UPGRADE') * 18000) + (u_has_trait('VAMPIRE_DISTILLATE_INNER_BLOOD') * 11200)) * 0.3333333"
           ]
         },
         {
           "math": [
-            "(10400 + (u_has_trait('VAMPIRE_STORE_MORE_BLOOD') * 9000) + (u_has_trait('VAMPIRE_STORE_MORE_BLOOD_UPGRADE') * 18000) + (u_has_trait('VAMPIRE_DISTILLATE_INNER_BLOOD') * 11200)) * 0.6666666"
+            "(5600 + (u_has_trait('VAMPIRE_STORE_MORE_BLOOD') * 9000) + (u_has_trait('VAMPIRE_STORE_MORE_BLOOD_UPGRADE') * 18000) + (u_has_trait('VAMPIRE_DISTILLATE_INNER_BLOOD') * 11200)) * 0.6666666"
           ]
         },
         {
           "math": [
-            "10400 + (u_has_trait('VAMPIRE_STORE_MORE_BLOOD') * 9000) + (u_has_trait('VAMPIRE_STORE_MORE_BLOOD_UPGRADE') * 18000) + (u_has_trait('VAMPIRE_DISTILLATE_INNER_BLOOD') * 11200)"
+            "5600 + (u_has_trait('VAMPIRE_STORE_MORE_BLOOD') * 9000) + (u_has_trait('VAMPIRE_STORE_MORE_BLOOD_UPGRADE') * 18000) + (u_has_trait('VAMPIRE_DISTILLATE_INNER_BLOOD') * 11200)"
           ]
         }
       ]

--- a/data/mods/Xedra_Evolved/ui/vamp_blood_levels.json
+++ b/data/mods/Xedra_Evolved/ui/vamp_blood_levels.json
@@ -13,7 +13,7 @@
         "condition": {
           "and": [
             { "or": [ { "u_has_trait": "DHAMPIR_TRAIT" }, { "u_has_effect": "vampire_virus" } ] },
-            { "math": [ "u_vitamin('human_blood_vitamin') <= -11999" ] }
+            { "math": [ "u_vitamin('human_blood_vitamin') <= -7199" ] }
           ]
         }
       },
@@ -24,8 +24,8 @@
         "condition": {
           "and": [
             { "or": [ { "u_has_trait": "DHAMPIR_TRAIT" }, { "u_has_effect": "vampire_virus" } ] },
-            { "math": [ "u_vitamin('human_blood_vitamin') <= -6401" ] },
-            { "math": [ "u_vitamin('human_blood_vitamin') > -11999" ] }
+            { "math": [ "u_vitamin('human_blood_vitamin') <= -1601" ] },
+            { "math": [ "u_vitamin('human_blood_vitamin') > -7199" ] }
           ]
         }
       },
@@ -36,8 +36,8 @@
         "condition": {
           "and": [
             { "or": [ { "u_has_trait": "DHAMPIR_TRAIT" }, { "u_has_effect": "vampire_virus" } ] },
-            { "math": [ "u_vitamin('human_blood_vitamin') <= -5601" ] },
-            { "math": [ "u_vitamin('human_blood_vitamin') > -6401" ] }
+            { "math": [ "u_vitamin('human_blood_vitamin') <= -801" ] },
+            { "math": [ "u_vitamin('human_blood_vitamin') > -2601" ] }
           ]
         }
       },
@@ -48,8 +48,8 @@
         "condition": {
           "and": [
             { "or": [ { "u_has_trait": "DHAMPIR_TRAIT" }, { "u_has_effect": "vampire_virus" } ] },
-            { "math": [ "u_vitamin('human_blood_vitamin') <= -4800" ] },
-            { "math": [ "u_vitamin('human_blood_vitamin') > -5601" ] }
+            { "math": [ "u_vitamin('human_blood_vitamin') <= -1" ] },
+            { "math": [ "u_vitamin('human_blood_vitamin') > -801" ] }
           ]
         }
       },
@@ -60,8 +60,8 @@
         "condition": {
           "and": [
             { "or": [ { "u_has_trait": "DHAMPIR_TRAIT" }, { "u_has_effect": "vampire_virus" } ] },
-            { "math": [ "u_vitamin('human_blood_vitamin') <= 1800" ] },
-            { "math": [ "u_vitamin('human_blood_vitamin') > -4800" ] }
+            { "math": [ "u_vitamin('human_blood_vitamin') <= 6599" ] },
+            { "math": [ "u_vitamin('human_blood_vitamin') > -1" ] }
           ]
         }
       },
@@ -73,8 +73,8 @@
           "and": [
             { "or": [ { "u_has_trait": "DHAMPIR_TRAIT" }, { "u_has_effect": "vampire_virus" } ] },
             { "not": { "u_has_trait": "VAMPIRE_DISTILLATE_INNER_BLOOD" } },
-            { "math": [ "u_vitamin('human_blood_vitamin') <= 2401" ] },
-            { "math": [ "u_vitamin('human_blood_vitamin') > 1800" ] }
+            { "math": [ "u_vitamin('human_blood_vitamin') <= 7200" ] },
+            { "math": [ "u_vitamin('human_blood_vitamin') > 6599" ] }
           ]
         }
       },
@@ -86,8 +86,8 @@
           "and": [
             { "or": [ { "u_has_trait": "DHAMPIR_TRAIT" }, { "u_has_effect": "vampire_virus" } ] },
             { "not": { "u_has_trait": "VAMPIRE_DISTILLATE_INNER_BLOOD" } },
-            { "math": [ "u_vitamin('human_blood_vitamin') <= 4401" ] },
-            { "math": [ "u_vitamin('human_blood_vitamin') > 2401" ] }
+            { "math": [ "u_vitamin('human_blood_vitamin') <= 9200" ] },
+            { "math": [ "u_vitamin('human_blood_vitamin') > 7200" ] }
           ]
         }
       },
@@ -99,7 +99,7 @@
           "and": [
             { "or": [ { "u_has_trait": "DHAMPIR_TRAIT" }, { "u_has_effect": "vampire_virus" } ] },
             { "not": { "u_has_trait": "VAMPIRE_DISTILLATE_INNER_BLOOD" } },
-            { "math": [ "u_vitamin('human_blood_vitamin') > 4401" ] }
+            { "math": [ "u_vitamin('human_blood_vitamin') > 9200" ] }
           ]
         }
       },
@@ -111,8 +111,8 @@
           "and": [
             { "or": [ { "u_has_trait": "DHAMPIR_TRAIT" }, { "u_has_effect": "vampire_virus" } ] },
             { "u_has_trait": "VAMPIRE_DISTILLATE_INNER_BLOOD" },
-            { "math": [ "u_vitamin('human_blood_vitamin') <= 2401" ] },
-            { "math": [ "u_vitamin('human_blood_vitamin') > 1800" ] }
+            { "math": [ "u_vitamin('human_blood_vitamin') <= 7200" ] },
+            { "math": [ "u_vitamin('human_blood_vitamin') > 6599" ] }
           ]
         }
       },
@@ -124,8 +124,8 @@
           "and": [
             { "or": [ { "u_has_trait": "DHAMPIR_TRAIT" }, { "u_has_effect": "vampire_virus" } ] },
             { "u_has_trait": "VAMPIRE_DISTILLATE_INNER_BLOOD" },
-            { "math": [ "u_vitamin('human_blood_vitamin') <= 4401" ] },
-            { "math": [ "u_vitamin('human_blood_vitamin') > 2401" ] }
+            { "math": [ "u_vitamin('human_blood_vitamin') <= 9200" ] },
+            { "math": [ "u_vitamin('human_blood_vitamin') > 7199" ] }
           ]
         }
       },
@@ -137,8 +137,8 @@
           "and": [
             { "or": [ { "u_has_trait": "DHAMPIR_TRAIT" }, { "u_has_effect": "vampire_virus" } ] },
             { "u_has_trait": "VAMPIRE_DISTILLATE_INNER_BLOOD" },
-            { "math": [ "u_vitamin('human_blood_vitamin') > 4401" ] },
-            { "math": [ "u_vitamin('human_blood_vitamin') < 8401" ] }
+            { "math": [ "u_vitamin('human_blood_vitamin') <= 13200" ] },
+            { "math": [ "u_vitamin('human_blood_vitamin') > 9200" ] }
           ]
         }
       },
@@ -150,8 +150,8 @@
           "and": [
             { "u_has_effect": "vampire_virus" },
             { "u_has_trait": "VAMPIRE_DISTILLATE_INNER_BLOOD" },
-            { "math": [ "u_vitamin('human_blood_vitamin') >= 8401" ] },
-            { "math": [ "u_vitamin('human_blood_vitamin') < 14401" ] }
+            { "math": [ "u_vitamin('human_blood_vitamin') >= 13201" ] },
+            { "math": [ "u_vitamin('human_blood_vitamin') < 19200" ] }
           ]
         }
       },
@@ -163,8 +163,8 @@
           "and": [
             { "u_has_effect": "vampire_virus" },
             { "u_has_trait": "VAMPIRE_DISTILLATE_INNER_BLOOD" },
-            { "math": [ "u_vitamin('human_blood_vitamin') >= 14401" ] },
-            { "math": [ "u_vitamin('human_blood_vitamin') < 24401" ] }
+            { "math": [ "u_vitamin('human_blood_vitamin') >= 19201" ] },
+            { "math": [ "u_vitamin('human_blood_vitamin') < 29200" ] }
           ]
         }
       },
@@ -176,7 +176,7 @@
           "and": [
             { "u_has_effect": "vampire_virus" },
             { "u_has_trait": "VAMPIRE_DISTILLATE_INNER_BLOOD" },
-            { "math": [ "u_vitamin('human_blood_vitamin') >= 24401" ] }
+            { "math": [ "u_vitamin('human_blood_vitamin') >= 29200" ] }
           ]
         }
       }
@@ -209,7 +209,7 @@
             { "or": [ { "u_has_trait": "DHAMPIR_TRAIT" }, { "u_has_effect": "vampire_virus" } ] },
             { "not": { "u_has_trait": "VAMPIRE_DISTILLATE_INNER_BLOOD" } },
             { "math": [ "u_vitamin('human_blood_vitamin') > 0" ] },
-            { "math": [ "u_vitamin('human_blood_vitamin') < 1800" ] }
+            { "math": [ "u_vitamin('human_blood_vitamin') < 6600" ] }
           ]
         }
       },
@@ -221,7 +221,7 @@
           "and": [
             { "or": [ { "u_has_trait": "DHAMPIR_TRAIT" }, { "u_has_effect": "vampire_virus" } ] },
             { "not": { "u_has_trait": "VAMPIRE_DISTILLATE_INNER_BLOOD" } },
-            { "math": [ "u_vitamin('human_blood_vitamin') > 1799" ] }
+            { "math": [ "u_vitamin('human_blood_vitamin') > 6599" ] }
           ]
         }
       },
@@ -249,17 +249,17 @@
         0,
         {
           "math": [
-            "(5600 + (u_has_trait('VAMPIRE_STORE_MORE_BLOOD') * 9000) + (u_has_trait('VAMPIRE_STORE_MORE_BLOOD_UPGRADE') * 18000) + (u_has_trait('VAMPIRE_DISTILLATE_INNER_BLOOD') * 11200)) * 0.3333333"
+            "(10400 + (u_has_trait('VAMPIRE_STORE_MORE_BLOOD') * 9000) + (u_has_trait('VAMPIRE_STORE_MORE_BLOOD_UPGRADE') * 18000) + (u_has_trait('VAMPIRE_DISTILLATE_INNER_BLOOD') * 11200)) * 0.3333333"
           ]
         },
         {
           "math": [
-            "(5600 + (u_has_trait('VAMPIRE_STORE_MORE_BLOOD') * 9000) + (u_has_trait('VAMPIRE_STORE_MORE_BLOOD_UPGRADE') * 18000) + (u_has_trait('VAMPIRE_DISTILLATE_INNER_BLOOD') * 11200)) * 0.6666666"
+            "(10400 + (u_has_trait('VAMPIRE_STORE_MORE_BLOOD') * 9000) + (u_has_trait('VAMPIRE_STORE_MORE_BLOOD_UPGRADE') * 18000) + (u_has_trait('VAMPIRE_DISTILLATE_INNER_BLOOD') * 11200)) * 0.6666666"
           ]
         },
         {
           "math": [
-            "5600 + (u_has_trait('VAMPIRE_STORE_MORE_BLOOD') * 9000) + (u_has_trait('VAMPIRE_STORE_MORE_BLOOD_UPGRADE') * 18000) + (u_has_trait('VAMPIRE_DISTILLATE_INNER_BLOOD') * 11200)"
+            "10400 + (u_has_trait('VAMPIRE_STORE_MORE_BLOOD') * 9000) + (u_has_trait('VAMPIRE_STORE_MORE_BLOOD_UPGRADE') * 18000) + (u_has_trait('VAMPIRE_DISTILLATE_INNER_BLOOD') * 11200)"
           ]
         }
       ]

--- a/data/mods/Xedra_Evolved/vitamin.json
+++ b/data/mods/Xedra_Evolved/vitamin.json
@@ -14,16 +14,16 @@
     "id": "human_blood_vitamin",
     "type": "vitamin",
     "//": "Only Vampires have the ability to process this vitamin so if other characters gain any amount of this it will stick around forever and potentially give them the excess disease.",
-    "//2": "Regular vampires have a maximum of 10400 blood vitamin.  Only Vampire Anathema can obtain the capacity increase mutations.",
+    "//2": "Regular vampires have a maximum of 5600 blood vitamin.  Only Vampire Anathema can obtain the capacity increase mutations.",
     "vit_type": "counter",
     "name": { "str": "Stolen Blood" },
     "excess": "blood_quenched",
     "deficiency": "withering",
-    "min": -7200,
-    "max": 37400,
+    "min": -1502,
+    "max": 32600,
     "rate": "0 m",
-    "disease": [ [ -1, -800 ], [ -801, -1600 ], [ -1601, -7198 ], [ -7199, -7200 ] ],
-    "disease_excess": [ [ 6600, 7200 ], [ 7201, 9200 ], [ 9201, 10400 ] ]
+    "disease": [ [ -1, -300 ], [ -301, -750 ], [ -751, -1500 ], [ -1501, -1502 ] ],
+    "disease_excess": [ [ 1800, 2400 ], [ 2401, 4400 ], [ 4401, 5600 ] ]
   },
   {
     "id": "vampire_blood_vitamin",

--- a/data/mods/Xedra_Evolved/vitamin.json
+++ b/data/mods/Xedra_Evolved/vitamin.json
@@ -14,16 +14,16 @@
     "id": "human_blood_vitamin",
     "type": "vitamin",
     "//": "Only Vampires have the ability to process this vitamin so if other characters gain any amount of this it will stick around forever and potentially give them the excess disease.",
-    "//2": "Regular vampires have a maximum of 5600 blood vitamin.  Only Vampire Anathema can obtain the capacity increase mutations.",
+    "//2": "Regular vampires have a maximum of 10400 blood vitamin.  Only Vampire Anathema can obtain the capacity increase mutations.",
     "vit_type": "counter",
     "name": { "str": "Stolen Blood" },
     "excess": "blood_quenched",
     "deficiency": "withering",
-    "min": -12000,
-    "max": 32600,
+    "min": -7200,
+    "max": 37400,
     "rate": "0 m",
-    "disease": [ [ -4800, -5600 ], [ -5601, -6400 ], [ -6401, -11998 ], [ -11999, -12000 ] ],
-    "disease_excess": [ [ 1800, 2400 ], [ 2401, 4400 ], [ 4401, 5600 ] ]
+    "disease": [ [ -1, -800 ], [ -801, -1600 ], [ -1601, -7198 ], [ -7199, -7200 ] ],
+    "disease_excess": [ [ 6600, 7200 ], [ 7201, 9200 ], [ 9201, 10400 ] ]
   },
   {
     "id": "vampire_blood_vitamin",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Xedra Evolved] Rescale blood vitamin "
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

I made the suggestion, I might as well implement it. 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Rescale the blood vitamin so going below 0 is bad. 

~~- [X] Add 4800 to existing vampire/dhampir characters~~
~~- [X] Rework dhampir empowered blood (it now starts at 3200 blood vitamin. The effect in your @ sheet starts at 3500 blood vitamin, slightly above half the top level)~~

Withering now begins at zero. Vampires passively consume blood 4x slower (to account for the removed "grace level" below 0 blood vitamin). The levels of withering are also more compressed, so that once you're in withering it scales up as fast as before.  The goal is that if you just exist, you can go a long time, but using your powers will require you to drink blood, possibly a lot of it.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Loaded game when blood was below 0, got blood to the new content level.
UI accounts for new values below 0.
Becoming a vampire gives you some blood so you don't immediately wither.
Dhampirs are immune to withering (below 0 the UI says they're "enervated")
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Dhampir should also be penalized for going below zero but it should be a different penalty, so I'll do another PR for that.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
