### PR TITLE
Don't load invalid/removed map extras into overmap layers

### DIFF
--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -996,7 +996,10 @@ void overmap::unserialize_view( const JsonObject &jsobj )
                         extra_json.throw_error( "Too many values for extra" );
                     }
 
-                    layer[z].extras.push_back( tmp );
+                    // obsoleted extras can still appear here, so skip them
+                    if( tmp.id.is_valid() ) {
+                        layer[z].extras.push_back( tmp );
+                    }
                 }
             }
             if( extras_json.has_more() ) {


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Fixes #80835

#### Describe the solution

Simply skip loading if the id is not valid.

#### Describe alternatives you've considered

Maybe still show a one time error message? I don't really think that's necessary, but I'm also not at all a specialist on mapgen.

Another approach would be handling this differently in overmap drawing.
https://github.com/CleverRaven/Cataclysm-DDA/blob/e6363599d9831d09d3b8342814bb1e4d2b191525/src/sdltiles.cpp#L869-L872
What triggers the error is `mx->autonote` to determine if it should be drawn, because it tries to resolve the invalid id. It also does not error when removing that, so the actual drawing is fine or at least can fail quietly. But I'm not comfortable changing logic in that part of the code. However moving the check for validity there is an option if for some reason we want to preserve the invalid id in the save itself.

#### Testing

1. Load the save from the issue.
2. Open overmap.
3. Scroll a bunch to the northwest.
4. Errored before, now not anymore.

#### Additional context

