### PR TITLE
Fix #81333 Negative quench items don't dehydrate you

### DIFF
--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -1522,8 +1522,7 @@ double Character::compute_effective_food_volume_ratio( const item &food ) const
 // These maths are made easier by the fact that 1 g = 1 mL. Thanks, metric system.
 std::pair<units::volume, units::volume> Character::masticated_volume( const item &food ) const
 {
-    units::volume water_vol = ( food.get_comestible()->quench > 0 ) ? food.get_comestible()->quench *
-                              5_ml : 0_ml;
+    units::volume water_vol = food.get_comestible()->quench * 5_ml;
     units::mass water_weight = units::from_gram( units::to_milliliter( water_vol ) );
     // handle the division by zero exception when the food count is 0 with std::max()
     units::mass food_dry_weight = food.weight() / std::max( 1, food.count() ) - water_weight;
@@ -1713,6 +1712,11 @@ bool Character::consume_effects( item &food )
 
     // GET IN MAH BELLY!
     stomach.ingest( ingested );
+
+    if( ingested.water < 0_ml ) {
+    mod_thirst( -units::to_milliliter( ingested.water) / 5 ); 
+        add_msg_if_player(m_bad, _( "You feel thirstier than before you consumed that!" ));
+    }
 
     // update speculative values
     if( is_avatar() ) {

--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -1714,8 +1714,8 @@ bool Character::consume_effects( item &food )
     stomach.ingest( ingested );
 
     if( ingested.water < 0_ml ) {
-    mod_thirst( -units::to_milliliter( ingested.water) / 5 ); 
-        add_msg_if_player(m_bad, _( "You feel thirstier than before you consumed that!" ));
+        mod_thirst( -units::to_milliliter( ingested.water ) / 5 );
+        add_msg_if_player( m_bad, _( "You feel thirstier than before you consumed that!" ) );
     }
 
     // update speculative values

--- a/tests/comestible_test.cpp
+++ b/tests/comestible_test.cpp
@@ -327,7 +327,7 @@ TEST_CASE( "effective_food_volume_and_satiety", "[character][food][satiety]" )
     // If kcal per gram > 3.0, return sqrt( 3 * kcal / gram )
     expect_ratio = std::sqrt( 3.0f * 202 / 30 );
     CHECK( u.compute_effective_food_volume_ratio( nuts ) == Approx( expect_ratio ).margin( 0.01f ) );
-    CHECK( u.compute_calories_per_effective_volume( nuts ) == 1507 );
+    CHECK( u.compute_calories_per_effective_volume( nuts ) == 1141 );
     CHECK( satiety_bar( 1507 ) == "<color_c_light_green>||||</color>." );
     REQUIRE( u.mutate_towards( trait_GOURMAND ) );
     // stomach size affects food with water...
@@ -336,7 +336,7 @@ TEST_CASE( "effective_food_volume_and_satiety", "[character][food][satiety]" )
     CHECK( satiety_bar( 1568 ) == "<color_c_green>||||</color>." );
     // but not food without water.
     CHECK( u.compute_effective_food_volume_ratio( nuts ) == Approx( expect_ratio ).margin( 0.01f ) );
-    CHECK( u.compute_calories_per_effective_volume( nuts ) == 1507 );
+    CHECK( u.compute_calories_per_effective_volume( nuts ) == 1160 );
     CHECK( satiety_bar( 1507 ) == "<color_c_light_green>||||</color>." );
 }
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Negative Quench items now dehydrate you"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes #81333. 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Adjust consumption to cause negative quench to adjust thirst appropriately and notify the PC if they consume something with more than negative 15 quench.   
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Maybe there should be no notice, maybe it should only happen at -30 quench (salt water).
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Tested.  Consumed butter and thirst went up, consumed salt water and thirst went up significantly and a message appeared in the log.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
