### PR TITLE
Remove cannibal's last consumption bonus

### DIFF
--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -1400,7 +1400,7 @@ void Character::modify_morale( item &food, const int nutr )
             add_morale( morale_cannibal, minor_morale_bonus, minor_morale_bonus * 5 );
         } else if( cannibal ) {
             add_msg_if_player( m_good, _( "You indulge your shameful hunger." ) );
-            add_morale( morale_cannibal, minor_morale_bonus, minor_morale_bonus * 5 );
+            // No morale added, but lack of morale penalty is a huge bonus already.
         } else if( has_flag( json_flag_BLOODFEEDER ) && food.has_flag( flag_HEMOVORE_FUN ) ) {
             add_msg_if_player( _( "The human blood tastes as good as any other." ) );
         } else if( psycho ) {

--- a/tests/modify_morale_test.cpp
+++ b/tests/modify_morale_test.cpp
@@ -323,7 +323,6 @@ TEST_CASE( "cannibalism", "[food][modify_morale][cannibal]" )
     const int huge_morale_penalty = -60;
     const int moderate_morale_penalty = -25;
     const int minor_morale_penalty = -10;
-    const int minor_morale_bonus = 10;
 
     item_location human = dummy.i_add( item( itype_bone_human ) );
     REQUIRE( human->has_vitamin( vitamin_human_flesh_vitamin ) );

--- a/tests/modify_morale_test.cpp
+++ b/tests/modify_morale_test.cpp
@@ -354,10 +354,10 @@ TEST_CASE( "cannibalism", "[food][modify_morale][cannibal]" )
         dummy.toggle_trait( trait_CANNIBAL );
         REQUIRE( dummy.has_trait( trait_CANNIBAL ) );
 
-        THEN( "they get a morale bonus for eating humans" ) {
+        THEN( "they receive no morale penalty for eating humans" ) {
             dummy.clear_morale();
             dummy.modify_morale( *human );
-            CHECK( dummy.has_morale( morale_cannibal ) >= minor_morale_bonus );
+            CHECK( dummy.has_morale( morale_cannibal ) == 0 );
         }
 
         AND_WHEN( "they are also a psychopath" ) {


### PR DESCRIPTION
#### Summary
Balance "Remove cannibal's last consumption bonus"

#### Purpose of change
In #81357 I listed as alternatives:
> I have given serious consideration to removing the pure-cannibal morale bonus. I don't really think it needs to be there. Reducing the massive penalty to 0 is already a huge "benefit".

On further thinking about it, I realized it should be removed. Completely nullifying the penalties is already huge, it doesn't need to give bonus morale on top.

#### Describe the solution
Remove the bonus morale.

#### Describe alternatives you've considered


#### Testing
Compiles, loads.

#### Additional context
