### PR TITLE
Fix mesa generation test failure by making tropicata/desertpack/backrooms incompatible

### DIFF
--- a/data/mods/Backrooms/modinfo.json
+++ b/data/mods/Backrooms/modinfo.json
@@ -7,6 +7,7 @@
     "maintainers": [ "onura46" ],
     "description": "A strange place between dimensions traps you.  Can you survive among endless halls of yellowed carpet and harshly humming fluorescents?\n\nReplaces all normal worldgen: no wilderness, no rivers, no cities, no farms, no sky.  Just endless, winding indoor halls of mildewy carpeting, faded drywall, desolate breakrooms and abandoned boardrooms.\n\nRecommended city size is 0.  Play Now!  (Default Scenario) is not supported.",
     "category": "total_conversion",
+    "conflicts": [ "desertpack", "tropicata" ],
     "dependencies": [ "dda" ],
     "version": "0.1"
   }

--- a/data/mods/TropiCataclysm/modinfo.json
+++ b/data/mods/TropiCataclysm/modinfo.json
@@ -7,6 +7,7 @@
     "maintainers": [ "Karol1223" ],
     "description": "Changes the setting from New England to an undisclosed region in Brazil.  Initially based out of Desert Region mod.",
     "category": "content",
+    "conflicts": [ "backrooms", "desertpack" ],
     "dependencies": [ "dda" ],
     "version": "0.80"
   },

--- a/data/mods/desert_region/modinfo.json
+++ b/data/mods/desert_region/modinfo.json
@@ -7,6 +7,7 @@
     "maintainers": [ "LovamkKicsiGazsii", "Procyonae" ],
     "description": "A testbed/WIP mod to showcase regional_map_settings JSON changes.",
     "category": "content",
+    "conflicts": [ "backrooms", "tropicata" ],
     "dependencies": [ "dda" ],
     "version": "0.1",
     "obsolete": false


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Test failures on my PR https://github.com/CleverRaven/Cataclysm-DDA/pull/81233

#### Describe the solution
A mesa (from `desertpack`) generation test failure on
```
./tests/cata_test --min-duration 20 --use-colour yes --rng-seed time --order lex --error-format=github-action '[force_load_game]' --user-dir=all_modded --mods=dda,tropicata,my_sweet_cataclysm,translate_dialogue,Only_Wildlife,bombastic_perks,DinoMod,generic_guns,deadly_bites,railroads,cbm_slots,backrooms,extra_mut_scens,standard_combat_test,Mythos-Creatures,crazy_cataclysm,no_hope,MMA,stats_through_kills,magiclysm,package_bionic_professions,no_npc_food,perk_melee_system,personal_portal_storms,Tamable_Wildlife,desertpack,xedra_evolved,mindovermatter,speedydex,alt_map_key,megafauna,limb_wip
(all_mods)=> 19:17:36.113 INFO : Randomness seeded to: 1750187856
ERROR : src/overmap.cpp:2864 [virtual special_placement_result mutable_overmap_special_data::place(overmap &, const tripoint_om_omt &, om_direction::type, bool, const city &, bool) const] Spawn of mutable special Mesa Mutable had unresolved joins.  Existing terrain at (140,5,0) was field; joins were east: mesa_to_mesa
(all_mods)=> Complete record of placement follows:
```
Goes away when `backrooms` and `tropicata` are removed from the mod list. Make all these mods incompatible, they don't make sense to combine anyways.

#### Testing
I consistently trigger the failure with 
`tests/cata_test --rng-seed=time '[force_load_game]' --mods=dda,tropicata,backrooms,desertpack`.

top fails, bottom passes:
```diff
-./tests/cata_test --min-duration 20 --use-colour yes --rng-seed 1750187856  --order lex --error-format=github-action '[force_load_game]' --user-dir=all_modded --mods=dda,tropicata,my_sweet_cataclysm,translate_dialogue,Only_Wildlife,bombastic_perks,DinoMod,generic_guns,deadly_bites,railroads,cbm_slots,backrooms,extra_mut_scens,standard_combat_test,Mythos-Creatures,crazy_cataclysm,no_hope,MMA,stats_through_kills,magiclysm,package_bionic_professions,no_npc_food,perk_melee_system,personal_portal_storms,Tamable_Wildlife,desertpack,xedra_evolved,mindovermatter,speedydex,alt_map_key,megafauna,limb_wip
+./tests/cata_test --min-duration 20 --use-colour yes --rng-seed 1750187856  --order lex --error-format=github-action '[force_load_game]' --user-dir=all_modded --mods=dda,my_sweet_cataclysm,translate_dialogue,Only_Wildlife,bombastic_perks,DinoMod,generic_guns,deadly_bites,railroads,cbm_slots,extra_mut_scens,standard_combat_test,Mythos-Creatures,crazy_cataclysm,no_hope,MMA,stats_through_kills,magiclysm,package_bionic_professions,no_npc_food,perk_melee_system,personal_portal_storms,Tamable_Wildlife,desertpack,xedra_evolved,mindovermatter,speedydex,alt_map_key,megafauna,limb_wip
```