### PR TITLE
put vehicles inbound

### DIFF
--- a/data/json/mapgen/nested/road_vehicles_nested.json
+++ b/data/json/mapgen/nested/road_vehicles_nested.json
@@ -589,7 +589,7 @@
     "object": {
       "mapgensize": [ 24, 24 ],
       "rotation": [ 0 ],
-      "place_nested": [ { "chunks": [ "24x24_road_vehicles_country_out_of_fuel_north_north_facing" ], "x": 0, "y": 12 } ]
+      "place_nested": [ { "chunks": [ "24x24_road_vehicles_country_out_of_fuel_north_north_facing" ], "x": 0, "y": 7 } ]
     }
   },
   {
@@ -599,7 +599,7 @@
     "object": {
       "mapgensize": [ 24, 24 ],
       "rotation": [ 0 ],
-      "place_nested": [ { "chunks": [ "24x24_road_vehicles_country_out_of_fuel_north_south_facing" ], "x": 0, "y": 12 } ]
+      "place_nested": [ { "chunks": [ "24x24_road_vehicles_country_out_of_fuel_north_south_facing" ], "x": 0, "y": 7 } ]
     }
   },
   {
@@ -609,7 +609,7 @@
     "object": {
       "mapgensize": [ 24, 24 ],
       "rotation": [ 0 ],
-      "place_nested": [ { "chunks": [ "24x24_road_vehicles_country_out_of_fuel_west_east_facing" ], "x": 12, "y": 0 } ]
+      "place_nested": [ { "chunks": [ "24x24_road_vehicles_country_out_of_fuel_west_east_facing" ], "x": 7, "y": 0 } ]
     }
   },
   {
@@ -619,7 +619,7 @@
     "object": {
       "mapgensize": [ 24, 24 ],
       "rotation": [ 0 ],
-      "place_nested": [ { "chunks": [ "24x24_road_vehicles_country_out_of_fuel_west_west_facing" ], "x": 12, "y": 0 } ]
+      "place_nested": [ { "chunks": [ "24x24_road_vehicles_country_out_of_fuel_west_west_facing" ], "x": 7, "y": 0 } ]
     }
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Place vehicles fully inside their OMTs to avoid weird errors. Part of #80556.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Don't perform the disgusting offset of 24x24 chunks further than the vehicle bounding box for the vehicle set allows without jutting out of the OMT. This means cutting the offsets down from 12 to 7 (it could probably be increased to 9 if front heavy vehicles were redefined to fit within the bounding box of the flatbed truck).

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
- Just let it fester.
- Also redefine the chunks so they match the vehicle bounding boxes to clearly indicate what the bounds are.
- Redefine military vehicles to fit within the flatbed truck bounding box. Note that these vehicles might not be only ones bloating the vehicle group bounding boxes.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Increasing the weight of one of the affected chunks to 10000 (from 1) and teleported along previously unviewed roads observe the vehicles. Nothing odd seen (such as non scripted vehicle collisions), but OMT boundaries aren't clearly visible, and there's certainly no chance to cover all possible combinations.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
There's a chance this might cause placement of a minefield with vehicles over road tile vehicles to just result in a weird mess rather than a crash (at least some of the time). However, it could still result in a crash if the wrecking can cause vehicle sections to be pushed away like individual parts can. That's no excuse not to fix placement of map extra vehicles on top of base map generated vehicles, though, as a weird wreck mess is still bad.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
