### PR TITLE
Add mod src info to effect info

### DIFF
--- a/src/effect.cpp
+++ b/src/effect.cpp
@@ -994,8 +994,6 @@ std::string effect::disp_desc( bool reduced ) const
             ret += tmp_str;
         }
     }
-    ret +='\n';
-    ret += get_origin( eff_type->src );
     if( debug_mode ) {
         ret += string_format(
                    _( "\nDEBUG: ID: <color_white>%s</color> Intensity: <color_white>%d</color>" ),
@@ -1020,6 +1018,10 @@ std::string effect::disp_short_desc( bool reduced ) const
             return eff_type->desc[0].translated();
         }
     }
+}
+std::string effect::disp_mod_source_info() const
+{
+    return get_origin( eff_type->src );
 }
 
 static bool effect_is_blocked( const efftype_id &e, const effects_map &eff_map )

--- a/src/effect.cpp
+++ b/src/effect.cpp
@@ -20,6 +20,7 @@
 #include "json.h"
 #include "magic_enchantment.h"
 #include "messages.h"
+#include "mod_manager.h"
 #include "output.h"
 #include "rng.h"
 #include "string_formatter.h"
@@ -993,7 +994,8 @@ std::string effect::disp_desc( bool reduced ) const
             ret += tmp_str;
         }
     }
-
+    ret +='\n';
+    ret += get_origin( eff_type->src );
     if( debug_mode ) {
         ret += string_format(
                    _( "\nDEBUG: ID: <color_white>%s</color> Intensity: <color_white>%d</color>" ),
@@ -1607,6 +1609,7 @@ void load_effect_type( const JsonObject &jo, const std::string_view src )
                                        enchant_num++ );
         new_etype.enchantments.push_back( enchantment::load_inline_enchantment( jv, src, enchant_name ) );
     }
+    mod_tracker::assign_src(new_etype, src);
     effect_types[new_etype.id] = new_etype;
 }
 

--- a/src/effect.cpp
+++ b/src/effect.cpp
@@ -21,6 +21,7 @@
 #include "magic_enchantment.h"
 #include "messages.h"
 #include "mod_manager.h"
+#include "mod_tracker.h"
 #include "output.h"
 #include "rng.h"
 #include "string_formatter.h"

--- a/src/effect.cpp
+++ b/src/effect.cpp
@@ -1611,7 +1611,7 @@ void load_effect_type( const JsonObject &jo, const std::string_view src )
                                        enchant_num++ );
         new_etype.enchantments.push_back( enchantment::load_inline_enchantment( jv, src, enchant_name ) );
     }
-    mod_tracker::assign_src(new_etype, src);
+    mod_tracker::assign_src( new_etype, src );
     effect_types[new_etype.id] = new_etype;
 }
 

--- a/src/effect.h
+++ b/src/effect.h
@@ -105,6 +105,7 @@ class effect_type
 {
         friend void load_effect_type( const JsonObject &jo, std::string_view src );
         friend class effect;
+        friend struct mod_tracker;
     public:
         enum class memorial_gender : int {
             male,
@@ -246,6 +247,8 @@ class effect_type
         std::vector<effect_dur_mod> effect_dur_scaling;
         std::vector<std::pair<int, int>> kill_chance;
         std::vector<std::pair<int, int>> red_kill_chance;
+
+        std::vector<std::pair<efftype_id, mod_id>> src;
 };
 
 class effect;

--- a/src/effect.h
+++ b/src/effect.h
@@ -293,6 +293,9 @@ class effect
         std::string disp_desc( bool reduced = false ) const;
         /** Returns the short description as set in json. */
         std::string disp_short_desc( bool reduced = false ) const;
+        /** Returns the mod source info. */
+        std::string disp_mod_source_info() const;
+
         /** Returns true if a description will be formatted as "Your" + body_part + description. */
         bool use_part_descs() const;
 

--- a/src/medical_ui.cpp
+++ b/src/medical_ui.cpp
@@ -525,7 +525,7 @@ static medical_column draw_effects_summary( const int column_count, Character &y
         if( name.empty() ) {
             continue;
         }
-        effects_column.add_column_line( selection_line( name, eff.disp_desc(), max_width ) );
+        effects_column.add_column_line( selection_line( name, eff.disp_desc()+'\n'+eff.disp_mod_source_info(), max_width ) );
     }
 
     const float bmi = you.get_bmi_fat();

--- a/src/medical_ui.cpp
+++ b/src/medical_ui.cpp
@@ -525,7 +525,8 @@ static medical_column draw_effects_summary( const int column_count, Character &y
         if( name.empty() ) {
             continue;
         }
-        effects_column.add_column_line( selection_line( name, eff.disp_desc()+'\n'+eff.disp_mod_source_info(), max_width ) );
+        effects_column.add_column_line( selection_line( name,
+                                        eff.disp_desc() + '\n' + eff.disp_mod_source_info(), max_width ) );
     }
 
     const float bmi = you.get_bmi_fat();

--- a/src/player_display.cpp
+++ b/src/player_display.cpp
@@ -1548,7 +1548,7 @@ void Character::disp_info( bool customize_character )
     for( auto &elem : *effects ) {
         for( auto &_effect_it : elem.second ) {
             const std::string name = _effect_it.second.disp_name();
-            effect_name_and_text.emplace_back( name, _effect_it.second.disp_desc() );
+            effect_name_and_text.emplace_back( name, _effect_it.second.disp_desc()+'\n'+_effect_it.second.disp_mod_source_info() );
         }
     }
     if( get_perceived_pain() > 0 ) {

--- a/src/player_display.cpp
+++ b/src/player_display.cpp
@@ -1548,7 +1548,8 @@ void Character::disp_info( bool customize_character )
     for( auto &elem : *effects ) {
         for( auto &_effect_it : elem.second ) {
             const std::string name = _effect_it.second.disp_name();
-            effect_name_and_text.emplace_back( name, _effect_it.second.disp_desc()+'\n'+_effect_it.second.disp_mod_source_info() );
+            effect_name_and_text.emplace_back( name,
+                                               _effect_it.second.disp_desc() + '\n' + _effect_it.second.disp_mod_source_info() );
         }
     }
     if( get_perceived_pain() > 0 ) {

--- a/src/wish.cpp
+++ b/src/wish.cpp
@@ -498,6 +498,7 @@ void debug_menu::wisheffect( Creature &p )
         {
             descstr << eff.disp_desc( false ) << '\n';
         }
+        descstr << eff.disp_mod_source_info() << '\n';
 
         return descstr.str();
     };


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "Add mod src info to effect info"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Sometimes some players I know don't know which mod provides an effect they don‘t want, and need to look up the json data to determine which mod should be disabled in the new world's mod settings. It would be more convenient if the mod source of the effect could be displayed in the effect's info.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add a src member to effect_type; use mod_tracker::assign_src to initialize src; use get_origin to get the mod source string.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
None
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
In character menu effect info, mod source info are displayed normally.
In DEBUG menu -> add effect menu, mod source info are displayed normally.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
