### PR TITLE
vitamin C fragment

### DIFF
--- a/data/json/items/comestibles/med.json
+++ b/data/json/items/comestibles/med.json
@@ -1953,7 +1953,7 @@
     "use_action": { "type": "consume_drug", "activation_message": "You take the %s.", "vitamins": [ [ "vitC", 556 ] ] }
   },
   {
-  "id": "vitc_fragment",
+    "id": "vitc_fragment",
     "type": "ITEM",
     "subtypes": [ "COMESTIBLE" ],
     "comestible_type": "MED",

--- a/data/json/items/comestibles/med.json
+++ b/data/json/items/comestibles/med.json
@@ -1961,7 +1961,7 @@
     "description": "a small slice of a vitamin C supplement, providing as much vitamin C as a human can conceivably absorb.",
     "material": [ "drug_filler" ],
     "weight": "1 g",
-    "volume": "5 ml",
+    "volume": "1 ml",
     "price": "0 cent",
     "price_postapoc": "2 cent",
     "flags": [ "IRREPLACEABLE_CONSUMABLE", "NO_TEMP" ],

--- a/data/json/items/comestibles/med.json
+++ b/data/json/items/comestibles/med.json
@@ -1953,6 +1953,23 @@
     "use_action": { "type": "consume_drug", "activation_message": "You take the %s.", "vitamins": [ [ "vitC", 556 ] ] }
   },
   {
+  "id": "vitc_fragment",
+    "type": "ITEM",
+    "subtypes": [ "COMESTIBLE" ],
+    "comestible_type": "MED",
+    "name": { "str": "vitamin C supplement fragment" },
+    "description": "a small slice of a vitamin C supplement, providing as much vitamin C as a human can conceivably absorb.",
+    "material": [ "drug_filler" ],
+    "weight": "1 g",
+    "volume": "5 ml",
+    "price": "0 cent",
+    "price_postapoc": "2 cent",
+    "flags": [ "IRREPLACEABLE_CONSUMABLE", "NO_TEMP" ],
+    "symbol": "!",
+    "color": "magenta",
+    "use_action": { "type": "consume_drug", "activation_message": "You take the %s.", "vitamins": [ [ "vitC", 92 ] ] }
+  },
+  {
     "id": "gummy_vitamins",
     "copy-from": "vitamins",
     "type": "ITEM",

--- a/data/json/recipes/other/medical.json
+++ b/data/json/recipes/other/medical.json
@@ -467,5 +467,20 @@
       [ [ "cordage", 2, "LIST" ], [ "duct_tape", 100 ], [ "medical_tape", 50 ] ],
       [ [ "stick", 2 ], [ "broom", 2 ], [ "2x4", 2 ], [ "pool_cue", 2 ] ]
     ]
+  },
+  {
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "result": "vitc_fragment" ,
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_MATERIALS",
+    "id_suffix": "by hand",
+    "skill_used": "cooking",
+    "difficulty": 2,
+    "result_mult": 6,
+    "time": "1m",
+    "autolearn": true,
+    "qualities": [{"id": "CUT_FINE", "level":2}],
+    "components": [ [ [ "vitc_tablet", 1 ] ] ]
   }
 ]

--- a/data/json/recipes/other/medical.json
+++ b/data/json/recipes/other/medical.json
@@ -480,7 +480,7 @@
     "result_mult": 6,
     "time": "1m",
     "autolearn": true,
-    "qualities": [{"id": "CUT_FINE", "level":2}],
+    "qualities": [ { "id": "CUT_FINE", "level": 2 } ],
     "components": [ [ [ "vitc_tablet", 1 ] ] ]
   }
 ]

--- a/data/json/recipes/other/medical.json
+++ b/data/json/recipes/other/medical.json
@@ -471,7 +471,7 @@
   {
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",
-    "result": "vitc_fragment" ,
+    "result": "vitc_fragment",
     "category": "CC_OTHER",
     "subcategory": "CSC_OTHER_MATERIALS",
     "id_suffix": "by hand",


### PR DESCRIPTION


#### Summary
content "option to cut up a vitamin C tablet into roughly DV sized bits."

#### Purpose of change

a crafty, or desperate survivor may wish to extend their supply of vitamin C cutting up the pill that provides 600(ish)% daily value into chunks with an exacto blade just makes sense.

#### Describe the solution

adds a vitamin C fragment item, and crafting recipe. no natural spawn.

#### Describe alternatives you've considered

not adding this, increasing the loss rate on the cutting up the tablet.

#### Testing

spawn vit-C tablet. cut it up, eat result.

#### Additional context

right now this recipe does not respect the conservation of mass, but i dont think there is a way to track weights below one gram. or volumes below 1ml.



