### PR TITLE
Replace `const std::string_view &` with `std::string_view`

### DIFF
--- a/src/bodygraph.cpp
+++ b/src/bodygraph.cpp
@@ -650,7 +650,7 @@ void display_bodygraph( const Character &u, const bodygraph_id &id )
 
 std::vector<std::string> get_bodygraph_lines( const Character &u,
         const bodygraph_callback &fragment_cb, const bodygraph_id &id, int width, int height,
-        const std::string_view &label )
+        std::string_view label )
 {
     width = ( width <= 0 || width > BPGRAPH_MAXCOLS ) ? BPGRAPH_MAXCOLS : width;
     height = ( height <= 0 || height > BPGRAPH_MAXROWS ) ? BPGRAPH_MAXROWS : height;

--- a/src/bodygraph.h
+++ b/src/bodygraph.h
@@ -88,6 +88,6 @@ using bodygraph_callback =
  */
 std::vector<std::string> get_bodygraph_lines( const Character &u,
         const bodygraph_callback &fragment_cb, const bodygraph_id &id = bodygraph_id::NULL_ID(),
-        int width = 0, int height = 0, const std::string_view &label = "" );
+        int width = 0, int height = 0, std::string_view label = "" );
 
 #endif // CATA_SRC_BODYGRAPH_H

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -259,7 +259,7 @@ duration_or_var_part get_duration_or_var_part( const JsonValue &jv )
     return ret_val;
 }
 
