### PR TITLE
Stop setting small city dumps on fire

### DIFF
--- a/data/json/overmap/overmap_terrain/overmap_terrain_waste_junk.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_waste_junk.json
@@ -310,7 +310,8 @@
     "name": "small dump",
     "sym": "d",
     "color": "i_brown",
-    "extend": { "flags": [ "SOURCE_FABRICATION", "SOURCE_CONSTRUCTION", "SOURCE_VEHICLES" ] }
+    "extend": { "flags": [ "SOURCE_FABRICATION", "SOURCE_CONSTRUCTION", "SOURCE_VEHICLES" ] },
+    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
   },
   {
     "type": "overmap_terrain",


### PR DESCRIPTION
#### Summary
Bugfixes "Stop setting small city dumps on fire"

#### Purpose of change
(Image borrowed from JP discord):
![image](https://github.com/user-attachments/assets/cd5ed850-8a4c-4109-9774-447c481ad302)

#### Describe the solution
Stop setting the small dumps on fire.

We already deleted this flag from the larger dumps, it seems like this one was just missed. We have like 4 different kinds of dump sites, so this is an understandable oversight.

#### Describe alternatives you've considered
Add flaming piles of garbage to places other than dump sites?

#### Testing


#### Additional context
