### PR TITLE
Remove almost all consumption bonuses from cannibals, make human flesh tank morale

### DIFF
--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -1379,28 +1379,28 @@ void Character::modify_morale( item &food, const int nutr )
         const bool sapiovore = has_flag( json_flag_SAPIOVORE );
         const bool spiritual = has_flag( json_flag_SPIRITUAL );
         const bool numb = has_flag( json_flag_NUMB );
-        if( cannibal && psycho && spiritual ) {
+        const int huge_morale_penalty = -60;
+        const int moderate_morale_penalty = -25;
+        const int minor_morale_penalty = -10;
+        const int minor_morale_bonus = 10;
+        const int maximum_stacked_morale_penalty = -400;
+        if( cannibal && psycho ) {
             add_msg_if_player( m_good,
-                               _( "You feast upon the human flesh, and in doing so, devour their spirit." ) );
-            // You're not really consuming anything special; you just think you are.
-            add_morale( morale_cannibal, 25, 300 );
-        } else if( cannibal && psycho ) {
-            add_msg_if_player( m_good, _( "You feast upon the human flesh." ) );
-            add_morale( morale_cannibal, 15, 200 );
+                               _( "You worry that your hunger for human flesh is going to be a liability one of these days." ) );
+            // Reduced penalties
+            add_morale( morale_cannibal, minor_morale_penalty, minor_morale_penalty * 5, 6_hours, 3_hours );
         } else if( cannibal && spiritual ) {
-            add_msg_if_player( m_good, _( "You consume the sacred human flesh." ) );
-            // Boosted because you understand the philosophical implications of your actions, and YOU LIKE THEM.
-            add_morale( morale_cannibal, 15, 200 );
+            add_msg_if_player( m_good,
+                               _( "Even as you indulge your darkest impulses, you dread what judgement may come." ) );
+            // Reduced penalties
+            add_morale( morale_cannibal, moderate_morale_penalty, maximum_stacked_morale_penalty,
+                        7_days, 4_days );
         } else if( sapiovore && spiritual ) {
             add_msg_if_player( m_good, _( "You eat the human flesh, and in doing so, devour their spirit." ) );
-            add_morale( morale_cannibal, 10, 50 );
+            add_morale( morale_cannibal, minor_morale_bonus, minor_morale_bonus * 5 );
         } else if( cannibal ) {
             add_msg_if_player( m_good, _( "You indulge your shameful hunger." ) );
-            add_morale( morale_cannibal, 10, 50 );
-        } else if( psycho && spiritual ) {
-            add_msg_if_player( _( "You greedily devour the taboo meat." ) );
-            // Small bonus for violating a taboo.
-            add_morale( morale_cannibal, 5, 50 );
+            add_morale( morale_cannibal, minor_morale_bonus, minor_morale_bonus * 5 );
         } else if( has_flag( json_flag_BLOODFEEDER ) && food.has_flag( flag_HEMOVORE_FUN ) ) {
             add_msg_if_player( _( "The human blood tastes as good as any other." ) );
         } else if( psycho ) {
@@ -1410,17 +1410,18 @@ void Character::modify_morale( item &food, const int nutr )
         } else if( has_flag( json_flag_HEMOVORE ) && food.has_flag( flag_HEMOVORE_FUN ) ) {
             add_msg_if_player(
                 _( "Despite your cravings, you still can't help feeling weird about drinking somebody's blood." ) );
-            add_morale( morale_cannibal, -10, -30, 30_minutes, 15_minutes );
+            add_morale( morale_cannibal, minor_morale_penalty, minor_morale_penalty * 3,
+                        30_minutes, 15_minutes );
         } else if( spiritual ) {
             add_msg_if_player( m_bad,
                                _( "This is probably going to count against you if there's still an afterlife." ) );
-            add_morale( morale_cannibal, -60, -400, 60_minutes, 30_minutes );
+            add_morale( morale_cannibal, huge_morale_penalty, maximum_stacked_morale_penalty, 7_days, 4_days );
         } else if( numb ) {
             add_msg_if_player( m_bad, _( "You find this meal distasteful, but necessary." ) );
-            add_morale( morale_cannibal, -60, -400, 60_minutes, 30_minutes );
+            add_morale( morale_cannibal, huge_morale_penalty, maximum_stacked_morale_penalty, 7_days, 4_days );
         } else {
             add_msg_if_player( m_bad, _( "You feel horrible for eating a person." ) );
-            add_morale( morale_cannibal, -60, -400, 60_minutes, 30_minutes );
+            add_morale( morale_cannibal, huge_morale_penalty, maximum_stacked_morale_penalty, 7_days, 4_days );
         }
     }
 

--- a/tests/modify_morale_test.cpp
+++ b/tests/modify_morale_test.cpp
@@ -320,6 +320,10 @@ TEST_CASE( "cannibalism", "[food][modify_morale][cannibal]" )
     avatar dummy;
     dummy.set_body();
     dummy.worn.wear_item( dummy, item( itype_backpack ), false, false );
