### PR TITLE
Don't show hostile NPCs on overmap

### DIFF
--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -670,6 +670,12 @@ static void draw_ascii( const catacurses::window &w, overmap_draw_data_t &data )
                 continue;
             }
 
+            // Since most hostiles are "bandits", including *ambushes*, being able to see them in advance makes them largely impotent.
+            // This can be revisited when/if we get NPC overmap behavior to act in a more directed hostile fashion.
+            if( np->guaranteed_hostile() ) {
+                continue;
+            }
+
             const tripoint_abs_omt pos = np->pos_abs_omt();
             if( has_debug_vision || overmap_buffer.seen_more_than( pos, om_vision_level::details ) ) {
                 auto iter = npc_color.find( pos );
@@ -893,7 +899,7 @@ static void draw_ascii( const catacurses::window &w, overmap_draw_data_t &data )
 
     if( has_debug_vision || overmap_buffer.seen_more_than( cursor_pos, om_vision_level::details ) ) {
         for( const auto &npc : npcs_near_player ) {
-            if( !npc->marked_for_death && npc->pos_abs_omt() == cursor_pos ) {
+            if( !npc->marked_for_death && npc->pos_abs_omt() == cursor_pos && !npc->guaranteed_hostile() ) {
                 corner_text.emplace_back( npc->basic_symbol_color(), npc->get_name() );
             }
         }

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -1002,8 +1002,9 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
     // draw nearby seen npcs
     for( const shared_ptr_fast<npc> &guy : npcs_near_player ) {
         const tripoint_abs_omt &guy_loc = guy->pos_abs_omt();
-        if( guy_loc.z() == center_pos.z() && ( has_debug_vision ||
-                                               overmap_buffer.seen_more_than( guy_loc, om_vision_level::details ) ) ) {
+        if( guy_loc.z() == center_pos.z() &&
+            ( has_debug_vision || overmap_buffer.seen_more_than( guy_loc, om_vision_level::details ) ) &&
+            !guy->guaranteed_hostile() ) {
             draw_entity_with_overlays( *guy, global_omt_to_draw_position( guy_loc ),
                                        lit_level::LIT,
                                        height_3d );
@@ -1111,7 +1112,7 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
     if( has_debug_vision ||
         overmap_buffer.seen_more_than( center_pos, om_vision_level::details ) ) {
         for( const auto &npc : npcs_near_player ) {
-            if( !npc->marked_for_death && npc->pos_abs_omt() == center_pos ) {
+            if( !npc->marked_for_death && npc->pos_abs_omt() == center_pos && !npc->guaranteed_hostile() ) {
                 notes_window_text.emplace_back( npc->basic_symbol_color(), npc->get_name() );
             }
         }


### PR DESCRIPTION
#### Summary
Balance "Don't show hostile NPCs on overmap"

#### Purpose of change
Being able to see hostile NPCs on the overmap is basically a free forever opt-out button. This is especially egregious when it comes to the "bandit garage" or roadblock spawn. 

Since the NPCs cannot see or react to the player's overmap presence in any way, it can simply be assumed that both the player and they are taking steps to conceal their presence at range.

#### Describe the solution
When going through the list of NPCs that the player can see, simply skip rendering any that are guaranteed hostile. e.g. NPCs which do not start hostile but may aim to mug the player are still rendered.

#### Describe alternatives you've considered
For the "ambush" spawns we could instead wait until the player/victim enters the area *and then spawn the bandits*. But making bandits appear from thin air is both very 'cheap' (unfair) and immersion breaking.

#### Testing
Before:
![image](https://github.com/user-attachments/assets/3596db66-6398-417e-9232-983091c1ce77)

After:
![image](https://github.com/user-attachments/assets/e78f0620-9188-4d91-beba-197cbe527102)

Note the Zs in the city, showing that both images were taken during an active 'blink'.

Graphics (separate code path):

![image](https://github.com/user-attachments/assets/5250a98c-db46-4f3a-a473-32ce561cbbef)


#### Additional context

