### PR TITLE
Add "Lone Evacuee" scenario – default shelter start without NPCs

### DIFF
--- a/data/json/scenarios.json
+++ b/data/json/scenarios.json
@@ -11,6 +11,16 @@
   },
   {
     "type": "scenario",
+    "id": "lone_evacuee",
+    "name": "Lone Evacuee",
+    "points": 0,
+    "description": "You arrive at a government evac shelter expecting help.  Instead, you find cold silence and empty bunks.  No one made it.  You're on your own.",
+    "allowed_locs": [ "sloc_shelter_a", "sloc_shelter_b", "sloc_shelter_c" ],
+    "start_name": "Evac Shelter",
+    "flags": [ "CITY_START", "LONE_START" ]
+  },
+  {
+    "type": "scenario",
     "id": "refugeecenter",
     "name": "Refugee Center",
     "points": 0,


### PR DESCRIPTION
#### Summary

Content "Add 'Lone Evacuee' scenario – default shelter start without NPCs"

#### Purpose of change

> "You arrive at a government evac shelter expecting help. Instead, you find cold silence and empty bunks. No one made it. You're on your own."

This PR introduces a new scenario titled "Lone Evacuee", which mirrors the default evac shelter start but without any NPCs nearby.

Every time I update the game, I find myself manually editing `scenarios.json` to add a `LONE_START` flag to the default scenario. For players like myself, the presence of NPCs at the start can break the immersion of being truly alone in a crumbling world. This new scenario preserves the iconic "government evac shelter" starting location, but emphasizes solitude -- providing a thematic and gameplay alternative for those who prefer a solitary survival experience.