### PR TITLE
Add myself (-Kray4000) to comment-commands list

### DIFF
--- a/.github/comment-commands.yml
+++ b/.github/comment-commands.yml
@@ -55,6 +55,7 @@ users:
     - Standing-Storm
     - terribleperson
     - moxian
+    - Kray4000
 
 keywords:
   - name: confirm-bug


### PR DESCRIPTION


#### Summary
 None

#### Purpose of change

RenechCDDA mention that I can add myself to special list that will allow me to use / (slash) commands. 
https://github.com/CleverRaven/Cataclysm-DDA/issues/80713#issuecomment-2831523873


#### Describe the solution

Add `-Kray4000` to [.github/comment-commands.yml](https://github.com/CleverRaven/Cataclysm-DDA/blob/master/.github/comment-commands.yml)

#### Describe alternatives you've considered

Do not do nothing. I'm not really experienced contributor, can do mistakes and can live without this feature.





