### PR TITLE
Allow monsters to have different climb/swim/dig speeds

### DIFF
--- a/data/json/monsters/feral_humans.json
+++ b/data/json/monsters/feral_humans.json
@@ -12,7 +12,7 @@
     "weight": "81500 g",
     "hp": 84,
     "speed": 100,
-    "move_skills": { "climb": 1 },
+    "move_skills": { "climb": 8 },
     "material": [ "flesh" ],
     "symbol": "@",
     "color": "magenta",

--- a/data/json/monsters/feral_humans.json
+++ b/data/json/monsters/feral_humans.json
@@ -12,6 +12,7 @@
     "weight": "81500 g",
     "hp": 84,
     "speed": 100,
+    "move_skills": { "climb": 1 },
     "material": [ "flesh" ],
     "symbol": "@",
     "color": "magenta",

--- a/data/json/monsters/fish.json
+++ b/data/json/monsters/fish.json
@@ -54,6 +54,7 @@
     "weight": "680 g",
     "hp": 2,
     "speed": 150,
+    "move_skills": { "swim": 10 },
     "dodge": 8,
     "material": [ "flesh" ],
     "symbol": "f",
@@ -69,7 +70,7 @@
     "fear_triggers": [ "PLAYER_CLOSE", "SOUND" ],
     "harvest": "fish_tiny",
     "families": [ "prof_gross_anatomy", "prof_intro_biology", "prof_physiology" ],
-    "flags": [ "FISHABLE", "SEES", "SMELLS", "SWIMS", "AQUATIC", "WATER_CAMOUFLAGE" ]
+    "flags": [ "FISHABLE", "SEES", "SMELLS", "AQUATIC", "WATER_CAMOUFLAGE" ]
   },
   {
     "abstract": "mon_fish_small",
@@ -85,6 +86,7 @@
     "weight": "1500 g",
     "hp": 6,
     "speed": 150,
+    "move_skills": { "swim": 10 },
     "dodge": 8,
     "material": [ "flesh" ],
     "symbol": "f",
@@ -101,7 +103,7 @@
     "harvest": "fish_small",
     "families": [ "prof_gross_anatomy", "prof_intro_biology", "prof_physiology" ],
     "dissect": "dissect_fish_sample_single",
-    "flags": [ "FISHABLE", "SEES", "SMELLS", "SWIMS", "AQUATIC", "WATER_CAMOUFLAGE" ]
+    "flags": [ "FISHABLE", "SEES", "SMELLS", "AQUATIC", "WATER_CAMOUFLAGE" ]
   },
   {
     "abstract": "mon_fish_medium",
@@ -117,6 +119,7 @@
     "weight": "4535 g",
     "hp": 10,
     "speed": 150,
+    "move_skills": { "swim": 9 },
     "dodge": 8,
     "material": [ "flesh" ],
     "symbol": "f",
@@ -133,7 +136,7 @@
     "harvest": "fish_small",
     "families": [ "prof_gross_anatomy", "prof_intro_biology", "prof_physiology" ],
     "dissect": "dissect_fish_sample_single",
-    "flags": [ "FISHABLE", "SEES", "SMELLS", "SWIMS", "AQUATIC", "WATER_CAMOUFLAGE" ]
+    "flags": [ "FISHABLE", "SEES", "SMELLS", "AQUATIC", "WATER_CAMOUFLAGE" ]
   },
   {
     "abstract": "mon_fish_large",
@@ -149,6 +152,7 @@
     "weight": "12 kg",
     "hp": 20,
     "speed": 150,
+    "move_skills": { "swim": 8 },
     "dodge": 8,
     "material": [ "flesh" ],
     "symbol": "F",
@@ -165,7 +169,7 @@
     "harvest": "fish_large",
     "families": [ "prof_gross_anatomy", "prof_intro_biology", "prof_physiology" ],
     "dissect": "dissect_fish_sample_small",
-    "flags": [ "FISHABLE", "SEES", "SMELLS", "SWIMS", "AQUATIC", "WATER_CAMOUFLAGE" ]
+    "flags": [ "FISHABLE", "SEES", "SMELLS", "AQUATIC", "WATER_CAMOUFLAGE" ]
   },
   {
     "abstract": "mon_fish_huge",

--- a/data/json/monsters/fish.json
+++ b/data/json/monsters/fish.json
@@ -185,6 +185,7 @@
     "weight": "40750 g",
     "hp": 30,
     "speed": 150,
+    "move_skills": { "swim": 7 },
     "dodge": 8,
     "material": [ "flesh" ],
     "symbol": "F",
@@ -200,7 +201,7 @@
     "harvest": "fish_large",
     "families": [ "prof_gross_anatomy", "prof_intro_biology", "prof_physiology" ],
     "dissect": "dissect_fish_sample_small",
-    "flags": [ "FISHABLE", "SEES", "SMELLS", "SWIMS", "AQUATIC", "WATER_CAMOUFLAGE" ]
+    "flags": [ "FISHABLE", "SEES", "SMELLS", "AQUATIC", "WATER_CAMOUFLAGE" ]
   },
   {
     "abstract": "mon_fry",
@@ -216,6 +217,7 @@
     "weight": "1 g",
     "hp": 1,
     "speed": 150,
+    "move_skills": { "swim": 1 },
     "dodge": 10,
     "material": [ "flesh" ],
     "families": [ "prof_gross_anatomy", "prof_intro_biology", "prof_physiology" ],
@@ -230,7 +232,7 @@
     "melee_training_cap": 0,
     "fear_triggers": [ "PLAYER_CLOSE", "SOUND" ],
     "death_function": { "corpse_type": "NO_CORPSE", "message": "The %s is smashed to non-recognizable pieces." },
-    "flags": [ "SEES", "SMELLS", "SWIMS", "AQUATIC", "WATER_CAMOUFLAGE" ]
+    "flags": [ "SEES", "SMELLS", "AQUATIC", "WATER_CAMOUFLAGE" ]
   },
   {
     "abstract": "mon_fry_mutant",
@@ -245,6 +247,7 @@
     "weight": "275 g",
     "hp": 3,
     "speed": 150,
+    "move_skills": { "swim": 1 },
     "dodge": 8,
     "material": [ "flesh" ],
     "families": [ "prof_gross_anatomy", "prof_intro_biology", "prof_physiology" ],
@@ -259,7 +262,7 @@
     "fear_triggers": [ "PLAYER_CLOSE", "SOUND" ],
     "harvest": "mutant_fish",
     "dissect": "dissect_fish_sample_single",
-    "flags": [ "SEES", "SWIMS", "AQUATIC", "WATER_CAMOUFLAGE" ]
+    "flags": [ "SEES", "AQUATIC", "WATER_CAMOUFLAGE" ]
   },
   {
     "id": "mon_fish_brown_trout",

--- a/data/json/monsters/insect_spider.json
+++ b/data/json/monsters/insect_spider.json
@@ -137,6 +137,7 @@
     "weight": "122250 g",
     "hp": 115,
     "speed": 55,
+    "move_skills": { "dig": 9 },
     "material": [ "flesh" ],
     "symbol": "W",
     "color": "pink",

--- a/data/json/monsters/nether.json
+++ b/data/json/monsters/nether.json
@@ -1510,6 +1510,7 @@
     "weight": "800 kg",
     "hp": 320,
     "speed": 80,
+    "move_skills": { "dig": 9 },
     "material": [ "flesh" ],
     "symbol": "W",
     "color": "white",

--- a/data/mods/TEST_DATA/monsters.json
+++ b/data/mods/TEST_DATA/monsters.json
@@ -542,5 +542,21 @@
       }
     ],
     "delete": { "weakpoint_sets": [ "wps_animal_quadruped" ] }
