### PR TITLE
[Magiclysm] Convert shapeshifter attunement to use encumbrance_modifier enchant

### DIFF
--- a/data/mods/Magiclysm/mutations/magic_classes/attunements.json
+++ b/data/mods/Magiclysm/mutations/magic_classes/attunements.json
@@ -945,7 +945,19 @@
     "spells_learned": [ [ "shapeshifter_alkahest", 5 ], [ "biomechanic", 5 ] ],
     "prereqs": [ "BIOMANCER", "MAGUS" ],
     "//": "Purposefully omits torso, head, etc.",
-    "encumbrance_multiplier_always": { "arm_l": 0.4, "arm_r": 0.4, "hand_l": 0.4, "hand_r": 0.4, "leg_l": 0.4, "leg_r": 0.4, "mouth": 0.4 },
+    "enchantments": [
+      {
+        "encumbrance_modifier": [
+          { "part": "mouth", "multiply": 0.4 },
+          { "part": "arm_r", "multiply": 0.4 },
+          { "part": "arm_l", "multiply": 0.4 },
+          { "part": "hand_r", "multiply": 0.4 },
+          { "part": "hand_l", "multiply": 0.4 },
+          { "part": "leg_r", "multiply": 0.4 },
+          { "part": "leg_l", "multiply": 0.4 }
+        ]
+      }
+    ],
     "ugliness": -7,
     "social_modifiers": { "persuade": 10, "lie": 10, "intimidate": 10 },
     "cancels": [

--- a/data/mods/Magiclysm/mutations/magic_classes/attunements.json
+++ b/data/mods/Magiclysm/mutations/magic_classes/attunements.json
@@ -948,13 +948,13 @@
     "enchantments": [
       {
         "encumbrance_modifier": [
-          { "part": "mouth", "multiply": 0.4 },
-          { "part": "arm_r", "multiply": 0.4 },
-          { "part": "arm_l", "multiply": 0.4 },
-          { "part": "hand_r", "multiply": 0.4 },
-          { "part": "hand_l", "multiply": 0.4 },
-          { "part": "leg_r", "multiply": 0.4 },
-          { "part": "leg_l", "multiply": 0.4 }
+          { "part": "mouth", "multiply": -0.6 },
+          { "part": "arm_r", "multiply": -0.6 },
+          { "part": "arm_l", "multiply": -0.6 },
+          { "part": "hand_r", "multiply": -0.6 },
+          { "part": "hand_l", "multiply": -0.6 },
+          { "part": "leg_r", "multiply": -0.6 },
+          { "part": "leg_l", "multiply": -0.6 }
         ]
       }
     ],


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Magiclysm] Convert shapeshifter attunement to use encumbrance_modifier enchant"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Encumbrance_modifier_always is a kind of strange property that just specifically modifies encumbrance caused by mutations.
Shapeshifter feels like it would work better with just a straight encumbrance decrease due to shapeshifting, rather than just very rarely doing something if the character has a rare mutation.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Move to encumbrance_modifier enchant, which just always reduces encumbrance for the specified parts
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Also make the attunement reduce foot encumbrance.  Based on the comment I see that torso / head encumbrance specifically aren't included, likely to not affect the character carrying a lot of weight / very heavy helmets, but I'm not sure if the logic applies to foot encumbrance or not.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Wore nomad armor and debug adding / removing shapeshifter attunement, then observing that encumbrance changed as expected.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
