### PR TITLE
Update scenarios to use distance_initial_visibility

### DIFF
--- a/data/json/scenarios.json
+++ b/data/json/scenarios.json
@@ -490,6 +490,7 @@
     "forbidden_traits": [ "FASTREADER", "SLOWREADER" ],
     "requirement": "achievement_witnessed_portal_storm",
     "reveal_locale": false,
+    "distance_initial_visibility": 0,
     "flags": [ "CHALLENGE", "LONE_START" ]
   },
   {
@@ -544,6 +545,7 @@
     ],
     "requirement": "achievement_reach_lab_finale",
     "reveal_locale": false,
+    "distance_initial_visibility": 0,
     "flags": [ "CHALLENGE", "CITY_START", "LONE_START" ]
   },
   {
@@ -604,6 +606,7 @@
     "start_of_game": { "hour": 8, "day": 1, "season": "winter", "year": 1 },
     "add_professions": true,
     "professions": [ "sheltered_survivor", "sheltered_militia", "winter_scavenger", "winter_army" ],
+    "distance_initial_visibility": 0,
     "requirement": "achievement_survive_91_days"
   },
   {
@@ -631,6 +634,7 @@
     "start_of_game": { "hour": 8, "day": 1, "season": "summer", "year": 2 },
     "add_professions": true,
     "professions": [ "sheltered_survivor", "sheltered_militia", "winter_scavenger", "winter_army" ],
+    "distance_initial_visibility": 50,
     "requirement": "achievement_survive_91_days"
   },
   {
@@ -647,6 +651,7 @@
     "professions": [ "sheltered_survivor", "sheltered_militia", "winter_scavenger", "winter_army" ],
     "requirement": "achievement_survive_91_days",
     "eoc": [ "faction_camp_start" ],
+    "distance_initial_visibility": 50,
     "flags": [ "CITY_START", "LONE_START" ]
   },
   {
@@ -660,6 +665,7 @@
     "flags": [ "LONE_START" ],
     "start_of_cataclysm": { "hour": 0, "day": 61, "season": "spring", "year": 1 },
     "start_of_game": { "hour": 8, "day": 1, "season": "winter", "year": 1 },
+    "distance_initial_visibility": 0,
     "professions": [ "sheltered_militia", "sheltered_survivor", "unemployed" ]
   },
   {
@@ -674,6 +680,7 @@
     "forbidden_traits": [ "TOUGH", "DISRESISTANT" ],
     "professions": [ "unemployed", "patient", "veteran" ],
     "requirement": "achievement_reach_hospital",
+    "distance_initial_visibility": 0,
     "flags": [ "CHALLENGE", "CITY_START", "LONE_START" ]
   },
   {
@@ -696,6 +703,7 @@
       "k9_cop",
       "cop"
     ],
+    "distance_initial_visibility": 0,
     "flags": [ "CITY_START", "LONE_START" ]
   },
   {
@@ -720,6 +728,7 @@
     ],
     "requirement": "achievement_reach_island_prison",
     "reveal_locale": false,
+    "distance_initial_visibility": 0,
     "flags": [ "LONE_START", "CHALLENGE" ]
   },
   {
@@ -733,6 +742,7 @@
     "professions": [ "captive", "rescuer" ],
     "requirement": "achievement_reach_mi-Go_encampment",
     "reveal_locale": false,
+    "distance_initial_visibility": 0,
     "flags": [ "LONE_START", "CHALLENGE" ],
     "start_of_cataclysm": { "hour": 0, "day": 61, "season": "spring", "year": 1 },
     "start_of_game": { "hour": 8, "day": 1, "season": "winter", "year": 1 }
@@ -786,6 +796,7 @@
       "ELECTRORECEPTORS"
     ],
     "reveal_locale": false,
+    "distance_initial_visibility": 0,
     "flags": [ "LONE_START" ]
   },
   {
@@ -833,6 +844,8 @@
     "description": "You find yourself among trees.  The screaming and moaning is fainter this far from civilization, but you'd better know what you're doing out here.",
     "start_name": "Wilderness",
     "allowed_locs": [ "sloc_field", "sloc_forest", "sloc_campsite", "sloc_campground", "sloc_desert_island", "sloc_river" ],
+    "reveal_locale": false,
+    "distance_initial_visibility": 0,
     "flags": [ "LONE_START" ]
   },
   {
@@ -866,6 +879,7 @@
       "combat-engineer"
     ],
     "map_extra": "mx_helicopter",
+    "distance_initial_visibility": 0,
     "flags": [ "HELI_CRASH", "LONE_START" ],
     "missions": [ "MISSION_HELICOPTER_CRASH" ]
   },
@@ -912,6 +926,7 @@
       "combat-engineer"
     ],
     "requirement": "achievement_reach_military_base",
