### PR TITLE
Explicitly set base zombie grab cooldown to 2

### DIFF
--- a/data/json/monsters/zed-classic.json
+++ b/data/json/monsters/zed-classic.json
@@ -29,7 +29,7 @@
     "special_attacks": [
       [ "PARROT", 400 ],
       [ "PARROT_AT_DANGER", 0 ],
-      { "id": "grab" },
+      { "id": "grab", "cooldown": 2 },
       { "id": "bite_humanoid", "cooldown": 5 },
       { "id": "scratch_humanoid" }
     ],


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
As highlighted in #75659 special attack cooldowns were intended to be set by the special attack itself, and inherited by monsters if not overridden.
The most visible impact of this is zombies going from one grab every 10 turns to attempting to grab every turn.
Looking at the overall design of zombies, I don't think a 10 turn cooldown is appropriate, grabs are a core ability of zombies and their best option for harassing/damaging the player, so it should be front-and-center.

#### Describe the solution
This sets the grab cooldown in mon_zombie_base to 2 turns.  The expected result of which is any zombies that inherit from mon_zombie_base will use this cooldown.


#### Describe alternatives you've considered
Different cooldown values might also be valid, IMO extremely short is good, but I'm open to discussion.

#### Testing
Spawned several zombies pre-this-change and observe attack patterns.
Grab every turn unless the zombie had estblished a grab, then it would usually bite.

Apply this change and observe new attack patterns.
Multiple different zombie types would alternate grab and other attacks.