### PR TITLE
[MoM] Add new Nether Attunement/portal storm effect, the Crack in Reality

### DIFF
--- a/data/mods/MindOverMatter/effectoncondition/eoc_nether_attunement_events.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_nether_attunement_events.json
@@ -1280,10 +1280,11 @@
           { "u_location_variable": { "context_val": "loc" }, "min_radius": 1, "max_radius": 3 },
           {
             "u_set_field": "fd_tear_in_reality_temporary",
+            "radius": 0,
             "intensity": 3,
-            "target_var": { "context_val": "loc" },
-            "spawn_message": "The nearby air warps in on itself!"
-          }
+            "target_var": { "context_val": "loc" }
+          },
+          { "message": "The nearby air cracks.", "type": "bad" }
         ]
       }
     ],

--- a/data/mods/MindOverMatter/effectoncondition/eoc_nether_attunement_events.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_nether_attunement_events.json
@@ -354,6 +354,7 @@
         [ "EOC_NETHER_EFFECT_CHECK_TELEPORT_MISJUMP", 4 ],
         [ "EOC_NETHER_EFFECT_CHECK_PHOTOKIN_EMP", 3 ],
         [ "EOC_NETHER_EFFECT_CHECK_NETHER_LIGHTNING", 3 ],
+        [ "EOC_NETHER_EFFECT_CHECK_TEMPORARY_TEAR_IN_REALITY", 2 ],
         [ "EOC_NETHER_EFFECT_CHECK_NO_PSIONICS", 3 ],
         [ "EOC_NETHER_EFFECT_CHECK_SUMMON_HOUNDS", 2 ],
         [ "EOC_NETHER_EFFECT_CHECK_MUTATION", 2 ],
@@ -635,7 +636,9 @@
     "type": "effect_on_condition",
     "id": "EOC_DRAIN_EFFECT_CHECK_POWER_SURGE",
     "//": "Base is 1.5% chance from 80 attunement to 120 attunement, then scaling up 0.2% per attunement up to 13.5% chance at 180 attunement, then scaling up 0.35% chance per attunement up to 38% chance at max, plus 1/10th the Difficulty squared.",
