### PR TITLE
Revert vehicle cargo sizes to sane values

### DIFF
--- a/data/json/vehicleparts/doors.json
+++ b/data/json/vehicleparts/doors.json
@@ -138,7 +138,7 @@
       },
       "repair": { "skills": [ [ "mechanics", 3 ] ], "time": "5 m", "using": [ [ "repair_welding_lc_steel", 3 ] ] }
     },
-    "size": "200 L",
+    "size": "37500 ml",
     "extend": { "flags": [ "LOCKABLE_CARGO", "MULTISQUARE", "COVERED" ] },
     "type": "vehicle_part"
   },
@@ -176,7 +176,6 @@
       },
       "repair": { "skills": [ [ "mechanics", 4 ] ], "time": "8 m", "using": [ [ "repair_welding_lc_steel", 4 ] ] }
     },
-    "size": "100 L",
     "type": "vehicle_part"
   },
   {

--- a/data/json/vehicleparts/seats.json
+++ b/data/json/vehicleparts/seats.json
@@ -49,7 +49,7 @@
         "using": [ [ "repair_welding_standard", 1 ], [ "sewing_standard", 8 ] ]
       }
     },
-    "size": "85 L",
+    "size": "25 L",
     "type": "vehicle_part",
     "variants_bases": [ { "id": "windshield", "label": "Windshield" }, { "id": "swivel_chair", "label": "Swivel Chair" } ],
     "variants": [
@@ -76,10 +76,9 @@
     "id": "reclining_seat",
     "copy-from": "seat",
     "comfort": 3,
-    "//": "reclining and bench seats are roomier than standard and are able to fit Large characters, if not comfortably",
     "description": "A soft seat with an adjustable backrest, making it a reasonably comfortable place to sleep.",
     "durability": 100,
-    "size": "95 L",
+    "size": "6250 ml",
     "floor_bedding_warmth": 350,
     "name": { "str": "reclining bucket seat" },
     "extend": { "flags": [ "BED" ] },
@@ -103,7 +102,6 @@
     "description": "A soft, wide seat with a high back, the kind often used in back seats or older cars.  It might be a decent place to sleep.",
     "floor_bedding_warmth": 500,
     "item": "seat_bench",
-    "size": "95 L",
     "name": { "str": "bench seat" },
     "extend": { "flags": [ "BED" ] },
     "type": "vehicle_part"

--- a/data/json/vehicleparts/vehicle_parts.json
+++ b/data/json/vehicleparts/vehicle_parts.json
@@ -207,7 +207,7 @@
     "damage_modifier": 60,
     "durability": 95,
     "description": "A small but comfortable bed.",
-    "size": "100 L",
+    "size": "50 L",
     "item": "mattress",
     "comfort": 4,
     "floor_bedding_warmth": 700,
@@ -309,7 +309,6 @@
     "color": "white",
     "durability": 400,
     "description": "An aisle.",
-    "size": "100 L",
     "item": "sheet_metal",
     "location": "center",
     "//": ".5 m square sheet of metal, likely affixed with bolts in places, assume 200 cm weld to install and 50 cm weld to repair",
@@ -326,7 +325,7 @@
       },
       "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "6 m", "using": [ [ "repair_welding_lc_steel", 5 ] ] }
     },
-    "flags": [ "AISLE", "BOARDABLE", "CARGO" ],
+    "flags": [ "AISLE", "BOARDABLE" ],
     "breaks_into": [
       { "item": "sheet_metal_small", "count": [ 0, 1 ] },
       { "item": "lc_steel_lump", "count": [ 1, 2 ] },
@@ -366,7 +365,7 @@
     "folded_volume": "12500 ml",
     "item": "foldwoodframe",
     "breaks_into": [ { "item": "splinter", "count": [ 7, 11 ] }, { "item": "nail", "charges": [ 5, 10 ] } ],
-    "flags": [ "AISLE", "BOARDABLE", "CARGO" ]
+    "flags": [ "AISLE", "BOARDABLE" ]
   },
   {
     "type": "vehicle_part",
@@ -2294,8 +2293,7 @@
     "durability": 250,
     "description": "A cargo space for carrying livestock.  'e'xamine it to capture an animal next to you, or to release the animal currently contained.  When selecting an animal to capture, choose its tile relative to you, not the part.",
     "//1": "240 cm weld to install, 60 cm per damage quadrant to repair",
-    "size": "300 L",
-    "comfort": 2,
+    "size": "200 L",
     "item": "livestock_carrier",
     "location": "center",
     "requirements": {
@@ -2311,7 +2309,7 @@
       },
       "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "20 m", "using": [ [ "repair_welding_standard", 12 ] ] }
     },
