### PR TITLE
Nerf default thrown damage

### DIFF
--- a/data/json/items/ammo.json
+++ b/data/json/items/ammo.json
@@ -574,7 +574,8 @@
     "recovery_chance": 99,
     "effects": [ "NEVER_MISFIRES", "NON_FOULING", "ALLOWS_BODY_BLOCK" ],
     "qualities": [ [ "HAMMER", 1 ] ],
-    "melee_damage": { "bash": 7 }
+    "melee_damage": { "bash": 7 },
+    "thrown_damage": { "damage_type": "bash", "amount": 7 }
   },
   {
     "type": "ITEM",

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -322,8 +322,7 @@ void Item_factory::finalize_pre( itype &obj )
     }
 
     if( obj.thrown_damage.empty() ) {
-        obj.thrown_damage.add_damage( damage_bash,
-                                      obj.melee.damage_map[damage_bash] + obj.weight / 1.0_kilogram );
+        obj.thrown_damage.add_damage( damage_bash, obj.melee.damage_map[damage_bash] * 0.75 );
     }
 
     if( obj.has_flag( flag_STAB ) ) {


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Base thrown damage being higher than base melee damage is strange since you're losing any follow-through force and a great deal of precision about where it lands.
Was brought up in #81351 with respect to sledgehammers in general, but I think adjusting the default is also worthwhile.

#### Describe the solution
Drop the default thrown damage number from melee bash damage plus one damage per kg of item weight (???) to 75% of melee bash damage.
The rationale is that you're losing any follow-up force in a swing, plus uncontrolled impact orientation of an object limits the amount of damage it can do. For example with a hammer you have a relatively small "face" where the blow lands and transmits force to the target, once you throw it you have little to no chance of the object impacting squarely with that face, instead glancing off or hitting with a surface with a larger cross section, limiting damage.
From a maintenance point of view, any item that's actually able to be thrown proficiently should have an explicit thrown damage, everything else is kinda bad at it.

#### Describe alternatives you've considered
Potentially some kind of formula that characterizes impact potential based on item density and shape? Sounds complicated.
Other formulas are welcome, I'm just going for "you're generally limiting impact damage by throwing an item instead of swinging it"