### PR TITLE
Give generators ALLOWS_REMOTE_USE flag

### DIFF
--- a/data/json/items/appliances/appliances_generators.json
+++ b/data/json/items/appliances/appliances_generators.json
@@ -30,7 +30,7 @@
     "symbol": "O",
     "color": "green_white",
     "//2": "Prevent loading items into the generator while it's not in appliance form.",
-    "flags": [ "NO_RELOAD" ],
+    "flags": [ "NO_RELOAD", "ALLOWS_REMOTE_USE" ],
     "melee_damage": { "bash": 5 }
   },
   {


### PR DESCRIPTION

#### Summary
None

#### Purpose of change
I find it a bit annoying that i need to wield the heavy generators to place it down as an appliance, so i give it the ALLOWS_REMOTE_USE flag so i can activate it when adjacent and on ground.

#### Describe the solution

gives ALLOWS_REMOTE_USE flag to the generator

#### Describe alternatives you've considered

Not doing so

#### Testing

well it works, but i found a bug with the `"deploy_appliance"` use action. See Additional context about it.
![Screenshot_20250611_175351](https://github.com/user-attachments/assets/3aa3d251-0f3b-41fc-bbea-1f8958d346bb)


#### Additional context
When i tested the generator placing action, it gave me an error screen about not finding the item target to delete. While it does place down the generator as an appliance, it still kept the generator item on the ground. it's up to the mergers if they merge the pr before or after fixing the issue
![Screenshot_20250611_175631](https://github.com/user-attachments/assets/9f419a06-6ff6-4d5a-8c5e-932d71034eff)



<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
