### PR TITLE
Expand faults

### DIFF
--- a/data/json/items/bionics.json
+++ b/data/json/items/bionics.json
@@ -13,7 +13,7 @@
     "use_action": [ "install_bionic" ],
     "flags": [ "CBM", "FRAGILE_MELEE" ],
     "is_upgrade": false,
-    "faults": [ "fault_bionic_salvaged" ]
+    "faults": [ { "fault": "fault_bionic_salvaged" } ]
   },
   {
     "abstract": "bionic_general_npc_usable",

--- a/data/json/items/classes/gun.json
+++ b/data/json/items/classes/gun.json
@@ -9,12 +9,12 @@
     "symbol": "(",
     "color": "light_gray",
     "faults": [
-      "fault_gun_blackpowder",
-      "fault_gun_dirt",
-      "fault_gun_chamber_spent",
-      "fault_fail_to_feed",
-      "fault_stovepipe",
-      "fault_double_feed"
+      { "fault": "fault_gun_blackpowder" },
+      { "fault": "fault_gun_dirt" },
+      { "fault": "fault_gun_chamber_spent" },
+      { "fault": "fault_fail_to_feed" },
+      { "fault": "fault_stovepipe" },
+      { "fault": "fault_double_feed" }
     ],
     "ranged_damage": { "damage_type": "bullet", "amount": 0 }
   },
@@ -28,12 +28,12 @@
     "symbol": "(",
     "color": "light_gray",
     "faults": [
-      "fault_gun_blackpowder",
-      "fault_gun_dirt",
-      "fault_gun_chamber_spent",
-      "fault_fail_to_feed",
-      "fault_stovepipe",
-      "fault_double_feed"
+      { "fault": "fault_gun_blackpowder" },
+      { "fault": "fault_gun_dirt" },
+      { "fault": "fault_gun_chamber_spent" },
+      { "fault": "fault_fail_to_feed" },
+      { "fault": "fault_stovepipe" },
+      { "fault": "fault_double_feed" }
     ],
     "ranged_damage": { "damage_type": "bullet", "amount": 0 }
   },
@@ -63,7 +63,7 @@
     "handling": 10,
     "valid_mod_locations": [ [ "barrel", 1 ], [ "sights", 1 ], [ "sling", 1 ] ],
     "flags": [ "RELOAD_ONE", "RELOAD_EJECT", "NEVER_JAMS" ],
-    "faults": [ "fault_gun_blackpowder", "fault_gun_dirt" ]
+    "faults": [ { "fault": "fault_gun_blackpowder" }, { "fault": "fault_gun_dirt" } ]
   },
   {
     "abstract": "pistol_base",
@@ -132,7 +132,7 @@
     "//proportional": { "reload": 0.7 },
     "extend": { "flags": [ "RELOAD_ONE", "RELOAD_EJECT", "NEVER_JAMS", "EASY_CLEAN" ] },
     "//": "Revolvers exclude the muzzle location preventing installation of suppressors",
-    "faults": [ "fault_gun_blackpowder", "fault_gun_dirt" ],
+    "faults": [ { "fault": "fault_gun_blackpowder" }, { "fault": "fault_gun_dirt" } ],
     "valid_mod_locations": [
       [ "barrel", 1 ],
       [ "grip", 1 ],
@@ -152,7 +152,7 @@
     "extend": { "flags": [ "RELOAD_ONE", "NO_UNLOAD", "EASY_CLEAN" ] },
     "//": "Slower reloads, no unloading.  Base, unskilled person should take 1.5 seconds per chamber.  No underbarrel mods, that's where the ram goes.",
     "valid_mod_locations": [ [ "barrel", 1 ], [ "grip", 1 ], [ "stock", 1 ], [ "rail mount", 1 ], [ "sights mount", 1 ] ],
-    "faults": [ "fault_gun_blackpowder", "fault_gun_dirt" ]
+    "faults": [ { "fault": "fault_gun_blackpowder" }, { "fault": "fault_gun_dirt" } ]
   },
   {
     "abstract": "rifle_base",
@@ -181,7 +181,7 @@
     "type": "GUN",
     "name": { "str": "rifle with manual actions", "str_pl": "rifles with manual actions", "//~": "NO_I18N" },
     "//": "Manual actions exclude the magazine location preventing installation of belt-feed adaptors",
-    "faults": [ "fault_gun_blackpowder", "fault_gun_dirt" ],
+    "faults": [ { "fault": "fault_gun_blackpowder" }, { "fault": "fault_gun_dirt" } ],
     "valid_mod_locations": [
       [ "barrel", 1 ],
       [ "brass catcher", 1 ],
@@ -201,7 +201,7 @@
     "copy-from": "rifle_base",
     "type": "GUN",
     "name": { "str": "vintage semi rifle", "//~": "NO_I18N" },
-    "faults": [ "fault_gun_blackpowder", "fault_gun_dirt" ],
+    "faults": [ { "fault": "fault_gun_blackpowder" }, { "fault": "fault_gun_dirt" } ],
     "valid_mod_locations": [
       [ "barrel", 1 ],
       [ "brass catcher", 1 ],
@@ -258,7 +258,7 @@
     "name": { "str": "pump-action shotgun", "//~": "NO_I18N" },
     "reload_noise": "chuk chuk.",
     "flags": [ "RELOAD_ONE", "PUMP_ACTION" ],
-    "faults": [ "fault_gun_blackpowder", "fault_gun_dirt" ]
+    "faults": [ { "fault": "fault_gun_blackpowder" }, { "fault": "fault_gun_dirt" } ]
   },
   {
     "abstract": "shotgun_pump_3gun",
@@ -305,7 +305,7 @@
     "handling": 10,
     "reload": 200,
     "reload_noise_volume": 10,
-    "faults": [ "fault_gun_blackpowder", "fault_gun_dirt" ]
+    "faults": [ { "fault": "fault_gun_blackpowder" }, { "fault": "fault_gun_dirt" } ]
   },
   {
     "abstract": "gun_base_handgun_semi",
@@ -324,12 +324,12 @@
     "reload": 150,
     "reload_noise_volume": 10,
     "faults": [
-      "fault_gun_blackpowder",
-      "fault_gun_dirt",
-      "fault_gun_chamber_spent",
-      "fault_fail_to_feed",
-      "fault_stovepipe",
-      "fault_double_feed"
+      { "fault": "fault_gun_blackpowder" },
+      { "fault": "fault_gun_dirt" },
+      { "fault": "fault_gun_chamber_spent" },
+      { "fault": "fault_fail_to_feed" },
+      { "fault": "fault_stovepipe" },
+      { "fault": "fault_double_feed" }
     ]
   },
   {
@@ -430,7 +430,7 @@
     "reload": 150,
     "reload_noise_volume": 10,
     "blackpowder_tolerance": 56,
-    "faults": [ "fault_gun_blackpowder", "fault_gun_dirt", "fault_gun_chamber_spent" ]
+    "faults": [ { "fault": "fault_gun_blackpowder" }, { "fault": "fault_gun_dirt" }, { "fault": "fault_gun_chamber_spent" } ]
   },
   {
     "abstract": "gun_base_rifle_semi",
@@ -448,12 +448,12 @@
     "reload": 150,
     "reload_noise_volume": 10,
     "faults": [
-      "fault_gun_blackpowder",
-      "fault_gun_dirt",
-      "fault_gun_chamber_spent",
-      "fault_fail_to_feed",
-      "fault_stovepipe",
-      "fault_double_feed"
+      { "fault": "fault_gun_blackpowder" },
+      { "fault": "fault_gun_dirt" },
+      { "fault": "fault_gun_chamber_spent" },
+      { "fault": "fault_fail_to_feed" },
+      { "fault": "fault_stovepipe" },
+      { "fault": "fault_double_feed" }
     ]
   },
   {
@@ -557,7 +557,7 @@
     "reload": 150,
     "reload_noise_volume": 10,
     "blackpowder_tolerance": 56,
-    "faults": [ "fault_gun_blackpowder", "fault_gun_dirt", "fault_gun_chamber_spent" ]
+    "faults": [ { "fault": "fault_gun_blackpowder" }, { "fault": "fault_gun_dirt" }, { "fault": "fault_gun_chamber_spent" } ]
   },
   {
     "abstract": "gun_base_shotgun_semi",
@@ -579,12 +579,12 @@
     "reload_noise_volume": 10,
     "min_cycle_recoil": 2400,
     "faults": [
-      "fault_gun_blackpowder",
-      "fault_gun_dirt",
-      "fault_gun_chamber_spent",
-      "fault_fail_to_feed",
-      "fault_stovepipe",
-      "fault_double_feed"
+      { "fault": "fault_gun_blackpowder" },
+      { "fault": "fault_gun_dirt" },
+      { "fault": "fault_gun_chamber_spent" },
+      { "fault": "fault_fail_to_feed" },
+      { "fault": "fault_stovepipe" },
+      { "fault": "fault_double_feed" }
     ]
   }
 ]

--- a/data/json/items/gun/308.json
+++ b/data/json/items/gun/308.json
@@ -104,7 +104,7 @@
     "energy_drain": "1 kJ",
     "reload": 400,
     "modes": [ [ "DEFAULT", "low auto", 50 ], [ "AUTO", "high auto", 100 ] ],
-    "faults": [ "fault_gun_blackpowder", "fault_gun_dirt" ],
+    "faults": [ { "fault": "fault_gun_blackpowder" }, { "fault": "fault_gun_dirt" } ],
     "flags": [ "NEVER_JAMS", "MOUNTED_GUN", "USE_UPS" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "belt308" ] } ],
     "melee_damage": { "bash": 18 }

