### PR TITLE
Mutation description can parse tags now

### DIFF
--- a/doc/JSON/MUTATIONS.md
+++ b/doc/JSON/MUTATIONS.md
@@ -94,7 +94,7 @@ Note that **all new traits that can be obtained through mutation must be purifia
   "bodytemp_modifiers": [ 100, 150 ],           // Range of additional bodytemp units (these units are described in 'weather.h'.  First value is used if the person is already overheated, second one if it's not.
   "initial_ma_styles": [ "style_crane" ],     // (optional) A list of IDs of martial art styles of which the player can choose one when starting a game.
   "mixed_effect": false,                      // Whether the trait has both positive and negative effects.  This is purely declarative and is only used for the user interface (default: false).
-  "description": "Nothing gets you down!",    // In-game description.
+  "description": "Nothing gets you down!",    // In-game description. Supports snippets and u/global variables
   "starting_trait": true,                     // Can be selected at character creation (default: false).
   "random_at_chargen": false,                 // (Optional) Starting traits can be randomly assigned to NPCs during chargen.  This options prevents that (default: true).
   "valid": false,                             // Can be mutated ingame (default: true).  Note that prerequisites can even mutate invalid mutations.

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -2768,7 +2768,7 @@ bionic_uid Character::add_bionic( const bionic_id &b, bionic_uid parent_uid,
             if( !has_trait( spell_class ) ) {
                 set_mutation( spell_class );
                 on_mutation_gain( spell_class );
-                add_msg_if_player( spell_class->desc() );
+                add_msg_if_player( mutation_desc( spell_class ) );
             }
         }
         if( !magic->knows_spell( learned_spell ) ) {

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -845,7 +845,7 @@ void iexamine::attunement_altar( Character &you, const tripoint_bub_ms & )
                                  attunement->name() ) ) ) {
         you.toggle_trait( attunement );
         // There's no way for you to have this mutation, so a variant is pointless
-        you.add_msg_if_player( m_info, attunement->desc() );
+        you.add_msg_if_player( m_info, you.mutation_desc( attunement ) );
     } else {
         you.add_msg_if_player( _( "Maybe later." ) );
     }

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -2417,10 +2417,10 @@ void known_magic::learn_spell( const spell_type *sp, Character &guy, bool force 
                 } else if( cancel == sp->spell_class->cancels.front() ) {
                     trait_cancel = cancel->name();
                     if( sp->spell_class->cancels.size() == 1 ) {
-                        trait_cancel = string_format( "%s: %s", trait_cancel, cancel->desc() );
+                        trait_cancel = string_format( "%s: %s", trait_cancel, guy.mutation_desc( cancel ) );
                     }
                 } else {
-                    trait_cancel = string_format( _( "%s, %s" ), trait_cancel, cancel->name() );
+                    trait_cancel = string_format( _( "%s, %s" ), trait_cancel, guy.mutation_desc( cancel ) );
                 }
                 if( cancel == sp->spell_class->cancels.back() ) {
                     trait_cancel += ".";
@@ -2428,10 +2428,10 @@ void known_magic::learn_spell( const spell_type *sp, Character &guy, bool force 
             }
             if( !guy.is_avatar() || query_yn(
                     _( "Learning this spell will make you a\n\n%s: %s\n\nand lock you out of\n\n%s\n\nContinue?" ),
-                    sp->spell_class->name(), sp->spell_class->desc(), trait_cancel ) ) {
+                    sp->spell_class->name(), guy.mutation_desc( sp->spell_class ), trait_cancel ) ) {
                 guy.set_mutation( sp->spell_class );
                 guy.on_mutation_gain( sp->spell_class );
-                guy.add_msg_if_player( sp->spell_class.obj().desc() );
+                guy.add_msg_if_player( guy.mutation_desc( sp->spell_class ) );
             } else {
                 return;
             }

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -2596,7 +2596,6 @@ std::string Character::mutation_desc( const trait_id &mut ) const
     }
 
     parse_tags( description, *this, *this );
-     
 
     return description;
 }

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -35,6 +35,7 @@
 #include "messages.h"
 #include "monster.h"
 #include "omdata.h"
+#include "npc.h"
 #include "options.h"
 #include "output.h"
 #include "overmapbuffer.h"
@@ -2586,12 +2587,18 @@ std::string Character::mutation_name( const trait_id &mut ) const
 
 std::string Character::mutation_desc( const trait_id &mut ) const
 {
+    std::string description;
     auto it = cached_mutations.find( mut );
     if( it != cached_mutations.end() && it->second.variant != nullptr ) {
-        return mut->desc( it->second.variant->id );
+        description = mut->desc( it->second.variant->id );
+    } else {
+        description = mut->desc();
     }
 
-    return mut->desc();
+    parse_tags( description, *this, *this );
+     
+
+    return description;
 }
 
 void Character::customize_appearance( customize_appearance_choice choice )

--- a/src/mutation.h
+++ b/src/mutation.h
@@ -363,6 +363,7 @@ struct mutation_branch {
         translation raw_desc;
     public:
         std::string name( const std::string &variant = "" ) const;
+        // Stored description of mutation. Character::mutation_desc() should be prioritized over this, if possible, for parse_tags support
         std::string desc( const std::string &variant = "" ) const;
 
         /**

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -2488,7 +2488,7 @@ void parse_tags( std::string &phrase, const_talker const &u, const_talker const 
             // resolve nest
             parse_tags( var, u, me, d, item_type );
             // attempt to cast as an item
-            phrase.replace( fa, l, trait_id( var )->desc() );
+            phrase.replace( fa, l, me_chr->mutation_desc( trait_id( var ) ) );
         } else if( tag.find( "<spell_name:" ) == 0 ) {
             //embedding an items name in the string
             std::string var = tag.substr( tag.find( ':' ) + 1 );

--- a/src/player_display.cpp
+++ b/src/player_display.cpp
@@ -649,7 +649,7 @@ static void draw_traits_info( const catacurses::window &w_info, const Character 
     werase( w_info );
     if( line < traitslist.size() ) {
         const trait_and_var &cur = traitslist[line];
-        std::string trait_desc = cur.desc();
+        std::string trait_desc = you.mutation_desc( cur.trait );
         if( !you.purifiable( cur.trait ) ) {
             trait_desc +=
                 _( "\n<color_yellow>This trait is an intrinsic part of you now, purifier won't be able to remove it.</color>" );

--- a/src/wish.cpp
+++ b/src/wish.cpp
@@ -232,7 +232,7 @@ class wish_mutate_callback: public uilist_callback
                              mdata.visibility,
                              mdata.ugliness );
                 ImGui::NewLine();
-                ImGui::TextWrapped( "%s", mdata.desc().c_str() );
+                ImGui::TextWrapped( "%s", you->mutation_desc( mdata.id ).c_str() );
             }
 
             float y = ImGui::GetContentRegionMax().y - 3 * ImGui::GetTextLineHeightWithSpacing();


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Storm asked for it, and it generally sound like a cool idea
#### Describe the solution
Mutations support parse_tags now, meaning they can add the snippets and custom variables in the text body
Also replaced calls to raw mutation description with call to characater `mutation_desc()` so most places that call for description would have the tags parsed - the notable exception is chargen, that, for obvious reasons, do not have parse_tags, so it may need separate handling?
#### Testing
![image](https://github.com/user-attachments/assets/3ad66e76-85c6-4434-bb43-7d21170b3e51)
![image](https://github.com/user-attachments/assets/6b975193-6110-4d0d-9877-ca7706a415ce)
