### PR TITLE
converts military ammo can to +P 

### DIFF
--- a/data/json/itemgroups/Weapons_Mods_Ammo/arsenal/ammo_9mm.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/arsenal/ammo_9mm.json
@@ -2,12 +2,12 @@
   {
     "id": "ammo_can_9mm_any_full",
     "type": "item_group",
-    "items": [ { "group": "ammo_can_9mm_full", "prob": 50 }, { "group": "ammo_can_9mmP_full", "prob": 100 } ]
+    "items": [ { "group": "ammo_can_9mm_full", "prob": 100 }, { "group": "ammo_can_9mmP_full", "prob": 100 } ]
   },
   {
     "id": "ammo_can_9mm_any_part",
     "type": "item_group",
-    "items": [ { "group": "ammo_can_9mm_part", "prob": 50 }, { "group": "ammo_can_9mmP_part", "prob": 100 } ]
+    "items": [ { "group": "ammo_can_9mm_part", "prob": 100 }, { "group": "ammo_can_9mmP_part", "prob": 100 } ]
   },
   {
     "//": "---------------------------------------------------",

--- a/data/json/itemgroups/Weapons_Mods_Ammo/arsenal/ammo_9mm.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/arsenal/ammo_9mm.json
@@ -2,31 +2,31 @@
   {
     "id": "ammo_can_9mm_any_full",
     "type": "item_group",
-    "items": [ { "group": "ammo_can_9mm_full", "prob": 100 }, { "group": "ammo_can_9mmfmj_full", "prob": 100 } ]
+    "items": [ { "group": "ammo_can_9mm_full", "prob": 50 }, { "group": "ammo_can_9mmP_full", "prob": 100 } ]
   },
   {
     "id": "ammo_can_9mm_any_part",
     "type": "item_group",
-    "items": [ { "group": "ammo_can_9mm_part", "prob": 100 }, { "group": "ammo_can_9mmfmj_part", "prob": 100 } ]
+    "items": [ { "group": "ammo_can_9mm_part", "prob": 50 }, { "group": "ammo_can_9mmP_part", "prob": 100 } ]
   },
   {
     "//": "---------------------------------------------------",
     "type": "item_group",
-    "id": "ammo_can_9mmfmj_full",
-    "container-item": { "item": "ammunition_can_30", "variant": "ammunition_can_30_9mm_fmj_1000" },
-    "items": [ { "group": "ammo_box_9mmfmj", "count": 10 } ]
+    "id": "ammo_can_9mmP_full",
+    "container-item": { "item": "ammunition_can_30", "variant": "ammunition_can_30_9mm_P_1000" },
+    "items": [ { "group": "ammo_box_9mmP", "count": 20 } ]
   },
   {
     "type": "item_group",
-    "id": "ammo_can_9mmfmj_part",
+    "id": "ammo_can_9mmP_part",
     "container-item": { "item": "ammunition_can_30", "variant": "ammunition_can_30_9mm_fmj_1000" },
-    "items": [ { "group": "ammo_box_9mmfmj", "count": [ 0, 5 ] } ]
+    "items": [ { "group": "ammo_box_9mmP", "count": [ 0, 10 ] } ]
   },
   {
     "type": "item_group",
-    "id": "ammo_box_9mmfmj",
-    "container-item": { "item": "9mm_ammo_box_100", "variant": "ammo_box_army_100_9mm_fmj" },
-    "items": [ { "item": "9mmfmj", "charges": 100 } ]
+    "id": "ammo_box_9mmP",
+    "container-item": { "item": "9mm_ammo_box_50", "variant": "ammo_box_army_50_9mm_P" },
+    "items": [ { "item": "9mmP", "charges": 50 } ]
   },
   {
     "//": "---------------------------------------------------",
@@ -45,6 +45,6 @@
     "type": "item_group",
     "id": "ammo_box_9mm",
     "container-item": { "item": "9mm_ammo_box_100", "variant": "ammo_box_army_100_9mm_jhp" },
-    "items": [ { "item": "9mm", "charges": 100 } ]
+    "items": [ { "item": "9mm", "charges": 50 } ]
   }
 ]

--- a/data/json/items/containers/ammo_boxes.json
+++ b/data/json/items/containers/ammo_boxes.json
@@ -37,7 +37,6 @@
         "id": "ammo_box_army_50_9mm_P",
         "name": { "str": "9mm ammo box", "str_pl": "9mm ammo boxes" },
         "description": "A small, plain brown ammo box.  Black text printed on the front says \"\n50 CARTRIDGES\n9MM BALL\nM1152\""
-        
       }
     ]
   },

--- a/data/json/items/containers/ammo_boxes.json
+++ b/data/json/items/containers/ammo_boxes.json
@@ -30,7 +30,16 @@
     "description": "This box holds 50 rounds of 9mm ammo.  It's made of a thin cardboard plastered with text about the ammo, and the manufacturer's logo.",
     "weight": "15 g",
     "volume": "160 ml",
-    "pocket_data": [ { "pocket_type": "CONTAINER", "max_contains_volume": "115 ml", "max_contains_weight": "600 g", "rigid": true } ]
+    "pocket_data": [ { "pocket_type": "CONTAINER", "max_contains_volume": "115 ml", "max_contains_weight": "600 g", "rigid": true } ],
+    "variant_type": "generic",
+    "variants": [
+      {
+        "id": "ammo_box_army_50_9mm_P",
+        "name": { "str": "9mm ammo box", "str_pl": "9mm ammo boxes" },
+        "description": "A small, plain brown ammo box.  Black text printed on the front says \"\n50 CARTRIDGES\n9MM BALL\nM1152\""
+        
+      }
+    ]
   },
   {
     "id": "9mm_ammo_box_100",

--- a/data/json/items/containers/military.json
+++ b/data/json/items/containers/military.json
@@ -39,6 +39,12 @@
         "description": "A solid metal ammo box with a small handle on top.  Front side has printed:\n<color_yellow>1305-01-172-9558 A363\n1000 CRTG 9 MM\nBALL M882</color>"
       },
       {
+        "id": "ammunition_can_30_9mm_P_1000",
+        "name": { "str": "1000 9x19mm FMJ ammo can" },
+        "weight": 0,
+        "description": "A solid metal ammo box with a small handle on top.  Front side has printed:\n<color_yellow>1305-01-663-9409\n1000 CRTG 9 MM\nBALL M1152</color>"
+      },
+      {
         "id": "ammunition_can_30_9mm_jhp_1000",
         "name": { "str": "1000 9x19mm JHP ammo can" },
         "weight": 0,


### PR DESCRIPTION

#### Summary
content "military 9mm +P"

#### Purpose of change
US military issued 9mm is +P, its a little strange that the FMJ found in military locations is not +p
#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

NA, potentially keep the older 9mm loads around as a box name variant, despite them also being +P.

#### Testing

confirmed item group spawns +p, confirmed item group still spawns.

#### Additional context

forum post displaying m1152 packaging.

https://www.usmilitariaforum.com/forums/index.php?/topic/394084-does-anyone-know-what-9mm-ammo-the-us-military-uses/

source on NSN used

https://www.iso-group.com/NSN/1305-01-663-9409

source for it being +P

https://www.ammunitiontogo.com/lodge/m1152-ammunition/#:~:text=The%20M1152%20cartridge%20has%20a,capable%20of%20handling%20these%20pressures.

todo: change other military spawns to also be +P, including soldier zombies.