### PR TITLE
Bugfixes: Allow NPCs to use practice crafting recipes

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -4249,7 +4249,7 @@ void craft_activity_actor::do_turn( player_activity &act, Character &crafter )
     // if item_counter has reached 100% or more
     if( craft.item_counter >= 10000000 ) {
         if( rec.is_practice() && !is_long && craft.get_making_batch_size() == 1 ) {
-            if( query_yn( _( "Keep practicing until proficiency increases?" ) ) ) {
+            if( crafter.is_avatar() && query_yn( _( "Keep practicing until proficiency increases?" ) ) ) {
                 is_long = true;
                 *( crafter.last_craft ) = craft_command( &craft.get_making(), 1, is_long, &crafter, location );
             }
@@ -4266,10 +4266,19 @@ void craft_activity_actor::do_turn( player_activity &act, Character &crafter )
             }
         }
     } else {
-        if( level_up && craft.get_making().is_practice() &&
-            query_yn( _( "Your proficiency has increased.  Stop practicing?" ) ) ) {
-            crafter.cancel_activity();
-        } else if( craft.item_counter >= craft.get_next_failure_point() ) {
+        if( level_up && craft.get_making().is_practice() ) {
+            if( crafter.is_avatar() ) {
+                if( query_yn( _( "Your proficiency has increased.  Stop practicing?" ) ) ) {
+                    crafter.cancel_activity();
+                    return;
+                }
+            } else if( crafter.is_npc() ) {
+                crafter.cancel_activity();
+                return;
+            }
+        }
+
+        if( craft.item_counter >= craft.get_next_failure_point() ) {
             bool destroy = craft.handle_craft_failure( crafter );
             // If the craft needs to be destroyed, do it and stop crafting.
             if( destroy ) {

--- a/src/recipe.cpp
+++ b/src/recipe.cpp
@@ -1330,10 +1330,6 @@ std::function<bool( const item & )> recipe::get_component_filter(
 
 bool recipe::npc_can_craft( std::string &reason ) const
 {
-    if( is_practice() ) {
-        reason = _( "Ordering NPC to practice is not implemented yet." );
-        return false;
-    }
     if( result()->phase != phase_id::SOLID ) {
         reason = _( "Ordering NPC to craft non-solid item is currently only implemented for camps." );
         return false;


### PR DESCRIPTION
#### Summary  
Bugfixes "Allow NPCs to use practice crafting recipes"

#### Purpose of change

NPCs were previously unable to engage properly with practice recipes due to checks intended solely for the player avatar. Since NPCs now skill up similarly to players, there's no longer a reason to prevent them from accessing these recipes.

Currently, NPCs either couldn't use practice recipes at all, or if allowed, would incorrectly stop or continue practicing due to inconsistent level-up checks.


#### Describe the solution

- Allowed NPCs to initiate practice recipes by removing outdated restrictions in `recipe.cpp`.
- Adjusted `craft_skill_gain` and `craft_proficiency_gain` to explicitly check if an actual skill level or proficiency has increased, rather than relying solely on the return value of practice functions. This ensures NPC activities reflect meaningful progress.
- Adjusted messaging prompts (`query_yn`) to only trigger for the avatar, ensuring NPC activities are handled automatically without player prompts.

#### Describe alternatives you've considered

We considered implementing an explicit tracking method (`pc_starting_skill_level`) in `activity_actor.cpp`, similar to the approach in [PR #80627](https://github.com/CleverRaven/Cataclysm-DDA/pull/80627). While effective, it seemed cleaner and more maintainable to correct the underlying issue directly within `craft_skill_gain` and `craft_proficiency_gain`.


#### Testing

Tested by:
- Having NPC perform practice recipes.
- Verifying that NPC now correctly practice until an actual level or proficiency is gained.
- Ensuring NPC automatically stop practicing when gaining proficiency without prompting the player.

No regressions were observed in player behavior.


#### Additional context

This is a follow-up to [PR #80627](https://github.com/CleverRaven/Cataclysm-DDA/pull/80627), addressing a closely related issue uncovered during that implementation.
