### PR TITLE
Adjust sledgehammer throwing damage

### DIFF
--- a/data/json/items/melee/bludgeons.json
+++ b/data/json/items/melee/bludgeons.json
@@ -663,7 +663,8 @@
     "price": "120 USD",
     "price_postapoc": "5 USD",
     "qualities": [ [ "HAMMER", 1 ] ],
-    "melee_damage": { "bash": 50 }
+    "melee_damage": { "bash": 50 },
+    "thrown_damage": [ { "damage_type": "bash", "amount": 12 } ]
   },
   {
     "type": "ITEM",
@@ -681,7 +682,8 @@
       "volume": "-350 ml",
       "longest_side": "-20 cm",
       "price_postapoc": "-2 USD 50 cent"
-    }
+    },
+    "thrown_damage": [ { "damage_type": "bash", "amount": 9 } ]
   },
   {
     "type": "ITEM",
@@ -701,7 +703,8 @@
       "price_postapoc": 0.5,
       "melee_damage": { "bash": 0.5 }
     },
-    "relative": { "qualities": [ [ "HAMMER", 1 ] ] }
+    "relative": { "qualities": [ [ "HAMMER", 1 ] ] },
+    "thrown_damage": [ { "damage_type": "bash", "amount": 6 } ]
   },
   {
     "type": "ITEM",
@@ -711,7 +714,8 @@
     "description": "A large sledge hammer with a massive, heavy head.  This unwieldy tool is meant to break concrete, rock, brick, anything really.",
     "to_hit": { "grip": "weapon", "length": "long", "surface": "any", "balance": "clumsy" },
     "proportional": { "price_postapoc": 2, "price": 2 },
-    "relative": { "melee_damage": { "bash": 30 }, "weight": "5250 g", "volume": "450 ml", "longest_side": "20 cm" }
+    "relative": { "melee_damage": { "bash": 30 }, "weight": "5250 g", "volume": "450 ml", "longest_side": "20 cm" },
+    "thrown_damage": [ { "damage_type": "bash", "amount": 20 } ]
   },
   {
     "type": "ITEM",


### PR DESCRIPTION


#### Summary
None

#### Purpose of change
Adjust the throwing damage of sledgehammer, short sledgehammer, heavy sledgehammer, and engineer's hammer.

#### Describe the solution
Give the aforementioned sledgehammers their own "thrown_damage" with the damage being the sledgehammer's bash damage divided by 4.
#### Describe alternatives you've considered
Not doing so.
Thinking of a better formula to get the thrown damage.

#### Testing
Give the "thrown_damage" thing to my build of the game, spawn in the sledgehammers, and then chuck it at a debug monster. see that it is roughly somewhat lower than their melee bash damage.
![Screenshot_20250619_223414](https://github.com/user-attachments/assets/d6228367-248d-4f40-bb5d-98d5c8919d63)

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
