### PR TITLE
Use dbl_or_var for variable "nested":/"place_nested": weights

### DIFF
--- a/data/json/mapgen/s_grocery.json
+++ b/data/json/mapgen/s_grocery.json
@@ -1,9 +1,20 @@
 [
   {
     "type": "mapgen",
-    "om_terrain": [ "s_grocery" ],
-    "weight": 100,
+    "om_terrain": "s_grocery",
     "object": {
+      "fill_ter": { "param": "linoleum_color", "fallback": "t_linoleum_white" },
+      "palettes": [ "grocery_store_palette" ],
+      "place_nested": [
+        { "chunks": [ [ "s_grocery_unlooted", 100 ], [ "s_grocery_empty", 500 ], [ "s_grocery_looted", 300 ] ], "x": 0, "y": 0 }
+      ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "s_grocery_unlooted",
+    "object": {
+      "mapgensize": [ 24, 24 ],
       "rows": [
         "__sssssssssssssssssssss_",
         "__WWWWWWWWsssssssssssss_",
@@ -30,7 +41,6 @@
         "sssL***+**************#_",
         "sss####################_"
       ],
-      "fill_ter": { "param": "linoleum_color", "fallback": "t_linoleum_white" },
       "palettes": [ "grocery_store_palette" ],
       "terrain": { "l": { "param": "linoleum_color", "fallback": "t_linoleum_gray" } },
       "place_items": [
@@ -74,9 +84,9 @@
   },
   {
     "type": "mapgen",
-    "om_terrain": [ "s_grocery" ],
-    "weight": 500,
+    "nested_mapgen_id": "s_grocery_empty",
     "object": {
+      "mapgensize": [ 24, 24 ],
       "rows": [
         "__sssssssssssssssssssss_",
         "__WWWWWWWWsssssssssssss_",
@@ -103,7 +113,6 @@
         "sss#***+**************#_",
         "sss####################_"
       ],
-      "fill_ter": { "param": "linoleum_color", "fallback": "t_linoleum_white" },
       "terrain": { "l": { "param": "linoleum_color", "fallback": "t_linoleum_white" } },
       "palettes": [ "grocery_store_palette" ],
       "fields": { "T": { "field": "fd_bile", "intensity": 1, "age": 10 }, "S": { "field": "fd_bile", "intensity": 1, "age": 10 } },
@@ -197,9 +206,9 @@
   },
   {
     "type": "mapgen",
-    "om_terrain": [ "s_grocery" ],
-    "weight": 300,
+    "nested_mapgen_id": "s_grocery_looted",
     "object": {
+      "mapgensize": [ 24, 24 ],
       "rows": [
         "__sssssssssssssssssssss_",
         "__WWWWWWWWsssssssssssss_",
@@ -226,7 +235,6 @@
         "sssL***+**************#_",
         "sss####################_"
       ],
-      "fill_ter": { "param": "linoleum_color", "fallback": "t_linoleum_gray" },
       "palettes": [ "grocery_store_palette" ],
       "terrain": {
         "+": "t_door_boarded",

--- a/data/json/mapgen/s_grocery.json
+++ b/data/json/mapgen/s_grocery.json
@@ -6,7 +6,15 @@
       "fill_ter": { "param": "linoleum_color", "fallback": "t_linoleum_white" },
       "palettes": [ "grocery_store_palette" ],
       "place_nested": [
-        { "chunks": [ [ "s_grocery_unlooted", 100 ], [ "s_grocery_empty", 500 ], [ "s_grocery_looted", 300 ] ], "x": 0, "y": 0 }
+        {
+          "chunks": [
+            [ "s_grocery_unlooted", { "math": [ "250 * time_since_cata_quadratic_neg( 365 )" ] } ],
+            [ "s_grocery_empty", 500 ],
+            [ "s_grocery_looted", { "math": [ "250 + ( 250 * time_since_cata_quadratic_pos( 365 ) )" ] } ]
+          ],
+          "x": 0,
+          "y": 0
+        }
       ]
     }
   },

--- a/data/json/weight_functions.json
+++ b/data/json/weight_functions.json
@@ -1,0 +1,116 @@
+[
+  {
+    "type": "jmath_function",
+    "id": "weight_start",
+    "//": "These functions return a value between 0 and 1 to be multiplied with mapgen weights and hopefully in the future specials occurances and for use in mapgen value conditionals.  Usage weight_start( days of 0 weight ).  Sets weight from 0 to 'weight' after 'days of 0 weight' have passed.",
+    "num_args": 1,
+    "return": "u_val('time_since_cataclysm: days') < _0 ? 0 : 1"
+  },
+  {
+    "type": "jmath_function",
+    "id": "weight_end",
+    "//": "Usage weight_end( days until 0 weight ).  Sets weight from 'weight' to 0 after 'days until 0 weight' have passed.",
+    "num_args": 1,
+    "return": "u_val('time_since_cataclysm: days') < _0 ? 1 : 0"
+  },
+  {
+    "type": "jmath_function",
+    "id": "weight_start_min",
+    "//": "Usage weight_start_min( days of 0 weight, minimum multiplier ).  Sets weight from 0 to 'weight' after 'days of 0 weight' have passed but never returns less than 'minimum multiplier'.",
+    "num_args": 2,
+    "return": "u_val('time_since_cataclysm: days') < _0 ? _1 : 1"
+  },
+  {
+    "type": "jmath_function",
+    "id": "weight_end_min",
+    "//": "Usage weight_end_min( days until 0 weight, minimum multiplier ).  Sets weight from 'weight' to 0 after 'days until 0 weight' have passed but never returns less than 'minimum multiplier'.",
+    "num_args": 2,
+    "return": "u_val('time_since_cataclysm: days') < _0 ? 1 : _1"
+  },
+  {
+    "type": "jmath_function",
+    "id": "weight_linear_pos",
+    "//": "Usage weight_linear_pos( days until max weight ).  Linearly increases weight from 0 to 'weight' until 'days until max weight' have passed.",
+    "num_args": 1,
+    "return": "u_val('time_since_cataclysm: days') < _0 ? u_val('time_since_cataclysm: days') / _0 : 1"
+  },
+  {
+    "type": "jmath_function",
+    "id": "weight_linear_neg",
+    "//": "Usage weight_linear_neg( days until 0 weight ).  Linearly decreases weight from 'weight' to 0 until 'days until 0 weight' have passed.",
+    "num_args": 1,
+    "return": "u_val('time_since_cataclysm: days') < _0 ? 1 - ( u_val('time_since_cataclysm: days') / _0 ) : 0"
+  },
+  {
+    "type": "jmath_function",
+    "id": "weight_linear_pos_min",
+    "//": "Usage weight_linear_pos_min( days until max weight, minimum multiplier ).  Linearly increases weight from 0 to 'weight' until 'days until max weight' have passed but never returns less than 'minimum multiplier'.",
+    "num_args": 2,
+    "return": "u_val('time_since_cataclysm: days') < _0 ? max( u_val('time_since_cataclysm: days') / _0, _1 ) : 1"
+  },
+  {
+    "type": "jmath_function",
+    "id": "weight_linear_neg_min",
+    "//": "Usage weight_linear_neg_min( days until 0 weight, minimum multiplier ).  Linearly decreases weight from 'weight' to 0 until 'days until 0 weight' have passed but never returns less than 'minimum multiplier'.",
+    "num_args": 2,
+    "return": "u_val('time_since_cataclysm: days') < _0 ? max( 1 - ( u_val('time_since_cataclysm: days') / _0 ), _1 ) : _1"
+  },
+  {
+    "type": "jmath_function",
+    "id": "weight_quadratic_pos",
+    "//": "Use completing the square to generalise",
+    "//1": "Usage weight_quadratic_u_pos( days until max weight ).  Quadratically varies weight from to 0 to 'weight' until 'days until max weight' have passed.",
+    "num_args": 1,
+    "return": "u_val('time_since_cataclysm: days') < _0 ? ( u_val('time_since_cataclysm: days') / _0 ) ^ 2 : 1"
+  },
+  {
+    "type": "jmath_function",
+    "id": "weight_quadratic_neg",
+    "//": "Usage weight_quadratic_u_neg( days until 0 weight ).  Quadratically varies weight from 'weight' to 0 until 'days until 0 weight' have passed.",
+    "num_args": 1,
+    "return": "u_val('time_since_cataclysm: days') < _0 ? 1 - ( ( u_val('time_since_cataclysm: days') / _0 ) ^ 2 ) : 0"
+  },
+  {
+    "type": "jmath_function",
+    "id": "weight_quadratic_pos_min",
+    "//": "Usage weight_quadratic_u_pos_min( days until max weight, minimum multiplier ).  Quadratically varies weight from 0 to 'weight' until 'days until max weight' have passed but never returns less than 'minimum multiplier'.",
+    "num_args": 2,
+    "return": "u_val('time_since_cataclysm: days') < _0 ? max( _1, ( u_val('time_since_cataclysm: days') / _0 ) ^ 2 ) : 1"
+  },
+  {
+    "type": "jmath_function",
+    "id": "weight_quadratic_neg_min",
+    "//": "Usage weight_quadratic_neg_min( days until 0 weight, minimum multiplier ).  Quadratically varies weight from 'weight' to 0 until 'days until 0 weight' have passed but never returns less than 'minimum multiplier'.",
+    "num_args": 2,
+    "return": "u_val('time_since_cataclysm: days') < _0 ? max( _1, 1 - ( ( u_val('time_since_cataclysm: days') / _0 ) ^ 2 ) ) : _1"
+  },
+  {
+    "type": "jmath_function",
+    "id": "weight_quadratic_u_pos",
+    "//": "Use completing the square to generalise",
+    "//1": "Usage weight_quadratic_u_pos( days until max weight ).  Quadratically varies weight from 'weight' to 0 and back to 'weight' until 'days until max weight' have passed.",
+    "num_args": 1,
+    "return": "u_val('time_since_cataclysm: days') < _0 ? ( 1 / ( ( _0 / 2 ) ^ 2 ) ) * ( ( u_val('time_since_cataclysm: days') - ( _0 / 2 ) ) ^ 2 ) : 1"
+  },
+  {
+    "type": "jmath_function",
+    "id": "weight_quadratic_u_neg",
+    "//": "Usage weight_quadratic_u_neg( days until 0 weight ).  Quadratically varies weight from 0 to 'weight' and back to 0 until 'days until 0 weight' have passed.",
+    "num_args": 1,
+    "return": "u_val('time_since_cataclysm: days') < _0 ? 1 - ( ( 1 / ( ( _0 / 2 ) ^ 2 ) ) * ( ( u_val('time_since_cataclysm: days') - ( _0 / 2 ) ) ^ 2 ) ) : 0"
+  },
+  {
+    "type": "jmath_function",
+    "id": "weight_quadratic_u_pos_min",
+    "//": "Usage weight_quadratic_u_pos_min( days until max weight, minimum multiplier ).  Quadratically varies weight from 'weight' to 0 and back to 'weight' until 'days until max weight' have passed but never returns less than 'minimum multiplier'.",
+    "num_args": 2,
+    "return": "u_val('time_since_cataclysm: days') < _0 ? max( _1, ( 1 / ( ( _0 / 2 ) ^ 2 ) ) * ( ( u_val('time_since_cataclysm: days') - ( _0 / 2 ) ) ^ 2 ) ) : 1"
+  },
+  {
+    "type": "jmath_function",
+    "id": "weight_quadratic_u_neg_min",
+    "//": "Usage weight_quadratic_u_neg_min( days until 0 weight, minimum multiplier ).  Quadratically varies weight from 0 to 'weight' and back to 0 until 'days until 0 weight' have passed but never returns less than 'minimum multiplier'.",
+    "num_args": 2,
+    "return": "u_val('time_since_cataclysm: days') < _0 ? max( _1, 1 - ( ( 1 / ( ( _0 / 2 ) ^ 2 ) ) * ( ( u_val('time_since_cataclysm: days') - ( _0 / 2 ) ) ^ 2 ) ) ) : _1"
+  }
+]

--- a/data/json/weight_functions.json
+++ b/data/json/weight_functions.json
@@ -1,116 +1,59 @@
 [
   {
     "type": "jmath_function",
-    "id": "weight_start",
-    "//": "These functions return a value between 0 and 1 to be multiplied with mapgen weights and hopefully in the future specials occurances and for use in mapgen value conditionals.  Usage weight_start( days of 0 weight ).  Sets weight from 0 to 'weight' after 'days of 0 weight' have passed.",
+    "id": "time_since_cata_start",
+    "//": "These functions return a value between 0 and 1 to be multiplied by a variable amount and potentially added to a flat amount to for example manipulate weights.",
+    "//1": "Usage time_since_cata_start( days until 1 )",
     "num_args": 1,
-    "return": "u_val('time_since_cataclysm: days') < _0 ? 0 : 1"
+    "return": "time_since('cataclysm', 'unit':'days') < _0 ? 0 : 1"
   },
   {
     "type": "jmath_function",
-    "id": "weight_end",
-    "//": "Usage weight_end( days until 0 weight ).  Sets weight from 'weight' to 0 after 'days until 0 weight' have passed.",
+    "id": "time_since_cata_end",
+    "//": "Usage time_since_cata_end( days until 0 )",
     "num_args": 1,
-    "return": "u_val('time_since_cataclysm: days') < _0 ? 1 : 0"
+    "return": "time_since('cataclysm', 'unit':'days') < _0 ? 1 : 0"
   },
   {
     "type": "jmath_function",
-    "id": "weight_start_min",
-    "//": "Usage weight_start_min( days of 0 weight, minimum multiplier ).  Sets weight from 0 to 'weight' after 'days of 0 weight' have passed but never returns less than 'minimum multiplier'.",
-    "num_args": 2,
-    "return": "u_val('time_since_cataclysm: days') < _0 ? _1 : 1"
-  },
-  {
-    "type": "jmath_function",
-    "id": "weight_end_min",
-    "//": "Usage weight_end_min( days until 0 weight, minimum multiplier ).  Sets weight from 'weight' to 0 after 'days until 0 weight' have passed but never returns less than 'minimum multiplier'.",
-    "num_args": 2,
-    "return": "u_val('time_since_cataclysm: days') < _0 ? 1 : _1"
-  },
-  {
-    "type": "jmath_function",
-    "id": "weight_linear_pos",
-    "//": "Usage weight_linear_pos( days until max weight ).  Linearly increases weight from 0 to 'weight' until 'days until max weight' have passed.",
+    "id": "time_since_cata_linear_pos",
+    "//": "Usage time_since_cata_linear_pos( days until 1 ).  Linearly increases from 0 to 1.",
     "num_args": 1,
-    "return": "u_val('time_since_cataclysm: days') < _0 ? u_val('time_since_cataclysm: days') / _0 : 1"
+    "return": "time_since('cataclysm', 'unit':'days') < _0 ? time_since('cataclysm', 'unit':'days') / _0 : 1"
   },
   {
     "type": "jmath_function",
-    "id": "weight_linear_neg",
-    "//": "Usage weight_linear_neg( days until 0 weight ).  Linearly decreases weight from 'weight' to 0 until 'days until 0 weight' have passed.",
+    "id": "time_since_cata_linear_neg",
+    "//": "Usage time_since_cata_linear_neg( days until 0 ).  Linearly decreases from 1 to 0.",
     "num_args": 1,
-    "return": "u_val('time_since_cataclysm: days') < _0 ? 1 - ( u_val('time_since_cataclysm: days') / _0 ) : 0"
+    "return": "time_since('cataclysm', 'unit':'days') < _0 ? 1 - ( time_since('cataclysm', 'unit':'days') / _0 ) : 0"
   },
   {
     "type": "jmath_function",
-    "id": "weight_linear_pos_min",
-    "//": "Usage weight_linear_pos_min( days until max weight, minimum multiplier ).  Linearly increases weight from 0 to 'weight' until 'days until max weight' have passed but never returns less than 'minimum multiplier'.",
-    "num_args": 2,
-    "return": "u_val('time_since_cataclysm: days') < _0 ? max( u_val('time_since_cataclysm: days') / _0, _1 ) : 1"
-  },
-  {
-    "type": "jmath_function",
-    "id": "weight_linear_neg_min",
-    "//": "Usage weight_linear_neg_min( days until 0 weight, minimum multiplier ).  Linearly decreases weight from 'weight' to 0 until 'days until 0 weight' have passed but never returns less than 'minimum multiplier'.",
-    "num_args": 2,
-    "return": "u_val('time_since_cataclysm: days') < _0 ? max( 1 - ( u_val('time_since_cataclysm: days') / _0 ), _1 ) : _1"
-  },
-  {
-    "type": "jmath_function",
-    "id": "weight_quadratic_pos",
-    "//": "Use completing the square to generalise",
-    "//1": "Usage weight_quadratic_u_pos( days until max weight ).  Quadratically varies weight from to 0 to 'weight' until 'days until max weight' have passed.",
+    "id": "time_since_cata_quadratic_pos",
+    "//": "Usage time_since_cata_quadratic_pos( days until 1 ).  Quadratically increases from 0 to 1.",
     "num_args": 1,
-    "return": "u_val('time_since_cataclysm: days') < _0 ? ( u_val('time_since_cataclysm: days') / _0 ) ^ 2 : 1"
+    "return": "time_since('cataclysm', 'unit':'days') < _0 ? ( time_since('cataclysm', 'unit':'days') / _0 ) ^ 2 : 1"
   },
   {
     "type": "jmath_function",
-    "id": "weight_quadratic_neg",
-    "//": "Usage weight_quadratic_u_neg( days until 0 weight ).  Quadratically varies weight from 'weight' to 0 until 'days until 0 weight' have passed.",
+    "id": "time_since_cata_quadratic_neg",
+    "//": "Usage time_since_cata_quadratic_neg( days until 0 ).  Quadratically decreases from 1 to 0.",
     "num_args": 1,
-    "return": "u_val('time_since_cataclysm: days') < _0 ? 1 - ( ( u_val('time_since_cataclysm: days') / _0 ) ^ 2 ) : 0"
+    "return": "time_since('cataclysm', 'unit':'days') < _0 ? 1 - ( ( time_since('cataclysm', 'unit':'days') / _0 ) ^ 2 ) : 0"
   },
   {
     "type": "jmath_function",
-    "id": "weight_quadratic_pos_min",
-    "//": "Usage weight_quadratic_u_pos_min( days until max weight, minimum multiplier ).  Quadratically varies weight from 0 to 'weight' until 'days until max weight' have passed but never returns less than 'minimum multiplier'.",
-    "num_args": 2,
-    "return": "u_val('time_since_cataclysm: days') < _0 ? max( _1, ( u_val('time_since_cataclysm: days') / _0 ) ^ 2 ) : 1"
-  },
-  {
-    "type": "jmath_function",
-    "id": "weight_quadratic_neg_min",
-    "//": "Usage weight_quadratic_neg_min( days until 0 weight, minimum multiplier ).  Quadratically varies weight from 'weight' to 0 until 'days until 0 weight' have passed but never returns less than 'minimum multiplier'.",
-    "num_args": 2,
-    "return": "u_val('time_since_cataclysm: days') < _0 ? max( _1, 1 - ( ( u_val('time_since_cataclysm: days') / _0 ) ^ 2 ) ) : _1"
-  },
-  {
-    "type": "jmath_function",
-    "id": "weight_quadratic_u_pos",
-    "//": "Use completing the square to generalise",
-    "//1": "Usage weight_quadratic_u_pos( days until max weight ).  Quadratically varies weight from 'weight' to 0 and back to 'weight' until 'days until max weight' have passed.",
+    "id": "time_since_cata_quadratic_u_pos",
+    "//": "Usage time_since_cata_quadratic_u_pos( days until 1 ).  Quadratically varies from 0 to 1 then back to 0 in the same amount of time.",
     "num_args": 1,
-    "return": "u_val('time_since_cataclysm: days') < _0 ? ( 1 / ( ( _0 / 2 ) ^ 2 ) ) * ( ( u_val('time_since_cataclysm: days') - ( _0 / 2 ) ) ^ 2 ) : 1"
+    "return": "time_since('cataclysm', 'unit':'days') < ( _0 * 2 ) ? ( 1 / ( _0 ^ 2 ) ) * ( ( time_since('cataclysm', 'unit':'days') - _0 ) ^ 2 ) : 1"
   },
   {
     "type": "jmath_function",
-    "id": "weight_quadratic_u_neg",
-    "//": "Usage weight_quadratic_u_neg( days until 0 weight ).  Quadratically varies weight from 0 to 'weight' and back to 0 until 'days until 0 weight' have passed.",
+    "id": "time_since_cata_quadratic_u_neg",
+    "//": "Usage time_since_cata_quadratic_u_neg( days until 0 ).  Quadratically varies from 1 to 0 then back to 1 in the same amount of time.",
     "num_args": 1,
-    "return": "u_val('time_since_cataclysm: days') < _0 ? 1 - ( ( 1 / ( ( _0 / 2 ) ^ 2 ) ) * ( ( u_val('time_since_cataclysm: days') - ( _0 / 2 ) ) ^ 2 ) ) : 0"
-  },
-  {
-    "type": "jmath_function",
-    "id": "weight_quadratic_u_pos_min",
-    "//": "Usage weight_quadratic_u_pos_min( days until max weight, minimum multiplier ).  Quadratically varies weight from 'weight' to 0 and back to 'weight' until 'days until max weight' have passed but never returns less than 'minimum multiplier'.",
-    "num_args": 2,
-    "return": "u_val('time_since_cataclysm: days') < _0 ? max( _1, ( 1 / ( ( _0 / 2 ) ^ 2 ) ) * ( ( u_val('time_since_cataclysm: days') - ( _0 / 2 ) ) ^ 2 ) ) : 1"
-  },
-  {
-    "type": "jmath_function",
-    "id": "weight_quadratic_u_neg_min",
-    "//": "Usage weight_quadratic_u_neg_min( days until 0 weight, minimum multiplier ).  Quadratically varies weight from 0 to 'weight' and back to 0 until 'days until 0 weight' have passed but never returns less than 'minimum multiplier'.",
-    "num_args": 2,
-    "return": "u_val('time_since_cataclysm: days') < _0 ? max( _1, 1 - ( ( 1 / ( ( _0 / 2 ) ^ 2 ) ) * ( ( u_val('time_since_cataclysm: days') - ( _0 / 2 ) ) ^ 2 ) ) ) : _1"
+    "return": "time_since('cataclysm', 'unit':'days') < ( _0 * 2 ) ? 1 - ( ( 1 / ( _0 ^ 2 ) ) * ( ( time_since('cataclysm', 'unit':'days') - _0 ) ^ 2 ) ) : 0"
   }
 ]

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -223,6 +223,20 @@ dbl_or_var get_dbl_or_var( const JsonObject &jo, std::string_view member, bool r
     return ret_val;
 }
 
+dbl_or_var get_dbl_or_var( const JsonValue &jv )
+{
+    dbl_or_var ret_val;
+    if( jv.test_array() ) {
+        JsonArray ja = jv.get_array();
+        ret_val.min = get_dbl_or_var_part( ja.next_value() );
+        ret_val.max = get_dbl_or_var_part( ja.next_value() );
+        ret_val.pair = true;
+    } else {
+        ret_val.min = get_dbl_or_var_part( jv );
+    }
+    return ret_val;
+}
+
 duration_or_var_part get_duration_or_var_part( const JsonValue &jv )
 {
     duration_or_var_part ret_val;

--- a/src/condition.h
+++ b/src/condition.h
@@ -46,6 +46,7 @@ str_translation_or_var get_str_translation_or_var(
     const JsonValue &jv, std::string_view member, bool required = true );
 dbl_or_var get_dbl_or_var( const JsonObject &jo, std::string_view member, bool required = true,
                            double default_val = 0.0 );
+dbl_or_var get_dbl_or_var( const JsonValue &jv );
 dbl_or_var_part get_dbl_or_var_part( const JsonValue &jv );
 duration_or_var get_duration_or_var( const JsonObject &jo, std::string_view member,
                                      bool required = true,

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -100,6 +100,7 @@
 #include "vehicle_group.h"
 #include "vpart_position.h"
 #include "vpart_range.h"
+#include "weighted_dbl_or_var_list.h"
 #include "weighted_list.h"
 
 static const field_type_str_id field_fd_blood( "fd_blood" );
@@ -4290,8 +4291,8 @@ class jmapgen_nested : public jmapgen_piece
         };
 
     public:
-        weighted_int_list<mapgen_value<nested_mapgen_id>> entries;
-        weighted_int_list<mapgen_value<nested_mapgen_id>> else_entries;
+        weighted_dbl_or_var_list<mapgen_value<nested_mapgen_id>> entries;
+        weighted_dbl_or_var_list<mapgen_value<nested_mapgen_id>> else_entries;
         neighbor_oter_check neighbor_oters;
         neighbor_join_check neighbor_joins;
         neighbor_flag_check neighbor_flags;
@@ -4306,10 +4307,10 @@ class jmapgen_nested : public jmapgen_piece
             , predecessors( jsi.get_array( "predecessors" ) )
             , correct_z_level( jsi.get_array( "check_z" ) ) {
             if( jsi.has_member( "chunks" ) ) {
-                load_weighted_list( jsi.get_member( "chunks" ), entries, 100 );
+                entries.load( jsi.get_member( "chunks" ), 100 );
             }
             if( jsi.has_member( "else_chunks" ) ) {
-                load_weighted_list( jsi.get_member( "else_chunks" ), else_entries, 100 );
+                else_entries.load( jsi.get_member( "else_chunks" ), 100 );
             }
         }
         mapgen_phase phase() const override {
@@ -4333,14 +4334,14 @@ class jmapgen_nested : public jmapgen_piece
                     }
                 }
             };
-            for( const weighted_object<int, mapgen_value<nested_mapgen_id>> &name : entries ) {
+            for( const weighted_object<dbl_or_var, mapgen_value<nested_mapgen_id>> &name : entries ) {
                 merge_from( name.obj );
             }
-            for( const weighted_object<int, mapgen_value<nested_mapgen_id>> &name : else_entries ) {
+            for( const weighted_object<dbl_or_var, mapgen_value<nested_mapgen_id>> &name : else_entries ) {
                 merge_from( name.obj );
             }
         }
-        const weighted_int_list<mapgen_value<nested_mapgen_id>> &get_entries(
+        const weighted_dbl_or_var_list<mapgen_value<nested_mapgen_id>> &get_entries(
         const mapgendata &dat ) const {
             if( neighbor_oters.test( dat ) && neighbor_joins.test( dat ) && neighbor_flags.test( dat ) &&
                 neighbor_flags_any.test( dat ) && predecessors.test( dat ) && correct_z_level.test( dat ) ) {
@@ -4351,7 +4352,7 @@ class jmapgen_nested : public jmapgen_piece
         }
         void apply( const mapgendata &dat, const jmapgen_int &x, const jmapgen_int &y, const jmapgen_int &z,
                     const std::string &context ) const override {
-            const mapgen_value<nested_mapgen_id> *val = get_entries( dat ).pick();
+            mapgen_value<nested_mapgen_id> *val = get_entries( dat ).pick();
             if( val == nullptr ) {
                 return;
             }

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -4341,8 +4341,7 @@ class jmapgen_nested : public jmapgen_piece
                 merge_from( name.obj );
             }
         }
-        const weighted_dbl_or_var_list<mapgen_value<nested_mapgen_id>> &get_entries(
-        const mapgendata &dat ) const {
+        weighted_dbl_or_var_list<mapgen_value<nested_mapgen_id>> &get_entries( const mapgendata &dat ) {
             if( neighbor_oters.test( dat ) && neighbor_joins.test( dat ) && neighbor_flags.test( dat ) &&
                 neighbor_flags_any.test( dat ) && predecessors.test( dat ) && correct_z_level.test( dat ) ) {
                 return entries;
@@ -4380,10 +4379,10 @@ class jmapgen_nested : public jmapgen_piece
         void check( const std::string &oter_name, const mapgen_parameters &parameters,
                     const jmapgen_int &x, const jmapgen_int &y, const jmapgen_int &z
                   ) const override {
-            for( const weighted_object<int, mapgen_value<nested_mapgen_id>> &p : entries ) {
+            for( const weighted_object<dbl_or_var, mapgen_value<nested_mapgen_id>> &p : entries ) {
                 p.obj.check( oter_name, parameters );
             }
-            for( const weighted_object<int, mapgen_value<nested_mapgen_id>> &p : else_entries ) {
+            for( const weighted_object<dbl_or_var, mapgen_value<nested_mapgen_id>> &p : entries ) {
                 p.obj.check( oter_name, parameters );
             }
             neighbor_joins.check( oter_name, parameters );
@@ -4402,10 +4401,10 @@ class jmapgen_nested : public jmapgen_piece
                     }
                 }
             };
-            for( const weighted_object<int, mapgen_value<nested_mapgen_id>> &p : entries ) {
+            for( const weighted_object<dbl_or_var, mapgen_value<nested_mapgen_id>> &p : entries ) {
                 add_coords_from( p.obj );
             }
-            for( const weighted_object<int, mapgen_value<nested_mapgen_id>> &p : else_entries ) {
+            for( const weighted_object<dbl_or_var, mapgen_value<nested_mapgen_id>> &p : else_entries ) {
                 add_coords_from( p.obj );
             }
 
@@ -4450,7 +4449,7 @@ class jmapgen_nested : public jmapgen_piece
         }
         ret_val<void> has_vehicle_collision( const mapgendata &dat,
                                              const tripoint_rel_ms &p ) const override {
-            const weighted_int_list<mapgen_value<nested_mapgen_id>> &selected_entries =
+            const weighted_dbl_or_var_list<mapgen_value<nested_mapgen_id>> &selected_entries =
                         get_entries( dat );
             if( selected_entries.empty() ) {
                 return ret_val<void>::make_success();

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -4341,7 +4341,8 @@ class jmapgen_nested : public jmapgen_piece
                 merge_from( name.obj );
             }
         }
-        weighted_dbl_or_var_list<mapgen_value<nested_mapgen_id>> &get_entries( const mapgendata &dat ) {
+        const weighted_dbl_or_var_list<mapgen_value<nested_mapgen_id>> &get_entries(
+        const mapgendata &dat ) const {
             if( neighbor_oters.test( dat ) && neighbor_joins.test( dat ) && neighbor_flags.test( dat ) &&
                 neighbor_flags_any.test( dat ) && predecessors.test( dat ) && correct_z_level.test( dat ) ) {
                 return entries;
@@ -4351,7 +4352,7 @@ class jmapgen_nested : public jmapgen_piece
         }
         void apply( const mapgendata &dat, const jmapgen_int &x, const jmapgen_int &y, const jmapgen_int &z,
                     const std::string &context ) const override {
-            mapgen_value<nested_mapgen_id> *val = get_entries( dat ).pick();
+            const mapgen_value<nested_mapgen_id> *val = get_entries( dat ).pick();
             if( val == nullptr ) {
                 return;
             }

--- a/src/weighted_dbl_or_var_list.h
+++ b/src/weighted_dbl_or_var_list.h
@@ -1,0 +1,276 @@
+#pragma once
+#ifndef CATA_SRC_WEIGHTED_DBL_OR_VAR_LIST_H
+#define CATA_SRC_WEIGHTED_DBL_OR_VAR_LIST_H
+
+#include "dialogue_helpers.h"
+#include "weighted_list.h"
+
+//BEFOREMERGE: Redo copied comments
+// Works similarly to weighted_list except weights are stored as dbl_or_var, so total_weight isn't constant unless all weights are etc
+
+static const const_dialogue d_dummy;
+
+template <typename T> struct weighted_dbl_or_var_list {
+        weighted_dbl_or_var_list() : total_weight( 0 ) { }
+
+        weighted_dbl_or_var_list( const weighted_dbl_or_var_list & ) = default;
+        weighted_dbl_or_var_list( weighted_dbl_or_var_list && ) noexcept = default;
+        weighted_dbl_or_var_list &operator=( const weighted_dbl_or_var_list & ) = default;
+        weighted_dbl_or_var_list &operator=( weighted_dbl_or_var_list && ) noexcept = default;
+        virtual ~weighted_dbl_or_var_list() = default;
+
+        void load( const JsonValue &jsv, double default_weight ) {
+            for( const JsonValue entry : jsv.get_array() ) {
+                if( entry.test_array() ) {
+                    std::pair<T, double> p;
+                    entry.read( p, true );
+                    add( p.first, p.second );
+                } else {
+                    T val;
+                    entry.read( val );
+                    add( val, default_weight );
+                }
+            }
+        }
+
+        /**
+         * This will add a new object to the weighted list. Returns a pointer to
+           the added object, or NULL if weight was zero.
+         * @param obj The object that will be added to the list.
+         * @param weight The weight of the object.
+         */
+        T *add( const T &obj, const double &weight ) {
+            if( weight.is_constant() && weight <= 0 ) {
+                return nullptr;
+            }
+            objects.emplace_back( obj, weight );
+            invalidate_precalc();
+            return &( objects[objects.size() - 1].obj );
+        }
+
+        dialogue d() const {
+            return dialogue( get_talker_for( get_avatar() ), std::make_unique<talker>() );
+        }
+
+        bool is_precalced() const {
+            return _precalced;
+        }
+
+        void precalc() {
+            for( const auto object : objects ) {
+                _is_constant &= object.is_constant();
+            }
+            if( _is_constant ) {
+                for( const auto object : objects ) {
+                    _constant_total_weight += object.evaluate( d() );
+                }
+            }
+            _precalced = true;
+        }
+
+        void invalidate_precalc() {
+            _is_constant = true;
+            _precalced = false;
+        }
+
+        bool is_constant() {
+            if( !is_precalced() ) {
+                precalc();
+            }
+            return _is_constant;
+        }
+
+        void remove( const T &obj ) {
+            auto itr_end = std::remove_if( objects.begin(),
+            objects.end(), [&obj]( typename decltype( objects )::value_type const & itr ) {
+                return itr.obj == obj;
+            } );
+            objects.erase( itr_end, objects.end() );
+            invalidate_precalc();
+        }
+
+        /**
+         * This will check to see if the given object is already in the weighted
+           list. If it is, we update its weight with the new weight value. If it
+           is not, we add it normally. Returns a pointer to the added or updated
+           object, or NULL if weight was zero.
+         * @param obj The object that will be updated or added to the list.
+         * @param weight The new weight of the object.
+         */
+        T *add_or_replace( const T &obj, const dbl_or_var &weight ) {
+
+            if( weight.is_constant() && weight <= 0 ) {
+                remove( obj );
+                invalidate_precalc();
+            }
+            for( auto &itr : objects ) {
+                if( itr.obj == obj ) {
+                    if( obj.weight != weight ) {
+                        itr.weight = weight;
+                        invalidate_precalc();
+                    }
+                    return &( itr.obj );
+                }
+            }
+            // if not found, add to end of list
+            return add( obj, weight );
+        }
+
+        /**
+         * This will call the given callback function once for every object in the weighted list.
+         * @param func The callback function.
+         */
+        void apply( std::function<void( const T & )> func ) const {
+            for( auto &itr : objects ) {
+                func( itr.obj );
+            }
+        }
+
+        /**
+         * This will call the given callback function once for every object in the weighted list.
+         * This is the non-const version.
+         * @param func The callback function.
+         */
+        void apply( std::function<void( T & )> func ) {
+            for( auto &itr : objects ) {
+                func( itr.obj );
+            }
+        }
+
+        /**
+         * This will return a pointer to an object from the list randomly selected
+         * and biased by weight. If the weighted list is empty or all items in it
+         * have a weight of zero, it will return a NULL pointer.
+         */
+        const T *pick( unsigned int randi ) const {
+            if( get_weight() > 0 ) {
+                return &( objects[pick_ent( randi )].obj );
+            }
+            return nullptr;
+        }
+        const T *pick() const {
+            return pick( rng_bits() );
+        }
+
+        /**
+         * This will return a pointer to an object from the list randomly selected
+         * and biased by weight. If the weighted list is empty or all items in it
+         * have a weight of zero, it will return a NULL pointer. This is the
+         * non-const version so that the returned result may be modified.
+         */
+        T *pick( unsigned int randi ) {
+            if( get_weight() > 0 ) {
+                return &( objects[pick_ent( randi )].obj );
+            }
+            return nullptr;
+        }
+        T *pick() {
+            return pick( rng_bits() );
+        }
+
+        /**
+         * This will remove all objects from the list.
+         */
+        void clear() {
+            objects.clear();
+            invalidate_precalc();
+        }
+
+        /**
+         * This will return the weight of a specific object. If the object is not
+         * in the weighted list it will return 0.
+         */
+        double get_specific_weight( const T &obj ) const {
+            for( auto &itr : objects ) {
+                if( itr.obj == obj ) {
+                    return itr.weight.evaluate( d() );
+                }
+            }
+            return 0;
+        }
+
+        /**
+         * This will return the sum of all the object's weights in the list.
+         */
+        double get_weight() const {
+            if( is_constant() ) {
+                return _constant_total_weight;
+            } else {
+                double ret;
+                for( auto &itr : objects ) {
+                    ret += itr.weight.evaluate( d() );
+                }
+                return ret;
+            }
+        }
+
+        bool is_valid() const {
+            return !is_constant() || _constant_total_weight > 0;
+        }
+
+        typename std::vector<weighted_object<dbl_or_var, T> >::iterator begin() {
+            return objects.begin();
+        }
+        typename std::vector<weighted_object<dbl_or_var, T> >::iterator end() {
+            return objects.end();
+        }
+        typename std::vector<weighted_object<dbl_or_var, T> >::const_iterator begin() const {
+            return objects.begin();
+        }
+        typename std::vector<weighted_object<dbl_or_var, T> >::const_iterator end() const {
+            return objects.end();
+        }
+        typename std::vector<weighted_object<dbl_or_var, T> >::iterator erase(
+            typename std::vector<weighted_object<dbl_or_var, T> >::iterator first,
+            typename std::vector<weighted_object<dbl_or_var, T> >::iterator last ) {
+            invalidate_precalc();
+            return objects.erase( first, last );
+        }
+        size_t size() const noexcept {
+            return objects.size();
+        }
+        bool empty() const noexcept {
+            return objects.empty();
+        }
+        //TODO: Might want to add is_constant() somewhere
+        std::string to_debug_string() const {
+            std::ostringstream os;
+            os << "[ ";
+            for( const weighted_object<dbl_or_var, T> &o : objects ) {
+                os << o.obj << ":" << o.weight.evaluate( d() ) << ", ";
+            }
+            os << "]";
+            return os.str();
+        }
+
+        friend bool operator==( const weighted_list &l, const weighted_list &r ) {
+            return l.objects == r.objects;
+        }
+
+        friend bool operator!=( const weighted_list &l, const weighted_list &r ) {
+            return !( l == r );
+        }
+
+    protected:
+        double _constant_total_weight;
+        bool _precalced = false;
+        bool _is_constant = true;
+
+        size_t pick_ent( unsigned int randi ) const override {
+            const double picked = static_cast<double>( randi ) / UINT_MAX * get_weight();
+            double accumulated_weight = 0;
+            dialogue &d = is_constant() ? d_dummy : d();
+            size_t i;
+            for( i = 0; i < this->objects.size(); i++ ) {
+                accumulated_weight += this->objects[i].weight.evaluate( d );
+                if( accumulated_weight >= picked ) {
+                    break;
+                }
+            }
+            return i;
+        }
+
+        std::vector<weighted_object<dbl_or_var, T>> objects;
+};
+
+#endif // CATA_SRC_WEIGHTED_LIST_H

--- a/src/weighted_dbl_or_var_list.h
+++ b/src/weighted_dbl_or_var_list.h
@@ -8,8 +8,7 @@
 // Works similarly to weighted_list except weights are stored as dbl_or_var, so total_weight isn't constant unless all weights are etc
 
 template <typename T> struct weighted_dbl_or_var_list {
-        weighted_dbl_or_var_list() {}
-
+        weighted_dbl_or_var_list() = default;
         weighted_dbl_or_var_list( const weighted_dbl_or_var_list & ) = default;
         weighted_dbl_or_var_list( weighted_dbl_or_var_list && ) noexcept = default;
         weighted_dbl_or_var_list &operator=( const weighted_dbl_or_var_list & ) = default;

--- a/src/weighted_dbl_or_var_list.h
+++ b/src/weighted_dbl_or_var_list.h
@@ -72,14 +72,15 @@ template <typename T> struct weighted_dbl_or_var_list {
             _precalced = false;
         }
 
-        void precalc_error() const {
+        //BEFOREMERGE: This error is important and needed for pick() constness but is triggering erroneously on every chunk member
+        /*void precalc_error() const {
             debugmsg( "weighted_dbl_or_var_list precalc has been invalidated, call weighted_dbl_or_var_list::precalc() first" );
-        }
+        }*/
 
         bool is_constant() const {
-            if( !_precalced ) {
+            /*if( !_precalced ) {
                 precalc_error();
-            }
+            }*/
             return _is_constant;
         }
 

--- a/src/weighted_list.h
+++ b/src/weighted_list.h
@@ -38,7 +38,7 @@ template <typename W, typename T> struct weighted_list {
          * @param weight The weight of the object.
          */
         T *add( const T &obj, const W &weight ) {
-            if( weight >= 0 ) {
+            if( weight > 0 ) {
                 objects.emplace_back( obj, weight );
                 total_weight += weight;
                 invalidate_precalc();
@@ -67,8 +67,9 @@ template <typename W, typename T> struct weighted_list {
          * @param obj The object that will be updated or added to the list.
          * @param weight The new weight of the object.
          */
+        //TODO: Shouldn't this remove on weight <= 0?
         T *add_or_replace( const T &obj, const W &weight ) {
-            if( weight >= 0 ) {
+            if( weight > 0 ) {
                 invalidate_precalc();
                 for( auto &itr : objects ) {
                     if( itr.obj == obj ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Replicating #66919 somewhere is a blocker to #70522
Allows nest weights to vary based on math, inc using player variables, jmath functions, global variables like faction progress etc
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Adds weighted_dbl_or_var_list which behaves similarly to a weighted_[int/float]_list but needs to be seperate bc those rely on total_weight being constant and recalculable.
Applies it to the "chunks" and "else_chunks" in "nested"/"place_nested"
Includes some jmath functions for varying stuff over time for reuse
Adds an example usage with s_grocery's variants
 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
I were getting CTDs which I thought was when a math weight was returning 0 or ~0 but I can't repro it anymore and it was leaving no crash log.

Changed the grocery chunks to test various things eg
```json
            [ "s_grocery_unlooted", { "math": [ "250 * time_since_cata_quadratic_neg( 365 )" ] } ],
            [ "s_grocery_empty", 0 ],
            [ "s_grocery_looted", { "math": [ "250 * time_since_cata_quadratic_pos( 365 )" ] } ]
```
spawn several and approach them at start date, skip 3 years, spawn several more and see they're the other version etc
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Random background info that noone need read:
This was actually what I originally wanted way back in traces #66409 but due to ~~my lack of understanding code~~ a miscommunication in I had tried and failed to move various weight fields in the game to be able to take variable weights, eventually settling on mapgen weights not because I thought they were useful there but just bc the main issue I were having was scoping the various puzzle pieces needed throughout the tangled webs of most other places and thought that seemed the easiest to tackle first. Bombastic picked it up in #66890 and then andrei reworked it in #66919 to its current form without much (if any I forget) prior communication about it, and I were just glad the feature was making it in in any usable form, but it's kind of been a thorn in my side bc I've felt bad for barely using it so far while at the same time not wanting to bc I wanted the field yeeting altogether. Hopefully if I can get this in I'll do some followup PRs making more stuff vary over time and potentially expand it to other fields now I've made some type templated infra for it.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
