### PR TITLE
Fix crash after deleting items immediately in character_takeoff_item eoc

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -6191,13 +6191,13 @@ void outfit_swap_actor::finish( player_activity &act, Character &who )
     // Taken-off items are put in this temporary list, then naturally deleted from the world when the function returns.
     std::list<item> it_list;
     for( item_location &worn_item : who.get_visible_worn_items() ) {
-        if (!static_cast<bool>(worn_item)){
+        if( !static_cast<bool>( worn_item ) ) {
             //Due to the eoc triggered who.takeoff, the item may become invalid.
             continue;
         }
         item outfit_component( *worn_item );
         std::size_t old_it_list_size = it_list.size();
-        if( who.takeoff( worn_item, &it_list ) && it_list.size() > old_it_list_size) {
+        if( who.takeoff( worn_item, &it_list ) && it_list.size() > old_it_list_size ) {
             ground->force_insert_item( outfit_component, pocket_type::CONTAINER );
         }
     }

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -6191,8 +6191,13 @@ void outfit_swap_actor::finish( player_activity &act, Character &who )
     // Taken-off items are put in this temporary list, then naturally deleted from the world when the function returns.
     std::list<item> it_list;
     for( item_location &worn_item : who.get_visible_worn_items() ) {
+        if (!static_cast<bool>(worn_item)){
+            //Due to the eoc triggered who.takeoff, the item may become invalid.
+            continue;
+        }
         item outfit_component( *worn_item );
-        if( who.takeoff( worn_item, &it_list ) ) {
+        std::size_t old_it_list_size = it_list.size();
+        if( who.takeoff( worn_item, &it_list ) && it_list.size() > old_it_list_size) {
             ground->force_insert_item( outfit_component, pocket_type::CONTAINER );
         }
     }

--- a/src/character.h
+++ b/src/character.h
@@ -926,7 +926,9 @@ class Character : public Creature, public visitable
         stat_mod read_pain_penalty() const;
         /** returns players strength adjusted by any traits that affect strength during lifting jobs */
         int get_lift_str() const;
-        /** Takes off an item, returning false on fail. The taken off item is processed in the interact */
+        /** Takes off an item, returning false on fail. The taken off item is processed in the interact.
+         * Due to eoc event character_takeoff_item trigger here, item that be takeoff successfully may be deleted by eoc.
+         */
         bool takeoff( item_location loc, std::list<item> *res = nullptr );
         bool takeoff( int pos );
 

--- a/src/character_attire.cpp
+++ b/src/character_attire.cpp
@@ -1518,6 +1518,12 @@ bool outfit::takeoff( item_location loc, std::list<item> *res, Character &guy )
     cata::event e = cata::event::make<event_type::character_takeoff_item>( guy.getID(),
                     it.typeId() );
     get_event_bus().send_with_talker( &guy, &loc, e );
+    // Catching eoc of character_takeoff_item event may cause item to be invalid.
+    // If so, skip worn.erase and guy.i_add or res->push_back.
+    bool is_item_vaild = static_cast<bool>(loc);
+    if (!is_item_vaild){
+        return true;
+    }
     item takeoff_copy( it );
     worn.erase( iter );
     if( res == nullptr ) {

--- a/src/character_attire.cpp
+++ b/src/character_attire.cpp
@@ -1520,8 +1520,8 @@ bool outfit::takeoff( item_location loc, std::list<item> *res, Character &guy )
     get_event_bus().send_with_talker( &guy, &loc, e );
     // Catching eoc of character_takeoff_item event may cause item to be invalid.
     // If so, skip worn.erase and guy.i_add or res->push_back.
-    bool is_item_vaild = static_cast<bool>(loc);
-    if (!is_item_vaild){
+    bool is_item_vaild = static_cast<bool>( loc );
+    if( !is_item_vaild ) {
         return true;
     }
     item takeoff_copy( it );

--- a/src/character_attire.h
+++ b/src/character_attire.h
@@ -181,6 +181,10 @@ class outfit
         void add_dependent_item( std::list<item *> &dependent, const item &it );
         std::list<item> remove_worn_items_with( const std::function<bool( item & )> &filter,
                                                 Character &guy );
+        // takeoff item from character
+        // return true mean takeoff item successfully
+        // Due to eoc event character_takeoff_item trigger here, item that be takeoff successfully may be deleted by eoc.
+        // If the above situation does not happen, when res is not empty, the removed item will be put into res, otherwise it will be put into guy.
         bool takeoff( item_location loc, std::list<item> *res, Character &guy );
         std::list<item> use_amount(
             const itype_id &it, int quantity, std::list<item> &used,


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Fix crash after deleting items in character_takeoff_item eoc"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
This issue was originally mentioned in #80061, caused by deleting items in eoc that will be erased or moved later.
Additionally, during testing, it was found that if any items that were worn at the start of the activity were removed in eoc when performing an outfit_swap activity, it could cause items to be complex or crash.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
1.According to the discussion in #80570, add a check for the validity of the item_location of the takenoff item after event eoc.
2.Add comments to worn::takeoff and character::takeoff to note that event eoc may occur in them.
3.In the take off item part of outfit_swap activity, added a check for item validity before takeoff and a check for whether the item is put into the res parameter array after takeoff.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Perhaps, in event eoc, should prevent perform immediate effects that delete items (allow delayed deletion)?
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Use the following eoc to test:
```
  {
    "type": "effect_on_condition",
    "id": "event_test_hc_demi_gaunt",
    "eoc_type": "EVENT",
    "required_event": "character_takeoff_item",
    "effect": [
      {
        "u_consume_item": "hc_demi_gaunt"
      }
    ]
  }
```
1.Wear hc_demi_gaunt, take off hc_demi_gaunt. hc_demi_gaunt disappears normally, no bugs or crashes.
2. Wear hc_demi_gaunt and other clothes, activate "set of clothes". hc_demi_gaunt disappears normally, other clothes are put into "set of clothes", no bugs or crashes.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Now, in an event eoc, using an immediate effect that may delete an item in an event eoc always seems to be a dangerous behavior. There is no guarantee that the outer function of the function that triggers the event eoc does not save a reference to the deleted item and use it later.
If not prevent immediate deletion of items in event eoc, may need to check the call chain of all functions that trigger event eoc and add item validity checks.

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
