### PR TITLE
tweak metal requirements

### DIFF
--- a/data/json/recipes/ammo/rifle.json
+++ b/data/json/recipes/ammo/rifle.json
@@ -1319,7 +1319,7 @@
     "book_learn": [ [ "textbook_fabrication", 1 ] ],
     "using": [ [ "forging_standard", 5 ] ],
     "tools": [ [ [ "press", -1 ] ], [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
-    "components": [ [ [ "weights", 34, "LIST" ], [ "steel_tiny", 2, "LIST" ] ] ]
+    "components": [ [ [ "weights", 34, "LIST" ], [ "steel_chunk_any", 2, "LIST" ] ] ]
   },
   {
     "result": "reloaded_303",

--- a/data/json/recipes/armor/feet.json
+++ b/data/json/recipes/armor/feet.json
@@ -352,7 +352,7 @@
       [ "adhesive_rubber", 1 ],
       [ "tailoring_leather_small", 16 ],
       [ "welding_standard", 10 ],
-      [ "steel_tiny", 2 ]
+      [ "steel_chunk_any", 2 ]
     ],
     "proficiencies": [
       { "proficiency": "prof_leatherworking_basic" },
@@ -965,7 +965,7 @@
       [ "adhesive_rubber", 1 ],
       [ "tailoring_leather_small", 16 ],
       [ "welding_standard", 10 ],
-      [ "steel_tiny", 2 ]
+      [ "steel_chunk_any", 2 ]
     ],
     "proficiencies": [
       { "proficiency": "prof_leatherworking_basic" },
@@ -1002,7 +1002,7 @@
       [ "tailoring_leather_small", 30 ],
       [ "welding_standard", 12 ],
       [ "blacksmithing_standard", 2 ],
-      [ "steel_tiny", 2 ]
+      [ "steel_chunk_any", 2 ]
     ],
     "proficiencies": [
       { "proficiency": "prof_leatherworking_basic" },

--- a/data/json/recipes/armor/legs.json
+++ b/data/json/recipes/armor/legs.json
@@ -741,7 +741,7 @@
       [ "bronzesmithing_tools", 1 ],
       [ "strap_small", 4 ],
       [ "clasps", 4 ],
-      [ "steel_tiny", 12 ]
+      [ "steel_chunk_any", 12 ]
     ],
     "proficiencies": [
       { "proficiency": "prof_metalworking" },
@@ -754,7 +754,13 @@
     "type": "recipe",
     "copy-from": "legguard_metal",
     "time": "8 h",
-    "using": [ [ "forging_standard", 4 ], [ "bronzesmithing_tools", 1 ], [ "strap_small", 3 ], [ "clasps", 3 ], [ "steel_tiny", 9 ] ]
+    "using": [
+      [ "forging_standard", 4 ],
+      [ "bronzesmithing_tools", 1 ],
+      [ "strap_small", 3 ],
+      [ "clasps", 3 ],
+      [ "steel_chunk_any", 9 ]
+    ]
   },
   {
     "result": "xl_legguard_metal",
@@ -766,7 +772,7 @@
       [ "bronzesmithing_tools", 1 ],
       [ "strap_small", 4 ],
       [ "clasps", 4 ],
-      [ "steel_tiny", 16 ]
+      [ "steel_chunk_any", 16 ]
     ]
   },
   {

--- a/data/json/recipes/other/materials.json
+++ b/data/json/recipes/other/materials.json
@@ -1219,7 +1219,7 @@
     "batch_time_factors": [ 90, 4 ],
     "reversible": true,
     "autolearn": true,
-    "using": [ [ "forging_standard", 4 ], [ "steel_tiny", 4 ] ],
+    "using": [ [ "forging_standard", 4 ], [ "steel_chunk_any", 4 ] ],
     "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ]
   },
   {
@@ -1570,7 +1570,7 @@
     "batch_time_factors": [ 90, 4 ],
     "reversible": true,
     "autolearn": true,
-    "using": [ [ "forging_standard", 8 ], [ "steel_tiny", 8 ] ],
+    "using": [ [ "forging_standard", 8 ], [ "steel_chunk_any", 8 ] ],
     "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ]
   },
   {

--- a/data/json/recipes/other/parts.json
+++ b/data/json/recipes/other/parts.json
@@ -148,7 +148,7 @@
     "autolearn": [ [ "electronics", 3 ] ],
     "book_learn": [ [ "manual_electronics", 1 ], [ "textbook_electronics", 1 ], [ "advanced_electronics", 1 ] ],
     "proficiencies": [ { "proficiency": "prof_metalworking" }, { "proficiency": "prof_blacksmithing" } ],
-    "using": [ [ "blacksmithing_standard", 1 ], [ "steel_tiny", 1 ] ],
+    "using": [ [ "blacksmithing_standard", 1 ], [ "steel_chunk_any", 1 ] ],
     "tools": [ [ [ "swage", -1 ] ] ]
   },
   {
@@ -196,7 +196,7 @@
     "difficulty": 2,
     "time": "1 h",
     "autolearn": true,
-    "using": [ [ "blacksmithing_standard", 1 ], [ "steel_tiny", 1 ] ],
+    "using": [ [ "blacksmithing_standard", 1 ], [ "steel_chunk_any", 1 ] ],
     "proficiencies": [
       { "proficiency": "prof_metalworking" },
       { "proficiency": "prof_blacksmithing" },
@@ -229,7 +229,7 @@
     "difficulty": 6,
     "time": "10 h",
     "autolearn": true,
-    "using": [ [ "blacksmithing_standard", 2 ], [ "steel_tiny", 2 ] ],
+    "using": [ [ "blacksmithing_standard", 2 ], [ "steel_chunk_any", 2 ] ],
     "proficiencies": [
       { "proficiency": "prof_metalworking" },
       { "proficiency": "prof_blacksmithing" },
@@ -314,9 +314,10 @@
     "difficulty": 5,
     "time": "180 m",
     "autolearn": true,
-    "using": [ [ "blacksmithing_standard", 1 ], [ "lc_steel_tiny", 1 ] ],
+    "using": [ [ "blacksmithing_standard", 1 ] ],
     "proficiencies": [ { "proficiency": "prof_metalworking" }, { "proficiency": "prof_blacksmithing" } ],
-    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ]
+    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
+    "components": [ [ [ "lc_steel_chunk", 1 ] ] ]
   },
   {
     "result": "xlframe",
@@ -383,7 +384,7 @@
     "reversible": true,
     "decomp_learn": 2,
     "book_learn": [ [ "manual_electronics", 2 ], [ "mag_electronics", 2 ], [ "manual_mechanics", 2 ] ],
-    "using": [ [ "soldering_standard", 5 ], [ "steel_tiny", 1 ], [ "welding_standard", 2 ] ],
+    "using": [ [ "soldering_standard", 5 ], [ "steel_chunk_any", 1 ], [ "welding_standard", 2 ] ],
     "proficiencies": [ { "proficiency": "prof_elec_soldering" } ],
     "qualities": [ { "id": "HAMMER", "level": 1 }, { "id": "SCREW_FINE", "level": 1 } ],
     "components": [ [ [ "cable", 28 ] ], [ [ "e_scrap", 3 ] ], [ [ "scrap", 1 ] ], [ [ "bearing", 4 ] ] ]
@@ -950,7 +951,7 @@
     "time": "3 h",
     "batch_time_factors": [ 25, 2 ],
     "autolearn": true,
-    "using": [ [ "blacksmithing_standard", 1 ], [ "steel_tiny", 2 ] ],
+    "using": [ [ "blacksmithing_standard", 1 ], [ "steel_chunk_any", 2 ] ],
     "book_learn": [ [ "textbook_fabrication", 3 ], [ "manual_mechanics", 3 ], [ "manual_fabrication", 3 ] ],
     "proficiencies": [ { "proficiency": "prof_metalworking" }, { "proficiency": "prof_blacksmithing" } ],
     "qualities": [

--- a/data/json/recipes/other/parts_construction.json
+++ b/data/json/recipes/other/parts_construction.json
@@ -9,7 +9,7 @@
     "difficulty": 1,
     "time": "3 h",
     "autolearn": true,
-    "using": [ [ "blacksmithing_standard", 1 ], [ "steel_tiny", 1 ] ],
+    "using": [ [ "blacksmithing_standard", 1 ], [ "steel_chunk_any", 1 ] ],
     "proficiencies": [ { "proficiency": "prof_metalworking" }, { "proficiency": "prof_blacksmithing" } ],
     "tools": [ [ [ "hotcut_any", 1, "LIST" ] ] ]
   },
@@ -459,7 +459,7 @@
     "difficulty": 4,
     "time": "2 h",
     "autolearn": true,
-    "using": [ [ "blacksmithing_standard", 2 ], [ "steel_tiny", 2 ] ],
+    "using": [ [ "blacksmithing_standard", 2 ], [ "steel_chunk_any", 2 ] ],
     "proficiencies": [ { "proficiency": "prof_metalworking" }, { "proficiency": "prof_blacksmithing" } ],
     "tools": [ [ [ "hotcut_any", 1, "LIST" ] ] ]
   },
@@ -473,7 +473,7 @@
     "difficulty": 2,
     "time": "1 h 30 m",
     "autolearn": true,
-    "using": [ [ "blacksmithing_standard", 1 ], [ "steel_tiny", 1 ] ],
+    "using": [ [ "blacksmithing_standard", 1 ], [ "steel_chunk_any", 1 ] ],
     "proficiencies": [ { "proficiency": "prof_metalworking" }, { "proficiency": "prof_blacksmithing" } ],
     "tools": [ [ [ "hotcut_any", 1, "LIST" ] ] ]
   },
