### PR TITLE
Some home wardrobe clothes are stored as sets of clothes

### DIFF
--- a/data/json/itemgroups/SUS/domestic.json
+++ b/data/json/itemgroups/SUS/domestic.json
@@ -1109,6 +1109,29 @@
       { "group": "pants_male", "count": [ 4, 7 ], "prob": 5 },
       { "group": "gloves_unisex", "prob": 30 },
       { "group": "hats_unisex", "prob": 10 },
+      { "group": "bags_unisex", "prob": 50 },
+      { "group": "SUS_dresser_mens_single_outfit", "count": [ 1, 2 ], "prob": 80 }
+    ]
+  },
+  {
+    "id": "SUS_dresser_mens_single_outfit",
+    "type": "item_group",
+    "//COMMENT": "One specific set of clothing found in a man's dresser. Should not contain more than one shirt, more than one pants, etc. All of these should be wearable at once without anything being too strange.",
+    "//COMMENT2": "This is largely a copy of SUS_dresser_mens with the counts removed and inline distributions to make sure we only get one of each main clothing.",
+    "subtype": "collection",
+    "container-item": "outfit_storage",
+    "entries": [
+      {
+        "distribution": [ { "group": "accesories_personal_unisex", "prob": 50 }, { "group": "accesories_personal_mens", "prob": 50 } ]
+      },
+      { "group": "masks_unisex", "prob": 3 },
+      { "group": "socks_unisex", "prob": 100 },
+      { "group": "scarfs_unisex", "prob": 30 },
+      { "group": "shirts_unisex", "prob": 100 },
+      { "distribution": [ { "group": "underwear_mens", "prob": 50 }, { "group": "underwear_unisex", "prob": 50 } ] },
+      { "distribution": [ { "group": "pants_male", "prob": 50 }, { "group": "pants_unisex", "prob": 5 } ] },
+      { "group": "gloves_unisex", "prob": 30 },
+      { "group": "hats_unisex", "prob": 10 },
       { "group": "bags_unisex", "prob": 50 }
     ]
   },
@@ -1152,6 +1175,29 @@
       { "group": "pants_female", "count": [ 4, 7 ], "prob": 100 },
       { "group": "gloves_womens", "prob": 5 },
       { "group": "gloves_unisex", "prob": 30 },
+      { "group": "hats_unisex", "prob": 10 },
+      { "group": "bags_unisex", "prob": 50 },
+      { "group": "SUS_dresser_womens_single_outfit", "count": [ 1, 2 ], "prob": 80 }
+    ]
+  },
+  {
+    "id": "SUS_dresser_womens_single_outfit",
+    "type": "item_group",
+    "//COMMENT": "One specific set of clothing found in a woman's dresser. Should not contain more than one shirt, more than one pants, etc. All of these should be wearable at once without anything being too strange.",
+    "//COMMENT2": "This is largely a copy of SUS_dresser_womens with the counts removed and inline distributions to make sure we only get one of each main clothing.",
+    "subtype": "collection",
+    "container-item": "outfit_storage",
+    "entries": [
+      {
+        "distribution": [ { "group": "accesories_personal_unisex", "prob": 30 }, { "group": "accesories_personal_womens", "prob": 5 } ]
+      },
+      { "group": "masks_unisex", "prob": 3 },
+      { "group": "socks_unisex", "prob": 100 },
+      { "group": "scarfs_unisex", "prob": 30 },
+      { "distribution": [ { "group": "shirts_unisex", "prob": 100 }, { "group": "shirts_womens", "prob": 50 } ] },
+      { "distribution": [ { "group": "underwear_womens", "prob": 50 }, { "group": "underwear_unisex", "prob": 50 } ] },
+      { "distribution": [ { "group": "pants_unisex", "prob": 50 }, { "group": "pants_female", "prob": 50 } ] },
+      { "distribution": [ { "group": "gloves_womens", "prob": 5 }, { "group": "gloves_unisex", "prob": 30 } ] },
       { "group": "hats_unisex", "prob": 10 },
       { "group": "bags_unisex", "prob": 50 }
     ]

--- a/data/json/items/containers/generic.json
+++ b/data/json/items/containers/generic.json
@@ -167,7 +167,7 @@
     "subtypes": [ "TOOL" ],
     "category": "container",
     "name": { "str": "set of clothes", "str_pl": "sets of clothes" },
-    "description": "A bundle of presses, coat hangars, and other miscellaneous items needed to store and keep a good change of clothes.  You can interact with it to swap to the clothes it's currently containing, or disassemble it to get the clothes back.",
+    "description": "A bundle of presses, coat hangars, and other miscellaneous items needed to store and keep a good change of clothes.  You can interact with it to swap to the clothes it's currently containing, or put your current clothes in if there's nothing already inside.",
     "weight": "1 kg",
     "volume": "1 L",
     "longest_side": "150 cm",


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
This PR aims to tackle two issues:

1) The "set of clothes" item exists, but it's only available through player crafting. The chance of any given player stumbling into it in the crafting menu, reading the description, and understanding that it is a functional item is *extraordinarily low*. This PR aims to make it a bit more possible to discover it naturally, by having natural spawns of the item in the world.

2) People sometimes store clothes together for a specific purpose, like a nice suit for special occasions. This isn't really represented in the game world, where you'll find a closet full of a bunch of clothes all mixed up.

#### Describe the solution
New entries to the SUS_dresser_mens and SUS_dresser_womens groups which represent an entire outfit being stored together. The entries are for a new collection group contained inside of a single "set of clothes" (as the "container-item"). The collections (SUS_dresser_mens_single_outfit) are basically a single 'instance' of their parent group but modified to make sure they only come with one of each main clothing.

Also I updated the description of the "set of clothes" item, since it wasn't updated after I moved away from storing the clothes as an item_components.

#### Describe alternatives you've considered
Tons of bespoke custom-made outfits which completely blow up our existing clothing distributions to make sure each outfit has some sort of theme/styling/could be expected to be found in public

NOTE: This is a not-negligible increase in the overall number of clothes spawned in wardrobes. I considered reducing the `count` and `prob` of existing entries to somewhat counteract this, but regardless there's no easy way to insert this without some changes to the distribution. I think an overall increase in clothes is probably the least disruptive way to do that.

#### Testing
![image](https://github.com/user-attachments/assets/c4caeeb1-f620-479b-8774-1b7950be30d4)


#### Additional context