+    "distance_initial_visibility": 25,
     "flags": [ "CHALLENGE", "LONE_START" ]
   },
   {
@@ -963,6 +978,7 @@
     "allowed_locs": [ "sloc_road" ],
     "start_name": "Crash Site",
     "map_extra": "mx_mayhem_crash_start",
+    "distance_initial_visibility": 0,
     "flags": [ "CHALLENGE", "HELI_CRASH", "LONE_START" ]
   },
   {
@@ -1014,6 +1030,7 @@
     "allowed_locs": [ "sloc_field", "sloc_forest", "sloc_desert_island" ],
     "eoc": [ "scenario_strong_portal_storm", "scenario_portal_dependent" ],
     "requirement": "achievement_reach_lab_finale",
+    "distance_initial_visibility": 0,
     "reveal_locale": false,
     "professions": [
       "portal_traveler",
@@ -1117,6 +1134,7 @@
     ],
     "requirement": "achievement_reach_aircraft_carrier",
     "reveal_locale": false,
+    "distance_initial_visibility": 0,
     "flags": [ "CHALLENGE", "LONE_START" ]
   },
   {
@@ -1331,6 +1349,7 @@
     "start_name": "Outside Town",
     "allowed_locs": [ "sloc_mobile_home", "sloc_motel" ],
     "eoc": [ "EOC_scenario_drunk" ],
+    "distance_initial_visibility": 6,
     "flags": [ "LONE_START" ]
   },
   {
@@ -1341,6 +1360,7 @@
     "description": "When FEMA camps ran out of space the authorities used what was left of their manpower to round up people at gunpoint.  The stadiums they forced everyone into did nothing to slow down the madness and it spread like wildfire.  You managed to slip away from the worst violence but you are now surrounded and need to escape quickly!",
     "start_name": "Stadium",
     "allowed_locs": [ "sloc_stadium" ],
+    "distance_initial_visibility": 0,
     "map_extra": "mx_corpses"
   },
   {
@@ -1351,7 +1371,8 @@
     "description": "During your escape you got lost and ended up at the wrong location.  Get your bearings and make a plan.  You'll need it.",
     "start_name": "Middle of Nowhere",
     "allowed_locs": [ "sloc_middle_of_nowhere" ],
-    "reveal_locale": false
+    "reveal_locale": false,
+    "distance_initial_visibility": 0
   },
   {
     "type": "scenario",
@@ -1361,7 +1382,8 @@
     "description": "When the riots came to your home, you ran underground and hid.  Now days later you are lost and hear movement echoing in the dark.",
     "start_name": "Underground",
     "allowed_locs": [ "sloc_sewer" ],
-    "reveal_locale": false
+    "reveal_locale": false,
+    "distance_initial_visibility": 0
   },
   {
     "type": "scenario",

--- a/data/mods/innawood/scenarios.json
+++ b/data/mods/innawood/scenarios.json
@@ -37,7 +37,8 @@
       "bricklayer"
     ],
     "flags": [  ],
-    "reveal_locale": false
+    "reveal_locale": false,
+    "distance_initial_visibility": 0
   },
   {
     "type": "scenario",
@@ -76,7 +77,8 @@
       "carpenter",
       "bricklayer"
     ],
-    "reveal_locale": false
+    "reveal_locale": false,
+    "distance_initial_visibility": 0
   },
   {
     "type": "scenario",
@@ -116,7 +118,8 @@
       "carpenter",
       "bricklayer"
     ],
-    "reveal_locale": false
+    "reveal_locale": false,
+    "distance_initial_visibility": 0
   },
   {
     "type": "scenario",
@@ -157,7 +160,8 @@
       "carpenter",
       "bricklayer"
     ],
-    "reveal_locale": false
+    "reveal_locale": false,
+    "distance_initial_visibility": 0
   },
   {
     "type": "scenario",
@@ -197,7 +201,8 @@
       "carpenter",
       "bricklayer"
     ],
-    "reveal_locale": false
+    "reveal_locale": false,
+    "distance_initial_visibility": 0
   },
   {
     "type": "scenario",
@@ -210,7 +215,8 @@
     "professions": [ "svictim", "naked", "unemployed", "homeless", "hitchhiker", "musician" ],
     "eoc": [ "scenario_infected", "scenario_bad_day" ],
     "flags": [ "FIRE_START", "CHALLENGE", "LONE_START" ],
-    "reveal_locale": false
+    "reveal_locale": false,
+    "distance_initial_visibility": 0
   },
   {
     "type": "scenario",
@@ -249,7 +255,8 @@
       "carpenter",
       "bricklayer"
     ],
-    "reveal_locale": false
+    "reveal_locale": false,
+    "distance_initial_visibility": 0
   },
   {
     "type": "scenario",
@@ -291,7 +298,8 @@
       "carpenter",
       "bricklayer"
     ],
