### PR TITLE
Some recipes have 'hard' proficiency requirements (Bronze edition)

### DIFF
--- a/data/json/recipes/ammo/weldgas.json
+++ b/data/json/recipes/ammo/weldgas.json
@@ -209,7 +209,7 @@
     "tools": [ [ [ "metalworking_tongs_any", 1, "LIST" ] ], [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ], [ [ "forge", 50 ] ] ],
     "proficiencies": [
       { "proficiency": "prof_metalworking" },
-      { "proficiency": "prof_redsmithing" },
+      { "proficiency": "prof_redsmithing", "required": true },
       { "proficiency": "prof_intro_chemistry" }
     ],
     "components": [ [ [ "scrap_bronze", 1 ] ], [ [ "detergent", 7 ] ] ]

--- a/data/json/recipes/armor/arms.json
+++ b/data/json/recipes/armor/arms.json
@@ -797,8 +797,8 @@
     "using": [ [ "forging_standard", 6 ], [ "bronzesmithing_tools", 1 ], [ "strap_small", 4 ], [ "clasps", 4 ] ],
     "proficiencies": [
       { "proficiency": "prof_metalworking" },
-      { "proficiency": "prof_redsmithing" },
-      { "proficiency": "prof_articulation" }
+      { "proficiency": "prof_redsmithing", "required": true },
+      { "proficiency": "prof_articulation", "required": true }
     ],
     "components": [ [ [ "scrap_bronze", 10 ] ] ]
   },

--- a/data/json/recipes/armor/head.json
+++ b/data/json/recipes/armor/head.json
@@ -2611,7 +2611,7 @@
     "book_learn": [ [ "bronze_book", 4 ], [ "textbook_armwest", 5 ] ],
     "using": [ [ "forging_standard", 3 ], [ "bronzesmithing_tools", 1 ] ],
     "components": [ [ [ "scrap_bronze", 7 ] ], [ [ "fur", 4 ], [ "leather", 4 ] ] ],
-    "proficiencies": [ { "proficiency": "prof_armorsmithing" }, { "proficiency": "prof_redsmithing" } ]
+    "proficiencies": [ { "proficiency": "prof_armorsmithing" }, { "proficiency": "prof_redsmithing", "required": true } ]
   },
   {
     "result": "helmet_corinthian_xs",
@@ -2642,7 +2642,7 @@
     "book_learn": [ [ "bronze_book", 4 ], [ "textbook_armwest", 4 ], [ "recipe_melee", 4 ] ],
     "using": [ [ "forging_standard", 3 ], [ "bronzesmithing_tools", 1 ] ],
     "components": [ [ [ "scrap_bronze", 7 ] ], [ [ "fur", 4 ], [ "leather", 4 ] ] ],
-    "proficiencies": [ { "proficiency": "prof_armorsmithing" }, { "proficiency": "prof_redsmithing" } ]
+    "proficiencies": [ { "proficiency": "prof_armorsmithing" }, { "proficiency": "prof_redsmithing", "required": true } ]
   },
   {
     "result": "xs_helmet_bronze",

--- a/data/json/recipes/armor/legs.json
+++ b/data/json/recipes/armor/legs.json
@@ -1623,8 +1623,8 @@
     "using": [ [ "forging_standard", 6 ], [ "bronzesmithing_tools", 1 ], [ "strap_small", 4 ], [ "clasps", 4 ] ],
     "proficiencies": [
       { "proficiency": "prof_metalworking" },
-      { "proficiency": "prof_redsmithing" },
-      { "proficiency": "prof_articulation" }
+      { "proficiency": "prof_redsmithing", "required": true },
+      { "proficiency": "prof_articulation", "required": true }
     ],
     "components": [ [ [ "scrap_bronze", 12 ] ] ]
   },

--- a/data/json/recipes/armor/torso.json
+++ b/data/json/recipes/armor/torso.json
@@ -3050,7 +3050,7 @@
     "book_learn": [ [ "bronze_book", 5 ], [ "textbook_armwest", 8 ] ],
     "using": [ [ "forging_standard", 14 ], [ "bronzesmithing_tools", 1 ] ],
     "components": [ [ [ "scrap_bronze", 28 ] ] ],
