### PR TITLE
Break up/refactor the shadow singularity's EOCs

### DIFF
--- a/data/json/monsters/singularities.json
+++ b/data/json/monsters/singularities.json
@@ -332,20 +332,27 @@
   },
   {
     "type": "effect_on_condition",
-    "id": "EOC_LIEUTENANT_SPAWN_SHADOW",
-    "recurrence": [ "15 minutes", "9 hours" ],
-    "global": true,
-    "run_for_npcs": false,
-    "//1": "Night time, shadow is active, you are outdoors *and awake*, and you are not likely to be near shelter.",
-    "//2": "Requires at least one warning to have been given before spawning can succeed. The warnings are global, not character-unique.",
+    "id": "EOC_SHADOW_SPAWN_CONDITIONS_SHOULD_SPAWN",
+    "condition": { "one_in_chance": 6 }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_SHADOW_SPAWN_CONDITIONS_CAN_SPAWN",
     "condition": {
       "and": [
-        { "one_in_chance": 6 },
         { "not": "is_day" },
         { "not": { "u_has_effect": "sleep" } },
         { "math": [ "Lieutenants_active > 0" ] },
         { "math": [ "Shadow_Lurking > 0" ] },
-        { "math": [ "Shadow_Warnings >= 1" ] },
+        { "math": [ "Shadow_Warnings >= 1" ] }
+      ]
+    }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_SHADOW_SPAWN_CONDITIONS_VALID_LOCATION",
+    "condition": {
+      "and": [
         "u_is_outside",
         {
           "or": [
@@ -356,14 +363,46 @@
           ]
         }
       ]
-    },
+    }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_SHADOW_SPAWN_CONDITIONS",
+    "//1": "Night time, shadow is active, you are outdoors *and awake*, and you are not likely to be near shelter.",
+    "//2": "Requires at least one warning to have been given before spawning can succeed. The warnings are global, not character-unique.",
+    "condition": {
+      "and": [
+        { "test_eoc": "EOC_SHADOW_SPAWN_CONDITIONS_SHOULD_SPAWN" },
+        { "test_eoc": "EOC_SHADOW_SPAWN_CONDITIONS_CAN_SPAWN" },
+        { "test_eoc": "EOC_SHADOW_SPAWN_CONDITIONS_VALID_LOCATION" }
+      ]
+    }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_LIEUTENANT_SPAWN_SHADOW",
+    "recurrence": [ "15 minutes", "9 hours" ],
+    "global": true,
+    "run_for_npcs": false,
+    "condition": { "test_eoc": "EOC_SHADOW_SPAWN_CONDITIONS" },
+    "effect": [ { "run_eocs": [ "EOC_LIEUTENANT_SPAWN_SHADOW_PREP" ] } ],
+    "false_effect": [ { "run_eocs": [ "EOC_LIEUTENANT_SHADOW_WARN" ] } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_LIEUTENANT_SPAWN_SHADOW_PREP",
+    "//COMMENT": "The purpose of this prep stage is to allow our in-repo mods to selectively hook into the spawn logic without overriding critical parts of the EOC chain. For example Mind over Matter delays the spawn for clairsentients, implementing a 'premonition' of the incoming danger. Here in vanilla we just spawn it, right now.",
+    "effect": [ { "run_eocs": [ "EOC_LIEUTENANT_SPAWN_SHADOW_NOW" ] } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_LIEUTENANT_SPAWN_SHADOW_NOW",
     "effect": [
       { "math": [ "Shadow_Lurking", "-=", "1" ] },
       { "u_spawn_monster": "mon_lieutenant_shadow", "real_count": 1, "min_radius": 10, "max_radius": 15 },
       { "u_location_variable": { "global_val": "shadow_encounter_XYZ_pos" }, "min_radius": 1, "max_radius": 1 },
       { "run_eocs": "EOC_LIEUTENANT_SPAWN_SHADOW_MESSAGE", "time_in_future": 1 }
-    ],
-    "false_effect": [ { "run_eocs": [ "EOC_LIEUTENANT_SHADOW_WARN" ] } ]
+    ]
   },
   {
     "type": "effect_on_condition",

--- a/data/mods/MindOverMatter/effectoncondition/eoc_premonition_instances.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_premonition_instances.json
@@ -1,21 +1,8 @@
 [
   {
     "type": "effect_on_condition",
-    "id": "EOC_LIEUTENANT_SPAWN_SHADOW",
-    "recurrence": [ "4 hours", "4 hours" ],
-    "//": "Copy EoC: original in json/monsters/singularities.json",
-    "condition": {
-      "and": [
-        { "one_in_chance": 6 },
-        { "not": "is_day" },
-        { "math": [ "u_Lieutenants_active > 0" ] },
-        { "math": [ "u_Shadow_Lurking > 0" ] },
-        "u_is_outside",
-        {
-          "or": [ { "u_at_om_location": "field" }, { "u_at_om_location": "forest" }, { "u_at_om_location": "forest_thick" } ]
-        }
-      ]
-    },
+    "id": "EOC_LIEUTENANT_SPAWN_SHADOW_PREP",
+    "//": "Copy and overwrite of EoC: original in json/monsters/singularities.json",
     "effect": [
       {
         "run_eocs": [
@@ -29,23 +16,14 @@
                 "popup": true
               },
               {
-                "run_eocs": "EOC_LIEUTENANT_SPAWN_SHADOW_ACTUAL",
+                "run_eocs": "EOC_LIEUTENANT_SPAWN_SHADOW_NOW",
                 "time_in_future": { "math": [ "(u_spell_level('clair_danger_sense') * 5) + 10" ] }
               }
             ],
-            "false_effect": [ { "run_eocs": [ "EOC_LIEUTENANT_SPAWN_SHADOW_ACTUAL" ] } ]
+            "false_effect": [ { "run_eocs": [ "EOC_LIEUTENANT_SPAWN_SHADOW_NOW" ] } ]
           }
         ]
       }
-    ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "EOC_LIEUTENANT_SPAWN_SHADOW_ACTUAL",
-    "effect": [
-      { "math": [ "u_Shadow_Lurking--" ] },
-      { "u_spawn_monster": "mon_lieutenant_shadow", "real_count": 1, "min_radius": 10, "max_radius": 15 },
-      { "run_eocs": "EOC_LIEUTENANT_SPAWN_SHADOW_MESSAGE", "time_in_future": 1 }
     ]
   },
   {

--- a/data/mods/MindOverMatter/obsolete/eocs.json
+++ b/data/mods/MindOverMatter/obsolete/eocs.json
@@ -79,5 +79,10 @@
     "type": "effect_on_condition",
     "id": "EOC_BIOKIN_ENHANCE_MOBILITY_SWITCHER",
     "effect": [  ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_LIEUTENANT_SPAWN_SHADOW_ACTUAL",
+    "effect": [  ]
   }
 ]