+    const int huge_morale_penalty = -60;
+    const int moderate_morale_penalty = -25;
+    const int minor_morale_penalty = -10;
+    const int minor_morale_bonus = 10;
 
     item_location human = dummy.i_add( item( itype_bone_human ) );
     REQUIRE( human->has_vitamin( vitamin_human_flesh_vitamin ) );
@@ -331,7 +335,7 @@ TEST_CASE( "cannibalism", "[food][modify_morale][cannibal]" )
         THEN( "they get a large morale penalty for eating humans" ) {
             dummy.clear_morale();
             dummy.modify_morale( *human );
-            CHECK( dummy.has_morale( morale_cannibal ) <= -60 );
+            CHECK( dummy.has_morale( morale_cannibal ) <= huge_morale_penalty );
         }
 
         WHEN( "character is a psychopath" ) {
@@ -343,17 +347,6 @@ TEST_CASE( "cannibalism", "[food][modify_morale][cannibal]" )
                 dummy.modify_morale( *human );
                 CHECK( dummy.has_morale( morale_cannibal ) == 0 );
             }
-
-            AND_WHEN( "character is a spiritual psychopath" ) {
-                dummy.toggle_trait( trait_SPIRITUAL );
-                REQUIRE( dummy.has_trait( trait_SPIRITUAL ) );
-
-                THEN( "they get a small morale bonus for eating humans" ) {
-                    dummy.clear_morale();
-                    dummy.modify_morale( *human );
-                    CHECK( dummy.has_morale( morale_cannibal ) >= 5 );
-                }
-            }
         }
     }
 
@@ -364,28 +357,29 @@ TEST_CASE( "cannibalism", "[food][modify_morale][cannibal]" )
         THEN( "they get a morale bonus for eating humans" ) {
             dummy.clear_morale();
             dummy.modify_morale( *human );
-            CHECK( dummy.has_morale( morale_cannibal ) >= 10 );
+            CHECK( dummy.has_morale( morale_cannibal ) >= minor_morale_bonus );
         }
 
         AND_WHEN( "they are also a psychopath" ) {
             dummy.toggle_trait( trait_PSYCHOPATH );
             REQUIRE( dummy.has_trait( trait_PSYCHOPATH ) );
 
-            THEN( "they get a substantial morale bonus for eating humans" ) {
+            THEN( "they get a reduced morale penalty for eating humans" ) {
                 dummy.clear_morale();
                 dummy.modify_morale( *human );
-                CHECK( dummy.has_morale( morale_cannibal ) >= 15 );
+                CHECK( dummy.has_morale( morale_cannibal ) <= minor_morale_penalty );
             }
+        }
 
-            AND_WHEN( "they are also spiritual" ) {
-                dummy.toggle_trait( trait_SPIRITUAL );
-                REQUIRE( dummy.has_trait( trait_SPIRITUAL ) );
+        AND_WHEN( "they are also spiritual" ) {
+            dummy.toggle_trait( trait_SPIRITUAL );
+            REQUIRE( dummy.has_trait( trait_SPIRITUAL ) );
+            REQUIRE( !dummy.has_trait( trait_PSYCHOPATH ) );
 
-                THEN( "they get a large morale bonus for eating humans" ) {
-                    dummy.clear_morale();
-                    dummy.modify_morale( *human );
-                    CHECK( dummy.has_morale( morale_cannibal ) >= 25 );
-                }
+            THEN( "they get a moderate morale penalty for eating humans" ) {
+                dummy.clear_morale();
+                dummy.modify_morale( *human );
+                CHECK( dummy.has_morale( morale_cannibal ) <= moderate_morale_penalty );
             }
         }
     }


### PR DESCRIPTION
#### Summary
Content "Remove almost all consumption bonuses from cannibals"

#### Purpose of change
There were many problems with the values assigned to various cannibal combinations eating human flesh.

-The morale penalty for consuming human flesh without being a cannibal wore off in **one single hour**.

-A cannibal character would bizarrely get extra enormous morale bonuses if they were also spiritual or uncaring.

-All of these used magic numbers which made reading through them and understanding them needlessly annoying



#### Describe the solution

Pure cannibals still get a minor morale bonus

Cannibal-spirituals and cannibal-psychopaths(uncaring) are respectively worried about their beliefs/other survivors respectively, and get reduced **penalties** instead of bonuses.

The cannibal-spiritual-uncaring trifecta was just plain removed

Morale penalty total time: 60 minutes ---> 7 days

Morale penalty decay start: 30 minutes ---> 4 days


(Mostly) replace the magic numbers with constants.


#### Describe alternatives you've considered
I have given serious consideration to removing the pure-cannibal morale bonus. I don't really think it needs to be there. Reducing the massive penalty to 0 is already a huge "benefit".


#### Testing
I've updated CI for the new values


#### Additional context

