### PR TITLE
Aftershock: You can now spot the spaceport during clear nights.

### DIFF
--- a/data/mods/aftershock_exoplanet/EOC/world_eocs.json
+++ b/data/mods/aftershock_exoplanet/EOC/world_eocs.json
@@ -1,0 +1,31 @@
+[
+  {
+    "type": "effect_on_condition",
+    "id": "afs_spot_spaceport",
+    "recurrence": [ "8 hours", "48 hours" ],
+    "condition": {
+      "and": [
+        { "one_in_chance": 2 },
+        { "not": { "math": [ "has_var(know_spaceport)" ] } },
+        { "not": { "u_has_mission": "MISSION_REACH_SPACEPORT" } },
+        { "not": "is_day" },
+        "u_can_see",
+        { "is_weather": "clear" },
+        "u_is_outside"
+      ]
+    },
+    "effect": [
+      { "assign_mission": "MISSION_REACH_SPACEPORT" },
+      {
+        "u_message": "You notice the rocket plumes of three ascending ships in the distance.  There must be a large space port in that direction."
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_KNOW_SPACEPORT",
+    "global": true,
+    "condition": { "not": { "math": [ "has_var(know_spaceport)" ] } },
+    "effect": [ { "math": [ "know_spaceport = 1" ] } ]
+  }
+]

--- a/data/mods/aftershock_exoplanet/maps/overmap_terrain.json
+++ b/data/mods/aftershock_exoplanet/maps/overmap_terrain.json
@@ -671,6 +671,7 @@
     "color": "light_blue",
     "see_cost": "high",
     "mondensity": 2,
+    "entry_eoc": "EOC_KNOW_SPACEPORT",
     "flags": [ "SIDEWALK" ]
   },
   {

--- a/data/mods/aftershock_exoplanet/missions/exploration_missions.json
+++ b/data/mods/aftershock_exoplanet/missions/exploration_missions.json
@@ -1,0 +1,12 @@
+[
+  {
+    "id": "MISSION_REACH_SPACEPORT",
+    "type": "mission_definition",
+    "name": { "str": "Reach the spaceport" },
+    "goal": "MGOAL_GO_TO",
+    "description": "You spotted a spaceport in the distance.  You should head there to see if you can find a way off this planet.",
+    "difficulty": 0,
+    "value": 0,
+    "start": { "assign_mission_target": { "om_terrain": "land_pad_outpost_a1", "om_special": "landing_pad", "reveal_radius": 5 } }
+  }
+]


### PR DESCRIPTION
#### Summary
Mods "Aftershock: You can now spot the spaceport during clear nights."

#### Purpose of change
Its difficult but still extremely important to find the spaceport in the scenarios where you dont start there, this adds a way to passively mark it on the map.

#### Describe the solution
Works with recurrent eocs

#### Testing
Triggered the EOC to make sure it worked.

#### Additional context
I'll probably add some extra ways of finding this in the future.