### PR TITLE
math/json: fix (de)serialization of inf and nan

### DIFF
--- a/src/math_parser_diag_value.cpp
+++ b/src/math_parser_diag_value.cpp
@@ -292,7 +292,14 @@ void _serialize( diag_value::impl_t const &data, JsonOut &jsout )
         },
         [&jsout]( double v )
         {
-            jsout.write( v );
+            if( std::isfinite( v ) ) {
+                jsout.write( v );
+            } else {
+                // inf and nan aren't allowed in JSON
+                jsout.start_object();
+                jsout.member( "dbl", std::to_string( v ) );
+                jsout.end_object();
+            }
         },
         [&jsout]( std::string const & v )
         {
@@ -351,6 +358,11 @@ void diag_value::deserialize( const JsonValue &jsin )
             std::string str;
             jo.read( "str", str );
             data = str;
+        } else if( jo.has_member( "dbl" ) ) {
+            // inf and nan
+            std::string str;
+            jo.read( "dbl", str );
+            data = std::stof( str );
         }
     }
 }


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Dialogue variables can end up holding `inf` or `nan` and their serialization doesn't follow JSON spec.

- Hotfix for #80455
- Fixes: #80593


#### Describe the solution

~~1. Adjust the JSON parser to read `inf` and `nan`. The existing code is perfectly capable of ingesting those tokens but doesn't because it's not part of spec~~ Dropped this part to prevent this issue from silently recurring

2. Serialize `inf` and `nan` as a special string object from now on

#### Describe alternatives you've considered
N/A

#### Testing

Use this EOC:
```JSON
  {
    "type": "effect_on_condition",
    "id": "AAA",
    "effect": [ { "math": [ "u_blorg = 1/0" ] }, { "math": [ "u_blorg2 = -1 ^ 0.5" ] } ]
  },
```
then save and inspect the savefile:
`"blorg": { "dbl": "inf" },`
`"blorg2": { "dbl": "-nan" },`

Reload and verify the values with the debug menu.

#### Additional context
N/A

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
