### PR TITLE
Prevent mechanical_damage fault from being applied when repairing item

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -9427,7 +9427,9 @@ bool item::mod_damage( int qty )
         }
 
         // TODO: think about better way to telling the game what faults should be applied when
-        set_random_fault_of_type( "mechanical_damage" );
+        if( qty > 0 ) {
+            set_random_fault_of_type( "mechanical_damage" );
+        }
 
         return destroy;
     }


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
in #80684, the code applies the fault when item get damaged, and repaired when you fix the fault
apparently "repairing" part is just damaging with negative sign, which means fixing the fault runs the code for damaging and applies another fault
#### Describe the solution
Add check, so if input damage is negative quantity (ie repairing), it does not apply fault