### PR TITLE
Striped shirt audit

### DIFF
--- a/data/json/itemgroups/Locations_MapExtras/locations.json
+++ b/data/json/itemgroups/Locations_MapExtras/locations.json
@@ -2833,7 +2833,7 @@
         "distribution": [
           { "item": "jersey", "prob": 5 },
           { "item": "longshirt", "prob": 20 },
-          { "item": "striped_shirt", "prob": 10 },
+          { "item": "buttonshirt", "variant": "striped", "prob": 10 },
           { "item": "denim_shirt", "prob": 5 },
           { "item": "sweater", "prob": 20 },
           { "item": "sweatshirt", "prob": 20 },

--- a/data/json/items/armor/torso_clothes.json
+++ b/data/json/items/armor/torso_clothes.json
@@ -730,15 +730,6 @@
       { "covers": [ "torso" ], "coverage": 90, "encumbrance": [ 4, 5 ] },
       { "covers": [ "arm_l", "arm_r" ], "coverage": 90, "encumbrance": [ 4, 4 ] }
     ],
-    "pocket_data": [
-      {
-        "pocket_type": "CONTAINER",
-        "max_contains_volume": "350 ml",
-        "max_contains_weight": "2 kg",
-        "max_item_length": "9 cm",
-        "moves": 80
-      }
-    ],
     "warmth": 10,
     "material_thickness": 0.1,
     "flags": [ "VARSIZE" ],

--- a/data/json/items/armor/torso_clothes.json
+++ b/data/json/items/armor/torso_clothes.json
@@ -713,11 +713,11 @@
     ]
   },
   {
-    "id": "dress_shirt",
+    "id": "buttonshirt",
     "type": "ITEM",
     "subtypes": [ "ARMOR" ],
-    "name": { "str": "dress shirt" },
-    "description": "A white button-down shirt with long sleeves.  Looks professional!",
+    "name": { "str": "button shirt" },
+    "description": "A button-down shirt with long sleeves.  Looks professional!",
     "weight": "250 g",
     "volume": "750 ml",
     "price": "15 USD",
@@ -741,7 +741,35 @@
     ],
     "warmth": 10,
     "material_thickness": 0.1,
-    "flags": [ "VARSIZE" ]
+    "flags": [ "VARSIZE" ],
+    "variant_type": "generic",
+    "variants": [
+      { "id": "white", "name": { "str": "white button shirt" }, "append": true, "description": "This one is white." },
+      {
+        "id": "striped",
+        "name": { "str": "striped button shirt" },
+        "append": true,
+        "expand_snippets": true,
+        "description": "This one has <color> stripes."
+      }
+    ]
+  },
+  {
+    "copy-from": "buttonshirt",
+    "id": "dress_shirt",
+    "type": "ITEM",
+    "subtypes": [ "ARMOR" ],
+    "name": { "str": "pocket shirt" },
+    "description": "A white button-down shirt with long sleeves and a pocket on the front.  Looks professional!",
+    "pocket_data": [
+      {
+        "pocket_type": "CONTAINER",
+        "max_contains_volume": "350 ml",
+        "max_contains_weight": "2 kg",
+        "max_item_length": "9 cm",
+        "moves": 80
+      }
+    ]
   },
   {
     "id": "dress_wedding",
@@ -1617,25 +1645,6 @@
       { "covers": [ "arm_l", "arm_r" ], "coverage": 100, "encumbrance": 8 },
       { "covers": [ "leg_l", "leg_r" ], "coverage": 100, "encumbrance": 14 }
     ]
