### PR TITLE
Better fault UI

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -6654,10 +6654,12 @@ void Character::mend_item( item_location &&obj, bool interactive )
             for( const fault_id &fid : fix.faults_added ) {
                 descr += string_format( _( "Adds fault: <color_yellow>%s</color>\n" ), fid->name() );
             }
-            if( fix.mod_damage > 0 ) {
-                descr += string_format( _( "<color_green>Repairs</color> %d damage.\n" ), fix.mod_damage );
-            } else if( fix.mod_damage < 0 ) {
-                descr += string_format( _( "<color_red>Applies</color> %d damage.\n" ), -fix.mod_damage );
+            if( fix.mod_damage < 0 ) {
+                descr += string_format( _( "<color_green>Repairs</color> %d damage.\n" ),
+                                        -fix.mod_damage / itype::damage_scale );
+            } else if( fix.mod_damage > 0 ) {
+                descr += string_format( _( "<color_red>Applies</color> %d damage.\n" ),
+                                        fix.mod_damage / itype::damage_scale );
             }
 
             opt.time_to_fix = fix.time;


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Someone pointed that UI shows repairing as damaging
#### Describe the solution
Swap a sign in function that print the message
also switch the UI from showing the raw damage number to one affected by damage_scale
#### Testing
Before
![image](https://github.com/user-attachments/assets/8ebdadb4-4efe-496c-8121-0954ff3ad070)
After:
![image](https://github.com/user-attachments/assets/64efa13a-9daf-4ac6-ac7b-eb5ee800f8ff)
#### Additional context
Need to make mod_damage not input raw damage number, but one affected by itype::damage_scale methinks
Also there seems to be some weirdness with fault fix fixing only one fault at a time instead of all affected faults, and some issues with fault_staff_short_cracked that makes it not go away, but i could not figure it quickly enough to fix here