### PR TITLE
add pulp_or_dismember autopulp option + minor edits

### DIFF
--- a/data/json/snippets/snippets.json
+++ b/data/json/snippets/snippets.json
@@ -729,5 +729,35 @@
       { "id": "random_color_silver", "text": { "ctxt": "<color>", "str": "silver" } },
       { "id": "random_color_white", "text": { "ctxt": "<color>", "str": "white" } }
     ]
+  },
+  {
+    "type": "snippet",
+    "//": "This is a dissection, and we are trained for dissection, so no morale penalty, anger, and lighter flavor text.",
+    "category": "msg_human_dissection_with_prof",
+    "text": [
+      "You grit your teeth and get to work.",
+      "The task at hand is unpleasant, but you steel your nerves regardless.",
+      "Hopefully whatever you can glean from this autopsy is worth the effort."
+    ]
+  },
+  {
+    "type": "snippet",
+    "//": "Message indicating we are dissecting without the stomach for it, but not actually butchering.  Lower morale penalty",
+    "category": "msg_human_dissection_no_prof",
+    "text": [
+      "This is nothing like dissecting a frog in biology class.  You feel sick inside.",
+      "You wonder how anyone manages to do this ghastly work.",
+      "The grim nature of your task deeply upsets you, leaving you feeling disgusted with yourself."
+    ]
+  },
+  {
+    "type": "snippet",
+    "//": "Message showing a character disgust of butchering a fellow human.  Do not include dissection or dismemberment.",
+    "category": "msg_human_butchery",
+    "text": [
+      "You clench your teeth at the prospect of this gruesome job.",
+      "This will haunt you in your dreams.",
+      "You try to look away, but this gruesome image will stay on your mind for some time."
+    ]
   }
 ]

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -2423,10 +2423,11 @@ class pulp_activity_actor : public activity_actor
 {
     public:
         pulp_activity_actor() = default;
-        explicit pulp_activity_actor( const tripoint_abs_ms placement ) : placement( { placement } ),
-        num_corpses( 0 ) {}
-        explicit pulp_activity_actor( const std::set<tripoint_abs_ms> &placement ) : placement( placement ),
-            num_corpses( 0 ) {}
+        explicit pulp_activity_actor( const tripoint_abs_ms placement ) : placement( { placement } ) {}
+        explicit pulp_activity_actor( const std::set<tripoint_abs_ms> &placement ) : placement(
+                placement ) {}
+        explicit pulp_activity_actor( const item_location &corpses ) : corpses( { corpses } ) {}
+        explicit pulp_activity_actor( const std::vector<item_location> &corpses ) : corpses( corpses ) {}
         const activity_id &get_type() const override {
             static const activity_id ACT_PULP( "ACT_PULP" );
             return ACT_PULP;
@@ -2437,6 +2438,7 @@ class pulp_activity_actor : public activity_actor
         bool punch_corpse_once( item &corpse, Character &you, tripoint_bub_ms pos, map &here );
         void finish( player_activity &, Character & ) override;
 
+        bool can_pulp( item &corpse, Character &you );
         void send_final_message( Character &you ) const;
 
         std::unique_ptr<activity_actor> clone() const override {
@@ -2447,9 +2449,13 @@ class pulp_activity_actor : public activity_actor
         static std::unique_ptr<activity_actor> deserialize( JsonValue &jsin );
 
     private:
+        // list of corpses we are iterating over, from last
+        // if not provided, is constructed from `placement`
+        std::vector<item_location> corpses;
+
         // tripoints with corpses we need to pulp;
         // either single tripoint shoved into set, or 3x3 zone around u/npc
-        std::set<tripoint_abs_ms> placement;
+        std::set<tripoint_abs_ms> placement; // NOLINT(cata-serialize)
 
         float float_corpse_damage_accum = 0.0f; // NOLINT(cata-serialize)
 

--- a/src/butchery.cpp
+++ b/src/butchery.cpp
@@ -338,37 +338,15 @@ bool set_up_butchery( player_activity &act, Character &you, butchery_data bd )
         if( you.has_proficiency( proficiency_prof_dissect_humans ) ) {
             if( you.empathizes_with_monster( corpse.id ) ) {
                 // this is a dissection, and we are trained for dissection, so no morale penalty, anger, and lighter flavor text.
-                switch( rng( 1, 3 ) ) {
-                    case 1:
-                        you.add_msg_if_player( m_good, _( "You grit your teeth and get to work." ) );
-                        break;
-                    case 2:
-                        you.add_msg_if_player( m_good,
-                                               _( "The task at hand is unpleasant, but you steel your nerves regardless." ) );
-                        break;
-                    case 3:
-                        you.add_msg_if_player( m_good,
-                                               _( "Hopefully whatever you can glean from this autopsy is worth the effort." ) );
-                        break;
-                }
+                you.add_msg_if_player( m_good, SNIPPET.random_from_category(
+                                           "msg_human_dissection_with_prof" ).value_or( translation() ).translated() );
             }
         } else {
             if( check_anger_empathetic_npcs_with_cannibalism( you, corpse.id ) ) {
                 if( you.empathizes_with_monster( corpse.id ) ) {
                     // give us a message indicating we are dissecting without the stomach for it, but not actually butchering. lower morale penalty.
-                    switch( rng( 1, 3 ) ) {
-                        case 1:
-                            you.add_msg_if_player( m_bad,
-                                                   _( "This is nothing like dissecting a frog in biology class.  You feel sick inside." ) );
-                            break;
-                        case 2:
-                            you.add_msg_if_player( m_bad, _( "You wonder how anyone manages to do this ghastly work." ) );
-                            break;
-                        case 3:
-                            you.add_msg_if_player( m_bad,
-                                                   _( "The grim nature of your task deeply upsets you, leaving you feeling disgusted with yourself." ) );
-                            break;
-                    }
+                    you.add_msg_if_player( m_good, SNIPPET.random_from_category(
+                                               "msg_human_dissection_no_prof" ).value_or( translation() ).translated() );
                     you.add_morale( morale_butcher, -40, 0, 1_days, 2_hours );
                 }
             } else {
@@ -381,18 +359,8 @@ bool set_up_butchery( player_activity &act, Character &you, butchery_data bd )
         if( check_anger_empathetic_npcs_with_cannibalism( you, corpse.id ) ) {
             if( you.empathizes_with_monster( corpse.id ) ) {
                 // give the player a random message showing their disgust and cause morale penalty.
-                switch( rng( 1, 3 ) ) {
-                    case 1:
-                        you.add_msg_if_player( m_bad, _( "You clench your teeth at the prospect of this gruesome job." ) );
-                        break;
-                    case 2:
-                        you.add_msg_if_player( m_bad, _( "This will haunt you in your dreams." ) );
-                        break;
-                    case 3:
-                        you.add_msg_if_player( m_bad,
-                                               _( "You try to look away, but this gruesome image will stay on your mind for some time." ) );
-                        break;
-                }
+                you.add_msg_if_player( m_good, SNIPPET.random_from_category(
+                                           "msg_human_butchery" ).value_or( translation() ).translated() );
                 you.add_morale( morale_butcher, -50, 0, 2_days, 3_hours );
             }
         } else {
@@ -416,7 +384,7 @@ int butcher_time_to_cut( Character &you, const item &corpse_item, const butcher_
     const mtype &corpse = *corpse_item.get_mtype();
     const int factor = you.max_quality( action == butcher_type::DISSECT ? qual_CUT_FINE : qual_BUTCHER,
                                         PICKUP_RANGE );
-
+    // in moves
     int time_to_cut;
     switch( corpse.size ) {
         // Time (roughly) in turns to cut up the corpse
@@ -726,6 +694,7 @@ bool butchery_drops_harvest( butchery_data bt, Character &you )
     }
 
     map &here = get_map();
+    const tripoint_bub_ms corpse_loc = bt.corpse.pos_bub( here );
 
     for( const harvest_entry &entry : ( action == butcher_type::DISSECT &&
                                         !mt.dissect.is_empty() ) ? *mt.dissect : *mt.harvest ) {
@@ -906,14 +875,14 @@ bool butchery_drops_harvest( butchery_data bt, Character &you )
                 // TODO: smarter NPC liquid handling
                 // If we're not bleeding the animal we don't care about the blood being wasted
                 if( you.is_npc() || action != butcher_type::BLEED ) {
-                    drop_on_map( you, item_drop_reason::deliberate, { obj }, &here, you.pos_bub( here ) );
+                    drop_on_map( you, item_drop_reason::deliberate, { obj }, &here, corpse_loc );
                 } else {
                     liquid_handler::handle_all_liquid( obj, 1 );
                 }
             } else if( drop->count_by_charges() ) {
                 std::vector<item> objs = create_charge_items( drop, roll, entry, &corpse_item, you );
                 for( item &obj : objs ) {
-                    item_location loc = here.add_item_or_charges_ret_loc( you.pos_bub(), obj );
+                    item_location loc = here.add_item_or_charges_ret_loc( corpse_loc, obj );
                     if( loc ) {
                         you.may_activity_occupancy_after_end_items_loc.push_back( loc );
                     }
@@ -937,7 +906,7 @@ bool butchery_drops_harvest( butchery_data bt, Character &you )
                     obj.set_var( "activity_var", you.name );
                 }
                 for( int i = 0; i != roll; ++i ) {
-                    item_location loc = here.add_item_or_charges_ret_loc( you.pos_bub(), obj );
+                    item_location loc = here.add_item_or_charges_ret_loc( corpse_loc, obj );
                     if( loc ) {
                         you.may_activity_occupancy_after_end_items_loc.push_back( loc );
                     }
@@ -981,7 +950,7 @@ bool butchery_drops_harvest( butchery_data bt, Character &you )
                 ruined_parts.set_var( "activity_var", you.name );
             }
             for( int i = 0; i < item_charges; ++i ) {
-                item_location loc = here.add_item_or_charges_ret_loc( you.pos_bub(), ruined_parts );
+                item_location loc = here.add_item_or_charges_ret_loc( corpse_loc, ruined_parts );
                 if( loc ) {
                     you.may_activity_occupancy_after_end_items_loc.push_back( loc );
                 }
@@ -1097,7 +1066,7 @@ void destroy_the_carcass( const butchery_data &bd, Character &you )
     map &here = get_map();
 
     item_location target = bd.corpse;
-
+    const tripoint_bub_ms corpse_pos = target.pos_bub( here );
     const butcher_type action = bd.b_type;
     item &corpse_item = *target;
     const mtype *corpse = corpse_item.get_mtype();
@@ -1112,7 +1081,8 @@ void destroy_the_carcass( const butchery_data &bd, Character &you )
     }
 
     if( action == butcher_type::DISMEMBER ) {
-        here.add_splatter( type_gib, you.pos_bub(), rng( corpse->size + 2, ( corpse->size + 1 ) * 2 ) );
+        here.add_splatter( type_gib, corpse_pos, rng( corpse->size + 2,
+                           ( corpse->size + 1 ) * 2 ) );
     }
 
     // all action types - yields
@@ -1124,14 +1094,14 @@ void destroy_the_carcass( const butchery_data &bd, Character &you )
         // Remove the target from the map
         target.remove_item();
 
-        here.add_splatter( type_gib, you.pos_bub(), rng( corpse->size + 2, ( corpse->size + 1 ) * 2 ) );
-        here.add_splatter( type_blood, you.pos_bub(), rng( corpse->size + 2, ( corpse->size + 1 ) * 2 ) );
+        here.add_splatter( type_gib, corpse_pos, rng( corpse->size + 2, ( corpse->size + 1 ) * 2 ) );
+        here.add_splatter( type_blood, corpse_pos, rng( corpse->size + 2, ( corpse->size + 1 ) * 2 ) );
         for( int i = 1; i <= corpse->size; i++ ) {
-            here.add_splatter_trail( type_gib, you.pos_bub(),
-                                     random_entry( here.points_in_radius( you.pos_bub(),
+            here.add_splatter_trail( type_gib, corpse_pos,
+                                     random_entry( here.points_in_radius( corpse_pos,
                                                    corpse->size + 1 ) ) );
-            here.add_splatter_trail( type_blood, you.pos_bub(),
-                                     random_entry( here.points_in_radius( you.pos_bub(),
+            here.add_splatter_trail( type_blood, corpse_pos,
+                                     random_entry( here.points_in_radius( corpse_pos,
                                                    corpse->size + 1 ) ) );
         }
 
@@ -1163,14 +1133,14 @@ void destroy_the_carcass( const butchery_data &bd, Character &you )
                      SNIPPET.random_from_category( success ? "harvest_drop_default_field_dress_success" :
                                                    "harvest_drop_default_field_dress_failed" ).value_or( translation() ).translated() );
             corpse_item.set_flag( success ? flag_FIELD_DRESS : flag_FIELD_DRESS_FAILED );
-            here.add_splatter( type_gib, you.pos_bub(), rng( corpse->size + 2, ( corpse->size + 1 ) * 2 ) );
-            here.add_splatter( type_blood, you.pos_bub(), rng( corpse->size + 2, ( corpse->size + 1 ) * 2 ) );
+            here.add_splatter( type_gib, corpse_pos, rng( corpse->size + 2, ( corpse->size + 1 ) * 2 ) );
+            here.add_splatter( type_blood, corpse_pos, rng( corpse->size + 2, ( corpse->size + 1 ) * 2 ) );
             for( int i = 1; i <= corpse->size; i++ ) {
-                here.add_splatter_trail( type_gib, you.pos_bub(),
-                                         random_entry( here.points_in_radius( you.pos_bub(),
+                here.add_splatter_trail( type_gib, corpse_pos,
+                                         random_entry( here.points_in_radius( corpse_pos,
                                                        corpse->size + 1 ) ) );
-                here.add_splatter_trail( type_blood, you.pos_bub(),
-                                         random_entry( here.points_in_radius( you.pos_bub(),
+                here.add_splatter_trail( type_blood, corpse_pos,
+                                         random_entry( here.points_in_radius( corpse_pos,
                                                        corpse->size + 1 ) ) );
             }
             break;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1531,7 +1531,18 @@ void options_manager::add_options_general()
 
         add( "AUTO_PULP_BUTCHER", page_id, to_translation( "Auto pulp or butcher" ),
              to_translation( "Action to perform when 'Auto pulp or butcher' is enabled.  Pulp: Pulp corpses you stand on.  - Pulp Adjacent: Also pulp corpses adjacent from you.  - Butcher: Butcher corpses you stand on." ),
-        { { "off", to_translation( "options", "Disabled" ) }, { "pulp", to_translation( "Pulp" ) }, { "pulp_zombie_only", to_translation( "Pulp Zombies Only" ) }, { "pulp_adjacent", to_translation( "Pulp Adjacent" ) }, { "pulp_adjacent_zombie_only", to_translation( "Pulp Adjacent Zombie Only" ) }, { "butcher", to_translation( "Butcher" ) } },
+        {
+            { "off", to_translation( "options", "Disabled" ) },
+            { "pulp", to_translation( "Pulp" ) },
+            { "pulp_zombie_only", to_translation( "Pulp Zombies Only" ) },
+            { "pulp_adjacent", to_translation( "Pulp Adjacent" ) },
+            { "pulp_adjacent_zombie_only", to_translation( "Pulp Adjacent Zombie Only" ) },
+            { "pulp_or_dismember", to_translation( "Pulp or Dismember" ) },
+            { "pulp_or_dismember_adjacent", to_translation( "Pulp or Dismember Adjacent" ) },
+            { "pulp_or_dismember_zombies_only", to_translation( "Pulp or Dismember Zombie Only" ) },
+            { "pulp_or_dismember_zombies_only_adjacent", to_translation( "Pulp or Dismember Adjacent Zombie Only" ) },
+            { "butcher", to_translation( "Butcher" ) }
+        },
         "off"
            );
 


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
This supposed to be a step 3 in all the pulping/butchery shenanigans i started, but i started this one before butchery was moved to actor, so here it is
#### Describe the solution
- Add 4 new options, `pulp_or_dismember`, `pulp_or_dismember_adjacent`, `pulp_or_dismember_zombies_only`, `pulp_or_dismember_zombies_only_adjacent`, which check if you can pulp the adjacent corpses, and if you cannot/it would take too long, start to dismember it
- Move to separate function and refactor butchery/pulp auto option, for better readability
- Refactor pulping to not use a raw tripoints as main type, but instead harvest all the items in the vector of item_locations, and iterate over it instead, popping elements we do not need anymore
- [x] Deal with serialization of the new type in pulping
- Move human and adjacent butchery messages to snippets 
- Adjust acid corpse message, adjust finishing message to prevent weird `something. .` in log
- Redo the pulping messages to be more translator friendly, fix various mistakes in it
#### Testing
Compiled, run a lot trying to pulp and dismember all sorts of corpses manually and using function