### PR TITLE
math: implement dot operator for tripoints

### DIFF
--- a/doc/JSON/NPCs.md
+++ b/doc/JSON/NPCs.md
@@ -1274,6 +1274,17 @@ Examples:
     { "math": [ "n_crazyness * 2 >= ( x + y ) * u_z" ] },
 ```
 
+#### Tripoints
+Members of tripoint variables can be accessed with the dot operator in the usual way
+```jsonc
+      { "u_location_variable": { "u_val": "mypos" } },
+      { "math": [ "u_myx = u_mypos.x" ] },
+      { "math": [ "u_myy = u_mypos.y" ] },
+      { "math": [ "u_myz = u_mypos.z" ] },
+      // assignment works too
+      { "math": [ "u_mypos.z = 12" ] },
+```
+
 #### Constants
 The tokens `π` (and `pi` alias ) and `e` are recognized as mathematical constants and get replaced by their nominal values.
 

--- a/src/math_parser_impl.h
+++ b/src/math_parser_impl.h
@@ -71,6 +71,16 @@ struct oper {
     std::shared_ptr<thingie> l, r;
     binary_op::f_t op{};
 };
+
+struct dot_oper {
+    dot_oper( var_info v_, std::string_view m_ );
+
+    double eval( const_dialogue const &d ) const;
+    void assign( dialogue &d, double val ) const;
+
+    var_info v;
+    char member{};
+};
 struct func {
     explicit func( std::vector<thingie> &&params_, math_func::f_t f_ );
 
@@ -164,7 +174,7 @@ struct thingie {
     constexpr double eval( const_dialogue const &d ) const;
 
     using impl_t =
-        std::variant<double, std::string, oper, ass_oper, func, func_jmath, func_diag, var, kwarg, ternary, array>;
+        std::variant<double, std::string, oper, dot_oper, ass_oper, func, func_jmath, func_diag, var, kwarg, ternary, array>;
     impl_t data;
 };
 
@@ -315,7 +325,7 @@ inline double b_neg( double /* zero */, double r )
 
 constexpr binary_op assignment_op{ "", -10, binary_op::associativity::left };
 
-constexpr std::array<binary_op, 14> binary_ops{
+constexpr std::array<binary_op, 15> binary_ops{
     binary_op{ "?", 0, binary_op::associativity::right },
     binary_op{ ":", 0, binary_op::associativity::right },
     binary_op{ "<", 1, binary_op::associativity::left, math_opers::lt },
@@ -330,6 +340,7 @@ constexpr std::array<binary_op, 14> binary_ops{
     binary_op{ "/", 3, binary_op::associativity::left, math_opers::div },
     binary_op{ "%", 3, binary_op::associativity::right, math_opers::mod },
     binary_op{ "^", 4, binary_op::associativity::right, math_opers::math_pow },
+    binary_op{ ".", 10, binary_op::associativity::right },
 };
 
 constexpr std::array<unary_op, 3> prefix_unary_ops{

--- a/tests/math_parser_test.cpp
+++ b/tests/math_parser_test.cpp
@@ -12,6 +12,7 @@
 #include "avatar.h"
 #include "cata_catch.h"
 #include "cata_scope_helpers.h"
+#include "coordinates.h"
 #include "debug.h"
 #include "dialogue.h"
 #include "global_vars.h"
@@ -20,6 +21,7 @@
 #include "math_parser_func.h"
 #include "math_parser_type.h"
 #include "npc.h"
+#include "point.h"
 #include "talker.h"
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity): false positive
@@ -210,6 +212,18 @@ TEST_CASE( "math_parser_parsing", "[math_parser]" )
     CHECK( testexp.parse( "_test_str_len_((['1',('2')]))" ) ); // pointless parens
     CHECK( testexp.eval( d ) == Approx( 2 ) );
 
+    // dot operator
+    get_globals().set_global_value( "mytripoint", tripoint_abs_ms{ 1, 2, 3 } );
+    CHECK( testexp.parse( "mytripoint.x" ) );
+    CHECK( testexp.eval( d ) == Approx( 1 ) );
+    CHECK( testexp.parse( "mytripoint.y" ) );
+    CHECK( testexp.eval( d ) == Approx( 2 ) );
+    CHECK( testexp.parse( "mytripoint.z" ) );
+    CHECK( testexp.eval( d ) == Approx( 3 ) );
+    CHECK( testexp.parse( "mytripoint.z = 4" ) );
+    testexp.eval( d );
+    CHECK( get_globals().get_global_value( "mytripoint" ).tripoint().z() == 4 );
+
     // failed validation
     // NOLINTNEXTLINE(readability-function-cognitive-complexity): false positive
     std::string dmsg = capture_debugmsg_during( [&testexp, &d]() {
@@ -296,6 +310,12 @@ TEST_CASE( "math_parser_parsing", "[math_parser]" )
         CHECK_FALSE( testexp.parse( "_test_diag_([a=+])" ) );
         CHECK_FALSE( testexp.parse( "_test_diag_('1':0=0?1:2)" ) );
         CHECK_FALSE( testexp.parse( "_test_diag_('1':a=2)" ) );
+
+        CHECK_FALSE( testexp.parse( "mytripoint.(z)" ) );
+        CHECK_FALSE( testexp.parse( "mytripoint.2" ) );
+        CHECK_FALSE( testexp.parse( "mytripoint.w" ) );
+        CHECK_FALSE( testexp.parse( "mytripoint.+x" ) );
+        CHECK_FALSE( testexp.parse( "mytripoint.rand(1)" ) );
     } );
 }
 


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
People want to access tripoint members in JSON math.

#### Describe the solution
Implement a tripoint dot operator

~~- Depends on: #80795~~
~~This PR starts at 44e0ade842159ddac864008b8835585bf397698e `math: implement dot operator for tripoints`~~

#### Describe alternatives you've considered
- this can be done with dialogue functions, as seen in #80369, though I prefer it as a `math` feature

- #80795 isn't strictly needed and this can be done with the old tokenizer, though it's fugly


#### Testing
Expanded test unit

#### Additional context
N/A