### PR TITLE
Fix builds without BACKTRACE defined

### DIFF
--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -352,9 +352,9 @@ static void debug_error_prompt(
                                           " %s\n" // translated user string: where to find backtrace
 #endif
                                           , _( "An error has occurred!  Written below is the error report:" ),
-                                          formatted_report,
+                                          formatted_report
 #if defined(BACKTRACE)
-                                          backtrace_instructions
+                                          , backtrace_instructions
 #endif
                                       );
     const std::string instructions = string_format(


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Compiles e.g. in VS with default settings.

#### Describe the solution

Move the offending comma.

#### Describe alternatives you've considered



#### Testing

Didn't compile before, compiles after.

#### Additional context

