### PR TITLE
Bulk overmap testing debug tools

### DIFF
--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -501,6 +501,22 @@ void prompt_map_reveal( const std::optional<tripoint_abs_omt> &p )
     if( vis_sel.ret == UILIST_CANCEL ) {
         return;
     }
+    if( vis_sel.ret == static_cast<int>( om_vision_level::full ) ) {
+        if( !!p ) {
+            int reveal_radius = 0;
+            if( query_int( reveal_radius, false,
+                           _( "Overmap reveal radius: (0-5)" ) ) ) {
+                reveal_radius = std::clamp( reveal_radius, 0, 5 );
+            }
+            tripoint_abs_om p_om = project_to<coords::om>( *p );
+            tripoint_range<tripoint_abs_om> p_om_radius = points_in_radius( p_om, reveal_radius );
+
+            for( const tripoint_abs_om &surrounding_om : p_om_radius ) {
+                map_reveal( vis_sel.ret, project_to<coords::omt>( surrounding_om ) );
+            }
+        }
+        return;
+    }
     map_reveal( vis_sel.ret, p );
 }
 

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -64,6 +64,7 @@
 #include "game.h"
 #include "game_inventory.h"
 #include "global_vars.h"
+#include "imgui/imgui.h"
 #include "imgui_demo.h"
 #include "input.h"
 #include "input_context.h"
@@ -109,7 +110,6 @@
 #include "recipe_dictionary.h"
 #include "relic.h"
 #include "requirements.h"
-#include "ret_val.h"
 #include "skill.h"
 #include "sounds.h"
 #include "stomach.h"
@@ -121,7 +121,6 @@
 #include "trait_group.h"
 #include "translation.h"
 #include "translations.h"
-#include "try_parse_integer.h"
 #include "type_id.h"
 #include "uilist.h"
 #include "ui_manager.h"
@@ -236,6 +235,7 @@ std::string enum_to_string<debug_menu::debug_menu_index>( debug_menu::debug_menu
         case debug_menu::debug_menu_index::OM_TELEPORT: return "OM_TELEPORT";
         case debug_menu::debug_menu_index::OM_TELEPORT_COORDINATES: return "OM_TELEPORT_COORDINATES";
         case debug_menu::debug_menu_index::OM_TELEPORT_CITY: return "OM_TELEPORT_CITY";
+        case debug_menu::debug_menu_index::PRINT_OVERMAPS: return "PRINT_OVERMAP";
         case debug_menu::debug_menu_index::TRAIT_GROUP: return "TRAIT_GROUP";
         case debug_menu::debug_menu_index::ENABLE_ACHIEVEMENTS: return "ENABLE_ACHIEVEMENTS";
         case debug_menu::debug_menu_index::UNLOCK_ALL: return "UNLOCK_ALL";
@@ -1007,6 +1007,7 @@ static int map_uilist()
         { uilist_entry( debug_menu_index::OM_EDITOR, true, 'O', _( "Overmap editor" ) ) },
         { uilist_entry( debug_menu_index::MAP_EXTRA, true, 'm', _( "Spawn map extra" ) ) },
         { uilist_entry( debug_menu_index::NESTED_MAPGEN, true, 'n', _( "Spawn nested mapgen" ) ) },
+        { uilist_entry( debug_menu_index::PRINT_OVERMAPS, true, 'v', _( "Print overmaps" ) ) }
     };
 
     return uilist( _( "Map…" ), uilist_initializer );
