### PR TITLE
add soccer as hobbies

### DIFF
--- a/data/json/hobbies.json
+++ b/data/json/hobbies.json
@@ -1072,7 +1072,7 @@
     "subtype": "hobby",
     "id": "soccer_beginner",
     "name": "Soccer (Beginner)",
-    "description": "You used to kick a ball around with your friends, having fun together. Though it may not be the case anymore.",
+    "description": "You used to kick a ball around with your friends, having fun together.  Though it may not be the case anymore.",
     "points": 1,
     "skills": [ { "level": 2, "name": "dodge" }, { "level": 1, "name": "swimming" } ]
   },

--- a/data/json/hobbies.json
+++ b/data/json/hobbies.json
@@ -1082,10 +1082,10 @@
     "id": "soccer",
     "name": "Soccer (Intermediate)",
     "description": "Your fondness for the beautiful game shows with your flairs, skills and tackles.  Whether you can go past the backline of the undead is a question yet to be answered.",
-    "points": 5,
+    "points": 4,
     "skills": [ { "level": 3, "name": "dodge" }, { "level": 1, "name": "swimming" } ],
     "proficiencies": [ "prof_athlete_basic" ],
-    "traits": [ "TOUGH", "QUICK", "FLEET" ]
+    "traits": [ "QUICK", "FLEET" ]
   },
   {
     "type": "profession",
@@ -1093,10 +1093,10 @@
     "id": "soccer_expert",
     "name": "Soccer (Expert)",
     "description": "You were on trial at a professional club, ready to get a contract.  What a great opportunity for you, if only your coaches were still alive.",
-    "points": 8,
+    "points": 7,
     "skills": [ { "level": 5, "name": "dodge" }, { "level": 3, "name": "swimming" } ],
     "proficiencies": [ "prof_athlete_basic", "prof_athlete_expert" ],
-    "traits": [ "TOUGH", "QUICK", "FLEET", "PAINRESIST" ]
+    "traits": [ "QUICK", "FLEET", "PAINRESIST" ]
   },
   {
     "type": "profession",

--- a/data/json/hobbies.json
+++ b/data/json/hobbies.json
@@ -1070,6 +1070,37 @@
   {
     "type": "profession",
     "subtype": "hobby",
+    "id": "soccer_beginner",
+    "name": "Soccer (Beginner)",
+    "description": "You used to kick a ball around with your friends, having fun together. Though it may not be the case anymore.",
+    "points": 1,
+    "skills": [ { "level": 2, "name": "dodge" }, { "level": 1, "name": "swimming" } ]
+  },
+  {
+    "type": "profession",
+    "subtype": "hobby",
+    "id": "soccer",
+    "name": "Soccer (Intermediate)",
+    "description": "Your fondness for the beautiful game shows with your flairs, skills and tackles. Whether you can go past the backline of the undead is a question yet to be answered.",
+    "points": 5,
+    "skills": [ { "level": 3, "name": "dodge" }, { "level": 1, "name": "swimming" } ],
+    "proficiencies": [ "prof_athlete_basic" ],
+    "traits": [ "TOUGH", "QUICK", "FLEET" ]
+  },
+  {
+    "type": "profession",
+    "subtype": "hobby",
+    "id": "soccer_expert",
+    "name": "Soccer (Expert)",
+    "description": "You were on trial at a professional club, ready to get a contract. What a great opportunity for you, if only your coaches were still alive.",
+    "points": 8,
+    "skills": [ { "level": 5, "name": "dodge" }, { "level": 3, "name": "swimming" } ],
+    "proficiencies": [ "prof_athlete_basic", "prof_athlete_expert" ],
+    "traits": [ "TOUGH", "QUICK", "FLEET", "PAINRESIST" ]
+  },
+  {
+    "type": "profession",
+    "subtype": "hobby",
     "id": "shooter_beginner",
     "name": "Shooting (Beginner)",
     "description": "You've been to a gun range once or twice and maybe took a firearm safety class.  At the very least, you're confident you can point the gun in the correct direction.",

--- a/data/json/hobbies.json
+++ b/data/json/hobbies.json
@@ -1092,7 +1092,7 @@
     "subtype": "hobby",
     "id": "soccer_expert",
     "name": "Soccer (Expert)",
-    "description": "You were on trial at a professional club, ready to get a contract. What a great opportunity for you, if only your coaches were still alive.",
+    "description": "You were on trial at a professional club, ready to get a contract.  What a great opportunity for you, if only your coaches were still alive.",
     "points": 8,
     "skills": [ { "level": 5, "name": "dodge" }, { "level": 3, "name": "swimming" } ],
     "proficiencies": [ "prof_athlete_basic", "prof_athlete_expert" ],

--- a/data/json/hobbies.json
+++ b/data/json/hobbies.json
@@ -1081,7 +1081,7 @@
     "subtype": "hobby",
     "id": "soccer",
     "name": "Soccer (Intermediate)",
-    "description": "Your fondness for the beautiful game shows with your flairs, skills and tackles. Whether you can go past the backline of the undead is a question yet to be answered.",
+    "description": "Your fondness for the beautiful game shows with your flairs, skills and tackles.  Whether you can go past the backline of the undead is a question yet to be answered.",
     "points": 5,
     "skills": [ { "level": 3, "name": "dodge" }, { "level": 1, "name": "swimming" } ],
     "proficiencies": [ "prof_athlete_basic" ],


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
New England absolutely has [soccer](https://en.wikipedia.org/wiki/New_England_Revolution). It doesn't make sense to not have it as a hobby

#### Describe the solution
Added hobbies, with skillsets similar to (American) football. But since I don't feel any skills fitting a soccer player (maybe unarmed fits idk), so I decided to add "Quick" as a trait instead

#### Describe alternatives you've considered
None

#### Testing
Loaded, and it works

#### Additional context
I absolutely hate the fact that I have to say the word "soccer" instead of "football" >:(
