### PR TITLE
diag_value: improve error message

### DIFF
--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -418,7 +418,7 @@ void _write_var_value( var_type type, const std::string &name, dialogue *d,
             globvars.set_global_value( name, value );
             break;
         case var_type::var:
-            ret = d->get_value( name ).str();
+            ret = d->get_value( name ).str( name );
             vinfo = process_variable( ret );
             _write_var_value( vinfo.type, vinfo.name, d, value );
             break;
@@ -1687,7 +1687,7 @@ conditional_t::func f_tile_is_outside( const JsonObject &jo, std::string_view me
         map &here = get_map();
         tripoint_abs_ms target_location;
         if( loc_var.has_value() ) {
-            target_location = read_var_value( *loc_var, d ).tripoint();
+            target_location = read_var_value( *loc_var, d ).tripoint( loc_var->name );
         } else {
             target_location = d.const_actor( false )->pos_abs();
         }
@@ -1723,8 +1723,8 @@ conditional_t::func f_line_of_sight( const JsonObject &jo, std::string_view memb
     }
     return [range, loc_var_1, loc_var_2, with_fields]( const_dialogue const & d ) {
         map &here = get_map();
-        tripoint_bub_ms loc_1 = here.get_bub( read_var_value( loc_var_1, d ).tripoint() );
-        tripoint_bub_ms loc_2 = here.get_bub( read_var_value( loc_var_2, d ).tripoint() );
+        tripoint_bub_ms loc_1 = here.get_bub( read_var_value( loc_var_1, d ).tripoint( loc_var_1.name ) );
+        tripoint_bub_ms loc_2 = here.get_bub( read_var_value( loc_var_2, d ).tripoint( loc_var_1.name ) );
 
         return here.sees( loc_1, loc_2, range.evaluate( d ), with_fields );
     };
@@ -1776,7 +1776,7 @@ conditional_t::func f_map_ter_furn_with_flag( const JsonObject &jo, std::string_
     }
     return [terrain, furn_type, loc_var]( const_dialogue const & d ) {
         map &here = get_map();
-        tripoint_bub_ms loc = here.get_bub( read_var_value( loc_var, d ).tripoint() );
+        tripoint_bub_ms loc = here.get_bub( read_var_value( loc_var, d ).tripoint( loc_var.name ) );
         if( terrain ) {
             return here.ter( loc )->has_flag( furn_type.evaluate( d ) );
         } else {
@@ -1792,7 +1792,7 @@ conditional_t::func f_map_ter_furn_id( const JsonObject &jo, std::string_view me
 
     return [member, furn_type, loc_var]( const_dialogue const & d ) {
         map &here = get_map();
-        tripoint_bub_ms loc = here.get_bub( read_var_value( loc_var, d ).tripoint() );
+        tripoint_bub_ms loc = here.get_bub( read_var_value( loc_var, d ).tripoint( loc_var.name ) );
         if( member == "map_terrain_id" ) {
             return here.ter( loc ) == ter_id( furn_type.evaluate( d ) );
         } else if( member == "map_furniture_id" ) {

--- a/src/dialogue_helpers.cpp
+++ b/src/dialogue_helpers.cpp
@@ -29,7 +29,7 @@ diag_value const *maybe_read_var_value( const var_info &info, const_dialogue con
             return d.const_actor( true )->maybe_get_value( info.name );
         case var_type::var: {
             diag_value const *const var_val = d.maybe_get_value( info.name );
-            return var_val ? maybe_read_var_value( process_variable( var_val->str() ), d ) : nullptr;
+            return var_val ? maybe_read_var_value( process_variable( var_val->str( info.name ) ), d ) : nullptr;
         }
         case var_type::last:
             return nullptr;
@@ -71,7 +71,7 @@ std::string str_or_var::evaluate( const_dialogue const &d, bool convert ) const
             if( convert ) {
                 return val->to_string();
             }
-            return val->str();
+            return val->str( var_val->name );
         }
         if( default_val.has_value() ) {
             return default_val.value();
@@ -97,7 +97,7 @@ std::string translation_or_var::evaluate( const_dialogue const &d, bool convert 
             if( convert ) {
                 return val->to_string( true );
             }
-            return val->str();
+            return val->str( var_val->name );
         }
         if( default_val.has_value() ) {
             return default_val.value().translated();
@@ -123,7 +123,7 @@ double dbl_or_var_part::evaluate( const_dialogue const &d ) const
     if( var_val.has_value() ) {
         diag_value const *val = maybe_read_var_value( var_val.value(), d );
         if( val ) {
-            return val->dbl();
+            return val->dbl( var_val->name );
         }
         if( default_val.has_value() ) {
             return default_val.value();
@@ -153,7 +153,7 @@ time_duration duration_or_var_part::evaluate( const_dialogue const &d ) const
     if( var_val.has_value() ) {
         diag_value const *val = maybe_read_var_value( var_val.value(), d );
         if( val ) {
-            return time_duration::from_turns( val->dbl() );
+            return time_duration::from_turns( val->dbl( var_val->name ) );
         }
         if( default_val.has_value() ) {
             return default_val.value();

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1872,7 +1872,7 @@ void item::set_var( const std::string &key, diag_value value )
 double item::get_var( const std::string &key, double default_value ) const
 {
     if( diag_value const *ret = maybe_get_value( key ); ret ) {
-        return ret->dbl();
+        return ret->dbl( key );
     }
 
     return default_value;
@@ -1881,7 +1881,7 @@ double item::get_var( const std::string &key, double default_value ) const
 std::string item::get_var( const std::string &key, std::string default_value ) const
 {
     if( diag_value const *ret = maybe_get_value( key ); ret ) {
-        return ret->str();
+        return ret->str( key );
     }
 
     return default_value;
@@ -1890,7 +1890,7 @@ std::string item::get_var( const std::string &key, std::string default_value ) c
 tripoint_abs_ms item::get_var( const std::string &key, tripoint_abs_ms default_value ) const
 {
     if( diag_value const *ret = maybe_get_value( key ); ret ) {
-        return ret->tripoint();
+        return ret->tripoint( key );
     }
 
     return default_value;

--- a/src/math_parser.cpp
+++ b/src/math_parser.cpp
@@ -267,13 +267,7 @@ double func_jmath::eval( const_dialogue const &d ) const
 double var::eval( const_dialogue const &d ) const
 {
     if( diag_value const *ret = maybe_read_var_value( varinfo, d ); ret ) {
-        try {
-            return ret->dbl( d );
-        } catch( math::exception &ex ) {
-            throw math::runtime_error(
-                R"(Type mismatch in variable "%s" with value "%s": %s)", varinfo.name,
-                ret->to_string(), ex.what() );
-        }
+        return ret->dbl( d, varinfo.name );
     }
     return 0;
 }

--- a/src/math_parser_diag_value.cpp
+++ b/src/math_parser_diag_value.cpp
@@ -60,7 +60,8 @@ T _convert( diag_value::legacy_value const &val )
 }
 
 template<typename C, bool at_runtime = false, typename R = C const &>
-constexpr R _diag_value_helper( diag_value::impl_t const &data, const_dialogue const &/* d */ = {} )
+constexpr R _diag_value_helper( diag_value::impl_t const &data, const_dialogue const &/* d */ = {},
+                                std::string_view key = {} )
 {
     return std::visit( overloaded{
         []( std::monostate const &/* std */ ) -> R
@@ -68,7 +69,7 @@ constexpr R _diag_value_helper( diag_value::impl_t const &data, const_dialogue c
             static C const null_R{};
             return null_R;
         },
-        []( auto const & v ) -> R
+        [key]( auto const & v ) -> R
         {
             if constexpr( std::is_same_v<std::decay_t<decltype( v )>, C> )
             {
@@ -81,13 +82,13 @@ constexpr R _diag_value_helper( diag_value::impl_t const &data, const_dialogue c
                 return _diag_value_helper<C, at_runtime, R>( *v.converted );
             } else if constexpr( at_runtime )
             {
-                throw math::runtime_error( "Type mismatch in diag_value: requested %s, got %s", _str_type_of( C{} ),
-                                           _str_type_of( v ) );
+                throw math::runtime_error(
+                    R"(Type mismatch in diag_value %s: requested %s, got %s)", key,
+                    _str_type_of( C{} ), _str_type_of( v ) );
             } else
             {
-
-                debugmsg( "Type mismatch in diag_value: requested %s, got %s", _str_type_of( C{} ),
-                          _str_type_of( v ) );
+                debugmsg( R"(Type mismatch in diag_value %s: requested %s, got %s)", key,
+                          _str_type_of( C{} ), _str_type_of( v ) );
                 static C const null_R{};
                 return null_R;
             }
@@ -165,14 +166,14 @@ bool diag_value::is_dbl() const
     return std::holds_alternative<double>( data );
 }
 
-double diag_value::dbl() const
+double diag_value::dbl( std::string_view key ) const
 {
-    return _diag_value_helper<double, false, double>( data );
+    return _diag_value_helper<double, false, double>( data, {}, key );
 }
 
-double diag_value::dbl( const_dialogue const &d ) const
+double diag_value::dbl( const_dialogue const &d, std::string_view key ) const
 {
-    return _diag_value_helper<double, true, double>( data, d );
+    return _diag_value_helper<double, true, double>( data, d, key );
 }
 
 bool diag_value::is_tripoint() const
@@ -180,14 +181,14 @@ bool diag_value::is_tripoint() const
     return std::holds_alternative<tripoint_abs_ms>( data );
 }
 
-tripoint_abs_ms const &diag_value::tripoint() const
+tripoint_abs_ms const &diag_value::tripoint( std::string_view key ) const
 {
-    return _diag_value_helper<tripoint_abs_ms>( data );
+    return _diag_value_helper<tripoint_abs_ms>( data, {}, key );
 }
 
-tripoint_abs_ms const &diag_value::tripoint( const_dialogue const &d ) const
+tripoint_abs_ms const &diag_value::tripoint( const_dialogue const &d, std::string_view key ) const
 {
-    return _diag_value_helper<tripoint_abs_ms, true>( data, d );
+    return _diag_value_helper<tripoint_abs_ms, true>( data, d, key );
 }
 
 bool diag_value::is_str() const
@@ -195,14 +196,14 @@ bool diag_value::is_str() const
     return std::holds_alternative<std::string>( data );
 }
 
-std::string const &diag_value::str() const
+std::string const &diag_value::str( std::string_view key ) const
 {
-    return _diag_value_helper<std::string>( data );
+    return _diag_value_helper<std::string>( data, {}, key );
 }
 
-std::string const &diag_value::str( const_dialogue const &d ) const
+std::string const &diag_value::str( const_dialogue const &d, std::string_view key ) const
 {
-    return _diag_value_helper<std::string, true>( data, d );
+    return _diag_value_helper<std::string, true>( data, d, key );
 }
 
 bool diag_value::is_array() const
@@ -215,14 +216,14 @@ bool diag_value::is_empty() const
     return std::holds_alternative<std::monostate>( data );
 }
 
-diag_array const &diag_value::array() const
+diag_array const &diag_value::array( std::string_view key ) const
 {
-    return _diag_value_helper<diag_array>( data );
+    return _diag_value_helper<diag_array>( data, {}, key );
 }
 
-diag_array const &diag_value::array( const_dialogue const &d ) const
+diag_array const &diag_value::array( const_dialogue const &d, std::string_view key ) const
 {
-    return _diag_value_helper<diag_array, true>( data, d );
+    return _diag_value_helper<diag_array, true>( data, d, key );
 }
 
 bool operator==( diag_value::legacy_value const &lhs, diag_value::legacy_value const &rhs )

--- a/src/math_parser_diag_value.h
+++ b/src/math_parser_diag_value.h
@@ -68,17 +68,18 @@ struct diag_value {
     bool is_empty() const;
 
     // These functions show a debugmsg on type mismatches
-    double dbl() const;
-    std::string const &str() const;
-    diag_array const &array() const;
-    tripoint_abs_ms const &tripoint() const;
+    // key is only used in the mismatch error message
+    double dbl( std::string_view key = {} ) const;
+    std::string const &str( std::string_view key = {} ) const;
+    diag_array const &array( std::string_view key = {} ) const;
+    tripoint_abs_ms const &tripoint( std::string_view key = {} ) const;
 
     // These functions throw a math::runtime_error on type mismatches
     // and are meant to be used only inside EOC and math code
-    double dbl( const_dialogue const &d ) const;
-    std::string const &str( const_dialogue const &d ) const;
-    diag_array const &array( const_dialogue const &d ) const;
-    tripoint_abs_ms const &tripoint( const_dialogue const &d ) const;
+    double dbl( const_dialogue const &d, std::string_view key = {} ) const;
+    std::string const &str( const_dialogue const &d, std::string_view key = {} ) const;
+    diag_array const &array( const_dialogue const &d, std::string_view key = {} ) const;
+    tripoint_abs_ms const &tripoint( const_dialogue const &d, std::string_view key = {} ) const;
 
     std::string to_string( bool i18n = false ) const;
 

--- a/src/mission_util.cpp
+++ b/src/mission_util.cpp
@@ -181,7 +181,8 @@ static std::optional<tripoint_abs_omt> find_or_create_om_terrain(
     tripoint_abs_omt target_pos = tripoint_abs_omt::invalid;
 
     if( params.target_var.has_value() ) {
-        return project_to<coords::omt>( read_var_value( *params.target_var, d ).tripoint() );
+        return project_to<coords::omt>(
+                   read_var_value( *params.target_var, d ).tripoint( params.target_var->name ) );
     }
 
     omt_find_params find_params;

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -3777,7 +3777,7 @@ talk_effect_fun_t f_spawn_item( const JsonObject &jo, std::string_view member,
                add_talker, loc_var, force_equip, flags]( dialogue & d ) {
         tripoint_abs_ms target_location;
         if( loc_var ) {
-            target_location = read_var_value( *loc_var, d ).tripoint();
+            target_location = read_var_value( *loc_var, d ).tripoint( loc_var->name );
         } else {
             target_location = d.actor( false )->pos_abs();
         }
@@ -4396,7 +4396,7 @@ talk_effect_fun_t::func f_location_variable_adjust( const JsonObject &jo,
     }
     return [input_var, dov_x_adjust, dov_y_adjust, dov_z_adjust, z_override,
                output_var, overmap_tile ]( dialogue & d ) {
-        tripoint_abs_ms target_pos = read_var_value( input_var, d ).tripoint();
+        tripoint_abs_ms target_pos = read_var_value( input_var, d ).tripoint( input_var.name );
 
         if( overmap_tile ) {
             target_pos = target_pos + tripoint( dov_x_adjust.evaluate( d ) * coords::map_squares_per(
@@ -4439,7 +4439,7 @@ talk_effect_fun_t::func f_transform_radius( const JsonObject &jo, std::string_vi
     return [dov, transform, target_var, dov_time_in_future, key, is_npc]( dialogue & d ) {
         tripoint_abs_ms target_pos = d.actor( is_npc )->pos_abs();
         if( target_var.has_value() ) {
-            target_pos = read_var_value( *target_var, d ).tripoint();
+            target_pos = read_var_value( *target_var, d ).tripoint( target_var->name );
         } else {
             target_pos = d.actor( is_npc )->pos_abs();
         }
@@ -4509,7 +4509,7 @@ talk_effect_fun_t::func f_explosion( const JsonObject &jo, std::string_view memb
                 is_npc, &here]( dialogue const & d ) {
         tripoint_bub_ms target_pos;
         if( target_var.has_value() ) {
-            tripoint_abs_ms abs_ms = read_var_value( *target_var, d ).tripoint();
+            tripoint_abs_ms abs_ms = read_var_value( *target_var, d ).tripoint( target_var->name );
             target_pos = here.get_bub( abs_ms );
         } else {
             target_pos = d.actor( is_npc )->pos_bub( here );
@@ -4558,7 +4558,7 @@ talk_effect_fun_t::func f_query_tile( const JsonObject &jo, std::string_view mem
         Character *ch = d.actor( is_npc )->get_character();
         tripoint_bub_ms center;
         if( center_var.has_value() ) {
-            tripoint_abs_ms abs_ms = read_var_value( *center_var, d ).tripoint();
+            tripoint_abs_ms abs_ms = read_var_value( *center_var, d ).tripoint( center_var->name );
             center = here.get_bub( abs_ms );
         } else {
             center = d.actor( is_npc )->pos_bub( here );
@@ -4628,7 +4628,7 @@ talk_effect_fun_t::func f_query_omt( const JsonObject &jo, std::string_view memb
 
             tripoint_abs_omt target_pos = d.actor( is_npc )->pos_abs_omt();
             if( target_var.has_value() ) {
-                tripoint_abs_ms abs_ms = read_var_value( *target_var, d ).tripoint();
+                tripoint_abs_ms abs_ms = read_var_value( *target_var, d ).tripoint( target_var->name );
                 target_pos = project_to<coords::omt>( abs_ms );
             }
 
@@ -4688,7 +4688,7 @@ talk_effect_fun_t::func f_choose_adjacent_highlight( const JsonObject &jo, std::
                 false_eocs, is_npc, &here]( dialogue & d ) {
         tripoint_bub_ms target_pos;
         if( target_var.has_value() ) {
-            tripoint_abs_ms abs_ms = read_var_value( *target_var, d ).tripoint();
+            tripoint_abs_ms abs_ms = read_var_value( *target_var, d ).tripoint( target_var->name );
             target_pos = here.get_bub( abs_ms );
         } else {
             target_pos = d.actor( is_npc )->pos_bub( here );
@@ -4729,8 +4729,8 @@ talk_effect_fun_t::func f_mirror_coordinates( const JsonObject &jo, std::string_
         output_var = read_var_info( jo.get_object( member ) );
     }
     return [center_var, relative_var, output_var]( dialogue & d ) {
-        tripoint_abs_ms const center = read_var_value( center_var, d ).tripoint();
-        tripoint_abs_ms const relative = read_var_value( relative_var, d ).tripoint();
+        tripoint_abs_ms const center = read_var_value( center_var, d ).tripoint( center_var.name );
+        tripoint_abs_ms const relative = read_var_value( relative_var, d ).tripoint( relative_var.name );
 
         tripoint_abs_ms const mirrored( center.x() * 2 - relative.x(),
                                         center.y() * 2 - relative.y(),
@@ -4749,8 +4749,8 @@ talk_effect_fun_t::func f_transform_line( const JsonObject &jo, std::string_view
     var_info second = read_var_info( jo.get_object( "second" ) );
 
     return [transform, first, second]( dialogue const & d ) {
-        tripoint_abs_ms const t_first = read_var_value( first, d ).tripoint();
-        tripoint_abs_ms const t_second = read_var_value( second, d ).tripoint();
+        tripoint_abs_ms const t_first = read_var_value( first, d ).tripoint( first.name );
+        tripoint_abs_ms const t_second = read_var_value( second, d ).tripoint( second.name );
         tripoint_abs_ms const orig = coord_min( t_first, t_second );
         map tm;
         tm.load( project_to<coords::sm>( orig ), false );
@@ -4804,7 +4804,7 @@ talk_effect_fun_t::func f_mapgen_update( const JsonObject &jo, std::string_view 
     return [target_params, update_ids, target_var, dov_time_in_future, key]( dialogue & d ) {
         tripoint_abs_omt omt_pos;
         if( target_var.has_value() ) {
-            const tripoint_abs_ms abs_ms = read_var_value( *target_var, d ).tripoint();
+            const tripoint_abs_ms abs_ms = read_var_value( *target_var, d ).tripoint( target_var->name );
             omt_pos = project_to<coords::omt>( abs_ms );
         } else {
             mission_target_params update_params = target_params;
@@ -4856,7 +4856,7 @@ talk_effect_fun_t::func f_revert_location( const JsonObject &jo, std::string_vie
     }
     var_info target_var = read_var_info( jo.get_object( member ) );
     return [target_var, dov_time_in_future, key]( dialogue & d ) {
-        const tripoint_abs_ms abs_ms = read_var_value( target_var, d ).tripoint();
+        const tripoint_abs_ms abs_ms = read_var_value( target_var, d ).tripoint( target_var.name );
         tripoint_abs_omt omt_pos = project_to<coords::omt>( abs_ms );
         time_point tif = calendar::turn + dov_time_in_future.evaluate( d ) + 1_seconds;
         // Timed events happen before the player turn and eocs are during so we add a second here to sync them up using the same variable
@@ -4927,7 +4927,7 @@ talk_effect_fun_t::func f_guard_pos( const JsonObject &jo, std::string_view memb
             if( unique_id ) {
                 cur_var.name.insert( 0, guy->get_unique_id() );
             }
-            tripoint_abs_ms target_location = read_var_value( cur_var, d ).tripoint();
+            tripoint_abs_ms target_location = read_var_value( cur_var, d ).tripoint( cur_var.name );
             guy->set_guard_pos( target_location );
         }
     };
@@ -5569,7 +5569,7 @@ talk_effect_fun_t::func f_cast_spell( const JsonObject &jo, std::string_view mem
                 }
             } else {
                 const tripoint_bub_ms target_pos = loc_var
-                                                   ? get_map().get_bub( read_var_value( *loc_var, d ).tripoint() )
+                                                   ? get_map().get_bub( read_var_value( *loc_var, d ).tripoint( loc_var->name ) )
                                                    : caster->pos_bub();
                 sp.cast_all_effects( *caster, target_pos );
                 caster->add_msg_player_or_npc( fake.trigger_message, fake.npc_trigger_message );
@@ -5996,7 +5996,7 @@ talk_effect_fun_t::func f_activate( const JsonObject &jo, std::string_view membe
                     return;
                 }
                 if( target_var.has_value() ) {
-                    tripoint_abs_ms target_pos = read_var_value( *target_var, d ).tripoint();
+                    tripoint_abs_ms target_pos = read_var_value( *target_var, d ).tripoint( target_var->name );
                     if( get_map().inbounds( target_pos ) ) {
                         guy->invoke_item( it->get_item(), method_str, here.get_bub( target_pos ) );
                         return;
@@ -6094,7 +6094,7 @@ talk_effect_fun_t::func f_make_sound( const JsonObject &jo, std::string_view mem
             same_snippet]( dialogue & d ) {
         tripoint_abs_ms target_pos;
         if( target_var ) {
-            target_pos = read_var_value( *target_var, d ).tripoint();
+            target_pos = read_var_value( *target_var, d ).tripoint( target_var->name );
         } else {
             target_pos = d.actor( is_npc )->pos_abs();
         }
@@ -6202,7 +6202,7 @@ std::unique_ptr<talker> get_talker( dialogue const &d, std::optional<str_or_var>
         }
 
     } else if( loc ) {
-        crit = get_creature_tracker().creature_at( read_var_value( *loc, d ).tripoint() );
+        crit = get_creature_tracker().creature_at( read_var_value( *loc, d ).tripoint( loc->name ) );
     }
 
     if( crit != nullptr ) {
@@ -6653,7 +6653,7 @@ talk_effect_fun_t::func f_map_run_item_eocs( const JsonObject &jo, std::string_v
             title]( dialogue & d ) {
         tripoint_abs_ms target_location;
         if( loc_var ) {
-            target_location = read_var_value( *loc_var, d ).tripoint();
+            target_location = read_var_value( *loc_var, d ).tripoint( loc_var->name );
         } else {
             target_location = d.actor( is_npc )->pos_abs();
         }
@@ -6735,7 +6735,7 @@ talk_effect_fun_t::func f_map_run_eocs( const JsonObject &jo, std::string_view m
 
         tripoint_abs_ms pos;
         if( target_var.has_value() ) {
-            pos = read_var_value( *target_var, d ).tripoint();
+            pos = read_var_value( *target_var, d ).tripoint( target_var->name );
         } else {
             pos = d.actor( is_npc )->pos_abs();
         }
@@ -7074,7 +7074,7 @@ talk_effect_fun_t::func f_knockback( const JsonObject &jo, std::string_view memb
         map &here = get_map();
         tripoint_bub_ms target_pos;
         if( target_var.has_value() ) {
-            tripoint_abs_ms abs_ms = read_var_value( *target_var, d ).tripoint();
+            tripoint_abs_ms abs_ms = read_var_value( *target_var, d ).tripoint( target_var->name );
             target_pos = here.get_bub( abs_ms );
         } else {
             target_pos = d.actor( is_npc )->pos_bub( here );
@@ -7082,7 +7082,7 @@ talk_effect_fun_t::func f_knockback( const JsonObject &jo, std::string_view memb
 
         tripoint_bub_ms direction_pos;
         if( direction_var.has_value() ) {
-            tripoint_abs_ms abs_ms = read_var_value( *direction_var, d ).tripoint();
+            tripoint_abs_ms abs_ms = read_var_value( *direction_var, d ).tripoint( direction_var->name );
             direction_pos = here.get_bub( abs_ms );
         } else {
             direction_pos = d.actor( is_npc )->pos_bub( here );
@@ -7304,7 +7304,7 @@ talk_effect_fun_t::func f_spawn_monster( const JsonObject &jo, std::string_view 
         std::optional<time_duration> lifespan;
         tripoint_bub_ms target_pos = d.actor( is_npc )->pos_bub( here );
         if( target_var.has_value() ) {
-            target_pos = here.get_bub( read_var_value( *target_var, d ).tripoint() );
+            target_pos = here.get_bub( read_var_value( *target_var, d ).tripoint( target_var->name ) );
         }
         int visible_spawns = 0;
         int spawns = 0;
@@ -7453,7 +7453,7 @@ talk_effect_fun_t::func f_spawn_npc( const JsonObject &jo, std::string_view memb
         std::optional<time_duration> lifespan;
         tripoint_bub_ms target_pos = d.actor( is_npc )->pos_bub( here );
         if( target_var.has_value() ) {
-            target_pos = here.get_bub( read_var_value( *target_var, d ).tripoint() );
+            target_pos = here.get_bub( read_var_value( *target_var, d ).tripoint( target_var->name ) );
         }
         int visible_spawns = 0;
         int spawns = 0;
@@ -7535,7 +7535,7 @@ talk_effect_fun_t::func f_field( const JsonObject &jo, std::string_view member,
 
         tripoint_abs_ms target_pos = d.actor( is_npc )->pos_abs();
         if( target_var.has_value() ) {
-            target_pos = read_var_value( *target_var, d ).tripoint();
+            target_pos = read_var_value( *target_var, d ).tripoint( target_var->name );
         }
         for( const tripoint_bub_ms &dest : here.points_in_radius( here.get_bub( target_pos ),
                 radius ) ) {
@@ -7564,7 +7564,7 @@ talk_effect_fun_t::func f_emit( const JsonObject &jo, std::string_view member,
 
         tripoint_abs_ms target_pos = d.actor( is_npc )->pos_abs();
         if( target_var.has_value() ) {
-            target_pos = read_var_value( *target_var, d ).tripoint();
+            target_pos = read_var_value( *target_var, d ).tripoint( target_var->name );
         }
         tripoint_bub_ms target = here.get_bub( target_pos );
         here.emit_field( target, emit_id( emit.evaluate( d ) ), chance_mult.evaluate( d ) );
@@ -7577,8 +7577,9 @@ talk_effect_fun_t::func f_reveal_map( const JsonObject &jo, std::string_view mem
     var_info target_var = read_var_info( jo.get_object( member ) );
     dbl_or_var radius = get_dbl_or_var( jo, "radius", false, 0 );
 
-    return [ radius, target_var ]( dialogue & d ) {
-        tripoint_abs_omt omt = project_to<coords::omt>( read_var_value( target_var, d ).tripoint() );
+    return [radius, target_var]( dialogue & d ) {
+        tripoint_abs_omt omt =
+            project_to<coords::omt>( read_var_value( target_var, d ).tripoint( target_var.name ) );
         overmap_buffer.reveal( omt, radius.evaluate( d ) );
     };
 }
@@ -7592,9 +7593,9 @@ talk_effect_fun_t::func f_reveal_route( const JsonObject &jo, std::string_view m
     bool road_only = jo.get_bool( "road_only", false );
 
     return [ radius, from, to, road_only ]( dialogue & d ) {
-        tripoint_abs_ms from_pos = read_var_value( from, d ).tripoint();
+        tripoint_abs_ms from_pos = read_var_value( from, d ).tripoint( from.name );
         tripoint_abs_omt omt_from = project_to<coords::omt>( from_pos );
-        tripoint_abs_ms to_pos = read_var_value( to, d ).tripoint();
+        tripoint_abs_ms to_pos = read_var_value( to, d ).tripoint( to.name );
         tripoint_abs_omt omt_to = project_to<coords::omt>( to_pos );
 
         overmap_buffer.reveal_route( omt_from, omt_to, radius.evaluate( d ), road_only );
@@ -7610,7 +7611,7 @@ talk_effect_fun_t::func f_closest_city( const JsonObject &jo, std::string_view m
     bool known = jo.get_bool( "known", true );
 
     return [var, type, var_name, known]( dialogue & d ) {
-        tripoint_abs_ms loc_ms = read_var_value( var, d ).tripoint();
+        tripoint_abs_ms loc_ms = read_var_value( var, d ).tripoint( var.name );
         tripoint_abs_sm loc_sm = project_to<coords::sm>( loc_ms );
 
         if( known ) {
@@ -7657,7 +7658,7 @@ talk_effect_fun_t::func f_teleport( const JsonObject &jo, std::string_view membe
     bool force_safe = jo.get_bool( "force_safe", false );
     return [is_npc, target_var, fail_message, success_message, force,
             force_safe]( dialogue const & d ) {
-        tripoint_abs_ms target_pos = read_var_value( target_var, d ).tripoint();
+        tripoint_abs_ms target_pos = read_var_value( target_var, d ).tripoint( target_var.name );
         Creature *teleporter = d.actor( is_npc )->get_creature();
         if( teleporter ) {
             if( teleport::teleport_to_point( *teleporter, get_map().get_bub( target_pos ), true, false,


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Type mismatches in dialogue variables can be hard to debug because `diag_value` has no knowledge of its use context.

#### Describe the solution
Add an optional `key` argument to `diag_value`'s type accessors and use that in all code exposed to JSON.

#### Describe alternatives you've considered
Interning `key` in `diag_value` and changing variable storage to a set: large and fairly complicated. Needs at least a set variant of `map_equal_ignoring_keys()`.

#### Testing
Using the save from #80655

Before:
![before](https://github.com/user-attachments/assets/60d49f64-6868-429a-87b0-5abab9cb6b34)

After:
![after](https://github.com/user-attachments/assets/118f4d54-550d-4bc5-993e-48a3c658228e)

#### Additional context
Complexity demon spirit is starting to smile