### PR TITLE
Update Mod StatsThroughSkills

### DIFF
--- a/data/mods/StatsThroughSkills/EOC/game_eoc.json
+++ b/data/mods/StatsThroughSkills/EOC/game_eoc.json
@@ -1,5 +1,5 @@
 [
-    {
+  {
     "type": "effect_on_condition",
     "id": "EOC_StatsThroughSkills_initialize",
     "eoc_type": "EVENT",
@@ -9,9 +9,7 @@
       {
         "u_message": "StatsThroughSkills is loaded.  If the mod is properly loaded you should have a new mutation called \"Stats Through Skills\"."
       },
-      { 
-		"u_add_trait": "mutation_statsThroughSkills"
-	  }
+      { "u_add_trait": "mutation_statsThroughSkills" }
     ]
   }
 ]

--- a/data/mods/StatsThroughSkills/EOC/game_eoc.json
+++ b/data/mods/StatsThroughSkills/EOC/game_eoc.json
@@ -1,0 +1,17 @@
+[
+    {
+    "type": "effect_on_condition",
+    "id": "EOC_StatsThroughSkills_initialize",
+    "eoc_type": "EVENT",
+    "required_event": "game_begin",
+    "condition": { "and": [ { "not": { "u_has_trait": "mutation_statsThroughSkills" } } ] },
+    "effect": [
+      {
+        "u_message": "StatsThroughSkills is loaded.  If the mod is properly loaded you should have a new mutation called \"Stats Through Skills\"."
+      },
+      { 
+		"u_add_trait": "mutation_statsThroughSkills"
+	  }
+    ]
+	}  
+]

--- a/data/mods/StatsThroughSkills/EOC/game_eoc.json
+++ b/data/mods/StatsThroughSkills/EOC/game_eoc.json
@@ -13,5 +13,5 @@
 		"u_add_trait": "mutation_statsThroughSkills"
 	  }
     ]
-	}  
+  }
 ]

--- a/data/mods/StatsThroughSkills/modinfo.json
+++ b/data/mods/StatsThroughSkills/modinfo.json
@@ -1,0 +1,11 @@
+[
+  {
+    "type": "MOD_INFO",
+    "id": "StatsThroughSkills",
+    "name": "Stats Through Skills",
+    "authors": [ "Ryan \"DeNarr\" Saige", "Kevin Granade" ],
+    "description": "Allows stats to raise via skill progression.",
+    "category": "rebalance",
+    "dependencies": [ "dda" ]
+  }
+]

--- a/data/mods/StatsThroughSkills/mutations/stats_mutation.json
+++ b/data/mods/StatsThroughSkills/mutations/stats_mutation.json
@@ -1,5 +1,5 @@
 [
-    {
+  {
     "type": "mutation",
     "id": "mutation_statsThroughSkills",
     "name": { "str": "Stats Through Skills" },

--- a/data/mods/StatsThroughSkills/mutations/stats_mutation.json
+++ b/data/mods/StatsThroughSkills/mutations/stats_mutation.json
@@ -8,11 +8,44 @@
     "purifiable": false,
     "valid": false,
     "active": true,
-	"enchantments": [ { "condition": "ALWAYS", "values": [ 
-			{ "value": "STRENGTH", "add": { "math": [ "max((u_skill('mechanics') + u_skill('swimming') + u_skill('bashing') + u_skill('cutting') + u_skill('melee') + u_skill('throw')) * 0.4 - 3, 0)" ] } },
-			{ "value": "DEXTERITY", "add": { "math": [ "max((u_skill('driving') + u_skill('survival') + u_skill('tailor') + u_skill('traps') + u_skill('dodge') + u_skill('stabbing') + u_skill('unarmed')) * 0.4 - 3, 0)" ] } },
-			{ "value": "INTELLIGENCE", "add": { "math": [ "max((u_skill('computer') + u_skill('cooking') + u_skill('electronics') + u_skill('fabrication') + u_skill('firstaid') + u_skill('speech') + u_skill('chemistry')) * 0.4 - 3, 0)" ] } },
-			{ "value": "PERCEPTION", "add": { "math": [ "max((u_skill('archery') + u_skill('gun') + u_skill('launcher') + u_skill('pistol') + u_skill('rifle') + u_skill('shotgun') + u_skill('smg')) * 0.4 - 3, 0)" ] } }
-	] } ]
-	}
+    "enchantments": [
+      {
+        "condition": "ALWAYS",
+        "values": [
+          {
+            "value": "STRENGTH",
+            "add": {
+              "math": [
+                "max((u_skill('mechanics') + u_skill('swimming') + u_skill('bashing') + u_skill('cutting') + u_skill('melee') + u_skill('throw')) * 0.4 - 3, 0)"
+              ]
+            }
+          },
+          {
+            "value": "DEXTERITY",
+            "add": {
+              "math": [
+                "max((u_skill('driving') + u_skill('survival') + u_skill('tailor') + u_skill('traps') + u_skill('dodge') + u_skill('stabbing') + u_skill('unarmed')) * 0.4 - 3, 0)"
+              ]
+            }
+          },
+          {
+            "value": "INTELLIGENCE",
+            "add": {
+              "math": [
+                "max((u_skill('computer') + u_skill('cooking') + u_skill('electronics') + u_skill('fabrication') + u_skill('firstaid') + u_skill('speech') + u_skill('chemistry')) * 0.4 - 3, 0)"
+              ]
+            }
+          },
+          {
+            "value": "PERCEPTION",
+            "add": {
+              "math": [
+                "max((u_skill('archery') + u_skill('gun') + u_skill('launcher') + u_skill('pistol') + u_skill('rifle') + u_skill('shotgun') + u_skill('smg')) * 0.4 - 3, 0)"
+              ]
+            }
+          }
+        ]
+      }
+    ]
+  }
 ]