+  },
+  {
+    "type": "MONSTER",
+    "id": "mon_test_climb_nobash",
+    "name": { "str_sp": "climbing, non bashing monster" },
+    "description": "climbing, non bashing monster",
+    "default_faction": "zombie",
+    "material": [ "flesh" ],
+    "symbol": "S",
+    "volume": "81500 ml",
+    "weight": "81500 g",
+    "hp": 100,
+    "speed": 100,
+    "move_skills": { "climb": 8 },
+    "flags": [ "SEES", "HEARS", "SMELLS" ],
+    "upgrades": { "half_life": 0, "into_group": "test_upgrades_multi", "multiple_spawns": true, "spawn_range": 5 }
   }
 ]

--- a/doc/JSON/MONSTERS.md
+++ b/doc/JSON/MONSTERS.md
@@ -109,7 +109,8 @@ Property                 | Description
 `absorb_material`        | (array of string) For monsters with the `ABSORB_ITEMS` special attack. Specifies the types of materials that the monster will seek to absorb. Items with multiple materials will be matched as long as it is made of at least one of the materials in this list. If not specified the monster will absorb all materials.
 `no_absorb_material`        | (array of string) For monsters with the `ABSORB_ITEMS` special attack. Specifies the types of materials that the monster is unable to absorb. This takes precedence over absorb_material; even if the monster is whitelisted for this material, it cannot do so if any of its materials are found here. If not specified, there are no limits placed on what was whitelisted.
 `split_move_cost`        | (int) For monsters with the `SPLIT` special attack. Determines the move cost when splitting into a copy of itself.
-`revive_forms`           | (array of objects) allows to define conditional monster revival, see explanation below
+`revive_forms`           | (array of objects) allows to define conditional monster 
+`move_skills`           | (object with optional members) allows to define how well the monster moves on difficult terrain. Skill can range from 0-10.
 
 Properties in the above tables are explained in more detail in the sections below.
 
@@ -680,6 +681,16 @@ Field                | Description
 `avoid_rough_terrain` | (bool, default false) Monster may avoid rough terrain like rubble
 `avoid_sharp`        | (bool, default false) Monster may avoid sharp things like barbed wire
 `avoid_dangerous_fields` | (bool, default false) Monster may avoid dangerous fields like fire or acid
+
+## "move_skills"
+(object, optional)
+
+Field                | Description
+---                  | ---
+`swim`           | (int, 0-10,optional) swimming monsters ignore SWIMMABLE terrain-cost. Instead it applies a flat movecost penalty inversly related to the skill.
+`dig`         | (int, 0-10, optional) swimming monsters ignore DIGGABLE terrain-cost. Instead it applies a flat movecost penalty inversly related to the skill.
+`climb`      | (int, 0-10, optional) climbing monsters can climb CLIMBABLE ter/furn and can use DIFFICULT_Z ter/furn (i.e. ladders). The ter/furn cost gets multiplied by the skill modifier
+
 
 ## "special_attacks"
 

--- a/doc/JSON/MONSTERS.md
+++ b/doc/JSON/MONSTERS.md
@@ -687,9 +687,9 @@ Field                | Description
 
 Field                | Description
 ---                  | ---
