### PR TITLE
Remove 'Rural' setting from city size slider

### DIFF
--- a/data/core/world_option_sliders.json
+++ b/data/core/world_option_sliders.json
@@ -4,28 +4,22 @@
     "id": "world_cities",
     "context": "WORLDGEN",
     "name": "Cities",
-    "default": 1,
+    "default": 0,
     "levels": [
       {
         "level": 0,
-        "name": "Rural",
-        "description": "Cities are half as large and twice as far apart.",
-        "options": [ { "option": "CITY_SIZE", "type": "int", "val": 4 }, { "option": "CITY_SPACING", "type": "int", "val": 8 } ]
-      },
-      {
-        "level": 1,
         "name": "Suburbia",
         "description": "Cities use default size and distances, with small to large cities separated by large rural areas.",
         "options": [ { "option": "CITY_SIZE", "type": "int", "val": 8 }, { "option": "CITY_SPACING", "type": "int", "val": 4 } ]
       },
       {
-        "level": 2,
+        "level": 1,
         "name": "Cityscape",
         "description": "Cities are 50% larger and 25% closer to each other.",
         "options": [ { "option": "CITY_SIZE", "type": "int", "val": 12 }, { "option": "CITY_SPACING", "type": "int", "val": 3 } ]
       },
       {
-        "level": 3,
+        "level": 2,
         "name": "Megacity",
         "description": "Cities are nearly continuous, with minimal distance between them.",
         "options": [ { "option": "CITY_SIZE", "type": "int", "val": 16 }, { "option": "CITY_SPACING", "type": "int", "val": 1 } ]


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
* Fixes #80528

After another round of discussion in the development discord, there has been no other way to guarantee that the content in game works as we expect. We cannot rewrite all the quests in the game to assume the user broke their world settings and made things not spawn.

#### Describe the solution
Remove the foot-gun

#### Describe alternatives you've considered
Do nothing, let the game be broken forever. Cancel all cdda development because people get mad that new versions come out.

Honestly, we should be removing the higher sizes too. I am simply doing the bare minimum here.

#### Testing
Slider still works as expected.

![image](https://github.com/user-attachments/assets/4fbecade-f8bb-4e6f-a7f8-ca5823db5dc7)


#### Additional context

