### PR TITLE
un-magic-number monster movecost calculation

### DIFF
--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -462,6 +462,11 @@ bool Creature::is_dangerous_field( const field_entry &entry ) const
     return entry.is_dangerous() && !is_immune_field( entry.get_field_type() );
 }
 
+bool Creature::is_immune_fields( map &here, const tripoint_bub_ms &pos ) const
+{
+    return is_immune_fields( here.get_impassable_field_type_ids_at( pos ) );
+}
+
 bool Creature::is_immune_fields( const std::vector<field_type_id> &fields ) const
 {
     for( const field_type_id fi : fields ) {

--- a/src/creature.h
+++ b/src/creature.h
@@ -591,6 +591,9 @@ class Creature : public viewer
             return false;
         }
 
+        // Returns is_immune_fields for a given position.
+        bool is_immune_fields( map &here, const tripoint_bub_ms &pos ) const;
+
         // Returns if the creature is immune to every given field type.
         bool is_immune_fields( const std::vector<field_type_id> &fields ) const;
 

--- a/src/line.h
+++ b/src/line.h
@@ -190,7 +190,10 @@ inline int square_dist( const point &loc1, const point &loc2 )
     return std::max( d.x, d.y );
 }
 
-// Choose between the above two according to the "circular distances" option
+/*
+ * Choose between the above two according to the "circular distances" option.
+ * Since it returns int, trig_dist should still be used directly for short distances.
+*/
 inline int rl_dist( const tripoint &loc1, const tripoint &loc2 )
 {
     if( trigdist ) {

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2493,10 +2493,10 @@ int map::combined_movecost( const tripoint_bub_ms &from, const tripoint_bub_ms &
     const bool swims_to = swimming && has_flag_ter( ter_furn_flag::TFLAG_SWIMMABLE, to );
 
     // swimmers and diggers ignore terraincost
-    const int cost1 = swims_from ? 0 :
+    const int cost1 = flying || swims_from ? 0 :
                       move_cost( from, ignored_vehicle, ignore_fields, climbing &&
                                  has_flag_furn( ter_furn_flag::TFLAG_CLIMBABLE, from ) );
-    const int cost2 = swims_to || digs_to ? 0 :
+    const int cost2 = flying || swims_to || digs_to ? 0 :
                       move_cost( to, ignored_vehicle, ignore_fields, climbing &&
                                  has_flag_furn( ter_furn_flag::TFLAG_CLIMBABLE, to ) );
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2488,17 +2488,18 @@ int map::combined_movecost( const tripoint_bub_ms &from, const tripoint_bub_ms &
     static constexpr std::array<int, 4> mults = { 0, 50, 71, 100 };
 
     // from tile should never be digable
-    const bool digs_to = digging && has_flag_furn( ter_furn_flag::TFLAG_CLIMBABLE, to );
-    const bool swims_from = swimming && has_flag_ter( ter_furn_flag::TFLAG_SWIMMABLE, from );
-    const bool swims_to = swimming && has_flag_ter( ter_furn_flag::TFLAG_SWIMMABLE, to );
+    const bool digs_to = digging && has_flag( ter_furn_flag::TFLAG_CLIMBABLE, to );
+    const bool swims_from = swimming && has_flag( ter_furn_flag::TFLAG_SWIMMABLE, from );
+    const bool swims_to = swimming && has_flag( ter_furn_flag::TFLAG_SWIMMABLE, to );
+    const bool climbs_from = climbing && has_flag( ter_furn_flag::TFLAG_CLIMBABLE, from );
+    const bool climbs_to = climbing && has_flag( ter_furn_flag::TFLAG_CLIMBABLE, to );
 
     // swimmers and diggers ignore terraincost
-    const int cost1 = flying || swims_from ? 0 :
-                      move_cost( from, ignored_vehicle, ignore_fields, climbing &&
-                                 has_flag_furn( ter_furn_flag::TFLAG_CLIMBABLE, from ) );
-    const int cost2 = flying || swims_to || digs_to ? 0 :
-                      move_cost( to, ignored_vehicle, ignore_fields, climbing &&
-                                 has_flag_furn( ter_furn_flag::TFLAG_CLIMBABLE, to ) );
+    const int cost1 = flying || swims_from || climbs_from ? 0 :
+                      move_cost( from, ignored_vehicle, ignore_fields );
+    const int cost2 = flying || swims_to || digs_to || climbs_to ? 0 :
+                      move_cost( to, ignored_vehicle, ignore_fields );
+
 
     // Multiply cost depending on the number of differing axes
     // 0 if all axes are equal, 100% if only 1 differs, 141% for 2, 200% for 3

--- a/src/map.h
+++ b/src/map.h
@@ -575,10 +575,10 @@ class map
         * n > 0     | x*n turns to move past this
         */
         int move_cost( const tripoint_bub_ms &p, const vehicle *ignored_vehicle = nullptr,
-                       bool ignore_fields = false, bool ignore_terrain = false, bool ignore_furn = false ) const;
+                       bool ignore_fields = false, bool ignore_furn = false ) const;
         int move_cost( const point_bub_ms &p, const vehicle *ignored_vehicle = nullptr,
-                       bool ignore_fields = false, bool ignore_terrain = false, bool ignore_furn = false ) const {
-            return move_cost( tripoint_bub_ms( p, abs_sub.z() ), ignored_vehicle, ignore_fields, ignore_terrain,
+                       bool ignore_fields = false, bool ignore_furn = false ) const {
+            return move_cost( tripoint_bub_ms( p, abs_sub.z() ), ignored_vehicle, ignore_fields,
                               ignore_furn );
         }
         bool impassable( const tripoint_bub_ms &p ) const;
@@ -611,13 +611,22 @@ class map
 
         /**
         * Cost to move out of one tile and into the next.
-        *
-        * @return The cost in turns to move out of tripoint `from` and into `to`
+        * @param from Source location
+        * @param to Target location
+        * @param ignored_vehicle do not apply vehicle penalty
+        * @param modifier generally 1 modifier is 25 movecost for adjacent tiles
+        * @param flying
+        * @param via_ramp allow going up/down ramps
+        * @param ignore_fields ignore field-effects like smoke
+        * @param digging ignore diggable terrain
+        * @param swimming ignore swimmable terrain
+        * @param ignore_trig consider location as adjacent
+        * @return The cost in turns to move out of tripoint `from` and into `to`. Movecost of 0 implies an invalid move.
         */
         int combined_movecost( const tripoint_bub_ms &from, const tripoint_bub_ms &to,
                                const vehicle *ignored_vehicle = nullptr,
                                int modifier = 0, bool flying = false, bool via_ramp = false,
-                               bool ignore_fields = false, bool ignore_terrain = false, bool ignore_furn = false,
+                               bool ignore_fields = false, bool digging = false, bool swimming = false, bool climbing = false,
                                bool ignore_trig = false ) const;
 
         /**

--- a/src/map.h
+++ b/src/map.h
@@ -620,6 +620,7 @@ class map
         * @param ignore_fields ignore field-effects like smoke
         * @param digging ignore diggable terrain
         * @param swimming ignore swimmable terrain
+        * @param climbing ignores terrain if there is climbable furn
         * @param ignore_trig consider location as adjacent
         * @return The cost in turns to move out of tripoint `from` and into `to`. Movecost of 0 implies an invalid move.
         */

--- a/src/map.h
+++ b/src/map.h
@@ -575,10 +575,11 @@ class map
         * n > 0     | x*n turns to move past this
         */
         int move_cost( const tripoint_bub_ms &p, const vehicle *ignored_vehicle = nullptr,
-                       bool ignore_fields = false ) const;
+                       bool ignore_fields = false, bool ignore_terrain = false, bool ignore_furn = false ) const;
         int move_cost( const point_bub_ms &p, const vehicle *ignored_vehicle = nullptr,
-                       bool ignore_fields = false ) const {
-            return move_cost( tripoint_bub_ms( p, abs_sub.z() ), ignored_vehicle, ignore_fields );
+                       bool ignore_fields = false, bool ignore_terrain = false, bool ignore_furn = false ) const {
+            return move_cost( tripoint_bub_ms( p, abs_sub.z() ), ignored_vehicle, ignore_fields, ignore_terrain,
+                              ignore_furn );
         }
         bool impassable( const tripoint_bub_ms &p ) const;
         bool impassable( const point_bub_ms &p ) const {
@@ -616,7 +617,8 @@ class map
         int combined_movecost( const tripoint_bub_ms &from, const tripoint_bub_ms &to,
                                const vehicle *ignored_vehicle = nullptr,
                                int modifier = 0, bool flying = false, bool via_ramp = false,
-                               bool ignore_fields = false ) const;
+                               bool ignore_fields = false, bool ignore_terrain = false, bool ignore_furn = false,
+                               bool ignore_trig = false ) const;
 
         /**
          * Returns true if a creature could walk from `from` to `to` in one step.

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -1545,9 +1545,13 @@ int monster::calc_movecost( const tripoint_bub_ms &from, const tripoint_bub_ms &
     map &here = get_map();
     int modifier = 0;
 
-    //temp hackery. We shouldnt get here if the target location is climbable as it will run calc_climb_cost instead, so only mod 'from'
+    // temp hackery. We shouldnt get here if the target location is climbable as it will run calc_climb_cost instead, so only mod 'from'
     if( digging() && here.has_flag_furn( ter_furn_flag::TFLAG_CLIMBABLE, from ) ) {
         modifier += 3;      // basic climbing cost. should probably be handeled somewhere else?
+    }
+    // do flyers always fly or can they walk?
+    if( flies() ) {
+        modifier += 4;
     }
     // TODO: if Z movement are handled here, add via_ramp
     // TODO: returns 0 when failed. Check it?

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -1546,13 +1546,20 @@ int monster::calc_movecost( const tripoint_bub_ms &from, const tripoint_bub_ms &
     int modifier = 0;
 
     // temp hackery. We shouldnt get here if the target location is climbable as it will run calc_climb_cost instead, so only mod 'from'
-    if( digging() && here.has_flag_furn( ter_furn_flag::TFLAG_CLIMBABLE, from ) ) {
+    if( digging() && here.has_flag( ter_furn_flag::TFLAG_DIGGABLE, from ) ) {
         modifier += 3;      // basic climbing cost. should probably be handeled somewhere else?
     }
     // do flyers always fly or can they walk?
     if( flies() ) {
         modifier += 4;
     }
+    if( climbs() && here.has_flag( ter_furn_flag::TFLAG_CLIMBABLE, from ) ) {
+        modifier += 3;
+    }
+    if( climbs() && here.has_flag( ter_furn_flag::TFLAG_CLIMBABLE, to ) ) {
+        modifier += 3;
+    }
+
     // TODO: if Z movement are handled here, add via_ramp
     // TODO: returns 0 when failed. Check it?
     int movecost = here.combined_movecost( from, to, nullptr, modifier, flies(), false,

--- a/src/monster.h
+++ b/src/monster.h
@@ -291,7 +291,7 @@ class monster : public Creature
          * @return true if movement successful, false otherwise
          */
         bool move_to( const tripoint_bub_ms &p, bool force = false, bool step_on_critter = false,
-                      float stagger_adjustment = 1.0 );
+                      float move_cost_multiplier = 1.0 );
 
         /**
          * Attack any enemies at the given location.


### PR DESCRIPTION
#### Summary
Infrastructure "un-magic-number monset movecost calculation."

#### Purpose of change
while working on #80555 (which I cannot reproduce with "circular distances" enabled) I found this Monstrosity:
https://github.com/CleverRaven/Cataclysm-DDA/blob/02f75a2231393db391d883b357d93b5e26757cb4/src/monmove.cpp#L1619-L1671

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
un-hardcode the monster::calc_movecost method. Make use of the existing map::combined_movecost method with arguments to be able to ignore terrain/furn/field penalties, and add the desired penalty in calc_movecost.

When ignoring terrain cost, add modifier to ensure movecost matches pre-PR values.
- [x] Swimming (25)
- [x] climbing (150)
- [ ] Submerged walking (originally 250, but should be handled by terrain cost)
- [ ] digging (100)
- [x] flying (100)

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Being able to separately ignore 'from' and 'to' tile. Currently it doesn't matter if only one or both tiles can be ignored.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
TODO: create CI

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
rl_dist actually checks for trigdist and returns it, but since it returns int there a 1-tile diagonal distance of 1.41 gets floored to 1 (probable issue of #71699). I believe it makes sense to make it return float.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
