### PR TITLE
[CR] Game warns when item group copy-froms nonexistent parent

### DIFF
--- a/data/mods/Magiclysm/items/forage.json
+++ b/data/mods/Magiclysm/items/forage.json
@@ -38,10 +38,10 @@
     }
   },
   {
-    "id": "forage_fall",
+    "id": "forage_autumn",
     "type": "item_group",
     "subtype": "distribution",
-    "copy-from": "forage_fall",
+    "copy-from": "forage_autumn",
     "extend": {
       "entries": [
         { "item": "whiskflower", "prob": 30, "count": [ 1, 2 ] },
@@ -82,9 +82,9 @@
     }
   },
   {
-    "id": "foraging_faction_camp_fall",
+    "id": "foraging_faction_camp_autumn",
     "type": "item_group",
-    "copy-from": "foraging_faction_camp_fall",
+    "copy-from": "foraging_faction_camp_autumn",
     "subtype": "distribution",
     "extend": {
       "entries": [

--- a/data/mods/No_Hope/item_groups.json
+++ b/data/mods/No_Hope/item_groups.json
@@ -157,13 +157,6 @@
   },
   {
     "type": "item_group",
-    "id": "rare",
-    "subtype": "distribution",
-    "copy-from": "rare",
-    "extend": { "entries": [ { "item": "bio_blade", "prob": 10 }, { "item": "bio_speed", "prob": 10 } ] }
-  },
-  {
-    "type": "item_group",
     "id": "sewage_plant",
     "subtype": "distribution",
     "copy-from": "sewage_plant",
@@ -307,13 +300,6 @@
     "ammo": 50,
     "magazine": 100,
     "entries": [ { "item": "flamethrower", "charges": [ 0, 500 ] } ]
-  },
-  {
-    "type": "item_group",
-    "id": "bunker_basement_loot",
-    "subtype": "distribution",
-    "copy-from": "bunker_basement_loot",
-    "extend": { "entries": [ { "group": "bionics_mil", "prob": 1 } ] }
   },
   {
     "id": "necropolis_visitors",

--- a/data/mods/aftershock_exoplanet/itemgroups/item_groups.json
+++ b/data/mods/aftershock_exoplanet/itemgroups/item_groups.json
@@ -46,12 +46,6 @@
     }
   },
   {
-    "id": "spider",
-    "type": "item_group",
-    "copy-from": "spider",
-    "extend": { "items": [ [ "afs_energy_saber_off", 1 ], [ "afs_hydraulic_gauntlet", 1 ], [ "alien_battery", 1 ] ] }
-  },
-  {
     "id": "camping",
     "type": "item_group",
     "copy-from": "camping",

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -4678,15 +4678,23 @@ void Item_factory::load_item_group( const JsonObject &jsobj, const item_group_id
     if( context.empty() ) {
         context = group_id.str();
     }
+    // Check if the copy-from target exists BEFORE we get a reference to it!
+    // std::map's [] operator inserts a reference if one isn't found!
+    auto copy_frommed_group = m_template_groups.find( group_id );
     std::unique_ptr<Item_spawn_data> &isd = m_template_groups[group_id];
     // If we copy-from, do copy-from
     // Otherwise, unconditionally overwrite
     if( jsobj.has_member( "copy-from" ) ) {
+        const std::string target_grp_str = jsobj.get_string( "copy-from" );
         // We can only copy-from a group with the same id (for now)
-        if( jsobj.get_string( "copy-from" ) != group_id.str() ) {
+        if( target_grp_str != group_id.str() ) {
             debugmsg( "Item group '%s' tries to copy from different group '%s'", group_id.str(),
-                      jsobj.get_string( "copy-from" ) );
+                      target_grp_str );
             return;
+        }
+        if( copy_frommed_group == m_template_groups.end() ) {
+            debugmsg( "%1$s was unable to find item group %2$s to copy-from during loading.  Context: %3$s",
+                      group_id.str(), target_grp_str, context );
         }
     } else {
         isd.reset();

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -4680,7 +4680,7 @@ void Item_factory::load_item_group( const JsonObject &jsobj, const item_group_id
     }
     // Check if the copy-from target exists BEFORE we get a reference to it!
     // std::map's [] operator inserts a reference if one isn't found!
-    auto copy_frommed_group = m_template_groups.find( group_id );
+    const bool already_exists = m_template_groups.find( group_id ) != m_template_groups.end();
     std::unique_ptr<Item_spawn_data> &isd = m_template_groups[group_id];
     // If we copy-from, do copy-from
     // Otherwise, unconditionally overwrite
@@ -4692,7 +4692,7 @@ void Item_factory::load_item_group( const JsonObject &jsobj, const item_group_id
                       target_grp_str );
             return;
         }
-        if( copy_frommed_group == m_template_groups.end() ) {
+        if( !already_exists ) {
             debugmsg( "%1$s was unable to find item group %2$s to copy-from during loading.  Context: %3$s",
                       group_id.str(), target_grp_str, context );
         }


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
![image](https://github.com/user-attachments/assets/da4b33d3-4fec-4f92-82d7-8d34bb106f12)


#### Describe the solution
Game throws a warning when we're extending something that doesn't exist. At least for item groups.

#### Describe alternatives you've considered


#### Testing
![image](https://github.com/user-attachments/assets/af060e6b-676e-4632-a000-0e59f79ec6fe)


#### Additional context

This appears to work in practice but I am not very confident in my manipulation of our json loading. Review is greatly appreciated.