### PR TITLE
Properly get recipes for NPC crafting dummy at camp

### DIFF
--- a/src/character.h
+++ b/src/character.h
@@ -3585,8 +3585,9 @@ class Character : public Creature, public visitable
     public:
         /**
           * Return all available recipes for any member of `this` crafter's group. Using `this` inventory.
+          * If a valid inventory pointer is passed as an argument then returns early with only 'this' crafter using the passed inventory.
           */
-        recipe_subset &get_group_available_recipes() const;
+        recipe_subset &get_group_available_recipes( inventory *inventory_override = nullptr ) const;
         /**
           * Returns the set of book types in crafting_inv that provide the
           * given recipe.

--- a/src/character_crafting.cpp
+++ b/src/character_crafting.cpp
@@ -183,7 +183,7 @@ recipe_subset Character::get_available_recipes( const inventory &crafting_inv,
     return res;
 }
 
-recipe_subset &Character::get_group_available_recipes() const
+recipe_subset &Character::get_group_available_recipes( inventory *inventory_override ) const
 {
     if( !test_mode && calendar::turn == cached_recipe_turn && cached_recipe_subset->size() > 0 ) {
         return *cached_recipe_subset;
@@ -191,6 +191,11 @@ recipe_subset &Character::get_group_available_recipes() const
 
     cached_recipe_turn = calendar::turn;
     cached_recipe_subset->clear();
+
+    if( inventory_override ) {
+        cached_recipe_subset->include( get_available_recipes( *inventory_override ) );
+        return *cached_recipe_subset;
+    }
 
     for( const Character *guy : get_crafting_group() ) {
         cached_recipe_subset->include( guy->get_available_recipes( crafting_inventory() ) );

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -1380,10 +1380,7 @@ std::pair<Character *, const recipe *> select_crafter_and_crafting_recipe( int &
                           crafter ) - crafting_group.begin();
 
     // Get everyone's recipes
-    // WTF? If called with dummy npc, we have to do this. Why? Why doesn't Character::get_group_available_recipes()
-    // already include get_learned_recipes()?
-    const recipe_subset &available_recipes = camp_crafting ? crafter->get_learned_recipes() :
-            crafter->get_group_available_recipes();
+    const recipe_subset &available_recipes = crafter->get_group_available_recipes( inventory_override );
     std::map<character_id, std::map<const recipe *, availability>> guy_availability_cache;
     // next line also inserts empty cache for crafter->getID()
     std::map<const recipe *, availability> *availability_cache =


### PR DESCRIPTION
#### Summary
Bugfixes "Book recipes are now available through camp crafting"

#### Purpose of change
* Fixes #81144

#### Describe the solution
The dummy NPC  used for crafting returns false for npc::is_active() so therefore game::get_characters_if() **does not iterate them at all** -  because they are never put into the `npc_range` of the game object. This makes Character::get_crafting_group() return an empty subset of recipes (since it iterates no characters)

We instead pass the camp inventory pointer into Character::get_crafting_group(). If not nullptr we know it wants to be overridden and early return with that inventory, skipping the iteration in Character::get_crafting_group() and game::get_characters_if().

#### Describe alternatives you've considered
I considered changing game::get_characters_if() to not skip "inactive" characters. But that's very spooky, I prefer to extend the hack a little bit.

Making the character "active". Similarly spooky, lots of potential for unintended consequences.

Refactoring the entire way that camp crafting accesses the crafting UI to pre-select who you're crafting with --> Probably the safest idea, but this implementation was way easier at the time and I believe it still remains the easier, superior choice

#### Testing
Loaded the save from the linked issue and confirmed that all forms of katana now appear as possible crafting choices in the camp crafting window. The UI reports that they are from "The swords of the samurai" which is in an e-book several tiles below the player, in a basecamp zone. So it works as expeted.

#### Additional context

