### PR TITLE
Describe stat level in new character window

### DIFF
--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -1487,7 +1487,7 @@ static std::string stat_level_description( int stat_value )
         description = _( "impaired" );
     } else if( stat_value >= 0 ) {
         //~Description of a character's main stats. Should not exceed 18 characters of width.
-        description = _( "legally disabled" );
+        description = _( "incapacitated" );
     }
 
     return description;

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -1462,31 +1462,31 @@ static std::string stat_level_description( int stat_value )
     // Breakpoint values are largely borrowed from GAME_BALANCE.md.
     std::string description;
     if( stat_value >= 20 ) {
-        //~Description of a character's main stats. Should not exceed 17 characters of width.
+        //~Description of a character's main stats. Should not exceed 18 characters of width.
         description = _( "superhuman" );
     } else if( stat_value > 14 ) {
-        //~Description of a character's main stats. Should not exceed 17 characters of width.
+        //~Description of a character's main stats. Should not exceed 18 characters of width.
         description = _( "olympian" );
     } else if( stat_value > 12 ) {
-        //~Description of a character's main stats. Should not exceed 17 characters of width.
+        //~Description of a character's main stats. Should not exceed 18 characters of width.
         description = _( "top 1%" );
     } else if( stat_value > 10 ) {
-        //~Description of a character's main stats. Should not exceed 17 characters of width.
+        //~Description of a character's main stats. Should not exceed 18 characters of width.
         description = _( "top 10%" );
     } else if( stat_value > 8 ) {
-        //~Description of a character's main stats. Should not exceed 17 characters of width.
+        //~Description of a character's main stats. Should not exceed 18 characters of width.
         description = _( "above average" );
     } else if( stat_value == 8 ) { // special handling
-        //~Description of a character's main stats. Should not exceed 17 characters of width.
+        //~Description of a character's main stats. Should not exceed 18 characters of width.
         description = _( "average human" );
     } else if( stat_value > 6 ) {
-        //~Description of a character's main stats. Should not exceed 17 characters of width.
+        //~Description of a character's main stats. Should not exceed 18 characters of width.
         description = _( "below average" );
     } else if( stat_value > 4 ) {
-        //~Description of a character's main stats. Should not exceed 17 characters of width.
+        //~Description of a character's main stats. Should not exceed 18 characters of width.
         description = _( "crippled" );
     } else if( stat_value >= 0 ) {
-        //~Description of a character's main stats. Should not exceed 17 characters of width.
+        //~Description of a character's main stats. Should not exceed 18 characters of width.
         description = _( "legally disabled" );
     }
 
@@ -1562,7 +1562,7 @@ void set_stats( tab_manager &tabs, avatar &u, pool_type pool )
                 mvwprintz( w, point( 2, i + iHeaderHeight ), i == sel ? COL_SELECT : c_light_gray, "%s:",
                            stat_labels[i].translated() );
                 mvwprintz( w, point( 16, i + iHeaderHeight ), c_light_gray, "%2d", *stats[i] );