-    "reveal_locale": false
+    "reveal_locale": false,
+    "distance_initial_visibility": 0
   },
   {
     "type": "scenario",
@@ -346,7 +354,8 @@
     "vehicle": "2seater2_scenario",
     "professions": [ "heli_pilot" ],
     "flags": [ "LONE_START" ],
-    "reveal_locale": false
+    "reveal_locale": false,
+    "distance_initial_visibility": 0
   },
   {
     "type": "scenario",
@@ -385,7 +394,8 @@
       "carpenter",
       "bricklayer"
     ],
-    "reveal_locale": false
+    "reveal_locale": false,
+    "distance_initial_visibility": 0
   },
   {
     "type": "scenario",
@@ -398,7 +408,8 @@
     "start_name": "Crash Site",
     "map_extra": "mx_mayhem",
     "flags": [ "CHALLENGE", "HELI_CRASH", "LONE_START" ],
-    "reveal_locale": false
+    "reveal_locale": false,
+    "distance_initial_visibility": 0
   },
   {
     "type": "scenario",
@@ -413,6 +424,7 @@
     "allowed_locs": [ "sloc_field", "sloc_forest", "sloc_desert_island" ],
     "eoc": [ "scenario_strong_portal_storm", "scenario_portal_dependent" ],
     "requirement": "achievement_witnessed_portal_storm",
+    "distance_initial_visibility": 0,
     "reveal_locale": false,
     "professions": [
       "portal_traveler",
@@ -440,6 +452,7 @@
     "forced_traits": [ "ILLITERATE", "ANTIJUNK", "STRONGSTOMACH", "SPIRITUAL" ],
     "forbidden_traits": [ "FASTREADER", "SLOWREADER" ],
     "flags": [ "CHALLENGE", "LONE_START" ],
+    "distance_initial_visibility": 0,
     "reveal_locale": false
   }
 ]


### PR DESCRIPTION
#### Summary
Content "Some scenarios have different distances revealed at the start"

#### Purpose of change
I moved starting visibility to scenarios in #79310. This PR aims to update scenarios to use it.

#### Describe the solution
Update the following scenarios:
* Churl/Medieval peasant (Set to 0, no idea where you are)
* Lost and afraid (Set to 0, no idea where you are)
* Lab patient (Set to 0, no idea where you are)
* Ambushed (still reveals locale, so it seems like you were traveling out in the wild before you were attacked! Very immersive)
* The next summer/summer_advanced_start (INCREASED to 50, since you've been around a while it's likely that you've explored the area.)
* Brave New World/faction_camp_start (INCREASED to 50, since you've been around a while it's likely that you've explored the area.)
* Sheltered (Set to 0. The description mentions you never leaving, so being ignorant of the outside world makes sense)
* (Hospital) patient (same as above)
* Prison (Set to 0. well you COULDN'T leave, so how could you know about the local area?)
* Island prison (ditto)
* Mi-go prisoner (ditto)
* Experiment (Set to 0. Mentions you've wandered aimlessly into a forest, so...)
* Wilderness (Set to 0. Seems thematically appropriate. Also removed reveal_locale from it, just in case)
* Helicopter crash (Set to 0. Even if you were looking outside as you flew, I doubt you'd remember those fleeting details after hitting the ground)
* Challenge - Overrun (Set to 25. If you're a member of the military and have been stationed at a base, it's likely you'd know a good portion of the local area.)
* Car Crash (Set to 0. Just because you crashed somewhere doesn't mean you should know everything nearby. Still uses reveal_locale, intentionally.)
* Portal Storm Dependent (Set to 0. This scenario already implies you may not be at the same earth you know.)
* Aircraft carrier start (Set to 0. You got portal'd from off the coast of Korea! How would you know where you are?!)
* Low Profile (Set to 6. Not much time to get out and about if you were hiding.)
* Mass Quarantine (Set to 0. Another prisoner-esque start)
* Middle of nowhere (Set to 0. No idea where you are.)
* Challenge - Lost Underground (Set to 0. No idea where you are.)

INNAWOODS:
All set to 0 except the 'summer advanced start'


#### Describe alternatives you've considered
Non-circular areas revealed that also don't use reveal_locale, would need more code and more work. Could probably be done with scenario-start EOCs

#### Testing
Loaded ambushed scenario a few times (all forced to start at field), confirmed I didn't have an enormous area revealed.

#### Additional context
The previous default value was 15. So all changes are relative to that.

Many scenarios had the initial distance set to 0. The first turn will still 'tick' updating the overmap once, so that the resulting reveal will follow regular overmap sight rules. Initial visibility will never actually be 0, but dependent on the start conditions, player's perception stat, etc.
