### PR TITLE
add magazine wells to non-rigid containers

### DIFF
--- a/data/json/items/containers/containers.json
+++ b/data/json/items/containers/containers.json
@@ -229,7 +229,7 @@
       {
         "pocket_type": "CONTAINER",
         "transparent": true,
-        "magazine_well": "10 ml",
+        "magazine_well": "8 ml",
         "max_contains_volume": "6 L",
         "max_contains_weight": "10 kg",
         "moves": 400
@@ -247,7 +247,7 @@
     "looks_like": "bag_plastic",
     "description": "A small, open plastic bag.  Essentially trash.",
     "weight": "1 g",
-    "volume": "2 ml",
+    "volume": "5 ml",
     "price": "0 cent",
     "price_postapoc": "0 cent",
     "material": [ "plastic" ],
@@ -256,7 +256,7 @@
         "pocket_type": "CONTAINER",
         "watertight": true,
         "transparent": true,
-        "magazine_well": "2 ml",
+        "magazine_well": "4 ml",
         "max_contains_volume": "500 ml",
         "max_contains_weight": "1250 g",
         "moves": 400
@@ -368,7 +368,7 @@
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
-        "magazine_well": "20 ml",
+        "magazine_well": "15 ml",
         "max_contains_volume": "2500 ml",
         "max_contains_weight": "2 kg",
         "moves": 200
@@ -393,7 +393,7 @@
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
-        "magazine_well": "60 ml",
+        "magazine_well": "45 ml",
         "max_contains_volume": "10000 ml",
         "max_contains_weight": "15 kg",
         "moves": 200

--- a/data/json/items/containers/containers.json
+++ b/data/json/items/containers/containers.json
@@ -136,11 +136,19 @@
     "description": "A large and sturdy sack, made out of some plastic material.  Popular choice to store sand, gravel, cement, or stop some local flood.",
     "//": "durasack woven polypropylene bags",
     "weight": "750 g",
-    "volume": "750 ml",
+    "volume": "1250 ml",
     "price": "85 cent",
     "price_postapoc": "5 cent",
     "material": [ "plastic" ],
-    "pocket_data": [ { "pocket_type": "CONTAINER", "max_contains_volume": "18 L", "max_contains_weight": "22 kg", "moves": 500 } ],
+    "pocket_data": [
+      {
+        "pocket_type": "CONTAINER",
+        "magazine_well": "750 ml",
+        "max_contains_volume": "18 L",
+        "max_contains_weight": "22 kg",
+        "moves": 500
+      }
+    ],
     "symbol": ")",
     "color": "white"
   },
@@ -169,7 +177,15 @@
     "price": "0 cent",
     "price_postapoc": "10 cent",
     "material": [ "canvas" ],
-    "pocket_data": [ { "pocket_type": "CONTAINER", "max_contains_volume": "15 L", "max_contains_weight": "15 kg", "moves": 400 } ],
+    "pocket_data": [
+      {
+        "pocket_type": "CONTAINER",
+        "magazine_well": "750 ml",
+        "max_contains_volume": "15 L",
+        "max_contains_weight": "15 kg",
+        "moves": 400
+      }
+    ],
     "symbol": ")",
     "color": "brown"
   },
@@ -182,11 +198,19 @@
     "description": "A small bag made of canvas.  Looks fine to store dried herbs in.",
     "ascii_picture": "bag_canvas_small",
     "weight": "20 g",
-    "volume": "14 ml",
+    "volume": "60 ml",
     "price": "0 cent",
     "price_postapoc": "10 cent",
     "material": [ "canvas" ],
-    "pocket_data": [ { "pocket_type": "CONTAINER", "max_contains_volume": "1 L", "max_contains_weight": "3 kg", "moves": 400 } ],
+    "pocket_data": [
+      {
+        "pocket_type": "CONTAINER",
+        "magazine_well": "45 ml",
+        "max_contains_volume": "1 L",
+        "max_contains_weight": "3 kg",
+        "moves": 400
+      }
+    ],
     "symbol": ")",
     "color": "brown"
   },
@@ -299,6 +323,7 @@
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
+        "magazine_well": "1 L",
         "max_contains_volume": "3 L",
         "max_contains_weight": "3 kg",
         "max_item_length": "22 cm",

