### PR TITLE
Fix sdl_mouse.h include

### DIFF
--- a/src/uilist.cpp
+++ b/src/uilist.cpp
@@ -28,11 +28,11 @@
 #if defined(__ANDROID__)
 #include <jni.h>
 #include <SDL_keyboard.h>
-
+#include <SDL_mouse.h>
 #endif
 
-#if defined(TILES)
-#include <SDL_mouse.h>
+#if defined(TILES) && !defined(__ANDROID__)
+#include <SDL2/SDL_mouse.h>
 #endif
 
 class uilist_impl : cataimgui::window


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Fixes #80768

#### Describe the solution

Add `SDL2/` to the include, but keep it as is for Android.

#### Describe alternatives you've considered



#### Testing

Compiled and checked the option and mouse functionality in main menu.

#### Additional context

