### PR TITLE
[MoM] Add enervating amalgamation

### DIFF
--- a/data/mods/MindOverMatter/monstergroups/monstergroups_edited.json
+++ b/data/mods/MindOverMatter/monstergroups/monstergroups_edited.json
@@ -174,7 +174,8 @@
       { "monster": "mon_amalgamation_zapper", "weight": 1, "starts": "56 days" },
       { "monster": "mon_jabberwock", "weight": 1, "starts": "28 days" },
       { "monster": "mon_amalgamation_telepathic_distractor", "weight": 1, "starts": "112 days" },
-      { "monster": "mon_amalgamation_telekinetic_shielder", "weight": 1, "starts": "112 days" }
+      { "monster": "mon_amalgamation_telekinetic_shielder", "weight": 1, "starts": "112 days" },
+      { "monster": "mon_amalgamation_vitakinetic_debuffer", "weight": 1, "starts": "112 days" }
     ]
   },
   {
@@ -187,7 +188,8 @@
       { "monster": "mon_amalgamation_corroder", "weight": 4, "starts": "112 days" },
       { "monster": "mon_amalgamation_corroder", "weight": 6, "starts": "224 days" },
       { "monster": "mon_amalgamation_telepathic_distractor", "weight": 1, "starts": "112 days" },
-      { "monster": "mon_amalgamation_telekinetic_shielder", "weight": 1, "starts": "112 days" }
+      { "monster": "mon_amalgamation_telekinetic_shielder", "weight": 1, "starts": "112 days" },
+      { "monster": "mon_amalgamation_vitakinetic_debuffer", "weight": 1, "starts": "112 days" }
     ]
   },
   {

--- a/data/mods/MindOverMatter/monsters/amalgamations.json
+++ b/data/mods/MindOverMatter/monsters/amalgamations.json
@@ -84,5 +84,37 @@
     "vision_day": 5,
     "tracking_distance": 8,
     "extend": { "flags": [ "MIND_SEEING", "KEEP_DISTANCE" ] }
+  },
+  {
+    "type": "MONSTER",
+    "id": "mon_amalgamation_vitakinetic_debuffer",
+    "copy-from": "mon_amalgamation_abstract_small",
+    "symbol": "ä",
+    "name": { "str": "enervating amalgamation" },
+    "description": "An elongated body moving irregularly on five legs, with two flexible tentacles waving in the air as it moves.  It seems to have no head, with a ring of black spots on top that might be sensory organs.  Its skin is perfectly smooth and greyish-white, without a single spot or blemish.",
+    "speed": 100,
+    "regenerates": 3,
+    "special_attacks": [
+      {
+        "type": "monster_attack",
+        "attack_type": "melee",
+        "id": "mon_amalgamation_vitakinetic_debuff",
+        "cooldown": { "math": [ "7 + rand(14)" ] },
+        "accuracy": 6,
+        "move_cost": 60,
+        "damage_max_instance": [ { "damage_type": "biological", "amount": 1 } ],
+        "dodgeable": true,
+        "blockable": true,
+        "eoc": [ "EOC_FERAL_VITAKIN2_ENERVATING_TOUCH" ],
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
+        "hit_dmg_u": "%1$s touches you and you feel weaker!",
+        "hit_dmg_npc": "%1$s touches <npcname> and they flinch!",
+        "miss_msg_u": "%1$s tries to touch you, but you dodge!",
+        "miss_msg_npc": "%1$s tries to touch <npcname>, but they dodge!",
+        "no_dmg_msg_u": "%1$s touches you but only hits your armor.",
+        "no_dmg_msg_npc": "%1$s touches <npcname> but only hits their armor."
+      }
+    ],
+    "extend": { "flags": [ "HIT_AND_RUN" ] }
   }
 ]

--- a/data/mods/MindOverMatter/monsters/amalgamations.json
+++ b/data/mods/MindOverMatter/monsters/amalgamations.json
@@ -111,8 +111,8 @@
         "hit_dmg_npc": "%1$s touches <npcname> and they flinch!",
         "miss_msg_u": "%1$s tries to touch you, but you dodge!",
         "miss_msg_npc": "%1$s tries to touch <npcname>, but they dodge!",
-        "no_dmg_msg_u": "%1$s touches you but only hits your armor.",
-        "no_dmg_msg_npc": "%1$s touches <npcname> but only hits their armor."
+        "no_dmg_msg_u": "%1$s touches you and you feel weaker!",
+        "no_dmg_msg_npc": "%1$s touches <npcname> and they flinch!"
       }
     ],
     "extend": { "flags": [ "HIT_AND_RUN" ] }

--- a/data/mods/MindOverMatter/monsters/amalgamations.json
+++ b/data/mods/MindOverMatter/monsters/amalgamations.json
@@ -92,7 +92,7 @@
     "symbol": "ä",
     "name": { "str": "enervating amalgamation" },
     "description": "An elongated body moving irregularly on five legs, with two flexible tentacles waving in the air as it moves.  It seems to have no head, with a ring of black spots on top that might be sensory organs.  Its skin is perfectly smooth and greyish-white, without a single spot or blemish.",
-    "speed": 100,
+    "speed": 95,
     "regenerates": 3,
     "special_attacks": [
       {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[MoM] Add enervating amalgamation"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Someone was complaining about the MoM psychic amalgamations so ~~of course I must add more hahaha~~ that brought them to the front of my mind and gave me the idea for another one.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add the `enervating amalgamation`, a vitakinetic amalgamation. It regenerates slightly and will do hit and run attacks where it uses Enervating Touch on you. It is slower than other amalgamations.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Enervating amalgamation exists and behaves appropriately.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
