### PR TITLE
`debugmsg` clear instructions after keypress

### DIFF
--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -398,6 +398,8 @@ static void debug_error_prompt(
                 [[fallthrough]];
             case ' ':
                 stop = true;
+                message = error_message;
+                ui_manager::redraw();
                 break;
         }
     }

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -342,7 +342,7 @@ static void debug_error_prompt(
     };
     init_window( ui );
     ui.on_screen_resize( init_window );
-    const std::string message = string_format(
+    const std::string error_message = string_format(
                                     "\n\n" // Looks nicer with some space
                                     " %s\n" // translated user string: error notification
                                     " -----------------------------------------------------------\n"
@@ -351,22 +351,25 @@ static void debug_error_prompt(
 #if defined(BACKTRACE)
                                     " %s\n" // translated user string: where to find backtrace
 #endif
-                                    " %s\n" // translated user string: space to continue
-                                    " %s\n" // translated user string: ignore key
-#if defined(TILES)
-                                    " %s\n" // translated user string: copy
-#endif // TILES
                                     , _( "An error has occurred!  Written below is the error report:" ),
                                     formatted_report,
 #if defined(BACKTRACE)
-                                    backtrace_instructions,
+                                    backtrace_instructions
 #endif
+                                );
+    const std::string instructions = string_format(
+                                    " %s\n" // translated user string: space to continue
+                                    " %s\n" // translated user string: ignore key
+#if defined(TILES)
+                                    " %s\n",// translated user string: copy
+#endif // TILES
                                     _( "Press <color_white>space bar</color> to continue the game." ),
                                     _( "Press <color_white>I</color> (or <color_white>i</color>) to also ignore this particular message in the future." )
 #if defined(TILES)
                                     , _( "Press <color_white>C</color> (or <color_white>c</color>) to copy this message to the clipboard." )
 #endif // TILES
                                 );
+    std::string message = error_message + instructions;
     ui.on_redraw( [&]( const ui_adaptor & ) {
         catacurses::erase();
         fold_and_print( catacurses::stdscr, point::zero, getmaxx( catacurses::stdscr ), c_light_red,

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -361,10 +361,10 @@ static void debug_error_prompt(
                                          " %s\n" // translated user string: space to continue
                                          " %s\n" // translated user string: ignore key
 #if defined(TILES)
-                                         " %s\n",// translated user string: copy
+                                         " %s\n" // translated user string: copy
 #endif // TILES
-                                         _( "Press <color_white>space bar</color> to continue the game." ),
-                                         _( "Press <color_white>I</color> (or <color_white>i</color>) to also ignore this particular message in the future." )
+                                         , _( "Press <color_white>space bar</color> to continue the game." )
+                                         , _( "Press <color_white>I</color> (or <color_white>i</color>) to also ignore this particular message in the future." )
 #if defined(TILES)
                                          , _( "Press <color_white>C</color> (or <color_white>c</color>) to copy this message to the clipboard." )
 #endif // TILES

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -343,32 +343,32 @@ static void debug_error_prompt(
     init_window( ui );
     ui.on_screen_resize( init_window );
     const std::string error_message = string_format(
-                                    "\n\n" // Looks nicer with some space
-                                    " %s\n" // translated user string: error notification
-                                    " -----------------------------------------------------------\n"
-                                    "%s"
-                                    " -----------------------------------------------------------\n"
+                                          "\n\n" // Looks nicer with some space
+                                          " %s\n" // translated user string: error notification
+                                          " -----------------------------------------------------------\n"
+                                          "%s"
+                                          " -----------------------------------------------------------\n"
 #if defined(BACKTRACE)
-                                    " %s\n" // translated user string: where to find backtrace
+                                          " %s\n" // translated user string: where to find backtrace
 #endif
-                                    , _( "An error has occurred!  Written below is the error report:" ),
-                                    formatted_report,
+                                          , _( "An error has occurred!  Written below is the error report:" ),
+                                          formatted_report,
 #if defined(BACKTRACE)
-                                    backtrace_instructions
+                                          backtrace_instructions
 #endif
-                                );
+                                      );
     const std::string instructions = string_format(
-                                    " %s\n" // translated user string: space to continue
-                                    " %s\n" // translated user string: ignore key
+                                         " %s\n" // translated user string: space to continue
+                                         " %s\n" // translated user string: ignore key
 #if defined(TILES)
-                                    " %s\n",// translated user string: copy
+                                         " %s\n",// translated user string: copy
 #endif // TILES
-                                    _( "Press <color_white>space bar</color> to continue the game." ),
-                                    _( "Press <color_white>I</color> (or <color_white>i</color>) to also ignore this particular message in the future." )
+                                         _( "Press <color_white>space bar</color> to continue the game." ),
+                                         _( "Press <color_white>I</color> (or <color_white>i</color>) to also ignore this particular message in the future." )
 #if defined(TILES)
-                                    , _( "Press <color_white>C</color> (or <color_white>c</color>) to copy this message to the clipboard." )
+                                         , _( "Press <color_white>C</color> (or <color_white>c</color>) to copy this message to the clipboard." )
 #endif // TILES
-                                );
+                                     );
     std::string message = error_message + instructions;
     ui.on_redraw( [&]( const ui_adaptor & ) {
         catacurses::erase();


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Interface "`debugmsg` clear instructions after keypress"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
The game prints a debug message and asks to press keys. You press a key like 'i' and the message remains on screen. If the screen does not refresh in short time, you wonder if the game got the keypress.

The change immediately remove the "Press key ..." text so there is no confusion.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Split the debug message in two. Redraw the screen with only one after user pressed 'i', 'I', or Space.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
None
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Tested by fiddling with json/data and triggering some messages.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
![image](https://github.com/user-attachments/assets/c7c8976c-7e05-48f8-928f-c79da1e19f5f)

![image](https://github.com/user-attachments/assets/999804b4-8a47-4fb1-960e-db7b5834919a)

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
