### PR TITLE
Fix damage instance deserialize function

### DIFF
--- a/data/json/items/ranged/archery.json
+++ b/data/json/items/ranged/archery.json
@@ -461,7 +461,7 @@
     "description": "A high-powered bow with shaped cams and extra cables for high-velocity shots that can be used effectively by very strong archers.  Currently set to a high weight, and ready to cause some real damage - if you can draw it.",
     "//": "80 lb draw weight, efficient, 0.62 slugs of momentum with a 30g arrow.",
     "min_strength": 11,
-    "ranged_damage": { "damage_type": "stab", "amount": 2 },
+    "ranged_damage": { "damage_type": "stab", "amount": 12 },
     "use_action": {
       "ammo_scale": 0,
       "menu_text": "Loosen Limbs",
@@ -480,7 +480,7 @@
     "description": "A high-powered bow with shaped cams and extra cables for high-velocity shots that can be used effectively by average archers.  Currently set to a low weight, making it much easier to draw.",
     "//": "40 lb draw weight, efficient, 0.45 slugs of momentum with a 30g arrow.",
     "min_strength": 7,
-    "ranged_damage": { "damage_type": "stab", "amount": -3 },
+    "ranged_damage": { "damage_type": "stab", "amount": 7 },
     "use_action": {
       "ammo_scale": 0,
       "menu_text": "Tighten Limbs",

--- a/data/mods/TEST_DATA/items.json
+++ b/data/mods/TEST_DATA/items.json
@@ -5423,6 +5423,27 @@
     "ememory_size": "1 MB"
   },
   {
+    "id": "test_copyfrom_base",
+    "type": "ITEM",
+    "subtypes": [ "GUN" ],
+    "name": { "str": "base" },
+    "description": "copy-from base item",
+    "symbol": "!",
+    "color": "white",
+    "flags": [ "NO_TURRET" ],
+    "volume": "1 L",
+    "weight": "1 kg",
+    "skill": "pistol",
+    "ranged_damage": { "damage_type": "heat", "amount": 3 }
+  },
+  {
+    "id": "test_copyfrom_overwrite",
+    "type": "ITEM",
+    "subtypes": [ "GUN" ],
+    "copy-from": "test_copyfrom_base",
+    "ranged_damage": { "damage_type": "cut", "amount": 5 }
+  },
+  {
     "id": "carver_off_test",
     "type": "ITEM",
     "subtypes": [ "TOOL" ],

--- a/src/damage.cpp
+++ b/src/damage.cpp
@@ -636,6 +636,8 @@ void damage_instance::deserialize( const JsonValue &val )
         return du;
     };
 
+    // reset before loading, in case this has already been used
+    clear();
     if( val.test_object() ) {
         add( read_damage_unit( val.get_object() ) );
     } else if( val.test_array() ) {

--- a/tests/json_load_test.cpp
+++ b/tests/json_load_test.cpp
@@ -8,7 +8,7 @@ static const damage_type_id damage_heat( "heat" );
 static const itype_id itype_test_copyfrom_base( "test_copyfrom_base" );
 static const itype_id itype_test_copyfrom_overwrite( "test_copyfrom_overwrite" );
 
-TEST_CASE( "damage_instance load does not extend", "[json][damage][load]" )
+TEST_CASE( "damage_instance_load_does_not_extend", "[json][damage][load]" )
 {
     REQUIRE( itype_test_copyfrom_base.is_valid() );
     REQUIRE( itype_test_copyfrom_overwrite.is_valid() );

--- a/tests/json_load_test.cpp
+++ b/tests/json_load_test.cpp
@@ -1,0 +1,34 @@
+#include "damage.h"
+#include "cata_catch.h"
+#include "itype.h"
+
+static const damage_type_id damage_cut( "cut" );
+static const damage_type_id damage_heat( "heat" );
+
+static const itype_id itype_test_copyfrom_base( "test_copyfrom_base" );
+static const itype_id itype_test_copyfrom_overwrite( "test_copyfrom_overwrite" );
+
+TEST_CASE( "damage_instance load does not extend", "[json][damage][load]" )
+{
+    REQUIRE( itype_test_copyfrom_base.is_valid() );
+    REQUIRE( itype_test_copyfrom_overwrite.is_valid() );
+
+
+    REQUIRE( itype_test_copyfrom_base->gun );
+    REQUIRE( itype_test_copyfrom_overwrite->gun );
+
+    const damage_instance &base = itype_test_copyfrom_base->gun->damage;
+    const damage_instance &overwrite = itype_test_copyfrom_overwrite->gun->damage;
+    REQUIRE_FALSE( base.empty() );
+    REQUIRE_FALSE( overwrite.empty() );
+
+    CHECK_FALSE( base == overwrite );
+
+    CHECK( base.total_damage() == 3.f );
+    CHECK( base.type_damage( damage_heat ) == 3.f );
+    CHECK( base.type_damage( damage_cut ) == 0.f );
+
+    CHECK( overwrite.total_damage() == 5.f );
+    CHECK( overwrite.type_damage( damage_cut ) == 5.f );
+    CHECK( overwrite.type_damage( damage_heat ) == 0.f );
+}


### PR DESCRIPTION
#### Summary
Bugfixes "Fix ranged_damage automatically extending"

#### Purpose of change
https://github.com/CleverRaven/Cataclysm-DDA/pull/81198

#### Describe the solution
Ensure it resets the damage instance, instead of simply adding what was read to it.
Reverts https://github.com/CleverRaven/Cataclysm-DDA/pull/80787

#### Testing
![image](https://github.com/user-attachments/assets/b829ff0a-0c6b-4262-b11f-cfc116454527)
