### PR TITLE
Fix the issue of activity_var not being erased and when using fishing rod activity_var setting wrong

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -6999,7 +6999,7 @@ void chop_logs_activity_actor::finish( player_activity &act, Character &who )
         //The item may exceed the capacity of the pos and move to another coordinate.So get loc.
         item_location loc = here.add_item_or_charges_ret_loc( pos, obj );
         if (loc.where() == item_location::type::map){
-            who.may_activity_occupancy_items_loc_points.insert(loc.pos_abs());
+            who.may_activity_occupancy_after_end_items_loc.insert(loc.pos_abs());
         }
 
     }
@@ -7009,7 +7009,7 @@ void chop_logs_activity_actor::finish( player_activity &act, Character &who )
         //The item may exceed the capacity of the pos and move to another coordinate.So get loc.
         item_location loc = here.add_item_or_charges_ret_loc( pos, obj );
         if (loc.where() == item_location::type::map){
-            who.may_activity_occupancy_items_loc_points.insert(loc.pos_abs());
+            who.may_activity_occupancy_after_end_items_loc.insert(loc.pos_abs());
         }
     }
     for( int i = 0; i != splint_quan; ++i ) {
@@ -7018,7 +7018,7 @@ void chop_logs_activity_actor::finish( player_activity &act, Character &who )
         //The item may exceed the capacity of the pos and move to another coordinate.So get loc.
         item_location loc = here.add_item_or_charges_ret_loc( pos, obj );
         if (loc.where() == item_location::type::map){
-            who.may_activity_occupancy_items_loc_points.insert(loc.pos_abs());
+            who.may_activity_occupancy_after_end_items_loc.insert(loc.pos_abs());
         }
     }
     here.ter_set( pos, ter_t_dirt );

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -6998,8 +6998,8 @@ void chop_logs_activity_actor::finish( player_activity &act, Character &who )
         obj.set_var( "activity_var", who.name );
         //The item may exceed the capacity of the pos and move to another coordinate.So get loc.
         item_location loc = here.add_item_or_charges_ret_loc( pos, obj );
-        if (loc){
-            who.may_activity_occupancy_after_end_items_loc.push_back(loc);
+        if( loc ) {
+            who.may_activity_occupancy_after_end_items_loc.push_back( loc );
         }
 
     }
@@ -7008,8 +7008,8 @@ void chop_logs_activity_actor::finish( player_activity &act, Character &who )
         obj.set_var( "activity_var", who.name );
         //The item may exceed the capacity of the pos and move to another coordinate.So get loc.
         item_location loc = here.add_item_or_charges_ret_loc( pos, obj );
-        if (loc){
-            who.may_activity_occupancy_after_end_items_loc.push_back(loc);
+        if( loc ) {
+            who.may_activity_occupancy_after_end_items_loc.push_back( loc );
         }
     }
     for( int i = 0; i != splint_quan; ++i ) {
@@ -7017,8 +7017,8 @@ void chop_logs_activity_actor::finish( player_activity &act, Character &who )
         obj.set_var( "activity_var", who.name );
         //The item may exceed the capacity of the pos and move to another coordinate.So get loc.
         item_location loc = here.add_item_or_charges_ret_loc( pos, obj );
-        if (loc){
-            who.may_activity_occupancy_after_end_items_loc.push_back(loc);
+        if( loc ) {
+            who.may_activity_occupancy_after_end_items_loc.push_back( loc );
         }
     }
     here.ter_set( pos, ter_t_dirt );

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -6996,17 +6996,33 @@ void chop_logs_activity_actor::finish( player_activity &act, Character &who )
     for( int i = 0; i != log_quan; ++i ) {
         item obj( itype_log, calendar::turn );
         obj.set_var( "activity_var", who.name );
-        here.add_item_or_charges( pos, obj );
+        //The item may exceed the capacity of the pos and move to another coordinate.So get loc.
+        item_location loc = here.add_item_or_charges_ret_loc( pos, obj );
+        // debugmsg(std::to_string(static_cast<int>(loc.where())) + loc.pos_abs().to_string());
+        if (loc.where() == item_location::type::map){
+            who.may_activity_occupancy_items_loc_points.insert(loc.pos_abs());
+        }
+
     }
     for( int i = 0; i != stick_quan; ++i ) {
         item obj( itype_stick_long, calendar::turn );
         obj.set_var( "activity_var", who.name );
-        here.add_item_or_charges( pos, obj );
+        //The item may exceed the capacity of the pos and move to another coordinate.So get loc.
+        item_location loc = here.add_item_or_charges_ret_loc( pos, obj );
+        // debugmsg(std::to_string(static_cast<int>(loc.where())) + loc.pos_abs().to_string());
+        if (loc.where() == item_location::type::map){
+            who.may_activity_occupancy_items_loc_points.insert(loc.pos_abs());
+        }
     }
     for( int i = 0; i != splint_quan; ++i ) {
         item obj( itype_splinter, calendar::turn );
         obj.set_var( "activity_var", who.name );
-        here.add_item_or_charges( pos, obj );
+        //The item may exceed the capacity of the pos and move to another coordinate.So get loc.
+        item_location loc = here.add_item_or_charges_ret_loc( pos, obj );
+        // debugmsg(std::to_string(static_cast<int>(loc.where())) + loc.pos_abs().to_string());
+        if (loc.where() == item_location::type::map){
+            who.may_activity_occupancy_items_loc_points.insert(loc.pos_abs());
+        }
     }
     here.ter_set( pos, ter_t_dirt );
     who.add_msg_if_player( m_good, _( "You finish chopping wood." ) );

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -6998,7 +6998,6 @@ void chop_logs_activity_actor::finish( player_activity &act, Character &who )
         obj.set_var( "activity_var", who.name );
         //The item may exceed the capacity of the pos and move to another coordinate.So get loc.
         item_location loc = here.add_item_or_charges_ret_loc( pos, obj );
-        // debugmsg(std::to_string(static_cast<int>(loc.where())) + loc.pos_abs().to_string());
         if (loc.where() == item_location::type::map){
             who.may_activity_occupancy_items_loc_points.insert(loc.pos_abs());
         }
@@ -7009,7 +7008,6 @@ void chop_logs_activity_actor::finish( player_activity &act, Character &who )
         obj.set_var( "activity_var", who.name );
         //The item may exceed the capacity of the pos and move to another coordinate.So get loc.
         item_location loc = here.add_item_or_charges_ret_loc( pos, obj );
-        // debugmsg(std::to_string(static_cast<int>(loc.where())) + loc.pos_abs().to_string());
         if (loc.where() == item_location::type::map){
             who.may_activity_occupancy_items_loc_points.insert(loc.pos_abs());
         }
@@ -7019,7 +7017,6 @@ void chop_logs_activity_actor::finish( player_activity &act, Character &who )
         obj.set_var( "activity_var", who.name );
         //The item may exceed the capacity of the pos and move to another coordinate.So get loc.
         item_location loc = here.add_item_or_charges_ret_loc( pos, obj );
-        // debugmsg(std::to_string(static_cast<int>(loc.where())) + loc.pos_abs().to_string());
         if (loc.where() == item_location::type::map){
             who.may_activity_occupancy_items_loc_points.insert(loc.pos_abs());
         }

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -6998,8 +6998,8 @@ void chop_logs_activity_actor::finish( player_activity &act, Character &who )
         obj.set_var( "activity_var", who.name );
         //The item may exceed the capacity of the pos and move to another coordinate.So get loc.
         item_location loc = here.add_item_or_charges_ret_loc( pos, obj );
-        if (loc.where() == item_location::type::map){
-            who.may_activity_occupancy_after_end_items_loc.insert(loc.pos_abs());
+        if (loc){
+            who.may_activity_occupancy_after_end_items_loc.push_back(loc);
         }
 
     }
@@ -7008,8 +7008,8 @@ void chop_logs_activity_actor::finish( player_activity &act, Character &who )
         obj.set_var( "activity_var", who.name );
         //The item may exceed the capacity of the pos and move to another coordinate.So get loc.
         item_location loc = here.add_item_or_charges_ret_loc( pos, obj );
-        if (loc.where() == item_location::type::map){
-            who.may_activity_occupancy_after_end_items_loc.insert(loc.pos_abs());
+        if (loc){
+            who.may_activity_occupancy_after_end_items_loc.push_back(loc);
         }
     }
     for( int i = 0; i != splint_quan; ++i ) {
@@ -7017,8 +7017,8 @@ void chop_logs_activity_actor::finish( player_activity &act, Character &who )
         obj.set_var( "activity_var", who.name );
         //The item may exceed the capacity of the pos and move to another coordinate.So get loc.
         item_location loc = here.add_item_or_charges_ret_loc( pos, obj );
-        if (loc.where() == item_location::type::map){
-            who.may_activity_occupancy_after_end_items_loc.insert(loc.pos_abs());
+        if (loc){
+            who.may_activity_occupancy_after_end_items_loc.push_back(loc);
         }
     }
     here.ter_set( pos, ter_t_dirt );

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -2948,7 +2948,7 @@ static void rod_fish( Character *you, const std::vector<monster *> &fishables )
         item corpse = item::make_corpse( corpse_type.id,
                                   calendar::turn + rng( 0_turns,
                                   3_hours ) );
-        corpse.set_var( "activity_var", you->getID().get_value() );
+        corpse.set_var( "activity_var", you->name );
         item_location loc = here.add_item_or_charges_ret_loc( you->pos_bub(), corpse );
         you->add_msg_if_player( m_good, _( "You caught a %s." ), corpse_type.nname());
         if (loc.where() == item_location::type::map){

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -1888,6 +1888,7 @@ void activity_handlers::pickaxe_finish( player_activity *act, Character *you )
         for( item &elem : here.i_at( pos ) ) {
             elem.set_var( "activity_var", you->name );
         }
+        you->may_activity_occupancy_after_end_items_loc.insert(here.get_abs(pos));
     }
 }
 
@@ -2949,6 +2950,7 @@ static void rod_fish( Character *you, const std::vector<monster *> &fishables )
         if( chosen_fish->fish_population <= 0 ) {
             g->catch_a_monster( chosen_fish, you->pos_bub(), you, 50_hours );
         } else {
+
             here.add_item_or_charges( you->pos_bub(), item::make_corpse( chosen_fish->type->id,
                                       calendar::turn + rng( 0_turns,
                                               3_hours ) ) );
@@ -2960,6 +2962,7 @@ static void rod_fish( Character *you, const std::vector<monster *> &fishables )
             elem.set_var( "activity_var", you->name );
         }
     }
