### PR TITLE
Make buried landmines impossible to spot

### DIFF
--- a/data/json/items/tool/traps.json
+++ b/data/json/items/tool/traps.json
@@ -243,7 +243,7 @@
     "use_action": {
       "type": "place_trap",
       "bury_question": "Bury the land mine?",
-      "bury": { "trap": "tr_landmine_buried", "moves": 275, "practice": 7, "done_message": "You bury the land mine." },
+      "bury": { "trap": "tr_landmine_buried", "moves": 36000, "practice": 7, "done_message": "You bury the land mine." },
       "trap": "tr_landmine",
       "moves": 200,
       "practice": 4,

--- a/data/json/traps.json
+++ b/data/json/traps.json
@@ -480,7 +480,7 @@
     "memorial_male": { "ctxt": "memorial_male", "str": "Stepped on a land mine." },
     "memorial_female": { "ctxt": "memorial_female", "str": "Stepped on a land mine." },
     "symbol": "_",
-    "visibility": 10,
+    "visibility": 999,
     "avoidance": 14,
     "difficulty": 10,
     "action": "landmine",


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Humans do not have ground-penetrating vision. There is no reasonable indication of where mines have been emplaced. 

#### Describe the solution
Make landmines impossible to spot

Also make it take 6 minutes to bury an active landmine instead of.... 3 seconds. Roughly reasoned out by this table in mine/countermine operations. Since you are an amateur, and you're doing two people's jobs it takes slightly longer than twice the time for a 2-man team.

![image](https://github.com/user-attachments/assets/0be9037b-6e2a-45f2-87d6-695804c8d21b)


#### Describe alternatives you've considered
Letting players dig up the minefield at random looking for mines until they blow themselves up --> pointless, stupid

#### Testing

#### Additional context