-    "flags": [ "BOARDABLE", "CARGO", "COVERED", "CAPTURE_MONSTER_VEH", "HUGE_OK", "BED", "BELTABLE" ],
+    "flags": [ "BOARDABLE", "CARGO", "COVERED", "CAPTURE_MONSTER_VEH", "HUGE_OK" ],
     "breaks_into": [
       { "item": "mc_steel_lump", "count": [ 6, 8 ] },
       { "item": "mc_steel_chunk", "count": [ 6, 8 ] },

--- a/data/mods/TEST_DATA/vehicle.json
+++ b/data/mods/TEST_DATA/vehicle.json
@@ -500,50 +500,5 @@
       { "x": -1, "y": 1, "parts": [ "frame#horizontal_rear", "halfboard#horizontal_2_rear" ] },
       { "x": -1, "y": 2, "parts": [ "frame#se", "halfboard#hatch_wheel_right", "wheel_mount_medium", "wheel" ] }
     ]
-  },
-  {
-    "id": "character_volume_test_car",
-    "type": "vehicle",
-    "name": "DEBUG volume test car DEBUG",
-    "blueprint": [
-      [ "=====" ],
-      [ "=====" ],
-      [ "=====" ],
-      [ "=====" ],
-      [ "=====" ]
-    ],
-    "parts": [
-      { "x": -1, "y": -1, "parts": [ "frame", "aisle", "roof" ] },
-      { "x": 0, "y": -1, "parts": [ "frame", "aisle", "roof" ] },
-      { "x": 1, "y": -1, "parts": [ "frame", "aisle", "roof" ] },
-      { "x": -1, "y": 0, "parts": [ "frame", "aisle", "roof" ] },
-      { "x": 0, "y": 0, "parts": [ "frame", "aisle", "roof" ] },
-      { "x": 1, "y": 0, "parts": [ "frame", "aisle", "roof" ] },
-      { "x": -1, "y": 1, "parts": [ "frame", "aisle", "roof" ] },
-      { "x": 0, "y": 1, "parts": [ "frame", "aisle", "roof" ] },
-      { "x": 1, "y": 1, "parts": [ "frame", "aisle", "roof" ] },
-      { "x": -1, "y": 2, "parts": [ "frame", "aisle", "roof" ] },
-      { "x": 0, "y": 2, "parts": [ "frame", "aisle", "roof" ] },
-      { "x": 1, "y": 2, "parts": [ "frame", "aisle", "roof" ] },
-      { "x": 2, "y": 2, "parts": [ "frame", "aisle", "roof" ] },
-      { "x": 0, "y": -2, "parts": [ "frame", "aisle", "roof" ] },
-      { "x": 1, "y": -2, "parts": [ "frame", "aisle", "roof" ] },
-      { "x": 2, "y": -1, "parts": [ "frame", "aisle", "roof" ] },
-      { "x": 2, "y": 0, "parts": [ "frame", "aisle", "roof" ] },
-      { "x": 2, "y": 1, "parts": [ "frame", "aisle", "roof" ] },
-      { "x": -2, "y": -1, "parts": [ "frame", "aisle", "roof" ] },
-      { "x": -2, "y": 0, "parts": [ "frame", "aisle", "roof" ] },
-      { "x": -2, "y": -2, "parts": [ "frame", "aisle", "roof" ] },
-      { "x": -1, "y": -2, "parts": [ "frame", "aisle", "roof" ] },
-      { "x": 2, "y": -2, "parts": [ "frame", "aisle", "roof" ] },
-      { "x": -2, "y": 2, "parts": [ "frame", "aisle", "roof" ] },
-      { "x": -2, "y": 1, "parts": [ "frame", "aisle", "roof" ] }
-    ],
-    "items": [
-      { "x": 1, "y": 0, "chance": 100, "items": [ "rock_volume_test" ] },
-      { "x": -1, "y": 0, "chance": 100, "items": [ "rock_volume_test" ] },
-      { "x": 0, "y": 1, "chance": 100, "items": [ "rock_volume_test" ] },
-      { "x": 0, "y": -1, "chance": 100, "items": [ "rock_volume_test" ] }
-    ]
   }
 ]

--- a/tests/char_volume_test.cpp
+++ b/tests/char_volume_test.cpp
@@ -2,25 +2,14 @@
 
 #include "cata_catch.h"
 #include "character.h"
-#include "coordinates.h"
-#include "item.h"
-#include "map.h"
-#include "map_helpers.h"
 #include "player_helpers.h"
