### PR TITLE
No gas zombies

### DIFF
--- a/data/json/mapgen/gas_stations/s_gas.json
+++ b/data/json/mapgen/gas_stations/s_gas.json
@@ -319,7 +319,7 @@
           "y": [ 15, 16 ]
         }
       ],
-      "place_monster": [ { "group": "GROUP_ZOMBIE_GAS", "x": [ 5, 10 ], "y": [ 6, 10 ], "repeat": [ 1, 2 ], "chance": 25 } ]
+      "place_monster": [ { "group": "GROUP_ZOMBIE", "x": [ 5, 10 ], "y": [ 6, 10 ], "repeat": [ 1, 2 ], "chance": 25 } ]
     }
   },
   {
@@ -418,7 +418,7 @@
         { "item": "softdrugs", "x": [ 8, 8 ], "y": [ 13, 15 ], "chance": 80, "repeat": [ 1, 8 ] },
         { "item": "nested_shotgun_s", "x": 3, "y": 20, "chance": 10 }
       ],
-      "place_monster": [ { "group": "GROUP_ZOMBIE_GAS", "x": [ 5, 10 ], "y": [ 6, 10 ], "repeat": [ 1, 2 ], "chance": 25 } ]
+      "place_monster": [ { "group": "GROUP_ZOMBIE", "x": [ 5, 10 ], "y": [ 6, 10 ], "repeat": [ 1, 2 ], "chance": 25 } ]
     }
   },
   {
@@ -467,7 +467,7 @@
           "y": [ 12, 17 ]
         }
       ],
-      "place_monster": [ { "group": "GROUP_ZOMBIE_GAS", "x": [ 5, 10 ], "y": [ 6, 10 ], "repeat": [ 1, 2 ], "chance": 25 } ]
+      "place_monster": [ { "group": "GROUP_ZOMBIE", "x": [ 5, 10 ], "y": [ 6, 10 ], "repeat": [ 1, 2 ], "chance": 25 } ]
     }
   }
 ]

--- a/data/json/mapgen_palettes/oil_platform_palette.json
+++ b/data/json/mapgen_palettes/oil_platform_palette.json
@@ -269,7 +269,7 @@
     "vendingmachines": { "D": { "item_group": "vending_drink_items" }, "F": { "item_group": "vending_food_items" } },
     "monster": {
       "i": { "monster": "mon_zombie_swimmer_base", "chance": 30 },
-      "↨": { "monster": "mon_gas_zombie", "chance": 5 },
+      "↨": { "monster": "mon_zombie", "chance": 5 },
       "←": { "monster": "mon_zombie_scientist", "chance": 70 }
     }
   },

--- a/data/json/monstergroups/misc.json
+++ b/data/json/monstergroups/misc.json
@@ -472,7 +472,6 @@
       { "monster": "mon_zombear_skeleton" },
       { "monster": "mon_zoose_brute" },
       { "monster": "mon_zombie_nullfield" },
-      { "monster": "mon_gas_zombie" },
       { "monster": "mon_zombie_urchin" },
       { "monster": "mon_devourer" },
       { "monster": "mon_zombie_hulk" },

--- a/data/json/monstergroups/zombies.json
+++ b/data/json/monstergroups/zombies.json
@@ -181,15 +181,8 @@
       { "group": "GROUP_FERAL", "weight": 13 },
       { "monster": "mon_feral_soldier", "weight": 1, "cost_multiplier": 5 },
       { "monster": "mon_zombie_runner", "weight": 20, "cost_multiplier": 5, "pack_size": [ 1, 4 ] },
-      { "monster": "mon_zombie_brainless", "weight": 65 },
-      { "monster": "mon_gas_zombie", "weight": 1, "cost_multiplier": 2, "starts": "28 days" }
+      { "monster": "mon_zombie_brainless", "weight": 65 }
     ]
