### PR TITLE
Remove all hope from no hope

### DIFF
--- a/data/mods/No_Hope/eocs/eocs.json
+++ b/data/mods/No_Hope/eocs/eocs.json
@@ -1,0 +1,36 @@
+[
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_SHADOW_SPAWN_CONDITIONS_VALID_LOCATION",
+    "//COMMENT": "This override adds roads and a few rural-but-not-desolate locations to the valid spawn locations.",
+    "//COMMENT2": "TODO: Get this working with a are-you-in-a-city check, because roads are quite common there but so are buildings to hide in!",
+    "condition": {
+      "and": [
+        "u_is_outside",
+        {
+          "or": [
+            { "u_at_om_location": "field" },
+            { "u_at_om_location": "pond_field" },
+            { "u_at_om_location": "natural_spring" },
+            { "u_at_om_location": "forest" },
+            { "u_at_om_location": "trailhead" },
+            { "u_at_om_location": "forest_trail" },
+            { "u_at_om_location": "forest_thick" },
+            { "u_at_om_location": "forest_water" },
+            { "u_at_om_location": "road" },
+            { "u_at_om_location": "meadow_core" },
+            { "u_at_om_location": "meadow_end" },
+            { "u_at_om_location": "farmland_turn" },
+            { "u_at_om_location": "farmland_straight" }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_LIEUTENANT_SPAWN_SHADOW",
+    "copy-from": "EOC_LIEUTENANT_SPAWN_SHADOW",
+    "recurrence": [ "5 minutes", "1 hours" ]
+  }
+]

--- a/data/mods/No_Hope/game_balance.json
+++ b/data/mods/No_Hope/game_balance.json
@@ -101,12 +101,5 @@
     "//COMMENT": "Note that this is only intended to change the climate. The mod is not set in Russia, even though the geographic coordinates would suggest so. Technically there is no reason to change the longitude. I just felt like it, and since it will have a minute impact on sunrise times it may be a fun detail for some of our players.",
     "stype": "float",
     "value": 30.0
-  },
-  {
-    "type": "EXTERNAL_OPTION",
-    "name": "WEARY_RECOVERY_MULT",
-    "//COMMENT": "Slower weariness recovery than DDA. You sleep for hours and yet you wake up still weary. Languish, and let all hope leave you.",
-    "stype": "float",
-    "value": 0.025
   }
 ]

--- a/data/mods/No_Hope/game_balance.json
+++ b/data/mods/No_Hope/game_balance.json
@@ -16,5 +16,97 @@
     "name": "VEHICLE_FUEL_AT_SPAWN",
     "stype": "int",
     "value": 0
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "INITIAL_STAT_POINTS",
+    "stype": "int",
+    "//COMMENT": "Only relevant if points are enabled. A few points are still provided. Can be used to shore up trait points if single pool is selected, but otherwise doesn't allow someone to pick particularly high stats.",
+    "value": 2
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "INITIAL_TRAIT_POINTS",
+    "stype": "int",
+    "//COMMENT": "Only relevant if points are enabled. A negative starting balance forces points players to pick massive negative traits.",
+    "value": -10
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "INITIAL_SKILL_POINTS",
+    "stype": "int",
+    "//COMMENT": "Only relevant if points are enabled. Zeroed out intentionally. Behold the tasks ahead of you, mortal, and realize that you are not prepared.",
+    "value": 0
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "MAX_TRAIT_POINTS",
+    "stype": "int",
+    "//COMMENT": "Only relevant if points are enabled. Must be high enough to overcome INITIAL_TRAIT_POINTS.",
+    "value": 14
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "SKILL_TRAINING_SPEED",
+    "//COMMENT": "Speed is slightly slowed down. Not enough to make the game into a grind, but to contribute to the general feeling that 'there is no hope'. Everything the player does here is a little harder, a little more difficult, and it only gets worse.",
+    "stype": "float",
+    "value": 0.9
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "PROFICIENCY_TRAINING_SPEED",
+    "//COMMENT": "Speed is slightly slowed down. Not enough to make the game into a grind, but to contribute to the general feeling that 'there is no hope'. Everything the player does here is a little harder, a little more difficult, and it only gets worse.",
+    "stype": "float",
+    "value": 0.9
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "PAIN_PENALTY_MOD_STR",
+    "//COMMENT": "Extra pain scaling on strength, but only strength. Having strength lower at a much faster rate means that combat is more explosively threatening, where damage can quickly tip a fight into unwinnable and inescapable.",
+    "stype": "float",
+    "value": 0.01
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "PLAYER_HEALING_RATE",
+    "//COMMENT": "No natural regen at all, only bandaged healing works. Note that this only affects passive regeneration, healing via bandaging is unaffected!",
+    "stype": "float",
+    "value": 0.0
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "NPC_HEALING_RATE",
+    "//COMMENT": "Just to equalize the rates.",
+    "stype": "float",
+    "value": 0.0
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "EVOLUTION_INVERSE_MULTIPLIER",
+    "//COMMENT": "The end is approaching faster than you can imagine.",
+    "stype": "float",
+    "value": 0.667
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "LATITUDE",
+    "//COMMENT": "Note that this is only intended to change the climate. The mod is not set in Russia, even though the geographic coordinates would suggest so.",
+    "//COMMENT2": "Cold, miserable, with little sunlight and much twilight. This makes solar power less effective. In combination with scarce fuel, it better fits the setting.",
+    "stype": "float",
+    "value": 60.0
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "LONGITUDE",
+    "//COMMENT": "Note that this is only intended to change the climate. The mod is not set in Russia, even though the geographic coordinates would suggest so. Technically there is no reason to change the longitude. I just felt like it, and since it will have a minute impact on sunrise times it may be a fun detail for some of our players.",
+    "stype": "float",
+    "value": 30.0
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "WEARY_RECOVERY_MULT",
+    "//COMMENT": "Slower weariness recovery than DDA. You sleep for hours and yet you wake up still weary. Languish, and let all hope leave you.",
+    "stype": "float",
+    "value": 0.025
   }
 ]


