### PR TITLE
Remove map note if favorite item is picked up

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -13247,6 +13247,11 @@ bool Character::wield( item_location loc, bool remove_old )
     }
 
     if( remove_old && loc ) {
+        // Remove DROPPED_FAVORITES autonote if exists.
+        if( overmap_buffer.note( pos_abs_omt() ) == loc.get_item()->display_name() ) {
+            overmap_buffer.delete_note( pos_abs_omt() );
+        }
+
         loc.remove_item();
     }
     return true;

--- a/src/pickup.cpp
+++ b/src/pickup.cpp
@@ -33,6 +33,7 @@
 #include "mapdata.h"
 #include "math_parser_diag_value.h"
 #include "messages.h"
+#include "overmapbuffer.h"
 #include "options.h"
 #include "player_activity.h"
 #include "point.h"
@@ -336,6 +337,12 @@ static bool pick_one_up( item_location &loc, int quantity, bool &got_water, bool
         }
         player_character.flag_encumbrance();
         player_character.invalidate_weight_carried_cache();
+
+        // Remove DROPPED_FAVORITES autonote if exists.
+        const tripoint_abs_omt note_pos = player_character.pos_abs_omt();
+        if( overmap_buffer.note( note_pos ) == newit.display_name() ) {
+            overmap_buffer.delete_note( note_pos );
+        }
     }
 
     return picked_up || !did_prompt;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Picking favorite item back up will now remove map note if possible"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
If you enable map notes for dropped favorite item, i.e backpack and try to use this feature, you will soon end up with like 40 map notes. Personally, I would prefer the note being deleted once I repicked my item. #75785 is a good example of this.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
With the current note system, full handling of this is difficult as one tile can have multiple notes at the same time, so we are going with a simple "good enough" approximation. If an item's tile only has one note containing its precise name, the note will be deleted. This doesn't cover all the cases, but vast majority of them.

The solution is not perfect. It only handles picking item up or wielding it. It does not work with hauling, auto sort and other esoteric options.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Refactor the notes system, storing each note added to a tile as a separate object instead of bundling everything into one raw string. Then an universal solution could be produced, capable of handling any case.

Gating the removal behind autonote option being enabled. For it to trigger falsely someone would have to make a map note be the precise display name of an item and then proceed to pick this item up in the same tile - highly improbable.

#### Testing

Favorited an item and tried:
  * Dropping and picking them up -> success
  * Dropping and wielding them -> success
  * Dropping and hauling them -> does not work + autonote feature itself does not work as well
  * Dropping and autosorting them -> does not work

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->



<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
