### PR TITLE
Make milking a gradual transfer activity with an up front destination selection.

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -5522,7 +5522,9 @@ void milk_activity_actor::finish( player_activity &act, Character &who )
     }
     item milk( milked_item->first, calendar::turn, milked_item->second );
     milk.set_item_temperature( units::from_celsius( 38.6 ) );
-    if( liquid_handler::handle_liquid( milk, nullptr, 1, nullptr, nullptr, -1, source_mon ) ) {
+    liquid_dest_opt liquid_target;
+    if( liquid_handler::handle_liquid( milk, liquid_target, nullptr, 1, nullptr, nullptr, -1,
+                                       source_mon ) ) {
         milked_item->second = 0;
         if( milk.charges > 0 ) {
             milked_item->second = milk.charges;

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -5490,6 +5490,7 @@ void milk_activity_actor::do_turn( player_activity &act, Character &who )
         // We might end up here if the creature dies while being milked
         who.add_msg_if_player( m_bad, _( "The udders slip out of your hands." ) );
         act.set_to_null();
+        return;
     }
 
     if( target.dest_opt != LD_NULL ) { // Backward compatibility check 2025-04-29.
@@ -5535,7 +5536,6 @@ void milk_activity_actor::finish( player_activity &act, Character &who )
     }
     item milk( milked_item->first, calendar::turn, milked_item->second );
     milk.set_item_temperature( units::from_celsius( 38.6 ) );
-    target;
     if( liquid_handler::handle_liquid( milk, target, nullptr, 1, nullptr, nullptr, -1,
                                        source_mon ) ) {
         milked_item->second = 0;

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -5478,34 +5478,47 @@ void milk_activity_actor::start( player_activity &act, Character &/*who*/ )
 {
     act.moves_total = total_moves;
     act.moves_left = total_moves;
+    next_unit_move = calendar::turn + time_duration::from_moves( moves_per_unit );
 }
 
 void milk_activity_actor::do_turn( player_activity &act, Character &who )
 {
-    if( monster_coords.empty() ) {
-        debugmsg( "milking activity with no position of monster stored" );
-        act.set_to_null();
-        return;
-    }
     map &here = get_map();
-    const tripoint_bub_ms source_pos = here.get_bub( tripoint_abs_ms( monster_coords.at( 0 ) ) );
+    const tripoint_bub_ms source_pos = here.get_bub( monster_coords );
     monster *source_mon = get_creature_tracker().creature_at<monster>( source_pos );
     if( source_mon == nullptr ) {
         // We might end up here if the creature dies while being milked
         who.add_msg_if_player( m_bad, _( "The udders slip out of your hands." ) );
         act.set_to_null();
     }
+
+    if( target.dest_opt != LD_NULL ) { // Backward compatibility check 2025-04-29.
+        if( calendar::turn >= next_unit_move ) {
+            // Add one since we've included that in next_unit_move.
+            int units = to_moves<int>( calendar::turn - next_unit_move ) / moves_per_unit + 1;
+            next_unit_move += time_duration::from_moves( moves_per_unit );
+
+            auto milked_item = source_mon->ammo.find( source_mon->type->starting_ammo.begin()->first );
+            units = std::min( units, milked_item->second );
+            item milk( milked_item->first, calendar::turn, units );
+            milk.set_item_temperature( units::from_celsius( 38.6 ) );
+
+            if( liquid_handler::handle_liquid( milk, target, nullptr, 1, nullptr, nullptr, -1,
+                                               source_mon, true ) ) {
+                milked_item->second--;
+                if( milked_item->second == 0 ) {
+                    who.add_msg_if_player( _( "The %s's udders run dry." ), source_mon->get_name() );
+                }
+            }
+        }
+    }
 }
 
 void milk_activity_actor::finish( player_activity &act, Character &who )
 {
     act.set_to_null();
-    if( monster_coords.empty() ) {
-        debugmsg( "milking activity with no position of monster stored" );
-        return;
-    }
     map &here = get_map();
-    const tripoint_bub_ms source_pos = here.get_bub( tripoint_abs_ms( monster_coords.at( 0 ) ) );
+    const tripoint_bub_ms source_pos = here.get_bub( monster_coords );
     monster *source_mon = get_creature_tracker().creature_at<monster>( source_pos );
     if( source_mon == nullptr ) {
         debugmsg( "could not find source creature for liquid transfer" );
@@ -5522,8 +5535,8 @@ void milk_activity_actor::finish( player_activity &act, Character &who )
     }
     item milk( milked_item->first, calendar::turn, milked_item->second );
     milk.set_item_temperature( units::from_celsius( 38.6 ) );
-    liquid_dest_opt liquid_target;
-    if( liquid_handler::handle_liquid( milk, liquid_target, nullptr, 1, nullptr, nullptr, -1,
+    target;
+    if( liquid_handler::handle_liquid( milk, target, nullptr, 1, nullptr, nullptr, -1,
                                        source_mon ) ) {
         milked_item->second = 0;
         if( milk.charges > 0 ) {
@@ -5534,7 +5547,7 @@ void milk_activity_actor::finish( player_activity &act, Character &who )
     }
     // if the monster was not manually tied up, but needed to be fixed in place temporarily then
     // remove that now.
-    if( !string_values.empty() && string_values[0] == "temp_tie" ) {
+    if( milking_tie ) {
         source_mon->remove_effect( effect_tied );
     }
 }
@@ -5545,7 +5558,26 @@ void milk_activity_actor::serialize( JsonOut &jsout ) const
 
     jsout.member( "total_moves", total_moves );
     jsout.member( "monster_coords", monster_coords );
-    jsout.member( "string_values", string_values );
+    jsout.member( "milking_tie", milking_tie );
+    jsout.member( "targer_dest_opt", static_cast<int>( target.dest_opt ) );
+
+    switch( target.dest_opt ) {
+        case LD_ITEM:
+            jsout.member( "target_item_loc", target.item_loc );
+            break;
+
+        case LD_KEG:
+            jsout.member( "target_pos", target.pos );
+            break;
+
+        case LD_NULL:
+        case LD_CONSUME:
+        case LD_GROUND:
+        case LD_VEH:
+            break;
+    }
+    jsout.member( "moves_per_unit", moves_per_unit );
+    jsout.member( "next_unit_move", next_unit_move );
 
     jsout.end_object();
 }
@@ -5557,7 +5589,40 @@ std::unique_ptr<activity_actor> milk_activity_actor::deserialize( JsonValue &jsi
 
     data.read( "moves_total", actor.total_moves );
     data.read( "monster_coords", actor.monster_coords );
-    data.read( "string_values", actor.string_values );
+    // Backward compatibility introduced 2025-04-29.
+    // When removing it, there's no need for the 'if' check.
+    if( data.read( "milking_tie", actor.milking_tie ) ) {
+        int temp;
+        data.read( "target_dest_opt", temp );
+        actor.target.dest_opt = static_cast<liquid_dest>( temp );
+
+        switch( actor.target.dest_opt ) {
+            case LD_ITEM:
+                data.read( "target_item_loc", actor.target.item_loc );
+                break;
+
+            case LD_KEG:
+                data.read( "target_pos", actor.target.pos );
+                break;
+
+            case LD_NULL:
+            case LD_CONSUME:
+            case LD_GROUND:
+            case LD_VEH:
+                actor.target.dest_opt = LD_NULL;
+                break;
+        }
+
+        data.read( "moves_per_unit", actor.moves_per_unit );
+        data.read( "next_unit_move", actor.next_unit_move );
+    } else {
+        std::string temp;
+        data.read( "string_values", temp );
+        actor.milking_tie = !temp.empty();
+        actor.target.dest_opt = LD_NULL;
+        actor.moves_per_unit = 3000;
+        actor.next_unit_move = calendar::turn;
+    }
 
     return actor.clone();
 }

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -1407,9 +1407,10 @@ class milk_activity_actor : public activity_actor
 {
     public:
         milk_activity_actor() = default;
-        milk_activity_actor( int moves, std::vector<tripoint_abs_ms> coords,
-                             std::vector<std::string> str_values ) : total_moves( moves ), monster_coords( std::move( coords ) ),
-            string_values( std::move( str_values ) ) {}
+        milk_activity_actor( int moves, int moves_per_unit, tripoint_abs_ms coords,
+                             liquid_dest_opt &target, bool milking_tie = true ) : total_moves( moves ),
+            moves_per_unit( moves_per_unit ), monster_coords( std::move( coords ) ), target( target ),
+            milking_tie( milking_tie ) {}
 
         const activity_id &get_type() const override {
             static const activity_id ACT_MILK( "ACT_MILK" );
@@ -1430,8 +1431,11 @@ class milk_activity_actor : public activity_actor
 
     private:
         int total_moves {};
-        std::vector<tripoint_abs_ms> monster_coords;
-        std::vector<std::string> string_values;
+        tripoint_abs_ms monster_coords;
+        bool milking_tie; // was the monster tied due to milking.
+        liquid_dest_opt target;
+        int moves_per_unit;
+        time_point next_unit_move;
 };
 
 class shearing_activity_actor : public activity_actor

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -1409,7 +1409,7 @@ class milk_activity_actor : public activity_actor
         milk_activity_actor() = default;
         milk_activity_actor( int moves, int moves_per_unit, tripoint_abs_ms coords,
                              liquid_dest_opt &target, bool milking_tie = true ) : total_moves( moves ),
-            moves_per_unit( moves_per_unit ), monster_coords( std::move( coords ) ), target( target ),
+            moves_per_unit( moves_per_unit ), monster_coords( coords ), target( target ),
             milking_tie( milking_tie ) {}
 
         const activity_id &get_type() const override {
@@ -1431,10 +1431,10 @@ class milk_activity_actor : public activity_actor
 
     private:
         int total_moves {};
-        tripoint_abs_ms monster_coords;
-        bool milking_tie; // was the monster tied due to milking.
-        liquid_dest_opt target;
         int moves_per_unit;
+        tripoint_abs_ms monster_coords;
+        liquid_dest_opt target;
+        bool milking_tie; // was the monster tied due to milking.
         time_point next_unit_move;
 };
 

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -1670,11 +1670,11 @@ void activity_handlers::fill_liquid_do_turn( player_activity *act, Character *yo
                 break;
             }
             case liquid_target_type::CONTAINER:
-                you->pour_into( act_ref.targets.at( 0 ), liquid, true );
+                you->pour_into( act_ref.targets.at( 0 ), liquid, true, false );
                 break;
             case liquid_target_type::MAP:
                 if( iexamine::has_keg( here.get_bub( act_ref.coords.at( 1 ) ) ) ) {
-                    iexamine::pour_into_keg( here.get_bub( act_ref.coords.at( 1 ) ), liquid );
+                    iexamine::pour_into_keg( here.get_bub( act_ref.coords.at( 1 ) ), liquid, false );
                 } else {
                     here.add_item_or_charges( here.get_bub( act_ref.coords.at( 1 ) ), liquid );
                     you->add_msg_if_player( _( "You pour %1$s onto the ground." ), liquid.tname() );

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -6070,7 +6070,8 @@ bool Character::sees_with_specials( const Creature &critter ) const
     return false;
 }
 
-bool Character::pour_into( item_location &container, item &liquid, bool ignore_settings )
+bool Character::pour_into( item_location &container, item &liquid, bool ignore_settings,
+                           bool silent )
 {
     std::string err;
     int max_remaining_capacity = container->get_remaining_capacity_for_liquid( liquid, *this, &err );
@@ -6101,12 +6102,14 @@ bool Character::pour_into( item_location &container, item &liquid, bool ignore_s
         amount = std::min( amount, liquid.charges );
     }
 
-    add_msg_if_player( _( "You pour %1$s into the %2$s." ), liquid.tname(), container->tname() );
+    if( !silent ) {
+        add_msg_if_player( _( "You pour %1$s into the %2$s." ), liquid.tname(), container->tname() );
+    }
 
     liquid.charges -= container->fill_with( liquid, amount, false, false, ignore_settings );
     inv->unsort();
 
-    if( liquid.charges > 0 ) {
+    if( liquid.charges > 0 && !silent ) {
         add_msg_if_player( _( "There's some left over!" ) );
     }
 

--- a/src/character.h
+++ b/src/character.h
@@ -2116,7 +2116,7 @@ class Character : public Creature, public visitable
          * possible at all. `true` indicates at least some of the liquid has been moved.
          */
         /**@{*/
-        bool pour_into( item_location &container, item &liquid, bool ignore_settings );
+        bool pour_into( item_location &container, item &liquid, bool ignore_settings, bool silent );
         bool pour_into( const vpart_reference &vp, item &liquid ) const;
         /**@}*/
 

--- a/src/handle_liquid.cpp
+++ b/src/handle_liquid.cpp
@@ -116,14 +116,17 @@ void handle_all_liquid( item liquid, const int radius, const item *const avoid )
         // handle_liquid allows to pour onto the ground, which will handle all the liquid and
         // set charges to 0. This allows terminating the loop.
         // The result of handle_liquid is ignored, the player *has* to handle all the liquid.
-        handle_liquid( liquid, avoid, radius );
+        liquid_dest_opt liquid_target;
+        handle_liquid( liquid, liquid_target, avoid, radius );
     }
 }
 
 bool consume_liquid( item &liquid, const int radius, const item *const avoid )
 {
     const int original_charges = liquid.charges;
-    while( liquid.charges > 0 && handle_liquid( liquid, avoid, radius ) ) {
+    liquid_dest_opt liquid_target;
+    while( liquid.charges > 0 && handle_liquid( liquid, liquid_target, avoid, radius ) ) {
+        liquid_target.dest_opt = LD_NULL;
         // try again with the remaining charges
     }
     return original_charges != liquid.charges;
@@ -536,7 +539,8 @@ bool can_handle_liquid( const item &liquid )
     return true;
 }
 
-bool handle_liquid( item &liquid, const item *const source, const int radius,
+bool handle_liquid( item &liquid, liquid_dest_opt &liquid_target, const item *const source,
+                    const int radius,
                     const tripoint_bub_ms *const source_pos,
                     const vehicle *const source_veh, const int part_num,
                     const monster *const source_mon )
@@ -545,8 +549,8 @@ bool handle_liquid( item &liquid, const item *const source, const int radius,
     if( !can_handle_liquid( liquid ) ) {
         return false;
     }
-    struct liquid_dest_opt liquid_target;
-    if( get_liquid_target( liquid, source, radius, source_pos, source_veh, source_mon,
+    if( liquid_target.dest_opt != LD_NULL ||
+        get_liquid_target( liquid, source, radius, source_pos, source_veh, source_mon,
                            liquid_target ) ) {
         success = perform_liquid_transfer( liquid, source_pos, source_veh, part_num, source_mon,
                                            liquid_target );

--- a/src/handle_liquid.h
+++ b/src/handle_liquid.h
@@ -91,14 +91,18 @@ bool handle_liquid( item &liquid, liquid_dest_opt &liquid_target, const item *so
                     int radius = 0,
                     const tripoint_bub_ms *source_pos = nullptr,
                     const vehicle *source_veh = nullptr, int part_num = -1,
-                    const monster *source_mon = nullptr );
+                    const monster *source_mon = nullptr, bool silent = true );
 bool handle_liquid( item_location &liquid, const item *source = nullptr, int radius = 0 );
 
 /* Not to be used directly. Use liquid_handler::handle_liquid instead. */
 bool perform_liquid_transfer( item &liquid, const tripoint_bub_ms *source_pos,
                               const vehicle *source_veh, int part_num,
-                              const monster * /*source_mon*/, liquid_dest_opt &target );
+                              const monster * /*source_mon*/, liquid_dest_opt &target, bool silent );
 bool perform_liquid_transfer( item_location &liquid, liquid_dest_opt &target );
+
+// Select destination to use, but don't actually do anything with it. Does not allow for spilling.
+liquid_dest_opt select_liquid_target( item &liquid, const int radius );
+
 } // namespace liquid_handler
 
 #endif // CATA_SRC_HANDLE_LIQUID_H

--- a/src/handle_liquid.h
+++ b/src/handle_liquid.h
@@ -101,7 +101,7 @@ bool perform_liquid_transfer( item &liquid, const tripoint_bub_ms *source_pos,
 bool perform_liquid_transfer( item_location &liquid, liquid_dest_opt &target );
 
 // Select destination to use, but don't actually do anything with it. Does not allow for spilling.
-liquid_dest_opt select_liquid_target( item &liquid, const int radius );
+liquid_dest_opt select_liquid_target( item &liquid, int radius );
 
 } // namespace liquid_handler
 

--- a/src/handle_liquid.h
+++ b/src/handle_liquid.h
@@ -75,6 +75,7 @@ bool can_handle_liquid( const item &liquid );
  * into that "container". If no source parameter is given, the liquid must not be in a
  * container at all (e.g. freshly crafted, or already removed from the container).
  * @param liquid The actual liquid
+ * @param liquid_target is the destination, with LD_NULL indicating it should be fetched.
  * @param source The container that currently contains the liquid.
  * @param radius Radius to look for liquid around pos
  * @param source_pos The source of the liquid when it's from the map.
@@ -86,7 +87,8 @@ bool can_handle_liquid( const item &liquid );
  * Basically `false` indicates the user does not *want* to handle the liquid, `true`
  * indicates they want to handle it.
  */
-bool handle_liquid( item &liquid, const item *source = nullptr, int radius = 0,
+bool handle_liquid( item &liquid, liquid_dest_opt &liquid_target, const item *source = nullptr,
+                    int radius = 0,
                     const tripoint_bub_ms *source_pos = nullptr,
                     const vehicle *source_veh = nullptr, int part_num = -1,
                     const monster *source_mon = nullptr );

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -5047,7 +5047,8 @@ void iexamine::water_source( Character &, const tripoint_bub_ms &examp )
 {
     map &here = get_map();
     item water = here.liquid_from( examp );
-    liquid_handler::handle_liquid( water, nullptr, 0, &examp );
+    liquid_dest_opt liquid_target;
+    liquid_handler::handle_liquid( water, liquid_target, nullptr, 0, &examp );
 }
 
 void iexamine::finite_water_source( Character &, const tripoint_bub_ms &examp )

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -4590,7 +4590,7 @@ void iexamine::keg( Character &you, const tripoint_bub_ms &examp )
                     return;
                 }
                 item tmp( drink.typeId(), calendar::turn, charges_held );
-                pour_into_keg( examp, tmp );
+                pour_into_keg( examp, tmp, false );
                 you.use_charges( drink.typeId(), charges_held - tmp.charges );
                 add_msg( _( "You fill the %1$s with %2$s." ), keg_name, drink_nname );
                 you.mod_moves( -to_moves<int>( 10_seconds ) );
@@ -4608,7 +4608,7 @@ void iexamine::keg( Character &you, const tripoint_bub_ms &examp )
  * will be removed from the liquid item.
  * @return Whether any charges have been transferred at all.
  */
-bool iexamine::pour_into_keg( const tripoint_bub_ms &pos, item &liquid )
+bool iexamine::pour_into_keg( const tripoint_bub_ms &pos, item &liquid, bool silent )
 {
     const units::volume keg_cap = get_keg_capacity( pos );
     if( keg_cap <= 0_ml ) {
@@ -4633,7 +4633,9 @@ bool iexamine::pour_into_keg( const tripoint_bub_ms &pos, item &liquid )
         return false;
     }
 
-    add_msg( _( "You pour %1$s into the %2$s." ), liquid.tname(), keg_name );
+    if( !silent ) {
+        add_msg( _( "You pour %1$s into the %2$s." ), liquid.tname(), keg_name );
+    }
     while( liquid.charges > 0 && drink.volume() < keg_cap ) {
         drink.charges++;
         liquid.charges--;

--- a/src/iexamine.h
+++ b/src/iexamine.h
@@ -150,7 +150,7 @@ void workbench_internal( Character &you, const tripoint_bub_ms &examp,
 void workout( Character &you, const tripoint_bub_ms &examp );
 void invalid( Character &you, const tripoint_bub_ms &examp );
 
-bool pour_into_keg( const tripoint_bub_ms &pos, item &liquid );
+bool pour_into_keg( const tripoint_bub_ms &pos, item &liquid, bool silent );
 std::optional<tripoint_bub_ms> getGasPumpByNumber( const tripoint_bub_ms &p, int number );
 bool toPumpFuel( const tripoint_bub_ms &src, const tripoint_bub_ms &dst, int units );
 std::optional<tripoint_bub_ms> getNearFilledGasTank( const tripoint_bub_ms &center, int &fuel_units,

--- a/src/item_pocket.cpp
+++ b/src/item_pocket.cpp
@@ -808,7 +808,8 @@ void item_pocket::handle_liquid_or_spill( Character &guy, const item *avoid )
 
     for( auto iter = contents.begin(); iter != contents.end(); ) {
         if( iter->made_of( phase_id::LIQUID ) ) {
-            while( iter->charges > 0 && liquid_handler::handle_liquid( *iter, avoid, 1 ) ) {
+            liquid_dest_opt liquid_target;
+            while( iter->charges > 0 && liquid_handler::handle_liquid( *iter, liquid_target, avoid, 1 ) ) {
                 // query until completely handled or explicitly canceled
             }
             if( iter->charges == 0 ) {

--- a/src/monexamine.cpp
+++ b/src/monexamine.cpp
@@ -27,6 +27,7 @@
 #include "iuse.h"
 #include "iuse_actor.h"
 #include "map.h"
+#include "mapdata.h"
 #include "messages.h"
 #include "monster.h"
 #include "mtype.h"

--- a/src/monexamine.cpp
+++ b/src/monexamine.cpp
@@ -20,6 +20,7 @@
 #include "flag.h"
 #include "game.h"
 #include "game_inventory.h"
+#include "handle_liquid.h"
 #include "item.h"
 #include "item_location.h"
 #include "itype.h"
@@ -503,6 +504,7 @@ void stop_leading( monster &z )
  */
 void milk_source( monster &source_mon )
 {
+    map &here = get_map();
 
     itype_id milked_item = source_mon.type->starting_ammo.begin()->first;
     auto milkable_ammo = source_mon.ammo.find( milked_item );
@@ -512,18 +514,59 @@ void milk_source( monster &source_mon )
     }
 
     else if( milkable_ammo->second > 0 ) {
-        const int moves = to_moves<int>( time_duration::from_minutes( milkable_ammo->second / 2 ) );
-        std::vector<tripoint_abs_ms> coords{};
-        std::vector<std::string> str_values{};
+        // This could be expanded upon by taking species and actor skills into consideration.
+        const int moves_per_unit = to_moves<int>( time_duration::from_minutes( 1.0 / 2 ) );
+        int moves = milkable_ammo->second * moves_per_unit;
+        tripoint_abs_ms coords;
         Character &player_character = get_player_character();
-        coords.push_back( get_map().get_abs( source_mon.pos_bub() ) );
+        coords = source_mon.pos_abs();
         // pin the cow in place if it isn't already
         bool temp_tie = !source_mon.has_effect( effect_tied );
         if( temp_tie ) {
             source_mon.add_effect( effect_tied, 1_turns, true );
-            str_values.emplace_back( "temp_tie" );
         }
-        player_character.assign_activity( milk_activity_actor( moves, coords, str_values ) );
+
+        item milk( milked_item, calendar::turn, milkable_ammo->second );
+        liquid_dest_opt liquid_target = liquid_handler::select_liquid_target( milk, 1 );
+
+        if( liquid_target.dest_opt == LD_NULL ) {
+            return;
+        }
+
+        units::volume target_volume;
+
+        switch( liquid_target.dest_opt ) {
+            case LD_ITEM:
+                target_volume = liquid_target.item_loc.get_item()->max_containable_volume() -
+                                liquid_target.item_loc.get_item()->total_contained_volume();
+
+                if( target_volume < milk.volume() ) {
+                    const item single_unit( milked_item, calendar::turn, 1 );
+                    int target_units = target_volume / single_unit.volume();
+                    moves = target_units * moves_per_unit;
+                }
+                break;
+
+            case LD_KEG:
+                target_volume = here.furn( liquid_target.pos ).obj().keg_capacity;
+
+                if( target_volume < milk.volume() ) {
+                    const item single_unit( milked_item, calendar::turn, 1 );
+                    int target_units = target_volume / single_unit.volume();
+                    moves = target_units * moves_per_unit;
+                }
+                break;
+
+            // None of these should happen
+            case LD_NULL:
+            case LD_CONSUME:
+            case LD_GROUND:
+            case LD_VEH:
+                break;
+        }
+
+        player_character.assign_activity( milk_activity_actor( moves, moves_per_unit, coords, liquid_target,
+                                          temp_tie ) );
 
         add_msg( _( "You milk the %s." ), source_mon.get_name() );
     } else {

--- a/src/veh_appliance.cpp
+++ b/src/veh_appliance.cpp
@@ -462,7 +462,9 @@ void veh_app_interact::siphon( map &here )
     const int idx = veh->index_of_part( pt );
     item liquid( base.legacy_front() );
     const int liq_charges = liquid.charges;
-    if( liquid_handler::handle_liquid( liquid, nullptr, 1, nullptr, veh, idx ) ) {
+    liquid_dest_opt liquid_target;
+
+    if( liquid_handler::handle_liquid( liquid, liquid_target, nullptr, 1, nullptr, veh, idx ) ) {
         veh->drain( here, idx, liq_charges - liquid.charges );
     }
 }

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -1931,7 +1931,8 @@ void veh_interact::do_siphon( map &here )
         const int idx = veh->index_of_part( &pt );
         item liquid( base.legacy_front() );
         const int liq_charges = liquid.charges;
-        if( liquid_handler::handle_liquid( liquid, nullptr, 1, nullptr, veh, idx ) ) {
+        liquid_dest_opt liquid_target;
+        if( liquid_handler::handle_liquid( liquid, liquid_target, nullptr, 1, nullptr, veh, idx ) ) {
             veh->drain( here, idx, liq_charges - liquid.charges );
         }
     };
@@ -2973,7 +2974,9 @@ void act_vehicle_siphon( map &here, vehicle *veh )
             title ) ) {
         item liquid( tank->part().get_base().only_item() );
         const int liq_charges = liquid.charges;
-        if( liquid_handler::handle_liquid( liquid, nullptr, 1, nullptr, veh, tank->part_index() ) ) {
+        liquid_dest_opt liquid_target;
+        if( liquid_handler::handle_liquid( liquid, liquid_target, nullptr, 1, nullptr, veh,
+                                           tank->part_index() ) ) {
             veh->drain( here, tank->part_index(), liq_charges - liquid.charges );
             veh->invalidate_mass();
         }

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -2274,7 +2274,8 @@ void vehicle::build_interact_menu( veh_menu &menu, map *here, const tripoint_bub
             .on_submit( [this, vp_tank_idx] {
                 item &vp_tank_item = parts[vp_tank_idx].base;
                 item &water = vp_tank_item.only_item();
-                liquid_handler::handle_liquid( water, &vp_tank_item, 1, nullptr, this, vp_tank_idx );
+                liquid_dest_opt liquid_target;
+                liquid_handler::handle_liquid( water, liquid_target, &vp_tank_item, 1, nullptr, this, vp_tank_idx );
             } );
 
             menu.add( _( "Have a drink" ) )

--- a/tests/item_pocket_test.cpp
+++ b/tests/item_pocket_test.cpp
@@ -2339,7 +2339,7 @@ TEST_CASE( "multipocket_liquid_transfer_test", "[pocket][item][liquid]" )
             liquid_target.item_loc = suit;
             u.set_moves( 100 );
             liquid_handler::perform_liquid_transfer( *jug_w_water->all_items_top().front(), nullptr,
-                    nullptr, -1, nullptr, liquid_target );
+                    nullptr, -1, nullptr, liquid_target, false );
             THEN( "liquid fills the worn container's pockets, some left over" ) {
                 CHECK( u.get_moves() == 0 );
                 CHECK( !jug_w_water->only_item().is_null() );
@@ -2367,7 +2367,7 @@ TEST_CASE( "multipocket_liquid_transfer_test", "[pocket][item][liquid]" )
             liquid_target.item_loc = suit;
             u.set_moves( 100 );
             liquid_handler::perform_liquid_transfer( *jug_w_water->all_items_top().front(), nullptr,
-                    nullptr, -1, nullptr, liquid_target );
+                    nullptr, -1, nullptr, liquid_target, false );
             THEN( "liquid fills the worn container's pockets, some left over" ) {
                 CHECK( u.get_moves() == 0 );
                 CHECK( !jug_w_water->only_item().is_null() );
@@ -2393,7 +2393,7 @@ TEST_CASE( "multipocket_liquid_transfer_test", "[pocket][item][liquid]" )
             liquid_target.item_loc = suit;
             u.set_moves( 100 );
             liquid_handler::perform_liquid_transfer( *jug_w_water->all_items_top().front(), nullptr,
-                    nullptr, -1, nullptr, liquid_target );
+                    nullptr, -1, nullptr, liquid_target, false );
             m.make_active( jug_w_water );
             CHECK( jug_w_water->only_item().charges == 0 );
             jug_w_water->remove_item( jug_w_water->only_item() );
@@ -2417,7 +2417,7 @@ TEST_CASE( "multipocket_liquid_transfer_test", "[pocket][item][liquid]" )
             liquid_target.item_loc = suit;
             u.set_moves( 100 );
             liquid_handler::perform_liquid_transfer( *jug_w_water->all_items_top().front(), nullptr,
-                    nullptr, -1, nullptr, liquid_target );
+                    nullptr, -1, nullptr, liquid_target, false );
             m.make_active( jug_w_water );
             CHECK( jug_w_water->only_item().charges == 0 );
             jug_w_water->remove_item( jug_w_water->only_item() );
@@ -2446,7 +2446,7 @@ TEST_CASE( "multipocket_liquid_transfer_test", "[pocket][item][liquid]" )
             for( item *&it : suit->all_items_top() ) {
                 u.set_moves( 100 );
                 REQUIRE( it->charges == 6 );
-                liquid_handler::perform_liquid_transfer( *it, nullptr, nullptr, -1, nullptr, liquid_target );
+                liquid_handler::perform_liquid_transfer( *it, nullptr, nullptr, -1, nullptr, liquid_target, false );
                 CHECK( u.get_moves() == 0 );
                 CHECK( it->charges == 0 );
                 suit->remove_item( *it );
@@ -2471,7 +2471,7 @@ TEST_CASE( "multipocket_liquid_transfer_test", "[pocket][item][liquid]" )
             for( item *&it : suit->all_items_top() ) {
                 u.set_moves( 100 );
                 REQUIRE( it->charges == 6 );
-                liquid_handler::perform_liquid_transfer( *it, nullptr, nullptr, -1, nullptr, liquid_target );
+                liquid_handler::perform_liquid_transfer( *it, nullptr, nullptr, -1, nullptr, liquid_target, false );
                 if( u.get_moves() == 0 && it->charges == 0 ) {
                     suit->remove_item( *it );
                 }

--- a/tests/player_activities_test.cpp
+++ b/tests/player_activities_test.cpp
@@ -16,6 +16,7 @@
 #include "coordinates.h"
 #include "enums.h"
 #include "flag.h"
+#include "handle_liquid.h"
 #include "inventory.h"
 #include "item.h"
 #include "item_group.h"

--- a/tests/player_activities_test.cpp
+++ b/tests/player_activities_test.cpp
@@ -1923,6 +1923,8 @@ TEST_CASE( "edevice", "[activity][edevice]" )
     }
 }
 
+liquid_dest_opt dest_opt; // Defaults to LD_NULL, which is good enough when not used.
+
 /**
 * Helper method to create activity stubs that aren't meant to be processed.
 * The activities here still need to be able to pass activity_actor::start and
@@ -1932,6 +1934,7 @@ TEST_CASE( "edevice", "[activity][edevice]" )
 * Activity actors that use ui functionality in their start methods cannot work at all,
 * only affects workout_activity_actor right now
 */
+
 static const std::vector<std::function<player_activity()>> test_activities {
     //player_activity( autodrive_activity_actor() ),
     //player_activity( bikerack_racking_activity_actor() ),
@@ -1961,7 +1964,7 @@ static const std::vector<std::function<player_activity()>> test_activities {
     //player_activity( longsalvage_activity_actor() ),
     [] { return player_activity( meditate_activity_actor() ); },
     [] { return player_activity( migration_cancel_activity_actor() ); },
-    [] { return player_activity( milk_activity_actor( 1, {get_avatar().pos_abs()}, {std::string()} ) ); },
+    [] { return player_activity( milk_activity_actor( 1, 3000, get_avatar().pos_abs(), dest_opt, false ) ); },
     [] { return player_activity( mop_activity_actor( 1 ) ); },
     //player_activity( move_furniture_activity_actor( p, false ) ),
     [] { return player_activity( move_items_activity_actor( {}, {}, false, tripoint_rel_ms::north ) ); },

--- a/tests/player_activities_test.cpp
+++ b/tests/player_activities_test.cpp
@@ -1924,7 +1924,7 @@ TEST_CASE( "edevice", "[activity][edevice]" )
     }
 }
 
-liquid_dest_opt dest_opt; // Defaults to LD_NULL, which is good enough when not used.
+static liquid_dest_opt dest_opt; // Defaults to LD_NULL, which is good enough when not used.
 
 /**
 * Helper method to create activity stubs that aren't meant to be processed.


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fix #80735, i.e. to make milking incremental as well as moving the target selection before the processing rather than at the end.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Some initial cleanup:
- Remove list of creature target locations and replace it with a single target. The code didn't work with a list anyway (hard coded usage of the first entry, rather than looping), and any order to process multiple animals would probably require traveling between the animals (which may move) anyway.
- Replaced the ugly usage of a string match for tying down the animal with a boolean as is done for shearing.

The intended changes:
- Introduce a function to fetch a liquid_destination object by copying the relevant code from internal functionality.
- Use the function to fetch the destination container or "keg" up front, before starting the actual activity and pass it into the operation. This would allow future usage of the operation to provide the destination through other means, such as selection from zones.
- Calculation of how many moves the transfer of each unit of liquid takes, and storage of this in the milking action object. This is currently constant, but the design allows for it to be dependent on factors such as the creature species and the actor's skills and proficiencies in the future.
- Calculation of how many moves it takes to move each unit of milk for usage in the do_turn activity.
- Calculation of when the next unit of milk is to be transferred.
- The do_turn activity moves one unit of milk once the next movement time has been passed (untested since the data are hard coded, but the code should be capable of moving multiple units if the rate is high enough, or the turns are delayed for some reason, such as (currently unsupported) companion activities interrupted by exit from the reality bubble).
- The code should fallback to move everything at the end if a save is made during milking before the change. I don't know how to test that, however.
- Introduction of a parameter to silence reporting of transfer so as to not get spammed when one unit is moved at a time rather than a big transfer at the end (It can be noted that extracting milk from a keg does produce such spam, but that was considered out of the bounds of this PR).

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Support additional targets. Currently only a container or a "keg" (i.e. furniture containers) is supported, but liquid_dest_opt also supports vehicles, direct imbibing, and dumping on the ground.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
- Debug spawned bucket, cattle fodder, and a cow.
- Tamed the cow with the fodder.
- Tried to milk the cow, but it fails since the bucket is in the inventory. The UI requires escaping out of it, which is a bit annoying, but that how it worked originally (but at the end).
- Carried the bucket in the hands.
- Milked the cow and interrupted the process. Noted that the bucket was partially filled.
- Milked the cow again, filling the bucket. Earlier I had done the milking from scratch and noted that the time taken was 10 minutes as per the bucket capacity, rather than the original 20.
- Debug spawned a plastic bucket (larger capacity than the now half depleted cow).
- Milked again, depleting the cow, taking 10 minutes.
- Debug spawned a sheep and milked it.
- Moved adjacent to a wooden barrel and debug spawned and tamed a new cow.
- Milked the cow into the barrel.

Not tested: JSON saving/loading. I don't know how to trigger saving in the middle of an activity, and since companion milking isn't supported I can't use that and save manually.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
It can be noted that the code is littered with fetching of the PC for various calculations, so any future support for companion milking would have to clean that up.

There are a lot of other activities that shift liquids around that could also be modified for gradual transfer (and less chatty transfer, in the case of extracting from a keg). Those are out of scope for this PR.

There is a comment in the liquid handling code indicating a desire to move over to usage of item_locations for liquid transfer. However, that doesn't work when animals are the source, since there is no item_locator support for that, and it's probably not a good idea to introduce it for a rather niche use case.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
