### PR TITLE
Make imgui use theme colors by default

### DIFF
--- a/data/raw/imgui_style.json
+++ b/data/raw/imgui_style.json
@@ -1,6 +1,6 @@
 {
   "//": "See doc/user-guides/COLOR.md for documentation on how to use this file.",
-  "inherit_base_colors": false,
+  "inherit_base_colors": true,
   "colors": {
     
   }

--- a/doc/user-guides/COLOR.md
+++ b/doc/user-guides/COLOR.md
@@ -160,17 +160,17 @@ The game provides a nice built-in color manager with several pre-defined color t
 The UI *menus* do not (always) adhere to the base color customization, and can be customized separately, in the `config/imgui_style.json`. The default config is:
 ```jsonc
 {
-  "inherit_base_colors": false,
+  "inherit_base_colors": true,
   "colors": {
   }
 }
 ```
-Changing  `inherit_base_colors` to `true` would make the imgui menus follow the base colors theme with some reasonable defaults.
+Changing  `inherit_base_colors` to `false` would make the imgui use it's default theme, otherwise imgui menus would follow the base colors theme with some reasonable defaults.
 
 It is, however, also possible to tweak the specific element colors with higher fidelity and not be restricted to the 8-color pallete by specifying the respective elements and colors in the `colors` object. Like so:
 ```jsonc
 {
-  "inherit_base_colors": false,
+  "inherit_base_colors": true,
   "colors": {
     "ImGuiCol_Text"                   : [1.00, 1.00, 1.00, 1.00],
     "ImGuiCol_TextDisabled"           : [0.50, 0.50, 0.50, 1.00],


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Someone in discord pointed out, once again, that imgui color scheme do not match the old game look
#77842 was already merged, why not use it?
#### Describe the solution
Switch inherit_base_colors to `true`
#### Describe alternatives you've considered
Also tweak some menu coloring? It looks okay for me, but not entirely
#### Testing
![image](https://github.com/user-attachments/assets/567c13c0-4022-4ee5-b110-fcdf83d214e5)
![image](https://github.com/user-attachments/assets/2371f4bb-4900-471d-ac78-ab2709a42006)
![image](https://github.com/user-attachments/assets/093b8cd8-5c64-4192-b9f5-ca419d0357b5)
![image](https://github.com/user-attachments/assets/18bcca19-cd0d-4ea7-aac0-431c47caf711)
(i don't like this one, btw, @RenechCDDA any ideas is it the fault of the menu or color scheme?)

Same menus but with solarized theme
![image](https://github.com/user-attachments/assets/e1f0454b-503d-4e07-bd46-ea7c44738772)
![image](https://github.com/user-attachments/assets/70c66f85-bbc0-498f-979b-f3ae2bf01860)
![image](https://github.com/user-attachments/assets/09c50ab0-11e6-423c-8233-78440716b2af)
![image](https://github.com/user-attachments/assets/e44c1312-18ec-40b8-b4a8-1aae71c86ac4)

#### Additional context
I suspect a lot of people would miss it, because after the first load the game create secondary imgui_style.json file in game config, but still