-duration_or_var get_duration_or_var( const JsonObject &jo, const std::string_view &member,
+duration_or_var get_duration_or_var( const JsonObject &jo, std::string_view member,
                                      bool required,
                                      time_duration default_val )
 {

--- a/src/condition.h
+++ b/src/condition.h
@@ -47,7 +47,7 @@ str_translation_or_var get_str_translation_or_var(
 dbl_or_var get_dbl_or_var( const JsonObject &jo, std::string_view member, bool required = true,
                            double default_val = 0.0 );
 dbl_or_var_part get_dbl_or_var_part( const JsonValue &jv );
-duration_or_var get_duration_or_var( const JsonObject &jo, const std::string_view &member,
+duration_or_var get_duration_or_var( const JsonObject &jo, std::string_view member,
                                      bool required = true,
                                      time_duration default_val = 0_seconds );
 duration_or_var_part get_duration_or_var_part( const JsonValue &jv );

--- a/src/generic_factory.cpp
+++ b/src/generic_factory.cpp
@@ -50,7 +50,7 @@ bool unicode_codepoint_from_symbol_reader( const JsonObject &jo,
     return true;
 }
 
-float read_proportional_entry( const JsonObject &jo, const std::string_view &key )
+float read_proportional_entry( const JsonObject &jo, std::string_view key )
 {
     if( jo.has_float( key ) ) {
         float scalar = jo.get_float( key );

--- a/src/generic_factory.h
+++ b/src/generic_factory.h
@@ -938,7 +938,7 @@ bool unicode_codepoint_from_symbol_reader(
     const JsonObject &jo, std::string_view member_name, uint32_t &member, bool );
 
 //Reads a standard single-float "proportional" entry
-float read_proportional_entry( const JsonObject &jo, const std::string_view &key );
+float read_proportional_entry( const JsonObject &jo, std::string_view key );
 
 namespace reader_detail
 {

--- a/src/global_vars.h
+++ b/src/global_vars.h
@@ -63,7 +63,7 @@ class global_variables
         void serialize( JsonOut &jsout ) const;
 
         std::map<std::string, std::string> migrations; // NOLINT(cata-serialize)
-        static void load_migrations( const JsonObject &jo, const std::string_view &src );
+        static void load_migrations( const JsonObject &jo, std::string_view src );
 
     private:
         impl_t global_values;

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -1833,7 +1833,7 @@ use_function Item_factory::read_use_function( const JsonObject &jo,
 //reads a single use_function from the provided JsonValue
 static std::pair<std::string, use_function> use_function_reader_helper(
     std::map<std::string, int> &ammo_scale,
-    const std::string_view &src, const JsonValue &val )
+    std::string_view src, const JsonValue &val )
 {
     if( val.test_object() ) {
         JsonObject use_obj = val.get_object();
@@ -1865,8 +1865,8 @@ class use_function_reader_map : public generic_typed_reader<use_function_reader_
 {
     public:
         std::map<std::string, int> &ammo_scale;
-        const std::string_view &src;
-        use_function_reader_map( std::map<std::string, int> &ammo_scale, const std::string_view &src ) :
+        std::string_view src;
+        use_function_reader_map( std::map<std::string, int> &ammo_scale, std::string_view src ) :
             ammo_scale( ammo_scale ), src( src ) {};
         std::pair<std::string, use_function> get_next( const JsonValue &val ) const {
             return use_function_reader_helper( ammo_scale, src, val );
@@ -1878,8 +1878,8 @@ class use_function_reader_single : public generic_typed_reader<use_function_read
 {
     public:
         std::map<std::string, int> &ammo_scale;
-        const std::string_view &src;
-        use_function_reader_single( std::map<std::string, int> &ammo_scale, const std::string_view &src ) :
+        std::string_view src;
+        use_function_reader_single( std::map<std::string, int> &ammo_scale, std::string_view src ) :
             ammo_scale( ammo_scale ), src( src ) {
         };
         use_function get_next( const JsonValue &val ) const {
@@ -2137,8 +2137,8 @@ class snippet_reader : public generic_typed_reader<snippet_reader>
 {
     public:
         const itype &def;
-        const std::string_view &src;
-        explicit snippet_reader( const itype &def, const std::string_view &src ) : def( def ),
+        std::string_view src;
+        explicit snippet_reader( const itype &def, std::string_view src ) : def( def ),
             src( src ) {};
         std::string get_next( const JsonValue &val ) const {
             if( val.test_array() ) {
@@ -4695,7 +4695,7 @@ void itype::relative_qualities_from_json( const JsonObject &jo,
     }
 }
 
-void itype::set_techniques_from_json( const JsonObject &jo, const std::string_view &member,
+void itype::set_techniques_from_json( const JsonObject &jo, std::string_view member,
                                       itype &def )
 {
     if( jo.has_array( member ) ) {

--- a/src/itype.h
+++ b/src/itype.h
@@ -1647,7 +1647,7 @@ struct itype {
         void extend_qualities_from_json( const JsonObject &jo, std::string_view member, itype &def );
         void delete_qualities_from_json( const JsonObject &jo, std::string_view member, itype &def );
         void relative_qualities_from_json( const JsonObject &jo, std::string_view member, itype &def );
-        void set_techniques_from_json( const JsonObject &jo, const std::string_view &member, itype &def );
+        void set_techniques_from_json( const JsonObject &jo, std::string_view member, itype &def );
         void extend_techniques_from_json( const JsonObject &jo, std::string_view member, itype &def );
         void delete_techniques_from_json( const JsonObject &jo, std::string_view member, itype &def );
 

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -3829,7 +3829,7 @@ class jmapgen_variable : public jmapgen_piece
 {
     public:
         std::string name;
-        jmapgen_variable( const JsonObject &jsi, const std::string_view &/*context*/ ) {
+        jmapgen_variable( const JsonObject &jsi, std::string_view /*context*/ ) {
             name = jsi.get_string( "name" );
         }
         mapgen_phase phase() const override {

--- a/src/profession_group.cpp
+++ b/src/profession_group.cpp
@@ -28,7 +28,7 @@ void profession_group::load_profession_group( const JsonObject &jo, const std::s
     profession_group_factory.load( jo, src );
 }
 
-void profession_group::load( const JsonObject &jo, const std::string_view & )
+void profession_group::load( const JsonObject &jo, std::string_view )
 {
     assign( jo, "id", id );
     assign( jo, "professions", profession_list );

--- a/src/profession_group.h
+++ b/src/profession_group.h
@@ -13,7 +13,7 @@ class JsonObject;
 struct profession_group {
 
         static void load_profession_group( const JsonObject &jo, const std::string &src );
-        void load( const JsonObject &jo, const std::string_view & );
+        void load( const JsonObject &jo, std::string_view );
         static const std::vector<profession_group> &get_all();
         static void check_profession_group_consistency();
         bool was_loaded = false;

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -1656,7 +1656,7 @@ void global_variables::serialize( JsonOut &jsout ) const
     jsout.member( "global_vals", global_values );
 }
 
-void global_variables::load_migrations( const JsonObject &jo, const std::string_view & )
+void global_variables::load_migrations( const JsonObject &jo, std::string_view )
 {
     const std::string from( jo.get_string( "from" ) );
     const std::string to = jo.has_string( "to" )

--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -216,7 +216,7 @@ static void parse_vp_reqs( const JsonObject &obj, const vpart_id &id, const std:
 }
 
 static void parse_vp_control_reqs( const JsonObject &obj, const vpart_id &id,
-                                   const std::string_view &key,
+                                   std::string_view key,
                                    vp_control_req &req )
 {
     if( !obj.has_object( key ) ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
This avoids unnecessary reference passing.  
There is no need to use `const std::string_view &`, because `std::string_view` itself is a reference to a string (`std::string` or `const char*`).
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Although `const std::string_view` is closer to the original semantics, since it is a function parameter, omitting the `const` modifier here might be more appropriate.

Although this change might have an impact on performance, even if it does, it would be negligible.  
The main purpose is to simplify the code, so I filled in "None" in the Summary section.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
This change will hardly affect the behavior of the code, so no testing is necessary.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
