### PR TITLE
Allow city specials to use OVERMAP_UNIQUE

### DIFF
--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -581,6 +581,12 @@ void overmap_specials::check_consistency()
             debugmsg( "Overmap special id %s has been migrated.  Use %s instead.", os.id.str(),
                       new_id.str() );
         }
+        if( static_cast<int>( os.has_flag( "GLOBALLY_UNIQUE" ) ) +
+            static_cast<int>( os.has_flag( "OVERMAP_UNIQUE" ) ) +
+            static_cast<int>( os.has_flag( "CITY_UNIQUE" ) ) > 1 ) {
+            debugmsg( "In special %s, the mutually exclusive flags GLOBALLY_UNIQUE, "
+                      "OVERMAP_UNIQUE and CITY_UNIQUE cannot be used together.", os.id.str() );
+        }
     }
 }
 
@@ -3696,6 +3702,7 @@ void overmap::generate( const overmap *north, const overmap *east,
     if( get_option<bool>( "OVERMAP_PLACE_SPECIALS" ) ) {
         place_specials( enabled_specials );
     }
+    overmap_buffer.clear_overmap_uniques();
     if( get_option<bool>( "OVERMAP_PLACE_FOREST_TRAILHEADS" ) ) {
         place_forest_trailheads();
     }
@@ -5983,10 +5990,9 @@ overmap_special_id overmap::pick_random_building_to_place( int town_dist, int to
     bool existing_unique;
     do {
         ret = pick_building( city_spec );
-        // TODO: Add OVERMAP_UNIQUE handling, doesn't seem to be kept track of in an ideal way atm
         if( ret->has_flag( "CITY_UNIQUE" ) ) {
             existing_unique = placed_unique_buildings.find( ret ) != placed_unique_buildings.end();
-        } else if( ret->has_flag( "GLOBALLY_UNIQUE" ) ) {
+        } else if( ret->has_flag( "GLOBALLY_UNIQUE" ) || ret->has_flag( "OVERMAP_UNIQUE" ) ) {
             existing_unique = overmap_buffer.contains_unique_special( ret );
         } else {
             existing_unique = false;
@@ -6954,7 +6960,7 @@ bool overmap::can_place_special( const overmap_special &special, const tripoint_
     if( !special.id ) {
         return false;
     }
-    if( special.has_flag( "GLOBALLY_UNIQUE" ) &&
+    if( ( special.has_flag( "GLOBALLY_UNIQUE" ) || special.has_flag( "OVERMAP_UNIQUE" ) ) &&
         overmap_buffer.contains_unique_special( special.id ) ) {
         return false;
     }
@@ -7029,7 +7035,7 @@ std::vector<tripoint_om_omt> overmap::place_special(
         //       point_abs_omt location = coords::project_to<coords::omt>(this->pos()) + p.xy().raw();
         //        DebugLog(DL_ALL, DC_ALL) << "Globally Unique " << special.id.c_str() << " added at " << location.to_string_writable();
     } else if( special.has_flag( "OVERMAP_UNIQUE" ) ) {
-        overmap_buffer.log_unique_special( special.id );
+        overmap_buffer.add_overmap_unique_special( special.id );
     }
     // CITY_UNIQUE is handled in place_building()
 
@@ -7214,7 +7220,7 @@ void overmap::place_specials( overmap_special_batch &enabled_specials )
                               constraints.occurrences.min;
             const float max = std::max( overmap_count > 0 ? constraints.occurrences.max / overmap_count :
                                         constraints.occurrences.max, min );
-            if( x_in_y( min, max ) && ( !globally_unique || !overmap_buffer.contains_unique_special( id ) ) ) {
+            if( x_in_y( min, max ) && ( !overmap_buffer.contains_unique_special( id ) ) ) {
                 // Min and max are overloaded to be the chance of occurrence,
                 // so reset instances placed to one short of max so we don't place several.
                 iter->instances_placed = constraints.occurrences.max - 1;

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -1092,14 +1092,24 @@ bool overmapbuffer::check_overmap_special_type( const overmap_special_id &id,
 void overmapbuffer::add_unique_special( const overmap_special_id &id )
 {
     if( contains_unique_special( id ) ) {
-        debugmsg( "Unique overmap special placed more than once: %s", id.str() );
+        debugmsg( "Globally unique overmap special placed more than once: %s", id.str() );
     }
     placed_unique_specials.emplace( id );
 }
 
+void overmapbuffer::add_overmap_unique_special( const overmap_special_id &id )
+{
+    if( contains_unique_special( id ) ) {
+        debugmsg( "Overmap unique overmap special placed more than once: %s", id.str() );
+    }
+    placed_overmap_unique_specials.emplace( id );
+    unique_special_count[id]++;
+}
+
 bool overmapbuffer::contains_unique_special( const overmap_special_id &id ) const
 {
-    return placed_unique_specials.find( id ) != placed_unique_specials.end();
+    return placed_unique_specials.find( id ) != placed_unique_specials.end() ||
+           placed_overmap_unique_specials.find( id ) != placed_overmap_unique_specials.end();
 }
 
 static omt_find_params assign_params(

--- a/src/overmapbuffer.h
+++ b/src/overmapbuffer.h
@@ -578,7 +578,9 @@ class overmapbuffer
         overmap mutable *last_requested_overmap;
         // Set of globally unique overmap specials that have already been placed
         std::unordered_set<overmap_special_id> placed_unique_specials;
-        // This tracks the unique specials we have placed. It is used to
+        // This tracks the overmap unique specials we have placed during the current oms generate().
+        std::unordered_set<overmap_special_id> placed_overmap_unique_specials;
+        // This tracks the overmap unique specials we have placed. It is used to
         // Adjust weights of special spawns to correct for things like failure to spawn.
         std::unordered_map<overmap_special_id, int> unique_special_count;
         // Global count of number of overmaps generated for this world.
@@ -623,13 +625,14 @@ class overmapbuffer
          */
         void add_unique_special( const overmap_special_id &id );
         /**
-         * Logs the placement of the given unique overmap special.
+         * Adds the given overmap unique overmap special to the lists of placed specials.
          */
-        void log_unique_special( const overmap_special_id &id ) {
-            unique_special_count[id]++;
+        void add_overmap_unique_special( const overmap_special_id &id );
+        void clear_overmap_uniques() {
+            placed_overmap_unique_specials.clear();
         }
         /**
-         * Returns true if the given globally unique overmap special has already been placed.
+         * Returns true if the given globally/overmap unique overmap special has already been placed.
          */
         bool contains_unique_special( const overmap_special_id &id ) const;
         /**

--- a/tests/overmap_test.cpp
+++ b/tests/overmap_test.cpp
@@ -232,7 +232,7 @@ TEST_CASE( "is_ot_match", "[overmap][terrain]" )
 TEST_CASE( "mutable_overmap_placement", "[overmap][slow]" )
 {
     const overmap_special &special =
-        *overmap_special_id( GENERATE( "test_anthill", "test_crater", "test_microlab" ) );
+        *overmap_special_id( GENERATE( "test_crater", "test_microlab" ) );
     const city cit;
 
     constexpr int num_overmaps = 100;
@@ -245,7 +245,6 @@ TEST_CASE( "mutable_overmap_placement", "[overmap][slow]" )
         // overmap objects are really large, so we don't want them on the
         // stack.  Use unique_ptr and put it on the heap
         std::unique_ptr<overmap> om = std::make_unique<overmap>( point_abs_om::zero );
-        overmap_buffer.clear_overmap_uniques();
         om_direction::type dir = om_direction::type::north;
 
         int successes = 0;
@@ -267,6 +266,7 @@ TEST_CASE( "mutable_overmap_placement", "[overmap][slow]" )
             }
         }
 
+        CAPTURE( special.id.str() );
         CHECK( successes > num_trials_per_overmap / 2 );
     }
 }

--- a/tests/overmap_test.cpp
+++ b/tests/overmap_test.cpp
@@ -245,6 +245,7 @@ TEST_CASE( "mutable_overmap_placement", "[overmap][slow]" )
         // overmap objects are really large, so we don't want them on the
         // stack.  Use unique_ptr and put it on the heap
         std::unique_ptr<overmap> om = std::make_unique<overmap>( point_abs_om::zero );
+        overmap_buffer.clear_overmap_uniques();
         om_direction::type dir = om_direction::type::north;
 
         int successes = 0;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Adds missing support for city specials to use OVERMAP_UNIQUE that I brainfarted into thinking wasn't easy in #74290
Adds an error I meant to add in #74290, the CITY_UNIQUE one seems like a pita tho bc you can't distinguish city special vs non city special at the verification step unless I'm missing something
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
The error would have been slightly more efficient inside the std::accumulate loop but that seemed gross
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Used this
```diff
diff --git a/data/json/overmap/multitile_city_buildings.json b/data/json/overmap/multitile_city_buildings.json
index f9484eaffa..191a1a2444 100644
--- a/data/json/overmap/multitile_city_buildings.json
+++ b/data/json/overmap/multitile_city_buildings.json
@@ -1334,6 +1334,13 @@
       { "point": [ 0, 0, 1 ], "overmap": "paintball_field_roof_1_north" }
     ]
   },
+  {
+    "type": "city_building",
+    "id": "house_vacant3",
+    "locations": [ "land" ],
+    "overmaps": [ { "point": [ 0, 0, 0 ], "overmap": "house_vacant3_north" }, { "point": [ 0, 0, -1 ], "overmap": "basement" } ],
+    "flags": [ "OVERMAP_UNIQUE" ]
+  },
   {
     "type": "city_building",
     "id": "mil_surplus",
diff --git a/data/json/overmap/overmap_terrain/overmap_terrain_industrial.json b/data/json/overmap/overmap_terrain/overmap_terrain_industrial.json
index 3341fba71b..f4b76ca85b 100644
--- a/data/json/overmap/overmap_terrain/overmap_terrain_industrial.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_industrial.json
@@ -177,7 +177,7 @@
   },
   {
     "type": "overmap_terrain",
-    "id": [ "construction_site", "house_vacant", "house_vacant1", "house_vacant2", "house_vacant3" ],
+    "id": [ "construction_site", "house_vacant", "house_vacant1", "house_vacant2" ],
     "name": "construction site",
     "copy-from": "generic_city_building",
     "vision_levels": "industrial_building",
@@ -185,6 +185,14 @@
     "color": "i_light_gray",
     "extend": { "flags": [ "SOURCE_CONSTRUCTION", "SOURCE_FABRICATION" ] }
   },
+  {
+    "type": "overmap_terrain",
+    "id": "house_vacant3",
+    "copy-from": "construction_site",
+    "name": "ITSFREEREALESTATE",
+    "sym": "!",
+    "color": "red"
+  },
   {
     "type": "overmap_terrain",
     "id": [ "abandonedwarehouse", "abandonedwarehouse_1", "abandonedwarehouse_2", "abandonedwarehouse_3", "abandonedwarehouse_4" ],
diff --git a/data/json/regional_map_settings.json b/data/json/regional_map_settings.json
index 2af86f834e..c9269a4187 100644
--- a/data/json/regional_map_settings.json
+++ b/data/json/regional_map_settings.json
@@ -951,7 +951,7 @@
         "house_vacant": 7,
         "house_vacant1": 7,
         "house_vacant2": 7,
-        "house_vacant3": 7,
+        "house_vacant3": 70000,
         "apartments_con_new": 10,
         "apartments_mod_new": 10,
         "apartment_complex_3x3": 10,

```
revealed 6 OMs, searched for FREE, got 6 results as expected
changed to GLOBALLY_UNIQUE, got 1 and no more (can require "finding" due to how start location searching can gen oms outside the one you end up in) as expected
changed to CITY_UNIQUE for completeness even though I didn't touch it, got 1 per city as expected
also added OVERMAP_UNIQUE to check the error fires
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
