### PR TITLE
Update npctalk.cpp for blindness

### DIFF
--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -1766,6 +1766,8 @@ std::string dialogue::dynamic_line( const talk_topic &the_topic )
     } else if( topic == "TALK_TRAIN" ) {
         if( !player_character.backlog.empty() && player_character.backlog.front().id() == ACT_TRAIN ) {
             return _( "Shall we resume?" );
+        } else if ( !actor( false )->can_see()) {
+            return _( "Sorry, I'm not sure how to teach the blind." );
         } else if( actor( true )->skills_offered_to( *actor( false ) ).empty() &&
                    actor( true )->styles_offered_to( *actor( false ) ).empty() &&
                    actor( true )->spells_offered_to( *actor( false ) ).empty() &&
@@ -1978,6 +1980,10 @@ void dialogue::gen_responses( const talk_topic &the_topic )
             add_response_none( _( "Oh, okay." ) );
             return;
         }
+        if (!actor( false )->can_see()) {
+           add_response_none( _( "You're not sure how to teach them while blind." ) );
+           return;
+        }
         for( const spell_id &sp : spells ) {
             const std::string &text =
                 string_format( "%s: %s", _( "Spell" ), actor( false )->spell_training_text( *actor( true ), sp ) );
@@ -2015,6 +2021,10 @@ void dialogue::gen_responses( const talk_topic &the_topic )
         const std::vector<spell_id> &splist = actor( true )->spells_teacheable();
         if( sklist.empty() && prlist.empty() && malist.empty() && splist.empty() ) {
             add_response_none( _( "Oh, okay." ) );
+            return;
+        }
+        if (!actor(false)->can_see()) {
+            add_response_none( _("You wish you could see what they're doing.") );
             return;
         }
         for( const skill_id &sk : sklist ) {
@@ -2071,6 +2081,11 @@ void dialogue::gen_responses( const talk_topic &the_topic )
                 add_response( string_format( _( "Yes, let's resume training %s" ), skillt->name() ),
                               "TALK_TRAIN_START", skillt );
             }
+        }
+
+        if (!actor(false)->can_see()) {
+            add_response_none( _("Oh, okay."));
+            return;
         }
         const std::vector<matype_id> &styles = actor( true )->styles_offered_to( *actor( false ) );
         const std::vector<skill_id> &trainable = actor( true )->skills_offered_to( *actor( false ) );

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -2023,10 +2023,6 @@ void dialogue::gen_responses( const talk_topic &the_topic )
             add_response_none( _( "Oh, okay." ) );
             return;
         }
-        if (!actor(false)->can_see()) {
-            add_response_none( _("You wish you could see what they're doing.") );
-            return;
-        }
         for( const skill_id &sk : sklist ) {
             if( sk->obsolete() ) {
                 continue;

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -2079,8 +2079,8 @@ void dialogue::gen_responses( const talk_topic &the_topic )
             }
         }
 
-        if (!actor(false)->can_see()) {
-            add_response_none( _("Oh, okay."));
+        if( !actor( false )->can_see() ) {
+            add_response_none( _( "Oh, okay." ) );
             return;
         }
         const std::vector<matype_id> &styles = actor( true )->styles_offered_to( *actor( false ) );

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -1980,9 +1980,9 @@ void dialogue::gen_responses( const talk_topic &the_topic )
             add_response_none( _( "Oh, okay." ) );
             return;
         }
-        if (!actor( false )->can_see()) {
-           add_response_none( _( "You're not sure how to teach them while blind." ) );
-           return;
+        if( !actor( false )->can_see() ) {
+            add_response_none( _( "You're not sure how to teach them while blind." ) );
+            return;
         }
         for( const spell_id &sp : spells ) {
             const std::string &text =

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -1766,7 +1766,7 @@ std::string dialogue::dynamic_line( const talk_topic &the_topic )
     } else if( topic == "TALK_TRAIN" ) {
         if( !player_character.backlog.empty() && player_character.backlog.front().id() == ACT_TRAIN ) {
             return _( "Shall we resume?" );
-        } else if ( !actor( false )->can_see()) {
+        } else if( !actor( false )->can_see() ) {
             return _( "Sorry, I'm not sure how to teach the blind." );
         } else if( actor( true )->skills_offered_to( *actor( false ) ).empty() &&
                    actor( true )->styles_offered_to( *actor( false ) ).empty() &&


### PR DESCRIPTION
#### Summary
Bugfixes "Players learning from NPCs while blind and teaching NPCs while blind." 

#### Purpose of change
Fixes issue still leftover from #55803, players were able to learn from NPCs and teach NPCs while blind. 


#### Describe the solution
My solution was to add if statements that check if the player can see while attempting to teach or be taught and add extra text if the blindness check wasn't passed. This fix does not include seminars.


#### Describe alternatives you've considered

I wanted to prevent the player on the dialogue before my check runs. However, I was not able to find where those NPC dialogues were after searching each NPC file.

#### Testing

I loaded up into the game, used debug to spawn an NPC and make them my follower. Then I put on a blindfold and attempted to learn from them and teach them.

#### Additional context