-`swim`           | (int, 0-10,optional) swimming monsters ignore SWIMMABLE terrain-cost. Instead it applies a flat movecost penalty inversly related to the skill.
-`dig`         | (int, 0-10, optional) swimming monsters ignore DIGGABLE terrain-cost. Instead it applies a flat movecost penalty inversly related to the skill.
-`climb`      | (int, 0-10, optional) climbing monsters can climb CLIMBABLE ter/furn and can use DIFFICULT_Z ter/furn (i.e. ladders). The ter/furn cost gets multiplied by the skill modifier
+`swim`               | (int, 0-10,optional) swimming monsters ignore SWIMMABLE terrain-cost. Instead it applies a flat movecost penalty inversly related to the skill.
+`dig`                | (int, 0-10, optional) swimming monsters ignore DIGGABLE terrain-cost. Instead it applies a flat movecost penalty inversly related to the skill.
+`climb`              | (int, 0-10, optional) climbing monsters can climb CLIMBABLE ter/furn and can use DIFFICULT_Z ter/furn (i.e. ladders). The ter/furn cost gets multiplied by the skill modifier
 
 
 ## "special_attacks"

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2392,7 +2392,7 @@ bool map::is_open_air( const tripoint_bub_ms &p ) const
 // Move cost: 3D
 
 int map::move_cost( const tripoint_bub_ms &p, const vehicle *ignored_vehicle,
-                    const bool ignore_fields, const bool ignore_furn ) const
+                    const bool ignore_fields ) const
 {
     // To save all of the bound checks and submaps fetching, we extract it
     // here instead of using furn(), field_at() and ter().

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2351,13 +2351,7 @@ int map::move_cost_internal( const furn_t &furniture, const ter_t &terrain, cons
 
     if( veh != nullptr ) {
         const vpart_position vp( const_cast<vehicle &>( *veh ), vpart );
-        if( vp.obstacle_at_part() ) {
-            return 0;
-        } else if( vp.part_with_feature( VPFLAG_AISLE, true ) ) {
-            return 2;
-        } else {
-            return 8;
-        }
+        return vp.get_movecost();
     }
     int movecost = std::max( terrain.movecost + field.total_move_cost(), 0 );
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2398,7 +2398,7 @@ bool map::is_open_air( const tripoint_bub_ms &p ) const
 // Move cost: 3D
 
 int map::move_cost( const tripoint_bub_ms &p, const vehicle *ignored_vehicle,
-                    const bool ignore_fields ) const
+                    const bool ignore_fields, const bool ignore_furn ) const
 {
     // To save all of the bound checks and submaps fetching, we extract it
     // here instead of using furn(), field_at() and ter().
@@ -2420,7 +2420,8 @@ int map::move_cost( const tripoint_bub_ms &p, const vehicle *ignored_vehicle,
     vehicle *const veh = ( !vp || &vp->vehicle() == ignored_vehicle ) ? nullptr : &vp->vehicle();
     const int part = veh ? vp->part_index() : -1;
 
-    return move_cost_internal( furniture, terrain, ( !ignore_fields ? field : nofield ), veh, part );
+    return move_cost_internal( ( ignore_furn ? furn_t() : furniture ), terrain,
+                               ( !ignore_fields ? field : nofield ), veh, part );
 }
 
 bool map::impassable( const tripoint_bub_ms &p ) const

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2414,7 +2414,7 @@ int map::move_cost( const tripoint_bub_ms &p, const vehicle *ignored_vehicle,
     vehicle *const veh = ( !vp || &vp->vehicle() == ignored_vehicle ) ? nullptr : &vp->vehicle();
     const int part = veh ? vp->part_index() : -1;
 
-    return move_cost_internal( ( ignore_furn ? furn_t() : furniture ), terrain,
+    return move_cost_internal( furniture, terrain,
                                ( !ignore_fields ? field : nofield ), veh, part );
 }
 

--- a/src/map.h
+++ b/src/map.h
@@ -575,10 +575,10 @@ class map
         * n > 0     | x*n turns to move past this
         */
         int move_cost( const tripoint_bub_ms &p, const vehicle *ignored_vehicle = nullptr,
-                       bool ignore_fields = false ) const;
+                       bool ignore_fields = false, bool ignore_furn = false ) const;
         int move_cost( const point_bub_ms &p, const vehicle *ignored_vehicle = nullptr,
-                       bool ignore_fields = false ) const {
-            return move_cost( tripoint_bub_ms( p, abs_sub.z() ), ignored_vehicle, ignore_fields );
+                       bool ignore_fields = false, bool ignore_furn = false ) const {
+            return move_cost( tripoint_bub_ms( p, abs_sub.z() ), ignored_vehicle, ignore_fields, ignore_furn );
         }
         bool impassable( const tripoint_bub_ms &p ) const;
         bool impassable( const point_bub_ms &p ) const {

--- a/src/map.h
+++ b/src/map.h
@@ -575,10 +575,10 @@ class map
         * n > 0     | x*n turns to move past this
         */
         int move_cost( const tripoint_bub_ms &p, const vehicle *ignored_vehicle = nullptr,
-                       bool ignore_fields = false, bool ignore_furn = false ) const;
+                       bool ignore_fields = false ) const;
         int move_cost( const point_bub_ms &p, const vehicle *ignored_vehicle = nullptr,
-                       bool ignore_fields = false, bool ignore_furn = false ) const {
-            return move_cost( tripoint_bub_ms( p, abs_sub.z() ), ignored_vehicle, ignore_fields, ignore_furn );
+                       bool ignore_fields = false ) const {
+            return move_cost( tripoint_bub_ms( p, abs_sub.z() ), ignored_vehicle, ignore_fields );
         }
         bool impassable( const tripoint_bub_ms &p ) const;
         bool impassable( const point_bub_ms &p ) const {

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -17,7 +17,6 @@
 #include "cata_assert.h"
 #include "cata_utility.h"
 #include "character.h"
-#include "coords_fwd.h"
 #include "creature_tracker.h"
 #include "damage.h"
 #include "debug.h"
@@ -1539,17 +1538,19 @@ tripoint_bub_ms monster::scent_move()
 int monster::calc_movecost( const map &here, const tripoint_bub_ms &from,
                             const tripoint_bub_ms &to ) const
 {
+
+    // im sure you can optimize this
     auto get_filtered_fieldcost = [&]( const field & field ) {
         int cost = 0;
         // filter fields wethere they are ignored
-        for( const std::pair<const field_type_id, field_entry> ft : field ) {
-            if( !is_immune_field( ft.first ) ) {
-                const int mc = ft.second.get_intensity_level().move_cost;
+        for( const auto [field_id, field_entry] : field ) {
+            if( !is_immune_field( field_id ) ) {
+                const int mc = field_entry.get_intensity_level().move_cost;
                 if( mc >= 0 ) {
                     cost += mc;
                 } else {
                     debugmsg( "%s cannot pass through field %s. monster::calc_movecost expects to be called with valid destination.",
-                              get_name(), ft.first->get_name() );
+                              get_name(), field_id->get_name() );
                     return -1;
                 }
             }
@@ -1663,7 +1664,7 @@ int monster::calc_movecost( const map &here, const tripoint_bub_ms &from,
 
             } else {
                 if( furniture.has_flag( "BRIDGE" ) ) {
-                    // if its a bridge, we dont care about the terrain-cost
+                    // if its a bridge, we dont care about the terrain-cost, so override
                     cost = furniture.movecost + 2;
                 } else {
                     cost += furniture.movecost;

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -1573,19 +1573,19 @@ int monster::calc_movecost( const map &here, const tripoint_bub_ms &from,
 
     // modifiers that get applied to both locations
     for( auto& [where, cost] : tilecosts ) {
-        // flying creatures ignore all terrain/furniture.
-        // TODO: field efefcts?
+
         add_msg_debug( debugmode::DF_MONMOVE, "%s calculating: (%i, %i, %i)", name(),
                        where.x(), where.y(), where.z() );
 
-        // TODO: field_effects?
+        // flying creatures ignore all terrain/furniture.
+        // TODO: field efefcts?
         if( flies() ) {
             cost += 2;
             continue;
         }
 
         // my implementation of map::movecost
-        // TODO: move to map to make same submap optimizations as map::movecost?
+        // TODO: maybe move to map to make same submap optimizations as map::movecost?
         const furn_t &furniture = here.furn( where ).obj();
         const ter_t &terrain = here.ter( where ).obj();
         const field &field = here.field_at( where );
@@ -1594,11 +1594,9 @@ int monster::calc_movecost( const map &here, const tripoint_bub_ms &from,
         const int part = veh ? vp->part_index() : -1;
         const int swimmod = get_swim_mod();
 
-
-
         // vehicle. Aquatic monsters swim under boats, ignoring its movecost.
         if( veh != nullptr && !has_flag( json_flag_AQUATIC ) ) {
-            // TODO: make monsters with climbing be faster in vehicles?
+            // TODO: maybe make monsters with climbing be faster in vehicles?
             const vpart_position vp( const_cast<vehicle &>( *veh ), part );
             int veh_movecost = vp.get_movecost();
             int fieldcost = get_filtered_fieldcost( field );
@@ -1619,10 +1617,10 @@ int monster::calc_movecost( const map &here, const tripoint_bub_ms &from,
                       get_name(), terrain.name() );
             continue;
         } else if( terrain.has_flag( ter_furn_flag::TFLAG_SWIMMABLE ) ) {
-            // cannot swim or walk underwater.
+
             if( swims() ) {
                 // swimmers dont care about terraincost/other effects.
-                // fish move as quickly as
+                // fish move as quickly as possible with a swimmod of 0.
                 cost += swimmod;
                 continue;
 
@@ -1630,7 +1628,7 @@ int monster::calc_movecost( const map &here, const tripoint_bub_ms &from,
             } else if( has_flag( mon_flag_NO_BREATHE ) || force ) {
                 cost += terrain.movecost;
             } else {
-                // min 1 for forced terrestial monster move
+                // cannot swim or walk underwater.
                 debugmsg( "%s cannot swim or move in %s. monster::calc_movecost expects to be called with valid destination.",
                           get_name(), veh ? veh->disp_name() : terrain.name() );
                 return 0;
@@ -1686,7 +1684,6 @@ int monster::calc_movecost( const map &here, const tripoint_bub_ms &from,
             } else {
                 cost += furniture.movecost;
             }
-
         }
 
         // fields
@@ -2322,7 +2319,7 @@ void monster::stumble()
                here.has_flag( ter_furn_flag::TFLAG_SWIMMABLE, dest ) &&
                !here.has_flag( ter_furn_flag::TFLAG_SWIMMABLE, pos_bub() ) ) &&
             ( creatures.creature_at( dest, is_hallucination() ) == nullptr ) ) {
-            if( move_to( dest, false, false ) ) {
+            if( move_to( dest, true, false ) ) {
                 break;
             }
         }

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -1600,12 +1600,8 @@ int monster::calc_movecost( const map &here, const tripoint_bub_ms &from,
                            where.x(), where.y(), where.z(), terrain.name(), terrain.movecost );
         }
 
-        // vehicle. Aquatic monsters cant enter boats.
-        if( veh && has_flag( json_flag_AQUATIC ) ) {
-            debugmsg( "%s cannot enter %s, as its aquatic. monster::calc_movecost expects to be called with valid destination.",
-                      get_name(), veh->disp_name() );
-            return 0;
-        } else if( veh != nullptr ) {
+        // vehicle. Aquatic monsters swim under boats, ignoring its movecost.
+        if( veh != nullptr && !has_flag( json_flag_AQUATIC ) ) {
             // TODO: make monsters with climbing be faster in vehicles?
             const vpart_position vp( const_cast<vehicle &>( *veh ), part );
             int veh_movecost = vp.get_movecost();

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -1569,7 +1569,7 @@ int monster::calc_movecost( const map &here, const tripoint_bub_ms &from,
                    to.x(), to.y(), to.z() );
     const vehicle *ignored_vehicle = nullptr;
 
-    std::map<tripoint_bub_ms, int> tilecosts = {{from, 0}, {to, 1}};
+    std::map<tripoint_bub_ms, int> tilecosts = {{from, 0}, {to, 0}};
 
     // modifiers that get applied to both locations
     for( auto& [where, cost] : tilecosts ) {

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -1602,7 +1602,7 @@ int monster::calc_movecost( const map &here, const tripoint_bub_ms &from,
             const vpart_position vp( const_cast<vehicle &>( *veh ), part );
             int veh_movecost = vp.get_movecost();
             int fieldcost = get_filtered_fieldcost( field );
-            if( ( veh_movecost > 0 && fieldcost >= 0 ) ) {
+            if( veh_movecost > 0 && fieldcost >= 0 ) {
                 cost += veh_movecost + fieldcost;
                 // vehicle movement ignores the rest
                 continue;

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -1627,13 +1627,13 @@ int monster::calc_movecost( const map &here, const tripoint_bub_ms &from,
                 continue;
 
                 // walk on the bottom of the water
-            } else if( !force ) {
+            } else if( has_flag( mon_flag_NO_BREATHE ) || force ) {
+                cost += terrain.movecost;
+            } else {
+                // min 1 for forced terrestial monster move
                 debugmsg( "%s cannot swim or move in %s. monster::calc_movecost expects to be called with valid destination.",
                           get_name(), veh ? veh->disp_name() : terrain.name() );
                 return 0;
-            } else {
-                // min 1 for forced terrestial monster move
-                cost += terrain.movecost * std::max( swimmod, 1 );
             }
         } else if( has_flag( mon_flag_AQUATIC ) && !force ) {
             debugmsg( "Aquatic %s cannot enter non-swimmable %s. monster::calc_movecost expects to be called with valid destination.",

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -1420,7 +1420,25 @@ bool monster::can_dig() const
 
 bool monster::digs() const
 {
-    return has_flag( mon_flag_DIGS );
+    return has_flag( mon_flag_DIGS ) || type->move_skills.dig.has_value() ;
+}
+
+int monster::get_dig_mod() const
+{
+    const int max_penalty = 10;            // * 50 means max movecost of 500 with 0 skill
+    if( type->move_skills.dig.has_value() ) {
+        int percentile = type->move_skills.dig.value() * ( max_penalty / 10 );
+        return max_penalty - percentile;
+    }
+    if( type->move_skills.dig.has_value() ) {
+        return type->move_skills.dig.value();
+    } else if( has_flag( mon_flag_DIGS ) ) {
+        // only for backwards compatibility. In future move away from flags
+        return 2;
+    }
+
+    // cannot dig
+    return -1;
 }
 
 bool monster::flies() const
@@ -1430,13 +1448,47 @@ bool monster::flies() const
 
 bool monster::climbs() const
 {
-    return has_flag( mon_flag_CLIMBS );
+    return has_flag( mon_flag_CLIMBS ) || type->move_skills.climb.has_value();
+}
+
+int monster::get_climb_mod() const
+{
+    const int max_penalty = 10;            // * 50 means max movecost of 500 with 0 skill
+    if( type->move_skills.climb.has_value() ) {
+        int percentile = type->move_skills.climb.value() * ( max_penalty / 10 );
+        return max_penalty - percentile;
+    } else if( has_flag( mon_flag_CLIMBS ) ) {
+        // only for backwards compatibility. In future move away from flags
+        // was: 150 / 50 = 3
+        return 3;
+    }
+
+    // cannot climb
+    return -1;
 }
 
 bool monster::swims() const
 {
-    return has_flag( mon_flag_SWIMS );
+    return has_flag( mon_flag_SWIMS ) || type->move_skills.swim.has_value();
 }
+
+int monster::get_swim_mod() const
+{
+    const int max_penalty = 10;            // * 50 means max movecost of 500 with 0 skill
+    if( type->move_skills.swim.has_value() ) {
+        int percentile = type->move_skills.swim.value() * ( max_penalty / 10 );
+        return max_penalty - percentile;
+
+    } else if( has_flag( mon_flag_SWIMS ) ) {
+        // only for backwards compatibility. In future move away from flags
+        // vanilla fish have fastest possible swimspeed
+        return 0;
+    }
+
+    // cannot swim
+    return -1;
+}
+
 
 bool monster::can_act() const
 {

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -1428,12 +1428,9 @@ int monster::get_dig_mod() const
     if( type->move_skills.dig.has_value() ) {
         int percentile = type->move_skills.dig.value() * ( max_obstacle_penalty / 10 );
         return max_obstacle_penalty - percentile;
-    }
-    if( type->move_skills.dig.has_value() ) {
-        return type->move_skills.dig.value();
     } else if( has_flag( mon_flag_DIGS ) ) {
         // only for backwards compatibility. In future move away from flags
-        return 2;
+        return 1;
     }
 
     // cannot dig
@@ -1457,8 +1454,7 @@ int monster::get_climb_mod() const
         return max_obstacle_penalty - percentile;
     } else if( has_flag( mon_flag_CLIMBS ) ) {
         // only for backwards compatibility. In future move away from flags
-        // was: 150 / 50 = 3
-        return 3;
+        return 1;
     }
 
     // cannot climb

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -1428,13 +1428,19 @@ int monster::get_dig_mod() const
     if( type->move_skills.dig.has_value() ) {
         int percentile = type->move_skills.dig.value() * ( max_obstacle_penalty / 10 );
         return max_obstacle_penalty - percentile;
-    } else if( has_flag( mon_flag_DIGS ) ) {
+    } else if( has_flag( mon_flag_DIGS ) || has_flag( mon_flag_CAN_DIG ) ) {
         // only for backwards compatibility. In future move away from flags
         return 1;
     }
 
     // cannot dig
     return -1;
+}
+
+int monster::dig_skill() const
+{
+    return type->move_skills.dig.value_or( has_flag( mon_flag_DIGS ) ||
+                                           has_flag( mon_flag_CAN_DIG ) ? 9 : -1 );
 }
 
 bool monster::flies() const
@@ -1446,6 +1452,12 @@ bool monster::climbs() const
 {
     return has_flag( mon_flag_CLIMBS ) || type->move_skills.climb.has_value();
 }
+
+int monster::climb_skill() const
+{
+    return type->move_skills.climb.value_or( has_flag( mon_flag_CLIMBS ) ? 9 : -1 );
+}
+
 
 int monster::get_climb_mod() const
 {
@@ -1464,6 +1476,11 @@ int monster::get_climb_mod() const
 bool monster::swims() const
 {
     return has_flag( mon_flag_SWIMS ) || type->move_skills.swim.has_value();
+}
+
+int monster::swim_skill() const
+{
+    return type->move_skills.swim.value_or( has_flag( mon_flag_SWIMS ) ? 10 : -1 );
 }
 
 int monster::get_swim_mod() const

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -1429,7 +1429,6 @@ int monster::get_dig_mod() const
         int percentile = type->move_skills.dig.value() * ( max_obstacle_penalty / 10 );
         return max_obstacle_penalty - percentile;
     } else if( has_flag( mon_flag_DIGS ) || has_flag( mon_flag_CAN_DIG ) ) {
-        // only for backwards compatibility. In future move away from flags
         return 1;
     }
 
@@ -1501,7 +1500,6 @@ int monster::get_swim_mod() const
     // cannot swim
     return -1;
 }
-
 
 bool monster::can_act() const
 {

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -1425,10 +1425,9 @@ bool monster::digs() const
 
 int monster::get_dig_mod() const
 {
-    const int max_penalty = 10;            // * 50 means max movecost of 500 with 0 skill
     if( type->move_skills.dig.has_value() ) {
-        int percentile = type->move_skills.dig.value() * ( max_penalty / 10 );
-        return max_penalty - percentile;
+        int percentile = type->move_skills.dig.value() * ( max_obstacle_penalty / 10 );
+        return max_obstacle_penalty - percentile;
     }
     if( type->move_skills.dig.has_value() ) {
         return type->move_skills.dig.value();
@@ -1453,10 +1452,9 @@ bool monster::climbs() const
 
 int monster::get_climb_mod() const
 {
-    const int max_penalty = 10;            // * 50 means max movecost of 500 with 0 skill
     if( type->move_skills.climb.has_value() ) {
-        int percentile = type->move_skills.climb.value() * ( max_penalty / 10 );
-        return max_penalty - percentile;
+        int percentile = type->move_skills.climb.value() * ( max_obstacle_penalty / 10 );
+        return max_obstacle_penalty - percentile;
     } else if( has_flag( mon_flag_CLIMBS ) ) {
         // only for backwards compatibility. In future move away from flags
         // was: 150 / 50 = 3
@@ -1474,15 +1472,17 @@ bool monster::swims() const
 
 int monster::get_swim_mod() const
 {
-    const int max_penalty = 10;            // * 50 means max movecost of 500 with 0 skill
     if( type->move_skills.swim.has_value() ) {
-        int percentile = type->move_skills.swim.value() * ( max_penalty / 10 );
-        return max_penalty - percentile;
+        int percentile = type->move_skills.swim.value() * ( max_obstacle_penalty / 10 );
+        return max_obstacle_penalty - percentile;
 
     } else if( has_flag( mon_flag_SWIMS ) ) {
         // only for backwards compatibility. In future move away from flags
         // vanilla fish have fastest possible swimspeed
         return 0;
+    } else if( can_submerge() ) {
+        // monsters that can submerge can walk underwater. Simulated with min swimskill
+        return max_obstacle_penalty;
     }
 
     // cannot swim

--- a/src/monster.h
+++ b/src/monster.h
@@ -22,7 +22,6 @@
 #include "color.h"
 #include "compatibility.h"
 #include "coordinates.h"
-#include "coords_fwd.h"
 #include "creature.h"
 #include "type_id.h"
 #include "units_fwd.h"

--- a/src/monster.h
+++ b/src/monster.h
@@ -22,6 +22,7 @@
 #include "color.h"
 #include "compatibility.h"
 #include "coordinates.h"
+#include "coords_fwd.h"
 #include "creature.h"
 #include "type_id.h"
 #include "units_fwd.h"
@@ -269,8 +270,7 @@ class monster : public Creature
         bool die_if_drowning( const tripoint_bub_ms &at_pos, int chance = 1 );
 
         tripoint_bub_ms scent_move();
-        int calc_movecost( const tripoint_bub_ms &f, const tripoint_bub_ms &t,
-                           bool ignore_fields = false ) const;
+        int calc_movecost( const map &here, const tripoint_bub_ms &f, const tripoint_bub_ms &t ) const;
         int calc_climb_cost( const tripoint_bub_ms &f, const tripoint_bub_ms &t ) const;
 
         bool is_immune_field( const field_type_id &fid ) const override;
@@ -644,6 +644,9 @@ class monster : public Creature
         monster_horde_attraction horde_attraction = MHA_NULL;
         /** Found path. Note: Not used by monsters that don't pathfind! **/
         std::vector<tripoint_bub_ms> path;
+
+        // 10 * 50 means max movecost of 500 with 0 skill
+        static const int max_obstacle_penalty = 10;
 
         // Exponential backoff for stuck monsters. Massively reduces pathfinding CPU.
         time_point pathfinding_cd = calendar::turn;

--- a/src/monster.h
+++ b/src/monster.h
@@ -174,11 +174,17 @@ class monster : public Creature
         bool digging() const override;  // digs() or can_dig() and diggable terrain
         bool can_dig() const;
         bool digs() const;
+
+        /** @returns dig modifier. -1 if unable */
         int get_dig_mod() const;
         bool flies() const;
         bool climbs() const;
+
+        /** @returns climb modifier. -1 if unable */
         int get_climb_mod() const;
         bool swims() const;
+
+        /** @returns swim modifier. -1 if unable */
         int get_swim_mod() const;
         // Returns false if the monster is stunned, has 0 moves or otherwise wouldn't act this turn
         bool can_act() const;

--- a/src/monster.h
+++ b/src/monster.h
@@ -650,7 +650,7 @@ class monster : public Creature
         /** Found path. Note: Not used by monsters that don't pathfind! **/
         std::vector<tripoint_bub_ms> path;
 
-        // 10 * 50 means max movecost of 500 with 0 skill
+        // 10 means max movecost of 500 * terrain-difficulty with 0 skill
         static const int max_obstacle_penalty = 10;
 
         // Exponential backoff for stuck monsters. Massively reduces pathfinding CPU.

--- a/src/monster.h
+++ b/src/monster.h
@@ -173,18 +173,25 @@ class monster : public Creature
         bool digging() const override;  // digs() or can_dig() and diggable terrain
         bool can_dig() const;
         bool digs() const;
-
-        /** @returns dig modifier. -1 if unable */
-        int get_dig_mod() const;
         bool flies() const;
         bool climbs() const;
-
-        /** @returns climb modifier. -1 if unable */
-        int get_climb_mod() const;
         bool swims() const;
 
+        /** @returns dig skill. -1 if unable */
+        int dig_skill() const;
+        /** @returns dig modifier. -1 if unable */
+        int get_dig_mod() const;
+
+        /** @returns climb skill. -1 if unable */
+        int climb_skill() const;
+        /** @returns climb modifier. -1 if unable */
+        int get_climb_mod() const;
+
+        /** @returns swim skill. -1 if unable */
+        int swim_skill() const;
         /** @returns swim modifier. -1 if unable */
         int get_swim_mod() const;
+
         // Returns false if the monster is stunned, has 0 moves or otherwise wouldn't act this turn
         bool can_act() const;
         int sight_range( float light_level ) const override;
@@ -275,8 +282,8 @@ class monster : public Creature
         bool die_if_drowning( const tripoint_bub_ms &at_pos, int chance = 1 );
 
         tripoint_bub_ms scent_move();
-        int calc_movecost( const map &here, const tripoint_bub_ms &f, const tripoint_bub_ms &t ) const;
-        int calc_climb_cost( const tripoint_bub_ms &f, const tripoint_bub_ms &t ) const;
+        int calc_movecost( const map &here, const tripoint_bub_ms &f,
+                           const tripoint_bub_ms &t, const bool force  = false ) const;
 
         bool is_immune_field( const field_type_id &fid ) const override;
         bool check_immunity_data( const field_immunity_data &ft ) const override;

--- a/src/monster.h
+++ b/src/monster.h
@@ -173,9 +173,12 @@ class monster : public Creature
         bool digging() const override;  // digs() or can_dig() and diggable terrain
         bool can_dig() const;
         bool digs() const;
+        int get_dig_mod() const;
         bool flies() const;
         bool climbs() const;
+        int get_climb_mod() const;
         bool swims() const;
+        int get_swim_mod() const;
         // Returns false if the monster is stunned, has 0 moves or otherwise wouldn't act this turn
         bool can_act() const;
         int sight_range( float light_level ) const override;

--- a/src/monster.h
+++ b/src/monster.h
@@ -283,7 +283,7 @@ class monster : public Creature
 
         tripoint_bub_ms scent_move();
         int calc_movecost( const map &here, const tripoint_bub_ms &f,
-                           const tripoint_bub_ms &t, const bool force  = false ) const;
+                           const tripoint_bub_ms &t, bool force  = false ) const;
 
         bool is_immune_field( const field_type_id &fid ) const override;
         bool check_immunity_data( const field_immunity_data &ft ) const override;

--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -5,7 +5,6 @@
 #include <optional>
 #include <set>
 #include <string>
-#include <sys/types.h>
 #include <unordered_set>
 #include <utility>
 

--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -960,9 +960,7 @@ void mtype::load( const JsonObject &jo, const std::string &src )
 
     optional( jo, was_loaded, "petfood", petfood );
 
-    // if its not present, load will insert default values
-    JsonObject jo_move_skills = jo.get_object( "move_skills" );
-    move_skills.load( jo_move_skills );
+    optional( jo, was_loaded, "move_skills", move_skills );
 
     assign( jo, "vision_day", vision_day, strict, 0 );
     assign( jo, "vision_night", vision_night, strict, 0 );

--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -5,6 +5,7 @@
 #include <optional>
 #include <set>
 #include <string>
+#include <sys/types.h>
 #include <unordered_set>
 #include <utility>
 
@@ -959,6 +960,10 @@ void mtype::load( const JsonObject &jo, const std::string &src )
 
     optional( jo, was_loaded, "petfood", petfood );
 
+    // if its not present, load will insert default values
+    JsonObject jo_move_skills = jo.get_object( "move_skills" );
+    move_skills.load( jo_move_skills );
+
     assign( jo, "vision_day", vision_day, strict, 0 );
     assign( jo, "vision_night", vision_night, strict, 0 );
 
@@ -1849,6 +1854,31 @@ void pet_food_data::load( const JsonObject &jo )
 }
 
 void pet_food_data::deserialize( const JsonObject &data )
+{
+    load( data );
+}
+
+void move_skills_data::load( const JsonObject &jo )
+{
+    optional( jo, was_loaded, "climb", climb );
+    optional( jo, was_loaded, "dig", dig );
+    optional( jo, was_loaded, "swim", swim );
+
+    if( climb && ( climb.value() < 0 || climb.value() > 10 ) ) {
+        debugmsg( "climb value out of range. It has to be between 0 and 10" );
+        climb = std::max( std::min( climb.value(), 10 ), 0 );
+    }
+    if( dig && ( dig.value() < 0 || dig.value() > 10 ) ) {
+        debugmsg( "dig value out of range. It has to be between 0 and 10" );
+        dig = std::max( std::min( dig.value(), 10 ), 0 );
+    }
+    if( dig && ( dig.value() < 0 || dig.value() > 10 ) ) {
+        debugmsg( "dig value out of range. It has to be between 0 and 10" );
+        dig = std::max( std::min( dig.value(), 10 ), 0 );
+    }
+}
+
+void move_skills_data::deserialize( const JsonObject &data )
 {
     load( data );
 }

--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -1862,15 +1862,15 @@ void move_skills_data::load( const JsonObject &jo )
     optional( jo, was_loaded, "swim", swim );
 
     if( climb && ( climb.value() < 0 || climb.value() > 10 ) ) {
-        debugmsg( "climb value out of range. It has to be between 0 and 10" );
+        debugmsg( "climb value out of range.  It has to be between 0 and 10" );
         climb = std::max( std::min( climb.value(), 10 ), 0 );
     }
     if( dig && ( dig.value() < 0 || dig.value() > 10 ) ) {
-        debugmsg( "dig value out of range. It has to be between 0 and 10" );
+        debugmsg( "dig value out of range.  It has to be between 0 and 10" );
         dig = std::max( std::min( dig.value(), 10 ), 0 );
     }
     if( dig && ( dig.value() < 0 || dig.value() > 10 ) ) {
-        debugmsg( "dig value out of range. It has to be between 0 and 10" );
+        debugmsg( "dig value out of range.  It has to be between 0 and 10" );
         dig = std::max( std::min( dig.value(), 10 ), 0 );
     }
 }

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <sys/types.h>
 #ifndef CATA_SRC_MTYPE_H
 #define CATA_SRC_MTYPE_H
 
@@ -246,6 +247,17 @@ struct pet_food_data {
     void deserialize( const JsonObject &data );
 };
 
+/** movement data */
+struct move_skills_data {
+    std::optional<int> climb;
+    std::optional<int> dig;
+    std::optional<int> swim;
+
+    bool was_loaded = false;
+    void load( const JsonObject &jo );
+    void deserialize( const JsonObject &data );
+};
+
 enum class mdeath_type {
     NORMAL,
     SPLATTER,
@@ -443,6 +455,8 @@ struct mtype {
 
         int hp = 0;
         int speed = 0;          /** e.g. human = 100 */
+        move_skills_data move_skills;   /** climb, dig, swim; 0-100, defaults to 0 */
+
         int agro = 0;           /** chance will attack [-100,100] */
         int morale = 0;         /** initial morale level at spawn */
         int stomach_size = 0;         /** how many times this monster will eat */

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -1,5 +1,4 @@
 #pragma once
-#include <sys/types.h>
 #ifndef CATA_SRC_MTYPE_H
 #define CATA_SRC_MTYPE_H
 

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -2709,6 +2709,18 @@ std::optional<vpart_reference> vpart_position::obstacle_at_part() const
     return part;
 }
 
+int vpart_position::get_movecost() const
+{
+
+    if( obstacle_at_part() ) {
+        return 0;
+    } else if( part_with_feature( VPFLAG_AISLE, true ) ) {
+        return 2;
+    } else {
+        return 8;
+    }
+}
+
 std::optional<vpart_reference> vpart_position::part_displayed() const
 {
     int part_id = vehicle().part_displayed_at( mount_pos(), true );

--- a/src/vpart_position.h
+++ b/src/vpart_position.h
@@ -57,6 +57,11 @@ class vpart_position
         bool is_inside() const;
 
         /**
+         * @returns Movement difficulty. 0 for impassable.
+         */
+        int get_movecost() const;
+
+        /**
          * Sets the label at this part of the vehicle. Removes the label if @p text is empty.
          */
         void set_label( const std::string &text ) const;

--- a/tests/monster_test.cpp
+++ b/tests/monster_test.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <cmath>
 #include <filesystem>
 #include <fstream>
@@ -467,10 +468,27 @@ TEST_CASE( "monster_special_move", "[speed]" )
             }
         }
         AND_GIVEN( "NOBREATH monster" ) {
+            const std::string &zed = "mon_zombie";
+            const mtype_id zed_id( zed );
+            REQUIRE_FALSE( zed_id->move_skills.swim.has_value() );
+            REQUIRE_FALSE( zed_id->has_flag( mon_flag_SWIMS ) );
+            REQUIRE( zed_id->has_flag( mon_flag_NO_BREATHE ) );
 
+            WHEN( "Moving to swimable tile" ) {
+                moves = moves_to_destination( zed, from, to );
+
+                THEN( "The monster is impacted by terrain-cost" ) {
+                    INFO( "from: " << ter_from->name() << " to " << ter->name() );
+                    const int expected_movecost = ( ter->movecost + ter_from->movecost ) * 25 ;
+                    INFO( "expected: " << expected_movecost ) ;
+                    INFO( "actual: " << moves );
+                    CHECK( moves == expected_movecost );
+                }
+            }
         }
-        moves = 0;
+
         AND_GIVEN( "AQUATIC monster and from ter is swimmable" ) {
+            moves = 0;
             REQUIRE( here.ter_set( from, ter_t_water_dp ) );
             const std::string &swimmer = "mon_fish_brook_trout";
             const mtype_id swimmer_id( swimmer );
@@ -496,8 +514,9 @@ TEST_CASE( "monster_special_move", "[speed]" )
                     CHECK( moves == expected_movecost );
                 }
             }
-            moves = 0;
+
             AND_WHEN( "trying to move onto land" ) {
+                moves = 0;
                 REQUIRE( here.ter_set( to,  ter_t_grass ) );
                 ter = here.ter( to );
                 ter_from = here.ter( from );
@@ -539,8 +558,8 @@ TEST_CASE( "monster_special_move", "[speed]" )
                     CHECK( moves == expected_movecost );
                 }
             }
-            moves = 0;
             AND_WHEN( "trying to move into non-diggable terrain" ) {
+                moves = 0;
                 REQUIRE( here.ter_set( to,  ter_t_water_dp ) );
                 ter = here.ter( to );
                 ter_from = here.ter( from );

--- a/tests/monster_test.cpp
+++ b/tests/monster_test.cpp
@@ -70,6 +70,8 @@ static int moves_to_destination( const std::string &monster_type,
             if( test_monster.pos_bub() == end ) {
                 g->remove_zombie( test_monster );
                 return moves_spent;
+
+                // return early if it doesn't move at all
             } else if( test_monster.pos_bub() == start ) {
                 return 100000;
             }

--- a/tests/monster_test.cpp
+++ b/tests/monster_test.cpp
@@ -38,8 +38,6 @@ class item;
 
 using move_statistics = statistics<int>;
 
-static const furn_str_id furn_f_clear( "f_clear" );
-
 static const mtype_id mon_dog_zombie_brute( "mon_dog_zombie_brute" );
 
 static const ter_str_id ter_t_fence( "t_fence" );

--- a/tests/monster_test.cpp
+++ b/tests/monster_test.cpp
@@ -4,6 +4,7 @@
 #include <functional>
 #include <map>
 #include <memory>
+#include <optional>
 #include <sstream>
 #include <string>
 #include <utility>
@@ -15,7 +16,6 @@
 #include "cata_scope_helpers.h"
 #include "character.h"
 #include "coordinates.h"
-#include "coords_fwd.h"
 #include "creature.h"
 #include "creature_tracker.h"
 #include "game.h"
@@ -27,13 +27,11 @@
 #include "monster.h"
 #include "monstergenerator.h"
 #include "mtype.h"
-#include "omdata.h"
 #include "options.h"
 #include "options_helpers.h"
 #include "point.h"
 #include "test_statistics.h"
 #include "type_id.h"
-#include "widget.h"
 
 class item;
 

--- a/tests/monster_test.cpp
+++ b/tests/monster_test.cpp
@@ -38,12 +38,14 @@ class item;
 
 using move_statistics = statistics<int>;
 
+static const furn_str_id furn_f_clear( "f_clear" );
 
 static const mtype_id mon_dog_zombie_brute( "mon_dog_zombie_brute" );
+
 static const ter_str_id ter_t_fence( "t_fence" );
-static const ter_str_id ter_t_water_dp( "t_water_dp" );
 static const ter_str_id ter_t_grass( "t_grass" );
-static const furn_str_id furn_f_clear( "f_clear" );
+static const ter_str_id ter_t_water_dp( "t_water_dp" );
+
 
 static int moves_to_destination( const std::string &monster_type,
                                  const tripoint_bub_ms &start, const tripoint_bub_ms &end )
@@ -393,7 +395,7 @@ TEST_CASE( "monster_special_move", "[speed]" )
 
         REQUIRE( here.has_flag( ter_furn_flag::TFLAG_CLIMBABLE, to ) );
 
-        int moves = 0;
+        ;
 
         AND_GIVEN( "Non-climbing monster" ) {
             const std::string &non_climber = "mon_pig";
@@ -402,14 +404,14 @@ TEST_CASE( "monster_special_move", "[speed]" )
             REQUIRE( !nclimber_id->has_flag( mon_flag_CLIMBS ) );
 
             WHEN( "Moving to climbable tile" ) {
-                moves = moves_to_destination( non_climber, from, to );
+                const int moves = moves_to_destination( non_climber, from, to );
 
                 THEN( "The monster cannot go there" ) {
                     CHECK( moves == 100000 );
                 }
             }
         }
-        moves = 0;
+        ;
         AND_GIVEN( "Climbing monster" ) {
             const std::string &climber = "mon_test_climb_nobash";
             const mtype_id climber_id( climber );
@@ -424,14 +426,14 @@ TEST_CASE( "monster_special_move", "[speed]" )
             }
 
             AND_WHEN( "Moving to climbable tile" ) {
-                moves = moves_to_destination( climber, from, to );
+                const int moves = moves_to_destination( climber, from, to );
 
                 THEN( "It took the correct amount of moves" ) {
                     const int expected_mod = ter_mod * ( 10 - mon_skill );
                     INFO( "if the expected formula changes, change here too expected_mod = ter_mod * ( 10 - mon_skill )" );
                     INFO( "expected_movecost = ( ( expected_mod * 50 ) + 100 ) / 2" );
                     INFO( "from: " << ter_from->name() << " to " << ter->name() );
-                    const int expected_movecost = ( ( expected_mod + 2 ) * 25 );
+                    const int expected_movecost = ( expected_mod + 2 ) * 25;
                     INFO( "expected: " << expected_movecost ) ;
                     INFO( "actual: " << moves );
                     CHECK( moves == expected_movecost );
@@ -450,7 +452,7 @@ TEST_CASE( "monster_special_move", "[speed]" )
 
         REQUIRE( here.has_flag( ter_furn_flag::TFLAG_SWIMMABLE, to ) );
 
-        int moves = 0;
+        ;
 
         AND_GIVEN( "Non-swimming breathing monster" ) {
             const std::string &non_swimmer = "mon_pig";
@@ -460,7 +462,7 @@ TEST_CASE( "monster_special_move", "[speed]" )
             REQUIRE( !non_swimmer_id->has_flag( mon_flag_AQUATIC ) );
 
             WHEN( "Moving to swimable tile" ) {
-                moves = moves_to_destination( non_swimmer, from, to );
+                const int moves = moves_to_destination( non_swimmer, from, to );
 
                 THEN( "The monster cannot go there" ) {
                     CHECK( moves == 100000 );
@@ -475,7 +477,7 @@ TEST_CASE( "monster_special_move", "[speed]" )
             REQUIRE( zed_id->has_flag( mon_flag_NO_BREATHE ) );
 
             WHEN( "Moving to swimable tile" ) {
-                moves = moves_to_destination( zed, from, to );
+                const int moves = moves_to_destination( zed, from, to );
 
                 THEN( "The monster is impacted by terrain-cost" ) {
                     INFO( "from: " << ter_from->name() << " to " << ter->name() );
@@ -488,7 +490,7 @@ TEST_CASE( "monster_special_move", "[speed]" )
         }
 
         AND_GIVEN( "AQUATIC monster and from ter is swimmable" ) {
-            moves = 0;
+            ;
             REQUIRE( here.ter_set( from, ter_t_water_dp ) );
             const std::string &swimmer = "mon_fish_brook_trout";
             const mtype_id swimmer_id( swimmer );
@@ -503,7 +505,7 @@ TEST_CASE( "monster_special_move", "[speed]" )
             }
 
             AND_WHEN( "Moving to swimable tile" ) {
-                moves = moves_to_destination( swimmer, from, to );
+                const int moves = moves_to_destination( swimmer, from, to );
 
                 THEN( "It took the correct amount of moves" ) {
                     INFO( "SWIMMERS ignore terraincost, resulting in the formular std::max( ( 10 - mon_skill ) * 50, 25 )" );
@@ -516,12 +518,12 @@ TEST_CASE( "monster_special_move", "[speed]" )
             }
 
             AND_WHEN( "trying to move onto land" ) {
-                moves = 0;
+                ;
                 REQUIRE( here.ter_set( to,  ter_t_grass ) );
                 ter = here.ter( to );
                 ter_from = here.ter( from );
                 REQUIRE_FALSE( here.has_flag( ter_furn_flag::TFLAG_SWIMMABLE, to ) );
-                moves = moves_to_destination( swimmer, from, to );
+                const int moves = moves_to_destination( swimmer, from, to );
 
                 THEN( "It cannot move" ) {
                     INFO( "from: " << ter_from->name() << " to " << ter->name() );
@@ -537,7 +539,7 @@ TEST_CASE( "monster_special_move", "[speed]" )
 
         REQUIRE( here.has_flag( ter_furn_flag::TFLAG_DIGGABLE, to ) );
 
-        int moves = 0;
+        ;
         AND_GIVEN( "DIGGING monster and from ter is digmable" ) {
             const std::string &digger = "mon_yugg";
             const mtype_id digger_id( digger );
@@ -547,10 +549,10 @@ TEST_CASE( "monster_special_move", "[speed]" )
                 REQUIRE( digger_id->move_skills.dig.value() == mon_skill );
             }
             AND_WHEN( "Moving to digable tile" ) {
-                moves = moves_to_destination( digger, from, to );
+                const int moves = moves_to_destination( digger, from, to );
 
                 THEN( "It took the correct amount of moves" ) {
-                    INFO( "Diggers, just like swimmers ignore terraincost. movecost = std::max( ( 10 - mon_skill ) * 50, 25 )" );
+                    INFO( "Diggers, just like swimmers ignore terraincost.  movecost = std::max( ( 10 - mon_skill ) * 50, 25 )" );
                     INFO( "from: " << ter_from->name() << " to " << ter->name() );
                     const int expected_movecost =  std::max( ( 10 - mon_skill ) * 50, 25 ) ;
                     INFO( "expected: " << expected_movecost ) ;
@@ -559,12 +561,12 @@ TEST_CASE( "monster_special_move", "[speed]" )
                 }
             }
             AND_WHEN( "trying to move into non-diggable terrain" ) {
-                moves = 0;
+                ;
                 REQUIRE( here.ter_set( to,  ter_t_water_dp ) );
                 ter = here.ter( to );
                 ter_from = here.ter( from );
                 REQUIRE_FALSE( here.has_flag( ter_furn_flag::TFLAG_DIGGABLE, to ) );
-                moves = moves_to_destination( digger, from, to );
+                const int moves = moves_to_destination( digger, from, to );
 
                 THEN( "It cannot move" ) {
                     INFO( "from: " << ter_from->name() << " to " << ter->name() );


### PR DESCRIPTION
#### Summary
Infrastructure "Allow monsters to have different climb/swim/dig speeds"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
closes #80846 , closes #80673

previously monster movement calculation would just return hardcoded values, which ignored many possible modifiers. Not happy with my original fix (#80673), I decided to rework how special movements get calculated, by allowing monsters to have movement-skills in those special movement types.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Make a new optional JSON field for movement skills (every entry is also optional):
```jsonc
...
"move_skills": [ { "climb": 1 }, { "dig": 2 }, { "swim": 3} ],
...
```
those skills range from 0-10 and indicate how much of some max_move_mod (currently 10) gets applied. a skill of 0 means the entire penalty gets applied. For swimming and digging terrain-cost gets ignored and the penalty is the only cost. ( movement always has a minimum of 25 moves ). If both tiles ( source and dest) are affected by the skill the movecost ultimately gets calculated as `movemod * 25` where `movemod = 10-skill` (if the max_move_mod stays as 10).

for climbing, where the furn-/ter-cost should get applied, it gets multiplied by the movemod. 
`movecost = (move_cost_mod*movemod*50;` assuming, again, that both tiles are CLIMBABLE, and both have the same move_cost_mod. Note that move_cost_mod <= 0 means impassable.

Where having some value allows the monster to do the action and the value itself would say how fast it can do the action.
with the general formula
```cpp
movecost = (movemod_from*50+ movemodto *50)/2;
```
or the less readable, but equivilent
```cpp
movecost = (movemod_from + movemod_to)*25;
```




Example:
```jsonc
    "abstract": "mon_fry",
    ...
    "move_skills": { "swim": 1 },
```
```jsonc
    "abstract": "mon_fish_small",
    ...
    "move_skills": { "swim": 9 },
```

![image](https://github.com/user-attachments/assets/75d26c35-e55b-47b1-b87c-e554686c2c78)


Misc. changes:
* only climbers can climb furn with `DIFFICULT_Z`. Previously the flag didn't get checked for by monsters. (boars could climb ladders??)
*  `DIFFICULT_Z` climbing scales with climb-mod
* other modifiers like field effects also apply when stepping out of them
* monsters can ignore the movement penalty from field effects (previously only checked if immune to impassable fields)

#### Describe alternatives you've considered
Instead of multiplying movecost by the skill-mod, add a flat penalty. But intuitively cost should scale more with difficulty.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Automated tests, hours of different monsters chasing me through different terrain
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
when `calc_movecost` encounters an invalid move, something went wron in the pathfinding/perfiltering, therefor show a debugmsg. When thats the case it needs to be filtered out in `monster::will_move_to` (if the obstruction is permantend) or `monster::move_to` (if the obstruction is not permanent) function.

-----
https://github.com/CleverRaven/Cataclysm-DDA/blob/93e97e5837fea1617689e2c848cfdfc1406c5232/src/monmove.cpp#L1888-L1890


calls `monster::calc_climb_cost` when the monster climbs and target tile has no floor, but `calc_climb_cost` then only returns a valid number if the monster flies or there is a floor, so its only useful for fliers:
https://github.com/CleverRaven/Cataclysm-DDA/blob/93e97e5837fea1617689e2c848cfdfc1406c5232/src/monmove.cpp#L1589-L1603

I did not check for burrowing monster. Not sure how they behave.


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
