### PR TITLE
eoc/json: don't use string comparison for numbers

### DIFF
--- a/data/json/npcs/Lighthouse_Family/NPC_lighthouse_man.json
+++ b/data/json/npcs/Lighthouse_Family/NPC_lighthouse_man.json
@@ -140,11 +140,7 @@
         "text": "Yes.  First floor is clear.",
         "topic": "TALK_lighthouse_man_cleaned",
         "condition": {
-          "and": [
-            { "compare_string": [ "1", { "npc_val": "count_cleaning_lighthouse_man" } ] },
-            "at_safe_space",
-            { "npc_at_om_location": "lighthouse_z1" }
-          ]
+          "and": [ { "math": [ "n_count_cleaning_lighthouse_man == 1 " ] }, "at_safe_space", { "npc_at_om_location": "lighthouse_z1" } ]
         },
         "effect": { "math": [ "n_count_cleaning_lighthouse_man++" ] }
       },
@@ -152,11 +148,7 @@
         "text": "Yes.  Second floor is clear.",
         "topic": "TALK_lighthouse_man_cleaned",
         "condition": {
-          "and": [
-            { "compare_string": [ "2", { "npc_val": "count_cleaning_lighthouse_man" } ] },
-            "at_safe_space",
-            { "npc_at_om_location": "lighthouse_z2" }
-          ]
+          "and": [ { "math": [ "n_count_cleaning_lighthouse_man == 2 " ] }, "at_safe_space", { "npc_at_om_location": "lighthouse_z2" } ]
         },
         "effect": { "math": [ "n_count_cleaning_lighthouse_man++" ] }
       },
@@ -164,11 +156,7 @@
         "text": "Yes.  Third floor is clear.",
         "topic": "TALK_lighthouse_man_cleaned",
         "condition": {
-          "and": [
-            { "compare_string": [ "3", { "npc_val": "count_cleaning_lighthouse_man" } ] },
-            "at_safe_space",
-            { "npc_at_om_location": "lighthouse_z3" }
-          ]
+          "and": [ { "math": [ "n_count_cleaning_lighthouse_man == 3 " ] }, "at_safe_space", { "npc_at_om_location": "lighthouse_z3" } ]
         },
         "effect": { "math": [ "n_count_cleaning_lighthouse_man++" ] }
       },
