### PR TITLE
coord: silence clang warning about unused value

### DIFF
--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -297,11 +297,18 @@ namespace
 {
 struct fake_tripoint { // NOLINT(cata-xy)
     int x = 0, y = 0, z = 0;
+
+    static const fake_tripoint invalid;
 };
 
 struct OM_point { // NOLINT(cata-xy)
     int x = 0, y = 0;
+
+    static const OM_point invalid;
 };
+
+const fake_tripoint fake_tripoint::invalid{ tripoint::invalid.x, tripoint::invalid.y, tripoint::invalid.z };
+const OM_point OM_point::invalid{ point::invalid.x, point::invalid.y };
 
 std::istream &operator>>( std::istream &is, fake_tripoint &pos )
 {
@@ -325,8 +332,9 @@ T _from_fs_string( std::string const &s )
     is.imbue( std::locale::classic() );
     T result;
     is >> result;
-    if( !is ) {
-        return T{};
+    if( !is || !is.eof() ) {
+        debugmsg( "Invalid map/OM coordinate %s", s );
+        return T::invalid;
     }
     return result;
 }

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -306,14 +306,15 @@ struct OM_point { // NOLINT(cata-xy)
 std::istream &operator>>( std::istream &is, fake_tripoint &pos )
 {
     char c = 0;
-    is >> pos.x &&is.get( c ) &&c == '.' &&is >> pos.y &&is.get( c ) &&c == '.' &&is >> pos.z;
+    static_cast<void>( is >> pos.x && is.get( c ) && c == '.' && is >> pos.y && is.get( c ) &&
+                       c == '.' && is >> pos.z );
     return is;
 }
 
 std::istream &operator>>( std::istream &is, OM_point &pos )
 {
     char c = 0;
-    is >> pos.x &&is.get( c ) &&c == '.' &&is >> pos.y;
+    static_cast<void>( is >> pos.x && is.get( c ) && c == '.' && is >> pos.y );
     return is;
 }
 

--- a/src/point.cpp
+++ b/src/point.cpp
@@ -105,16 +105,17 @@ std::ostream &operator<<( std::ostream &os, const tripoint &pos )
 std::istream &operator>>( std::istream &is, point &pos )
 {
     char c;
-    is.get( c ) &&c == '(' &&is >> pos.x &&is.get( c ) &&c == ',' &&is >> pos.y &&
-                                is.get( c ) &&c == ')';
+    // silence -Wunused-value
+    static_cast<void>( is.get( c ) && c == '(' && is >> pos.x && is.get( c ) && c == ',' &&
+                       is >> pos.y && is.get( c ) && c == ')' );
     return is;
 }
 
 std::istream &operator>>( std::istream &is, tripoint &pos )
 {
     char c;
-    is.get( c ) &&c == '(' &&is >> pos.x &&is.get( c ) &&c == ',' &&is >> pos.y &&
-                                is.get( c ) &&c == ',' &&is >> pos.z &&is.get( c ) &&c == ')';
+    static_cast<void>( is.get( c ) && c == '(' && is >> pos.x && is.get( c ) && c == ',' &&
+                       is >> pos.y && is.get( c ) && c == ',' && is >> pos.z && is.get( c ) && c == ')' );
     return is;
 }
 


### PR DESCRIPTION

#### Summary
None

#### Purpose of change
(Tri)point de-serialization uses a boolean chain as a shortcut. clang + libstdc++15 insists that the result of this chain must be used. Clang is wrong.

Technically unrelated, but in the same code: files with invalid formats are silently added to the debug minimized archive instead of getting discarded as intended.

#### Describe the solution
Silence clang.

Fix a return value for invalid files so they get discarded.

#### Describe alternatives you've considered
Replacing the boolean shortcut with an if-forest: no.

#### Testing
clang + libstdc++15 compiles. We don't have this in CI so you'll have to trust me (bro). Someone on discord [confirmed the fix](https://discord.com/channels/598523535169945603/598529174302490644/1369231216670281738).

Bad filenames show an error and aren't added to the debug archive

![Screenshot From 2025-05-06 12-17-42](https://github.com/user-attachments/assets/26756609-26dd-49cf-b411-9e8b6bf0f0ff)
![Screenshot From 2025-05-06 12-17-49](https://github.com/user-attachments/assets/26134a21-906a-4c53-b8de-ea019161d4f4)

#### Additional context
N/A