### PR TITLE
Print snippet in loading screen

### DIFF
--- a/src/loading_ui.cpp
+++ b/src/loading_ui.cpp
@@ -2,7 +2,6 @@
 
 #include "cached_options.h"
 #include "options.h"
-#include "cata_imgui.h"
 #include "input.h"
 #include "output.h"
 #include "text_snippets.h"
@@ -20,6 +19,8 @@
 #else
 #include "cursesdef.h"
 #endif // TILES
+
+#include "cata_imgui.h"
 
 struct ui_state {
     ui_adaptor *ui;
@@ -48,23 +49,49 @@ static void redraw()
     ImVec2 pos = { 0.5f, 0.5f };
     ImGui::SetNextWindowPos( ImGui::GetMainViewport()->Size * pos, ImGuiCond_Always, { 0.5f, 0.5f } );
     ImGui::SetNextWindowSize( gLUI->window_size );
-    ImGui::PushStyleVar( ImGuiStyleVar_WindowBorderSize, 0.0f );
+    ImGui::PushStyleVar( ImGuiStyleVar_WindowBorderSize, 1.0f );
+    ImGui::PushStyleVar( ImGuiStyleVar_WindowPadding, {0.0f, 0.0f} );
     ImGui::PushStyleColor( ImGuiCol_WindowBg, { 0.0f, 0.0f, 0.0f, 1.0f } );
     if( ImGui::Begin( "Loading…", nullptr,
                       ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove |
                       ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoSavedSettings ) ) {
-        ImGui::Image( reinterpret_cast<ImTextureID>( gLUI->splash.get() ), gLUI->splash_size );
+        // first draw the snippet, putting some space before and after to ensure it wraps nicely and isn’t super wide
+        float empty_space = 0.125f * gLUI->splash_size.x;
+        ImGui::Indent( empty_space );
+        ImGui::BeginGroup();
+        cataimgui::TextColoredParagraph( c_light_cyan, gLUI->snippet, std::nullopt,
+                                         ImGui::GetWindowWidth() - empty_space );
+        ImGui::EndGroup();
+        // draw a debug rectangle around it
+        ImGui::GetForegroundDrawList()->AddRect( ImGui::GetItemRectMin(), ImGui::GetItemRectMax(),
+                IM_COL32( 255, 0, 255, 255 ) );
+        auto actual_text_size = ImGui::GetItemRectSize();
+        ImGui::Unindent( empty_space );
+        // move back to the top of the window
+        ImGui::SetCursorPos( {0.0f, 0.0f} );
+        // draw the image over top of the text
+        ImGui::Image( reinterpret_cast<ImTextureID>( gLUI->splash.get() ), gLUI->splash_size, {0.0f, 0.0f}, {1.0f, 1.0f}, {1.0f, 1.0f, 1.0f, 1.0f}, {1.0f, 0.0f, 1.0f, 1.0f} );
+        // now display the loading status
         float w = ImGui::CalcTextSize( gLUI->context.c_str() ).x + ImGui::CalcTextSize( " " ).x +
                   ImGui::CalcTextSize( gLUI->step.c_str() ).x;
-        ImGui::SetCursorPosX( ( ( ImGui::GetWindowWidth() - w ) * 0.5f ) );
+        ImGui::SetCursorPosX( ( ImGui::GetWindowWidth() - w ) * 0.5f );
         ImGui::Text( "%s %s", gLUI->context.c_str(), gLUI->step.c_str() );
-        // terrible
-        ImGui::SetCursorPosX( std::max( 0.0f, ( ( ImGui::GetWindowWidth() - ImGui::CalcTextSize(
-                gLUI->snippet.c_str() ).x ) * 0.5f ) ) );
-        cataimgui::draw_colored_text( gLUI->snippet, c_light_cyan, gLUI->splash_size.x );
+        ImGui::NewLine();
+        // finally draw the snippet but this time centered in the window
+        empty_space = 0.5 * ( gLUI->splash_size.x - actual_text_size.x );
+        ImGui::Indent( empty_space );
+        ImGui::BeginGroup();
+        cataimgui::TextColoredParagraph( c_light_cyan, gLUI->snippet, std::nullopt,
+                                         ImGui::GetWindowWidth() - empty_space );
+        ImGui::EndGroup();
+        // draw another debug rectangle around it
+        ImGui::GetForegroundDrawList()->AddRect( ImGui::GetItemRectMin(), ImGui::GetItemRectMax(),
+                IM_COL32( 255, 0, 255, 255 ) );
+        ImGui::Unindent( empty_space );
     }
     ImGui::End();
     ImGui::PopStyleColor();
+    ImGui::PopStyleVar();
     ImGui::PopStyleVar();
 #else
     int x = ( TERMX - static_cast<int>( gLUI->splash_width ) ) / 2;
@@ -101,8 +128,7 @@ static void update_state( const std::string &context, const std::string &step )
             resize();
         } );
 
