### PR TITLE
[Magiclysm/Bombastic Perks]: Add Efficient Spell metamagic perk

### DIFF
--- a/data/mods/BombasticPerks/perkdata/metamagic/efficient.json
+++ b/data/mods/BombasticPerks/perkdata/metamagic/efficient.json
@@ -1,0 +1,31 @@
+[
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_metamagic_toggle_efficient",
+    "condition": { "compare_string": [ "yes", { "u_val": "perk_metamagic_efficient_deactivated" } ] },
+    "effect": [
+      { "u_message": "You activate your efficient metamagic" },
+      { "u_add_var": "perk_metamagic_efficient_deactivated", "value": "no" }
+    ],
+    "false_effect": [
+      { "u_message": "You deactivate your efficient metamagic" },
+      { "u_add_var": "perk_metamagic_efficient_deactivated", "value": "yes" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_metamagic_efficient",
+    "eoc_type": "EVENT",
+    "required_event": "opens_spellbook",
+    "condition": {
+      "and": [
+        { "u_has_trait": "perk_metamagic_efficient" },
+        { "not": { "compare_string": [ "yes", { "u_val": "perk_metamagic_efficient_deactivated" } ] } }
+      ]
+    },
+    "effect": [
+      { "math": [ "u_spellcasting_adjustment('cost', 'mod': 'magiclysm'  ) = -.25" ] },
+      { "math": [ "u_spellcasting_adjustment('difficulty', 'mod': 'magiclysm' ) = +5" ] }
+    ]
+  }
+]

--- a/data/mods/BombasticPerks/perkmenu.json
+++ b/data/mods/BombasticPerks/perkmenu.json
@@ -2004,6 +2004,25 @@
         "topic": "TALK_PERK_MENU_SELECT"
       },
       {
+        "condition": { "not": { "u_has_trait": "perk_metamagic_efficient" } },
+        "text": "Gain [<trait_name:perk_metamagic_efficient>]",
+        "effect": [
+          { "set_string_var": "<trait_name:perk_metamagic_efficient>", "target_var": { "context_val": "trait_name" } },
+          {
+            "set_string_var": "<trait_description:perk_metamagic_efficient>",
+            "target_var": { "context_val": "trait_description" }
+          },
+          { "set_string_var": "perk_metamagic_efficient", "target_var": { "context_val": "trait_id" } },
+          {
+            "set_string_var": "Requires a spell known",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
+          { "set_condition": "perk_condition", "condition": { "math": [ "u_spell_level('null') >= 0" ] } }
+        ],
+        "topic": "TALK_PERK_MENU_SELECT"
+      },
+      {
         "condition": { "not": { "u_has_trait": "perk_metamagic_intuitive" } },
         "text": "Gain [<trait_name:perk_metamagic_intuitive>]",
         "effect": [

--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -767,6 +767,17 @@
   },
   {
     "type": "mutation",
+    "id": "perk_metamagic_efficient",
+    "name": { "str": "Metamagic: Efficient Spell" },
+    "points": 0,
+    "purifiable": false,
+    "valid": false,
+    "description": "You can cast your spells more efficiently at the cost of a more difficult cast.  *75% casting cost, +5 difficulty.  Can be toggled on or of by activating this trait.",
+    "active": true,
+    "activated_eocs": [ "EOC_metamagic_toggle_efficient" ]
+  },
+  {
+    "type": "mutation",
     "id": "perk_metamagic_intuitive",
     "name": { "str": "Metamagic: Intuitive Spell" },
     "points": 0,


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Magiclysm/Bombastic Perks]: Add Efficient Spell metamagic perk"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Adds a new metamagic perk: Efficient Spell.
Efficient Spell makes all spells 25% cheaper to cast at the cost of 5 extra difficulty.
Largely intended to have its best use at high spellcraft / spell levels
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Largely, just implement the above using the existing perk structure
Obviously has a wide variety of outcomes depending on spell level / spellcraft skill, but some spells will never actually reach 100% spell success chance with efficient spell on, such as phase door.  So there is still some downside to using the perk even at high skill levels.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
N/A
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
![efficient spell](https://github.com/user-attachments/assets/6629f22d-1858-4532-a1ee-ec8ca4df84ae)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