--- a/data/json/items/gun/380.json
+++ b/data/json/items/gun/380.json
@@ -112,12 +112,12 @@
       [ "underbarrel", 1 ]
     ],
     "faults": [
-      "fault_gun_blackpowder",
-      "fault_gun_dirt",
-      "fault_gun_chamber_spent",
-      "fault_fail_to_feed",
-      "fault_stovepipe",
-      "fault_double_feed"
+      { "fault": "fault_gun_blackpowder" },
+      { "fault": "fault_gun_dirt" },
+      { "fault": "fault_gun_chamber_spent" },
+      { "fault": "fault_fail_to_feed" },
+      { "fault": "fault_stovepipe" },
+      { "fault": "fault_double_feed" }
     ],
     "pocket_data": [ { "magazine_well": "236 ml", "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "hpt3895mag_10rd" ] } ],
     "melee_damage": { "bash": 10 }

--- a/data/json/items/gun/40x53mm.json
+++ b/data/json/items/gun/40x53mm.json
@@ -32,12 +32,12 @@
     "modes": [ [ "DEFAULT", "semi-auto", 1, "NPC_AVOID" ], [ "AUTO", "auto", 2, "NPC_AVOID" ] ],
     "flags": [ "MOUNTED_GUN" ],
     "faults": [
-      "fault_gun_blackpowder",
-      "fault_gun_dirt",
-      "fault_gun_chamber_spent",
-      "fault_fail_to_feed",
-      "fault_stovepipe",
-      "fault_double_feed"
+      { "fault": "fault_gun_blackpowder" },
+      { "fault": "fault_gun_dirt" },
+      { "fault": "fault_gun_chamber_spent" },
+      { "fault": "fault_fail_to_feed" },
+      { "fault": "fault_stovepipe" },
+      { "fault": "fault_double_feed" }
     ],
     "pocket_data": [ { "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "belt40mm" ] } ],
     "melee_damage": { "bash": 14 }

--- a/data/json/items/gun/44.json
+++ b/data/json/items/gun/44.json
@@ -39,12 +39,12 @@
     "weapon_category": [ "AUTOMATIC_PISTOLS" ],
     "valid_mod_locations": [ [ "bore", 1 ], [ "mechanism", 2 ], [ "rail mount", 1 ], [ "stock mount", 1 ] ],
     "faults": [
-      "fault_gun_blackpowder",
-      "fault_gun_dirt",
-      "fault_gun_chamber_spent",
-      "fault_fail_to_feed",
-      "fault_stovepipe",
-      "fault_double_feed"
+      { "fault": "fault_gun_blackpowder" },
+      { "fault": "fault_gun_dirt" },
+      { "fault": "fault_gun_chamber_spent" },
+      { "fault": "fault_fail_to_feed" },
+      { "fault": "fault_stovepipe" },
+      { "fault": "fault_double_feed" }
     ],
     "melee_damage": { "bash": 12 }
   },

--- a/data/json/items/gun/45.json
+++ b/data/json/items/gun/45.json
@@ -95,12 +95,12 @@
       [ "underbarrel", 1 ]
     ],
     "faults": [
-      "fault_gun_blackpowder",
-      "fault_gun_dirt",
-      "fault_gun_chamber_spent",
-      "fault_fail_to_feed",
-      "fault_stovepipe",
-      "fault_double_feed"
+      { "fault": "fault_gun_blackpowder" },
+      { "fault": "fault_gun_dirt" },
+      { "fault": "fault_gun_chamber_spent" },
+      { "fault": "fault_fail_to_feed" },
+      { "fault": "fault_stovepipe" },
+      { "fault": "fault_double_feed" }
     ],
     "default_mods": [ "folding_stock" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "ump45mag" ] } ],

--- a/data/json/items/gun/46.json
+++ b/data/json/items/gun/46.json
@@ -35,12 +35,12 @@
       [ "underbarrel", 1 ]
     ],
     "faults": [
-      "fault_gun_blackpowder",
-      "fault_gun_dirt",
-      "fault_gun_chamber_spent",
-      "fault_fail_to_feed",
-      "fault_stovepipe",
-      "fault_double_feed"
+      { "fault": "fault_gun_blackpowder" },
+      { "fault": "fault_gun_dirt" },
+      { "fault": "fault_gun_chamber_spent" },
+      { "fault": "fault_fail_to_feed" },
+      { "fault": "fault_stovepipe" },
+      { "fault": "fault_double_feed" }
     ],
     "pocket_data": [ { "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "hk46mag", "hk46bigmag" ] } ],
     "melee_damage": { "bash": 7 }

--- a/data/json/items/gun/combination.json
+++ b/data/json/items/gun/combination.json
@@ -25,7 +25,7 @@
     "loudness": 25,
     "barrel_volume": "500 ml",
     "built_in_mods": [ "combination_gun_shotgun" ],
-    "faults": [ "fault_gun_blackpowder", "fault_gun_dirt" ],
+    "faults": [ { "fault": "fault_gun_blackpowder" }, { "fault": "fault_gun_dirt" } ],
     "valid_mod_locations": [
       [ "barrel", 1 ],
       [ "conversion", 1 ],

--- a/data/json/items/gun/exodii.json
+++ b/data/json/items/gun/exodii.json
@@ -252,7 +252,13 @@
       [ "underbarrel", 1 ]
     ],
     "barrel_volume": "1200 ml",
-    "faults": [ "fault_gun_dirt", "fault_gun_chamber_spent", "fault_fail_to_feed", "fault_stovepipe", "fault_double_feed" ],
+    "faults": [
+      { "fault": "fault_gun_dirt" },
+      { "fault": "fault_gun_chamber_spent" },
+      { "fault": "fault_fail_to_feed" },
+      { "fault": "fault_stovepipe" },
+      { "fault": "fault_double_feed" }
+    ],
     "pocket_data": [ { "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "exodiiBRmag", "exodiiBRmag_153", "exodiiBRmag_26" ] } ],
     "melee_damage": { "bash": 12 }
   },
@@ -286,7 +292,13 @@
     "durability": 8,
     "modes": [ [ "DEFAULT", "semi-auto", 1 ], [ "AUTO", "burst", 2 ] ],
     "barrel_volume": "250 ml",
-    "faults": [ "fault_gun_dirt", "fault_gun_chamber_spent", "fault_fail_to_feed", "fault_stovepipe", "fault_double_feed" ],
+    "faults": [
+      { "fault": "fault_gun_dirt" },
+      { "fault": "fault_gun_chamber_spent" },
+      { "fault": "fault_fail_to_feed" },
+      { "fault": "fault_stovepipe" },
+      { "fault": "fault_double_feed" }
+    ],
     "pocket_data": [ { "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "exodiiminimag" ] } ],
     "melee_damage": { "bash": 12 }
   },
@@ -353,7 +365,7 @@
       "ammo_scale": 0
     },
     "valid_mod_locations": [ [ "sling", 1 ], [ "condenser", 1 ] ],
-    "faults": [ "fault_overheat_explosion", "fault_overheat_venting", "fault_overheat_safety" ]
+    "faults": [ { "fault": "fault_overheat_explosion" }, { "fault": "fault_overheat_venting" }, { "fault": "fault_overheat_safety" } ]
   },
   {
     "id": "exodii_plasma_fan",

--- a/data/json/items/gun/ups.json
+++ b/data/json/items/gun/ups.json
@@ -39,7 +39,7 @@
     ],
     "ammo_effects": [ "LASER", "EMP" ],
     "flags": [ "NEVER_JAMS", "NO_UNLOAD", "NON_FOULING", "NEEDS_NO_LUBE", "USE_UPS", "OVERHEATS" ],
-    "faults": [ "fault_overheat_melting", "fault_overheat_safety" ],
+    "faults": [ { "fault": "fault_overheat_melting" }, { "fault": "fault_overheat_safety" } ],
     "melee_damage": { "bash": 12 }
   },
   {
@@ -71,7 +71,7 @@
     "overheat_threshold": 200,
     "cooling_value": 2,
     "heat_per_shot": 6,
-    "faults": [ "fault_overheat_melting", "fault_overheat_safety" ],
+    "faults": [ { "fault": "fault_overheat_melting" }, { "fault": "fault_overheat_safety" } ],
     "melee_damage": { "bash": 8 }
   },
   {
@@ -111,7 +111,7 @@
     "overheat_threshold": 100,
     "cooling_value": 2,
     "heat_per_shot": 17,
-    "faults": [ "fault_overheat_melting", "fault_overheat_safety" ],
+    "faults": [ { "fault": "fault_overheat_melting" }, { "fault": "fault_overheat_safety" } ],
     "melee_damage": { "bash": 6 }
   },
   {
@@ -155,7 +155,7 @@
     ],
     "ammo_effects": [ "LASER", "IGNITE" ],
     "flags": [ "NEVER_JAMS", "NO_UNLOAD", "NON_FOULING", "NEEDS_NO_LUBE", "USE_UPS", "OVERHEATS" ],
-    "faults": [ "fault_overheat_melting", "fault_overheat_safety" ],
+    "faults": [ { "fault": "fault_overheat_melting" }, { "fault": "fault_overheat_safety" } ],
     "melee_damage": { "bash": 12 }
   },
   {
@@ -210,7 +210,7 @@
     "valid_mod_locations": [ [ "emitter", 1 ], [ "grip", 1 ], [ "lens", 1 ], [ "rail", 1 ], [ "sights", 1 ], [ "stock", 1 ], [ "underbarrel", 1 ] ],
     "ammo_effects": [ "LASER", "INCENDIARY" ],
     "flags": [ "NEVER_JAMS", "NO_UNLOAD", "NON_FOULING", "NEEDS_NO_LUBE", "USE_UPS", "OVERHEATS" ],
-    "faults": [ "fault_overheat_melting", "fault_overheat_safety" ],
+    "faults": [ { "fault": "fault_overheat_melting" }, { "fault": "fault_overheat_safety" } ],
     "melee_damage": { "bash": 5 }
   },
   {

--- a/data/json/items/gunmod/underbarrel.json
+++ b/data/json/items/gunmod/underbarrel.json
@@ -270,7 +270,7 @@
     "min_skills": [ [ "weapon", 1 ], [ "launcher", 1 ] ],
     "flags": [ "NEVER_JAMS", "RELOAD_EJECT" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "ammo_restriction": { "40x46mm": 1 } } ],
-    "faults": [ "fault_gun_blackpowder", "fault_gun_dirt" ]
+    "faults": [ { "fault": "fault_gun_blackpowder" }, { "fault": "fault_gun_dirt" } ]
   },
   {
     "id": "m203_mod",
@@ -309,7 +309,7 @@
     "min_skills": [ [ "weapon", 1 ], [ "launcher", 1 ] ],
     "flags": [ "NEVER_JAMS", "RELOAD_EJECT" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "ammo_restriction": { "40x46mm": 1 } } ],
