### PR TITLE
[MoM] Update Wave of Force to use `u_knockback`

### DIFF
--- a/data/mods/MindOverMatter/PowerDescriptionSpoilers.md
+++ b/data/mods/MindOverMatter/PowerDescriptionSpoilers.md
@@ -1055,7 +1055,7 @@ Powers causing telekinetic damage have a 40% chance to stagger the target for 2 
 *Duration*: Instant<br />
 *Stamina Cost*: 4500, minus 125 per level to a minimum of 2250<br />
 *Channeling Time*: 50 moves, minus 4 moves per level to a minimum of 20<br />
-*Effects*: Unleash an indiscriminate wave of force, knocking back everything nearby by 2 to 6 squares, plus 1 square per 10 power levels to 1 square per four power levels. This power affects item and allies as well as enemies.<br />
+*Effects*: Unleash an indiscriminate wave of force, knocking back everything nearby. Like Force Shove, the distance is based on the weight ratio: (power level * 55 kg) * Intelligence modifier * Nether Attunement modifier, divided by the target's weight in kg.  This power affects allies as well as enemies.<br />
 *Prerequisites*: Force Shove 7, Knockdown 4 <br />
 </details>
 <details>

--- a/data/mods/MindOverMatter/powers/telekinesis.json
+++ b/data/mods/MindOverMatter/powers/telekinesis.json
@@ -317,51 +317,32 @@
     "description": "Unleash a telekinetic wave around you that indiscriminately knocks everything back.",
     "message": "You knock everything nearby backwards!",
     "teachable": false,
-    "valid_targets": [ "self" ],
+    "valid_targets": [ "hostile", "ally" ],
     "spell_class": "TELEKINETIC",
     "magic_type": "mom_psionics",
     "skill": "metaphysics",
-    "flags": [ "PSIONIC", "CONCENTRATE", "WONDER", "NO_HANDS", "NO_LEGS" ],
+    "flags": [ "PSIONIC", "CONCENTRATE", "NO_HANDS", "NO_LEGS" ],
     "difficulty": 4,
     "max_level": { "math": [ "int_to_level(1)" ] },
-    "effect": "attack",
-    "extra_effects": [ { "id": "telekinetic_wavepush", "hit_self": true } ],
+    "effect": "effect_on_condition",
+    "effect_str": "EOC_TELEKIN_WAVE_TARGETS",
     "shape": "blast",
-    "min_damage": 12,
-    "max_damage": 12,
+    "min_aoe": {
+      "math": [
+        "min( ( ( (u_spell_level('telekinetic_wave') * 0.2) + 1) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling), 4)"
+      ]
+    },
+    "max_aoe": {
+      "math": [
+        "min( ( ( (u_spell_level('telekinetic_wave') * 0.2) + 1) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling), 4)"
+      ]
+    },
     "base_energy_cost": 4500,
     "final_energy_cost": 2250,
     "energy_increment": -125,
     "base_casting_time": 50,
     "final_casting_time": 20,
     "casting_time_increment": -4
