### PR TITLE
Standardize query_int()

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -4440,8 +4440,8 @@ void workout_activity_actor::start( player_activity &act, Character &who )
             intensity_modifier = 1;
             break;
     }
-    int length;
-    query_int( length, _( "Train for how long (minutes): " ) );
+    int length = 0;
+    query_int( length, false, _( "Train for how long (minutes): " ) );
     if( length > 0 ) {
         duration = length * 1_minutes;
     } else {
@@ -4543,7 +4543,7 @@ bool workout_activity_actor::query_keep_training( player_activity &act, Characte
             return true;
         case 2:
         default:
-            query_int( length, _( "Train for how long (minutes): " ) );
+            query_int( length, false, _( "Train for how long (minutes): " ) );
             elapsed += act.moves_total - act.moves_left;
             duration = 0_minutes;
             if( length > 0 ) {

--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -2336,11 +2336,7 @@ bool advanced_inventory::query_charges( aim_location destarea, const advanced_in
         } else {
             // In test_mode always use max possible
             // TODO: maybe a way to provide a custom amount?
-            amount = test_mode ? possible_max : string_input_popup()
-                     .title( popupmsg )
-                     .width( 20 )
-                     .only_digits( true )
-                     .query_int();
+            test_mode ? amount = possible_max : query_int( amount, false, popupmsg );
         }
         if( amount <= 0 ) {
             return false;

--- a/src/calendar_ui.cpp
+++ b/src/calendar_ui.cpp
@@ -8,8 +8,8 @@
 
 #include "color.h"
 #include "input_context.h"
+#include "output.h"
 #include "string_formatter.h"
-#include "string_input_popup.h"
 #include "translation.h"
 #include "uilist.h"
 
@@ -21,14 +21,7 @@ time_point calendar_ui::select_time_point( time_point initial_value, std::string
     int auto_value = 0 ) {
         int new_value = initial + auto_value;
         if( new_value == initial ) {
-            string_input_popup pop;
-            new_value = pop
-                        .title( msg )
-                        .width( 20 )
-                        .text( std::to_string( initial ) )
-                        .only_digits( true )
-                        .query_int();
-            if( pop.canceled() ) {
+            if( !query_int( new_value, true, msg ) ) {
                 return;
             }
         }

--- a/src/clzones.cpp
+++ b/src/clzones.cpp
@@ -278,9 +278,9 @@ unload_options::query_unload_result unload_options::query_unload()
     sparse_only = query_yn( string_format(
                                 _( "Avoid unloading items stacks (not charges) greater than a certain amount?  (Amount defined in next window)" ) ) );
     if( sparse_only ) {
-        int threshold;
-        if( query_int( threshold,
-                       _( "What is the maximum stack size to unload?  (20 is a good default)" ) ) ) {
+        int threshold = 20;
+        if( query_int( threshold, true,
+                       _( "What is the maximum stack size to unload?" ) ) ) {
             if( sparse_threshold < 1 ) {
                 sparse_threshold = 1;
             } else {

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -573,9 +573,10 @@ static void monster_ammo_edit( monster &mon )
     itype_id new_ammo;
     new_ammo = ammos[smenu.ret];
     if( new_ammo.is_valid() ) {
-        int value;
+        int value = 0;
         const itype *display_type = item::find_type( new_ammo );
-        if( query_int( value, _( "Set %s to how much ammo?  Currently: %d" ), display_type->nname( 1 ),
+        if( query_int( value, false, _( "Set %s to how much ammo?  Currently: %d" ),
+                       display_type->nname( 1 ),
                        mon.ammo[new_ammo] ) )  {
             if( value < 0 ) {
                 value = 0;
@@ -785,21 +786,21 @@ static void monster_edit_menu()
     switch( nmenu.ret ) {
         case D_HP: {
             int value = 0;
-            if( query_int( value,  _( "Set the hitpoints to?  Currently: %d" ), critter->get_hp() ) ) {
+            if( query_int( value, false, _( "Set the hitpoints to?  Currently: %d" ), critter->get_hp() ) ) {
                 critter->set_hp( value );
             }
         }
         break;
         case D_MORALE: {
             int value = 0;
-            if( query_int( value, _( "Set the morale to?  Currently: %d" ), critter->morale ) ) {
+            if( query_int( value, false, _( "Set the morale to?  Currently: %d" ), critter->morale ) ) {
                 critter->morale = value;
             }
         }
         break;
         case D_AGGRO: {
             int value = 0;
-            if( query_int( value, _( "Set aggression to?  Currently: %d" ), critter->anger ) ) {
+            if( query_int( value, false, _( "Set aggression to?  Currently: %d" ), critter->anger ) ) {
                 critter->anger = value;
             }
         }
@@ -830,7 +831,7 @@ static void monster_edit_menu()
         }
         case D_WANDER: {
             int value = 0;
-            if( query_int( value, _( "Set wander desire to?  Currently: %d" ), critter->wandf ) ) {
+            if( query_int( value, false, _( "Set wander desire to?  Currently: %d" ), critter->wandf ) ) {
                 critter->wandf = value;
             }
             break;
@@ -1640,7 +1641,7 @@ static void change_spells( Character &character )
 
         } else if( action == "CONFIRM" ) {
             int &spell_level = std::get<1>( *spells_relative[spell_selected] );
-            query_int( spell_level, _( "Set spell level to?  Currently: %1$d" ), spell_level );
+            query_int( spell_level, false, _( "Set spell level to?  Currently: %1$d" ), spell_level );
             spell_level = clamp( spell_level, -1,
                                  static_cast<int>( std::get<0>( *spells_relative[spell_selected] ).max_level.evaluate( d ) ) );
             set_spell( std::get<0>( *spells_relative[spell_selected] ), spell_level );
@@ -1707,14 +1708,14 @@ static void spawn_artifact()
         ++menu_ind;
     }
     relic_menu.query();
-    int artifact_max_attributes;
-    int artifact_power_level;
+    int artifact_max_attributes = 0;
+    int artifact_power_level = 0;
     bool artifact_is_resonant = false;
-    int artifact_max_negative_value;
+    int artifact_max_negative_value = 0;
     if( relic_menu.ret >= 0 && relic_menu.ret < static_cast<int>( relic_list.size() ) ) {
-        if( query_int( artifact_max_attributes, _( "Enter max attributes:" ) )
-            && query_int( artifact_power_level, _( "Enter power level:" ) )
-            && query_int( artifact_max_negative_value, _( "Enter negative power limit:" ) ) ) {
+        if( query_int( artifact_max_attributes, false, _( "Enter max attributes:" ) )
+            && query_int( artifact_power_level, false, _( "Enter power level:" ) )
+            && query_int( artifact_max_negative_value, false, _( "Enter negative power limit:" ) ) ) {
             if( const std::optional<tripoint_bub_ms> center = g->look_around() ) {
                 if( query_yn( _( "Is the artifact resonant?" ) ) ) {
                     artifact_is_resonant = true;
@@ -1899,8 +1900,8 @@ static void character_edit_stats_menu( Character &you )
     }
 
     if( bp_ptr != nullptr ) {
-        int value;
-        if( query_int( value, _( "Set the stat to?  Currently: %d" ), *bp_ptr ) && value >= 0 ) {
+        int value = 0;
+        if( query_int( value, false, _( "Set the stat to?  Currently: %d" ), *bp_ptr ) && value >= 0 ) {
             *bp_ptr = value;
             you.reset_stats();
         }
@@ -1964,43 +1965,44 @@ static void character_edit_needs_menu( Character &you )
     int value;
     switch( smenu.ret ) {
         case 0:
-            if( query_int( value, _( "Set hunger to?  Currently: %d" ), you.get_hunger() ) ) {
+            if( query_int( value, false, _( "Set hunger to?  Currently: %d" ), you.get_hunger() ) ) {
                 you.set_hunger( value );
             }
             break;
 
         case 1:
-            if( query_int( value, _( "Set stored kcal to?  Currently: %d" ), you.get_stored_kcal() ) ) {
+            if( query_int( value, false, _( "Set stored kcal to?  Currently: %d" ), you.get_stored_kcal() ) ) {
                 you.set_stored_kcal( value );
             }
             break;
 
         case 2:
-            if( query_int( value, _( "Set stomach kcal to?  Currently: %d" ), you.stomach.get_calories() ) ) {
+            if( query_int( value, false, _( "Set stomach kcal to?  Currently: %d" ),
+                           you.stomach.get_calories() ) ) {
                 you.stomach.mod_calories( value - you.stomach.get_calories() );
             }
             break;
 
         case 3:
-            if( query_int( value, _( "Set gut kcal to?  Currently: %d" ), you.guts.get_calories() ) ) {
+            if( query_int( value, false, _( "Set gut kcal to?  Currently: %d" ), you.guts.get_calories() ) ) {
                 you.guts.mod_calories( value - you.guts.get_calories() );
             }
             break;
 
         case 4:
-            if( query_int( value, _( "Set thirst to?  Currently: %d" ), you.get_thirst() ) ) {
+            if( query_int( value, false, _( "Set thirst to?  Currently: %d" ), you.get_thirst() ) ) {
                 you.set_thirst( value );
             }
             break;
 
         case 5:
-            if( query_int( value, _( "Set sleepiness to?  Currently: %d" ), you.get_sleepiness() ) ) {
+            if( query_int( value, false, _( "Set sleepiness to?  Currently: %d" ), you.get_sleepiness() ) ) {
                 you.set_sleepiness( value );
             }
             break;
 
         case 6:
-            if( query_int( value, _( "Set sleep deprivation to?  Currently: %d" ),
+            if( query_int( value, false, _( "Set sleep deprivation to?  Currently: %d" ),
                            you.get_sleep_deprivation() ) ) {
                 you.set_sleep_deprivation( value );
             }
@@ -2013,7 +2015,7 @@ static void character_edit_needs_menu( Character &you )
             }
             break;
         case 10:
-            if( query_int( value, _( "Set weariness tracker to?  Currently: %d" ),
+            if( query_int( value, false, _( "Set weariness tracker to?  Currently: %d" ),
                            you.activity_history.debug_get_tracker() ) ) {
                 you.activity_history.debug_set_tracker( value );
             }
@@ -2034,7 +2036,7 @@ static void character_edit_needs_menu( Character &you )
         default:
             if( smenu.ret >= 10 && smenu.ret < static_cast<int>( vits.size() + 10 ) ) {
                 auto iter = std::next( vits.begin(), smenu.ret - 10 );
-                if( query_int( value, _( "Set %s to?  Currently: %d" ),
+                if( query_int( value, false, _( "Set %s to?  Currently: %d" ),
                                iter->second.name(), you.vitamin_get( iter->first ) ) ) {
                     you.vitamin_set( iter->first, value );
                 }
@@ -2069,7 +2071,7 @@ static void character_edit_hp_menu( Character &you )
 
     if( bp.is_valid() && bp != bodypart_str_id::NULL_ID() ) {
         int value;
-        if( query_int( value, _( "Set the hitpoints to?  Currently: %d" ),
+        if( query_int( value, false, _( "Set the hitpoints to?  Currently: %d" ),
                        you.get_part_hp_cur( bp.id() ) ) &&
             value >= 0 )  {
             you.set_part_hp_cur( bp.id(), value );
@@ -2077,7 +2079,7 @@ static void character_edit_hp_menu( Character &you )
         }
     } else if( all_select ) {
         int value;
-        if( query_int( value, _( "Set the hitpoints to?  Currently: %d" ), you.get_lowest_hp() ) &&
+        if( query_int( value, false, _( "Set the hitpoints to?  Currently: %d" ), you.get_lowest_hp() ) &&
             value >= 0 ) {
             for( bodypart_id part_id : you.get_all_body_parts( get_body_part_flags::only_main ) ) {
                 you.set_part_hp_cur( part_id, value );
@@ -2101,35 +2103,35 @@ static void character_edit_opinion_menu( npc *np )
     int value;
     switch( smenu.ret ) {
         case 0:
-            if( query_int( value, _( "Set trust to?  Currently: %d" ),
+            if( query_int( value, false, _( "Set trust to?  Currently: %d" ),
                            np->op_of_u.trust ) ) {
                 np->op_of_u.trust = value;
             }
             break;
         case 1:
-            if( query_int( value, _( "Set fear to?  Currently: %d" ), np->op_of_u.fear ) ) {
+            if( query_int( value, false, _( "Set fear to?  Currently: %d" ), np->op_of_u.fear ) ) {
                 np->op_of_u.fear = value;
             }
             break;
         case 2:
-            if( query_int( value, _( "Set value to?  Currently: %d" ),
+            if( query_int( value, false, _( "Set value to?  Currently: %d" ),
                            np->op_of_u.value ) ) {
                 np->op_of_u.value = value;
             }
             break;
         case 3:
-            if( query_int( value, _( "Set anger to?  Currently: %d" ),
+            if( query_int( value, false, _( "Set anger to?  Currently: %d" ),
                            np->op_of_u.anger ) ) {
                 np->op_of_u.anger = value;
             }
             break;
         case 4:
-            if( query_int( value, _( "Set owed to?  Currently: %d" ), np->op_of_u.owed ) ) {
+            if( query_int( value, false, _( "Set owed to?  Currently: %d" ), np->op_of_u.owed ) ) {
                 np->op_of_u.owed = value;
             }
             break;
         case 5:
-            if( query_int( value, _( "Set sold to?  Currently: %d" ), np->op_of_u.sold ) ) {
+            if( query_int( value, false, _( "Set sold to?  Currently: %d" ), np->op_of_u.sold ) ) {
                 np->op_of_u.sold = value;
             }
             break;
@@ -2148,24 +2150,24 @@ static void character_edit_personality_menu( npc *np )
     int value;
     switch( smenu.ret ) {
         case 0:
-            if( query_int( value, _( "Set aggression to?  Currently: %d" ),
+            if( query_int( value, false, _( "Set aggression to?  Currently: %d" ),
                            np->personality.aggression ) ) {
                 np->personality.aggression = value;
             }
             break;
         case 1:
-            if( query_int( value, _( "Set bravery to?  Currently: %d" ), np->personality.bravery ) ) {
+            if( query_int( value, false, _( "Set bravery to?  Currently: %d" ), np->personality.bravery ) ) {
                 np->personality.bravery = value;
             }
             break;
         case 2:
-            if( query_int( value, _( "Set collector to?  Currently: %d" ),
+            if( query_int( value, false, _( "Set collector to?  Currently: %d" ),
                            np->personality.collector ) ) {
                 np->personality.collector = value;
             }
             break;
         case 3:
-            if( query_int( value, _( "Set altruism to?  Currently: %d" ),
+            if( query_int( value, false, _( "Set altruism to?  Currently: %d" ),
                            np->personality.altruism ) ) {
                 np->personality.altruism = value;
             }
@@ -2213,25 +2215,16 @@ static void character_edit_desc_menu( Character &you )
         }
         break;
         case 2: {
-            string_input_popup popup;
-            popup.title( _( "Enter age in years.  Minimum 16, maximum 55" ) )
-            .text( string_format( "%d", you.base_age() ) )
-            .only_digits( true );
-            const int result = popup.query_int();
-            if( result != 0 ) {
+            int result = you.base_age();
+            if( query_int( result, true, _( "Enter age in years.  Minimum 16, maximum 55" ) ) && result > 0 ) {
                 you.set_base_age( clamp( result, 16, 55 ) );
             }
         }
         break;
         case 3: {
-            string_input_popup popup;
-            popup.title( string_format( _( "Enter height in centimeters.  Minimum %d, maximum %d" ),
-                                        Character::min_height(),
-                                        Character::max_height() ) )
-            .text( string_format( "%d", you.base_height() ) )
-            .only_digits( true );
-            const int result = popup.query_int();
-            if( result != 0 ) {
+            int result = you.base_height();
+            if( query_int( result, true, _( "Enter height in centimeters.  Minimum %d, maximum %d" ),
+                           Character::min_height(), Character::max_height() ) && result > 0 ) {
                 you.set_base_height( clamp( result, Character::min_height(), Character::max_height() ) );
             }
         }
@@ -2461,7 +2454,7 @@ static void character_edit_menu()
         break;
         case D_RADS: {
             int value;
-            if( query_int( value, _( "Set rads to?  Currently: %d" ), you.get_rad() ) ) {
+            if( query_int( value, false, _( "Set rads to?  Currently: %d" ), you.get_rad() ) ) {
                 you.set_rad( value );
             }
         }
@@ -2471,7 +2464,7 @@ static void character_edit_menu()
             break;
         case D_STAMINA:
             int value;
-            if( query_int( value, _( "Set stamina to?  Current: %d. Max: %d." ), you.get_stamina(),
+            if( query_int( value, false, _( "Set stamina to?  Current: %d. Max: %d." ), you.get_stamina(),
                            you.get_stamina_max() ) ) {
                 if( value >= 0 && value <= you.get_stamina_max() ) {
                     you.set_stamina( value );
@@ -2482,7 +2475,7 @@ static void character_edit_menu()
             break;
         case D_MORALE: {
             int value;
-            if( query_int( value, _( "Set the morale to?  Currently: %d" ), you.get_morale_level() ) ) {
+            if( query_int( value, false, _( "Set the morale to?  Currently: %d" ), you.get_morale_level() ) ) {
                 you.rem_morale( morale_perm_debug );
                 int morale_level_delta = value - you.get_morale_level();
                 you.add_morale( morale_perm_debug, morale_level_delta );
@@ -2492,7 +2485,7 @@ static void character_edit_menu()
         break;
         case D_KILL_XP: {
             int value;
-            if( query_int( value, _( "Set kill XP to?  Currently: %d" ), you.kill_xp ) ) {
+            if( query_int( value, false, _( "Set kill XP to?  Currently: %d" ), you.kill_xp ) ) {
                 you.kill_xp = value;
             }
         }
@@ -2508,7 +2501,7 @@ static void character_edit_menu()
             break;
         case D_PAIN: {
             int value;
-            if( query_int( value, _( "Cause how much pain?  pain: %d" ), you.get_pain() ) ) {
+            if( query_int( value, false, _( "Cause how much pain?  Current pain: %d" ), you.get_pain() ) ) {
                 you.mod_pain( value );
             }
         }
@@ -2573,17 +2566,19 @@ static void character_edit_menu()
             int value;
             switch( smenu.ret ) {
                 case 0:
-                    if( query_int( value, _( "Set the value to?  Currently: %d" ), you.get_lifestyle() ) ) {
+                    if( query_int( value, false, _( "Set lifestyle value to?  Currently: %d" ),
+                                   you.get_lifestyle() ) ) {
                         you.set_lifestyle( value );
                     }
                     break;
                 case 1:
-                    if( query_int( value, _( "Set the value to?  Currently: %d" ), you.get_daily_health() ) ) {
+                    if( query_int( value, false, _( "Set the daily health value to?  Currently: %d" ),
+                                   you.get_daily_health() ) ) {
                         you.set_daily_health( value );
                     }
                     break;
                 case 2:
-                    if( query_int( value, _( "Set the value to?  Currently: %d" ), you.get_rad() ) ) {
+                    if( query_int( value, false, _( "Set the radiation to?  Currently: %d" ), you.get_rad() ) ) {
                         you.set_rad( value );
                     }
                     break;
@@ -2734,17 +2729,17 @@ static void faction_edit_opinion_menu( faction *fac )
     int value;
     switch( smenu.ret ) {
         case 0:
-            if( query_int( value, _( "Change like from %d to: " ), fac->likes_u ) ) {
+            if( query_int( value, false, _( "Change like from %d to: " ), fac->likes_u ) ) {
                 fac->likes_u = value;
             }
             break;
         case 1:
-            if( query_int( value, _( "Change respect from %d to: " ), fac->respects_u ) ) {
+            if( query_int( value, false, _( "Change respect from %d to: " ), fac->respects_u ) ) {
                 fac->respects_u = value;
             }
             break;
         case 2:
-            if( query_int( value, _( "Change trust from %d to: " ), fac->trusts_u ) ) {
+            if( query_int( value, false, _( "Change trust from %d to: " ), fac->trusts_u ) ) {
                 fac->trusts_u = value;
             }
             break;
@@ -2765,14 +2760,14 @@ static void faction_edit_larder_menu( faction *fac )
     int value;
     switch( smenu.ret ) {
         case 0:
-            if( query_int( value, _( "Change food from %d to: " ), fac->food_supply.kcal() ) ) {
+            if( query_int( value, false, _( "Change food from %d to: " ), fac->food_supply.kcal() ) ) {
                 fac->food_supply.calories = ( value * 1000 );
             }
             break;
         default:
             if( smenu.ret >= 1 && smenu.ret < static_cast<int>( vits.size() + 1 ) ) {
                 auto iter = std::next( vits.begin(), smenu.ret - 1 );
-                if( query_int( value, _( "Set %s to?  Currently: %d" ),
+                if( query_int( value, false, _( "Set %s to?  Currently: %d" ),
                                iter->second.name(), fac->food_supply.get_vitamin( iter->first ) ) ) {
                     fac->food_supply.set_vitamin( iter->first, value );
                 }
@@ -2823,17 +2818,17 @@ static void faction_edit_menu()
     int value;
     switch( nmenu.ret ) {
         case D_WEALTH:
-            if( query_int( value, _( "Change wealth from %d to: " ), fac->wealth ) ) {
+            if( query_int( value, false, _( "Change wealth from %d to: " ), fac->wealth ) ) {
                 fac->wealth = value;
             }
             break;
         case D_SIZE:
-            if( query_int( value, _( "Change size from %d to: " ), fac->size ) ) {
+            if( query_int( value, false, _( "Change size from %d to: " ), fac->size ) ) {
                 fac->size = value;
             }
             break;
         case D_POWER:
-            if( query_int( value, _( "Change power from %d to: " ), fac->power ) ) {
+            if( query_int( value, false, _( "Change power from %d to: " ), fac->power ) ) {
                 fac->power = value;
             }
             break;
@@ -3240,15 +3235,11 @@ static void debug_menu_force_temperature()
     if( tempmenu.ret == 0 ) {
         forced_temp.reset();
     } else {
-        string_input_popup pop;
-
-        auto ask = [&pop]( const std::string & unit, std::optional<float> current ) {
-            int ret = pop.title( string_format( _( "Set temperature to?  [%s]" ), unit ) )
-                      .width( 20 )
-                      .text( current ? std::to_string( static_cast<int>( std::round( *current ) ) ) : "" )
-                      .query_int();
-
-            return pop.canceled() ? current : std::optional<float>( static_cast<float>( ret ) );
+        auto ask = []( const std::string & unit, std::optional<float> current ) {
+            int ret = !!current ? static_cast<int>( std::round( *current ) ) :
+                      static_cast<int>( std::round( get_weather().temperature.value() ) );
+            return query_int( ret, !!current, _( "Set temperature to?  [%s]" ), unit ) ?
+                   std::optional<float>( static_cast<float>( ret ) ) : current;
         };
 
         std::optional<float> current;
@@ -3352,7 +3343,7 @@ static void bleed_self()
         default:
             break;
     }
-    if( query_int( intensity, _( "Add bleeding duration in minutes, equal to intensity:" ) ) ) {
+    if( query_int( intensity, false, _( "Add bleeding duration in minutes, equal to intensity:" ) ) ) {
         get_avatar().add_effect( effect_bleed,  1_minutes * intensity, part );
     }
 }
@@ -3457,12 +3448,8 @@ static void gen_sound()
         return;
     }
 
-    int volume;
-    if( !query_int( volume, _( "Volume of sound: " ) ) ) {
-        return;
-    }
-
-    if( volume < 0 ) {
+    int volume = 0;
+    if( !query_int( volume, false, _( "Volume of sound: " ) ) || volume < 0 ) {
         return;
     }
 
@@ -3928,7 +3915,7 @@ void debug()
 
         case debug_menu_index::SPAWN_OM_NPC: {
             int num_of_npcs = 1;
-            if( query_int( num_of_npcs, _( "How many NPCs to try spawning?" ), num_of_npcs ) ) {
+            if( query_int( num_of_npcs, false, _( "How many NPCs to try spawning?" ), num_of_npcs ) ) {
                 for( int i = 0; i < num_of_npcs; i++ ) {
                     g->perhaps_add_random_npc( true );
                 }
@@ -4150,12 +4137,10 @@ void debug()
             break;
 
         case debug_menu_index::BENCHMARK: {
-            const int ms = string_input_popup()
-                           .title( _( "Enter benchmark length (in milliseconds):" ) )
-                           .width( 20 )
-                           .text( "5000" )
-                           .query_int();
-            debug_menu::draw_benchmark( ms );
+            int ms = 5000;
+            if( query_int( ms, true, _( "Enter benchmark length (in milliseconds):" ) ) ) {
+                debug_menu::draw_benchmark( ms );
+            }
         }
         break;
 

--- a/src/editmap.cpp
+++ b/src/editmap.cpp
@@ -1225,7 +1225,7 @@ void editmap::edit_rads() const
 {
     map &here = get_map();
     int value = 0;
-    if( query_int( value, _( "Set rads to?  Currently: %d" ), here.get_radiation( target ) ) ) {
+    if( query_int( value, false, _( "Set rads to?  Currently: %d" ), here.get_radiation( target ) ) ) {
         here.set_radiation( target, value );
     }
 }
@@ -1483,12 +1483,10 @@ void editmap::edit_itm()
                     }
                     string_input_popup popup;
                     int retval = 0;
+                    bool confirmed = false;
                     if( imenu.ret < imenu_tags ) {
-                        retval = popup
-                                 .title( "set:" )
-                                 .width( 20 )
-                                 .text( std::to_string( intval ) )
-                                 .query_int();
+                        retval = intval;
+                        confirmed = query_int( retval, true, "set:" );
                     } else if( imenu.ret == imenu_tags ) {
                         strval = popup
                                  .title( _( "Flags:" ) )
@@ -1496,7 +1494,7 @@ void editmap::edit_itm()
                                  .text( strval )
                                  .query_string();
                     }
-                    if( popup.confirmed() ) {
+                    if( popup.confirmed() || confirmed ) {
                         switch( imenu.ret ) {
                             case imenu_bday:
                                 it.set_birthday( time_point::from_turn( retval ) );

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -89,7 +89,6 @@
 #include "skill.h"
 #include "stomach.h"
 #include "string_formatter.h"
-#include "string_input_popup.h"
 #include "translation.h"
 #include "translations.h"
 #include "type_id.h"
@@ -2463,21 +2462,14 @@ void basecamp::job_assignment_ui()
                     if( smenu.ret == 0 ) {
                         cur_npc->job.clear_all_priorities();
                     } else if( smenu.ret == 1 ) {
-                        const int priority = string_input_popup()
-                                             .title( _( "Priority for all jobs " ) )
-                                             .width( 20 )
-                                             .only_digits( true )
-                                             .query_int();
+                        int priority;
+                        query_int( priority, false, _( "Priority for all jobs " ) );
                         cur_npc->job.set_all_priorities( priority );
                     } else if( smenu.ret > 1 && smenu.ret <= static_cast<int>( job_vec.size() ) + 1 ) {
                         activity_id sel_job = job_vec[size_t( smenu.ret - 2 )];
                         player_activity test_act = player_activity( sel_job );
-                        const std::string formatted = string_format( _( "Priority for %s " ), test_act.get_verb() );
-                        const int priority = string_input_popup()
-                                             .title( formatted )
-                                             .width( 20 )
-                                             .only_digits( true )
-                                             .query_int();
+                        int priority;
+                        query_int( priority, false, _( "Priority for %s " ), test_act.get_verb() );
                         cur_npc->job.set_task_priority( sel_job, priority );
                     } else {
                         break;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -13502,10 +13502,8 @@ void game::display_scent()
     if( use_tiles ) {
         display_toggle_overlay( ACTION_DISPLAY_SCENT );
     } else {
-        int div;
-        bool got_value = query_int( div, _( "Set the Scent Map sensitivity to (0 to cancel)?" ) );
-        if( !got_value || div < 1 ) {
-            add_msg( _( "Never mind." ) );
+        int div = 0;
+        if( !query_int( div, false, _( "Set scent map sensitivity to?" ) ) || div != 0 ) {
             return;
         }
         shared_ptr_fast<game::draw_callback_t> scent_cb = make_shared_fast<game::draw_callback_t>( [&]() {

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -1037,14 +1037,8 @@ class atm_menu
 
         //! Prompt for an integral value clamped to [0, max].
         static int prompt_for_amount( const char *const msg, const int max ) {
-            const std::string formatted = string_format( msg, max );
-            const int amount = string_input_popup()
-                               .title( formatted )
-                               .width( 20 )
-                               .text( std::to_string( max ) )
-                               .only_digits( true )
-                               .query_int();
-
+            int amount = max;
+            query_int( amount, true, msg, max );
             return clamp( amount, 0, max );
         }
 
@@ -5212,14 +5206,9 @@ static void reload_furniture( Character &you, const tripoint_bub_ms &examp, bool
                                       opt.ammo->ammo_type() ) - amount_in_furn;
     const itype *opt_type = opt.ammo->type;
     const int max_amount = std::min( opt.qty(), max_reload_amount );
-    const std::string popupmsg = string_format( _( "Put how many of the %1$s into the %2$s?" ),
-                                 opt_type->nname( max_amount ), f.name() );
-    int amount = string_input_popup()
-                 .title( popupmsg )
-                 .width( 20 )
-                 .text( std::to_string( max_amount ) )
-                 .only_digits( true )
-                 .query_int();
+    int amount = max_amount;
+    query_int( amount, true, _( "Put how many of the %s into the %s?" ), opt_type->nname( max_amount ),
+               f.name() );
     if( amount <= 0 || amount > max_amount ) {
         return;
     }
@@ -5692,20 +5681,13 @@ void iexamine::pay_gas( Character &you, const tripoint_bub_ms &examp )
 
         int maximum_liters = std::min( money / pricePerUnit, tankUnits / 1000 );
 
-        std::string popupmsg = str_to_illiterate_str( string_format(
-                                   _( "How many liters of %s to buy?  Max: %d L.  (0 to cancel)" ), fuelTypeStr, maximum_liters ) );
-        int liters = string_input_popup()
-                     .title( popupmsg )
-                     .width( 20 )
-                     .text( std::to_string( maximum_liters ) )
-                     .only_digits( true )
-                     .query_int();
-        if( liters <= 0 ) {
+        int liters = maximum_liters;
+        if( !query_int( liters, true, str_to_illiterate_str(
+                            _( "How many liters of %s to buy?  Max: %d L." ) ).c_str(),
+                        fuelTypeStr, maximum_liters ) || liters <= 0 ) {
             return;
         }
-        if( liters > maximum_liters ) {
-            liters = maximum_liters;
-        }
+        clamp( liters, 0, maximum_liters );
 
         const std::optional<tripoint_bub_ms> pGasPump = getGasPumpByNumber( examp,
                 uistate.ags_pay_gas_selected_pump );
@@ -7097,16 +7079,9 @@ static void mill_load_food( Character &you, const tripoint_bub_ms &examp,
     const int max_count = std::min( count, max_count_for_capacity );
 
     // ... then ask how many to put it
-    const std::string popupmsg = string_format( _( "Insert how many %s into the mill?" ),
-                                 item::nname( what->typeId(), count ) );
-    int amount = string_input_popup()
-                 .title( popupmsg )
-                 .width( 20 )
-                 .text( std::to_string( max_count ) )
-                 .only_digits( true )
-                 .query_int();
-
-    if( amount == 0 ) {
+    int amount = max_count;
+    if( !query_int( amount, true, _( "Insert how many %s into the mill?" ),
+                    item::nname( what->typeId(), count ) ) || amount <= 0 ) {
         add_msg( m_info, _( "Never mind." ) );
         return;
     } else if( amount > count ) {

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -3528,7 +3528,7 @@ std::optional<int> iuse::c4( Character *p, item *it, const tripoint_bub_ms & )
     int time = 0;
     bool got_value = false;
     if( p->is_avatar() ) {
-        got_value = query_int( time, _( "Set the timer to how many seconds (0 to cancel)?" ) );
+        got_value = query_int( time, false, _( "Set the timer to how many seconds (0 to cancel)?" ) );
         if( !got_value || time <= 0 ) {
             p->add_msg_if_player( _( "Never mind." ) );
             return std::nullopt;
@@ -3672,7 +3672,7 @@ std::optional<int> iuse::firecracker( Character *p, item *it, const tripoint_bub
 std::optional<int> iuse::mininuke( Character *p, item *it, const tripoint_bub_ms & )
 {
     int time;
-    bool got_value = query_int( time, _( "Set the timer to ___ turns (0 to cancel)?" ) );
+    bool got_value = query_int( time, false, _( "Set the timer to ___ turns (0 to cancel)?" ) );
     if( !got_value || time <= 0 ) {
         p->add_msg_if_player( _( "Never mind." ) );
         return std::nullopt;

--- a/src/monexamine.cpp
+++ b/src/monexamine.cpp
@@ -950,14 +950,8 @@ bool monexamine::mech_hack( monster &z )
 
 static int prompt_for_amount( const char *const msg, const int max )
 {
-    const std::string formatted = string_format( msg, max );
-    const int amount = string_input_popup()
-                       .title( formatted )
-                       .width( 20 )
-                       .text( std::to_string( max ) )
-                       .only_digits( true )
-                       .query_int();
-
+    int amount = max;
+    query_int( amount, true, msg, max );
     return clamp( amount, 0, max );
 }
 

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -4710,23 +4710,16 @@ void set_description( tab_manager &tabs, avatar &you, const bool allow_reroll,
                     break;
                 }
                 case char_creation::AGE: {
-                    popup.title( _( "Enter age in years.  Minimum 16, maximum 55" ) )
-                    .text( string_format( "%d", you.base_age() ) )
-                    .only_digits( true );
-                    const int result = popup.query_int();
-                    if( result != 0 ) {
+                    int result = you.base_age();
+                    if( query_int( result, false, _( "Enter age in years.  Minimum 16, maximum 55" ) ) && result > 0 ) {
                         you.set_base_age( clamp( result, 16, 55 ) );
                     }
                     break;
                 }
                 case char_creation::HEIGHT: {
-                    popup.title( string_format( _( "Enter height in centimeters.  Minimum %d, maximum %d" ),
-                                                min_allowed_height,
-                                                max_allowed_height ) )
-                    .text( string_format( "%d", you.base_height() ) )
-                    .only_digits( true );
-                    const int result = popup.query_int();
-                    if( result != 0 ) {
+                    int result = you.base_height();
+                    if( query_int( result, false, _( "Enter height in centimeters.  Minimum %d, maximum %d" ),
+                                   min_allowed_height, max_allowed_height ) && result > 0 ) {
                         you.set_base_height( clamp( result, min_allowed_height, max_allowed_height ) );
                     }
                     break;

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -909,16 +909,16 @@ query_ynq_result query_ynq( const std::string &text )
     return query_ynq_result::quit;
 }
 
-bool query_int( int &result, const std::string &text )
+bool query_int( int &result, bool show_default, const std::string &text )
 {
     string_input_popup popup;
     popup.title( text );
-    popup.text( "" ).only_digits( true );
-    int temp = popup.query_int();
-    if( popup.canceled() ) {
+    popup.text( show_default ? std::to_string( result ) : "" ).only_digits( true );
+    std::optional<int> temp = popup.query_int();
+    if( popup.canceled() || !temp ) {
         return false;
     }
-    result = temp;
+    result = *temp;
     return true;
 }
 

--- a/src/output.h
+++ b/src/output.h
@@ -471,11 +471,12 @@ inline query_ynq_result query_ynq( const char *const msg, Args &&... args )
     return query_ynq( string_format( msg, std::forward<Args>( args )... ) );
 }
 
-bool query_int( int &result, const std::string &text );
+//text query for getting integer input
+bool query_int( int &result, bool show_default, const std::string &text );
 template<typename ...Args>
-inline bool query_int( int &result, const char *const msg, Args &&... args )
+inline bool query_int( int &result, bool show_default, const char *const msg, Args &&... args )
 {
-    return query_int( result, string_format( msg, std::forward<Args>( args )... ) );
+    return query_int( result, show_default, string_format( msg, std::forward<Args>( args )... ) );
 }
 
 std::vector<std::string> get_hotkeys( std::string_view s );

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -440,17 +440,10 @@ class map_notes_callback : public uilist_callback
                             return true;
                         }
                         const int max_amount = 20;
+                        int amount = clamp( danger_radius, 0, max_amount );
                         // NOLINTNEXTLINE(cata-text-style): No need for two whitespaces
-                        const std::string popupmsg = string_format( _( "Danger radius in overmap squares? (0-%d)" ),
-                                                     max_amount );
-                        string_input_popup pop;
-                        const int amount = pop
-                                           .title( popupmsg )
-                                           .width( 20 )
-                                           .text( std::to_string( clamp( danger_radius, 0, max_amount ) ) )
-                                           .only_digits( true )
-                                           .query_int();
-                        if( !pop.canceled() && amount >= 0 && amount <= max_amount ) {
+                        if( query_int( amount, true, _( "Danger radius in overmap squares? (0-%d)" ), max_amount )
+                            && amount >= 0 && amount <= max_amount ) {
                             overmap_buffer.mark_note_dangerous( note_location(), amount, true );
                             menu->ret = UILIST_MAP_NOTE_EDITED;
                             return true;
@@ -1744,8 +1737,10 @@ static void modify_horde_func( tripoint_abs_omt &curs )
     switch( smenu.ret ) {
         case 0:
             new_value = chosen_group.interest;
-            query_int( new_value, _( "Set interest to what value?  Currently %d" ), chosen_group.interest );
-            chosen_group.set_interest( new_value );
+            if( query_int( new_value, false, _( "Set interest to what value?  Currently %d" ),
+                           chosen_group.interest ) ) {
+                chosen_group.set_interest( new_value );
+            }
             break;
         case 1:
             horde_destination = ui::omap::choose_point( _( "Select a target destination for the horde." ),
@@ -1757,8 +1752,10 @@ static void modify_horde_func( tripoint_abs_omt &curs )
             break;
         case 2:
             new_value = chosen_group.population;
-            query_int( new_value, _( "Set population to what value?  Currently %d" ), chosen_group.population );
-            chosen_group.population = new_value;
+            if( query_int( new_value, false, _( "Set population to what value?  Currently %d" ),
+                           chosen_group.population ) ) {
+                chosen_group.population = new_value;
+            }
             break;
         case 3:
             debug_menu::wishmonstergroup_mon_selection( chosen_group );
@@ -1768,7 +1765,7 @@ static void modify_horde_func( tripoint_abs_omt &curs )
             // Screw it we hardcode a popup, if you really want to use this you're welcome to improve it
             popup( _( "Set behavior to which enum value?  Currently %d.  \nAccepted values:\n0 = none,\n1 = city,\n2=roam,\n3=nemesis" ),
                    static_cast<int>( chosen_group.behaviour ) );
-            query_int( new_value, "" );
+            query_int( new_value, false, "" );
             chosen_group.behaviour = static_cast<mongroup::horde_behaviour>( new_value );
             break;
         case 5:
@@ -2108,17 +2105,10 @@ static tripoint_abs_omt display()
                 }
                 if( has_note ) {
                     const int max_amount = 20;
+                    int amount = clamp( danger_radius, 0, max_amount );
                     // NOLINTNEXTLINE(cata-text-style): No need for two whitespaces
-                    const std::string popupmsg = string_format( _( "Danger radius in overmap squares? (0-%d)" ),
-                                                 max_amount );
-                    string_input_popup pop;
-                    const int amount = pop
-                                       .title( popupmsg )
-                                       .width( 20 )
-                                       .text( std::to_string( clamp( danger_radius, 0, max_amount ) ) )
-                                       .only_digits( true )
-                                       .query_int();
-                    if( !pop.canceled() && amount >= 0 && amount <= max_amount ) {
+                    if( query_int( amount, true, _( "Danger radius in overmap squares? (0-%d)" ),
+                                   max_amount ) && amount >= 0 && amount <= max_amount ) {
                         overmap_buffer.mark_note_dangerous( curs, amount, true );
                     }
                 }

--- a/src/string_input_popup.cpp
+++ b/src/string_input_popup.cpp
@@ -334,12 +334,13 @@ void string_input_popup::query( const bool loop, const bool draw_only )
 }
 
 template<typename T>
-T query_int_impl( string_input_popup &p, const bool loop, const bool draw_only )
+std::optional<T> query_int_impl( string_input_popup &p, const bool loop, const bool draw_only )
 {
     do {
-        ret_val<T> result = try_parse_integer<T>( p.query_string( loop, draw_only ), true );
-        if( p.canceled() ) {
-            return 0;
+        const std::string &queried_string = p.query_string( loop, draw_only );
+        ret_val<T> result = try_parse_integer<T>( queried_string, true );
+        if( p.canceled() || queried_string.empty() ) {
+            return std::nullopt;
         }
         if( result.success() ) {
             return result.value();
@@ -350,12 +351,12 @@ T query_int_impl( string_input_popup &p, const bool loop, const bool draw_only )
     return 0;
 }
 
-int string_input_popup::query_int( const bool loop, const bool draw_only )
+std::optional<int> string_input_popup::query_int( const bool loop, const bool draw_only )
 {
     return query_int_impl<int>( *this, loop, draw_only );
 }
 
-int64_t string_input_popup::query_int64_t( const bool loop, const bool draw_only )
+std::optional<int64_t> string_input_popup::query_int64_t( const bool loop, const bool draw_only )
 {
     return query_int_impl<int64_t>( *this, loop, draw_only );
 }

--- a/src/string_input_popup.h
+++ b/src/string_input_popup.h
@@ -248,8 +248,8 @@ class string_input_popup // NOLINT(cata-xy)
          */
         /**@{*/
         void query( bool loop = true, bool draw_only = false );
-        int query_int( bool loop = true, bool draw_only = false );
-        int64_t query_int64_t( bool loop = true, bool draw_only = false );
+        std::optional<int> query_int( bool loop = true, bool draw_only = false );
+        std::optional<int64_t> query_int64_t( bool loop = true, bool draw_only = false );
         const std::string &query_string( bool loop = true, bool draw_only = false );
         /**@}*/
         /**

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -37,6 +37,7 @@
 #include "messages.h"
 #include "monster.h"
 #include "mtype.h"
+#include "output.h"
 #include "overmapbuffer.h"
 #include "player_activity.h"
 #include "pocket_type.h"
@@ -46,7 +47,6 @@
 #include "smart_controller_ui.h"
 #include "sounds.h"
 #include "string_formatter.h"
-#include "string_input_popup.h"
 #include "translations.h"
 #include "uilist.h"
 #include "units.h"
@@ -892,13 +892,7 @@ void vehicle::reload_seeds( map *here, const tripoint_bub_ms &pos )
     if( seed_index > 0 && seed_index < static_cast<int>( seed_entries.size() ) ) {
         const int count = std::get<2>( seed_entries[seed_index] );
         int amount = 0;
-        const std::string popupmsg = string_format( _( "Move how many?  [Have %d] (0 to cancel)" ), count );
-
-        amount = string_input_popup()
-                 .title( popupmsg )
-                 .width( 5 )
-                 .only_digits( true )
-                 .query_int();
+        query_int( amount, false, _( "Move how many?  [Have %d] (0 to cancel)" ), count );
 
         if( amount > 0 ) {
             int actual_amount = std::min( amount, count );

--- a/src/wish.cpp
+++ b/src/wish.cpp
@@ -424,7 +424,7 @@ void debug_menu::wishbionics( Character *you )
             }
             case 3: {
                 int new_value = 0;
-                if( query_int( new_value, _( "Set the value to (in kJ)?  Currently: %s" ),
+                if( query_int( new_value, false, _( "Set the value to (in kJ)?  Currently: %s" ),
                                units::display( power_max ) ) ) {
                     you->set_max_power_level( units::from_kilojoule( static_cast<std::int64_t>( new_value ) ) );
                     you->set_power_level( you->get_power_level() );
@@ -433,7 +433,7 @@ void debug_menu::wishbionics( Character *you )
             }
             case 4: {
                 int new_value = 0;
-                if( query_int( new_value, _( "Set the value to (in J)?  Currently: %s" ),
+                if( query_int( new_value, false, _( "Set the value to (in J)?  Currently: %s" ),
                                units::display( power_max ) ) ) {
                     you->set_max_power_level( units::from_joule( static_cast<std::int64_t>( new_value ) ) );
                     you->set_power_level( you->get_power_level() );
@@ -442,7 +442,7 @@ void debug_menu::wishbionics( Character *you )
             }
             case 5: {
                 int new_value = 0;
-                if( query_int( new_value, _( "Set the value to (in kJ)?  Currently: %s" ),
+                if( query_int( new_value, false, _( "Set the value to (in kJ)?  Currently: %s" ),
                                units::display( power_level ) ) ) {
                     you->set_power_level( units::from_kilojoule( static_cast<std::int64_t>( new_value ) ) );
                 }
@@ -450,7 +450,7 @@ void debug_menu::wishbionics( Character *you )
             }
             case 6: {
                 int new_value = 0;
-                if( query_int( new_value, _( "Set the value to (in J)?  Currently: %s" ),
+                if( query_int( new_value, false, _( "Set the value to (in J)?  Currently: %s" ),
                                units::display( power_level ) ) ) {
                     you->set_power_level( units::from_joule( static_cast<std::int64_t>( new_value ) ) );
                 }
@@ -584,7 +584,7 @@ void debug_menu::wisheffect( Creature &p )
             effect &eff = effects[efmenu.ret - offset];
 
             int duration = to_seconds<int>( eff.get_duration() );
-            query_int( duration, _( "Set duration (current %1$d): " ), duration );
+            query_int( duration, false, _( "Set duration (current %1$d): " ), duration );
             if( duration < 0 ) {
                 continue;
             }
@@ -774,7 +774,8 @@ void debug_menu::wishmonstergroup( tripoint_abs_omt &loc )
         const mongroup_id selected_group( possible_groups[selected] );
         new_group.type = selected_group;
         int new_value = new_group.population; // default value if query declined
-        query_int( new_value, _( "Set population to what value?  Currently %d" ), new_group.population );
+        query_int( new_value, false, _( "Set population to what value?  Currently %d" ),
+                   new_group.population );
         new_group.population = new_value;
         overmap &there = overmap_buffer.get( project_to<coords::om>( loc ).xy() );
         there.debug_force_add_group( new_group );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Infrastructure "standardize query_int()"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

1. query_int() would display an error if an empty string was submitted. This could hypothetically make sense, but usually it's just annoying, forcing the player to enter some value where it isn't necessary.
2. query_int() did not have a method of displaying a default value. 

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

1. query_int() now treats an empty string as a cancel (like hitting ESC).
2. query_int() now has a parameter to auto-insert a default integer value to the input text (must be loaded before use). In instances where this was needed before, `string_input_popup` was used to query_int instead, so all of those instances were replaced to standardize use of query_int().

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Set some debug menu values
In particular, tested force temperature and map editor's edit items

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
