### PR TITLE
Refactor riot damage + add 'pre-burnt' generator

### DIFF
--- a/data/json/furniture_and_terrain/terrain-floors-indoor.json
+++ b/data/json/furniture_and_terrain/terrain-floors-indoor.json
@@ -1631,6 +1631,28 @@
   },
   {
     "type": "terrain",
+    "id": "t_floor_burnt",
+    "name": "burnt floor",
+    "description": "Whatever this floor used to be made of, it's little more than charred remains now.",
+    "symbol": ".",
+    "looks_like": "t_dirtfloor",
+    "color": "black",
+    "move_cost": 2,
+    "connect_groups": "INDOORFLOOR",
+    "flags": [ "TRANSPARENT", "COLLAPSES", "INDOORS" ],
+    "bash": {
+      "str_min": 1,
+      "str_max": 6,
+      "//COMMENT": "I don't know, charcoal breaking sounds? Onomatopoeia is outside my skillset!",
+      "sound": "crunch!",
+      "sound_fail": "twang!",
+      "sound_vol": 8,
+      "sound_fail_vol": 4,
+      "ter_set": "t_null"
+    }
+  },
+  {
+    "type": "terrain",
     "id": "t_floor_paper",
     "name": "paper floor",
     "description": "A floor made of ambiguous pulpy matter, covered in sticky wasp saliva.  It has, or at least had, a roof of similar a material.",

--- a/data/json/furniture_and_terrain/terrain-walls.json
+++ b/data/json/furniture_and_terrain/terrain-walls.json
@@ -1175,6 +1175,29 @@
   },
   {
     "type": "terrain",
+    "id": "t_wall_burnt",
+    "name": "burnt wall",
+    "looks_like": "t_wall_wood_broken",
+    "description": "Whatever this wall used to be made of, it's little more than charred remains now.",
+    "symbol": "#",
+    "color": "black",
+    "move_cost": 0,
+    "coverage": 35,
+    "connect_groups": "WALL",
+    "connects_to": "WALL",
+    "flags": [ "TRANSPARENT", "NOITEM", "SUPPORTS_ROOF", "REDUCE_SCENT", "PERMEABLE" ],
+    "bash": {
+      "str_min": 4,
+      "str_max": 20,
+      "sound": "crash!",
+      "sound_fail": "whump!",
+      "ter_set": "t_null",
+      "items": [ { "item": "ash", "count": [ 200, 500 ] }, { "item": "scrap", "count": [ 2, 5 ] } ]
+    },
+    "shoot": { "chance_to_hit": 25, "reduce_damage": [ 5, 10 ], "reduce_damage_laser": [ 10, 30 ], "destroy_damage": [ 5, 20 ] }
+  },
+  {
+    "type": "terrain",
     "id": "t_wall_log_half",
     "name": "half-built log wall",
     "looks_like": "t_wall_log",


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
#79943

This PR breaks up the bashing, item moving, and fire-setting into separate standardized functions. It aims to eliminate 'magic numbers' and prepare the code to be loaded from JSON definitions.

Additionally, another generator is added along the same principles. 'Pre-brunt'. This is used to simulate fires having already happened before the player visited, and is intended to largely be a 1:1 replacement for fires for later arrivals.

#### Describe the solution
#79943

For pre-burnt structures we designate a square, or a circle, or some area, and we say "That had a fire". We replace anything with the `WALL` flag with a hardcoded terrain, `burnt wall` or whatever. We replace floors with a similar one. Outside areas get torched into dirt. Delete all furniture and items in the affected area, litter some ash piles.

**The current implementation simply burns the entire OMT**, without trying to make any fun shapes.

#### Describe alternatives you've considered


#### Testing
(Taken during development, floors were not properly burned. They are burned now, and look like `t_dirtfloor`)
![image](https://github.com/user-attachments/assets/987d8056-e9d8-4c8a-9dae-299643076a3b)


#### Additional context
Ugh git makes a really awful looking diff for this.