### PR TITLE
Mark season scaling options as hidden

### DIFF
--- a/data/core/external_options.json
+++ b/data/core/external_options.json
@@ -621,5 +621,37 @@
     "//": "Scales experience gained from practicing proficiencies.  0.5 is half as fast as default, 2.0 is twice as fast, 0.0 disables proficiency training except for NPC training.",
     "stype": "float",
     "value": 1.0
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "SEASON_LENGTH",
+    "//": "Season length, in days.  Warning: Very little other than the duration of seasons scales with this value, so adjusting it may cause nonsensical results.",
+    "stub": true,
+    "stype": "int",
+    "value": 91
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "CONSTRUCTION_SCALING",
+    "//": "Sets the time of construction in percents.  '50' is two times faster than default, '200' is two times longer.  '0' automatically scales construction time to match the world's season length.",
+    "stub": true,
+    "stype": "int",
+    "value": 100
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "ETERNAL_SEASON",
+    "//": "If true, keep the initial season for ever.",
+    "stub": true,
+    "stype": "bool",
+    "value": false
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "ETERNAL_TIME_OF_DAY",
+    "//": "Day/night cycle settings.  'normal' sets a normal cycle.  'day' sets eternal day.  'night' sets eternal night.",
+    "stub": true,
+    "stype": "string_input",
+    "value": "normal"
   }
 ]

--- a/doc/JSON/OPTIONS.md
+++ b/doc/JSON/OPTIONS.md
@@ -1,0 +1,27 @@
+# Game Options
+
+DDA has a moderately complex system for recording user preferences about the operation of the game, these are called options.  Throughout the game code there are statements of the form get_option<type>( "OPTION_NAME" ), the return values of which are used to adjust the operation of the game.
+
+## Load/override order
+
+The load ordering and override behavior has more accreted than been designed, so it's a bit gnarly.
+
+In main(), we init the option manager and initalize options with hard-coded defaults.
+Immediately afterwards we load config/options.json.
+In init(), we load json, including data/core/external_options.json.
+During world load, we load save/world/worldoptions.json.
+Later in world load, we load mods and external options defined there.
+
+The ordering is important, because at each stage, the previous values can be overwritten.
+
+Options must be defined at either the first stage of hardcoded option enumeration or in an external_option json entry. Options not present in one of these two sources, but present in options.json or worldoptions.json are ignored.
+config/options.json stores most options, and is persistent across seperate game worlds.
+save/<world>/worldoptions.json stores just a subset of options that are appropriate to change on a per-world basis, and override options specified in options.json when present.
+
+Options are split into "menu options" and "external options", which are usually seperate, but options can be migrated back and forth.
+"menu options" are displayed in an in-game menu for adjustment, and are intended to be adjusted by plyters to tune the game to their liking. Their use is documented within this menu.
+"external options" are mostly intended to be used to expose options to mods that have imact on the game outside the norm for adjustments we expect players to make, though if you have a text editior you can still hve at it. Expected uses for these options are included in their entry in data/core/external_options.json
+
+### Hack for migrating menu options
+In the case when a menu option is migrated to an external option, it is desireable to have already-adjusted world or global options take precedence over the new external option.
+In this case, leave the hard-coded defintion of the option in place in options.cpp, but add the COPT_HIDE flag to the definition to hide it from the menu.  If it is a "world_default" type entry, leave it defined as such.  Then add a redundant entry to data/core/external_options.json with the addition of the "stub": true member, which indicates to the loading code that this entry should not override already-set values.

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2751,8 +2751,6 @@ void options_manager::add_options_world_default()
     add( "CITY_SIZE", "world_default", translation(), translation(), 0, 16, 8, COPT_ALWAYS_HIDE
        );
 
-    add_empty_line();
-
     add( "CITY_SPACING", "world_default", translation(), translation(), 0, 8, 4, COPT_ALWAYS_HIDE
        );
 
@@ -2780,36 +2778,16 @@ void options_manager::add_options_world_default()
          0.0, 100, 1.0, 0.01, COPT_ALWAYS_HIDE
        );
 
-    add_empty_line();
+    add( "SEASON_LENGTH", "world_default", translation(), translation(), 14, 127, 91,
+         COPT_ALWAYS_HIDE );
 
