### PR TITLE
Fungalizing enemies should be neutral to Mycus players

### DIFF
--- a/data/json/monsters/fungus_zombie.json
+++ b/data/json/monsters/fungus_zombie.json
@@ -11,7 +11,7 @@
     "upgrades": { "age_grow": 1, "into": "mon_zombie_fungalize" },
     "proportional": { "speed": 0.6 },
     "relative": { "melee_skill": -1, "melee_dice": -1 },
-    "extend": { "flags": [ "NO_FUNG_DMG" ] }
+    "extend": { "species": [ "FUNGUS" ], "flags": [ "NO_FUNG_DMG" ] }
   },
   {
     "id": "mon_zombie_fungalize",
@@ -28,7 +28,7 @@
     "upgrades": { "age_grow": 1, "into": "mon_zombie_fungus" },
     "proportional": { "speed": 0.3 },
     "relative": { "melee_skill": -1, "melee_dice": -1, "armor": { "bash": 1, "electric": 2 } },
-    "extend": { "flags": [ "NO_FUNG_DMG" ] }
+    "extend": { "species": [ "FUNGUS" ], "flags": [ "NO_FUNG_DMG" ] }
   },
   {
     "id": "mon_zombie_fungus",
@@ -54,7 +54,7 @@
     "upgrades": { "age_grow": 1, "into": "mon_gasbag_fungalize" },
     "proportional": { "speed": 0.6 },
     "relative": { "melee_skill": -1, "melee_dice": -1 },
-    "extend": { "flags": [ "NO_FUNG_DMG" ] }
+    "extend": { "species": [ "FUNGUS" ], "flags": [ "NO_FUNG_DMG" ] }
   },
   {
     "id": "mon_gasbag_fungalize",
@@ -70,7 +70,7 @@
     "upgrades": { "age_grow": 1, "into": "mon_zombie_gasbag_fungus" },
     "proportional": { "speed": 0.3 },
     "relative": { "melee_skill": -1, "melee_dice": -1, "armor": { "bash": 1, "electric": 2 } },
-    "extend": { "flags": [ "NO_FUNG_DMG" ] }
+    "extend": { "species": [ "FUNGUS" ], "flags": [ "NO_FUNG_DMG" ] }
   },
   {
     "id": "mon_zombie_gasbag_fungus",
@@ -103,7 +103,7 @@
     "upgrades": { "age_grow": 1, "into": "mon_zombie_smoker_fungalize" },
     "proportional": { "speed": 0.6 },
     "relative": { "melee_skill": -1, "melee_dice": -1 },
-    "extend": { "flags": [ "NO_FUNG_DMG" ] }
+    "extend": { "species": [ "FUNGUS" ], "flags": [ "NO_FUNG_DMG" ] }
   },
   {
     "id": "mon_zombie_smoker_fungalize",
@@ -120,7 +120,7 @@
     "upgrades": { "age_grow": 1, "into": "mon_zombie_smoker_fungus" },
     "proportional": { "speed": 0.3 },
     "relative": { "melee_skill": -1, "melee_dice": -1, "armor": { "bash": 1, "electric": 2 } },
-    "extend": { "flags": [ "NO_FUNG_DMG" ] }
+    "extend": { "species": [ "FUNGUS" ], "flags": [ "NO_FUNG_DMG" ] }
   },
   {
     "id": "mon_zombie_smoker_fungus",
@@ -153,7 +153,7 @@
     "upgrades": { "age_grow": 1, "into": "mon_skeleton_fungalize" },
     "proportional": { "speed": 0.6 },
     "relative": { "melee_skill": -1, "melee_dice": -1 },
-    "extend": { "flags": [ "NO_FUNG_DMG" ] }
+    "extend": { "species": [ "FUNGUS" ], "flags": [ "NO_FUNG_DMG" ] }
   },
   {
     "id": "mon_skeleton_fungalize",
@@ -170,7 +170,7 @@
     "upgrades": { "age_grow": 1, "into": "mon_skeleton_fungus" },
     "proportional": { "speed": 0.3 },
     "relative": { "melee_skill": -1, "melee_dice": -1, "armor": { "bash": 1, "electric": 2 } },
-    "extend": { "flags": [ "NO_FUNG_DMG" ] }
+    "extend": { "species": [ "FUNGUS" ], "flags": [ "NO_FUNG_DMG" ] }
   },
   {
     "type": "MONSTER",
@@ -200,7 +200,7 @@
     "upgrades": { "age_grow": 1, "into": "mon_skeleton_brute_fungalize" },
     "proportional": { "speed": 0.6 },
     "relative": { "melee_skill": -1, "melee_dice": -1 },
-    "extend": { "flags": [ "NO_FUNG_DMG" ] }
+    "extend": { "species": [ "FUNGUS" ], "flags": [ "NO_FUNG_DMG" ] }
   },
   {
     "id": "mon_skeleton_brute_fungalize",
@@ -217,7 +217,7 @@
     "upgrades": { "age_grow": 1, "into": "mon_skeleton_brute_fungus" },
     "proportional": { "speed": 0.3 },
     "relative": { "melee_skill": -1, "melee_dice": -1, "armor": { "bash": 1, "electric": 2 } },
-    "extend": { "flags": [ "NO_FUNG_DMG" ] }
+    "extend": { "species": [ "FUNGUS" ], "flags": [ "NO_FUNG_DMG" ] }
   },
   {
     "type": "MONSTER",
@@ -247,7 +247,7 @@
     "upgrades": { "age_grow": 1, "into": "mon_skeleton_hulk_fungalize" },
     "proportional": { "speed": 0.6 },
     "relative": { "melee_skill": -1, "melee_dice": -1 },
-    "extend": { "flags": [ "NO_FUNG_DMG" ] }
+    "extend": { "species": [ "FUNGUS" ], "flags": [ "NO_FUNG_DMG" ] }
   },
   {
     "id": "mon_skeleton_hulk_fungalize",
@@ -264,7 +264,7 @@
     "upgrades": { "age_grow": 2, "into": "mon_skeleton_hulk_fungus" },
     "proportional": { "speed": 0.3 },
     "relative": { "melee_skill": -1, "melee_dice": -1, "armor": { "bash": 1, "electric": 2 } },
-    "extend": { "flags": [ "NO_FUNG_DMG" ] }
+    "extend": { "species": [ "FUNGUS" ], "flags": [ "NO_FUNG_DMG" ] }
   },
   {
     "id": "mon_skeleton_hulk_fungus",
@@ -294,7 +294,7 @@
     "upgrades": { "age_grow": 1, "into": "mon_zombie_child_fungalize" },
     "proportional": { "speed": 0.6 },
     "relative": { "melee_skill": -1, "melee_dice": -1 },
-    "extend": { "flags": [ "NO_FUNG_DMG" ] }
+    "extend": { "species": [ "FUNGUS" ], "flags": [ "NO_FUNG_DMG" ] }
   },
   {
     "id": "mon_zombie_child_fungalize",
@@ -311,7 +311,7 @@
     "upgrades": { "age_grow": 1, "into": "mon_zombie_child_fungus" },
     "proportional": { "speed": 0.3 },
     "relative": { "melee_skill": -1, "melee_dice": -1, "armor": { "bash": 1, "electric": 2 } },
-    "extend": { "flags": [ "NO_FUNG_DMG" ] }
+    "extend": { "species": [ "FUNGUS" ], "flags": [ "NO_FUNG_DMG" ] }
   },
   {
     "id": "mon_zombie_child_fungus",
@@ -342,7 +342,7 @@
     "upgrades": { "age_grow": 1, "into": "mon_boomer_fungalize" },
     "proportional": { "speed": 0.6 },
     "relative": { "melee_skill": -1, "melee_dice": -1 },
-    "extend": { "flags": [ "NO_FUNG_DMG" ] }
+    "extend": { "species": [ "FUNGUS" ], "flags": [ "NO_FUNG_DMG" ] }
   },
   {
     "id": "mon_boomer_fungalize",
@@ -358,7 +358,7 @@
     "upgrades": { "age_grow": 1, "into": "mon_boomer_fungus" },
     "proportional": { "speed": 0.3 },
     "relative": { "melee_skill": -1, "melee_dice": -1, "armor": { "bash": 1, "electric": 2 } },
-    "extend": { "flags": [ "NO_FUNG_DMG" ] }
+    "extend": { "species": [ "FUNGUS" ], "flags": [ "NO_FUNG_DMG" ] }
   },
   {
     "id": "mon_boomer_fungus",
@@ -389,7 +389,7 @@
     "upgrades": { "age_grow": 1, "into": "mon_zombie_wretch_fungalize" },
     "proportional": { "speed": 0.6 },
     "relative": { "melee_skill": -1, "melee_dice": -1 },
-    "extend": { "flags": [ "NO_FUNG_DMG" ] }
+    "extend": { "species": [ "FUNGUS" ], "flags": [ "NO_FUNG_DMG" ] }
   },
   {
     "id": "mon_zombie_wretch_fungalize",
@@ -405,7 +405,7 @@
     "upgrades": { "age_grow": 1, "into": "mon_fungal_wretch" },
     "proportional": { "speed": 0.3 },
     "relative": { "melee_skill": -1, "melee_dice": -1, "armor": { "bash": 1, "electric": 2 } },
-    "extend": { "flags": [ "NO_FUNG_DMG" ] }
+    "extend": { "species": [ "FUNGUS" ], "flags": [ "NO_FUNG_DMG" ] }
   },
   {
     "id": "mon_fungal_wretch",
@@ -445,7 +445,7 @@
     "upgrades": { "age_grow": 1, "into": "mon_spawn_raptor_fungalize" },
     "proportional": { "speed": 0.6 },
     "relative": { "melee_skill": -1, "melee_dice": -1 },
-    "extend": { "flags": [ "NO_FUNG_DMG" ] }
+    "extend": { "species": [ "FUNGUS" ], "flags": [ "NO_FUNG_DMG" ] }
   },
   {
     "id": "mon_spawn_raptor_fungalize",
@@ -461,7 +461,7 @@
     "upgrades": { "age_grow": 1, "into": "mon_fungal_raptor" },
     "proportional": { "speed": 0.3 },
     "relative": { "melee_skill": -1, "melee_dice": -1, "armor": { "bash": 1, "electric": 2 } },
-    "extend": { "flags": [ "NO_FUNG_DMG" ] }
+    "extend": { "species": [ "FUNGUS" ], "flags": [ "NO_FUNG_DMG" ] }
   },
   {
     "id": "mon_fungal_raptor",
@@ -486,7 +486,7 @@
     "upgrades": { "age_grow": 1, "into": "mon_zombie_runner_fungalize" },
     "proportional": { "speed": 0.6 },
     "relative": { "melee_skill": -1, "melee_dice": -1 },
-    "extend": { "flags": [ "NO_FUNG_DMG" ] }
+    "extend": { "species": [ "FUNGUS" ], "flags": [ "NO_FUNG_DMG" ] }
   },
   {
     "id": "mon_zombie_runner_fungalize",
@@ -503,7 +503,7 @@
     "upgrades": { "age_grow": 1, "into": "mon_zombie_runner_fungal" },
     "proportional": { "speed": 0.3 },
     "relative": { "melee_skill": -1, "melee_dice": -1, "armor": { "bash": 1, "electric": 2 } },
-    "extend": { "flags": [ "NO_FUNG_DMG" ] }
+    "extend": { "species": [ "FUNGUS" ], "flags": [ "NO_FUNG_DMG" ] }
   },
   {
     "id": "mon_zombie_runner_fungal",
@@ -534,7 +534,7 @@
     "upgrades": { "age_grow": 1, "into": "mon_zombie_rot_fungalize" },
     "proportional": { "speed": 0.6 },
     "relative": { "melee_skill": -1, "melee_dice": -1 },
-    "extend": { "flags": [ "NO_FUNG_DMG" ] }
+    "extend": { "species": [ "FUNGUS" ], "flags": [ "NO_FUNG_DMG" ] }
   },
   {
     "id": "mon_zombie_rot_fungalize",
@@ -551,7 +551,7 @@
     "upgrades": { "age_grow": 1, "into": "mon_zombie_rot_fungal" },
     "proportional": { "speed": 0.3 },
     "relative": { "melee_skill": -1, "melee_dice": -1, "armor": { "bash": 1, "electric": 2 } },
-    "extend": { "flags": [ "NO_FUNG_DMG" ] }
+    "extend": { "species": [ "FUNGUS" ], "flags": [ "NO_FUNG_DMG" ] }
   },
   {
     "id": "mon_zombie_rot_fungal",
@@ -582,7 +582,7 @@
     "upgrades": { "age_grow": 1, "into": "mon_zombie_tough_fungalize" },
     "proportional": { "speed": 0.6 },
     "relative": { "melee_skill": -1, "melee_dice": -1 },
-    "extend": { "flags": [ "NO_FUNG_DMG" ] }
+    "extend": { "species": [ "FUNGUS" ], "flags": [ "NO_FUNG_DMG" ] }
   },
   {
     "id": "mon_zombie_tough_fungalize",
@@ -599,7 +599,7 @@
     "upgrades": { "age_grow": 1, "into": "mon_zombie_tough_fungal" },
     "proportional": { "speed": 0.3 },
     "relative": { "melee_skill": -1, "melee_dice": -1, "armor": { "bash": 1, "electric": 2 } },
-    "extend": { "flags": [ "NO_FUNG_DMG" ] }
+    "extend": { "species": [ "FUNGUS" ], "flags": [ "NO_FUNG_DMG" ] }
   },
   {
     "id": "mon_zombie_tough_fungal",
@@ -630,7 +630,7 @@
     "upgrades": { "age_grow": 1, "into": "mon_zombie_brute_fungalize" },
     "proportional": { "speed": 0.6 },
     "relative": { "melee_skill": -1, "melee_dice": -1 },
-    "extend": { "flags": [ "NO_FUNG_DMG" ] }
+    "extend": { "species": [ "FUNGUS" ], "flags": [ "NO_FUNG_DMG" ] }
   },
   {
     "id": "mon_zombie_brute_fungalize",
@@ -647,7 +647,7 @@
     "upgrades": { "age_grow": 1, "into": "mon_zombie_brute_fungal" },
     "proportional": { "speed": 0.3 },
     "relative": { "melee_skill": -1, "melee_dice": -1, "armor": { "bash": 1, "electric": 2 } },
-    "extend": { "flags": [ "NO_FUNG_DMG" ] }
+    "extend": { "species": [ "FUNGUS" ], "flags": [ "NO_FUNG_DMG" ] }
   },
   {
     "id": "mon_zombie_brute_fungal",
@@ -678,7 +678,7 @@
     "upgrades": { "age_grow": 1, "into": "mon_zombie_hulk_fungalize" },
     "proportional": { "speed": 0.6 },
     "relative": { "melee_skill": -1, "melee_dice": -1 },
-    "extend": { "flags": [ "NO_FUNG_DMG" ] }
+    "extend": { "species": [ "FUNGUS" ], "flags": [ "NO_FUNG_DMG" ] }
   },
   {
     "id": "mon_zombie_hulk_fungalize",
@@ -695,7 +695,7 @@
     "upgrades": { "age_grow": 2, "into": "mon_zombie_hulk_fungal" },
     "proportional": { "speed": 0.3 },
     "relative": { "melee_skill": -1, "melee_dice": -1, "armor": { "bash": 1, "electric": 2 } },
-    "extend": { "flags": [ "NO_FUNG_DMG" ] }
+    "extend": { "species": [ "FUNGUS" ], "flags": [ "NO_FUNG_DMG" ] }
   },
   {
     "id": "mon_zombie_hulk_fungal",
@@ -725,7 +725,7 @@
     "upgrades": { "age_grow": 1, "into": "mon_zombie_crawler_fungalize" },
     "proportional": { "speed": 0.6 },
     "relative": { "melee_skill": -1, "melee_dice": -1 },
-    "extend": { "flags": [ "NO_FUNG_DMG" ] }
+    "extend": { "species": [ "FUNGUS" ], "flags": [ "NO_FUNG_DMG" ] }
   },
   {
     "id": "mon_zombie_crawler_fungalize",
@@ -742,7 +742,7 @@
     "upgrades": { "age_grow": 1, "into": "mon_zombie_crawler_fungal" },
     "proportional": { "speed": 0.3 },
     "relative": { "melee_skill": -1, "melee_dice": -1, "armor": { "bash": 1, "electric": 2 } },
-    "extend": { "flags": [ "NO_FUNG_DMG" ] }
+    "extend": { "species": [ "FUNGUS" ], "flags": [ "NO_FUNG_DMG" ] }
   },
   {
     "id": "mon_zombie_crawler_fungal",
@@ -773,7 +773,7 @@
     "upgrades": { "age_grow": 1, "into": "mon_zombie_fat_fungalize" },
     "proportional": { "speed": 0.6 },
     "relative": { "melee_skill": -1, "melee_dice": -1 },
-    "extend": { "flags": [ "NO_FUNG_DMG" ] }
+    "extend": { "species": [ "FUNGUS" ], "flags": [ "NO_FUNG_DMG" ] }
   },
   {
     "id": "mon_zombie_fat_fungalize",
@@ -790,7 +790,7 @@
     "upgrades": { "age_grow": 1, "into": "mon_zombie_fat_fungus" },
     "proportional": { "speed": 0.3 },
     "relative": { "melee_skill": -1, "melee_dice": -1, "armor": { "bash": 1, "electric": 2 } },
-    "extend": { "flags": [ "NO_FUNG_DMG" ] }
+    "extend": { "species": [ "FUNGUS" ], "flags": [ "NO_FUNG_DMG" ] }
   },
   {
     "id": "mon_zombie_fat_fungus",
@@ -821,7 +821,7 @@
     "upgrades": { "age_grow": 1, "into": "mon_beekeeper_fungalize" },
     "proportional": { "speed": 0.6 },
     "relative": { "melee_skill": -1, "melee_dice": -1 },
-    "extend": { "flags": [ "NO_FUNG_DMG" ] }
+    "extend": { "species": [ "FUNGUS" ], "flags": [ "NO_FUNG_DMG" ] }
   },
   {
     "id": "mon_beekeeper_fungalize",
@@ -838,7 +838,7 @@
     "upgrades": { "age_grow": 1, "into": "mon_beekeeper_fungal" },
     "proportional": { "speed": 0.3 },
     "relative": { "melee_skill": -1, "melee_dice": -1, "armor": { "bash": 1, "electric": 2 } },
-    "extend": { "flags": [ "NO_FUNG_DMG" ] }
+    "extend": { "species": [ "FUNGUS" ], "flags": [ "NO_FUNG_DMG" ] }
   },
   {
     "id": "mon_beekeeper_fungal",
@@ -869,7 +869,7 @@
     "upgrades": { "age_grow": 1, "into": "mon_zombie_acidic_fungalize" },
     "proportional": { "speed": 0.6 },
     "relative": { "melee_skill": -1, "melee_dice": -1 },
-    "extend": { "flags": [ "NO_FUNG_DMG" ] }
+    "extend": { "species": [ "FUNGUS" ], "flags": [ "NO_FUNG_DMG" ] }
   },
   {
     "id": "mon_zombie_acidic_fungalize",
@@ -886,7 +886,7 @@
     "upgrades": { "age_grow": 1, "into": "mon_zombie_fungus_acidic" },
     "proportional": { "speed": 0.3 },
     "relative": { "melee_skill": -1, "melee_dice": -1, "armor": { "bash": 1, "electric": 2 } },
-    "extend": { "flags": [ "NO_FUNG_DMG" ] }
+    "extend": { "species": [ "FUNGUS" ], "flags": [ "NO_FUNG_DMG" ] }
   },
   {
     "id": "mon_zombie_fungus_acidic",

--- a/data/json/monsters/fungus_zombie.json
+++ b/data/json/monsters/fungus_zombie.json
@@ -11,7 +11,7 @@
     "upgrades": { "age_grow": 1, "into": "mon_zombie_fungalize" },
     "proportional": { "speed": 0.6 },
     "relative": { "melee_skill": -1, "melee_dice": -1 },
-    "extend": { "species": [ "FUNGUS" ], "flags": [ "NO_FUNG_DMG" ] },
+    "extend": { "species": [ "FUNGUS" ], "flags": [ "NO_FUNG_DMG" ] }
   },
   {
     "id": "mon_zombie_fungalize",

--- a/data/json/monsters/fungus_zombie.json
+++ b/data/json/monsters/fungus_zombie.json
@@ -11,7 +11,7 @@
     "upgrades": { "age_grow": 1, "into": "mon_zombie_fungalize" },
     "proportional": { "speed": 0.6 },
     "relative": { "melee_skill": -1, "melee_dice": -1 },
-    "extend": { "species": [ "FUNGUS" ], "flags": [ "NO_FUNG_DMG" ] }
+    "extend": { "species": [ "FUNGUS" ], "flags": [ "NO_FUNG_DMG" ] },
   },
   {
     "id": "mon_zombie_fungalize",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Make fungalizing enemies neutral to Mycus player"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fungalizing enemies (both dusted and stalk) are currently hostile to Mycus players despite being friendly towards all other Mycus. This PR changes that to make them friendly to Mycus players, that way behavior of fungalizing zombies is consistent between Mycus NPCs and Mycus player
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add the "FUNGUS" species to all fungalizing zombies.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
If there is a way to make Mycus mutation define allies based on faction instead of species this would be more versatile, unfortunately I do not know how to do this.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
No issues cropped up in testing, stalk zombies are now friendly to Mycus player while still attacking non-fungals, dusted zombies are friendly to zombies, fungus, and Mycus player. All of them still attack non-Mycus player as expected.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Now friendly
![fungi](https://github.com/user-attachments/assets/7640c581-5e4c-4934-b915-730393176bf6)
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
