### PR TITLE
Fix WearMan

### DIFF
--- a/data/json/bionics.json
+++ b/data/json/bionics.json
@@ -801,8 +801,12 @@
     "name": { "str": "WearMan" },
     "description": "Surgically implanted into your skull near the eardrums are two speakers, as well as a small port behind the left earlobe.  They can pick up local radio waves and play downloaded music in concert hall quality.  It came pre-installed with \"Rubik's Mickse\".",
     "occupied_bodyparts": [ [ "head", 1 ] ],
-    "flags": [ "USES_BIONIC_POWER" ],
-    "passive_pseudo_items": [ "internal_mp3" ]
+    "flags": [ "USES_BIONIC_POWER", "BIONIC_TOGGLED" ],
+    "act_cost": "1 J",
+    "react_cost": "1 J",
+    "time": "1 s",
+    "activated_eocs": [ "EOC_BIONIC_WEARMAN_SELECTOR" ],
+    "deactivated_eocs": [ "EOC_BIONIC_WEARMAN_REMOVAL" ]
   },
   {
     "id": "bio_voice_b",

--- a/data/json/effects_on_condition/bionic_eocs.json
+++ b/data/json/effects_on_condition/bionic_eocs.json
@@ -153,5 +153,47 @@
     "id": "EOC_BIO_SONAR_deactivated",
     "condition": { "u_has_effect": "subaquatic_sonar" },
     "effect": [ { "u_lose_effect": "subaquatic_sonar" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_BIONIC_WEARMAN_SELECTOR",
+    "effect": [
+      {
+        "run_eoc_selector": [ "EOC_BIONIC_WEARMAN_ACTIVATE_MUSIC", "EOC_BIONIC_WEARMAN_ACTIVATE_RADIO" ],
+        "allow_cancel": true,
+        "names": [ "Music", "Radio" ],
+        "title": "Pick the action",
+        "descriptions": [ "Activate the WearMan in music mode.", "Activate the WearMan in radio mode." ]
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_BIONIC_WEARMAN_ACTIVATE_MUSIC",
+    "effect": [
+      { "u_spawn_item": "internal_mp3_music_group", "suppress_message": true, "force_equip": true, "use_item_group": true }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "internal_mp3_music_group",
+    "items": [ { "item": "internal_mp3_music", "active": true } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_BIONIC_WEARMAN_ACTIVATE_RADIO",
+    "effect": [
+      { "u_spawn_item": "internal_mp3_radio_group", "suppress_message": true, "force_equip": true, "use_item_group": true }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "internal_mp3_radio_group",
+    "items": [ { "item": "internal_mp3_radio", "active": true } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_BIONIC_WEARMAN_REMOVAL",
+    "effect": [ { "u_remove_item_with": "internal_mp3_music" }, { "u_remove_item_with": "internal_mp3_radio" } ]
   }
 ]

--- a/data/json/items/fake.json
+++ b/data/json/items/fake.json
@@ -96,7 +96,7 @@
         "menu_text": "Turn off the radio",
         "msg": "You turn off the radio.",
         "type": "transform",
-        "active": true,
+        "active": false,
         "need_charges": 1,
         "need_charges_msg": "You're out of juice, recharge and you'll be hot to go."
       }

--- a/data/json/items/fake.json
+++ b/data/json/items/fake.json
@@ -41,69 +41,22 @@
     "qualities": [ [ "DIG", 2 ] ]
   },
   {
-    "id": "internal_mp3",
-    "type": "TOOL_ARMOR",
-    "copy-from": "fake_item",
-    "name": { "str": "WearMan" },
-    "description": "A set of speakers implanted into your skull, that can receive local radiowaves and play downloaded music at a concert hall quality.  It comes with \"Rubik's Mickse\" preloaded.  Activate it to start playing some tunes.",
-    "use_action": [
-      {
-        "target": "internal_mp3_music",
-        "menu_text": "Play music",
-        "msg": "Your ears are alive with the sound of music.",
-        "type": "transform",
-        "active": true,
-        "need_charges": 1,
-        "need_charges_msg": "You're out of juice, recharge and you'll be hot to go."
-      }
-    ],
-    "charges_per_use": 1,
-    "flags": [ "INTEGRATED", "UNBREAKABLE", "PERSONAL", "NO_REPAIR", "ALLOWS_NATURAL_ATTACKS", "USES_BIONIC_POWER" ]
-  },
-  {
     "id": "internal_mp3_music",
     "type": "TOOL_ARMOR",
     "copy-from": "fake_item",
-    "name": { "str": "WearMan" },
-    "description": "A set of speakers implanted into your skull, that can receive local radiowaves and play downloaded music at a concert hall quality.  It is currently playing \"Rubik's Mickse\".  Activate it to find the Spirit of the Radio.",
-    "use_action": [
-      {
-        "target": "internal_mp3_radio",
-        "menu_text": "Switch to radio",
-        "msg": "You switch your WearMan to the radio.",
-        "type": "transform",
-        "active": true,
-        "need_charges": 1,
-        "need_charges_msg": "You're out of juice, recharge and you'll be hot to go."
-      }
-    ],
-    "charges_per_use": 1,
-    "flags": [ "INTEGRATED", "UNBREAKABLE", "PERSONAL", "NO_REPAIR", "ALLOWS_NATURAL_ATTACKS", "USES_BIONIC_POWER" ],
-    "power_draw": "1 W",
-    "revert_to": "internal_mp3",
+    "name": { "str": "WearMan Music" },
+    "description": "A set of speakers implanted into your skull, that can receive local radiowaves and play downloaded music at a concert hall quality.  It is currently playing \"Rubik's Mickse\".",
+    "flags": [ "INTEGRATED", "UNBREAKABLE", "PERSONAL", "NO_REPAIR", "ALLOWS_NATURAL_ATTACKS" ],
     "tick_action": [ "MP3_ON" ]
   },
   {
     "id": "internal_mp3_radio",
     "type": "TOOL_ARMOR",
     "copy-from": "fake_item",
-    "name": { "str": "WearMan" },
-    "description": "A set of speakers implanted into your skull, that can receive local radiowaves and play downloaded music at a concert hall quality.  It is currently playing \"Rubik's Mickse\".  Activate it to turn it off.",
-    "use_action": [
-      "RADIO_ON",
-      {
-        "target": "internal_mp3",
-        "menu_text": "Turn off the radio",
-        "msg": "You turn off the radio.",
-        "type": "transform",
-        "active": false,
-        "need_charges": 1,
-        "need_charges_msg": "You're out of juice, recharge and you'll be hot to go."
-      }
-    ],
-    "flags": [ "INTEGRATED", "UNBREAKABLE", "PERSONAL", "NO_REPAIR", "ALLOWS_NATURAL_ATTACKS", "USES_BIONIC_POWER" ],
-    "power_draw": "1 W",
-    "revert_to": "internal_mp3",
+    "name": { "str": "WearMan Radio" },
+    "description": "A set of speakers implanted into your skull, that can receive local radiowaves and play downloaded music at a concert hall quality.  It is currently listening to the radio.",
+    "use_action": [ "RADIO_ON" ],
+    "flags": [ "INTEGRATED", "UNBREAKABLE", "PERSONAL", "NO_REPAIR", "ALLOWS_NATURAL_ATTACKS" ],
     "tick_action": [ "RADIO_TICK" ]
   },
   {

--- a/data/json/obsoletion_and_migration_0.I/migration_items.json
+++ b/data/json/obsoletion_and_migration_0.I/migration_items.json
@@ -2493,5 +2493,10 @@
     "id": "u_shotgun_mod",
     "type": "MIGRATION",
     "replace": "u_shotgun"
+  },
+  {
+    "id": "internal_mp3",
+    "type": "MIGRATION",
+    "replace": "manual_swimming"
   }
 ]

--- a/data/mods/Xedra_Evolved/items/armor/integrated.json
+++ b/data/mods/Xedra_Evolved/items/armor/integrated.json
@@ -966,7 +966,7 @@
     "charges_per_use": 0,
     "flags": [ "INTEGRATED", "UNBREAKABLE", "PERSONAL", "NO_REPAIR", "ALLOWS_NATURAL_ATTACKS" ],
     "power_draw": "0 W",
-    "revert_to": "internal_mp3",
+    "revert_to": "corpse_ash",
     "tick_action": [ "MP3_ON" ]
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Fix WearMan"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Fixes #76459
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

~~Change the transform on the radio from `"active": true` to `"active": false`~~

While working on this I did notice an unreported problem where if you save and quit while the WearMan is active, when reloading you have your active WearMan and a second, inactive WearMan. I assume this is because the bionic has `"passive_pseudo_items": [ "internal_mp3" ]` and gives you another one if you have `internal_mp3_music` or `internal_mp3_radio` instead. As such, I totally redid how it works.

Now you have no items when the WearMan is off. When you turn it on, you get the option to use the radio, or the music. Each one spawns a dummy item to run the `tick_action` which is deleted when the WearMan is turned off or powers down. These items are mostly non-interactive (though the radio one lets you switch channels). 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Radio functions properly.
Music functions properly.
Turning the WearMan on lets you pick an option and turning it off deletes the item from the option you picked.
The WearMan draws power and turns off when it runs out of power.
The previous default WearMan item was deleted and migrated.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

XE tag is because an item in XE was set to revert to the default WearMan item (which has been deleted). 
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
