### PR TITLE
Fix emscripten build

### DIFF
--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -524,7 +524,7 @@ void overmap::unserialize( const JsonObject &jsobj )
                 optional( river_json, false, "control1", control_1, point_om_omt::invalid );
                 optional( river_json, false, "control2", control_2, point_om_omt::invalid );
                 mandatory( river_json, false, "size", size );
-                rivers.push_back( overmap_river_node{ start_point, end_point, control_1, control_2, size } );
+                rivers.push_back( overmap_river_node{ start_point, end_point, control_1, control_2, static_cast<size_t>( size ) } );
             }
         } else if( name == "connections_out" ) {
             om_member.read( connections_out );


### PR DESCRIPTION

#### Summary
None
#### Purpose of change
https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/15501992988/job/43657940029?pr=81195#step:7:457
```
 src/savegame.cpp:527:101: error: non-constant-expression cannot be narrowed from type 'uint64_t' (aka 'unsigned long long') to 'size_t' (aka 'unsigned long') in initializer list [-Wc++11-narrowing]
  527 |                 rivers.push_back( overmap_river_node{ start_point, end_point, control_1, control_2, size } );
      |                                                                                                     ^~~~
src/savegame.cpp:527:101: note: insert an explicit cast to silence this issue
  527 |                 rivers.push_back( overmap_river_node{ start_point, end_point, control_1, control_2, size } );
      |                                                                                                     ^~~~
      |                                                                                                     static_cast<size_t>( )
1 error generated.
```
https://github.com/CleverRaven/Cataclysm-DDA/pull/81087

#### Describe the solution
Use a cast to silence it.

#### Testing
Wait for emscripten build to complete.