### PR TITLE
actual back berm for shooting range

### DIFF
--- a/data/json/mapgen/shooting_range.json
+++ b/data/json/mapgen/shooting_range.json
@@ -4,6 +4,7 @@
     "type": "mapgen",
     "om_terrain": [ [ "shootingrange_1a" ], [ "shootingrange_2a" ] ],
     "object": {
+      "fill_ter":"t_region_groundcover_barren",
       "rows": [
         "........................",
         "........................",
@@ -64,7 +65,8 @@
         "c": "f_counter",
         "d": "f_desk",
         "s": "f_sign",
-        "/": "f_wooden_flagpole"
+        "/": "f_wooden_flagpole",
+        "O": "f_dirtmound_tall"
       },
       "terrain": {
         "-": "t_thconc_floor",
@@ -84,8 +86,8 @@
         "c": "t_thconc_floor",
         "d": "t_floor",
         "f": "t_floor",
-        "w": "t_thconc_floor",
-        "O": "t_dirtmound"
+        "w": "t_thconc_floor"
+        
       },
       "place_items": [
         { "chance": 10, "item": "ammo_common_boxed_used", "x": 6, "y": 9 },

--- a/data/json/mapgen/shooting_range.json
+++ b/data/json/mapgen/shooting_range.json
@@ -87,7 +87,6 @@
         "d": "t_floor",
         "f": "t_floor",
         "w": "t_thconc_floor"
-        
       },
       "place_items": [
         { "chance": 10, "item": "ammo_common_boxed_used", "x": 6, "y": 9 },

--- a/data/json/mapgen/shooting_range.json
+++ b/data/json/mapgen/shooting_range.json
@@ -4,7 +4,7 @@
     "type": "mapgen",
     "om_terrain": [ [ "shootingrange_1a" ], [ "shootingrange_2a" ] ],
     "object": {
-      "fill_ter":"t_region_groundcover_barren",
+      "fill_ter": "t_region_groundcover_barren",
       "rows": [
         "........................",
         "........................",


### PR DESCRIPTION
#### Summary
bugfixes "replaced tilled soil background for shooting range with tall dirt."

#### Purpose of change

noticed that the back berm of a shooting range is made of tilled soil instead of a nice tall mound of dirt to actually catch bullets.

#### Describe the solution

replaced the tilled soil with a high mound of dirt. provided filler to go under it in order to prevent error
#### Describe alternatives you've considered

perhaps people in NE pre cataclysm thought that a solid backstop was optional

I don't think there is anything where you need a bunch of dirt, but these mounds provide a comically large amount for little effort.

#### Testing

changed json, generated structure. confirmed new generation.

dug up pile, confirmed that dirt spawned under.

#### Additional context

0 and O look very similar, I suffered the smallest amount. 