+    you->may_activity_occupancy_after_end_items_loc.insert(here.get_abs(you->pos_bub()));
 }
 
 void activity_handlers::fish_do_turn( player_activity *act, Character *you )
@@ -3521,6 +3524,7 @@ void activity_handlers::jackhammer_finish( player_activity *act, Character *you 
         for( item &elem : here.i_at( pos ) ) {
             elem.set_var( "activity_var", you->name );
         }
+        you->may_activity_occupancy_after_end_items_loc.insert(here.get_abs(pos));
     }
 }
 

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -63,6 +63,7 @@
 #include "map.h"
 #include "map_iterator.h"
 #include "mapdata.h"
+#include "map_selector.h"
 #include "martialarts.h"
 #include "math_parser_diag_value.h"
 #include "memory_fast.h"

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -970,6 +970,7 @@ static std::vector<item> create_charge_items( const itype *drop, int count,
         }
         if( !you.backlog.empty() && you.backlog.front().id() == ACT_MULTIPLE_BUTCHER ) {
             obj.set_var( "activity_var", you.name );
+
         }
         objs.push_back( obj );
     }
@@ -1233,8 +1234,8 @@ static bool butchery_drops_harvest( item *corpse_item, const mtype &mt, Characte
                 std::vector<item> objs = create_charge_items( drop, roll, entry, corpse_item, you );
                 for( item &obj : objs ) {
                     item_location loc = here.add_item_or_charges_ret_loc( you.pos_bub(), obj );
-                    if (loc.where() == item_location::type::map){
-                        you.may_activity_occupancy_after_end_items_loc.insert(loc.pos_abs());
+                    if (loc){
+                        you.may_activity_occupancy_after_end_items_loc.push_back(loc);
                     }
                 }
             } else {
@@ -1257,8 +1258,8 @@ static bool butchery_drops_harvest( item *corpse_item, const mtype &mt, Characte
                 }
                 for( int i = 0; i != roll; ++i ) {
                     item_location loc = here.add_item_or_charges_ret_loc( you.pos_bub(), obj );
-                    if (loc.where() == item_location::type::map){
-                        you.may_activity_occupancy_after_end_items_loc.insert(loc.pos_abs());
+                    if (loc){
+                        you.may_activity_occupancy_after_end_items_loc.push_back(loc);
                     }
                 }
             }
@@ -1301,8 +1302,8 @@ static bool butchery_drops_harvest( item *corpse_item, const mtype &mt, Characte
             }
             for( int i = 0; i < item_charges; ++i ) {
                 item_location loc = here.add_item_or_charges_ret_loc( you.pos_bub(), ruined_parts );
-                if (loc.where() == item_location::type::map){
-                    you.may_activity_occupancy_after_end_items_loc.insert(loc.pos_abs());
+                if (loc){
+                    you.may_activity_occupancy_after_end_items_loc.push_back(loc);
                 }
             }
         }
@@ -1896,8 +1897,8 @@ void activity_handlers::pickaxe_finish( player_activity *act, Character *you )
     if( resume_for_multi_activities( *you ) ) {
         for( item &elem : here.i_at( pos ) ) {
             elem.set_var( "activity_var", you->name );
+            you->may_activity_occupancy_after_end_items_loc.emplace_back(map_cursor{here.get_abs(pos)},&elem);
         }
-        you->may_activity_occupancy_after_end_items_loc.insert(here.get_abs(pos));
     }
 }
 
@@ -2951,8 +2952,8 @@ static void rod_fish( Character *you, const std::vector<monster *> &fishables )
         corpse.set_var( "activity_var", you->name );
         item_location loc = here.add_item_or_charges_ret_loc( you->pos_bub(), corpse );
         you->add_msg_if_player( m_good, _( "You caught a %s." ), corpse_type.nname());
-        if (loc.where() == item_location::type::map){
-            you->may_activity_occupancy_after_end_items_loc.insert(loc.pos_abs());
+        if (loc){
+            you->may_activity_occupancy_after_end_items_loc.push_back(loc);
         }
     };
     //if the vector is empty (no fish around) the player is still given a small chance to get a (let us say it was hidden) fish
@@ -3532,8 +3533,8 @@ void activity_handlers::jackhammer_finish( player_activity *act, Character *you 
     if( resume_for_multi_activities( *you ) ) {
         for( item &elem : here.i_at( pos ) ) {
             elem.set_var( "activity_var", you->name );
+            you->may_activity_occupancy_after_end_items_loc.emplace_back(map_cursor{here.get_abs(pos)},&elem);
         }
-        you->may_activity_occupancy_after_end_items_loc.insert(here.get_abs(pos));
     }
 }
 

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -1234,8 +1234,8 @@ static bool butchery_drops_harvest( item *corpse_item, const mtype &mt, Characte
                 std::vector<item> objs = create_charge_items( drop, roll, entry, corpse_item, you );
                 for( item &obj : objs ) {
                     item_location loc = here.add_item_or_charges_ret_loc( you.pos_bub(), obj );
-                    if (loc){
-                        you.may_activity_occupancy_after_end_items_loc.push_back(loc);
+                    if( loc ) {
+                        you.may_activity_occupancy_after_end_items_loc.push_back( loc );
                     }
                 }
             } else {
@@ -1258,8 +1258,8 @@ static bool butchery_drops_harvest( item *corpse_item, const mtype &mt, Characte
                 }
                 for( int i = 0; i != roll; ++i ) {
                     item_location loc = here.add_item_or_charges_ret_loc( you.pos_bub(), obj );
-                    if (loc){
-                        you.may_activity_occupancy_after_end_items_loc.push_back(loc);
+                    if( loc ) {
+                        you.may_activity_occupancy_after_end_items_loc.push_back( loc );
                     }
                 }
             }
@@ -1302,8 +1302,8 @@ static bool butchery_drops_harvest( item *corpse_item, const mtype &mt, Characte
             }
             for( int i = 0; i < item_charges; ++i ) {
                 item_location loc = here.add_item_or_charges_ret_loc( you.pos_bub(), ruined_parts );
-                if (loc){
-                    you.may_activity_occupancy_after_end_items_loc.push_back(loc);
+                if( loc ) {
+                    you.may_activity_occupancy_after_end_items_loc.push_back( loc );
                 }
             }
         }
@@ -1897,7 +1897,8 @@ void activity_handlers::pickaxe_finish( player_activity *act, Character *you )
     if( resume_for_multi_activities( *you ) ) {
         for( item &elem : here.i_at( pos ) ) {
             elem.set_var( "activity_var", you->name );
-            you->may_activity_occupancy_after_end_items_loc.emplace_back(map_cursor{here.get_abs(pos)},&elem);
+            you->may_activity_occupancy_after_end_items_loc.emplace_back( map_cursor{here.get_abs( pos )},
+                    &elem );
         }
     }
 }
@@ -2945,15 +2946,15 @@ void activity_handlers::atm_do_turn( player_activity *, Character *you )
 static void rod_fish( Character *you, const std::vector<monster *> &fishables )
 {
     map &here = get_map();
-    constexpr auto caught_corpse = [](Character *you,map &here,const mtype &corpse_type){
+    constexpr auto caught_corpse = []( Character * you, map & here, const mtype & corpse_type ) {
         item corpse = item::make_corpse( corpse_type.id,
-                                  calendar::turn + rng( 0_turns,
-                                  3_hours ) );
+                                         calendar::turn + rng( 0_turns,
+                                                 3_hours ) );
         corpse.set_var( "activity_var", you->name );
         item_location loc = here.add_item_or_charges_ret_loc( you->pos_bub(), corpse );
-        you->add_msg_if_player( m_good, _( "You caught a %s." ), corpse_type.nname());
-        if (loc){
-            you->may_activity_occupancy_after_end_items_loc.push_back(loc);
+        you->add_msg_if_player( m_good, _( "You caught a %s." ), corpse_type.nname() );
+        if( loc ) {
+            you->may_activity_occupancy_after_end_items_loc.push_back( loc );
         }
     };
     //if the vector is empty (no fish around) the player is still given a small chance to get a (let us say it was hidden) fish
@@ -2961,15 +2962,15 @@ static void rod_fish( Character *you, const std::vector<monster *> &fishables )
         const std::vector<mtype_id> fish_group = MonsterGroupManager::GetMonstersFromGroup(
                     GROUP_FISH, true );
         const mtype_id fish_mon = random_entry_ref( fish_group );
-        caught_corpse(you,here,fish_mon.obj());
+        caught_corpse( you, here, fish_mon.obj() );
     } else {
         monster *chosen_fish = random_entry( fishables );
         chosen_fish->fish_population -= 1;
         if( chosen_fish->fish_population <= 0 ) {
             g->catch_a_monster( chosen_fish, you->pos_bub(), you, 50_hours );
         } else {
-            if (chosen_fish->type !=nullptr){
-                caught_corpse(you,here,*(chosen_fish->type));
+            if( chosen_fish->type != nullptr ) {
+                caught_corpse( you, here, *( chosen_fish->type ) );
             }
         }
     }
@@ -3533,7 +3534,8 @@ void activity_handlers::jackhammer_finish( player_activity *act, Character *you 
     if( resume_for_multi_activities( *you ) ) {
         for( item &elem : here.i_at( pos ) ) {
             elem.set_var( "activity_var", you->name );
-            you->may_activity_occupancy_after_end_items_loc.emplace_back(map_cursor{here.get_abs(pos)},&elem);
+            you->may_activity_occupancy_after_end_items_loc.emplace_back( map_cursor{here.get_abs( pos )},
+                    &elem );
         }
     }
 }

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -1232,7 +1232,10 @@ static bool butchery_drops_harvest( item *corpse_item, const mtype &mt, Characte
             } else if( drop->count_by_charges() ) {
                 std::vector<item> objs = create_charge_items( drop, roll, entry, corpse_item, you );
                 for( item &obj : objs ) {
-                    here.add_item_or_charges( you.pos_bub(), obj );
+                    item_location loc = here.add_item_or_charges_ret_loc( you.pos_bub(), obj );
+                    if (loc.where() == item_location::type::map){
+                        you.may_activity_occupancy_after_end_items_loc.insert(loc.pos_abs());
+                    }
                 }
             } else {
                 item obj( drop, calendar::turn );
@@ -1253,7 +1256,10 @@ static bool butchery_drops_harvest( item *corpse_item, const mtype &mt, Characte
                     obj.set_var( "activity_var", you.name );
                 }
                 for( int i = 0; i != roll; ++i ) {
-                    here.add_item_or_charges( you.pos_bub(), obj );
+                    item_location loc = here.add_item_or_charges_ret_loc( you.pos_bub(), obj );
+                    if (loc.where() == item_location::type::map){
+                        you.may_activity_occupancy_after_end_items_loc.insert(loc.pos_abs());
+                    }
                 }
             }
             you.add_msg_if_player( m_good, _( "You harvest: %s" ), drop->nname( roll ) );
@@ -1294,7 +1300,10 @@ static bool butchery_drops_harvest( item *corpse_item, const mtype &mt, Characte
                 ruined_parts.set_var( "activity_var", you.name );
             }
             for( int i = 0; i < item_charges; ++i ) {
-                here.add_item_or_charges( you.pos_bub(), ruined_parts );
+                item_location loc = here.add_item_or_charges_ret_loc( you.pos_bub(), ruined_parts );
+                if (loc.where() == item_location::type::map){
+                    you.may_activity_occupancy_after_end_items_loc.insert(loc.pos_abs());
+                }
             }
         }
     }

--- a/src/activity_handlers.h
+++ b/src/activity_handlers.h
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "coords_fwd.h"
+#include "map_selector.h"
 #include "requirements.h"
 #include "type_id.h"
 #include "units_fwd.h"

--- a/src/activity_handlers.h
+++ b/src/activity_handlers.h
@@ -289,6 +289,7 @@ int move_cost_cart( const item &it, const tripoint_bub_ms &src, const tripoint_b
 int move_cost_inv( const item &it, const tripoint_bub_ms &src, const tripoint_bub_ms &dest );
 
 void clean_may_activity_occupancy_items_var( Character &you );
+void clean_may_activity_occupancy_items_var_if_is_avatar_and_no_activity_now( Character &you );
 // defined in activity_handlers.cpp
 extern const std::map< activity_id, std::function<void( player_activity *, Character * )> >
 finish_functions;

--- a/src/activity_handlers.h
+++ b/src/activity_handlers.h
@@ -11,7 +11,6 @@
 #include <vector>
 
 #include "coords_fwd.h"
-#include "map_selector.h"
 #include "requirements.h"
 #include "type_id.h"
 #include "units_fwd.h"

--- a/src/activity_handlers.h
+++ b/src/activity_handlers.h
@@ -283,6 +283,7 @@ int move_cost_cart( const item &it, const tripoint_bub_ms &src, const tripoint_b
                     const units::volume &capacity );
 int move_cost_inv( const item &it, const tripoint_bub_ms &src, const tripoint_bub_ms &dest );
 
+void clean_may_activity_occupancy_items_var(Character & you);
 // defined in activity_handlers.cpp
 extern const std::map< activity_id, std::function<void( player_activity *, Character * )> >
 finish_functions;

--- a/src/activity_handlers.h
+++ b/src/activity_handlers.h
@@ -185,12 +185,12 @@ enum class item_drop_reason : int {
 
 void put_into_vehicle_or_drop( Character &you, item_drop_reason, const std::list<item> &items );
 void put_into_vehicle_or_drop( Character &you, item_drop_reason, const std::list<item> &items,
-map *here, const tripoint_bub_ms &where, bool force_ground = false );
+                               map *here, const tripoint_bub_ms &where, bool force_ground = false );
 std::vector<item_location> put_into_vehicle_or_drop_ret_locs( Character &you, item_drop_reason,
-                                const std::list<item> &items );
+        const std::list<item> &items );
 std::vector<item_location> put_into_vehicle_or_drop_ret_locs( Character &you, item_drop_reason,
-                                const std::list<item> &items,map *here, const tripoint_bub_ms &where,
-                                bool force_ground = false );
+        const std::list<item> &items, map *here, const tripoint_bub_ms &where,
+        bool force_ground = false );
 std::vector<item_location> drop_on_map( Character &you, item_drop_reason reason,
                                         const std::list<item> &items,
                                         map *here, const tripoint_bub_ms &where );
@@ -288,7 +288,7 @@ int move_cost_cart( const item &it, const tripoint_bub_ms &src, const tripoint_b
                     const units::volume &capacity );
 int move_cost_inv( const item &it, const tripoint_bub_ms &src, const tripoint_bub_ms &dest );
 
-void clean_may_activity_occupancy_items_var(Character & you);
+void clean_may_activity_occupancy_items_var( Character &you );
 // defined in activity_handlers.cpp
 extern const std::map< activity_id, std::function<void( player_activity *, Character * )> >
 finish_functions;

--- a/src/activity_handlers.h
+++ b/src/activity_handlers.h
@@ -185,7 +185,12 @@ enum class item_drop_reason : int {
 
 void put_into_vehicle_or_drop( Character &you, item_drop_reason, const std::list<item> &items );
 void put_into_vehicle_or_drop( Character &you, item_drop_reason, const std::list<item> &items,
-                               map *here, const tripoint_bub_ms &where, bool force_ground = false );
+map *here, const tripoint_bub_ms &where, bool force_ground = false );
+std::vector<item_location> put_into_vehicle_or_drop_ret_locs( Character &you, item_drop_reason,
+                                const std::list<item> &items );
+std::vector<item_location> put_into_vehicle_or_drop_ret_locs( Character &you, item_drop_reason,
+                                const std::list<item> &items,map *here, const tripoint_bub_ms &where,
+                                bool force_ground = false );
 std::vector<item_location> drop_on_map( Character &you, item_drop_reason reason,
                                         const std::list<item> &items,
                                         map *here, const tripoint_bub_ms &where );

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -3855,7 +3855,7 @@ void activity_handlers::clean_may_activity_occupancy_items_var(Character & you){
         && static_cast<int>(it.get_var("activity_var",-1)) == character_id;
     };
     map &here = get_map();
-    for (const auto & pos:you.may_activity_occupancy_items_loc_points){
+    for (const auto & pos:you.may_activity_occupancy_after_end_items_loc){
         auto item_locs = here.items_with(here.get_bub(pos),activity_var_checker);
         for (auto & item_loc:item_locs){
             item *it = item_loc.get_item();
@@ -3863,6 +3863,7 @@ void activity_handlers::clean_may_activity_occupancy_items_var(Character & you){
             it->erase_var("activity_var");
         }
     }
+    you.may_activity_occupancy_after_end_items_loc.clear();
     auto items = you.items_with(activity_var_checker);
     for (auto *it:items){
         if (it == nullptr || it->is_null()) { continue;}

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -3874,18 +3874,7 @@ bool try_fuel_fire( player_activity &act, Character &you, const bool starting_fi
     }
     return true;
 }
-static void erase_item_contents_activity_var( const std::function<bool( const item & )>
-        &activity_var_checker, item &it )
-{
-    const std::vector<item *> contents_items = it.items_with( activity_var_checker );
-    for( item *inner_item : contents_items ) {
-        if( inner_item == nullptr || inner_item->is_null() ) {
-            continue;
-        }
-        inner_item->erase_var( "activity_var" );
-        erase_item_contents_activity_var( activity_var_checker, *inner_item );
-    }
-};
+
 void activity_handlers::clean_may_activity_occupancy_items_var_if_is_avatar_and_no_activity_now(
     Character &you )
 {

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -212,12 +212,14 @@ static bool handle_spillable_contents( Character &c, item &it, map &m )
     return false;
 }
 
-static void put_into_vehicle( Character &c, item_drop_reason reason, const std::list<item> &items,
+//try to put items into_vehicle .If fail,first try to add to character bag, then character try wield  it, last drop.
+static std::vector<item_location> try_to_put_into_vehicle( Character &c, item_drop_reason reason, const std::list<item> &items,
                               const vpart_reference &vpr )
 {
     map &here = get_map();
+    std::vector<item_location> result;
     if( items.empty() ) {
-        return;
+        return result;
     }
     c.invalidate_weight_carried_cache();
     vehicle_part &vp = vpr.part();
@@ -226,7 +228,6 @@ static void put_into_vehicle( Character &c, item_drop_reason reason, const std::
     int items_did_not_fit_count = 0;
     int into_vehicle_count = 0;
     const std::string part_name = vp.info().name();
-
     // can't use constant reference here because of the spill_contents()
     for( item it : items ) {
         if( handle_spillable_contents( c, it, here ) ) {
@@ -252,13 +253,14 @@ static void put_into_vehicle( Character &c, item_drop_reason reason, const std::
             add_msg( m_mixed, _( "Unable to fit %1$s in the %2$s's %3$s." ), it.tname(), veh.name, part_name );
             // Retain item in inventory if overflow not too large/heavy or wield if possible otherwise drop on the ground
             if( c.can_pickVolume( it ) && c.can_pickWeight( it, !get_option<bool>( "DANGEROUS_PICKUPS" ) ) ) {
-                c.i_add( it );
+                result.push_back(c.i_add( it ));
             } else if( !c.has_wield_conflicts( it ) && c.can_wield( it ).success() ) {
                 c.wield( it );
+                result.emplace_back(c.get_wielded_item());
             } else {
                 const std::string ter_name = here.name( where );
                 add_msg( _( "The %s falls to the %s." ), it.tname(), ter_name );
-                here.add_item_or_charges( where, it );
+                result.push_back(here.add_item_or_charges_ret_loc( where, it ));
             }
         }
         it.handle_pickup_ownership( c );
@@ -333,6 +335,7 @@ static void put_into_vehicle( Character &c, item_drop_reason reason, const std::
                 break;
         }
     }
+    return result;
 }
 
 std::vector<item_location> drop_on_map( Character &you, item_drop_reason reason,
@@ -457,10 +460,29 @@ void put_into_vehicle_or_drop( Character &you, item_drop_reason reason,
 {
     const std::optional<vpart_reference> vp = here->veh_at( where ).cargo();
     if( vp && !force_ground ) {
-        put_into_vehicle( you, reason, items, *vp );
+        try_to_put_into_vehicle( you, reason, items, *vp );
         return;
     }
     drop_on_map( you, reason, items, here, where );
+}
+
+std::vector<item_location> put_into_vehicle_or_drop_ret_locs( Character &you, item_drop_reason reason,
+                               const std::list<item> &items )
+{
+    map &here = get_map();
+
+    return put_into_vehicle_or_drop_ret_locs( you, reason, items, &here, you.pos_bub( here ) );
+}
+
+std::vector<item_location> put_into_vehicle_or_drop_ret_locs( Character &you, item_drop_reason reason,
+                               const std::list<item> &items,
+                               map *here, const tripoint_bub_ms &where, bool force_ground )
+{
+    const std::optional<vpart_reference> vp = here->veh_at( where ).cargo();
+    if( vp && !force_ground ) {
+        return try_to_put_into_vehicle( you, reason, items, *vp );
+    }
+    return drop_on_map( you, reason, items, here, where );
 }
 
 static double get_capacity_fraction( int capacity, int volume )

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -3879,10 +3879,10 @@ static void erase_item_contents_activity_var(const std::function<bool(const item
     }
 };
 void activity_handlers::clean_may_activity_occupancy_items_var(Character & you){
-    int character_id = you.getID().get_value();
-    const std::function<bool(const item *const)> activity_var_checker = [character_id](const item *const it)->bool{
+    std::string character_name = you.name;
+    const std::function<bool(const item *const)> activity_var_checker = [character_name](const item *const it)->bool{
         return it->has_var("activity_var")
-        && static_cast<int>(it->get_var("activity_var",-1)) == character_id;
+        && it->get_var("activity_var","") == character_name;
     };
     for (item_location &loc:you.may_activity_occupancy_after_end_items_loc){
         if (loc && activity_var_checker(loc.get_item())){

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -3886,6 +3886,12 @@ static void erase_item_contents_activity_var( const std::function<bool( const it
         erase_item_contents_activity_var( activity_var_checker, *inner_item );
     }
 };
+void activity_handlers::clean_may_activity_occupancy_items_var_if_is_avatar_and_no_activity_now( Character &you )
+{
+    if( you.is_avatar() && ( !you.activity )  && ( !you.get_destination_activity() ) ) {
+        clean_may_activity_occupancy_items_var( you );
+    }
+}
 void activity_handlers::clean_may_activity_occupancy_items_var( Character &you )
 {
     std::string character_name = you.name;

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -3886,7 +3886,8 @@ static void erase_item_contents_activity_var( const std::function<bool( const it
         erase_item_contents_activity_var( activity_var_checker, *inner_item );
     }
 };
-void activity_handlers::clean_may_activity_occupancy_items_var_if_is_avatar_and_no_activity_now( Character &you )
+void activity_handlers::clean_may_activity_occupancy_items_var_if_is_avatar_and_no_activity_now(
+    Character &you )
 {
     if( you.is_avatar() && ( !you.activity )  && ( !you.get_destination_activity() ) ) {
         clean_may_activity_occupancy_items_var( you );

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -213,8 +213,9 @@ static bool handle_spillable_contents( Character &c, item &it, map &m )
 }
 
 //try to put items into_vehicle .If fail,first try to add to character bag, then character try wield  it, last drop.
-static std::vector<item_location> try_to_put_into_vehicle( Character &c, item_drop_reason reason, const std::list<item> &items,
-                              const vpart_reference &vpr )
+static std::vector<item_location> try_to_put_into_vehicle( Character &c, item_drop_reason reason,
+        const std::list<item> &items,
+        const vpart_reference &vpr )
 {
     map &here = get_map();
     std::vector<item_location> result;
@@ -253,14 +254,14 @@ static std::vector<item_location> try_to_put_into_vehicle( Character &c, item_dr
             add_msg( m_mixed, _( "Unable to fit %1$s in the %2$s's %3$s." ), it.tname(), veh.name, part_name );
             // Retain item in inventory if overflow not too large/heavy or wield if possible otherwise drop on the ground
             if( c.can_pickVolume( it ) && c.can_pickWeight( it, !get_option<bool>( "DANGEROUS_PICKUPS" ) ) ) {
-                result.push_back(c.i_add( it ));
+                result.push_back( c.i_add( it ) );
             } else if( !c.has_wield_conflicts( it ) && c.can_wield( it ).success() ) {
                 c.wield( it );
-                result.emplace_back(c.get_wielded_item());
+                result.emplace_back( c.get_wielded_item() );
             } else {
                 const std::string ter_name = here.name( where );
                 add_msg( _( "The %s falls to the %s." ), it.tname(), ter_name );
-                result.push_back(here.add_item_or_charges_ret_loc( where, it ));
+                result.push_back( here.add_item_or_charges_ret_loc( where, it ) );
             }
         }
         it.handle_pickup_ownership( c );
@@ -466,17 +467,19 @@ void put_into_vehicle_or_drop( Character &you, item_drop_reason reason,
     drop_on_map( you, reason, items, here, where );
 }
 
-std::vector<item_location> put_into_vehicle_or_drop_ret_locs( Character &you, item_drop_reason reason,
-                               const std::list<item> &items )
+std::vector<item_location> put_into_vehicle_or_drop_ret_locs( Character &you,
+        item_drop_reason reason,
+        const std::list<item> &items )
 {
     map &here = get_map();
 
     return put_into_vehicle_or_drop_ret_locs( you, reason, items, &here, you.pos_bub( here ) );
 }
 
-std::vector<item_location> put_into_vehicle_or_drop_ret_locs( Character &you, item_drop_reason reason,
-                               const std::list<item> &items,
-                               map *here, const tripoint_bub_ms &where, bool force_ground )
+std::vector<item_location> put_into_vehicle_or_drop_ret_locs( Character &you,
+        item_drop_reason reason,
+        const std::list<item> &items,
+        map *here, const tripoint_bub_ms &where, bool force_ground )
 {
     const std::optional<vpart_reference> vp = here->veh_at( where ).cargo();
     if( vp && !force_ground ) {
@@ -1981,7 +1984,8 @@ static bool butcher_corpse_activity( Character &you, const tripoint_bub_ms &src_
             you.assign_activity( ACT_BUTCHER_FULL, 0, true );
             you.activity.targets.emplace_back( map_cursor( src_loc ), &elem );
             you.activity.placement = here.get_abs( src_loc );
-            you.may_activity_occupancy_after_end_items_loc.emplace_back(map_cursor{here.get_abs(src_loc)},&elem);
+            you.may_activity_occupancy_after_end_items_loc.emplace_back( map_cursor{here.get_abs( src_loc )},
+                    &elem );
             return true;
         }
     }
@@ -3870,23 +3874,29 @@ bool try_fuel_fire( player_activity &act, Character &you, const bool starting_fi
     }
     return true;
 }
-static void erase_item_contents_activity_var(const std::function<bool(const item &)> &activity_var_checker,item &it){
-    const std::vector<item*> contents_items = it.items_with(activity_var_checker);
-    for (item *inner_item:contents_items){
-        if (inner_item == nullptr || inner_item->is_null()) { continue;}
-        inner_item->erase_var("activity_var");
-        erase_item_contents_activity_var(activity_var_checker,*inner_item);
+static void erase_item_contents_activity_var( const std::function<bool( const item & )>
+        &activity_var_checker, item &it )
+{
+    const std::vector<item *> contents_items = it.items_with( activity_var_checker );
+    for( item *inner_item : contents_items ) {
+        if( inner_item == nullptr || inner_item->is_null() ) {
+            continue;
+        }
+        inner_item->erase_var( "activity_var" );
+        erase_item_contents_activity_var( activity_var_checker, *inner_item );
     }
 };
-void activity_handlers::clean_may_activity_occupancy_items_var(Character & you){
+void activity_handlers::clean_may_activity_occupancy_items_var( Character &you )
+{
     std::string character_name = you.name;
-    const std::function<bool(const item *const)> activity_var_checker = [character_name](const item *const it)->bool{
-        return it->has_var("activity_var")
-        && it->get_var("activity_var","") == character_name;
+    const std::function<bool( const item *const )> activity_var_checker = [character_name](
+    const item * const it )->bool{
+        return it->has_var( "activity_var" )
+        && it->get_var( "activity_var", "" ) == character_name;
     };
-    for (item_location &loc:you.may_activity_occupancy_after_end_items_loc){
-        if (loc && activity_var_checker(loc.get_item())){
-            loc.get_item()->erase_var("activity_var");
+    for( item_location &loc : you.may_activity_occupancy_after_end_items_loc ) {
+        if( loc && activity_var_checker( loc.get_item() ) ) {
+            loc.get_item()->erase_var( "activity_var" );
         }
     }
     you.may_activity_occupancy_after_end_items_loc.clear();

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -3847,3 +3847,25 @@ bool try_fuel_fire( player_activity &act, Character &you, const bool starting_fi
     }
     return true;
 }
+
+void activity_handlers::clean_may_activity_occupancy_items_var(Character & you){
+    int character_id = you.getID().get_value();
+    auto activity_var_checker = [character_id](const item &it)->bool{
+        return it.has_var("activity_var")
+        && static_cast<int>(it.get_var("activity_var",-1)) == character_id;
+    };
+    map &here = get_map();
+    for (const auto & pos:you.may_activity_occupancy_items_loc_points){
+        auto item_locs = here.items_with(here.get_bub(pos),activity_var_checker);
+        for (auto & item_loc:item_locs){
+            item *it = item_loc.get_item();
+            if (it == nullptr || it->is_null()) { continue;}
+            it->erase_var("activity_var");
+        }
+    }
+    auto items = you.items_with(activity_var_checker);
+    for (auto *it:items){
+        if (it == nullptr || it->is_null()) { continue;}
+        it->erase_var("activity_var");
+    }
+}

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -1959,6 +1959,7 @@ static bool butcher_corpse_activity( Character &you, const tripoint_bub_ms &src_
             you.assign_activity( ACT_BUTCHER_FULL, 0, true );
             you.activity.targets.emplace_back( map_cursor( src_loc ), &elem );
             you.activity.placement = here.get_abs( src_loc );
+            you.may_activity_occupancy_after_end_items_loc.insert(here.get_abs(src_loc));
             return true;
         }
     }

--- a/src/character.h
+++ b/src/character.h
@@ -4001,7 +4001,7 @@ class Character : public Creature, public visitable
 
         // the player's activity level for metabolism calculations
         activity_tracker activity_history;
-        std::set<tripoint_abs_ms> may_activity_occupancy_after_end_items_loc;
+        std::vector<item_location> may_activity_occupancy_after_end_items_loc;
         // Our weariness level last turn, so we know when we transition
         int old_weary_level = 0;
 

--- a/src/character.h
+++ b/src/character.h
@@ -4001,7 +4001,7 @@ class Character : public Creature, public visitable
 
         // the player's activity level for metabolism calculations
         activity_tracker activity_history;
-        std::set<tripoint_abs_ms> may_activity_occupancy_items_loc_points;
+        std::set<tripoint_abs_ms> may_activity_occupancy_after_end_items_loc;
         // Our weariness level last turn, so we know when we transition
         int old_weary_level = 0;
 

--- a/src/character.h
+++ b/src/character.h
@@ -4001,7 +4001,7 @@ class Character : public Creature, public visitable
 
         // the player's activity level for metabolism calculations
         activity_tracker activity_history;
-
+        std::set<tripoint_abs_ms> may_activity_occupancy_items_loc_points;
         // Our weariness level last turn, so we know when we transition
         int old_weary_level = 0;
 

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -3040,10 +3040,10 @@ void iexamine::harvest_plant( Character &you, const tripoint_bub_ms &examp, bool
             for( item &i : get_harvest_items( type, plant_count, seedCount, true ) ) {
                 if( from_activity ) {
                     i.set_var( "activity_var", you.name );
-                }
-                item_location loc = here.add_item_or_charges_ret_loc( you.pos_bub(), i );
-                if (from_activity && loc.where() == item_location::type::map ){
-                    you.may_activity_occupancy_after_end_items_loc.insert(loc.pos_abs());
+                    item_location loc = here.add_item_or_charges_ret_loc( you.pos_bub(), i );
+                    if (from_activity && loc){
+                        you.may_activity_occupancy_after_end_items_loc.push_back(loc);
+                    }
                 }
             }
             here.furn_set( examp, furn_str_id( fp->base ) );

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -3041,7 +3041,7 @@ void iexamine::harvest_plant( Character &you, const tripoint_bub_ms &examp, bool
                 if( from_activity ) {
                     i.set_var( "activity_var", you.name );
                     item_location loc = here.add_item_or_charges_ret_loc( you.pos_bub(), i );
-                    if( from_activity && loc ) {
+                    if( loc ) {
                         you.may_activity_occupancy_after_end_items_loc.push_back( loc );
                     }
                 }

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -3041,7 +3041,10 @@ void iexamine::harvest_plant( Character &you, const tripoint_bub_ms &examp, bool
                 if( from_activity ) {
                     i.set_var( "activity_var", you.name );
                 }
-                here.add_item_or_charges( you.pos_bub(), i );
+                item_location loc = here.add_item_or_charges_ret_loc( you.pos_bub(), i );
+                if (from_activity && loc.where() == item_location::type::map ){
+                    you.may_activity_occupancy_after_end_items_loc.insert(loc.pos_abs());
+                }
             }
             here.furn_set( examp, furn_str_id( fp->base ) );
             you.add_msg_if_player( m_neutral, _( "You harvest the plant." ) );

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -3041,8 +3041,8 @@ void iexamine::harvest_plant( Character &you, const tripoint_bub_ms &examp, bool
                 if( from_activity ) {
                     i.set_var( "activity_var", you.name );
                     item_location loc = here.add_item_or_charges_ret_loc( you.pos_bub(), i );
-                    if (from_activity && loc){
-                        you.may_activity_occupancy_after_end_items_loc.push_back(loc);
+                    if( from_activity && loc ) {
+                        you.may_activity_occupancy_after_end_items_loc.push_back( loc );
                     }
                 }
             }

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1094,7 +1094,7 @@ void npc::revert_after_activity()
     current_activity_id = activity_id::NULL_ID();
     clear_destination();
     backlog.clear();
-    activity_handlers::clean_may_activity_occupancy_items_var(*this);
+    activity_handlers::clean_may_activity_occupancy_items_var( *this );
 }
 
 npc_mission npc::get_previous_mission() const
@@ -2949,7 +2949,7 @@ void npc::reboot()
     ai_cache.searched_tiles.clear();
     activity = player_activity();
     clear_destination();
-    activity_handlers::clean_may_activity_occupancy_items_var(*this);
+    activity_handlers::clean_may_activity_occupancy_items_var( *this );
     add_effect( effect_npc_suspend, 24_hours, true, 1 );
 }
 

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -10,6 +10,7 @@
 #include <ostream>
 
 #include "activity_actor_definitions.h"
+#include "activity_handlers.h"
 #include "activity_type.h"
 #include "auto_pickup.h"
 #include "basecamp.h"
@@ -1093,6 +1094,7 @@ void npc::revert_after_activity()
     current_activity_id = activity_id::NULL_ID();
     clear_destination();
     backlog.clear();
+    activity_handlers::clean_may_activity_occupancy_items_var(*this);
 }
 
 npc_mission npc::get_previous_mission() const
@@ -2947,6 +2949,7 @@ void npc::reboot()
     ai_cache.searched_tiles.clear();
     activity = player_activity();
     clear_destination();
+    activity_handlers::clean_may_activity_occupancy_items_var(*this);
     add_effect( effect_npc_suspend, 24_hours, true, 1 );
 }
 

--- a/src/player_activity.cpp
+++ b/src/player_activity.cpp
@@ -410,6 +410,10 @@ void player_activity::do_turn( Character &you )
         // handle it, drop any overflow that may have caused
         you.drop_invalid_inventory();
     }
+    // According to the existing code, if 'you' is an NPC, the outer layer may try to resume activity from the
+    // backlog  (in npc::do_player_activity()), which results is (!you.activity) && (!you.get_destination_activity())
+    // is true here not meaning that mult_activity ends, so npc's activity_var cannot be handled here.
+    // only avatar's activity_var is erased in player_activity::do_turn.
     activity_handlers::clean_may_activity_occupancy_items_var_if_is_avatar_and_no_activity_now( you );
 }
 

--- a/src/player_activity.cpp
+++ b/src/player_activity.cpp
@@ -238,7 +238,7 @@ void player_activity::do_turn( Character &you )
     // This is because the game can get stuck trying to fuel a fire when it's not...
     if( type == ACT_MIGRATION_CANCEL ) {
         actor->do_turn( *this, you );
-        activity_handlers::clean_may_activity_occupancy_items_var_if_is_avatar_and_no_activity_now(you);
+        activity_handlers::clean_may_activity_occupancy_items_var_if_is_avatar_and_no_activity_now( you );
         return;
     }
     // first to ensure sync with actor
@@ -314,7 +314,7 @@ void player_activity::do_turn( Character &you )
         }
         // We may have canceled this via a message interrupt.
         if( type.is_null() ) {
-            activity_handlers::clean_may_activity_occupancy_items_var_if_is_avatar_and_no_activity_now(you);
+            activity_handlers::clean_may_activity_occupancy_items_var_if_is_avatar_and_no_activity_now( you );
             return;
         }
     }
@@ -371,7 +371,7 @@ void player_activity::do_turn( Character &you )
         if( !ignoreQuery && auto_resume ) {
             you.assign_activity( wait_stamina_activity_actor( you.get_stamina_max() ) );
         }
-        activity_handlers::clean_may_activity_occupancy_items_var_if_is_avatar_and_no_activity_now(you);
+        activity_handlers::clean_may_activity_occupancy_items_var_if_is_avatar_and_no_activity_now( you );
         return;
     }
     if( *this && type->rooted() ) {
@@ -410,7 +410,7 @@ void player_activity::do_turn( Character &you )
         // handle it, drop any overflow that may have caused
         you.drop_invalid_inventory();
     }
-    activity_handlers::clean_may_activity_occupancy_items_var_if_is_avatar_and_no_activity_now(you);
+    activity_handlers::clean_may_activity_occupancy_items_var_if_is_avatar_and_no_activity_now( you );
 }
 
 void player_activity::canceled( Character &who )

--- a/src/player_activity.cpp
+++ b/src/player_activity.cpp
@@ -238,6 +238,7 @@ void player_activity::do_turn( Character &you )
     // This is because the game can get stuck trying to fuel a fire when it's not...
     if( type == ACT_MIGRATION_CANCEL ) {
         actor->do_turn( *this, you );
+        activity_handlers::clean_may_activity_occupancy_items_var_if_is_avatar_and_no_activity_now(you);
         return;
     }
     // first to ensure sync with actor
@@ -313,6 +314,7 @@ void player_activity::do_turn( Character &you )
         }
         // We may have canceled this via a message interrupt.
         if( type.is_null() ) {
+            activity_handlers::clean_may_activity_occupancy_items_var_if_is_avatar_and_no_activity_now(you);
             return;
         }
     }
@@ -369,6 +371,7 @@ void player_activity::do_turn( Character &you )
         if( !ignoreQuery && auto_resume ) {
             you.assign_activity( wait_stamina_activity_actor( you.get_stamina_max() ) );
         }
+        activity_handlers::clean_may_activity_occupancy_items_var_if_is_avatar_and_no_activity_now(you);
         return;
     }
     if( *this && type->rooted() ) {
@@ -407,9 +410,7 @@ void player_activity::do_turn( Character &you )
         // handle it, drop any overflow that may have caused
         you.drop_invalid_inventory();
     }
-    if( ( !you.activity ) && you.backlog.empty() && ( !you.get_destination_activity() ) ) {
-        activity_handlers::clean_may_activity_occupancy_items_var( you );
-    }
+    activity_handlers::clean_may_activity_occupancy_items_var_if_is_avatar_and_no_activity_now(you);
 }
 
 void player_activity::canceled( Character &who )

--- a/src/player_activity.cpp
+++ b/src/player_activity.cpp
@@ -403,10 +403,12 @@ void player_activity::do_turn( Character &you )
         // Make sure data of previous activity is cleared
         you.activity = player_activity();
         you.resume_backlog_activity();
-
         // If whatever activity we were doing forced us to pick something up to
         // handle it, drop any overflow that may have caused
         you.drop_invalid_inventory();
+    }
+    if ((!you.activity)&&you.backlog.empty()&&(!you.get_destination_activity())){
+        activity_handlers::clean_may_activity_occupancy_items_var(you);
     }
 }
 
@@ -415,6 +417,7 @@ void player_activity::canceled( Character &who )
     if( *this && actor ) {
         actor->canceled( *this, who );
     }
+    activity_handlers::clean_may_activity_occupancy_items_var(who);
     get_event_bus().send<event_type::character_finished_activity>( who.getID(), type, true );
     g->wait_popup_reset();
 }

--- a/src/player_activity.cpp
+++ b/src/player_activity.cpp
@@ -407,8 +407,8 @@ void player_activity::do_turn( Character &you )
         // handle it, drop any overflow that may have caused
         you.drop_invalid_inventory();
     }
-    if ((!you.activity)&&you.backlog.empty()&&(!you.get_destination_activity())){
-        activity_handlers::clean_may_activity_occupancy_items_var(you);
+    if( ( !you.activity ) && you.backlog.empty() && ( !you.get_destination_activity() ) ) {
+        activity_handlers::clean_may_activity_occupancy_items_var( you );
     }
 }
 
@@ -417,7 +417,7 @@ void player_activity::canceled( Character &who )
     if( *this && actor ) {
         actor->canceled( *this, who );
     }
-    activity_handlers::clean_may_activity_occupancy_items_var(who);
+    activity_handlers::clean_may_activity_occupancy_items_var( who );
     get_event_bus().send<event_type::character_finished_activity>( who.getID(), type, true );
     g->wait_popup_reset();
 }

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -1641,7 +1641,7 @@ void avatar::store( JsonOut &json ) const
     json.member( "preferred_aiming_mode", preferred_aiming_mode );
 
     json.member( "power_prev_turn", power_prev_turn );
-    json.member("may_activity_occupancy_items_loc_points",may_activity_occupancy_items_loc_points);
+    json.member("may_activity_occupancy_after_end_items_loc",may_activity_occupancy_after_end_items_loc);
 }
 
 void avatar::deserialize( const JsonObject &data )
@@ -1778,7 +1778,7 @@ void avatar::load( const JsonObject &data )
     }
 
     data.read( "snippets_read", snippets_read );
-    data.read("may_activity_occupancy_items_loc_points",may_activity_occupancy_items_loc_points);
+    data.read("may_activity_occupancy_after_end_items_loc",may_activity_occupancy_after_end_items_loc);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -2259,7 +2259,7 @@ void npc::load( const JsonObject &data )
     data.read( "unique_id", unique_id );
     clear_personality_traits();
     generate_personality_traits();
-    data.read( "may_activity_occupancy_items_loc_points", may_activity_occupancy_items_loc_points );
+    data.read( "may_activity_occupancy_after_end_items_loc", may_activity_occupancy_after_end_items_loc );
 }
 
 /*
@@ -2331,7 +2331,7 @@ void npc::store( JsonOut &json ) const
 
     json.member( "complaints", complaints );
     json.member( "unique_id", unique_id );
-    json.member( "may_activity_occupancy_items_loc_points", may_activity_occupancy_items_loc_points );
+    json.member( "may_activity_occupancy_after_end_items_loc", may_activity_occupancy_after_end_items_loc );
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -1641,6 +1641,7 @@ void avatar::store( JsonOut &json ) const
     json.member( "preferred_aiming_mode", preferred_aiming_mode );
 
     json.member( "power_prev_turn", power_prev_turn );
+    json.member("may_activity_occupancy_items_loc_points",may_activity_occupancy_items_loc_points);
 }
 
 void avatar::deserialize( const JsonObject &data )
@@ -1777,6 +1778,7 @@ void avatar::load( const JsonObject &data )
     }
 
     data.read( "snippets_read", snippets_read );
+    data.read("may_activity_occupancy_items_loc_points",may_activity_occupancy_items_loc_points);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -2257,6 +2259,7 @@ void npc::load( const JsonObject &data )
     data.read( "unique_id", unique_id );
     clear_personality_traits();
     generate_personality_traits();
+    data.read( "may_activity_occupancy_items_loc_points", may_activity_occupancy_items_loc_points );
 }
 
 /*
@@ -2328,6 +2331,7 @@ void npc::store( JsonOut &json ) const
 
     json.member( "complaints", complaints );
     json.member( "unique_id", unique_id );
+    json.member( "may_activity_occupancy_items_loc_points", may_activity_occupancy_items_loc_points );
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -1641,7 +1641,8 @@ void avatar::store( JsonOut &json ) const
     json.member( "preferred_aiming_mode", preferred_aiming_mode );
 
     json.member( "power_prev_turn", power_prev_turn );
-    json.member("may_activity_occupancy_after_end_items_loc",may_activity_occupancy_after_end_items_loc);
+    json.member( "may_activity_occupancy_after_end_items_loc",
+                 may_activity_occupancy_after_end_items_loc );
 }
 
 void avatar::deserialize( const JsonObject &data )
@@ -1778,7 +1779,8 @@ void avatar::load( const JsonObject &data )
     }
 
     data.read( "snippets_read", snippets_read );
-    data.read("may_activity_occupancy_after_end_items_loc",may_activity_occupancy_after_end_items_loc);
+    data.read( "may_activity_occupancy_after_end_items_loc",
+               may_activity_occupancy_after_end_items_loc );
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -2259,7 +2261,8 @@ void npc::load( const JsonObject &data )
     data.read( "unique_id", unique_id );
     clear_personality_traits();
     generate_personality_traits();
-    data.read( "may_activity_occupancy_after_end_items_loc", may_activity_occupancy_after_end_items_loc );
+    data.read( "may_activity_occupancy_after_end_items_loc",
+               may_activity_occupancy_after_end_items_loc );
 }
 
 /*
@@ -2331,7 +2334,8 @@ void npc::store( JsonOut &json ) const
 
     json.member( "complaints", complaints );
     json.member( "unique_id", unique_id );
-    json.member( "may_activity_occupancy_after_end_items_loc", may_activity_occupancy_after_end_items_loc );
+    json.member( "may_activity_occupancy_after_end_items_loc",
+                 may_activity_occupancy_after_end_items_loc );
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -3370,7 +3370,13 @@ void veh_interact::complete_vehicle( map &here, Character &you )
             // Finally, put all the results somewhere (we wanted to wait until this
             // point because we don't want to put them back into the vehicle part
             // that just got removed).
-            put_into_vehicle_or_drop( you, item_drop_reason::deliberate, resulting_items );
+            std::vector<item_location> locs = put_into_vehicle_or_drop_ret_locs( you, item_drop_reason::deliberate,
+                resulting_items );
+            if (you.is_npc()) {
+                for (const item_location &itl:locs){
+                    you.may_activity_occupancy_after_end_items_loc.push_back(itl);
+                }
+            }
             break;
         }
         case 'u': {

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -3370,11 +3370,12 @@ void veh_interact::complete_vehicle( map &here, Character &you )
             // Finally, put all the results somewhere (we wanted to wait until this
             // point because we don't want to put them back into the vehicle part
             // that just got removed).
-            std::vector<item_location> locs = put_into_vehicle_or_drop_ret_locs( you, item_drop_reason::deliberate,
-                resulting_items );
-            if (you.is_npc()) {
-                for (const item_location &itl:locs){
-                    you.may_activity_occupancy_after_end_items_loc.push_back(itl);
+            std::vector<item_location> locs = put_into_vehicle_or_drop_ret_locs( you,
+                                              item_drop_reason::deliberate,
+                                              resulting_items );
+            if( you.is_npc() ) {
+                for( const item_location &itl : locs ) {
+                    you.may_activity_occupancy_after_end_items_loc.push_back( itl );
                 }
             }
             break;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Fix the issue of activity_var not being erased and when using fishing rod activity_var setting wrong"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
activity_var is used to mark items as currently being used by an activity, but there are quite a few issues with erasing activity_var :

1. After the activity is canceled, the item's activity_var is not erased.
2. The products of many activities are marked with activity_var (such as logging, mining, or vehicle demolition by NPCs), which is supposed to prevent the products from being used when repeated activities are not completed due to mult_activity. However, activity_var is not erased after the repeated activities are completed. Like #80106 and #80749.

In addition, when using a fishing rod to catch a fish, activity_var is added to all corpses at the character's location - even the migo corpse placed at your feet before fishing will have activity_var added.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
1. Add `std::vector<item_location> charcter::may_activity_occupancy_after_end_items_loc` to store the location of items added to the activity_var. Add processing for `may_activity_occupancy_after_end_items_loc` in the serialization and deserialization of avatar and npc.
2. After set activity_var to a item, store the item_location of the item into `may_activity_occupancy_after_end_items_loc`
3. For avatar's activity finish or fail: Before the return of `player_activity::do_turn`, if the character is avatar, has no activity, and the character has no destination activity( This means that the player can then control the avatar ), erase all items‘ activity_var in `may_activity_occupancy_after_end_items_loc`.
4. For avatar's activity cancel: In `player_activity::canceled`, erase all items‘ activity_var in `may_activity_occupancy_after_end_items_loc`.
5. For npc's activity finish, fail or cancel:  In `revert_after_activity`, erase all items‘ activity_var in `may_activity_occupancy_after_end_items_loc`.
6. In `npc::reboot`, erase all items‘ activity_var in `may_activity_occupancy_after_end_items_loc`.
7. Fix the logic of adding activity_var to the corpse when catching fish with a fishing rod.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
1. Avatar chop logs, mines, harvests crops, and butchery; NPC chop logs, mines, harvests crops, and butchery. There is no activity_var left after canceling or completing. During the work of the NPC, both the raw materials and the products have activity_var.
2. Place the migo corpse at the location of the avatar, go fishing, and after catching a fish, use the debugging tool before the end of fishing to confirm that there is no activity_var on the migo corpse but the fish corpse has activity_var.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
fix  #80106 ,  fix  #80749
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