-    "faults": [ "fault_gun_blackpowder", "fault_gun_dirt" ]
+    "faults": [ { "fault": "fault_gun_blackpowder" }, { "fault": "fault_gun_dirt" } ]
   },
   {
     "id": "m320_mod_mod",

--- a/data/json/items/vehicle/engine.json
+++ b/data/json/items/vehicle/engine.json
@@ -14,13 +14,13 @@
     "type": "ENGINE",
     "name": { "str": "base diesel engine", "//~": "NO_I18N" },
     "faults": [
-      "fault_engine_belt_drive",
-      "fault_engine_filter_air",
-      "fault_engine_filter_fuel",
-      "fault_engine_glow_plug",
-      "fault_engine_immobiliser",
-      "fault_engine_pump_diesel",
-      "fault_engine_starter"
+      { "fault": "fault_engine_belt_drive" },
+      { "fault": "fault_engine_filter_air" },
+      { "fault": "fault_engine_filter_fuel" },
+      { "fault": "fault_engine_glow_plug" },
+      { "fault": "fault_engine_immobiliser" },
+      { "fault": "fault_engine_pump_diesel" },
+      { "fault": "fault_engine_starter" }
     ]
   },
   {
@@ -29,12 +29,12 @@
     "type": "ENGINE",
     "name": { "str": "base gasoline engine", "//~": "NO_I18N" },
     "faults": [
-      "fault_engine_belt_drive",
-      "fault_engine_filter_air",
-      "fault_engine_filter_fuel",
-      "fault_engine_immobiliser",
-      "fault_engine_pump_fuel",
-      "fault_engine_starter"
+      { "fault": "fault_engine_belt_drive" },
+      { "fault": "fault_engine_filter_air" },
+      { "fault": "fault_engine_filter_fuel" },
+      { "fault": "fault_engine_immobiliser" },
+      { "fault": "fault_engine_pump_fuel" },
+      { "fault": "fault_engine_starter" }
     ]
   },
   {
@@ -43,7 +43,7 @@
     "type": "ENGINE",
     "name": { "str": "base steam engine", "//~": "NO_I18N" },
     "looks_like": "v12_diesel",
-    "faults": [ "fault_engine_belt_drive", "fault_engine_filter_air", "fault_engine_starter" ]
+    "faults": [ { "fault": "fault_engine_belt_drive" }, { "fault": "fault_engine_filter_air" }, { "fault": "fault_engine_starter" } ]
   },
   {
     "id": "1cyl_combustion",
@@ -56,7 +56,7 @@
     "volume": "12 L",
     "price": "100 USD",
     "price_postapoc": "10 USD",
-    "faults": [ "fault_engine_starter" ]
+    "faults": [ { "fault": "fault_engine_starter" } ]
   },
   {
     "id": "1cyl_combustion_large",
@@ -69,7 +69,7 @@
     "volume": "42 L",
     "price": "100 USD",
     "price_postapoc": "12 USD 50 cent",
-    "faults": [ "fault_engine_starter" ]
+    "faults": [ { "fault": "fault_engine_starter" } ]
   },
   {
     "id": "1cyl_combustion_med",
@@ -94,7 +94,7 @@
     "volume": "42 L",
     "price": "100 USD",
     "price_postapoc": "12 USD 50 cent",
-    "faults": [ "fault_engine_starter" ]
+    "faults": [ { "fault": "fault_engine_starter" } ]
   },
   {
     "id": "1cyl_combustion_small",

--- a/data/json/obsoletion_and_migration_0.I/gun.json
+++ b/data/json/obsoletion_and_migration_0.I/gun.json
@@ -45,7 +45,6 @@
       [ "underbarrel", 1 ],
       [ "rail mount", 1 ]
     ],
-    "faults": [ "fault_gun_blackpowder", "fault_gun_dirt", "fault_gun_chamber_spent" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "ppshmag", "ppshdrum" ] } ],
     "melee_damage": { "bash": 10 }
   },
@@ -344,7 +343,6 @@
       [ "stock accessory", 2 ],
       [ "underbarrel", 1 ]
     ],
-    "faults": [ "fault_gun_blackpowder", "fault_gun_dirt", "fault_gun_chamber_spent" ],
     "pocket_data": [
       { "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "a180mag", "a180mag1", "a180mag2", "a180mag3", "a180mag4" ] }
     ],
@@ -532,14 +530,6 @@
     "min_cycle_recoil": 225,
     "blackpowder_tolerance": 48,
     "modes": [ [ "DEFAULT", "double", 2 ] ],
-    "faults": [
-      "fault_gun_blackpowder",
-      "fault_gun_dirt",
-      "fault_gun_chamber_spent",
-      "fault_fail_to_feed",
-      "fault_stovepipe",
-      "fault_double_feed"
-    ],
     "valid_mod_locations": [
       [ "barrel", 1 ],
       [ "brass catcher", 1 ],

--- a/data/mods/Aftershock/items/gun/7.50mm.json
+++ b/data/mods/Aftershock/items/gun/7.50mm.json
@@ -59,7 +59,7 @@
     "blackpowder_tolerance": 60,
     "ammo": [ "afs_7.50mm" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "afs_7.50mm": 1 } } ],
-    "faults": [ "fault_gun_blackpowder", "fault_gun_dirt" ]
+    "faults": [ { "fault": "fault_gun_blackpowder" }, { "fault": "fault_gun_dirt" } ]
   },
   {
     "id": "afs_Accipitermg",
@@ -205,7 +205,12 @@
       [ "underbarrel", 1 ],
       [ "stock accessory", 2 ]
     ],
-    "faults": [ "fault_gun_blackpowder", "fault_gun_dirt", "fault_fail_to_feed", "fault_double_feed" ],
+    "faults": [
+      { "fault": "fault_gun_blackpowder" },
+      { "fault": "fault_gun_dirt" },
+      { "fault": "fault_fail_to_feed" },
+      { "fault": "fault_double_feed" }
+    ],
     "pocket_data": [ { "magazine_well": "500 ml", "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "afs_sr77_45mag" ] } ],
     "melee_damage": { "bash": 10 }
   },

--- a/data/mods/Aftershock/items/gun/plasma.json
+++ b/data/mods/Aftershock/items/gun/plasma.json
@@ -61,7 +61,7 @@
         "item_restriction": [ "afs_20g_plasma", "afs_4g_plasma" ]
       }
     ],
-    "faults": [ "fault_overheat_explosion", "fault_overheat_venting", "fault_overheat_safety" ]
+    "faults": [ { "fault": "fault_overheat_explosion" }, { "fault": "fault_overheat_venting" }, { "fault": "fault_overheat_safety" } ]
   },
   {
     "id": "afs_pam-41",
@@ -140,7 +140,7 @@
         "item_restriction": [ "afs_40g_plasma_civ" ]
       }
     ],
-    "faults": [ "fault_overheat_melting" ],
+    "faults": [ { "fault": "fault_overheat_melting" } ],
     "tool_ammo": [ "afs_shydrogen" ]
   },
   {
@@ -181,6 +181,6 @@
         "item_restriction": [ "afs_40g_plasma_civ" ]
       }
     ],
-    "faults": [ "fault_overheat_explosion", "fault_overheat_venting" ]
+    "faults": [ { "fault": "fault_overheat_explosion" }, { "fault": "fault_overheat_venting" } ]
   }
 ]

--- a/data/mods/Generic_Guns/firearms/pistol_magnum.json
+++ b/data/mods/Generic_Guns/firearms/pistol_magnum.json
@@ -35,12 +35,12 @@
       [ "underbarrel", 1 ]
     ],
     "faults": [
-      "fault_gun_blackpowder",
-      "fault_gun_dirt",
-      "fault_gun_chamber_spent",
-      "fault_fail_to_feed",
-      "fault_stovepipe",
-      "fault_double_feed"
+      { "fault": "fault_gun_blackpowder" },
+      { "fault": "fault_gun_dirt" },
+      { "fault": "fault_gun_chamber_spent" },
+      { "fault": "fault_fail_to_feed" },
+      { "fault": "fault_stovepipe" },
+      { "fault": "fault_double_feed" }
     ],
     "pocket_data": [
       {

--- a/data/mods/Isolation-Protocol/unique_items.json
+++ b/data/mods/Isolation-Protocol/unique_items.json
@@ -170,7 +170,13 @@
       [ "stock accessory", 2 ],
       [ "underbarrel", 1 ]
     ],
-    "faults": [ "fault_gun_dirt", "fault_gun_chamber_spent", "fault_fail_to_feed", "fault_stovepipe", "fault_double_feed" ],
+    "faults": [
+      { "fault": "fault_gun_dirt" },
+      { "fault": "fault_gun_chamber_spent" },
+      { "fault": "fault_fail_to_feed" },
+      { "fault": "fault_stovepipe" },
+      { "fault": "fault_double_feed" }
+    ],
     "pocket_data": [ { "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "iso_lewis_mag" ] } ]
   },
   {

--- a/data/mods/Magiclysm/items/enchanted_ranged.json
+++ b/data/mods/Magiclysm/items/enchanted_ranged.json
@@ -128,7 +128,7 @@
     "reload_noise": "chuk chuk.",
     "weapon_category": [ "MEDIUM_SWORDS" ],
     "flags": [ "RELOAD_ONE", "PUMP_ACTION", "DURABLE_MELEE", "SHEATH_SWORD" ],
-    "faults": [ "fault_gun_blackpowder", "fault_gun_dirt" ],
+    "faults": [ { "fault": "fault_gun_blackpowder" }, { "fault": "fault_gun_dirt" } ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "ammo_restriction": { "shot": 3 } } ],
     "melee_damage": { "bash": 10, "cut": 32 }
   },

--- a/data/mods/Magiclysm/migration_and_obsoletion/items.json
+++ b/data/mods/Magiclysm/migration_and_obsoletion/items.json
@@ -140,7 +140,6 @@
     "techniques": [ "WBLOCK_1", "BRUTAL" ],
     "min_strength": 7,
     "flags": [ "DURABLE_MELEE", "NEVER_JAMS", "RELOAD_EJECT", "RELOAD_ONE", "OBSOLETE" ],
-    "faults": [ "fault_gun_blackpowder", "fault_gun_dirt" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "ammo_restriction": { "shot": 2 } } ],
     "armor": [ { "encumbrance": 5, "coverage": 20, "covers": [ "hand_r" ] } ],
     "melee_damage": { "bash": 12 }

