### PR TITLE
River generation overhaul

### DIFF
--- a/data/json/regional_map_settings.json
+++ b/data/json/regional_map_settings.json
@@ -314,7 +314,13 @@
         }
       }
     },
-    "river_scale": 1.0,
+    "overmap_river_settings": {
+      "river_scale": 1.0,
+      "river_frequency": 1.5,
+      "river_branch_chance": 64.0,
+      "river_branch_remerge_chance": 2.0,
+      "river_branch_scale_decrease": 1.0
+    },
     "overmap_lake_settings": {
       "noise_threshold_lake": 0.25,
       "lake_size_min": 20,

--- a/data/mods/Backrooms/regional_map_settings.json
+++ b/data/mods/Backrooms/regional_map_settings.json
@@ -39,7 +39,7 @@
       },
       "furniture": { "f_region_flower": { "f_rack_coat": 1, "f_sign_warning": 1, "f_sign": 1 } }
     },
-    "river_scale": 0.0,
+    "overmap_river_settings": { "river_scale": 0.0 },
     "overmap_lake_settings": {
       "noise_threshold_lake": 1.0,
       "lake_size_min": 0,

--- a/data/mods/Isolation-Protocol/region_settings.json
+++ b/data/mods/Isolation-Protocol/region_settings.json
@@ -31,7 +31,7 @@
       "clear_whitelist": false,
       "whitelist": [ "ISO_MAP" ]
     },
-    "river_scale": 0,
+    "overmap_river_settings": { "river_scale": 0.0 },
     "overmap_lake_settings": {
       "noise_threshold_lake": 10.0,
       "lake_size_min": 20,

--- a/data/mods/TEST_DATA/overmap_terrain_coverage_test/overmap_terrain_coverage_whitelist.json
+++ b/data/mods/TEST_DATA/overmap_terrain_coverage_test/overmap_terrain_coverage_whitelist.json
@@ -42,7 +42,14 @@
       "farm_isherwood_.*",
       "corpse_head_neck_(l|r|center)_decap",
       "abandoned_textile_mill(_b)?_\\d_\\d",
-      "hotel_tower(_flr2)_1_5B?"
+      "hotel_tower(_flr2)_1_5B?",
+      "pottery_cottage",
+      "pottery_cottage_2nd",
+      "pottery_cottage_roof",
+      "pottery_cottage_field_2nd",
+      "pottery_cottage_field_roof",
+      "pottery_cottage_field",
+      "pottery_cottage_basement"
     ]
   }
 ]

--- a/data/mods/TropiCataclysm/tropical_regional_map_settings.json
+++ b/data/mods/TropiCataclysm/tropical_regional_map_settings.json
@@ -314,7 +314,13 @@
         }
       }
     },
-    "river_scale": 1.0,
+    "overmap_river_settings": {
+      "river_scale": 1.0,
+      "river_frequency": 1.2,
+      "river_branch_chance": 48.0,
+      "river_branch_remerge_chance": 2.0,
+      "river_branch_scale_decrease": 1.0
+    },
     "overmap_lake_settings": {
       "noise_threshold_lake": 0.25,
       "lake_size_min": 20,

--- a/data/mods/aftershock_exoplanet/region_settings.json
+++ b/data/mods/aftershock_exoplanet/region_settings.json
@@ -27,7 +27,7 @@
       "empty_rock"
     ],
     "default_groundcover": [ [ "t_region_groundcover", 1 ] ],
-    "river_scale": 0,
+    "overmap_river_settings": { "river_scale": 0.0 },
     "city": {
       "shop_radius": 30,
       "shop_sigma": 80,

--- a/data/mods/desert_region/desert_regional_map_settings.json
+++ b/data/mods/desert_region/desert_regional_map_settings.json
@@ -58,7 +58,13 @@
         "f_region_water_plant": { "f_cattails": 15, "f_lilypad": 1, "f_lotus": 5 }
       }
     },
-    "river_scale": 0.6,
+    "overmap_river_settings": {
+      "river_scale": 1.0,
+      "river_frequency": 4.5,
+      "river_branch_chance": 128.0,
+      "river_branch_remerge_chance": 4.0,
+      "river_branch_scale_decrease": 1.0
+    },
     "overmap_lake_settings": {
       "noise_threshold_lake": 0.4,
       "lake_size_min": 4,

--- a/data/mods/rural_biome/rural_regional_map_settings.json
+++ b/data/mods/rural_biome/rural_regional_map_settings.json
@@ -345,7 +345,13 @@
         "terrain_furniture": { "t_water_murky": { "chance": 2, "clear_furniture": false, "furniture": { "f_region_water_plant": 1 } } }
       }
     },
-    "river_scale": 1.0,
+    "overmap_river_settings": {
+      "river_scale": 1.0,
+      "river_frequency": 1.5,
+      "river_branch_chance": 64.0,
+      "river_branch_remerge_chance": 2.0,
+      "river_branch_scale_decrease": 1.0
+    },
     "forest_trail_settings": {
       "chance": 20,
       "border_point_chance": 2,

--- a/src/line.h
+++ b/src/line.h
@@ -203,6 +203,26 @@ inline int rl_dist( const point &a, const point &b )
     return rl_dist( tripoint( a, 0 ), tripoint( b, 0 ) );
 }
 
