### PR TITLE
Guilt trip murderers for more than 7 minutes

### DIFF
--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -3057,11 +3057,11 @@ void npc::die( map *here, Creature *nkiller )
             if( morale_effect == 0 ) {
                 // No morale effect
             } else if( morale_effect <= -50 ) {
-                player_character.add_morale( morale_killed_innocent, morale_effect, 0, 2_days, 3_hours );
+                player_character.add_morale( morale_killed_innocent, morale_effect, 0, 14_days, 7_days );
             } else if( morale_effect > -50 && morale_effect < 0 ) {
-                player_character.add_morale( morale_killed_innocent, morale_effect, 0, 1_days, 1_hours );
+                player_character.add_morale( morale_killed_innocent, morale_effect, 0, 10_days, 7_days );
             } else {
-                player_character.add_morale( morale_killed_innocent, morale_effect, 0, 3_hours, 7_minutes );
+                player_character.add_morale( morale_killed_innocent, morale_effect, 0, 7_days, 4_days );
             }
         }
     }


### PR DESCRIPTION
#### Summary
Balance "Guilt trip murderers for more than 7 minutes"

#### Purpose of change
After doing some recent thinking, I realized the morale penalties for murder are also very silly.

#### Describe the solution
Murdering someone actually sticks around and bothers you for a while instead of starting to evaporate in **7 minutes**. That is hyperbole, but not by much! For the smallest penalty, it really did start to decay after 7 minutes.

Worst-case penalty total duration: 2 days ---> 14 days

Worst-case penalty decay starts after: 3 hours --> 7 days

---

Middling penalty total duration: 1 day ---> 10 days

Middling penalty decay starts after: 1 hour --> 7 days

---

Smallest penalty total duration: 3 hours ---> 7 days

Smallest penalty decay starts after: 7 minutes --> 4 days

#### Describe alternatives you've considered


#### Testing
Compiles, loads. Simple value changes.

#### Additional context

