### PR TITLE
Mildly improve overmap generation performance

### DIFF
--- a/src/coordinates.h
+++ b/src/coordinates.h
@@ -1094,8 +1094,8 @@ std::vector<coords::coord_point_ob<Point, Origin, Scale>>
 {
     std::vector<Point> raw_result = closest_points_first( loc.raw(), min_dist, max_dist );
     std::vector<coords::coord_point_ob<Point, Origin, Scale>> result;
-    result.reserve( raw_result.size() );
-    std::transform( raw_result.begin(), raw_result.end(), std::back_inserter( result ),
+    result.resize( raw_result.size() );
+    std::transform( raw_result.begin(), raw_result.end(), result.begin(),
     []( const Point & p ) {
         return coords::coord_point_ob<Point, Origin, Scale>( p );
     } );

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -4208,12 +4208,12 @@ std::optional<int> overmap::distance_to_city( const tripoint_om_omt &p,
         int max_dist_to_check ) const
 {
     if( !city_tiles.empty() ) {
-        for( int i = 0; i <= max_dist_to_check; i++ ) {
-            for( const tripoint_om_omt &tile : closest_points_first( p, i, i ) ) {
-                if( is_in_city( tile ) ) {
-                    return i;
-                }
-            }
+        std::optional<tripoint_om_omt> city_tile = find_point_closest_first( p,
+        0, max_dist_to_check, [this]( const tripoint_om_omt & tile ) {
+            return is_in_city( tile );
+        } );
+        if( city_tile.has_value() ) {
+            return std::abs( city_tile->x() - p.x() );
         }
     } else {
         // Legacy handling

--- a/src/point.cpp
+++ b/src/point.cpp
@@ -149,10 +149,12 @@ std::vector<tripoint> closest_points_first( const tripoint &center, int min_dist
     }
 
     std::vector<tripoint> result;
-    result.reserve( *n );
+    result.resize( *n );
+    auto it = result.begin();
 
-    find_point_closest_first( center, min_dist, max_dist, [&result]( const tripoint & p ) {
-        result.push_back( p );
+    find_point_closest_first( center, min_dist, max_dist, [it]( const tripoint & p ) mutable {
+        *it = p;
+        ++it;
         return false;
     } );
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Technically helps the performance problem that #81235 is trying to categorically address. Distance calculations from specials to cities is stupid right now.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Use non allocating versions of functions. Use unchecked insertions with preallocated space where we know exact bounds.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Run a Sky Islands run on a fresh world, profile it, see that maybe 10% less time is spent calculating city distances than before.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
