### PR TITLE
various move_skills bugfixes

### DIFF
--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -1600,40 +1600,39 @@ int monster::calc_movecost( const map &here, const tripoint_bub_ms &from,
             const vpart_position vp( const_cast<vehicle &>( *veh ), part );
             int veh_movecost = vp.get_movecost();
             int fieldcost = get_filtered_fieldcost( field );
-            if( veh_movecost > 0 && fieldcost >= 0 ) {
-                cost += veh_movecost + fieldcost;
-                // vehicle movement ignores the rest
-                continue;
-            } else {
+            if( ( veh_movecost <= 0 || fieldcost < 0 ) && where == from ) {
                 debugmsg( "%s cannot move to %s. monster::calc_movecost expects to be called with valid destination.",
                           get_name(), veh_movecost ? veh->disp_name() :  field.displayed_field_type().id().str() );
                 return 0;
+            } else {
+                cost += veh_movecost + fieldcost;
+                // vehicle movement ignores the rest
+                continue;
             }
         }
 
         //terrain
-        if( terrain.movecost < 0 ) {
+        if( terrain.movecost < 0 && where == to ) {
             debugmsg( "%s cannot enter unwalkable terrain %s. monster::calc_movecost expects to be called with valid destination.",
                       get_name(), terrain.name() );
-            continue;
-        } else if( terrain.has_flag( ter_furn_flag::TFLAG_SWIMMABLE ) ) {
+            return 0;
+        } else if( is_aquatic_danger( where ) && where == to ) {
+            debugmsg( "%s cannot swim or move in %s. monster::calc_movecost expects to be called with valid destination.",
+                      get_name(), veh ? veh->disp_name() : terrain.name() );
+            return 0;
 
+        } else if( terrain.has_flag( ter_furn_flag::TFLAG_SWIMMABLE ) ) {
             if( swims() ) {
                 // swimmers dont care about terraincost/other effects.
                 // fish move as quickly as possible with a swimmod of 0.
                 cost += swimmod;
                 continue;
 
-                // walk on the bottom of the water
-            } else if( has_flag( mon_flag_NO_BREATHE ) || force ) {
-                cost += terrain.movecost;
+                // walk on the bottom of the water. Monsters that cannot walk here should have been filtered out by is_aquatic_danger()
             } else {
-                // cannot swim or walk underwater.
-                debugmsg( "%s cannot swim or move in %s. monster::calc_movecost expects to be called with valid destination.",
-                          get_name(), veh ? veh->disp_name() : terrain.name() );
-                return 0;
+                cost += terrain.movecost;
             }
-        } else if( has_flag( mon_flag_AQUATIC ) && !force ) {
+        } else if( has_flag( mon_flag_AQUATIC ) && !force && where == to ) {
             debugmsg( "Aquatic %s cannot enter non-swimmable %s. monster::calc_movecost expects to be called with valid destination.",
                       get_name(), veh ? veh->disp_name() : terrain.name() );
             return 0;
@@ -1650,7 +1649,7 @@ int monster::calc_movecost( const map &here, const tripoint_bub_ms &from,
                    ( from.z() != to.z() && terrain.has_flag( ter_furn_flag::TFLAG_DIFFICULT_Z ) ) ) {
             if( climbs() ) {
                 cost += terrain.movecost * get_climb_mod();
-            } else if( force ) {
+            }  else if( force || where == from ) {
                 cost += terrain.movecost;
                 continue;
             } else {
@@ -1672,6 +1671,8 @@ int monster::calc_movecost( const map &here, const tripoint_bub_ms &from,
                        ( from.z() != to.z() && terrain.has_flag( ter_furn_flag::TFLAG_DIFFICULT_Z ) ) ) {
                 if( climbs() || force ) {
                     cost += furniture.movecost * get_climb_mod();
+                } else if( where == to ) {
+                    cost += furniture.movecost;
                 } else {
                     debugmsg( "%s cannot climb over %s. monster::calc_movecost expects to be called with valid destination.",
                               get_name(), furniture.name() );

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -1474,12 +1474,22 @@ int monster::get_climb_mod() const
 
 bool monster::swims() const
 {
-    return has_flag( mon_flag_SWIMS ) || type->move_skills.swim.has_value();
+    return has_flag( mon_flag_SWIMS ) || has_flag( mon_flag_AQUATIC ) ||
+           type->move_skills.swim.has_value();
 }
 
 int monster::swim_skill() const
 {
-    return type->move_skills.swim.value_or( has_flag( mon_flag_SWIMS ) ? 10 : -1 );
+    if( type->move_skills.swim.has_value() ) {
+        return type->move_skills.swim.value();
+    } else if( has_flag( mon_flag_SWIMS ) ) {
+        // Backwardscompatibility only
+        return 10;
+    } else if( has_flag( mon_flag_AQUATIC ) ) {
+        // arbitrary value, if a specific speed is desired, use move_skills
+        return 6;
+    }
+    return -1;
 }
 
 int monster::get_swim_mod() const


### PR DESCRIPTION
#### Summary
Bugfixes "Allow moving out of impassable, aquatic treated as swimming, non-swimmers can walk in shallow water"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
fix #81012, fix #80939
* monsters could not path out ofout of terrain the monster usually can't enter (if hey spawned there or get pushed into it)
* Monsters that only had the AQUATIC flag (and not the SWIMS flag or move_skill) could not path in water. 
* Non-swimmers could not walk in shallow water
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
* Allow pathing (calculating movecost) out of terrain the monster usually can't enter (if hey spawned there or get pushed into it) by checking if the invalid tile is the current location or target.
* Treat AQUATIC only monsters as if they have a low  swimskill
* use monster::is_aquatic_danger instead of just checking for "SWIMMABLE" flag
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
When a monster tries to path out of a non-traversable tile, should it not move, die or be able to move out if the destination is valid?
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
