### PR TITLE
Fix ALLOWS_REMOTE_USE not being compatible with deploy_furn/deploy_appliance

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -7218,8 +7218,7 @@ bool Character::invoke_item( item *used, const std::string &method, const tripoi
 
     actually_used->activation_consume( charges_used.value(), pt, this );
 
-    if( actually_used->has_flag( flag_SINGLE_USE ) || actually_used->is_bionic() ||
-        actually_used->is_deployable() ) {
+    if( actually_used->has_flag( flag_SINGLE_USE ) || actually_used->is_bionic() ) {
         i_rem( actually_used );
         return true;
     }

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -176,32 +176,37 @@ static const trap_str_id tr_firewood_source( "tr_firewood_source" );
 
 static const zone_type_id zone_type_SOURCE_FIREWOOD( "SOURCE_FIREWOOD" );
 
-static item_location get_item_location( Character &p, item &it, map *here,
-                                        const tripoint_bub_ms &pos )
+template<typename T>
+static item_location form_loc_recursive( T &loc, item &it )
 {
-    // Item on a character
-    if( p.has_item( it ) ) {
-        return item_location( p, &it );
+    item *parent = loc.find_parent( it );
+    if( parent != nullptr ) {
+        return item_location( form_loc_recursive( loc, *parent ), &it );
     }
 
-    // Item in a vehicle
-    if( const optional_vpart_position &vp = here->veh_at( pos ) ) {
+    return item_location( loc, &it );
+}
+
+static item_location form_loc( Character &you, map *here, const tripoint_bub_ms &p, item &it )
+{
+    if( you.has_item( it ) ) {
+        return form_loc_recursive( you, it );
+    }
+    map_cursor mc( here, p );
+    if( mc.has_item( it ) ) {
+        return form_loc_recursive( mc, it );
+    }
+    const optional_vpart_position vp = here->veh_at( p );
+    if( vp ) {
         vehicle_cursor vc( vp->vehicle(), vp->part_index() );
-        bool found_in_vehicle = false;
-        vc.visit_items( [&]( const item * e, item * ) {
-            if( e == &it ) {
-                found_in_vehicle = true;
-                return VisitResponse::ABORT;
-            }
-            return VisitResponse::NEXT;
-        } );
-        if( found_in_vehicle ) {
-            return item_location( vc, &it );
+        if( vc.has_item( it ) ) {
+            return form_loc_recursive( vc, it );
         }
     }
 
-    // Item on the map
-    return item_location( map_cursor( here, pos ), &it );
+    debugmsg( "Couldn't find item %s to form item_location, forming dummy location to ensure minimum functionality",
+              it.display_name() );
+    return item_location( you, &it );
 }
 
 std::unique_ptr<iuse_actor> iuse_transform::clone() const
@@ -1331,7 +1336,7 @@ std::optional<int> deploy_furn_actor::use( Character *p, item &it,
 
     here->furn_set( suitable.value(), furn_type, false, false, true );
     it.spill_contents( suitable.value() );
-    get_item_location( *p, it, here, pos ).remove_item();
+    form_loc( *p, here, pos, it ).remove_item();
     p->mod_moves( -to_moves<int>( 2_seconds ) );
     return 0;
 }
@@ -1373,7 +1378,7 @@ std::optional<int> deploy_appliance_actor::use( Character *p, item &it,
     // TODO: Use map aware operation when available
     if( place_appliance( *here, suitable.value(),
                          vpart_appliance_from_item( appliance_base ), *p, it ) ) {
-        get_item_location( *p, it, here, pos ).remove_item();
+        form_loc( *p, here, pos, it ).remove_item();
         p->mod_moves( -to_moves<int>( 2_seconds ) );
     }
     return 0;
@@ -2934,39 +2939,6 @@ bool holster_actor::store( Character &you, item &holster, item &obj ) const
     return true;
 }
 
-template<typename T>
-static item_location form_loc_recursive( T &loc, item &it )
-{
-    item *parent = loc.find_parent( it );
-    if( parent != nullptr ) {
-        return item_location( form_loc_recursive( loc, *parent ), &it );
-    }
-
-    return item_location( loc, &it );
-}
-
-static item_location form_loc( Character &you, map *here, const tripoint_bub_ms &p, item &it )
-{
-    if( you.has_item( it ) ) {
-        return form_loc_recursive( you, it );
-    }
-    map_cursor mc( here, p );
-    if( mc.has_item( it ) ) {
-        return form_loc_recursive( mc, it );
-    }
-    const optional_vpart_position vp = here->veh_at( p );
-    if( vp ) {
-        vehicle_cursor vc( vp->vehicle(), vp->part_index() );
-        if( vc.has_item( it ) ) {
-            return form_loc_recursive( vc, it );
-        }
-    }
-
-    debugmsg( "Couldn't find item %s to form item_location, forming dummy location to ensure minimum functionality",
-              it.display_name() );
-    return item_location( you, &it );
-}
-
 std::optional<int> holster_actor::use( Character *you, item &it, const tripoint_bub_ms &p ) const
 {
     return holster_actor::use( you, it, &get_map(), p );
@@ -3164,7 +3136,7 @@ std::optional<int> repair_item_actor::use( Character *p, item &it,
     // We also need to store the repair actor subtype in the activity
     p->activity.str_values.push_back( type );
     // storing of item_location to support repairs by tools on the ground
-    p->activity.targets.emplace_back( get_item_location( *p, it, here, pos ) );
+    p->activity.targets.emplace_back( form_loc( *p, here, pos, it ) );
     // All repairs are done in the activity, including charge cost and target item selection
     return 0;
 }

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -1229,17 +1229,29 @@ void deploy_furn_actor::load( const JsonObject &obj, const std::string & )
 
 
 static ret_val<tripoint_bub_ms> check_deploy_square( Character *p, item &it,
-        map *here, const tripoint_bub_ms &pos )
+        map *here, const tripoint_bub_ms &pos, item_location &loc )
 {
     if( p->cant_do_mounted() ) {
         return ret_val<tripoint_bub_ms>::make_failure( pos );
     }
     tripoint_bub_ms pnt( pos );
-    if( pos == p->pos_bub( *here ) ) {
+    const auto choose = [&]() {
         // TODO: Use map aware 'choose_adjacent' when available, or reject operation if not reality bubble map
         if( const std::optional<tripoint_bub_ms> pnt_ = choose_adjacent( _( "Deploy where?" ) ) ) {
             pnt = *pnt_;
         } else {
+            return false;
+        }
+        return true;
+    };
+    if( pos == p->pos_bub( *here ) ) {
+        if( !choose() ) {
+            return ret_val<tripoint_bub_ms>::make_failure( pos );
+        }
+    } else if( p->can_stash( it ) ) {
+        // If we could pick it up for ALLOWS_REMOTE_USE items
+        p->assign_activity( pickup_activity_actor( { loc }, { 0 }, p->pos_bub(), false ) );
+        if( !choose() ) {
             return ret_val<tripoint_bub_ms>::make_failure( pos );
         }
     }
@@ -1323,7 +1335,8 @@ std::optional<int> deploy_furn_actor::use( Character *p, item &it,
 std::optional<int> deploy_furn_actor::use( Character *p, item &it,
         map *here, const tripoint_bub_ms &pos ) const
 {
-    ret_val<tripoint_bub_ms> suitable = check_deploy_square( p, it, here, pos );
+    item_location loc = get_item_location( *p, it, here, pos );
+    ret_val<tripoint_bub_ms> suitable = check_deploy_square( p, it, here, pos, loc );
     if( !suitable.success() ) {
         p->add_msg_if_player( m_info, suitable.str() );
         return std::nullopt;
@@ -1331,7 +1344,7 @@ std::optional<int> deploy_furn_actor::use( Character *p, item &it,
 
     here->furn_set( suitable.value(), furn_type, false, false, true );
     it.spill_contents( suitable.value() );
-    get_item_location( *p, it, here, pos ).remove_item();
+    loc.remove_item();
     p->mod_moves( -to_moves<int>( 2_seconds ) );
     return 0;
 }
@@ -1362,7 +1375,8 @@ std::optional<int> deploy_appliance_actor::use( Character *p, item &it,
 std::optional<int> deploy_appliance_actor::use( Character *p, item &it,
         map *here, const tripoint_bub_ms &pos ) const
 {
-    ret_val<tripoint_bub_ms> suitable = check_deploy_square( p, it, here, pos );
+    item_location loc = get_item_location( *p, it, here, pos );
+    ret_val<tripoint_bub_ms> suitable = check_deploy_square( p, it, here, pos, loc );
     if( !suitable.success() ) {
         p->add_msg_if_player( m_info, suitable.str() );
         return std::nullopt;
@@ -1373,7 +1387,7 @@ std::optional<int> deploy_appliance_actor::use( Character *p, item &it,
     // TODO: Use map aware operation when available
     if( place_appliance( *here, suitable.value(),
                          vpart_appliance_from_item( appliance_base ), *p, it ) ) {
-        get_item_location( *p, it, here, pos ).remove_item();
+        loc.remove_item();
         p->mod_moves( -to_moves<int>( 2_seconds ) );
     }
     return 0;

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -97,7 +97,6 @@
 #include "veh_type.h"
 #include "vehicle.h"
 #include "vehicle_selector.h"
-#include "visitable.h"
 #include "vitamin.h"
 #include "vpart_position.h"
 #include "weather.h"


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes #81260
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Use the get_item_location helper to find the item if it's not in the player's inventory
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
It's kind of funky that an item without ALLOWS_REMOTE_USE will let you choose an adjacent location while one without won't regardless of whether you could have picked it up so the second commit was an attempt at making it so it picks it up and lets you choose if it can be picked up or deploy where it is otherwise but it needs to actually run the activity actor and idk if you can do that while in the middle of a use_actor? Either way it'd still be kind of weird
Ideally the whole use actor stuff would just pass down the item location rather than need to find it bc I presume there's other ones that don't work correctly use with ALLOWS_REMOTE_USE rn
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Tested placing appliances with and without ALLOWS_REMOTE_USE in and out of inventory with expected results
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
