### PR TITLE
use climb skill for pathfinding and showing ability

### DIFF
--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -1426,8 +1426,8 @@ bool monster::digs() const
 int monster::get_dig_mod() const
 {
     if( type->move_skills.dig.has_value() ) {
-        int percentile = type->move_skills.dig.value() * ( max_obstacle_penalty / 10 );
-        return max_obstacle_penalty - percentile;
+        int percentile = type->move_skills.dig.value() * ( move_skills_data::max_movemod_penalty / 10 );
+        return move_skills_data::max_movemod_penalty - percentile;
     } else if( has_flag( mon_flag_DIGS ) || has_flag( mon_flag_CAN_DIG ) ) {
         return 1;
     }
@@ -1461,8 +1461,8 @@ int monster::climb_skill() const
 int monster::get_climb_mod() const
 {
     if( type->move_skills.climb.has_value() ) {
-        int percentile = type->move_skills.climb.value() * ( max_obstacle_penalty / 10 );
-        return max_obstacle_penalty - percentile;
+        int percentile = type->move_skills.climb.value() * ( move_skills_data::max_movemod_penalty / 10 );
+        return move_skills_data::max_movemod_penalty - percentile;
     } else if( has_flag( mon_flag_CLIMBS ) ) {
         // only for backwards compatibility. In future move away from flags
         return 1;
@@ -1485,8 +1485,8 @@ int monster::swim_skill() const
 int monster::get_swim_mod() const
 {
     if( type->move_skills.swim.has_value() ) {
-        int percentile = type->move_skills.swim.value() * ( max_obstacle_penalty / 10 );
-        return max_obstacle_penalty - percentile;
+        int percentile = type->move_skills.swim.value() * ( move_skills_data::max_movemod_penalty / 10 );
+        return move_skills_data::max_movemod_penalty - percentile;
 
     } else if( has_flag( mon_flag_SWIMS ) ) {
         // only for backwards compatibility. In future move away from flags
@@ -1494,7 +1494,7 @@ int monster::get_swim_mod() const
         return 0;
     } else if( can_submerge() ) {
         // monsters that can submerge can walk underwater. Simulated with min swimskill
-        return max_obstacle_penalty;
+        return move_skills_data::max_movemod_penalty;
     }
 
     // cannot swim

--- a/src/monster.h
+++ b/src/monster.h
@@ -657,9 +657,6 @@ class monster : public Creature
         /** Found path. Note: Not used by monsters that don't pathfind! **/
         std::vector<tripoint_bub_ms> path;
 
-        // 10 means max movecost of 500 * terrain-difficulty with 0 skill
-        static const int max_obstacle_penalty = 10;
-
         // Exponential backoff for stuck monsters. Massively reduces pathfinding CPU.
         time_point pathfinding_cd = calendar::turn;
         time_duration pathfinding_backoff = 2_seconds;

--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -30,6 +30,7 @@
 #include "mondefense.h"
 #include "mongroup.h"
 #include "monster.h"
+#include "mtype.h"
 #include "options.h"
 #include "pathfinding.h"
 #include "rng.h"
@@ -571,7 +572,10 @@ void MonsterGenerator::finalize_pathfinding_settings( mtype &mon )
         mon.path_settings.bash_strength = mon.bash_skill;
     }
 
-    if( mon.has_flag( mon_flag_CLIMBS ) ) {
+    if( mon.move_skills.climb.has_value() ) {
+        mon.path_settings.climb_cost = move_skills_data::max_movemod_penalty -
+                                       mon.move_skills.climb.value();
+    } else if( mon.has_flag( mon_flag_CLIMBS ) ) {
         mon.path_settings.climb_cost = 3;
     }
 }

--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -574,7 +574,7 @@ void MonsterGenerator::finalize_pathfinding_settings( mtype &mon )
 
     if( mon.move_skills.climb.has_value() ) {
         mon.path_settings.climb_cost = move_skills_data::max_movemod_penalty -
-                                       mon.move_skills.climb.value();
+                                       ( mon.move_skills.climb.value() * ( move_skills_data::max_movemod_penalty / 10 ) );
     } else if( mon.has_flag( mon_flag_CLIMBS ) ) {
         mon.path_settings.climb_cost = 3;
     }

--- a/src/mtype.cpp
+++ b/src/mtype.cpp
@@ -622,7 +622,7 @@ void mtype::faction_display( catacurses::window &w, const point &top_left, const
     if( has_flag( mon_flag_DIGS ) ) {
         trim_and_print( w, top_left + point( 0, ++y ), width, c_white, _( "It can burrow underground." ) );
     }
-    if( has_flag( mon_flag_CLIMBS ) ) {
+    if( has_flag( mon_flag_CLIMBS ) || move_skills.climb.has_value() ) {
         trim_and_print( w, top_left + point( 0, ++y ), width, c_white, _( "It can climb." ) );
     }
     if( has_flag( mon_flag_GRABS ) ) {

--- a/src/mtype.cpp
+++ b/src/mtype.cpp
@@ -613,13 +613,13 @@ void mtype::faction_display( catacurses::window &w, const point &top_left, const
     trim_and_print( w, top_left + point( 0, ++y ), width, c_light_gray,
                     string_format( "%s: %s", colorize( _( "Senses" ), c_white ), enumerate_as_string( senses_str ) ) );
     // Abilities
-    if( has_flag( mon_flag_SWIMS ) ) {
+    if( has_flag( mon_flag_SWIMS ) || move_skills.swim.has_value() ) {
         trim_and_print( w, top_left + point( 0, ++y ), width, c_white, _( "It can swim." ) );
     }
     if( has_flag( mon_flag_FLIES ) ) {
         trim_and_print( w, top_left + point( 0, ++y ), width, c_white, _( "It can fly." ) );
     }
-    if( has_flag( mon_flag_DIGS ) ) {
+    if( has_flag( mon_flag_DIGS )   || move_skills.dig.has_value() ) {
         trim_and_print( w, top_left + point( 0, ++y ), width, c_white, _( "It can burrow underground." ) );
     }
     if( has_flag( mon_flag_CLIMBS ) || move_skills.climb.has_value() ) {

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -248,6 +248,8 @@ struct pet_food_data {
 
 /** movement data */
 struct move_skills_data {
+    // 10 means max movecost of 500 * terrain-difficulty with 0 skill
+    const static int max_movemod_penalty = 10;
     std::optional<int> climb;
     std::optional<int> dig;
     std::optional<int> swim;


### PR DESCRIPTION
#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
add move_skill checks to the last places swim/climb flags are checked.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Also check for skill, where previously only the flag was checked.
Since the max_penalty was required outside of the monster, move it to the move_skills_data struct. While at it rename it to better say that it effects the modifier, not the final movecost.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
--
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
