### PR TITLE
Bugfixes: Stop crashing when SLEEPINESS enchant value <= 0

### DIFF
--- a/src/activity_tracker.cpp
+++ b/src/activity_tracker.cpp
@@ -22,31 +22,37 @@ int activity_tracker::weariness() const
 void activity_tracker::try_reduce_weariness( int bmr, float sleepiness_mod,
         float sleepiness_regen_mod )
 {
-    if( average_activity() < LIGHT_EXERCISE ) {
-        cata_assert( sleepiness_mod > 0.0f );
-        low_activity_ticks += std::min( 1.0f, ( ( LIGHT_EXERCISE - average_activity() ) /
-                                                ( LIGHT_EXERCISE - NO_EXERCISE ) ) ) / sleepiness_mod;
-        // Recover (by default) twice as fast while sleeping
-        if( average_activity() < NO_EXERCISE ) {
-            low_activity_ticks += ( ( NO_EXERCISE - average_activity() ) /
-                                    ( NO_EXERCISE - SLEEP_EXERCISE ) ) * sleepiness_regen_mod;
-        }
-    }
-
     const float recovery_mult = get_option<float>( "WEARY_RECOVERY_MULT" );
-    const int bmr_cal = bmr * 1000;
-
-    if( low_activity_ticks >= 1.0f ) {
-        int reduction = tracker;
-        // 1/120 of whichever's bigger
-        if( bmr_cal > reduction ) {
-            reduction = std::floor( bmr_cal * recovery_mult * low_activity_ticks / 6.0f );
-        } else {
-            reduction = std::ceil( reduction * recovery_mult * low_activity_ticks / 6.0f );
+    // As sleepiness_mod approaches zero, low_activity_ticks and reduction approach infinity which in turn make tracker approach - infinity before being capped at 0.
+    // Skip the math and just automatically set tracker to 0.
+    if( sleepiness_mod <= 0.0f ) {
+        tracker = 0;
+    } else {
+        if( average_activity() < LIGHT_EXERCISE ) {
+            // cata_assert( sleepiness_mod > 0.0f );
+            low_activity_ticks += std::min( 1.0f,
+                                            ( ( LIGHT_EXERCISE - average_activity() ) / ( LIGHT_EXERCISE - NO_EXERCISE ) ) ) / sleepiness_mod;
+            // Recover (by default) twice as fast while sleeping
+            if( average_activity() < NO_EXERCISE ) {
+                low_activity_ticks += ( ( NO_EXERCISE - average_activity() ) / ( NO_EXERCISE - SLEEP_EXERCISE ) ) *
+                                      sleepiness_regen_mod;
+            }
         }
-        low_activity_ticks = 0.0f;
 
-        tracker -= std::max( reduction, 1 );
+        const int bmr_cal = bmr * 1000;
+
+        if( low_activity_ticks >= 1.0f ) {
+            int reduction = tracker;
+            // 1/120 of whichever's bigger
+            if( bmr_cal > reduction ) {
+                reduction = std::floor( bmr_cal * recovery_mult * low_activity_ticks / 6.0f );
+            } else {
+                reduction = std::ceil( reduction * recovery_mult * low_activity_ticks / 6.0f );
+            }
+            low_activity_ticks = 0.0f;
+
+            tracker -= std::max( reduction, 1 );
+        }
     }
 
     // If happens to be no reduction, character is not (as) hypoglycemic

--- a/src/activity_tracker.cpp
+++ b/src/activity_tracker.cpp
@@ -5,7 +5,6 @@
 #include <map>
 #include <utility>
 
-#include "cata_assert.h"
 #include "game_constants.h"
 #include "options.h"
 #include "string_formatter.h"


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Stop crashing when SLEEPINESS enchant value <= 0"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Stop crashing when SLEEPINESS enchant value <= 0
Fixes #80720
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Code previously used an assert to check that the value was not <= 0 to prevent a divide by zero, but that crashes the game anyways if it is triggered.
Remove the assert, and instead just set the calculated value to zero since that's what the final result approaches the closer SLEEPINESS enchant gets to zero.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Not diving into weariness code calculations
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Booted the attached save and waited 5 minutes to trigger the function and observed 1), no crash, and 2) weariness decreased correctly.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
