### PR TITLE
[MoM] Fix crafting contemplation recipes your followers know

### DIFF
--- a/data/mods/MindOverMatter/recipes/practice/biokinetic_practice.json
+++ b/data/mods/MindOverMatter/recipes/practice/biokinetic_practice.json
@@ -51,6 +51,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_BIOKIN_OVERCOME_PAIN",
+        "condition": { "u_has_trait": "BIOKINETIC" },
         "effect": [
           { "set_string_var": "biokin_overcome_pain", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_BIOKIN_POWER_SETUP" },
@@ -82,6 +83,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_BIOKIN_PHYSICAL_ENHANCE",
+        "condition": { "u_has_trait": "BIOKINETIC" },
         "effect": [
           { "set_string_var": "biokin_physical_enhance", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_BIOKIN_POWER_SETUP" },
@@ -113,6 +115,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_BIOKIN_BREATHE_SKIN",
+        "condition": { "u_has_trait": "BIOKINETIC" },
         "effect": [
           { "set_string_var": "biokin_breathe_skin", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_BIOKIN_POWER_SETUP" },
@@ -165,6 +168,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_BIOKIN_FLEXIBILITY",
+        "condition": { "u_has_trait": "BIOKINETIC" },
         "effect": [
           { "set_string_var": "biokin_flexibility", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_BIOKIN_POWER_SETUP" },
@@ -217,6 +221,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_BIOKIN_DASH",
+        "condition": { "u_has_trait": "BIOKINETIC" },
         "effect": [
           { "set_string_var": "biokin_dash", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_BIOKIN_POWER_SETUP" },
@@ -270,6 +275,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_BIOKIN_ARMOR_SKIN",
+        "condition": { "u_has_trait": "BIOKINETIC" },
         "effect": [
           { "set_string_var": "biokin_armor_skin", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_BIOKIN_POWER_SETUP" },
@@ -323,6 +329,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_BIOKIN_CLIMATE_CONTROL",
+        "condition": { "u_has_trait": "BIOKINETIC" },
         "effect": [
           { "set_string_var": "biokin_climate_control", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_BIOKIN_POWER_SETUP" },
@@ -376,6 +383,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_BIOKIN_ADRENALINE",
+        "condition": { "u_has_trait": "BIOKINETIC" },
         "effect": [
           { "set_string_var": "biokin_adrenaline", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_BIOKIN_POWER_SETUP" },
@@ -429,6 +437,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_BIOKIN_ENHANCE_MOBILITY",
+        "condition": { "u_has_trait": "BIOKINETIC" },
         "effect": [
           { "set_string_var": "biokin_enhance_mobility", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_BIOKIN_POWER_SETUP" },
@@ -482,6 +491,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_BIOKIN_HAMMERHAND",
+        "condition": { "u_has_trait": "BIOKINETIC" },
         "effect": [
           { "set_string_var": "biokin_hammerhand", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_BIOKIN_POWER_SETUP" },
@@ -535,6 +545,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_BIOKIN_REFLEX_ENHANCE",
+        "condition": { "u_has_trait": "BIOKINETIC" },
         "effect": [
           { "set_string_var": "biokin_reflex_enhance", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_BIOKIN_POWER_SETUP" },
@@ -588,6 +599,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_BIOKIN_SEALED_SYSTEM",
+        "condition": { "u_has_trait": "BIOKINETIC" },
         "effect": [
           { "set_string_var": "biokin_sealed_system", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_BIOKIN_POWER_SETUP" },
@@ -641,6 +653,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_BIOKIN_METABOLISM_ENHANCE",
+        "condition": { "u_has_trait": "BIOKINETIC" },
         "effect": [
           { "set_string_var": "biokin_metabolism_enhance", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_BIOKIN_POWER_SETUP" },
@@ -694,6 +707,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_BIOKIN_VITAMINOSIS",
+        "condition": { "u_has_trait": "BIOKINETIC" },
         "effect": [
           { "set_string_var": "biokin_vitaminosis", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_BIOKIN_POWER_SETUP" },
@@ -747,6 +761,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_BIOKIN_GUIDED_EVOLUTION",
+        "condition": { "u_has_trait": "BIOKINETIC" },
         "effect": [
           { "set_string_var": "biokin_guided_evolution", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_BIOKIN_POWER_SETUP" },
@@ -800,6 +815,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_BIOKIN_COMBAT_DANCE",
+        "condition": { "u_has_trait": "BIOKINETIC" },
         "effect": [
           { "set_string_var": "biokin_combat_dance", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_BIOKIN_POWER_SETUP" },
@@ -853,6 +869,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_BIOKIN_PERFECTED_MOTION",
+        "condition": { "u_has_trait": "BIOKINETIC" },
         "effect": [
           { "set_string_var": "biokin_perfected_motion", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_BIOKIN_POWER_SETUP" },
@@ -906,6 +923,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_BIOKIN_HURRICANE_BLOWS",
+        "condition": { "u_has_trait": "BIOKINETIC" },
         "effect": [
           { "set_string_var": "biokin_hurricane_blows", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_BIOKIN_POWER_SETUP" },

--- a/data/mods/MindOverMatter/recipes/practice/clairsentient_practice.json
+++ b/data/mods/MindOverMatter/recipes/practice/clairsentient_practice.json
@@ -53,7 +53,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_CLAIR_BETTER_SENSES",
-        "condition": { "math": [ "u_spell_level('clair_better_senses') >= 1" ] },
+        "condition": { "u_has_trait": "CLAIRSENTIENT" },
         "effect": [
           { "set_string_var": "clair_better_senses", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_CLAIR_POWER_SETUP" },
@@ -86,7 +86,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_CLAIR_SPEED_READING",
-        "condition": { "math": [ "u_spell_level('clair_speed_reading') >= 1" ] },
+        "condition": { "u_has_trait": "CLAIRSENTIENT" },
         "effect": [
           { "set_string_var": "clair_speed_reading", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_CLAIR_POWER_SETUP" },
@@ -119,6 +119,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_CLAIR_DANGER_SENSE",
+        "condition": { "u_has_trait": "CLAIRSENTIENT" },
         "effect": [
           { "set_string_var": "clair_danger_sense", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_CLAIR_POWER_SETUP" },
@@ -175,6 +176,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_CLAIR_NIGHT_VISION",
+        "condition": { "u_has_trait": "CLAIRSENTIENT" },
         "effect": [
           { "set_string_var": "clair_night_vision", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_CLAIR_POWER_SETUP" },
@@ -231,6 +233,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_CLAIR_SPOT_WEAKNESS",
+        "condition": { "u_has_trait": "CLAIRSENTIENT" },
         "effect": [
           { "set_string_var": "clair_spot_weakness", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_CLAIR_POWER_SETUP" },
@@ -287,7 +290,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_CLAIR_SENSE_RADS",
-        "condition": { "math": [ "u_spell_level('clair_sense_rads') >= 1" ] },
+        "condition": { "and": [ { "u_has_trait": "CLAIRSENTIENT" }, { "math": [ "u_spell_level('clair_sense_rads') >= 1" ] } ] },
         "effect": [
           { "set_string_var": "clair_sense_rads", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_CLAIR_POWER_SETUP" },
@@ -320,6 +323,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_CLAIR_SEE_AURAS",
+        "condition": { "u_has_trait": "CLAIRSENTIENT" },
         "effect": [
           { "set_string_var": "clair_see_auras", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_CLAIR_POWER_SETUP" },
@@ -377,6 +381,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_CLAIR_RANGED_ENHANCE",
+        "condition": { "u_has_trait": "CLAIRSENTIENT" },
         "effect": [
           { "set_string_var": "clair_ranged_enhance", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_CLAIR_POWER_SETUP" },
@@ -434,6 +439,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_CLAIR_VOYANCE",
+        "condition": { "u_has_trait": "CLAIRSENTIENT" },
         "effect": [
           { "set_string_var": "clair_voyance", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_CLAIR_POWER_SETUP" },
@@ -491,6 +497,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_CLAIR_COMBAT_SENSE",
+        "condition": { "u_has_trait": "CLAIRSENTIENT" },
         "effect": [
           { "set_string_var": "clair_dodge_power", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_CLAIR_POWER_SETUP" },
@@ -548,6 +555,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_CLAIR_CRAFT_BONUS",
+        "condition": { "u_has_trait": "CLAIRSENTIENT" },
         "effect": [
           { "set_string_var": "clair_craft_bonus", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_CLAIR_POWER_SETUP" },
@@ -605,6 +613,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_CLAIR_SEE_MAP",
+        "condition": { "u_has_trait": "CLAIRSENTIENT" },
         "effect": [
           { "set_string_var": "clair_see_map", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_CLAIR_POWER_SETUP" },
@@ -662,6 +671,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_CLAIR_PERFECT_SHOT",
+        "condition": { "u_has_trait": "CLAIRSENTIENT" },
         "effect": [
           { "set_string_var": "clair_perfect_shot", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_CLAIR_POWER_SETUP" },
@@ -719,6 +729,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_CLAIR_CLEAR_SIGHT",
+        "condition": { "u_has_trait": "CLAIRSENTIENT" },
         "effect": [
           { "set_string_var": "clair_clear_sight", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_CLAIR_POWER_SETUP" },
@@ -776,6 +787,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_CLAIR_ASTRAL_PROJECTION",
+        "condition": { "u_has_trait": "CLAIRSENTIENT" },
         "effect": [
           { "set_string_var": "clair_astral_projection", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_CLAIR_POWER_SETUP" },
@@ -833,6 +845,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_CLAIR_GROUP_TACTICS",
+        "condition": { "u_has_trait": "CLAIRSENTIENT" },
         "effect": [
           { "set_string_var": "clair_group_tactics", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_CLAIR_POWER_SETUP" },
@@ -890,6 +903,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_CLAIR_OMNISCENCE",
+        "condition": { "u_has_trait": "CLAIRSENTIENT" },
         "effect": [
           { "set_string_var": "clair_omniscience", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_CLAIR_POWER_SETUP" },

--- a/data/mods/MindOverMatter/recipes/practice/electrokinesis_practice.json
+++ b/data/mods/MindOverMatter/recipes/practice/electrokinesis_practice.json
@@ -53,7 +53,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_ELECTROKIN_SPARK_SIGHT",
-        "condition": { "math": [ "u_spell_level('electrokinetic_see_electric') >= 1" ] },
+        "condition": { "u_has_trait": "ELECTROKINETIC" },
         "effect": [
           { "set_string_var": "electrokinetic_see_electric", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_ELECTROKIN_POWER_SETUP" },
@@ -86,7 +86,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_ELECTROKIN_SHOCK_TOUCH",
-        "condition": { "math": [ "u_spell_level('electrokinetic_shock_touch') >= 1" ] },
+        "condition": { "u_has_trait": "ELECTROKINETIC" },
         "effect": [
           { "set_string_var": "electrokinetic_shock_touch", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_ELECTROKIN_POWER_SETUP" },
@@ -119,6 +119,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_ELECTROKIN_ZAP_ENEMIES",
+        "condition": { "u_has_trait": "ELECTROKINETIC" },
         "effect": [
           { "set_string_var": "electrokinetic_zap_enemies", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_ELECTROKIN_POWER_SETUP" },
@@ -175,6 +176,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_ELECTROKIN_MELEE_ATTACKS",
+        "condition": { "u_has_trait": "ELECTROKINETIC" },
         "effect": [
           { "set_string_var": "electrokinetic_melee_attacks", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_ELECTROKIN_POWER_SETUP" },
@@ -231,6 +233,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_ELECTRO_PERSONAL_BATTERY",
+        "condition": { "u_has_trait": "ELECTROKINETIC" },
         "effect": [
           { "set_string_var": "electrokinetic_personal_battery", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_ELECTROKIN_POWER_SETUP" },
@@ -288,6 +291,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_ELECTROKIN_PARALYSIS",
+        "condition": { "u_has_trait": "ELECTROKINETIC" },
         "effect": [
           { "set_string_var": "electrokinetic_paralysis", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_ELECTROKIN_POWER_SETUP" },
@@ -345,6 +349,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_ELECTRO_HACKING_INTERFACE",
+        "condition": { "u_has_trait": "ELECTROKINETIC" },
         "effect": [
           { "set_string_var": "electrokinetic_hacking_interface", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_ELECTROKIN_POWER_SETUP" },
@@ -402,6 +407,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_ELECTROKIN_REDUCE_PAIN",
+        "condition": { "u_has_trait": "ELECTROKINETIC" },
         "effect": [
           { "set_string_var": "electrokinetic_reduce_pain", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_ELECTROKIN_POWER_SETUP" },
@@ -459,6 +465,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_ELECTROKIN_LIGHTNING_BOLT",
+        "condition": { "u_has_trait": "ELECTROKINETIC" },
         "effect": [
           { "set_string_var": "electrokinetic_lightning_bolt", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_ELECTROKIN_POWER_SETUP" },
@@ -516,6 +523,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_ELECTROKIN_RECHARGE_VEHICLE",
+        "condition": { "u_has_trait": "ELECTROKINETIC" },
         "effect": [
           { "set_string_var": "electrokinetic_recharge_vehicle", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_ELECTROKIN_POWER_SETUP" },
@@ -573,6 +581,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_ELECTROKIN_SPEED_BOOST",
+        "condition": { "u_has_trait": "ELECTROKINETIC" },
         "effect": [
           { "set_string_var": "electrokinetic_speed_boost", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_ELECTROKIN_POWER_SETUP" },
@@ -630,6 +639,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_ELECTROKIN_PAIN_IMMUNE",
+        "condition": { "u_has_trait": "ELECTROKINETIC" },
         "effect": [
           { "set_string_var": "electrokinetic_pain_immune", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_ELECTROKIN_POWER_SETUP" },
@@ -687,6 +697,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_ELECTROKIN_KILL_ROBOT",
+        "condition": { "u_has_trait": "ELECTROKINETIC" },
         "effect": [
           { "set_string_var": "electrokinetic_kill_robot", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_ELECTROKIN_POWER_SETUP" },
@@ -744,6 +755,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_ELECTRO_ROBOT_INTERFACE",
+        "condition": { "u_has_trait": "ELECTROKINETIC" },
         "effect": [
           { "set_string_var": "electrokinetic_robot_interface", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_ELECTROKIN_POWER_SETUP" },
@@ -801,6 +813,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_ELECTROKIN_LIGHTNING_AURA",
+        "condition": { "u_has_trait": "ELECTROKINETIC" },
         "effect": [
           { "set_string_var": "electrokinetic_lightning_aura", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_ELECTROKIN_POWER_SETUP" },
@@ -858,6 +871,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_ELECTROKIN_LIGHTNING_BLAST",
+        "condition": { "u_has_trait": "ELECTROKINETIC" },
         "effect": [
           { "set_string_var": "electrokinetic_lightning_blast", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_ELECTROKIN_POWER_SETUP" },
@@ -915,6 +929,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_ELECTROKIN_REVIVE",
+        "condition": { "u_has_trait": "ELECTROKINETIC" },
         "effect": [
           { "set_string_var": "electrokinetic_revive", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_ELECTROKIN_POWER_SETUP" },

--- a/data/mods/MindOverMatter/recipes/practice/photokinesis_practice.json
+++ b/data/mods/MindOverMatter/recipes/practice/photokinesis_practice.json
@@ -51,7 +51,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_PHOTOKIN_LIGHT_LOCAL",
-        "condition": { "math": [ "u_spell_level('photokinetic_light_local') >= 1" ] },
+        "condition": { "u_has_trait": "PHOTOKINETIC" },
         "effect": [
           { "set_string_var": "photokinetic_light_local", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_PHOTOKIN_POWER_SETUP" },
@@ -80,7 +80,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_PHOTOKIN_CREATE_LIGHT",
-        "condition": { "math": [ "u_spell_level('photokinetic_create_light') >= 1" ] },
+        "condition": { "u_has_trait": "PHOTOKINETIC" },
         "effect": [
           { "set_string_var": "photokinetic_create_light", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_PHOTOKIN_POWER_SETUP" },
@@ -109,6 +109,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_PHOTOKIN_SNUFF_LIGHT",
+        "condition": { "u_has_trait": "PHOTOKINETIC" },
         "effect": [
           { "set_string_var": "photokinetic_snuff_light", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_PHOTOKIN_POWER_SETUP" },
@@ -161,6 +162,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_PHOTOKIN_LIGHT_UP_ENEMY",
+        "condition": { "u_has_trait": "PHOTOKINETIC" },
         "effect": [
           { "set_string_var": "photokinetic_light_up_enemy", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_PHOTOKIN_POWER_SETUP" },
@@ -213,6 +215,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_PHOTOKIN_LIGHT_DODGE",
+        "condition": { "u_has_trait": "PHOTOKINETIC" },
         "effect": [
           { "set_string_var": "photokinetic_light_dodge", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_PHOTOKIN_POWER_SETUP" },
@@ -265,6 +268,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_PHOTOKIN_LIGHT_BEAM",
+        "condition": { "u_has_trait": "PHOTOKINETIC" },
         "effect": [
           { "set_string_var": "photokinetic_light_beam", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_PHOTOKIN_POWER_SETUP" },
@@ -317,6 +321,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_PHOTOKIN_CAMOUFLAGE",
+        "condition": { "u_has_trait": "PHOTOKINETIC" },
         "effect": [
           { "set_string_var": "photokinetic_camouflage", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_PHOTOKIN_POWER_SETUP" },
@@ -369,6 +374,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_PHOTOKIN_RAD_IMMUNITY",
+        "condition": { "u_has_trait": "PHOTOKINETIC" },
         "effect": [
           { "set_string_var": "photokinetic_rad_immunity", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_PHOTOKIN_POWER_SETUP" },
@@ -422,6 +428,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_PHOTOKIN_LIGHT_ARMS",
+        "condition": { "u_has_trait": "PHOTOKINETIC" },
         "effect": [
           { "set_string_var": "photokinetic_light_arms", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_PHOTOKIN_POWER_SETUP" },
@@ -475,6 +482,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_PHOTOKIN_HIDE_UGLY",
+        "condition": { "u_has_trait": "PHOTOKINETIC" },
         "effect": [
           { "set_string_var": "photokinetic_hide_ugly", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_PHOTOKIN_POWER_SETUP" },
@@ -528,6 +536,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_PHOTOKIN_LIGHT_IMAGE",
+        "condition": { "u_has_trait": "PHOTOKINETIC" },
         "effect": [
           { "set_string_var": "photokinetic_light_image", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_PHOTOKIN_POWER_SETUP" },
@@ -581,6 +590,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_PHOTOKIN_RADIO",
+        "condition": { "u_has_trait": "PHOTOKINETIC" },
         "effect": [
           { "set_string_var": "photokinetic_radio", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_PHOTOKIN_POWER_SETUP" },
@@ -634,6 +644,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_PHOTOKIN_STERILIZE_FOOD",
+        "condition": { "u_has_trait": "PHOTOKINETIC" },
         "effect": [
           { "set_string_var": "photokinetic_sterilize_food", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_PHOTOKIN_POWER_SETUP" },
@@ -687,6 +698,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_PHOTOKIN_STUN_ROBOTS",
+        "condition": { "u_has_trait": "PHOTOKINETIC" },
         "effect": [
           { "set_string_var": "photokinetic_stun_robots", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_PHOTOKIN_POWER_SETUP" },
@@ -740,6 +752,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_PHOTOKIN_INVISIBILITY",
+        "condition": { "u_has_trait": "PHOTOKINETIC" },
         "effect": [
           { "set_string_var": "photokinetic_invisibility", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_PHOTOKIN_POWER_SETUP" },
@@ -793,6 +806,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_PHOTOKIN_LIGHT_FLASH",
+        "condition": { "u_has_trait": "PHOTOKINETIC" },
         "effect": [
           { "set_string_var": "photokinetic_light_flash", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_PHOTOKIN_POWER_SETUP" },
@@ -846,6 +860,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_PHOTOKIN_BLINDING_GLARE",
+        "condition": { "u_has_trait": "PHOTOKINETIC" },
         "effect": [
           { "set_string_var": "photokinetic_blinding_glare", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_PHOTOKIN_POWER_SETUP" },
@@ -899,6 +914,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_PHOTOKIN_LIGHT_DISINTEGRATE",
+        "condition": { "u_has_trait": "PHOTOKINETIC" },
         "effect": [
           { "set_string_var": "photokinetic_light_disintegrate", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_PHOTOKIN_POWER_SETUP" },
@@ -952,6 +968,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_PHOTOKIN_LIGHT_ARMY",
+        "condition": { "u_has_trait": "PHOTOKINETIC" },
         "effect": [
           { "set_string_var": "photokinetic_light_army", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_PHOTOKIN_POWER_SETUP" },

--- a/data/mods/MindOverMatter/recipes/practice/pyrokinesis_practice.json
+++ b/data/mods/MindOverMatter/recipes/practice/pyrokinesis_practice.json
@@ -46,7 +46,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_PYROKIN_FLASH",
-        "condition": { "math": [ "u_spell_level('pyrokinetic_flash') >= 1" ] },
+        "condition": { "u_has_trait": "PYROKINETIC" },
         "effect": [
           { "set_string_var": "pyrokinetic_flash", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_PYROKIN_POWER_SETUP" },
@@ -75,7 +75,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_PYROKIN_FLAMES",
-        "condition": { "math": [ "u_spell_level('pyrokinetic_eruption') >= 1" ] },
+        "condition": { "u_has_trait": "PYROKINETIC" },
         "effect": [
           { "set_string_var": "pyrokinetic_eruption", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_PYROKIN_POWER_SETUP" },
@@ -104,6 +104,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_PYROKIN_CAUTERIZE",
+        "condition": { "u_has_trait": "PYROKINETIC" },
         "effect": [
           { "set_string_var": "pyrokinetic_cauterize", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_PYROKIN_POWER_SETUP" },
@@ -156,6 +157,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_PYROKIN_QUELL_FIRE",
+        "condition": { "u_has_trait": "PYROKINETIC" },
         "effect": [
           { "set_string_var": "pyrokinetic_quell_flames", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_PYROKIN_POWER_SETUP" },
@@ -208,6 +210,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_PYROKIN_CALL_FLAMES",
+        "condition": { "u_has_trait": "PYROKINETIC" },
         "effect": [
           { "set_string_var": "pyrokinetic_call_flames", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_PYROKIN_POWER_SETUP" },
@@ -261,6 +264,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_PYROKIN_CLOAK",
+        "condition": { "u_has_trait": "PYROKINETIC" },
         "effect": [
           { "set_string_var": "pyrokinetic_cloak", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_PYROKIN_POWER_SETUP" },
@@ -314,6 +318,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_PYROKIN_FLAMETHROWER",
+        "condition": { "u_has_trait": "PYROKINETIC" },
         "effect": [
           { "set_string_var": "pyrokinetic_flamethrower", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_PYROKIN_POWER_SETUP" },
@@ -367,6 +372,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_PYROKIN_LANCE",
+        "condition": { "u_has_trait": "PYROKINETIC" },
         "effect": [
           { "set_string_var": "pyrokinetic_lance", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_PYROKIN_POWER_SETUP" },
@@ -420,6 +426,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_PYROKIN_THERMOGENESIS",
+        "condition": { "u_has_trait": "PYROKINETIC" },
         "effect": [
           { "set_string_var": "pyrokinetic_thermogenesis", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_PYROKIN_POWER_SETUP" },
@@ -473,6 +480,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_PYROKIN_AURA",
+        "condition": { "u_has_trait": "PYROKINETIC" },
         "effect": [
           { "set_string_var": "pyrokinetic_aura", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_PYROKIN_POWER_SETUP" },
@@ -526,6 +534,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_PYROKIN_FLAME_IMMUNITY",
+        "condition": { "u_has_trait": "PYROKINETIC" },
         "effect": [
           { "set_string_var": "pyrokinetic_flame_immunity", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_PYROKIN_POWER_SETUP" },
@@ -579,6 +588,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_PYROKIN_BLAST",
+        "condition": { "u_has_trait": "PYROKINETIC" },
         "effect": [
           { "set_string_var": "pyrokinetic_blast", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_PYROKIN_POWER_SETUP" },
@@ -632,6 +642,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_PYROKIN_AOE_BLAST",
+        "condition": { "u_has_trait": "PYROKINETIC" },
         "effect": [
           { "set_string_var": "pyrokinetic_aoe_blast", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_PYROKIN_POWER_SETUP" },
@@ -685,6 +696,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_PYROKIN_INCINERATION",
+        "condition": { "u_has_trait": "PYROKINETIC" },
         "effect": [
           { "set_string_var": "pyrokinetic_incineration", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_PYROKIN_POWER_SETUP" },

--- a/data/mods/MindOverMatter/recipes/practice/telekinesis_practice.json
+++ b/data/mods/MindOverMatter/recipes/practice/telekinesis_practice.json
@@ -50,7 +50,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_TELEKIN_PULL",
-        "condition": { "math": [ "u_spell_level('telekinetic_pull') >= 1" ] },
+        "condition": { "u_has_trait": "TELEKINETIC" },
         "effect": [
           { "set_string_var": "telekinetic_pull", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_TELEKIN_POWER_SETUP" },
@@ -79,7 +79,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_TELEKIN_PUSH",
-        "condition": { "math": [ "u_spell_level('telekinetic_push') >= 1" ] },
+        "condition": { "u_has_trait": "TELEKINETIC" },
         "effect": [
           { "set_string_var": "telekinetic_push", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_TELEKIN_POWER_SETUP" },
@@ -108,6 +108,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_TELEKIN_NOISEMAKER",
+        "condition": { "u_has_trait": "TELEKINETIC" },
         "effect": [
           { "set_string_var": "telekinetic_noise", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_TELEKIN_POWER_SETUP" },
@@ -160,6 +161,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_TELEKIN_SLAM_DOWN",
+        "condition": { "u_has_trait": "TELEKINETIC" },
         "effect": [
           { "set_string_var": "telekinetic_slam_down", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_TELEKIN_POWER_SETUP" },
@@ -212,6 +214,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_TELEKIN_MOMENTUM",
+        "condition": { "u_has_trait": "TELEKINETIC" },
         "effect": [
           { "set_string_var": "telekinetic_momentum", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_TELEKIN_POWER_SETUP" },
@@ -265,6 +268,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_TELEKIN_SLOWFALL",
+        "condition": { "u_has_trait": "TELEKINETIC" },
         "effect": [
           { "set_string_var": "telekinetic_slowfall", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_TELEKIN_POWER_SETUP" },
@@ -318,6 +322,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_TELEKIN_FORCE_WAVE",
+        "condition": { "u_has_trait": "TELEKINETIC" },
         "effect": [
           { "set_string_var": "telekinetic_wave", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_TELEKIN_POWER_SETUP" },
@@ -371,6 +376,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_TELEKIN_WATER_WALKING",
+        "condition": { "u_has_trait": "TELEKINETIC" },
         "effect": [
           { "set_string_var": "telekinetic_water_walk", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_TELEKIN_POWER_SETUP" },
@@ -424,6 +430,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_TELEKIN_LIFTING_FIELD",
+        "condition": { "u_has_trait": "TELEKINETIC" },
         "effect": [
           { "set_string_var": "telekinetic_lifting_field", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_TELEKIN_POWER_SETUP" },
@@ -477,6 +484,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_TELEKIN_ENHANCE_STRENGTH",
+        "condition": { "u_has_trait": "TELEKINETIC" },
         "effect": [
           { "set_string_var": "telekinetic_strength", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_TELEKIN_POWER_SETUP" },
@@ -530,6 +538,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_TELEKIN_MINDHAMMER",
+        "condition": { "u_has_trait": "TELEKINETIC" },
         "effect": [
           { "set_string_var": "telekinetic_hammer", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_TELEKIN_POWER_SETUP" },
@@ -583,6 +592,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_TELEKIN_VEHICLE_LIFT",
+        "condition": { "u_has_trait": "TELEKINETIC" },
         "effect": [
           { "set_string_var": "telekinetic_vehicle_lift", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_TELEKIN_POWER_SETUP" },
@@ -636,6 +646,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_TELEKIN_BARRIER",
+        "condition": { "u_has_trait": "TELEKINETIC" },
         "effect": [
           { "set_string_var": "telekinetic_shield", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_TELEKIN_POWER_SETUP" },
@@ -689,6 +700,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_TELEKIN_BLAST",
+        "condition": { "u_has_trait": "TELEKINETIC" },
         "effect": [
           { "set_string_var": "telekinetic_explosion", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_TELEKIN_POWER_SETUP" },
@@ -742,6 +754,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_LEVITATION",
+        "condition": { "u_has_trait": "TELEKINETIC" },
         "effect": [
           { "set_string_var": "telekinetic_levitation", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_TELEKIN_POWER_SETUP" },
@@ -793,6 +806,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_MOVE_LARGE_WEIGHT",
+        "condition": { "u_has_trait": "TELEKINETIC" },
         "effect": [
           { "set_string_var": "telekinetic_move_large_weight", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_TELEKIN_POWER_SETUP" },
@@ -846,6 +860,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_TELEKIN_AEGIS",
+        "condition": { "u_has_trait": "TELEKINETIC" },
         "effect": [
           { "set_string_var": "telekinetic_aegis", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_TELEKIN_POWER_SETUP" },
@@ -899,6 +914,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_TELEKIN_EARTHSHAKER",
+        "condition": { "u_has_trait": "TELEKINETIC" },
         "effect": [
           { "set_string_var": "telekinetic_earthshaker", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_TELEKIN_POWER_SETUP" },

--- a/data/mods/MindOverMatter/recipes/practice/telepathy_practice.json
+++ b/data/mods/MindOverMatter/recipes/practice/telepathy_practice.json
@@ -44,7 +44,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_TELEPATH_CONCENTRATION",
-        "condition": { "math": [ "u_spell_level('telepathic_concentration') >= 1" ] },
+        "condition": { "u_has_trait": "TELEPATH" },
         "effect": [
           { "set_string_var": "telepathic_concentration", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_TELEPATH_POWER_SETUP" },
@@ -71,7 +71,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_TELEPATH_MIND_SENSE",
-        "condition": { "math": [ "u_spell_level('telepathic_mind_sense') >= 1" ] },
+        "condition": { "u_has_trait": "TELEPATH" },
         "effect": [
           { "set_string_var": "telepathic_mind_sense", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_TELEPATH_POWER_SETUP" },
@@ -98,6 +98,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_TELEPATH_SHIELD",
+        "condition": { "u_has_trait": "TELEPATH" },
         "effect": [
           { "set_string_var": "telepathic_shield", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_TELEPATH_POWER_SETUP" },
@@ -148,6 +149,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_TELEPATHIC_MESMERIZE",
+        "condition": { "u_has_trait": "TELEPATH" },
         "effect": [
           { "set_string_var": "telepathic_mesmerize", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_TELEPATH_POWER_SETUP" },
@@ -198,6 +200,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_TELEPATH_MORALE",
+        "condition": { "u_has_trait": "TELEPATH" },
         "effect": [
           { "set_string_var": "telepathic_morale", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_TELEPATH_POWER_SETUP" },
@@ -249,6 +252,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_TELEPATHIC_BLAST",
+        "condition": { "u_has_trait": "TELEPATH" },
         "effect": [
           { "set_string_var": "telepathic_blast", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_TELEPATH_POWER_SETUP" },
@@ -300,6 +304,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_TELEPATHIC_ANIMAL_MIND_CONTROL",
+        "condition": { "u_has_trait": "TELEPATH" },
         "effect": [
           { "set_string_var": "telepathic_animal_mind_control", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_TELEPATH_POWER_SETUP" },
@@ -351,6 +356,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_TELEPATH_CONFUSION",
+        "condition": { "u_has_trait": "TELEPATH" },
         "effect": [
           { "set_string_var": "telepathic_confusion", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_TELEPATH_POWER_SETUP" },
@@ -402,6 +408,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_TELEPATH_OBSCURITY",
+        "condition": { "u_has_trait": "TELEPATH" },
         "effect": [
           { "set_string_var": "telepathic_invisibility", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_TELEPATH_POWER_SETUP" },
@@ -453,6 +460,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_TELEPATH_PRIMAL_FEAR",
+        "condition": { "u_has_trait": "TELEPATH" },
         "effect": [
           { "set_string_var": "telepathic_fear", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_TELEPATH_POWER_SETUP" },
@@ -504,6 +512,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_TELEPATH_SCREAM_RADIUS",
+        "condition": { "u_has_trait": "TELEPATH" },
         "effect": [
           { "set_string_var": "telepathic_blast_radius", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_TELEPATH_POWER_SETUP" },
@@ -555,6 +564,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_TELEPATH_BEAST_TAMING",
+        "condition": { "u_has_trait": "TELEPATH" },
         "effect": [
           { "set_string_var": "telepathic_beast_taming", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_TELEPATH_POWER_SETUP" },
@@ -606,6 +616,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_TELEPATH_MIND_CONTROL",
+        "condition": { "u_has_trait": "TELEPATH" },
         "effect": [
           { "set_string_var": "telepathic_mind_control", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_TELEPATH_POWER_SETUP" },
@@ -657,6 +668,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_TELEPATH_NETWORK_EFFECT",
+        "condition": { "u_has_trait": "TELEPATH" },
         "effect": [
           { "set_string_var": "telepathic_network", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_TELEPATH_POWER_SETUP" },

--- a/data/mods/MindOverMatter/recipes/practice/teleportation_practice.json
+++ b/data/mods/MindOverMatter/recipes/practice/teleportation_practice.json
@@ -53,7 +53,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_TELEPORT_BLINK",
-        "condition": { "math": [ "u_spell_level('teleport_blink') >= 1" ] },
+        "condition": { "u_has_trait": "TELEPORTER" },
         "effect": [
           { "set_string_var": "teleport_blink", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_TELEPORT_POWER_SETUP" },
@@ -82,7 +82,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_TELEPORT_SLOW",
-        "condition": { "math": [ "u_spell_level('teleport_slow') >= 1" ] },
+        "condition": { "u_has_trait": "TELEPORTER" },
         "effect": [
           { "set_string_var": "teleport_slow", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_TELEPORT_POWER_SETUP" },
@@ -111,6 +111,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_TELEPORT_PHASE",
+        "condition": { "u_has_trait": "TELEPORTER" },
         "effect": [
           { "set_string_var": "teleport_phase", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_TELEPORT_POWER_SETUP" },
@@ -163,6 +164,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_TELEPORT_ITEM_APPORT",
+        "condition": { "u_has_trait": "TELEPORTER" },
         "effect": [
           { "set_string_var": "teleport_item_apport", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_TELEPORT_POWER_SETUP" },
@@ -215,6 +217,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_TELEPORT_STRIDE",
+        "condition": { "u_has_trait": "TELEPORTER" },
         "effect": [
           { "set_string_var": "teleport_stride", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_TELEPORT_POWER_SETUP" },
@@ -267,6 +270,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_TELEPORT_SWAP",
+        "condition": { "u_has_trait": "TELEPORTER" },
         "effect": [
           { "set_string_var": "teleport_transpose", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_TELEPORT_POWER_SETUP" },
@@ -320,6 +324,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_TELEPORT_DISPLACEMENT",
+        "condition": { "u_has_trait": "TELEPORTER" },
         "effect": [
           { "set_string_var": "teleport_displacement", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_TELEPORT_POWER_SETUP" },
@@ -373,6 +378,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_TELEPORT_REACTIVE_DISPLACEMENT",
+        "condition": { "u_has_trait": "TELEPORTER" },
         "effect": [
           { "set_string_var": "teleport_reactive_displacement", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_TELEPORT_POWER_SETUP" },
@@ -426,6 +432,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_TELEPORT_COLLAPSE",
+        "condition": { "u_has_trait": "TELEPORTER" },
         "effect": [
           { "set_string_var": "teleport_collapse", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_TELEPORT_POWER_SETUP" },
@@ -478,6 +485,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_TELEPORT_WARPED_STRIKES",
+        "condition": { "u_has_trait": "TELEPORTER" },
         "effect": [
           { "set_string_var": "teleport_warped_strikes", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_TELEPORT_POWER_SETUP" },
@@ -530,6 +538,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_TELEPORT_EPHEMERAL_WALK",
+        "condition": { "u_has_trait": "TELEPORTER" },
         "effect": [
           { "set_string_var": "teleport_ephemeral_walk", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_TELEPORT_POWER_SETUP" },
@@ -583,6 +592,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_TELEPORT_FARSTEP",
+        "condition": { "u_has_trait": "TELEPORTER" },
         "effect": [
           { "set_string_var": "teleport_farstep", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_TELEPORT_POWER_SETUP" },
@@ -636,6 +646,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_TELEPORT_BANISH",
+        "condition": { "u_has_trait": "TELEPORTER" },
         "effect": [
           { "set_string_var": "teleport_banish", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_TELEPORT_POWER_SETUP" },
@@ -689,6 +700,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_TELEPORT_LOCI_ESTABLISHMENT",
+        "condition": { "u_has_trait": "TELEPORTER" },
         "effect": [
           { "set_string_var": "teleport_loci_establishment", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_TELEPORT_POWER_SETUP" },
@@ -743,7 +755,7 @@
       {
         "id": "EOC_PRACTICE_TELEPORT_LOCI_TECHNIQUET",
         "//": "EOC is intentionally missing false effect since the loci technique power is learned via the loci establishment EOC rather than on its own.",
-        "condition": { "math": [ "u_spell_level('teleport_loci_technique') >= 1" ] },
+        "condition": { "and": [ { "u_has_trait": "TELEPORTER" }, { "math": [ "u_spell_level('teleport_loci_technique') >= 1" ] } ] },
         "effect": [
           { "set_string_var": "teleport_loci_technique", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_TELEPORT_POWER_SETUP" },
@@ -773,6 +785,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_TELEPORT_GATEWAY",
+        "condition": { "u_has_trait": "TELEPORTER" },
         "effect": [
           { "set_string_var": "teleport_gateway", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_TELEPORT_POWER_SETUP" },
@@ -826,6 +839,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_TELEPORT_dilated_gateway",
+        "condition": { "u_has_trait": "TELEPORTER" },
         "effect": [
           { "set_string_var": "teleport_dilated_gateway", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_TELEPORT_POWER_SETUP" },
@@ -879,6 +893,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_TELEPORT_RELOCATION",
+        "condition": { "u_has_trait": "TELEPORTER" },
         "effect": [
           { "set_string_var": "teleport_relocation", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_TELEPORT_POWER_SETUP" },
@@ -932,6 +947,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_TELEPORT_BREACH",
+        "condition": { "u_has_trait": "TELEPORTER" },
         "effect": [
           { "set_string_var": "teleport_summon", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_TELEPORT_POWER_SETUP" },
@@ -984,7 +1000,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_TELEPORT_WARPER_COMBAT",
-        "condition": { "math": [ "u_spell_level('teleport_warper_combat') >= 1" ] },
+        "condition": { "and": [ { "u_has_trait": "TELEPORTER" }, { "math": [ "u_spell_level('teleport_warper_combat') >= 1" ] } ] },
         "effect": [
           { "set_string_var": "teleport_warper_combat", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_TELEPORT_POWER_SETUP" },
@@ -1014,6 +1030,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_TELEPORT_REALITY_TEAR",
+        "condition": { "u_has_trait": "TELEPORTER" },
         "effect": [
           { "set_string_var": "teleport_reality_tear", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_TELEPORT_POWER_SETUP" },

--- a/data/mods/MindOverMatter/recipes/practice/vitakinesis_practice.json
+++ b/data/mods/MindOverMatter/recipes/practice/vitakinesis_practice.json
@@ -51,7 +51,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_VITAKIN_HEALTH",
-        "condition": { "math": [ "u_spell_level('vita_health_power') >= 1" ] },
+        "condition": { "u_has_trait": "VITAKINETIC" },
         "effect": [
           { "set_string_var": "vita_health_power", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_VITAKIN_POWER_SETUP" },
@@ -80,7 +80,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_VITAKIN_SLOW_BLEEDING",
-        "condition": { "math": [ "u_spell_level('vita_slow_bleeding') >= 1" ] },
+        "condition": { "u_has_trait": "VITAKINETIC" },
         "effect": [
           { "set_string_var": "vita_slow_bleeding", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_VITAKIN_POWER_SETUP" },
@@ -109,6 +109,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_VITAKIN_CONCENTRATED_HEALING",
+        "condition": { "u_has_trait": "VITAKINETIC" },
         "effect": [
           { "set_string_var": "vita_concentrated_healing", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_VITAKIN_POWER_SETUP" },
@@ -161,6 +162,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_VITAKIN_STAUNCHING",
+        "condition": { "u_has_trait": "VITAKINETIC" },
         "effect": [
           { "set_string_var": "vita_stop_bleeding", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_VITAKIN_POWER_SETUP" },
@@ -213,6 +215,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_VITAKIN_HURT",
+        "condition": { "u_has_trait": "VITAKINETIC" },
         "effect": [
           { "set_string_var": "vita_hurt_touch", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_VITAKIN_POWER_SETUP" },
@@ -265,6 +268,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_VITAKIN_HEAL_TOUCH_ALLY",
+        "condition": { "u_has_trait": "VITAKINETIC" },
         "effect": [
           { "set_string_var": "vita_health_power_ally", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_VITAKIN_POWER_SETUP" },
@@ -317,6 +321,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_VITAKIN_REMOVE_POISON",
+        "condition": { "u_has_trait": "VITAKINETIC" },
         "effect": [
           { "set_string_var": "vita_remove_poison", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_VITAKIN_POWER_SETUP" },
@@ -370,6 +375,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_VITAKIN_SLEEP",
+        "condition": { "u_has_trait": "VITAKINETIC" },
         "effect": [
           { "set_string_var": "vita_sleeping_trance", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_VITAKIN_POWER_SETUP" },
@@ -423,6 +429,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_VITAKIN_CURE_DISEASE",
+        "condition": { "u_has_trait": "VITAKINETIC" },
         "effect": [
           { "set_string_var": "vita_cure_disease", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_VITAKIN_POWER_SETUP" },
@@ -476,6 +483,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_VITAKIN_STOP_INFECTION",
+        "condition": { "u_has_trait": "VITAKINETIC" },
         "effect": [
           { "set_string_var": "vita_stop_infection", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_VITAKIN_POWER_SETUP" },
@@ -529,6 +537,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_VITAKIN_HEALING_TRANCE",
+        "condition": { "u_has_trait": "VITAKINETIC" },
         "effect": [
           { "set_string_var": "vita_healing_trance", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_VITAKIN_POWER_SETUP" },
@@ -582,7 +591,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_VITAKIN_PURGE_RADS",
-        "condition": { "math": [ "u_spell_level('vita_purge_rads') >= 1" ] },
+        "condition": { "and": [ { "u_has_trait": "VITAKINETIC" }, { "math": [ "u_spell_level('vita_purge_rads') >= 1" ] } ] },
         "effect": [
           { "set_string_var": "vita_purge_rads", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_VITAKIN_POWER_SETUP" },
@@ -611,6 +620,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_VITAKIN_ATTACK_TOUCH",
+        "condition": { "u_has_trait": "VITAKINETIC" },
         "effect": [
           { "set_string_var": "vita_attack_touch", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_VITAKIN_POWER_SETUP" },
@@ -664,6 +674,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_VITAKIN_PURGE",
+        "condition": { "u_has_trait": "VITAKINETIC" },
         "effect": [
           { "set_string_var": "vita_blood_purge", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_VITAKIN_POWER_SETUP" },
@@ -717,6 +728,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_VITAKIN_BANISH_ILLNESS",
+        "condition": { "u_has_trait": "VITAKINETIC" },
         "effect": [
           { "set_string_var": "vita_banish_illness", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_VITAKIN_POWER_SETUP" },
@@ -770,6 +782,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_VITAKIN_SUPER_HEAL",
+        "condition": { "u_has_trait": "VITAKINETIC" },
         "effect": [
           { "set_string_var": "vita_super_heal", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_VITAKIN_POWER_SETUP" },
@@ -823,7 +836,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_VITAKIN_LIMB_RESTORE",
-        "condition": { "math": [ "u_spell_level('vita_limb_restore') >= 1" ] },
+        "condition": { "u_has_trait": "VITAKINETIC" },
         "effect": [
           { "set_string_var": "vita_limb_restore", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_VITAKIN_POWER_SETUP" },
@@ -853,6 +866,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_VITAKIN_DEGENERATING_TOUCH",
+        "condition": { "u_has_trait": "VITAKINETIC" },
         "effect": [
           { "set_string_var": "vita_degenerating_touch", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_VITAKIN_POWER_SETUP" },
@@ -906,6 +920,7 @@
     "result_eocs": [
       {
         "id": "EOC_PRACTICE_VITAKIN_RETURN_FROM_DEATH",
+        "condition": { "u_has_trait": "VITAKINETIC" },
         "effect": [
           { "set_string_var": "vita_return_from_death", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_VITAKIN_POWER_SETUP" },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "[MoM] Fix crafting contemplation recipes your followers know"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

People occasionally mention that they manage to do contemplation recipes because they have psychic followers, which breaks a lot of things both mechanically and narratively. 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Make each contemplation recipe require the appropriate psion trait or it does nothing. Your follower can tell you how to set things on fire with your mind, but if you can't actually set fire to anything with your mind, it won't help.

You can still, if you have a powerful psion follower with the same powerset as you, have them teach you contemplation recipes, but this is _good_. I made every single power non-teachable because use of psionics is supposed to be very idiosyncratic, but the various document-based power teaching has always felt out of place due to that. This unifies both paradigms. The more powerful follower isn't teaching you the power like it's a magic spell, they're explaining the concepts for you and demonstrating it, but then (crucially) you still have to perform the actual contemplation recipe yourself and figure out the basics of the power and your own way to do it. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Gave a follower some psi, tried contemplation recipes on my non-psion, they did nothing.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

I might make Guided Evolution a "requires PHAVIAN documentation to figure out" power but not until there's a biokinetic/vitakinetic lab you can go to to find it. 

I also need to go through and remove the Metaphysics requirement for contemplation recipes. You should be able to _try_ to learn whatever you want.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
