### PR TITLE
Remove some particularly WTF crafting recipes

### DIFF
--- a/data/json/recipes/tools/tools_electronic.json
+++ b/data/json/recipes/tools/tools_electronic.json
@@ -233,27 +233,6 @@
   {
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",
-    "result": "tazer",
-    "category": "CC_ELECTRONIC",
-    "subcategory": "CSC_ELECTRONIC_TOOLS",
-    "skill_used": "electronics",
-    "difficulty": 3,
-    "time": "25 m",
-    "reversible": true,
-    "decomp_learn": 3,
-    "book_learn": [ [ "advanced_electronics", 2 ], [ "textbook_electronics", 3 ], [ "textbook_anarch", 3 ] ],
-    "using": [ [ "soldering_standard", 10 ] ],
-    "proficiencies": [
-      { "proficiency": "prof_elec_soldering" },
-      { "proficiency": "prof_elec_circuits" },
-      { "proficiency": "prof_elec_semiconductors" }
-    ],
-    "qualities": [ { "id": "SCREW", "level": 1 } ],
-    "components": [ [ [ "amplifier", 1 ] ], [ [ "power_supply", 1 ] ], [ [ "scrap_aluminum", 2 ] ] ]
-  },
-  {
-    "type": "recipe",
-    "activity_level": "LIGHT_EXERCISE",
     "result": "carver_off",
     "category": "CC_ELECTRONIC",
     "subcategory": "CSC_ELECTRONIC_TOOLS",
@@ -299,68 +278,12 @@
     "using": [ [ "soldering_standard", 10 ], [ "plastic_molding", 4 ] ],
     "qualities": [ { "id": "SCREW", "level": 1 } ],
     "components": [
-      [ [ "antenna", 1 ], [ "screwdriver", 1 ], [ "xacto", 1 ], [ "knife_butter", 1 ] ],
+      [ [ "screwdriver", 1 ] ],
       [ [ "plastic_chunk", 6 ] ],
       [ [ "motor_tiny", 1 ] ],
       [ [ "power_supply", 1 ] ],
       [ [ "cable", 5 ] ],
       [ [ "scrap", 1 ], [ "steel_chunk_any", 1, "LIST" ] ]
-    ]
-  },
-  {
-    "type": "recipe",
-    "activity_level": "LIGHT_EXERCISE",
-    "result": "trimmer_off",
-    "category": "CC_ELECTRONIC",
-    "subcategory": "CSC_ELECTRONIC_TOOLS",
-    "skill_used": "fabrication",
-    "skills_required": [ "electronics", 3 ],
-    "difficulty": 5,
-    "time": "1 h",
-    "decomp_learn": 5,
-    "book_learn": [ [ "advanced_electronics", 4 ], [ "textbook_electronics", 4 ] ],
-    "proficiencies": [
-      { "proficiency": "prof_plasticworking", "time_multiplier": 1.5 },
-      { "proficiency": "prof_elec_soldering" },
-      { "proficiency": "prof_elec_circuits" }
-    ],
-    "using": [ [ "soldering_standard", 12 ], [ "plastic_molding", 4 ] ],
-    "qualities": [ { "id": "SCREW", "level": 1 } ],
-    "components": [
-      [ [ "plastic_chunk", 6 ] ],
-      [ [ "chain", 1 ] ],
-      [ [ "motor_tiny", 1 ] ],
-      [ [ "metal_tank_little", 1 ] ],
-      [ [ "scrap", 2 ] ],
-      [ [ "cable", 4 ] ],
-      [ [ "1cyl_combustion_small", 1 ] ]
-    ]
-  },
-  {
-    "type": "recipe",
-    "activity_level": "LIGHT_EXERCISE",
-    "result": "circsaw_off",
-    "category": "CC_ELECTRONIC",
-    "subcategory": "CSC_ELECTRONIC_TOOLS",
-    "skill_used": "fabrication",
-    "skills_required": [ "electronics", 3 ],
-    "difficulty": 5,
-    "time": "1 h",
-    "book_learn": [ [ "advanced_electronics", 4 ], [ "textbook_electronics", 4 ], [ "textbook_carpentry", 5 ] ],
-    "proficiencies": [
-      { "proficiency": "prof_plasticworking", "required": false, "time_multiplier": 1.5 },
-      { "proficiency": "prof_elec_soldering" },
-      { "proficiency": "prof_elec_circuits" }
-    ],
-    "using": [ [ "soldering_standard", 10 ], [ "plastic_molding", 4 ] ],
-    "qualities": [ { "id": "SCREW", "level": 1 } ],
-    "components": [
-      [ [ "plastic_chunk", 6 ] ],
-      [ [ "circsaw_blade", 1 ] ],
-      [ [ "motor_tiny", 1 ] ],
-      [ [ "power_supply", 1 ] ],
-      [ [ "scrap", 1 ] ],
-      [ [ "cable", 5 ] ]
     ]
   },
   {
@@ -542,63 +465,6 @@
       { "proficiency": "prof_elec_circuits" }
     ],
     "components": [ [ [ "scrap", 1 ] ], [ [ "plastic_chunk", 3 ] ], [ [ "cable", 5 ] ], [ [ "motor_micro", 1 ] ] ]
