### PR TITLE
Minor tweaks in fault stuff

### DIFF
--- a/data/json/items/tool/debug_tools.json
+++ b/data/json/items/tool/debug_tools.json
@@ -107,5 +107,65 @@
         }
       ]
     }
+  },
+  {
+    "id": "debug_apply_fault",
+    "type": "TOOL",
+    "category": "tools",
+    "name": { "str_sp": "debug fault applier" },
+    "description": "Applies the fault on item by id.",
+    "weight": "1 g",
+    "volume": "1 ml",
+    "material": [ "plastic" ],
+    "symbol": ";",
+    "color": "light_gray",
+    "use_action": {
+      "type": "effect_on_conditions",
+      "menu_text": "Damage item",
+      "effect_on_conditions": [
+        {
+          "id": "EOC_FIND_ITEM_fault",
+          "effect": {
+            "u_run_inv_eocs": "manual_mult",
+            "true_eocs": {
+              "id": "EOC_APPLY_FAULT",
+              "effect": [
+                {
+                  "set_string_var": "",
+                  "string_input": { "title": "", "description": "fault_id or fault_type_id", "identifier": "debug_apply_fault", "width": 30 },
+                  "target_var": { "context_val": "str" }
+                },
+                {
+                  "if": { "u_query": "Provided id is fault_type or fault?  \"Yes\" for fault_type, \"No\" for fault_id", "default": false },
+                  "then": { "math": [ "_is_group = 1" ] }
+                },
+                { "if": { "u_query": "Forced?", "default": false }, "then": { "math": [ "_is_force = 1" ] } },
+                {
+                  "if": { "math": [ "_is_group" ] },
+                  "then": [
+                    {
+                      "if": { "math": [ "_is_force" ] },
+                      "then": { "u_set_random_fault_of_type": { "context_val": "str" }, "force": true },
+                      "else": { "u_set_random_fault_of_type": { "context_val": "str" } }
+                    },
+                    {
+                      "u_message": "<npc_name> has random fault from fault_type \"<context_val:str>\" added, if such group exists."
+                    }
+                  ],
+                  "else": [
+                    {
+                      "if": { "math": [ "_is_force" ] },
+                      "then": { "npc_set_fault": { "context_val": "str" }, "force": true },
+                      "else": { "npc_set_fault": { "context_val": "str" } }
+                    },
+                    { "u_message": "<npc_name> has \"<context_val:str>\" fault added, if such id exists." }
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
   }
 ]

--- a/doc/JSON/EFFECT_ON_CONDITION.md
+++ b/doc/JSON/EFFECT_ON_CONDITION.md
@@ -3472,7 +3472,6 @@ Store string from `set_string_var` in the variable object `target_var`
 | "title" | optional | string, [variable object](#variable-object) | The title of the input popup window, can be localized (e.g., `"title": { "i18n": true, "str": "Input a value:" }`). |
 | "description" | optional | string, [variable object](#variable-object) | The description of the input popup window, can be localized. |
 | "default_text" | optional | string, [variable object](##variable-object) | The default text in the input popup window, can be localized. |
-
 | "width" | optional | integer | The character length of the input box. Default is 20. |
 | "identifier" | optional | string | Input boxes with the same identifier share input history. Default is `""`. |
 | "only_digits" | optional | boolean | Whether the input is purely numeric. Default is false. |
@@ -4786,6 +4785,48 @@ You activate beta talker / NPC activates alpha talker. One must be a Character a
 Force you consume drug item
 ```jsonc
 { "u_activate": "consume_drug" }
+```
+
+#### `u_set_fault`, `npc_set_fault`
+Applies a fault on item
+
+| Syntax | Optionality | Value  | Info |
+| ------ | ----------- | ------ | ---- | 
+| "u_set_fault" / "npc_set_fault" | **mandatory** | string or [variable object](#variable-object) | id of a fault applied |
+| "force" | optional | bool | if true, the fault is applied onto item even if item do not define it as possible fault. Default false | 
+| "message" | optional | bool | if truem the fault would print a message defined in fault `message` field. Default true | 
+
+##### Valid talkers:
+
+| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
+| ------ | --------- | --------- | ---- | ------- | --- | ---- |
+| ❌ | ❌ | ❌ | ❌ | ❌ | ✔️ | ❌ |
+
+##### Examples
+Beta talker adds `fault_electronic_blown_capacitor` as it's fault
+```jsonc
+{ "npc_set_fault": "fault_electronic_blown_capacitor" }
+```
+
+#### `u_set_random_fault_of_type`, `npc_set_random_fault_of_type`
+Picks a random fault from a type, and applies it onto item
+
+| Syntax | Optionality | Value  | Info |
+| ------ | ----------- | ------ | ---- | 
+| "u_set_random_fault_of_type" / "npc_set_random_fault_of_type" | **mandatory** | string or [variable object](#variable-object) | type of a fault applied |
+| "force" | optional | bool | if true, the fault is applied onto item even if item do not define it as possible fault. Default false | 
+| "message" | optional | bool | if truem the fault would print a message defined in fault `message` field. Default true | 
+
+##### Valid talkers:
+
+| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
+| ------ | --------- | --------- | ---- | ------- | --- | ---- |
+| ❌ | ❌ | ❌ | ❌ | ❌ | ✔️ | ❌ |
+
+##### Examples
+Beta talker adds a random fault from `shorted` type as it's fault
+```jsonc
+{ "npc_set_random_fault_of_type": "shorted" }
 ```
 
 ## Map effects

--- a/doc/JSON/JSON_INFO.md
+++ b/doc/JSON/JSON_INFO.md
@@ -1598,6 +1598,7 @@ Faults can be defined for more specialized damage of an item.
   "description": "This gun currently...", // fault description
   "item_prefix": "jammed", // optional string, items with this fault will be prefixed with this
   "item_suffix": "no handle", // optional string, items with this fault will be suffixed with this. The string would be encased in parentheses, like `sword (no handle)`
+  "message": "%s has it's handle broken!", // Message, that would be shown when such fault is applied, unless supressed
   "fault_type": "gun_mechanical_simple", // type of a fault, code may call for a random fault in a group instead of specific fault
   "affected_by_degradation": false, // default false. If true, the item degradation value would be added to fault weight on roll
   "price_modifier": 0.4, // (Optional, double) Defaults to 1 if not specified. A multiplier on the price of an item when this fault is present. Values above 1.0 will increase the item's value.

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -358,7 +358,7 @@ bool aim_activity_actor::check_gun_ability_to_shoot( Character &who, item &it )
             who.add_msg_if_player( m_good,
                                    _( "Your %s has some mechanical malfunction.  You tried to quickly fix it, and it works now!" ),
                                    it.tname() );
-            it.faults.erase( faults::random_of_type_item_has( it, gun_mechanical_simple ) );
+            it.remove_single_fault_of_type( gun_mechanical_simple );
             it.set_var( "u_know_round_in_chamber", true );
         } else {
             who.add_msg_if_player( m_bad,
@@ -455,7 +455,8 @@ void aim_activity_actor::finish( player_activity &act, Character &who )
     gun_mode gun = weapon->gun_current_mode();
     who.fire_gun( here, fin_trajectory.back(), gun.qty, *gun, reload_loc );
 
-    if( !get_option<bool>( "AIM_AFTER_FIRING" ) ) {
+    if( !get_option<bool>( "AIM_AFTER_FIRING" ) ||
+        weapon.get_item()->has_fault_of_type( gun_mechanical_simple ) ) {
         restore_view();
         return;
     }

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -966,7 +966,7 @@ static std::vector<item> create_charge_items( const itype *drop, int count,
             obj.set_flag( flg );
         }
         for( const fault_id &flt : entry.faults ) {
-            obj.faults.emplace( flt );
+            obj.set_fault( flt );
         }
         if( !you.backlog.empty() && you.backlog.front().id() == ACT_MULTIPLE_BUTCHER ) {
             obj.set_var( "activity_var", you.name );
@@ -1219,7 +1219,7 @@ static bool butchery_drops_harvest( item *corpse_item, const mtype &mt, Characte
                     obj.set_flag( flg );
                 }
                 for( const fault_id &flt : entry.faults ) {
-                    obj.faults.emplace( flt );
+                    obj.remove_fault( flt );
                 }
 
                 // TODO: smarter NPC liquid handling
@@ -1247,7 +1247,7 @@ static bool butchery_drops_harvest( item *corpse_item, const mtype &mt, Characte
                     obj.set_flag( flg );
                 }
                 for( const fault_id &flt : entry.faults ) {
-                    obj.faults.emplace( flt );
+                    obj.remove_fault( flt );
                 }
                 if( !you.backlog.empty() && you.backlog.front().id() == ACT_MULTIPLE_BUTCHER ) {
                     obj.set_var( "activity_var", you.name );
@@ -2789,10 +2789,10 @@ void activity_handlers::mend_item_finish( player_activity *act, Character *you )
     you->invalidate_crafting_inventory();
 
     for( const ::fault_id &id : fix.faults_removed ) {
-        target.faults.erase( id );
+        target.remove_fault( id );
     }
     for( const ::fault_id &id : fix.faults_added ) {
-        target.set_fault( id );
+        act->targets[0].set_fault( id, true, false );
     }
     for( const auto &[var_name, var_value] : fix.set_variables ) {
         target.set_var( var_name, var_value );

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -1170,10 +1170,10 @@ void avatar_action::use_item( avatar &you, item_location &loc, std::string const
     if( loc->wetness && loc->has_flag( flag_WATER_BREAK_ACTIVE ) ) {
         if( query_yn( _( "This item is still wet and it will break if you turn it on.  Proceed?" ) ) ) {
             loc->deactivate();
-            loc.get_item()->set_random_fault_of_type( "wet" );
+            loc.get_item()->set_random_fault_of_type( "wet", true );
             // An electronic item in water is also shorted.
             if( loc->has_flag( flag_ELECTRONIC ) ) {
-                loc.get_item()->set_random_fault_of_type( "shorted" );
+                loc.get_item()->set_random_fault_of_type( "shorted", true );
             }
         } else {
             return;

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -2205,7 +2205,7 @@ void Character::perform_uninstall( const bionic &bio, int difficulty, int succes
         cbm.set_flag( flag_FILTHY );
         cbm.set_flag( flag_NO_STERILE );
         cbm.set_flag( flag_NO_PACKED );
-        cbm.faults.emplace( fault_bionic_salvaged );
+        cbm.set_fault( fault_bionic_salvaged );
         here.add_item( pos_bub(), cbm );
     } else {
         get_event_bus().send<event_type::fails_to_remove_cbm>( getID(), bio.id );
@@ -2282,7 +2282,7 @@ bool Character::uninstall_bionic( const bionic &bio, monster &installer, Charact
         cbm.set_flag( flag_FILTHY );
         cbm.set_flag( flag_NO_STERILE );
         cbm.set_flag( flag_NO_PACKED );
-        cbm.faults.emplace( fault_bionic_salvaged );
+        cbm.set_fault( fault_bionic_salvaged );
         here.add_item( patient.pos_bub(), cbm );
     } else {
         bionics_uninstall_failure( installer, patient, difficulty, success, adjusted_skill );
@@ -2625,7 +2625,7 @@ void Character::bionics_install_failure( const bionic_id &bid, const std::string
         item cbm( bid->itype() );
         cbm.set_flag( flag_NO_STERILE );
         cbm.set_flag( flag_NO_PACKED );
-        cbm.faults.emplace( fault_bionic_salvaged );
+        cbm.set_fault( fault_bionic_salvaged );
         get_map().add_item( patient_pos, cbm );
     }
 }

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -6583,7 +6583,7 @@ void Character::mend_item( item_location &&obj, bool interactive )
         menu.text = _( "Toggle which fault?" );
         std::vector<std::pair<fault_id, bool>> opts;
         for( const auto &f : obj->faults_potential() ) {
-            opts.emplace_back( f, !!obj->faults.count( f ) );
+            opts.emplace_back( f, obj->has_fault( f ) );
             menu.addentry( -1, true, -1, string_format(
                                opts.back().second ? pgettext( "fault", "Mend: %s" ) : pgettext( "fault", "Set: %s" ),
                                f.obj().name() ) );
@@ -6595,9 +6595,9 @@ void Character::mend_item( item_location &&obj, bool interactive )
         menu.query();
         if( menu.ret >= 0 ) {
             if( opts[menu.ret].second ) {
-                obj->faults.erase( opts[menu.ret].first );
+                obj->remove_fault( opts[menu.ret].first );
             } else {
-                obj->set_fault( opts[menu.ret].first );
+                obj.set_fault( opts[menu.ret].first, true, false );
             }
         }
         return;
@@ -10579,7 +10579,7 @@ void Character::place_corpse( map *here )
             cbm.set_flag( flag_FILTHY );
             cbm.set_flag( flag_NO_STERILE );
             cbm.set_flag( flag_NO_PACKED );
-            cbm.faults.emplace( fault_bionic_salvaged );
+            cbm.set_fault( fault_bionic_salvaged );
             body.put_in( cbm, pocket_type::CORPSE );
         }
     }

--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -831,9 +831,9 @@ void emp_blast( const tripoint_bub_ms &p )
                 add_msg( m_bad, _( "The EMP blast fries your %s!" ), it->tname() );
                 it->deactivate();
                 if( get_option<bool>( "GAME_EMP" ) ) {
-                    it->set_fault( fault_emp_reboot );
+                    it.set_fault( fault_emp_reboot, true );
                 } else {
-                    it->set_random_fault_of_type( "shorted" );
+                    it.set_random_fault_of_type( "shorted", true );
                 }
             }
         }
@@ -846,13 +846,14 @@ void emp_blast( const tripoint_bub_ms &p )
                 add_msg( _( "The EMP blast fries the %s!" ), it.tname() );
             }
             it.deactivate();
+            item_location loc = item_location( map_cursor( p ), &it );
+
             if( get_option<bool>( "GAME_EMP" ) ) {
-                it.set_fault( fault_emp_reboot );
+                loc.set_fault( fault_emp_reboot, true, false );
             } else {
-                it.set_random_fault_of_type( "shorted" );
+                loc.set_random_fault_of_type( "shorted", true, false );
             }
             //map::make_active adds the item to the active item processing list, so that it can reboot without further interaction
-            item_location loc = item_location( map_cursor( p ), &it );
             here.make_active( loc );
         }
     }

--- a/src/fault.cpp
+++ b/src/fault.cpp
@@ -163,6 +163,11 @@ std::string fault::item_suffix() const
     return item_suffix_.translated();
 }
 
+std::string fault::message() const
+{
+    return message_.translated();
+}
+
 double fault::price_mod() const
 {
     return price_modifier;
@@ -205,6 +210,7 @@ void fault::load( const JsonObject &jo, std::string_view )
     mandatory( jo, was_loaded, "description", description_ );
     optional( jo, was_loaded, "item_prefix", item_prefix_ );
     optional( jo, was_loaded, "item_suffix", item_suffix_ );
+    optional( jo, was_loaded, "message", message_ );
     optional( jo, was_loaded, "fault_type", type_ );
     optional( jo, was_loaded, "flags", flags );
     optional( jo, was_loaded, "price_modifier", price_modifier, 1.0 );

--- a/src/fault.cpp
+++ b/src/fault.cpp
@@ -220,7 +220,7 @@ void fault::load( const JsonObject &jo, std::string_view )
         for( JsonObject jo_f : jo.get_array( "melee_damage_mod" ) ) {
             melee_damage_mod_.emplace_back(
                 jo_f.get_int( "add", 0 ),
-                jo_f.get_float( "multiply", 1.0f ),
+                static_cast<float>( jo_f.get_float( "multiply", 1.0f ) ),
                 jo_f.get_string( "damage_id" ) );
         }
     }
@@ -229,7 +229,7 @@ void fault::load( const JsonObject &jo, std::string_view )
         for( JsonObject jo_f : jo.get_array( "armor_mod" ) ) {
             armor_mod_.emplace_back(
                 jo_f.get_int( "add", 0 ),
-                jo_f.get_float( "multiply", 1.0f ),
+                static_cast<float>( jo_f.get_float( "multiply", 1.0f ) ),
                 jo_f.get_string( "damage_id" ) );
         }
     }

--- a/src/fault.h
+++ b/src/fault.h
@@ -79,6 +79,7 @@ class fault
         std::string description() const;
         std::string item_prefix() const;
         std::string item_suffix() const;
+        std::string message() const;
         double price_mod() const;
         // int is additive (default 0), float is multiplier (default 1)
         std::vector<std::tuple<int, float, damage_type_id>> melee_damage_mod() const;
@@ -100,6 +101,7 @@ class fault
         translation description_;
         translation item_prefix_; // prefix added to affected item's name
         translation item_suffix_;
+        translation message_;
         std::set<fault_fix_id> fixes;
         std::set<std::string> flags;
         double price_modifier = 1.0;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1,4 +1,5 @@
 #include "item.h"
+#include "item.h"
 
 #include <algorithm>
 #include <array>
@@ -6871,7 +6872,7 @@ std::string item::overheat_symbol() const
         modifier += mod->type->gunmod->overheat_threshold_modifier;
         multiplier *= mod->type->gunmod->overheat_threshold_multiplier;
     }
-    if( faults.count( fault_overheat_safety ) ) {
+    if( has_fault( fault_overheat_safety ) ) {
         return string_format( _( "<color_light_green>\u2588VNT </color>" ) );
     }
     switch( std::min( 5, static_cast<int>( get_var( "gun_heat",
@@ -7698,6 +7699,16 @@ bool item::has_fault( const fault_id &fault ) const
     return faults.count( fault );
 }
 
+bool item::has_fault_of_type( const std::string fault_type ) const
+{
+    for( const fault_id f : faults ) {
+        if( f.obj().type() == fault_type ) {
+            return true;
+        }
+    }
+    return false;
+}
+
 bool item::has_fault_flag( const std::string &searched_flag ) const
 {
     for( const fault_id &fault : faults ) {
@@ -7767,15 +7778,19 @@ bool item::has_vitamin( const vitamin_id &v ) const
     return false;
 }
 
-void item::set_fault( const fault_id &fault_id )
+void item::set_fault( const fault_id &fault_id, const bool force )
 {
+    if( !force && type->faults.get_specific_weight( fault_id ) == 0 ) {
+        return;
+    }
+
     faults.insert( fault_id );
 }
 
-void item::set_random_fault_of_type( const std::string &fault_type, const bool &force )
+void item::set_random_fault_of_type( const std::string &fault_type, const bool force )
 {
     if( force ) {
-        set_fault( random_entry( faults::all_of_type( fault_type ) ) );
+        set_fault( random_entry( faults::all_of_type( fault_type ) ), true );
         return;
     }
 
@@ -7784,37 +7799,22 @@ void item::set_random_fault_of_type( const std::string &fault_type, const bool &
         faults_by_type.add( f.obj, f.weight );
     }
 
-    set_fault( *faults_by_type.pick() );
+    faults.insert( *faults_by_type.pick() );
 }
 
-weighted_int_list<fault_id> item::all_potential_faults() const
+void item::remove_fault( const fault_id &fault_id )
 {
-    weighted_int_list<fault_id> potential_faults;
-    for( const weighted_object<int, fault_id> &potential_fault : type->faults ) {
-        if( potential_fault.obj.obj().affected_by_degradation() ) {
-            potential_faults.add( potential_fault.obj, potential_fault.weight + degradation() );
-        } else {
-            potential_faults.add( potential_fault.obj, potential_fault.weight );
+    faults.erase( fault_id );
+}
+
+void item::remove_single_fault_of_type( const std::string &fault_type )
+{
+    for( const fault_id f : faults ) {
+        if( f.obj().type() == fault_type ) {
+            faults.erase( f );
+            return;
         }
     }
-    return potential_faults;
-}
-
-weighted_int_list<fault_id> item::all_potential_faults_of_type(
-    const std::string &fault_type ) const
-{
-    weighted_int_list<fault_id> potential_faults_of_type;
-    for( const weighted_object<int, fault_id> &potential_fault : all_potential_faults() ) {
-        if( potential_fault.obj.obj().type() == fault_type ) {
-            potential_faults_of_type.add( potential_fault.obj, potential_fault.weight );
-        }
-    }
-    return potential_faults_of_type;
-}
-
-const fault_id &item::random_potential_fault_of_type( const std::string &fault_type ) const
-{
-    return *all_potential_faults_of_type( fault_type ).pick();
 }
 
 item &item::unset_flag( const flag_id &flag )
@@ -10322,16 +10322,6 @@ std::set<fault_id> item::faults_potential() const
         res.insert( fault_pair.obj );
     }
     return res;
-}
-
-bool item::can_have_fault_type( const std::string &fault_type ) const
-{
-    for( const weighted_object<int, fault_id> &some_fault : type->faults ) {
-        if( some_fault.obj->type() == fault_type ) {
-            return true;
-        }
-    }
-    return false;
 }
 
 std::set<fault_id> item::faults_potential_of_type( const std::string &fault_type ) const
@@ -14775,8 +14765,8 @@ bool item::process_gun_cooling( Character *carrier )
                                  overheat_modifier, 5.0 );
     heat -= std::max( ( type->gun->cooling_value * cooling_multiplier ) + cooling_modifier, 0.5 );
     set_var( "gun_heat", std::max( 0.0, heat ) );
-    if( faults.count( fault_overheat_safety ) && heat < threshold * 0.2 ) {
-        faults.erase( fault_overheat_safety );
+    if( has_fault( fault_overheat_safety ) && heat < threshold * 0.2 ) {
+        remove_fault( fault_overheat_safety );
         if( carrier ) {
             carrier->add_msg_if_player( m_good, _( "Your %s beeps as its cooling cycle concludes." ), tname() );
         }
@@ -14970,15 +14960,15 @@ bool item::process_internal( map &here, Character *carrier, const tripoint_bub_m
         if( get_var( "gun_heat", 0 ) > 0 ) {
             return process_gun_cooling( carrier );
         }
-        if( faults.count( fault_emp_reboot ) ) {
+        if( has_fault( fault_emp_reboot ) ) {
             if( one_in( 60 ) ) {
                 if( !one_in( 20 ) ) {
-                    faults.erase( fault_emp_reboot );
+                    remove_fault( fault_emp_reboot );
                     if( carrier ) {
                         carrier->add_msg_if_player( m_good, _( "Your %s reboots successfully." ), tname() );
                     }
                 } else {
-                    faults.erase( fault_emp_reboot );
+                    remove_fault( fault_emp_reboot );
                     set_random_fault_of_type( "shorted" );
                     if( carrier ) {
                         carrier->add_msg_if_player( m_bad, _( "Your %s fails to reboot properly." ), tname() );

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -7777,7 +7777,7 @@ bool item::has_vitamin( const vitamin_id &v ) const
     return false;
 }
 
-void item::set_fault( const fault_id &fault_id, const bool force )
+void item::set_fault( const fault_id fault_id, bool force )
 {
     if( !force && type->faults.get_specific_weight( fault_id ) == 0 ) {
         return;
@@ -7786,7 +7786,7 @@ void item::set_fault( const fault_id &fault_id, const bool force )
     faults.insert( fault_id );
 }
 
-void item::set_random_fault_of_type( const std::string &fault_type, const bool force )
+void item::set_random_fault_of_type( const std::string fault_type, const bool force )
 {
     if( force ) {
         set_fault( random_entry( faults::all_of_type( fault_type ) ), true );

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -7698,7 +7698,7 @@ bool item::has_fault( const fault_id &fault ) const
     return faults.count( fault );
 }
 
-bool item::has_fault_of_type( const std::string fault_type ) const
+bool item::has_fault_of_type( const std::string &fault_type ) const
 {
     for( const fault_id &f : faults ) {
         if( f.obj().type() == fault_type ) {

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -7777,7 +7777,7 @@ bool item::has_vitamin( const vitamin_id &v ) const
     return false;
 }
 
-void item::set_fault( const fault_id fault_id, bool force )
+void item::set_fault( const fault_id &fault_id, bool force )
 {
     if( !force && type->faults.get_specific_weight( fault_id ) == 0 ) {
         return;
@@ -7786,7 +7786,7 @@ void item::set_fault( const fault_id fault_id, bool force )
     faults.insert( fault_id );
 }
 
-void item::set_random_fault_of_type( const std::string fault_type, const bool force )
+void item::set_random_fault_of_type( const std::string &fault_type, bool force )
 {
     if( force ) {
         set_fault( random_entry( faults::all_of_type( fault_type ) ), true );
@@ -14857,9 +14857,9 @@ bool item::process_internal( map &here, Character *carrier, const tripoint_bub_m
 
         if( wetness && has_flag( flag_WATER_BREAK ) ) {
             deactivate();
-            set_random_fault_of_type( "wet" );
+            set_random_fault_of_type( "wet", true );
             if( has_flag( flag_ELECTRONIC ) ) {
-                set_random_fault_of_type( "shorted" );
+                set_random_fault_of_type( "shorted", true );
             }
         }
 
@@ -14968,7 +14968,7 @@ bool item::process_internal( map &here, Character *carrier, const tripoint_bub_m
                     }
                 } else {
                     remove_fault( fault_emp_reboot );
-                    set_random_fault_of_type( "shorted" );
+                    set_random_fault_of_type( "shorted", true );
                     if( carrier ) {
                         carrier->add_msg_if_player( m_bad, _( "Your %s fails to reboot properly." ), tname() );
                     }

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1,5 +1,4 @@
 #include "item.h"
-#include "item.h"
 
 #include <algorithm>
 #include <array>
@@ -7701,7 +7700,7 @@ bool item::has_fault( const fault_id &fault ) const
 
 bool item::has_fault_of_type( const std::string fault_type ) const
 {
-    for( const fault_id f : faults ) {
+    for( const fault_id &f : faults ) {
         if( f.obj().type() == fault_type ) {
             return true;
         }

--- a/src/item.h
+++ b/src/item.h
@@ -2062,7 +2062,7 @@ class item : public visitable
         /** Check if item can have a fault, and if yes, applies it. This version do not print a message, use item_location version instead
          * `force`, if true, bypasses the check and applies the fault item do not define
          */
-        void set_fault( const fault_id &fault_id, bool force = false );
+        void set_fault( const fault_id fault_id, bool force = false );
 
         /** Check if item can have any fault of type, and if yes, applies it. This version do not print a message, use item_location version instead
         * `force`, if true, bypasses the check and applies the fault item do not define

--- a/src/item.h
+++ b/src/item.h
@@ -2062,7 +2062,7 @@ class item : public visitable
         /** Check if item can have a fault, and if yes, applies it. This version do not print a message, use item_location version instead
          * `force`, if true, bypasses the check and applies the fault item do not define
          */
-        void set_fault( const fault_id fault_id, bool force = false );
+        void set_fault( const fault_id &fault_id, bool force = false );
 
         /** Check if item can have any fault of type, and if yes, applies it. This version do not print a message, use item_location version instead
         * `force`, if true, bypasses the check and applies the fault item do not define

--- a/src/item.h
+++ b/src/item.h
@@ -1734,11 +1734,7 @@ class item : public visitable
         /** Return faults that can potentially occur with this item. */
         std::set<fault_id> faults_potential() const;
 
-        bool can_have_fault_type( const std::string &fault_type ) const;
-
         std::set<fault_id> faults_potential_of_type( const std::string &fault_type ) const;
-
-        void apply_fault();
 
         /** Returns the total area of this wheel or 0 if it isn't one. */
         int wheel_area() const;
@@ -2063,17 +2059,21 @@ class item : public visitable
         /** Idempotent filter setting an item specific flag. */
         item &set_flag( const flag_id &flag );
 
-        /** Idempotent filter setting an item specific fault. */
-        void set_fault( const fault_id &fault_id );
+        /** Check if item can have a fault, and if yes, applies it. This version do not print a message, use item_location version instead
+         * `force`, if true, bypasses the check and applies the fault item do not define
+         */
+        void set_fault( const fault_id &fault_id, const bool force = false );
 
-        void set_random_fault_of_type( const std::string &fault_type, const bool &force = false );
+        /** Check if item can have any fault of type, and if yes, applies it. This version do not print a message, use item_location version instead
+        * `force`, if true, bypasses the check and applies the fault item do not define
+        */
+        void set_random_fault_of_type( const std::string &fault_type, const bool force = false );
 
-        weighted_int_list<fault_id> all_potential_faults() const;
+        /** Removes the fault from the item, if such is presented. */
+        void remove_fault( const fault_id &fault_id );
 
-        weighted_int_list<fault_id> all_potential_faults_of_type( const std::string
-                &fault_type ) const;
-
-        const fault_id &random_potential_fault_of_type( const std::string &fault_type ) const;
+        /** Checks all the faults in item, and if there is any of this type, removes it. */
+        void remove_single_fault_of_type( const std::string &fault_type );
 
         /** Idempotent filter removing an item specific flag */
         item &unset_flag( const flag_id &flag );
@@ -2090,6 +2090,8 @@ class item : public visitable
 
         /** Does this item have the specified fault? */
         bool has_fault( const fault_id &fault ) const;
+
+        bool has_fault_of_type( const std::string fault_type ) const;
 
         /** Does this item part have a fault with this flag */
         bool has_fault_flag( const std::string &searched_flag ) const;

--- a/src/item.h
+++ b/src/item.h
@@ -40,7 +40,6 @@
 #include "units.h"
 #include "value_ptr.h"
 #include "visitable.h"
-#include "weighted_list.h"
 
 class Character;
 class Creature;
@@ -2091,7 +2090,7 @@ class item : public visitable
         /** Does this item have the specified fault? */
         bool has_fault( const fault_id &fault ) const;
 
-        bool has_fault_of_type( std::string fault_type ) const;
+        bool has_fault_of_type( const std::string &fault_type ) const;
 
         /** Does this item part have a fault with this flag */
         bool has_fault_flag( const std::string &searched_flag ) const;

--- a/src/item.h
+++ b/src/item.h
@@ -2062,12 +2062,12 @@ class item : public visitable
         /** Check if item can have a fault, and if yes, applies it. This version do not print a message, use item_location version instead
          * `force`, if true, bypasses the check and applies the fault item do not define
          */
-        void set_fault( const fault_id &fault_id, const bool force = false );
+        void set_fault( const fault_id &fault_id, bool force = false );
 
         /** Check if item can have any fault of type, and if yes, applies it. This version do not print a message, use item_location version instead
         * `force`, if true, bypasses the check and applies the fault item do not define
         */
-        void set_random_fault_of_type( const std::string &fault_type, const bool force = false );
+        void set_random_fault_of_type( const std::string &fault_type, bool force = false );
 
         /** Removes the fault from the item, if such is presented. */
         void remove_fault( const fault_id &fault_id );
@@ -2091,7 +2091,7 @@ class item : public visitable
         /** Does this item have the specified fault? */
         bool has_fault( const fault_id &fault ) const;
 
-        bool has_fault_of_type( const std::string fault_type ) const;
+        bool has_fault_of_type( std::string fault_type ) const;
 
         /** Does this item part have a fault with this flag */
         bool has_fault_flag( const std::string &searched_flag ) const;

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -4391,7 +4391,7 @@ void itype::load( const JsonObject &jo, const std::string_view src )
                 fault_groups.emplace_back(
                     jo_f.get_int( "weight_override", -1 ),
                     jo_f.get_int( "weight_add", 0 ),
-                    jo_f.get_float( "weight_mult", 1.0f ),
+                    static_cast<float>( jo_f.get_float( "weight_mult", 1.0f ) ),
                     jo_f.get_string( "fault_group" ) );
             } else {
                 jo_f.throw_error( R"("faults" should specify either a "fault" or a "fault_group")" );

--- a/src/item_group.cpp
+++ b/src/item_group.cpp
@@ -34,6 +34,9 @@
 #include "type_id.h"
 #include "units.h"
 
+static const fault_id fault_gun_dirt( "fault_gun_dirt" );
+static const fault_id fault_gun_unlubricated( "fault_gun_unlubricated" );
+
 std::size_t Item_spawn_data::create( ItemList &list,
                                      const time_point &birthday, spawn_flags flags ) const
 {
@@ -505,10 +508,10 @@ void Item_modifier::modify( item &new_item, const std::string &context ) const
         // if gun RNG is dirty, must add dirt fault to allow cleaning
         if( random_dirt > 0 ) {
             new_item.set_var( "dirt", random_dirt );
-            new_item.faults.emplace( "fault_gun_dirt" );
+            new_item.set_fault( fault_gun_dirt );
             // chance to be unlubed, but only if it's not a laser or something
         } else if( one_in( 10 ) && !new_item.has_flag( flag_NEEDS_NO_LUBE ) ) {
-            new_item.faults.emplace( "fault_gun_unlubricated" );
+            new_item.faults.emplace( fault_gun_unlubricated );
         }
     }
 

--- a/src/item_location.cpp
+++ b/src/item_location.cpp
@@ -1207,7 +1207,7 @@ bool item_location::protected_from_liquids() const
     return false;
 }
 
-void item_location::set_fault( const fault_id &fault_id, const bool force, const bool message )
+void item_location::set_fault( const fault_id fault_id, bool force, bool message )
 {
     map &here = get_map();
     item &it = *item_location::get_item();
@@ -1222,13 +1222,13 @@ void item_location::set_fault( const fault_id &fault_id, const bool force, const
     it.faults.insert( fault_id );
 }
 
-void item_location::set_random_fault_of_type( const std::string &fault_type, const bool force,
+void item_location::set_random_fault_of_type( const std::string fault_type, const bool force,
         const bool message )
 {
     map &here = get_map();
     item &it = *get_item();
     if( force ) {
-        item_location::set_fault( random_entry( faults::all_of_type( fault_type ) ), true, true );
+        set_fault( random_entry( faults::all_of_type( fault_type ) ), true, true );
         return;
     }
 

--- a/src/item_location.cpp
+++ b/src/item_location.cpp
@@ -1207,7 +1207,7 @@ bool item_location::protected_from_liquids() const
     return false;
 }
 
-void item_location::set_fault( const fault_id fault_id, bool force, bool message )
+void item_location::set_fault( const fault_id &fault_id, bool force, bool message )
 {
     map &here = get_map();
     item &it = *item_location::get_item();
@@ -1222,8 +1222,7 @@ void item_location::set_fault( const fault_id fault_id, bool force, bool message
     it.faults.insert( fault_id );
 }
 
-void item_location::set_random_fault_of_type( const std::string fault_type, const bool force,
-        const bool message )
+void item_location::set_random_fault_of_type( const std::string &fault_type, bool force, bool message )
 {
     map &here = get_map();
     item &it = *get_item();

--- a/src/item_location.cpp
+++ b/src/item_location.cpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <optional>
 #include <ostream>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -29,9 +30,11 @@
 #include "magic_enchantment.h"
 #include "map.h"
 #include "map_selector.h"
+#include "messages.h"
 #include "pimpl.h"
 #include "point.h"
 #include "ret_val.h"
+#include "rng.h"
 #include "safe_reference.h"
 #include "string_formatter.h"
 #include "talker.h"
@@ -43,6 +46,8 @@
 #include "vehicle_selector.h"
 #include "visitable.h"
 #include "vpart_position.h"
+#include "value_ptr.h"
+#include "weighted_list.h"
 
 template <typename T>
 static int find_index( const T &sel, const item *obj )
@@ -1222,7 +1227,8 @@ void item_location::set_fault( const fault_id &fault_id, bool force, bool messag
     it.faults.insert( fault_id );
 }
 
-void item_location::set_random_fault_of_type( const std::string &fault_type, bool force, bool message )
+void item_location::set_random_fault_of_type( const std::string &fault_type, bool force,
+        bool message )
 {
     map &here = get_map();
     item &it = *get_item();

--- a/src/item_location.h
+++ b/src/item_location.h
@@ -157,14 +157,14 @@ class item_location
         * `force` allow to bypass check and apply fault item do not define
         * `message` defines if fault message will be printed
         **/
-        void set_fault( const fault_id &fault_id, bool force = false, bool message = true );
+        void set_fault( const fault_id fault_id, bool force = false, bool message = true );
 
         /**
         * Checks if item has any fault of type, and if so, applies it
         * `force` allow to bypass check and apply fault item do not define
         * `message` defines if fault message will be printed
         **/
-        void set_random_fault_of_type( const std::string &fault_type, bool force = false,
+        void set_random_fault_of_type( const std::string fault_type, bool force = false,
                                        bool message = true );
 
         ret_val<void> parents_can_contain_recursive( item *it ) const;

--- a/src/item_location.h
+++ b/src/item_location.h
@@ -157,14 +157,14 @@ class item_location
         * `force` allow to bypass check and apply fault item do not define
         * `message` defines if fault message will be printed
         **/
-        void set_fault( const fault_id fault_id, bool force = false, bool message = true );
+        void set_fault( const fault_id &fault_id, bool force = false, bool message = true );
 
         /**
         * Checks if item has any fault of type, and if so, applies it
         * `force` allow to bypass check and apply fault item do not define
         * `message` defines if fault message will be printed
         **/
-        void set_random_fault_of_type( const std::string fault_type, bool force = false,
+        void set_random_fault_of_type( const std::string &fault_type, bool force = false,
                                        bool message = true );
 
         ret_val<void> parents_can_contain_recursive( item *it ) const;

--- a/src/item_location.h
+++ b/src/item_location.h
@@ -8,7 +8,7 @@
 #include <utility>
 
 #include "coords_fwd.h"
-#include "fault.h"
+#include "type_id.h"
 #include "units_fwd.h"
 
 class Character;

--- a/src/item_location.h
+++ b/src/item_location.h
@@ -8,6 +8,7 @@
 #include <utility>
 
 #include "coords_fwd.h"
+#include "fault.h"
 #include "units_fwd.h"
 
 class Character;
@@ -150,6 +151,21 @@ class item_location
         * true if the item is inside a not open watertight container
         **/
         bool protected_from_liquids() const;
+
+        /**
+        * Checks if item can have fault, and if so, applies it
+        * `force` allow to bypass check and apply fault item do not define
+        * `message` defines if fault message will be printed
+        **/
+        void set_fault( const fault_id &fault_id, const bool force = false, const bool message = true );
+
+        /**
+        * Checks if item has any fault of type, and if so, applies it
+        * `force` allow to bypass check and apply fault item do not define
+        * `message` defines if fault message will be printed
+        **/
+        void set_random_fault_of_type( const std::string &fault_type, const bool force = false,
+                                       const bool message = true );
 
         ret_val<void> parents_can_contain_recursive( item *it ) const;
         ret_val<int> max_charges_by_parent_recursive( const item &it ) const;

--- a/src/item_location.h
+++ b/src/item_location.h
@@ -157,15 +157,15 @@ class item_location
         * `force` allow to bypass check and apply fault item do not define
         * `message` defines if fault message will be printed
         **/
-        void set_fault( const fault_id &fault_id, const bool force = false, const bool message = true );
+        void set_fault( const fault_id &fault_id, bool force = false, bool message = true );
 
         /**
         * Checks if item has any fault of type, and if so, applies it
         * `force` allow to bypass check and apply fault item do not define
         * `message` defines if fault message will be printed
         **/
-        void set_random_fault_of_type( const std::string &fault_type, const bool force = false,
-                                       const bool message = true );
+        void set_random_fault_of_type( const std::string &fault_type, bool force = false,
+                                       bool message = true );
 
         ret_val<void> parents_can_contain_recursive( item *it ) const;
         ret_val<int> max_charges_by_parent_recursive( const item &it ) const;

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -3312,7 +3312,7 @@ void monster::spawn_dissectables_on_death( item *corpse ) const
                 dissectable.set_flag( flg );
             }
             for( const fault_id &flt : entry.faults ) {
-                dissectable.faults.emplace( flt );
+                dissectable.set_fault( flt );
             }
             if( corpse ) {
                 corpse->put_in( dissectable, pocket_type::CORPSE );

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -5946,9 +5946,7 @@ talk_effect_fun_t::func f_set_fault( const JsonObject &jo, std::string_view memb
     bool msg = jo.get_bool( "message", true );
     return [fault_var, force, msg, is_npc]( dialogue const & d ) {
         item_location &it = *d.actor( is_npc )->get_item();
-        if( &it ) {
-            it.set_fault( fault_id( fault_var.evaluate( d ) ), force, msg );
-        }
+        it.set_fault( fault_id( fault_var.evaluate( d ) ), force, msg );
     };
 }
 
@@ -5960,9 +5958,7 @@ talk_effect_fun_t::func f_set_random_fault_of_type( const JsonObject &jo, std::s
     bool msg = jo.get_bool( "message", true );
     return [fault_type_var, force, msg, is_npc]( dialogue const & d ) {
         item_location &it = *d.actor( is_npc )->get_item();
-        if( &it ) {
-            it.set_random_fault_of_type( fault_type_var.evaluate( d ), force, msg );
-        }
+        it.set_random_fault_of_type( fault_type_var.evaluate( d ), force, msg );
     };
 }
 

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -5938,6 +5938,34 @@ talk_effect_fun_t::func f_unset_flag( const JsonObject &jo, std::string_view mem
     };
 }
 
+talk_effect_fun_t::func f_set_fault( const JsonObject &jo, std::string_view member,
+                                     const std::string_view, bool is_npc )
+{
+    str_or_var fault_var = get_str_or_var( jo.get_member( member ), member, true );
+    bool force = jo.get_bool( "force", false );
+    bool msg = jo.get_bool( "message", true );
+    return [fault_var, force, msg, is_npc]( dialogue const & d ) {
+        item_location &it = *d.actor( is_npc )->get_item();
+        if( &it ) {
+            it.set_fault( fault_id( fault_var.evaluate( d ) ), force, msg );
+        }
+    };
+}
+
+talk_effect_fun_t::func f_set_random_fault_of_type( const JsonObject &jo, std::string_view member,
+        const std::string_view, bool is_npc )
+{
+    str_or_var fault_type_var = get_str_or_var( jo.get_member( member ), member, true );
+    bool force = jo.get_bool( "force", false );
+    bool msg = jo.get_bool( "message", true );
+    return [fault_type_var, force, msg, is_npc]( dialogue const & d ) {
+        item_location &it = *d.actor( is_npc )->get_item();
+        if( &it ) {
+            it.set_random_fault_of_type( fault_type_var.evaluate( d ), force, msg );
+        }
+    };
+}
+
 talk_effect_fun_t::func f_activate( const JsonObject &jo, std::string_view member,
                                     const std::string_view, bool is_npc )
 {
@@ -7847,6 +7875,8 @@ parsers = {
     { "u_teleport", "npc_teleport", jarg::object, &talk_effect_fun::f_teleport },
     { "u_set_flag", "npc_set_flag", jarg::member, &talk_effect_fun::f_set_flag },
     { "u_unset_flag", "npc_unset_flag", jarg::member, &talk_effect_fun::f_unset_flag },
+    { "u_set_fault", "npc_set_fault", jarg::member, &talk_effect_fun::f_set_fault },
+    { "u_set_random_fault_of_type", "npc_set_random_fault_of_type", jarg::member, &talk_effect_fun::f_set_random_fault_of_type },
     { "u_activate", "npc_activate", jarg::member, &talk_effect_fun::f_activate },
     { "u_consume_item", "npc_consume_item", jarg::member, &talk_effect_fun::f_consume_item },
     { "u_consume_item_sum", "npc_consume_item_sum", jarg::array, &talk_effect_fun::f_consume_item_sum },

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -796,8 +796,7 @@ bool Character::handle_gun_damage( item &it )
         return false;
 
         // Chance for the weapon to suffer a failure, caused by the magazine size, quality, or condition
-    } else if( x_in_y( jam_chance, 1 ) && !it.has_var( "u_know_round_in_chamber" ) &&
-               it.can_have_fault_type( gun_mechanical_simple ) ) {
+    } else if( x_in_y( jam_chance, 1 ) && !it.has_var( "u_know_round_in_chamber" ) ) {
         add_msg_player_or_npc( m_bad, _( "Your %s malfunctions!" ),
                                _( "<npcname>'s %s malfunctions!" ),
                                it.tname() );
@@ -881,7 +880,7 @@ bool Character::handle_gun_damage( item &it )
                 it.set_fault( fault_gun_dirt );
             }
             if( dirt > 0 && curammo_effects.count( ammo_effect_BLACKPOWDER ) ) {
-                it.faults.erase( fault_gun_dirt );
+                it.remove_fault( fault_gun_dirt );
                 it.set_fault( fault_gun_blackpowder );
             }
             // end fouling mechanics

--- a/src/talker.h
+++ b/src/talker.h
@@ -861,6 +861,8 @@ class talker: virtual public const_talker
         virtual void set_all_parts_hp_cur( int ) {}
         virtual void set_degradation( int ) {}
         virtual void die( map * ) {}
+        virtual void set_fault( const fault_id ) {};
+        virtual void set_random_fault_of_type( const std::string &, const bool & ) {};
         virtual void set_mana_cur( int ) {}
         virtual void mod_daily_health( int, int ) {}
         virtual void mod_livestyle( int ) {}

--- a/src/talker.h
+++ b/src/talker.h
@@ -861,8 +861,8 @@ class talker: virtual public const_talker
         virtual void set_all_parts_hp_cur( int ) {}
         virtual void set_degradation( int ) {}
         virtual void die( map * ) {}
-        virtual void set_fault( const fault_id, bool, bool ) {};
-        virtual void set_random_fault_of_type( const std::string, bool, bool ) {};
+        virtual void set_fault( const fault_id &, bool, bool ) {};
+        virtual void set_random_fault_of_type( const std::string &, bool, bool ) {};
         virtual void set_mana_cur( int ) {}
         virtual void mod_daily_health( int, int ) {}
         virtual void mod_livestyle( int ) {}

--- a/src/talker.h
+++ b/src/talker.h
@@ -861,8 +861,8 @@ class talker: virtual public const_talker
         virtual void set_all_parts_hp_cur( int ) {}
         virtual void set_degradation( int ) {}
         virtual void die( map * ) {}
-        virtual void set_fault( const fault_id, const bool &, const bool & ) {};
-        virtual void set_random_fault_of_type( const std::string &, const bool &, const bool & ) {};
+        virtual void set_fault( const fault_id, bool, bool ) {};
+        virtual void set_random_fault_of_type( const std::string, bool, bool ) {};
         virtual void set_mana_cur( int ) {}
         virtual void mod_daily_health( int, int ) {}
         virtual void mod_livestyle( int ) {}

--- a/src/talker.h
+++ b/src/talker.h
@@ -861,8 +861,8 @@ class talker: virtual public const_talker
         virtual void set_all_parts_hp_cur( int ) {}
         virtual void set_degradation( int ) {}
         virtual void die( map * ) {}
-        virtual void set_fault( const fault_id ) {};
-        virtual void set_random_fault_of_type( const std::string &, const bool & ) {};
+        virtual void set_fault( const fault_id, const bool &, const bool & ) {};
+        virtual void set_random_fault_of_type( const std::string &, const bool &, const bool & ) {};
         virtual void set_mana_cur( int ) {}
         virtual void mod_daily_health( int, int ) {}
         virtual void mod_livestyle( int ) {}

--- a/src/talker_item.cpp
+++ b/src/talker_item.cpp
@@ -174,7 +174,7 @@ void talker_item::set_fault( const fault_id &fault_id, bool force, bool message 
     me_it->set_fault( fault_id, force, message );
 }
 
-void talker_item::set_random_fault_of_type( const std::string & fault_type, bool force,
+void talker_item::set_random_fault_of_type( const std::string &fault_type, bool force,
         const bool message )
 {
     me_it->set_random_fault_of_type( fault_type, force, message );

--- a/src/talker_item.cpp
+++ b/src/talker_item.cpp
@@ -174,7 +174,8 @@ void talker_item::set_fault( const fault_id &fault_id, const bool force, const b
     me_it->set_fault( fault_id );
 }
 
-void talker_item::set_random_fault_of_type( const std::string &fault_type, const bool force, const bool message )
+void talker_item::set_random_fault_of_type( const std::string &fault_type, const bool force,
+        const bool message )
 {
     me_it->set_random_fault_of_type( fault_type, force, message );
 }

--- a/src/talker_item.cpp
+++ b/src/talker_item.cpp
@@ -171,7 +171,7 @@ void talker_item::die( map * )
 
 void talker_item::set_fault( const fault_id &fault_id, const bool force, const bool message )
 {
-    me_it->set_fault( fault_id );
+    me_it->set_fault( fault_id, force, message );
 }
 
 void talker_item::set_random_fault_of_type( const std::string &fault_type, const bool force,

--- a/src/talker_item.cpp
+++ b/src/talker_item.cpp
@@ -168,3 +168,13 @@ void talker_item::die( map * )
 {
     me_it->remove_item();
 }
+
+void talker_item::set_fault( const fault_id &fault_id, const bool force, const bool message )
+{
+    me_it->set_fault( fault_id );
+}
+
+void talker_item::set_random_fault_of_type( const std::string &fault_type, const bool force, const bool message )
+{
+    me_it->set_random_fault_of_type( fault_type, force, message );
+}

--- a/src/talker_item.cpp
+++ b/src/talker_item.cpp
@@ -169,12 +169,12 @@ void talker_item::die( map * )
     me_it->remove_item();
 }
 
-void talker_item::set_fault( const fault_id &fault_id, const bool force, const bool message )
+void talker_item::set_fault( const fault_id fault_id, bool force, bool message )
 {
     me_it->set_fault( fault_id, force, message );
 }
 
-void talker_item::set_random_fault_of_type( const std::string &fault_type, const bool force,
+void talker_item::set_random_fault_of_type( std::string fault_type, bool force,
         const bool message )
 {
     me_it->set_random_fault_of_type( fault_type, force, message );

--- a/src/talker_item.cpp
+++ b/src/talker_item.cpp
@@ -169,12 +169,12 @@ void talker_item::die( map * )
     me_it->remove_item();
 }
 
-void talker_item::set_fault( const fault_id fault_id, bool force, bool message )
+void talker_item::set_fault( const fault_id &fault_id, bool force, bool message )
 {
     me_it->set_fault( fault_id, force, message );
 }
 
-void talker_item::set_random_fault_of_type( std::string fault_type, bool force,
+void talker_item::set_random_fault_of_type( const std::string & fault_type, bool force,
         const bool message )
 {
     me_it->set_random_fault_of_type( fault_type, force, message );

--- a/src/talker_item.h
+++ b/src/talker_item.h
@@ -87,6 +87,9 @@ class talker_item: public talker_item_const, public talker_cloner<talker_item>
         void set_all_parts_hp_cur( int ) override;
         void set_degradation( int ) override;
         void die( map *here ) override;
+        void set_fault( const fault_id &fault_id, const bool force, const bool message );
+        void set_random_fault_of_type( const std::string &fault_type, const bool force,
+                                       const bool message );
 
     private:
         item_location *me_it{};

--- a/src/talker_item.h
+++ b/src/talker_item.h
@@ -87,8 +87,8 @@ class talker_item: public talker_item_const, public talker_cloner<talker_item>
         void set_all_parts_hp_cur( int ) override;
         void set_degradation( int ) override;
         void die( map *here ) override;
-        void set_fault( const fault_id &fault_id, bool force, bool message );
-        void set_random_fault_of_type( const std::string &fault_type, bool force, bool message );
+        void set_fault( const fault_id &fault_id, bool force, bool message ) override;
+        void set_random_fault_of_type( const std::string &fault_type, bool force, bool message ) override;
 
     private:
         item_location *me_it{};

--- a/src/talker_item.h
+++ b/src/talker_item.h
@@ -87,8 +87,8 @@ class talker_item: public talker_item_const, public talker_cloner<talker_item>
         void set_all_parts_hp_cur( int ) override;
         void set_degradation( int ) override;
         void die( map *here ) override;
-        void set_fault( const fault_id fault_id, bool force, bool message );
-        void set_random_fault_of_type( const std::string fault_type, bool force, bool message );
+        void set_fault( const fault_id &fault_id, bool force, bool message );
+        void set_random_fault_of_type( const std::string &fault_type, bool force, bool message );
 
     private:
         item_location *me_it{};

--- a/src/talker_item.h
+++ b/src/talker_item.h
@@ -87,8 +87,8 @@ class talker_item: public talker_item_const, public talker_cloner<talker_item>
         void set_all_parts_hp_cur( int ) override;
         void set_degradation( int ) override;
         void die( map *here ) override;
-        void set_fault( const fault_id &fault_id, bool force, bool message );
-        void set_random_fault_of_type( const std::string &fault_type, bool force, bool message );
+        void set_fault( const fault_id fault_id, bool force, bool message );
+        void set_random_fault_of_type( const std::string fault_type, bool force, bool message );
 
     private:
         item_location *me_it{};

--- a/src/talker_item.h
+++ b/src/talker_item.h
@@ -87,9 +87,8 @@ class talker_item: public talker_item_const, public talker_cloner<talker_item>
         void set_all_parts_hp_cur( int ) override;
         void set_degradation( int ) override;
         void die( map *here ) override;
-        void set_fault( const fault_id &fault_id, const bool force, const bool message );
-        void set_random_fault_of_type( const std::string &fault_type, const bool force,
-                                       const bool message );
+        void set_fault( const fault_id &fault_id, bool force, bool message );
+        void set_random_fault_of_type( const std::string &fault_type, bool force, bool message );
 
     private:
         item_location *me_it{};

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -1088,7 +1088,7 @@ void vehicle::unlock()
             vp.enabled = false;
         }
         if( vp.is_engine() ) {
-            vp.base.faults.erase( fault_engine_immobiliser );
+            vp.base.remove_fault( fault_engine_immobiliser );
         }
     }
 }

--- a/tests/item_tname_test.cpp
+++ b/tests/item_tname_test.cpp
@@ -1,5 +1,4 @@
 #include <memory>
-#include <set>
 #include <string>
 #include <vector>
 

--- a/tests/item_tname_test.cpp
+++ b/tests/item_tname_test.cpp
@@ -628,7 +628,7 @@ TEST_CASE( "weapon_fouling", "[item][tname][fouling][dirt]" )
         }
 
         WHEN( "it is fouled" ) {
-            gun.faults.insert( fault_gun_dirt );
+            gun.set_fault( fault_gun_dirt );
             REQUIRE( gun.has_fault( fault_gun_dirt ) );
 
             // Max dirt is 10,000


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Apparently i didn't finish all the stuff i wanted before making a proper PR for fault
#### Describe the solution
Clean up few fault functions that were not used
Make new helpert function to remove faults, switch all manual adding and removing faults to this helper functions
Expose applying faults to eoc
Make an item_location version for faults, so they can also print a message (item_loc is required since add_msg_if_player_sees() Requires a coordinate of an item to print a message), switch using this variant instead of `item` version where possible
Added a debug tool to apply faults, not very good, but i don't have experience nor will to deal with bespoke debug menu
Fixed a very annoying for me bug where malfunctioned gun forced you to spend time repairing it without your agreement - now it properly malfunction and takes you out of aiming instead of malfunctioning, spending 1 second fixing the gun, and only then snapping back from aiming
#### Testing
Walked to a water, applied EMP - electronic still fries as expected
used new tool, applied fault - works as expected
checked items with different faults, they still behave correctly
#### Additional context
I also tried to switch using item_loc variant of add_fault in handle_gun_damage, but apparently there was a few thing nailed to the `item` class, and dealing with it was out of scope of a PR