### PR TITLE
Attempt to make anger relations work inside of aggro_character

### DIFF
--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -1869,8 +1869,8 @@ monster_attitude monster::attitude( const Character *u ) const
     }
 
     bool target_has_anger_relation = false;
-        if( u != nullptr ) {
-        for( const trait_id &mut : u->get_functioning_mutations() ) {
+if( u != nullptr ) {
+    for( const trait_id &mut : u->get_functioning_mutations() ) {
         const mutation_branch &branch = *mut;
         for( const std::pair<const species_id, int> &elem : branch.anger_relations ) {
             if( type->in_species( elem.first ) ) {
@@ -1884,11 +1884,8 @@ monster_attitude monster::attitude( const Character *u ) const
     }
 }
 
-    if( u != nullptr && !aggro_character && !u->is_monster() ) {
-        return MATT_IGNORE;
-    }
-
-    return MATT_ATTACK;
+if( u != nullptr && !aggro_character && !u->is_monster() && !target_has_anger_relation ) {
+    return MATT_IGNORE;
 }
 
 int monster::hp_percentage() const

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -1757,6 +1757,22 @@ monster_attitude monster::attitude( const Character *u ) const
         return MATT_FLEE;
     }
 
+        bool target_has_anger_relation = false;
+if( u != nullptr ) {
+    for( const trait_id &mut : u->get_functioning_mutations() ) {
+        const mutation_branch &branch = *mut;
+        for( const std::pair<const species_id, int> &elem : branch.anger_relations ) {
+            if( type->in_species( elem.first ) ) {
+                target_has_anger_relation = true;
+                break;
+            }
+        }
+        if( target_has_anger_relation ) {
+            break;
+        }
+    }
+}
+
     int effective_anger  = anger;
     int effective_morale = morale;
 
@@ -1867,22 +1883,6 @@ monster_attitude monster::attitude( const Character *u ) const
         rl_dist( pos_abs(), get_dest() ) < type->tracking_distance ) {
         return MATT_FLEE;
     }
-
-    bool target_has_anger_relation = false;
-if( u != nullptr ) {
-    for( const trait_id &mut : u->get_functioning_mutations() ) {
-        const mutation_branch &branch = *mut;
-        for( const std::pair<const species_id, int> &elem : branch.anger_relations ) {
-            if( type->in_species( elem.first ) ) {
-                target_has_anger_relation = true;
-                break;
-            }
-        }
-        if( target_has_anger_relation ) {
-            break;
-        }
-    }
-}
 
 if( u != nullptr && !aggro_character && !u->is_monster() && !target_has_anger_relation ) {
     return MATT_IGNORE;

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -1868,6 +1868,22 @@ monster_attitude monster::attitude( const Character *u ) const
         return MATT_FLEE;
     }
 
+    bool target_has_anger_relation = false;
+        if( u != nullptr ) {
+        for( const trait_id &mut : u->get_functioning_mutations() ) {
+        const mutation_branch &branch = *mut;
+        for( const std::pair<const species_id, int> &elem : branch.anger_relations ) {
+            if( type->in_species( elem.first ) ) {
+                target_has_anger_relation = true;
+                break;
+            }
+        }
+        if( target_has_anger_relation ) {
+            break;
+        }
+    }
+}
+
     if( u != nullptr && !aggro_character && !u->is_monster() ) {
         return MATT_IGNORE;
     }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "Make aggro_character respect anger_relations"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
#79991 Was an absolutely awful hack to try and resolve the issues it describes.  Renech made a good point.  This attempts to resolve the issues more cleanly by adding on to the work from  #59795.   
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Inserts a check for anger relations by species at the front of the function and slightly rearranges the order of operations.  Ithink i've done this correctly now that it finally compiles.  
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Begging someone else to do this.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
I tested with Xedra Evolved Cyborg professions now are targeted for murder by Exodii, and tested with Goblins and Wargs in Magiclysm and the warg ignores the goblin still while it's fighting with others.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
