### PR TITLE
Evac shelter info board

### DIFF
--- a/data/json/furniture_and_terrain/furniture-signs.json
+++ b/data/json/furniture_and_terrain/furniture-signs.json
@@ -70,6 +70,59 @@
   },
   {
     "type": "furniture",
+    "id": "f_bulletin_evac",
+    "name": "evac shelter info board",
+    "looks_like": "f_bulletin",
+    "description": "A wide wooden frame with a sheet of corkboard inside, whih resides a bunch of tacked on papers giving emergency safety informations that's basically useless at this point considering the situation, and among other things, a map pointing to the nearest refugee center.  You should take a closer look. ",
+    "symbol": "6",
+    "color": "blue",
+    "move_cost_mod": -1,
+    "coverage": 75,
+    "required_str": -1,
+    "flags": [ "FLAMMABLE", "ORGANIC", "TRANSPARENT", "FREE_TO_EXAMINE" ],
+    "max_volume": "120 ml",
+    "deconstruct": { "furn_set": "f_bulletin", "items": [ { "item": "paper", "count": 4 } ] },
+    "bash": {
+      "str_min": 3,
+      "str_max": 40,
+      "sound": "crunch!",
+      "sound_fail": "whump.",
+      "items": [
+        { "item": "2x4", "count": [ 0, 3 ] },
+        { "item": "nail", "charges": [ 4, 6 ] },
+        { "item": "splinter", "count": [ 1, 4 ] },
+        { "item": "paper", "count": [ 1, 4 ] }
+      ]
+    },
+    "examine_action": {
+      "type": "effect_on_condition",
+      "effect_on_conditions": [
+        {
+          "id": "EOC_EVAC_BOARD_FALSE",
+          "condition": { "u_has_mission": "MISSION_REACH_REFUGEE_CENTER" },
+          "effect": [
+            {
+              "u_message": "You study the board.  It shows a similar set of directions to the ones you already have.  You cross-reference them and don't learn anything new.",
+              "popup": true
+            }
+          ]
+        },
+        {
+          "id": "EOC_EVAC_BOARD",
+          "condition": { "not": { "u_has_mission": "MISSION_REACH_REFUGEE_CENTER" } },
+          "effect": [
+            {
+              "u_message": "You study the board.  One of the paper shows a map and address for the nearest refugee center among others.  You take note of the map on the board and mark the likely location to your map.",
+              "popup": true
+            },
+            { "assign_mission": "MISSION_REACH_REFUGEE_CENTER" }
+          ]
+        }
+      ]
+    }
+  },  
+  {
+    "type": "furniture",
     "id": "f_sign_stop",
     "name": "stop sign",
     "symbol": "P",

--- a/data/json/furniture_and_terrain/furniture-signs.json
+++ b/data/json/furniture_and_terrain/furniture-signs.json
@@ -73,7 +73,7 @@
     "id": "f_bulletin_evac",
     "name": "evac shelter info board",
     "looks_like": "f_bulletin",
-    "description": "A wide wooden frame with a sheet of corkboard inside, which resides a bunch of tacked on papers giving emergency safety information that's basically useless at this point considering the situation, and among other things, a map pointing to the nearest refugee center.  You should take a closer look. ",
+    "description": "A wide wooden frame with a sheet of corkboard inside, which resides a bunch of tacked on papers giving emergency safety information that's basically useless at this point considering the situation, and among other things, a map pointing to the nearest refugee center.  You should take a closer look.",
     "symbol": "6",
     "color": "blue",
     "move_cost_mod": -1,

--- a/data/json/furniture_and_terrain/furniture-signs.json
+++ b/data/json/furniture_and_terrain/furniture-signs.json
@@ -79,7 +79,7 @@
     "move_cost_mod": -1,
     "coverage": 75,
     "required_str": -1,
-    "flags": [ "FLAMMABLE", "ORGANIC", "TRANSPARENT", "FREE_TO_EXAMINE" ],
+    "flags": [ "FLAMMABLE", "ORGANIC", "TRANSPARENT", "FREE_TO_EXAMINE", "EASY_DECONSTRUCT" ],
     "max_volume": "120 ml",
     "deconstruct": { "furn_set": "f_bulletin", "items": [ { "item": "paper", "count": 4 } ] },
     "bash": {

--- a/data/json/furniture_and_terrain/furniture-signs.json
+++ b/data/json/furniture_and_terrain/furniture-signs.json
@@ -120,7 +120,7 @@
         }
       ]
     }
