### PR TITLE
fix 0.H for GCC 15

### DIFF
--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -87,8 +87,6 @@ static const item_category_id item_category_tools( "tools" );
 static const item_category_id item_category_veh_parts( "veh_parts" );
 static const item_category_id item_category_weapons( "weapons" );
 
-static const item_group_id Item_spawn_data_EMPTY_GROUP( "EMPTY_GROUP" );
-
 static const material_id material_bean( "bean" );
 static const material_id material_blood( "blood" );
 static const material_id material_bone( "bone" );
@@ -1891,7 +1889,7 @@ void Item_factory::init()
     add_actor( std::make_unique<effect_on_conditons_actor>() );
     // An empty dummy group, it will not spawn anything. However, it makes that item group
     // id valid, so it can be used all over the place without need to explicitly check for it.
-    m_template_groups[Item_spawn_data_EMPTY_GROUP] =
+    m_template_groups[get_Item_spawn_data_EMPTY_GROUP()] =
         std::make_unique<Item_group>( Item_group::G_COLLECTION, 100, 0, 0, "EMPTY_GROUP" );
 }
 

--- a/src/item_group.cpp
+++ b/src/item_group.cpp
@@ -67,6 +67,12 @@ void Item_spawn_data::relic_generator::load( const JsonObject &jo )
     mandatory( jo, was_loaded, "procgen_id", id );
 }
 
+item_group_id get_Item_spawn_data_EMPTY_GROUP()
+{
+    static const item_group_id Item_spawn_data_EMPTY_GROUP( "EMPTY_GROUP" );
+    return Item_spawn_data_EMPTY_GROUP;
+}
+
 relic Item_spawn_data::relic_generator::generate_relic( const itype_id &it_id ) const
 {
     return id->generate( rules, it_id );

--- a/src/item_group.h
+++ b/src/item_group.h
@@ -411,4 +411,6 @@ class Item_group : public Item_spawn_data
         prop_list items;
 };
 
+item_group_id get_Item_spawn_data_EMPTY_GROUP();
+
 #endif // CATA_SRC_ITEM_GROUP_H

--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -26,8 +26,6 @@
 #include "trap.h"
 #include "type_id.h"
 
-static const item_group_id Item_spawn_data_EMPTY_GROUP( "EMPTY_GROUP" );
-
 namespace
 {
 
@@ -340,7 +338,7 @@ map_bash_info::map_bash_info() : str_min( -1 ), str_max( -1 ),
     str_min_supported( -1 ), str_max_supported( -1 ),
     explosive( 0 ), sound_vol( -1 ), sound_fail_vol( -1 ),
     collapse_radius( 1 ), destroy_only( false ), bash_below( false ),
-    drop_group( Item_spawn_data_EMPTY_GROUP ),
+    drop_group( get_Item_spawn_data_EMPTY_GROUP() ),
     ter_set( ter_str_id::NULL_ID() ), furn_set( furn_str_id::NULL_ID() ) {}
 
 bool map_bash_info::load( const JsonObject &jsobj, const std::string_view member,
@@ -395,7 +393,7 @@ bool map_bash_info::load( const JsonObject &jsobj, const std::string_view member
         drop_group = item_group::load_item_group( j.get_member( "items" ), "collection",
                      "map_bash_info for " + context );
     } else {
-        drop_group = Item_spawn_data_EMPTY_GROUP;
+        drop_group = get_Item_spawn_data_EMPTY_GROUP();
     }
 
     if( j.has_array( "tent_centers" ) ) {

--- a/src/third-party/flatbuffers/stl_emulation.h
+++ b/src/third-party/flatbuffers/stl_emulation.h
@@ -626,7 +626,7 @@ class span FLATBUFFERS_FINAL_CLASS {
  private:
   // This is a naive implementation with 'count_' member even if (Extent != dynamic_extent).
   pointer const data_;
-  const size_type count_;
+  size_type count_;
 };
 
  #if !defined(FLATBUFFERS_SPAN_MINIMAL)


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Our existing 0.H builds don't run anymore with libstdc++ 15.1. At least Fedora and Arch ship it so our stable builds don't work on those distros.

Furthermore, 0.H doesn't compile with GCC 15 either.

- Closes: #80799

#### Describe the solution

Cherry-pick #74229 and ~~#71522~~ so it compiles.

Reorder initialization of the problematic static global so it doesn't crash.

#### Describe alternatives you've considered
??

#### Testing
It builds and runs on Arch.


#### Additional context

<details>
<summary>backtrace</summary>

```gdb
Program received signal SIGSEGV, Segmentation fault.
bstd::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_S_copy (__d=0x5555581d9da0 <get_all_field_types()::all_field_types+512> "", __s=0x0, __n=1) at /usr/src/debug/gcc/gcc-build/x86_64-pc-linux-gnu/libstdc++-v3/include/bits/basic_string.h:451
warning: 451	/usr/src/debug/gcc/gcc-build/x86_64-pc-linux-gnu/libstdc++-v3/include/bits/basic_string.h: No such file or directory
(gdb) bt
#0  std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_S_copy (__d=0x5555581d9da0 <get_all_field_types()::all_field_types+512> "", __s=0x0, __n=1) at /usr/src/debug/gcc/gcc-build/x86_64-pc-linux-gnu/libstdc++-v3/include/bits/basic_string.h:451
#1  0x00005555562e3fa8 in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_construct<true> (this=0x5555581d9d90 <get_all_field_types()::all_field_types+496>, __str=0x0, __n=<optimized out>) at /usr/include/c++/15.1.1/bits/basic_string.tcc:298
#2  0x000055555634fe7e in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::basic_string (this=<optimized out>, __str=...) at /usr/include/c++/15.1.1/bits/basic_string.h:617
#3  string_identity_dynamic::string_identity_dynamic (this=<optimized out>) at src/string_id.h:171
#4  string_id<Item_spawn_data>::string_id (this=<optimized out>) at src/string_id.h:197
#5  0x0000555556ea9c0a in map_bash_info::map_bash_info (this=this@entry=0x5555581d9d50 <get_all_field_types()::all_field_types+432>) at src/mapdata.cpp:345
#6  0x000055555698a651 in field_type::field_type (this=0x5555581d9cd0 <get_all_field_types()::all_field_types+304>) at src/field_type.h:181
#7  0x000055555698b2ec in generic_factory<field_type>::generic_factory (this=0x5555581d9ba0 <get_all_field_types()::all_field_types>, type_name=..., id_member_name=..., alias_member_name=...) at /usr/include/c++/15.1.1/bits/new_allocator.h:104
#8  0x0000555556986489 in get_all_field_types () at src/field_type.cpp:108
#9  0x00005555569868c6 in string_id<field_type>::id_or (this=0x5555581d9b60 <fd_null>, fallback=...) at src/field_type.cpp:150
#10 0x0000555556983ff0 in field::field (this=this@entry=0x555558304ae0 <nulfield>) at src/field.cpp:113
#11 0x0000555556e4ac0d in __static_initialization_and_destruction_0 () at src/map.cpp:168
#12 0x0000555556e4e242 in _GLOBAL__sub_I__ZN9map_stack5eraseEN4cata6colonyI4itemSaIS2_EtE15colony_iteratorILb1EEE () at src/map.cpp:10390
#13 0x00007ffff7627cff in __libc_start_main () from /usr/lib/libc.so.6
#14 0x00005555562dde25 in _start (
```

</details>

The relevant code changed significantly since then so this doesn't need to be ported to master.