### PR TITLE
Fix game warning over 'stale data' on achievements json

### DIFF
--- a/src/flexbuffer_cache.cpp
+++ b/src/flexbuffer_cache.cpp
@@ -329,7 +329,8 @@ class flexbuffer_disk_cache
                 std::string filepath_and_name = disk_entry->first;
                 // we use this as an exclusion condition. Configuration options can be changed all the time, we don't want to warn over those. Same for achievements.
                 bool stale_game_data = *root_relative_source_path.begin() != std::filesystem::u8path( "config" ) &&
-                                       *root_relative_source_path.begin() != std::filesystem::u8path( "achievements" );
+                                       *root_relative_source_path.begin() != std::filesystem::u8path( "achievements" ) &&
+                                       *root_relative_source_path.begin() != std::filesystem::u8path( "templates" );
                 if( stale_game_data ) {
                     if( get_option<bool>( "WARN_ON_MODIFIED" ) ) {
                         debugmsg( "Stale game data detected at %s, did you overwrite old files?  When updating the game you must install to a fresh folder, overwriting old files will cause errors.",

--- a/src/flexbuffer_cache.cpp
+++ b/src/flexbuffer_cache.cpp
@@ -327,8 +327,9 @@ class flexbuffer_disk_cache
             // Does the source file's mtime match what we cached previously
             if( source_mtime != disk_entry->second.mtime ) {
                 std::string filepath_and_name = disk_entry->first;
-                // we use this as an exclusion condition. Configuration options can be changed all the time, we don't want to warn over those.
-                bool stale_game_data = *root_relative_source_path.begin() != std::filesystem::u8path( "config" );
+                // we use this as an exclusion condition. Configuration options can be changed all the time, we don't want to warn over those. Same for achievements.
+                bool stale_game_data = *root_relative_source_path.begin() != std::filesystem::u8path( "config" ) &&
+                                       *root_relative_source_path.begin() != std::filesystem::u8path( "achievements" );
                 if( stale_game_data ) {
                     if( get_option<bool>( "WARN_ON_MODIFIED" ) ) {
                         debugmsg( "Stale game data detected at %s, did you overwrite old files?  When updating the game you must install to a fresh folder, overwriting old files will cause errors.",


### PR DESCRIPTION
#### Summary
Bugfixes "Fix game warning over 'stale data' on achievements json"

#### Purpose of change
Oops - achievements are stored as json data and flexbuffers caches them. So it warns when it finds out you earned new achievements.

#### Describe the solution
Exclude the achievements folder from the warning check.

#### Describe alternatives you've considered


#### Testing


#### Additional context

Nobody reported this?!