-#include "point.h"
 #include "type_id.h"
 #include "units.h"
-#include "vpart_position.h"
-
-static const itype_id itype_backpack_giant( "backpack_giant" );
-static const itype_id itype_rock_volume_test( "rock_volume_test" );
 
 static const trait_id trait_HUGE( "HUGE" );
 static const trait_id trait_LARGE( "LARGE" );
 static const trait_id trait_SMALL( "SMALL" );
 static const trait_id trait_SMALL2( "SMALL2" );
-
-static const vproto_id vehicle_prototype_character_volume_test_car( "character_volume_test_car" );
 
 static units::volume your_volume_with_trait( trait_id new_trait )
 {
@@ -59,62 +48,4 @@ TEST_CASE( "character_baseline_volumes", "[volume]" )
 
     REQUIRE( your_height_with_trait( trait_HUGE ) == 280 );
     CHECK( your_volume_with_trait( trait_HUGE ) == 156228_ml );
-}
-
-TEST_CASE( "character_at_volume_will_be_cramped_in_vehicle", "[volume]" )
-{
-    clear_avatar();
-    clear_map();
-    map &here = get_map();
-    Character &you = get_player_character();
-    REQUIRE( you.get_mutations().empty() );
-
-    tripoint_bub_ms test_pos {10, 10, 0 };
-
-
-    clear_vehicles(); // extra safety
-    here.add_vehicle( vehicle_prototype_character_volume_test_car, test_pos, 0_degrees, 0, 0 );
-    you.setpos( here, test_pos );
-    const optional_vpart_position vp_there = here.veh_at( you.pos_bub( here ) );
-    REQUIRE( vp_there );
-    tripoint_abs_ms dest_loc = you.pos_abs();
-
-    // Empty aisle
-    dest_loc = dest_loc + tripoint::north_west;
-    CHECK( !you.will_be_cramped_in_vehicle_tile( here, dest_loc ) );
-    dest_loc = you.pos_abs(); //reset
-
-    // Aisle with 10L rock, a tight fit but not impossible
-    dest_loc = dest_loc + tripoint::north;
-    CHECK( you.will_be_cramped_in_vehicle_tile( here, dest_loc ) );
-    dest_loc = you.pos_abs(); //reset
-
-    // Empty aisle, but we've put on a backpack and a 10L rock in that backpack
-    item backpack( itype_backpack_giant );
-    auto worn_success = you.wear_item( backpack );
-    CHECK( worn_success );
-    you.i_add( item( itype_rock_volume_test ) );
-    CHECK( 75_liter <= you.get_total_volume() );
-    CHECK( you.get_total_volume() <= 100_liter );
-    dest_loc = dest_loc + tripoint::north_west;
-    CHECK( you.will_be_cramped_in_vehicle_tile( here, dest_loc ) );
-    dest_loc = you.pos_abs(); //reset
-
-    // Try the cramped aisle with a rock again, but now we are tiny, so it is easy.
-    CHECK( your_volume_with_trait( trait_SMALL2 ) == 23326_ml );
-    you.setpos( here, test_pos ); // set our position again, clear_avatar() moved us
-    dest_loc = dest_loc + tripoint::north;
-    CHECK( !you.will_be_cramped_in_vehicle_tile( here, dest_loc ) );
-    dest_loc = you.pos_abs(); //reset
-
-    // Same aisle, but now we have HUGE GUTS. We will never fit.
-    CHECK( your_volume_with_trait( trait_HUGE ) == 156228_ml );
-    you.setpos( here, test_pos ); // set our position again, clear_avatar() moved us
-    dest_loc = dest_loc + tripoint::north;
-    CHECK( you.will_be_cramped_in_vehicle_tile( here, dest_loc ) );
-    dest_loc = you.pos_abs(); //reset
-
-    // And finally, check that our HUGE body won't fit even into an empty aisle.
-    dest_loc = dest_loc + tripoint::north_west;
-    CHECK( you.will_be_cramped_in_vehicle_tile( here, dest_loc ) );
 }


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
* Fixes #78532

#### Describe the solution
Revert vehicle size changes from #67986 (???), #70393, and #70184

Also remove the use of a livestock stall as a bed (???????????????) and clean up any CARGO flag additions which are no longer appropriate.

As it stands (and until someone wants to put in even more work) the cargo size does not prevent a player or other character from moving through a tile, so there is no reason for these absurd values to be kept.

#### Describe alternatives you've considered
Completely reverting the PRs in question

#### Testing


#### Additional context