-                mvwprintz( w, point( 20, i + iHeaderHeight ), c_light_gray, "(%s)",
+                mvwprintz( w, point( 19, i + iHeaderHeight ), c_light_gray, "(%s)",
                            stat_level_description( *stats[i] ) );
             }
         }

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -1467,9 +1467,12 @@ static std::string stat_level_description( int stat_value )
     } else if( stat_value > 14 ) {
         //~Description of a character's main stats. Should not exceed 17 characters of width.
         description = _( "olympian" );
-    } else if( stat_value > 10 ) {
+    } else if( stat_value > 12 ) {
         //~Description of a character's main stats. Should not exceed 17 characters of width.
         description = _( "top 1%" );
+    } else if( stat_value > 10 ) {
+        //~Description of a character's main stats. Should not exceed 17 characters of width.
+        description = _( "top 10%" );
     } else if( stat_value > 8 ) {
         //~Description of a character's main stats. Should not exceed 17 characters of width.
         description = _( "above average" );

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -1463,7 +1463,7 @@ static std::string stat_level_description( int stat_value )
     std::string description;
     if( stat_value >= 20 ) {
         //~Description of a character's main stats. Should not exceed 18 characters of width.
-        description = _( "superhuman" );
+        description = _( "inhuman" );
     } else if( stat_value > 14 ) {
         //~Description of a character's main stats. Should not exceed 18 characters of width.
         description = _( "olympian" );
@@ -1484,7 +1484,7 @@ static std::string stat_level_description( int stat_value )
         description = _( "below average" );
     } else if( stat_value > 4 ) {
         //~Description of a character's main stats. Should not exceed 18 characters of width.
-        description = _( "crippled" );
+        description = _( "impaired" );
     } else if( stat_value >= 0 ) {
         //~Description of a character's main stats. Should not exceed 18 characters of width.
         description = _( "legally disabled" );

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -1466,7 +1466,7 @@ static std::string stat_level_description( int stat_value )
         description = _( "inhuman" );
     } else if( stat_value > 14 ) {
         //~Description of a character's main stats. Should not exceed 18 characters of width.
-        description = _( "olympian" );
+        description = _( "extraordinary" );
     } else if( stat_value > 12 ) {
         //~Description of a character's main stats. Should not exceed 18 characters of width.
         description = _( "top 1%" );

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -1457,6 +1457,39 @@ static std::string assemble_stat_help( const input_context &ctxt )
                ctxt.get_desc( "NEXT_TAB" ), ctxt.get_desc( "PREV_TAB" ) );
 }
 
+static std::string stat_level_description( int stat_value )
+{
+    // Breakpoint values are largely borrowed from GAME_BALANCE.md.
+    std::string description;
+    if( stat_value >= 20 ) {
+        //~Description of a character's main stats. Should not exceed 17 characters of width.
+        description = _( "superhuman" );
+    } else if( stat_value > 14 ) {
+        //~Description of a character's main stats. Should not exceed 17 characters of width.
+        description = _( "olympian" );
+    } else if( stat_value > 10 ) {
+        //~Description of a character's main stats. Should not exceed 17 characters of width.
+        description = _( "top 1%" );
+    } else if( stat_value > 8 ) {
+        //~Description of a character's main stats. Should not exceed 17 characters of width.
+        description = _( "above average" );
+    } else if( stat_value == 8 ) { // special handling
+        //~Description of a character's main stats. Should not exceed 17 characters of width.
+        description = _( "average human" );
+    } else if( stat_value > 6 ) {
+        //~Description of a character's main stats. Should not exceed 17 characters of width.
+        description = _( "below average" );
+    } else if( stat_value > 4 ) {
+        //~Description of a character's main stats. Should not exceed 17 characters of width.
+        description = _( "crippled" );
+    } else if( stat_value >= 0 ) {
+        //~Description of a character's main stats. Should not exceed 17 characters of width.
+        description = _( "legally disabled" );
+    }
+
+    return description;
+}
+
 /** Handle the stats tab of the character generation menu */
 void set_stats( tab_manager &tabs, avatar &u, pool_type pool )
 {
@@ -1526,6 +1559,8 @@ void set_stats( tab_manager &tabs, avatar &u, pool_type pool )
                 mvwprintz( w, point( 2, i + iHeaderHeight ), i == sel ? COL_SELECT : c_light_gray, "%s:",
                            stat_labels[i].translated() );
                 mvwprintz( w, point( 16, i + iHeaderHeight ), c_light_gray, "%2d", *stats[i] );
+                mvwprintz( w, point( 20, i + iHeaderHeight ), c_light_gray, "(%s)",
+                           stat_level_description( *stats[i] ) );
             }
         }
 


### PR DESCRIPTION
#### Summary
Interface "Describe stat level in new character window"

#### Purpose of change
Many people ask "What does 8 strength mean?" or "Why can't I raise my strength once I get ingame?". We have those sorts of answers scattered around the documentation, but we could make it clearer ingame too.

#### Describe the solution
Describe the stat level in the new character window. This provides another 'soft' suggestion for what stat level you should (not) select. It also helps to show people why massively increasing their stats at the start is unbalanced, besides just kicking around their lifestyle score.

#### Describe alternatives you've considered
Repeating the same translator comment over and over again is kind of awkward, I could probably format this static function differently.

#### Testing
![image](https://github.com/user-attachments/assets/13cfc3ca-b10b-442c-aef4-a114256261e0)


#### Additional context
