### PR TITLE
Query to quick-reveal all nearby wires when revealing wall wires

### DIFF
--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -1741,6 +1741,19 @@ void construct::done_wiring( const tripoint_bub_ms &p, Character &who )
     here.partial_con_remove( p );
 
     place_appliance( here, p, vpart_from_item( itype_wall_wiring ), who );
+    if( who.is_avatar() && query_yn( _( "Also reveal all nearby wirings?" ) ) ) {
+        // This is a *really* terrible check to ensure we iterate the current OMT and nothing else.
+        const tripoint_abs_omt current_omt( coords::project_to<coords::omt>( here.get_abs( p ) ) );
+        for( const tripoint_bub_ms &target : here.points_on_zlevel() ) {
+            const tripoint_abs_omt target_omt( coords::project_to<coords::omt>( here.get_abs( target ) ) );
+            if( target_omt != current_omt ) {
+                continue;
+            }
+            if( here.has_flag_ter( ter_furn_flag::TFLAG_WIRED_WALL, target ) && check_no_wiring( target ) ) {
+                place_appliance( here, target, vpart_from_item( itype_wall_wiring ), who );
+            }
+        }
+    }
 }
 
 void construct::done_appliance( const tripoint_bub_ms &p, Character &who )

--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -280,6 +280,7 @@ std::string enum_to_string<ter_furn_flag>( ter_furn_flag data )
         case ter_furn_flag::TFLAG_FLOATS_IN_AIR: return "FLOATS_IN_AIR";
         case ter_furn_flag::TFLAG_HARVEST_REQ_CUT1: return "HARVEST_REQ_CUT1";
         case ter_furn_flag::TFLAG_NATURAL_UNDERGROUND: return "NATURAL_UNDERGROUND";
+        case ter_furn_flag::TFLAG_WIRED_WALL: return "WIRED_WALL";
 
         // *INDENT-ON*
         case ter_furn_flag::NUM_TFLAG_FLAGS:

--- a/src/mapdata.h
+++ b/src/mapdata.h
@@ -356,6 +356,7 @@ enum class ter_furn_flag : int {
     TFLAG_FLOATS_IN_AIR,
     TFLAG_HARVEST_REQ_CUT1,
     TFLAG_NATURAL_UNDERGROUND,
+    TFLAG_WIRED_WALL,
 
     NUM_TFLAG_FLAGS
 };


### PR DESCRIPTION
#### Summary
Features "Query to quick-reveal all nearby wires when revealing wall wires"

#### Purpose of change
Little bit of QoL to save button presses.

#### Describe the solution
Query when any wall wire reveal is done by the player. If user accepts the query then just automatically complete the reveal wall wiring action on all valid walls **within the construction's OMT**.

It specifically is restricted to the current OMT so to avoid weird occurrences like having half of the neighboring home suddenly spawn wirings.

#### Describe alternatives you've considered
"Homemade" wiring should maybe use a different post_special which doesn't query? The presumption being that if you have to manually wire up one wall you probably have to manually wire up many more.

#### Testing

https://github.com/user-attachments/assets/2cbae10d-b2ad-4786-b915-33d0c1148559



#### Additional context
