### PR TITLE
resize bag_zipper & sandwiches

### DIFF
--- a/data/json/items/comestibles/sandwich.json
+++ b/data/json/items/comestibles/sandwich.json
@@ -426,6 +426,7 @@
     "price_postapoc": "1 USD 75 cent",
     "material": [ "fruit", "wheat" ],
     "primary_material": "wheat",
+    "//": "Sandwich is 500ml so it fills up a sealed 500 ml bag_zipper. See issue 45650",
     "volume": "500 ml",
     "fun": 15,
     "vitamins": [ [ "vitC", 3 ], [ "calcium", 7 ], [ "iron", 14 ], [ "wheat_allergen", 1 ], [ "fruit_allergen", 1 ] ]

--- a/data/json/items/comestibles/sandwich.json
+++ b/data/json/items/comestibles/sandwich.json
@@ -17,7 +17,7 @@
     "price_postapoc": "2 USD",
     "material": [ "milk", "wheat" ],
     "primary_material": "wheat",
-    "volume": "250 ml",
+    "volume": "400 ml",
     "flags": [ "EATEN_HOT" ],
     "fun": 10,
     "vitamins": [ [ "calcium", 50 ], [ "iron", 12 ], [ "wheat_allergen", 1 ], [ "milk_allergen", 1 ] ]
@@ -40,7 +40,7 @@
     "price_postapoc": "2 USD",
     "material": [ "egg", "wheat" ],
     "primary_material": "wheat",
-    "volume": "250 ml",
+    "volume": "400 ml",
     "fun": 6,
     "vitamins": [ [ "calcium", 50 ], [ "iron", 12 ], [ "wheat_allergen", 1 ], [ "egg_allergen", 1 ] ]
   },
@@ -138,7 +138,7 @@
     "calories": 227,
     "description": "A refreshing cucumber sandwich.  Not very filling, but quite tasty.",
     "price": "4 USD",
-    "volume": "250 ml",
+    "volume": "400 ml",
     "material": [ "wheat", "veggy" ],
     "flags": [ "EATEN_COLD" ],
     "fun": 8,
@@ -161,7 +161,7 @@
     "price_postapoc": "2 USD",
     "material": [ "milk", "wheat" ],
     "primary_material": "wheat",
-    "volume": "250 ml",
+    "volume": "400 ml",
     "fun": 8,
     "vitamins": [ [ "calcium", 50 ], [ "iron", 12 ], [ "wheat_allergen", 1 ], [ "milk_allergen", 1 ] ]
   },
@@ -183,7 +183,7 @@
     "price_postapoc": "2 USD",
     "material": [ "fruit", "wheat" ],
     "primary_material": "wheat",
-    "volume": "250 ml",
+    "volume": "400 ml",
     "fun": 6,
     "vitamins": [ [ "vitC", 6 ], [ "calcium", 7 ], [ "iron", 12 ], [ "wheat_allergen", 1 ], [ "fruit_allergen", 1 ] ]
   },
@@ -205,7 +205,7 @@
     "price_postapoc": "2 USD",
     "material": [ "fruit", "wheat", "milk" ],
     "primary_material": "wheat",
