### PR TITLE
Roads cross streams, fix stream predecessors

### DIFF
--- a/data/json/mapgen/nested/road_nested.json
+++ b/data/json/mapgen/nested/road_nested.json
@@ -42,6 +42,54 @@
   },
   {
     "type": "mapgen",
+    "nested_mapgen_id": "culvert_east",
+    "object": {
+      "mapgensize": [ 12, 12 ],
+      "rows": [
+        "        ____",
+        "        ___.",
+        "        __..",
+        "        _~~~",
+        "        _~~~",
+        "        _~~~",
+        "        _~~~",
+        "        _~~~",
+        "        _~~~",
+        "        __..",
+        "        ___.",
+        "        ____"
+      ],
+      "terrain": { ".": "t_region_groundcover", "~": "t_water_moving_sh", "_": "t_concrete" },
+      "furniture": { ".": "f_null", "~": "f_null", "_": "f_null" },
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "culvert_west",
+    "object": {
+      "mapgensize": [ 12, 12 ],
+      "rows": [
+        "____        ",
+        ".___        ",
+        "..__        ",
+        "~~~_        ",
+        "~~~_        ",
+        "~~~_        ",
+        "~~~_        ",
+        "~~~_        ",
+        "~~~_        ",
+        "..__        ",
+        ".___        ",
+        "____        "
+      ],
+      "terrain": { ".": "t_region_groundcover", "~": "t_water_moving_sh", "_": "t_concrete" },
+      "furniture": { ".": "f_null", "~": "f_null", "_": "f_null" },
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ]
+    }
+  },
+  {
+    "type": "mapgen",
     "nested_mapgen_id": "16x16_marked_crosswalk_h",
     "object": {
       "mapgensize": [ 16, 16 ],

--- a/data/json/mapgen/road.json
+++ b/data/json/mapgen/road.json
@@ -199,6 +199,8 @@
         { "chunks": [ "12x12_sidewalk_ns_half" ], "x": 0, "y": 12, "flags": { "south_west": [ "SIDEWALK" ] } },
         { "chunks": [ "24x24_sidewalk_ns_long" ], "x": 0, "y": 0, "flags": { "west": [ "SIDEWALK" ] } },
         { "chunks": [ "12x12_sidewalk_ns_half" ], "x": 0, "y": 0, "flags": { "north_west": [ "SIDEWALK" ] } },
+        { "chunks": [ "culvert_west" ], "x": 0, "y": 5, "predecessors": [ "stream" ] },
+        { "chunks": [ "culvert_east" ], "x": 12, "y": 5, "predecessors": [ "stream" ] },
         {
           "chunks": [ "3x3_road_corner_ne" ],
           "x": 1,

--- a/data/json/mapgen/stream.json
+++ b/data/json/mapgen/stream.json
@@ -4,7 +4,6 @@
     "type": "mapgen",
     "weight": 1,
     "object": {
-      "fill_ter": "t_region_groundcover",
       "fallback_predecessor_mapgen": "field",
       "rows": [
         "      22211~~11222      ",
@@ -42,7 +41,6 @@
     "type": "mapgen",
     "weight": 10,
     "object": {
-      "fill_ter": "t_region_groundcover",
       "fallback_predecessor_mapgen": "field",
       "rows": [
         "      22211~~11222      ",
@@ -121,7 +119,6 @@
     "om_terrain": "stream_end",
     "type": "mapgen",
     "object": {
-      "fill_ter": "t_region_groundcover",
       "fallback_predecessor_mapgen": "field",
       "rows": [
         "       222111222        ",
@@ -160,7 +157,6 @@
     "type": "mapgen",
     "weight": 1,
     "object": {
-      "fill_ter": "t_region_groundcover",
       "fallback_predecessor_mapgen": "field",
       "rows": [
         "      22211~~11222      ",
@@ -198,7 +194,6 @@
     "type": "mapgen",
     "weight": 10,
     "object": {
-      "fill_ter": "t_region_groundcover",
       "fallback_predecessor_mapgen": "field",
       "rows": [
         "      22211~~11222      ",
@@ -236,7 +231,6 @@
     "type": "mapgen",
     "weight": 50,
     "object": {
-      "fill_ter": "t_region_groundcover",
       "fallback_predecessor_mapgen": "field",
       "rows": [
         "      22211~~11222      ",

--- a/data/json/overmap/overmap_connections.json
+++ b/data/json/overmap/overmap_connections.json
@@ -4,6 +4,7 @@
     "id": "local_road",
     "subtypes": [
       { "terrain": "road", "locations": [ "road" ], "basic_cost": 0, "flags": [ "ORTHOGONAL" ] },
+      { "terrain": "road", "locations": [ "stream" ], "basic_cost": 30, "flags": [ "ORTHOGONAL" ] },
       { "terrain": "road", "locations": [ "field" ], "basic_cost": 5 },
       { "terrain": "road", "locations": [ "forest" ], "basic_cost": 20 },
       { "terrain": "road", "locations": [ "swamp" ], "basic_cost": 40 },

--- a/data/json/overmap/special_locations.json
+++ b/data/json/overmap/special_locations.json
@@ -11,6 +11,11 @@
   },
   {
     "type": "overmap_location",
+    "id": "stream",
+    "terrains": [ "stream" ]
+  },
+  {
+    "type": "overmap_location",
     "id": "forest_without_trail",
     "terrains": [ "forest", "forest_thick" ]
   },


### PR DESCRIPTION
#### Summary
Features "Roads cross streams at culverts"

#### Purpose of change
Fixes https://github.com/CleverRaven/Cataclysm-DDA/issues/76576

Streams can take up large areas of the overmap, and break road connections, as roads will not generate across overmaps. 

Also don't overwrite predecessor mapgen by specifying fill_ter. Streams through forests now are surrounded by trees.


#### Describe the solution
Allow roads to cross streams and generate culverts where they do.

#### Testing
Generate overmaps and visit some stream/road crossings.