-        //  static const std::string snippet = string_format( _( "Tip of the day: %s" ), SNIPPET.random_from_category( "tip" ).value_or( translation() ).translated() );
-
+        // static const std::string snippet = string_format( _( "Tip of the day: %s" ), SNIPPET.random_from_category( "tip" ).value_or( translation() ).translated() );
         static const std::string snippet =
             "I think that you should figure out the size of the snippet first, then subtract it from the size of the viewport when computing max_size. That would eliminate the * 0.9 hack. The image would then be scaled to fit the remaining available space. One way to do this would be to write a function called measure_colored_text that does all the same things as draw_colored_text but doesn’t actually draw it. It would just add up the bounding boxes and return the final one.";
 
@@ -132,7 +158,9 @@ static void update_state( const std::string &context, const std::string &step )
             }
         }
         SDL_Surface_Ptr surf = load_image( gLUI->chosen_load_img.get_unrelative_path().u8string().c_str() );
-        ImVec2 max_size = ImGui::GetMainViewport()->Size * 0.98;
+        // reserve room for a few lines of text
+        float text_height = 5.0f * ImGui::GetTextLineHeightWithSpacing();
+        ImVec2 max_size = ImGui::GetMainViewport()->Size - ImVec2{0.0f, text_height};
         // preserve aspect ratio by finding the longest **relative** side and scaling both sides by its ratio to max_size
         // scales both "up" and "down"
         float width_ratio = static_cast<float>( surf->w ) / max_size.x;
@@ -142,20 +170,7 @@ static void update_state( const std::string &context, const std::string &step )
                               static_cast<float>( surf->h ) / longest_side_ratio
                             };
         gLUI->splash = CreateTextureFromSurface( get_sdl_renderer(), surf );
-
-        // turbo cursed
-        if( ImGui::Begin( "calculate snippet height", nullptr,
-                          ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove |
-                          ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoSavedSettings ) ) {
-            const int cursos_init_pos = ImGui::GetCursorPosY();
-            cataimgui::draw_colored_text( gLUI->snippet, c_light_cyan, gLUI->splash_size.x );
-            ImGui::Text( "%s %s", gLUI->context.c_str(), gLUI->step.c_str() );
-            ImGui::NewLine();
-            gLUI->snippet_height = ImGui::GetCursorPosY() - cursos_init_pos;
-        }
-        ImGui::End();
-
-        gLUI->window_size = { 0.0f, gLUI->splash_size.y + gLUI->snippet_height };
+        gLUI->window_size = gLUI->splash_size + ImVec2{ 0.0f, text_height };
 #else
         std::string splash = PATH_INFO::title( get_holiday_from_time() );
         if( get_option<bool>( "ENABLE_ASCII_TITLE" ) ) {


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Wanted to do it for a long time
#### Describe the solution
Print a string with a randomly picked snippet on the loading screen
Works fine for a bigger screen, but shifts the printed image up so it is cut for a smaller screens, and doesn't work for curses, i was told to seek advice of @db48x, may i ask?
#### Testing
Everything works...
![image](https://github.com/user-attachments/assets/5cca5f05-d740-414d-b104-a19ab7210289)
and then everything falls apart... (also double space is not removed when paragraphed? weird)
![image](https://github.com/user-attachments/assets/5e9e9af8-cadd-4f7d-946b-ef4251a81fd9)