### PR TITLE
Fix not removing consumed faction camp calories

### DIFF
--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -6130,12 +6130,19 @@ nutrients faction_template::consume_food_supply( const nutrients &consumed )
         // whatever remains was not consumed
         return to_supply;
     }
-    for( auto it = _food_supply.begin(); it != _food_supply.end(); ++it ) {
+    for( auto it = _food_supply.begin(); it != _food_supply.end(); ) {
         // start by skipping the non-perishable food
         if( it == _food_supply.begin() ) {
+            ++it;
             continue;
         }
         it->second = consume_left_behind( to_supply, it->second );
+        // remove consumed entries
+        if( it->second.calories == 0 && it->second.vitamins().empty() ) {
+            it = _food_supply.erase( it );
+        } else {
+            ++it;
+        }
         if( to_supply.calories == 0 && to_supply.vitamins().empty() ) {
             break;
         }


### PR DESCRIPTION
#### Summary
Bugfixes "Remove consumed faction camp calorie stores instead of leaving zombie entries"

#### Purpose of change
This got lost when shuffling code around to use the consume_left_behind function.

https://github.com/CleverRaven/Cataclysm-DDA/pull/81189 fixed the player-visible bug, but I meant to remove entries that were empty, which is why the iterator increment was missing.

#### Describe the solution
Increment the iterator by deleting the entry if it's empty, otherwise normally increment.