### PR TITLE
Remove toggling skill training on/off

### DIFF
--- a/data/json/skills.json
+++ b/data/json/skills.json
@@ -137,6 +137,7 @@
     "name": { "str": "vehicles" },
     "description": "Your skill in operating and steering a vehicle in motion, from cars and boats to helicopters and hot air balloons.  A higher level allows greater control over vehicles at higher speeds, and reduces the penalty of shooting while driving.",
     "display_category": "display_interaction",
+    "consumes_focus": false,
     "level_descriptions_theory": [
       { "level": 0, "description": "You know what a car looks like." },
       { "level": 1, "description": "You know the basics of driving a car." },

--- a/doc/JSON/JSON_INFO.md
+++ b/doc/JSON/JSON_INFO.md
@@ -2451,6 +2451,7 @@ it is present to help catch errors.
   "tags": [ "combat_skill" ],
   "time_to_attack": { "min_time": 20, "base_time": 30, "time_reduction_per_level": 1 },
   "display_category": "display_ranged",
+  "consumes_focus": true,
   "sort_rank": 11000,
   "teachable": true,
   "level_descriptions_theory": [
@@ -2478,6 +2479,7 @@ it is present to help catch errors.
 | `tags`                     | Identifies special cases. Currently valid tags are: "combat_skill" and "contextual_skill". |
 | `time_to_attack`           | Object used to calculate the movecost for firing a gun. |
 | `display_category`         | Category in the character info screen where this skill is displayed. |
+| `consumes_focus`           | (Boolean) Whether focus is consumed when this skill is trained.
 | `sort_rank`                | Order in which the skill is shown. |
 | `teachable`                | Whether it's possible to teach this skill between characters. (Default = true) |
 | `companion_skill_practice` | Determines the priority of this skill within a mision skill category when an NPC gains experience from a companion mission. |

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -2853,6 +2853,7 @@ bool Character::practice( const skill_id &id, int amount, int cap, bool suppress
         }
     }
     bool level_up = false;
+    // NOTE: Normally always training, this training toggle is just retained for tests
     if( amount > 0 && level.isTraining() ) {
         int old_practical_level = static_cast<int>( get_skill_level( id ) );
         int old_theoretical_level = get_knowledge_level( id );

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -2882,7 +2882,8 @@ bool Character::practice( const skill_id &id, int amount, int cap, bool suppress
 
         // Apex Predators don't think about much other than killing.
         // They don't lose Focus when practicing combat skills.
-        if( !( has_flag( json_flag_PRED4 ) && skill.is_combat_skill() ) ) {
+        const bool predator_training_combat = has_flag( json_flag_PRED4 ) && skill.is_combat_skill();
+        if( skill.training_consumes_focus() && !predator_training_combat ) {
             // Base reduction on the larger of 1% of total, or practice amount.
             // The latter kicks in when long actions like crafting
             // apply many turns of gains at once.

--- a/src/player_display.cpp
+++ b/src/player_display.cpp
@@ -821,7 +821,6 @@ static void draw_skills_tab( ui_adaptor &ui, const catacurses::window &w_skills,
             int exercise = level.knowledgeExperience();
             int level_num = level.knowledgeLevel();
             const bool can_train = level.can_train();
-            const bool training = level.isTraining();
             const bool skill_gap = level_num > level.level();
             const bool skill_small_gap = exercise > level.exercise();
             bool locked = false;
@@ -838,21 +837,21 @@ static void draw_skills_tab( ui_adaptor &ui, const catacurses::window &w_skills,
                 } else if( !can_train ) {
                     cstatus = h_white;
                 } else if( exercise >= 100 ) {
-                    cstatus = training ? h_pink : h_magenta;
+                    cstatus = h_pink;
                 } else if( skill_gap || skill_small_gap ) {
-                    cstatus = training ? h_light_cyan : h_cyan;
+                    cstatus = h_light_cyan;
                 } else {
-                    cstatus = training ? h_light_blue : h_blue;
+                    cstatus = h_light_blue;
                 }
             } else {
                 if( locked ) {
                     cstatus = c_yellow;
                 } else if( skill_gap || skill_small_gap ) {
-                    cstatus = training ? c_light_cyan : c_cyan;
+                    cstatus = c_light_cyan;
                 } else if( !can_train ) {
                     cstatus = c_white;
                 } else {
-                    cstatus = training ? c_light_blue : c_blue;
+                    cstatus = c_light_blue;
                 }
             }
             mvwprintz( w_skills, point( 1, y_pos ), cstatus, "%s:", aSkill->name() );
@@ -945,15 +944,6 @@ static void draw_skills_info( const catacurses::window &w_info, const Character 
             } else {
                 info_text = string_format( _( "%s| Learning bonus: %.0f%%" ), info_text,
                                            learning_bonus );
-            }
-            if( !level.isTraining() ) {
-                info_text = string_format( "%s | %s", info_text,
-                                           _( "<color_yellow>Learning is disabled.</color>" ) );
-            }
-        } else {
-            if( !level.isTraining() ) {
-                info_text = string_format( "%s\n\n%s", info_text,
-                                           _( "<color_yellow>Learning is disabled.</color>" ) );
             }
         }
         draw_x_info( w_info, info_text, info_line );
@@ -1412,18 +1402,6 @@ static bool handle_player_display_action( Character &you, unsigned int &line,
 
                 invalidate_tab( curtab );
                 break;
-            case player_display_tab::skills: {
-                const Skill *selectedSkill = nullptr;
-                if( line < skillslist.size() && !skillslist[line].is_header ) {
-                    selectedSkill = skillslist[line].skill;
-                }
-                if( selectedSkill ) {
-                    you.get_skill_level_object( selectedSkill->ident() ).toggleTraining();
-                }
-                invalidate_tab( curtab );
-                ui_info.invalidate_ui();
-                break;
-            }
             case player_display_tab::proficiencies:
                 const std::vector<display_proficiency> profs = you.display_proficiencies();
                 if( !profs.empty() ) {

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -472,7 +472,6 @@ void SkillLevel::serialize( JsonOut &json ) const
     json.start_object();
     json.member( "level", _level );
     json.member( "exercise", _exercise );
-    json.member( "istraining", _isTraining );
     json.member( "lastpracticed", _lastPracticed );
     json.member( "knowledgeLevel", _knowledgeLevel );
     json.member( "knowledgeExperience", _knowledgeExperience );
@@ -492,7 +491,6 @@ void SkillLevel::deserialize( const JsonObject &data )
     if( _exercise < 0 ) {
         _exercise = 0;
     }
-    data.read( "istraining", _isTraining );
     data.read( "rustaccumulator", _rustAccumulator );
     if( !data.read( "lastpracticed", _lastPracticed ) ) {
         _lastPracticed = calendar::start_of_game;

--- a/src/skill.cpp
+++ b/src/skill.cpp
@@ -157,6 +157,10 @@ void Skill::load_skill( const JsonObject &jsobj )
         debugmsg( "skill '%s' missing 'sort_rank' field.", ident.str() );
     }
 
+    if( jsobj.has_bool( "consumes_focus" ) ) {
+        sk.consumes_focus = jsobj.get_bool( "consumes_focus" );
+    }
+
     sk._time_to_attack = time_to_attack;
     sk._companion_combat_rank_factor = jsobj.get_int( "companion_combat_rank_factor", 0 );
     sk._companion_survival_rank_factor = jsobj.get_int( "companion_survival_rank_factor", 0 );

--- a/src/skill.h
+++ b/src/skill.h
@@ -127,20 +127,23 @@ class SkillLevel
         int _level = 0;
         int _exercise = 0;
         time_point _lastPracticed = calendar::turn;
-        bool _isTraining = true;
         int _knowledgeLevel = 0;
         int _knowledgeExperience = 0;
         int _rustAccumulator = 0;
 
+        // NOLINTNEXTLINE(cata-serialize)
+        bool _skillisTraining = true;
+
     public:
         SkillLevel() = default;
 
+        // Only used for tests!
         bool isTraining() const {
-            return _isTraining;
+            return _skillisTraining;
         }
         bool toggleTraining() {
-            _isTraining = !_isTraining;
-            return _isTraining;
+            _skillisTraining = !_skillisTraining;
+            return _skillisTraining;
         }
 
         int level() const {

--- a/src/skill.h
+++ b/src/skill.h
@@ -50,6 +50,7 @@ class Skill
         int _companion_industry_rank_factor = 0;
         bool _teachable = true;
         bool _obsolete = false;
+        bool consumes_focus = true;
     public:
         static std::vector<Skill> skills;
         static void load_skill( const JsonObject &jsobj );
@@ -115,6 +116,10 @@ class Skill
 
         bool obsolete() const {
             return _obsolete;
+        }
+
+        bool training_consumes_focus() const {
+            return consumes_focus;
         }
 
         bool is_combat_skill() const;


### PR DESCRIPTION
#### Summary
Balance "Remove toggling skill training on/off"

#### Purpose of change
The option to toggle skill training on/off had several issues.

-It encourages micromanagement of skills. Pressing a button to turn your brain on and off was not fun, and it was even less fun when the design seemed to encourage you to do it. CDDA is a game about zombies and stuff, managing button presses is not wanted!

-It could be "tactically abused" with some of our special traits like savant.

-Players could (and did!) accidentally turn learning off, and then became upset when the game seemed to malfunction. If you use a skill, you should learn! Having an option to throw away your own exp doesn't make much sense.

#### Describe the solution
Completely nix it. Skill training is always on.

One of the previous rationales for not removing it was that some activities (driving around in a vehicle) would "drain" focus, and be a serious drag on a player that was doing some skill-related activity shortly after (e.g. driving to the city and then engaging in combat). This is being dealt with by special-casing the vehicles skill to not consume focus.

#### Describe alternatives you've considered


#### Testing
Saved a character before the changes with all skill learning disabled. Loaded character afterwards, skills were no longer colored as disabled. Did some crafting, gained a skill level.

#### Additional context

Opened as draft - the vehicles skill is not yet modified.

Known issues:
Driving proficiencies still exist and any unlearned ones will continue to consume focus 
