### PR TITLE
Adjust world sliders for actually different gameplay experiences

### DIFF
--- a/data/core/world_option_sliders.json
+++ b/data/core/world_option_sliders.json
@@ -4,46 +4,28 @@
     "id": "world_cities",
     "context": "WORLDGEN",
     "name": "Cities",
-    "default": 3,
+    "default": 1,
     "levels": [
       {
         "level": 0,
-        "name": "Remote",
-        "description": "Cities are basically non-existent.  Expect rural-only areas with rare tiny villages.",
-        "options": [ { "option": "CITY_SIZE", "type": "int", "val": 1 }, { "option": "CITY_SPACING", "type": "int", "val": 8 } ]
-      },
-      {
-        "level": 1,
         "name": "Rural",
         "description": "Cities are half as large and twice as far apart.",
         "options": [ { "option": "CITY_SIZE", "type": "int", "val": 4 }, { "option": "CITY_SPACING", "type": "int", "val": 8 } ]
       },
       {
-        "level": 2,
-        "name": "Semirural",
-        "description": "Cities are 25% smaller and 50% farther apart.",
-        "options": [ { "option": "CITY_SIZE", "type": "int", "val": 6 }, { "option": "CITY_SPACING", "type": "int", "val": 6 } ]
-      },
-      {
-        "level": 3,
+        "level": 1,
         "name": "Suburbia",
         "description": "Cities use default size and distances, with small to large cities separated by large rural areas.",
         "options": [ { "option": "CITY_SIZE", "type": "int", "val": 8 }, { "option": "CITY_SPACING", "type": "int", "val": 4 } ]
       },
       {
-        "level": 4,
-        "name": "Townscape",
-        "description": "Cities are 50% larger.",
-        "options": [ { "option": "CITY_SIZE", "type": "int", "val": 12 }, { "option": "CITY_SPACING", "type": "int", "val": 4 } ]
-      },
-      {
-        "level": 5,
+        "level": 2,
         "name": "Cityscape",
-        "description": "Cities are twice as large and 25% closer to each other.",
-        "options": [ { "option": "CITY_SIZE", "type": "int", "val": 16 }, { "option": "CITY_SPACING", "type": "int", "val": 3 } ]
+        "description": "Cities are 50% larger and 25% closer to each other.",
+        "options": [ { "option": "CITY_SIZE", "type": "int", "val": 12 }, { "option": "CITY_SPACING", "type": "int", "val": 3 } ]
       },
       {
-        "level": 6,
+        "level": 3,
         "name": "Megacity",
         "description": "Cities are nearly continuous, with minimal distance between them.",
         "options": [ { "option": "CITY_SIZE", "type": "int", "val": 16 }, { "option": "CITY_SPACING", "type": "int", "val": 1 } ]
@@ -55,7 +37,7 @@
     "id": "world_difficulty",
     "context": "WORLDGEN",
     "name": "Difficulty",
-    "default": 3,
+    "default": 2,
     "levels": [
       {
         "level": 0,
@@ -71,30 +53,18 @@
       },
       {
         "level": 1,
-        "name": "Be really nice to me",
-        "description": "Monsters are less tough; move, evolve and spawn slower; and items are a bit easier to come by.",
+        "name": "Be nice to me",
+        "description": "Monsters are weaker, appear in smaller numbers, and evolve at a slower rate.",
         "options": [
-          { "option": "MONSTER_SPEED", "type": "int", "val": 95 },
+          { "option": "MONSTER_SPEED", "type": "int", "val": 100 },
           { "option": "MONSTER_RESILIENCE", "type": "int", "val": 85 },
           { "option": "SPAWN_DENSITY", "type": "float", "val": 0.9 },
           { "option": "EVOLUTION_INVERSE_MULTIPLIER", "type": "float", "val": 1.5 },
-          { "option": "ITEM_SPAWNRATE", "type": "float", "val": 1.25 }
-        ]
-      },
-      {
-        "level": 2,
-        "name": "Be nice to me",
-        "description": "Monsters are a bit slower, and evolve at a slower rate.",
-        "options": [
-          { "option": "MONSTER_SPEED", "type": "int", "val": 95 },
-          { "option": "MONSTER_RESILIENCE", "type": "int", "val": 90 },
-          { "option": "SPAWN_DENSITY", "type": "float", "val": 1 },
-          { "option": "EVOLUTION_INVERSE_MULTIPLIER", "type": "float", "val": 1.25 },
           { "option": "ITEM_SPAWNRATE", "type": "float", "val": 1 }
         ]
       },
       {
-        "level": 3,
+        "level": 2,
         "name": "Cataclysm",
         "description": "The default monster hunting and item collecting experience.",
         "options": [
@@ -106,19 +76,19 @@
         ]
       },
       {
-        "level": 4,
+        "level": 3,
         "name": "Hurt me",
-        "description": "Monsters are a bit tougher and faster, and spawn 50% more.",
+        "description": "Monsters are stronger, appear 50% more often, and evolve faster.",
         "options": [
-          { "option": "MONSTER_SPEED", "type": "int", "val": 105 },
+          { "option": "MONSTER_SPEED", "type": "int", "val": 100 },
           { "option": "MONSTER_RESILIENCE", "type": "int", "val": 120 },
           { "option": "SPAWN_DENSITY", "type": "float", "val": 1.5 },
-          { "option": "EVOLUTION_INVERSE_MULTIPLIER", "type": "float", "val": 0.94 },
+          { "option": "EVOLUTION_INVERSE_MULTIPLIER", "type": "float", "val": 0.91 },
           { "option": "ITEM_SPAWNRATE", "type": "float", "val": 1 }
         ]
       },
       {
-        "level": 5,
+        "level": 4,
         "name": "Punish me",
         "description": "Monsters are significantly tougher and faster, spawn more, and evolve faster.  Items are a bit rarer too.",
         "options": [
@@ -130,7 +100,7 @@
         ]
       },
       {
-        "level": 6,
+        "level": 5,
         "name": "Punish me more!",
         "description": "Monsters are much tougher, extremely fast, and spawn 3x more.  Items are half as likely to spawn.",
         "options": [
@@ -148,34 +118,28 @@
     "id": "world_random_npcs",
     "context": "WORLDGEN",
     "name": "Random NPCs",
-    "default": 2,
+    "default": 1,
     "levels": [
       {
         "level": 0,
         "name": "Where is everyone?",
         "description": "You are very unlikely to encounter random NPCs.",
-        "options": [ { "option": "NPC_SPAWNTIME", "type": "float", "val": 12 } ]
+        "options": [ { "option": "NPC_SPAWNTIME", "type": "float", "val": 10 } ]
       },
       {
         "level": 1,
-        "name": "Empty world",
-        "description": "You are half as likely to encounter random NPCs.",
-        "options": [ { "option": "NPC_SPAWNTIME", "type": "float", "val": 8 } ]
-      },
-      {
-        "level": 2,
         "name": "Lonely",
         "description": "The default: NPCs are rare, but as expected in this ruined world.",
         "options": [ { "option": "NPC_SPAWNTIME", "type": "float", "val": 4 } ]
       },
       {
-        "level": 3,
+        "level": 2,
         "name": "Party time",
         "description": "You are twice as likely to encounter random NPCs.",
         "options": [ { "option": "NPC_SPAWNTIME", "type": "float", "val": 2 } ]
       },
       {
-        "level": 4,
+        "level": 3,
         "name": "Crowded",
         "description": "Random NPCs are fairly common.  Go meet some friends!",
         "options": [ { "option": "NPC_SPAWNTIME", "type": "float", "val": 1 } ]

--- a/tests/options_test.cpp
+++ b/tests/options_test.cpp
@@ -16,15 +16,19 @@ TEST_CASE( "option_slider_test", "[option]" )
     options_manager::options_container opts = get_options().get_world_defaults();
     options_manager::options_container old_opts = opts;
 
+    // Simple reused variables, for ease of updating the test.
+    const int num_slider_options = 7;
+    const int level_of_last_slider = num_slider_options - 1;
+
     const option_slider &slider = option_slider_test_world_difficulty.obj();
-    REQUIRE( slider.count() == 7 );
+    REQUIRE( slider.count() == num_slider_options );
 
     // check reordering
-    for( int i = 0; i < 7; i++ ) {
+    for( int i = 0; i < num_slider_options; i++ ) {
         REQUIRE( slider.level_name( i ).translated() == string_format( "TEST %d", i ) );
     }
 
-    const std::map<std::string, std::string> expected_3 {
+    const std::map<std::string, std::string> expected_default_lvl3 {
         { "MONSTER_SPEED", "100%" },
         { "MONSTER_RESILIENCE", "100%" },
         { "SPAWN_DENSITY", "1.00" },
@@ -34,7 +38,7 @@ TEST_CASE( "option_slider_test", "[option]" )
         { "ETERNAL_TIME_OF_DAY", "normal" }
     };
 
-    const std::map<std::string, std::string> expected_6 {
+    const std::map<std::string, std::string> expected_highest_difficulty_lvl6 {
         { "MONSTER_SPEED", "120%" },
         { "MONSTER_RESILIENCE", "200%" },
         { "SPAWN_DENSITY", "3.00" },
@@ -48,36 +52,36 @@ TEST_CASE( "option_slider_test", "[option]" )
     int checked = 0;
     for( const auto &opt : opts ) {
         CHECK( opt.second == old_opts.at( opt.first ) );
-        const auto iter = expected_3.find( opt.first );
-        if( iter != expected_3.end() ) {
+        const auto iter = expected_default_lvl3.find( opt.first );
+        if( iter != expected_default_lvl3.end() ) {
             CHECK( opt.second.getValue() == iter->second );
             checked++;
         }
     }
-    CHECK( checked == 7 );
+    CHECK( checked == num_slider_options );
 
     // check modified
-    slider.apply_opts( 6, opts );
+    slider.apply_opts( level_of_last_slider, opts );
     checked = 0;
     for( const auto &opt : opts ) {
-        const auto iter = expected_6.find( opt.first );
-        if( iter != expected_6.end() ) {
+        const auto iter = expected_highest_difficulty_lvl6.find( opt.first );
+        if( iter != expected_highest_difficulty_lvl6.end() ) {
             CHECK( opt.second.getValue() == iter->second );
             checked++;
         }
     }
-    CHECK( checked == 7 );
+    CHECK( checked == num_slider_options );
 
     // check defaults
     slider.apply_opts( 3, opts );
     checked = 0;
     for( const auto &opt : opts ) {
         CHECK( opt.second == old_opts.at( opt.first ) );
-        const auto iter = expected_3.find( opt.first );
-        if( iter != expected_3.end() ) {
+        const auto iter = expected_default_lvl3.find( opt.first );
+        if( iter != expected_default_lvl3.end() ) {
             CHECK( opt.second.getValue() == iter->second );
             checked++;
         }
     }
-    CHECK( checked == 7 );
+    CHECK( checked == num_slider_options );
 }


### PR DESCRIPTION
#### Summary
Balance "World sliders rebalanced to offer differing gameplay experiences"

#### Purpose of change
On the heels of #79310, I am looking at the world sliders and see we have multiple, redundant options for our slider options. We have **seven** difficulty levels. Seven. C'mon, seven?

#### Describe the solution
Trim the fat.

City size and spacing:
Remove remote, semirural, and townscape. "Remote" is redundant with the Innawoods mod, so it got the chop without much further consideration.

The options are now rural, default, big cities, and MEGACITIES. There is a clear progression of options, and each one is significantly different. 'Cityscape' copied the removed townscape's city size, reducing in size from 16(max) to 12. This also makes megacities more obviously mega.

Difficulty:
Remove "Be really nice to me". We don't need three different "easy modes".

Eliminate monster speed scaling from "Be really nice to me" and "Hurt me". Speed scaling is **extraordinarily impactful**, even the previous 5% speed loss on monsters grossly warped the balance of the game. Therefore speed scaling is only present on the 'very easy' and 'very hard' options. Resilience and evolution scaling were tweaked a bit to make a good 'difficulty curve'.

Random NPCs:
Remove "Empty world", reduce the scaling on the least-NPCs option ("Where is everyone?").

NPCs are intended to be an important part of the game and having an option which largely 'turns them off' is honestly bad, I would be interested in removing the lower scaling altogether.

#### Describe alternatives you've considered
Several.

I am still of the opinion that we could remove all the world sliders and be better off for it, but if we must have them I think they should be as good as possible.

We still have six difficulty options, which is like... three too many, at least. We could trim more there, or at least differentiate the hard modes into "less items", "harder monsters", and "both, plus it's harder in every way".

The name scaling (e.g. "Be nice to me." --> "Be really nice to me.") was fun at least. I would've kept it if it could make thematic sense with fewer options.

#### Testing
Load game, play with the sliders, start world. The slider UI still works and the changes to slider values are just numerical, so besides spot checking the options there's not much to test.

#### Additional context