-  },
-  {
-    "type": "recipe",
-    "activity_level": "BRISK_EXERCISE",
-    "result": "elec_jackhammer",
-    "category": "CC_ELECTRONIC",
-    "subcategory": "CSC_ELECTRONIC_TOOLS",
-    "skill_used": "electronics",
-    "difficulty": 5,
-    "time": "60 m",
-    "reversible": true,
-    "decomp_learn": 5,
-    "book_learn": [
-      [ "textbook_mechanics", 6 ],
-      [ "textbook_carpentry", 6 ],
-      [ "advanced_electronics", 5 ],
-      [ "textbook_electronics", 5 ]
-    ],
-    "//": "130cm weld",
-    "using": [ [ "welding_standard", 130 ] ],
-    "proficiencies": [
-      { "proficiency": "prof_welding_basic" },
-      { "proficiency": "prof_welding" },
-      { "proficiency": "prof_elec_soldering" },
-      { "proficiency": "prof_elec_circuits" }
-    ],
-    "qualities": [ { "id": "HAMMER", "level": 3 }, { "id": "SCREW", "level": 1 }, { "id": "WRENCH", "level": 1 } ],
-    "components": [
-      [ [ "motor_small", 1 ] ],
-      [ [ "UPS_OFF", 1 ] ],
-      [ [ "medium_storage_battery", 1 ] ],
-      [ [ "cable", 12 ] ],
-      [ [ "rebar", 2 ], [ "steel_chunk_any", 4, "LIST" ] ],
-      [ [ "scrap", 3 ] ]
-    ]
-  },
-  {
-    "type": "recipe",
-    "activity_level": "BRISK_EXERCISE",
-    "result": "elec_chainsaw_off",
-    "category": "CC_ELECTRONIC",
-    "subcategory": "CSC_ELECTRONIC_TOOLS",
-    "skill_used": "electronics",
-    "difficulty": 4,
-    "time": "40 m",
-    "reversible": true,
-    "decomp_learn": 4,
-    "//": "100cm weld",
-    "book_learn": [
-      [ "textbook_mechanics", 4 ],
-      [ "textbook_carpentry", 4 ],
-      [ "advanced_electronics", 3 ],
-      [ "textbook_electronics", 3 ]
-    ],
-    "using": [ [ "welding_standard", 100 ] ],
-    "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SCREW", "level": 1 }, { "id": "WRENCH", "level": 1 } ],
-    "components": [ [ [ "motor_tiny", 1 ] ], [ [ "cable", 12 ] ], [ [ "chain", 1 ] ], [ [ "scrap", 3 ] ] ]
   },
   {
     "type": "recipe",


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Remove chainsaw, electric trimmer, tazer, and a few other recipes that *might* be possible to basement craft but certainly not using these recipes.
The circuit components for the tazer, blades and cogs for the trimmer,  chain and cogs for the chainsaw, and appropriate motors for all of the above are not really represented in any kind of meaningful way, not to mention the fabrication requirements which would actually require quite a lot of blacksmithing and/or other fabrication techniques.

#### Describe the solution
Just remove the recipes, removed a few nonsense shaft alternatives from the drill.

#### Describe alternatives you've considered
It's reasonable for these to be craftable *somehow*, but with a rather prohibitive amount of scavenging of rare parts or much more involved crafting-from-scratch instead of just assuming you can weld misc scrap into the right shape.  