-  },
-  {
-    "id": "telekinetic_wavepush",
-    "type": "SPELL",
-    "name": { "str": "[Ψ]Telekinetic Wave Push", "//~": "NO_I18N" },
-    "description": { "str": "Part of Wave of Force.  If you see this it's a bug.", "//~": "NO_I18N" },
-    "message": "",
-    "valid_targets": [ "ally", "hostile", "item" ],
-    "skill": "metaphysics",
-    "flags": [ "PSIONIC", "CONCENTRATE", "RANDOM_DAMAGE", "NO_HANDS", "NO_LEGS", "RANDOM_TARGET", "NO_EXPLOSION_SFX" ],
-    "effect": "directed_push",
-    "shape": "blast",
-    "max_level": { "math": [ "int_to_level(1)" ] },
-    "damage_type": "psi_telekinetic_damage",
-    "min_damage": {
-      "math": [
-        "min( ( ( ( (u_spell_level('telekinetic_wave') + u_spell_level('telekinetic_wave_knack') ) * 0.1) + 2) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling), 15)"
-      ]
-    },
-    "max_damage": {
-      "math": [
-        "( ( (u_spell_level('telekinetic_wave') + u_spell_level('telekinetic_wave_knack') ) * 0.25) + 6) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling"
-      ]
-    },
-    "min_range": 1,
-    "max_range": 1,
-    "ignored_monster_species": [ "PSI_NULL", "TELEKIN_PUSHPULL_NULL" ]
   },
   {
     "id": "telekinetic_water_walk",

--- a/data/mods/MindOverMatter/powers/telekinesis_eoc.json
+++ b/data/mods/MindOverMatter/powers/telekinesis_eoc.json
@@ -140,6 +140,35 @@
   },
   {
     "type": "effect_on_condition",
+    "id": "EOC_TELEKIN_WAVE_TARGETS",
+    "condition": "has_alpha",
+    "effect": [
+      { "npc_location_variable": { "context_val": "player_position" } },
+      { "math": [ "u_telekinesis_intelligence = ( ( n_val('intelligence') + 10) / 20 )" ] },
+      { "math": [ "u_nether_attunement_telekinesis_scaling = n_nether_attunement_power_scaling" ] },
+      { "math": [ "u_telekinesis_weight_ratio = 55" ] },
+      {
+        "math": [
+          "u_weight_ratio",
+          "=",
+          "( ( (u_telekinesis_power_level * u_telekinesis_weight_ratio) * u_telekinesis_intelligence * u_nether_attunement_telekinesis_scaling) + (u_telekinesis_weight_ratio / 2) ) / (u_weight() / 1000000)"
+        ]
+      },
+      { "math": [ "u_telekinesis_shove_spell_level = clamp(((u_weight_ratio - 1) * 2), 0, 30)" ] },
+      {
+        "if": { "x_in_y_chance": { "x": { "math": [ "u_weight_ratio * 1000" ] }, "y": 1000 } },
+        "then": [ { "u_add_effect": "downed", "duration": 2 } ]
+      },
+      {
+        "u_knockback": 3,
+        "stun": 1,
+        "dam_mult": { "math": [ "1 + (u_telekinesis_shove_spell_level * 0.4)" ] },
+        "direction_var": { "context_val": "player_position" }
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
     "id": "EOC_TELEKINETIC_MOVE_LARGE_WEIGHT_SELECTOR",
     "effect": [
       { "math": [ "u_telekinesis_power_level = n_spell_level('telekinetic_move_large_weight')" ] },

--- a/data/mods/MindOverMatter/powers/telekinesis_eoc.json
+++ b/data/mods/MindOverMatter/powers/telekinesis_eoc.json
@@ -144,6 +144,9 @@
     "condition": "has_alpha",
     "effect": [
       { "npc_location_variable": { "context_val": "player_position" } },
+      {
+        "math": [ "u_telekinesis_power_level = (n_spell_level('telekinetic_wave') + n_spell_level('telekinetic_wave_knack') )" ]
+      },
       { "math": [ "u_telekinesis_intelligence = ( ( n_val('intelligence') + 10) / 20 )" ] },
       { "math": [ "u_nether_attunement_telekinesis_scaling = n_nether_attunement_power_scaling" ] },
       { "math": [ "u_telekinesis_weight_ratio = 55" ] },

--- a/data/mods/MindOverMatter/powers/telekinesis_eoc.json
+++ b/data/mods/MindOverMatter/powers/telekinesis_eoc.json
@@ -154,14 +154,14 @@
           "( ( (u_telekinesis_power_level * u_telekinesis_weight_ratio) * u_telekinesis_intelligence * u_nether_attunement_telekinesis_scaling) + (u_telekinesis_weight_ratio / 2) ) / (u_weight() / 1000000)"
         ]
       },
-      { "math": [ "u_telekinesis_shove_spell_level = clamp(((u_weight_ratio - 1) * 2), 0, 30)" ] },
+      { "math": [ "u_telekinesis_shove_spell_level = clamp( ( (u_weight_ratio - 1) * 2), 0, 30)" ] },
       {
         "if": { "x_in_y_chance": { "x": { "math": [ "u_weight_ratio * 1000" ] }, "y": 1000 } },
         "then": [ { "u_add_effect": "downed", "duration": 2 } ]
       },
       {
-        "u_knockback": 3,
-        "stun": 1,
+        "u_knockback": { "math": [ "u_telekinesis_shove_spell_level" ] },
+        "stun": 2,
         "dam_mult": { "math": [ "1 + (u_telekinesis_shove_spell_level * 0.4)" ] },
         "direction_var": { "context_val": "player_position" }
       }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[MoM] Update Wave of Force to use `u_knockback`"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

`u_knockback` has more interesting interactions with terrain and other creatures, best to use it.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Rewrite Wave of Force to use u_knockback and be affected by weight (55 kg per power level is the ratio). Update it so it can affect targets at a larger radius at higher levels/Nether Attunement.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Surrounded self with zombies, used Wave of Force.  They went flying.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
