### PR TITLE
Adds a small supply of icons with the traders from NECR

### DIFF
--- a/data/json/npcs/godco/classes.json
+++ b/data/json/npcs/godco/classes.json
@@ -1117,7 +1117,8 @@
       { "item": "thyme", "prob": 75, "count": [ 1, 10 ] },
       { "item": "hickory_nut", "prob": 66, "count": [ 1, 10 ] },
       { "prob": 80, "group": "poppy_pain_jar_glass_sealed_2" },
-      { "prob": 80, "group": "poppy_sleep_jar_glass_sealed_2" }
+      { "prob": 80, "group": "poppy_sleep_jar_glass_sealed_2" },
+      { "item": "icon", "prob": 100, "count": [ 10, 20 ] }
     ]
   },
   {
@@ -1298,7 +1299,11 @@
     "type": "item_group",
     "id": "GODCO_russell_sell",
     "subtype": "collection",
-    "entries": [ { "item": "tanned_hide", "count": [ 10, 12 ] }, { "item": "tanned_pelt", "count": [ 8, 10 ] } ]
+    "entries": [
+      { "item": "tanned_hide", "count": [ 10, 12 ] },
+      { "item": "tanned_pelt", "count": [ 8, 10 ] },
+      { "item": "icon", "count": [ 5, 10 ] }
+    ]
   },
   {
     "type": "item_group",


### PR DESCRIPTION
#### Summary
Balance "Icons can now be resupplied in a small amount with the 2 traders of the NECR"

#### Purpose of change
The money of the NECR can be pretty hard to resupply if you use it as intended (To exchange it for things/services with the NECR), there are no merchants that provide the money so...

#### Describe the solution
Adds a small amount of icons for sale with the 2 traders of the NECR, I decided against the outside merchant too because they already have their own notes.

#### Describe alternatives you've considered
To have the outside merchant sell some icons too?

#### Testing

#### Additional context
