### PR TITLE
Prisoner uniform audit

### DIFF
--- a/data/json/itemgroups/Clothing_Gear/costumes.json
+++ b/data/json/itemgroups/Clothing_Gear/costumes.json
@@ -326,8 +326,7 @@
       { "item": "postman_shirt", "prob": 10 },
       { "item": "tshirt", "variant": "flag_shirt" },
       { "item": "dress_shirt", "prob": 10 },
-      { "item": "longshirt", "prob": 10 },
-      { "item": "striped_shirt", "prob": 15 }
+      { "item": "longshirt", "prob": 10 }
     ]
   },
   {
@@ -352,7 +351,8 @@
       { "item": "dinosuit", "prob": 10 },
       { "item": "sharksuit", "prob": 10 },
       { "item": "beekeeping_suit", "prob": 5 },
-      { "item": "zentai", "prob": 5 }
+      { "item": "zentai", "prob": 5 },
+      { "item": "jumpsuit_pocketless", "variant": "orange" }
     ]
   },
   {

--- a/data/json/itemgroups/Locations_MapExtras/locations.json
+++ b/data/json/itemgroups/Locations_MapExtras/locations.json
@@ -269,13 +269,7 @@
     "id": "prison_textile",
     "type": "item_group",
     "subtype": "collection",
-    "entries": [
-      { "item": "blanket", "prob": 25 },
-      { "item": "striped_shirt", "prob": 35 },
-      { "item": "striped_shirt", "prob": 35 },
-      { "item": "striped_pants", "prob": 35 },
-      { "item": "striped_pants", "prob": 35 }
-    ]
+    "entries": [ { "item": "blanket", "prob": 25 }, { "item": "jumpsuit_pocketless", "variant": "orange", "prob": 70 } ]
   },
   {
     "id": "boxing_misc",

--- a/data/json/itemgroups/Locations_MapExtras/prison_item_groups.json
+++ b/data/json/itemgroups/Locations_MapExtras/prison_item_groups.json
@@ -37,7 +37,7 @@
   {
     "id": "prison_jumpsuit",
     "type": "item_group",
-    "items": [ { "item": "jumpsuit", "prob": 75, "damage": [ 1, 4 ] } ]
+    "items": [ { "item": "jumpsuit_pocketless", "variant": "orange", "prob": 75, "damage": [ 1, 4 ] } ]
   },
   {
     "type": "item_group",
@@ -57,8 +57,7 @@
         "distribution": [
           {
             "collection": [
-              { "item": "striped_shirt", "damage": [ 1, 4 ] },
-              { "item": "striped_pants", "damage": [ 1, 4 ] },
+              { "item": "jumpsuit_pocketless", "variant": "orange", "damage": [ 1, 4 ] },
               { "group": "clothing_prisoner_shoes", "damage": [ 1, 4 ], "prob": 20 },
               { "item": "bandana", "damage": [ 1, 4 ] }
             ]

--- a/data/json/itemgroups/military.json
+++ b/data/json/itemgroups/military.json
@@ -577,7 +577,7 @@
     "id": "army_personal_locker",
     "subtype": "distribution",
     "entries": [
-      { "item": "jumpsuit", "prob": 40 },
+      { "item": "jumpsuit", "variant": "green", "prob": 40 },
       { "item": "officer_uniform", "prob": 20 },
       { "item": "flight_helmet", "prob": 5, "charges": [ 0, 100 ] },
       { "item": "mil_flight_suit", "prob": 30 },
@@ -737,7 +737,7 @@
       { "item": "tank_top", "variant": "tank_top_camo", "prob": 30 },
       { "item": "boots_combat", "prob": 10 },
       { "item": "gloves_tactical", "prob": 10 },
-      { "item": "jumpsuit", "prob": 20 },
+      { "item": "jumpsuit", "variant": "green", "prob": 20 },
       { "item": "kevlar", "prob": 10 },
       { "item": "officer_uniform", "prob": 5 },
       { "item": "combo_cover", "prob": 5 },

--- a/data/json/items/armor/suits_clothes.json
+++ b/data/json/items/armor/suits_clothes.json
@@ -416,7 +416,7 @@
     "price_postapoc": "50 cent",
     "material": [ "cotton" ],
     "symbol": "[",
-    "looks_like": "touring_suit",
+    "looks_like": "jumpsuit",
     "armor": [
       { "covers": [ "torso" ], "coverage": 95, "encumbrance": [ 1, 2 ] },
       { "covers": [ "arm_l", "arm_r" ], "coverage": 50, "encumbrance": [ 1, 1 ] },

--- a/data/json/items/armor/suits_clothes.json
+++ b/data/json/items/armor/suits_clothes.json
@@ -405,11 +405,11 @@
     "flags": [ "VARSIZE", "POCKETS", "HOOD" ]
   },
   {
-    "id": "jumpsuit",
+    "id": "jumpsuit_pocketless",
     "type": "ITEM",
     "subtypes": [ "ARMOR" ],
-    "name": { "str": "jumpsuit" },
-    "description": "A thin, short-sleeved jumpsuit similar to those worn by prisoners.  Provides decent storage and is not very encumbering.",
+    "name": { "str": "pocketless jumpsuit" },
+    "description": "A thin, short-sleeved jumpsuit without pockets, similar to those worn by prisoners.  Not very encumbering.",
     "weight": "610 g",
     "volume": "3500 ml",
     "price": "89 USD",
@@ -417,12 +417,39 @@
     "material": [ "cotton" ],
     "symbol": "[",
     "looks_like": "touring_suit",
-    "color": "yellow",
     "armor": [
       { "covers": [ "torso" ], "coverage": 95, "encumbrance": [ 1, 2 ] },
       { "covers": [ "arm_l", "arm_r" ], "coverage": 50, "encumbrance": [ 1, 1 ] },
       { "covers": [ "leg_l", "leg_r" ], "coverage": 80, "encumbrance": [ 1, 2 ] }
     ],
+    "warmth": 15,
+    "material_thickness": 0.2,
+    "flags": [ "VARSIZE" ],
+    "variant_type": "generic",
+    "variants": [
+      {
+        "id": "white",
+        "name": { "str": "white jumpsuit" },
+        "append": true,
+        "description": "This one is white.",
+        "color": "white"
+      },
+      {
+        "id": "orange",
+        "name": { "str": "orange jumpsuit" },
+        "append": true,
+        "description": "This one is orange.",
+        "color": "yellow"
+      }
+    ]
+  },
+  {
+    "copy-from": "jumpsuit_pocketless",
+    "id": "jumpsuit",
+    "type": "ITEM",
+    "subtypes": [ "ARMOR" ],
+    "name": { "str": "jumpsuit" },
+    "description": "A thin, short-sleeved jumpsuit similar to those worn by prisoners.  Provides decent storage and is not very encumbering.",
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
@@ -453,9 +480,24 @@
         "moves": 100
       }
     ],
-    "warmth": 15,
-    "material_thickness": 0.2,
-    "flags": [ "VARSIZE", "POCKETS" ]
+    "extend": { "flags": [ "POCKETS" ] },
+    "variant_type": "generic",
+    "variants": [
+      {
+        "id": "white",
+        "name": { "str": "white jumpsuit" },
+        "append": true,
+        "description": "This one is white.",
+        "color": "white"
+      },
+      {
+        "id": "green",
+        "name": { "str": "green jumpsuit" },
+        "append": true,
+        "description": "This one is green.",
+        "color": "green"
+      }
+    ]
   },
   {
     "id": "jumpsuit_xl",

--- a/data/json/monsterdrops/mutant_experimental.json
+++ b/data/json/monsterdrops/mutant_experimental.json
@@ -32,7 +32,7 @@
           { "group": "lab_files_biology", "prob": 5 }
         ]
       },
-      { "item": "jumpsuit" }
+      { "item": "jumpsuit_pocketless", "variant": "orange" }
     ]
   }
 ]