### PR DESCRIPTION
#### Summary
Mods "Remove all hope from no hope"

#### Purpose of change
This is supposed to be a dark, bleak world?

#### Describe the solution
Let's actually make it bleak.

First, some changes using [the settings moved to externals](https://github.com/CleverRaven/Cataclysm-DDA/pull/80640) and some of our existing externals.

The starting point costs were made overall negative. **(No effect on 'survivor' mode.)** A negative starting balance forces points players to pick massive negative traits. A few stat points are still provided which can be used to shore up trait points if single pool is selected, but otherwise doesn't allow someone to pick particularly high stats. No skill points are provided at all. Behold the tasks ahead of you, mortal, and realize that you are not prepared.

Learning speed is slightly slowed down. Not enough to make the game into a grind, but to contribute to the general feeling that 'there is no hope'.

Weariness recovery is slower. Everything the player does here is a little harder, a little more difficult, and it only gets worse.

Passive non-bandaged healing is completely eliminated. (Bandaged healing is not affected or modified in any way, it's not even available via externals)

Combat pain will affect the player's strength more. Having strength lower at a much faster rate means that combat is more explosively threatening, where damage can quickly tip a fight into unwinnable and inescapable.

Monsters evolve faster. No direct changes were made to their stat blocks, because fighting a wall of stats isn't fun. Instead you get more *evolved* zombies, which means more special ones. Necromancers, grapplers, hive hulks, acids.

The latitude was changed to a more appropriate locale (60° north). This makes solar power less effective. In combination with scarce fuel, it better fits the setting. Note that this is only intended to change the climate. The mod is still set in New England, even though the geographic coordinates would suggest otherwise.



Past that I've changed some existing content to make it better fit:

(NOT DONE YET) A certain shadowy friend will visit more often and in more parts of the wilderness.

(NOT DONE YET) The shadowy friend will be persistent, even if you kill it, it will come back.

#### Describe alternatives you've considered


#### Testing


#### Additional context

Known issues:
Some mutation lines intentionally buff passive non-bandaged healing. With the changes to healing rate, these buffs become meaningless. (Though in my strong opinion these buffs were always rather useless, passive healing is very slow even without the change to healing rate. The change mostly makes it more *thematic*.)