--- a/data/json/items/containers/containers.json
+++ b/data/json/items/containers/containers.json
@@ -205,6 +205,7 @@
       {
         "pocket_type": "CONTAINER",
         "transparent": true,
+        "magazine_well": "10 ml",
         "max_contains_volume": "6 L",
         "max_contains_weight": "10 kg",
         "moves": 400
@@ -231,6 +232,7 @@
         "pocket_type": "CONTAINER",
         "watertight": true,
         "transparent": true,
+        "magazine_well": "2 ml",
         "max_contains_volume": "500 ml",
         "max_contains_weight": "1250 g",
         "moves": 400
@@ -335,10 +337,10 @@
     "description": "A small but sturdy paper bag.  Rock solid when packed full with powder.",
     "ascii_picture": "bag_paper_powder",
     "weight": "5 g",
-    "volume": "10 ml",
+    "volume": "20 ml",
     "price": "0 cent",
     "price_postapoc": "0 cent",
-    "pocket_data": [ { "pocket_type": "CONTAINER", "max_contains_volume": "2500 ml", "max_contains_weight": "2 kg", "moves": 200 } ],
+    "pocket_data": [ { "pocket_type": "CONTAINER", "magazine_well": "20 ml", "max_contains_volume": "2500 ml", "max_contains_weight": "2 kg", "moves": 200 } ],
     "material": [ "paper" ],
     "symbol": ")",
     "color": "white"
@@ -352,10 +354,10 @@
     "description": "A large paper bag, for bulk storage and transport of powdered goods.",
     "ascii_picture": "bag_paper_powder",
     "weight": "20 g",
-    "volume": "40 ml",
+    "volume": "60 ml",
     "price": "0 cent",
     "price_postapoc": "0 cent",
-    "pocket_data": [ { "pocket_type": "CONTAINER", "max_contains_volume": "10000 ml", "max_contains_weight": "15 kg", "moves": 200 } ],
+    "pocket_data": [ { "pocket_type": "CONTAINER", "magazine_well": "60 ml", "max_contains_volume": "10000 ml", "max_contains_weight": "15 kg", "moves": 200 } ],
     "material": [ "paper" ],
     "symbol": ")",
     "color": "white"
@@ -369,7 +371,7 @@
     "description": "A resealable, watertight transparent plastic bag roomy enough to hold a sandwich.  Known generically as a Ziploc bag, it can be sealed and opened with a press-together mechanism similar to a zipper.",
     "ascii_picture": "bag_zipper",
     "weight": "2 g",
-    "volume": "10 ml",
+    "volume": "20 ml",
     "price": "0 cent",
     "price_postapoc": "10 cent",
     "material": [ "plastic" ],
@@ -378,6 +380,7 @@
         "pocket_type": "CONTAINER",
         "watertight": true,
         "transparent": true,
+        "magazine_well": "10 ml",
         "max_contains_volume": "500 ml",
         "max_contains_weight": "750 g",
         "max_item_length": "14 cm",
@@ -403,6 +406,7 @@
         "pocket_type": "CONTAINER",
         "watertight": true,
         "transparent": true,
+        "magazine_well": "50 ml",
         "max_contains_volume": "4500 ml",
         "max_contains_weight": "3000 g",
         "max_item_length": "29 cm",
@@ -421,7 +425,7 @@
     "description": "A huge watertight bag made of strong plastic.  Commonly used in activities with high risk of wetting the equipment, such as kayaking.",
     "ascii_picture": "dry_bag_large",
     "weight": "1500 g",
-    "volume": "1500 ml",
+    "volume": "7500 ml",
     "longest_side": "35 cm",
     "price": "0 cent",
     "price_postapoc": "10 cent",
@@ -433,6 +437,7 @@
       {
         "pocket_type": "CONTAINER",
         "watertight": true,
+        "magazine_well": "6 L",
         "max_contains_volume": "80 L",
         "max_contains_weight": "100 kg",
         "max_item_length": "100 cm",
@@ -451,7 +456,7 @@
     "description": "A human-sized rectangular bag made of strong plastic, with a zipper in the middle.  Intended to hold a dead body.",
     "ascii_picture": "bag_body_bag",
     "weight": "1061 g",
-    "volume": "5500 ml",
+    "volume": "15 L",
     "//1": "This is ~85% of the package volume from the amazon listing, with the assumption that the player would be squishing it harder to condense the volume.",
     "price": "30 USD",
     "price_postapoc": "10 cent",
@@ -461,6 +466,7 @@
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
+        "magazine_well": "10 L",
         "max_contains_volume": "100 L",
         "max_contains_weight": "100 kg",
         "max_item_length": "200 cm",
@@ -480,7 +486,7 @@
     "description": "A five-foot-long cylindrical leather sack, a foot in diameter, with attachment points at the top.  With some bags of sand, some chains, and a bunch of blankets, you could hang it from the ceiling as a heavy punching bag.",
     "ascii_picture": "heavy_punching_bag_sack",
     "weight": "2400g",
-    "volume": "2260 ml",
+    "volume": "12260 ml",
     "longest_side": "150 cm",
     "price": "0 cent",
     "price_postapoc": "10 cent",
@@ -491,6 +497,7 @@
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
+        "magazine_well": "10 L",
         "max_contains_volume": "110 L",
         "max_contains_weight": "100 kg",
         "max_item_length": "150 cm",
@@ -520,6 +527,7 @@
         "pocket_type": "CONTAINER",
         "watertight": true,
         "transparent": true,
+        "magazine_well": "25 ml",
         "max_contains_volume": "500 ml",
         "max_contains_weight": "3 kg",
         "moves": 400
@@ -2832,6 +2840,7 @@
       {
         "pocket_type": "CONTAINER",
         "watertight": true,
+        "magazine_well": "250 ml",
         "max_contains_volume": "3 L",
         "max_item_volume": "17 ml",
         "max_contains_weight": "6 kg"
@@ -3332,13 +3341,13 @@
     "description": "Just a piece of butcher's paper.  Good for starting fires.",
     "ascii_picture": "wrapper",
     "weight": "3 g",
-    "volume": "5 ml",
+    "volume": "50 ml",
     "price": "0 cent",
     "price_postapoc": "0 cent",
     "material": [ "paper" ],
     "symbol": ",",
     "color": "light_gray",
-    "pocket_data": [ { "pocket_type": "CONTAINER", "max_contains_volume": "2500 ml", "max_contains_weight": "6 kg" } ],
+    "pocket_data": [ { "pocket_type": "CONTAINER", "magazine_well": "50 ml", "max_contains_volume": "2500 ml", "max_contains_weight": "6 kg" } ],
     "flags": [ "TINDER" ]
   },
   {
@@ -3356,7 +3365,7 @@
     "material": [ "aluminum" ],
     "symbol": ",",
     "color": "light_gray",
-    "//2": "mathematically perfect sprehe out of sheet is 2110 ml, but we are less than perfect",
+    "//2": "mathematically perfect sphere out of sheet is 2110 ml, but we are less than perfect",
     "pocket_data": [ { "pocket_type": "CONTAINER", "max_contains_volume": "1500 ml", "max_contains_weight": "6 kg" } ],
     "qualities": [ [ "COOK", 1 ] ],
     "use_action": [ "HEAT_SOLID_ITEMS" ],
@@ -3380,10 +3389,10 @@
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
-        "max_contains_volume": "1 L",
+        "max_contains_volume": "120 ml",
         "max_contains_weight": "1 kg",
         "item_restriction": [ "wrapper_foil" ],
-        "volume_multiplier": 0.75
+        "volume_multiplier": 0.25
       }
     ],
     "flags": [ "NO_RELOAD" ]
@@ -3399,7 +3408,8 @@
     "ascii_picture": "wrapper_pr",
     "copy-from": "wrapper",
     "weight": "1 g",
-    "pocket_data": [ { "pocket_type": "CONTAINER", "max_contains_volume": "175 ml", "max_contains_weight": "1 kg" } ]
+    "volume": "5 ml",
+    "pocket_data": [ { "pocket_type": "CONTAINER", "magazine_well": "5 ml", "max_contains_volume": "175 ml", "max_contains_weight": "1 kg" } ]
   },
   {
     "id": "styrofoam_cup",

--- a/data/json/items/containers/containers.json
+++ b/data/json/items/containers/containers.json
@@ -340,7 +340,15 @@
     "volume": "20 ml",
     "price": "0 cent",
     "price_postapoc": "0 cent",
-    "pocket_data": [ { "pocket_type": "CONTAINER", "magazine_well": "20 ml", "max_contains_volume": "2500 ml", "max_contains_weight": "2 kg", "moves": 200 } ],
+    "pocket_data": [
+      {
+        "pocket_type": "CONTAINER",
+        "magazine_well": "20 ml",
+        "max_contains_volume": "2500 ml",
+        "max_contains_weight": "2 kg",
+        "moves": 200
+      }
+    ],
     "material": [ "paper" ],
     "symbol": ")",
     "color": "white"
@@ -357,7 +365,15 @@
     "volume": "60 ml",
     "price": "0 cent",
     "price_postapoc": "0 cent",
-    "pocket_data": [ { "pocket_type": "CONTAINER", "magazine_well": "60 ml", "max_contains_volume": "10000 ml", "max_contains_weight": "15 kg", "moves": 200 } ],
+    "pocket_data": [
+      {
+        "pocket_type": "CONTAINER",
+        "magazine_well": "60 ml",
+        "max_contains_volume": "10000 ml",
+        "max_contains_weight": "15 kg",
+        "moves": 200
+      }
+    ],
     "material": [ "paper" ],
     "symbol": ")",
     "color": "white"
@@ -3347,7 +3363,14 @@
     "material": [ "paper" ],
     "symbol": ",",
     "color": "light_gray",
-    "pocket_data": [ { "pocket_type": "CONTAINER", "magazine_well": "50 ml", "max_contains_volume": "2500 ml", "max_contains_weight": "6 kg" } ],
+    "pocket_data": [
+      {
+        "pocket_type": "CONTAINER",
+        "magazine_well": "50 ml",
+        "max_contains_volume": "2500 ml",
+        "max_contains_weight": "6 kg"
+      }
+    ],
     "flags": [ "TINDER" ]
   },
   {
@@ -3409,7 +3432,9 @@
     "copy-from": "wrapper",
     "weight": "1 g",
     "volume": "5 ml",
-    "pocket_data": [ { "pocket_type": "CONTAINER", "magazine_well": "5 ml", "max_contains_volume": "175 ml", "max_contains_weight": "1 kg" } ]
+    "pocket_data": [
+      { "pocket_type": "CONTAINER", "magazine_well": "5 ml", "max_contains_volume": "175 ml", "max_contains_weight": "1 kg" }
+    ]
   },
   {
     "id": "styrofoam_cup",

--- a/data/json/items/containers/containers.json
+++ b/data/json/items/containers/containers.json
@@ -3438,7 +3438,7 @@
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
-        "max_contains_volume": "120 ml",
+        "max_contains_volume": "480 ml",
         "max_contains_weight": "1 kg",
         "item_restriction": [ "wrapper_foil" ],
         "volume_multiplier": 0.25

--- a/data/json/items/containers/containers.json
+++ b/data/json/items/containers/containers.json
@@ -2020,6 +2020,7 @@
       {
         "pocket_type": "CONTAINER",
         "watertight": true,
+        "magazine_well": "9 ml",
         "max_contains_volume": "500 ml",
         "max_contains_weight": "1 kg",
         "sealed_data": { "spoil_multiplier": 0.5 }

--- a/data/json/items/containers/containers.json
+++ b/data/json/items/containers/containers.json
@@ -3392,7 +3392,7 @@
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
-        "magazine_well": "50 ml",
+        "magazine_well": "45 ml",
         "max_contains_volume": "2500 ml",
         "max_contains_weight": "6 kg"
       }
@@ -3459,7 +3459,7 @@
     "weight": "1 g",
     "volume": "5 ml",
     "pocket_data": [
-      { "pocket_type": "CONTAINER", "magazine_well": "5 ml", "max_contains_volume": "175 ml", "max_contains_weight": "1 kg" }
+      { "pocket_type": "CONTAINER", "magazine_well": "4 ml", "max_contains_volume": "175 ml", "max_contains_weight": "1 kg" }
     ]
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "Make flexible containers add less bulk when full"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

`"magazine_well"` was hardly used at all on containers that aren't classified as armor like backpacks and duffel bags.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

Add it to items to make them add less bulk to their contents as they get fuller.

Add it to some other gigantic items like the punching bag, but neutralized by an increase in their base volume to represent how awkward things like an empty 100L body bag or an 80 L capacity kayaking bag are to handle.

And fix the `wrapper_foil_roll` to actually fit exactly 12 ml * 40 units of foil like it was designed to.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Change foil spawning to add more than 40 units per roll, since there was plenty of room for 111 units of foil.

Change C++ item container capacity code to count the post-`"volume_multipler"` volume of items instead of the pre-multiplier volume.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
