### PR TITLE
Updated correct batttery on electric shears

### DIFF
--- a/data/json/items/tool/pets.json
+++ b/data/json/items/tool/pets.json
@@ -106,7 +106,7 @@
     "color": "dark_gray",
     "charged_qualities": [ [ "SHEAR", 3 ] ],
     "flags": [ "WATER_BREAK", "ALLOWS_BODY_BLOCK", "FRAGILE_MELEE" ],
-    "use_action": { "type": "link_up", "cable_length": 5},
+    "use_action": { "type": "link_up", "cable_length": 5 },
     "charges_per_use": 1,
     "power_draw": "850 W",
     "melee_damage": { "bash": 2 },

--- a/data/json/items/tool/pets.json
+++ b/data/json/items/tool/pets.json
@@ -107,7 +107,7 @@
     "charged_qualities": [ [ "SHEAR", 3 ] ],
     "flags": [ "WATER_BREAK", "ALLOWS_BODY_BLOCK", "FRAGILE_MELEE" ],
     "use_action": { "type": "link_up", "cable_length": 5 },
-    "charges_per_use": 1,
+    "charges_per_use": 250,
     "power_draw": "850 W",
     "melee_damage": { "bash": 2 },
     "tool_ammo": [ "battery" ]

--- a/data/json/items/tool/pets.json
+++ b/data/json/items/tool/pets.json
@@ -111,8 +111,8 @@
       {
         "pocket_type": "MAGAZINE_WELL",
         "rigid": true,
-        "flag_restriction": [ "BATTERY_ULTRA_LIGHT" ],
-        "default_magazine": "light_minus_battery_cell"
+        "flag_restriction": [ "BATTERY_MEDIUM" ],
+        "default_magazine": "medium_battery_cell"
       }
     ],
     "melee_damage": { "bash": 2 },

--- a/data/json/items/tool/pets.json
+++ b/data/json/items/tool/pets.json
@@ -95,7 +95,7 @@
     "type": "ITEM",
     "subtypes": [ "TOOL" ],
     "name": { "str_sp": "electric shears" },
-    "description": "Electric shears, used to quickly shear animals.",
+    "description": "Electric corded shears, used to quickly shear animals.",
     "weight": "1200 g",
     "volume": "1200 ml",
     "price": "24 USD",
@@ -106,15 +106,9 @@
     "color": "dark_gray",
     "charged_qualities": [ [ "SHEAR", 3 ] ],
     "flags": [ "WATER_BREAK", "ALLOWS_BODY_BLOCK", "FRAGILE_MELEE" ],
-    "charges_per_use": 25,
-    "pocket_data": [
-      {
-        "pocket_type": "MAGAZINE_WELL",
-        "rigid": true,
-        "flag_restriction": [ "BATTERY_MEDIUM" ],
-        "default_magazine": "medium_battery_cell"
-      }
-    ],
+    "use_action": { "type": "link_up", "cable_length": 5},
+    "charges_per_use": 1,
+    "power_draw": "850 W",
     "melee_damage": { "bash": 2 },
     "tool_ammo": [ "battery" ]
   },


### PR DESCRIPTION
#### Summary

Bugfixes "Electric shears now use medium batteries instead of incorrect light batteries"

Purpose of change

The old electric shears used the incorrect light_battery_cell type, which made them useless as it requires 25 charges and light battery has max 2. This fixes an oversight and makes the item functional using medium batteries.

Describe the solution

Edited pets.json to change the tool magazine

Describe alternatives you've considered

None. This is a direct fix for incorrect item configuration.

Testing

Loaded the game and spawned the electric shears. Confirmed that they now use medium batteries and can be loaded/used as expected. No errors on load.

Additional context

None.