### PR TITLE
[Mods] Update and expand some special vision IDs

### DIFF
--- a/data/mods/Magiclysm/effects/effects.json
+++ b/data/mods/Magiclysm/effects/effects.json
@@ -1213,7 +1213,7 @@
               "or": [ { "npc_has_flag": "MAGIC_USER" }, { "and": [ "npc_is_character", { "math": [ "n_spell_count() >= 6" ] } ] } ]
             },
             "distance": { "math": [ "( u_spell_level('animist_detect_wizards') * 2) + 3" ] },
-            "descriptions": [ { "id": "fae_sense", "symbol": "?", "color": "cyan", "text": "You see the ley lines of a wielder of magic." } ]
+            "descriptions": [ { "id": "wizard_sense", "symbol": "?", "color": "cyan", "text": "You see the ley lines of a wielder of magic." } ]
           }
         ]
       }

--- a/data/mods/Xedra_Evolved/effects/effects.json
+++ b/data/mods/Xedra_Evolved/effects/effects.json
@@ -2228,7 +2228,7 @@
             "distance": { "math": [ "u_val('perception') * 2" ] },
             "precise": true,
             "ignores_aiming_cone": true,
-            "descriptions": [ { "id": "vampire", "text": "You detect a vampire here.", "symbol": "V", "color": "red" } ]
+            "descriptions": [ { "id": "vamnpire_sense", "text": "You detect a vampire here.", "symbol": "V", "color": "red" } ]
           }
         ]
       }

--- a/data/mods/Xedra_Evolved/effects/effects_changeling_seasonal_magic.json
+++ b/data/mods/Xedra_Evolved/effects/effects_changeling_seasonal_magic.json
@@ -315,7 +315,7 @@
                 "min( ( 3 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 0.2) + (u_skill('deduction') * 0.5)), 25)"
               ]
             },
-            "descriptions": [ { "id": "fae_sense", "symbol": "?", "color": "cyan", "text": "You sense a sorcerer here." } ]
+            "descriptions": [ { "id": "wizard_sense", "symbol": "?", "color": "cyan", "text": "You sense a sorcerer here." } ]
           }
         ]
       }

--- a/data/mods/Xedra_Evolved/mutations/mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/mutations.json
@@ -228,14 +228,7 @@
           {
             "condition": { "npc_has_species": "RENFIELD" },
             "distance": { "math": [ "u_val('perception') * 1.5" ] },
-            "descriptions": [
-              {
-                "id": "infrared_creature_medium",
-                "text": "You sense one of the vampires' servants here.",
-                "symbol": "R",
-                "color": "red"
-              }
-            ]
+            "descriptions": [ { "id": "vampire_sense", "text": "You sense one of the vampires' servants here.", "symbol": "R", "color": "red" } ]
           },
           {
             "condition": {
@@ -774,7 +767,7 @@
             "ignores_aiming_cone": true,
             "descriptions": [
               {
-                "id": "infrared_creature_medium",
+                "id": "night_creature_sense",
                 "text": "You sense one of the creatures of the night.",
                 "symbol": "N",
                 "color": "white"
@@ -1704,7 +1697,7 @@
             "distance": { "math": [ "u_val('perception') * 3" ] },
             "precise": true,
             "ignores_aiming_cone": true,
-            "descriptions": [ { "id": "vampire", "text": "You detect a vampire here.", "symbol": "V", "color": "red" } ]
+            "descriptions": [ { "id": "vampire_sense", "text": "You detect a vampire here.", "symbol": "V", "color": "red" } ]
           }
         ]
       }

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/arvore_mutation_spells.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/arvore_mutation_spells.json
@@ -44,7 +44,7 @@
         },
         "descriptions": [
           {
-            "id": "moving_creature",
+            "id": "human_sense",
             "symbol": "?",
             "color": "c_white",
             "text": "The forest nervously whispers to you about the presence of humans."

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/arvore_mutation_spells.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/arvore_mutation_spells.json
@@ -45,7 +45,7 @@
         "descriptions": [
           {
             "id": "human_sense",
-            "symbol": "?",
+            "symbol": "@",
             "color": "c_white",
             "text": "The forest nervously whispers to you about the presence of humans."
           }

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_mutations.json
@@ -142,7 +142,7 @@
           {
             "condition": { "or": [ { "npc_has_species": "HUMAN" }, { "npc_has_species": "FERAL" }, { "npc_has_species": "RENFIELD" } ] },
             "distance": { "math": [ "u_val('perception') * 1.5" ] },
-            "descriptions": [ { "id": "infrared_creature_medium", "text": "You sense a human here." } ]
+            "descriptions": [ { "id": "human_sense", "text": "You sense a human here." } ]
           }
         ]
       }

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_mutations.json
@@ -142,7 +142,7 @@
           {
             "condition": { "or": [ { "npc_has_species": "HUMAN" }, { "npc_has_species": "FERAL" }, { "npc_has_species": "RENFIELD" } ] },
             "distance": { "math": [ "u_val('perception') * 1.5" ] },
-            "descriptions": [ { "id": "human_sense", "text": "You sense a human here." } ]
+            "descriptions": [ { "id": "human_sense", "text": "You sense a human here.", "symbol": "@", "color": "c_white" } ]
           }
         ]
       }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Mods] Update and expand some special vision IDs"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

I have been informed that adding new ids for special_vision sprites is not just fine, but actually good.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Update several special_visions that use already-existing sprites to use new sprite IDs.

Add the following ids: 

- `vampire_sense` (collapsed both `vampire` and `vampire_sense` into `vampire_sense`, since most special_vision ids end in _sense and `vampire` doesn't seem to have an attached sprite yet)
- `human_sense`
- `night_creature_sense`
- `wizard_sense`

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Everything is infrared blobs

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
