### PR TITLE
Removed wooden panel bash drop from Half Built wall

### DIFF
--- a/data/json/furniture_and_terrain/terrain-walls.json
+++ b/data/json/furniture_and_terrain/terrain-walls.json
@@ -156,7 +156,6 @@
       "ter_set": "t_null",
       "items": [
         { "item": "2x4", "count": [ 0, 5 ] },
-        { "item": "wood_panel", "count": [ 0, 1 ] },
         { "item": "nail", "charges": [ 0, 5 ] },
         { "item": "splinter", "count": [ 5, 10 ] }
       ]


### PR DESCRIPTION
#### Summary
Content "Removed wooden panel bash item drop from Half Built wall"

#### Purpose of change

You build 'half-built wall' terrain with no wooden panels, there should be none that drop if you destroy it by smashing it.

#### Describe the solution

I just removed the drop.

#### Describe alternatives you've considered

none

#### Testing

checked, it works.

#### Additional context

None


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
