### PR TITLE
Fix mac build

### DIFF
--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -518,7 +518,7 @@ void overmap::unserialize( const JsonObject &jsobj )
                 point_om_omt end_point;
                 point_om_omt control_1;
                 point_om_omt control_2;
-                size_t size;
+                uint64_t size;
                 mandatory( river_json, false, "entry", start_point );
                 mandatory( river_json, false, "exit", end_point );
                 mandatory( river_json, false, "control1", control_1 );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Fix mac build.

#### Describe the solution

Use `uint64_t` instead of `size_t`.

#### Describe alternatives you've considered



#### Testing

Can't test, have to rely on CI.

#### Additional context

