### PR TITLE
Adds a vertical omt stack scope for mapgen parameters

### DIFF
--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -32,7 +32,6 @@
 #include "bodypart.h"
 #include "calendar.h"
 #include "calendar_ui.h"
-#include "cata_assert.h"
 #include "cata_path.h"
 #include "cata_utility.h"
 #include "catacharset.h"

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -2298,7 +2298,7 @@ mapgen_arguments mapgen_parameters::get_args(
                 result.emplace( param_name, *v );
             } else {
                 cata_variant value = md.get_arg_or( param_name, param.get( md ) );
-                om->add_omt_stack_arguments( p_scope, md.get_args() );
+                om->add_omt_stack_argument( p_scope, param_name, value );
                 result.emplace( param_name, value );
             }
         }

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -2292,22 +2292,15 @@ mapgen_arguments mapgen_parameters::get_args(
         }
         if( param.scope() == mapgen_parameter_scope::smallmap &&
             scope == mapgen_parameter_scope::omt ) {
-            //BEFOREMERGE Replace with a std::optional<cata_variant> overmapbuffer::get_existing_smallmap_parameter( const point_abs_omt & )?
-            std::unordered_map<point_abs_omt, std::unordered_map<std::string, cata_variant>>
-                    &all_existing_params = overmap_buffer.get_existing_om_global(
-                                               md.pos() ).om->smallmap_parameter_map;
-            if( auto here_existing_params = all_existing_params.find( md.pos().xy() );
-                here_existing_params != all_existing_params.end() ) {
-                if( auto found_param = here_existing_params->second.find( param_name );
-                    found_param != here_existing_params->second.end() ) {
-                    result.emplace( param_name, found_param->second );
-                    continue;
-                }
+            overmap *om = overmap_buffer.get_existing_om_global( md.pos() ).om;
+            std::optional<cata_variant> v = om->get_existing_smallmap_argument( md.pos().xy(), param_name );
+            if( !!v ) {
+                result.emplace( param_name, *v );
+            } else {
+                cata_variant value = md.get_arg_or( param_name, param.get( md ) );
+                om->add_smallmap_arguments( md.pos().xy(), md.get_args() );
+                result.emplace( param_name, value );
             }
-            cata_variant value = md.get_arg_or( param_name, param.get( md ) );
-            //BEFOREMERGE Replace with a void overmapbuffer::add_smallmap_parameter( const point_abs_omt &, const std::string & )?
-            all_existing_params[md.pos().xy()][param_name] = value;
-            result.emplace( param_name, value );
         }
     }
     return mapgen_arguments{ result };

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -2180,7 +2180,7 @@ std::string enum_to_string<mapgen_parameter_scope>( mapgen_parameter_scope v )
     switch( v ) {
         // *INDENT-OFF*
         case mapgen_parameter_scope::overmap_special: return "overmap_special";
-        case mapgen_parameter_scope::smallmap: return "smallmap";
+        case mapgen_parameter_scope::omt_stack: return "omt_stack";
         case mapgen_parameter_scope::omt: return "omt";
         case mapgen_parameter_scope::nest: return "nest";
         // *INDENT-ON*
@@ -2290,15 +2290,15 @@ mapgen_arguments mapgen_parameters::get_args(
             cata_variant value = md.get_arg_or( param_name, param.get( md ) );
             result.emplace( param_name, value );
         }
-        if( param.scope() == mapgen_parameter_scope::smallmap &&
-            scope == mapgen_parameter_scope::omt ) {
-            overmap *om = overmap_buffer.get_existing_om_global( md.pos() ).om;
-            std::optional<cata_variant> v = om->get_existing_smallmap_argument( md.pos().xy(), param_name );
+        if( param.scope() == mapgen_parameter_scope::omt_stack && scope == mapgen_parameter_scope::omt ) {
+            const point_abs_omt &p_scope = md.pos().xy();
+            overmap *om = overmap_buffer.get_existing_om_global( p_scope ).om;
+            std::optional<cata_variant> v = om->get_existing_omt_stack_argument( p_scope, param_name );
             if( !!v ) {
                 result.emplace( param_name, *v );
             } else {
                 cata_variant value = md.get_arg_or( param_name, param.get( md ) );
-                om->add_smallmap_arguments( md.pos().xy(), md.get_args() );
+                om->add_omt_stack_arguments( p_scope, md.get_args() );
                 result.emplace( param_name, value );
             }
         }

--- a/src/mapgen_parameter.h
+++ b/src/mapgen_parameter.h
@@ -13,6 +13,8 @@ enum class mapgen_parameter_scope {
     // Should be ordered from most general to most specific
     overmap_special,
     omt,
+    // Wants to be equal to omt bc they're evaluated in the same place but that borks enum_to_string
+    smallmap,
     nest,
     last
 };

--- a/src/mapgen_parameter.h
+++ b/src/mapgen_parameter.h
@@ -14,7 +14,8 @@ enum class mapgen_parameter_scope {
     overmap_special,
     omt,
     // Wants to be equal to omt bc they're evaluated in the same place but that borks enum_to_string
-    smallmap,
+    // Represents a vertical stack of omts sharing the same point_abs_omt
+    omt_stack,
     nest,
     last
 };

--- a/src/mapgendata.cpp
+++ b/src/mapgendata.cpp
@@ -47,7 +47,7 @@ size_t std::hash<mapgen_arguments>::operator()( const mapgen_arguments &args ) c
 static const regional_settings dummy_regional_settings;
 
 mapgendata::mapgendata( map &mp, dummy_settings_t )
-    : pos_( tripoint_abs_omt::zero )
+    : pos_( tripoint_abs_omt::invalid )
     , density_( 0 )
     , when_( calendar::turn )
     , mission_( nullptr )

--- a/src/mapgendata.cpp
+++ b/src/mapgendata.cpp
@@ -45,10 +45,10 @@ size_t std::hash<mapgen_arguments>::operator()( const mapgen_arguments &args ) c
 static const regional_settings dummy_regional_settings;
 
 mapgendata::mapgendata( map &mp, dummy_settings_t )
-    : density_( 0 )
+    : pos_( tripoint_abs_omt::zero )
+    , density_( 0 )
     , when_( calendar::turn )
     , mission_( nullptr )
-    , zlevel_( 0 )
     , region( dummy_regional_settings )
     , m( mp )
     , default_groundcover( region.default_groundcover )
@@ -60,11 +60,11 @@ mapgendata::mapgendata( map &mp, dummy_settings_t )
 
 mapgendata::mapgendata( const tripoint_abs_omt &over, map &mp, const float density,
                         const time_point &when, ::mission *const miss )
-    : terrain_type_( overmap_buffer.ter( over ) )
+    : pos_( over )
+    , terrain_type_( overmap_buffer.ter( over ) )
     , density_( density )
     , when_( when )
     , mission_( miss )
-    , zlevel_( over.z() )
     , predecessors_( overmap_buffer.predecessors( over ) )
     , t_above( overmap_buffer.ter( over + tripoint::above ) )
     , t_below( overmap_buffer.ter( over + tripoint::below ) )

--- a/src/mapgendata.cpp
+++ b/src/mapgendata.cpp
@@ -19,10 +19,12 @@
 #include "point.h"
 #include "regional_settings.h"
 
-void mapgen_arguments::merge( const mapgen_arguments &other )
+void mapgen_arguments::merge( const mapgen_arguments &other, bool overwrite )
 {
     for( const std::pair<const std::string, cata_variant> &p : other.map ) {
-        map[p.first] = p.second;
+        if( overwrite || map.find( p.first ) == map.end() ) {
+            map[p.first] = p.second;
+        }
     }
 }
 

--- a/src/mapgendata.cpp
+++ b/src/mapgendata.cpp
@@ -50,7 +50,7 @@ size_t std::hash<mapgen_arguments>::operator()( const mapgen_arguments &args ) c
 static const regional_settings dummy_regional_settings;
 
 mapgendata::mapgendata( map &mp, dummy_settings_t )
-    : pos_( tripoint_abs_omt::invalid )
+    : pos_( tripoint_abs_omt::zero )
     , density_( 0 )
     , when_( calendar::turn )
     , mission_( nullptr )

--- a/src/mapgendata.cpp
+++ b/src/mapgendata.cpp
@@ -19,13 +19,16 @@
 #include "point.h"
 #include "regional_settings.h"
 
-void mapgen_arguments::merge( const mapgen_arguments &other, bool overwrite )
+void mapgen_arguments::merge( const mapgen_arguments &other )
 {
     for( const std::pair<const std::string, cata_variant> &p : other.map ) {
-        if( overwrite || map.find( p.first ) == map.end() ) {
-            map[p.first] = p.second;
-        }
+        map[p.first] = p.second;
     }
+}
+
+void mapgen_arguments::add( const std::string &param_name, const cata_variant &value )
+{
+    map[param_name] = value;
 }
 
 void mapgen_arguments::serialize( JsonOut &jo ) const

--- a/src/mapgendata.h
+++ b/src/mapgendata.h
@@ -17,6 +17,7 @@
 #include "debug.h"
 #include "enum_bitset.h"
 #include "jmapgen_flags.h"
+#include "point.h"
 #include "type_id.h"
 #include "weighted_list.h"
 
@@ -58,7 +59,7 @@ struct mapgen_arguments {
         return map == other.map;
     }
 
-    void merge( const mapgen_arguments & );
+    void merge( const mapgen_arguments &, bool overwrite = true );
     void serialize( JsonOut & ) const;
     void deserialize( const JsonValue &ji );
 };
@@ -198,6 +199,9 @@ class mapgendata
         }
         const tripoint_abs_omt &pos() const {
             return pos_;
+        }
+        const mapgen_arguments &get_args() const {
+            return mapgen_args_;
         }
         std::vector<oter_id> get_predecessors() const {
             return predecessors_;

--- a/src/mapgendata.h
+++ b/src/mapgendata.h
@@ -12,7 +12,7 @@
 
 #include "calendar.h"
 #include "cata_variant.h"
-#include "coords_fwd.h"
+#include "coordinates.h"
 #include "cube_direction.h"
 #include "debug.h"
 #include "enum_bitset.h"
@@ -113,11 +113,11 @@ inline cata_variant extract_variant_value<cata_variant>( const cata_variant &v )
 class mapgendata
 {
     private:
+        tripoint_abs_omt pos_;
         oter_id terrain_type_;
         float density_;
         time_point when_;
         ::mission *mission_;
-        int zlevel_;
         mapgen_arguments mapgen_args_;
         enum_bitset<jmapgen_flags> mapgen_flags_;
         std::vector<oter_id> predecessors_;
@@ -194,8 +194,10 @@ class mapgendata
             return mission_;
         }
         int zlevel() const {
-            // TODO: should be able to determine this from the map itself
-            return zlevel_;
+            return pos_.z();
+        }
+        const tripoint_abs_omt &pos() const {
+            return pos_;
         }
         std::vector<oter_id> get_predecessors() const {
             return predecessors_;

--- a/src/mapgendata.h
+++ b/src/mapgendata.h
@@ -59,7 +59,8 @@ struct mapgen_arguments {
         return map == other.map;
     }
 
-    void merge( const mapgen_arguments &, bool overwrite = true );
+    void merge( const mapgen_arguments & );
+    void add( const std::string &param_name, const cata_variant &value );
     void serialize( JsonOut & ) const;
     void deserialize( const JsonValue &ji );
 };

--- a/src/omdata.h
+++ b/src/omdata.h
@@ -691,7 +691,7 @@ class overmap_special
 
         void force_one_occurrence();
 
-        const mapgen_parameters get_params() const {
+        const mapgen_parameters &get_params() const {
             return mapgen_params_;
         }
         mapgen_arguments get_args( const mapgendata & ) const;

--- a/src/omdata.h
+++ b/src/omdata.h
@@ -691,7 +691,7 @@ class overmap_special
 
         void force_one_occurrence();
 
-        const mapgen_parameters &get_params() const {
+        const mapgen_parameters get_params() const {
             return mapgen_params_;
         }
         mapgen_arguments get_args( const mapgendata & ) const;

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -3599,6 +3599,16 @@ std::vector<point_abs_omt> overmap::find_extras( const int z, const std::string 
     return extra_locations;
 }
 
+std::optional<mapgen_arguments> overmap::get_existing_omt_stack_arguments(
+    const point_abs_omt &p ) const
+{
+    auto it_args = omt_stack_arguments_map.find( p );
+    if( it_args != omt_stack_arguments_map.end() ) {
+        return it_args->second;
+    }
+    return std::nullopt;
+}
+
 std::optional<cata_variant> overmap::get_existing_omt_stack_argument( const point_abs_omt &p,
         std::string param_name ) const
 {

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -3599,21 +3599,23 @@ std::vector<point_abs_omt> overmap::find_extras( const int z, const std::string 
     return extra_locations;
 }
 
-std::optional<cata_variant> overmap::get_existing_smallmap_argument( const point_abs_omt &p,
+std::optional<cata_variant> overmap::get_existing_omt_stack_argument( const point_abs_omt &p,
         std::string param_name ) const
 {
-    if( auto it_args = smallmap_arguments_map.find( p ); it_args != smallmap_arguments_map.end() ) {
+    auto it_args = omt_stack_arguments_map.find( p );
+    if( it_args != omt_stack_arguments_map.end() ) {
         const std::unordered_map<std::string, cata_variant> &args_map = it_args->second.map;
-        if( auto it_arg = args_map.find( param_name ); it_arg != args_map.end() ) {
+        auto it_arg = args_map.find( param_name );
+        if( it_arg != args_map.end() ) {
             return it_arg->second;
         }
     }
     return std::nullopt;
 }
 
-void overmap::add_smallmap_arguments( const point_abs_omt &p, const mapgen_arguments &args )
+void overmap::add_omt_stack_arguments( const point_abs_omt &p, const mapgen_arguments &args )
 {
-    smallmap_arguments_map[p].merge( args, false );
+    omt_stack_arguments_map[p].merge( args, false );
 }
 
 bool overmap::inbounds( const tripoint_om_omt &p, int clearance )

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -3610,7 +3610,7 @@ std::optional<mapgen_arguments> overmap::get_existing_omt_stack_arguments(
 }
 
 std::optional<cata_variant> overmap::get_existing_omt_stack_argument( const point_abs_omt &p,
-        std::string param_name ) const
+        const std::string &param_name ) const
 {
     auto it_args = omt_stack_arguments_map.find( p );
     if( it_args != omt_stack_arguments_map.end() ) {

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -3613,9 +3613,10 @@ std::optional<cata_variant> overmap::get_existing_omt_stack_argument( const poin
     return std::nullopt;
 }
 
-void overmap::add_omt_stack_arguments( const point_abs_omt &p, const mapgen_arguments &args )
+void overmap::add_omt_stack_argument( const point_abs_omt &p, const std::string &param_name,
+                                      const cata_variant &value )
 {
-    omt_stack_arguments_map[p].merge( args, false );
+    omt_stack_arguments_map[p].add( param_name, value );
 }
 
 bool overmap::inbounds( const tripoint_om_omt &p, int clearance )

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -3599,6 +3599,23 @@ std::vector<point_abs_omt> overmap::find_extras( const int z, const std::string 
     return extra_locations;
 }
 
+std::optional<cata_variant> overmap::get_existing_smallmap_argument( const point_abs_omt &p,
+        std::string param_name ) const
+{
+    if( auto it_args = smallmap_arguments_map.find( p ); it_args != smallmap_arguments_map.end() ) {
+        const std::unordered_map<std::string, cata_variant> &args_map = it_args->second.map;
+        if( auto it_arg = args_map.find( param_name ); it_arg != args_map.end() ) {
+            return it_arg->second;
+        }
+    }
+    return std::nullopt;
+}
+
+void overmap::add_smallmap_arguments( const point_abs_omt &p, const mapgen_arguments &args )
+{
+    smallmap_arguments_map[p].merge( args, false );
+}
+
 bool overmap::inbounds( const tripoint_om_omt &p, int clearance )
 {
     static constexpr tripoint_om_omt overmap_boundary_min( 0, 0, -OVERMAP_DEPTH );

--- a/src/overmap.h
+++ b/src/overmap.h
@@ -462,8 +462,9 @@ class overmap
         // Get value from omt_stack_arguments_map or nullopt if not set yet
         std::optional<cata_variant> get_existing_omt_stack_argument( const point_abs_omt &p,
                 std::string param_name ) const;
-        // Set or merge without overwriting to omt_stack_arguments_map
-        void add_omt_stack_arguments( const point_abs_omt &p, const mapgen_arguments &args );
+        // Set a value in omt_stack_arguments_map
+        void add_omt_stack_argument( const point_abs_omt &p, const std::string &param_name,
+                                     const cata_variant &value );
         /**
          * When monsters despawn during map-shifting they will be added here.
          * map::spawn_monsters will load them and place them into the reality bubble

--- a/src/overmap.h
+++ b/src/overmap.h
@@ -21,6 +21,7 @@
 #include <vector>
 
 #include "basecamp.h"
+#include "cata_variant.h"
 #include "city.h"
 #include "colony.h"
 #include "color.h"
@@ -442,6 +443,8 @@ class overmap
         // to be evaluated.
         cata::colony<std::optional<mapgen_arguments>> mapgen_arg_storage;
         std::unordered_map<tripoint_om_omt, std::optional<mapgen_arguments> *> mapgen_args_index;
+        // Records mapgen parameters required at the omt level, fixed at the same values vertically
+        std::unordered_map<point_abs_omt, mapgen_arguments> smallmap_arguments_map;
 
         // Records the joins that were chosen during placement of a mutable
         // special, so that it can be queried later by mapgen
@@ -456,9 +459,11 @@ class overmap
         // open existing overmap, or generate a new one
         void open( overmap_special_batch &enabled_specials );
     public:
-        //BEFOREMERGE Should just be a std::unordered_map<point_abs_omt, mapgen_arguments>?
-        std::unordered_map<point_abs_omt, std::unordered_map<std::string, cata_variant>>
-                smallmap_parameter_map;
+        // Get value from smallmap_arguments_map or nullopt if not set yet
+        std::optional<cata_variant> get_existing_smallmap_argument( const point_abs_omt &p,
+                std::string param_name ) const;
+        // Set or merge without overwriting to smallmap_arguments_map
+        void add_smallmap_arguments( const point_abs_omt &p, const mapgen_arguments &args );
         /**
          * When monsters despawn during map-shifting they will be added here.
          * map::spawn_monsters will load them and place them into the reality bubble

--- a/src/overmap.h
+++ b/src/overmap.h
@@ -459,6 +459,9 @@ class overmap
         // open existing overmap, or generate a new one
         void open( overmap_special_batch &enabled_specials );
     public:
+        // Get all values from omt_stack_arguments_map at the given point or nullopt if not set yet
+        std::optional<mapgen_arguments> get_existing_omt_stack_arguments(
+            const point_abs_omt &p ) const;
         // Get value from omt_stack_arguments_map or nullopt if not set yet
         std::optional<cata_variant> get_existing_omt_stack_argument( const point_abs_omt &p,
                 std::string param_name ) const;

--- a/src/overmap.h
+++ b/src/overmap.h
@@ -444,7 +444,7 @@ class overmap
         cata::colony<std::optional<mapgen_arguments>> mapgen_arg_storage;
         std::unordered_map<tripoint_om_omt, std::optional<mapgen_arguments> *> mapgen_args_index;
         // Records mapgen parameters required at the omt level, fixed at the same values vertically
-        std::unordered_map<point_abs_omt, mapgen_arguments> smallmap_arguments_map;
+        std::unordered_map<point_abs_omt, mapgen_arguments> omt_stack_arguments_map;
 
         // Records the joins that were chosen during placement of a mutable
         // special, so that it can be queried later by mapgen
@@ -459,11 +459,11 @@ class overmap
         // open existing overmap, or generate a new one
         void open( overmap_special_batch &enabled_specials );
     public:
-        // Get value from smallmap_arguments_map or nullopt if not set yet
-        std::optional<cata_variant> get_existing_smallmap_argument( const point_abs_omt &p,
+        // Get value from omt_stack_arguments_map or nullopt if not set yet
+        std::optional<cata_variant> get_existing_omt_stack_argument( const point_abs_omt &p,
                 std::string param_name ) const;
-        // Set or merge without overwriting to smallmap_arguments_map
-        void add_smallmap_arguments( const point_abs_omt &p, const mapgen_arguments &args );
+        // Set or merge without overwriting to omt_stack_arguments_map
+        void add_omt_stack_arguments( const point_abs_omt &p, const mapgen_arguments &args );
         /**
          * When monsters despawn during map-shifting they will be added here.
          * map::spawn_monsters will load them and place them into the reality bubble

--- a/src/overmap.h
+++ b/src/overmap.h
@@ -464,7 +464,7 @@ class overmap
             const point_abs_omt &p ) const;
         // Get value from omt_stack_arguments_map or nullopt if not set yet
         std::optional<cata_variant> get_existing_omt_stack_argument( const point_abs_omt &p,
-                std::string param_name ) const;
+                const std::string &param_name ) const;
         // Set a value in omt_stack_arguments_map
         void add_omt_stack_argument( const point_abs_omt &p, const std::string &param_name,
                                      const cata_variant &value );

--- a/src/overmap.h
+++ b/src/overmap.h
@@ -456,7 +456,9 @@ class overmap
         // open existing overmap, or generate a new one
         void open( overmap_special_batch &enabled_specials );
     public:
-
+        //BEFOREMERGE Should just be a std::unordered_map<point_abs_omt, mapgen_arguments>?
+        std::unordered_map<point_abs_omt, std::unordered_map<std::string, cata_variant>>
+                smallmap_parameter_map;
         /**
          * When monsters despawn during map-shifting they will be added here.
          * map::spawn_monsters will load them and place them into the reality bubble

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -1097,15 +1097,24 @@ static void draw_om_sidebar( ui_adaptor &ui,
                 mvwprintw( wbar, point( 1, ++lines ), "- %s", pred->id().str() );
             }
         }
+
+        auto print_arguments = [&]( std::unordered_map<std::string, cata_variant> &map ) {
+            for( const std::pair<const std::string, cata_variant> &arg : map ) {
+                mvwprintw( wbar, point( 1, ++lines ), "%s = %s", arg.first, arg.second.get_string() );
+            }
+        };
         std::optional<mapgen_arguments> *args = overmap_buffer.mapgen_args( cursor_pos );
         if( args ) {
             if( *args ) {
-                for( const std::pair<const std::string, cata_variant> &arg : ( **args ).map ) {
-                    mvwprintw( wbar, point( 1, ++lines ), "%s = %s", arg.first, arg.second.get_string() );
-                }
+                print_arguments( ( **args ).map );
             } else {
-                mvwprintw( wbar, point( 1, ++lines ), "args not yet set" );
+                mvwprintw( wbar, point( 1, ++lines ), "Special scoped parameter values not set yet" );
             }
+        }
+        std::optional<mapgen_arguments> args_omt_stack =
+            overmap_buffer.get_existing_omt_stack_arguments( cursor_pos.xy() );
+        if( args_omt_stack ) {
+            print_arguments( args_omt_stack->map );
         }
 
         for( cube_direction dir : all_enum_values<cube_direction>() ) {

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -25,6 +25,7 @@
 #include "game.h"
 #include "line.h"
 #include "map.h"
+#include "mapgendata.h"
 #include "memory_fast.h"
 #include "mod_manager.h"
 #include "mongroup.h"

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -1076,6 +1076,13 @@ std::optional<overmap_special_id> overmapbuffer::overmap_special_at(
     return om_loc.om->overmap_special_at( om_loc.local );
 }
 
+std::optional<mapgen_arguments> overmapbuffer::get_existing_omt_stack_arguments(
+    const point_abs_omt &p )
+{
+    const overmap_with_local_coords om_loc = get_om_global( p );
+    return om_loc.om->get_existing_omt_stack_arguments( p );
+}
+
 bool overmapbuffer::check_ot( const std::string &type, ot_match_type match_type,
                               const tripoint_abs_omt &p )
 {

--- a/src/overmapbuffer.h
+++ b/src/overmapbuffer.h
@@ -620,6 +620,7 @@ class overmapbuffer
                        const tripoint_abs_omt &p );
         bool check_overmap_special_type( const overmap_special_id &id, const tripoint_abs_omt &loc );
         std::optional<overmap_special_id> overmap_special_at( const tripoint_abs_omt & );
+        std::optional<mapgen_arguments> get_existing_omt_stack_arguments( const point_abs_omt &p );
 
         /**
         * These versions of the check_* methods will only check existing overmaps, and

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -418,7 +418,13 @@ void overmap::unserialize( const JsonObject &jsobj )
             mapgen_args_index.emplace( p.first, &*it );
         }
     }
-    //BEFOREMERGE: Add smallmap_parameter_map unserialize
+    if( jsobj.has_member( "smallmap_arguments_map" ) ) {
+        std::vector<std::pair<point_abs_omt, mapgen_arguments>> flat_smallmap_arguments_map;
+        jsobj.read( "smallmap_arguments_map", flat_smallmap_arguments_map, true );
+        for( const std::pair<point_abs_omt, mapgen_arguments> &p : flat_smallmap_arguments_map ) {
+            smallmap_arguments_map.emplace( p );
+        }
+    }
     // Extract layers first so predecessor deduplication can happen.
     if( jsobj.has_member( "layers" ) ) {
         std::unordered_map<tripoint_om_omt, std::string> oter_id_migrations;
@@ -1404,7 +1410,17 @@ void overmap::serialize( std::ostream &fout ) const
     json.end_array();
     fout << std::endl;
 
-    //BEFOREMERGE: Add smallmap_parameter_map serialize
+    json.member( "smallmap_arguments_map" );
+    json.start_array();
+    for( const std::pair<const point_abs_omt, mapgen_arguments> &p : smallmap_arguments_map ) {
+        json.start_array();
+        json.write( p.first );
+        p.second.serialize( json );
+        json.end_array();
+    }
+    json.end_array();
+    fout << std::endl;
+
     std::vector<std::pair<om_pos_dir, std::string>> flattened_joins_used(
                 joins_used.begin(), joins_used.end() );
     json.member( "joins_used", flattened_joins_used );

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -418,11 +418,11 @@ void overmap::unserialize( const JsonObject &jsobj )
             mapgen_args_index.emplace( p.first, &*it );
         }
     }
-    if( jsobj.has_member( "smallmap_arguments_map" ) ) {
-        std::vector<std::pair<point_abs_omt, mapgen_arguments>> flat_smallmap_arguments_map;
-        jsobj.read( "smallmap_arguments_map", flat_smallmap_arguments_map, true );
-        for( const std::pair<point_abs_omt, mapgen_arguments> &p : flat_smallmap_arguments_map ) {
-            smallmap_arguments_map.emplace( p );
+    if( jsobj.has_member( "omt_stack_arguments_map" ) ) {
+        std::vector<std::pair<point_abs_omt, mapgen_arguments>> flat_omt_stack_arguments_map;
+        jsobj.read( "omt_stack_arguments_map", flat_omt_stack_arguments_map, true );
+        for( const std::pair<point_abs_omt, mapgen_arguments> &p : flat_omt_stack_arguments_map ) {
+            omt_stack_arguments_map.emplace( p );
         }
     }
     // Extract layers first so predecessor deduplication can happen.
@@ -1410,9 +1410,9 @@ void overmap::serialize( std::ostream &fout ) const
     json.end_array();
     fout << std::endl;
 
-    json.member( "smallmap_arguments_map" );
+    json.member( "omt_stack_arguments_map" );
     json.start_array();
-    for( const std::pair<const point_abs_omt, mapgen_arguments> &p : smallmap_arguments_map ) {
+    for( const std::pair<const point_abs_omt, mapgen_arguments> &p : omt_stack_arguments_map ) {
         json.start_array();
         json.write( p.first );
         p.second.serialize( json );

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -418,6 +418,7 @@ void overmap::unserialize( const JsonObject &jsobj )
             mapgen_args_index.emplace( p.first, &*it );
         }
     }
+    //BEFOREMERGE: Add smallmap_parameter_map unserialize
     // Extract layers first so predecessor deduplication can happen.
     if( jsobj.has_member( "layers" ) ) {
         std::unordered_map<tripoint_om_omt, std::string> oter_id_migrations;
@@ -1403,6 +1404,7 @@ void overmap::serialize( std::ostream &fout ) const
     json.end_array();
     fout << std::endl;
 
+    //BEFOREMERGE: Add smallmap_parameter_map serialize
     std::vector<std::pair<om_pos_dir, std::string>> flattened_joins_used(
                 joins_used.begin(), joins_used.end() );
     json.member( "joins_used", flattened_joins_used );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Infrastructure "Adds a vertical stack of omt scope for mapgen parameters"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Closes #73021
Will make making unhardcoded shaped lake/ocean edges better
Makes #78899 much less [jank](https://github.com/CleverRaven/Cataclysm-DDA/pull/78899/commits/2817ad3964cdd852086260f981d54e5bb28bbce6#diff-0c6907602e4e3ef65540a66a4661f98c68fe786f106a225d7f24d351d9f2fb33L310-L331)
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Allows parameters to be scoped to be the same at a given xy coordinate of omt so you can have things match up vertically
Makes set name/value pairs visible with overmap editor
Potentially wants omt and omt_stack swapping around in the enum and various scope usages changing to it bc that'd be more logical even if functionally identical?
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
~~Calling the scope "smallmap" is dubious as Patrick discusses in #73021, the scope is the shape of a smallmap and we have no name for a vertical stack of omts to my knowledge so this seemed ok but it doesn't actually use the smallmap class at all it's evaluated at the same time as omt scope and cached for other omt gen in the vertical stack so if anyone has a suggestion for a better name go ahead '^^~~
Replacing mapgendata::zlevel() usages with pos().z() instead and removing the former, kind of alot of usages tho and I don't want to muddy the important stuff so I'll make it a follow up.
Also considered
```c++
        int zlevel() const {
            // If pos_ is ever made changeable post-initialisation zlevel() should be removed in favour of pos().z()
            static const int z = pos_.z();
            return z;
        }
```
but I don't think that's significantly more efficient?
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Tested using #78899, seems to be working as intended incl/ (de/)serialising
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
