### PR TITLE
Add missing migration exodii_ingot_steel --> exodii_ingot_lc_steel

### DIFF
--- a/data/json/obsoletion_and_migration_0.I/migration_items.json
+++ b/data/json/obsoletion_and_migration_0.I/migration_items.json
@@ -2567,5 +2567,10 @@
     "type": "MIGRATION",
     "id": "robofac_head_rig_ir",
     "replace": "robofac_head_rig_nv"
+  },
+  {
+    "type": "MIGRATION",
+    "id": "exodii_ingot_steel",
+    "replace": "exodii_ingot_lc_steel"
   }
 ]


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
#77484 changed the ID of an item but did not add a migration. This causes an error on load and makes the old item useless

![image](https://github.com/user-attachments/assets/31441c1d-09b8-4d7a-afe0-2fe05d1dc91f)


#### Describe the solution
Properly migrate it

#### Describe alternatives you've considered

#### Testing


#### Additional context