--- a/data/mods/StatsThroughSkills/mutations/stats_mutation.json
+++ b/data/mods/StatsThroughSkills/mutations/stats_mutation.json
@@ -1,0 +1,18 @@
+[
+    {
+    "type": "mutation",
+    "id": "mutation_statsThroughSkills",
+    "name": { "str": "Stats Through Skills" },
+    "description": "Your stats have been increased based on your skills:\nSTRENGTH increased by Mechanics, Athletics, Bashing Weapons, Cutting Weapons, Melee, and Throwing.\nDEXTERITY increased by Driving, Survival, Tailoring, Devices, Dodging, Piercing Weapons, and Unarmed.\nINTELLIGENCE increased by Computers, Cooking, Electronics, Fabrication, Health Care, Social, and Applied Science.\nPERCEPTION increased by Archery, Marksmanship, Launchers, Handguns, Rifles, Shotguns, and Submachine Guns.",
+    "points": 0,
+    "purifiable": false,
+    "valid": false,
+    "active": true,
+	"enchantments": [ { "condition": "ALWAYS", "values": [ 
+			{ "value": "STRENGTH", "add": { "math": [ "max((u_skill('mechanics') + u_skill('swimming') + u_skill('bashing') + u_skill('cutting') + u_skill('melee') + u_skill('throw')) * 0.4 - 3, 0)" ] } },
+			{ "value": "DEXTERITY", "add": { "math": [ "max((u_skill('driving') + u_skill('survival') + u_skill('tailor') + u_skill('traps') + u_skill('dodge') + u_skill('stabbing') + u_skill('unarmed')) * 0.4 - 3, 0)" ] } },
+			{ "value": "INTELLIGENCE", "add": { "math": [ "max((u_skill('computer') + u_skill('cooking') + u_skill('electronics') + u_skill('fabrication') + u_skill('firstaid') + u_skill('speech') + u_skill('chemistry')) * 0.4 - 3, 0)" ] } },
+			{ "value": "PERCEPTION", "add": { "math": [ "max((u_skill('archery') + u_skill('gun') + u_skill('launcher') + u_skill('pistol') + u_skill('rifle') + u_skill('shotgun') + u_skill('smg')) * 0.4 - 3, 0)" ] } }
+	] } ]
+	}
+]


### PR DESCRIPTION
#### Summary
Mods

#### Purpose of change
Adds an updated version of the mod StatsThroughSkills while keeping all the same values that were already used to determine stats points distribution.

#### Describe the solution
This has been implemented with the addition of traits/enchantments. Using the same previous formula that sums all skills from that category, multiplies by 0.4, and adds an offset of -3 points, then takes the maximum value between this formula's result and zero.

#### Describe alternatives you've considered
Initially, I attempted an implementation using effects, but later decided to go with a simpler solution instead.

#### Testing
I modified my in-game skills and verified that the stat changes correctly reflected the formula.

#### Additional context
This is my first time contributing, and I'd greatly appreciate any improvements, feedback, or suggestions you might have.
