### PR TITLE
Manually define electronic faults in item def

### DIFF
--- a/data/json/faults/fault_groups_electronics.json
+++ b/data/json/faults/fault_groups_electronics.json
@@ -1,0 +1,13 @@
+[
+  {
+    "type": "fault_group",
+    "id": "electronic_general",
+    "//": "faults that can happen when item is dropped into the water or fried by EMP. If GAME_EMP option is used, EMP can only apply fault_emp_reboot",
+    "group": [
+      { "fault": "fault_electronic_blown_fuse" },
+      { "fault": "fault_electronic_blown_capacitor" },
+      { "fault": "fault_electronic_shorted_circuit" },
+      { "fault": "fault_emp_reboot" }
+    ]
+  }
+]

--- a/data/json/items/armor/head_attachments.json
+++ b/data/json/items/armor/head_attachments.json
@@ -239,6 +239,7 @@
     ],
     "relic_data": { "passive_effects": [ { "id": "nvg_normal" } ] },
     "flags": [ "HELMET_FRONT_ATTACHMENT", "CANT_WEAR", "OUTER", "ELECTRONIC", "MUNDANE" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "armor": [
       { "covers": [ "eyes" ], "coverage": 10, "encumbrance": 0, "rigid_layer_only": true },
       { "covers": [ "head" ], "encumbrance": 8, "coverage": 70, "specifically_covers": [ "head_forehead" ] }
@@ -297,6 +298,7 @@
     ],
     "relic_data": { "passive_effects": [ { "id": "nvg_good" } ] },
     "flags": [ "HELMET_FRONT_ATTACHMENT", "CANT_WEAR", "OUTER", "ELECTRONIC", "MUNDANE" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "armor": [
       { "covers": [ "eyes" ], "coverage": 10, "encumbrance": 0, "rigid_layer_only": true },
       {
@@ -363,6 +365,7 @@
     ],
     "relic_data": { "passive_effects": [ { "id": "nvg_good" }, { "id": "THERMAL_VISION_GOOD" } ] },
     "flags": [ "HELMET_FRONT_ATTACHMENT", "CANT_WEAR", "OUTER", "ELECTRONIC", "MUNDANE" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "armor": [
       { "covers": [ "eyes" ], "coverage": 10, "encumbrance": 0, "rigid_layer_only": true },
       {

--- a/data/json/items/generic/toys_and_sports.json
+++ b/data/json/items/generic/toys_and_sports.json
@@ -13,6 +13,7 @@
     "symbol": "|",
     "color": "pink",
     "flags": [ "WATER_BREAK", "ELECTRONIC" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "charges_per_use": 1,
     "turns_per_charge": 20,
     "use_action": [ "DOLLCHAT" ],
@@ -292,6 +293,7 @@
     "volume": "62500 ml",
     "longest_side": "180 cm",
     "flags": [ "WATER_BREAK", "SINGLE_USE", "ELECTRONIC" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "pocket_data": [
       {
         "pocket_type": "MAGAZINE_WELL",

--- a/data/json/items/melee/swords_and_blades.json
+++ b/data/json/items/melee/swords_and_blades.json
@@ -2966,6 +2966,7 @@
     },
     "techniques": [ "WBLOCK_1", "SWEEP" ],
     "flags": [ "ALWAYS_TWOHAND", "FRAGILE_MELEE", "WATER_BREAK", "ELECTRONIC" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "pocket_data": [
       {
         "pocket_type": "MAGAZINE_WELL",

--- a/data/json/items/tool/cooking.json
+++ b/data/json/items/tool/cooking.json
@@ -339,6 +339,7 @@
     "symbol": ";",
     "color": "blue",
     "flags": [ "ALLOWS_REMOTE_USE", "WATER_BREAK", "ELECTRONIC" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "use_action": { "type": "link_up", "cable_length": 2, "charge_rate": "600 W" },
     "melee_damage": { "bash": 8 },
     "tool_ammo": [ "battery" ]
@@ -432,6 +433,7 @@
     "symbol": "%",
     "color": "white",
     "flags": [ "ALLOWS_REMOTE_USE", "WATER_BREAK", "ELECTRONIC" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "use_action": { "type": "link_up", "cable_length": 2, "charge_rate": "450 W" },
     "melee_damage": { "bash": 10 },
     "tool_ammo": [ "battery" ]
@@ -522,6 +524,7 @@
     "symbol": ";",
     "color": "green",
     "flags": [ "WATER_BREAK", "ELECTRONIC", "ALLOWS_REMOTE_USE", "NO_SALVAGE" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "charges_per_use": 25,
     "qualities": [ [ "HOTPLATE", 2 ] ],
     "use_action": [ "HEAT_SOLID_ITEMS", { "type": "link_up", "cable_length": 3, "charge_rate": "1500 W" } ],
@@ -641,6 +644,7 @@
     "symbol": ";",
     "color": "red",
     "flags": [ "WATER_BREAK", "ELECTRONIC", "ALLOWS_REMOTE_USE" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "power_draw": "100 W",
     "qualities": [ [ "CONTAIN", 1 ] ],
     "tick_action": "MULTICOOKER_TICK",
@@ -865,6 +869,7 @@
     "charges_per_use": 8,
     "use_action": [ { "type": "link_up", "menu_text": "Plug in / Unplug", "ammo_scale": 0, "cable_length": 3, "charge_rate": "55 W" } ],
     "flags": [ "NONCONDUCTIVE", "FRAGILE_MELEE", "NO_UNLOAD", "NO_RELOAD", "WATER_BREAK", "ELECTRONIC" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "melee_damage": { "bash": 2 },
     "tool_ammo": [ "battery" ]
   },

--- a/data/json/items/tool/electronics.json
+++ b/data/json/items/tool/electronics.json
@@ -6,6 +6,7 @@
     "material": [ "plastic", "steel" ],
     "charges_per_use": 1,
     "flags": [ "NO_UNLOAD", "NO_RELOAD", "WATER_BREAK_ACTIVE", "ELECTRONIC" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "e_port": "camera",
     "etransfer_rate": "20 MB",
     "melee_damage": { "bash": 1 },
@@ -21,6 +22,7 @@
     "etransfer_rate": "30 MB",
     "e_port": "laptop",
     "flags": [ "NO_UNLOAD", "NO_RELOAD", "WATCH", "WATER_BREAK", "ELECTRONIC", "ALLOWS_REMOTE_USE" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "melee_damage": { "bash": 6 },
     "tool_ammo": [ "battery" ]
   },
@@ -44,6 +46,7 @@
     "e_port": "tablet",
     "e_ports_banned": [ "USB-A" ],
     "flags": [ "NO_UNLOAD", "NO_RELOAD", "WATCH", "WATER_BREAK", "ELECTRONIC" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "variables": { "browsed": "false" },
     "tool_ammo": [ "battery" ]
   },
@@ -109,6 +112,7 @@
     "color": "yellow",
     "use_action": [ "CAMERA", { "type": "link_up", "cable_length": 3, "charge_rate": "50 W" } ],
     "flags": [ "NO_UNLOAD", "NO_RELOAD", "WATER_BREAK_ACTIVE", "ELECTRONIC", "CAMERA_PRO", "ALWAYS_TWOHAND" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "//": "swappable, but proprietary 160g Li-Ion battery",
     "pocket_data": [
       { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 100 } },
@@ -148,6 +152,7 @@
       { "type": "link_up", "cable_length": 3, "charge_rate": "20 W" }
     ],
     "flags": [ "NO_UNLOAD", "NO_RELOAD", "WATCH", "ALARMCLOCK", "WATER_BREAK", "ELECTRONIC" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 17 } } ],
     "tool_ammo": [ "battery" ]
   },
@@ -168,6 +173,7 @@
       },
       { "type": "link_up", "cable_length": 3, "charge_rate": "20 W" }
     ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "flags": [ "NO_UNLOAD", "NO_RELOAD", "WATCH", "LIGHT_8", "CHARGEDIM", "TRADER_AVOID", "WATER_BREAK", "ELECTRONIC" ]
   },
   {
@@ -266,6 +272,7 @@
     ],
     "tick_action": [ "EPIC_MUSIC" ],
     "//": "LIGHT_10 is the bare minimum for reading without penalties",
+    "faults": [ { "fault_group": "electronic_general" } ],
     "flags": [ "NO_UNLOAD", "NO_RELOAD", "WATCH", "WATER_BREAK", "ELECTRONIC", "LIGHT_10", "TRADER_AVOID" ]
   },
   {
@@ -410,6 +417,7 @@
     "symbol": ",",
     "color": "green",
     "flags": [ "WATER_BREAK", "ELECTRONIC" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "pocket_data": [
       {
         "pocket_type": "MAGAZINE_WELL",
@@ -605,6 +613,7 @@
       { "type": "link_up", "cable_length": 5, "charge_rate": "140 W" }
     ],
     "tick_action": [ "EPIC_MUSIC" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "flags": [ "NO_UNLOAD", "NO_RELOAD", "WATCH", "LIGHT_10", "TRADER_AVOID", "WATER_BREAK", "ELECTRONIC", "ALLOWS_REMOTE_USE" ]
   },
   {
@@ -624,6 +633,7 @@
     "use_action": [ "MP3", { "type": "link_up", "cable_length": 2, "charge_rate": "5 W" } ],
     "charges_per_use": 1,
     "flags": [ "NO_UNLOAD", "NO_RELOAD", "WATER_BREAK_ACTIVE", "ELECTRONIC" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 50 } } ],
     "tool_ammo": [ "battery" ]
   },
@@ -637,6 +647,7 @@
     "revert_to": "mp3",
     "tick_action": [ "MP3_ON" ],
     "use_action": [ "MP3_DEACTIVATE", { "type": "link_up", "cable_length": 2, "charge_rate": "5 W" } ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "flags": [ "NO_UNLOAD", "NO_RELOAD", "TRADER_AVOID", "WATER_BREAK", "ELECTRONIC" ]
   },
   {
@@ -714,6 +725,7 @@
       "need_charges_msg": "It's dead."
     },
     "flags": [ "WATER_BREAK", "ELECTRONIC" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "pocket_data": [
       {
         "pocket_type": "MAGAZINE_WELL",
@@ -742,6 +754,7 @@
       "menu_text": "Turn off"
     },
     "tick_action": [ "EMF_PASSIVE_ON" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "flags": [ "TRADER_AVOID", "WATER_BREAK", "ELECTRONIC" ]
   },
   {
@@ -759,6 +772,7 @@
     "color": "light_gray",
     "charges_per_use": 1,
     "flags": [ "NO_UNLOAD", "NO_RELOAD", "WATER_BREAK", "ELECTRONIC" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "use_action": [ "PORTABLE_GAME", { "type": "link_up", "cable_length": 4, "charge_rate": "39 W" } ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 48 } } ],
     "tool_ammo": [ "battery" ]
@@ -797,6 +811,7 @@
       { "type": "link_up", "cable_length": 3, "charge_rate": "20 W" }
     ],
     "flags": [ "WATCH", "ALARMCLOCK", "USE_UPS", "NO_UNLOAD", "NO_RELOAD", "WATER_BREAK", "CALORIES_INTAKE", "ELECTRONIC" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "pocket_data": [
       { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 56 } },
       {
@@ -876,6 +891,7 @@
       }
     ],
     "flags": [ "WATCH", "USE_UPS", "NO_UNLOAD", "NO_RELOAD", "WATER_BREAK", "ELECTRONIC" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "pocket_data": [
       { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 56 } },
       {
@@ -1033,6 +1049,7 @@
     "charges_per_use": 1,
     "use_action": [ "VIBE", { "type": "link_up", "cable_length": 3, "charge_rate": "10 W" } ],
     "flags": [ "WATER_BREAK", "NO_UNLOAD", "NO_RELOAD", "ELECTRONIC" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 58 } } ],
     "tool_ammo": [ "battery" ]
   },

--- a/data/json/items/tool/fire.json
+++ b/data/json/items/tool/fire.json
@@ -377,6 +377,7 @@
       { "type": "link_up", "cable_length": 3, "//": "USB 1/2 should take 2 hours for full", "charge_rate": "5 W" }
     ],
     "flags": [ "FIRESTARTER", "NO_UNLOAD", "NO_RELOAD", "ELECTRONIC" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 30 } } ],
     "tool_ammo": [ "battery" ]
   },

--- a/data/json/items/tool/lighting.json
+++ b/data/json/items/tool/lighting.json
@@ -945,6 +945,7 @@
       "WATER_BREAK",
       "ELECTRONIC"
     ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "melee_damage": { "bash": 1 },
     "tool_ammo": [ "battery" ]
   },

--- a/data/json/items/tool/masonry.json
+++ b/data/json/items/tool/masonry.json
@@ -112,6 +112,7 @@
       }
     ],
     "flags": [ "NONCONDUCTIVE", "FRAGILE_MELEE", "USE_UPS", "NO_UNLOAD", "NO_RELOAD", "WATER_BREAK", "ELECTRONIC" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "melee_damage": { "bash": 4 },
     "tool_ammo": [ "battery" ]
   },
@@ -178,6 +179,7 @@
       "WATER_BREAK",
       "ELECTRONIC"
     ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "melee_damage": { "bash": 4, "cut": 70 }
   },
   {

--- a/data/json/items/tool/metalworking.json
+++ b/data/json/items/tool/metalworking.json
@@ -229,6 +229,7 @@
     "symbol": ";",
     "color": "light_gray",
     "flags": [ "ALLOWS_REMOTE_USE", "WATER_BREAK", "ELECTRONIC" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "use_action": { "type": "link_up", "cable_length": 2, "charge_rate": "1400 W" },
     "melee_damage": { "bash": 8 },
     "tool_ammo": [ "battery" ]

--- a/data/json/items/tool/misc.json
+++ b/data/json/items/tool/misc.json
@@ -367,6 +367,7 @@
     "symbol": ";",
     "color": "brown",
     "flags": [ "ALLOWS_REMOTE_USE", "WATER_BREAK", "ELECTRONIC" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "use_action": [
       {
         "target": "large_space_heater_on",

--- a/data/json/items/tool/radio_tools.json
+++ b/data/json/items/tool/radio_tools.json
@@ -7,6 +7,7 @@
     "symbol": "#",
     "color": "yellow",
     "flags": [ "WATER_BREAK", "ELECTRONIC" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "material": [ "plastic" ],
     "charges_per_use": 1,
     "turns_per_charge": 5,
@@ -40,6 +41,7 @@
     "price_postapoc": "2 USD 50 cent",
     "use_action": [ "RADIOCAR" ],
     "flags": [ "RADIO_CONTAINER", "WATER_BREAK", "ELECTRONIC" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
@@ -75,6 +77,7 @@
         "sound_variant": "rc_car_drives"
       }
     ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "flags": [ "LIGHT_15", "RADIO_CONTAINER", "TRADER_AVOID", "RADIOCAR", "WATER_BREAK", "ELECTRONIC" ]
   },
   {
@@ -91,6 +94,7 @@
     "symbol": ";",
     "color": "dark_gray",
     "use_action": [ "RADIO_MOD" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "flags": [ "SINGLE_USE", "WATER_BREAK", "ELECTRONIC" ]
   },
   {
@@ -106,6 +110,7 @@
     "symbol": ";",
     "color": "light_gray",
     "flags": [ "WATER_BREAK", "ELECTRONIC" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "charges_per_use": 1,
     "use_action": [ "RADIO_OFF", { "type": "link_up", "cable_length": 3, "charge_rate": "5 W" } ],
     "pocket_data": [
@@ -132,6 +137,7 @@
       { "type": "transform", "target": "radio", "ammo_scale": 0, "menu_text": "Turn off" }
     ],
     "tick_action": [ "RADIO_TICK" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "flags": [ "TRADER_AVOID", "WATER_BREAK", "ELECTRONIC" ]
   },
   {
@@ -148,6 +154,7 @@
     "color": "green",
     "charges_per_use": 1,
     "flags": [ "TWO_WAY_RADIO", "WATER_BREAK", "ELECTRONIC" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "use_action": [ { "type": "link_up", "cable_length": 3, "charge_rate": "5 W" } ],
     "pocket_data": [
       {
@@ -173,6 +180,7 @@
     "symbol": "#",
     "color": "yellow",
     "flags": [ "WATER_BREAK", "ELECTRONIC" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "charges_per_use": 1,
     "turns_per_charge": 10,
     "use_action": [ "REMOTEVEH" ],

--- a/data/json/items/tool/science.json
+++ b/data/json/items/tool/science.json
@@ -131,6 +131,7 @@
     "symbol": "^",
     "color": "dark_gray",
     "flags": [ "WATER_BREAK", "ELECTRONIC" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "charges_per_use": 1,
     "pocket_data": [
       {
@@ -170,6 +171,7 @@
     "symbol": ":",
     "color": "dark_gray",
     "flags": [ "WATER_BREAK", "ELECTRONIC" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "charges_per_use": 1,
     "pocket_data": [
       {
@@ -240,6 +242,7 @@
     "material": [ "steel" ],
     "symbol": "E",
     "flags": [ "ALLOWS_REMOTE_USE", "WATER_BREAK", "ELECTRONIC" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "color": "dark_gray",
     "use_action": [ { "type": "link_up", "cable_length": 2, "charge_rate": "1200 W" } ],
     "melee_damage": { "bash": 10 },
@@ -279,6 +282,7 @@
     "symbol": "E",
     "color": "dark_gray",
     "flags": [ "ALLOWS_REMOTE_USE", "TRADER_AVOID", "WATER_BREAK", "ELECTRONIC" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "qualities": [ [ "EXTRACT", 1 ] ],
     "use_action": [ { "type": "link_up", "cable_length": 2, "charge_rate": "1800 W" } ],
     "tool_ammo": [ "battery" ]
@@ -442,6 +446,7 @@
     "color": "light_gray",
     "use_action": [ { "type": "link_up", "cable_length": 2, "charge_rate": "800 W" } ],
     "flags": [ "ALLOWS_REMOTE_USE", "WATER_BREAK", "ELECTRONIC" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "pocket_data": [ { "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "large_storage_battery" ] } ],
     "tool_ammo": [ "battery" ]
   },
@@ -462,6 +467,7 @@
     "color": "light_gray",
     "use_action": [ { "type": "link_up", "cable_length": 2, "charge_rate": "350 W" } ],
     "flags": [ "ALLOWS_REMOTE_USE", "WATER_BREAK", "ELECTRONIC" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "pocket_data": [ { "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "large_storage_battery" ] } ],
     "tool_ammo": [ "battery" ]
   },
@@ -483,6 +489,7 @@
     "color": "light_gray",
     "use_action": [ { "type": "link_up", "cable_length": 2, "charge_rate": "1200 W" } ],
     "flags": [ "ALLOWS_REMOTE_USE", "WATER_BREAK", "ELECTRONIC" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "pocket_data": [
       {
         "pocket_type": "MAGAZINE_WELL",
@@ -750,6 +757,7 @@
     "charges_per_use": 5,
     "use_action": [ "WEATHER_TOOL" ],
     "flags": [ "THERMOMETER", "HYGROMETER", "BAROMETER", "WATER_BREAK", "ELECTRONIC" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "pocket_data": [
       {
         "pocket_type": "MAGAZINE_WELL",
@@ -772,6 +780,7 @@
     "price": "250 USD",
     "price_postapoc": "10 USD",
     "flags": [ "WATER_BREAK", "ELECTRONIC" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "to_hit": { "grip": "bad", "length": "short", "surface": "any", "balance": "clumsy" },
     "material": [ "plastic", "steel" ],
     "symbol": ";",
@@ -808,6 +817,7 @@
     "price": "80 USD",
     "price_postapoc": "5 USD",
     "flags": [ "WATER_BREAK", "ELECTRONIC" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "to_hit": { "grip": "bad", "length": "short", "surface": "any", "balance": "clumsy" },
     "material": [ "plastic", "steel" ],
     "symbol": ";",
@@ -894,6 +904,7 @@
     "material": [ "plastic" ],
     "use_action": [ "VOLTMETER" ],
     "flags": [ "WATER_BREAK", "ELECTRONIC" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "symbol": ";",
     "color": "light_gray",
     "pocket_data": [
@@ -952,6 +963,7 @@
     "price_postapoc": "2 USD 50 cent",
     "looks_like": "e_scrap",
     "flags": [ "WATER_BREAK", "ELECTRONIC" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "material": [ "plastic" ],
     "symbol": "#",
     "color": "light_gray"
@@ -1070,6 +1082,7 @@
     "to_hit": { "grip": "bad", "length": "long", "surface": "any", "balance": "clumsy" },
     "material": [ "steel", "glass" ],
     "flags": [ "WATER_BREAK", "ELECTRONIC" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "symbol": "R",
     "color": "white",
     "charges_per_use": 5,
@@ -1128,6 +1141,7 @@
     "symbol": "n",
     "color": "white",
     "flags": [ "WATER_BREAK", "ELECTRONIC" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "charges_per_use": 5,
     "charged_qualities": [ [ "CONCENTRATE", 1 ] ],
     "use_action": [ { "type": "link_up", "cable_length": 2, "charge_rate": "400 W" } ],
@@ -1254,6 +1268,7 @@
     "color": "light_gray",
     "use_action": [ "LUX_METER" ],
     "flags": [ "WATER_BREAK", "ELECTRONIC" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "charges_per_use": 10,
     "pocket_data": [
       {

--- a/data/json/items/tool/smoking.json
+++ b/data/json/items/tool/smoking.json
@@ -13,6 +13,7 @@
     "symbol": "!",
     "color": "white",
     "flags": [ "WATER_BREAK", "ELECTRONIC" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "charges_per_use": 1,
     "power_draw": "7500 mW",
     "use_action": [ "ECIG" ],

--- a/data/json/items/tool/workshop.json
+++ b/data/json/items/tool/workshop.json
@@ -316,6 +316,7 @@
     "charges_per_use": 5,
     "use_action": [ { "type": "link_up", "menu_text": "Plug in / Unplug", "ammo_scale": 0, "cable_length": 3, "charge_rate": "2200 W" } ],
     "flags": [ "NONCONDUCTIVE", "FRAGILE_MELEE", "NO_UNLOAD", "NO_RELOAD", "WATER_BREAK", "ELECTRONIC" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "to_hit": { "grip": "solid", "length": "hand", "surface": "point", "balance": "uneven" },
     "melee_damage": { "bash": 3, "cut": 1 },
     "tool_ammo": [ "battery" ]
@@ -382,6 +383,7 @@
     "charges_per_use": 3960,
     "use_action": [ "JACKHAMMER", { "type": "link_up", "cable_length": 33, "charge_rate": "2200 W" } ],
     "flags": [ "DIG_TOOL", "POWERED", "USE_UPS", "NO_UNLOAD", "NO_RELOAD", "WATER_BREAK", "ELECTRONIC" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "melee_damage": { "bash": 14, "stab": 6 },
     "tool_ammo": [ "battery" ]
   },
@@ -610,6 +612,7 @@
     "symbol": ";",
     "color": "dark_gray",
     "flags": [ "ALLOWS_REMOTE_USE", "WATER_BREAK", "ELECTRONIC" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "use_action": [ { "type": "link_up", "cable_length": 2, "charge_rate": "1500 W" } ],
     "melee_damage": { "bash": 12 },
     "tool_ammo": [ "battery" ]

--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -505,6 +505,7 @@
       "CALORIE_BURN",
       "ELECTRONIC"
     ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "symbol": "[",
     "charges_per_use": 1,
     "use_action": [ "MP3", "CALORIES_INTAKE_TRACKER", "FITNESS_CHECK", "PORTABLE_GAME" ],
@@ -951,6 +952,7 @@
     "price_postapoc": "50 cent",
     "material": [ "plastic", "steel" ],
     "flags": [ "NO_UNLOAD", "NO_RELOAD", "OVERSIZE", "BELTED", "ALLOWS_NATURAL_ATTACKS", "WATER_BREAK", "ELECTRONIC" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "weight": "520 g",
     "volume": "500 ml",
     "charges_per_use": 1,
@@ -982,6 +984,7 @@
       "WATER_BREAK",
       "ELECTRONIC"
     ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "weight": "520 g",
     "volume": "500 ml",
     "charges_per_use": 1,
@@ -1142,6 +1145,7 @@
     "material_thickness": 1,
     "environmental_protection": 1,
     "flags": [ "WATCH", "ALARMCLOCK", "FRAGILE", "WATER_BREAK", "PADDED", "ELECTRONIC" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "tool_ammo": "battery"
   },
   {
@@ -1192,6 +1196,7 @@
       "PADDED",
       "ELECTRONIC"
     ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "tool_ammo": "battery"
   },
   {
@@ -2363,6 +2368,7 @@
     "name": { "str": "pair of light amp goggles", "str_pl": "pairs of light amp goggles" },
     "description": "A pair of battery-powered goggles that use a infrared LED in conjunction with a IR camera, allowing you to see in the dark.  Use it to turn them on.",
     "flags": [ "FRAGILE", "OUTER", "ELECTRONIC", "MUNDANE" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "price": "300 USD",
     "price_postapoc": "30 USD",
     "material": [ "plastic", "steel" ],
@@ -2416,6 +2422,7 @@
     "name": { "str": "pair of infrared goggles", "str_pl": "pairs of infrared goggles" },
     "description": "A pair of battery-powered goggles that grant infrared vision, allowing you to see warm-blooded creatures in the dark.  Use it to turn them on.",
     "flags": [ "FRAGILE", "OUTER", "ELECTRONIC" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "price": "920 USD",
     "price_postapoc": "25 USD",
     "material": [ "plastic", "steel" ],
@@ -2453,6 +2460,7 @@
     "description": "A pair of battery-powered goggles that grant infrared vision, allowing you to see warm-blooded creatures in the dark.  Use it to turn them off.",
     "material": [ "plastic", "steel" ],
     "flags": [ "FRAGILE", "TRADER_AVOID", "OUTER", "ELECTRONIC" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "power_draw": "1 W",
     "revert_to": "goggles_ir",
     "use_action": { "ammo_scale": 0, "type": "transform", "menu_text": "Turn off", "msg": "Your %s deactivates.", "target": "goggles_ir" },
@@ -3034,6 +3042,7 @@
     "name": { "str_sp": "shooter's earmuffs" },
     "description": "A pair of earmuffs favored by shooters.  Without batteries or when turned off, they function like normal earmuffs and block all sound.  They will only block sounds over a certain decibel amount when turned on, to protect your ears from injury while otherwise allowing you to hear normally.  The earmuffs are currently off.",
     "flags": [ "DEAF", "OVERSIZE", "BELTED", "ALLOWS_NATURAL_ATTACKS", "WATER_BREAK", "ELECTRONIC" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "price": "125 USD",
     "price_postapoc": "7 USD 50 cent",
     "material": [ "plastic" ],
@@ -3070,6 +3079,7 @@
     "name": { "str_sp": "shooter's earmuffs" },
     "description": "A pair of earmuffs favored by shooters.  The earmuffs are turned on, and will block sounds over a certain decibel amount while otherwise allowing you to hear normally.",
     "flags": [ "OVERSIZE", "BELTED", "ALLOWS_NATURAL_ATTACKS", "PARTIAL_DEAF", "WATER_BREAK", "ELECTRONIC" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "price": "125 USD",
     "price_postapoc": "7 USD 50 cent",
     "material": [ "plastic" ],
@@ -3108,6 +3118,7 @@
     "name": { "str_sp": "shooter's ear plugs" },
     "description": "A pair of in-ear drivers designed to dampen loud sounds and amplify quiet sounds.  Without batteries or when turned off, they function like normal earplugs and block most sound.  They will only block sounds over a certain decibel amount when turned on, to protect your ears from injury while otherwise allowing you to hear normally.  The earplugs are currently off.",
     "flags": [ "DEAF", "OVERSIZE", "USE_UPS", "NO_UNLOAD", "NO_RELOAD", "WATER_BREAK", "ELECTRONIC" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "price": "125 USD",
     "price_postapoc": "12 USD 50 cent",
     "material": [ "plastic" ],
@@ -3191,6 +3202,7 @@
     "material_thickness": 3,
     "use_action": [ "SOLARPACK" ],
     "flags": [ "BELTED", "FRAGILE", "SOLARPACK", "WATER_BREAK", "ELECTRONIC" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "max_worn": 1,
     "armor": [ { "encumbrance": 10, "coverage": 100, "covers": [ "torso" ], "specifically_covers": [ "torso_hanging_back" ] } ],
     "melee_damage": { "bash": 10 }
@@ -3211,6 +3223,7 @@
     "use_action": [ "SOLARPACK_OFF" ],
     "solar_efficiency": 0.05,
     "flags": [ "BELTED", "FRAGILE", "SOLARPACK_ON", "WATER_BREAK", "ELECTRONIC" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "max_worn": 1,
     "armor": [ { "encumbrance": 10, "coverage": 100, "covers": [ "torso" ], "specifically_covers": [ "torso_hanging_back" ] } ],
     "melee_damage": { "bash": 4 }
@@ -3832,6 +3845,7 @@
     "charges_per_use": 1,
     "use_action": { "type": "transform", "msg": "The %s engages.", "target": "utility_exoskeleton_on", "active": true },
     "flags": [ "STURDY", "OVERSIZE", "BELTED", "WATER_FRIENDLY", "ELECTRONIC" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "relic_data": {
       "passive_effects": [
         { "id": "ench_exo_strength" },
@@ -3891,6 +3905,7 @@
     "charges_per_use": 1,
     "use_action": { "type": "transform", "msg": "The %s engages.", "target": "ice_utility_exoskeleton_on", "active": true },
     "flags": [ "STURDY", "OVERSIZE", "BELTED", "WATER_FRIENDLY", "ELECTRONIC" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "relic_data": {
       "passive_effects": [
         { "id": "ench_exo_strength" },

--- a/data/json/items/vehicle/controls.json
+++ b/data/json/items/vehicle/controls.json
@@ -13,6 +13,7 @@
     "category": "veh_parts",
     "price": "100 USD",
     "price_postapoc": "12 USD 50 cent",
+    "faults": [ { "fault_group": "electronic_general" } ],
     "flags": [ "WATER_BREAK", "ELECTRONIC" ]
   },
   {
@@ -29,6 +30,7 @@
     "category": "veh_parts",
     "price": "100 USD",
     "price_postapoc": "7 USD 50 cent",
+    "faults": [ { "fault_group": "electronic_general" } ],
     "flags": [ "WATER_BREAK", "ELECTRONIC" ]
   },
   {
@@ -59,6 +61,7 @@
     "price": "400 USD",
     "price_postapoc": "5 USD",
     "flags": [ "WATER_BREAK", "ELECTRONIC" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "melee_damage": { "bash": 2 }
   },
   {
@@ -91,6 +94,7 @@
     "price": "80 USD",
     "price_postapoc": "2 USD 50 cent",
     "flags": [ "WATER_BREAK", "ELECTRONIC" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "melee_damage": { "bash": 1 }
   },
   {
@@ -105,6 +109,7 @@
     "volume": "1500 ml",
     "price": "40 USD",
     "price_postapoc": "2 USD 50 cent",
+    "faults": [ { "fault_group": "electronic_general" } ],
     "flags": [ "WATER_BREAK", "ELECTRONIC" ]
   },
   {

--- a/data/json/items/vehicle/motors.json
+++ b/data/json/items/vehicle/motors.json
@@ -13,6 +13,7 @@
     "price": "120 USD",
     "price_postapoc": "15 USD",
     "flags": [ "WATER_BREAK", "ELECTRONIC" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "melee_damage": { "bash": 4 }
   },
   {

--- a/data/json/items/vehicle/noise.json
+++ b/data/json/items/vehicle/noise.json
@@ -32,6 +32,7 @@
     "price": "60 USD",
     "price_postapoc": "1 USD",
     "flags": [ "WATER_BREAK", "ELECTRONIC" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "melee_damage": { "bash": 2 }
   },
   {
@@ -47,6 +48,7 @@
     "category": "veh_parts",
     "price": "8 USD",
     "price_postapoc": "1 USD",
+    "faults": [ { "fault_group": "electronic_general" } ],
     "flags": [ "WATER_BREAK", "ELECTRONIC" ]
   },
   {
@@ -62,6 +64,7 @@
     "category": "veh_parts",
     "price": "50 USD",
     "price_postapoc": "2 USD 50 cent",
+    "faults": [ { "fault_group": "electronic_general" } ],
     "flags": [ "WATER_BREAK", "ELECTRONIC" ]
   }
 ]

--- a/data/mods/Aftershock/items/armor/headsets.json
+++ b/data/mods/Aftershock/items/armor/headsets.json
@@ -60,6 +60,7 @@
       "PADDED",
       "ELECTRONIC"
     ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "revert_to": "afs_combat_headset_off",
     "use_action": [
       {

--- a/data/mods/Aftershock/items/tools.json
+++ b/data/mods/Aftershock/items/tools.json
@@ -783,6 +783,7 @@
     "symbol": ";",
     "color": "red",
     "flags": [ "ELECTRONIC", "ALLOWS_REMOTE_USE", "BELT_CLIP" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "power_draw": "100 W",
     "qualities": [ [ "CONTAIN", 1 ] ],
     "tick_action": "MULTICOOKER_TICK",

--- a/data/mods/Magiclysm/items/caster_level_boosters.json
+++ b/data/mods/Magiclysm/items/caster_level_boosters.json
@@ -237,6 +237,7 @@
     "symbol": "%",
     "color": "white",
     "flags": [ "WATER_BREAK", "ELECTRONIC" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "pocket_data": [
       {
         "pocket_type": "MAGAZINE_WELL",
@@ -273,6 +274,7 @@
     "symbol": "%",
     "color": "white",
     "flags": [ "WATER_BREAK", "ELECTRONIC" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "pocket_data": [
       {
         "pocket_type": "MAGAZINE_WELL",

--- a/data/mods/MindOverMatter/items/armor/head.json
+++ b/data/mods/MindOverMatter/items/armor/head.json
@@ -72,6 +72,7 @@
     "material_thickness": 1,
     "environmental_protection": 1,
     "flags": [ "OUTER", "FRAGILE", "SUN_GLASSES", "WATER_BREAK", "PADDED", "ELECTRONIC" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "relic_data": {
       "passive_effects": [
         {

--- a/data/mods/MindOverMatter/items/tools/travel.json
+++ b/data/mods/MindOverMatter/items/tools/travel.json
@@ -44,6 +44,7 @@
       "type": "transform"
     },
     "flags": [ "WATER_BREAK", "ELECTRONIC" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "pocket_data": [
       {
         "pocket_type": "MAGAZINE_WELL",
@@ -85,6 +86,7 @@
       }
     ],
     "flags": [ "TRADER_AVOID", "WATER_BREAK", "ELECTRONIC" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "pocket_data": [
       {
         "pocket_type": "MAGAZINE_WELL",

--- a/data/mods/Xedra_Evolved/items/electronics.json
+++ b/data/mods/Xedra_Evolved/items/electronics.json
@@ -42,6 +42,7 @@
       }
     ],
     "flags": [ "WATCH", "WATER_BREAK", "ELECTRONIC" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "pocket_data": [
       {
         "pocket_type": "MAGAZINE_WELL",
@@ -81,6 +82,7 @@
         "charge_rate": "140 W"
       }
     ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "flags": [ "WATCH", "LIGHT_10", "TRADER_AVOID", "WATER_BREAK", "ELECTRONIC" ]
   }
 ]

--- a/data/mods/Xedra_Evolved/items/inventor/armor.json
+++ b/data/mods/Xedra_Evolved/items/inventor/armor.json
@@ -390,6 +390,7 @@
       "MUNDANE",
       "INVENTOR_CRAFTED"
     ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "pocket_data": [
       {
         "pocket_type": "MAGAZINE_WELL",
@@ -723,6 +724,7 @@
       "STURDY",
       "PADDED"
     ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "armor": [ { "coverage": 50, "covers": [ "hand_l", "hand_r" ], "specifically_covers": [ "hand_wrist_l", "hand_wrist_r" ] } ],
     "tool_ammo": [ "battery" ]
   }

--- a/data/mods/Xedra_Evolved/items/inventor/gun.json
+++ b/data/mods/Xedra_Evolved/items/inventor/gun.json
@@ -718,6 +718,7 @@
       "ELECTRONIC",
       "INVENTOR_CRAFTED"
     ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "pocket_data": [
       {
         "pocket_type": "MAGAZINE_WELL",

--- a/data/mods/Xedra_Evolved/items/inventor/misc.json
+++ b/data/mods/Xedra_Evolved/items/inventor/misc.json
@@ -85,6 +85,7 @@
     "symbol": ";",
     "color": "green",
     "flags": [ "WATER_BREAK", "ELECTRONIC", "ALLOWS_REMOTE_USE", "INVENTOR_CRAFTED" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "charges_per_use": 20,
     "qualities": [ [ "COOK", 2 ], [ "BOIL", 2 ] ],
     "use_action": [
@@ -151,6 +152,7 @@
     ],
     "use_action": [ { "type": "cast_spell", "spell_id": "inventor_portal_closer_spell", "no_fail": true, "level": 0 } ],
     "flags": [ "ELECTRONIC", "INVENTOR_CRAFTED" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "tool_ammo": "battery"
   },
   {
@@ -166,6 +168,7 @@
     "symbol": ";",
     "color": "white",
     "flags": [ "ELECTRONIC", "INVENTOR_CRAFTED", "TRADER_AVOID" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "charges_per_use": 150,
     "use_action": {
       "type": "cast_spell",

--- a/data/mods/aftershock_exoplanet/faults/fault_group_electronics.json
+++ b/data/mods/aftershock_exoplanet/faults/fault_group_electronics.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "fault_group",
+    "id": "electronic_general",
+    "group": [ { "fault": "fault_emp_reboot" } ]
+  }
+]

--- a/data/mods/aftershock_exoplanet/items/armor/headsets.json
+++ b/data/mods/aftershock_exoplanet/items/armor/headsets.json
@@ -60,6 +60,7 @@
       "PADDED",
       "ELECTRONIC"
     ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "revert_to": "afs_combat_headset_off",
     "use_action": [
       {

--- a/data/mods/aftershock_exoplanet/items/tools.json
+++ b/data/mods/aftershock_exoplanet/items/tools.json
@@ -783,6 +783,7 @@
     "symbol": ";",
     "color": "red",
     "flags": [ "ELECTRONIC", "ALLOWS_REMOTE_USE", "BELT_CLIP" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
     "power_draw": "100 W",
     "qualities": [ [ "CONTAIN", 1 ] ],
     "tick_action": "MULTICOOKER_TICK",

--- a/lang/string_extractor/parser.py
+++ b/lang/string_extractor/parser.py
@@ -147,6 +147,7 @@ parsers = {
     "faction": parse_faction,
     "fault": parse_fault,
     "fault_fix": parse_fault_fix,
+    "fault_group": dummy_parser,
     "field_type": parse_field_type,
     "furniture": parse_furniture,
     "gate": parse_gate,


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Part of fault stuff, it would be better to have faults defined on item, so it is clear what faults item can have and what faults it can not
#### Describe the solution
Add electronic_general fault group, add it to all electronic items in game and mods
#### Testing
Faults appear in item def, and properly overriden in mods like AFS
![image](https://github.com/user-attachments/assets/9bcfbe78-31a9-4a5b-ac54-30da11b1fe99)
![image](https://github.com/user-attachments/assets/e008e30f-2f4c-45b8-b2a3-7ded29c2f3bd)
#### Additional context
We probably can remove GAME_EMP fault later, since aftershock can just override the electronic_general fault group now