### PR TITLE
duffel bags should be big

### DIFF
--- a/data/json/items/armor/bespoke_armor/custom_storage.json
+++ b/data/json/items/armor/bespoke_armor/custom_storage.json
@@ -16,7 +16,7 @@
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
-        "max_contains_volume": "75 L",
+        "max_contains_volume": "66 L",
         "max_contains_weight": "60 kg",
         "max_item_length": "60 cm",
         "magazine_well": "7500 ml",

--- a/data/json/items/armor/bespoke_armor/custom_storage.json
+++ b/data/json/items/armor/bespoke_armor/custom_storage.json
@@ -16,7 +16,7 @@
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
-        "max_contains_volume": "38 L",
+        "max_contains_volume": "75 L",
         "max_contains_weight": "60 kg",
         "max_item_length": "60 cm",
         "magazine_well": "7500 ml",

--- a/data/json/items/armor/storage.json
+++ b/data/json/items/armor/storage.json
@@ -1049,7 +1049,7 @@
     "type": "ITEM",
     "subtypes": [ "ARMOR" ],
     "name": { "str": "duffel bag" },
-    "description": "A large duffel bag.  Provides plenty of storage, but is severely encumbering.",
+    "description": "A canvas duffel bag.  Provides plenty of storage, but is fairly encumbering.",
     "weight": "933 g",
     "volume": "6 L",
     "price": "120 USD",
@@ -1061,7 +1061,7 @@
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
-        "max_contains_volume": "70 L",
+        "max_contains_volume": "60 L",
         "max_contains_weight": "60 kg",
         "max_item_length": "55 cm",
         "magazine_well": "5 L",

--- a/data/json/items/armor/storage.json
+++ b/data/json/items/armor/storage.json
@@ -1049,7 +1049,7 @@
     "type": "ITEM",
     "subtypes": [ "ARMOR" ],
     "name": { "str": "duffel bag" },
-    "description": "A huge duffel bag.  Provides plenty of storage, but is severely encumbering.",
+    "description": "A large duffel bag.  Provides plenty of storage, but is severely encumbering.",
     "weight": "933 g",
     "volume": "6 L",
     "price": "120 USD",
@@ -1061,7 +1061,7 @@
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
-        "max_contains_volume": "35 L",
+        "max_contains_volume": "70 L",
         "max_contains_weight": "60 kg",
         "max_item_length": "55 cm",
         "magazine_well": "5 L",
@@ -2974,8 +2974,8 @@
     "id": "long_duffelbag",
     "type": "ITEM",
     "subtypes": [ "ARMOR" ],
-    "name": { "str": "longarm bag" },
-    "description": "A long duffel bag.  Provides storage for long arms and rifles.  Quite cumbersome.",
+    "name": { "str": "huge duffel bag" },
+    "description": "An extra huge duffel bag.  Could fit long items like rifles inside it.  Quite cumbersome.",
     "weight": "1203 g",
     "volume": "12 L",
     "price": "180 USD",
@@ -2987,7 +2987,7 @@
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
-        "max_contains_volume": "50 L",
+        "max_contains_volume": "140 L",
         "max_contains_weight": "80 kg",
         "max_item_length": "150 cm",
         "magazine_well": "10 L",
@@ -2998,7 +2998,7 @@
     "material_thickness": 1,
     "flags": [ "BELTED", "WATER_FRIENDLY" ],
     "armor": [
-      { "encumbrance": [ 8, 42 ], "coverage": 100, "covers": [ "torso" ], "specifically_covers": [ "torso_hanging_back" ] }
+      { "encumbrance": [ 15, 50 ], "coverage": 100, "covers": [ "torso" ], "specifically_covers": [ "torso_hanging_back" ] }
     ]
   },
   {

--- a/data/json/items/armor/storage.json
+++ b/data/json/items/armor/storage.json
@@ -2974,8 +2974,8 @@
     "id": "long_duffelbag",
     "type": "ITEM",
     "subtypes": [ "ARMOR" ],
-    "name": { "str": "huge duffel bag" },
-    "description": "An extra huge duffel bag.  Could fit long items like rifles inside it.  Quite cumbersome.",
+    "name": { "str": "longarm bag" },
+    "description": "A long duffel bag.  Provides storage for long arms and rifles.  Quite cumbersome.",
     "weight": "1203 g",
     "volume": "12 L",
     "price": "180 USD",
@@ -2987,7 +2987,7 @@
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
-        "max_contains_volume": "140 L",
+        "max_contains_volume": "50 L",
         "max_contains_weight": "80 kg",
         "max_item_length": "150 cm",
         "magazine_well": "10 L",
@@ -2998,7 +2998,7 @@
     "material_thickness": 1,
     "flags": [ "BELTED", "WATER_FRIENDLY" ],
     "armor": [
-      { "encumbrance": [ 15, 50 ], "coverage": 100, "covers": [ "torso" ], "specifically_covers": [ "torso_hanging_back" ] }
+      { "encumbrance": [ 8, 42 ], "coverage": 100, "covers": [ "torso" ], "specifically_covers": [ "torso_hanging_back" ] }
     ]
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "Embiggen duffel bag pocket"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

A `duffelbag` currently only holds 35L. This is one of the smaller sizes of duffel bag around, it's a little laughable this is still described as a "large" duffel bag with "plenty" of storage when it's dwarfed by numerous backpacks that have been added to the game since that was written.

In real life, some brands don't even sell 35L bags - Cabela's considers 60L to be "[medium](https://www.cabelas.com/shop/en/cabelas-heavy-canvas-duffel-bag)" (their absolutely smallest size available) for a duffel bag. (XXL is 223L.)

Meanwhile a `long_duffelbag` has an absolutely huge length capacity but its volume isn't proportionate, giving it full dimensions of something like 150cm × 20cm diameter... is it even supposed to be a duffelbag? It's named a 'longarm bag,' a term that basically doesn't exist.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

Increase `duffelbag` capacity to 60L, the same as the similar waterproof variant `dry_duffelbag`. 60L is considered "medium" so stop describing this item as a 'large duffel bag.'

<del>Scale up `long_duffelbag` accordingly to the hugest size in real life, 140L, and rename it from the bizarrely purpose-specific 'longarm bag' to just 'huge duffel bag.' Give it a base encumbrance when empty that's 50% higher than backpacks.</del>

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Create a new item for 'small duffel bag' almost as small as a backpack.

Create a new item for '[extremely huge duffel bag](https://thegothamite.com/products/gothamite-50-duffel-bag)' around 330L.

Take a closer look if current maximum item lengths make sense for both duffel bags and backpacks.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

#42386

#64479 A `backpack_hunting` is described as 'a large hunting backpack,' has a base encumbrance of 10 when empty, and offers 72L in its primary pocket (with a `"max_item_length": "80 cm"`, 25cm more than the duffelbag), and offers an additional +40L pocket for +15 extra encumbrance (total of 25). `"volume_encumber_modifier": 0.2` is, sensibly, lower than a duffelbag's.

https://github.com/CleverRaven/Cataclysm-DDA/pull/33347#issuecomment-522416758 #41568 A `backpack_hiking` has base encumbrance 10, a 50 L / 60 cm pocket (5cm more than the duffelbag) and a combined 31.25L of extra capacity divided among 10 secondary pockets. `"volume_encumber_modifier": 0.2` is, sensibly, lower than a duffelbag's.

The `molle_large_rucksack`, the best encumbrance-reducing pack there is, has a limit of 50 L / 55cm on its primary pocket, base encumbrance 8, `"volume_encumber_modifier": 0.15`.

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