--- a/data/mods/MindOverMatter/items/weapons.json
+++ b/data/mods/MindOverMatter/items/weapons.json
@@ -246,7 +246,7 @@
     "ammo": [ "mom_pulse_rifle_ammo" ],
     "ammo_effects": [ "LASER", "IGNITE" ],
     "flags": [ "NEVER_JAMS", "NO_UNLOAD", "NON_FOULING", "NEEDS_NO_LUBE", "NO_REPAIR", "OVERHEATS" ],
-    "faults": [ "fault_overheat_explosion", "fault_overheat_melting" ],
+    "faults": [ { "fault": "fault_overheat_explosion" }, { "fault": "fault_overheat_melting" } ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "ammo_restriction": { "mom_pulse_rifle_ammo": 1 } } ],
     "relic_data": { "charge_info": { "recharge_type": "periodic", "time": "8 s", "regenerate_ammo": true } },
     "//": "Recharge time is 8 seconds due to bug #48019, making it actually 4 seconds. Reduce to 4 seconds if that ever gets fixed."

--- a/data/mods/Xedra_Evolved/items/inventor/gun.json
+++ b/data/mods/Xedra_Evolved/items/inventor/gun.json
@@ -36,7 +36,12 @@
       [ "underbarrel", 1 ]
     ],
     "ammo_effects": [ "LASER" ],
-    "faults": [ "fault_overheat_explosion", "fault_overheat_venting", "fault_overheat_melting", "fault_overheat_safety" ],
+    "faults": [
+      { "fault": "fault_overheat_explosion" },
+      { "fault": "fault_overheat_venting" },
+      { "fault": "fault_overheat_melting" },
+      { "fault": "fault_overheat_safety" }
+    ],
     "flags": [
       "NEVER_JAMS",
       "NO_SALVAGE",
@@ -98,7 +103,12 @@
       [ "underbarrel", 1 ]
     ],
     "ammo_effects": [ "LASER", "IGNITE" ],
-    "faults": [ "fault_overheat_explosion", "fault_overheat_venting", "fault_overheat_melting", "fault_overheat_safety" ],
+    "faults": [
+      { "fault": "fault_overheat_explosion" },
+      { "fault": "fault_overheat_venting" },
+      { "fault": "fault_overheat_melting" },
+      { "fault": "fault_overheat_safety" }
+    ],
     "flags": [
       "NEVER_JAMS",
       "NO_SALVAGE",
@@ -160,7 +170,12 @@
       [ "underbarrel", 1 ]
     ],
     "ammo_effects": [ "LASER", "IGNITE" ],
-    "faults": [ "fault_overheat_explosion", "fault_overheat_venting", "fault_overheat_melting", "fault_overheat_safety" ],
+    "faults": [
+      { "fault": "fault_overheat_explosion" },
+      { "fault": "fault_overheat_venting" },
+      { "fault": "fault_overheat_melting" },
+      { "fault": "fault_overheat_safety" }
+    ],
     "flags": [
       "NEVER_JAMS",
       "NO_SALVAGE",
@@ -219,7 +234,12 @@
       [ "underbarrel", 1 ]
     ],
     "ammo_effects": [ "LASER", "PLASMA_BUBBLE", "IGNITE" ],
-    "faults": [ "fault_overheat_explosion", "fault_overheat_venting", "fault_overheat_melting", "fault_overheat_safety" ],
+    "faults": [
+      { "fault": "fault_overheat_explosion" },
+      { "fault": "fault_overheat_venting" },
+      { "fault": "fault_overheat_melting" },
+      { "fault": "fault_overheat_safety" }
+    ],
     "flags": [
       "NEVER_JAMS",
       "NO_SALVAGE",

--- a/data/mods/Xedra_Evolved/monsters/monsterattacks.json
+++ b/data/mods/Xedra_Evolved/monsters/monsterattacks.json
@@ -177,12 +177,12 @@
       [ "stock accessory", 2 ]
     ],
     "faults": [
-      "fault_gun_blackpowder",
-      "fault_gun_dirt",
-      "fault_gun_chamber_spent",
-      "fault_fail_to_feed",
-      "fault_stovepipe",
-      "fault_double_feed"
+      { "fault": "fault_gun_blackpowder" },
+      { "fault": "fault_gun_dirt" },
+      { "fault": "fault_gun_chamber_spent" },
+      { "fault": "fault_fail_to_feed" },
+      { "fault": "fault_stovepipe" },
+      { "fault": "fault_double_feed" }
     ],
     "pocket_data": [ { "magazine_well": "500 ml", "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "fnp90mag" ] } ],
     "melee_damage": { "bash": 10 }

--- a/data/mods/aftershock_exoplanet/items/gun/7.50mm.json
+++ b/data/mods/aftershock_exoplanet/items/gun/7.50mm.json
@@ -59,7 +59,7 @@
     "blackpowder_tolerance": 60,
     "ammo": [ "afs_7.50mm" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "afs_7.50mm": 1 } } ],
-    "faults": [ "fault_gun_blackpowder", "fault_gun_dirt" ]
+    "faults": [ { "fault": "fault_gun_blackpowder" }, { "fault": "fault_gun_dirt" } ]
   },
   {
     "id": "afs_Accipitermg",
@@ -205,7 +205,12 @@
       [ "underbarrel", 1 ],
       [ "stock accessory", 2 ]
     ],
-    "faults": [ "fault_gun_blackpowder", "fault_gun_dirt", "fault_fail_to_feed", "fault_double_feed" ],
+    "faults": [
+      { "fault": "fault_gun_blackpowder" },
+      { "fault": "fault_gun_dirt" },
+      { "fault": "fault_fail_to_feed" },
+      { "fault": "fault_double_feed" }
+    ],
     "pocket_data": [ { "magazine_well": "500 ml", "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "afs_sr77_45mag" ] } ],
     "melee_damage": { "bash": 10 }
   },

--- a/data/mods/aftershock_exoplanet/items/gun/plasma.json
+++ b/data/mods/aftershock_exoplanet/items/gun/plasma.json
@@ -61,7 +61,7 @@
         "item_restriction": [ "afs_20g_plasma", "afs_4g_plasma" ]
       }
     ],
-    "faults": [ "fault_overheat_explosion", "fault_overheat_venting", "fault_overheat_safety" ]
+    "faults": [ { "fault": "fault_overheat_explosion" }, { "fault": "fault_overheat_venting" }, { "fault": "fault_overheat_safety" } ]
   },
   {
     "id": "afs_pam-41",
@@ -140,7 +140,7 @@
         "item_restriction": [ "afs_40g_plasma_civ" ]
       }
     ],
-    "faults": [ "fault_overheat_melting" ],
+    "faults": [ { "fault": "fault_overheat_melting" } ],
     "tool_ammo": [ "afs_shydrogen" ]
   },
   {
@@ -181,6 +181,6 @@
         "item_restriction": [ "afs_40g_plasma_civ" ]
       }
     ],
-    "faults": [ "fault_overheat_explosion", "fault_overheat_venting" ]
+    "faults": [ { "fault": "fault_overheat_explosion" }, { "fault": "fault_overheat_venting" } ]
   }
 ]

--- a/doc/JSON/ITEM.md
+++ b/doc/JSON/ITEM.md
@@ -844,7 +844,13 @@ Guns can be defined like this:
 "blackpowder_tolerance": 8,// One in X chance to get clogged up (per shot) when firing blackpowder ammunition (higher is better). Optional, default is 8.
 "min_cycle_recoil": 0,     // Minimum ammo recoil for the gun to be able to fire more than once per attack (to cycle), else shooting it results in a cycling failure. Set at 90% of the base ammo recoil, or 75% of the value if the weapon is known to cycle with blackpowder. This is to prevent the weapon from cycling with any kind of ammo
 "clip_size": 100,          // Maximum amount of ammo that can be loaded
-"faults": [ "fault_gun_dirt", "fault_gun_chamber_spent" ], // Type of faults, that can be applied to this gun; usually are inherited from single abstract like rifle_base, but exceptions exist
+"faults": [                                     // Type of faults, that can be applied to this item; usually are inherited from single abstract like rifle_base, but exceptions exist
+  { "fault": "fault_gun_dirt" },                // `fault` defines this fault can be applied to this item
+  { "fault": "fault_stovepipe", "weight": 20 }  // `weight` defines the chance of this specific fault to be applied. default weight is 100 
+  { "fault_group": "handles" },                 // `fault_group` defines the fault group that would be applied to this item
+  { "fault_group": "handles", "weight_override": 20 } // if weight_override is used, the weight of an entire fault group is assigned to this value, and original weight is deleted
+  { "fault_group": "handles", "weight_add": -5, "weight_mult": 0.8 } // weight_add and weight_mult both modify the weight of each fault in fault group. Default add is 0, default mult is 1
+  ],                                            // Faults are applied from the code side
 "handling": 10             // handling of the weapon; better handling means less recoil
 "energy_drain": "2 kJ",    // Additionally to the normal ammo (if any), a gun can require some electric energy. Drains from battery in gun. Use flags "USE_UPS" and "USES_BIONIC_POWER" to drain other sources. This also works on mods. Attaching a mod with energy_drain will add/increase drain on the weapon.
 "heat_per_shot": 10,       // Each shot from this weapon adds this amount of heat

--- a/doc/JSON/JSON_INFO.md
+++ b/doc/JSON/JSON_INFO.md
@@ -1596,7 +1596,12 @@ Faults can be defined for more specialized damage of an item.
   "name": { "str": "Spent casing in chamber" }, // fault name for display
   "description": "This gun currently...", // fault description
   "item_prefix": "jammed", // optional string, items with this fault will be prefixed with this
+  "item_suffix": "no handle", // optional string, items with this fault will be suffixed with this. The string would be encased in parentheses, like `sword (no handle)`
+  "fault_type": "gun_mechanical_simple", // type of a fault, code may call for a random fault in a group instead of specific fault
+  "affected_by_degradation": false, // default false. If true, the item degradation value would be added to fault weight on roll
   "price_modifier": 0.4, // (Optional, double) Defaults to 1 if not specified. A multiplier on the price of an item when this fault is present. Values above 1.0 will increase the item's value.
