### PR TITLE
Remove camouflage from 'A shadow?'

### DIFF
--- a/data/json/monsters/singularities.json
+++ b/data/json/monsters/singularities.json
@@ -94,7 +94,6 @@
       "ALWAYS_SEES_YOU",
       "HAS_MIND",
       "NIGHT_INVISIBILITY",
-      "CAMOUFLAGE",
       "NO_FUNG_DMG",
       "FILTHY",
       "STUN_IMMUNE",


### PR DESCRIPTION
#### Summary
Balance "Make 'A shadow?' visible to low-PER characters"

#### Purpose of change
I have seen many people saying they encountered an "event" that is this guy spawning, without understanding that they were facing a real enemy. They assumed that the amalgamations just appear out of nowhere, with no cause or way to stop them.

Upon further investigation I concluded that they were unable to see the Shadow because it tries really damn hard to stay at a specific range. That range is just within visibility of a character with 8 perception, the default. But not all characters come with default perception...

Thus, characters with lower perception would have no way of seeing the enemy or knowing which direction they needed to go to make them become visible. This made it appear as though there was no enemy, and is frankly very bad.

#### Describe the solution
Remove the CAMOUFLAGE flag which causes this.

NIGHT_INVSIBILITY is kept so that an actual light still needs to be used to spot them. This is thematically appropriate, and frankly if you don't have a light you aren't going to be killing it anyway.

#### Describe alternatives you've considered
We could remove NIGHT_INVSIBILITY as well. If I continue to see reports of people being unaware of the enemy, I think I might do this.

#### Testing


#### Additional context
