### PR TITLE
Make random location missions select from increasing range rings

### DIFF
--- a/doc/JSON/MISSIONS_JSON.md
+++ b/doc/JSON/MISSIONS_JSON.md
@@ -186,7 +186,7 @@ Identifier             | Description
 `must_see`             | If true, the `om_terrain` must have been seen already.
 `cant_see`             | If true, the `om_terrain` must not have been seen already.
 `random`               | If true, a random matching `om_terrain` is used. If false, the closest is used.
-`search_range`         | Maximum range in overmap terrain coordinates to look for a matching `om_terrain`.  Int or or [variable object](#variable-object). Default 2520. Should only be used to limit maximum range when multiple valid destinations are possible, and only works to do that when random is also set to true.
+`search_range`         | Maximum range in overmap terrain coordinates to look for a matching `om_terrain`.  Int or or [variable object](#variable-object). Default 2520. Should only be used to limit maximum range when multiple valid destinations are possible, and only works to do that when random is also set to true. When left at default and random is true, the range between min_distance and search_range is split up into 50 range rings searched one after the other until a random match is found within a ring. This causes "random" locations to only be random within a limited range, i.e. within the shortest range band where a match exists.
 `min_distance`         | Range in overmap terrain coordinates.  Instances of `om_terrain` in this range will be ignored.  Int or or [variable object](#variable-object)
 `origin_npc`           | Start the search at the NPC's, rather than the player's, current position.
 `z`                    | If specified, will be used rather than the player or NPC's z when searching.  Int or or [variable object](#variable-object)

--- a/src/mission.h
+++ b/src/mission.h
@@ -145,6 +145,8 @@ struct mission_target_params {
 
 namespace mission_util
 {
+const int default_min_search_range = OMAPX * 14;
+
 tripoint_abs_omt random_house_in_closest_city();
 tripoint_abs_omt target_closest_lab_entrance( const tripoint_abs_omt &origin, int reveal_rad,
         mission *miss );

--- a/src/mission.h
+++ b/src/mission.h
@@ -15,6 +15,7 @@
 #include "coordinates.h"
 #include "dialogue_helpers.h"
 #include "enums.h"
+#include "map_scale_constants.h"
 #include "npc_favor.h"
 #include "point.h"
 #include "translation.h"

--- a/src/mission_util.cpp
+++ b/src/mission_util.cpp
@@ -21,7 +21,6 @@
 #include "flexbuffer_json.h"
 #include "game.h"
 #include "map_iterator.h"
-#include "map_scale_constants.h"
 #include "mapgen_functions.h"
 #include "math_parser_diag_value.h"
 #include "messages.h"


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fix #80774, i.e. extension of default max search range for random missions causing them to end up absurdly far away.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Iterate over range rings to search for matching targets and select a random entry within the first ring with at least one match, but only when the search range is the default and the search match is random.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Leave to to someone else to implement a more elegant solution, probably involving changing the JSON syntax.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Teleporting to the Isherwood farm and accept the monster killing mission from Jesse. Noting that it doesn't take minutes to generate the mission, and that the target ends up somewhere random a bit over a kilometer away.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
There is still a potential issue in that there is a two step evaluation, so you may end up with a result really far away from the first invocation, and thus not get to the second one.

If you want to actually randomize the location within a certain larger range you have to select a non default search range. Doing that causes you to lose the ability to have a fallback range, but you can't have both a random "normal" search range and a fallback range without changing the JSON.

There's some weird syntax in MISIONS_JSON.md: "int/string or or...". It's probably a copy/paste error, but I'm not sure if there's something clever I don't get there, so I haven't tried to fix it.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