+template< class Point >
+const std::vector<Point> cubic_bezier( const Point &pa, const Point &pb,
+                                       const Point &pc, const Point &pd, const int n_segs )
+{
+    const auto cubic_bezier_single_axis = []( const int pa, const int pb, const int pc, const int pd,
+    const double t ) {
+        // a(1-t)^3 + 3bt(1-t)^2 + 3ct^2(1-t) + dt^3
+        return static_cast<int>( pow( ( 1.0 - t ), 3.0 ) * pa + ( 3.0 * t * pow( ( 1.0 - t ),
+                                 2.0 ) ) * pb + ( 3.0 * pow( t, 2.0 ) * ( 1.0 - t ) ) * pc + pow( t, 3.0 ) * pd );
+    };
+    std::vector<Point> pts;
+    for( int i = 0; i <= n_segs; ++i ) {
+        const double t = i / static_cast<double>( n_segs );
+        const int x = cubic_bezier_single_axis( pa.x(), pb.x(), pc.x(), pd.x(), t );
+        const int y = cubic_bezier_single_axis( pa.y(), pb.y(), pc.y(), pd.y(), t );
+        pts.push_back( Point{ x, y } );
+    }
+    return pts;
+}
+
 /**
  * Helper type for the return value of dist_fast().
  *

--- a/src/line.h
+++ b/src/line.h
@@ -204,8 +204,8 @@ inline int rl_dist( const point &a, const point &b )
 }
 
 template< class Point >
-const std::vector<Point> cubic_bezier( const Point &pa, const Point &pb,
-                                       const Point &pc, const Point &pd, const int n_segs )
+std::vector<Point> cubic_bezier( const Point &pa, const Point &pb,
+                                 const Point &pc, const Point &pd, const int n_segs )
 {
     const auto cubic_bezier_single_axis = []( const int pa, const int pb, const int pc, const int pd,
     const double t ) {
@@ -216,9 +216,9 @@ const std::vector<Point> cubic_bezier( const Point &pa, const Point &pb,
     std::vector<Point> pts;
     for( int i = 0; i <= n_segs; ++i ) {
         const double t = i / static_cast<double>( n_segs );
-        const int x = cubic_bezier_single_axis( pa.x(), pb.x(), pc.x(), pd.x(), t );
-        const int y = cubic_bezier_single_axis( pa.y(), pb.y(), pc.y(), pd.y(), t );
-        pts.push_back( Point{ x, y } );
+        pts.push_back( Point{
+            cubic_bezier_single_axis( pa.x(), pb.x(), pc.x(), pd.x(), t ),
+            cubic_bezier_single_axis( pa.y(), pb.y(), pc.y(), pd.y(), t ) } );
     }
     return pts;
 }

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -624,6 +624,11 @@ bool is_water_body( const oter_id &ter )
            ter->is_ocean_shore();
 }
 
+bool is_water_body_not_shore( const oter_id &ter )
+{
+    return ter->is_river() || ter->is_lake() || ter->is_ocean();
+}
+
 bool is_ocean( const oter_id &ter )
 {
     return ter->is_ocean() || ter->is_ocean_shore();
@@ -3657,10 +3662,10 @@ void overmap::generate( const std::vector<const overmap *> &neighbor_overmaps,
         place_rivers( neighbor_overmaps );
     }
     if( get_option<bool>( "OVERMAP_PLACE_LAKES" ) ) {
-        place_lakes();
+        place_lakes( neighbor_overmaps );
     }
     if( get_option<bool>( "OVERMAP_PLACE_OCEANS" ) ) {
-        place_oceans();
+        place_oceans( neighbor_overmaps );
     }
     if( get_option<bool>( "OVERMAP_PLACE_FORESTS" ) ) {
         place_forests();
@@ -3699,7 +3704,7 @@ void overmap::generate( const std::vector<const overmap *> &neighbor_overmaps,
         place_forest_trailheads();
     }
 
-    polish_river();
+    polish_river( neighbor_overmaps );
 
     // TODO: there is no reason we can't generate the sublevels in one pass
     //       for that matter there is no reason we can't as we add the entrance ways either
@@ -4964,7 +4969,7 @@ void overmap::place_forests()
 }
 
 
-void overmap::place_lakes()
+void overmap::place_lakes( const std::vector<const overmap *> &neighbor_overmaps )
 {
     const om_noise::om_noise_layer_lake f( global_base_point(), g->get_seed() );
 
@@ -5019,6 +5024,22 @@ void overmap::place_lakes()
                 lake_set.emplace( p );
             }
 
+            // Before we place the lake terrain and get river points, generate a river to somewhere
+            // in the lake from an existing river.
+            if( !rivers.empty() ) {
+                const tripoint_om_omt random_lake_point( random_entry( lake_set ), 0 );
+                point_om_omt river_connection = point_om_omt::invalid;
+                for( const tripoint_om_omt &find_river : closest_points_first( random_lake_point, OMAPX / 2 ) ) {
+                    if( inbounds( find_river ) && ter( find_river )->is_river() ) {
+                        river_connection = find_river.xy();
+                        break;
+                    }
+                }
+                if( !river_connection.is_invalid() ) {
+                    place_river( neighbor_overmaps, overmap_river_node{ river_connection, random_lake_point.xy() } );
+                }
+            }
+
             for( int x = 0; x < OMAPX; x++ ) {
                 for( int y = 0; y < OMAPY; y++ ) {
                     const tripoint_om_omt p( x, y, 0 );
@@ -5059,49 +5080,6 @@ void overmap::place_lakes()
                     ter_set( tripoint_om_omt( p, settings->overmap_lake.lake_depth ), lake_bed );
                 }
             }
-
-            // We're going to attempt to connect some points on this lake to the nearest river.
-            const auto connect_lake_to_closest_river =
-            [&]( const point_om_omt & lake_connection_point ) {
-                int closest_distance = -1;
-                point_om_omt closest_point;
-                for( int x = 0; x < OMAPX; x++ ) {
-                    for( int y = 0; y < OMAPY; y++ ) {
-                        const tripoint_om_omt p( x, y, 0 );
-                        if( !ter( p )->is_river() ) {
-                            continue;
-                        }
-                        const int distance = square_dist( lake_connection_point, p.xy() );
-                        if( distance < closest_distance || closest_distance < 0 ) {
-                            closest_point = p.xy();
-                            closest_distance = distance;
-                        }
-                    }
-                }
-
-                if( closest_distance > 0 ) {
-                    place_river( closest_point, lake_connection_point );
-                }
-            };
-
-            // Get the north and south most points in our lake.
-            auto north_south_most = std::minmax_element( lake_points.begin(), lake_points.end(),
-            []( const point_om_omt & lhs, const point_om_omt & rhs ) {
-                return lhs.y() < rhs.y();
-            } );
-
-            point_om_omt northmost = *north_south_most.first;
-            point_om_omt southmost = *north_south_most.second;
-
-            // It's possible that our northmost/southmost points in the lake are not on this overmap, because our
-            // lake may extend across multiple overmaps.
-            if( inbounds( northmost ) ) {
-                connect_lake_to_closest_river( northmost );
-            }
-
-            if( inbounds( southmost ) ) {
-                connect_lake_to_closest_river( southmost );
-            }
         }
     }
 }
@@ -5136,7 +5114,7 @@ float overmap::calculate_ocean_gradient( const point_om_omt &p, const point_abs_
     return std::max( { ocean_adjust_N, ocean_adjust_E, ocean_adjust_W, ocean_adjust_S } );
 }
 
-void overmap::place_oceans()
+void overmap::place_oceans( const std::vector<const overmap *> &neighbor_overmaps )
 {
     int northern_ocean = settings->overmap_ocean.ocean_start_north;
     int eastern_ocean = settings->overmap_ocean.ocean_start_east;
@@ -5254,7 +5232,7 @@ void overmap::place_oceans()
                 }
 
                 if( closest_distance > 0 ) {
-                    place_river( closest_point, lake_connection_point );
+                    place_river( neighbor_overmaps, overmap_river_node{ closest_point, lake_connection_point } );
                 }
             };
 
@@ -5282,169 +5260,146 @@ void overmap::place_oceans()
 
 void overmap::place_rivers( const std::vector<const overmap *> &neighbor_overmaps )
 {
-    if( settings->river_scale == 0.0 ) {
+    const int OMAPX_edge = OMAPX - 1;
+    const int OMAPY_edge = OMAPY - 1;
+    const int directions = neighbor_overmaps.size();
+    const int max_rivers = 2;
+    int river_scale = settings->overmap_river.river_scale;
+    if( river_scale == 0 ) {
         return;
     }
-    int river_chance = static_cast<int>( std::max( 1.0, 1.0 / settings->river_scale ) );
-    int river_scale = static_cast<int>( std::max( 1.0, settings->river_scale ) );
-    // West/North endpoints of rivers
-    std::vector<point_om_omt> river_start;
+    river_scale = 1 + std::max( 1, river_scale );
+    // North/West endpoints of rivers (2 major rivers max per overmap)
+    std::array<point_om_omt, max_rivers> river_start = { point_om_omt::invalid, point_om_omt::invalid };
     // East/South endpoints of rivers
-    std::vector<point_om_omt> river_end;
+    std::array<point_om_omt, max_rivers> river_end = { point_om_omt::invalid, point_om_omt::invalid };
+    // forced river bezier curve control points (closer to start point)
+    std::array<point_om_omt, max_rivers> control_start = { point_om_omt::invalid, point_om_omt::invalid };
+    // ..closer to end point
+    std::array<point_om_omt, max_rivers> control_end = { point_om_omt::invalid, point_om_omt::invalid };
 
-    // Determine points where rivers & roads should connect w/ adjacent maps
-    // optimized comparison.
-    const int border = 2;
-    const int corner = 6;
-    const int opposite_x_edge = OMAPX - 1;
-    const int opposite_y_edge = OMAPY - 1;
-
-    const overmap *north = neighbor_overmaps[static_cast<int>( om_direction::type::north )];
-    const overmap *east = neighbor_overmaps[static_cast<int>( om_direction::type::east )];
-    const overmap *south = neighbor_overmaps[static_cast<int>( om_direction::type::south )];
-    const overmap *west = neighbor_overmaps[static_cast<int>( om_direction::type::west )];
-
-    if( north != nullptr ) {
-        for( int i = border; i < OMAPX - border; i++ ) {
-            //get opposite edge of neighbor overmap
-            const tripoint_om_omt p_neighbour( i, opposite_y_edge, 0 );
-            const tripoint_om_omt p_mine( i, 0, 0 );
-
-            bool directly_adjacent_river = is_river( north->ter( p_neighbour ) );
-            if( directly_adjacent_river ) {
-                ter_set( p_mine, oter_river_center );
-            }
-            if( directly_adjacent_river &&
-                is_river( north->ter( p_neighbour + point::east ) ) &&
-                is_river( north->ter( p_neighbour + point::west ) ) ) {
-                if( one_in( river_chance ) && ( river_start.empty() ||
-                                                river_start[river_start.size() - 1].x() < ( i - corner ) * river_scale ) ) {
-                    river_start.push_back( p_mine.xy() );
-                }
-            }
+    auto bound_control_point = []( const point_om_omt & p, const point_rel_omt & init_diff ) {
+        point_rel_omt diff = init_diff;
+        point_om_omt continue_line = p + diff;
+        while( !inbounds( continue_line ) ) {
+            diff = point_rel_omt( diff.x() * 0.5, diff.y() * 0.5 );
+            continue_line = p + diff;
         }
-    }
-    size_t rivers_from_north = river_start.size();
-    if( west != nullptr ) {
-        for( int i = border; i < OMAPY - border; i++ ) {
-            const tripoint_om_omt p_neighbour( opposite_x_edge, i, 0 );
-            const tripoint_om_omt p_mine( 0, i, 0 );
+        return continue_line;
+    };
 
-            bool directly_adjacent_river = is_river( west->ter( p_neighbour ) );
-            if( directly_adjacent_river ) {
-                ter_set( p_mine, oter_river_center );
-            }
-            if( directly_adjacent_river &&
-                is_river( west->ter( p_neighbour + point::north ) ) &&
-                is_river( west->ter( p_neighbour + point::south ) ) ) {
-                if( one_in( river_chance ) && ( river_start.size() == rivers_from_north ||
-                                                river_start[river_start.size() - 1].y() < ( i - corner ) * river_scale ) ) {
-                    river_start.push_back( p_mine.xy() );
-                }
-            }
-        }
-    }
-    if( south != nullptr ) {
-        for( int i = border; i < OMAPX - border; i++ ) {
-            const tripoint_om_omt p_neighbour( i, 0, 0 );
-            const tripoint_om_omt p_mine( i, opposite_y_edge, 0 );
-
-            bool directly_adjacent_river = is_river( south->ter( p_neighbour ) );
-            if( directly_adjacent_river ) {
-                ter_set( p_mine, oter_river_center );
-            }
-            if( directly_adjacent_river &&
-                is_river( south->ter( p_neighbour + point::east ) ) &&
-                is_river( south->ter( p_neighbour + point::west ) ) ) {
-                if( river_end.empty() ||
-                    river_end[river_end.size() - 1].x() < i - corner ) {
-                    river_end.push_back( p_mine.xy() );
-                }
-            }
-        }
-    }
-    size_t rivers_to_south = river_end.size();
-    if( east != nullptr ) {
-        for( int i = border; i < OMAPY - border; i++ ) {
-            const tripoint_om_omt p_neighbour( 0, i, 0 );
-            const tripoint_om_omt p_mine( opposite_x_edge, i, 0 );
-
-            bool directly_adjacent_river = is_river( east->ter( p_neighbour ) );
-            if( directly_adjacent_river ) {
-                ter_set( p_mine, oter_river_center );
-            }
-            if( directly_adjacent_river &&
-                is_river( east->ter( p_neighbour + point::north ) ) &&
-                is_river( east->ter( p_neighbour + point::south ) ) ) {
-                if( river_end.size() == rivers_to_south ||
-                    river_end[river_end.size() - 1].y() < i - corner ) {
-                    river_end.push_back( p_mine.xy() );
-                }
-            }
-        }
+    std::array<bool, 4> is_start = { true, false, false, true };
+    std::array<bool, 4> node_present;
+    for( int i = 0; i < directions; i++ ) {
+        node_present[i] = neighbor_overmaps[i] == nullptr;
     }
 
-    // Even up the start and end points of rivers. (difference of 1 is acceptable)
-    // Also ensure there's at least one of each.
-    std::vector<point_om_omt> new_rivers;
-    int new_river_border = 10;
-    if( north == nullptr || west == nullptr ) {
-        while( river_start.empty() || river_start.size() + 1 < river_end.size() ) {
-            new_rivers.clear();
-            if( north == nullptr && one_in( river_chance ) ) {
-                new_rivers.emplace_back( rng( new_river_border, opposite_x_edge - new_river_border ), 0 );
-            }
-            if( west == nullptr && one_in( river_chance ) ) {
-                new_rivers.emplace_back( 0, rng( new_river_border, opposite_y_edge - new_river_border ) );
-            }
-            river_start.push_back( random_entry( new_rivers ) );
-        }
-    }
-    if( south == nullptr || east == nullptr ) {
-        while( river_end.empty() || river_end.size() + 1 < river_start.size() ) {
-            new_rivers.clear();
-            if( south == nullptr && one_in( river_chance ) ) {
-                new_rivers.emplace_back( rng( new_river_border, opposite_x_edge - new_river_border ),
-                                         opposite_y_edge );
-            }
-            if( east == nullptr && one_in( river_chance ) ) {
-                new_rivers.emplace_back( opposite_x_edge, rng( new_river_border,
-                                         opposite_y_edge - new_river_border ) );
-            }
-            river_end.push_back( random_entry( new_rivers ) );
-        }
-    }
-
-    // Now actually place those rivers.
-    if( river_start.size() > river_end.size() && !river_end.empty() ) {
-        std::vector<point_om_omt> river_end_copy = river_end;
-        while( !river_start.empty() ) {
-            const point_om_omt start = random_entry_removed( river_start );
-            if( !river_end.empty() ) {
-                place_river( start, river_end[0] );
-                river_end.erase( river_end.begin() );
+    // set river starts and ends from neighboring overmaps' existing rivers
+    // force control points from adjacent overmap to this overmap to smooth river curve
+    int preset_start_nodes = 0;
+    int preset_end_nodes = 0;
+    std::array<overmap_river_border, 4> river_borders;
+    for( int i = 0; i < directions; i++ ) {
+        river_borders[i] = setup_adjacent_river( point_rel_om( four_adjacent_offsets[i] ), RIVER_BORDER );
+        const overmap_river_border &river_border = river_borders[i];
+        if( !river_border.border_river_nodes.empty() ) {
+            //take the first node (major river) only
+            point_om_omt p = river_border.border_river_nodes_omt.front();
+            const overmap_river_node *river_node = river_border.border_river_nodes.front();
+            if( is_start[i] ) {
+                river_start[preset_start_nodes] = p;
+                point_rel_omt diff = river_node->river_end - ( river_node->control_p2.is_invalid() ?
+                                     river_node->river_end : river_node->control_p2 );
+                control_start[preset_start_nodes] = bound_control_point( p, diff );
             } else {
-                place_river( start, random_entry( river_end_copy ) );
+                river_end[preset_end_nodes] = p;
+                point_rel_omt diff = river_node->river_start - ( river_node->control_p1.is_invalid() ?
+                                     river_node->river_start : river_node->control_p1 );
+                control_end[preset_end_nodes] = bound_control_point( p, diff );
             }
+
+            node_present[i] = true;
+            is_start[i] ? preset_start_nodes++ : preset_end_nodes++;
         }
-    } else if( river_end.size() > river_start.size() && !river_start.empty() ) {
-        std::vector<point_om_omt> river_start_copy = river_start;
-        while( !river_end.empty() ) {
-            const point_om_omt end = random_entry_removed( river_end );
-            if( !river_start.empty() ) {
-                place_river( river_start[0], end );
-                river_start.erase( river_start.begin() );
+    }
+
+    //if there wasn't an neighboring river, 1 / (river frequency ^ rivers generated) chance to continue
+    bool no_neighboring_rivers = preset_start_nodes == 0 && preset_end_nodes == 0;
+    if( no_neighboring_rivers ) {
+        if( !x_in_y( 1.0, std::pow( settings->overmap_river.river_frequency,
+                                    overmap_buffer.get_major_river_count() ) ) ) {
+            return;
+        }
+    }
+
+    // if there are two river start/ends from neighbor overmaps,
+    // they must flow N->E, W->S to avoid intersecting
+    bool lock_rivers = preset_start_nodes == max_rivers || preset_end_nodes == max_rivers;
+
+    auto generate_new_node_point = [&]( int dir ) {
+        switch( dir ) {
+            case 0:
+                return point_om_omt( rng( RIVER_BORDER, OMAPX_edge - RIVER_BORDER ), 0 );
+            case 1:
+                return point_om_omt( OMAPX_edge, rng( RIVER_BORDER, OMAPY_edge - RIVER_BORDER ) );
+            case 2:
+                return point_om_omt( rng( RIVER_BORDER, OMAPX_edge - RIVER_BORDER ), OMAPY_edge );
+            case 3:
+                return point_om_omt( 0, rng( RIVER_BORDER, OMAPY_edge - RIVER_BORDER ) );
+            default:
+                return point_om_omt( rng( RIVER_BORDER, OMAPX_edge - RIVER_BORDER ), rng( RIVER_BORDER,
+                                     OMAPY_edge - RIVER_BORDER ) );
+        }
+    };
+
+    // generate brand-new river nodes
+    // generate two rivers if locking
+    if( lock_rivers ) {
+        if( river_start[0].is_invalid() ) {
+            river_start[0] = generate_new_node_point( 0 );
+        }
+        if( river_start[1].is_invalid() ) {
+            river_start[1] = generate_new_node_point( 3 );
+        }
+        if( river_end[0].is_invalid() ) {
+            river_end[0] = generate_new_node_point( 1 );
+        }
+        if( river_end[1].is_invalid() ) {
+            river_end[1] = generate_new_node_point( 2 );
+        }
+    }
+    // if no river nodes were present, generate one river based on existing adjacent overmaps
+    else {
+        if( river_start[0].is_invalid() ) {
+            if( node_present[0] && ( !node_present[3] || one_in( 2 ) ) ) {
+                river_start[0] = generate_new_node_point( 0 );
+            } else if( node_present[3] ) {
+                river_start[0] = generate_new_node_point( 3 );
             } else {
-                place_river( random_entry( river_start_copy ), end );
+                river_start[0] = generate_new_node_point( -1 );
             }
         }
-    } else if( !river_end.empty() ) {
-        if( river_start.size() != river_end.size() ) {
-            river_start.emplace_back( rng( OMAPX / 4, ( OMAPX * 3 ) / 4 ),
-                                      rng( OMAPY / 4, ( OMAPY * 3 ) / 4 ) );
+        if( river_end[0].is_invalid() ) {
+            if( node_present[2] && ( !node_present[1] || one_in( 2 ) ) ) {
+                river_end[0] = generate_new_node_point( 2 );
+            } else if( node_present[1] ) {
+                river_end[0] = generate_new_node_point( 1 );
+            } else {
+                river_end[0] = generate_new_node_point( -1 );
+            }
         }
-        for( size_t i = 0; i < river_start.size(); i++ ) {
-            place_river( river_start[i], river_end[i] );
+    }
+
+    //Finally, place rivers from start point to end point
+    for( size_t i = 0; i < max_rivers; i++ ) {
+        point_om_omt pa = river_start.at( i );
+        point_om_omt pb = river_end.at( i );
+        if( !pa.is_invalid() && !pb.is_invalid() ) {
+            overmap_river_node temp_node{ pa, pb, control_start.at( i ), control_end.at( i ) };
+            place_river( neighbor_overmaps, temp_node, river_scale, true );
+            if( no_neighboring_rivers ) {
+                overmap_buffer.inc_major_river_count();
+            }
         }
     }
 }
@@ -5460,6 +5415,7 @@ void overmap::place_swamps()
     for( int x = 0; x < OMAPX; x++ ) {
         for( int y = 0; y < OMAPY; y++ ) {
             const tripoint_om_omt pos( x, y, 0 );
+            // TODO: Use is_river or similar not a ot match
             if( is_ot_match( "river", ter_unsafe( pos ), ot_match_type::contains ) ) {
                 std::vector<point_om_omt> buffered_points =
                     closest_points_first(
@@ -5545,8 +5501,8 @@ void overmap::place_roads( const std::vector<const overmap *> &neighbor_overmaps
                     if( !( is_river( ter( tmp ) ) ||
                            // avoid adjacent rivers
                            // east/west of a point on the north/south edge, and vice versa
-                           is_river( ter( tmp + tripoint_rel_omt::adjacent_cardinal[( dir + 1 ) % 4] ) ) ||
-                           is_river( ter( tmp + tripoint_rel_omt::adjacent_cardinal[( dir + 3 ) % 4] ) ) ) ) {
+                           is_river( ter( tmp + point_rel_omt( four_adjacent_offsets[( dir + 1 ) % 4] ) ) ) ||
+                           is_river( ter( tmp + point_rel_omt( four_adjacent_offsets[( dir + 3 ) % 4] ) ) ) ) ) {
                         roads_out.push_back( tmp );
                         break;
                     }
@@ -5621,8 +5577,8 @@ void overmap::place_railroads( const std::vector<const overmap *> &neighbor_over
                     if( !( is_river( ter( tmp ) ) ||
                            // avoid adjacent rivers
                            // east/west of a point on the north/south edge, and vice versa
-                           is_river( ter( tmp + tripoint_rel_omt::adjacent_cardinal[( dir + 1 ) % 4] ) ) ||
-                           is_river( ter( tmp + tripoint_rel_omt::adjacent_cardinal[( dir + 3 ) % 4] ) ) ) ) {
+                           is_river( ter( tmp + point_rel_omt( four_adjacent_offsets[( dir + 1 ) % 4] ) ) ) ||
+                           is_river( ter( tmp + point_rel_omt( four_adjacent_offsets[( dir + 3 ) % 4] ) ) ) ) ) {
                         railroads_out.push_back( tmp );
                         break;
                     }
@@ -5651,88 +5607,277 @@ void overmap::place_railroads( const std::vector<const overmap *> &neighbor_over
     connect_closest_points( railroad_points, 0, *overmap_connection_local_railroad );
 }
 
-void overmap::place_river( const point_om_omt &pa, const point_om_omt &pb )
+void overmap::place_river( const std::vector<const overmap *> &neighbor_overmaps,
+                           const overmap_river_node &initial_points, int river_scale, bool major_river )
 {
-    int river_chance = static_cast<int>( std::max( 1.0, 1.0 / settings->river_scale ) );
-    int river_scale = static_cast<int>( std::max( 1.0, settings->river_scale ) );
-    point_om_omt p2( pa );
-    do {
-        p2.x() += rng( -1, 1 );
-        p2.y() += rng( -1, 1 );
-        if( p2.x() < 0 ) {
-            p2.x() = 0;
-        }
-        if( p2.x() > OMAPX - 1 ) {
-            p2.x() = OMAPX - 1;
-        }
-        if( p2.y() < 0 ) {
-            p2.y() = 0;
-        }
-        if( p2.y() > OMAPY - 1 ) {
-            p2.y() = OMAPY - 1;
-        }
-        for( int i = -1 * river_scale; i <= 1 * river_scale; i++ ) {
-            for( int j = -1 * river_scale; j <= 1 * river_scale; j++ ) {
-                tripoint_om_omt p( p2 + point( j, i ), 0 );
-                if( p.y() >= 0 && p.y() < OMAPY && p.x() >= 0 && p.x() < OMAPX ) {
-                    if( !ter( p )->is_lake() && one_in( river_chance ) ) {
-                        ter_set( p, oter_river_center );
-                    }
-                }
-            }
-        }
-        if( pb.x() > p2.x() && ( rng( 0, static_cast<int>( OMAPX * 1.2 ) - 1 ) < pb.x() - p2.x() ||
-                                 ( rng( 0, static_cast<int>( OMAPX * 0.2 ) - 1 ) > pb.x() - p2.x() &&
-                                   rng( 0, static_cast<int>( OMAPY * 0.2 ) - 1 ) > std::abs( pb.y() - p2.y() ) ) ) ) {
-            p2.x()++;
-        }
-        if( pb.x() < p2.x() && ( rng( 0, static_cast<int>( OMAPX * 1.2 ) - 1 ) < p2.x() - pb.x() ||
-                                 ( rng( 0, static_cast<int>( OMAPX * 0.2 ) - 1 ) > p2.x() - pb.x() &&
-                                   rng( 0, static_cast<int>( OMAPY * 0.2 ) - 1 ) > std::abs( pb.y() - p2.y() ) ) ) ) {
-            p2.x()--;
-        }
-        if( pb.y() > p2.y() && ( rng( 0, static_cast<int>( OMAPY * 1.2 ) - 1 ) < pb.y() - p2.y() ||
-                                 ( rng( 0, static_cast<int>( OMAPY * 0.2 ) - 1 ) > pb.y() - p2.y() &&
-                                   rng( 0, static_cast<int>( OMAPX * 0.2 ) - 1 ) > std::abs( p2.x() - pb.x() ) ) ) ) {
-            p2.y()++;
-        }
-        if( pb.y() < p2.y() && ( rng( 0, static_cast<int>( OMAPY * 1.2 ) - 1 ) < p2.y() - pb.y() ||
-                                 ( rng( 0, static_cast<int>( OMAPY * 0.2 ) - 1 ) > p2.y() - pb.y() &&
-                                   rng( 0, static_cast<int>( OMAPX * 0.2 ) - 1 ) > std::abs( p2.x() - pb.x() ) ) ) ) {
-            p2.y()--;
-        }
-        p2.x() += rng( -1, 1 );
-        p2.y() += rng( -1, 1 );
-        if( p2.x() < 0 ) {
-            p2.x() = 0;
-        }
-        if( p2.x() > OMAPX - 1 ) {
-            p2.x() = OMAPX - 2;
-        }
-        if( p2.y() < 0 ) {
-            p2.y() = 0;
-        }
-        if( p2.y() > OMAPY - 1 ) {
-            p2.y() = OMAPY - 1;
-        }
-        for( int i = -1 * river_scale; i <= 1 * river_scale; i++ ) {
-            for( int j = -1 * river_scale; j <= 1 * river_scale; j++ ) {
-                // We don't want our riverbanks touching the edge of the map for many reasons
-                tripoint_om_omt p( p2 + point( j, i ), 0 );
-                if( inbounds( p, 1 ) ||
-                    // UNLESS, of course, that's where the river is headed!
-                    ( std::abs( pb.y() - p.y() ) < 4 && std::abs( pb.x() - p.x() ) < 4 ) ) {
-                    if( !inbounds( p ) ) {
-                        continue;
-                    }
+    const int OMAPX_edge = OMAPX - 1;
+    const int OMAPY_edge = OMAPY - 1;
+    const int directions = 4;
+    // TODO: Retain river_scale for the river node and allow branches to extend overmaps?
+    if( river_scale <= 0 ) {
+        return;
+    }
 
-                    if( !ter( p )->is_lake() && one_in( river_chance ) ) {
-                        ter_set( p, oter_river_center );
+    std::vector <std::vector<tripoint_om_omt>> border_points_by_dir;
+    for( int i = 0; i < directions; i++ ) {
+        const point_rel_om &p = point_rel_om( four_adjacent_offsets[i] );
+        std::vector<tripoint_om_omt> border_points;
+        if( neighbor_overmaps[i] == nullptr ) {
+            border_points = get_border( p, RIVER_Z, RIVER_BORDER );
+        }
+        border_points_by_dir.emplace_back( border_points );
+    }
+
+    // Generate control points for Bezier curve
+    // the start/end of the curve are the start/end of the river
+    // the remaining control points are:
+    // - one-third between river start and end
+    // - two-thirds between river start and end
+
+    const point_om_omt &river_start = initial_points.river_start;
+    point_om_omt river_end = initial_points.river_end;
+    const int distance = rl_dist( river_start, river_end );
+    // variance of control points from the initial curve
+    const int amplitude = distance / 2;
+    point_rel_omt one_third(
+        abs( river_start.x() - river_end.x() ) * ( 1.0 / 3.0 ),
+        abs( river_start.y() - river_end.y() ) * ( 1.0 / 3.0 ) );
+    const int river_z = 0;
+
+    point_om_omt control_p1 = initial_points.control_p1;
+    if( control_p1.is_invalid() ) {
+        point_om_omt one_third_point = point_om_omt( river_start.x() + one_third.x(),
+                                       river_start.y() + one_third.y() );
+        control_p1 = point_om_omt( std::clamp( one_third_point.x() + rng( amplitude, 0 ), 0, OMAPX_edge ),
+                                   std::clamp( one_third_point.y() + rng( amplitude, 0 ), 0, OMAPY_edge ) );
+    }
+    point_om_omt control_p2 = initial_points.control_p2;
+    if( control_p2.is_invalid() ) {
+        point_om_omt two_third_point = point_om_omt( river_start.x() + one_third.x() * 2,
+                                       river_start.y() + one_third.y() * 2 );
+        control_p2 = point_om_omt(
+                         std::clamp( two_third_point.x() + rng( 0, -amplitude ), 0, OMAPX_edge ),
+                         std::clamp( two_third_point.y() + rng( 0, -amplitude ), 0, OMAPY_edge ) );
+    }
+    const int n_segs = distance / 2; // Number of Bezier curve segments to calculate
+    //there should be at least four points on the curve
+    if( n_segs < 4 ) {
+        return;
+    }
+    //Note: this is a list of *segments*; the points in this list are not always adjacent!
+    std::vector<point_om_omt> segmented_curve = cubic_bezier( river_start, control_p1,
+            control_p2, river_end, n_segs );
+    //remove index-adjacent duplicate points
+    auto iter = std::unique( segmented_curve.begin(), segmented_curve.end() );
+    segmented_curve.erase( iter, segmented_curve.end() );
+
+    //line_to only draws interval (p1, p2], so add the start again
+    segmented_curve.emplace( segmented_curve.begin(), river_start );
+
+    std::vector<point_om_omt> bezier_segment; // a complete Bezier segment (all points are adjacent)
+    size_t size = 0;
+    int curve_size = segmented_curve.size() - 1;
+    int river_check_index = 0;
+
+    for( river_check_index = 0; river_check_index < curve_size / 3; river_check_index++ ) {
+        const point_om_omt &segment_start = segmented_curve.at( river_check_index );
+        if( !is_water_body_not_shore( ter( tripoint_om_omt( segment_start.x(), segment_start.y(),
+                                           river_z ) ) ) ) {
+            break;
+        }
+    }
+
+    //if the first third of the river is already water, abort
+    if( river_check_index == curve_size / 3 ) {
+        return;
+    }
+
+    //if any remaining points are water, stop the river at that point
+    for( int i = river_check_index; i < curve_size; i++ ) {
+        const point_om_omt segment_start = segmented_curve.at( i );
+        tripoint_om_omt segment_start_tri( segment_start.x(), segment_start.y(), river_z );
+        const oter_id &ter_here = ter( segment_start_tri );
+        if( is_water_body_not_shore( ter_here ) ) {
+            river_end = segment_start;
+            curve_size = i;
+            break;
+        }
+    }
+
+    //draw the river by placing river OMTs between curve points
+    for( int i = 0; i < curve_size; i++ ) {
+        bezier_segment.clear();
+        bezier_segment = line_to( segmented_curve.at( i ), segmented_curve.at( i + 1 ), 0 );
+        // Now, draw the actual river tiles along the segment
+        for( const point_om_omt &bezier_point : bezier_segment ) {
+
+            tripoint_om_omt meandered_point( bezier_point, RIVER_Z );
+            // no meander for start/end
+            if( !( i == 0 || i == curve_size - 1 ) ) {
+                river_meander( river_end, meandered_point, river_scale );
+            }
+
+            auto draw_river = [&size, this]( const tripoint_om_omt & pt ) {
+                size++;
+                ter_set( pt, oter_river_center );
+            };
+            // Draw river in radius [-river_scale, +river_scale]
+            for( const tripoint_om_omt &pt : points_in_radius_circ( meandered_point, river_scale ) ) {
+                // river points on the edge of the overmap are automatically drawn from neighbor,
+                // but only if that neighbor doesn't exist
+                if( !is_water_body_not_shore( ter( pt ) ) ) {
+                    if( inbounds( pt, 1 ) ) {
+                        draw_river( pt );
+                    } else if( inbounds( pt ) ) {
+                        for( int i = 0; i < directions; i++ ) {
+                            if( !border_points_by_dir[i].empty() &&
+                                std::find( border_points_by_dir[i].begin(), border_points_by_dir[i].end(),
+                                           pt ) != border_points_by_dir[i].end() ) {
+                                draw_river( pt );
+                            }
+                        }
                     }
                 }
             }
         }
-    } while( pb != p2 );
+    }
+
+    // create river branches
+    const int branch_ahead_points = std::max( 2, curve_size / 5 );
+    int branch_last_end = 0;
+    for( int i = 0; i < curve_size; i++ ) {
+        const point_om_omt &bezier_point = segmented_curve.at( i );
+        if( inbounds( bezier_point, river_scale + 1 ) &&
+            one_in( settings->overmap_river.river_branch_chance ) ) {
+            point_om_omt branch_end_point = point_om_omt::invalid;
+
+            //pick an end point from later along the curve
+            //TODO: make remerge branches have control points that aren't straight;
+            // remerges are less common because they get stopped by the already-generated river
+            if( i > branch_last_end ) {
+                if( one_in( settings->overmap_river.river_branch_remerge_chance ) ) {
+                    int end_branch_node = rng( i + branch_ahead_points, i + branch_ahead_points * 2 );
+                    if( end_branch_node < curve_size ) {
+                        branch_end_point = segmented_curve.at( end_branch_node );
+                        branch_last_end = end_branch_node;
+                    }
+                } else {
+                    //or just randomly from the current segment
+                    const int rad = 64;
+                    branch_end_point = point_om_omt(
+                                           rng( bezier_point.x() + rad / 2, bezier_point.x() + rad ),
+                                           rng( bezier_point.y() + rad / 2, bezier_point.y() + rad ) );
+                }
+            }
+            // if the end point is valid, place a new, smaller, overmap-local branch river
+            if( !branch_end_point.is_invalid() && inbounds( branch_end_point ) ) {
+                place_river( neighbor_overmaps, overmap_river_node{ bezier_point, branch_end_point },
+                             river_scale - settings->overmap_river.river_branch_scale_decrease );
+            }
+        }
+    }
+
+    add_msg_debug( debugmode::DF_OVERMAP,
+                   "for overmap %s, drew river at: start = %s, control points: %s, %s, end = %s",
+                   loc.to_string_writable(), river_start.to_string_writable(),
+                   control_p1.to_string_writable(), control_p2.to_string_writable(),
+                   river_end.to_string_writable() );
+
+    overmap_river_node new_node = { river_start, river_end, control_p1, control_p2, size, major_river };
+    rivers.push_back( new_node );
+}
+
+void overmap::river_meander( const point_om_omt &river_end, tripoint_om_omt &current_point,
+                             int river_scale )
+{
+    const auto random_uniform = []( int i ) -> bool {
+        return rng( 0, static_cast<int>( OMAPX * 1.2 ) - 1 ) < i;
+    };
+    const auto random_close = []( int i ) -> bool {
+        return rng( 0, static_cast<int>( OMAPX * 0.2 ) - 1 ) > i;
+    };
+
+    point_rel_omt abs_distances( abs( river_end.x() - current_point.x() ),
+                                 abs( river_end.y() - current_point.y() ) );
+
+    //as distance to river end decreases, meander closer to the river end
+    if( current_point.x() != river_end.x() && ( random_uniform( abs_distances.x() ) ||
+            ( random_close( abs_distances.x() ) &&
+              random_close( abs_distances.y() ) ) ) ) {
+        current_point += river_end.x() > current_point.x() ? tripoint::east : tripoint::west;
+    }
+    if( current_point.y() != river_end.y() && ( random_uniform( abs_distances.y() ) ||
+            ( random_close( abs_distances.y() ) &&
+              random_close( abs_distances.x() ) ) ) ) {
+        current_point += river_end.y() > current_point.y() ? tripoint::south : tripoint::north;
+    }
+    //meander randomly, but not for rivers of size 1 (would exceed above meander)
+    if( river_scale > 1 ) {
+        current_point += tripoint_rel_omt( rng( -1, 1 ), rng( -1, 1 ), 0 );
+    }
+}
+
+std::vector<tripoint_om_omt> overmap::get_neighbor_border( const point_rel_om &direction, int z,
+        int distance_corner )
+{
+    const int OMAPX_edge = OMAPX - 1;
+    const int OMAPY_edge = OMAPY - 1;
+
+    tripoint_om_omt edges( direction.x() >= 0 ? 0 : OMAPX_edge, direction.y() >= 0 ? 0 : OMAPY_edge,
+                           0 );
+    bool iterx = direction.x() == 0;
+    int corner_upper = iterx ? OMAPX_edge - distance_corner : OMAPY_edge - distance_corner;
+
+    return iterx ?
+           line_to( tripoint_om_omt( distance_corner, edges.y(), 0 ), tripoint_om_omt( corner_upper, edges.y(),
+                    z ) ) :
+           line_to( tripoint_om_omt( edges.x(), distance_corner, 0 ), tripoint_om_omt( edges.x(), corner_upper,
+                    z ) );
+}
+
+std::vector<tripoint_om_omt> overmap::get_border( const point_rel_om &direction, int z,
+        int distance_corner )
+{
+    point_rel_om flip_direction( -direction.x(), -direction.y() );
+    return get_neighbor_border( flip_direction, z, distance_corner );
+}
+
+overmap_river_border overmap::setup_adjacent_river( const point_rel_om &adjacent_om, int border )
+{
+    overmap_river_border adjacent_border;
+    std::vector<point_om_omt> &border_river_omt = adjacent_border.border_river_omt;
+    std::vector<point_om_omt> &border_river_nodes_omt = adjacent_border.border_river_nodes_omt;
+    std::vector<const overmap_river_node *> &border_river_nodes = adjacent_border.border_river_nodes;
+    const overmap *adjacent_overmap = overmap_buffer.get_existing( pos() + adjacent_om );
+
+    //if overmap doesn't exist yet, no need to check it
+    if( adjacent_overmap == nullptr ) {
+        return adjacent_border;
+    }
+
+    const int river_z = 0;
+    std::vector<tripoint_om_omt> neighbor_border = get_neighbor_border( adjacent_om, river_z, border );
+    std::vector<tripoint_om_omt> overmap_border = get_border( adjacent_om, river_z, border );
+    const int neighbor_border_size = neighbor_border.size();
+
+    for( int i = 0; i < neighbor_border_size; i++ ) {
+        const tripoint_om_omt &neighbor_pt = neighbor_border[i];
+        const tripoint_om_omt &current_pt = overmap_border[i];
+        const point_om_omt p_neighbor_point = neighbor_pt.xy();
+        const point_om_omt p_current_point = current_pt.xy();
+
+        if( is_river( adjacent_overmap->ter( neighbor_pt ) ) ) {
+            //if the neighbor overmap has an adjacent river tile, set to river
+            //this guarantees that an out-of-bounds point adjacent to a river is always a river
+            ter_set( current_pt, oter_river_center );
+            border_river_omt.emplace_back( p_current_point );
+            if( adjacent_overmap->is_river_node( p_neighbor_point ) ) {
+                border_river_nodes_omt.emplace_back( p_current_point );
+                border_river_nodes.emplace_back( adjacent_overmap->get_river_node_at( p_neighbor_point ) );
+            }
+        }
+    }
+    return adjacent_border;
 }
 
 void overmap::calculate_forestosity()
@@ -6654,11 +6799,11 @@ void overmap::connect_closest_points( const std::vector<point_om_omt> &points, i
     }
 }
 
-void overmap::polish_river()
+void overmap::polish_river( const std::vector<const overmap *> &neighbor_overmaps )
 {
     for( int x = 0; x < OMAPX; x++ ) {
         for( int y = 0; y < OMAPY; y++ ) {
-            good_river( { x, y, 0 } );
+            build_river_shores( neighbor_overmaps, { x, y, 0 } );
         }
     }
 }
@@ -6700,98 +6845,80 @@ std::optional<overmap_special_id> overmap::overmap_special_at( const tripoint_om
     return it->second;
 }
 
-void overmap::good_river( const tripoint_om_omt &p )
+bool overmap::is_river_node( const point_om_omt &p ) const
 {
+    return !!get_river_node_at( p );
+}
+
+const overmap_river_node *overmap::get_river_node_at( const point_om_omt &p ) const
+{
+    for( const overmap_river_node &n : rivers ) {
+        if( n.river_start == p || n.river_end == p ) {
+            return &n;
+        }
+    }
+    return nullptr;
+}
+
+void overmap::build_river_shores( const std::vector<const overmap *> &neighbor_overmaps,
+                                  const tripoint_om_omt &p )
+{
+    const int neighbor_overmap_size = neighbor_overmaps.size();
     if( !is_ot_match( "river", ter( p ), ot_match_type::prefix ) ) {
         return;
     }
-    if( ( p.x() == 0 ) || ( p.x() == OMAPX - 1 ) ) {
-        if( !is_water_body( ter( p + point::north ) ) ) {
-            ter_set( p, oter_river_north.id() );
-        } else if( !is_water_body( ter( p + point::south ) ) ) {
-            ter_set( p, oter_river_south.id() );
-        } else {
-            ter_set( p, oter_river_center.id() );
+    // Find and assign shores where they need to be.
+    int mask = 0;
+    int multiplier = 1;
+    auto mask_add = [&multiplier, &mask]() {
+        mask += ( 1 * multiplier );
+    };
+    const point_om_omt as_point( p.x(), p.y() );
+    // TODO: Expand to eight_horizontal_neighbors dealing with corners here instead of afterwards?
+    for( int i = 0; i < neighbor_overmap_size; i++ ) {
+        const tripoint_om_omt p_offset = p + point_rel_omt( four_adjacent_offsets[i] );
+
+        if( !inbounds( p_offset ) || is_water_body( ter( p_offset ) ) ) {
+            //out of bounds OMTs adjacent to border river OMTs are always river OMTs
+            mask_add();
         }
-        return;
+        multiplier *= 2;
     }
-    if( ( p.y() == 0 ) || ( p.y() == OMAPY - 1 ) ) {
-        if( !is_water_body( ter( p + point::west ) ) ) {
-            ter_set( p, oter_river_west.id() );
-        } else if( !is_water_body( ter( p + point::east ) ) ) {
-            ter_set( p, oter_river_east.id() );
-        } else {
-            ter_set( p, oter_river_center.id() );
-        }
-        return;
-    }
-    if( is_water_body( ter( p + point::west ) ) ) {
-        if( is_water_body( ter( p + point::north ) ) ) {
-            if( is_water_body( ter( p + point::south ) ) ) {
-                if( is_water_body( ter( p + point::east ) ) ) {
-                    // River on N, S, E, W;
-                    // but we might need to take a "bite" out of the corner
-                    if( !is_water_body( ter( p + point::north_west ) ) ) {
-                        ter_set( p, oter_river_c_not_nw.id() );
-                    } else if( !is_water_body( ter( p + point::north_east ) ) ) {
-                        ter_set( p, oter_river_c_not_ne.id() );
-                    } else if( !is_water_body( ter( p + point::south_west ) ) ) {
-                        ter_set( p, oter_river_c_not_sw.id() );
-                    } else if( !is_water_body( ter( p + point::south_east ) ) ) {
-                        ter_set( p, oter_river_c_not_se.id() );
-                    } else {
-                        ter_set( p, oter_river_center.id() );
-                    }
-                } else {
-                    ter_set( p, oter_river_east.id() );
-                }
-            } else {
-                if( is_water_body( ter( p + point::east ) ) ) {
-                    ter_set( p, oter_river_south.id() );
-                } else {
-                    ter_set( p, oter_river_se.id() );
-                }
-            }
-        } else {
-            if( is_water_body( ter( p + point::south ) ) ) {
-                if( is_water_body( ter( p + point::east ) ) ) {
-                    ter_set( p, oter_river_north.id() );
-                } else {
-                    ter_set( p, oter_river_ne.id() );
-                }
-            } else {
-                if( is_water_body( ter( p + point::east ) ) ) { // Means it's swampy
-                    ter_set( p, oter_forest_water.id() );
+
+    auto river_ter = [&]() {
+        const std::array<oter_str_id, 16> river_ters = {
+            oter_forest_water, // 0 = no adjacent rivers.
+            oter_river_south, // 1 = N adjacent river
+            oter_river_west, // 2 = E adjacent river
+            oter_river_sw, // 3 = 1+2 = N+E adjacent rivers
+            oter_river_north, // 4 = S adjacent river
+            oter_forest_water, // 5 = 1+4 = N+S adjacent rivers, no map though
+            oter_river_nw, // 6 = 2+4 = E+S adjacent rivers
+            oter_river_west, // 7 = 1+2+4 = N+E+S adjacent rivers
+            oter_river_east, // 8 = W adjacent river
+            oter_river_se, // 9 = 1+8 = N+W adjacent rivers
+            oter_forest_water, // 10 = 2+8 = E+W adjacent rivers, no map though
+            oter_river_south, // 11 = 1+2+8 = N+E+W adjacent rivers
+            oter_river_ne, // 12 = 4+8 = S+W adjacent rivers
+            oter_river_east, // 13 = 1+4+8 = N+S+W adjacent rivers
+            oter_river_north, // 14 = 2+4+8 = E+S+W adjacent rivers
+            oter_river_center // 15 = 1+2+4+8 = N+E+S+W adjacent rivers.
+        };
+
+        if( mask == 15 ) {
+            // Trim corners if neccessary
+            // We assume if corner are not inbounds then we are placed because of neighbouring overmap river
+            const std::array<oter_str_id, 4> trimmed_corner_ters = { oter_river_c_not_ne, oter_river_c_not_se, oter_river_c_not_sw, oter_river_c_not_nw };
+            for( int i = 0; i < 4; i++ ) {
+                const tripoint_om_omt &corner = p + point_rel_omt( four_ordinal_directions[i] );
+                if( inbounds( corner ) && !is_water_body( ter( corner ) ) ) {
+                    return trimmed_corner_ters[i];
                 }
             }
         }
-    } else {
-        if( is_water_body( ter( p + point::north ) ) ) {
-            if( is_water_body( ter( p + point::south ) ) ) {
-                if( is_water_body( ter( p + point::east ) ) ) {
-                    ter_set( p, oter_river_west.id() );
-                } else { // Should never happen
-                    ter_set( p, oter_forest_water.id() );
-                }
-            } else {
-                if( is_water_body( ter( p + point::east ) ) ) {
-                    ter_set( p, oter_river_sw.id() );
-                } else { // Should never happen
-                    ter_set( p, oter_forest_water.id() );
-                }
-            }
-        } else {
-            if( is_water_body( ter( p + point::south ) ) ) {
-                if( is_water_body( ter( p + point::east ) ) ) {
-                    ter_set( p, oter_river_nw.id() );
-                } else { // Should never happen
-                    ter_set( p, oter_forest_water.id() );
-                }
-            } else { // Should never happen
-                ter_set( p, oter_forest_water.id() );
-            }
-        }
-    }
+        return river_ters[mask];
+    };
+    ter_set( p, river_ter() );
 }
 
 std::string om_direction::name( type dir )
@@ -7617,8 +7744,8 @@ void overmap::open( overmap_special_batch &enabled_specials )
         } );
     } else { // No map exists!  Prepare neighbors, and generate one.
         std::vector<const overmap *> neighbors;
-        neighbors.reserve( point_rel_om::adjacent_cardinal.size() );
-        for( const point_rel_om &adjacent : point_rel_om::adjacent_cardinal ) {
+        neighbors.reserve( four_adjacent_offsets.size() );
+        for( const point &adjacent : four_adjacent_offsets ) {
             neighbors.emplace_back( overmap_buffer.get_existing( loc + adjacent ) );
         }
         generate( neighbors, enabled_specials );

--- a/src/overmap.h
+++ b/src/overmap.h
@@ -443,8 +443,7 @@ class overmap
         // Save per-player overmap view data.
         void serialize_view( std::ostream &fout ) const;
     private:
-        void generate( const overmap *north, const overmap *east,
-                       const overmap *south, const overmap *west,
+        void generate( const std::vector<const overmap *> &neighbor_overmaps,
                        overmap_special_batch &enabled_specials );
         bool generate_sub( int z );
         bool generate_over( int z );
@@ -473,20 +472,17 @@ class overmap
         void place_forests();
         void place_lakes();
         void place_oceans();
-        void place_rivers( const overmap *north, const overmap *east, const overmap *south,
-                           const overmap *west );
+        void place_rivers( const std::vector<const overmap *> &neighbor_overmaps );
         void place_swamps();
         void place_forest_trails();
         void place_forest_trailheads();
 
-        void place_roads( const overmap *north, const overmap *east, const overmap *south,
-                          const overmap *west );
+        void place_roads( const std::vector<const overmap *> &neighbor_overmaps );
 
-        void place_railroads( const overmap *north, const overmap *east, const overmap *south,
-                              const overmap *west );
+        void place_railroads( const std::vector<const overmap *> &neighbor_overmaps );
 
-        void populate_connections_out_from_neighbors( const overmap *north, const overmap *east,
-                const overmap *south, const overmap *west );
+        void populate_connections_out_from_neighbors( const std::vector<const overmap *>
+                &neighbor_overmaps );
 
         // City Building
         overmap_special_id pick_random_building_to_place( int town_dist, int town_size,

--- a/src/overmap.h
+++ b/src/overmap.h
@@ -83,6 +83,13 @@ extern std::map<radio_type, std::string> radio_type_names;
 
 constexpr int RADIO_MIN_STRENGTH = 120;
 constexpr int RADIO_MAX_STRENGTH = 360;
+/*
+* Indentation from edge of overmap where neighbouring rivers and nodes aren't checked
+* to avoid corners, where starts/ends would be arbitrary
+* TODO: could be smaller?
+*/
+constexpr int RIVER_BORDER = 10;
+constexpr int RIVER_Z = 0;
 
 struct radio_tower {
     // local (to the containing overmap) submap coordinates
@@ -136,6 +143,27 @@ struct om_special_sectors {
 struct overmap_special_placement {
     int instances_placed;
     const overmap_special *special_details;
+};
+
+// Wrapper around a river node to contain river data.
+// Could be used to determine entry/exit points for boats across overmaps.
+// Could also contain name.
+struct overmap_river_node {
+    const point_om_omt river_start;
+    const point_om_omt river_end;
+    point_om_omt control_p1 = point_om_omt::invalid; // control points for the Bezier curve
+    point_om_omt control_p2 = point_om_omt::invalid;
+    const size_t size = 0; // total omt of this river
+    bool is_branch = false; //was this river placed by place_rivers(), or place_river()?
+};
+
+// River data gathered from an existing adjacent overmap
+struct overmap_river_border {
+    std::vector<point_om_omt> border_river_omt; // OMT river points from the adjacent overmap's border
+    std::vector<point_om_omt>
+    border_river_nodes_omt; // OMT river node points from the adjacent overmap's border
+    std::vector<const overmap_river_node *>
+    border_river_nodes; //river nodes from the adjacent overmap's border
 };
 
 // A batch of overmap specials to place.
@@ -325,6 +353,12 @@ class overmap
          */
         bool is_omt_generated( const tripoint_om_omt &loc ) const;
 
+        /* Returns true if position is an entry/exit position of a river node. */
+        bool is_river_node( const point_om_omt &p ) const;
+
+        /* Returns the overmap river node if the position is an entry/exit node of river. */
+        const overmap_river_node *get_river_node_at( const point_om_omt &p ) const;
+
         /** Returns the (0, 0) corner of the overmap in the global coordinates. */
         point_abs_omt global_base_point() const;
 
@@ -360,6 +394,7 @@ class overmap
         std::map<int, om_vehicle> vehicles;
         std::vector<basecamp> camps;
         std::vector<city> cities;
+        std::vector<overmap_river_node> rivers;
         std::map<string_id<overmap_connection>, std::vector<tripoint_om_omt>> connections_out;
         std::optional<basecamp *> find_camp( const point_abs_omt &p );
         /// Adds the npc to the contained list of npcs ( @ref npcs ).
@@ -467,11 +502,15 @@ class overmap
 
         // code deduplication - calc ocean gradient
         float calculate_ocean_gradient( const point_om_omt &p, point_abs_om this_omt );
-        // Overall terrain
-        void place_river( const point_om_omt &pa, const point_om_omt &pb );
+        /*
+        * places an individual river; see place_rivers()
+        * @param temp_node precalculated points for river; should NOT be stored in overmap
+        */
+        void place_river( const std::vector<const overmap *> &neighbor_overmaps,
+                          const overmap_river_node &initial_points, int river_scale = 1.0, bool major_river = false );
         void place_forests();
-        void place_lakes();
-        void place_oceans();
+        void place_lakes( const std::vector<const overmap *> &neighbor_overmaps );
+        void place_oceans( const std::vector<const overmap *> &neighbor_overmaps );
         void place_rivers( const std::vector<const overmap *> &neighbor_overmaps );
         void place_swamps();
         void place_forest_trails();
@@ -483,6 +522,16 @@ class overmap
 
         void populate_connections_out_from_neighbors( const std::vector<const overmap *>
                 &neighbor_overmaps );
+
+        /*
+        * checks adjacent overmap in direction for river terrain bordering this overmap
+        * will not generate the adjacent overmap!
+        * @param border -- don't check this much from the corners
+        * @param is_river_node -- additionally check if the river is a river node
+        * @return { list of points on *calling* overmap that border rivers,
+        list of points on *neighbor* overmap that contain river nodes }
+        */
+        overmap_river_border setup_adjacent_river( const point_rel_om &adjacent_om, int border );
 
         // City Building
         overmap_special_id pick_random_building_to_place( int town_dist, int town_size,
@@ -534,8 +583,17 @@ class overmap
                                          const tripoint_om_omt &location ) const;
         std::optional<overmap_special_id> overmap_special_at( const tripoint_om_omt &p ) const;
 
-        void polish_river();
-        void good_river( const tripoint_om_omt &p );
+        //gets border OMT points of this overmap in cardinal direction
+        std::vector<tripoint_om_omt> get_border( const point_rel_om &direction, int z,
+                int distance_corner );
+        //gets border OMT points of the neighboring overmap in cardinal direction
+        std::vector<tripoint_om_omt> get_neighbor_border( const point_rel_om &direction, int z,
+                int distance_corner );
+        void polish_river( const std::vector<const overmap *> &neighbor_overmaps );
+        void build_river_shores( const std::vector<const overmap *> &neighbor_overmaps,
+                                 const tripoint_om_omt &p );
+        void river_meander( const point_om_omt &river_end, tripoint_om_omt &current_point,
+                            int river_scale );
 
         om_direction::type random_special_rotation( const overmap_special &special,
                 const tripoint_om_omt &p, bool must_be_unexplored ) const;
@@ -685,6 +743,7 @@ std::pair<std::string, nc_color> oter_symbol_and_color( const tripoint_abs_omt &
 
 bool is_river( const oter_id &ter );
 bool is_water_body( const oter_id &ter );
+bool is_water_body_not_shore( const oter_id &ter );
 bool is_lake_or_river( const oter_id &ter );
 bool is_ocean( const oter_id &ter );
 

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -249,6 +249,7 @@ void overmapbuffer::clear()
     placed_unique_specials.clear();
     unique_special_count.clear();
     overmap_count = 0;
+    major_river_count = 0;
     last_requested_overmap = nullptr;
 }
 

--- a/src/overmapbuffer.h
+++ b/src/overmapbuffer.h
@@ -559,6 +559,14 @@ class overmapbuffer
             return overmap_count;
         }
 
+        int get_major_river_count() const {
+            return major_river_count;
+        }
+
+        void inc_major_river_count() {
+            major_river_count++;
+        }
+
     private:
         /**
          * Common function used by the find_closest/all/random to determine if the location is
@@ -583,6 +591,8 @@ class overmapbuffer
         std::unordered_map<overmap_special_id, int> unique_special_count;
         // Global count of number of overmaps generated for this world.
         int overmap_count = 0;
+        // Global count of major rivers generated for this world
+        int major_river_count = 0;
 
         /**
          * Get a list of notes in the (loaded) overmaps.

--- a/src/point.h
+++ b/src/point.h
@@ -439,6 +439,10 @@ inline constexpr const std::array<point, 4> four_cardinal_directions{{
         point::west, point::east, point::north, point::south
     }};
 
+inline constexpr std::array<point, 4> four_ordinal_directions{ {
+        point::north_east, point::south_east, point::south_west, point::north_west
+    } };
+
 inline constexpr const std::array<point, 5> five_cardinal_directions{{
         point::west, point::east, point::north, point::south, point::zero
     }};

--- a/src/regional_settings.cpp
+++ b/src/regional_settings.cpp
@@ -411,6 +411,28 @@ static void load_overmap_lake_settings( const JsonObject &jo,
     }
 }
 
+static void load_overmap_river_settings( const JsonObject &jo,
+        overmap_river_settings &overmap_river_settings,
+        const bool strict, const bool overlay )
+{
+    if( !jo.has_object( "overmap_river_settings" ) ) {
+        if( strict ) {
+            jo.throw_error( "OVERMAP_PLACE_RIVERS set to true, but \"overmap_river_settings\" not defined in region_settings" );
+        }
+    } else {
+        JsonObject overmap_river_settings_jo = jo.get_object( "overmap_river_settings" );
+        read_and_set_or_throw<int>( overmap_river_settings_jo, "river_scale",
+                                    overmap_river_settings.river_scale, !overlay );
+        read_and_set_or_throw<double>( overmap_river_settings_jo, "river_frequency",
+                                       overmap_river_settings.river_frequency, false );
+        read_and_set_or_throw<double>( overmap_river_settings_jo, "river_branch_chance",
+                                       overmap_river_settings.river_branch_chance, false );
+        read_and_set_or_throw<double>( overmap_river_settings_jo, "river_branch_remerge_chance",
+                                       overmap_river_settings.river_branch_remerge_chance, false );
+        read_and_set_or_throw<double>( overmap_river_settings_jo, "river_branch_scale_decrease",
+                                       overmap_river_settings.river_branch_scale_decrease, false );
+    }
+}
 static void load_overmap_ocean_settings( const JsonObject &jo,
         overmap_ocean_settings &overmap_ocean_settings,
         const bool strict, const bool overlay )
@@ -503,9 +525,6 @@ void load_region_settings( const JsonObject &jo )
     mandatory( jo, false, "default_oter", new_region.default_oter );
     // So the data definition goes from z = OVERMAP_HEIGHT to z = OVERMAP_DEPTH
     std::reverse( new_region.default_oter.begin(), new_region.default_oter.end() );
-    if( !jo.read( "river_scale", new_region.river_scale ) && strict ) {
-        jo.throw_error( "river_scale required for default" );
-    }
     if( jo.has_array( "default_groundcover" ) ) {
         new_region.default_groundcover_str.reset( new weighted_int_list<ter_str_id> );
         for( JsonArray inner : jo.get_array( "default_groundcover" ) ) {
@@ -603,6 +622,8 @@ void load_region_settings( const JsonObject &jo )
 
     load_overmap_forest_settings( jo, new_region.overmap_forest, strict, false );
 
+    load_overmap_river_settings( jo, new_region.overmap_river, strict, false );
+
     load_overmap_lake_settings( jo, new_region.overmap_lake, strict, false );
 
     load_overmap_ocean_settings( jo, new_region.overmap_ocean, strict, false );
@@ -689,7 +710,6 @@ void load_region_overlay( const JsonObject &jo )
 void apply_region_overlay( const JsonObject &jo, regional_settings &region )
 {
     jo.read( "default_oter", region.default_oter );
-    jo.read( "river_scale", region.river_scale );
     if( jo.has_array( "default_groundcover" ) ) {
         region.default_groundcover_str.reset( new weighted_int_list<ter_str_id> );
         for( JsonArray inner : jo.get_array( "default_groundcover" ) ) {
@@ -758,6 +778,8 @@ void apply_region_overlay( const JsonObject &jo, regional_settings &region )
     load_overmap_feature_flag_settings( jo, region.overmap_feature_flag, false, true );
 
     load_overmap_forest_settings( jo, region.overmap_forest, false, true );
+
+    load_overmap_river_settings( jo, region.overmap_river, false, true );
 
     load_overmap_lake_settings( jo, region.overmap_lake, false, true );
 

--- a/src/regional_settings.h
+++ b/src/regional_settings.h
@@ -201,6 +201,16 @@ struct shore_extendable_overmap_terrain_alias {
     oter_str_id alias;
 };
 
+struct overmap_river_settings {
+    int river_scale = 1;
+    double river_frequency = 1.5;
+    double river_branch_chance = 64;
+    double river_branch_remerge_chance = 4;
+    double river_branch_scale_decrease = 1;
+
+    overmap_river_settings() = default;
+};
+
 struct overmap_lake_settings {
     double noise_threshold_lake = 0.25;
     int lake_size_min = 20;
@@ -276,7 +286,6 @@ struct region_terrain_and_furniture_settings {
 struct regional_settings {
     std::string id;           //
     std::array<oter_str_id, OVERMAP_LAYERS> default_oter;
-    double river_scale = 1;
     weighted_int_list<ter_id> default_groundcover; // i.e., 'grass_or_dirt'
     shared_ptr_fast<weighted_int_list<ter_str_id>> default_groundcover_str;
 
@@ -286,6 +295,7 @@ struct regional_settings {
     weather_generator weather;
     overmap_feature_flag_settings overmap_feature_flag;
     overmap_forest_settings overmap_forest;
+    overmap_river_settings overmap_river;
     overmap_lake_settings overmap_lake;
     overmap_ocean_settings overmap_ocean;
     overmap_ravine_settings overmap_ravine;

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -511,6 +511,21 @@ void overmap::unserialize( const JsonObject &jsobj )
             }
         } else if( name == "city_tiles" ) {
             om_member.read( city_tiles );
+        } else if( name == "rivers" ) {
+            JsonArray rivers_json = om_member;
+            for( JsonObject river_json : rivers_json ) {
+                point_om_omt start_point;
+                point_om_omt end_point;
+                point_om_omt control_1;
+                point_om_omt control_2;
+                size_t size;
+                mandatory( river_json, false, "entry", start_point );
+                mandatory( river_json, false, "exit", end_point );
+                mandatory( river_json, false, "control1", control_1 );
+                mandatory( river_json, false, "control2", control_2 );
+                mandatory( river_json, false, "size", size );
+                rivers.push_back( overmap_river_node{ start_point, end_point, control_1, control_2, size } );
+            }
         } else if( name == "connections_out" ) {
             om_member.read( connections_out );
         } else if( name == "roads_out" ) {
@@ -1253,6 +1268,16 @@ void overmap::serialize( std::ostream &fout ) const
     fout << std::endl;
 
     json.member( "city_tiles", city_tiles );
+    json.member( "rivers" );
+    json.start_array();
+    for( const overmap_river_node &i : rivers ) {
+        json.start_object();
+        json.member( "entry", i.river_start );
+        json.member( "exit", i.river_end );
+        json.member( "size", i.size );
+        json.end_object();
+    }
+    json.end_array();
     fout << std::endl;
 
     json.member( "connections_out", connections_out );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "river generation overhaul"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

- Complete #74261, which aimed to complete #38894
- Fixes #36630
- Fixes #59433

~mostly done, but still WIP do not merge~ ready to merge

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

First, credit to original authors @Procyonae and @Diabolus-Engi; the work they did was pretty solid and easy to rebase, and a decent chunk of it is still present here.

What's changed from their PRs:

- Rivers drawn with Bezier curves were crooked on the overmap boundaries because there wasn't any logic smoothing the curves. I used the simple fact that the derivative of a Bezier curve at its endpoints is the slope between the endpoints and their nearest control point to connect adjacent curves.
- N/S and E/W rivers intersected in a '+' regularly. This is less of a big deal, but rivers don't usually (if ever) do that. To fix this, if there are two rivers in an overmap, they'll always go N->E, W->S, and any river generating will stop once it hits any body of water.
- I've reduced the chance of "major" rivers to spawn -- there aren't a ton of them in Massachusetts, at least every 4.3km (overmap width). Every river generated past the first reduces the chance for a new river to spawn. To offset this, if a river makes it to the end of an overmap, it is guaranteed to continue to the next overmap.
- Rivers now have regional_settings
- General polish, documentation, and fixing bugs from above issues.

> 5. Rivers will 'pool up' creating small lakes if they haven't terminated on the overmap boundary.

This didn't seem to work, nor did I like having lakes generate separate from place_lakes(), so I instead reworked how lakes connect to rivers.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

To-do:
- Streams should almost always connect to rivers/lakes/oceans, but right now they just kinda go wherever, sometimes in a loop around themselves and/or the entire overmap. I think that streams should be much more common than rivers, too, and it'd be great if they could span overmaps.
- Ocean interaction is still buggy (mentioned in #70190), ocean OMTs can also spawn in "pools" inland disconnected from the main body of water, and overmap generation is very slow around oceans because of special placement, too. Lots of ocean bugs.
- I would absolutely favor a #70056 approach to rivers and overmap generation in general.
- River branching/meandering could be more sophisticated.

A lot of the concerns in #74261 still apply as well.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<details>
<summary>Lots of screenshots:</summary>

![Screenshot (21)](https://github.com/user-attachments/assets/20d6447a-b86a-45ff-93be-f051e9de9aec)
![Screenshot (22)](https://github.com/user-attachments/assets/b46c67a0-b736-4ca8-a6df-00c0848bd51d)
![Screenshot (23)](https://github.com/user-attachments/assets/53669d15-494f-4931-9058-538a4e9c7d2c)
![Screenshot (24)](https://github.com/user-attachments/assets/8ae1ba9c-e305-4f99-9bcc-2003cbec31c0)
![Screenshot (25)](https://github.com/user-attachments/assets/deedfc8c-3329-4531-8cc6-fde29c798085)
![Screenshot (26)](https://github.com/user-attachments/assets/110b2ed0-29a5-41b9-9fba-408724f6f320)
These ocean-adjacent rivers happened to generate correctly, but they can still clip along the ocean
![Screenshot (27)](https://github.com/user-attachments/assets/eb0b3934-4cb4-4c41-85ad-2ba19404d563)
![Screenshot (28)](https://github.com/user-attachments/assets/a0209fc5-f430-42e9-b083-8978b72be69d)

</details>

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

I'm more concerned about fixing bugs over tweaking the rivers to look just right in this PR.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
