### PR TITLE
allow extending/deleting move_skills

### DIFF
--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -30,6 +30,7 @@
 #include "mondefense.h"
 #include "mongroup.h"
 #include "monster.h"
+#include "mtype.h"
 #include "options.h"
 #include "pathfinding.h"
 #include "rng.h"
@@ -959,7 +960,43 @@ void mtype::load( const JsonObject &jo, const std::string &src )
 
     optional( jo, was_loaded, "petfood", petfood );
 
-    optional( jo, was_loaded, "move_skills", move_skills );
+    if( !was_loaded || jo.has_object( "move_skills" ) ) {
+        optional( jo, was_loaded, "move_skills", move_skills );
+    } else {
+        if( jo.has_object( "extend" ) ) {
+            JsonObject tmp = jo.get_object( "extend" );
+            tmp.allow_omitted_members();
+            if( tmp.has_object( "move_skills" ) ) {
+                JsonObject skills = tmp.get_object( "move_skills" );
+                if( skills.has_member( "swim" ) ) {
+                    move_skills.swim = std::optional<int>( skills.get_int( "swim" ) );
+                }
+                if( skills.has_member( "dig" ) ) {
+                    move_skills.dig = std::optional<int>( skills.get_int( "dig" ) );
+                }
+                if( skills.has_member( "climb" ) ) {
+                    move_skills.climb = std::optional<int>( skills.get_int( "climb" ) );
+                }
+            }
+        }
+        if( jo.has_object( "delete" ) ) {
+            JsonObject tmp = jo.get_object( "delete" );
+            tmp.allow_omitted_members();
+            if( tmp.has_object( "move_skills" ) ) {
+                JsonObject skills = tmp.get_object( "move_skills" );
+                if( skills.get_member_opt( "swim" ) ) {
+                    move_skills.swim = std::optional<int>( std::nullopt );
+                }
+                if( skills.get_member_opt( "dig" ) ) {
+                    move_skills.dig = std::nullopt;
+                }
+                if( skills.get_member_opt( "climb" ) ) {
+                    move_skills.climb = std::nullopt;
+                }
+            }
+        }
+    }
+
 
     assign( jo, "vision_day", vision_day, strict, 0 );
     assign( jo, "vision_night", vision_night, strict, 0 );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
follow-up to #80849
because move_skills is an object and not an array extend and delete did not work out of the box.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
implement it (took "families" as a template)
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
make a json monster with extend/delete, load, no error and the monster gets the skill / delete the skill
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
I have to use `get_member_opt` in delete, since it complains about invalid member.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