--- a/data/mods/Xedra_Evolved/eocs/vanilla_overwrites.json
+++ b/data/mods/Xedra_Evolved/eocs/vanilla_overwrites.json
@@ -20,34 +20,15 @@
   },
   {
     "type": "effect_on_condition",
-    "id": "EOC_LIEUTENANT_SPAWN_SHADOW",
-    "recurrence": [ "15 minutes", "9 hours" ],
-    "global": true,
-    "run_for_npcs": false,
-    "//1": "Night time, shadow is active, you are outdoors *and awake*, and you are not likely to be near shelter.",
-    "//2": "Requires at least one warning to have been given before spawning can succeed. The warnings are global, not character-unique.",
-    "condition": {
-      "and": [
-        { "one_in_chance": 6 },
-        { "not": "is_day" },
-        { "not": { "u_has_effect": "sleep" } },
-        { "math": [ "Lieutenants_active > 0" ] },
-        { "math": [ "Shadow_Lurking > 0" ] },
-        { "math": [ "Shadow_Warnings >= 1" ] },
-        "u_is_outside",
-        {
-          "or": [ { "u_at_om_location": "field" }, { "u_at_om_location": "forest" }, { "u_at_om_location": "forest_thick" } ]
-        }
-      ]
-    },
+    "id": "EOC_LIEUTENANT_SPAWN_SHADOW_NOW",
+    "//": "Copy and overwrite of EoC: original in json/monsters/singularities.json",
     "effect": [
       { "math": [ "Shadow_Lurking", "-=", "1" ] },
       { "assign_mission": "MISSION_KILL_SHADOW" },
       { "u_spawn_monster": "mon_lieutenant_shadow", "real_count": 1, "min_radius": 10, "max_radius": 15 },
       { "u_location_variable": { "global_val": "shadow_encounter_XYZ_pos" }, "min_radius": 1, "max_radius": 1 },
       { "run_eocs": "EOC_LIEUTENANT_SPAWN_SHADOW_MESSAGE", "time_in_future": 1 }
-    ],
-    "false_effect": [ { "run_eocs": [ "EOC_LIEUTENANT_SHADOW_WARN" ] } ]
+    ]
   },
   {
     "type": "effect_on_condition",


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Better maintainability, cleaner code, easier mod overrides.

#### Describe the solution
Break up the existing monolithic EOCs that spawn the shadow into a bunch of test_eocs and conditional run_eocs.

EOC_LIEUTENANT_SPAWN_SHADOW runs a test_eoc for EOC_SHADOW_SPAWN_CONDITIONS, which itself tests three different EOC blocks - SHOULD_SPAWN, CAN_SPAWN, and VALID_LOCATION (prefixes omitted). This will allow selectively changing bits and pieces of it without overriding everything.

Change the spawn eoc to run a prep stage (EOC_LIEUTENANT_SPAWN_SHADOW_PREP) which leads to the actual spawn (EOC_LIEUTENANT_SPAWN_SHADOW_NOW). This allows MoM to cleanly insert itself into the spawn logic and do nothing besides delay it for clairsentients, aka their warning premonition.

Update MoM's and XE's existing overrides to take advantage of it. Required for #80711

#### Describe alternatives you've considered
XE still overrides the spawning effects in EOC_LIEUTENANT_SPAWN_SHADOW_NOW. For even better maintainability we might want to change that? But I don't know where else we'd assign the mission - maybe in prep? But there's the "added bonus" that having XE and MoM overwrite different parts of the chain makes them, technically, compatible without any more work. XE was already overriding the spawn, so this isn't *worse*.

#### Testing
Game loads. The logic was mostly just shuffled around to make it much easier to manipulate, there should be no effective changes ingame. Except for MoM, as noted below.

#### Additional context