-    "volume": "250 ml",
+    "volume": "400 ml",
     "fun": 6,
     "vitamins": [
       [ "vitC", 6 ],
@@ -234,7 +234,7 @@
     "price_postapoc": "2 USD",
     "material": [ "milk", "fruit", "wheat" ],
     "primary_material": "wheat",
-    "volume": "250 ml",
+    "volume": "400 ml",
     "fun": 15,
     "vitamins": [
       [ "vitC", 6 ],
@@ -283,7 +283,7 @@
     "price": "1 USD 75 cent",
     "material": [ "honey", "wheat" ],
     "primary_material": "wheat",
-    "volume": "250 ml",
+    "volume": "400 ml",
     "fun": 6,
     "vitamins": [ [ "calcium", 10 ], [ "iron", 24 ], [ "wheat_allergen", 1 ] ]
   },
@@ -320,7 +320,7 @@
     "price": "8 USD",
     "price_postapoc": "2 USD 50 cent",
     "material": [ "veggy", "wheat" ],
-    "volume": "250 ml",
+    "volume": "400 ml",
     "flags": [ "EATEN_COLD" ],
     "fun": 1,
     "vitamins": [ [ "vitC", 36 ], [ "calcium", 34 ], [ "iron", 28 ], [ "veggy_allergen", 1 ], [ "wheat_allergen", 1 ] ]
@@ -342,7 +342,7 @@
     "price": "8 USD",
     "price_postapoc": "2 USD 50 cent",
     "material": [ "veggy", "wheat", "milk" ],
-    "volume": "250 ml",
+    "volume": "400 ml",
     "flags": [ "EATEN_COLD" ],
     "fun": 1,
     "vitamins": [
@@ -404,7 +404,7 @@
     "price": "2 USD 50 cent",
     "price_postapoc": "3 USD",
     "material": [ "wheat" ],
-    "volume": "250 ml",
+    "volume": "400 ml",
     "fun": 3,
     "vitamins": [ [ "calcium", 10 ], [ "iron", 28 ], [ "wheat_allergen", 1 ] ]
   },
@@ -426,7 +426,7 @@
     "price_postapoc": "1 USD 75 cent",
     "material": [ "fruit", "wheat" ],
     "primary_material": "wheat",
-    "volume": "250 ml",
+    "volume": "400 ml",
     "fun": 15,
     "vitamins": [ [ "vitC", 3 ], [ "calcium", 7 ], [ "iron", 14 ], [ "wheat_allergen", 1 ], [ "fruit_allergen", 1 ] ]
   },
@@ -448,7 +448,7 @@
     "price_postapoc": "1 USD 75 cent",
     "material": [ "wheat", "honey" ],
     "primary_material": "wheat",
-    "volume": "250 ml",
+    "volume": "400 ml",
     "fun": 10,
     "vitamins": [ [ "calcium", 8 ], [ "iron", 16 ], [ "wheat_allergen", 1 ] ]
   },
@@ -469,7 +469,7 @@
     "price": "1 USD 75 cent",
     "price_postapoc": "1 USD 75 cent",
     "material": [ "wheat" ],
-    "volume": "250 ml",
+    "volume": "400 ml",
     "fun": 6,
     "vitamins": [ [ "calcium", 12 ], [ "iron", 28 ], [ "wheat_allergen", 1 ] ]
   },
@@ -489,7 +489,7 @@
     "price": "8 USD",
     "price_postapoc": "2 USD 50 cent",
     "material": [ "flesh", "wheat" ],
-    "volume": "250 ml",
+    "volume": "400 ml",
     "fun": 14,
     "vitamins": [ [ "vitC", 5 ], [ "calcium", 19 ], [ "iron", 17 ], [ "meat_allergen", 1 ], [ "wheat_allergen", 1 ] ]
   },
@@ -509,7 +509,7 @@
     "price": "8 USD",
     "price_postapoc": "3 USD 50 cent",
     "material": [ "flesh", "wheat" ],
-    "volume": "250 ml",
+    "volume": "400 ml",
     "fun": 14,
     "vitamins": [ [ "vitC", 5 ], [ "calcium", 12 ], [ "iron", 24 ], [ "meat_allergen", 1 ], [ "wheat_allergen", 1 ] ]
   },
@@ -570,7 +570,7 @@
     "price": "10 USD",
     "price_postapoc": "2 USD 50 cent",
     "material": [ "flesh", "wheat", "veggy" ],