-    "proficiencies": [ { "proficiency": "prof_armorsmithing" }, { "proficiency": "prof_redsmithing" } ]
+    "proficiencies": [ { "proficiency": "prof_armorsmithing" }, { "proficiency": "prof_redsmithing", "required": true } ]
   },
   {
     "result": "xs_armor_cuirass",
@@ -3081,7 +3081,7 @@
     "book_learn": [ [ "bronze_book", 4 ], [ "textbook_armwest", 4 ], [ "recipe_melee", 4 ] ],
     "using": [ [ "forging_standard", 12 ], [ "bronzesmithing_tools", 1 ] ],
     "components": [ [ [ "scrap_bronze", 22 ] ] ],
-    "proficiencies": [ { "proficiency": "prof_armorsmithing" }, { "proficiency": "prof_redsmithing" } ]
+    "proficiencies": [ { "proficiency": "prof_armorsmithing" }, { "proficiency": "prof_redsmithing", "required": true } ]
   },
   {
     "result": "xs_cuirass_bronze",

--- a/data/json/recipes/recipe_others.json
+++ b/data/json/recipes/recipe_others.json
@@ -2940,7 +2940,7 @@
     "autolearn": true,
     "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "CHISEL", "level": 3 }, { "id": "GRIND", "level": 2 } ],
     "tools": [ [ [ "angle_grinder", 220 ] ], [ [ "drill_press_tool", 20 ] ] ],
-    "proficiencies": [ { "proficiency": "prof_metalworking" }, { "proficiency": "prof_blacksmithing" } ],
+    "proficiencies": [ { "proficiency": "prof_metalworking", "required": true }, { "proficiency": "prof_blacksmithing" } ],
     "components": [ [ [ "railroad_track_item_half", 1 ] ] ],
     "byproducts": [ [ "mc_steel_lump", 15 ] ]
   },
@@ -2956,7 +2956,7 @@
     "autolearn": true,
     "using": [ [ "forging_standard", 45 ] ],
     "qualities": [ { "id": "HAMMER", "level": 1 }, { "id": "DIG", "level": 2 } ],
-    "proficiencies": [ { "proficiency": "prof_metalworking" }, { "proficiency": "prof_redsmithing" } ],
+    "proficiencies": [ { "proficiency": "prof_metalworking", "required": true }, { "proficiency": "prof_redsmithing", "required": true } ],
     "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
     "components": [ [ [ "scrap_bronze", 90 ] ] ]
   },

--- a/data/json/recipes/tools/tool.json
+++ b/data/json/recipes/tools/tool.json
@@ -287,7 +287,11 @@
     "difficulty": 4,
     "time": "3 h",
     "autolearn": true,
-    "proficiencies": [ { "proficiency": "prof_metalworking" }, { "proficiency": "prof_redsmithing" }, { "proficiency": "prof_bladesmith" } ],
+    "proficiencies": [
+      { "proficiency": "prof_metalworking", "required": true },
+      { "proficiency": "prof_redsmithing", "required": true },
+      { "proficiency": "prof_bladesmith" }
+    ],
     "using": [ [ "forging_standard", 2 ], [ "bronzesmithing_tools", 1 ] ],
     "qualities": [ { "id": "GRIND", "level": 2 } ],
     "tools": [ [ [ "casting_mold", -1 ] ] ],

--- a/data/json/recipes/tools/tools_hand.json
+++ b/data/json/recipes/tools/tools_hand.json
@@ -101,9 +101,9 @@
     "autolearn": true,
     "using": [ [ "blacksmithing_standard", 1 ], [ "steel_chunk_any", 1 ] ],
     "proficiencies": [
-      { "proficiency": "prof_metalworking" },
-      { "proficiency": "prof_blacksmithing" },
-      { "proficiency": "prof_toolsmithing" }
+      { "proficiency": "prof_metalworking", "required": true },
+      { "proficiency": "prof_blacksmithing", "required": true },
+      { "proficiency": "prof_toolsmithing", "required": true }
     ]
   },
   {
@@ -118,9 +118,9 @@
     "autolearn": true,
     "using": [ [ "blacksmithing_standard", 3 ], [ "bronze_tiny", 3 ] ],
     "proficiencies": [
-      { "proficiency": "prof_metalworking" },
-      { "proficiency": "prof_redsmithing" },
-      { "proficiency": "prof_toolsmithing" }
+      { "proficiency": "prof_metalworking", "required": true },
+      { "proficiency": "prof_redsmithing", "required": true },
+      { "proficiency": "prof_toolsmithing", "required": true }
     ],
     "components": [ [ [ "nail", 1 ], [ "bronze_nail", 1 ], [ "nuts_bolts", 1 ] ] ]
   },
@@ -135,7 +135,7 @@
     "difficulty": 3,
     "time": "125 m",
     "autolearn": true,
-    "proficiencies": [ { "proficiency": "prof_metalworking" }, { "proficiency": "prof_toolsmithing" } ],
+    "proficiencies": [ { "proficiency": "prof_metalworking", "required": true }, { "proficiency": "prof_toolsmithing", "required": true } ],
     "using": [ [ "forging_standard", 3 ], [ "bronze_tiny", 3 ] ],
     "qualities": [ { "id": "ANVIL", "level": 3 }, { "id": "HAMMER", "level": 3 }, { "id": "GRIND", "level": 2 } ],
     "tools": [ [ [ "casting_mold_large", -1 ], [ "casting_mold_long", -1 ] ] ],
