### PR TITLE
Bugfix: continue with destination activity if route is empty

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -11577,8 +11577,9 @@ bool Character::has_destination() const
 
 bool Character::has_destination_activity() const
 {
-    return !get_destination_activity().is_null() && destination_point &&
-           pos_bub() == get_map().get_bub( *destination_point );
+    const bool has_reached_destination = destination_point &&
+                                         ( pos_abs() == *destination_point || auto_move_route.empty() );
+    return !get_destination_activity().is_null() && has_reached_destination;
 }
 
 void Character::start_destination_activity()


### PR DESCRIPTION


<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Continue with destination activity if route is empty"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Fixes an issue where a player's destination activity was not started even if the auto move route was empty. For example, fast-travel by foot across bridges would previously stop near a ramp and not proceed.

Fixes #80897 .

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Specifically, what could happen before was that an auto route would reach its destination, but depending on how the route was chosen, not stop on the exact destination point. It sometimes stops on a point with different z-level than `destination_point` because of ramps. The calling code in `game::handle_action` then evaluated
`has_destination()==false` but also `has_destination_activity()==false`, which made it behave like there never was any queued destination activity nor route to proceed with. With "fast travel" enabled on overmap view, this looked like a softlock for the user since the overmap was not closed after auto-move, and the game waited for regular game-view input while still showing overmap view.

This commit instead updates `has_destination_activity` so that it not only returns true when there is an activity and the player is on the exact destination point, but also when the player's auto move queue is empty. Semantically, having an empty auto move queue and a non-null `destination_point` should also mean that all previous steps in the auto move route have been traversed already. If auto move fails to move into any of the routed tiles, it stops automatically and aborts auto move anyway with other code, which also sets `destination_point` to null. The only way `auto_move_route` could be empty while `destination_point` is non-null is therefore if auto move has successfully completed.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

The method `has_destination_activity` might have changed meaning over time. Its current name does not unambiguously describe its purpose, since what it checks now includes not only whether there is a destination activity at all, but also whether the player is located at the destination point, as noted by the method comment: https://github.com/CleverRaven/Cataclysm-DDA/blob/22f9e267a0b62a95f0a677f4c56b45c6128188f7/src/character.h#L3836-L3837

Another name for it could have been `can_start_destination_activity` instead.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

* Have verified the steps provided in #80897 . Using map travel to walk across a bridge now works as expected. Both with or without "fast travel".
* Verified that NPC still follows me around. Also over bridges.
* Verified that NPC can still do zone sorting tasks, since those use the changed functionality.
* Verified that NPC can still mount a horse when told to mount up.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