-    add_option_group( "world_default", Group( "spawn_time_opts", to_translation( "World time options" ),
-                      to_translation( "Options regarding the passage of time in the world." ) ),
-    [&]( const std::string & page_id ) {
-        add( "SEASON_LENGTH", page_id, to_translation( "Season length" ),
-             to_translation( "Season length, in days.  Warning: Very little other than the duration of seasons scales with this value, so adjusting it may cause nonsensical results." ),
-             14, 127, 91
-           );
+    add( "CONSTRUCTION_SCALING", "world_default", translation(), translation(), 0, 1000, 100,
+         COPT_ALWAYS_HIDE );
 
-        add( "CONSTRUCTION_SCALING", page_id, to_translation( "Construction scaling" ),
-             to_translation( "Sets the time of construction in percents.  '50' is two times faster than default, '200' is two times longer.  '0' automatically scales construction time to match the world's season length." ),
-             0, 1000, 100
-           );
+    add( "ETERNAL_SEASON", "world_default", translation(), translation(), false, COPT_ALWAYS_HIDE );
 
-        add( "ETERNAL_SEASON", page_id, to_translation( "Eternal season" ),
-             to_translation( "If true, keep the initial season for ever." ),
-             false
-           );
-
-        add( "ETERNAL_TIME_OF_DAY", page_id, to_translation( "Day/night cycle" ),
-        to_translation( "Day/night cycle settings.  'Normal' sets a normal cycle.  'Eternal Day' sets eternal day.  'Eternal Night' sets eternal night." ), {
-            { "normal", to_translation( "Normal" ) },
-            { "day", to_translation( "Eternal Day" ) },
-            { "night", to_translation( "Eternal Night" ) },
-        }, "normal"
-           );
-    } );
-
-    add_empty_line();
+    add( "ETERNAL_TIME_OF_DAY", "world_default", translation(), translation(), "normal", 8,
+         COPT_ALWAYS_HIDE );
 
     add_option_group( "world_default", Group( "misc_worlddef_opts", to_translation( "Misc options" ),
                       to_translation( "Miscellaneous options." ) ),

--- a/src/worldfactory.cpp
+++ b/src/worldfactory.cpp
@@ -2033,6 +2033,13 @@ void load_external_option( const JsonObject &jo )
 {
     std::string name = jo.get_string( "name" );
     std::string stype = jo.get_string( "stype" );
+    bool stub = jo.get_bool( "stub", false );
+    // This is a hack to aid in migrating options to external without overriding already-set options.
+    // See doc/JSON/OPTIONS.md for more information.
+    if( stub ) {
+        jo.allow_omitted_members();
+        return;
+    }
     options_manager &opts = get_options();
     if( !opts.has_option( name ) ) {
         opts.add_external( name, "external_options", stype );

--- a/tests/options_test.cpp
+++ b/tests/options_test.cpp
@@ -54,6 +54,8 @@ TEST_CASE( "option_slider_test", "[option]" )
         CHECK( opt.second == old_opts.at( opt.first ) );
         const auto iter = expected_default_lvl3.find( opt.first );
         if( iter != expected_default_lvl3.end() ) {
+            CAPTURE( opt.first );
+            CAPTURE( opt.second.getType() );
             CHECK( opt.second.getValue() == iter->second );
             checked++;
         }
@@ -66,6 +68,8 @@ TEST_CASE( "option_slider_test", "[option]" )
     for( const auto &opt : opts ) {
         const auto iter = expected_highest_difficulty_lvl6.find( opt.first );
         if( iter != expected_highest_difficulty_lvl6.end() ) {
+            CAPTURE( opt.first );
+            CAPTURE( opt.second.getType() );
             CHECK( opt.second.getValue() == iter->second );
             checked++;
         }
@@ -79,6 +83,8 @@ TEST_CASE( "option_slider_test", "[option]" )
         CHECK( opt.second == old_opts.at( opt.first ) );
         const auto iter = expected_default_lvl3.find( opt.first );
         if( iter != expected_default_lvl3.end() ) {
+            CAPTURE( opt.first );
+            CAPTURE( opt.second.getType() );
             CHECK( opt.second.getValue() == iter->second );
             checked++;
         }


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Was reminded these nonsense options are still present when someone asked if it could break things (yes).

#### Describe the solution
Stop displaying them in the options menu, migrate to external options so mods can still override them.
Added a hack to ease migration. If an external option has the "stub": true field, it does not overwrite the existing value.
Added a docs/JSON/OPTIONS.md file to document some not-obvious things about options and also this hack.

#### Testing
Set ETERNAL_TIME_OF_DAY to "day", then loaded in updated version, setting is still present and takes effect.

#### Describe alternatives you've considered
Tempting to just remove them, but nah.

#### Additional context
The original rationale for crazy short seasons was "it's not feasible for people to survive all the way to winter which is why winter features are underdeveloped", but uh, about 10 years of development later has demonstrated that's not the case, winter features are just kind of a pain and get neglected.
Construction scaling is a tunable that mods might be interested in messing with, no reason for it to be front and center in the main game.
Eternal Season and Eternal Time of Day are ancient hacks to get some different play variation jammed into the game, but it's a severely lacking approach, if you want eternal winter it should really come bundled in a mod that gives it some framing instead of just changing that one thing and leaving everything else in place making no sense.