### PR TITLE
Whips update for Magiclysm and Xedra Evolved

### DIFF
--- a/data/mods/Magiclysm/items/enchanted_belts.json
+++ b/data/mods/Magiclysm/items/enchanted_belts.json
@@ -279,6 +279,7 @@
       "moves": 20,
       "msg": "You loop the whip in your hand and it coils back into a belt form in an instant."
     },
-    "melee_damage": { "bash": 8, "cut": 16 }
+    "melee_damage": { "bash": 8, "cut": 16 },
+    "weapon_category": [ "WHIPS" ]
   }
 ]

--- a/data/mods/Magiclysm/items/ethereal_items.json
+++ b/data/mods/Magiclysm/items/ethereal_items.json
@@ -234,7 +234,8 @@
     "flags": [ "REACH_ATTACK", "REACH3", "WHIP", "STURDY", "TRADER_AVOID", "UNBREAKABLE_MELEE", "NO_REPAIR", "MAGIC_FOCUS" ],
     "category": "weapons",
     "melee_damage": { "cut": 30 },
-    "passive_effects": [ { "has": "WIELD", "condition": "ALWAYS", "values": [ { "value": "UGLINESS", "add": 3 } ] } ]
+    "passive_effects": [ { "has": "WIELD", "condition": "ALWAYS", "values": [ { "value": "UGLINESS", "add": 3 } ] } ],
+    "weapon_category": [ "WHIPS" ]
   },
   {
     "id": "flarewhip",
@@ -266,7 +267,8 @@
     ],
     "to_hit": 3,
     "category": "weapons",
-    "melee_damage": { "cut": 6, "heat": 30 }
+    "melee_damage": { "cut": 6, "heat": 30 },
+    "weapon_category": [ "WHIPS" ]
   },
   {
     "id": "fleshpouch",

--- a/data/mods/Magiclysm/requirements/melee.json
+++ b/data/mods/Magiclysm/requirements/melee.json
@@ -306,5 +306,11 @@
         ]
       ]
     }
+  },
+  {
+    "id": "whips",
+    "type": "requirement",
+    "//": "Any weapon that features a handle and flexible lash.",
+    "tools": [ [ [ "tentacle_whip", -1 ], [ "flarewhip", -1 ], [ "mwhip_iron", -1 ] ] ]
   }
 ]

--- a/data/mods/Magiclysm/requirements/melee.json
+++ b/data/mods/Magiclysm/requirements/melee.json
@@ -311,6 +311,6 @@
     "id": "whips",
     "type": "requirement",
     "//": "Any weapon that features a handle and flexible lash.",
-    "tools": [ [ [ "tentacle_whip", -1 ], [ "flarewhip", -1 ], [ "mwhip_iron", -1 ] ] ]
+    "extend": { "tools": [ [ [ "tentacle_whip", -1 ], [ "flarewhip", -1 ], [ "mwhip_iron", -1 ] ] ] }
   }
 ]

--- a/data/mods/Xedra_Evolved/items/ethereal_items.json
+++ b/data/mods/Xedra_Evolved/items/ethereal_items.json
@@ -321,7 +321,8 @@
       "FLAMING",
       "FIRE"
     ],
-    "passive_effects": [ { "id": "SALAMANDER_SUMMON_WHIP" } ]
+    "passive_effects": [ { "id": "SALAMANDER_SUMMON_WHIP" } ],
+    "weapon_category": [ "WHIPS" ]
   },
   {
     "id": "undine_waters_map",

--- a/data/mods/Xedra_Evolved/requirements/melee.json
+++ b/data/mods/Xedra_Evolved/requirements/melee.json
@@ -1,8 +1,3 @@
-Cataclysm: Dark Days Ahead JSON Web Linting Tool
-This is a tool to help modders and editors of the open source game Cataclysm: Dark Days Ahead write JSON in the game's expected format.
-
-Paste some JSON into the field below and click "Lint" to run an autoformatter against it.
-
 [
   {
     "id": "real_knives",

--- a/data/mods/Xedra_Evolved/requirements/melee.json
+++ b/data/mods/Xedra_Evolved/requirements/melee.json
@@ -146,7 +146,6 @@
     "id": "whips",
     "type": "requirement",
     "//": "Any weapon that features a handle and flexible lash.",
-    "tools": [ [ [ "salamander_flaming_summon_whip", -1 ] ] ]
+    "extend": { "tools": [ [ [ "salamander_flaming_summon_whip", -1 ] ] ] }
   }
 ]
-

--- a/data/mods/Xedra_Evolved/requirements/melee.json
+++ b/data/mods/Xedra_Evolved/requirements/melee.json
@@ -1,3 +1,8 @@
+Cataclysm: Dark Days Ahead JSON Web Linting Tool
+This is a tool to help modders and editors of the open source game Cataclysm: Dark Days Ahead write JSON in the game's expected format.
+
+Paste some JSON into the field below and click "Lint" to run an autoformatter against it.
+
 [
   {
     "id": "real_knives",
@@ -141,5 +146,12 @@
     "type": "requirement",
     "//": "Any real, cutting weapons that can be used like an axe; large, heavy head with two sharp sides on a pole.",
     "extend": { "tools": [ [ [ "dreamforged_battleaxe", -1 ] ] ] }
+  },
+  {
+    "id": "whips",
+    "type": "requirement",
+    "//": "Any weapon that features a handle and flexible lash.",
+    "tools": [ [ [ "salamander_flaming_summon_whip", -1 ] ] ]
   }
 ]
+


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "Add weapon_category "WHIPS" to modded whips from Magiclysm and XE to take advantage of recently added whip weapon proficiencies and allow those whips to be used for practice."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Since #81238 was merged, adding whip weapon proficiencies and practice recipes to vanilla, I'm updating the mods I'm aware of with whips to take advantage of that capability.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
I'm adding the weapon_category of "WHIPS" to the items with the WHIP tag in Magiclysm and XE (tentacle whip, flarewhip, iron belt whip, and salamander whip) so that using them improves proficiency in Whips and allows them to take advantage of existing whip proficiency. Additionally, I've added whips tools lists to the requirements\melee.json for each mod that include the above whips so that they can be used in the training recipes.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Do nothing and consider these whips to be separate from vanilla whips.
Use copy_from to inherit attributes from vanilla whips? I think the weapons in question are sufficiently different that this would introduce more problems than it solved.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
In world with Magiclysm enabled, spawned enemy and hit it with conjured Magiclysm tentacle whip. Observed that progress towards Whip Proficiency was improved by this action. In same world, opened practice menu and observed that magiclysm whips had been added to the list of tools for whip training.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
![image](https://github.com/user-attachments/assets/8f268312-3f54-4d7c-94d3-1ad9e0e5b48c)

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
