### PR TITLE
Add a notice when in weather mode

### DIFF
--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -590,7 +590,7 @@ static void draw_ascii( const catacurses::window &w, overmap_draw_data_t &data )
     oter_display_lru lru_cache;
     oter_display_options oter_opts( orig, sight_points );
     oter_opts.show_weather = ( uistate.overmap_debug_weather || uistate.overmap_visible_weather ) &&
-                             cursor_pos.z() == 10;
+                             cursor_pos.z() == OVERMAP_HEIGHT;
     oter_opts.show_pc = true;
     oter_opts.debug_scent = data.debug_scent;
     oter_opts.show_map_revealed = uistate.overmap_show_revealed_omts;
@@ -874,6 +874,10 @@ static void draw_ascii( const catacurses::window &w, overmap_draw_data_t &data )
 
     if( !data.message.empty() ) {
         corner_text.emplace_back( c_white, data.message );
+    }
+
+    if( oter_opts.show_weather ) {
+        corner_text.emplace_back( c_yellow, _( "WEATHER MODE" ) );
     }
 
     if( uistate.overmap_show_map_notes ) {
@@ -2530,7 +2534,7 @@ void ui::omap::display_weather()
 {
     g->overmap_data = overmap_ui::overmap_draw_data_t();
     tripoint_abs_omt pos = get_player_character().pos_abs_omt();
-    pos.z() = 10;
+    pos.z() = OVERMAP_HEIGHT;
     g->overmap_data.origin_pos = pos;
     uistate.overmap_debug_weather = true;
     overmap_ui::display();
@@ -2541,7 +2545,7 @@ void ui::omap::display_visible_weather()
 {
     g->overmap_data = overmap_ui::overmap_draw_data_t();
     tripoint_abs_omt pos = get_player_character().pos_abs_omt();
-    pos.z() = 10;
+    pos.z() = OVERMAP_HEIGHT;
     g->overmap_data.origin_pos = pos;
     uistate.overmap_visible_weather = true;
     overmap_ui::display();

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -1093,6 +1093,11 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
 
     std::vector<std::pair<nc_color, std::string>> notes_window_text;
 
+    if( viewing_weather ) {
+        // We hijack this to avoid repeating code just for this simple notice. Notes will still display normally
+        notes_window_text.emplace_back( c_yellow, _( "WEATHER MODE" ) );
+    }
+
     if( uistate.overmap_show_map_notes ) {
         const std::string &note_text = overmap_buffer.note( center_pos );
         if( !note_text.empty() ) {


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
I have seen multiple cases of people mashing the toggle weather key and then being unable to figure out what they pressed.

Some quick search hits:

![image](https://github.com/user-attachments/assets/d2e7e61a-4ba8-4f4c-9639-3e516eb7a616)

![image](https://github.com/user-attachments/assets/9fe5e5ad-3e1e-49e4-8f03-e58883098cf5)

#### Describe the solution
Add a notice saying that you're in weather mode

Also replaced some magic number 10s with OVERMAP_HEIGHT

#### Describe alternatives you've considered
Migrate the entire overmap to imgui and make it much flashier (and obvious)

#### Testing

![image](https://github.com/user-attachments/assets/8b379d12-d343-4525-bf1b-fc266bf12af3)

![image](https://github.com/user-attachments/assets/c4b0a249-8574-438b-a789-f5857af5ca03)



#### Additional context
We have different draw paths for tiles/ASCII and I hate this