### PR TITLE
[DO NOT MERGE] Remove hardcoded reference to aftershock in test suite

### DIFF
--- a/build-scripts/get_all_mods.py
+++ b/build-scripts/get_all_mods.py
@@ -91,8 +91,6 @@ for r, d, f in os.walk('data/mods'):
 
 mods_remaining = set(all_mod_dependencies)
 
-# Make sure aftershock can load by itself.
-add_mods(["aftershock"])
 print_modlist(mods_this_time, mods_remaining)
 
 while mods_remaining:


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Aftershock is still being forced into testing, that should be covered now. Using the old ID is definitely wrong anyway

https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/15805803239/job/44551331779?pr=81341#step:19:418

#### Describe the solution
Just cut it and let the test suite automatically assemble the list of mods

#### Describe alternatives you've considered


#### Testing
Not opened as draft so that test suite can run

**Even if successful, do not merge**

#### Additional context
Not opened as draft so that test suite can run

**Even if successful, do not merge**