### PR TITLE
Let NPCs Practice

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -4282,9 +4282,10 @@ if( craft.item_counter >= 10000000 ) {
         }
     }
 
-    if( will_continue ) {
-        if( crafter.making_would_work( crafter.lastrecipe, craft_copy.get_making_batch_size() ) ) {
-            crafter.last_craft->execute( location );
+        if( will_continue ) {
+            if( crafter.making_would_work( crafter.lastrecipe, craft_copy.get_making_batch_size() ) ) {
+                crafter.last_craft->execute( location );
+            }
         }
     }
 

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -4274,11 +4274,12 @@ if( craft.item_counter >= 10000000 ) {
     crafter.cancel_activity();
     crafter.complete_craft( craft_copy, location );
 
-    // For NPCs: stop if skill increased
-    if( crafter.is_npc() && rec.is_practice() ) {
-        const skill_id &skill = rec.skill_used;
-        if( crafter.get_skill_level( skill ) > original_skill_level ) {
-            return; // Skill increased, do not continue practicing
+        // For NPCs: stop if skill increased
+        if( crafter.is_npc() && rec.is_practice() ) {
+            const skill_id &skill = rec.skill_used;
+            if( crafter.get_skill_level( skill ) > original_skill_level ) {
+                return; // Skill increased, do not continue practicing
+            }
         }
     }
 

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -4216,18 +4216,19 @@ void craft_activity_actor::do_turn( player_activity &act, Character &crafter )
     const double total_practice_ticks = rec.time_to_craft_moves( crafter,
                                         recipe_time_flag::ignore_proficiencies ) / 100.0;
 
-const int ticks_per_practice = 10000000.0 / total_practice_ticks;
-int num_practice_ticks = craft.item_counter / ticks_per_practice -
-                         old_counter / ticks_per_practice;
-bool level_up = false;
-if( num_practice_ticks > 0 ) {
-    level_up |= crafter.craft_skill_gain( craft, num_practice_ticks );
-    if( crafter.is_npc() && rec.is_practice() && npc_starting_skill_level >= 0 ) {
-        const skill_id &skill = rec.skill_used;
-        int current_practical_level = crafter.get_skill_level_object( skill ).level();
-        if( current_practical_level > npc_starting_skill_level ) {
-            crafter.cancel_activity();
-            return;
+    const int ticks_per_practice = 10000000.0 / total_practice_ticks;
+    int num_practice_ticks = craft.item_counter / ticks_per_practice -
+                             old_counter / ticks_per_practice;
+    bool level_up = false;
+    if( num_practice_ticks > 0 ) {
+        level_up |= crafter.craft_skill_gain( craft, num_practice_ticks );
+        if( crafter.is_npc() && rec.is_practice() && npc_starting_skill_level >= 0 ) {
+            const skill_id &skill = rec.skill_used;
+            int current_practical_level = crafter.get_skill_level_object( skill ).level();
+            if( current_practical_level > npc_starting_skill_level ) {
+                crafter.cancel_activity();
+                return;
+            }
         }
     }
 }

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -4288,20 +4288,21 @@ if( craft.item_counter >= 10000000 ) {
         }
     }
 
-} else {
-    if( level_up && craft.get_making().is_practice() ) {
-        if( crafter.is_avatar() && query_yn( _( "Your proficiency has increased.  Stop practicing?" ) ) ) {
-            crafter.cancel_activity();
-        } else if( crafter.is_npc() ) {
-            crafter.cancel_activity();
-        }
-    } else if( craft.item_counter >= craft.get_next_failure_point() ) {
-        bool destroy = craft.handle_craft_failure( crafter );
-        if( destroy ) {
-            crafter.add_msg_player_or_npc( _( "There is nothing left of the %s to craft from." ),
-                                           _( "There is nothing left of the %s <npcname> was crafting." ), craft.tname() );
-            craft_item.remove_item();
-            crafter.cancel_activity();
+    } else {
+        if( level_up && craft.get_making().is_practice() ) {
+            if( crafter.is_avatar() && query_yn( _( "Your proficiency has increased.  Stop practicing?" ) ) ) {
+                crafter.cancel_activity();
+            } else if( crafter.is_npc() ) {
+                crafter.cancel_activity();
+            }
+        } else if( craft.item_counter >= craft.get_next_failure_point() ) {
+            bool destroy = craft.handle_craft_failure( crafter );
+            if( destroy ) {
+                crafter.add_msg_player_or_npc( _( "There is nothing left of the %s to craft from." ),
+                                               _( "There is nothing left of the %s <npcname> was crafting." ), craft.tname() );
+                craft_item.remove_item();
+                crafter.cancel_activity();
+            }
         }
     }
 }

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -4268,11 +4268,11 @@ if( craft.item_counter >= 10000000 ) {
         original_skill_level = crafter.get_skill_level( rec.skill_used );
     }
 
-    item craft_copy = craft;
-    craft_item.remove_item();
-    const bool will_continue = is_long;
-    crafter.cancel_activity();
-    crafter.complete_craft( craft_copy, location );
+        item craft_copy = craft;
+        craft_item.remove_item();
+        const bool will_continue = is_long;
+        crafter.cancel_activity();
+        crafter.complete_craft( craft_copy, location );
 
         // For NPCs: stop if skill increased
         if( crafter.is_npc() && rec.is_practice() ) {

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -4231,14 +4231,13 @@ void craft_activity_actor::do_turn( player_activity &act, Character &crafter )
             }
         }
     }
-}
-int five_percent_steps = craft.item_counter / 500000 - old_counter / 500000;
-if( five_percent_steps > 0 ) {
-    const time_duration pct_time = time_duration::from_seconds( base_total_moves / 2000 );
-    level_up |= crafter.craft_proficiency_gain( craft, pct_time * five_percent_steps );
-    cached_crafting_speed = 0;
-    use_cached_workbench_multiplier = false;
-}
+    int five_percent_steps = craft.item_counter / 500000 - old_counter / 500000;
+    if( five_percent_steps > 0 ) {
+        const time_duration pct_time = time_duration::from_seconds( base_total_moves / 2000 );
+        level_up |= crafter.craft_proficiency_gain( craft, pct_time * five_percent_steps );
+        cached_crafting_speed = 0;
+        use_cached_workbench_multiplier = false;
+    }
     // Unlike skill, tools are consumed once at the start and should not be consumed at the end
     if( craft.item_counter >= 10000000 ) {
         --five_percent_steps;

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -4254,19 +4254,19 @@ void craft_activity_actor::do_turn( player_activity &act, Character &crafter )
     }
 
     // if item_counter has reached 100% or more
-if( craft.item_counter >= 10000000 ) {
-    if( rec.is_practice() && !is_long && craft.get_making_batch_size() == 1 ) {
-        if( crafter.is_avatar() && query_yn( _( "Keep practicing until proficiency increases?" ) ) ) {
-            is_long = true;
-            *( crafter.last_craft ) = craft_command( &craft.get_making(), 1, is_long, &crafter, location );
+    if( craft.item_counter >= 10000000 ) {
+        if( rec.is_practice() && !is_long && craft.get_making_batch_size() == 1 ) {
+            if( crafter.is_avatar() && query_yn( _( "Keep practicing until proficiency increases?" ) ) ) {
+                is_long = true;
+                *( crafter.last_craft ) = craft_command( &craft.get_making(), 1, is_long, &crafter, location );
+            }
         }
-    }
 
-    // Track the skill level before the craft finishes
-    int original_skill_level = 0;
-    if( rec.is_practice() ) {
-        original_skill_level = crafter.get_skill_level( rec.skill_used );
-    }
+        // Track the skill level before the craft finishes
+        int original_skill_level = 0;
+        if( rec.is_practice() ) {
+            original_skill_level = crafter.get_skill_level( rec.skill_used );
+        }
 
         item craft_copy = craft;
         craft_item.remove_item();
@@ -4283,30 +4283,31 @@ if( craft.item_counter >= 10000000 ) {
         }
     }
 
-        if( will_continue ) {
-            if( crafter.making_would_work( crafter.lastrecipe, craft_copy.get_making_batch_size() ) ) {
-                crafter.last_craft->execute( location );
-            }
+    if( will_continue ) {
+        if( crafter.making_would_work( crafter.lastrecipe, craft_copy.get_making_batch_size() ) ) {
+            crafter.last_craft->execute( location );
         }
     }
+}
 
-    } else {
-        if( level_up && craft.get_making().is_practice() ) {
-            if( crafter.is_avatar() && query_yn( _( "Your proficiency has increased.  Stop practicing?" ) ) ) {
-                crafter.cancel_activity();
-            } else if( crafter.is_npc() ) {
-                crafter.cancel_activity();
-            }
-        } else if( craft.item_counter >= craft.get_next_failure_point() ) {
-            bool destroy = craft.handle_craft_failure( crafter );
-            if( destroy ) {
-                crafter.add_msg_player_or_npc( _( "There is nothing left of the %s to craft from." ),
-                                               _( "There is nothing left of the %s <npcname> was crafting." ), craft.tname() );
-                craft_item.remove_item();
-                crafter.cancel_activity();
-            }
+} else
+{
+    if( level_up && craft.get_making().is_practice() ) {
+        if( crafter.is_avatar() && query_yn( _( "Your proficiency has increased.  Stop practicing?" ) ) ) {
+            crafter.cancel_activity();
+        } else if( crafter.is_npc() ) {
+            crafter.cancel_activity();
+        }
+    } else if( craft.item_counter >= craft.get_next_failure_point() ) {
+        bool destroy = craft.handle_craft_failure( crafter );
+        if( destroy ) {
+            crafter.add_msg_player_or_npc( _( "There is nothing left of the %s to craft from." ),
+                                           _( "There is nothing left of the %s <npcname> was crafting." ), craft.tname() );
+            craft_item.remove_item();
+            crafter.cancel_activity();
         }
     }
+}
 }
 }
 

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -1150,6 +1150,7 @@ class craft_activity_actor : public activity_actor
 
         item_location craft_item;
         bool is_long;
+        int npc_starting_skill_level = -1;
 
         float activity_override = NO_EXERCISE;
         std::optional<requirement_data> cached_continuation_requirements; // NOLINT(cata-serialize)

--- a/src/recipe.cpp
+++ b/src/recipe.cpp
@@ -1330,10 +1330,6 @@ std::function<bool( const item & )> recipe::get_component_filter(
 
 bool recipe::npc_can_craft( std::string &reason ) const
 {
-    if( is_practice() ) {
-        reason = _( "Ordering NPC to practice is not implemented yet." );
-        return false;
-    }
     if( result()->phase != phase_id::SOLID ) {
         reason = _( "Ordering NPC to craft non-solid item is currently only implemented for camps." );
         return false;


### PR DESCRIPTION
NPCs aren't allowed to practice. Now they can.

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "Let NPCs Practice"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->Now that NPCs craft and skill up like players do, there doesn't seem to be a reason to prevent them from accessing the practice recipes.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->I deleted a few lines in recipe.cpp that disallowed practice recipes for NPCs.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->N/A

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->I compiled and loaded a new world with the friends til the end scenario. I recruited Liam and brought him to a well lit area. Then I asked him to craft basic unarmed practice. He did, and his skill went up. I asked him to do athletics next, and he did, leveling up to 2. 

#### Additional context

The UI is a little wonky, asking you if YOU want to stop practicing once Liam's skilled up, and asking if YOU wish to continue until YOU level up the skill, even though it's Liam doing the training. Still seems to work, though! I'd say that's a separate problem.


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
