### PR TITLE
Aftershock: Reliably ruin roads

### DIFF
--- a/data/mods/aftershock_exoplanet/maps/mapgen/road.json
+++ b/data/mods/aftershock_exoplanet/maps/mapgen/road.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "mapgen",
-    "om_terrain": [ "road_straight" ],
+    "om_terrain": [ "ruin_road_straight" ],
     "object": {
       "predecessor_mapgen": "field",
       "rows": [
@@ -37,7 +37,7 @@
   },
   {
     "type": "mapgen",
-    "om_terrain": [ "road_end" ],
+    "om_terrain": [ "ruin_road_end" ],
     "object": {
       "predecessor_mapgen": "field",
       "rows": [
@@ -73,7 +73,7 @@
   },
   {
     "type": "mapgen",
-    "om_terrain": [ "road_curved" ],
+    "om_terrain": [ "ruin_road_curved" ],
     "object": {
       "predecessor_mapgen": "field",
       "rows": [
@@ -109,7 +109,7 @@
   },
   {
     "type": "mapgen",
-    "om_terrain": [ "road_tee" ],
+    "om_terrain": [ "ruin_road_tee" ],
     "object": {
       "predecessor_mapgen": "field",
       "rows": [
@@ -196,7 +196,7 @@
   },
   {
     "type": "mapgen",
-    "om_terrain": [ "road_four_way" ],
+    "om_terrain": [ "ruin_road_four_way" ],
     "weight": 100000,
     "object": {
       "predecessor_mapgen": "field",

--- a/data/mods/aftershock_exoplanet/maps/overmap_connections.json
+++ b/data/mods/aftershock_exoplanet/maps/overmap_connections.json
@@ -8,11 +8,12 @@
     "type": "overmap_connection",
     "id": "local_road",
     "subtypes": [
-      { "terrain": "road", "locations": [ "field", "road" ] },
-      { "terrain": "road", "locations": [ "forest_without_trail" ], "basic_cost": 20 },
-      { "terrain": "road", "locations": [ "forest_trail" ], "basic_cost": 25 },
-      { "terrain": "road", "locations": [ "swamp" ], "basic_cost": 40 },
-      { "terrain": "road", "locations": [  ] },
+      { "terrain": "ruin_road", "locations": [ "field", "road" ] },
+      { "terrain": "ruin_road", "locations": [ "forest_without_trail" ], "basic_cost": 20 },
+      { "terrain": "ruin_road", "locations": [ "forest_trail" ], "basic_cost": 25 },
+      { "terrain": "ruin_road", "locations": [ "swamp" ], "basic_cost": 40 },
+      { "terrain": "ruin_road", "locations": [ "aeolian_plain" ], "basic_cost": 40 },
+      { "terrain": "ruin_road", "locations": [  ] },
       { "terrain": "bridge", "locations": [ "ravine" ], "basic_cost": 120 }
     ]
   }

--- a/data/mods/aftershock_exoplanet/maps/overmap_location.json
+++ b/data/mods/aftershock_exoplanet/maps/overmap_location.json
@@ -3,5 +3,10 @@
     "type": "overmap_location",
     "id": "subterranean_empty",
     "terrains": [ "deep_rock", "solid_glacier", "empty_rock", "solid_earth" ]
+  },
+  {
+    "type": "overmap_location",
+    "id": "road",
+    "terrains": [ "ruin_road", "road", "road_nesw_manhole" ]
   }
 ]

--- a/data/mods/aftershock_exoplanet/maps/overmap_terrain/overmap_terrain_transportation.json
+++ b/data/mods/aftershock_exoplanet/maps/overmap_terrain/overmap_terrain_transportation.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "overmap_terrain",
-    "id": "road",
+    "id": "ruin_road",
     "name": "road",
     "copy-from": "generic_transportation",
     "travel_cost_type": "road",


### PR DESCRIPTION
#### Summary
Mods "Aftershock: Ensure all roads are generated in a ruined state"

#### Purpose of change
This should get rid of the rare non ruined roads that sometimes spawn in cities.

#### Describe the solution
Noticed that connections are more data driven today than when I originally added these ruined versions.

#### Testing
Loaded game and visited a town.
