### PR TITLE
Refactor pathfind: allow multiple targets

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -77,6 +77,7 @@
 #include "options.h"
 #include "output.h"
 #include "overmap_ui.h"
+#include "pathfinding.h"
 #include "pickup.h"
 #include "pimpl.h"
 #include "player_activity.h"
@@ -7747,8 +7748,7 @@ void unload_loot_activity_actor::do_turn( player_activity &act, Character &you )
                     return;
                 }
                 std::vector<tripoint_bub_ms> route;
-                route = here.route( you.pos_bub(), src_loc, you.get_pathfinding_settings(),
-                                    you.get_path_avoid() );
+                route = here.route( you, pathfinding_target::point( src_loc ) );
                 if( route.empty() ) {
                     // can't get there, can't do anything, skip it
                     continue;
@@ -7779,30 +7779,16 @@ void unload_loot_activity_actor::do_turn( player_activity &act, Character &you )
             // adjacent to the loot source tile
             if( !is_adjacent_or_closer ) {
                 std::vector<tripoint_bub_ms> route;
-                bool adjacent = false;
 
                 // get either direct route or route to nearest adjacent tile if
                 // source tile is impassable
-                if( here.passable_through( src_loc ) ) {
-                    route = here.route( you.pos_bub(), src_loc, you.get_pathfinding_settings(),
-                                        you.get_path_avoid() );
-                } else {
-                    // impassable source tile (locker etc.),
-                    // get route to nearest adjacent tile instead
-                    route = route_adjacent( you, src_loc );
-                    adjacent = true;
-                }
+                route = here.route( you, pathfinding_target::adjacent( src_loc ) );
 
                 // check if we found path to source / adjacent tile
                 if( route.empty() ) {
                     add_msg( m_info, _( "%s can't reach the source tile." ),
                              you.disp_name() );
                     continue;
-                }
-
-                // shorten the route to adjacent tile, if necessary
-                if( !adjacent ) {
-                    route.pop_back();
                 }
 
                 // set the destination and restart activity after player arrives there

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -77,6 +77,7 @@
 #include "overmap.h"
 #include "overmap_ui.h"
 #include "overmapbuffer.h"
+#include "pathfinding.h"
 #include "pimpl.h"
 #include "player_activity.h"
 #include "pocket_type.h"
@@ -2902,18 +2903,8 @@ void activity_handlers::travel_do_turn( player_activity *act, Character *you )
         }
         map &here = get_map();
         tripoint_bub_ms centre_sub = here.get_bub( waypoint );
-        if( !here.passable_through( centre_sub ) ) {
-            tripoint_range<tripoint_bub_ms> candidates = here.points_in_radius( centre_sub, 2 );
-            for( const tripoint_bub_ms &elem : candidates ) {
-                if( here.passable_through( elem ) ) {
-                    centre_sub = elem;
-                    break;
-                }
-            }
-        }
         const std::vector<tripoint_bub_ms> route_to =
-            here.route( you->pos_bub(), centre_sub, you->get_pathfinding_settings(),
-                        you->get_path_avoid() );
+            here.route( *you, pathfinding_target::radius( centre_sub, 2 ) );
         if( !route_to.empty() ) {
             const activity_id act_travel = ACT_TRAVELLING;
             you->set_destination( route_to, player_activity( act_travel ) );
@@ -3570,8 +3561,7 @@ static void perform_zone_activity_turn(
         const tripoint_bub_ms &tile_loc = here.get_bub( tile );
 
         std::vector<tripoint_bub_ms> route =
-            here.route( you->pos_bub(), tile_loc, you->get_pathfinding_settings(),
-                        you->get_path_avoid() );
+            here.route( *you, pathfinding_target::point( tile_loc ) );
         if( route.size() > 1 ) {
             route.pop_back();
 

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -53,6 +53,7 @@
 #include "npc.h"
 #include "options.h"
 #include "overmapbuffer.h"
+#include "pathfinding.h"
 #include "pickup.h"
 #include "player_activity.h"
 #include "pocket_type.h"
@@ -671,10 +672,9 @@ std::vector<tripoint_bub_ms> route_adjacent( const Character &you, const tripoin
     const std::vector<tripoint_bub_ms> &sorted =
         get_sorted_tiles_by_distance( you.pos_bub(), passable_tiles );
 
-    const auto &avoid = you.get_path_avoid();
     for( const tripoint_bub_ms &tp : sorted ) {
         std::vector<tripoint_bub_ms> route =
-            here.route( you.pos_bub(), tp, you.get_pathfinding_settings(), avoid );
+            here.route( you, pathfinding_target::point( tp ) );
 
         if( !route.empty() ) {
             return route;
@@ -745,14 +745,13 @@ static std::vector<tripoint_bub_ms> route_best_workbench(
         return best_bench_multi_a > best_bench_multi_b;
     };
     std::stable_sort( sorted.begin(), sorted.end(), cmp );
-    const auto &avoid = you.get_path_avoid();
     if( sorted.front() == you.pos_bub() ) {
         // We are on the best tile
         return {};
     }
     for( const tripoint_bub_ms &tp : sorted ) {
         std::vector<tripoint_bub_ms> route =
-            here.route( you.pos_bub(), tp, you.get_pathfinding_settings(), avoid );
+            here.route( you, pathfinding_target::point( tp ) );
 
         if( !route.empty() ) {
             return route;
@@ -2063,8 +2062,7 @@ void activity_on_turn_move_loot( player_activity &act, Character &you )
                     return;
                 }
                 std::vector<tripoint_bub_ms> route;
-                route = here.route( you.pos_bub(), src_loc, you.get_pathfinding_settings(),
-                                    you.get_path_avoid() );
+                route = here.route( you, pathfinding_target::adjacent( src_loc ) );
                 if( route.empty() ) {
                     // can't get there, can't do anything, skip it
                     continue;
@@ -2234,30 +2232,16 @@ void activity_on_turn_move_loot( player_activity &act, Character &you )
             // adjacent to the loot source tile
             if( !is_adjacent_or_closer ) {
                 std::vector<tripoint_bub_ms> route;
-                bool adjacent = false;
 
                 // get either direct route or route to nearest adjacent tile if
                 // source tile is impassable
-                if( here.passable_through( src_loc ) ) {
-                    route = here.route( you.pos_bub(), src_loc, you.get_pathfinding_settings(),
-                                        you.get_path_avoid() );
-                } else {
-                    // impassable source tile (locker etc.),
-                    // get route to nearest adjacent tile instead
-                    route = route_adjacent( you, src_loc );
-                    adjacent = true;
-                }
+                route = here.route( you, pathfinding_target::adjacent( src_loc ) );
 
                 // check if we found path to source / adjacent tile
                 if( route.empty() ) {
                     add_msg( m_info, _( "%s can't reach the source tile.  Try to sort out loot without a cart." ),
                              you.disp_name() );
                     continue;
-                }
-
-                // shorten the route to adjacent tile, if necessary
-                if( !adjacent ) {
-                    route.pop_back();
                 }
 
                 // set the destination and restart activity after player arrives there

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -100,6 +100,7 @@
 #include "overmap_ui.h"
 #include "overmapbuffer.h"
 #include "path_info.h"
+#include "pathfinding.h"
 #include "pimpl.h"
 #include "point.h"
 #include "popup.h"
@@ -3625,10 +3626,8 @@ static void set_automove()
         return;
     }
 
-    std::vector<tripoint_bub_ms> rt = get_map().route( player_character.pos_bub(),
-                                      tripoint_bub_ms( *dest ),
-                                      player_character.get_pathfinding_settings(),
-                                      player_character.get_path_avoid() );
+    std::vector<tripoint_bub_ms> rt = get_map().route( player_character,
+                                      pathfinding_target::point( *dest ) );
     if( !rt.empty() ) {
         player_character.set_destination( rt );
     } else {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4508,8 +4508,8 @@ Creature *game::is_hostile_within( int distance, bool dangerous )
                 }
 
                 const pathfinding_settings pf_settings = pathfinding_settings{ 8, distance, distance * 2, 4, true, true, false, true, false, false };
-
-                if( !get_map().route( u.pos_bub(), critter->pos_bub(), pf_settings ).empty() ) {
+                const pathfinding_target pf_t = pathfinding_target::point( critter->pos_bub() );
+                if( !get_map().route( u.pos_bub(), pf_t, pf_settings ).empty() ) {
                     return critter;
                 }
                 continue;
@@ -7906,7 +7906,7 @@ std::optional<std::vector<tripoint_bub_ms>> game::safe_route_to( Character &who,
         if( is_dangerous_tile( p ) ) {
             continue;
         }
-        const route_t route = here.route( who.pos_bub(), p,
+        const route_t route = here.route( who.pos_bub(), pathfinding_target::point( p ),
         who.get_pathfinding_settings(), [this]( const tripoint_bub_ms & p ) {
             return is_dangerous_tile( p );
         } );

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -76,6 +76,7 @@
 #include "output.h"
 #include "overmap_ui.h"
 #include "panels.h"
+#include "pathfinding.h"
 #include "player_activity.h"
 #include "point.h"
 #include "popup.h"
@@ -2356,9 +2357,7 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
                         tripoint_bub_ms auto_travel_destination =
                             player_character.pos_bub() + dest_delta * ( SEEX - i );
                         destination_preview =
-                            here.route( player_character.pos_bub(), auto_travel_destination,
-                                        player_character.get_pathfinding_settings(),
-                                        player_character.get_path_avoid() );
+                            here.route( player_character, pathfinding_target::point( auto_travel_destination ) );
                         if( !destination_preview.empty() ) {
                             destination_preview.erase(
                                 destination_preview.begin() + 1, destination_preview.end() );

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -5203,7 +5203,7 @@ std::pair<item *, tripoint_bub_ms> map::_add_item_or_charges( const tripoint_bub
                 continue;
             }
             //must be a path to the target tile
-            if( route( pos, e, setting ).empty() ) {
+            if( route( pos, pathfinding_target::point( e ), setting ).empty() ) {
                 continue;
             }
             if( obj.made_of( phase_id::LIQUID ) || !obj.has_flag( flag_DROP_ACTION_ONLY_IF_LIQUID ) ) {

--- a/src/map.h
+++ b/src/map.h
@@ -98,6 +98,7 @@ class map;
 enum class ter_furn_flag : int;
 struct pathfinding_cache;
 struct pathfinding_settings;
+struct pathfinding_target;
 template<typename T>
 struct weighted_int_list;
 struct field_proc_data;
@@ -715,15 +716,23 @@ class map
          * Calculate the best path using A*
          *
          * @param f The source location from which to path.
-         * @param t The destination to which to path.
+         * @param target The destination to which to path.
          * @param settings Structure describing pathfinding parameters.
          * @param pre_closed Never path through those points. They can still be the source or the destination.
          */
-        std::vector<tripoint_bub_ms> route( const tripoint_bub_ms &f, const tripoint_bub_ms &t,
+        std::vector<tripoint_bub_ms> route( const tripoint_bub_ms &f, const pathfinding_target &target,
                                             const pathfinding_settings &settings,
         const std::function<bool( const tripoint_bub_ms & )> &avoid = []( const tripoint_bub_ms & ) {
             return false;
         } ) const;
+
+        /**
+         * Calculate the best path using A*
+         *
+         * @param who The creature to find a path for.
+         * @param target The destination to which to path.
+         */
+        std::vector<tripoint_bub_ms> route( const Creature &who, const pathfinding_target &target ) const;
 
         // Get a straight route from f to t, only along non-rough terrain. Returns an empty vector
         // if that is not possible.

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -1610,8 +1610,9 @@ bool mattack::triffid_heartbeat( monster *z )
     creature_tracker &creatures = get_creature_tracker();
     static pathfinding_settings root_pathfind( 10, 20, 50, 0, false, false, false, false, false,
             false );
+    const pathfinding_target pf_t = pathfinding_target::point( z_pos );
     if( rl_dist( z_pos, pos ) > 5 &&
-        !here.route( pos, z_pos, root_pathfind ).empty() ) {
+        !here.route( pos, pf_t, root_pathfind ).empty() ) {
         add_msg( m_warning, _( "The root walls creak around you." ) );
         for( const tripoint_bub_ms &dest : here.points_in_radius( z_pos, 3 ) ) {
             if( g->is_empty( dest ) && one_in( 4 ) ) {
@@ -1622,7 +1623,7 @@ bool mattack::triffid_heartbeat( monster *z )
         }
         // Open blank tiles as long as there's no possible route
         int tries = 0;
-        while( here.route( pos, z_pos, root_pathfind ).empty() &&
+        while( here.route( pos, pf_t, root_pathfind ).empty() &&
                tries < 20 ) {
             point_bub_ms p( rng( pos.x(), z_pos.x() - 3 ),
                             rng( pos.y(), z_pos.y() - 3 ) );

--- a/src/monexamine.cpp
+++ b/src/monexamine.cpp
@@ -30,6 +30,7 @@
 #include "monster.h"
 #include "mtype.h"
 #include "output.h"
+#include "pathfinding.h"
 #include "point.h"
 #include "rng.h"
 #include "string_formatter.h"
@@ -592,9 +593,7 @@ void insert_battery( monster &z )
 
 bool Character::can_mount( const monster &critter ) const
 {
-    const auto &avoid = get_path_avoid();
-    auto route = get_map().route( pos_bub(), critter.pos_bub(), get_pathfinding_settings(), avoid );
-
+    auto route = get_map().route( *this, pathfinding_target::point( critter.pos_bub() ) );
     if( route.empty() ) {
         return false;
     }

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -1039,7 +1039,7 @@ void monster::move()
                 ( path.empty() || rl_dist( pos, path.front() ) >= 2 || path.back() != local_dest ) ) {
                 // We need a new path
                 if( can_pathfind() ) {
-                    path = here.route( pos, local_dest, pf_settings, get_path_avoid() );
+                    path = here.route( *this, pathfinding_target::point( local_dest ) );
                     if( path.empty() ) {
                         increment_pathfinding_cd();
                     }
@@ -2339,6 +2339,7 @@ void monster::knock_back_to( const tripoint_bub_ms &to )
 bool monster::will_reach( const point_bub_ms &p )
 {
     const map &here = get_map();
+    const tripoint_bub_ms t = { p, posz() };
 
     monster_attitude att = attitude( &get_player_character() );
     if( att != MATT_FOLLOW && att != MATT_ATTACK && att != MATT_FRIEND ) {
@@ -2355,8 +2356,7 @@ bool monster::will_reach( const point_bub_ms &p )
         return false;
     }
 
-    const std::vector<tripoint_bub_ms> path = here.route( pos_bub(), tripoint_bub_ms( p,
-            posz() ), get_pathfinding_settings() );
+    const std::vector<tripoint_bub_ms> path = here.route( *this, pathfinding_target::point( t ) );
     if( path.empty() ) {
         return false;
     }
@@ -2381,9 +2381,9 @@ bool monster::will_reach( const point_bub_ms &p )
 int monster::turns_to_reach( const point_bub_ms &p )
 {
     map &here = get_map();
+    const tripoint_bub_ms t = { p, posz() };
     // HACK: This function is a(n old) temporary hack that should soon be removed
-    const std::vector<tripoint_bub_ms> path = here.route( pos_bub(), tripoint_bub_ms( p,
-            posz() ), get_pathfinding_settings() );
+    const std::vector<tripoint_bub_ms> path = here.route( *this, pathfinding_target::point( t ) );
     if( path.empty() ) {
         return 999;
     }

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -82,6 +82,7 @@
 #include "options.h"
 #include "overmap_location.h"
 #include "overmapbuffer.h"
+#include "pathfinding.h"
 #include "pimpl.h"
 #include "player_activity.h"
 #include "point.h"
@@ -2895,7 +2896,7 @@ bool npc::update_path( const tripoint_bub_ms &p, const bool no_bashing, bool for
         }
     }
 
-    std::vector<tripoint_bub_ms> new_path = get_map().route( pos_bub(), p,
+    std::vector<tripoint_bub_ms> new_path = get_map().route( pos_bub(), pathfinding_target::point( p ),
                                             get_pathfinding_settings( no_bashing ),
                                             get_path_avoid() );
     if( new_path.empty() ) {
@@ -5048,16 +5049,7 @@ void npc::go_to_omt_destination()
     }
     tripoint_bub_ms sm_tri = here.get_bub( project_to<coords::ms>( omt_path.back() ) );
     tripoint_bub_ms centre_sub = sm_tri + point( SEEX, SEEY );
-    if( !here.passable_through( centre_sub ) ) {
-        auto candidates = here.points_in_radius( centre_sub, 2 );
-        for( const tripoint_bub_ms &elem : candidates ) {
-            if( here.passable_through( elem ) ) {
-                centre_sub = elem;
-                break;
-            }
-        }
-    }
-    path = here.route( pos_bub(), centre_sub, get_pathfinding_settings(), get_path_avoid() );
+    path = here.route( *this, pathfinding_target::radius( centre_sub, 2 ) );
     add_msg_debug( debugmode::DF_NPC, "%s going %s->%s", get_name(), omt_pos.to_string_writable(),
                    goal.to_string_writable() );
 

--- a/src/npctrade_utils.cpp
+++ b/src/npctrade_utils.cpp
@@ -23,6 +23,7 @@
 #include "mapdata.h"
 #include "npc.h"
 #include "npc_class.h"
+#include "pathfinding.h"
 #include "pocket_type.h"
 #include "point.h"
 #include "rng.h"
@@ -113,14 +114,13 @@ void add_fallback_zone( npc &guy )
     std::vector<tripoint_abs_ms> points;
     for( tripoint_abs_ms const &t : closest_points_first( loc, PICKUP_RANGE ) ) {
         tripoint_bub_ms const t_here = here.get_bub( t );
+        const pathfinding_target pf_t = pathfinding_target::point( t_here );
         const furn_id &f = here.furn( t_here );
         if( f != furn_str_id::NULL_ID() &&
             ( f->max_volume > ter_t_floor->max_volume ||
               f->has_flag( ter_furn_flag::TFLAG_CONTAINER ) ) &&
             here.can_put_items_ter_furn( t_here ) &&
-            !here.route( guy.pos_bub(), t_here, guy.get_pathfinding_settings(),
-                         guy.get_path_avoid() )
-            .empty() ) {
+            !here.route( guy, pf_t ).empty() ) {
             points.emplace_back( t );
         }
     }

--- a/src/pathfinding.cpp
+++ b/src/pathfinding.cpp
@@ -380,7 +380,14 @@ int map::extra_cost( const tripoint_bub_ms &cur, const tripoint_bub_ms &p,
     return pass_cost + avoid_cost;
 }
 
-std::vector<tripoint_bub_ms> map::route( const tripoint_bub_ms &f, const tripoint_bub_ms &t,
+std::vector<tripoint_bub_ms> map::route( const Creature &who,
+        const pathfinding_target &target ) const
+{
+    return route( who.pos_bub(), target, who.get_pathfinding_settings(), who.get_path_avoid() );
+}
+
+std::vector<tripoint_bub_ms> map::route( const tripoint_bub_ms &f,
+        const pathfinding_target &target,
         const pathfinding_settings &settings,
         const std::function<bool( const tripoint_bub_ms & )> &avoid ) const
 {
@@ -388,6 +395,7 @@ std::vector<tripoint_bub_ms> map::route( const tripoint_bub_ms &f, const tripoin
      * in-bounds point and go to that, then to the real origin/destination.
      */
     std::vector<tripoint_bub_ms> ret;
+    const tripoint_bub_ms &t = target.center;
 
     if( f == t || !inbounds( f ) ) {
         return ret;
@@ -396,7 +404,8 @@ std::vector<tripoint_bub_ms> map::route( const tripoint_bub_ms &f, const tripoin
     if( !inbounds( t ) ) {
         tripoint_bub_ms clipped = t;
         clip_to_bounds( clipped );
-        return route( f, clipped, settings, avoid );
+        const pathfinding_target clipped_target = { clipped, target.r };
+        return route( f, clipped_target, settings, avoid );
     }
     // First, check for a simple straight line on flat ground
     // Except when the line contains a pre-closed tile - we need to do regular pathing then
@@ -429,6 +438,7 @@ std::vector<tripoint_bub_ms> map::route( const tripoint_bub_ms &f, const tripoin
     pf.add_point( 0, 0, f, f );
 
     bool done = false;
+    tripoint_bub_ms found_target;
 
     do {
         tripoint_bub_ms cur( pf.get_next() );
@@ -444,8 +454,9 @@ std::vector<tripoint_bub_ms> map::route( const tripoint_bub_ms &f, const tripoin
             return std::vector<tripoint_bub_ms>();
         }
 
-        if( cur == t ) {
+        if( target.contains( cur ) ) {
             done = true;
+            found_target = cur;
             break;
         }
 
@@ -468,7 +479,7 @@ std::vector<tripoint_bub_ms> map::route( const tripoint_bub_ms &f, const tripoin
                 continue;
             }
 
-            if( p != t && avoid( p ) ) {
+            if( !target.contains( p ) && avoid( p ) ) {
                 layer.closed[index] = true;
                 continue;
             }
@@ -610,8 +621,8 @@ std::vector<tripoint_bub_ms> map::route( const tripoint_bub_ms &f, const tripoin
     } while( !done && !pf.empty() );
 
     if( done ) {
-        ret.reserve( rl_dist( f, t ) * 2 );
-        tripoint_bub_ms cur = t;
+        ret.reserve( rl_dist( f, found_target ) * 2 );
+        tripoint_bub_ms cur = found_target;
         // Just to limit max distance, in case something weird happens
         for( int fdist = max_length; fdist != 0; fdist-- ) {
             const int cur_index = flat_index( cur.xy() );
@@ -637,4 +648,12 @@ std::vector<tripoint_bub_ms> map::route( const tripoint_bub_ms &f, const tripoin
     }
 
     return ret;
+}
+
+bool pathfinding_target::contains( const tripoint_bub_ms &p ) const
+{
+    if( r == 0 ) {
+        return center == p;
+    }
+    return square_dist( center, p ) <= r;
 }

--- a/src/pathfinding.h
+++ b/src/pathfinding.h
@@ -8,6 +8,7 @@
 
 #include "coordinates.h"
 #include "mdarray.h"
+#include "point.h"
 
 enum class creature_size : int;
 
@@ -163,6 +164,27 @@ struct pathfinding_settings {
           avoid_rough_terrain( art ), avoid_sharp( as ), size( sz )  {}
 
     pathfinding_settings &operator=( const pathfinding_settings & ) = default;
+};
+
+struct pathfinding_target {
+    const tripoint_bub_ms center;
+    const int r;
+    bool contains( const tripoint_bub_ms &p ) const;
+
+    // Finds a path that ends on a specific tile
+    static pathfinding_target point( const tripoint_bub_ms &p ) {
+        return { p, 0 };
+    }
+
+    // Finds a path that ends on either the given tile, or one of the tiles directly adjacent to it
+    static pathfinding_target adjacent( const tripoint_bub_ms &p ) {
+        return { p, 1 };
+    }
+
+    // Finds a path that ends on any tile within the given radius of the specified tile, calculated by square distance
+    static pathfinding_target radius( const tripoint_bub_ms &p, int radius ) {
+        return { p, radius };
+    }
 };
 
 #endif // CATA_SRC_PATHFINDING_H

--- a/tests/map_path_test.cpp
+++ b/tests/map_path_test.cpp
@@ -1,13 +1,32 @@
 #include <algorithm>
+#include <memory>
 #include <vector>
 
 #include "cata_catch.h"
+#include "character.h"
 #include "coordinates.h"
+#include "game.h"
 #include "map.h"
 #include "map_helpers.h"
 #include "map_iterator.h"
+#include "pathfinding.h"
 #include "point.h"
 #include "type_id.h"
+
+static void clear_map_caches( map &m )
+{
+    m.set_transparency_cache_dirty( 0 );
+    m.set_pathfinding_cache_dirty( 0 );
+    m.build_map_cache( 0 );
+}
+
+static Character &place_player_at( const tripoint_bub_ms &p )
+{
+    Character &player = get_player_character();
+    g->place_player( p );
+    REQUIRE( player.pos_bub() == p );
+    return player;
+}
 
 static void place_obstacle( map &m, const std::vector<tripoint_bub_ms> &places )
 {
@@ -15,11 +34,28 @@ static void place_obstacle( map &m, const std::vector<tripoint_bub_ms> &places )
     for( const tripoint_bub_ms &p : places ) {
         m.ter_set( p, t_wall_metal );
     }
-    m.set_transparency_cache_dirty( 0 );
-    m.build_map_cache( 0 );
+    clear_map_caches( m );
     for( const tripoint_bub_ms &p : places ) {
         REQUIRE( !m.is_transparent( p ) );
     }
+}
+
+static void place_traps( map &m, const std::vector<tripoint_bub_ms> &places )
+{
+    const trap_id tr_beartrap( "tr_beartrap" );
+    for( const tripoint_bub_ms &p : places ) {
+        m.trap_set( p, tr_beartrap );
+    }
+    clear_map_caches( m );
+}
+
+static void place_wreckage( map &m, const std::vector<tripoint_bub_ms> &places )
+{
+    const furn_id f_wreckage( "f_wreckage" );
+    for( const tripoint_bub_ms &p : places ) {
+        m.furn_set( p, f_wreckage );
+    }
+    clear_map_caches( m );
 }
 
 static void expect_path( const std::vector<tripoint_bub_ms> &expected,
@@ -244,3 +280,298 @@ TEST_CASE( "find_clear_path_5tiles_with_obstacles", "[map]" )
     clear_map();
 }
 
+
+TEST_CASE( "map_route_player_without_obstacles", "[map][pathfinding]" )
+{
+    const map &m = setup_map_without_obstacles();
+    const tripoint_bub_ms source = { 65, 65, 0 };
+    const Character &pc = place_player_at( source );
+    GIVEN( "Player on an empty map" ) {
+        /*
+         * Map layout:
+         *   . . . . . .     @=player
+         *   . @ 2 . 1 .     .=empty floor
+         *   . . . . . .     1,2=targets
+         */
+        const tripoint_bub_ms t1 = { 68, 65, 0 };
+        const tripoint_bub_ms t2 = { 66, 65, 0 };
+        WHEN( "map::route does pathfinding to a tile 3 steps away" ) {
+            const std::vector<tripoint_bub_ms> path = m.route( pc, pathfinding_target::point( t1 ) );
+            THEN( "pathfinder finds a straight path" ) {
+                const std::vector<tripoint_bub_ms> expected_path = {
+                    { 66, 65, 0 }, { 67, 65, 0 }, { 68, 65, 0 }
+                };
+                CHECK( path == expected_path );
+            }
+        }
+        WHEN( "map::route does pathfinding to an adjacent tile" ) {
+            const std::vector<tripoint_bub_ms> path = m.route( pc, pathfinding_target::point( t2 ) );
+            THEN( "pathfinder finds a path with only one step" ) {
+                const std::vector<tripoint_bub_ms> expected_path = {
+                    { 66, 65, 0 }
+                };
+                CHECK( path == expected_path );
+            }
+        }
+        WHEN( "map::route does pathfinding to the same tile that player is already on" ) {
+            const std::vector<tripoint_bub_ms> path = m.route( pc, pathfinding_target::point( source ) );
+            THEN( "pathfinder returns an empty path" ) {
+                CHECK( path.empty() );
+            }
+        }
+    }
+    clear_map();
+}
+
+TEST_CASE( "map_route_player_around_obstacles", "[map][pathfinding]" )
+{
+    map &m = setup_map_without_obstacles();
+    const Character &pc = place_player_at( tripoint_bub_ms{ 65, 65, 0 } );
+    GIVEN( "Map has obstacles between player and target" ) {
+        /*
+         * Map layout:
+         *   . . @ . . .     @=player    .=empty floor
+         *   . # # # # .     #=trap or sharp wreckage
+         *   . t t t . .     t=tiles adjacent to target center
+         *   . t T t . .     T=target center
+         */
+        const pathfinding_target t = pathfinding_target::adjacent(
+                                         tripoint_bub_ms { 65, 68, 0 } );
+        const std::vector<tripoint_bub_ms> obstacles = {
+            { 64, 66, 0 }, { 65, 66, 0 }, { 66, 66, 0 }, { 67, 66, 0 }
+        };
+        const std::vector<tripoint_bub_ms> expected_path = {
+            { 64, 65, 0 }, { 63, 66, 0 }, { 64, 67, 0 }
+        };
+        GIVEN( "Obstacles are traps" ) {
+            place_traps( m, obstacles );
+            WHEN( "map::route does pathfinding" ) {
+                const std::vector<tripoint_bub_ms> path = m.route( pc, t );
+                THEN( "route avoids the traps" ) {
+                    CHECK( path == expected_path );
+                }
+            }
+            m.clear_traps();
+        }
+        GIVEN( "Obstacles are sharp wreckage" ) {
+            place_wreckage( m, obstacles );
+            WHEN( "map::route does pathfinding" ) {
+                const std::vector<tripoint_bub_ms> path = m.route( pc, t );
+                THEN( "route avoids the sharp wreckage" ) {
+                    CHECK( path == expected_path );
+                }
+            }
+        }
+    }
+
+    GIVEN( "An obstacle course between player and target" ) {
+        /*
+         * Map layout:
+         * # # # # # # . . .
+         * . . . . . # . # .    #=obstacle
+         * . . . # . # . # .    @=player
+         * . . @ # . . . # 1    1=target
+         * # # # # # # # # .
+         */
+        place_obstacle( m, {
+            { 63, 62, 0 }, { 63, 66, 0 },
+            { 64, 62, 0 }, { 64, 66, 0 },
+            { 65, 62, 0 }, { 65, 66, 0 },
+            { 66, 62, 0 }, { 66, 64, 0 }, { 66, 65, 0 }, { 66, 66, 0 },
+            { 67, 62, 0 }, { 67, 66, 0 },
+            { 68, 62, 0 }, { 68, 63, 0 }, { 68, 64, 0 }, { 68, 66, 0 },
+            { 69, 66, 0 },
+            { 70, 63, 0 }, { 70, 64, 0 }, { 70, 65, 0 }, { 70, 66, 0 },
+        } );
+        const tripoint_bub_ms target1{ 71, 65, 0 };
+        WHEN( "map::route does pathfinding of player to target" ) {
+            const std::vector<tripoint_bub_ms> path =
+                m.route( pc, pathfinding_target::point( target1 ) );
+            THEN( "path avoids the obstacles and ends at target" ) {
+                CHECK( path[0] == tripoint_bub_ms{ 65, 64, 0 } );
+                CHECK( path[1] == tripoint_bub_ms{ 66, 63, 0 } );
+                CHECK( path[2] == tripoint_bub_ms{ 67, 64, 0 } );
+                CHECK( path[3] == tripoint_bub_ms{ 68, 65, 0 } );
+                CHECK( path[4] == tripoint_bub_ms{ 69, 64, 0 } );
+                CHECK( path[5] == tripoint_bub_ms{ 69, 63, 0 } );
+                CHECK( path[6] == tripoint_bub_ms{ 70, 62, 0 } );
+                CHECK( path[7] == tripoint_bub_ms{ 71, 63, 0 } );
+                CHECK( path[8] == tripoint_bub_ms{ 71, 64, 0 } );
+                CHECK( path[9] == tripoint_bub_ms{ 71, 65, 0 } );
+                CHECK( path.size() == 10 );
+            }
+        }
+
+        const tripoint_bub_ms target2{ 68, 64, 0 };
+        REQUIRE( !m.is_transparent( target2 ) );
+        WHEN( "map::route does pathfinding of player to a target tile that is not walkable, with target radius 2" ) {
+            const std::vector<tripoint_bub_ms> path =
+                m.route( pc, pathfinding_target::radius( target2, 2 ) );
+            THEN( "path avoids the obstacles and ends 2 tiles from target" ) {
+                const std::vector<tripoint_bub_ms> expected_path = {
+                    { 65, 64, 0 }, { 66, 63, 0 }
+                };
+                CHECK( path == expected_path );
+            }
+        }
+    }
+    clear_map();
+}
+
+TEST_CASE( "map_route_player_into_danger", "[map][pathfinding]" )
+{
+    map &m = setup_map_without_obstacles();
+    const Character &pc = place_player_at( tripoint_bub_ms{ 65, 65, 0 } );
+    GIVEN( "Map has obstacles around player, and target is not reachable by flat ground" ) {
+        /*
+         * Map layout:
+         *   . # # # .     #=trap or sharp wreckage
+         *   . # @ # .     @=player
+         *   . # # # .
+         *   . . . . .     .=empty floor
+         *   . . t . .     t=target
+         */
+        const pathfinding_target t = pathfinding_target::point(
+                                         tripoint_bub_ms { 65, 68, 0 } );
+        const std::vector<tripoint_bub_ms> obstacles = {
+            { 64, 64, 0 }, { 65, 64, 0 }, { 66, 64, 0 },
+            { 64, 65, 0 },                { 66, 65, 0 },
+            { 64, 66, 0 }, { 65, 66, 0 }, { 66, 66, 0 }
+        };
+        const std::vector<tripoint_bub_ms> expected_path = {
+            { 65, 66, 0 }, { 65, 67, 0 }, { 65, 68, 0 }
+        };
+        GIVEN( "Obstacles are traps" ) {
+            place_traps( m, obstacles );
+            WHEN( "map::route does pathfinding" ) {
+                const std::vector<tripoint_bub_ms> path = m.route( pc, t );
+                THEN( "route goes through the traps" ) {
+                    CHECK( path == expected_path );
+                }
+            }
+            m.clear_traps();
+        }
+        GIVEN( "Obstacles are sharp wreckage" ) {
+            place_wreckage( m, obstacles );
+            WHEN( "map::route does pathfinding" ) {
+                const std::vector<tripoint_bub_ms> path = m.route( pc, t );
+                THEN( "route goes through the sharp wreckage" ) {
+                    CHECK( path == expected_path );
+                }
+            }
+        }
+    }
+    clear_map();
+}
+
+TEST_CASE( "map_route_player_up_down_stairs", "[map][pathfinding]" )
+{
+    map &m = setup_map_without_obstacles();
+    const ter_id t_stairs_up( "t_stairs_up" );
+    const ter_id t_stairs_down( "t_stairs_down" );
+    const ter_id t_floor( "t_floor" );
+    const Character &pc = place_player_at( tripoint_bub_ms{ 65, 65, 0 } );
+    GIVEN( "Map with stairs going up" ) {
+        /*
+         * Map layout:
+         *   . . . . . . .    .=empty floor
+         *   . @ . < . t .    @=player      <=stairs going up
+         *   . . . . . . .    t=target (one z-level above)
+         */
+        m.ter_set( tripoint_bub_ms{ 67, 65, 0 }, t_stairs_up );
+        m.ter_set( tripoint_bub_ms{ 67, 65, 1 }, t_stairs_down );
+        clear_map_caches( m );
+        WHEN( "map::route does pathfinding" ) {
+            const pathfinding_target t = pathfinding_target::point(
+                                             tripoint_bub_ms { 69, 65, 1 } );
+            const std::vector<tripoint_bub_ms> path = m.route( pc, t );
+            THEN( "route goes up the stairs" ) {
+                const std::vector<tripoint_bub_ms> expected_path = {
+                    { 66, 65, 0 }, { 67, 65, 0 }, { 67, 65, 1 },
+                    { 68, 65, 1 }, { 69, 65, 1 }
+                };
+                CHECK( path == expected_path );
+            }
+        }
+    }
+    GIVEN( "Map with stairs going down" ) {
+        /*
+         * Map layout:
+         *   . . . . . . .    .=empty floor
+         *   . @ . > . t .    @=player      >=stairs going down
+         *   . . . . . . .    t=target (one z-level below)
+         */
+        m.ter_set( tripoint_bub_ms{ 67, 65, 0 }, t_stairs_down );
+        m.ter_set( tripoint_bub_ms{ 67, 65, -1 }, t_stairs_up );
+        m.ter_set( tripoint_bub_ms{ 68, 65, -1 }, t_floor );
+        m.ter_set( tripoint_bub_ms{ 69, 65, -1 }, t_floor );
+        clear_map_caches( m );
+        WHEN( "map::route does pathfinding" ) {
+            const pathfinding_target t = pathfinding_target::point(
+                                             tripoint_bub_ms { 69, 65, -1 } );
+            const std::vector<tripoint_bub_ms> path = m.route( pc, t );
+            THEN( "route goes down the stairs" ) {
+                const std::vector<tripoint_bub_ms> expected_path = {
+                    { 66, 65, 0 }, { 67, 65, 0 }, { 67, 65, -1 },
+                    { 68, 65, -1 }, { 69, 65, -1 }
+                };
+                CHECK( path == expected_path );
+            }
+        }
+    }
+    clear_map();
+}
+
+TEST_CASE( "map_route_player_into_unreachable_tiles", "[map][pathfinding]" )
+{
+    map &m = setup_map_without_obstacles();
+    const Character &pc = place_player_at( tripoint_bub_ms{ 65, 65, 0 } );
+    const tripoint_bub_ms not_passable = { 68, 65, 0 };
+    GIVEN( "Map has unpassable tiles as target" ) {
+        /*
+         * Map layout:
+         *   . . . . . .    .=empty floor
+         *   . @ . . # .    @=player
+         *   . . . . . .    #=solid wall, is also the target
+         */
+        place_obstacle( m, { not_passable } );
+        WHEN( "map::route does pathfinding to a target tile that is not passable" ) {
+            const std::vector<tripoint_bub_ms> path = m.route( pc, pathfinding_target::point( not_passable ) );
+            THEN( "it does not find any route" ) {
+                CHECK( path.empty() );
+            }
+        }
+        WHEN( "map::route does pathfinding to any adjacent tile of an unpassable tile" ) {
+            const std::vector<tripoint_bub_ms> path = m.route( pc,
+                    pathfinding_target::adjacent( not_passable ) );
+            THEN( "route ends on one of the adjacent tiles" ) {
+                const std::vector<tripoint_bub_ms> expected_path = {
+                    { 66, 65, 0 }, { 67, 65, 0 }
+                };
+                CHECK( path == expected_path );
+            }
+        }
+    }
+    GIVEN( "Player is surrounded by walls" ) {
+        /*
+         * Map layout:
+         *   # # # . . .    .=empty floor
+         *   # @ # . t .    @=player     t=target
+         *   # # # . . .    #=solid wall
+         */
+        const std::vector<tripoint_bub_ms> obstacles = {
+            { 64, 64, 0 }, { 65, 64, 0 }, { 66, 64, 0 },
+            { 64, 65, 0 },                { 66, 65, 0 },
+            { 64, 66, 0 }, { 65, 66, 0 }, { 66, 66, 0 }
+        };
+        place_obstacle( m, obstacles );
+        WHEN( "map::route does pathfinding" ) {
+            const std::vector<tripoint_bub_ms> path = m.route( pc,
+                    pathfinding_target::adjacent( not_passable ) );
+            THEN( "it does not find any route" ) {
+                CHECK( path.empty() );
+            }
+        }
+    }
+    clear_map();
+}

--- a/tests/vehicle_fake_part_test.cpp
+++ b/tests/vehicle_fake_part_test.cpp
@@ -11,6 +11,7 @@
 #include "coordinates.h"
 #include "map.h"
 #include "map_helpers.h"
+#include "pathfinding.h"
 #include "player_helpers.h"
 #include "point.h"
 #include "tileray.h"
@@ -339,9 +340,10 @@ TEST_CASE( "vehicle_with_fake_obstacle_parts_block_movement", "[vehicle][vehicle
     here.set_seen_cache_dirty( 0 );
     here.build_map_cache( 0 );
     validate_part_count( *veh, 0, 315_degrees, 11, 6, 5 );
+    const tripoint_bub_ms src  = { test_origin - point( 2, 0 ) };
+    const tripoint_bub_ms dest = { test_origin + point( 2, 0 ) };
     std::vector<tripoint_bub_ms> route = here.route(
-            tripoint_bub_ms( test_origin - point( 2, 0 ) ),
-            tripoint_bub_ms( test_origin + point( 2, 0 ) ),
+            src, pathfinding_target::point( dest ),
             you.get_pathfinding_settings() );
     REQUIRE( !route.empty() );
     CAPTURE( route );


### PR DESCRIPTION


<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Infrastructure "Refactor pathfind: allow multiple targets"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Refactors pathfinding in `map::route` so that the target can not only be a single point, but also an area or any adjacent point.

Reason for changing is purely to make the calling code shorter.


<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

This is done by introducing a new struct `pathfinding_target` which allows the caller to specify either:
* a single point (like before)
* any tile adjacent to or on a single point
* any tile within a radius of a point

The logic of the pathfinder is not changed. What is changed is that the algorithm stops as soon as any of the target tiles have been found. Since the pathfinder picks points with lower weights first, this ensures that as soon as it has found any of the target tiles, it is therefore also the shortest path.

Adds rudimentary tests for easy scenarios such as avoiding dangers or passing through dangers when there are no other paths to pick.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Have played on my save for a few days on this branch. Player, monster and npc pathfinding seems to work as before.

Additional things explicitly tested:
* Spawned npc and a tamed horse. Told the npc to mount up. The npc successfully did pathfinding to the horse and mounted it.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Most likely causes diffing conflicts with #75945 . This change at least prepares the calling code to be shorter and not include `pathfinding_settings`, which presumably would make it easier for that PR.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
