### PR TITLE
Block unsuitable map extras in the air and fireweed on artificial ground (Research Facility)

### DIFF
--- a/data/json/overmap/overmap_terrain/overmap_terrain_lab.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_lab.json
@@ -363,6 +363,32 @@
   {
     "type": "overmap_terrain",
     "id": [
+      "lab_surface_brick_block2A2",
+      "lab_surface_brick_block2A3",
+      "lab_surface_brick_block2A4",
+      "lab_surface_brick_block2B2",
+      "lab_surface_brick_block2B3",
+      "lab_surface_brick_block2B4",
+      "lab_surface_brick_block2C3",
+      "lab_surface_brick_block2C4",
+      "lab_surface_brick_block2D2",
+      "lab_surface_brick_block2D3",
+      "lab_surface_brick_block2D4",
+      "lab_surface_brick_block2E2",
+      "lab_surface_brick_block2E3",
+      "lab_surface_brick_block2E4"
+    ],
+    "name": "research facility, second floor",
+    "vision_levels": "large_building",
+    "sym": "l",
+    "color": "light_gray",
+    "spawns": { "group": "GROUP_LAB_SURFACE", "population": [ 10, 25 ], "chance": 60 },
+    "see_cost": "full_high",
+    "mondensity": 2
+  },
+  {
+    "type": "overmap_terrain",
+    "id": [
       "lab_surface_brick_blockA2",
       "lab_surface_brick_blockA3",
       "lab_surface_brick_blockA4",
@@ -378,13 +404,8 @@
       "lab_surface_brick_blockE4"
     ],
     "name": "research facility",
-    "vision_levels": "large_building",
-    "sym": "l",
-    "color": "light_gray",
-    "spawns": { "group": "GROUP_LAB_SURFACE", "population": [ 10, 25 ], "chance": 60 },
-    "extras": "research_facility_interior",
-    "see_cost": "full_high",
-    "mondensity": 2
+    "copy-from": "lab_surface_brick_block2A2",
+    "extras": "research_facility_interior"
   },
   {
     "type": "overmap_terrain",
@@ -456,27 +477,6 @@
   {
     "type": "overmap_terrain",
     "id": [
-      "lab_surface_brick_block2A2",
-      "lab_surface_brick_block2A3",
-      "lab_surface_brick_block2A4",
-      "lab_surface_brick_block2B2",
-      "lab_surface_brick_block2B3",
-      "lab_surface_brick_block2B4",
-      "lab_surface_brick_block2C3",
-      "lab_surface_brick_block2C4",
-      "lab_surface_brick_block2D2",
-      "lab_surface_brick_block2D3",
-      "lab_surface_brick_block2D4",
-      "lab_surface_brick_block2E2",
-      "lab_surface_brick_block2E3",
-      "lab_surface_brick_block2E4"
-    ],
-    "name": "research facility, second floor",
-    "copy-from": "lab_surface_brick_blockA2"
-  },
-  {
-    "type": "overmap_terrain",
-    "id": [
       "lab_surface_brick_block3A2",
       "lab_surface_brick_block3A3",
       "lab_surface_brick_block3A4",
@@ -493,7 +493,7 @@
       "lab_surface_brick_block3E4"
     ],
     "name": "research facility, third floor",
-    "copy-from": "lab_surface_brick_blockA2"
+    "copy-from": "lab_surface_brick_block2A2"
   },
   {
     "type": "overmap_terrain",
@@ -514,7 +514,7 @@
       "lab_surface_brick_block4E4"
     ],
     "name": "research facility, fourth floor",
-    "copy-from": "lab_surface_brick_blockA2"
+    "copy-from": "lab_surface_brick_block2A2"
   },
   {
     "type": "overmap_terrain",

--- a/data/json/regional_map_settings.json
+++ b/data/json/regional_map_settings.json
@@ -740,7 +740,6 @@
           "mx_portal": 200,
           "mx_crater": 180,
           "mx_portal_in": 30,
-          "mx_point_burned_ground": 100,
           "mx_casings": 30,
           "mx_exocrash_1": 1,
           "mx_exocrash_2": 1
@@ -751,7 +750,6 @@
         "extras": {
           "mx_crater": 15000,
           "mx_portal": 5000,
-          "mx_point_burned_ground": 6250,
           "mx_portal_in": 2000,
           "mx_casings": 1500,
           "mx_military": 250,


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fix #80998, i.e. unsuitable map extra generation in research facilities.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
- Change the inheritance structure for the research facility so map extras are generated on the ground level only.
- Remove burnt ground map extra from the research facility since it places fireweed on artificial ground.
- Restricted burnt ground map extra to appear on the ground level only.
 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Try to continue to figure out if it's possible to retain the original inheritance order and remove the map extra group.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Teleported to a couple of unvisited research facilities a couple of times and note that auto notes only appear for the ground floor and the parking lot. Have not positively verified the absence of fireweed, but at least I haven't gotten error reports about it being placed in the air at ground level (z coordinate = 0), which presumably was caused by it being generated above craters.

Edit:
Reverted to master, made the change to burned ground, teleported around to a couple research facilities, and saw no burned ground above the ground level, despite there being quite a few of these before that change.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
This general issue is much broader, as the "build" map extra group is used above ground level, and thus should cause both inappropriate fireweed placement as well as levitating items (and associated error messages).

If you want map extras generated above ground you'd either have to tailor them carefully to the target locations to ensure they won't try to place stuff in the air, or develop some kind of infrastructure support that somehow constrains the mx extras to tiles they can actually be placed on, either through rejection of generated ones that don't fit, or by retrying or somehow constraining generation parameters so they generate suitable results.

Fireweed placement is a special headache, since I don't think there's support for transformation of "furniture" based on what the "terrain" is, which is what's needed for it to be used safely in (partially) man made environments.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