@@ -487,7 +487,7 @@
     "difficulty": 5,
     "time": "210 m",
     "autolearn": true,
-    "using": [ [ "blacksmithing_standard", 1 ], [ "steel_tiny", 1 ] ],
+    "using": [ [ "blacksmithing_standard", 1 ], [ "steel_chunk_any", 1 ] ],
     "proficiencies": [
       { "proficiency": "prof_metalworking" },
       { "proficiency": "prof_blacksmithing" },
@@ -564,7 +564,7 @@
     "difficulty": 5,
     "time": "3 h",
     "autolearn": true,
-    "using": [ [ "blacksmithing_standard", 2 ], [ "steel_tiny", 2 ] ],
+    "using": [ [ "blacksmithing_standard", 2 ], [ "steel_chunk_any", 2 ] ],
     "proficiencies": [
       { "proficiency": "prof_metalworking" },
       { "proficiency": "prof_blacksmithing" },

--- a/data/json/recipes/other/vehicle.json
+++ b/data/json/recipes/other/vehicle.json
@@ -27,7 +27,7 @@
     "time": "60 m",
     "//": "50cm weld",
     "book_learn": [ [ "textbook_fabrication", 4 ], [ "textbook_mechanics", 2 ], [ "manual_mechanics", 2 ] ],
-    "using": [ [ "welding_standard", 50 ], [ "steel_tiny", 2 ] ],
+    "using": [ [ "welding_standard", 50 ], [ "steel_chunk_any", 2 ] ],
     "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SAW_M", "level": 1 }, { "id": "WRENCH", "level": 1 } ],
     "components": [ [ [ "pipe", 8 ] ], [ [ "any_wire", 8, "LIST" ] ], [ [ "pipe_fittings", 4 ] ] ]
   },
@@ -43,7 +43,7 @@
     "time": "60 m",
     "autolearn": true,
     "//": "40cm weld",
-    "using": [ [ "welding_standard", 40 ], [ "steel_tiny", 2 ] ],
+    "using": [ [ "welding_standard", 40 ], [ "steel_chunk_any", 2 ] ],
     "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SAW_M", "level": 1 }, { "id": "WRENCH", "level": 1 } ],
     "components": [ [ [ "jack", 1 ] ], [ [ "pipe", 4 ] ], [ [ "pipe_fittings", 2 ] ] ]
   },

