### PR TITLE
Create a "thin" archive instead of copying objects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,8 @@
 #  make BACKTRACE=0
 # Use libbacktrace. Only has effect if BACKTRACE=1. (currently only for MinGW and Linux builds)
 #  make LIBBACKTRACE=1
+# Instruct $(AR) to create a thick archive, copying to object files to cataclysm.a
+#  make THIN_AR=0
 # Compile localization files for specified languages
 #  make localization LANGUAGES="<lang_id_1>[ lang_id_2][ ...]"
 #  (for example: make LANGUAGES="zh_CN zh_TW" for Chinese)
@@ -186,6 +188,11 @@ endif
 # Enable json format check by default
 ifndef LINTJSON
   LINTJSON = 1
+endif
+
+# Enable building a thin archive by default
+ifndef THIN_AR
+  THIN_AR = 1
 endif
 
 # We don't want to have both 'check' and 'tests' as targets, because that will
@@ -587,6 +594,8 @@ ifeq ($(NATIVE), osx)
   DEFINES += -DMACOSX
   CXXFLAGS += -mmacosx-version-min=10.15
   LDFLAGS += -mmacosx-version-min=10.15 -framework CoreFoundation -Wl,-headerpad_max_install_names
+  # doesn't use GNU ar
+  THIN_AR=0
   ifeq ($(UNIVERSAL_BINARY), 1)
     CXXFLAGS += -arch x86_64 -arch arm64
     LDFLAGS += -arch x86_64 -arch arm64
@@ -908,6 +917,12 @@ ifeq ($(LOCALIZE),1)
   LOCALIZE_TEST_DEPS = localization $(TEST_MO)
 endif
 
+ifeq ($(THIN_AR), 1)
+  AR_FLAGS = --thin
+else
+  AR_FLAGS =
+endif
+
 ifeq ($(TARGETSYSTEM),LINUX)
   BINDIST_EXTRAS += cataclysm-launcher
   ifneq ("$(wildcard LICENSE-SDL.txt)","")
@@ -1074,7 +1089,7 @@ $(PCH_P): $(PCH_H)
 	-$(CXX) $(CPPFLAGS) $(DEFINES) $(CXXFLAGS) -MMD -MP -Wno-error -c $(PCH_H) -o $(PCH_P)
 
 $(BUILD_PREFIX)$(TARGET_NAME).a: $(OBJS)
-	$(AR) rcs $(BUILD_PREFIX)$(TARGET_NAME).a $(filter-out $(ODIR)/main.o $(ODIR)/messages.o,$(OBJS))
+	$(AR) rcs $(AR_FLAGS) $(BUILD_PREFIX)$(TARGET_NAME).a $(filter-out $(ODIR)/main.o $(ODIR)/messages.o,$(OBJS))
 
 .PHONY: version prefix
 version:


### PR DESCRIPTION
#### Summary
Infrastructure "Improve tests build speed by creating a thin archive"

#### Purpose of change
I've consistently noticed the step of archiving the object files for building the tests taking some time, especially because the tests do not begin to be compiled in parallel until it is done.

#### Describe the solution
Use the `--thin` flag to indicate that `ar` should not copy the object files into the archive, but leave them in place instead.

The `ar` stage goes from 10-13s to 0.7s on my machine.

#### Describe alternatives you've considered

This probably needs a build flag, I just wanted to see what support looked like on the tests.

#### Testing

See CI.

#### Additional context

> GNU ar can optionally create a thin archive, which contains symbol index and references to the original copies of the member files of the archive.  This is useful for building libraries for use within a local build tree, where the relocatable objects are expected to remain available, and copying the contents of each object would only waste time and space.
>
> An archive can either be thin or it can be normal.  It cannot be both at the same time.  Once an archive is created its format cannot be changed without first deleting it and then creating a new archive in its place.

existing `cataclysm.a` files must be deleted.