### PR TITLE
[Bombastic Perks] Repeatable Stat Increases

### DIFF
--- a/data/mods/BombasticPerks/perkdata/rep_stat_up.json
+++ b/data/mods/BombasticPerks/perkdata/rep_stat_up.json
@@ -3,7 +3,7 @@
     "type": "enchantment",
     "id": "bonus_stats",
     "condition": "ALWAYS",
-    "values": [ 
+    "values": [
       { "value": "STRENGTH", "add": { "math": [ "rep_str_var" ] } },
       { "value": "DEXTERITY", "add": { "math": [ "rep_dex_var" ] } },
       { "value": "INTELLIGENCE", "add": { "math": [ "rep_int_var" ] } },
@@ -13,33 +13,21 @@
   {
     "id": "EOC_REP_STR_UP",
     "type": "effect_on_condition",
-    "effect": [
-      { "math": [ "rep_str_var", "+=", "1" ] },
-      { "u_lose_trait" : "REP_STR_UP" }
-    ]
+    "effect": [ { "math": [ "rep_str_var", "+=", "1" ] }, { "u_lose_trait": "REP_STR_UP" } ]
   },
   {
     "id": "EOC_REP_DEX_UP",
     "type": "effect_on_condition",
-    "effect": [
-      { "math": [ "rep_dex_var", "+=", "1" ] },
-      { "u_lose_trait" : "REP_DEX_UP" }
-    ]
+    "effect": [ { "math": [ "rep_dex_var", "+=", "1" ] }, { "u_lose_trait": "REP_DEX_UP" } ]
   },
   {
     "id": "EOC_REP_INT_UP",
     "type": "effect_on_condition",
-    "effect": [
-      { "math": [ "rep_int_var", "+=", "1" ] },
-      { "u_lose_trait" : "REP_INT_UP" }
-    ]
+    "effect": [ { "math": [ "rep_int_var", "+=", "1" ] }, { "u_lose_trait": "REP_INT_UP" } ]
   },
   {
     "id": "EOC_REP_PER_UP",
     "type": "effect_on_condition",
-    "effect": [
-      { "math": [ "rep_per_var", "+=", "1" ] },
-      { "u_lose_trait" : "REP_PER_UP" }
-    ]
+    "effect": [ { "math": [ "rep_per_var", "+=", "1" ] }, { "u_lose_trait": "REP_PER_UP" } ]
   }
 ]

--- a/data/mods/BombasticPerks/perkdata/rep_stat_up.json
+++ b/data/mods/BombasticPerks/perkdata/rep_stat_up.json
@@ -1,0 +1,45 @@
+[
+  {
+    "type": "enchantment",
+    "id": "bonus_stats",
+    "condition": "ALWAYS",
+    "values": [ 
+      { "value": "STRENGTH", "add": { "math": [ "rep_str_var" ] } },
+      { "value": "DEXTERITY", "add": { "math": [ "rep_dex_var" ] } },
+      { "value": "INTELLIGENCE", "add": { "math": [ "rep_int_var" ] } },
+      { "value": "PERCEPTION", "add": { "math": [ "rep_per_var" ] } }
+    ]
+  },
+  {
+    "id": "EOC_REP_STR_UP",
+    "type": "effect_on_condition",
+    "effect": [
+      { "math": [ "rep_str_var", "+=", "1" ] },
+      { "u_lose_trait" : "REP_STR_UP" }
+    ]
+  },
+  {
+    "id": "EOC_REP_DEX_UP",
+    "type": "effect_on_condition",
+    "effect": [
+      { "math": [ "rep_dex_var", "+=", "1" ] },
+      { "u_lose_trait" : "REP_DEX_UP" }
+    ]
+  },
+  {
+    "id": "EOC_REP_INT_UP",
+    "type": "effect_on_condition",
+    "effect": [
+      { "math": [ "rep_int_var", "+=", "1" ] },
+      { "u_lose_trait" : "REP_INT_UP" }
+    ]
+  },
+  {
+    "id": "EOC_REP_PER_UP",
+    "type": "effect_on_condition",
+    "effect": [
+      { "math": [ "rep_per_var", "+=", "1" ] },
+      { "u_lose_trait" : "REP_PER_UP" }
+    ]
+  }
+]

--- a/data/mods/BombasticPerks/perkmenu.json
+++ b/data/mods/BombasticPerks/perkmenu.json
@@ -5,150 +5,54 @@
     "dynamic_line": "Lifestyle Perks:\nLevel <u_val:current_level>.\n<u_val:num_perks> perk points to spend.\nCurrent EXP: <u_val:available_exp>.\nEXP to next level: <u_val:exp_to_perk>.",
     "responses": [
       {
-        "condition": { "and": [ { "not": { "u_has_trait": "perk_STR_UP" } }, { "not": { "u_has_trait": "perk_STR_UP_2" } } ] },
-        "text": "Gain [<trait_name:perk_STR_UP>]",
+        "condition": { "not": { "u_has_trait": "REP_STR_UP" } },
+        "text": "Gain [<trait_name:REP_STR_UP>]",
         "effect": [
-          { "set_string_var": "<trait_name:perk_STR_UP>", "target_var": { "context_val": "trait_name" } },
-          {
-            "set_string_var": "<trait_description:perk_STR_UP>",
-            "target_var": { "context_val": "trait_description" }
-          },
-          { "set_string_var": "perk_STR_UP", "target_var": { "context_val": "trait_id" } },
-          {
-            "set_string_var": "No Requirements",
-            "target_var": { "context_val": "trait_requirement_description" },
-            "i18n": true
-          },
-          { "set_condition": "perk_condition", "condition": { "not": { "u_has_trait": "perk_STR_UP_2" } } }
+          { "set_string_var": "<trait_name:REP_STR_UP>", "target_var": { "context_val": "trait_name" } },
+          { "set_string_var": "<trait_description:REP_STR_UP>", "target_var": { "context_val": "trait_description" } },
+          { "set_string_var": "REP_STR_UP", "target_var": { "context_val": "trait_id" } },
+          { "set_string_var": "", "target_var": { "context_val": "trait_requirement_description" } },
+          { "set_condition": "perk_condition", "condition": { "not": { "u_has_trait": "REP_STR_UP" } } },
+          { "set_string_var": "", "target_var": { "context_val": "trait_additional_details" } }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
       },
       {
-        "condition": { "not": { "u_has_trait": "perk_STR_UP_2" } },
-        "text": "Gain [<trait_name:perk_STR_UP_2>]",
+        "condition": { "not": { "u_has_trait": "REP_DEX_UP" } },
+        "text": "Gain [<trait_name:REP_DEX_UP>]",
         "effect": [
-          { "set_string_var": "<trait_name:perk_STR_UP_2>", "target_var": { "context_val": "trait_name" } },
-          {
-            "set_string_var": "<trait_description:perk_STR_UP_2>",
-            "target_var": { "context_val": "trait_description" }
-          },
-          { "set_string_var": "perk_STR_UP_2", "target_var": { "context_val": "trait_id" } },
-          {
-            "set_string_var": "Must have the Stronger perk.",
-            "target_var": { "context_val": "trait_requirement_description" }
-          },
-          { "set_condition": "perk_condition", "condition": { "u_has_trait": "perk_STR_UP" } }
+          { "set_string_var": "<trait_name:REP_DEX_UP>", "target_var": { "context_val": "trait_name" } },
+          { "set_string_var": "<trait_description:REP_DEX_UP>", "target_var": { "context_val": "trait_description" } },
+          { "set_string_var": "REP_DEX_UP", "target_var": { "context_val": "trait_id" } },
+          { "set_string_var": "", "target_var": { "context_val": "trait_requirement_description" } },
+          { "set_condition": "perk_condition", "condition": { "not": { "u_has_trait": "REP_DEX_UP" } } },
+          { "set_string_var": "", "target_var": { "context_val": "trait_additional_details" } }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
       },
       {
-        "condition": { "and": [ { "not": { "u_has_trait": "perk_DEX_UP" } }, { "not": { "u_has_trait": "perk_DEX_UP_2" } } ] },
-        "text": "Gain [<trait_name:perk_DEX_UP>]",
+        "condition": { "not": { "u_has_trait": "REP_INT_UP" } },
+        "text": "Gain [<trait_name:REP_INT_UP>]",
         "effect": [
-          { "set_string_var": "<trait_name:perk_DEX_UP>", "target_var": { "context_val": "trait_name" } },
-          {
-            "set_string_var": "<trait_description:perk_DEX_UP>",
-            "target_var": { "context_val": "trait_description" }
-          },
-          { "set_string_var": "perk_DEX_UP", "target_var": { "context_val": "trait_id" } },
-          {
-            "set_string_var": "No Requirements",
-            "target_var": { "context_val": "trait_requirement_description" },
-            "i18n": true
-          },
-          { "set_condition": "perk_condition", "condition": { "not": { "u_has_trait": "perk_DEX_UP_2" } } }
+          { "set_string_var": "<trait_name:REP_INT_UP>", "target_var": { "context_val": "trait_name" } },
+          { "set_string_var": "<trait_description:REP_INT_UP>", "target_var": { "context_val": "trait_description" } },
+          { "set_string_var": "REP_INT_UP", "target_var": { "context_val": "trait_id" } },
+          { "set_string_var": "", "target_var": { "context_val": "trait_requirement_description" } },
+          { "set_condition": "perk_condition", "condition": { "not": { "u_has_trait": "REP_INT_UP" } } },
+          { "set_string_var": "", "target_var": { "context_val": "trait_additional_details" } }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
       },
       {
-        "condition": { "not": { "u_has_trait": "perk_DEX_UP_2" } },
-        "text": "Gain [<trait_name:perk_DEX_UP_2>]",
+        "condition": { "not": { "u_has_trait": "REP_PER_UP" } },
+        "text": "Gain [<trait_name:REP_PER_UP>]",
         "effect": [
-          { "set_string_var": "<trait_name:perk_DEX_UP_2>", "target_var": { "context_val": "trait_name" } },
-          {
-            "set_string_var": "<trait_description:perk_DEX_UP_2>",
-            "target_var": { "context_val": "trait_description" }
-          },
-          { "set_string_var": "perk_DEX_UP_2", "target_var": { "context_val": "trait_id" } },
-          {
-            "set_string_var": "Must have the Faster perk",
-            "target_var": { "context_val": "trait_requirement_description" }
-          },
-          { "set_condition": "perk_condition", "condition": { "u_has_trait": "perk_DEX_UP" } }
-        ],
-        "topic": "TALK_PERK_MENU_SELECT"
-      },
-      {
-        "condition": { "and": [ { "not": { "u_has_trait": "perk_INT_UP" } }, { "not": { "u_has_trait": "perk_INT_UP_2" } } ] },
-        "text": "Gain [<trait_name:perk_INT_UP>]",
-        "effect": [
-          { "set_string_var": "<trait_name:perk_INT_UP>", "target_var": { "context_val": "trait_name" } },
-          {
-            "set_string_var": "<trait_description:perk_INT_UP>",
-            "target_var": { "context_val": "trait_description" }
-          },
-          { "set_string_var": "perk_INT_UP", "target_var": { "context_val": "trait_id" } },
-          {
-            "set_string_var": "No Requirements",
-            "target_var": { "context_val": "trait_requirement_description" },
-            "i18n": true
-          },
-          { "set_condition": "perk_condition", "condition": { "not": { "u_has_trait": "perk_INT_UP_2" } } }
-        ],
-        "topic": "TALK_PERK_MENU_SELECT"
-      },
-      {
-        "condition": { "not": { "u_has_trait": "perk_INT_UP_2" } },
-        "text": "Gain [<trait_name:perk_INT_UP_2>]",
-        "effect": [
-          { "set_string_var": "<trait_name:perk_INT_UP_2>", "target_var": { "context_val": "trait_name" } },
-          {
-            "set_string_var": "<trait_description:perk_INT_UP_2>",
-            "target_var": { "context_val": "trait_description" }
-          },
-          { "set_string_var": "perk_INT_UP_2", "target_var": { "context_val": "trait_id" } },
-          {
-            "set_string_var": "Must have the Smarter perk",
-            "target_var": { "context_val": "trait_requirement_description" }
-          },
-          { "set_condition": "perk_condition", "condition": { "u_has_trait": "perk_INT_UP" } }
-        ],
-        "topic": "TALK_PERK_MENU_SELECT"
-      },
-      {
-        "condition": { "and": [ { "not": { "u_has_trait": "perk_PER_UP" } }, { "not": { "u_has_trait": "perk_PER_UP_2" } } ] },
-        "text": "Gain [<trait_name:perk_PER_UP>]",
-        "effect": [
-          { "set_string_var": "<trait_name:perk_PER_UP>", "target_var": { "context_val": "trait_name" } },
-          {
-            "set_string_var": "<trait_description:perk_PER_UP>",
-            "target_var": { "context_val": "trait_description" }
-          },
-          { "set_string_var": "perk_PER_UP", "target_var": { "context_val": "trait_id" } },
-          {
-            "set_string_var": "No Requirements",
-            "target_var": { "context_val": "trait_requirement_description" },
-            "i18n": true
-          },
-          { "set_condition": "perk_condition", "condition": { "not": { "u_has_trait": "perk_PER_UP_2" } } }
-        ],
-        "topic": "TALK_PERK_MENU_SELECT"
-      },
-      {
-        "condition": { "not": { "u_has_trait": "perk_PER_UP_2" } },
-        "text": "Gain [<trait_name:perk_PER_UP_2>]",
-        "effect": [
-          { "set_string_var": "<trait_name:perk_PER_UP_2>", "target_var": { "context_val": "trait_name" } },
-          {
-            "set_string_var": "<trait_description:perk_PER_UP_2>",
-            "target_var": { "context_val": "trait_description" }
-          },
-          { "set_string_var": "perk_PER_UP_2", "target_var": { "context_val": "trait_id" } },
-          {
-            "set_string_var": "Must have the Sharper perk",
-            "target_var": { "context_val": "trait_requirement_description" }
-          },
-          { "set_condition": "perk_condition", "condition": { "u_has_trait": "perk_PER_UP" } }
+          { "set_string_var": "<trait_name:REP_PER_UP>", "target_var": { "context_val": "trait_name" } },
+          { "set_string_var": "<trait_description:REP_PER_UP>", "target_var": { "context_val": "trait_description" } },
+          { "set_string_var": "REP_PER_UP", "target_var": { "context_val": "trait_id" } },
+          { "set_string_var": "", "target_var": { "context_val": "trait_requirement_description" } },
+          { "set_condition": "perk_condition", "condition": { "not": { "u_has_trait": "REP_PER_UP" } } },
+          { "set_string_var": "", "target_var": { "context_val": "trait_additional_details" } }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
       },

--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -24,7 +24,7 @@
     "valid": false,
     "description": "Grants +1 Strength, repeatable.",
     "active": true,
-    "triggers": [ [ { "condition" : { "one_in_chance" : 1 } } ] ],
+    "triggers": [ [ { "condition": { "one_in_chance": 1 } } ] ],
     "activated_eocs": [ "EOC_REP_STR_UP" ]
   },
   {
@@ -36,7 +36,7 @@
     "valid": false,
     "description": "Grants +1 Dexterity, repeatable.",
     "active": true,
-    "triggers": [ [ { "condition" : { "one_in_chance" : 1 } } ] ],
+    "triggers": [ [ { "condition": { "one_in_chance": 1 } } ] ],
     "activated_eocs": [ "EOC_REP_DEX_UP" ]
   },
   {
@@ -48,7 +48,7 @@
     "valid": false,
     "description": "Grants +1 Intelligence, repeatable.",
     "active": true,
-    "triggers": [ [ { "condition" : { "one_in_chance" : 1 } } ] ],
+    "triggers": [ [ { "condition": { "one_in_chance": 1 } } ] ],
     "activated_eocs": [ "EOC_REP_INT_UP" ]
   },
   {
@@ -60,7 +60,7 @@
     "valid": false,
     "description": "Grants +1 Perception, repeatable.",
     "active": true,
-    "triggers": [ [ { "condition" : { "one_in_chance" : 1 } } ] ],
+    "triggers": [ [ { "condition": { "one_in_chance": 1 } } ] ],
     "activated_eocs": [ "EOC_REP_PER_UP" ]
   },
   {

--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -12,95 +12,56 @@
     "valid": false,
     "description": "Direct access to the perk menu.",
     "active": true,
-    "activated_eocs": [ "EOC_open_perk_menu" ]
+    "activated_eocs": [ "EOC_open_perk_menu" ],
+    "enchantments": [ "bonus_stats" ]
   },
   {
     "type": "mutation",
-    "id": "perk_STR_UP",
-    "name": { "str": "Stronger" },
+    "id": "REP_STR_UP",
+    "name": { "str": "Strength Training, Repeatable" },
     "points": 0,
     "purifiable": false,
     "valid": false,
-    "description": "Have you been working out?  +1 Strength.",
-    "changes_to": [ "perk_STR_UP_2" ],
-    "enchantments": [ { "condition": "ALWAYS", "values": [ { "value": "STRENGTH", "add": 1 } ] } ]
+    "description": "Grants +1 Strength, repeatable.",
+    "active": true,
+    "triggers": [ [ { "condition" : { "one_in_chance" : 1 } } ] ],
+    "activated_eocs": [ "EOC_REP_STR_UP" ]
   },
   {
     "type": "mutation",
-    "id": "perk_STR_UP_2",
-    "name": { "str": "Even Stronger" },
+    "id": "REP_DEX_UP",
+    "name": { "str": "Dexterity Training, Repeatable" },
     "points": 0,
     "purifiable": false,
     "valid": false,
-    "description": "You HAVE been working out.  +2 Strength.",
-    "prereqs": [ "perk_STR_UP" ],
-    "enchantments": [ { "condition": "ALWAYS", "values": [ { "value": "STRENGTH", "add": 2 } ] } ]
+    "description": "Grants +1 Dexterity, repeatable.",
+    "active": true,
+    "triggers": [ [ { "condition" : { "one_in_chance" : 1 } } ] ],
+    "activated_eocs": [ "EOC_REP_DEX_UP" ]
   },
   {
     "type": "mutation",
-    "id": "perk_DEX_UP",
-    "name": { "str": "Faster" },
+    "id": "REP_INT_UP",
+    "name": { "str": "Intelligence Training, Repeatable" },
     "points": 0,
     "purifiable": false,
     "valid": false,
-    "description": "Have you been doing cardio?  +1 Dexterity.",
-    "changes_to": [ "perk_DEX_UP_2" ],
-    "enchantments": [ { "condition": "ALWAYS", "values": [ { "value": "DEXTERITY", "add": 1 } ] } ]
+    "description": "Grants +1 Intelligence, repeatable.",
+    "active": true,
+    "triggers": [ [ { "condition" : { "one_in_chance" : 1 } } ] ],
+    "activated_eocs": [ "EOC_REP_INT_UP" ]
   },
   {
     "type": "mutation",
-    "id": "perk_DEX_UP_2",
-    "name": { "str": "Even Faster" },
+    "id": "REP_PER_UP",
+    "name": { "str": "Perception Training, Repeatable" },
     "points": 0,
     "purifiable": false,
     "valid": false,
-    "description": "You HAVE been doing cardio.  +2 Dexterity.",
-    "prereqs": [ "perk_DEX_UP" ],
-    "enchantments": [ { "condition": "ALWAYS", "values": [ { "value": "DEXTERITY", "add": 2 } ] } ]
-  },
-  {
-    "type": "mutation",
-    "id": "perk_INT_UP",
-    "name": { "str": "Smarter" },
-    "points": 0,
-    "purifiable": false,
-    "valid": false,
-    "description": "Have you been reading?  +1 Intelligence.",
-    "changes_to": [ "perk_INT_UP_2" ],
-    "enchantments": [ { "condition": "ALWAYS", "values": [ { "value": "INTELLIGENCE", "add": 1 } ] } ]
-  },
-  {
-    "type": "mutation",
-    "id": "perk_INT_UP_2",
-    "name": { "str": "Even Smarter" },
-    "points": 0,
-    "purifiable": false,
-    "valid": false,
-    "description": "You HAVE been reading.  +2 Intelligence.",
-    "prereqs": [ "perk_INT_UP" ],
-    "enchantments": [ { "condition": "ALWAYS", "values": [ { "value": "INTELLIGENCE", "add": 2 } ] } ]
-  },
-  {
-    "type": "mutation",
-    "id": "perk_PER_UP",
-    "name": { "str": "Sharper" },
-    "points": 0,
-    "purifiable": false,
-    "valid": false,
-    "description": "Have you been staring out into the middle distance?  +1 Perception.",
-    "changes_to": [ "perk_PER_UP_2" ],
-    "enchantments": [ { "condition": "ALWAYS", "values": [ { "value": "PERCEPTION", "add": 1 } ] } ]
-  },
-  {
-    "type": "mutation",
-    "id": "perk_PER_UP_2",
-    "name": { "str": "Even Sharper" },
-    "points": 0,
-    "purifiable": false,
-    "valid": false,
-    "description": "You HAVE been staring out into the middle distance.  +2 Perception.",
-    "prereqs": [ "perk_PER_UP" ],
-    "enchantments": [ { "condition": "ALWAYS", "values": [ { "value": "PERCEPTION", "add": 2 } ] } ]
+    "description": "Grants +1 Perception, repeatable.",
+    "active": true,
+    "triggers": [ [ { "condition" : { "one_in_chance" : 1 } } ] ],
+    "activated_eocs": [ "EOC_REP_PER_UP" ]
   },
   {
     "type": "mutation",


### PR DESCRIPTION
#### Summary
Mods "Make stat increases repeatable in Bombastic Perks, rather than limited to at most +2 per stat."

#### Purpose of Change

Way back when I first saw Bombastic Perks, my first thought was that it could basically take the place of Stats Through Kills, only moreso. It does the same thing, letting you level up your character by killing things, but also has many more things to spend level ups on, and also has a lot more customizability in having a user-definable xp curve instead of a hardcoded list of xp thresholds. The only thing holding it back from that potential was that the base stat increases were pretty limited.

This is my attempt to add that functionality.

#### Describe the solution

Basically what I've done is to add 4 dummy perks whose only function is to increment a variable and then delete themselves (so that they can later be added again). I then take those four variables, and add them as stat enhancements to the perk menu trait (the one trait that every user of the mod is guarenteed to have).

#### Describe alternatives you've considered

My original hope was to be able to directly increase the base stat. However, I couldn't find a way to do that within EOCs (there may be one, this was kind of a learning project for me to try and figure out EOCs).

I did consider making a separate perk to hold the bonuses. However, the character sheet already gets crowded when using Bombastic Perks, and it doesn't do anything visible to the player anyway. Maybe there's a reason I'm not seeing why this is a bad idea? IDK.

I did of course consider making the perk selection call the EOC to increment the bonus variable directly instead of using dummy perks, but that would involve messing with the functionality of the perk menu itself, and ultimately that's a lot messier than just doing the dummy perk thing. The mod is designed around the idea that the only thing it's going to do to the player is add traits, I'll work with that instead of against it.

I tried a couple different ways to make the dummy perks activate an EOC then delete themselves. Having it just start already activated doesn't call the EOC correctly. I didn't want to make the player manually activate it every time, that's annoying and unnecessary. The "trigger" thing works fine, but it was surprisingly hard to find a way to create an always true conditional. Trigger wants a condition, and from what I could find in the docs, it seems like there's not an option for always true. Telling it to roll a 1 in 1 chance is kind of silly, but hey it works. 

#### Testing

I created a character, got some xp, and bought each perk at least once, and a couple of them multiple times. It does require closing and reopening the menu so that the perk has time to process itself, which shouldn't be a problem in normal play.

#### Additional context

If accepted, this will be by far my biggest ever contribution, my only previous PR having been a minor change to mutation conflicts. I hope you like this, and that I can continue to make greater contributions in the future.