### PR TITLE
[MoM] Phase volume requirements

### DIFF
--- a/data/mods/MindOverMatter/PowerDescriptionSpoilers.md
+++ b/data/mods/MindOverMatter/PowerDescriptionSpoilers.md
@@ -1353,7 +1353,7 @@ Powers causing telepathic damage have a 5% chance to down the target, a 33% chan
 *Duration*: Instant<br />
 *Stamina Cost*: 900, minus 55 per level to a minimum of 350<br />
 *Channeling Time*: 50 moves, minus 3.5 moves per level to a minimum of 5<br />
-*Effects*: The psion vanishes and reappears nearby. They cannot control exactly where they end up. While there is no danger of teleporting into a wall or solid rock, if above ground level it is possible to teleport into open air, after which the psion will fall normally.  The psion may always teleport themselves, and can carry 5L of gear, plus 3.5L per power level<br />
+*Effects*: The psion vanishes and reappears nearby. They cannot control exactly where they end up. While there is no danger of teleporting into a wall or solid rock, if above ground level it is possible to teleport into open air, after which the psion will fall normally.  The psion may always teleport themselves, and can carry 5L of gear, plus 3.5L per power level.<br />
 *Prerequisites*: Starting power<br />
 </details>
 <details>
@@ -1375,7 +1375,7 @@ Powers causing telepathic damage have a 5% chance to down the target, a 33% chan
 *Duration*: Instant<br />
 *Stamina Cost*: 2500, minus 65 per level to a minimum of 1250<br />
 *Channeling Time*: 65 moves, minus 3 moves per level to a minimum of 15<br />
-*Effects*: Travel a short distance through the Nether and re-emerge nearby, allowing the psion to bypass a door or travel from the ground floor to the second floor.<br />
+*Effects*: Travel a short distance through the Nether and re-emerge nearby, allowing the psion to bypass a door or travel from the ground floor to the second floor.  The psion may always teleport themselves, and can carry 10L of gear, plus 5L per power level.<br />
 *Prerequisites*: Blink 6<br />
 </details>
 <details>

