### PR TITLE
Bugfix: Mi-go pathfinding avoids fire

### DIFF
--- a/data/json/monsters/mi-go.json
+++ b/data/json/monsters/mi-go.json
@@ -27,7 +27,7 @@
     "weakpoint_sets": [ "wps_mi-go", "wps_natural_armor" ],
     "families": [ "prof_wp_mi-go_basic", "prof_wp_mi-go_advanced", "prof_wp_nat_armored" ],
     "harvest": "mi-go",
-    "path_settings": { "max_dist": 50, "allow_open_doors": true, "avoid_traps": true, "avoid_sharp": true },
+    "path_settings": { "max_dist": 50, "allow_open_doors": true, "avoid_traps": true, "avoid_sharp": true, "avoid_dangerous_fields": true },
     "scents_ignored": [ "sc_fetid" ],
     "special_attacks": [
       [ "PARROT", 100 ],
@@ -79,7 +79,7 @@
     "harvest": "mi-go",
     "weakpoint_sets": [ "wps_mi-go", "wps_natural_armor" ],
     "families": [ "prof_wp_mi-go_basic", "prof_wp_mi-go_advanced", "prof_wp_nat_armored" ],
-    "path_settings": { "max_dist": 50, "allow_open_doors": true, "avoid_traps": true, "avoid_sharp": true },
+    "path_settings": { "max_dist": 50, "allow_open_doors": true, "avoid_traps": true, "avoid_sharp": true, "avoid_dangerous_fields": true },
     "scents_ignored": [ "sc_fetid" ],
     "special_attacks": [
       [ "PARROT", 100 ],
@@ -137,7 +137,7 @@
     "harvest": "mi-go",
     "weakpoint_sets": [ "wps_mi-go", "wps_natural_armor" ],
     "families": [ "prof_wp_mi-go_basic", "prof_wp_mi-go_advanced", "prof_wp_nat_armored" ],
-    "path_settings": { "max_dist": 50, "allow_open_doors": true, "avoid_traps": true, "avoid_sharp": true },
+    "path_settings": { "max_dist": 50, "allow_open_doors": true, "avoid_traps": true, "avoid_sharp": true, "avoid_dangerous_fields": true },
     "scents_ignored": [ "sc_fetid" ],
     "special_attacks": [
       [ "PARROT", 100 ],
@@ -189,7 +189,7 @@
     "harvest": "mi-go",
     "weakpoint_sets": [ "wps_mi-go", "wps_natural_armor" ],
     "families": [ "prof_wp_mi-go_basic", "prof_wp_mi-go_advanced", "prof_wp_nat_armored" ],
-    "path_settings": { "max_dist": 50, "allow_open_doors": true, "avoid_traps": true, "avoid_sharp": true },
+    "path_settings": { "max_dist": 50, "allow_open_doors": true, "avoid_traps": true, "avoid_sharp": true, "avoid_dangerous_fields": true },
     "scents_ignored": [ "sc_fetid" ],
     "special_attacks": [
       [ "PARROT", 100 ],
@@ -250,7 +250,7 @@
     "harvest": "mi-go",
     "weakpoint_sets": [ "wps_mi-go", "wps_natural_armor" ],
     "families": [ "prof_wp_mi-go_basic", "prof_wp_mi-go_advanced", "prof_wp_nat_armored" ],
-    "path_settings": { "max_dist": 50, "allow_open_doors": true, "avoid_traps": true, "avoid_sharp": true },
+    "path_settings": { "max_dist": 50, "allow_open_doors": true, "avoid_traps": true, "avoid_sharp": true, "avoid_dangerous_fields": true },
     "scents_ignored": [ "sc_fetid" ],
     "special_attacks": [
       [ "PARROT", 100 ],
@@ -349,7 +349,7 @@
     "harvest": "mi-go",
     "weakpoint_sets": [ "wps_mi-go", "wps_natural_armor" ],
     "families": [ "prof_wp_mi-go_basic", "prof_wp_mi-go_advanced", "prof_wp_nat_armored" ],
-    "path_settings": { "max_dist": 50, "allow_open_doors": true, "avoid_traps": true, "avoid_sharp": true },
+    "path_settings": { "max_dist": 50, "allow_open_doors": true, "avoid_traps": true, "avoid_sharp": true, "avoid_dangerous_fields": true },
     "scents_ignored": [ "sc_fetid" ],
     "special_attacks": [
       {

--- a/doc/JSON/MONSTERS.md
+++ b/doc/JSON/MONSTERS.md
@@ -674,9 +674,12 @@ Field                | Description
 `max_length`         | (int, default -1) Maximum total length of path
 `bash_strength`      | (int, default -1) Monster strength when bashing through an obstacle
 `allow_open_doors`   | (bool, default false) Monster knows how to open doors
+`allow_unlock_doors` | (bool, default false) Monster knows how to unlock doors
 `avoid_traps`        | (bool, default false) Monster avoids stepping into traps
 `allow_climb_stairs` | (bool, default true) Monster may climb stairs
+`avoid_rough_terrain` | (bool, default false) Monster may avoid rough terrain like rubble
 `avoid_sharp`        | (bool, default false) Monster may avoid sharp things like barbed wire
+`avoid_dangerous_fields` | (bool, default false) Monster may avoid dangerous fields like fire or acid
 
 ## "special_attacks"
 


### PR DESCRIPTION


<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Mi-go pathfinding avoids fire"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Bugfix for pathfinding to not use the straight-line optimization when there is some sort of non-normal tile between the source and target. Mi-go will now path around fires if there is such a route.

* Fixes #75009 .
* Relates to #77538 , #60581 , #73674 .

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution


There is an optimization in place before the A* pathfinder is invoked, that checks for whether the target is reachable by a straight-line. In such case, the A* pathfinder is not invoked, presumably because of performance reasons. The evaluation of this straight-line optimization does not use the same way of choosing whether or not each tile is walkable or not. The real A* pathfinder will usually route around tiles that are technically walkable but might be questionable (such as fires), but the straight-line optimization only checks for whether it's technically walkable. The real A* pathfinder might also pick a route through such questionable tiles if there are no other choices. For example, a monster might walk through fire if surrounded. So the question of whether or not to pick the straight-line optimization is a bit trickier than it might seem at first.

Because of these differences in the straight-line evaluation and the real A* pathfinder, the straight-line optimization was previously chosen even if the A* pathfinder would have picked a different path. For example: before, a mi-go picked a straight-line path through fire, even if it had `avoid_dangerous_fields` because, well, the tiles on fire are technically walkable, right?

This commit instead aborts the straight-line optimization if any of the tiles on the straight-line has any sort of non-normal characteristic. If so, the A* pathfinder is invoked, which will choose the best route given the circumstances. The route will probably walk around the fires, but if there's no other way, it will walk through it.

This commit also adds `avoid_dangerous_fields` to all mi-gos, because they're fairly intelligent and would likely not willingly walk into a fire. 

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

* The tests added in this branch fail on `master` but succeed here.
* Loaded the save from #75009 . A spawned mi-go now routes around the obstacle-of-fire.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

There are likely more monsters that should also have the `avoid_dangerous_fields`-flag set, such as most mammals?

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