+  "melee_damage_mod": [ { "damage_id": "cut", "add": -5, "multiply": 0.8 } ], // (Optional) alters the melee damage of this type for item, if fault of this type is presented. `damage_id` is mandatory, `add` is 0 by default, `multiply` is 1 by default
+  "armor_mod": [ { "damage_id": "cut", "add": -5, "multiply": 0.8 } ], // (Optional) Same as armor_mod, changes the protection value of damage type of the faulted item if it's presented
   "flags": [ "JAMMED_GUN" ] // optional flags, see below
 }
 ```
@@ -1630,6 +1635,24 @@ Fault fixes are methods to fix faults, the fixes can optionally add other faults
 `requirements` is an array of requirements, they can be specified in 2 ways:
 * An array specifying an already defined requirement by it's id and a multiplier, `[ "gun_lubrication", 2 ]` will add `gun_lubrication` requirement and multiply the components and tools ammo required by 2.
 * Inline object specifying the requirement in the same way [recipes define it](#recipe-requirements)
+
+### Item fault groups
+
+Fault group is a combination of a fault and corresponding weight, made so multiples of similar fault groups (handles, blades, cotton pieces of clothes etc) can be combined and reused
+
+```jsonc
+{
+  "type": "fault_group",
+  "id": "handles",
+  "group": [ 
+    { "fault": "fault_broken_handle", "weight": 100 }, // `fault` should be a fault id
+    { "fault": "fault_cracked_handle" }, // default weight is 100, if omitted
+    { "fault": "fault_broken_heart", "weight": 10 } 
+  ]
+}
+```
+
+The list of possible faults, their weight and actual chances can be checked in item info with a debug mode on
 
 ### Materials
 

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -2791,7 +2791,7 @@ void activity_handlers::mend_item_finish( player_activity *act, Character *you )
         target.faults.erase( id );
     }
     for( const ::fault_id &id : fix.faults_added ) {
-        target.faults.insert( id );
+        target.set_fault( id );
     }
     for( const auto &[var_name, var_value] : fix.set_variables ) {
         target.set_var( var_name, var_value );

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -1171,10 +1171,10 @@ void avatar_action::use_item( avatar &you, item_location &loc, std::string const
     if( loc->wetness && loc->has_flag( flag_WATER_BREAK_ACTIVE ) ) {
         if( query_yn( _( "This item is still wet and it will break if you turn it on.  Proceed?" ) ) ) {
             loc->deactivate();
-            loc.get_item()->set_fault( faults::random_of_type( "wet" ) );
+            loc.get_item()->set_random_fault_of_type( "wet" );
             // An electronic item in water is also shorted.
             if( loc->has_flag( flag_ELECTRONIC ) ) {
-                loc.get_item()->set_fault( faults::random_of_type( "shorted" ) );
+                loc.get_item()->set_random_fault_of_type( "shorted" );
             }
         } else {
             return;

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -23,7 +23,6 @@
 #include "creature_tracker.h"
 #include "debug.h"
 #include "enums.h"
-#include "fault.h"
 #include "flag.h"
 #include "game.h"
 #include "game_constants.h"

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -6597,7 +6597,7 @@ void Character::mend_item( item_location &&obj, bool interactive )
             if( opts[menu.ret].second ) {
                 obj->faults.erase( opts[menu.ret].first );
             } else {
-                obj->faults.insert( opts[menu.ret].first );
+                obj->set_fault( opts[menu.ret].first );
             }
         }
         return;

--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -832,8 +832,11 @@ void emp_blast( const tripoint_bub_ms &p )
                 !player_character.has_flag( json_flag_EMP_IMMUNE ) ) {
                 add_msg( m_bad, _( "The EMP blast fries your %s!" ), it->tname() );
                 it->deactivate();
-                it->faults.insert( get_option<bool>( "GAME_EMP" ) ? fault_emp_reboot :
-                                   faults::random_of_type( "shorted" ) );
+                if( get_option<bool>( "GAME_EMP" ) ) {
+                    it->set_fault( fault_emp_reboot );
+                } else {
+                    it->set_random_fault_of_type( "shorted" );
+                }
             }
         }
     }
@@ -845,8 +848,11 @@ void emp_blast( const tripoint_bub_ms &p )
                 add_msg( _( "The EMP blast fries the %s!" ), it.tname() );
             }
             it.deactivate();
-            it.set_fault( get_option<bool>( "GAME_EMP" ) ? fault_emp_reboot :
-                          faults::random_of_type( "shorted" ) );
+            if( get_option<bool>( "GAME_EMP" ) ) {
+                it.set_fault( fault_emp_reboot );
+            } else {
+                it.set_random_fault_of_type( "shorted" );
+            }
             //map::make_active adds the item to the active item processing list, so that it can reboot without further interaction
             item_location loc = item_location( map_cursor( p ), &it );
             here.make_active( loc );

--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -27,7 +27,6 @@
 #include "damage.h"
 #include "debug.h"
 #include "enums.h"
-#include "fault.h"
 #include "field_type.h"
 #include "flag.h"
 #include "flexbuffer_json.h"
@@ -60,7 +59,6 @@
 #include "translations.h"
 #include "type_id.h"
 #include "units.h"
-#include "value_ptr.h"
 #include "vehicle.h"
 #include "vpart_position.h"
 

--- a/src/fault.cpp
+++ b/src/fault.cpp
@@ -225,8 +225,8 @@ void fault::load( const JsonObject &jo, std::string_view )
                 jo_f.get_int( "add", 0 ),
                 jo_f.get_float( "multiply", 1.0f ),
                 jo_f.get_string( "damage_id" ) );
-            }
         }
+    }
 }
 
 void fault::check() const

--- a/src/fault.cpp
+++ b/src/fault.cpp
@@ -25,7 +25,7 @@ std::map<std::string, std::vector<fault_id>> faults_by_type;
 
 } // namespace
 
-const std::vector<fault_id> faults::all_of_type( const std::string &type )
+std::vector<fault_id> faults::all_of_type( const std::string &type )
 {
     const auto &typed = faults_by_type.find( type );
     if( typed == faults_by_type.end() ) {
@@ -211,21 +211,22 @@ void fault::load( const JsonObject &jo, std::string_view )
     optional( jo, was_loaded, "affected_by_degradation", affected_by_degradation_, false );
 
     if( jo.has_array( "melee_damage_mod" ) ) {
-        for( JsonObject jo_f : jo.get_array( "melee_damage_mod" ) )
+        for( JsonObject jo_f : jo.get_array( "melee_damage_mod" ) ) {
             melee_damage_mod_.emplace_back(
                 jo_f.get_int( "add", 0 ),
                 jo_f.get_float( "multiply", 1.0f ),
                 jo_f.get_string( "damage_id" ) );
+        }
     }
 
     if( jo.has_array( "armor_mod" ) ) {
-        for( JsonObject jo_f : jo.get_array( "armor_mod" ) )
+        for( JsonObject jo_f : jo.get_array( "armor_mod" ) ) {
             melee_damage_mod_.emplace_back(
                 jo_f.get_int( "add", 0 ),
                 jo_f.get_float( "multiply", 1.0f ),
                 jo_f.get_string( "damage_id" ) );
-    }
-
+            }
+        }
 }
 
 void fault::check() const

--- a/src/fault.cpp
+++ b/src/fault.cpp
@@ -221,7 +221,7 @@ void fault::load( const JsonObject &jo, std::string_view )
 
     if( jo.has_array( "armor_mod" ) ) {
         for( JsonObject jo_f : jo.get_array( "armor_mod" ) ) {
-            melee_damage_mod_.emplace_back(
+            armor_mod_.emplace_back(
                 jo_f.get_int( "add", 0 ),
                 jo_f.get_float( "multiply", 1.0f ),
                 jo_f.get_string( "damage_id" ) );

--- a/src/fault.cpp
+++ b/src/fault.cpp
@@ -15,6 +15,7 @@ namespace
 
 generic_factory<fault> fault_factory( "fault", "id" );
 generic_factory<fault_fix> fault_fixes_factory( "fault_fix", "id" );
+generic_factory<fault_group> fault_group_factory( "fault_group", "id" );
 
 // we'll store requirement_ids here and wait for requirements to load in, then we can actualize them
 std::multimap<fault_fix_id, std::pair<std::string, int>> reqs_temp_storage;
@@ -24,26 +25,27 @@ std::map<std::string, std::vector<fault_id>> faults_by_type;
 
 } // namespace
 
-const fault_id &faults::random_of_type( const std::string &type )
+const std::vector<fault_id> faults::all_of_type( const std::string &type )
 {
     const auto &typed = faults_by_type.find( type );
     if( typed == faults_by_type.end() ) {
         debugmsg( "there are no faults with type '%s'", type );
-        return fault_id::NULL_ID();
+        return {};
     }
-    return random_entry_ref( typed->second );
+    return typed->second ;
+}
+
+const fault_id &faults::random_of_type( const std::string &type )
+{
+    return random_entry_ref( all_of_type( type ) );
 }
 
 const fault_id &faults::random_of_type_item_has( const item &it, const std::string &type )
 {
-    const auto &typed = faults_by_type.find( type );
-    if( typed == faults_by_type.end() ) {
-        debugmsg( "there are no faults with type '%s'", type );
-        return fault_id::NULL_ID();
-    }
+    const std::vector<fault_id> &typed = all_of_type( type );
 
     // not actually random
-    for( const fault_id &fid : typed->second ) {
+    for( const fault_id &fid : typed ) {
         if( it.has_fault( fid ) ) {
             return fid;
         }
@@ -60,6 +62,11 @@ void faults::load_fault( const JsonObject &jo, const std::string &src )
 void faults::load_fix( const JsonObject &jo, const std::string &src )
 {
     fault_fixes_factory.load( jo, src );
+}
+
+void faults::load_group( const JsonObject &jo, const std::string &src )
+{
+    fault_group_factory.load( jo, src );
 }
 
 void faults::reset()
@@ -121,6 +128,21 @@ const fault_fix &string_id<fault_fix>::obj() const
     return fault_fixes_factory.obj( *this );
 }
 
+/** @relates string_id */
+template<>
+bool string_id<fault_group>::is_valid() const
+{
+    return fault_group_factory.is_valid( *this );
+}
+
+/** @relates string_id */
+template<>
+const fault_group &string_id<fault_group>::obj() const
+{
+    return fault_group_factory.obj( *this );
+}
+
+
 std::string fault::name() const
 {
     return name_.translated();
@@ -136,10 +158,29 @@ std::string fault::item_prefix() const
     return item_prefix_.translated();
 }
 
+std::string fault::item_suffix() const
+{
+    return item_suffix_.translated();
+}
 
 double fault::price_mod() const
 {
     return price_modifier;
+}
+
+std::vector<std::tuple<int, float, damage_type_id>> fault::melee_damage_mod() const
+{
+    return melee_damage_mod_;
+}
+
+std::vector<std::tuple<int, float, damage_type_id>> fault::armor_mod() const
+{
+    return armor_mod_;
+}
+
+bool fault::affected_by_degradation() const
+{
+    return affected_by_degradation_;
 }
 
 std::string fault::type() const
@@ -159,12 +200,32 @@ const std::set<fault_fix_id> &fault::get_fixes() const
 
 void fault::load( const JsonObject &jo, std::string_view )
 {
+
     mandatory( jo, was_loaded, "name", name_ );
     mandatory( jo, was_loaded, "description", description_ );
     optional( jo, was_loaded, "item_prefix", item_prefix_ );
+    optional( jo, was_loaded, "item_suffix", item_suffix_ );
     optional( jo, was_loaded, "fault_type", type_ );
     optional( jo, was_loaded, "flags", flags );
     optional( jo, was_loaded, "price_modifier", price_modifier, 1.0 );
+    optional( jo, was_loaded, "affected_by_degradation", affected_by_degradation_, false );
+
+    if( jo.has_array( "melee_damage_mod" ) ) {
+        for( JsonObject jo_f : jo.get_array( "melee_damage_mod" ) )
+            melee_damage_mod_.emplace_back(
+                jo_f.get_int( "add", 0 ),
+                jo_f.get_float( "multiply", 1.0f ),
+                jo_f.get_string( "damage_id" ) );
+    }
+
+    if( jo.has_array( "armor_mod" ) ) {
+        for( JsonObject jo_f : jo.get_array( "armor_mod" ) )
+            melee_damage_mod_.emplace_back(
+                jo_f.get_int( "add", 0 ),
+                jo_f.get_float( "multiply", 1.0f ),
+                jo_f.get_string( "damage_id" ) );
+    }
+
 }
 
 void fault::check() const
@@ -184,7 +245,6 @@ const requirement_data &fault_fix::get_requirements() const
 
 void fault_fix::load( const JsonObject &jo, std::string_view )
 {
-    fault_fix f;
     mandatory( jo, was_loaded, "name", name );
     optional( jo, was_loaded, "success_msg", success_msg );
     optional( jo, was_loaded, "time", time );
@@ -281,5 +341,20 @@ void fault_fix::check() const
             debugmsg( "fault_fix '%s' has negative mend time if item possesses flag '%s'",
                       id.str(), flag_id.str() );
         }
+    }
+}
+
+weighted_int_list<fault_id> fault_group::get_weighted_list() const
+{
+    return fault_weighted_list;
+}
+
+void fault_group::load( const JsonObject &jo, std::string_view )
+{
+    if( jo.has_array( "group" ) ) {
+        for( const JsonObject jog : jo.get_array( "group" ) ) {
+            fault_weighted_list.add( fault_id( jog.get_string( "fault" ) ), jog.get_int( "weight", 100 ) );
+        }
+
     }
 }

--- a/src/fault.h
+++ b/src/fault.h
@@ -7,6 +7,7 @@
 #include <set>
 #include <string>
 #include <string_view>
+#include <vector>
 
 #include "calendar.h"
 #include "math_parser_diag_value.h"
@@ -14,6 +15,7 @@
 #include "requirements.h"
 #include "translation.h"
 #include "type_id.h"
+#include "weighted_list.h"
 
 class JsonObject;
 class item;
@@ -23,10 +25,13 @@ namespace faults
 {
 void load_fault( const JsonObject &jo, const std::string &src );
 void load_fix( const JsonObject &jo, const std::string &src );
+void load_group( const JsonObject &jo, const std::string &src );
 
 void reset();
 void finalize();
 void check_consistency();
+
+const std::vector<fault_id> all_of_type( const std::string &type );
 
 const fault_id &random_of_type( const std::string &type );
 const fault_id &random_of_type_item_has( const item &it, const std::string &type );
@@ -72,7 +77,13 @@ class fault
         std::string type() const; // use a set of types?
         std::string description() const;
         std::string item_prefix() const;
+        std::string item_suffix() const;
         double price_mod() const;
+        // int is additive (default 0), float is multiplier (default 1)
+        std::vector<std::tuple<int, float, damage_type_id>> melee_damage_mod() const;
+        // int is additive (default 0), float is multiplier (default 1)
+        std::vector<std::tuple<int, float, damage_type_id>> armor_mod() const;
+        bool affected_by_degradation() const;
         bool has_flag( const std::string &flag ) const;
 
         const std::set<fault_fix_id> &get_fixes() const;
@@ -82,13 +93,33 @@ class fault
         bool was_loaded = false; // used by generic_factory
         friend class generic_factory<fault>;
         friend class fault_fix;
+
         std::string type_;
         translation name_;
         translation description_;
         translation item_prefix_; // prefix added to affected item's name
+        translation item_suffix_;
         std::set<fault_fix_id> fixes;
         std::set<std::string> flags;
         double price_modifier = 1.0;
+        std::vector<std::tuple<int, float, damage_type_id>> melee_damage_mod_;
+        std::vector<std::tuple<int, float, damage_type_id>> armor_mod_;
+        // todo add tool_quality_mod_; axe with no handle won't axe
+        bool affected_by_degradation_ = false;
+
+};
+
+class fault_group
+{
+    public:
+        fault_group_id id;
+        weighted_int_list<fault_id> get_weighted_list() const;
+
+    private:
+        void load( const JsonObject &jo, std::string_view );
+        bool was_loaded = false;
+        friend class generic_factory<fault_group>;
+        weighted_int_list<fault_id> fault_weighted_list;
 };
 
 #endif // CATA_SRC_FAULT_H

--- a/src/fault.h
+++ b/src/fault.h
@@ -7,6 +7,7 @@
 #include <set>
 #include <string>
 #include <string_view>
+#include <tuple>
 #include <vector>
 
 #include "calendar.h"

--- a/src/fault.h
+++ b/src/fault.h
@@ -31,7 +31,7 @@ void reset();
 void finalize();
 void check_consistency();
 
-const std::vector<fault_id> all_of_type( const std::string &type );
+std::vector<fault_id> all_of_type( const std::string &type );
 
 const fault_id &random_of_type( const std::string &type );
 const fault_id &random_of_type_item_has( const item &it, const std::string &type );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -12187,10 +12187,11 @@ void game::water_affect_items( Character &ch ) const
             loc->deactivate();
             // TODO: Maybe different types of wet faults? But I can't think of any.
             // This just means it's still too wet to use.
-            loc->set_fault( faults::random_of_type( "wet" ) ) ;
+            // TODO2: add fault types to electronics, remove `force` argument from here
+            loc->set_random_fault_of_type( "wet", true );
             // An electronic item in water is also shorted.
             if( loc->has_flag( flag_ELECTRONIC ) ) {
-                loc->set_fault( faults::random_of_type( "shorted" ) );
+                loc->set_random_fault_of_type( "shorted", true );
             }
         } else if( loc->has_flag( flag_WATER_BREAK_ACTIVE ) && !loc->is_broken()
                    && !loc.protected_from_liquids() ) {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -269,6 +269,7 @@ void DynamicDataLoader::initialize()
     add( "connect_group", &connect_group::load );
     add( "fault", &faults::load_fault );
     add( "fault_fix", &faults::load_fix );
+    add( "fault_group", &faults::load_group );
     add( "relic_procgen_data", &relic_procgen_data::load_relic_procgen_data );
     add( "effect_on_condition", &effect_on_conditions::load );
     add( "field_type", &field_types::load );
@@ -799,6 +800,7 @@ void DynamicDataLoader::finalize_loaded_data()
             { _( "Ammo effects" ), &ammo_effects::finalize_all },
             { _( "Emissions" ), &emit::finalize },
             { _( "Materials" ), &material_type::finalize_all },
+            { _( "Faults" ), &faults::finalize },
             {
                 _( "Items" ), []()
                 {
@@ -854,7 +856,6 @@ void DynamicDataLoader::finalize_loaded_data()
             { _( "Achievements" ), &achievement::finalize },
             { _( "Damage info orders" ), &damage_info_order::finalize_all },
             { _( "Widgets" ), &widget::finalize },
-            { _( "Faults" ), &faults::finalize },
 #if defined(TILES)
             { _( "Tileset" ), &load_tileset },
 #endif

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -909,12 +909,24 @@ int item::damage_level( bool precise ) const
     return precise ? damage_ : type->damage_level( damage_ );
 }
 
-float item::damage_adjusted_melee_weapon_damage( float value ) const
+float item::damage_adjusted_melee_weapon_damage( float value, const damage_type_id &dt ) const
 {
     if( type->count_by_charges() ) {
         return value; // count by charges items don't have partial damage
     }
-    return value * ( 1.0f - 0.1f * std::max( 0, damage_level() - 1 ) );
+
+    for( fault_id fault : faults ) {
+        for( const std::tuple<int, float, damage_type_id> &damage_mod : fault.obj().melee_damage_mod() ) {
+            const damage_type_id dmg_type_of_fault = std::get<2>( damage_mod );
+            if( dt == dmg_type_of_fault ) {
+                const int damage_added = std::get<0>( damage_mod );
+                const float damage_mult = std::get<1>( damage_mod );
+                value = ( value + damage_added ) * damage_mult;
+            }
+        }
+    }
+
+    return std::max( 0.0f, value * ( 1.0f - 0.1f * std::max( 0, damage_level() - 1 ) ) );
 }
 
 float item::damage_adjusted_gun_damage( float value ) const
@@ -925,12 +937,24 @@ float item::damage_adjusted_gun_damage( float value ) const
     return value - 2 * std::max( 0, damage_level() - 1 );
 }
 
-float item::damage_adjusted_armor_resist( float value ) const
+float item::damage_adjusted_armor_resist( float value, const damage_type_id &dmg_type ) const
 {
     if( type->count_by_charges() ) {
         return value; // count by charges items don't have partial damage
     }
-    return value * ( 1.0f - std::max( 0, damage_level() - 1 ) * 0.125f );
+
+    for( fault_id fault : faults ) {
+        for( const std::tuple<int, float, damage_type_id> &damage_mod : fault.obj().armor_mod() ) {
+            const damage_type_id dmg_type_of_fault = std::get<2>( damage_mod );
+            if( dmg_type == dmg_type_of_fault ) {
+                const int damage_added = std::get<0>( damage_mod );
+                const float damage_mult = std::get<1>( damage_mod );
+                value = ( value + damage_added ) * damage_mult;
+            }
+        }
+    }
+
+    return std::max( 0.0f, value * ( 1.0f - std::max( 0, damage_level() - 1 ) * 0.125f ) );
 }
 
 void item::set_damage( int qty )
@@ -1718,6 +1742,7 @@ stacking_info item::stacks_with( const item &rhs, bool check_components, bool co
     bits.set( tname::segments::CUSTOM_ITEM_SUFFIX, bits[tname::segments::TAGS] );
 
     bits.set( tname::segments::FAULTS, faults == rhs.faults );
+    bits.set( tname::segments::FAULTS_SUFFIX, faults == rhs.faults );
     bits.set( tname::segments::TECHNIQUES, techniques == rhs.techniques );
     bits.set( tname::segments::OVERHEAT, overheat_symbol() == rhs.overheat_symbol() );
     bits.set( tname::segments::DIRT, get_var( "dirt", 0 ) == rhs.get_var( "dirt", 0 ) );
@@ -2568,6 +2593,18 @@ void item::debug_info( std::vector<iteminfo> &info, const iteminfo_query *parts,
                                    iteminfo::lower_is_better | iteminfo::is_decimal,
                                    units::to_kelvin( get_freeze_point() ) );
             }
+
+            std::string faults;
+            for( const weighted_object<int, fault_id> &fault : type->faults ) {
+                const int weight_percent = static_cast<float>( fault.weight ) / type->faults.get_weight() * 100;
+                if( has_fault( fault.obj ) ) {
+                    faults += colorize( fault.obj.str() + string_format( " (%d, %d%%), ", fault.weight,
+                                        weight_percent ), c_yellow );
+                } else {
+                    faults += fault.obj.str() + string_format( " (%d, %d%%), ", fault.weight, weight_percent );
+                }
+            }
+            info.emplace_back( "BASE", string_format( "faults: %s", faults ) );
         }
     }
 }
@@ -7550,7 +7587,7 @@ int item::damage_melee( const damage_type_id &dt ) const
     if( type->melee.damage_map.count( dt ) > 0 ) {
         res = type->melee.damage_map.at( dt );
     }
-    res = damage_adjusted_melee_weapon_damage( res );
+    res = damage_adjusted_melee_weapon_damage( res, dt );
 
     // apply type specific flags
     // FIXME: Hardcoded damage types
@@ -7730,10 +7767,40 @@ bool item::has_vitamin( const vitamin_id &v ) const
     return false;
 }
 
-item &item::set_fault( const fault_id &fault_id )
+item item::set_fault( const fault_id &fault_id )
 {
     faults.insert( fault_id );
     return *this;
+}
+
+weighted_int_list<fault_id> item::all_potential_faults() const
+{
+    weighted_int_list<fault_id> potential_faults;
+    for( const weighted_object<int, fault_id> &potential_fault : type->faults ) {
+        if( potential_fault.obj.obj().affected_by_degradation() ) {
+            potential_faults.add( potential_fault.obj, potential_fault.weight + degradation() );
+        } else {
+            potential_faults.add( potential_fault.obj, potential_fault.weight );
+        }
+    }
+    return potential_faults;
+}
+
+weighted_int_list<fault_id> item::all_potential_faults_of_type(
+    const std::string &fault_type ) const
+{
+    weighted_int_list<fault_id> potential_faults_of_type;
+    for( const weighted_object<int, fault_id> &potential_fault : all_potential_faults() ) {
+        if( potential_fault.obj.obj().type() == fault_type ) {
+            potential_faults_of_type.add( potential_fault.obj, potential_fault.weight );
+        }
+    }
+    return potential_faults_of_type;
+}
+
+const fault_id &item::random_potential_fault_of_type( const std::string &fault_type ) const
+{
+    return *all_potential_faults_of_type( fault_type ).pick();
 }
 
 item &item::unset_flag( const flag_id &flag )
@@ -9050,7 +9117,7 @@ float item::_resist( const damage_type_id &dmg_type, bool to_self, int resist_va
     float resist = 0.0f;
     float mod = get_clothing_mod_val_for_damage_type( dmg_type );
 
-    const float damage_scale = damage_adjusted_armor_resist( 1.0f );
+    const float damage_scale = damage_adjusted_armor_resist( 1.0f, dmg_type );
 
     if( !bp_null ) {
         // If we have armour portion materials for this body part, use that instead
@@ -9294,6 +9361,7 @@ bool item::mod_damage( int qty )
         if( qty > 0 && !destroy ) { // apply automatic degradation
             set_degradation( degradation_ + get_degrade_amount( *this, damage_, dmg_before ) );
         }
+
         return destroy;
     }
 }
@@ -10236,15 +10304,16 @@ int item::wind_resist() const
 std::set<fault_id> item::faults_potential() const
 {
     std::set<fault_id> res;
-    res.insert( type->faults.begin(), type->faults.end() );
+    for( const weighted_object<int, fault_id> &fault_pair : type->faults ) {
+        res.insert( fault_pair.obj );
+    }
     return res;
 }
 
 bool item::can_have_fault_type( const std::string &fault_type ) const
 {
-    std::set<fault_id> res;
-    for( const auto &some_fault : type->faults ) {
-        if( some_fault->type() == fault_type ) {
+    for( const weighted_object<int, fault_id> &some_fault : type->faults ) {
+        if( some_fault.obj->type() == fault_type ) {
             return true;
         }
     }
@@ -10254,9 +10323,9 @@ bool item::can_have_fault_type( const std::string &fault_type ) const
 std::set<fault_id> item::faults_potential_of_type( const std::string &fault_type ) const
 {
     std::set<fault_id> res;
-    for( const auto &some_fault : type->faults ) {
-        if( some_fault->type() == fault_type ) {
-            res.emplace( some_fault );
+    for( const weighted_object<int, fault_id> &some_fault : type->faults ) {
+        if( some_fault.obj->type() == fault_type ) {
+            res.emplace( some_fault.obj );
         }
     }
     return res;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -7784,7 +7784,7 @@ void item::set_random_fault_of_type( const std::string &fault_type, const bool &
         faults_by_type.add( f.obj, f.weight );
     }
 
-    return set_fault( *faults_by_type.pick() );
+    set_fault( *faults_by_type.pick() );
 }
 
 weighted_int_list<fault_id> item::all_potential_faults() const

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -7767,10 +7767,24 @@ bool item::has_vitamin( const vitamin_id &v ) const
     return false;
 }
 
-item item::set_fault( const fault_id &fault_id )
+void item::set_fault( const fault_id &fault_id )
 {
     faults.insert( fault_id );
-    return *this;
+}
+
+void item::set_random_fault_of_type( const std::string &fault_type, const bool &force )
+{
+    if( force ) {
+        set_fault( random_entry( faults::all_of_type( fault_type ) ) );
+        return;
+    }
+
+    weighted_int_list<fault_id> faults_by_type;
+    for( const weighted_object<int, fault_id> &f : type->faults ) {
+        faults_by_type.add( f.obj, f.weight );
+    }
+
+    return set_fault( *faults_by_type.pick() );
 }
 
 weighted_int_list<fault_id> item::all_potential_faults() const
@@ -14854,9 +14868,9 @@ bool item::process_internal( map &here, Character *carrier, const tripoint_bub_m
 
         if( wetness && has_flag( flag_WATER_BREAK ) ) {
             deactivate();
-            set_fault( faults::random_of_type( "wet" ) );
+            set_random_fault_of_type( "wet" );
             if( has_flag( flag_ELECTRONIC ) ) {
-                set_fault( faults::random_of_type( "shorted" ) );
+                set_random_fault_of_type( "shorted" );
             }
         }
 
@@ -14965,7 +14979,7 @@ bool item::process_internal( map &here, Character *carrier, const tripoint_bub_m
                     }
                 } else {
                     faults.erase( fault_emp_reboot );
-                    set_fault( faults::random_of_type( "shorted" ) );
+                    set_random_fault_of_type( "shorted" );
                     if( carrier ) {
                         carrier->add_msg_if_player( m_bad, _( "Your %s fails to reboot properly." ), tname() );
                     }

--- a/src/item.h
+++ b/src/item.h
@@ -2064,7 +2064,9 @@ class item : public visitable
         item &set_flag( const flag_id &flag );
 
         /** Idempotent filter setting an item specific fault. */
-        item set_fault( const fault_id &fault_id );
+        void set_fault( const fault_id &fault_id );
+
+        void set_random_fault_of_type( const std::string &fault_type, const bool &force = false);
 
         weighted_int_list<fault_id> all_potential_faults() const;
 

--- a/src/item.h
+++ b/src/item.h
@@ -2066,7 +2066,7 @@ class item : public visitable
         /** Idempotent filter setting an item specific fault. */
         void set_fault( const fault_id &fault_id );
 
-        void set_random_fault_of_type( const std::string &fault_type, const bool &force = false);
+        void set_random_fault_of_type( const std::string &fault_type, const bool &force = false );
 
         weighted_int_list<fault_id> all_potential_faults() const;
 

--- a/src/item.h
+++ b/src/item.h
@@ -40,6 +40,7 @@
 #include "units.h"
 #include "value_ptr.h"
 #include "visitable.h"
+#include "weighted_list.h"
 
 class Character;
 class Creature;
@@ -1401,11 +1402,11 @@ class item : public visitable
         int damage_level( bool precise = false ) const;
 
         /** Modifiy melee weapon damage to account for item's damage. */
-        float damage_adjusted_melee_weapon_damage( float value ) const;
+        float damage_adjusted_melee_weapon_damage( float value, const damage_type_id &dt ) const;
         /** Modifiy gun damage to account for item's damage. */
         float damage_adjusted_gun_damage( float value ) const;
         /** Modifiy armor resist to account for item's damage. */
-        float damage_adjusted_armor_resist( float value ) const;
+        float damage_adjusted_armor_resist( float value, const damage_type_id &dmg_type ) const;
 
         /** @return 0 if item is count_by_charges() or 4000 ( value of itype::damage_max_ ). */
         int max_damage() const;
@@ -1737,6 +1738,8 @@ class item : public visitable
 
         std::set<fault_id> faults_potential_of_type( const std::string &fault_type ) const;
 
+        void apply_fault();
+
         /** Returns the total area of this wheel or 0 if it isn't one. */
         int wheel_area() const;
 
@@ -2061,7 +2064,14 @@ class item : public visitable
         item &set_flag( const flag_id &flag );
 
         /** Idempotent filter setting an item specific fault. */
-        item &set_fault( const fault_id &fault_id );
+        item set_fault( const fault_id &fault_id );
+
+        weighted_int_list<fault_id> all_potential_faults() const;
+
+        weighted_int_list<fault_id> all_potential_faults_of_type( const std::string
+                &fault_type ) const;
+
+        const fault_id &random_potential_fault_of_type( const std::string &fault_type ) const;
 
         /** Idempotent filter removing an item specific flag */
         item &unset_flag( const flag_id &flag );

--- a/src/item_tname.cpp
+++ b/src/item_tname.cpp
@@ -74,6 +74,27 @@ std::string faults( item const &it, unsigned int /* quantity */,
     return damtext;
 }
 
+std::string faults_suffix( item const &it, unsigned int /* quantity */,
+                           segment_bitset const &/* segments */ )
+{
+    std::string text;
+    for( const fault_id &f : it.faults ) {
+        const std::string suffix = f->item_suffix();
+        if( !suffix.empty() ) {
+            text = "(" + suffix + ") ";
+            break;
+        }
+    }
+    // remove excess space, add one space before the string
+    if( !text.empty() ) {
+        text.pop_back();
+        const std::string ret = " " + text;
+        return ret;
+    } else {
+        return "";
+    }
+}
+
 std::string dirt_symbol( item const &it, unsigned int /* quantity */,
                          segment_bitset const &/* segments */ )
 {
@@ -633,6 +654,7 @@ constexpr std::array<decl_f_print_segment *, num_segments> get_segs_array()
 {
     std::array<decl_f_print_segment *, num_segments> arr{};
     arr[static_cast<size_t>( tname::segments::FAULTS ) ] = faults;
+    arr[static_cast<size_t>( tname::segments::FAULTS_SUFFIX ) ] = faults_suffix;
     arr[static_cast<size_t>( tname::segments::DIRT ) ] = dirt_symbol;
     arr[static_cast<size_t>( tname::segments::OVERHEAT ) ] = overheat_symbol;
     arr[static_cast<size_t>( tname::segments::FAVORITE_PRE ) ] = pre_asterisk;
@@ -698,6 +720,7 @@ std::string enum_to_string<tname::segments>( tname::segments seg )
     switch( seg ) {
         // *INDENT-OFF*
         case tname::segments::FAULTS: return "FAULTS";
+        case tname::segments::FAULTS_SUFFIX: return "FAULTS_SUFFIX";
         case tname::segments::DIRT: return "DIRT";
         case tname::segments::OVERHEAT: return "OVERHEAT";
         case tname::segments::FAVORITE_PRE: return "FAVORITE_PRE";

--- a/src/item_tname.h
+++ b/src/item_tname.h
@@ -31,6 +31,7 @@ enum class segments : std::size_t {
     TYPE,
     CATEGORY,
     CUSTOM_ITEM_SUFFIX,
+    FAULTS_SUFFIX,
     MODS,
     CRAFT,
     WHITEBLACKLIST,

--- a/src/itype.h
+++ b/src/itype.h
@@ -1419,7 +1419,7 @@ struct itype {
         std::set<itype_id> repair;
 
         /** What faults (if any) can occur */
-        weighted_int_list<fault_id>faults;
+        weighted_int_list<fault_id> faults;
 
         /** used to store fault types on load, when we cannot populate `faults` just yet
         `faults` is populated with values from this in finalize_post() down the road, and then this var is never used again

--- a/src/itype.h
+++ b/src/itype.h
@@ -37,6 +37,7 @@
 #include "type_id.h"
 #include "units.h"
 #include "value_ptr.h"
+#include "weighted_list.h"
 
 // IWYU pragma: no_forward_declare std::hash
 class Character;
@@ -1418,7 +1419,16 @@ struct itype {
         std::set<itype_id> repair;
 
         /** What faults (if any) can occur */
-        std::set<fault_id> faults;
+        weighted_int_list<fault_id>faults;
+
+        /** used to store fault types on load, when we cannot populate `faults` just yet
+        `faults` is populated with values from this in finalize_post() down the road, and then this var is never used again
+        first int is weight if overriden
+        second int is weight added to original weight
+        third float is multiplier of original weight
+        fourth string is the fault group id
+        */
+        std::vector<std::tuple<int, int, float, std::string>> fault_groups;
 
         /** Magazine types (if any) for each ammo type that can be used to reload this item */
         std::map< ammotype, std::set<itype_id> > magazines;

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -801,7 +801,7 @@ bool Character::handle_gun_damage( item &it )
         add_msg_player_or_npc( m_bad, _( "Your %s malfunctions!" ),
                                _( "<npcname>'s %s malfunctions!" ),
                                it.tname() );
-        it.faults.insert( random_entry( it.faults_potential_of_type( gun_mechanical_simple ) ) );
+        it.set_random_fault_of_type( gun_mechanical_simple );
         return false;
 
         // Here we check for a chance for attached mods to get damaged if they are flagged as 'CONSUMABLE'.
@@ -856,7 +856,7 @@ bool Character::handle_gun_damage( item &it )
             add_msg_player_or_npc( m_bad, _( "Your %s fails to cycle!" ),
                                    _( "<npcname>'s %s fails to cycle!" ),
                                    it.tname() );
-            it.faults.insert( fault_gun_chamber_spent );
+            it.set_fault( fault_gun_chamber_spent );
             // Don't return false in this case; this shot happens, follow-up ones won't.
         }
         // These are the dirtying/fouling mechanics
@@ -878,11 +878,11 @@ bool Character::handle_gun_damage( item &it )
             dirt = it.get_var( "dirt", 0 );
             dirt_dbl = static_cast<double>( dirt );
             if( dirt > 0 && !it.has_fault_flag( "NO_DIRTYING" ) ) {
-                it.faults.insert( fault_gun_dirt );
+                it.set_fault( fault_gun_dirt );
             }
             if( dirt > 0 && curammo_effects.count( ammo_effect_BLACKPOWDER ) ) {
                 it.faults.erase( fault_gun_dirt );
-                it.faults.insert( fault_gun_blackpowder );
+                it.set_fault( fault_gun_blackpowder );
             }
             // end fouling mechanics
         }
@@ -931,7 +931,7 @@ bool Character::handle_gun_overheat( item &it )
             add_msg_if_player( m_bad,
                                _( "Your %s displays a warning sequence as its active cooling cycle engages." ),
                                it.tname() );
-            it.faults.insert( fault_overheat_safety );
+            it.set_fault( fault_overheat_safety );
             return false;
         }
 
@@ -944,13 +944,13 @@ bool Character::handle_gun_overheat( item &it )
                                it.tname() );
             add_msg_if_player( m_bad, _( "Your %s detonates!" ),
                                it.tname() );
-            it.faults.insert( fault_overheat_melting );
+            it.set_fault( fault_overheat_melting );
             explosion_handler::explosion( this, this->pos_bub(), 1200, 0.4 );
             return false;
         } else if( it.faults_potential().count( fault_overheat_melting ) && fault_roll > 6 ) {
             add_msg_if_player( m_bad, _( "Acrid smoke pours from your %s as its internals fuse together." ),
                                it.tname() );
-            it.faults.insert( fault_overheat_melting );
+            it.set_fault( fault_overheat_melting );
             return false;
         } else if( it.faults_potential().count( fault_overheat_venting ) && fault_roll > 2 ) {
             map &here = get_map();

--- a/src/type_id.h
+++ b/src/type_id.h
@@ -103,6 +103,9 @@ using fault_id = string_id<fault>;
 class fault_fix;
 using fault_fix_id = string_id<fault_fix>;
 
+class fault_group;
+using fault_group_id = string_id<fault_group>;
+
 struct field_type;
 using field_type_id = int_id<field_type>;
 using field_type_str_id = string_id<field_type>;

--- a/src/vehicle_part.cpp
+++ b/src/vehicle_part.cpp
@@ -514,7 +514,7 @@ bool vehicle_part::fault_set( const fault_id &f )
     if( !faults_potential().count( f ) ) {
         return false;
     }
-    base.faults.insert( f );
+    base.set_fault( f );
     return true;
 }
 


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
I planned to tackle #64528, but to make it, some legwork is required
#### Describe the solution
Added few additional fields to fault definition: `item_suffix`, `affected_by_degradation`, `melee_damage_mod` and `armor_mod`
Added new fault_group type, so similar faults can be groupped and applied in bulk
Fault itself is not a set now, but weighted list, and instead of picking one randomly, it picks one depending on it's weight
Various code stuff that should simplify applying faults from a code side
#### Testing
faults apply armor and melee damage penalties properly
![image](https://github.com/user-attachments/assets/bd079a1f-0cfe-45a4-98f1-ea0fc5b7159c)
![image](https://github.com/user-attachments/assets/8099bca8-b8af-4c4d-8b15-5180ee205019)
fault groups properly apply itself onto items
![image](https://github.com/user-attachments/assets/8da9d287-14c1-4181-a6ce-4950a22cc86b)
#### Potential ideas for expansion
~~`melee_damage_mod` and `armor_mod` to be not a flat reduction, but specifying the damage type it decreases~~ implemented
add `tool_quality_mod` - axe without handle won't axe 

This PR need a second pair of eyes to check all the code changes make sense, there is pretty big quantities of cargo culting