### PR TITLE
Added recipe to craft corded chainsaw

### DIFF
--- a/data/json/recipes/tools/tools_electronic.json
+++ b/data/json/recipes/tools/tools_electronic.json
@@ -601,39 +601,27 @@
     "components": [ [ [ "motor_tiny", 1 ] ], [ [ "cable", 12 ] ], [ [ "chain", 1 ] ], [ [ "scrap", 3 ] ] ]
   },
   {
-  "type": "recipe",
-  "activity_level": "BRISK_EXERCISE",
-  "result": "elec_chainsaw_cord_off",
-  "category": "CC_ELECTRONIC",
-  "subcategory": "CSC_ELECTRONIC_TOOLS",
-  "skill_used": "electronics",
-  "difficulty": 4,
-  "time": "40 m",
-  "reversible": true,
-  "decomp_learn": 4,
-  "//": "100cm weld",
-  "book_learn": [
-    [ "textbook_mechanics", 4 ],
-    [ "textbook_carpentry", 4 ],
-    [ "advanced_electronics", 3 ],
-    [ "textbook_electronics", 3 ]
-  ],
-  "using": [
-    [ "welding_standard", 100 ]
-  ],
-  "qualities": [
-    { "id": "HAMMER", "level": 2 },
-    { "id": "SCREW", "level": 1 },
-    { "id": "WRENCH", "level": 1 }
-  ],
-  "components": [
-    [ [ "motor_tiny", 1 ] ],
-    [ [ "cable", 12 ] ],
-    [ [ "chain", 1 ] ],
-    [ [ "scrap", 3 ] ],
-    [ [ "extension_cable", 1 ] ]
-  ]
-},  
+    "type": "recipe",
+    "activity_level": "BRISK_EXERCISE",
+    "result": "elec_chainsaw_cord_off",
+    "category": "CC_ELECTRONIC",
+    "subcategory": "CSC_ELECTRONIC_TOOLS",
+    "skill_used": "electronics",
+    "difficulty": 4,
+    "time": "40 m",
+    "reversible": true,
+    "decomp_learn": 4,
+    "//": "100cm weld",
+    "book_learn": [
+      [ "textbook_mechanics", 4 ],
+      [ "textbook_carpentry", 4 ],
+      [ "advanced_electronics", 3 ],
+      [ "textbook_electronics", 3 ]
+    ],
+    "using": [ [ "welding_standard", 100 ] ],
+    "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SCREW", "level": 1 }, { "id": "WRENCH", "level": 1 } ],
+    "components": [ [ [ "motor_tiny", 1 ] ], [ [ "cable", 12 ] ], [ [ "chain", 1 ] ], [ [ "scrap", 3 ] ], [ [ "extension_cable", 1 ] ] ]
+  },
   {
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",

--- a/data/json/recipes/tools/tools_electronic.json
+++ b/data/json/recipes/tools/tools_electronic.json
@@ -601,27 +601,39 @@
     "components": [ [ [ "motor_tiny", 1 ] ], [ [ "cable", 12 ] ], [ [ "chain", 1 ] ], [ [ "scrap", 3 ] ] ]
   },
   {
-    "type": "recipe",
-    "activity_level": "BRISK_EXERCISE",
-    "result": "elec_chainsaw_cord_off",
-    "category": "CC_ELECTRONIC",
-    "subcategory": "CSC_ELECTRONIC_TOOLS",
-    "skill_used": "electronics",
-    "difficulty": 4,
-    "time": "40 m",
-    "reversible": true,
-    "decomp_learn": 4,
-    "//": "100cm weld",
-    "book_learn": [
-      [ "textbook_mechanics", 4 ],
-      [ "textbook_carpentry", 4 ],
-      [ "advanced_electronics", 3 ],
-      [ "textbook_electronics", 3 ]
-    ],
-    "using": [ [ "welding_standard", 100 ] ],
-    "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SCREW", "level": 1 }, { "id": "WRENCH", "level": 1 } ],
-    "components": [ [ [ "motor_tiny", 1 ] ], [ [ "cable", 12 ] ], [ [ "chain", 1 ] ], [ [ "scrap", 3 ] ],[ ["extension_cable",1] ] ]
-  },  
+  "type": "recipe",
+  "activity_level": "BRISK_EXERCISE",
+  "result": "elec_chainsaw_cord_off",
+  "category": "CC_ELECTRONIC",
+  "subcategory": "CSC_ELECTRONIC_TOOLS",
+  "skill_used": "electronics",
+  "difficulty": 4,
+  "time": "40 m",
+  "reversible": true,
+  "decomp_learn": 4,
+  "//": "100cm weld",
+  "book_learn": [
+    [ "textbook_mechanics", 4 ],
+    [ "textbook_carpentry", 4 ],
+    [ "advanced_electronics", 3 ],
+    [ "textbook_electronics", 3 ]
+  ],
+  "using": [
+    [ "welding_standard", 100 ]
+  ],
+  "qualities": [
+    { "id": "HAMMER", "level": 2 },
+    { "id": "SCREW", "level": 1 },
+    { "id": "WRENCH", "level": 1 }
+  ],
+  "components": [
+    [ [ "motor_tiny", 1 ] ],
+    [ [ "cable", 12 ] ],
+    [ [ "chain", 1 ] ],
+    [ [ "scrap", 3 ] ],
+    [ [ "extension_cable", 1 ] ]
+  ]
+},  
   {
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",

--- a/data/json/recipes/tools/tools_electronic.json
+++ b/data/json/recipes/tools/tools_electronic.json
@@ -602,6 +602,28 @@
   },
   {
     "type": "recipe",
+    "activity_level": "BRISK_EXERCISE",
+    "result": "elec_chainsaw_cord_off",
+    "category": "CC_ELECTRONIC",
+    "subcategory": "CSC_ELECTRONIC_TOOLS",
+    "skill_used": "electronics",
+    "difficulty": 4,
+    "time": "40 m",
+    "reversible": true,
+    "decomp_learn": 4,
+    "//": "100cm weld",
+    "book_learn": [
+      [ "textbook_mechanics", 4 ],
+      [ "textbook_carpentry", 4 ],
+      [ "advanced_electronics", 3 ],
+      [ "textbook_electronics", 3 ]
+    ],
+    "using": [ [ "welding_standard", 100 ] ],
+    "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SCREW", "level": 1 }, { "id": "WRENCH", "level": 1 } ],
+    "components": [ [ [ "motor_tiny", 1 ] ], [ [ "cable", 12 ] ], [ [ "chain", 1 ] ], [ [ "scrap", 3 ] ],[ ["extension_cable",1] ] ]
+  },  
+  {
+    "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",
     "result": "makeshift_sealer",
     "category": "CC_ELECTRONIC",


### PR DESCRIPTION
#### Summary
Content "Added crafting recipe for corded chainsaw"

#### Purpose of change

To make it craftable with the same materials as the electric battery powered one plus an extension cable, recipe remains the same otherwise.

#### Describe the solution

Added a new recipe for the 'corded_chainsaw'
The recipe was added to appropriate crafting group and category to match similar powered tools like the corded electric jakchammer.

#### Describe alternatives you've considered

- well... not adding it?

#### Testing

- Loaded my game with the new recipe in place
- Verified it appears in the crafting menu under Electronics and Tools
- Crafted it and delivered the item it was intended to deliver
- This time I linted the code hopefully it passes all tests -_- pls be patient I'm a noob
