### PR TITLE
Typed coordinates: sets of adjacent relative coordinates

### DIFF
--- a/src/coordinates.h
+++ b/src/coordinates.h
@@ -3,6 +3,7 @@
 #define CATA_SRC_COORDINATES_H
 
 #include <algorithm>
+#include <array>
 #include <cmath>
 #include <cstddef>
 #include <functional>
@@ -179,6 +180,8 @@ class coord_point_ob_rel
         static const coord_point_ob<Point, Origin, Scale> south_west;
         static const coord_point_ob<Point, Origin, Scale> west;
         static const coord_point_ob<Point, Origin, Scale> north_west;
+        static const std::array<coord_point_ob<Point, Origin, Scale>, 4> adjacent_cardinal;
+        static const std::array<coord_point_ob<Point, Origin, Scale>, 8> adjacent_all;
 };
 
 template<typename Point, origin Origin, scale Scale>
@@ -354,6 +357,30 @@ const coord_point_ob<Point, Origin, Scale>
 coord_point_ob_3d<Point, Origin, Scale>::below
     =
         coord_point_ob<Point, Origin, Scale>( Point::below );
+
+//adjacent points, cardinal directions only, clockwise starting north
+template<typename Point, origin Origin, scale Scale>
+const std::array<coord_point_ob<Point, Origin, Scale>, 4>
+coord_point_ob_rel<Point, Origin, Scale>::adjacent_cardinal = {
+    coord_point_ob<Point, Origin, Scale>::north,
+    coord_point_ob<Point, Origin, Scale>::east,
+    coord_point_ob<Point, Origin, Scale>::south,
+    coord_point_ob<Point, Origin, Scale>::west
+};
+
+//adjacent points, cardinal and ordinal directions, left-to-right and top-to-bottom
+template<typename Point, origin Origin, scale Scale>
+const std::array<coord_point_ob<Point, Origin, Scale>, 8>
+coord_point_ob_rel<Point, Origin, Scale>::adjacent_all = {
+    coord_point_ob<Point, Origin, Scale>::northwest,
+    coord_point_ob<Point, Origin, Scale>::north,
+    coord_point_ob<Point, Origin, Scale>::northeast,
+    coord_point_ob<Point, Origin, Scale>::west,
+    coord_point_ob<Point, Origin, Scale>::east,
+    coord_point_ob<Point, Origin, Scale>::southwest,
+    coord_point_ob<Point, Origin, Scale>::south,
+    coord_point_ob<Point, Origin, Scale>::southeast
+};
 
 template<typename Point, origin Origin, scale Scale>
 class coord_point_ib : public coord_point_ob<Point, Origin, Scale>

--- a/src/overmap.h
+++ b/src/overmap.h
@@ -443,8 +443,7 @@ class overmap
         // Save per-player overmap view data.
         void serialize_view( std::ostream &fout ) const;
     private:
-        void generate( const overmap *north, const overmap *east,
-                       const overmap *south, const overmap *west,
+        void generate( const std::vector<const overmap *> &neighbor_overmaps,
                        overmap_special_batch &enabled_specials );
         bool generate_sub( int z );
         bool generate_over( int z );
@@ -473,20 +472,17 @@ class overmap
         void place_forests();
         void place_lakes();
         void place_oceans();
-        void place_rivers( const overmap *north, const overmap *east, const overmap *south,
-                           const overmap *west );
+        void place_rivers( const std::vector<const overmap *> &neighbor_overmaps );
         void place_swamps();
         void place_forest_trails();
         void place_forest_trailheads();
 
-        void place_roads( const overmap *north, const overmap *east, const overmap *south,
-                          const overmap *west );
+        void place_roads( const std::vector<const overmap *> &neighbor_overmaps );
 
-        void place_railroads( const overmap *north, const overmap *east, const overmap *south,
-                              const overmap *west );
+        void place_railroads( const std::vector<const overmap *> &neighbor_overmaps );
 
-        void populate_connections_out_from_neighbors( const overmap *north, const overmap *east,
-                const overmap *south, const overmap *west );
+        void populate_connections_out_from_neighbors( const std::vector<const overmap *>
+                &neighbor_overmaps );
 
         // City Building
         overmap_special_id pick_random_building_to_place( int town_dist, int town_size,


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Infrastructure "typed coordinates: sets of adjacent relative coordinates"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Overmap generation functions all took the neighboring four overmaps as separate parameters, which is unnecessary.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Each relative typed coordinate has a set of constant adjacency points:
- a set for each cardinal direction (4)
- a set for cardinal and ordinal directions (8)

So for example, `point_rel_om::adjacent_cardinal` can be used to get relative overmap coordinates: [ {0,-1}, {1,0}, {0,1}, {-1,0}] (point_rel_om::north, point_rel_om::east, etc).

I replaced the neighbor overmap point generation in `overmap::open` as a test.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

If there's a better way to do this, let me know

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Affected generation for overmaps looked normal (roads, rivers).

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

I've been experimenting with highway generation, but it looks like rivers need to be cleaned up first -- I've cleaned up some constants and repetition in this PR. Highways are really tough if #59433 is still a problem, and I have a pretty good idea why that's happening. I've looked over #74261 and related PRs and will likely be picking from those.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