--- a/data/json/recipes/recipe_ammo.json
+++ b/data/json/recipes/recipe_ammo.json
@@ -56,7 +56,7 @@
     "book_learn": [ [ "textbook_fabrication", 1 ] ],
     "using": [ [ "forging_standard", 2 ] ],
     "tools": [ [ [ "press", -1 ] ], [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
-    "components": [ [ [ "weights", 34, "LIST" ], [ "steel_tiny", 2, "LIST" ] ] ]
+    "components": [ [ [ "weights", 34, "LIST" ], [ "steel_chunk_any", 2, "LIST" ] ] ]
   },
   {
     "type": "recipe",
@@ -131,7 +131,7 @@
     "tools": [ [ [ "metalworking_tongs_any", 1, "LIST" ] ] ],
     "components": [
       [ [ "adhesive", 1, "LIST" ], [ "filament", 20, "LIST" ] ],
-      [ [ "steel_tiny", 1, "LIST" ] ],
+      [ [ "steel_chunk_any", 1, "LIST" ] ],
       [ [ "stick", 1 ], [ "broom", 1 ], [ "2x4", 1 ], [ "bee_sting", 1 ], [ "mop", 1 ] ],
       [ [ "fletching", 1, "LIST" ] ]
     ]
@@ -155,7 +155,7 @@
     "tools": [ [ [ "metalworking_tongs_any", 1, "LIST" ] ] ],
     "components": [
       [ [ "adhesive", 1, "LIST" ], [ "filament", 20, "LIST" ] ],
-      [ [ "steel_tiny", 1, "LIST" ] ],
+      [ [ "steel_chunk_any", 1, "LIST" ] ],
       [ [ "stick", 1 ], [ "broom", 1 ], [ "2x4", 1 ], [ "bee_sting", 1 ], [ "mop", 1 ] ],
       [ [ "fletching", 1, "LIST" ] ]
     ]
@@ -179,7 +179,7 @@
     "tools": [ [ [ "metalworking_tongs_any", 1, "LIST" ] ] ],
     "components": [
       [ [ "adhesive", 1, "LIST" ], [ "filament", 20, "LIST" ] ],
-      [ [ "steel_tiny", 1, "LIST" ] ],
+      [ [ "steel_chunk_any", 1, "LIST" ] ],
       [ [ "stick", 1 ], [ "broom", 1 ], [ "2x4", 1 ], [ "bee_sting", 1 ], [ "mop", 1 ] ],
       [ [ "fletching", 1, "LIST" ] ]
     ]
@@ -201,7 +201,7 @@
     "qualities": [ { "id": "HAMMER", "level": 1 }, { "id": "CUT", "level": 2 }, { "id": "GRIND", "level": 1 } ],
     "components": [
       [ [ "adhesive", 1, "LIST" ], [ "filament", 10, "LIST" ] ],
-      [ [ "steel_tiny", 1, "LIST" ] ],
+      [ [ "steel_chunk_any", 1, "LIST" ] ],
       [ [ "stick", 1 ], [ "broom", 1 ], [ "2x4", 1 ], [ "bee_sting", 1 ], [ "mop", 1 ] ],
       [ [ "fletching", 1, "LIST" ] ]
     ]
@@ -315,7 +315,7 @@
     "qualities": [ { "id": "CUT", "level": 2 } ],
     "components": [
       [ [ "adhesive", 1, "LIST" ], [ "filament", 20, "LIST" ] ],
-      [ [ "steel_tiny", 2, "LIST" ] ],
+      [ [ "steel_chunk_any", 2, "LIST" ] ],
       [ [ "stick", 1 ], [ "broom", 1 ], [ "2x4", 1 ], [ "bee_sting", 1 ], [ "mop", 1 ] ],
       [ [ "fletching", 1, "LIST" ] ]
     ]
@@ -356,7 +356,7 @@
     "tools": [ [ [ "metalworking_tongs_any", 1, "LIST" ] ] ],
     "components": [
       [ [ "adhesive", 1, "LIST" ], [ "filament", 20, "LIST" ] ],
-      [ [ "steel_tiny", 1, "LIST" ] ],
+      [ [ "steel_chunk_any", 1, "LIST" ] ],
       [ [ "stick", 1 ], [ "broom", 1 ], [ "2x4", 1 ], [ "bee_sting", 1 ], [ "mop", 1 ] ],
       [ [ "fletching", 1, "LIST" ] ]
     ]
@@ -380,7 +380,7 @@
     "tools": [ [ [ "metalworking_tongs_any", 1, "LIST" ] ] ],
     "components": [
       [ [ "adhesive", 1, "LIST" ], [ "filament", 20, "LIST" ] ],
-      [ [ "steel_tiny", 1, "LIST" ] ],
+      [ [ "steel_chunk_any", 1, "LIST" ] ],
       [ [ "stick", 1 ], [ "broom", 1 ], [ "2x4", 1 ], [ "bee_sting", 1 ], [ "mop", 1 ] ],
       [ [ "fletching", 1, "LIST" ] ]
     ]
@@ -404,7 +404,7 @@
     "tools": [ [ [ "metalworking_tongs_any", 1, "LIST" ] ] ],
     "components": [
       [ [ "adhesive", 1, "LIST" ], [ "filament", 20, "LIST" ] ],
-      [ [ "steel_tiny", 1, "LIST" ] ],
+      [ [ "steel_chunk_any", 1, "LIST" ] ],
       [ [ "stick", 1 ], [ "broom", 1 ], [ "2x4", 1 ], [ "bee_sting", 1 ], [ "mop", 1 ] ],
       [ [ "fletching", 1, "LIST" ] ]
     ]
@@ -426,7 +426,7 @@
     "qualities": [ { "id": "HAMMER", "level": 1 }, { "id": "CUT", "level": 2 }, { "id": "GRIND", "level": 1 } ],
     "components": [
       [ [ "adhesive", 1, "LIST" ], [ "filament", 10, "LIST" ] ],
-      [ [ "steel_tiny", 1, "LIST" ] ],
+      [ [ "steel_chunk_any", 1, "LIST" ] ],
       [ [ "stick", 1 ], [ "broom", 1 ], [ "2x4", 1 ], [ "bee_sting", 1 ], [ "mop", 1 ] ],
       [ [ "fletching", 1, "LIST" ] ]
     ]
@@ -703,7 +703,7 @@
     "difficulty": 2,
     "time": "180 m",
     "autolearn": true,
-    "using": [ [ "blacksmithing_standard", 1 ], [ "steel_tiny", 1 ] ],
+    "using": [ [ "blacksmithing_standard", 1 ], [ "steel_chunk_any", 1 ] ],
     "tools": [ [ [ "swage", -1 ] ] ]
   },
   {

--- a/data/json/recipes/recipe_others.json
+++ b/data/json/recipes/recipe_others.json
@@ -967,7 +967,7 @@
     "time": "60 m",
     "autolearn": true,
     "proficiencies": [ { "proficiency": "prof_metalworking" }, { "proficiency": "prof_blacksmithing" } ],
-    "using": [ [ "blacksmithing_standard", 2 ], [ "steel_tiny", 2 ] ]
+    "using": [ [ "blacksmithing_standard", 2 ], [ "steel_chunk_any", 2 ] ]
   },
   {
     "type": "recipe",
@@ -1693,7 +1693,7 @@
     "time": "1 h 30 m",
     "reversible": true,
     "book_learn": [ [ "mag_survival", 4 ], [ "atomic_survival", 3 ], [ "textbook_survival", 2 ] ],
-    "using": [ [ "blacksmithing_standard", 8 ], [ "steel_tiny", 8 ] ],
+    "using": [ [ "blacksmithing_standard", 8 ], [ "steel_chunk_any", 8 ] ],
     "proficiencies": [ { "proficiency": "prof_metalworking" }, { "proficiency": "prof_blacksmithing" } ],
     "tools": [ [ [ "hotcut_any", 1, "LIST" ] ] ],
     "components": [ [ [ "rope_natural", 1, "LIST" ] ] ]

--- a/data/json/recipes/recipe_traps.json
+++ b/data/json/recipes/recipe_traps.json
@@ -10,7 +10,7 @@
     "difficulty": 2,
     "time": "1 h 40 m",
     "autolearn": true,
-    "using": [ [ "blacksmithing_standard", 1 ], [ "steel_tiny", 1 ] ],
+    "using": [ [ "blacksmithing_standard", 1 ], [ "steel_chunk_any", 1 ] ],
     "proficiencies": [ { "proficiency": "prof_metalworking" }, { "proficiency": "prof_blacksmithing" } ],
     "tools": [ [ [ "swage", -1 ] ] ]
   },

--- a/data/json/recipes/recipe_vehicle.json
+++ b/data/json/recipes/recipe_vehicle.json
@@ -637,7 +637,7 @@
     "time": "90 m",
     "autolearn": true,
     "//": "20cm weld",
-    "using": [ [ "welding_standard", 20 ], [ "steel_tiny", 4 ], [ "plastic_molding", 3 ] ],
+    "using": [ [ "welding_standard", 20 ], [ "steel_chunk_any", 4 ], [ "plastic_molding", 3 ] ],
     "proficiencies": [ { "proficiency": "prof_plasticworking" } ],
     "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "WRENCH", "level": 1 }, { "id": "SAW_M_FINE", "level": 1 } ],
     "components": [ [ [ "plastic_chunk", 4 ] ] ]
@@ -653,7 +653,7 @@
     "time": "90 m",
     "autolearn": true,
     "//": "22cm weld",
-    "using": [ [ "welding_standard", 22 ], [ "steel_tiny", 5 ], [ "plastic_molding", 6 ] ],
+    "using": [ [ "welding_standard", 22 ], [ "steel_chunk_any", 5 ], [ "plastic_molding", 6 ] ],
     "proficiencies": [ { "proficiency": "prof_plasticworking" } ],
     "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "WRENCH", "level": 1 }, { "id": "SAW_M_FINE", "level": 1 } ],
     "components": [ [ [ "plastic_chunk", 12 ] ] ]
@@ -1340,7 +1340,7 @@
     "reversible": true,
     "decomp_learn": 2,
     "book_learn": [ [ "manual_electronics", 2 ], [ "mag_electronics", 2 ], [ "manual_mechanics", 2 ] ],
-    "using": [ [ "soldering_standard", 4 ], [ "steel_tiny", 1 ] ],
+    "using": [ [ "soldering_standard", 4 ], [ "steel_chunk_any", 1 ] ],
     "proficiencies": [ { "proficiency": "prof_elec_soldering" } ],
     "qualities": [ { "id": "HAMMER", "level": 1 }, { "id": "SCREW_FINE", "level": 1 } ],
     "components": [ [ [ "cable", 4 ] ], [ [ "e_scrap", 1 ] ] ]

--- a/data/json/recipes/tools/containers.json
+++ b/data/json/recipes/tools/containers.json
@@ -219,7 +219,7 @@
     "difficulty": 6,
     "time": "45 m",
     "autolearn": true,
-    "using": [ [ "blacksmithing_standard", 1 ], [ "steel_tiny", 1 ] ],
+    "using": [ [ "blacksmithing_standard", 1 ], [ "steel_chunk_any", 1 ] ],
     "proficiencies": [ { "proficiency": "prof_metalworking" }, { "proficiency": "prof_blacksmithing" } ],
     "qualities": [ { "id": "CHISEL", "level": 3 } ]
   },
