### PR TITLE
Update windows workflows to newer image

### DIFF
--- a/.github/workflows/msvc-full-features.yml
+++ b/.github/workflows/msvc-full-features.yml
@@ -55,7 +55,7 @@ env:
 jobs:
   build_catatclysm:
     name: Build
-    runs-on: windows-2019
+    runs-on: windows-2022
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
           - name: Windows Tiles x64 MSVC
             artifact: windows-with-graphics-x64
             arch: x64
-            os: windows-2019
+            os: windows-2022
             mxe: none
             ext: zip
             content: application/zip
@@ -67,7 +67,7 @@ jobs:
           - name: Windows Tiles Sounds x64 MSVC
             artifact: windows-with-graphics-and-sounds-x64
             arch: x64
-            os: windows-2019
+            os: windows-2022
             mxe: none
             ext: zip
             content: application/zip


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
The windows-2019 runner is being deprecated, see https://github.com/actions/runner-images/issues/12045

#### Describe the solution
Use `windows-2022` instead.

#### Describe alternatives you've considered
Using `windows-2025`

#### Testing
CI