### PR TITLE
Ensure ranged weapons with NEVER_JAMS never jam

### DIFF
--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -796,7 +796,8 @@ bool Character::handle_gun_damage( item &it )
         return false;
 
         // Chance for the weapon to suffer a failure, caused by the magazine size, quality, or condition
-    } else if( x_in_y( jam_chance, 1 ) && !it.has_var( "u_know_round_in_chamber" ) ) {
+    } else if( x_in_y( jam_chance, 1 ) && !it.has_flag( flag_NEVER_JAMS ) &&
+               !it.has_var( "u_know_round_in_chamber" ) ) {
         add_msg_player_or_npc( m_bad, _( "Your %s malfunctions!" ),
                                _( "<npcname>'s %s malfunctions!" ),
                                it.tname() );


### PR DESCRIPTION
#### Summary
Bugfixes "Ensure the NEVER_JAMS flag always applies"

#### Purpose of change
Test failures on my PR https://github.com/CleverRaven/Cataclysm-DDA/pull/81332
```
 (~[slow] ~[.],starting_items)=>   REQUIRE( shooter.fire_gun( here, spot, 1, *shooter.used_weapon(), shooter.ammo_location ) )
(~[slow] ~[.],starting_items)=> with expansion:
Error: (~[slow] ~[.],starting_items)=>   0
(~[slow] ~[.],starting_items)=> with messages:
(~[slow] ~[.],starting_items)=>   opt.moves() := 352 (0x160)
(~[slow] ~[.],starting_items)=>   opt.ammo.obtain_cost( shooter, 1 ) := 301 (0x12d)
(~[slow] ~[.],starting_items)=>   shooter.item_reload_cost( *shooter.used_weapon(), *opt.ammo, 1 ) := 51
(~[slow] ~[.],starting_items)=>   shooter.used_weapon()->get_reload_time() := 50
(~[slow] ~[.],starting_items)=>   shooter.item_handling_cost( *shooter.used_weapon(), true, 0 ) := 12
(~[slow] ~[.],starting_items)=>   shooter.used_weapon()->get_reload_time() := 50
(~[slow] ~[.],starting_items)=> 
(~[slow] ~[.],starting_items)=> Log messages during failed test:
(~[slow] ~[.],starting_items)=> 12:00:00PM: Your slingshot malfunctions!
(~[slow] ~[.],starting_items)=> 1359.421 s: starting_items
```
https://github.com/CleverRaven/Cataclysm-DDA/blob/47e044f072b53ae70bbf49784fa1952d71bf225e/data/json/items/ranged/slings.json#L36-L40

#### Describe the solution
It appears the check for the flag was missed in this case.

#### Testing
`reload_from_inventory_times` failed with `--rng-seed=1750216141` before this change, and no longer does after.