### PR TITLE
Imgui default style: Nav highlight is white

### DIFF
--- a/data/raw/imgui_styles/default_style.json
+++ b/data/raw/imgui_styles/default_style.json
@@ -51,7 +51,7 @@
     "ImGuiCol_TableRowBgAlt": [ 1.0, 1.0, 1.0, 0.0 ],
     "ImGuiCol_TextSelectedBg": [ 0.04, 0.04, 0.86, 0.65 ],
     "ImGuiCol_DragDropTarget": [ 1.0, 1.0, 0.0, 0.9 ],
-    "ImGuiCol_NavHighlight": [ 0.04, 0.04, 0.86, 0.65 ],
+    "ImGuiCol_NavHighlight": [ 1.0, 1.0, 1.0, 1.0 ],
     "ImGuiCol_NavWindowingHighlight": [ 1.0, 1.0, 1.0, 0.7 ],
     "ImGuiCol_NavWindowingDimBg": [ 0.8, 0.8, 0.8, 0.2 ],
     "ImGuiCol_ModalWindowDimBg": [ 80, 0.8, 0.8, 0.3 ]


### PR DESCRIPTION
#### Summary
Interface "Imgui default style: Nav highlight is white"

#### Purpose of change
Didnt notice that we were using this value to select buttons in the quit menu, and after changing the color to the game's blue selection tone, it was near impossible to notice it.

Thanks to gettingusedto for noticing this.

#### Describe the solution

Nav highlight is now white 
![imagen](https://github.com/user-attachments/assets/ec6c0072-7c99-4650-8591-c0f8c8d9ba4e)

#### Testing
See image