### PR TITLE
[Magiclysm] Rework Manatouched's glow mutations

### DIFF
--- a/data/mods/Magiclysm/effect_on_conditions/mutation_eocs.json
+++ b/data/mods/Magiclysm/effect_on_conditions/mutation_eocs.json
@@ -260,6 +260,69 @@
   },
   {
     "type": "effect_on_condition",
+    "id": "EOC_MANA_FLASH_SPELLCASTING_FINISH",
+    "eoc_type": "EVENT",
+    "required_event": "spellcasting_finish",
+    "condition": {
+      "and": [
+        {
+          "or": [
+            { "compare_string": [ "NONE", { "context_val": "school" } ] },
+            { "compare_string": [ "ANIMIST", { "context_val": "school" } ] },
+            { "compare_string": [ "BIOMANCER", { "context_val": "school" } ] },
+            { "compare_string": [ "DRUID", { "context_val": "school" } ] },
+            { "compare_string": [ "EARTHSHAPER", { "context_val": "school" } ] },
+            { "compare_string": [ "KELVINIST", { "context_val": "school" } ] },
+            { "compare_string": [ "MAGUS", { "context_val": "school" } ] },
+            { "compare_string": [ "STORMSHAPER", { "context_val": "school" } ] },
+            { "compare_string": [ "TECHNOMANCER", { "context_val": "school" } ] },
+            { "compare_string": [ "ALCHEMIST", { "context_val": "school" } ] },
+            { "compare_string": [ "ARTIFICER", { "context_val": "school" } ] },
+            { "compare_string": [ "BIOTEK", { "context_val": "school" } ] },
+            { "compare_string": [ "BLOOD_MAGE", { "context_val": "school" } ] },
+            { "compare_string": [ "BOREAL_MAGE", { "context_val": "school" } ] },
+            { "compare_string": [ "CLEANSING_FLAME", { "context_val": "school" } ] },
+            { "compare_string": [ "CRUSADER", { "context_val": "school" } ] },
+            { "compare_string": [ "EARTH_ELEMENTAL", { "context_val": "school" } ] },
+            { "compare_string": [ "FIRE_ELEMENTAL", { "context_val": "school" } ] },
+            { "compare_string": [ "FORCE_MAGE", { "context_val": "school" } ] },
+            { "compare_string": [ "GAIAS_CHOSEN", { "context_val": "school" } ] },
+            { "compare_string": [ "GOLEMANCER", { "context_val": "school" } ] },
+            { "compare_string": [ "GLACIER_MAGE", { "context_val": "school" } ] },
+            { "compare_string": [ "GRAVITY_MAGE", { "context_val": "school" } ] },
+            { "compare_string": [ "ICE_ELEMENTAL", { "context_val": "school" } ] },
+            { "compare_string": [ "ILLUSIONIST", { "context_val": "school" } ] },
+            { "compare_string": [ "MAGNETISM_MAGE", { "context_val": "school" } ] },
+            { "compare_string": [ "OVERCLOCKER", { "context_val": "school" } ] },
+            { "compare_string": [ "PERMAFROST_MAGE", { "context_val": "school" } ] },
+            { "compare_string": [ "RADIATION_MAGE", { "context_val": "school" } ] },
+            { "compare_string": [ "SHAMAN", { "context_val": "school" } ] },
+            { "compare_string": [ "SHAPESHIFTER", { "context_val": "school" } ] },
+            { "compare_string": [ "SOULFIRE", { "context_val": "school" } ] },
+            { "compare_string": [ "STORM_ELEMENTAL", { "context_val": "school" } ] },
+            { "compare_string": [ "STORMCALLER", { "context_val": "school" } ] },
+            { "compare_string": [ "SUN_MAGE", { "context_val": "school" } ] },
+            { "compare_string": [ "TUNDRA_MAGE", { "context_val": "school" } ] },
+            { "compare_string": [ "VOID_MAGE", { "context_val": "school" } ] },
+            { "compare_string": [ "VULCANIST", { "context_val": "school" } ] },
+            { "compare_string": [ "WITHER_MAGE", { "context_val": "school" } ] }
+          ]
+        },
+        { "u_has_trait": "MANA_LUM_FLASH" }
+      ]
+    },
+    "effect": [
+      {
+        "if": { "x_in_y_chance": { "x": 1, "y": 100 } },
+        "then": [
+          { "u_add_effect": "effect_manatouched_mana_flash_active", "duration": { "math": [ "5 * _difficulty * rng(0.5,2)" ] } },
+          { "u_message": "Your ley lines flare up!", "type": "mixed" }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
     "id": "EOC_MANA_LUM_EXTERNAL_SPELLCASTING_FINISH",
     "eoc_type": "EVENT",
     "required_event": "spellcasting_finish",

--- a/data/mods/Magiclysm/effect_on_conditions/mutation_eocs.json
+++ b/data/mods/Magiclysm/effect_on_conditions/mutation_eocs.json
@@ -241,5 +241,84 @@
         }
       }
     ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_MANA_LUM_EXTERNAL_RANDOM_TRIGGER",
+    "recurrence": [ "1 hours", "12 hours" ],
+    "condition": { "u_has_trait": "MANA_LUM_EXTERNAL" },
+    "deactivate_condition": { "not": { "u_has_trait": "MANA_LUM_EXTERNAL" } },
+    "effect": [
+      {
+        "if": { "x_in_y_chance": { "x": { "math": [ "u_val('mana')" ] }, "y": { "math": [ "u_val('mana_max') * 0.75" ] } } },
+        "then": [
+          { "u_add_effect": "effect_manatouched_external_mana_luminance", "duration": [ "5 minutes", "15 minutes" ] },
+          { "u_message": "The air around you suddenly shimmers with a lambent glow.", "type": "mixed" }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_MANA_LUM_EXTERNAL_SPELLCASTING_FINISH",
+    "eoc_type": "EVENT",
+    "required_event": "spellcasting_finish",
+    "condition": {
+      "and": [
+        {
+          "or": [
+            { "compare_string": [ "NONE", { "context_val": "school" } ] },
+            { "compare_string": [ "ANIMIST", { "context_val": "school" } ] },
+            { "compare_string": [ "BIOMANCER", { "context_val": "school" } ] },
+            { "compare_string": [ "DRUID", { "context_val": "school" } ] },
+            { "compare_string": [ "EARTHSHAPER", { "context_val": "school" } ] },
+            { "compare_string": [ "KELVINIST", { "context_val": "school" } ] },
+            { "compare_string": [ "MAGUS", { "context_val": "school" } ] },
+            { "compare_string": [ "STORMSHAPER", { "context_val": "school" } ] },
+            { "compare_string": [ "TECHNOMANCER", { "context_val": "school" } ] },
+            { "compare_string": [ "ALCHEMIST", { "context_val": "school" } ] },
+            { "compare_string": [ "ARTIFICER", { "context_val": "school" } ] },
+            { "compare_string": [ "BIOTEK", { "context_val": "school" } ] },
+            { "compare_string": [ "BLOOD_MAGE", { "context_val": "school" } ] },
+            { "compare_string": [ "BOREAL_MAGE", { "context_val": "school" } ] },
+            { "compare_string": [ "CLEANSING_FLAME", { "context_val": "school" } ] },
+            { "compare_string": [ "CRUSADER", { "context_val": "school" } ] },
+            { "compare_string": [ "EARTH_ELEMENTAL", { "context_val": "school" } ] },
+            { "compare_string": [ "FIRE_ELEMENTAL", { "context_val": "school" } ] },
+            { "compare_string": [ "FORCE_MAGE", { "context_val": "school" } ] },
+            { "compare_string": [ "GAIAS_CHOSEN", { "context_val": "school" } ] },
+            { "compare_string": [ "GOLEMANCER", { "context_val": "school" } ] },
+            { "compare_string": [ "GLACIER_MAGE", { "context_val": "school" } ] },
+            { "compare_string": [ "GRAVITY_MAGE", { "context_val": "school" } ] },
+            { "compare_string": [ "ICE_ELEMENTAL", { "context_val": "school" } ] },
+            { "compare_string": [ "ILLUSIONIST", { "context_val": "school" } ] },
+            { "compare_string": [ "MAGNETISM_MAGE", { "context_val": "school" } ] },
+            { "compare_string": [ "OVERCLOCKER", { "context_val": "school" } ] },
+            { "compare_string": [ "PERMAFROST_MAGE", { "context_val": "school" } ] },
+            { "compare_string": [ "RADIATION_MAGE", { "context_val": "school" } ] },
+            { "compare_string": [ "SHAMAN", { "context_val": "school" } ] },
+            { "compare_string": [ "SHAPESHIFTER", { "context_val": "school" } ] },
+            { "compare_string": [ "SOULFIRE", { "context_val": "school" } ] },
+            { "compare_string": [ "STORM_ELEMENTAL", { "context_val": "school" } ] },
+            { "compare_string": [ "STORMCALLER", { "context_val": "school" } ] },
+            { "compare_string": [ "SUN_MAGE", { "context_val": "school" } ] },
+            { "compare_string": [ "TUNDRA_MAGE", { "context_val": "school" } ] },
+            { "compare_string": [ "VOID_MAGE", { "context_val": "school" } ] },
+            { "compare_string": [ "VULCANIST", { "context_val": "school" } ] },
+            { "compare_string": [ "WITHER_MAGE", { "context_val": "school" } ] }
+          ]
+        },
+        { "u_has_trait": "MANA_LUM_EXTERNAL" }
+      ]
+    },
+    "effect": [
+      {
+        "if": { "x_in_y_chance": { "x": { "math": [ "u_val('mana')" ] }, "y": { "math": [ "u_val('mana_max') * 10" ] } } },
+        "then": [
+          { "u_add_effect": "effect_manatouched_external_mana_luminance", "duration": [ "5 minutes", "15 minutes" ] },
+          { "u_message": "The air around you suddenly shimmers with a lambent glow.", "type": "mixed" }
+        ]
+      }
+    ]
   }
 ]

--- a/data/mods/Magiclysm/effect_on_conditions/mutation_eocs.json
+++ b/data/mods/Magiclysm/effect_on_conditions/mutation_eocs.json
@@ -313,7 +313,7 @@
     },
     "effect": [
       {
-        "if": { "x_in_y_chance": { "x": { "math": [ "u_val('mana')" ] }, "y": { "math": [ "u_val('mana_max') * 10" ] } } },
+        "if": { "x_in_y_chance": { "x": { "math": [ "u_val('mana')" ] }, "y": { "math": [ "u_val('mana_max') * 15" ] } } },
         "then": [
           { "u_add_effect": "effect_manatouched_external_mana_luminance", "duration": [ "5 minutes", "15 minutes" ] },
           { "u_message": "The air around you suddenly shimmers with a lambent glow.", "type": "mixed" }

--- a/data/mods/Magiclysm/effects/effects.json
+++ b/data/mods/Magiclysm/effects/effects.json
@@ -1936,7 +1936,7 @@
   {
     "type": "effect_type",
     "id": "effect_manatouched_external_mana_luminance",
-    "name": [ "Eerie Glow" ],
+    "name": [ "Eldritch Glow" ],
     "desc": [ "The air around you shimmers in a multitude of colors." ],
     "enchantments": [
       {

--- a/data/mods/Magiclysm/effects/effects.json
+++ b/data/mods/Magiclysm/effects/effects.json
@@ -1934,6 +1934,17 @@
     ]
   },
   {
+    "type": "effect_type",
+    "id": "effect_manatouched_external_mana_luminance",
+    "name": [ "Eerie Glow" ],
+    "desc": [ "The air around you shimmers in a multitude of colors." ],
+    "enchantments": [
+      {
+        "values": [ { "value": "LUMINATION", "add": { "math": [ "min( (u_sum_traits_of_category_char_has('MANATOUCHED') * 3), 50)" ] } } ]
+      }
+    ]
+  },
+  {
     "id": "effect_dispel_magic",
     "type": "effect_type",
     "name": [ "Dispel Magic" ],

--- a/data/mods/Magiclysm/effects/effects.json
+++ b/data/mods/Magiclysm/effects/effects.json
@@ -1935,6 +1935,13 @@
   },
   {
     "type": "effect_type",
+    "id": "effect_manatouched_mana_flash_active",
+    "//": "Duration tracker, empty to hide effect",
+    "name": [ "" ],
+    "desc": [ "" ]
+  },
+  {
+    "type": "effect_type",
     "id": "effect_manatouched_external_mana_luminance",
     "name": [ "Eldritch Glow" ],
     "desc": [ "The air around you shimmers in a multitude of colors." ],

--- a/data/mods/Magiclysm/mutations/mutation_paths/manatouched.json
+++ b/data/mods/Magiclysm/mutations/mutation_paths/manatouched.json
@@ -112,10 +112,22 @@
     "id": "MANA_LUM",
     "name": { "str": "Mana Luminance" },
     "points": 0,
+    "mixed_effect": true,
     "bodytemp_modifiers": [ 100, 100 ],
-    "description": "Your body discards unusable mana as light and heat, making you glow softly.",
+    "description": "The constant thrum of mana makes your ley lines visibly glow beneath your skin, shedding a small amount of light.  However, it also makes you slightly warmer.",
     "category": [ "MANATOUCHED" ],
-    "lumination": [ [ "torso", 8 ] ]
+    "lumination": [ [ "torso", 3 ], [ "arm_l", 3 ], [ "arm_r", 3 ], [ "leg_l", 3 ], [ "leg_r", 3 ] ]
+  },
+  {
+    "type": "mutation",
+    "id": "MANA_LUM_EXTERNAL",
+    "name": { "str": "Eerie Glow" },
+    "points": -3,
+    "description": "Your mana sometimes swirls off your leylines and excites the air, creating a eldritch glow around you, occasionally happening when you cast or a spell or when your mana is high enough.  All you can do when it happens is wait for it to subside.",
+    "prereqs": [ "MANA_LUM" ],
+    "prereqs2": [ "MANA_SIPHON_1", "MANA_SIPHON_2", "MANA_SIPHON_3" ],
+    "category": [ "MANATOUCHED" ],
+    "threshreq": [ "THRESH_MANA" ]
   },
   {
     "type": "mutation",
@@ -130,12 +142,6 @@
     "type": "mutation",
     "id": "ALBINO",
     "copy-from": "ALBINO",
-    "extend": { "category": [ "MANATOUCHED" ] }
-  },
-  {
-    "type": "mutation",
-    "id": "BIOLUM0",
-    "copy-from": "BIOLUM0",
     "extend": { "category": [ "MANATOUCHED" ] }
   },
   {

--- a/data/mods/Magiclysm/mutations/mutation_paths/manatouched.json
+++ b/data/mods/Magiclysm/mutations/mutation_paths/manatouched.json
@@ -121,11 +121,11 @@
   {
     "type": "mutation",
     "id": "MANA_LUM_EXTERNAL",
-    "name": { "str": "Eerie Glow" },
+    "name": { "str": "Eldritch Glow" },
     "points": -3,
     "description": "Your mana sometimes swirls off your leylines and excites the air, creating a eldritch glow around you, occasionally happening when you cast or a spell or when your mana is high enough.  All you can do when it happens is wait for it to subside.",
     "prereqs": [ "MANA_LUM" ],
-    "prereqs2": [ "MANA_SIPHON_1", "MANA_SIPHON_2", "MANA_SIPHON_3" ],
+    "prereqs2": [ "MANA_SIPHON_1", "MANA_SIPHON_2" ],
     "category": [ "MANATOUCHED" ],
     "threshreq": [ "THRESH_MANA" ]
   },
@@ -224,6 +224,7 @@
     "threshreq": [ "THRESH_MANA", "THRESH_DRAGON_BLACK" ],
     "types": [ "MANA_SIPHON" ],
     "prereqs": [ "MANA_SIPHON_2" ],
+    "prereqs2": [ "MANA_LUM_EXTERNAL", "DRAGON_MAGIC", "DRAGON_SPELLS" ],
     "enchantments": [ "ench_mana_siphon_3" ]
   },
   {

--- a/data/mods/Magiclysm/mutations/mutation_paths/manatouched.json
+++ b/data/mods/Magiclysm/mutations/mutation_paths/manatouched.json
@@ -114,9 +114,44 @@
     "points": 0,
     "mixed_effect": true,
     "bodytemp_modifiers": [ 100, 100 ],
-    "description": "The constant thrum of mana makes your ley lines visibly glow beneath your skin, shedding a small amount of light.  However, it also makes you slightly warmer.",
+    "description": "The constant thrum of mana makes your ley lines visibly glow beneath the skin of your torso and limbs, shedding a small amount of light.  However, it also makes you slightly warmer.",
     "category": [ "MANATOUCHED" ],
     "lumination": [ [ "torso", 3 ], [ "arm_l", 3 ], [ "arm_r", 3 ], [ "leg_l", 3 ], [ "leg_r", 3 ] ]
+  },
+  {
+    "type": "mutation",
+    "id": "MANA_LUM_FLASH",
+    "name": { "str": "Mana Flares" },
+    "points": -1,
+    "description": "Casting a spell sometimes causes your mana to grow overexcited, making the normally-dim glow of your ley lines much brighter.  This extends the glow to your entire body.",
+    "prereqs": [ "MANA_LUM" ],
+    "prereqs2": [ "MANA_REGEN2", "MANA_REGEN_MANATOUCHED" ],
+    "category": [ "MANATOUCHED" ],
+    "enchantments": [
+      { "condition": { "u_has_effect": "effect_manatouched_mana_flash_active" }, "mutations": [ "MANA_LUM_FLASH_ACTIVE" ] }
+    ]
+  },
+  {
+    "type": "mutation",
+    "id": "MANA_LUM_FLASH_ACTIVE",
+    "name": { "str": "Mana Flares Active", "//~": "NO_I18N" },
+    "points": -1,
+    "description": { "str": "Mana Flares Active", "//~": "NO_I18N" },
+    "valid": false,
+    "player_display": false,
+    "category": [ "MANATOUCHED" ],
+    "lumination": [
+      [ "head", 15 ],
+      [ "torso", 15 ],
+      [ "arm_l", 15 ],
+      [ "arm_r", 15 ],
+      [ "hand_l", 15 ],
+      [ "hand_r", 15 ],
+      [ "leg_l", 15 ],
+      [ "leg_r", 15 ],
+      [ "foot_l", 15 ],
+      [ "foot_r", 15 ]
+    ]
   },
   {
     "type": "mutation",
@@ -124,7 +159,7 @@
     "name": { "str": "Eldritch Glow" },
     "points": -3,
     "description": "Your mana sometimes swirls off your leylines and excites the air, creating a eldritch glow around you, occasionally happening when you cast or a spell or when your mana is high enough.  All you can do when it happens is wait for it to subside.",
-    "prereqs": [ "MANA_LUM" ],
+    "prereqs": [ "MANA_LUM_FLASH" ],
     "prereqs2": [ "MANA_SIPHON_1", "MANA_SIPHON_2" ],
     "category": [ "MANATOUCHED" ],
     "threshreq": [ "THRESH_MANA" ]

--- a/data/mods/Magiclysm/mutations/mutations.json
+++ b/data/mods/Magiclysm/mutations/mutations.json
@@ -37,6 +37,7 @@
       "MANA_SUBTLE_SPELL",
       "MANA_SILENT_SPELL",
       "MANA_LUM",
+      "MANA_LUM_EXTERNAL",
       "OVERLY_ACID_GUT",
       "DRAGON_BREATH_BLACK",
       "DRAGON_SPELLS",

--- a/data/mods/Magiclysm/mutations/mutations.json
+++ b/data/mods/Magiclysm/mutations/mutations.json
@@ -37,6 +37,7 @@
       "MANA_SUBTLE_SPELL",
       "MANA_SILENT_SPELL",
       "MANA_LUM",
+      "MANA_LUM_FLASH",
       "MANA_LUM_EXTERNAL",
       "OVERLY_ACID_GUT",
       "DRAGON_BREATH_BLACK",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Magiclysm] Rework Manatouched's glow mutations"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Manatouched popping out an anglerfish bulb is pretty weird and unthematic, honestly. I assume it happened because back then there weren't a lot of ways to have random glows. 

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Remove `Reflex Photophore` from Manatouched.

Rework `Mana Luminance`. It now applies to every major body part except the head, requiring you fully cover your body--perhaps, in something like a wizard robe--to avoid the light. It doesn't apply to the hands or feet, just the torso, arms, and legs. The idea is that you have visible leylines glowing beneath your skin.

Add `Mana Flares`, which adds a small chance when you cast a spell that your ley lines grow overexcited, making the normally dim glow much brighter. This also extends the glow to all your body parts, including hands, feet, and head. This requires `Mana Luminance` and the 2nd tier Mana Regeneration mutation.

Add the `Eldritch Glow` trait, branching off of `Mana Flares`, which requires it and `Mana Siphon` or `Mana Drain` and which is now a prerequisite for `Mana Vortex` (Black Dragons instead have the `Draconic Magic` traits fulfill this prerequisite). Eldritch Glow has a chance equal to you (your current mana) out of (your maximum mana * 15) to go off every time you cast a spell, and every up to 12 hours regardless--the chance then is (your current mana) out of (your maximum mana * 0.75). When it goes off, the air around you glows with strength (total Manatouched mutations * 3), max of 45. for 5 to 15 minutes.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Checked, it works.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

There seems to be a bug with head luminance but everything else works
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
