### PR TITLE
Disable crafting volume restrictions for faction and construction cra…

### DIFF
--- a/src/basecamp.cpp
+++ b/src/basecamp.cpp
@@ -18,6 +18,7 @@
 #include "character_id.h"
 #include "clzones.h"
 #include "color.h"
+#include "crafting.h"
 #include "debug.h"
 #include "event.h"
 #include "event_bus.h"

--- a/src/basecamp.cpp
+++ b/src/basecamp.cpp
@@ -403,7 +403,7 @@ std::vector<basecamp_upgrade> basecamp::available_upgrades( const point_rel_omt 
                 const mapgen_arguments &args = args_and_reqs.first;
                 const requirement_data &reqs = args_and_reqs.second.consolidated_reqs;
                 bool can_make =
-                    reqs.can_make_with_inventory( _inv, recp.get_component_filter(), 1 );
+                    reqs.can_make_with_inventory( _inv, recp.get_component_filter(), 1, craft_flags::none, false );
                 ret_data.push_back( { bldg, args, recp.blueprint_name(), can_make, in_progress } );
             }
         }

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -590,7 +590,8 @@ construction_id construction_menu( const bool blueprint )
                     continue;
                 }
                 // Update the cached availability of components and tools in the requirement object
-                current_con->requirements->can_make_with_inventory( total_inv, is_crafting_component );
+                current_con->requirements->can_make_with_inventory( total_inv, is_crafting_component, 1,
+                        craft_flags::none, false );
 
                 std::vector<std::string> current_buffer;
 
@@ -1136,7 +1137,8 @@ bool player_can_build( Character &you, const read_only_visitable &inv, const con
     }
 
     // check for construction spot can be skipped by using can_construct_skip
-    return con.requirements->can_make_with_inventory( inv, is_crafting_component ) &&
+    return con.requirements->can_make_with_inventory( inv, is_crafting_component, 1, craft_flags::none,
+            false ) &&
            ( can_construct_skip || can_construct( con ) );
 }
 

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -20,6 +20,7 @@
 #include "construction_category.h"
 #include "construction_group.h"
 #include "coordinates.h"
+#include "crafting.h"
 #include "creature.h"
 #include "cursesdef.h"
 #include "debug.h"

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -2106,7 +2106,8 @@ void basecamp::start_upgrade( const mission_id &miss_id )
     const requirement_data &reqs = bld_reqs.consolidated_reqs;
 
     //Stop upgrade if you don't have materials
-    if( reqs.can_make_with_inventory( _inv, making.get_component_filter() ) ) {
+    if( reqs.can_make_with_inventory( _inv, making.get_component_filter(), 1, craft_flags::none,
+                                      false ) ) {
         bool must_feed = !making.has_flag( "NO_FOOD_REQ" );
 
         basecamp_action_components components( making, miss_id.mapgen_args, 1, *this );

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -31,6 +31,7 @@
 #include "clzones.h"
 #include "color.h"
 #include "coordinates.h"
+#include "crafting.h"
 #include "crafting_gui.h"
 #include "cursesdef.h"
 #include "debug.h"

--- a/src/requirements.cpp
+++ b/src/requirements.cpp
@@ -863,7 +863,8 @@ std::vector<std::string> requirement_data::get_folded_tools_list( int width, nc_
 }
 
 bool requirement_data::can_make_with_inventory( const read_only_visitable &crafting_inv,
-        const std::function<bool( const item & )> &filter, int batch, craft_flags flags ) const
+        const std::function<bool( const item & )> &filter, int batch, craft_flags flags,
+        bool restrict_volume ) const
 {
     if( get_player_character().has_trait( trait_DEBUG_HS ) ) {
         return true;
@@ -880,7 +881,7 @@ bool requirement_data::can_make_with_inventory( const read_only_visitable &craft
     if( !has_comps( crafting_inv, components, filter, batch ) ) {
         retval = false;
     }
-    if( !check_enough_materials( crafting_inv, filter, batch ) ) {
+    if( !check_enough_materials( crafting_inv, filter, batch, restrict_volume ) ) {
         retval = false;
     }
     return retval;
@@ -1048,7 +1049,7 @@ const T *requirement_data::find_by_type( const std::vector< std::vector<T> > &ve
 }
 
 bool requirement_data::check_enough_materials( const read_only_visitable &crafting_inv,
-        const std::function<bool( const item & )> &filter, int batch ) const
+        const std::function<bool( const item & )> &filter, int batch, bool restrict_volume ) const
 {
     bool retval = true;
     units::volume total_component_volume = 0_ml;
@@ -1071,7 +1072,7 @@ bool requirement_data::check_enough_materials( const read_only_visitable &crafti
 
     // This will be the volume of the resulting in-progress craft item (see item::volume), so we don't want to exceed it.
     // TODO: Feedback? Some sort of indicator to the player that resulting volume is why it can't be crafted
-    if( total_component_volume > MAX_ITEM_VOLUME ) {
+    if( restrict_volume && total_component_volume > MAX_ITEM_VOLUME ) {
         retval = false;
     }
 

--- a/src/requirements.h
+++ b/src/requirements.h
@@ -344,7 +344,7 @@ struct requirement_data {
          */
         bool can_make_with_inventory( const read_only_visitable &crafting_inv,
                                       const std::function<bool( const item & )> &filter, int batch = 1,
-                                      craft_flags = craft_flags::none ) const;
+                                      craft_flags = craft_flags::none, bool restrict_volume = true ) const;
 
         /** @param filter see @ref can_make_with_inventory */
         std::vector<std::string> get_folded_components_list( int width, nc_color col,
@@ -393,7 +393,8 @@ struct requirement_data {
         bool blacklisted = false;
 
         bool check_enough_materials( const read_only_visitable &crafting_inv,
-                                     const std::function<bool( const item & )> &filter, int batch = 1 ) const;
+                                     const std::function<bool( const item & )> &filter, int batch = 1,
+                                     bool restrict_volume = true ) const;
         bool check_enough_materials( const item_comp &comp, const read_only_visitable &crafting_inv,
                                      const std::function<bool( const item & )> &filter, int batch = 1 ) const;
 


### PR DESCRIPTION
…fting

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fix #80791, i.e. inability to perform faction camp crafting due to in-progress craft volume restrictions.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add a boolean parameter up the call chain telling the check whether to perform the volume restriction check. It's overridden for faction camp crafting and construction crafting, neither of which create any in-progress items, and thus have no need for a restriction.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Don't do it for construction. It could be argued that you'd like a sanity check for construction as well. However, a tile's total volume is larger than a tile's base storage capacity, so it would actually be quite reasonable to require several tile's worth of material to fully fill up a tile with a compact construction (such as an earthen wall). I have not checked if any constructions currently exceed the in-progress limit, however.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Verify that you can indeed start the faction camp construction indicated by the bug report with the changed code.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
The restriction was added by #80578, which is why the PR's problem is new.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