@@ -176,22 +164,14 @@
         "text": "Yes.  Fourth floor is clear.",
         "topic": "TALK_lighthouse_man_cleaned",
         "condition": {
-          "and": [
-            { "compare_string": [ "4", { "npc_val": "count_cleaning_lighthouse_man" } ] },
-            "at_safe_space",
-            { "npc_at_om_location": "lighthouse_z4" }
-          ]
+          "and": [ { "math": [ "n_count_cleaning_lighthouse_man == 4 " ] }, "at_safe_space", { "npc_at_om_location": "lighthouse_z4" } ]
         },
         "effect": { "math": [ "n_count_cleaning_lighthouse_man++" ] }
       },
       {
         "text": "Yes.  Top floor is clear.",
         "condition": {
-          "and": [
-            { "compare_string": [ "5", { "npc_val": "count_cleaning_lighthouse_man" } ] },
-            "at_safe_space",
-            { "npc_at_om_location": "lighthouse_z5" }
-          ]
+          "and": [ { "math": [ "n_count_cleaning_lighthouse_man == 5 " ] }, "at_safe_space", { "npc_at_om_location": "lighthouse_z5" } ]
         },
         "effect": { "math": [ "n_count_cleaning_lighthouse_man++" ] },
         "topic": "TALK_lighthouse_man_cleaned_done"
@@ -200,7 +180,7 @@
         "text": "Looks like that's over.",
         "condition": {
           "and": [
-            { "compare_string": [ "6", { "npc_val": "count_cleaning_lighthouse_man" } ] },
+            { "math": [ "n_count_cleaning_lighthouse_man == 6 " ] },
             "at_safe_space",
             { "npc_at_om_location": "lighthouse_ground" }
           ]
@@ -340,7 +320,7 @@
     "name": { "str": "House cleaning" },
     "description": "Clean lighthouse from <zombies> with Mikhail.",
     "goal": "MGOAL_CONDITION",
-    "goal_condition": { "compare_string": [ "7", { "npc_val": "count_cleaning_lighthouse_man" } ] },
+    "goal_condition": { "math": [ "n_count_cleaning_lighthouse_man == 7 " ] },
     "difficulty": 0,
     "value": 5000,
     "start": {

--- a/data/json/npcs/refugee_center/surface_refugees/NPC_Draco_Dune.json
+++ b/data/json/npcs/refugee_center/surface_refugees/NPC_Draco_Dune.json
@@ -97,25 +97,20 @@
         "text": "Hi, Draco, how are you doing?",
         "condition": {
           "and": [
-            { "not": { "compare_string": [ "3", { "u_val": "general_meeting_Draco_Dune_convo_depth" } ] } },
-            { "not": { "compare_string": [ "7", { "u_val": "general_meeting_Draco_Dune_convo_depth" } ] } }
+            { "math": [ "u_general_meeting_Draco_Dune_convo_depth != 3 " ] },
+            { "math": [ "u_general_meeting_Draco_Dune_convo_depth != 7 " ] }
           ]
         },
         "topic": "TALK_REFUGEE_Draco_2"
       },
       {
         "text": "Hi again, Draco, nice to see you too.",
-        "condition": {
-          "and": [
-            { "compare_string": [ "3", { "u_val": "general_meeting_Draco_Dune_convo_depth" } ] },
-            { "not": { "compare_string": [ "7", { "u_val": "general_meeting_Draco_Dune_convo_depth" } ] } }
-          ]
-        },
+        "condition": { "math": [ "u_general_meeting_Draco_Dune_convo_depth == 3 " ] },
         "topic": "TALK_REFUGEE_Draco_5a"
       },
       {
         "text": "Hi again, Draco, nice to see you too.",
-        "condition": { "compare_string": [ "7", { "u_val": "general_meeting_Draco_Dune_convo_depth" } ] },
+        "condition": { "math": [ "u_general_meeting_Draco_Dune_convo_depth == 7 " ] },
         "topic": "TALK_REFUGEE_Draco_7"
       },
       { "text": "Hi Draco, nice to see you too.  <end_talking_leave>", "topic": "TALK_DONE" }

--- a/data/json/npcs/robofac/NPC_Cranberry_Foster.json
+++ b/data/json/npcs/robofac/NPC_Cranberry_Foster.json
@@ -278,7 +278,7 @@
         "condition": {
           "and": [
             { "compare_string": [ "yes", { "u_val": "dialogue_robofac_merc_1_robofac_merc_1_HWP" } ] },
-            { "compare_string": [ "1", { "u_val": "favor_owed_to_u_robofac_merc_1_favor" } ] },
+            { "math": [ "u_favor_owed_to_u_robofac_merc_1_favor == 1 " ] },
             { "not": { "compare_string": [ "yes", { "u_val": "dialogue_hub_rnd_u_can_research_rifle" } ] } }
           ]
         },
@@ -289,7 +289,7 @@
         "condition": {
           "and": [
             { "compare_string": [ "yes", { "u_val": "dialogue_robofac_merc_1_robofac_merc_1_HWP" } ] },
-            { "not": { "compare_string": [ "1", { "u_val": "favor_owed_to_u_robofac_merc_1_favor" } ] } },
+            { "math": [ "u_favor_owed_to_u_robofac_merc_1_favor != 1 " ] },
             { "not": { "compare_string": [ "yes", { "u_val": "dialogue_hub_rnd_u_can_research_rifle" } ] } }
           ]
         },
@@ -457,7 +457,7 @@
       { "text": "Damn.  Where can I get one of those?", "topic": "TALK_ROBOFAC_MERC_1_HWP_EXPLANATION_WHERE" },
       {
         "text": "I've helped you out now.  Do you think you could vouch for me with our employers?",
-        "condition": { "compare_string": [ "1", { "u_val": "favor_owed_to_u_robofac_merc_1_favor" } ] },
+        "condition": { "math": [ "u_favor_owed_to_u_robofac_merc_1_favor == 1 " ] },
         "topic": "TALK_ROBOFAC_MERC_1_HWP_YES"
       },
       { "text": "I see.", "topic": "TALK_ROBOFAC_MERC_1_MAIN" }


### PR DESCRIPTION
#### Summary
None


#### Purpose of change
There are still some places where `"compare_string"` is used to compare variables that are not string.
- Fixup for #80455
- Fixes: #80655

#### Describe the solution
Replace `compare_string` with `math` for cases that match `compare_string": \[.*"[0-9]`

#### Describe alternatives you've considered
N/A

#### Testing
Can't reproduce #80655 anymore

Talking to Cranberry doesn't produce any errors and the dialogue seems to work correctly.

The Fisherman's quest to clear all the floors of zombies seems to work correctly. There are some oddities in the dialogue logic there, but variable use works correctly.

#### Additional context
N/A