-    "volume": "250 ml",
+    "volume": "400 ml",
     "flags": [ "EATEN_HOT" ],
     "fun": 17,
     "vitamins": [
@@ -597,7 +597,7 @@
     "price_postapoc": "1 USD 75 cent",
     "material": [ "nut", "junk", "wheat", "egg" ],
     "primary_material": "wheat",
-    "volume": "250 ml",
+    "volume": "400 ml",
     "fun": 15,
     "vitamins": [
       [ "calcium", 6 ],

--- a/data/json/items/comestibles/sandwich.json
+++ b/data/json/items/comestibles/sandwich.json
@@ -17,7 +17,7 @@
     "price_postapoc": "2 USD",
     "material": [ "milk", "wheat" ],
     "primary_material": "wheat",
-    "volume": "400 ml",
+    "volume": "500 ml",
     "flags": [ "EATEN_HOT" ],
     "fun": 10,
     "vitamins": [ [ "calcium", 50 ], [ "iron", 12 ], [ "wheat_allergen", 1 ], [ "milk_allergen", 1 ] ]
@@ -40,7 +40,7 @@
     "price_postapoc": "2 USD",
     "material": [ "egg", "wheat" ],
     "primary_material": "wheat",
-    "volume": "400 ml",
+    "volume": "500 ml",
     "fun": 6,
     "vitamins": [ [ "calcium", 50 ], [ "iron", 12 ], [ "wheat_allergen", 1 ], [ "egg_allergen", 1 ] ]
   },
@@ -138,7 +138,7 @@
     "calories": 227,
     "description": "A refreshing cucumber sandwich.  Not very filling, but quite tasty.",
     "price": "4 USD",
-    "volume": "400 ml",
+    "volume": "500 ml",
     "material": [ "wheat", "veggy" ],
     "flags": [ "EATEN_COLD" ],
     "fun": 8,
@@ -161,7 +161,7 @@
     "price_postapoc": "2 USD",
     "material": [ "milk", "wheat" ],
     "primary_material": "wheat",
-    "volume": "400 ml",
+    "volume": "500 ml",
     "fun": 8,
     "vitamins": [ [ "calcium", 50 ], [ "iron", 12 ], [ "wheat_allergen", 1 ], [ "milk_allergen", 1 ] ]
   },
@@ -183,7 +183,7 @@
     "price_postapoc": "2 USD",
     "material": [ "fruit", "wheat" ],
     "primary_material": "wheat",
-    "volume": "400 ml",
+    "volume": "500 ml",
     "fun": 6,
     "vitamins": [ [ "vitC", 6 ], [ "calcium", 7 ], [ "iron", 12 ], [ "wheat_allergen", 1 ], [ "fruit_allergen", 1 ] ]
   },
@@ -205,7 +205,7 @@
     "price_postapoc": "2 USD",
     "material": [ "fruit", "wheat", "milk" ],
     "primary_material": "wheat",
-    "volume": "400 ml",
+    "volume": "500 ml",
     "fun": 6,
     "vitamins": [
       [ "vitC", 6 ],
@@ -234,7 +234,7 @@
     "price_postapoc": "2 USD",
     "material": [ "milk", "fruit", "wheat" ],
     "primary_material": "wheat",
-    "volume": "400 ml",
+    "volume": "500 ml",
     "fun": 15,
     "vitamins": [
       [ "vitC", 6 ],
@@ -283,7 +283,7 @@
     "price": "1 USD 75 cent",
     "material": [ "honey", "wheat" ],
     "primary_material": "wheat",
-    "volume": "400 ml",
+    "volume": "500 ml",
     "fun": 6,
     "vitamins": [ [ "calcium", 10 ], [ "iron", 24 ], [ "wheat_allergen", 1 ] ]
   },
@@ -320,7 +320,7 @@
     "price": "8 USD",
     "price_postapoc": "2 USD 50 cent",
     "material": [ "veggy", "wheat" ],
-    "volume": "400 ml",
+    "volume": "500 ml",
     "flags": [ "EATEN_COLD" ],
     "fun": 1,
     "vitamins": [ [ "vitC", 36 ], [ "calcium", 34 ], [ "iron", 28 ], [ "veggy_allergen", 1 ], [ "wheat_allergen", 1 ] ]
@@ -342,7 +342,7 @@
     "price": "8 USD",
     "price_postapoc": "2 USD 50 cent",
     "material": [ "veggy", "wheat", "milk" ],
-    "volume": "400 ml",
+    "volume": "500 ml",
     "flags": [ "EATEN_COLD" ],
     "fun": 1,
     "vitamins": [
@@ -404,7 +404,7 @@
     "price": "2 USD 50 cent",
     "price_postapoc": "3 USD",
     "material": [ "wheat" ],
-    "volume": "400 ml",
+    "volume": "500 ml",
     "fun": 3,
     "vitamins": [ [ "calcium", 10 ], [ "iron", 28 ], [ "wheat_allergen", 1 ] ]
   },
@@ -426,7 +426,7 @@
     "price_postapoc": "1 USD 75 cent",
     "material": [ "fruit", "wheat" ],
     "primary_material": "wheat",
-    "volume": "400 ml",
+    "volume": "500 ml",
     "fun": 15,
     "vitamins": [ [ "vitC", 3 ], [ "calcium", 7 ], [ "iron", 14 ], [ "wheat_allergen", 1 ], [ "fruit_allergen", 1 ] ]
   },