-  },
-  {
-    "id": "striped_shirt",
-    "type": "ITEM",
-    "subtypes": [ "ARMOR" ],
-    "name": { "str": "striped shirt" },
-    "description": "A long-sleeved shirt with horizontal black and white stripes.",
-    "weight": "146 g",
-    "volume": "750 ml",
-    "price": "5 USD",
-    "price_postapoc": "50 cent",
-    "material": [ "cotton" ],
-    "symbol": "[",
-    "looks_like": "longshirt",
-    "color": "white",
-    "warmth": 5,
-    "material_thickness": 0.2,
-    "flags": [ "VARSIZE" ],
-    "armor": [ { "encumbrance": 5, "coverage": 90, "covers": [ "torso", "arm_l", "arm_r" ] } ]
   },
   {
     "id": "sundress",

--- a/data/json/npcs/island_prison/prisoners.json
+++ b/data/json/npcs/island_prison/prisoners.json
@@ -67,7 +67,7 @@
     "entries": [
       { "group": "male_underwear" },
       { "distribution": [ { "group": "clothing_prisoner_shoes" }, { "group": "cop_shoes" } ] },
-      { "distribution": [ { "item": "striped_shirt" }, { "group": "cop_torso" } ] },
+      { "distribution": [ { "item": "buttonshirt", "variant": "striped" }, { "group": "cop_torso" } ] },
       { "distribution": [ { "item": "striped_pants" }, { "group": "cop_pants" } ] },
       { "distribution": [ { "item": "tacvest" }, { "item": "kevlar" } ], "prob": 15 },
       { "group": "socks_unisex" },

--- a/data/json/npcs/items_generic.json
+++ b/data/json/npcs/items_generic.json
@@ -80,7 +80,7 @@
       [ "longshirt", 20 ],
       [ "denim_shirt", 10 ],
       [ "sweatshirt", 20 ],
-      [ "striped_shirt", 10 ],
+      { "item": "buttonshirt", "variant": "striped", "prob": 10 },
       [ "sweater", 20 ],
       [ "jersey", 10 ]
     ]
@@ -95,7 +95,7 @@
       [ "longshirt", 20 ],
       [ "denim_shirt", 10 ],
       [ "sweatshirt", 20 ],
-      [ "striped_shirt", 10 ],
+      { "item": "buttonshirt", "variant": "striped", "prob": 10 },
       [ "sweater", 20 ],
       [ "jersey", 10 ],
       [ "tank_top", 20 ],

--- a/data/json/npcs/refugee_center/surface_refugees/NPC_Pablo_Nunez.json
+++ b/data/json/npcs/refugee_center/surface_refugees/NPC_Pablo_Nunez.json
@@ -57,7 +57,7 @@
       { "item": "boxer_briefs" },
       { "item": "socks" },
       { "item": "tank_top" },
-      { "item": "striped_shirt" },
+      { "item": "buttonshirt", "variant": "striped" },
       { "item": "pants" },
       { "item": "jacket_evac" },
       { "item": "porkpie" },

--- a/data/json/npcs/tacoma_ranch/Nunez/NPC_Pablo_Tacoma.json
+++ b/data/json/npcs/tacoma_ranch/Nunez/NPC_Pablo_Tacoma.json
@@ -57,7 +57,7 @@
       { "item": "boxer_briefs" },
       { "item": "socks" },
       { "item": "tank_top" },
-      { "item": "striped_shirt" },
+      { "item": "buttonshirt", "variant": "striped" },
       { "item": "pants" },
       { "item": "armor_scrapsuit" },
       { "item": "helmet_scrap" },

--- a/data/json/obsoletion_and_migration_0.I/migration_items.json
+++ b/data/json/obsoletion_and_migration_0.I/migration_items.json
@@ -2538,5 +2538,11 @@
     "id": "subsuit_xl",
     "replace": "jumpsuit_pocketless",
     "variant": "orange"
+  },
+  {
+    "type": "MIGRATION",
+    "id": "striped_shirt",
+    "replace": "buttonshirt",
+    "variant": "striped"
   }
 ]

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -4739,7 +4739,7 @@
         "entries": [
           { "item": "socks" },
           { "item": "sneakers" },
-          { "item": "striped_shirt" },
+          { "item": "buttonshirt", "variant": "striped" },
           { "item": "hoodie" },
           { "item": "gloves_light" },
           { "item": "mask_ski" },

--- a/data/mods/Magiclysm/professions.json
+++ b/data/mods/Magiclysm/professions.json
@@ -376,7 +376,7 @@
           { "item": "socks" },
           { "item": "sneakers" },
           { "item": "pants" },
-          { "item": "striped_shirt" },
+          { "item": "buttonshirt", "variant": "striped" },
           { "item": "hoodie" },
           { "item": "gloves_light" },
           { "item": "swag_bag" },
@@ -1035,7 +1035,14 @@
     ],
     "traits": [ "DRUID", "PSYCHOPATH" ],
     "items": {
-      "both": { "entries": [ { "item": "striped_shirt" }, { "item": "striped_pants" }, { "item": "sneakers" }, { "item": "socks" } ] },
+      "both": {
+        "entries": [
+          { "item": "buttonshirt", "variant": "striped" },
+          { "item": "striped_pants" },
+          { "item": "sneakers" },
+          { "item": "socks" }
+        ]
+      },
       "male": { "entries": [ { "item": "briefs" } ] },
       "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "Striped shirt audit"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Our striped shirt is a completely different item from a dress shirt, this is arguably warranted as the striped shirt has no pockets but the dress shirt has one, what is not warranted is for them to not have a copy-from relationship and for the striped shirt to be so specific about its appearance, being striped or not should be details added by variants.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
- Create a "button shirt"
- Migrate most of the "dress shirt" definition to it except for the pockets
- Makes the dress shirt a copy-from which adds a pocket
- Create generic white and striped variants for the button shirt
- Migrate the striped shirt to the striped button shirt variant
- Remove the striped shirt
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Don't create a new item and apply the above solution using the striped shirt instead of it. It would be marginally simpler in terms of code manipulations but we would end up with a "striped_shirt" id which would belong to something that's not a "striped shirt" anymore. It's fairly easy to do if we absolutely need to avoid creating/deleting ids, feel free to request it if so.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Spawned the different shirts, no apparent issue.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