-    "condition": { "math": [ "u_vitamin('vitamin_psionic_drain') >= 85" ] },
+    "condition": {
+      "or": [ { "math": [ "u_vitamin('vitamin_psionic_drain') >= 85" ] }, { "u_has_trait": "PSI_TORRENTIAL_CHANNELING_active" } ]
+    },
     "effect": [
       {
         "if": {
@@ -665,7 +668,9 @@
     "//": "Base is 2% chance from 75 attunement to 130 attunement, then scaling up 0.15% per attunement up to 11% chance at 190 attunement, then scaling up 0.3% chance per attunement up to 29% chance at max, plus 1/10th the Difficulty squared.",
     "condition": {
       "and": [
-        { "math": [ "u_vitamin('vitamin_psionic_drain') >= 75" ] },
+        {
+          "or": [ { "math": [ "u_vitamin('vitamin_psionic_drain') >= 75" ] }, { "u_has_trait": "PSI_TORRENTIAL_CHANNELING_active" } ]
+        },
         { "not": { "u_has_trait": "PSI_EXTENDED_CHANNELING_active" } }
       ]
     },
@@ -930,7 +935,9 @@
     "type": "effect_on_condition",
     "id": "EOC_NETHER_EFFECT_CHECK_ATTENUATION",
     "//": "Base is 4% chance from 125 attunement to 160 attunement, then scaling up 0.15% per attunement up to 11.5% chance at 210 attunement, then scaling up 0.35% chance per attunement up to 25.5% chance at max, plus 1/10th the Difficulty squared.",
-    "condition": { "math": [ "u_vitamin('vitamin_psionic_drain') >= 125" ] },
+    "condition": {
+      "or": [ { "math": [ "u_vitamin('vitamin_psionic_drain') >= 125" ] }, { "u_has_trait": "PSI_TORRENTIAL_CHANNELING_active" } ]
+    },
     "effect": [
       {
         "if": {
@@ -1227,7 +1234,9 @@
     "type": "effect_on_condition",
     "id": "EOC_NETHER_EFFECT_CHECK_NETHER_LIGHTNING",
     "//": "Base is 3% chance from 175 attunement to 200 attunement, then scaling up 0.2% per attunement up to 8% chance at 225 attunement, then scaling up 0.45% chance per attunement up to 19.25% chance at max, plus 1/10th the Difficulty squared.",
-    "condition": { "math": [ "u_vitamin('vitamin_psionic_drain') >= 175" ] },
+    "condition": {
+      "or": [ { "math": [ "u_vitamin('vitamin_psionic_drain') >= 175" ] }, { "u_has_trait": "PSI_TORRENTIAL_CHANNELING_active" } ]
+    },
     "effect": [
       {
         "if": {
@@ -1243,6 +1252,38 @@
         "then": [
           { "u_message": "Crackling energy erupts all around you!", "type": "bad" },
           { "u_cast_spell": { "id": "nether_attunement_nether_lightning", "hit_self": false } }
+        ]
+      }
+    ],
+    "false_effect": [ { "run_eocs": "EOC_PSIONICS_NETHER_ATTUNEMENT_CONSEQUENCES" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_NETHER_EFFECT_CHECK_TEMPORARY_TEAR_IN_REALITY",
+    "//": "Base is 2% chance from 175 attunement to 200 attunement, then scaling up 0.1% per attunement up to 4.5% chance at 225 attunement, then scaling up 0.2% chance per attunement up to 9.5% chance at max, plus 1/10th the Difficulty squared.",
+    "condition": {
+      "or": [ { "math": [ "u_vitamin('vitamin_psionic_drain') >= 175" ] }, { "u_has_trait": "PSI_TORRENTIAL_CHANNELING_active" } ]
+    },
+    "effect": [
+      {
+        "if": {
+          "x_in_y_chance": {
+            "x": {
+              "math": [
+                "( clamp( ( (u_vitamin('vitamin_psionic_drain') - 200) * 1), 0, 25) + clamp( ( (u_vitamin('vitamin_psionic_drain') - 225) * 2 ), 0, 375) + (nether_attune_difficulty_scaler(u_latest_channeled_power_difficulty)) + 20)"
+              ]
+            },
+            "y": 1000
+          }
+        },
+        "then": [
+          { "u_location_variable": { "context_val": "loc" }, "min_radius": 1, "max_radius": 3 },
+          {
+            "u_set_field": "fd_tear_in_reality_temporary",
+            "intensity": 3,
+            "target_var": { "context_val": "loc" },
+            "spawn_message": "The nearby air warps in on itself!"
+          }
         ]
       }
     ],

--- a/data/mods/MindOverMatter/effectoncondition/eoc_portal_storm_effects.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_portal_storm_effects.json
@@ -1,0 +1,56 @@
+[
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PORTAL_EFFECTS_ACTIVE",
+    "//": "Overwrite of data/json/effects_on_condition/nether_eocs/portal_storm_effects_on_condition.json",
+    "//": "More dangerous portal effects, should cost IRE to do.",
+    "recurrence": [ "20 seconds", "50 seconds" ],
+    "global": true,
+    "condition": {
+      "and": [
+        {
+          "or": [
+            { "and": [ { "is_weather": "distant_portal_storm" }, { "x_in_y_chance": { "x": 5, "y": 10 } } ] },
+            { "and": [ { "is_weather": "near_portal_storm" }, { "x_in_y_chance": { "x": 7, "y": 10 } } ] },
+            { "is_weather": "portal_storm" }
+          ]
+        },
+        { "math": [ "portal_dungeon_level == 0" ] },
+        { "math": [ "u_ire > 0" ] }
+      ]
+    },
+    "deactivate_condition": { "not": { "is_weather": "portal_storm" } },
+    "effect": [
+      { "run_eocs": "EOC_PORTAL_MESSAGE" },
+      {
+        "weighted_list_eocs": [
+          [ "EOC_PORTAL_TELEPORT_STUCK_START", 2 ],
+          [ "EOC_PORTAL_PAIN", 2 ],
+          [ "EOC_PORTAL_HALLUCINATOR", 2 ],
+          [ "EOC_PORTAL_SMOKE", 2 ],
+          [ "EOC_PORTAL_YRAX_ATTENTION", 1 ],
+          [ "EOC_PORTAL_SWARM_STRUCTURE", 2 ],
+          [ "EOC_PORTAL_TAUNT", 1 ],
+          [ "EOC_PORTAL_SHIFTING_MASS", 1 ],
+          [ "EOC_PORTAL_ARTIFACT_WEAK", 1 ],
+          [ "EOC_PORTAL_TEMPORARY_TEARS_IN_REALITY", 1 ]
+        ]
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PORTAL_TEMPORARY_TEARS_IN_REALITY",
+    "condition": { "one_in_chance": 10 },
+    "effect": [
+      { "u_location_variable": { "context_val": "loc" }, "min_radius": 2, "max_radius": 8 },
+      {
+        "u_set_field": "fd_tear_in_reality_temporary",
+        "intensity": 3,
+        "target_var": { "context_val": "loc" },
+        "spawn_message": "The world cracks!"
+      },
+      { "math": [ "u_ire", "-=", "5" ] }
+    ]
+  }
+]

--- a/data/mods/MindOverMatter/effectoncondition/eoc_portal_storm_effects.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_portal_storm_effects.json
@@ -2,7 +2,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_PORTAL_EFFECTS_ACTIVE",
-    "//": "Overwrite of data/json/effects_on_condition/nether_eocs/portal_storm_effects_on_condition.json",
+    "//2": "Overwrite of data/json/effects_on_condition/nether_eocs/portal_storm_effects_on_condition.json",
     "//": "More dangerous portal effects, should cost IRE to do.",
     "recurrence": [ "20 seconds", "50 seconds" ],
     "global": true,
@@ -46,10 +46,11 @@
       { "u_location_variable": { "context_val": "loc" }, "min_radius": 2, "max_radius": 8 },
       {
         "u_set_field": "fd_tear_in_reality_temporary",
+        "radius": 0,
         "intensity": 3,
-        "target_var": { "context_val": "loc" },
-        "spawn_message": "The world cracks!"
+        "target_var": { "context_val": "loc" }
       },
+      { "message": "The nearby air cracks.", "type": "bad" },
       { "math": [ "u_ire", "-=", "5" ] }
     ]
   }

--- a/data/mods/MindOverMatter/fields.json
+++ b/data/mods/MindOverMatter/fields.json
@@ -19,7 +19,7 @@
     "priority": 8,
     "display_items": true,
     "display_field": true,
-    "looks_like": "fd_smoke",
+    "looks_like": "fd_fatigue",
     "half_life": "10 minutes"
   },
   {

--- a/data/mods/MindOverMatter/fields.json
+++ b/data/mods/MindOverMatter/fields.json
@@ -4,7 +4,6 @@
     "type": "field_type",
     "intensity_levels": [
       { "name": "odd ripple", "color": "light_gray", "sym": "*", "dangerous": true },
-      { "name": "swirling air", "color": "dark_gray" },
       {
         "name": "crack in reality",
         "color": "magenta",

--- a/data/mods/MindOverMatter/fields.json
+++ b/data/mods/MindOverMatter/fields.json
@@ -1,5 +1,28 @@
 [
   {
+    "id": "fd_tear_in_reality_temporary",
+    "type": "field_type",
+    "intensity_levels": [
+      { "name": "odd ripple", "color": "light_gray", "sym": "*", "dangerous": true },
+      { "name": "swirling air", "color": "dark_gray" },
+      {
+        "name": "tear in reality",
+        "color": "magenta",
+        "transparent": false,
+        "monster_spawn_chance": 60,
+        "monster_spawn_count": 1,
+        "monster_spawn_radius": 1,
+        "monster_spawn_group": "GROUP_NETHER_REALITY_TEAR_FIELD"
+      }
+    ],
+    "description_affix": "under",
+    "priority": 8,
+    "display_items": true,
+    "display_field": true,
+    "looks_like": "fd_smoke",
+    "half_life": "10 minutes"
+  },
+  {
     "id": "fd_pyrokinetic_summon_heat_1",
     "type": "field_type",
     "intensity_levels": [

--- a/data/mods/MindOverMatter/fields.json
+++ b/data/mods/MindOverMatter/fields.json
@@ -6,7 +6,7 @@
       { "name": "odd ripple", "color": "light_gray", "sym": "*", "dangerous": true },
       { "name": "swirling air", "color": "dark_gray" },
       {
-        "name": "tear in reality",
+        "name": "crack in reality",
         "color": "magenta",
         "transparent": false,
         "monster_spawn_chance": 60,

--- a/data/mods/MindOverMatter/fields.json
+++ b/data/mods/MindOverMatter/fields.json
@@ -3,7 +3,7 @@
     "id": "fd_tear_in_reality_temporary",
     "type": "field_type",
     "intensity_levels": [
-      { "name": "odd ripple", "color": "light_gray", "sym": "*", "dangerous": true },
+      { "name": "lingering distortion", "color": "light_gray", "sym": "*", "dangerous": true },
       {
         "name": "crack in reality",
         "color": "magenta",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[MoM] Add new Nether Attunement/portal storm effect, the Crack in Reality"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Realized I could do it and that it would fit perfectly.

Also, Torrential Channeling should be a bit more dangerous since it's such a big power jump at no (up-front) cost.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add the `fd_tear_in_reality_temporary` field called a "crack in reality", which works like a tear in reality but goes away after a short time. It's otherwise exactly the same--it spews out monsters, all of that.

Add a rare effect during portal storms where a crack in reality opens nearby. 

Add a Nether Attunement backlash where a crack in reality opens nearby. This requires having Nether Attunement (9) _or having Torrential Channeling active_. Extend that last bit to some other effects, like Nether Lightning, Observed, Nether Attenuation, or Power Surge. The actual equation still functions based on your underlying Nether Attunement, so it'll be at most 2-4%when under the minimum attunement requirement...but it exists. When you're filled with a raging torrent of power, some side effects may occur. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Effect triggers, crack appears, monsters step through, the crack vanishes after a time.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Always test your changes:

![Untitled](https://github.com/user-attachments/assets/109f778f-6629-48c9-85b9-460e48a851b7)

(bug since fixed)
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
