### PR TITLE
bombasticperks: add StatsThroughSkills

### DIFF
--- a/data/mods/BombasticPerks/perkmenu.json
+++ b/data/mods/BombasticPerks/perkmenu.json
@@ -1339,7 +1339,7 @@
       },
       {
         "condition": {
-          "or": [ { "mod_is_loaded": "magiclysm" }, { "mod_is_loaded": "mindovermatter" }, { "mod_is_loaded": "xedra_evolved" } ]
+          "or": [ { "mod_is_loaded": "magiclysm" } ]
         },
         "text": "Metamagic Perks",
         "topic": "TALK_PERK_MENU_METAMAGIC"

--- a/data/mods/BombasticPerks/perkmenu.json
+++ b/data/mods/BombasticPerks/perkmenu.json
@@ -1455,7 +1455,10 @@
         "text": "Gain [<trait_name:perk_statsThroughSkills>]",
         "effect": [
           { "set_string_var": "<trait_name:perk_statsThroughSkills>", "target_var": { "context_val": "trait_name" } },
-          { "set_string_var": "<trait_description:perk_statsThroughSkills>", "target_var": { "context_val": "trait_description" } },
+          {
+            "set_string_var": "<trait_description:perk_statsThroughSkills>",
+            "target_var": { "context_val": "trait_description" }
+          },
           { "set_string_var": "perk_statsThroughSkills", "target_var": { "context_val": "trait_id" } },
           {
             "set_string_var": "No Requirements",

--- a/data/mods/BombasticPerks/perkmenu.json
+++ b/data/mods/BombasticPerks/perkmenu.json
@@ -1338,7 +1338,9 @@
         "topic": "TALK_PERK_MENU_PLAYSTYLE"
       },
       {
-        "condition": { "mod_is_loaded": "magiclysm" },
+        "condition": {
+          "or": [ { "mod_is_loaded": "magiclysm" }, { "mod_is_loaded": "mindovermatter" }, { "mod_is_loaded": "xedra_evolved" } ]
+        },
         "text": "Metamagic Perks",
         "topic": "TALK_PERK_MENU_METAMAGIC"
       },
@@ -1439,6 +1441,22 @@
           { "set_string_var": "<trait_name:22_is_cool>", "target_var": { "context_val": "trait_name" } },
           { "set_string_var": "<trait_description:22_is_cool>", "target_var": { "context_val": "trait_description" } },
           { "set_string_var": "22_is_cool", "target_var": { "context_val": "trait_id" } },
+          {
+            "set_string_var": "No Requirements",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
+          { "set_condition": "perk_condition", "condition": { "math": [ "0 == 0" ] } }
+        ],
+        "topic": "TALK_PERK_MENU_SELECT_PLAYSTYLE"
+      },
+      {
+        "condition": { "not": { "u_has_trait": "perk_statsThroughSkills" } },
+        "text": "Gain [<trait_name:perk_statsThroughSkills>]",
+        "effect": [
+          { "set_string_var": "<trait_name:perk_statsThroughSkills>", "target_var": { "context_val": "trait_name" } },
+          { "set_string_var": "<trait_description:perk_statsThroughSkills>", "target_var": { "context_val": "trait_description" } },
+          { "set_string_var": "perk_statsThroughSkills", "target_var": { "context_val": "trait_id" } },
           {
             "set_string_var": "No Requirements",
             "target_var": { "context_val": "trait_requirement_description" },

--- a/data/mods/BombasticPerks/perkmenu.json
+++ b/data/mods/BombasticPerks/perkmenu.json
@@ -1338,9 +1338,7 @@
         "topic": "TALK_PERK_MENU_PLAYSTYLE"
       },
       {
-        "condition": {
-          "or": [ { "mod_is_loaded": "magiclysm" } ]
-        },
+        "condition": { "or": [ { "mod_is_loaded": "magiclysm" } ] },
         "text": "Metamagic Perks",
         "topic": "TALK_PERK_MENU_METAMAGIC"
       },

--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -1272,7 +1272,7 @@
     "points": 0,
     "purifiable": false,
     "valid": false,
-	"category": [ "perk" ],
+    "category": [ "perk" ],
     "enchantments": [
       {
         "condition": "ALWAYS",

--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -1263,5 +1263,54 @@
         "values": [ { "value": "RANGED_ARMOR_PENETRATION", "add": 5 }, { "value": "WEAKPOINT_ACCURACY", "multiply": 3 } ]
       }
     ]
+  },
+  {
+    "type": "mutation",
+    "id": "perk_statsthroughskills",
+    "name": { "str": "Stats Through Skills" },
+    "description": "Your stats have been increased based on your skills.",
+    "points": 0,
+    "purifiable": false,
+    "valid": false,
+	"category": [ "perk" ],
+    "enchantments": [
+      {
+        "condition": "ALWAYS",
+        "values": [
+          {
+            "value": "STRENGTH",
+            "add": {
+              "math": [
+                "max((u_skill('mechanics') + u_skill('swimming') + u_skill('bashing') + u_skill('cutting') + u_skill('melee') + u_skill('throw') - 3), 0) ^ 0.4"
+              ]
+            }
+          },
+          {
+            "value": "DEXTERITY",
+            "add": {
+              "math": [
+                "max((u_skill('driving') + u_skill('survival') + u_skill('tailor') + u_skill('traps') + u_skill('dodge') + u_skill('stabbing') + u_skill('unarmed') - 3) , 0) ^ 0.4"
+              ]
+            }
+          },
+          {
+            "value": "INTELLIGENCE",
+            "add": {
+              "math": [
+                "max((u_skill('computer') + u_skill('cooking') + u_skill('electronics') + u_skill('fabrication') + u_skill('firstaid') + u_skill('speech') + u_skill('chemistry') - 3), 0) ^ 0.4"
+              ]
+            }
+          },
+          {
+            "value": "PERCEPTION",
+            "add": {
+              "math": [
+                "max((u_skill('archery') + u_skill('gun') + u_skill('launcher') + u_skill('pistol') + u_skill('rifle') + u_skill('shotgun') + u_skill('smg') - 3), 0) ^ 0.4"
+              ]
+            }
+          }
+        ]
+      }
+    ]
   }
 ]


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Whilst the OG mod can't really fit in mainline, I find it fits for Bombastic Perks, due to its absurdity. (in addition, stats can still get reduced with skill rust.)

#### Describe the solution
Added the perks

#### Describe alternatives you've considered
NONE

#### Testing
Loaded the game, can confirm the mod menu & the perk itself functions

#### Additional context
Thanks to #81079 and [this mod](https://github.com/Erin105/StatsThroughSkills), I don't have to spend too much time making an implementation & stopped my procrastination ;)
