### PR TITLE
Enforce mod incompatibilities

### DIFF
--- a/src/mod_manager.h
+++ b/src/mod_manager.h
@@ -197,6 +197,8 @@ class mod_ui
         void try_rem( size_t selection, std::vector<mod_id> &active_list );
         void try_shift( char direction, size_t &selection, std::vector<mod_id> &active_list );
 
+        bool confirm_mod_compatibility( const mod_id &checked_mod, const std::vector<mod_id> &active_list );
+
         bool can_shift_up( size_t selection, const std::vector<mod_id> &active_list );
         bool can_shift_down( size_t selection, const std::vector<mod_id> &active_list );
 };

--- a/src/mod_manager_ui.cpp
+++ b/src/mod_manager_ui.cpp
@@ -68,6 +68,19 @@ std::string mod_ui::get_information( const MOD_INFORMATION *mod )
     return info;
 }
 
+bool mod_ui::confirm_mod_compatibility( const mod_id &checked_mod,
+                                        const std::vector<mod_id> &active_list )
+{
+    for( mod_id some_active_mod : active_list ) {
+        for( mod_id conflict_mod_id : some_active_mod->conflicts ) {
+            if( conflict_mod_id == checked_mod ) {
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
 void mod_ui::try_add( const mod_id &mod_to_add,
                       std::vector<mod_id> &active_list )
 {
@@ -79,6 +92,12 @@ void mod_ui::try_add( const mod_id &mod_to_add,
         debugmsg( "Unable to load mod \"%s\".", mod_to_add.c_str() );
         return;
     }
+    if( !confirm_mod_compatibility( mod_to_add, active_list ) ) {
+        popup( _( "Unable to add %s.  It is incompatible with a currently active mod." ),
+               mod_to_add->name() );
+        return;
+    }
+
     const MOD_INFORMATION &mod = *mod_to_add;
     bool errs;
     try {

--- a/src/worldfactory.h
+++ b/src/worldfactory.h
@@ -161,7 +161,8 @@ class worldfactory
         std::map<int, inclusive_rectangle<point>> draw_mod_list( const catacurses::window &w, int &start,
                                                size_t cursor, const std::vector<mod_id> &mods,
                                                bool is_active_list, const std::string &text_if_empty,
-                                               const catacurses::window &w_shift, bool recalc_start );
+                                               const catacurses::window &w_shift, bool recalc_start,
+                                               const std::vector<mod_id> &potential_conflicts = std::vector<mod_id>() );
 
         WORLD *add_world( std::unique_ptr<WORLD> retworld );
 


### PR DESCRIPTION
#### Summary
Infrastructure "Enforce mod incompatibilities"

#### Purpose of change
A while ago we added the mod incompatibility field, but they were not actually *functioning* when implemented. Afterwards, we started enforcing them for the tests. However we were still not enforcing them ingame 😬

#### Describe the solution
This PR prevents creating new worlds with any set of incompatible mods. It checks when a new mod is added to the active list, and as a failsafe it also checks all active mods when the world generation prompt is completed (aborting with a popup if there is any invalid combination).

This does not prevent loading existing saves, even if they have incompatible mods.

#### Describe alternatives you've considered


#### Testing

Trying to add an incompatible mod:


https://github.com/user-attachments/assets/c67442a5-8dd0-4834-932d-d309eaf21492


Trying to start world with pre-loaded default mod list that contains incompatible mods:
![image](https://github.com/user-attachments/assets/3a3902e9-ed4e-4c75-b80a-a8a1d9f065f9)



#### Additional context

Known (minor) issues:
The popups do not explicitly say which mod(s) is causing the incompatibility, but the mod list does refresh to show them when the first of the pair (causing the incompatibility) is added. This could definitely be improved, but I've not found a simple way to do that.

~~The placement of the "INCOMPATIBLE MODS" category is arbitrary and will break up existing categories in some circumstances. I consider this a minor UI blemish.~~ This doesn't matter anymore since we don't put them into a new/different category.
![image](https://github.com/user-attachments/assets/42b98f76-281d-4c5f-a3cb-06a7795186c4)
