### PR TITLE
remove u_lose_faction_trust

### DIFF
--- a/doc/JSON/EFFECT_ON_CONDITION.md
+++ b/doc/JSON/EFFECT_ON_CONDITION.md
@@ -4082,10 +4082,6 @@ adds [ your strength stat ] amount of faction trust
 { "u_add_faction_trust": { "math": [ "u_val('strength')" ] } }
 ```
 
-
-#### `u_lose_faction_trust`
-same as `u_add_faction_trust`, not used in favor of `u_add_faction_trust` with negative number
-
 #### `u_message`, `npc_message`, `message`
 Display a text message in the log. `u_message` and `npc_message` display a message only if you or NPC is avatar. `message` always displays a message.
 

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -7001,15 +7001,6 @@ talk_effect_fun_t::func f_add_faction_trust( const JsonObject &jo, std::string_v
     };
 }
 
-talk_effect_fun_t::func f_lose_faction_trust( const JsonObject &jo,
-        std::string_view member, std::string_view )
-{
-    dbl_or_var dov = get_dbl_or_var( jo, member );
-    return [dov]( dialogue & d ) {
-        d.actor( true )->get_faction()->trusts_u -= dov.evaluate( d );
-    };
-}
-
 talk_effect_fun_t::func f_custom_light_level( const JsonObject &jo,
         std::string_view member, std::string_view )
 {
@@ -7888,7 +7879,6 @@ parsers = {
     { "location_variable_adjust", jarg::member, &talk_effect_fun::f_location_variable_adjust },
     { "u_buy_monster", jarg::member, &talk_effect_fun::f_u_buy_monster },
     { "u_add_faction_trust", jarg::member | jarg::array, &talk_effect_fun::f_add_faction_trust },
-    { "u_lose_faction_trust", jarg::member | jarg::array, &talk_effect_fun::f_lose_faction_trust },
     { "npc_first_topic", jarg::member, &talk_effect_fun::f_npc_first_topic },
     { "sound_effect", jarg::member, &talk_effect_fun::f_sound_effect },
     { "give_achievement", jarg::member, &talk_effect_fun::f_give_achievment },


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
It was never used, and using `u_add_faction_trust` with negative number was
#### Describe the solution
Remove u_lose_faction_trust
#### Describe alternatives you've considered
Also rename `u_add_faction_trust` to something like `u_mod_faction_trust`