@@ -384,7 +384,7 @@
     "using": [ [ "forging_standard", 8 ], [ "bronzesmithing_tools", 1 ] ],
     "proficiencies": [
       { "proficiency": "prof_metalworking" },
-      { "proficiency": "prof_redsmithing" },
+      { "proficiency": "prof_redsmithing", "required": true },
       { "proficiency": "prof_toolsmithing" }
     ],
     "tools": [ [ [ "casting_mold", -1 ] ] ],
@@ -405,7 +405,7 @@
     "using": [ [ "forging_standard", 8 ], [ "bronzesmithing_tools", 1 ] ],
     "proficiencies": [
       { "proficiency": "prof_metalworking" },
-      { "proficiency": "prof_redsmithing" },
+      { "proficiency": "prof_redsmithing", "required": true },
       { "proficiency": "prof_toolsmithing" }
     ],
     "tools": [ [ [ "casting_mold", -1 ] ] ],

--- a/data/json/recipes/weapon/bashing.json
+++ b/data/json/recipes/weapon/bashing.json
@@ -925,7 +925,7 @@
     "skills_required": [ "bashing", 1 ],
     "proficiencies": [
       { "proficiency": "prof_metalworking" },
-      { "proficiency": "prof_redsmithing" },
+      { "proficiency": "prof_redsmithing", "required": true },
       { "proficiency": "prof_toolsmithing" }
     ],
     "difficulty": 3,

--- a/data/json/recipes/weapon/cutting.json
+++ b/data/json/recipes/weapon/cutting.json
@@ -174,7 +174,11 @@
     "difficulty": 7,
     "time": "3 h",
     "book_learn": [ [ "bronze_book", 4 ], [ "bronze_mag", 5 ], [ "textbook_weapwest", 5 ] ],
-    "proficiencies": [ { "proficiency": "prof_metalworking" }, { "proficiency": "prof_redsmithing" } ],
+    "proficiencies": [
+      { "proficiency": "prof_metalworking" },
+      { "proficiency": "prof_redsmithing", "required": true },
+      { "proficiency": "prof_bladesmith", "required": true }
+    ],
     "using": [ [ "forging_standard", 2 ], [ "bronzesmithing_tools", 1 ] ],
     "tools": [ [ [ "casting_mold", -1 ] ] ],
     "components": [


### PR DESCRIPTION
#### Summary
Balance "Some recipes have 'hard' proficiency requirements"

#### Purpose of change

My intention here is twofold

1) Apply the "required" field for recipe proficiencies to appropriate recipes. This field is otherwise is unused in vanilla, which always struck me as odd. All of these require you to have **a specific idea of what you are doing**, that is you must be *proficient* in a related proficiency before you can even begin to start working on these recipes. Simply knowing fabrication isn't enough, nor is having a mitigating book enough, you must actually be proficient. You cannot craft a hinged tool if you do not know the first thing about crafting tools or working with the metal it's made out of. What you'll get is two lumps which don't fit together and a hinge-like object which doesn't work as a hinge. It just doesn't work. So the game should stop you from trying in the first place.

2) Make it a less attractive option to re-create thousands of years of smithing knowledge from first principles by spending a few weeks endlessly crafting

#### Describe the solution

Changed the following recipes. I basically went down the list for redsmithing at the moment, might do more later.

Bell cuirass (Redsmithing required) - very complex shape and fitting requirements
Bronze cuirass (Redsmithing required) - very complex shape and fitting requirements
Brazing Rod (Redsmithing required) - very complex to shape *with just a hammer and saw*
Bronze anvil (Metalworking+Redsmithing required) - Good luck making this without knowing what you're doing.
Small Anvil (Metalworking required) - Good luck making this without knowing what you're doing.
All tongs recipes (All existing proficiencies made required) - It's a hinged tool.
Bronze nail puller (Redsmithing required) - Complex shape
Bronze helmets (Redsmithing required) - very complex shape and fitting requirements
Bronze shears (Metalworking + redsmithing required) - It's a hinged tool.
Bronze wood saw (Redsmithing required) - Complex shape. A thin flange of material that must have teeth!
Corinthian helmet (Redsmithing required) - very complex shape and fitting requirements
Khopesh (Redsmithing required + **ADDED BLADESMITHING** ) - Curved sword lol. Good luck making this without knowing what you're doing.
Brass Knuckles (Redsmithing required) - very complex shape and fitting requirements. Honestly this one should maybe have toolsmithing be the hard requirement instead?
Bronze Greaves (Redsmithing required + Joint Articulation required) - very complex shape and fitting requirements
Bronze Vambraces (Redsmithing required + Joint Articulation required) - very complex shape and fitting requirements

Note that there are still redsmithing recipes which don't have redsmithing as a *hard* requirement, including the humble chunk of bronze itself.

#### Describe alternatives you've considered
We could allow the recipe to proceed but have a character without the proficiencies only produce useless scrap. This would be more plausible, but also more "unfun". Also it would require new code to both do this and communicate to the player. It's an overly complex solution which isn't better.

Massive, massive increases to failure chances for unlearned proficiencies?

#### Testing
Game loads, recipes have hard requirements

#### Additional context
