### PR TITLE
Optimized search for existing specials

### DIFF
--- a/src/mission_util.cpp
+++ b/src/mission_util.cpp
@@ -200,9 +200,9 @@ static std::optional<tripoint_abs_omt> find_or_create_om_terrain(
     if( params.overmap_special.has_value() ) {
         const overmap_special_id special_id = static_cast<overmap_special_id>(
                 ( *params.overmap_special ).evaluate( d ) );
+        find_params.om_special = special_id;
 
         if( overmap_buffer.contains_unique_special( special_id ) ) {
-            find_params.om_special = special_id;
             return overmap_buffer.find_existing_globally_unique( origin_pos, find_params );
         }
     }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Make searches for existing specials faster.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Apply the same basic logic used to speed up searches for existing globally unique specials in #81219 to all existing specials.
I.e. search through the overmaps' map of special positions for matches rather than searching all OMT tiles within the search range.
The search is based on generated overmaps rather than OMTs, so OMTs within non generated OMs aren't considered, but on the other hand all special positions within the OMs are iterated over, filtering out those not within the search range.

This logic is added to both overmapbuffer::find_closest and overmapbuffer::find_all, which means searches for both closest and random match.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
- Trying to factor out the common logic, but two instances isn't enough incentive to try to deal with the complications.
- Trying to look at generation of new specials. This is considered out of scope for this PR, and I've not spent any time looking at those issues.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
None...

Here I have the problem that I don't know how to set up test cases. It would require setting up test (or real) mission target dialog that would end up searching for target specials.
- Closest special (actually OMT within the special) of a number of different types at different ranges with and without existing matches (and some ways to determine the matches found actually are the correct ones: checking valid range is easy, as the Mission log contains that info, but closest?).
- Random special missions. Here valid range is the only test measure for matches.
- Ideally some way to test that this won't screw up generation of specials that couldn't be found.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
This ought to be a lot faster than searching OMTs at increasing range. However, without tests it can't be verified.

Due to the lack of testing, this PR is being put in draft until either tests can be performed, or rigorous code reviewing by skilled reviewers would declare it to be sound. There is a significant risk this PR will just die due to an inability to test it properly.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