@@ -1788,51 +1789,10 @@ static void teleport_long()
 static void teleport_overmap( bool specific_coordinates = false )
 {
     Character &player_character = get_player_character();
-    tripoint_abs_omt where;
+    std::optional<tripoint_abs_omt> where;
     if( specific_coordinates ) {
-        const std::string text = string_input_popup()
-                                 .title( _( "Teleport where?" ) )
-                                 .width( 20 )
-                                 .query_string();
-        if( text.empty() ) {
-            return;
-        }
-        const std::vector<std::string> coord_strings = string_split( text, ',' );
-        if( coord_strings.size() < 2 || coord_strings.size() > 3 ) {
-            popup( _( "Error interpreting teleport target: "
-                      "expected two or three comma-separated values; got %zu" ),
-                   coord_strings.size() );
-            return;
-        }
-        std::vector<std::pair<int, int>> coord_ints;
-        for( const std::string &coord_string : coord_strings ) {
-            const std::vector<std::string> coord_parts = string_split( coord_string, '\'' );
-            if( coord_parts.empty() || coord_parts.size() > 2 ) {
-                popup( _( "Error interpreting teleport target: "
-                          "expected an integer or two integers separated by \'; got %s" ), coord_string );
-                return;
-            }
-            ret_val<int> parsed_coord = try_parse_integer<int>( coord_parts[0], true );
-            if( !parsed_coord.success() ) {
-                popup( _( "Error interpreting teleport target: %s" ), parsed_coord.str() );
-                return;
-            }
-            int major_coord = parsed_coord.value();
-            int minor_coord = 0;
-            if( coord_parts.size() >= 2 ) {
-                ret_val<int> parsed_coord2 = try_parse_integer<int>( coord_parts[1], true );
-                if( !parsed_coord2.success() ) {
-                    popup( _( "Error interpreting teleport target: %s" ), parsed_coord2.str() );
-                    return;
-                }
-                minor_coord = parsed_coord2.value();
-            }
-            coord_ints.emplace_back( major_coord, minor_coord );
-        }
-        cata_assert( coord_ints.size() >= 2 );
-        where = tripoint_abs_omt( OMAPX * coord_ints[0].first + coord_ints[0].second,
-                                  OMAPY * coord_ints[1].first + coord_ints[1].second,
-                                  ( coord_ints.size() >= 3 ? coord_ints[2].first : 0 ) );
+        where = string_input_popup().title( _( "Teleport where?" ) ).width(
+                    20 ).query_coordinate_abs_impl();
     } else {
         const std::optional<tripoint_rel_ms> dir_ = choose_direction(
                     _( "Where is the desired overmap?" ) );
@@ -1842,11 +1802,13 @@ static void teleport_overmap( bool specific_coordinates = false )
         const tripoint offset = tripoint( OMAPX * dir_->x(), OMAPY * dir_->y(), dir_->z() );
         where = player_character.pos_abs_omt() + offset;
     }
-    g->place_player_overmap( where );
+    if( !!where ) {
+        g->place_player_overmap( *where );
 
-    const tripoint_abs_om new_pos =
-        project_to<coords::om>( player_character.pos_abs_omt() );
-    add_msg( _( "You teleport to overmap %s." ), new_pos.to_string() );
+        const tripoint_abs_om new_pos =
+            project_to<coords::om>( player_character.pos_abs_omt() );
+        add_msg( _( "You teleport to overmap %s." ), new_pos.to_string() );
+    }
 }
 
 static void teleport_city()
@@ -3850,7 +3812,73 @@ static void wind_speed()
     }
 }
 