-  },  
+  },
   {
     "type": "furniture",
     "id": "f_sign_stop",

--- a/data/json/furniture_and_terrain/furniture-signs.json
+++ b/data/json/furniture_and_terrain/furniture-signs.json
@@ -73,7 +73,7 @@
     "id": "f_bulletin_evac",
     "name": "evac shelter info board",
     "looks_like": "f_bulletin",
-    "description": "A wide wooden frame with a sheet of corkboard inside, which resides a bunch of tacked on papers giving emergency safety information that's basically useless at this point considering the situation, and among other things, a map pointing to the nearest refugee center.  You should take a closer look.",
+    "description": "A wide wooden frame surrounding a sheet of cork, on to which a number of full-page notices have been neatly tacked.  Most seem to provide emergency information, or instructions now woefully outdated considering the state of things, but a map pointing to the nearest refugee center catches your eye.  You should take a closer look.",
     "symbol": "6",
     "color": "blue",
     "move_cost_mod": -1,
@@ -112,7 +112,7 @@
           "condition": { "not": { "u_has_mission": "MISSION_REACH_REFUGEE_CENTER" } },
           "effect": [
             {
-              "u_message": "You study the board.  One of the paper shows a map and address for the nearest refugee center among others.  You take note of the map on the board and mark the likely location to your map.",
+              "u_message": "You study the board.  One of the pages has a map and address for a nearby refugee center alongside minutia you no longer need trouble yourself with now that society has collapsed, like 'operating hours' and 'acceptable forms of ID'.  You take careful note of the map on the board and mark down the coordinates.",
               "popup": true
             },
             { "assign_mission": "MISSION_REACH_REFUGEE_CENTER" }

--- a/data/json/furniture_and_terrain/furniture-signs.json
+++ b/data/json/furniture_and_terrain/furniture-signs.json
@@ -73,7 +73,7 @@
     "id": "f_bulletin_evac",
     "name": "evac shelter info board",
     "looks_like": "f_bulletin",
-    "description": "A wide wooden frame with a sheet of corkboard inside, whih resides a bunch of tacked on papers giving emergency safety informations that's basically useless at this point considering the situation, and among other things, a map pointing to the nearest refugee center.  You should take a closer look. ",
+    "description": "A wide wooden frame with a sheet of corkboard inside, which resides a bunch of tacked on papers giving emergency safety information that's basically useless at this point considering the situation, and among other things, a map pointing to the nearest refugee center.  You should take a closer look. ",
     "symbol": "6",
     "color": "blue",
     "move_cost_mod": -1,

--- a/data/json/mapgen_palettes/shelter.json
+++ b/data/json/mapgen_palettes/shelter.json
@@ -21,8 +21,8 @@
       "4": "t_gutter_downspout"
     },
     "furniture": {
-      "6": "f_console",
-      "x": "f_console_broken",
+      "6": "f_bulletin_evac",
+      "x": "f_bulletin_evac",
       "b": "f_bench",
       "c": "f_cupboard",
       "l": "f_locker",
@@ -48,8 +48,7 @@
       "C": { "item": "SUS_evac_shelter_bathroom_counter", "chance": 40 },
       "_": { "item": "shelter_supplies", "chance": 1 },
       "T": { "item": "SUS_toilet", "chance": 50 }
-    },
-    "nested": { "6": { "chunks": [ "shelter_computer" ] } }
+    }
   },
   {
     "type": "palette",
@@ -74,8 +73,8 @@
       "4": "t_gutter_downspout"
     },
     "furniture": {
-      "6": "f_console",
-      "x": "f_console",
+      "6": "f_bulletin_evac",
+      "x": "f_bulletin_evac",
       "b": "f_bench",
       "c": "f_cupboard",
       "l": "f_locker",
@@ -112,9 +111,7 @@
       "|": { "chunks": [ [ "shelter_graffiti", 10 ], [ "null", 90 ] ] },
       "#": { "chunks": [ [ "shelter_graffiti", 10 ], [ "null", 90 ] ] },
       ";": { "chunks": [ [ "shelter_graffiti", 10 ], [ "null", 90 ] ] },
-      "/": { "chunks": [ [ "shelter_graffiti", 10 ], [ "null", 90 ] ] },
-      "6": { "chunks": [ "shelter_computer" ] },
-      "x": { "chunks": [ [ "shelter_computer", 20 ], [ "shelter_computer_broken", 80 ] ] }
+      "/": { "chunks": [ [ "shelter_graffiti", 10 ], [ "null", 90 ] ] }
     }
   },
   {
@@ -139,8 +136,8 @@
       "4": "t_gutter_downspout"
     },
     "furniture": {
-      "6": "f_console",
-      "x": "f_console",
+      "6": "f_bulletin_evac",
+      "x": "f_bulletin_evac",
       "b": "f_bench",
       "c": "f_cupboard",
       "l": [ "f_locker", "f_wreckage" ],
@@ -197,9 +194,7 @@
     "nested": {
       "|": { "chunks": [ [ "shelter_graffiti", 5 ], [ "general_graffiti", 20 ], [ "null", 75 ] ] },
       "#": { "chunks": [ [ "shelter_graffiti", 5 ], [ "general_graffiti", 20 ], [ "null", 75 ] ] },
-      ";": { "chunks": [ [ "shelter_graffiti", 5 ], [ "general_graffiti", 20 ], [ "null", 75 ] ] },
-      "6": { "chunks": [ [ "shelter_computer", 50 ], [ "shelter_computer_broken", 50 ] ] },
-      "x": { "chunks": [ [ "shelter_computer", 20 ], [ "shelter_computer_broken", 80 ] ] }
+      ";": { "chunks": [ [ "shelter_graffiti", 5 ], [ "general_graffiti", 20 ], [ "null", 75 ] ] }
     }
   },
   {
@@ -224,8 +219,8 @@
       "4": "t_gutter_downspout"
     },
     "furniture": {
-      "6": "f_console",
-      "x": "f_console_broken",
+      "6": "f_bulletin_evac",
+      "x": "f_bulletin_evac",
       "b": "f_bench",
       "c": "f_cupboard",
       "l": "f_locker",
@@ -258,7 +253,6 @@
       "C": { "item": "SUS_evac_shelter_bathroom_counter_used", "chance": 20 },
       "_": [ { "item": "shelter_supplies", "chance": 2 }, { "item": "SUS_trash_floor", "chance": 2 } ]
     },
