### PR TITLE
Remove opinion increases from failed recruitment

### DIFF
--- a/data/json/npcs/common_chat/TALK_COMMON_OTHER.json
+++ b/data/json/npcs/common_chat/TALK_COMMON_OTHER.json
@@ -134,7 +134,7 @@
           ],
           "opinion": { "value": -1 }
         },
-        "failure": { "topic": "TALK_DENY_FOLLOW", "effect": "deny_follow", "opinion": { "fear": -1, "value": -1, "anger": 1 } }
+        "failure": { "topic": "TALK_DENY_FOLLOW", "effect": "deny_follow", "opinion": { "value": -1, "anger": 1 } }
       },
       {
         "switch": true,
@@ -151,7 +151,7 @@
           ],
           "opinion": { "trust": 2, "anger": -1 }
         },
-        "failure": { "topic": "TALK_DENY_FOLLOW", "effect": "deny_follow", "opinion": { "trust": 1, "fear": -2, "value": -1, "anger": 1 } }
+        "failure": { "topic": "TALK_DENY_FOLLOW", "effect": "deny_follow", "opinion": { "value": -1, "anger": 1 } }
       },
       {
         "switch": true,


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Bothering a NPC 100 times makes your argument of "You should work for me" more effective

#### Describe the solution
It clearly shouldn't. Now it doesn't.

#### Describe alternatives you've considered
Make it reduce their trust and value in you if you fail?

#### Testing


#### Additional context