+//prints overmaps in provided bounds, saves to file, copies to clipboard
+static void print_overmaps()
+{
+    std::optional<tripoint_abs_omt> p1 = string_input_popup().title( _( "Top-left point?" ) ).width(
+            20 ).query_coordinate_abs_impl();
+    if( !!p1 ) {
+        std::optional<tripoint_abs_omt> p2 = string_input_popup().title( _( "Bottom-right point?" ) ).width(
+                20 ).query_coordinate_abs_impl();
+        if( !!p2 ) {
+            if( p1->z() != p2->z() ) {
+                popup( _( "z-values must match!  (provided %d, %d)" ), p1->z(), p2->z() );
+                return;
+            }
+            if( p1->x() > p2->x() || p1->y() > p2->y() ) {
+                popup( _( "Second point was not bottom-left!" ) );
+                return;
+            }
+            tripoint_abs_om p1_om = project_to<coords::om>( *p1 );
+            tripoint_abs_om p2_om = project_to<coords::om>( *p2 );
+            int p1_z = p1_om.z();
+            point_rel_om diff = p2_om.xy() - p1_om.xy();
 
+            std::vector<std::string> final_lines;
+            oter_display_args oter_args( om_vision_level::full );
+            const oter_display_options oter_opts( *p1, 100 );
+
+            for( int row = 0; row <= diff.y(); row++ ) {
+                std::vector<std::vector<std::string>> row_lines;
+                for( int col = 0; col <= diff.x(); col++ ) {
+
+                    const overmap *current_om = overmap_buffer.get_existing( point_abs_om( p1_om.x() + col,
+                                                p1_om.y() + row ) );
+                    std::vector<std::string> om_lines;
+                    for( int j = 0; j < OMAPY; j++ ) {
+                        std::string om_row;
+                        for( int i = 0; i < OMAPX; i++ ) {
+                            om_row += current_om != nullptr ?
+                                      oter_symbol_and_color( current_om->global_base_point() + tripoint_rel_omt( i, j, p1_z ), oter_args,
+                                                             oter_opts ).first
+                                      //current_om->ter( tripoint_om_omt( i, j, p1_z ) )->get_symbol( om_vision_level::full )
+                                      : " ";
+                        }
+                        om_lines.emplace_back( om_row );
+                    }
+                    row_lines.emplace_back( om_lines );
+                }
+                for( int r = 0; r < OMAPY; r++ ) {
+                    std::string final_line;
+                    for( const std::vector<std::string> &iter_om_lines : row_lines ) {
+                        final_line += iter_om_lines[r];
+                    }
+                    final_lines.emplace_back( final_line );
+                }
+            }
+
+            //build string
+            std::string final_text;
+            for( const std::string &line : final_lines ) {
+                final_text += line + '\n';
+            }
+            //copy to clipboard
+            ImGui::SetClipboardText( final_text.c_str() );
+            popup( _( "Copied overmap in points %s, %s to clipboard!" ), p1_om.to_string_writable(),
+                   p2_om.to_string_writable() );
+        }
+    }
+}
 
 static void run_imgui_demo()
 {
@@ -4212,6 +4240,9 @@ void debug()
             break;
         case debug_menu_index::OM_TELEPORT_CITY:
             debug_menu::teleport_city();
+            break;
+        case debug_menu_index::PRINT_OVERMAPS:
+            debug_menu::print_overmaps();
             break;
         case debug_menu_index::TRAIT_GROUP:
             trait_group::debug_spawn();

--- a/src/debug_menu.h
+++ b/src/debug_menu.h
@@ -68,6 +68,7 @@ enum class debug_menu_index : int {
     OM_TELEPORT,
     OM_TELEPORT_COORDINATES,
     OM_TELEPORT_CITY,
+    PRINT_OVERMAPS,
     TRAIT_GROUP,
     ENABLE_ACHIEVEMENTS,
     SHOW_MSG,

--- a/src/string_input_popup.cpp
+++ b/src/string_input_popup.cpp
@@ -351,6 +351,24 @@ std::optional<T> query_int_impl( string_input_popup &p, const bool loop, const b
     return 0;
 }
 
+std::optional<tripoint_abs_omt> string_input_popup::query_coordinate_abs_impl( bool loop,
+        bool draw_only )
+{
+    do {
+        const std::string &queried_string = query_string( loop, draw_only );
+        ret_val<tripoint_abs_omt> result = try_parse_coordinate_abs( queried_string );
+        if( canceled() || queried_string.empty() ) {
+            return std::nullopt;
+        }
+        if( result.success() ) {
+            return result.value();
+        }
+        popup( result.str() );
+    } while( loop );
+
+    return tripoint_abs_omt::zero;
+}
+
 std::optional<int> string_input_popup::query_int( const bool loop, const bool draw_only )
 {
     return query_int_impl<int>( *this, loop, draw_only );

--- a/src/string_input_popup.h
+++ b/src/string_input_popup.h
@@ -13,6 +13,7 @@
 #include <vector>
 
 #include "color.h"
+#include "coordinates.h"
 #include "cursesdef.h"
 #include "dialogue_helpers.h"
 
@@ -251,6 +252,8 @@ class string_input_popup // NOLINT(cata-xy)
         std::optional<int> query_int( bool loop = true, bool draw_only = false );
         std::optional<int64_t> query_int64_t( bool loop = true, bool draw_only = false );
         const std::string &query_string( bool loop = true, bool draw_only = false );
+        std::optional<tripoint_abs_omt> query_coordinate_abs_impl( bool loop = true,
+                bool draw_only = false );
         /**@}*/
         /**
          * Whether the input box was canceled via the ESCAPE key (or similar)

--- a/src/try_parse_integer.cpp
+++ b/src/try_parse_integer.cpp
@@ -3,9 +3,16 @@
 #include <locale>
 #include <sstream>
 #include <string>
+#include <utility>
+#include <vector>
 
+#include "cata_utility.h"
+#include "coordinates.h"
+#include "map_scale_constants.h"
+#include "point.h"
 #include "string_formatter.h"
 #include "translations.h"
+
 
 template<typename T>
 ret_val<T> try_parse_integer( std::string_view s, bool use_locale )
@@ -46,3 +53,44 @@ ret_val<T> try_parse_integer( std::string_view s, bool use_locale )
 template ret_val<int> try_parse_integer<int>( std::string_view, bool use_locale );
 template ret_val<long> try_parse_integer<long>( std::string_view, bool use_locale );
 template ret_val<long long> try_parse_integer<long long>( std::string_view, bool use_locale );
+
+ret_val<tripoint_abs_omt> try_parse_coordinate_abs( std::string_view s )
+{
+    const std::vector<std::string> coord_strings = string_split( s, ',' );
+    if( coord_strings.size() < 2 || coord_strings.size() > 3 ) {
+        return ret_val<tripoint_abs_omt>::make_failure( tripoint_abs_omt::zero,
+                string_format( _( "Error interpreting coordinate: "
+                                  "expected two or three comma-separated values; got %zu" ),
+                               coord_strings.size() ) );
+    }
+    std::vector<std::pair<int, int>> coord_ints;
+    for( const std::string &coord_string : coord_strings ) {
+        const std::vector<std::string> coord_parts = string_split( coord_string, '\'' );
+        if( coord_parts.empty() || coord_parts.size() > 2 ) {
+            return ret_val<tripoint_abs_omt>::make_failure( tripoint_abs_omt::zero,
+                    string_format( _( "Error interpreting coordinate: "
+                                      "expected an integer or two integers separated by \'; got %s" ), coord_string ) );
+        }
+        ret_val<int> parsed_coord = try_parse_integer<int>( coord_parts[0], true );
+        if( !parsed_coord.success() ) {
+            return ret_val<tripoint_abs_omt>::make_failure( tripoint_abs_omt::zero,
+                    string_format( _( "Error interpreting coordinate: %s" ), parsed_coord.str() ) );
+        }
+        int major_coord = parsed_coord.value();
+        int minor_coord = 0;
+        if( coord_parts.size() >= 2 ) {
+            ret_val<int> parsed_coord2 = try_parse_integer<int>( coord_parts[1], true );
+            if( !parsed_coord2.success() ) {
+                return ret_val<tripoint_abs_omt>::make_failure( tripoint_abs_omt::zero,
+                        string_format( _( "Error interpreting coordinate: %s" ), parsed_coord2.str() ) );
+            }
+            minor_coord = parsed_coord2.value();
+        }
+        coord_ints.emplace_back( major_coord, minor_coord );
+    }
+    cata_assert( coord_ints.size() >= 2 );
+    return ret_val<tripoint_abs_omt>::make_success( tripoint_abs_omt( OMAPX * coord_ints[0].first +
+            coord_ints[0].second,
+            OMAPY * coord_ints[1].first + coord_ints[1].second,
+            ( coord_ints.size() >= 3 ? coord_ints[2].first : 0 ) ) );
+}

--- a/src/try_parse_integer.h
+++ b/src/try_parse_integer.h
@@ -4,6 +4,7 @@
 
 #include <string_view>
 
+#include "coordinates.h"
 #include "ret_val.h"
 
 /**
@@ -21,5 +22,7 @@ extern template ret_val<int> try_parse_integer<int>( std::string_view, bool use_
 extern template ret_val<long> try_parse_integer<long>( std::string_view, bool use_locale );
 extern template ret_val<long long> try_parse_integer<long long>( std::string_view,
         bool use_locale );
+
+ret_val<tripoint_abs_omt> try_parse_coordinate_abs( std::string_view s );
 
 #endif // CATA_SRC_TRY_PARSE_INTEGER_H


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Infrastructure "bulk overmap testing debug tools"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

These are some commits that I've been using for rivers/highways that I wanted to keep separate.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

The first commit allows for full-revealing up to 5 overmaps in a radius. Defaults to current overmap if nothing is inputted.
The second commit allows for printing out ASCII overmaps in range [p1, p2], copying to clipboard.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

I've been using them pretty frequently, and they're debug tools.

![image](https://github.com/user-attachments/assets/d5742af5-c669-441d-9606-6a812c691f78)

I've been using Notepad++ UDLs to highlight certain OMTs, which lets me do things like highlight water (and farm fields, just ignore that):
![image](https://github.com/user-attachments/assets/bdd11f45-b4f8-41b5-99df-7bfdc2b85e19)


<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Update on highways: going okay, have a couple bugs to iron out, and probably need to make separate PRs for controlling road pathing under highways and predetermining lake overmaps so that intersections can't generate on lakes.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