@@ -233,7 +233,7 @@
     "difficulty": 6,
     "time": "30 m",
     "autolearn": true,
-    "using": [ [ "blacksmithing_standard", 1 ], [ "steel_tiny", 2 ] ],
+    "using": [ [ "blacksmithing_standard", 1 ], [ "steel_chunk_any", 2 ] ],
     "proficiencies": [
       { "proficiency": "prof_metalworking" },
       { "proficiency": "prof_blacksmithing" },
@@ -251,7 +251,7 @@
     "difficulty": 6,
     "time": "20 m",
     "autolearn": true,
-    "using": [ [ "blacksmithing_standard", 1 ], [ "steel_tiny", 1 ] ],
+    "using": [ [ "blacksmithing_standard", 1 ], [ "steel_chunk_any", 1 ] ],
     "proficiencies": [
       { "proficiency": "prof_metalworking" },
       { "proficiency": "prof_blacksmithing" },
@@ -269,7 +269,7 @@
     "difficulty": 6,
     "time": "30 m",
     "autolearn": true,
-    "using": [ [ "blacksmithing_standard", 1 ], [ "steel_tiny", 3 ] ],
+    "using": [ [ "blacksmithing_standard", 1 ], [ "steel_chunk_any", 3 ] ],
     "proficiencies": [
       { "proficiency": "prof_metalworking" },
       { "proficiency": "prof_blacksmithing" },

--- a/data/json/recipes/tools/tool.json
+++ b/data/json/recipes/tools/tool.json
@@ -57,7 +57,7 @@
     "difficulty": 4,
     "time": "3 h",
     "autolearn": true,
-    "using": [ [ "blacksmithing_standard", 1 ], [ "steel_tiny", 1 ] ],
+    "using": [ [ "blacksmithing_standard", 1 ], [ "steel_chunk_any", 1 ] ],
     "proficiencies": [
       { "proficiency": "prof_metalworking" },
       { "proficiency": "prof_blacksmithing" },
@@ -304,7 +304,7 @@
     "time": "1 h",
     "reversible": true,
     "autolearn": true,
-    "using": [ [ "blacksmithing_standard", 3 ], [ "steel_tiny", 3 ] ],
+    "using": [ [ "blacksmithing_standard", 3 ], [ "steel_chunk_any", 3 ] ],
     "proficiencies": [
       { "proficiency": "prof_metalworking" },
       { "proficiency": "prof_blacksmithing" },
@@ -338,7 +338,7 @@
     "time": "120 m",
     "autolearn": true,
     "tools": [ [ [ "hotcut_any", 1, "LIST" ] ] ],
-    "using": [ [ "blacksmithing_standard", 1 ], [ "steel_tiny", 1 ] ],
+    "using": [ [ "blacksmithing_standard", 1 ], [ "steel_chunk_any", 1 ] ],
     "proficiencies": [ { "proficiency": "prof_metalworking" }, { "proficiency": "prof_blacksmithing" } ],
     "qualities": [ { "id": "GRIND", "level": 2 } ],
     "components": [ [ [ "2x4", 1 ], [ "stick", 1 ] ] ]
@@ -1366,7 +1366,7 @@
     "difficulty": 6,
     "time": "10 h",
     "autolearn": true,
-    "using": [ [ "blacksmithing_standard", 2 ], [ "steel_tiny", 2 ] ],
+    "using": [ [ "blacksmithing_standard", 2 ], [ "steel_chunk_any", 2 ] ],
     "proficiencies": [
       { "proficiency": "prof_metalworking" },
       { "proficiency": "prof_blacksmithing" },
@@ -1397,7 +1397,7 @@
     "difficulty": 4,
     "time": "6 h",
     "autolearn": true,
-    "using": [ [ "blacksmithing_standard", 1 ], [ "steel_tiny", 1 ] ],
+    "using": [ [ "blacksmithing_standard", 1 ], [ "steel_chunk_any", 1 ] ],
     "proficiencies": [
       { "proficiency": "prof_metalworking" },
       { "proficiency": "prof_blacksmithing" },

--- a/data/json/recipes/tools/tools_hand.json
+++ b/data/json/recipes/tools/tools_hand.json
@@ -8,7 +8,7 @@
     "skill_used": "fabrication",
     "time": "2 m",
     "autolearn": true,
-    "using": [ [ "steel_tiny", 2 ] ],
+    "using": [ [ "steel_chunk_any", 2 ] ],
     "qualities": [ { "id": "HAMMER", "level": 2 } ],
     "components": [ [ [ "duct_tape", 30 ], [ "2x4", 1 ], [ "stick", 1 ] ] ]
   },
@@ -23,7 +23,7 @@
     "difficulty": 6,
     "time": "3 h",
     "autolearn": true,
-    "using": [ [ "blacksmithing_standard", 2 ], [ "steel_tiny", 2 ] ],
+    "using": [ [ "blacksmithing_standard", 2 ], [ "steel_chunk_any", 2 ] ],
     "proficiencies": [
       { "proficiency": "prof_metalworking" },
       { "proficiency": "prof_blacksmithing" },
@@ -43,7 +43,7 @@
     "difficulty": 7,
     "time": "4 h",
     "autolearn": true,
-    "using": [ [ "blacksmithing_standard", 2 ], [ "steel_tiny", 2 ] ],
+    "using": [ [ "blacksmithing_standard", 2 ], [ "steel_chunk_any", 2 ] ],
     "proficiencies": [
       { "proficiency": "prof_metalworking" },
       { "proficiency": "prof_blacksmithing" },
@@ -63,7 +63,7 @@
     "difficulty": 6,
     "time": "3 h",
     "autolearn": true,
-    "using": [ [ "blacksmithing_standard", 3 ], [ "steel_tiny", 3 ] ],
+    "using": [ [ "blacksmithing_standard", 3 ], [ "steel_chunk_any", 3 ] ],
     "proficiencies": [
       { "proficiency": "prof_metalworking" },
       { "proficiency": "prof_blacksmithing" },
@@ -99,7 +99,7 @@
     "difficulty": 3,
     "time": "30 m",
     "autolearn": true,
-    "using": [ [ "blacksmithing_standard", 1 ], [ "steel_tiny", 1 ] ],
+    "using": [ [ "blacksmithing_standard", 1 ], [ "steel_chunk_any", 1 ] ],
     "proficiencies": [
       { "proficiency": "prof_metalworking" },
       { "proficiency": "prof_blacksmithing" },
@@ -151,7 +151,7 @@
     "difficulty": 2,
     "time": "60 m",
     "autolearn": true,
-    "using": [ [ "blacksmithing_standard", 3 ], [ "steel_tiny", 3 ] ],
+    "using": [ [ "blacksmithing_standard", 3 ], [ "steel_chunk_any", 3 ] ],
     "proficiencies": [
       { "proficiency": "prof_metalworking" },
       { "proficiency": "prof_blacksmithing" },
@@ -194,7 +194,7 @@
       [ "textbook_armwest", 5 ],
       [ "textbook_weparabic", 5 ]
     ],
-    "using": [ [ "forging_standard", 3 ], [ "steel_tiny", 3 ] ],
+    "using": [ [ "forging_standard", 3 ], [ "steel_chunk_any", 3 ] ],
     "qualities": [ { "id": "ANVIL", "level": 3 }, { "id": "HAMMER", "level": 3 }, { "id": "GRIND", "level": 2 } ],
     "//": "Specifically avoids blacksmithing requirement groups so that it's craftable without the metal fileset - this process would still be possible, just realistically take slightly longer.",
     "tools": [ [ [ "metalworking_tongs_any", 1, "LIST" ] ] ],
@@ -556,7 +556,7 @@
     "difficulty": 6,
     "time": "5 h",
     "autolearn": true,
-    "using": [ [ "blacksmithing_standard", 1 ], [ "steel_tiny", 1 ] ],
+    "using": [ [ "blacksmithing_standard", 1 ], [ "steel_chunk_any", 1 ] ],
     "proficiencies": [
       { "proficiency": "prof_metalworking" },
       { "proficiency": "prof_blacksmithing" },
@@ -592,7 +592,7 @@
     "difficulty": 4,
     "time": "5 h",
     "autolearn": true,
-    "using": [ [ "blacksmithing_standard", 7 ], [ "steel_tiny", 7 ] ],
+    "using": [ [ "blacksmithing_standard", 7 ], [ "steel_chunk_any", 7 ] ],
     "proficiencies": [
       { "proficiency": "prof_metalworking" },
       { "proficiency": "prof_blacksmithing" },
@@ -610,7 +610,7 @@
     "difficulty": 2,
     "time": "5 h",
     "autolearn": true,
-    "using": [ [ "blacksmithing_standard", 1 ], [ "steel_tiny", 1 ] ],
+    "using": [ [ "blacksmithing_standard", 1 ], [ "steel_chunk_any", 1 ] ],
     "proficiencies": [
       { "proficiency": "prof_metalworking" },
       { "proficiency": "prof_blacksmithing" },
@@ -628,7 +628,7 @@
     "difficulty": 4,
     "time": "5 h",
     "autolearn": true,
-    "using": [ [ "blacksmithing_standard", 3 ], [ "steel_tiny", 3 ] ],
+    "using": [ [ "blacksmithing_standard", 3 ], [ "steel_chunk_any", 3 ] ],
     "proficiencies": [
       { "proficiency": "prof_metalworking" },
       { "proficiency": "prof_blacksmithing" },
@@ -646,7 +646,7 @@
     "difficulty": 5,
     "time": "5 h",
     "autolearn": true,
-    "using": [ [ "blacksmithing_standard", 1 ], [ "steel_tiny", 1 ] ],
+    "using": [ [ "blacksmithing_standard", 1 ], [ "steel_chunk_any", 1 ] ],
     "proficiencies": [
       { "proficiency": "prof_metalworking" },
       { "proficiency": "prof_blacksmithing" },
@@ -684,7 +684,7 @@
     "difficulty": 4,
     "time": "3 h",
     "autolearn": true,
-    "using": [ [ "blacksmithing_standard", 2 ], [ "steel_tiny", 2 ] ],
+    "using": [ [ "blacksmithing_standard", 2 ], [ "steel_chunk_any", 2 ] ],
     "proficiencies": [
       { "proficiency": "prof_metalworking" },
       { "proficiency": "prof_blacksmithing" },
@@ -1044,7 +1044,7 @@
         "learning_time_multiplier": 0.1
       }
     ],
-    "using": [ [ "blacksmithing_standard", 3 ], [ "steel_tiny", 2 ] ],
+    "using": [ [ "blacksmithing_standard", 3 ], [ "steel_chunk_any", 2 ] ],
     "qualities": [ { "id": "GRIND", "level": 2 } ],
     "tools": [ [ [ "hotcut_any", 1, "LIST" ] ] ],
     "components": [ [ [ "plastic_chunk", 2 ], [ "scrap", 2 ] ] ]
@@ -1117,7 +1117,7 @@
       { "proficiency": "prof_blacksmithing", "required": false, "time_multiplier": 3.0 },
       { "proficiency": "prof_bladesmith" }
     ],
-    "using": [ [ "blacksmithing_standard", 2 ], [ "steel_tiny", 2 ] ],
+    "using": [ [ "blacksmithing_standard", 2 ], [ "steel_chunk_any", 2 ] ],
     "qualities": [ { "id": "GRIND", "level": 2 } ],
     "tools": [ [ [ "hotcut_any", 1, "LIST" ] ] ]
   },
@@ -1295,7 +1295,7 @@
       { "proficiency": "prof_blacksmithing" },
       { "proficiency": "prof_bladesmith" }
     ],
-    "using": [ [ "blacksmithing_standard", 1 ], [ "steel_tiny", 1 ] ],
+    "using": [ [ "blacksmithing_standard", 1 ], [ "steel_chunk_any", 1 ] ],
     "qualities": [ { "id": "GRIND", "level": 2 } ],
     "tools": [ [ [ "hotcut_any", 1, "LIST" ] ] ]
   },
@@ -1316,7 +1316,7 @@
       { "proficiency": "prof_blacksmithing" },
       { "proficiency": "prof_bladesmith" }
     ],
-    "using": [ [ "blacksmithing_standard", 1 ], [ "steel_tiny", 1 ] ],
+    "using": [ [ "blacksmithing_standard", 1 ], [ "steel_chunk_any", 1 ] ],
     "qualities": [ { "id": "GRIND", "level": 2 } ],
     "tools": [ [ [ "hotcut_any", 1, "LIST" ] ] ]
   },
@@ -1332,7 +1332,7 @@
     "time": "3 h",
     "reversible": true,
     "autolearn": true,
-    "using": [ [ "blacksmithing_standard", 1 ], [ "steel_tiny", 1 ] ],
+    "using": [ [ "blacksmithing_standard", 1 ], [ "steel_chunk_any", 1 ] ],
     "proficiencies": [
       { "proficiency": "prof_metalworking" },
       { "proficiency": "prof_blacksmithing" },
@@ -1358,7 +1358,7 @@
       { "proficiency": "prof_blacksmithing" },
       { "proficiency": "prof_bladesmith" }
     ],
-    "using": [ [ "blacksmithing_standard", 2 ], [ "steel_tiny", 2 ] ],
+    "using": [ [ "blacksmithing_standard", 2 ], [ "steel_chunk_any", 2 ] ],
     "qualities": [ { "id": "GRIND", "level": 2 } ],
     "tools": [ [ [ "hotcut_any", 1, "LIST" ] ] ]
   },
@@ -1379,7 +1379,7 @@
       { "proficiency": "prof_blacksmithing" },
       { "proficiency": "prof_bladesmith" }
     ],
-    "using": [ [ "blacksmithing_standard", 2 ], [ "steel_tiny", 2 ] ],
+    "using": [ [ "blacksmithing_standard", 2 ], [ "steel_chunk_any", 2 ] ],
     "qualities": [ { "id": "GRIND", "level": 2 } ],
     "tools": [ [ [ "hotcut_any", 1, "LIST" ] ] ]
   },
@@ -1520,7 +1520,7 @@
     "difficulty": 3,
     "time": "100 m",
     "autolearn": true,
-    "using": [ [ "blacksmithing_standard", 2 ], [ "steel_tiny", 2 ] ],
+    "using": [ [ "blacksmithing_standard", 2 ], [ "steel_chunk_any", 2 ] ],
     "proficiencies": [
       { "proficiency": "prof_metalworking" },
       { "proficiency": "prof_blacksmithing" },

--- a/data/json/recipes/weapon/bashing.json
+++ b/data/json/recipes/weapon/bashing.json
@@ -89,7 +89,7 @@
     "qualities": [ { "id": "HAMMER", "level": 1 } ],
     "using": [ [ "sewing_standard", 10 ] ],
     "proficiencies": [ { "proficiency": "prof_leatherworking_basic", "time_multiplier": 2 } ],
-    "components": [ [ [ "leather", 2 ] ], [ [ "steel_tiny", 1, "LIST" ], [ "weights", 8, "LIST" ] ] ]
+    "components": [ [ [ "leather", 2 ] ], [ [ "steel_chunk_any", 1, "LIST" ], [ "weights", 8, "LIST" ] ] ]
   },
   {
     "type": "recipe",
@@ -1482,7 +1482,7 @@
     "time": "24 m",
     "autolearn": true,
     "book_learn": [ [ "textbook_weapwest", 2 ], [ "recipe_melee", 3 ] ],
-    "using": [ [ "blacksmithing_standard", 3 ], [ "steel_tiny", 3 ] ],
+    "using": [ [ "blacksmithing_standard", 3 ], [ "steel_chunk_any", 3 ] ],
     "proficiencies": [
       { "proficiency": "prof_metalworking" },
       { "proficiency": "prof_blacksmithing" },

--- a/data/json/recipes/weapon/cutting.json
+++ b/data/json/recipes/weapon/cutting.json
@@ -2160,7 +2160,7 @@
     "difficulty": 5,
     "time": "8 h",
     "book_learn": [ [ "textbook_weapeast", 9 ], [ "recipe_melee", 4 ] ],
-    "using": [ [ "blacksmithing_standard", 3 ], [ "steel_tiny", 3 ] ],
+    "using": [ [ "blacksmithing_standard", 3 ], [ "steel_chunk_any", 3 ] ],
     "proficiencies": [
       { "proficiency": "prof_metalworking" },
       { "proficiency": "prof_blacksmithing" },
@@ -2179,7 +2179,7 @@
     "difficulty": 6,
     "time": "8 h",
     "book_learn": [ [ "textbook_weapeast", 6 ] ],
-    "using": [ [ "blacksmithing_standard", 3 ], [ "steel_tiny", 3 ] ],
+    "using": [ [ "blacksmithing_standard", 3 ], [ "steel_chunk_any", 3 ] ],
     "proficiencies": [
       { "proficiency": "prof_metalworking" },
       { "proficiency": "prof_blacksmithing" },

--- a/data/json/recipes/weapon/mods.json
+++ b/data/json/recipes/weapon/mods.json
@@ -1092,7 +1092,7 @@
     "difficulty": 4,
     "time": "3 h",
     "autolearn": true,
-    "using": [ [ "blacksmithing_standard", 2 ], [ "steel_tiny", 1 ] ],
+    "using": [ [ "blacksmithing_standard", 2 ], [ "steel_chunk_any", 1 ] ],
     "proficiencies": [
       { "proficiency": "prof_metalworking" },
       { "proficiency": "prof_blacksmithing" },

--- a/data/json/recipes/weapon/piercing.json
+++ b/data/json/recipes/weapon/piercing.json
@@ -10,7 +10,7 @@
     "difficulty": 7,
     "time": "6 h",
     "book_learn": [ [ "textbook_weapwest", 6 ] ],
-    "using": [ [ "blacksmithing_standard", 3 ], [ "steel_tiny", 3 ] ],
+    "using": [ [ "blacksmithing_standard", 3 ], [ "steel_chunk_any", 3 ] ],
     "proficiencies": [
       { "proficiency": "prof_metalworking" },
       { "proficiency": "prof_blacksmithing" },
@@ -36,7 +36,7 @@
       { "proficiency": "prof_blacksmithing" },
       { "proficiency": "prof_bladesmith" }
     ],
-    "using": [ [ "blacksmithing_standard", 2 ], [ "steel_tiny", 2 ] ],
+    "using": [ [ "blacksmithing_standard", 2 ], [ "steel_chunk_any", 2 ] ],
     "qualities": [ { "id": "GRIND", "level": 2 } ],
     "tools": [ [ [ "hotcut_any", 1, "LIST" ] ] ]
   },
@@ -51,7 +51,7 @@
     "difficulty": 7,
     "time": "6 h",
     "book_learn": [ [ "textbook_weapwest", 6 ] ],
-    "using": [ [ "blacksmithing_standard", 2 ], [ "steel_tiny", 2 ] ],
+    "using": [ [ "blacksmithing_standard", 2 ], [ "steel_chunk_any", 2 ] ],
     "proficiencies": [
       { "proficiency": "prof_metalworking" },
       { "proficiency": "prof_blacksmithing" },
@@ -73,7 +73,7 @@
     "difficulty": 7,
     "time": "6 h",
     "book_learn": [ [ "textbook_weapwest", 6 ] ],
-    "using": [ [ "blacksmithing_standard", 1 ], [ "steel_tiny", 1 ] ],
+    "using": [ [ "blacksmithing_standard", 1 ], [ "steel_chunk_any", 1 ] ],
     "proficiencies": [
       { "proficiency": "prof_metalworking" },
       { "proficiency": "prof_blacksmithing" },
@@ -120,7 +120,7 @@
       { "proficiency": "prof_blacksmithing" },
       { "proficiency": "prof_bladesmith" }
     ],
-    "using": [ [ "blacksmithing_standard", 2 ], [ "steel_tiny", 2 ] ],
+    "using": [ [ "blacksmithing_standard", 2 ], [ "steel_chunk_any", 2 ] ],
     "qualities": [ { "id": "GRIND", "level": 2 } ],
     "tools": [ [ [ "hotcut_any", 1, "LIST" ] ] ]
   },
@@ -140,7 +140,7 @@
       { "proficiency": "prof_bladesmith" },
       { "proficiency": "prof_carving", "time_multiplier": 1.2, "learning_time_multiplier": 0.2, "skill_penalty": 0 }
     ],
-    "using": [ [ "blacksmithing_standard", 2 ], [ "steel_tiny", 2 ] ],
+    "using": [ [ "blacksmithing_standard", 2 ], [ "steel_chunk_any", 2 ] ],
     "qualities": [ { "id": "GRIND", "level": 2 } ],
     "tools": [ [ [ "hotcut_any", 1, "LIST" ] ] ],
     "components": [ [ [ "2x4", 1 ], [ "stick", 2 ] ] ]
@@ -155,7 +155,7 @@
     "difficulty": 5,
     "time": "3 h",
     "autolearn": true,
-    "using": [ [ "blacksmithing_standard", 2 ], [ "steel_tiny", 2 ] ],
+    "using": [ [ "blacksmithing_standard", 2 ], [ "steel_chunk_any", 2 ] ],
     "proficiencies": [
       { "proficiency": "prof_metalworking" },
       { "proficiency": "prof_blacksmithing" },
@@ -182,7 +182,7 @@
       { "proficiency": "prof_bladesmith" },
       { "proficiency": "prof_carving", "time_multiplier": 1.2, "learning_time_multiplier": 0.2, "skill_penalty": 0 }
     ],
-    "using": [ [ "blacksmithing_standard", 3 ], [ "steel_tiny", 3 ] ],
+    "using": [ [ "blacksmithing_standard", 3 ], [ "steel_chunk_any", 3 ] ],
     "qualities": [ { "id": "GRIND", "level": 2 } ],
     "tools": [ [ [ "hotcut_any", 1, "LIST" ] ] ],
     "components": [ [ [ "2x4", 1 ], [ "stick", 2 ] ] ]
@@ -298,7 +298,7 @@
     "time": "60 m",
     "autolearn": true,
     "//": "20cm weld",
-    "using": [ [ "welding_standard", 20 ], [ "steel_tiny", 1 ], [ "cordage_superior", 2 ] ],
+    "using": [ [ "welding_standard", 20 ], [ "steel_chunk_any", 1 ], [ "cordage_superior", 2 ] ],
     "proficiencies": [ { "proficiency": "prof_metalworking" }, { "proficiency": "prof_welding_basic" } ],
     "qualities": [ { "id": "HAMMER", "level": 3 }, { "id": "SAW_M", "level": 1 } ],
     "components": [ [ [ "simple_spear_pipe", 1 ] ] ]
@@ -314,7 +314,7 @@
     "time": "30 m",
     "autolearn": true,
     "//": "10cm weld",
-    "using": [ [ "welding_standard", 10 ], [ "steel_tiny", 1 ] ],
+    "using": [ [ "welding_standard", 10 ], [ "steel_chunk_any", 1 ] ],
     "proficiencies": [ { "proficiency": "prof_metalworking" }, { "proficiency": "prof_welding_basic" } ],
     "qualities": [ { "id": "HAMMER", "level": 3 }, { "id": "SAW_M", "level": 1 } ],
     "components": [ [ [ "spike", 1 ] ] ]
@@ -1246,7 +1246,7 @@
         "skill_penalty": 0
       }
     ],
-    "using": [ [ "blacksmithing_standard", 3 ], [ "steel_tiny", 3 ] ],
+    "using": [ [ "blacksmithing_standard", 3 ], [ "steel_chunk_any", 3 ] ],
     "qualities": [ { "id": "GRIND", "level": 2 } ],
     "tools": [ [ [ "hotcut_any", 1, "LIST" ] ] ],
     "components": [ [ [ "plastic_chunk", 1 ] ] ]

--- a/data/json/recipes/weapon/ranged.json
+++ b/data/json/recipes/weapon/ranged.json
@@ -1029,7 +1029,7 @@
       { "proficiency": "prof_blacksmithing" },
       { "proficiency": "prof_bladesmith" }
     ],
-    "using": [ [ "blacksmithing_standard", 2 ], [ "steel_tiny", 2 ] ],
+    "using": [ [ "blacksmithing_standard", 2 ], [ "steel_chunk_any", 2 ] ],
     "qualities": [ { "id": "GRIND", "level": 2 } ],
     "tools": [ [ [ "hotcut_any", 1, "LIST" ] ] ]
   },
@@ -1049,7 +1049,7 @@
       { "proficiency": "prof_blacksmithing" },
       { "proficiency": "prof_bladesmith" }
     ],
-    "using": [ [ "blacksmithing_standard", 3 ], [ "steel_tiny", 3 ] ],
+    "using": [ [ "blacksmithing_standard", 3 ], [ "steel_chunk_any", 3 ] ],
     "qualities": [ { "id": "CUT", "level": 2 }, { "id": "GRIND", "level": 2 } ],
     "components": [ [ [ "2x4", 1 ], [ "stick", 1 ] ] ]
   },
@@ -1268,7 +1268,7 @@
     "tools": [ [ [ "metalworking_tongs_any", 1, "LIST" ] ], [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
     "components": [
       [ [ "adhesive", 1, "LIST" ], [ "filament", 20, "LIST" ] ],
-      [ [ "steel_tiny", 1, "LIST" ] ],
+      [ [ "steel_chunk_any", 1, "LIST" ] ],
       [ [ "stick", 1 ], [ "2x4", 1 ] ],
       [ [ "fletching", 2, "LIST" ] ],
       [ [ "lead", 4 ] ]
@@ -1291,7 +1291,7 @@
       { "proficiency": "prof_fletching" },
       { "proficiency": "prof_carving" }
     ],
-    "using": [ [ "blacksmithing_standard", 2 ], [ "steel_tiny", 2 ] ],
+    "using": [ [ "blacksmithing_standard", 2 ], [ "steel_chunk_any", 2 ] ],
     "qualities": [ { "id": "CUT", "level": 2 } ],
     "components": [
       [ [ "adhesive", 1, "LIST" ], [ "filament", 20, "LIST" ] ],

--- a/data/json/requirements/materials.json
+++ b/data/json/requirements/materials.json
@@ -438,31 +438,7 @@
     "id": "mixed_steel",
     "type": "requirement",
     "//": "Materials for use in scrap armor",
-    "components": [
-      [
-        [ "scrap", 50 ],
-        [ "budget_steel_chunk", 4 ],
-        [ "budget_steel_lump", 1 ],
-        [ "lc_steel_chunk", 4 ],
-        [ "lc_steel_lump", 1 ],
-        [ "mc_steel_chunk", 4 ],
-        [ "mc_steel_lump", 1 ],
-        [ "hc_steel_chunk", 4 ],
-        [ "hc_steel_lump", 1 ]
-      ]
-    ]
-  },
-  {
-    "id": "steel_tiny",
-    "type": "requirement",
-    "//": "Materials for use when forging atypically small items from steel",
-    "components": [ [ [ "steel_chunk", 1 ] ] ]
-  },
-  {
-    "id": "lc_steel_tiny",
-    "type": "requirement",
-    "//": "Materials for use when forging atypically small items from mild steel",
-    "components": [ [ [ "lc_steel_chunk", 1 ] ] ]
+    "components": [ [ [ "scrap", 50 ], [ "steel_standard", 1, "LIST" ] ] ]
   },
   {
     "id": "bronze_tiny",

--- a/data/json/requirements/toolsets.json
+++ b/data/json/requirements/toolsets.json
@@ -203,7 +203,7 @@
     ],
     "components": [
       [ [ "welding_rod_steel", 10 ], [ "welding_wire_steel", 10 ], [ "brazing_rod_bronze", 10 ] ],
-      [ [ "steel_tiny", 1, "LIST" ] ]
+      [ [ "steel_chunk_any", 1, "LIST" ] ]
     ]
   },
   {
@@ -223,7 +223,7 @@
     ],
     "components": [
       [ [ "welding_rod_steel", 10 ], [ "welding_wire_steel", 10 ], [ "brazing_rod_bronze", 10 ] ],
-      [ [ "lc_steel_tiny", 1, "LIST" ] ]
+      [ [ "lc_steel_chunk", 1 ] ]
     ]
   },
   {

--- a/data/mods/Magiclysm/recipes/caster_level_boosters.json
+++ b/data/mods/Magiclysm/recipes/caster_level_boosters.json
@@ -28,7 +28,7 @@
     "book_learn": [ [ "caster_boosts_info", 6 ] ],
     "time": "8 h",
     "autolearn": false,
-    "using": [ [ "cordage_short", 1 ], [ "steel_tiny", 1 ] ],
+    "using": [ [ "cordage_short", 1 ], [ "steel_chunk_any", 1 ] ],
     "qualities": [
       { "id": "HAMMER", "level": 2 },
       { "id": "SCREW_FINE", "level": 1 },
@@ -77,7 +77,7 @@
     "time": "150 m",
     "autolearn": false,
     "qualities": [ { "id": "HAMMER", "level": 1 }, { "id": "CHISEL", "level": 3 } ],
-    "using": [ [ "blacksmithing_standard", 1 ], [ "steel_tiny", 1 ] ],
+    "using": [ [ "blacksmithing_standard", 1 ], [ "steel_chunk_any", 1 ] ],
     "proficiencies": [ { "proficiency": "prof_metalworking" }, { "proficiency": "prof_blacksmithing" } ],
     "components": [
       [ [ "scrap", 1 ] ],
@@ -158,7 +158,7 @@
     "book_learn": [ [ "caster_boosts_info", 4 ] ],
     "time": "6 h",
     "autolearn": false,
-    "using": [ [ "welding_standard", 10 ], [ "blacksmithing_standard", 5 ], [ "steel_tiny", 1 ] ],
+    "using": [ [ "welding_standard", 10 ], [ "blacksmithing_standard", 5 ], [ "steel_chunk_any", 1 ] ],
     "qualities": [
       { "id": "HAMMER", "level": 3 },
       { "id": "HAMMER_FINE", "level": 1 },

--- a/data/mods/Magiclysm/recipes/weapons.json
+++ b/data/mods/Magiclysm/recipes/weapons.json
@@ -130,7 +130,7 @@
     "difficulty": 4,
     "time": "360 m",
     "autolearn": true,
-    "using": [ [ "forging_standard", 2 ], [ "steel_tiny", 1 ] ],
+    "using": [ [ "forging_standard", 2 ], [ "steel_chunk_any", 1 ] ],
     "qualities": [
       { "id": "ANVIL", "level": 3 },
       { "id": "HAMMER", "level": 3 },
@@ -152,7 +152,7 @@
     "difficulty": 6,
     "time": "360 m",
     "autolearn": true,
-    "using": [ [ "forging_standard", 2 ], [ "steel_tiny", 1 ] ],
+    "using": [ [ "forging_standard", 2 ], [ "steel_chunk_any", 1 ] ],
     "qualities": [
       { "id": "ANVIL", "level": 3 },
       { "id": "HAMMER", "level": 3 },

--- a/data/mods/MindOverMatter/recipes/armor.json
+++ b/data/mods/MindOverMatter/recipes/armor.json
@@ -17,7 +17,7 @@
       { "proficiency": "prof_psionic_containment", "required": false },
       { "proficiency": "prof_psionic_warping", "required": false }
     ],
-    "using": [ [ "blacksmithing_standard", 3 ], [ "steel_tiny", 1 ] ],
+    "using": [ [ "blacksmithing_standard", 3 ], [ "steel_chunk_any", 1 ] ],
     "qualities": [ { "id": "MATRIX_CHANNEL", "level": 1 }, { "id": "MATRIX_FOCUS", "level": 1 } ],
     "tools": [ [ [ "swage", -1 ] ] ],
     "components": [
@@ -47,7 +47,7 @@
       { "proficiency": "prof_psionic_containment", "required": false },
       { "proficiency": "prof_psionic_warping", "required": false }
     ],
-    "using": [ [ "blacksmithing_standard", 3 ], [ "steel_tiny", 1 ] ],
+    "using": [ [ "blacksmithing_standard", 3 ], [ "steel_chunk_any", 1 ] ],
     "qualities": [ { "id": "MATRIX_CHANNEL", "level": 1 }, { "id": "MATRIX_FOCUS", "level": 1 } ],
     "tools": [ [ [ "swage", -1 ] ] ],
     "components": [

--- a/data/mods/MindOverMatter/recipes/tools.json
+++ b/data/mods/MindOverMatter/recipes/tools.json
@@ -13,7 +13,7 @@
     "qualities": [ { "id": "HAMMER_FINE", "level": 1 }, { "id": "FINE_GRIND", "level": 1 }, { "id": "VISE", "level": 1 } ],
     "tools": [ [ [ "angle_grinder", 50 ] ] ],
     "proficiencies": [ { "proficiency": "prof_metalworking" }, { "proficiency": "prof_matrix_technology_beginner", "required": false } ],
-    "using": [ [ "soldering_standard", 15 ], [ "steel_tiny", 5 ] ],
+    "using": [ [ "soldering_standard", 15 ], [ "steel_chunk_any", 5 ] ],
     "components": [ [ [ "matrix_crystal_drained", 1 ] ] ],
     "flags": [ "SECRET" ]
   },
@@ -40,7 +40,7 @@
       { "proficiency": "prof_matrix_technology_beginner", "required": false },
       { "proficiency": "prof_fine_metalsmithing", "required": false }
     ],
-    "using": [ [ "soldering_standard", 15 ], [ "steel_tiny", 5 ] ],
+    "using": [ [ "soldering_standard", 15 ], [ "steel_chunk_any", 5 ] ],
     "components": [
       [ [ "matrix_shard", 6 ] ],
       [ [ "matrix_crystal_drained_dust_refined", 5 ] ],
@@ -73,7 +73,7 @@
       { "proficiency": "prof_psionic_ritual", "required": false },
       { "proficiency": "prof_fine_metalsmithing", "required": false }
     ],
-    "using": [ [ "soldering_standard", 15 ], [ "steel_tiny", 15 ] ],
+    "using": [ [ "soldering_standard", 15 ], [ "steel_chunk_any", 15 ] ],
     "components": [ [ [ "matrix_shard", 12 ] ], [ [ "matrix_crystal_telepath_dust_refined", 5 ] ], [ [ "matrix_crystal_telepathy", 1 ] ] ],
     "flags": [ "SECRET" ]
   },

--- a/data/mods/innawood/recipes/other/parts.json
+++ b/data/mods/innawood/recipes/other/parts.json
@@ -100,7 +100,7 @@
     "reversible": true,
     "decomp_learn": 2,
     "autolearn": true,
-    "using": [ [ "soldering_standard", 5 ], [ "steel_tiny", 1 ] ],
+    "using": [ [ "soldering_standard", 5 ], [ "steel_chunk_any", 1 ] ],
     "qualities": [ { "id": "HAMMER", "level": 1 }, { "id": "SCREW_FINE", "level": 1 } ],
     "components": [ [ [ "cable", 3 ] ], [ [ "e_scrap", 3 ], [ "makeshift_transformer", 3 ] ] ]
   },

--- a/data/mods/innawood/recipes/recipe_vehicle.json
+++ b/data/mods/innawood/recipes/recipe_vehicle.json
@@ -41,7 +41,7 @@
     "autolearn": true,
     "decomp_learn": 2,
     "book_learn": [ [ "manual_electronics", 2 ], [ "mag_electronics", 2 ], [ "manual_mechanics", 2 ] ],
-    "using": [ [ "soldering_standard", 4 ], [ "steel_tiny", 1 ] ],
+    "using": [ [ "soldering_standard", 4 ], [ "steel_chunk_any", 1 ] ],
     "proficiencies": [ { "proficiency": "prof_elec_soldering" } ],
     "qualities": [ { "id": "HAMMER", "level": 1 }, { "id": "SCREW_FINE", "level": 1 } ],
     "components": [ [ [ "cable", 4 ] ], [ [ "makeshift_transformer", 1 ] ] ]
@@ -60,7 +60,7 @@
     "autolearn": true,
     "decomp_learn": 2,
     "book_learn": [ [ "manual_electronics", 2 ], [ "mag_electronics", 2 ], [ "manual_mechanics", 2 ] ],
-    "using": [ [ "soldering_standard", 4 ], [ "steel_tiny", 1 ] ],
+    "using": [ [ "soldering_standard", 4 ], [ "steel_chunk_any", 1 ] ],
     "proficiencies": [ { "proficiency": "prof_elec_soldering" } ],
     "qualities": [ { "id": "HAMMER", "level": 1 }, { "id": "SCREW_FINE", "level": 1 } ],
     "components": [ [ [ "cable", 30 ] ], [ [ "makeshift_transformer", 4 ] ] ]


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
I saw a few reports that few recipes still require metal chunk. It happens because few requirements were still trying to use the `steel_tiny` requirement, that defined only an ungraded steel chunk
#### Describe the solution
Remove `steel_tiny`, replace it with `steel_chunk_any`
Remove `lc_steel_tiny`, replace with just defining `lc_steel_chunk` directly (it has only two uses)
use `steel_standard` in `mixed_steel` requirement instead of manually defining chunks 