### PR TITLE
In-progress craft item can't exceed MAX_ITEM_VOLUME

### DIFF
--- a/src/requirements.cpp
+++ b/src/requirements.cpp
@@ -23,6 +23,7 @@
 #include "debug_menu.h"
 #include "enum_traits.h"
 #include "flexbuffer_json.h"
+#include "game_constants.h"
 #include "generic_factory.h"
 #include "inventory.h"
 #include "item.h"
@@ -37,6 +38,7 @@
 #include "pocket_type.h"
 #include "string_formatter.h"
 #include "translations.h"
+#include "units.h"
 #include "value_ptr.h"
 #include "visitable.h"
 
@@ -1049,17 +1051,30 @@ bool requirement_data::check_enough_materials( const read_only_visitable &crafti
         const std::function<bool( const item & )> &filter, int batch ) const
 {
     bool retval = true;
+    units::volume total_component_volume = 0_ml;
     for( const auto &component_choices : components ) {
         bool atleast_one_available = false;
+        units::volume volume_of_this_comp_choice = 0_ml;
         for( const item_comp &comp : component_choices ) {
             if( check_enough_materials( comp, crafting_inv, filter, batch ) ) {
+                // the worst case scenario is used to tally volume
+                volume_of_this_comp_choice = std::max( volume_of_this_comp_choice,
+                                                       comp.type->volume * comp.count * batch );
                 atleast_one_available = true;
             }
         }
+        total_component_volume += volume_of_this_comp_choice;
         if( !atleast_one_available ) {
             retval = false;
         }
     }
+
+    // This will be the volume of the resulting in-progress craft item (see item::volume), so we don't want to exceed it.
+    // TODO: Feedback? Some sort of indicator to the player that resulting volume is why it can't be crafted
+    if( total_component_volume > MAX_ITEM_VOLUME ) {
+        retval = false;
+    }
+
     return retval;
 }
 


### PR DESCRIPTION
#### Summary
Bugfixes "Can't craft batches so big that they vanish when the game has nowhere to put them"

#### Purpose of change
Fixes... at least one open issue, which I'll find later. The issue being that if we exceed MAX_ITEM_VOLUME then the game is basically guaranteed to not find a place to set it down. And when that happens, it simply vanishes. Gone!

#### Describe the solution
Pre-check the weight of our in-progress craft item, disallow the craft if we'd exceed MAX_ITEM_VOLUME (1000L).

Works for batches.

#### Describe alternatives you've considered
I realized we could hack-ily force the item's volume to a certain desired value in item::volume, but that's probably bad practice.

#### Testing

![image](https://github.com/user-attachments/assets/ab28123d-0f3f-40d1-aafc-7d5f0c1f5e19)

What still needs testing: Does this calculate properly for recipes with multiple possible components? If not I think I just need to switch to `total_component_volume = std::max(total_component_volume, volume_of_this_comp_choice);`

(mergers/reviewers I would appreciate if you could test this so I don't have to)

#### Additional context
It's still possible to craft while having the entire floor already covered in crap, resulting in the same failure to place on map.

Note: This does not give any feedback on the reason *why* the craft is unavailable, it simply disallows it and greys it out.
