### PR TITLE
Re-reduce mission search range so that failed search fails in reasonable time

### DIFF
--- a/src/mission_util.cpp
+++ b/src/mission_util.cpp
@@ -417,7 +417,7 @@ mission_target_params mission_util::parse_mission_om_target( const JsonObject &j
         jo.throw_error_at( "search_range",
                            "There's no reason to change max search range if your search isn't random." );
     }
-    p.search_range  = get_dbl_or_var( jo, "search_range", false, OMAPX * 14 );
+    p.search_range  = get_dbl_or_var( jo, "search_range", false, OMAPX * 3 );
     p.min_distance  = get_dbl_or_var( jo, "min_distance", false );
 
     if( jo.has_member( "offset_x" ) || jo.has_member( "offset_y" ) || jo.has_member( "offset_z" ) ) {


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
In #78949 I increased the radius of our mission search range by 14 times, resulting in (14^2 = ) 196 times more area to search.

It takes about 10-15 minutes for my beefy PC to generate that. I misunderstood how long it would take based on making a bad comparison. I compared it to e.g. missions pointing at the exodii or refugee center, which are global uniques. And actually do spawn pretty reliably - then the search for them **ends**. So I assumed that the missions searching for them (not-random) over ~2400 tiles that immediately stop when found would be equivalent to missions searching that entire range. Obviously, I was not correct to believe that.


#### Describe the solution

10-15 minutes is too long; OMAPX*3 would be about 36 overmaps instead of over 800. Rough napkin math would be that we shorten 15 minutes down to ~40 seconds, assuming generation time is linear and constant.

The OMAPX *3 figure is still 9 times more area than prior to #78949 , which is a massive improvement but should also allow failed searches to fail in a reasonable amount of time.


#### Describe alternatives you've considered


#### Testing


#### Additional context
