### PR TITLE
Attempt to increase average autotravel speed when driving on straight roads

### DIFF
--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -991,14 +991,16 @@ void sfx::do_vehicle_engine_sfx()
         current_gear = previous_gear;
     }
 
-    if( !veh->is_autodriving && current_gear > previous_gear ) {
-        play_variant_sound( "vehicle", "gear_shift", seas_str, indoors, night,
-                            get_heard_volume( player_character.pos_bub() ), 0_degrees, 0.8, 0.8 );
-        add_msg_debug( debugmode::DF_SOUND, "GEAR UP" );
-    } else if( !veh->is_autodriving && current_gear < previous_gear ) {
-        play_variant_sound( "vehicle", "gear_shift", seas_str, indoors, night,
-                            get_heard_volume( player_character.pos_bub() ), 0_degrees, 1.2, 1.2 );
-        add_msg_debug( debugmode::DF_SOUND, "GEAR DOWN" );
+    if( !veh->is_autodriving ) {
+        if( current_gear > previous_gear ) {
+            play_variant_sound( "vehicle", "gear_shift", seas_str, indoors, night,
+                                get_heard_volume( player_character.pos_bub() ), 0_degrees, 0.8, 0.8 );
+            add_msg_debug( debugmode::DF_SOUND, "GEAR UP" );
+        } else if( current_gear < previous_gear ) {
+            play_variant_sound( "vehicle", "gear_shift", seas_str, indoors, night,
+                                get_heard_volume( player_character.pos_bub() ), 0_degrees, 1.2, 1.2 );
+            add_msg_debug( debugmode::DF_SOUND, "GEAR DOWN" );
+        }
     }
     double pitch = 1.0;
     if( current_gear != 0 ) {

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -991,11 +991,11 @@ void sfx::do_vehicle_engine_sfx()
         current_gear = previous_gear;
     }
 
-    if( current_gear > previous_gear ) {
+    if( !veh->is_autodriving && current_gear > previous_gear ) {
         play_variant_sound( "vehicle", "gear_shift", seas_str, indoors, night,
                             get_heard_volume( player_character.pos_bub() ), 0_degrees, 0.8, 0.8 );
         add_msg_debug( debugmode::DF_SOUND, "GEAR UP" );
-    } else if( current_gear < previous_gear ) {
+    } else if( !veh->is_autodriving && current_gear < previous_gear ) {
         play_variant_sound( "vehicle", "gear_shift", seas_str, indoors, night,
                             get_heard_volume( player_character.pos_bub() ), 0_degrees, 1.2, 1.2 );
         add_msg_debug( debugmode::DF_SOUND, "GEAR DOWN" );
@@ -1010,7 +1010,7 @@ void sfx::do_vehicle_engine_sfx()
         }
     }
 
-    if( current_speed != previous_speed ) {
+    if( !veh->is_autodriving && current_speed != previous_speed ) {
         Mix_HaltChannel( static_cast<int>( ch ) );
         add_msg_debug( debugmode::DF_SOUND, "STOP speed %d =/= %d", current_speed, previous_speed );
         play_ambient_variant_sound( id_and_variant.first, id_and_variant.second,


### PR DESCRIPTION
#### Summary
Bugfixes "Attempt to increase average autotravel speed when driving on straight roads"

#### Purpose of change

Attempts to partially improve #53832

Currently, autotravel speed is limited to 3 tiles per second. When travelling over large distances it is not very fast, both in terms of real time and in-game time. This change attempts to increase this limit to 10 tiles per second in limited circumstances to provide an overall speedup, mainly when the vehicle is travelling over long straight distances, like roads.

#### Describe the solution
Current implementation uses A* to keep track of the path through the next 2 overmap tiles. After crossing a tile, the rest of the calculated path is disregarded and the route for the next 2 tiles is recalculated again. However, the algorithm struggles when the car is dealing with big speed differences, so if the speed limit is raised about 3 tiles per second collisions begin to frequently occur if a lot of turns are needed.

This change adds a greedy algorithm that is activated when the car is simply traveling in a straight line without any turning or obstacles to avoid. If the whole route through the next 2 overmap tiles calculated by A* is a straight line, the car will accelerate to 10 tiles per second, disregarding the A* suggestions until the next overmap tile is reached.

As the route is recalculated every overmap tile and we are checking the next 2 overmap tiles, the resulting acceleration is safe as A* always has enough time to brake if more delicate pathfinding is needed.

With the new approach, acceleration and deceleration of the car during travel is significantly more common and gear shift sound becomes very annoying (multiple times per second on a good CPU), so it is **disabled** if the car is used in autotravel mode.


#### Describe alternatives you've considered

Find a way to rewrite the A* approach. 
Theoretically, if acceleration/deceleration delays were properly included in the algorithm or car's speed was included as part of the graph's node, the collision problem may be solved at the core. That would make #57642 the best way forward. However, this requires significant research and time to maybe make it work.

Increase the current speed limit. 
3 tiles per second seems to be working, but it may not be the fastest safe option. We could slowly increase it and see if stability remains. With #70780 merged, the whole system has become more stable, so an increase may work this time.

#### Testing

A lot of driving around in spawned cars. It is very easy to spot when the greedy algorithm kicks in as the speed jumps significantly. Confirmed that the average travel time, especially if doing it over roads has decreased as expected.

Tried my best to crash, seems to be as crash-safe as the default autodriving.

However, a new quirk has been developed. Rarely, a car may decide to do a small loop before continuing forward. As this doesn't cause collisions and the overall travel time is still lower, I believe this to be an acceptable sacrifice. My best guess is that happens when you are driving diagonally right through a corner of overmap tiles due to pathfinding limitations (it doesn't consider overmap tiles to the left/right of you when pathfinding).

#### Additional context

I lack enough experience with weird car setups to ensure that I cover all edge-cases. I would greatly appreciate additional testing on this.

10 tiles per second was chosen somewhat arbitrarily to stay on the safe side. Technically, it should be possible to push this value up to 12-24 tiles per second, but I think it is best to play it safe.

