### PR TITLE
Add missing propane dialogue to Pablo Nunez

### DIFF
--- a/data/json/npcs/tacoma_ranch/Nunez/NPC_Pablo_Tacoma.json
+++ b/data/json/npcs/tacoma_ranch/Nunez/NPC_Pablo_Tacoma.json
@@ -126,6 +126,15 @@
   },
   {
     "type": "talk_topic",
+    "id": "TALK_TACOMA_Pablo_Propane1",
+    "dynamic_line": "Yeah, definitely.  Once things are up and running here, I'd be happy to trade you baked goods for propane.  For the moment, I can give you <merch> if you can bring me a full tank though.",
+    "responses": [
+      { "text": "What were you saying before?", "topic": "TALK_NONE" },
+      { "text": "Well, I'd better go.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
     "id": "TALK_TACOMA_Pablo_Bakery1",
     "dynamic_line": "Yeah, she would say that.\"  He makes intense eye contact.  \"Not just a bakery, my friend.  A real, post apocalyptic, honest-to-god culinary experience!  We're planning to grow food and crops here.  Central's plan is to import our crops directly, and pay us for our work.  I don't think they've even thought much about transport, outside just shipping them back home.  If we do local site processing we can prevent storage losses, and make higher value material to sell out!  And Central still benefits from having a dedicated bread basket!",
     "responses": [


### PR DESCRIPTION

#### Summary
Bugfixes "Adds missing propane dialogue and quest to pablo nunez"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes #81100

#### Describe the solution
1. Add missing dialogue
2. Add a mission to bring Pablo a propane tank in exchange for merch

#### Describe alternatives you've considered
At some point, Pablo should have the option to repay you for bringing him propane any time, but that should hinge on having his quest line go a little further.

#### Testing
Draft

#### Additional context
I haven't yet had a chance to calculate how many merch would be a good reward for a large propane tank full of propane. If someone has an answer I'm all ears