### PR TITLE
Overmaps track overmap unique specials instead of overmapbuffer

### DIFF
--- a/src/overmap.h
+++ b/src/overmap.h
@@ -524,6 +524,9 @@ class overmap
         void populate_connections_out_from_neighbors( const std::vector<const overmap *>
                 &neighbor_overmaps );
 
+        void log_unique_special( const overmap_special_id &id );
+        bool contains_unique_special( const overmap_special_id &id ) const;
+
         /*
         * checks adjacent overmap in direction for river terrain bordering this overmap
         * will not generate the adjacent overmap!

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -1098,19 +1098,9 @@ void overmapbuffer::add_unique_special( const overmap_special_id &id )
     placed_unique_specials.emplace( id );
 }
 
-void overmapbuffer::add_overmap_unique_special( const overmap_special_id &id )
-{
-    if( contains_unique_special( id ) ) {
-        debugmsg( "Overmap unique overmap special placed more than once: %s", id.str() );
-    }
-    placed_overmap_unique_specials.emplace( id );
-    unique_special_count[id]++;
-}
-
 bool overmapbuffer::contains_unique_special( const overmap_special_id &id ) const
 {
-    return placed_unique_specials.find( id ) != placed_unique_specials.end() ||
-           placed_overmap_unique_specials.find( id ) != placed_overmap_unique_specials.end();
+    return placed_unique_specials.find( id ) != placed_unique_specials.end();
 }
 
 static omt_find_params assign_params(

--- a/src/overmapbuffer.h
+++ b/src/overmapbuffer.h
@@ -586,8 +586,6 @@ class overmapbuffer
         overmap mutable *last_requested_overmap;
         // Set of globally unique overmap specials that have already been placed
         std::unordered_set<overmap_special_id> placed_unique_specials;
-        // This tracks the overmap unique specials we have placed during the current oms generate().
-        std::unordered_set<overmap_special_id> placed_overmap_unique_specials;
         // This tracks the overmap unique specials we have placed. It is used to
         // Adjust weights of special spawns to correct for things like failure to spawn.
         std::unordered_map<overmap_special_id, int> unique_special_count;
@@ -635,14 +633,13 @@ class overmapbuffer
          */
         void add_unique_special( const overmap_special_id &id );
         /**
-         * Adds the given overmap unique overmap special to the lists of placed specials.
+         * Logs the placement of the given unique overmap special
          */
-        void add_overmap_unique_special( const overmap_special_id &id );
-        void clear_overmap_uniques() {
-            placed_overmap_unique_specials.clear();
+        void log_unique_special( const overmap_special_id &id ) {
+            unique_special_count[id]++;
         }
         /**
-         * Returns true if the given globally/overmap unique overmap special has already been placed.
+         * Returns true if the given globally unique overmap special has already been placed.
          */
         bool contains_unique_special( const overmap_special_id &id ) const;
         /**


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
I saw this line in `overmap::generate` and wanted to know why it was there:
https://github.com/CleverRaven/Cataclysm-DDA/blob/5e49364b0c152e17f89818a0332a2f1fb8af8013/src/overmap.cpp#L3714

It turns out that unique placed specials on the overmap were tracked in the overmapbuffer, and cleared each time an overmap generated. This is fragile and breaks the abstraction of the overmap/overmapbuffer.


#### Describe the solution
Move that data to the overmap, instead of keeping it in the overmapbuffer and clearing it.

#### Testing
The test provided is in https://github.com/CleverRaven/Cataclysm-DDA/pull/81017

#### Additional context
This information is not saved, and the function to check if a special has been placed will not work after generation.