### PR TITLE
Cap maximum amount of follower 'forgiveness'

### DIFF
--- a/src/npc.h
+++ b/src/npc.h
@@ -1397,6 +1397,8 @@ class npc : public Character
         npc_follower_rules rules;
         bool marked_for_death = false; // If true, we die as soon as we respawn!
         bool hit_by_player = false;
+        // times their opinion has increased from chatting, upper bounds on 'forgiveness'
+        int opinion_values_raised = 0;
         bool hallucination = false; // If true, NPC is an hallucination
         bool spawn_corpse = true;
         bool quiet_death = false; // supress messages about death

--- a/src/npctalk_funcs.cpp
+++ b/src/npctalk_funcs.cpp
@@ -836,19 +836,27 @@ void talk_function::morale_chat_activity( npc &p )
     }
     add_msg( m_good, _( "That was a pleasant conversation with %s." ), p.disp_name() );
     // 50% chance of increasing 1 npc opinion value each social chat after 6hr
-    if( !p.has_effect( effect_socialized_recently ) ) {
+    if( !p.has_effect( effect_socialized_recently ) && p.opinion_values_raised <= 10 ) {
+        int value_change = 0;
         switch( rng( 1, 3 ) ) {
             case 1:
-                p.op_of_u.trust += rng( 0, 1 );
+                value_change = rng( 0, 1 );
+                p.op_of_u.trust += value_change;
                 break;
             case 2:
-                p.op_of_u.value += rng( 0, 1 );
+                value_change = rng( 0, 1 );
+                p.op_of_u.value += value_change;
                 break;
             case 3:
                 if( p.op_of_u.anger > 0 ) {
-                    p.op_of_u.anger += rng( 0, -1 );
+                    value_change = rng( -1, 0 );
+                    p.op_of_u.anger += value_change;
                 }
                 break;
+        }
+        // we need to check for any non-zero value, e.g. anger change might be negative
+        if( value_change != 0 ) {
+            p.opinion_values_raised++;
         }
         p.add_effect( effect_socialized_recently, 6_hours );
     }


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Some edgelord posting recently alerted me to the fact that players can infinitely seek 'forgiveness' for butchering humans etc as long as they chat their followers up enough

#### Describe the solution
Put a hard cap on the amount of 'forgiveness'

#### Describe alternatives you've considered
I considered reverting #64912 entirely

#### Testing
Test scenario
![image](https://github.com/user-attachments/assets/3daf4fb0-4199-47df-a75a-003fa9ff5943)


#### Additional context

