### PR TITLE
military 9mm spawning distribution

### DIFF
--- a/data/json/itemgroups/Weapons_Mods_Ammo/arsenal/ammo_9mm.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/arsenal/ammo_9mm.json
@@ -2,12 +2,12 @@
   {
     "id": "ammo_can_9mm_any_full",
     "type": "item_group",
-    "items": [ { "group": "ammo_can_9mm_full", "prob": 100 }, { "group": "ammo_can_9mmP_full", "prob": 100 } ]
+    "items": [ { "group": "ammo_can_9mm_full", "prob": 40 }, { "group": "ammo_can_9mmP_full", "prob": 100 } ]
   },
   {
     "id": "ammo_can_9mm_any_part",
     "type": "item_group",
-    "items": [ { "group": "ammo_can_9mm_part", "prob": 100 }, { "group": "ammo_can_9mmP_part", "prob": 100 } ]
+    "items": [ { "group": "ammo_can_9mm_part", "prob": 50 }, { "group": "ammo_can_9mmP_part", "prob": 100 } ]
   },
   {
     "//": "---------------------------------------------------",


### PR DESCRIPTION

#### Summary
balance "special purpose 9mm should be less common"

#### Purpose of change

during my research for #80861 it came to my attention that the JHP that the military uses is defined as "special purpose", it should spawn less often than normal ammo.

#### Describe the solution

probability change, in "used" boxes the JHP is more common, assuming people would grab for the normal ammo first.

#### Describe alternatives you've considered

i should probably find a source for the specific ratios, but i would assume it to be even more extreme than this. subsonic 9mm has a pretty specific use case.

#### Testing

nothing broke.

#### Additional context

NA