--- a/data/mods/MindOverMatter/powers/teleportation.json
+++ b/data/mods/MindOverMatter/powers/teleportation.json
@@ -25,20 +25,14 @@
   },
   {
     "id": "teleport_blink_real",
+    "copy-from": "teleport_blink",
     "type": "SPELL",
-    "name": { "str": "[Ψ]Blink", "//~": "NO_I18N" },
+    "name": { "str": "[Ψ]Blink Real", "//~": "NO_I18N" },
     "description": { "str": "The actual spell that blinks you.  You should not see this", "//~": "NO_I18N" },
     "message": "",
-    "teachable": false,
     "valid_targets": [ "none" ],
-    "spell_class": "TELEPORTER",
-    "magic_type": "mom_psionics",
-    "skill": "metaphysics",
     "flags": [ "PSIONIC", "CONCENTRATE", "SILENT", "NO_HANDS", "NO_LEGS", "RANDOM_AOE" ],
-    "difficulty": 1,
-    "max_level": { "math": [ "int_to_level(1)" ] },
     "effect": "short_range_teleport",
-    "shape": "blast",
     "min_aoe": 1,
     "max_aoe": 5,
     "min_range": 5,
@@ -94,29 +88,40 @@
     "type": "SPELL",
     "name": "[Ψ]Phase",
     "description": "By stepping for a moment into the void between dimensions, you can bypass a wall or walk from the ground to the roof of a house.",
-    "message": "There is a brief moment of darkness and terrible cold, and you are somewhere else.",
+    "message": "",
     "teachable": false,
-    "valid_targets": [ "ground" ],
+    "valid_targets": [ "self" ],
     "spell_class": "TELEPORTER",
     "magic_type": "mom_psionics",
     "skill": "metaphysics",
-    "flags": [ "PSIONIC", "CONCENTRATE", "SILENT", "NO_HANDS", "NO_LEGS", "TARGET_TELEPORT", "IGNORE_WALLS" ],
+    "flags": [ "PSIONIC", "CONCENTRATE", "SILENT", "NO_HANDS", "NO_LEGS" ],
     "difficulty": 2,
     "max_level": { "math": [ "int_to_level(1)" ] },
-    "effect": "short_range_teleport",
+    "effect": "effect_on_condition",
+    "effect_str": "EOC_TELEPORT_PHASE_INITIATE"
     "shape": "blast",
-    "min_range": {
-      "math": [
-        "clamp( (( (u_spell_level('teleport_phase') * 0.1) + 2) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling), 2, 4)"
-      ]
-    },
-    "max_range": 4,
     "base_energy_cost": 2500,
     "final_energy_cost": 1250,
     "energy_increment": -65,
     "base_casting_time": 65,
     "final_casting_time": 15,
     "casting_time_increment": -3
+  },
+  {
+    "id": "teleport_phase_real",
+    "copy-from": "teleport_phase"
+    "type": "SPELL",
+    "valid_targets": [ "ground" ],
+    "magic_type": "mom_psionics",
+    "flags": [ "PSIONIC", "CONCENTRATE", "SILENT", "NO_HANDS", "NO_LEGS", "TARGET_TELEPORT", "IGNORE_WALLS" ],
+    "effect": "short_range_teleport",
+    "shape": "blast",
+    "min_range": {
+      "math": [
+        "clamp( ( ( (u_spell_level('teleport_phase') * 0.1) + 2) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling), 2, 4)"
+      ]
+    },
+    "max_range": 4
   },
   {
     "id": "teleport_item_apport",

--- a/data/mods/MindOverMatter/powers/teleportation.json
+++ b/data/mods/MindOverMatter/powers/teleportation.json
@@ -98,7 +98,7 @@
     "difficulty": 2,
     "max_level": { "math": [ "int_to_level(1)" ] },
     "effect": "effect_on_condition",
-    "effect_str": "EOC_TELEPORT_PHASE_INITIATE"
+    "effect_str": "EOC_TELEPORT_PHASE_INITIATE",
     "shape": "blast",
     "base_energy_cost": 2500,
     "final_energy_cost": 1250,
@@ -109,7 +109,7 @@
   },
   {
     "id": "teleport_phase_real",
-    "copy-from": "teleport_phase"
+    "copy-from": "teleport_phase",
     "type": "SPELL",
     "valid_targets": [ "ground" ],
     "magic_type": "mom_psionics",

--- a/data/mods/MindOverMatter/powers/teleportation_eoc.json
+++ b/data/mods/MindOverMatter/powers/teleportation_eoc.json
@@ -50,7 +50,7 @@
       {
         "if": {
           "math": [
-            "u_teleport_total_carried_volume <= ( ( ( u_spell_level('teleport_blink') * 3500 ) + 5000 ) * scaling_factor( u_val('intelligence') ) * u_nether_attunement_power_scaling )"
+            "u_teleport_total_carried_volume <= _teleport_blink_limit"
           ]
         },
         "then": [
@@ -62,6 +62,46 @@
         "else": [
           {
             "u_message": "You attempt to teleport to somewhere nearby, but your skin merely tingles and nothing happens.  You're carrying too much.",
+            "type": "bad"
+          }
+        ]
+      }
+    ],
+    "false_effect": [ { "u_message": "You feel a strange, inward force.", "type": "bad" } ]
+  },
+   {
+    "type": "effect_on_condition",
+    "id": "EOC_TELEPORT_PHASE_INITIATE",
+    "condition": {
+      "and": [
+        { "not": { "u_has_worn_with_flag": "DIMENSIONAL_ANCHOR" } },
+        { "not": { "u_has_flag": "DIMENSIONAL_ANCHOR" } },
+        { "not": { "u_has_flag": "TELEPORT_LOCK" } }
+      ]
+    },
+    "effect": [
+      { "run_eocs": "EOC_TELEPORT_SELF_CARRIED_VOLUME_CHECKER" },
+      {
+        "math": [
+          "_teleport_phase_limit = ( ( ( u_spell_level('teleport_blink') * 5000 ) + 10000 ) * scaling_factor( u_val('intelligence') ) * u_nether_attunement_power_scaling )"
+        ]
+      },
+      { "u_message": "Your Phase volume limit is <context_val:teleport_blink_limit>.", "type": "debug" },
+      {
+        "if": {
+          "math": [
+            "u_teleport_total_carried_volume <= _teleport_phase_limit"
+          ]
+        },
+        "then": [
+          {
+            "u_cast_spell": { "id": "teleport_phase_real", "min_level": { "math": [ "u_spell_level('teleport_phase')" ] }, "targeted": true }
+          },
+          { "u_message": "There is a brief moment of darkness and terrible cold, and you are somewhere else.", "type": "neutral" }
+        ],
+        "else": [
+          {
+            "u_message": "You attempt to phase through the barrier, but your skin merely tingles and nothing happens.  You're carrying too much.",
             "type": "bad"
           }
         ]

--- a/data/mods/MindOverMatter/powers/teleportation_eoc.json
+++ b/data/mods/MindOverMatter/powers/teleportation_eoc.json
@@ -48,11 +48,7 @@
       },
       { "u_message": "Your Blink volume limit is <context_val:teleport_blink_limit>.", "type": "debug" },
       {
-        "if": {
-          "math": [
-            "u_teleport_total_carried_volume <= _teleport_blink_limit"
-          ]
-        },
+        "if": { "math": [ "u_teleport_total_carried_volume <= _teleport_blink_limit" ] },
         "then": [
           {
             "u_cast_spell": { "id": "teleport_blink_real", "min_level": { "math": [ "u_spell_level('teleport_blink')" ] }, "hit_self": true }
@@ -69,7 +65,7 @@
     ],
     "false_effect": [ { "u_message": "You feel a strange, inward force.", "type": "bad" } ]
   },
-   {
+  {
     "type": "effect_on_condition",
     "id": "EOC_TELEPORT_PHASE_INITIATE",
     "condition": {
@@ -88,16 +84,16 @@
       },
       { "u_message": "Your Phase volume limit is <context_val:teleport_blink_limit>.", "type": "debug" },
       {
-        "if": {
-          "math": [
-            "u_teleport_total_carried_volume <= _teleport_phase_limit"
-          ]
-        },
+        "if": { "math": [ "u_teleport_total_carried_volume <= _teleport_phase_limit" ] },
         "then": [
           {
-            "u_cast_spell": { "id": "teleport_phase_real", "min_level": { "math": [ "u_spell_level('teleport_phase')" ] }, "targeted": true }
+            "u_cast_spell": { "id": "teleport_phase_real", "min_level": { "math": [ "u_spell_level('teleport_phase')" ] } },
+            "targeted": true
           },
-          { "u_message": "There is a brief moment of darkness and terrible cold, and you are somewhere else.", "type": "neutral" }
+          {
+            "u_message": "There is a brief moment of darkness and terrible cold, and you are somewhere else.",
+            "type": "neutral"
+          }
         ],
         "else": [
           {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[MoM] Phase volume requirements"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Updating Phase to give it volume requirements.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add volume requirements to Phase. You can carry 10L + 5L per level. 

- [X] Update documentation

Also adds copy-from to the `_real` powers so their traits that are the same as the base aren't duplicated. 

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Picked up a golfbag full of pillows, could not phase.

Dropped the golfbag, could phase.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
