### PR TITLE
Characters do not automatically try to clear `downed` if they have the `CANNOT_MOVE` flag

### DIFF
--- a/src/character_escape.cpp
+++ b/src/character_escape.cpp
@@ -88,7 +88,6 @@ void Character::try_remove_downed()
                                    _( "<npcname> stands up." ) );
             remove_effect( effect_downed );
         }
-    
     }
 }
 

--- a/src/character_escape.cpp
+++ b/src/character_escape.cpp
@@ -49,8 +49,8 @@ static const itype_id itype_beartrap( "beartrap" );
 static const itype_id itype_rope_6( "rope_6" );
 static const itype_id itype_snare_trigger( "snare_trigger" );
 
-static const json_character_flag json_flag_DOWNED_RECOVERY( "DOWNED_RECOVERY" );
 static const json_character_flag json_flag_CANNOT_MOVE( "CANNOT_MOVE" );
+static const json_character_flag json_flag_DOWNED_RECOVERY( "DOWNED_RECOVERY" );
 
 static const limb_score_id limb_score_balance( "balance" );
 static const limb_score_id limb_score_grip( "grip" );

--- a/src/character_escape.cpp
+++ b/src/character_escape.cpp
@@ -83,10 +83,10 @@ void Character::try_remove_downed()
             add_msg_if_player( _( "You struggle to stand." ) );
         } else {
             add_msg_player_or_npc( m_good,
-                               has_flag( json_flag_DOWNED_RECOVERY ) ? _( "You deftly roll to your feet." ) : _( "You stand up." ),
-                               has_flag( json_flag_DOWNED_RECOVERY ) ? _( "<npcname> deftly rolls to their feet." ) :
-                               _( "<npcname> stands up." ) );
-        remove_effect( effect_downed );
+                                   has_flag( json_flag_DOWNED_RECOVERY ) ? _( "You deftly roll to your feet." ) : _( "You stand up." ),
+                                   has_flag( json_flag_DOWNED_RECOVERY ) ? _( "<npcname> deftly rolls to their feet." ) :
+                                   _( "<npcname> stands up." ) );
+            remove_effect( effect_downed );
         }
     
     }

--- a/src/character_escape.cpp
+++ b/src/character_escape.cpp
@@ -50,6 +50,7 @@ static const itype_id itype_rope_6( "rope_6" );
 static const itype_id itype_snare_trigger( "snare_trigger" );
 
 static const json_character_flag json_flag_DOWNED_RECOVERY( "DOWNED_RECOVERY" );
+static const json_character_flag json_flag_CANNOT_MOVE( "CANNOT_MOVE" );
 
 static const limb_score_id limb_score_balance( "balance" );
 static const limb_score_id limb_score_grip( "grip" );
@@ -77,14 +78,17 @@ void Character::try_remove_downed()
     int chance = ( get_dex() + get_arm_str() / 2.0 ) * get_limb_score( limb_score_balance ) * 10.0;
     // Always 2,5% chance to stand up
     chance += has_flag( json_flag_DOWNED_RECOVERY ) ? 20 : 1;
-    if( !x_in_y( chance, 40 ) ) {
-        add_msg_if_player( _( "You struggle to stand." ) );
-    } else {
-        add_msg_player_or_npc( m_good,
+    if ( !has_flag( json_flag_CANNOT_MOVE ) ) {
+        if( !x_in_y( chance, 40 ) ) {
+            add_msg_if_player( _( "You struggle to stand." ) );
+        } else {
+            add_msg_player_or_npc( m_good,
                                has_flag( json_flag_DOWNED_RECOVERY ) ? _( "You deftly roll to your feet." ) : _( "You stand up." ),
                                has_flag( json_flag_DOWNED_RECOVERY ) ? _( "<npcname> deftly rolls to their feet." ) :
                                _( "<npcname> stands up." ) );
         remove_effect( effect_downed );
+        }
+    
     }
 }
 

--- a/src/character_escape.cpp
+++ b/src/character_escape.cpp
@@ -78,7 +78,7 @@ void Character::try_remove_downed()
     int chance = ( get_dex() + get_arm_str() / 2.0 ) * get_limb_score( limb_score_balance ) * 10.0;
     // Always 2,5% chance to stand up
     chance += has_flag( json_flag_DOWNED_RECOVERY ) ? 20 : 1;
-    if ( !has_flag( json_flag_CANNOT_MOVE ) ) {
+    if( !has_flag( json_flag_CANNOT_MOVE ) ) {
         if( !x_in_y( chance, 40 ) ) {
             add_msg_if_player( _( "You struggle to stand." ) );
         } else {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "Characters do not automatically try to clear `downed` if they have the `CANNOT_MOVE` flag"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Every round you wait or move, your character tries to clear the `downed` status (i.e., stand up). But if you have an effect with the `CANNOT_MOVE` flag, then you obviously cannot stand up.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Check for the `CANNOT_MOVE` flag and skip the automatic `downed` clearing if it's found.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Used Corpse's Countenance from #80590 and was knocked to the floor. Did not repeatedly try to stand up. When the power ended (and the `CANNOT_MOVE` flag was removed), stood up successfully as normal
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Fixed my compile errors!
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
