### PR TITLE
Disable IWYU for third-party source code

### DIFF
--- a/tools/iwyu/bad_files.txt
+++ b/tools/iwyu/bad_files.txt
@@ -6,6 +6,8 @@
 flexbuffer
 json
 translation
+# we don't want to muck with third-party source code
+third-party
 # iwyu mangles these
 lightmap
 color


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
![image](https://github.com/user-attachments/assets/0858a245-7214-4041-a892-db5e1b230ac7)

I agree

#### Describe the solution
IWYU doesn't run when it finds `third-party` in the directory path

#### Describe alternatives you've considered
IWYU the third-party source code anyway??

#### Testing
The only way I can think of to test this is to make this change on my fork and then try to push a change to e.g. third-party/imgui.cpp and see if IWYU runs.

...But this seems pretty simple so I'm just gonna shoot from the hip

#### Additional context
