### PR TITLE
Separate out mission searches for existing globally uniques

### DIFF
--- a/data/json/npcs/exodii/common_talk.json
+++ b/data/json/npcs/exodii/common_talk.json
@@ -107,7 +107,9 @@
     "goal": "MGOAL_GO_TO",
     "difficulty": 2,
     "value": 0,
-    "start": { "assign_mission_target": { "om_special": "Strange warehouse", "om_terrain": "exo_warehouse_1", "reveal_radius": 2 } },
+    "start": {
+      "assign_mission_target": { "om_special": "Strange warehouse", "om_terrain": "exo_warehouse_1", "reveal_radius": 2, "z": 0 }
+    },
     "origins": [ "ORIGIN_SECONDARY" ],
     "dialogue": {
       "describe": ".",

--- a/src/mission_util.cpp
+++ b/src/mission_util.cpp
@@ -197,6 +197,11 @@ static std::optional<tripoint_abs_omt> find_or_create_om_terrain(
     find_params.cant_see = params.cant_see;
     find_params.existing_only = true;
 
+    if( overmap_buffer.contains_unique_special( static_cast<overmap_special_id>(
+                ( *params.overmap_special ).evaluate( d ) ) ) ) {
+        return overmap_buffer.find_existing_globally_unique( origin_pos, find_params );
+    }
+
     auto get_target_position = [&]() {
         // Either find a random or closest match, based on the criteria.
         if( params.random ) {

--- a/src/mission_util.cpp
+++ b/src/mission_util.cpp
@@ -197,11 +197,15 @@ static std::optional<tripoint_abs_omt> find_or_create_om_terrain(
     find_params.cant_see = params.cant_see;
     find_params.existing_only = true;
 
-    if( overmap_buffer.contains_unique_special( static_cast<overmap_special_id>(
-                ( *params.overmap_special ).evaluate( d ) ) ) ) {
-        return overmap_buffer.find_existing_globally_unique( origin_pos, find_params );
-    }
+    if( params.overmap_special.has_value() ) {
+        const overmap_special_id special_id = static_cast<overmap_special_id>(
+                ( *params.overmap_special ).evaluate( d ) );
 
+        if( overmap_buffer.contains_unique_special( special_id ) ) {
+            find_params.om_special = special_id;
+            return overmap_buffer.find_existing_globally_unique( origin_pos, find_params );
+        }
+    }
     auto get_target_position = [&]() {
         // Either find a random or closest match, based on the criteria.
         if( params.random ) {

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -1253,20 +1253,15 @@ tripoint_abs_omt overmapbuffer::find_existing_globally_unique( const tripoint_ab
     const tripoint_abs_om center = coords::project_to<coords::om>( origin );
 
     // Very long range which will take forever if filled. Max is an arbitrary number.
+    const overmap_special_id special_id = params.om_special.value();
     for( point_abs_om om : closest_points_first( center.xy(), 0, 100 ) ) {
         if( has( om ) ) {
-            const point_abs_omt omt_base = coords::project_to<coords::omt>( om );
+            overmap &om_data = get( om );
 
-            for( int i = 0; i < OMAPX; i ++ ) {
-                for( int k = 0; k < OMAPY; k++ ) {
-                    for( int z = params.min_z; z <= params.max_z; z++ ) {
-                        const tripoint_abs_omt loc( omt_base + tripoint_rel_omt{i, k, z} );
-
-                        if( is_findable_location( loc, params ) ) {
-                            return loc;
-                        }
-                    }
-
+            for( auto element : om_data.overmap_special_placements ) {
+                if( element.second == special_id ) {
+                    tripoint_om_omt local = element.first;
+                    return coords::project_to<coords::omt>( om ) + local.raw();
                 }
             }
         }

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -1257,11 +1257,14 @@ tripoint_abs_omt overmapbuffer::find_existing_globally_unique( const tripoint_ab
     for( point_abs_om om : closest_points_first( center.xy(), 0, 100 ) ) {
         if( has( om ) ) {
             overmap &om_data = get( om );
+            point_abs_omt om_base = coords::project_to<coords::omt>(om);
 
-            for( auto element : om_data.overmap_special_placements ) {
+            for( auto &element : om_data.overmap_special_placements ) {
                 if( element.second == special_id ) {
-                    tripoint_om_omt local = element.first;
-                    return coords::project_to<coords::omt>( om ) + local.raw();
+                    const tripoint_abs_omt loc = om_base + element.first.raw();
+                    if (is_findable_location(loc, params)) {
+                        return loc;
+                    }
                 }
             }
         }

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -1257,12 +1257,12 @@ tripoint_abs_omt overmapbuffer::find_existing_globally_unique( const tripoint_ab
     for( point_abs_om om : closest_points_first( center.xy(), 0, 100 ) ) {
         if( has( om ) ) {
             overmap &om_data = get( om );
-            point_abs_omt om_base = coords::project_to<coords::omt>(om);
+            point_abs_omt om_base = coords::project_to<coords::omt>( om );
 
             for( auto &element : om_data.overmap_special_placements ) {
                 if( element.second == special_id ) {
                     const tripoint_abs_omt loc = om_base + element.first.raw();
-                    if (is_findable_location(loc, params)) {
+                    if( is_findable_location( loc, params ) ) {
                         return loc;
                     }
                 }

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -1241,6 +1241,40 @@ tripoint_abs_omt overmapbuffer::find_closest( const tripoint_abs_omt &origin,
     return random_entry( result, tripoint_abs_omt::invalid );
 }
 
+tripoint_abs_omt overmapbuffer::find_existing_globally_unique( const tripoint_abs_omt &origin,
+        const omt_find_params &params )
+{
+    // Should only be called if the target is present in the set of placed globally unique specials.
+
+    //TODO: Update the globally unique set to contain positions and add code here
+    // to return that position and only fall through to the search code below if the position is
+    // invalid (because the entry is converted from an earlier version where the position wasn't
+    // recorded).
+    const tripoint_abs_om center = coords::project_to<coords::om>( origin );
+
+    // Very long range which will take forever if filled. Max is an arbitrary number.
+    for( point_abs_om om : closest_points_first( center.xy(), 0, 100 ) ) {
+        if( has( om ) ) {
+            const point_abs_omt omt_base = coords::project_to<coords::omt>( om );
+
+            for( int i = 0; i < OMAPX; i ++ ) {
+                for( int k = 0; k < OMAPY; k++ ) {
+                    for( int z = params.min_z; z <= params.max_z; z++ ) {
+                        const tripoint_abs_omt loc( omt_base + tripoint_rel_omt{i, k, z} );
+
+                        if( is_findable_location( loc, params ) ) {
+                            return loc;
+                        }
+                    }
+
+                }
+            }
+        }
+    }
+
+    return tripoint_abs_omt::invalid;
+}
+
 std::vector<tripoint_abs_omt> overmapbuffer::find_all( const tripoint_abs_omt &origin,
         const omt_find_params &params )
 {

--- a/src/overmapbuffer.h
+++ b/src/overmapbuffer.h
@@ -391,6 +391,8 @@ class overmapbuffer
             const tripoint_abs_omt &origin, const std::string &type, int radius, bool must_be_seen,
             ot_match_type match_type = ot_match_type::type, bool existing_overmaps_only = false,
             const std::optional<overmap_special_id> &om_special = std::nullopt );
+        tripoint_abs_omt find_existing_globally_unique( const tripoint_abs_omt &origin,
+                const omt_find_params &params );
 
         /* These functions return the overmap that contains the given
          * overmap terrain coordinate, and the local coordinates of that point


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Allow missions to existing globally unique locations to search intelligently by only searching generated OMs and by not being restricted by a range restriction (except for a hard coded arbitrary huge one).
Also stop useless searching for the exodii warehouse on Z levels other than 0.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
- Check whether a target is an existing globally unique special.
- If so call a dedicated search operation for this case that:
  - Iterates over nearest OMs up to an arbitrary range of 100.
  - Ignores OMs that haven't been generated, as a generated location cannot exist there.
  - Search the OM data to find a matching special's location with a matching omt tile.
  - Returns that location once found (it's unique, so there's no need for a list and then a selection an entry).
- Update the JSON for the real exodii warehouse mission to restrict the search to Z = 0, which is the only possible level.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
- Also trying to update the set of globally unique specials to contain their locations, allowing for just a search in this list. That's better put off to another PR.
- Trying to integrate the globally unique search into the regular one. I had a bail out before the second stage (try to create location), but that's not needed when existing globally uniques are handled by a separate operation.
- Trying to get a handle on the cost of usage of the operation that returns locations in distance order. The test case finds the test case unique at a range of 580 (just beyond the default range) in 5 seconds, while the failing search (with a creation bailout) takes about 55 minutes. This seems fishy.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
I've got a save where my PC can ask a logger for directions to the exodii warehouse, and it seems to reliably to for the real one, failing after about 2 hours. Changing the mission JSON to only search Z level = 0 cuts about 15 minutes of the time to failure.
With the code changes, I get a match in a few seconds, and teleporting to that location had the PC ending up in a structure which most likely is the correct one.

I haven't been able to come up with tests of other targets to verify the changes don't screw up those. Getting missions for testing purposes isn't exactly the easiest thing to do.

Edit:
I just tried this code with an unpacked compressed save, and it fails after a couple of minutes (i.e. generates a mission with no target). That shouldn't be a surprise, given that compression discards the overmap information, as far as I understand, so the code goes through a lot of overmaps to find the location, only to fail because almost no OMs remain. I don't think that's a serious flaw, as a lot of things are off if you try to use a compressed save for actual game play.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
I'm quite surprised how quick the search is, as it's just doing the same thing as the regular search with some optimizations possible (ignore non generated OMs, which I don't think are numerous, and skipping the nearest sorting of a very large number of OMTs (while still sorting a much smaller number of OMs by distance). Something doesn't seem to add up.

Edit: The implementation was changed to rely on the overmap's list of specials, as globally uniques within the OM reside there, together with their OM relative coordinates (the previous version did a search of all tiles of the OM, which worked).
The "list" contains all the tiles of the special, so it's then a matter of finding the first matching one (it's possible to have more than one instance of a tile within a single special).

Also note that the presence of an overmap specials list might be used to search for other specials instead of searching positions with the OM. Such exploration is outside of the scope of this PR, though.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
