### PR TITLE
[XEDRA Evolved] Government Buying Your Deceased Loved One's 'Dreams' Without Your Consent! More at Page 4

### DIFF
--- a/data/mods/Xedra_Evolved/mapgen/mortuary.json
+++ b/data/mods/Xedra_Evolved/mapgen/mortuary.json
@@ -1,0 +1,145 @@
+[
+  {
+    "type": "mapgen",
+    "om_terrain": [ "mortuary" ],
+    "weight": 100,
+    "object": {
+      "fill_ter": "t_floor",
+      "rows": [
+        "..,,,,,..uuuuuu..,,,,,..",
+        "..,,,,,.uuffffuu.,,,,,..",
+        "..,,,,,.uffffffu.,,,,,..",
+        "..,,,,,.uuffffuu.,,,,,..",
+        "..,,,,,..uuuuuu..,,,,,..",
+        "..,,,,,,........,,,,,,..",
+        "..,,,,,,,,,,,,,,,,,,,,..",
+        "..,,,,,,,,,,,,,,,,,,,,..",
+        "..,,,,,,,,,,,,,,,,,,,,..",
+        "..,,,,,,,,,,,,,,,,,,,,..",
+        "...,,,,,,,,,,,,,,,,,,...",
+        "....uuuu.#o++o#.uuuu....",
+        "..##oooo##P  P##oooo##uu",
+        "..oP cc P|H  H|      #fu",
+        "###c    c|H  H| H H  ofu",
+        "#&|c    c|    | H H  #fu",
+        "#~+      + DD + H H P#uu",
+        "#i|D ll P|P hP| H H C#..",
+        "###||||||||++|| H H P#uu",
+        ".4#dT~T~L|C  O| H H  #fu",
+        "..#d~~~~~*   O| H H  ofu",
+        "..#dT~T~i|C  O|      #fu",
+        "..#########++###o##o##uu",
+        ".........u.,,.u........."
+      ],
+      "palettes": [ "parametrized_linoleum_palette", "parametrized_walls_palette" ],
+      "terrain": {
+        " ": "t_floor",
+        "*": "t_door_locked_interior",
+        "+": "t_door_c",
+        ",": "t_pavement",
+        ".": "t_region_groundcover_urban",
+        "L": { "param": "linoleum_color", "fallback": "t_linoleum_white" },
+        "T": { "param": "linoleum_color", "fallback": "t_linoleum_white" },
+        "d": { "param": "linoleum_color", "fallback": "t_linoleum_white" },
+        "&": { "param": "linoleum_color", "fallback": "t_linoleum_white" },
+        "f": "t_region_groundcover_urban",
+        "i": { "param": "linoleum_color", "fallback": "t_linoleum_white" },
+        "o": [ "t_window_domestic", "t_window_open", "t_curtains" ],
+        "u": "t_region_groundcover_urban",
+        "4": "t_gutter_downspout"
+      },
+      "items": { "&": { "item": "SUS_toilet", "chance": 50 } },
+      "toilets": { "&": {  } },
+      "furniture": {
+        "u": "f_hedge_short",
+        "C": "f_coffin_c",
+        "D": "f_desk",
+        "H": "f_bench",
+        "h": "f_chair",
+        "L": "f_locker",
+        "O": "f_coffin_o",
+        "P": [ "f_indoor_plant_y", "f_indoor_plant" ],
+        "T": "f_table",
+        "c": "f_sofa",
+        "d": "f_rack",
+        "f": "f_region_flower_decorative",
+        "i": "f_sink",
+        "l": "f_bookcase"
+      },
+      "place_signs": [
+        {
+          "signage": "The mortuary name followed by a hastily written message that reads: 'I am not liable if your loved ones will not stay dead.'",
+          "x": 15,
+          "y": 11
+        }
+      ],
+      "place_item": [         
+       { "item": "scrap_dreamdross", "x": 8, "y": 19, "amount": [ 12, 36 ] } 
+       ],
+      "place_items": [
+        { "item": "cleaning", "x": 3, "y": [ 19, 20 ], "chance": 50 },
+        { "item": "dissection", "x": 3, "y": 21, "chance": 70 },
+        { "item": "church", "x": [ 16, 18 ], "y": [ 14, 20 ], "chance": 50 },
+        { "item": "lab_torso", "x": 8, "y": 19, "chance": 50 },
+        { "item": "homebooks", "x": [ 5, 6 ], "y": 17, "chance": 50 },
+        { "item": "magazines", "x": 3, "y": 17, "chance": 50 }
+      ],
+      "place_loot": [
+        { "group": "corpse_male_mortuary", "x": 4, "y": 19, "chance": 40 },
+        { "group": "corpse_male_mortuary", "x": 4, "y": 21, "chance": 40 },
+        { "group": "corpse_female_mortuary", "x": 6, "y": 19, "chance": 40 },
+        { "group": "corpse_female_mortuary", "x": 6, "y": 21, "chance": 40 },
+        { "group": "corpse_viewing", "x": 20, "y": 17, "chance": 50 }
+      ],
+      "place_vehicles": [ { "vehicle": "hearse", "x": 12, "y": 7, "chance": 90 } ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "om_terrain": "mortuary_roof",
+    "object": {
+      "fill_ter": "t_flat_roof",
+      "rows": [
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "         ------         ",
+        "  --------....--------  ",
+        "  -..................-  ",
+        "---..................-  ",
+        "-....................-  ",
+        "-.U..................-  ",
+        "-....................-  ",
+        "--5..................-  ",
+        "  -..................-  ",
+        "  -..................-  ",
+        "  -..................-  ",
+        "  --------------------  ",
+        "                        "
+      ],
+      "palettes": [ "roof_palette" ],
+      "nested": { "U": { "chunks": [ "roof_2x2_infrastructure" ] } },
+      "place_nested": [
+        {
+          "chunks": [
+            [ "null", 20 ],
+            [ "roof_2x2_utilities_b", 15 ],
+            [ "roof_2x2_utilities_c", 5 ],
+            [ "roof_2x2_utilities_d", 40 ],
+            [ "roof_2x2_utilities", 50 ]
+          ],
+          "x": [ 4, 17 ],
+          "y": [ 14, 19 ]
+        }
+      ]
+    }
+  }
+]

--- a/data/mods/Xedra_Evolved/mapgen/mortuary.json
+++ b/data/mods/Xedra_Evolved/mapgen/mortuary.json
@@ -74,7 +74,7 @@
         }
       ],
       "place_item": [         
-       { "item": "scrap_dreamdross", "x": 8, "y": 19, "amount": [ 12, 36 ] } 
+       { "item": "scrap_dreamdross", "x": 8, "y": 19, "amount": [ 6, 18 ] } 
        ],
       "place_items": [
         { "item": "cleaning", "x": 3, "y": [ 19, 20 ], "chance": 50 },

--- a/data/mods/Xedra_Evolved/mapgen/mortuary.json
+++ b/data/mods/Xedra_Evolved/mapgen/mortuary.json
@@ -73,9 +73,7 @@
           "y": 11
         }
       ],
-      "place_item": [         
-       { "item": "scrap_dreamdross", "x": 8, "y": 19, "amount": [ 6, 18 ] } 
-       ],
+      "place_item": [ { "item": "scrap_dreamdross", "x": 8, "y": 19, "amount": [ 6, 18 ] } ],
       "place_items": [
         { "item": "cleaning", "x": 3, "y": [ 19, 20 ], "chance": 50 },
         { "item": "dissection", "x": 3, "y": 21, "chance": 70 },


### PR DESCRIPTION

#### Summary
None

#### Purpose of change
Gives the mortuary a bunch of dreamdross scraps. I thought of this back when i was thinking about The Noon item, which is like one of the bombastic piece of yellow journalism article for such tabloid like The Noon. I got the go ahead from maleclypse and added it.

#### Describe the solution
Put 12-36 dreamdross scraps into the locker at the room where they treats the deceased bodies.

#### Describe alternatives you've considered

Not doing so
more dreamdross scraps?

#### Testing
I put the json into the mod, play a world, spawn in a mortuary, and check the locker inside, having the scrap dreamdross.
![Screenshot_20250615_200755](https://github.com/user-attachments/assets/322d349b-6e6b-448e-a6ed-8d2b95f11102)


#### Additional context



<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
