### PR TITLE
update the flag of sourdough bread

### DIFF
--- a/data/json/items/comestibles/bread.json
+++ b/data/json/items/comestibles/bread.json
@@ -115,9 +115,9 @@
     "material": [ "wheat" ],
     "looks_like": "bread",
     "volume": "75 ml",
-    "flags": [ "EATEN_HOT", "NUTRIENT_OVERRIDE" ],
+    "flags": [ "EATEN_HOT", "EDIBLE_FROZEN" ],
     "fun": 2,
-    "vitamins": [ [ "wheat_allergen", 1 ] ]
+    "vitamins": [ [ "calcium", 5 ], [ "iron", 10 ], [ "wheat_allergen", 1 ] ]
   },
   {
     "type": "ITEM",


### PR DESCRIPTION
from Nutrient-override to EDIBLE_FROZEN and EDIBLE_HOT, while also changing the nutrient value from just wheat alleergy to also give 5 calcium and 10 iron

Summary
Bugfixes "Sourdough bread has no nutrients"

Purpose of change
close https://github.com/CleverRaven/Cataclysm-DDA/pull/80438
To reproduce the bug: Make or spawn sourdough bread compare it to others.

Describe the solution
Update the flag of sourdough bread from Nutrient-override to EDIBLE_FROZEN and EDIBLE_HOT, while also changing the nutrient value from just wheat allergy to also give 5 calcium and 10 iron.

Describe alternatives you've considered
Tried just removing the Nutrient-override tag but did not entirely fix it, it still didn't give out iron or calcium.

Testing
I used the debug menu to spawn a sourdough bread and check the nutrient value. It does give out iron and calcium after the fix.