@@ -448,7 +448,7 @@
     "price_postapoc": "1 USD 75 cent",
     "material": [ "wheat", "honey" ],
     "primary_material": "wheat",
-    "volume": "400 ml",
+    "volume": "500 ml",
     "fun": 10,
     "vitamins": [ [ "calcium", 8 ], [ "iron", 16 ], [ "wheat_allergen", 1 ] ]
   },
@@ -469,7 +469,7 @@
     "price": "1 USD 75 cent",
     "price_postapoc": "1 USD 75 cent",
     "material": [ "wheat" ],
-    "volume": "400 ml",
+    "volume": "500 ml",
     "fun": 6,
     "vitamins": [ [ "calcium", 12 ], [ "iron", 28 ], [ "wheat_allergen", 1 ] ]
   },
@@ -489,7 +489,7 @@
     "price": "8 USD",
     "price_postapoc": "2 USD 50 cent",
     "material": [ "flesh", "wheat" ],
-    "volume": "400 ml",
+    "volume": "500 ml",
     "fun": 14,
     "vitamins": [ [ "vitC", 5 ], [ "calcium", 19 ], [ "iron", 17 ], [ "meat_allergen", 1 ], [ "wheat_allergen", 1 ] ]
   },
@@ -509,7 +509,7 @@
     "price": "8 USD",
     "price_postapoc": "3 USD 50 cent",
     "material": [ "flesh", "wheat" ],
-    "volume": "400 ml",
+    "volume": "500 ml",
     "fun": 14,
     "vitamins": [ [ "vitC", 5 ], [ "calcium", 12 ], [ "iron", 24 ], [ "meat_allergen", 1 ], [ "wheat_allergen", 1 ] ]
   },
@@ -570,7 +570,7 @@
     "price": "10 USD",
     "price_postapoc": "2 USD 50 cent",
     "material": [ "flesh", "wheat", "veggy" ],
-    "volume": "400 ml",
+    "volume": "500 ml",
     "flags": [ "EATEN_HOT" ],
     "fun": 17,
     "vitamins": [
@@ -597,7 +597,7 @@
     "price_postapoc": "1 USD 75 cent",
     "material": [ "nut", "junk", "wheat", "egg" ],
     "primary_material": "wheat",
-    "volume": "400 ml",
+    "volume": "500 ml",
     "fun": 15,
     "vitamins": [
       [ "calcium", 6 ],

--- a/data/json/items/containers/containers.json
+++ b/data/json/items/containers/containers.json
@@ -378,8 +378,9 @@
         "pocket_type": "CONTAINER",
         "watertight": true,
         "transparent": true,
-        "max_contains_volume": "250 ml",
+        "max_contains_volume": "500 ml",
         "max_contains_weight": "750 g",
+        "max_item_length": "14 cm",
         "spoil_multiplier": 0.8,
         "moves": 400
       }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "increase sandwich and ziploc bag sizes"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

More realistic and internally-consistent sizes of sandwiches & ziploc bags.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Double a ziploc bag's capacity to 500 mL; it can hold twice as many peanuts now for those long road trips with the kids.

<del>Set most sandwiches to be 400 mL, double the size of a single slice of `bread`.</del> As of #46359 sealable containers are only sealed if they're entirely full, so @Maleclypse has requested the sandwiches' sizes be kept in sync with the colloquial 'sandwich bags,' at 500ml.

(There are actually no sandwiches in the game that can randomly spawn in a sealed `bag_zipper`, as far as I can tell. Or any food items at all, it's mostly drugs in these bags right now.)

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Calculate and customize the volume of each sandwich individually, while making sure to also subtract the decreased volume of the bread slices as they get a bit compacted/soaked?

Find a way to customize the "is this sealable container full?" logic to instead ask "would adding 1 more to this sealable container overflow it?"

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

A standard Ziploc bag can hold 16 fluid ounces, and it's 6 inches on its longest side.

The volume of a sandwich IRL is definitely larger than 250 mL (though many bread slices are a bit smaller than 200 mL).

The `bag_plastic_small` and `plastic_bag_vac` are also 500 mL; the next size up Ziploc available, the `bag_zipper_gallon`, holds 4500 mL.

Historical note: The unrealistic volume of sandwiches, '250 mL,' was simply the most granular unit of volume in the game in the past. All smallish items simply had that size by default because they had `volume: 1`, up until #33367


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