-    "nested": { "6": { "chunks": [ "shelter_computer" ] } },
     "npcs": { "@": { "class": "NPC_evac_shelter_survivor" } }
   },
   {
@@ -332,8 +326,8 @@
       "4": "t_gutter_downspout"
     },
     "furniture": {
-      "6": "f_console",
-      "x": "f_console_broken",
+      "6": "f_bulletin_evac",
+      "x": "f_bulletin_evac",
       "b": "f_bench",
       "c": "f_cupboard",
       "l": "f_locker",
@@ -360,7 +354,6 @@
       "C": { "item": "SUS_evac_shelter_bathroom_counter", "chance": 40 },
       "_": { "item": "shelter_supplies", "chance": 1 }
     },
-    "nested": { "6": { "chunks": [ "shelter_computer" ] } },
     "monster": { "7": { "monster": "mon_feral_human_axe", "chance": 100 }, "8": { "monster": "mon_zombie_runner", "chance": 100 } }
   },
   {


### PR DESCRIPTION


#### Summary
None

#### Purpose of change
The one thing that bugs me about the evac shelter is the fact that it has a seemingly self-powering computer console. Their purpose could've been replaced by a bulletin board with buncha info on them, so im doing that.

#### Describe the solution

Replace the terminal computer in evac shelter to evac shelter info board, which works the same as Exodii's pictographic signpost that leads to their base.

#### Describe alternatives you've considered

Not doing so? 

Make the deconstruct of the board to give a map? Maybe on a different pr.

Give the evac shelter a portable gasoline generator? Also on a different pr.

#### Testing
spawning into an evac shelter, i int(e)ract the sign to see if i get the mission. I received the refugee cenrer mission and the route to it as expected.

Spawned in some more evac shelter variants and saw it having the board.

![Screenshot_20250507_031510](https://github.com/user-attachments/assets/951c9d11-0ac6-4334-83cb-f735a474b219)

![Screenshot_20250507_031526](https://github.com/user-attachments/assets/6c8ac4dc-7f3d-4c91-af46-17741db7cb9b)

![Screenshot_20250507_031628](https://github.com/user-attachments/assets/a1d8a6ce-8f2e-4b85-9859-be8286d2e6a9)



#### Additional context
There's no such thing as infinitely powered terminal computer.



<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