-  },
-  {
-    "type": "monstergroup",
-    "default": "mon_null",
-    "id": "GROUP_ZOMBIE_GAS",
-    "monsters": [ { "monster": "mon_gas_zombie", "weight": 250, "cost_multiplier": 2, "starts": "28 days" } ]
   },
   {
     "type": "monstergroup",
@@ -555,8 +548,7 @@
       { "monster": "mon_zombie_swimmer_base", "weight": 40 },
       { "monster": "mon_zombie_survivor", "weight": 4, "cost_multiplier": 5, "starts": "45 days" },
       { "monster": "mon_zombie_survivor_elite", "weight": 2, "cost_multiplier": 5, "starts": "90 days" },
-      { "monster": "mon_zombie_runner", "weight": 20, "cost_multiplier": 2 },
-      { "monster": "mon_gas_zombie", "weight": 1, "cost_multiplier": 6, "starts": "90 days" }
+      { "monster": "mon_zombie_runner", "weight": 20, "cost_multiplier": 2 }
     ]
   },
   {

--- a/data/json/monsters/zed_explosive.json
+++ b/data/json/monsters/zed_explosive.json
@@ -46,29 +46,6 @@
     "extend": { "special_attacks": [ [ "BOOMER_GLOW", 20 ] ] }
   },
   {
-    "id": "mon_gas_zombie",
-    "type": "MONSTER",
-    "name": { "str": "gasoline zombie" },
-    "description": "A huge, bloated zombie that appears to have consumed gasoline; fumes and flames escape from its mouth and liquid fuel leaks from its waddling form.",
-    "copy-from": "mon_boomer",
-    "diff": 20,
-    "weight": "160 kg",
-    "hp": 90,
-    "speed": 25,
-    "color": "dark_gray_red",
-    "luminance": 8,
-    "//grab": "Big lad",
-    "grab_strength": 30,
-    "death_function": {
-      "effect": { "id": "death_conflagration", "hit_self": true },
-      "message": "The %s explodes!",
-      "corpse_type": "NO_CORPSE"
-    },
-    "armor": { "electric": 1 },
-    "delete": { "flags": [ "BILE_BLOOD" ], "special_attacks": [ "BOOMER" ] },
-    "extend": { "flags": [ "DRIPS_GASOLINE" ] }
-  },
-  {
     "id": "mon_zombie_gasbag",
     "type": "MONSTER",
     "name": { "str": "bloated zombie" },

--- a/data/json/overmap/overmap_terrain/overmap_terrain_commercial.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_commercial.json
@@ -6,7 +6,7 @@
     "name": "gas station",
     "looks_like": "s_gas",
     "color": "light_blue",
-    "spawns": { "group": "GROUP_ZOMBIE_GAS", "population": [ 6, 12 ], "chance": 100 },
+    "spawns": { "group": "GROUP_ZOMBIE", "population": [ 6, 12 ], "chance": 100 },
     "extend": { "flags": [ "SOURCE_FUEL", "SOURCE_VEHICLES", "PP_GENERATE_RIOT_DAMAGE" ] },
     "land_use_code": "commercial"
   },
@@ -17,7 +17,7 @@
     "name": "gas station",
     "looks_like": "s_gas",
     "color": "light_blue",
-    "spawns": { "group": "GROUP_ZOMBIE_GAS", "population": [ 6, 12 ], "chance": 100 },
+    "spawns": { "group": "GROUP_ZOMBIE", "population": [ 6, 12 ], "chance": 100 },
     "extend": { "flags": [ "SOURCE_FUEL", "SOURCE_VEHICLES", "PP_GENERATE_RIOT_DAMAGE" ] }
   },
   {

--- a/data/json/speech.json
+++ b/data/json/speech.json
@@ -3638,7 +3638,6 @@
       "mon_zombie_dog_brute_acidic",
       "mon_boomer",
       "mon_boomer_huge",
-      "mon_gas_zombie",
       "mon_boomer_glutton",
       "mon_boomer_claymore"
     ],

--- a/data/mods/Magiclysm/monsters/vanilla_monster_damage_overwrite.json
+++ b/data/mods/Magiclysm/monsters/vanilla_monster_damage_overwrite.json
@@ -1615,12 +1615,6 @@
   },
   {
     "type": "MONSTER",
-    "id": "mon_gas_zombie",
-    "copy-from": "mon_gas_zombie",
-    "extend": { "armor": { "poison": 14 } }
-  },
-  {
-    "type": "MONSTER",
     "id": "mon_zombie_gasbag",
     "copy-from": "mon_zombie_gasbag",
     "extend": { "armor": { "poison": 14 } }


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Zombies that vomit gasoline? What is this Wyrmwood?
Lore-wise, they don't make sense, where is the gasoline coming from? who knows?
Balance wise, they're a pre-loaded molotov cocktail placed inside other zombie hordes ready for you to set them off, making encounters involving them much much easier.

#### Describe the solution
Remove the gasoline zombies.

#### Describe alternatives you've considered
There have been inumerable discussions about "fixing" these, with no real options other than "Replace them with something completely different", the core of their design is the problem, you can't fiddle with details to make them work.