--- a/data/json/monsterdrops/zombie_prisoner.json
+++ b/data/json/monsterdrops/zombie_prisoner.json
@@ -4,8 +4,7 @@
     "subtype": "collection",
     "id": "mon_zombie_prisoner_death_drops",
     "entries": [
-      { "item": "striped_shirt", "damage": [ 1, 4 ] },
-      { "item": "striped_pants", "damage": [ 1, 4 ] },
+      { "item": "jumpsuit_pocketless", "variant": "orange", "damage": [ 1, 4 ] },
       { "item": "bandana", "damage": [ 1, 4 ], "prob": 5 },
       { "group": "clothing_glasses", "prob": 10 },
       { "group": "underwear", "damage": [ 1, 4 ] },

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -4566,7 +4566,7 @@
     "npc_background": "BG_survival_story_PRISONER",
     "points": -1,
     "items": {
-      "both": [ "striped_shirt", "striped_pants", "sneakers", "socks" ],
+      "both": { "items": [ "sneakers", "socks", { "item": "jumpsuit_pocketless", "variant": "orange" } ] },
       "male": { "entries": [ { "item": "briefs" } ] },
       "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
@@ -4586,7 +4586,7 @@
       { "level": 2, "name": "traps" }
     ],
     "items": {
-      "both": [ "striped_shirt", "striped_pants", "sneakers", "socks", "glass_shiv" ],
+      "both": { "items": [ "sneakers", "socks", "glass_shiv", { "item": "jumpsuit_pocketless", "variant": "orange" } ] },
       "male": { "entries": [ { "item": "briefs" } ] },
       "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     },
@@ -4603,7 +4603,7 @@
     "skills": [ { "level": 3, "name": "melee" }, { "level": 3, "name": "stabbing" }, { "level": 2, "name": "unarmed" } ],
     "traits": [ "KILLER" ],
     "items": {
-      "both": [ "striped_shirt", "striped_pants", "sneakers", "socks", "glass_shiv" ],
+      "both": { "items": [ "sneakers", "socks", "glass_shiv", { "item": "jumpsuit_pocketless", "variant": "orange" } ] },
       "male": { "entries": [ { "item": "briefs" } ] },
       "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
@@ -4633,8 +4633,7 @@
     "items": {
       "both": {
         "entries": [
-          { "item": "striped_shirt" },
-          { "item": "striped_pants" },
+          { "item": "jumpsuit_pocketless", "variant": "orange" },
           { "item": "sneakers" },
           { "item": "socks" },
           { "item": "knife_rm42", "container-item": "gartersheath1" },
@@ -4655,7 +4654,7 @@
     "points": 0,
     "skills": [ { "level": 4, "name": "speech" }, { "level": 3, "name": "computer" } ],
     "items": {
-      "both": [ "striped_shirt", "striped_pants", "sneakers", "socks", "rock_sock" ],
+      "both": { "items": [ "sneakers", "socks", "rock_sock", { "item": "jumpsuit_pocketless", "variant": "orange" } ] },
       "male": { "entries": [ { "item": "briefs" } ] },
       "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     },
@@ -4672,8 +4671,7 @@
     "items": {
       "both": {
         "entries": [
-          { "item": "striped_shirt" },
-          { "item": "striped_pants" },
+          { "item": "jumpsuit_pocketless", "variant": "orange" },
           { "item": "sneakers" },
           { "item": "socks" },
           { "item": "adderall" },
@@ -4697,7 +4695,7 @@
     "items": {
       "both": {
         "entries": [
-          { "item": "striped_shirt" },
+          { "item": "jumpsuit_pocketless", "variant": "orange" },
           { "item": "striped_pants" },
           { "item": "sneakers" },
           { "item": "socks" },
@@ -4721,7 +4719,7 @@
     "traits": [ "ANIMALEMPATH" ],
     "pets": [ { "name": "mon_black_rat", "amount": 13 } ],
     "items": {
-      "both": [ "striped_shirt", "striped_pants", "sneakers", "socks", "fried_seeds" ],
+      "both": { "items": [ "sneakers", "socks", "fried_seeds", { "item": "jumpsuit_pocketless", "variant": "orange" } ] },
       "male": { "entries": [ { "item": "briefs" } ] },
       "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     },

--- a/data/mods/Magiclysm/professions.json
+++ b/data/mods/Magiclysm/professions.json
@@ -1003,8 +1003,7 @@
     "items": {
       "both": {
         "entries": [
-          { "item": "striped_shirt" },
-          { "item": "striped_pants" },
+          { "item": "jumpsuit_pocketless", "variant": "orange" },
           { "item": "sneakers" },
           { "item": "socks" },
           { "item": "sugar" }

--- a/tools/spell_checker/dictionary.txt
+++ b/tools/spell_checker/dictionary.txt
@@ -4788,6 +4788,7 @@ Plympton
 PM
 pm
 PMC
+pocketless
 podling
 podlings
 pokeball


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "Prisoner uniform audit"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Our prisoner uniforms are black and white striped shirts and pants 1920s style instead of actual modern orange jumpsuits, like the ones worn by mutants.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
TLDR: Prisoners, dead or alive will now spawn with orange jumpsuits.

I have separated jumpsuits into pocketless and "regular" jumpsuits. Since the ones worn by prisoners don't have pockets and you can't delete pockets in a `copy_from` object the pocketless jumpsuit is the base inherited by the regular one. The pocketless jumpsuit is only used in carceral contexts and the regular ones are used everywhere else, for military professions for example.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Spawned as convict, jumpsuit is on, spawned zombie convict, killed it, orange jumpsuit dropped.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Some issues may arise due to prisoner not having pockets anymore like spawning with items dropping on the ground, I didn't test all the convict professions.
I changed the `looks_like` field of the jumpsuit so that it looks like a prisoner jumpsuit but I'm not sure of it will mess with sprite or spriters in some way.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
