### PR TITLE
Update bunker.json to eliminate airgap in basement

### DIFF
--- a/data/json/mapgen/bunker.json
+++ b/data/json/mapgen/bunker.json
@@ -137,7 +137,7 @@
       ],
       "palettes": [ "domestic_general_and_variant_palette", "standard_domestic_basement_palette" ],
       "terrain": {
-        ".": "t_dirt",
+        ".": "t_soil",
         " ": "t_floor",
         "|": "t_wall_metal",
         "*": "t_door_metal_locked",


### PR DESCRIPTION
#### Summary
Bugfixes "bunker generated a ring of dirt around it, instead of soil."


#### Purpose of change

the military bunker currently generates an airgap of dirt around its basement layer, instead of it being filled in with dirt as feels intended.


#### Describe the solution

json change from t_dirt to t_soil in bunker.json.

#### Describe alternatives you've considered

NA

#### Testing

preformed json edit, proceeded to generate bunker and examine the lack of an airgap.


