### PR TITLE
Ban alcohol from camp larder

### DIFF
--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -103,6 +103,8 @@
 
 static const activity_id ACT_MOVE_LOOT( "ACT_MOVE_LOOT" );
 
+static const addiction_id addiction_alcohol( "alcohol" );
+
 static const efftype_id effect_HACK_camp_vision_for_npc( "HACK_camp_vision_for_npc" );
 
 static const furn_str_id furn_f_plant_harvest( "f_plant_harvest" );
@@ -5898,6 +5900,10 @@ bool basecamp::distribute_food( bool player_command )
             return false;
         }
         if( it.rotten() ) {
+            return false;
+        }
+        // Alcohol is specifically excluded until it can be turned into a vitamin/tracked by the larder
+        if( it.get_comestible()->addictions.count( addiction_alcohol ) ) {
             return false;
         }
         nutrients from_it = default_character_compute_effective_nutrients( it ) * it.count();


### PR DESCRIPTION
#### Summary
Balance "Ban alcohol from camp larder"

#### Purpose of change
It's very very easy to acquire or create huge amounts of calories through alcohol. Normally, alcohol has very bad effects - addictions, lowered health, etc. In the larder, none of this matters as the addictions and negative effects are not vitamin-based. This makes it completely "free", and allows both NPCs and the player to subsist on all-alcohol diets.

#### Describe the solution
Prevent alcohol from being distributed into the larder until the larder can apply its negative effects to those consuming it.

#### Describe alternatives you've considered
There's probably some other things that could/should get banned, but alcohol is the one that keeps coming up.

#### Testing
Spawned some barley wine, tried to put it into the larder. "No suitable items are located at the drop points..."

#### Additional context

