### PR TITLE
[ MoM ] Pyrokinetic Nether Attunement event

### DIFF
--- a/data/mods/MindOverMatter/effectoncondition/eoc_nether_attunement_events.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_nether_attunement_events.json
@@ -810,7 +810,10 @@
           }
         },
         "then": [
-          { "u_message": "Your skin feels a cycle of hot and cold flashes as the temperature drops and humidity rises.", "type": "bad" },
+          {
+            "u_message": "Your skin feels a cycle of hot and cold flashes as the temperature drops and humidity rises.",
+            "type": "bad"
+          },
           {
             "u_add_effect": "effect_nether_attunement_pyrokinetic_fog",
             "duration": {

--- a/data/mods/MindOverMatter/effectoncondition/eoc_nether_attunement_events.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_nether_attunement_events.json
@@ -747,7 +747,7 @@
         "then": [
           { "u_message": "Your throat and stomach feel warm.", "type": "bad" },
           {
-            "u_cast_spell": "mom_spell_pyrokinetic_fog",
+            "u_add_effect": "pyrokinetic_fog",
             "duration": {
               "math": [ "time(' 10 m') * rng( ( u_vitamin('vitamin_psionic_drain') / 2 ), ( u_vitamin('vitamin_psionic_drain') * 2 ) )" ]
             }

--- a/data/mods/MindOverMatter/effectoncondition/eoc_nether_attunement_events.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_nether_attunement_events.json
@@ -343,6 +343,7 @@
         [ "EOC_DRAIN_EFFECT_CHECK_TELEPORT_LOCK", 5 ],
         [ "EOC_NETHER_EFFECT_CHECK_BIOKIN_METABOLIC_INVERSION", 5 ],
         [ "EOC_DRAIN_EFFECT_CHECK_WEAKNESS", 5 ],
+        [ "EOC_NETHER_EFFECT_CHECK_PYROKINETIC_FOG", 5 ],
         [ "EOC_NETHER_EFFECT_CHECK_EXTRA_KCAL", 6 ],
         [ "EOC_NETHER_EFFECT_CHECK_ATTENUATION", 8 ],
         [ "EOC_NETHER_EFFECT_CHECK_BREATHING", 5 ],
@@ -746,7 +747,7 @@
         "then": [
           { "u_message": "Your throat and stomach feel warm.", "type": "bad" },
           {
-            "u_add_effect": "effect_nether_attunement_biokinetic_inversion",
+            "u_cast_spell": "mom_spell_pyrokinetic_fog",
             "duration": {
               "math": [ "time(' 10 m') * rng( ( u_vitamin('vitamin_psionic_drain') / 2 ), ( u_vitamin('vitamin_psionic_drain') * 2 ) )" ]
             }
@@ -779,6 +780,41 @@
             "u_add_effect": "effect_biokin_overload",
             "duration": {
               "math": [ "time(' 30 s') * rng( ( u_vitamin('vitamin_psionic_drain') / 2 ), ( u_vitamin('vitamin_psionic_drain') * 2 ) )" ]
+            }
+          }
+        ]
+      }
+    ],
+    "false_effect": [ { "run_eocs": "EOC_PSIONICS_NETHER_ATTUNEMENT_CONSEQUENCES" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_NETHER_EFFECT_CHECK_PYROKINETIC_FOG",
+    "//": "Base is 1% chance from 85 attunement to 120 attunement, then scaling up 0.1% per attunement up to 8% chance at 190 attunement, then scaling up 0.35% chance per attunement up to 29% chance at max, plus 1/10th the Difficulty squared.",
+    "condition": {
+      "and": [
+        { "compare_string": [ "PYROKINETIC", { "context_val": "school" } ] },
+        { "math": [ "u_vitamin('vitamin_psionic_drain') >= 85" ] }
+      ]
+    },
+    "effect": [
+      {
+        "if": {
+          "x_in_y_chance": {
+            "x": {
+              "math": [
+                "( clamp( (u_vitamin('vitamin_psionic_drain') - 120), 0, 130) + clamp( ( (u_vitamin('vitamin_psionic_drain') - 190) * 2.5 ), 0, 375) + (nether_attune_difficulty_scaler(u_latest_channeled_power_difficulty)) + 10)"
+              ]
+            },
+            "y": 1000
+          }
+        },
+        "then": [
+          { "u_message": "Your skin feels a cycle of hot and cold flashes as the temperature drops and humidity rises.", "type": "bad" },
+          {
+            "u_add_effect": "effect_nether_attunement_pyrokinetic_fog",
+            "duration": {
+              "math": [ "time(' 15 m') * rng( ( u_vitamin('vitamin_psionic_drain') / 2 ), ( u_vitamin('vitamin_psionic_drain') * 2 ) )" ]
             }
           }
         ]

--- a/data/mods/MindOverMatter/effects/effects_nether_attunement.json
+++ b/data/mods/MindOverMatter/effects/effects_nether_attunement.json
@@ -102,6 +102,16 @@
   },
   {
     "type": "effect_type",
+    "id": "effect_kelvinist_anti_cold",
+    "//": "Hidden effect, used as a tracker",
+    "name": [ "" ],
+    "desc": [ "" ],
+    "apply_message": "A roiling fog coalesces out of the surrounding air.",
+    "remove_message": "The roiling fog surrounding you dissipates.",
+    "enchantments": [ { "emitter": "emit_fog_plume" } ]
+  },
+  {
+    "type": "effect_type",
     "id": "effect_observed_rate_limiter",
     "//": "Hidden effect, used as a tracker",
     "name": [ "" ],

--- a/data/mods/MindOverMatter/powers/nether_attunement_spells.json
+++ b/data/mods/MindOverMatter/powers/nether_attunement_spells.json
@@ -21,35 +21,6 @@
     "effect": "emit",
     "effect_str": "emit_nether_chill"
   },
-    {
-    "id": "nether_attunement_pyrokinetic_fog_summon",
-    "type": "SPELL",
-    "name": { "str": "Pyrokinetic Fog", "//~": "NO_I18N" },
-    "description": { "str": "Summons a fog from using your powers.", "//~": "NO_I18N" },
-    "valid_targets": [ "self" ],
-    "flags": [ "PSIONIC", "SILENT", "NO_EXPLOSION_SFX" ],
-    "effect": "spawn_item",
-    "effect_str": "aura_pyrokinetic_fog",
-    "shape": "blast",
-    "min_damage": 1,
-    "max_damage": 1,
-    "min_duration": 10000
-  },
-  {
-    "id": "aura_pyrokinetic_fog",
-    "type": "ARMOR",
-    "name": { "str": "Pyrokinetic Fog", "//~": "NO_I18N" },
-    "//": "dirty hack till emit spell would be fixed",
-    "description": { "str": "Summons a fog from using your powers.", "//~": "NO_I18N" },
-    "weight": "1 g",
-    "volume": "1 ml",
-    "symbol": "o",
-    "color": "blue",
-    "material": [ "monolith" ],
-    "flags": [ "AURA", "TRADER_AVOID", "NO_TAKEOFF", "NONCONDUCTIVE", "OVERSIZE", "UNBREAKABLE", "ALLOWS_NATURAL_ATTACKS" ],
-    "max_worn": 1,
-    "relic_data": { "passive_effects": [ { "has": "WORN", "condition": "ALWAYS", "emitter": "emit_fog_plume" } ] }
-  },
   {
     "id": "nether_attunement_everyone_downed",
     "type": "SPELL",

--- a/data/mods/MindOverMatter/powers/nether_attunement_spells.json
+++ b/data/mods/MindOverMatter/powers/nether_attunement_spells.json
@@ -21,6 +21,35 @@
     "effect": "emit",
     "effect_str": "emit_nether_chill"
   },
+    {
+    "id": "nether_attunement_pyrokinetic_fog_summon",
+    "type": "SPELL",
+    "name": { "str": "Pyrokinetic Fog", "//~": "NO_I18N" },
+    "description": { "str": "Summons a fog from using your powers.", "//~": "NO_I18N" },
+    "valid_targets": [ "self" ],
+    "flags": [ "PSIONIC", "SILENT", "NO_EXPLOSION_SFX" ],
+    "effect": "spawn_item",
+    "effect_str": "aura_pyrokinetic_fog",
+    "shape": "blast",
+    "min_damage": 1,
+    "max_damage": 1,
+    "min_duration": 10000
+  },
+  {
+    "id": "aura_pyrokinetic_fog",
+    "type": "ARMOR",
+    "name": { "str": "Pyrokinetic Fog", "//~": "NO_I18N" },
+    "//": "dirty hack till emit spell would be fixed",
+    "description": { "str": "Summons a fog from using your powers.", "//~": "NO_I18N" },
+    "weight": "1 g",
+    "volume": "1 ml",
+    "symbol": "o",
+    "color": "blue",
+    "material": [ "monolith" ],
+    "flags": [ "AURA", "TRADER_AVOID", "NO_TAKEOFF", "NONCONDUCTIVE", "OVERSIZE", "UNBREAKABLE", "ALLOWS_NATURAL_ATTACKS" ],
+    "max_worn": 1,
+    "relic_data": { "passive_effects": [ { "has": "WORN", "condition": "ALWAYS", "emitter": "emit_fog_plume" } ] }
+  },
   {
     "id": "nether_attunement_everyone_downed",
     "type": "SPELL",

--- a/data/mods/MindOverMatter/powers/nether_attunement_spells.json
+++ b/data/mods/MindOverMatter/powers/nether_attunement_spells.json
@@ -21,7 +21,7 @@
     "effect": "emit",
     "effect_str": "emit_nether_chill"
   },
-    {
+  {
     "id": "nether_attunement_pyrokinetic_fog_summon",
     "type": "SPELL",
     "name": { "str": "Pyrokinetic Fog", "//~": "NO_I18N" },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Wanted to help make a pyrokinetic nether attunement event.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Creates a fog aura for pyrokinetic nether backlashes.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Also considering making one that summons a blizzard no matter the weather but figured to start smaller.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Needs testing.  Ideally it fogs all around the player and makes them lost at an innopportune time.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
