### PR TITLE
[Xedra] Time Frozen Things are Gray

### DIFF
--- a/data/mods/Xedra_Evolved/effects/effects.json
+++ b/data/mods/Xedra_Evolved/effects/effects.json
@@ -3295,6 +3295,7 @@
       "FREEZE_EFFECTS",
       "CANNOT_GAIN_EFFECTS"
     ],
+    "monochrome_overlay": true,
     "enchantments": [ { "values": [ { "value": "EQUIPMENT_DAMAGE_CHANCE", "multiply": -1 } ] } ],
     "show_in_info": true
   },

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -278,6 +278,8 @@ void cata_tiles::on_options_changed()
 void tileset::clear()
 {
     tile_values.clear();
+    monochrome_tile_values.clear();
+    greenchrome_tile_values.clear();
     shadow_tile_values.clear();
     night_tile_values.clear();
     overexposed_tile_values.clear();
@@ -488,6 +490,7 @@ void tileset_cache::loader::copy_surface_to_texture( const SDL_Surface_Ptr &surf
     }
 }
 
+// Tile color mods are stored here
 void tileset_cache::loader::create_textures_from_tile_atlas( const SDL_Surface_Ptr &tile_atlas,
         const point &offset )
 {
@@ -495,8 +498,10 @@ void tileset_cache::loader::create_textures_from_tile_atlas( const SDL_Surface_P
 
     /** perform color filter conversion here */
     using tiles_pixel_color_entry = std::tuple<std::vector<texture>*, std::string>;
-    std::array<tiles_pixel_color_entry, 5> tile_values_data = {{
+    std::array<tiles_pixel_color_entry, 7> tile_values_data = {{
             { std::make_tuple( &ts.tile_values, "color_pixel_none" ) },
+            { std::make_tuple( &ts.monochrome_tile_values, "color_pixel_monochrome" ) },
+            { std::make_tuple( &ts.greenchrome_tile_values, "color_pixel_greenchrome" ) },
             { std::make_tuple( &ts.shadow_tile_values, "color_pixel_grayscale" ) },
             { std::make_tuple( &ts.night_tile_values, "color_pixel_nightvision" ) },
             { std::make_tuple( &ts.overexposed_tile_values, "color_pixel_overexposed" ) },
@@ -593,6 +598,8 @@ void tileset_cache::loader::load_tileset( const cata_path &img_path, const bool 
     const int expected_tilecount = ( tile_atlas->w / sprite_width ) *
                                    ( tile_atlas->h / sprite_height );
     extend_vector_by( ts.tile_values, expected_tilecount );
+    extend_vector_by( ts.monochrome_tile_values, expected_tilecount );
+    extend_vector_by( ts.greenchrome_tile_values, expected_tilecount );
     extend_vector_by( ts.shadow_tile_values, expected_tilecount );
     extend_vector_by( ts.night_tile_values, expected_tilecount );
     extend_vector_by( ts.overexposed_tile_values, expected_tilecount );
@@ -1965,14 +1972,14 @@ void cata_tiles::draw( const point &dest, const tripoint_bub_ms &center, int wid
         // check to see if player is located at ter
         draw_from_id_string( "cursor", TILE_CATEGORY::NONE, empty_string,
                              tripoint_bub_ms( g->ter_view_p.xy(), center.z() ), 0, 0, lit_level::LIT,
-                             false );
+                             COLOR_OVERLAY::NONE );
     }
     if( you.controlling_vehicle ) {
         std::optional<tripoint_rel_ms> indicator_offset = g->get_veh_dir_indicator_location( true );
         if( indicator_offset ) {
             draw_from_id_string( "cursor", TILE_CATEGORY::NONE, empty_string,
                                  tripoint_bub_ms( you.pos_bub().xy(), center.z() ) + indicator_offset->xy(),
-                                 0, 0, lit_level::LIT, false );
+                                 0, 0, lit_level::LIT, COLOR_OVERLAY::NONE );
         }
     }
 
@@ -2250,71 +2257,71 @@ point_bub_ms cata_tiles::screen_to_player(
 bool cata_tiles::draw_from_id_string( const std::string &id, const tripoint_bub_ms &pos,
                                       int subtile,
                                       int rota,
-                                      lit_level ll, bool apply_night_vision_goggles )
+                                      lit_level ll, COLOR_OVERLAY color_overlay )
 {
     int nullint = 0;
     return cata_tiles::draw_from_id_string( id, TILE_CATEGORY::NONE, empty_string, pos, subtile,
-                                            rota, ll, apply_night_vision_goggles, nullint, 0 );
+                                            rota, ll, color_overlay, nullint, 0 );
 }
 
 bool cata_tiles::draw_from_id_string( const std::string &id, TILE_CATEGORY category,
                                       const std::string &subcategory, const tripoint_bub_ms &pos,
                                       int subtile, int rota, lit_level ll,
-                                      bool apply_night_vision_goggles )
+                                      COLOR_OVERLAY color_overlay )
 {
     int nullint = 0;
     return cata_tiles::draw_from_id_string( id, category, subcategory, pos, subtile, rota,
-                                            ll, apply_night_vision_goggles, nullint, 0 );
+                                            ll, color_overlay, nullint, 0 );
 }
 
 bool cata_tiles::draw_from_id_string( const std::string &id, TILE_CATEGORY category,
                                       const std::string &subcategory, const tripoint_bub_ms &pos,
                                       int subtile, int rota, lit_level ll,
-                                      bool apply_night_vision_goggles, int &height_3d, int intensity )
+                                      COLOR_OVERLAY color_overlay, int &height_3d, int intensity )
 {
     return cata_tiles::draw_from_id_string_internal( id, category, subcategory, pos, subtile, rota,
-            ll, -1, apply_night_vision_goggles, height_3d, intensity, "", point() );
+            ll, -1, color_overlay, height_3d, intensity, "", point() );
 }
 
 bool cata_tiles::draw_from_id_string( const std::string &id, TILE_CATEGORY category,
                                       const std::string &subcategory, const tripoint_bub_ms &pos,
                                       int subtile, int rota, lit_level ll,
-                                      bool apply_night_vision_goggles, int &height_3d )
+                                      COLOR_OVERLAY color_overlay, int &height_3d )
 {
     return cata_tiles::draw_from_id_string_internal( id, category, subcategory, pos, subtile, rota,
-            ll, -1, apply_night_vision_goggles, height_3d, 0, "", point() );
+            ll, -1, color_overlay, height_3d, 0, "", point() );
 }
 
 bool cata_tiles::draw_from_id_string( const std::string &id, TILE_CATEGORY category,
                                       const std::string &subcategory, const tripoint_bub_ms &pos,
                                       int subtile, int rota, lit_level ll,
-                                      bool apply_night_vision_goggles, int &height_3d,
+                                      COLOR_OVERLAY color_overlay, int &height_3d,
                                       int intensity_level, const std::string &variant )
 {
     return cata_tiles::draw_from_id_string_internal( id, category, subcategory, pos, subtile, rota,
-            ll, -1, apply_night_vision_goggles, height_3d, intensity_level,
+            ll, -1, color_overlay, height_3d, intensity_level,
             variant, point() );
 }
 
 bool cata_tiles::draw_from_id_string( const std::string &id, TILE_CATEGORY category,
                                       const std::string &subcategory, const tripoint_bub_ms &pos,
                                       int subtile, int rota, lit_level ll,
-                                      bool apply_night_vision_goggles, int &height_3d,
+                                      COLOR_OVERLAY color_overlay, int &height_3d,
                                       int intensity_level, const std::string &variant,
                                       const point &offset )
 {
     return cata_tiles::draw_from_id_string_internal( id, category, subcategory, pos, subtile, rota,
-            ll, -1, apply_night_vision_goggles, height_3d, intensity_level,
+            ll, -1, color_overlay, height_3d, intensity_level,
             variant, offset );
 }
 bool cata_tiles::draw_from_id_string_internal( const std::string &id, const tripoint_bub_ms &pos,
         int subtile,
         int rota,
-        lit_level ll, int retract, bool apply_night_vision_goggles, int &height_3d )
+        lit_level ll, int retract, COLOR_OVERLAY color_overlay, int &height_3d )
 {
     return cata_tiles::draw_from_id_string_internal( id, TILE_CATEGORY::NONE, empty_string, pos,
             subtile,
-            rota, ll, retract, apply_night_vision_goggles, height_3d, 0, "", point() );
+            rota, ll, retract, color_overlay, height_3d, 0, "", point() );
 }
 
 std::optional<tile_lookup_res>
@@ -2549,11 +2556,11 @@ void cata_tiles::set_disable_occlusion( const bool val )
 bool cata_tiles::draw_from_id_string_internal( const std::string &id, TILE_CATEGORY category,
         const std::string &subcategory, const tripoint_bub_ms &pos,
         int subtile, int rota, lit_level ll, int retract,
-        bool apply_night_vision_goggles, int &height_3d,
+        COLOR_OVERLAY color_overlay, int &height_3d,
         int intensity_level, const std::string &variant,
         const point &offset )
 {
-    bool nv_color_active = apply_night_vision_goggles && get_option<bool>( "NV_GREEN_TOGGLE" );
+    bool nv_color_active = color_overlay == COLOR_OVERLAY::NIGHT_VISION && get_option<bool>( "NV_GREEN_TOGGLE" );
     // If the ID string does not produce a drawable tile
     // it will revert to the "unknown" tile.
     // The "unknown" tile is one that is highly visible so you kinda can't miss it :D
@@ -2792,13 +2799,13 @@ bool cata_tiles::draw_from_id_string_internal( const std::string &id, TILE_CATEG
             }
             if( tileset_ptr->find_tile_type( generic_id ) ) {
                 return draw_from_id_string_internal( generic_id, pos, subtile, rota,
-                                                     ll, retract, nv_color_active, height_3d );
+                                                     ll, retract, color_overlay, height_3d );
             }
             // Try again without color this time (using default color).
             generic_id = get_ascii_tile_id( sym, -1, -1 );
             if( tileset_ptr->find_tile_type( generic_id ) ) {
                 return draw_from_id_string_internal( generic_id, pos, subtile, rota,
-                                                     ll, retract, nv_color_active, height_3d );
+                                                     ll, retract, color_overlay, height_3d );
             }
         }
     }
@@ -2839,7 +2846,7 @@ bool cata_tiles::draw_from_id_string_internal( const std::string &id, TILE_CATEG
             // append subtile name to tile and re-find display_tile
             return draw_from_id_string_internal(
                        found_id + "_" + multitile_keys[subtile], category, subcategory, pos, -1, rota, ll,
-                       retract, nv_color_active, height_3d, 0, "", point() );
+                       retract, color_overlay, height_3d, 0, "", point() );
         }
     }
 
@@ -2995,7 +3002,7 @@ bool cata_tiles::draw_from_id_string_internal( const std::string &id, TILE_CATEG
 
     //draw it!
     draw_tile_at( display_tile, screen_pos, loc_rand, rota, ll,
-                  nv_color_active, retract, height_3d, offset );
+                  color_overlay, retract, height_3d, offset );
 
     return true;
 }
@@ -3003,7 +3010,7 @@ bool cata_tiles::draw_from_id_string_internal( const std::string &id, TILE_CATEG
 bool cata_tiles::draw_sprite_at(
     const tile_type &tile, const weighted_int_list<std::vector<int>> &svlist,
     const point &p, unsigned int loc_rand, bool rota_fg, int rota, lit_level ll,
-    bool apply_night_vision_goggles, int retract, int &height_3d, const point &offset )
+    COLOR_OVERLAY color_overlay, int retract, int &height_3d, const point &offset )
 {
     const std::vector<int> *picked = svlist.pick( loc_rand );
     if( !picked ) {
@@ -3044,7 +3051,7 @@ bool cata_tiles::draw_sprite_at(
         if( const texture *ptr = tileset_ptr->get_memory_tile( sprite_index ) ) {
             sprite_tex = ptr;
         }
-    } else if( apply_night_vision_goggles ) {
+    } else if( color_overlay == COLOR_OVERLAY::NIGHT_VISION ) { // true will make character green too
         if( ll != lit_level::LOW ) {
             if( const texture *ptr = tileset_ptr->get_overexposed_tile( sprite_index ) ) {
                 sprite_tex = ptr;
@@ -3054,6 +3061,10 @@ bool cata_tiles::draw_sprite_at(
                 sprite_tex = ptr;
             }
         }
+    } else if( color_overlay == COLOR_OVERLAY::MONOCHROME ) {
+            if( const texture *ptr = tileset_ptr->get_monochrome_tile( sprite_index ) ) {
+                sprite_tex = ptr;
+            }
     } else if( ll == lit_level::LOW ) {
         if( const texture *ptr = tileset_ptr->get_shadow_tile( sprite_index ) ) {
             sprite_tex = ptr;
@@ -3159,14 +3170,14 @@ bool cata_tiles::draw_sprite_at(
 
 bool cata_tiles::draw_tile_at(
     const tile_type &tile, const point &p, unsigned int loc_rand, int rota,
-    lit_level ll, bool apply_night_vision_goggles, int retract, int &height_3d,
+    lit_level ll, COLOR_OVERLAY color_overlay, int retract, int &height_3d,
     const point &offset )
 {
     int fake_int = height_3d;
     draw_sprite_at( tile, tile.bg, p, loc_rand, /*fg:*/ false, rota, ll,
-                    apply_night_vision_goggles, retract, fake_int, offset );
+                    color_overlay, retract, fake_int, offset );
     draw_sprite_at( tile, tile.fg, p, loc_rand, /*fg:*/ true, rota, ll,
-                    apply_night_vision_goggles, retract, height_3d, offset );
+                    color_overlay, retract, height_3d, offset );
     return true;
 }
 
@@ -3206,7 +3217,7 @@ bool cata_tiles::apply_vision_effects( const tripoint_bub_ms &pos,
 
     // lighting is never rotated, though, could possibly add in random rotation?
     draw_from_id_string( light_name, TILE_CATEGORY::LIGHTING, empty_string, pos, 0, 0,
-                         lit_level::LIT, false, height_3d );
+                         lit_level::LIT, COLOR_OVERLAY::NONE, height_3d );
 
     return true;
 }
@@ -3379,7 +3390,7 @@ bool cata_tiles::draw_terrain( const tripoint_bub_ms &p, const lit_level ll, int
             return memorize_only
                    ? false
                    : draw_from_id_string( tname, TILE_CATEGORY::TERRAIN, empty_string, p, subtile,
-                                          rotation, ll, nv_goggles_activated, height_3d );
+                                          rotation, ll, calculate_color_overlay(), height_3d );
         }
     }
     if( invisible[0] ? overridden : neighborhood_overridden ) {
@@ -3408,7 +3419,7 @@ bool cata_tiles::draw_terrain( const tripoint_bub_ms &p, const lit_level ll, int
             return memorize_only
                    ? false
                    : draw_from_id_string( tname, TILE_CATEGORY::TERRAIN, empty_string, p, subtile,
-                                          rotation, lit, nv, height_3d );
+                                          rotation, lit, nv ? COLOR_OVERLAY::NIGHT_VISION : COLOR_OVERLAY::NONE, height_3d );
         }
     } else if( invisible[0] ) {
         // try drawing memory if invisible and not overridden
@@ -3418,7 +3429,7 @@ bool cata_tiles::draw_terrain( const tripoint_bub_ms &p, const lit_level ll, int
                    ? false
                    : draw_from_id_string(
                        mt.get_ter_id(), TILE_CATEGORY::TERRAIN, empty_string, p, mt.get_ter_subtile(),
-                       mt.get_ter_rotation(), lit_level::MEMORIZED, nv_goggles_activated, height_3d );
+                       mt.get_ter_rotation(), lit_level::MEMORIZED, calculate_color_overlay(), height_3d );
         }
     }
     return false;
@@ -3470,7 +3481,7 @@ bool cata_tiles::draw_furniture( const tripoint_bub_ms &p, const lit_level ll, i
             return memorize_only
                    ? false
                    : draw_from_id_string( fname, TILE_CATEGORY::FURNITURE, empty_string, p, subtile,
-                                          rotation, ll, nv_goggles_activated, height_3d );
+                                          rotation, ll, calculate_color_overlay(), height_3d );
         }
     }
     if( invisible[0] ? overridden : neighborhood_overridden ) {
@@ -3509,7 +3520,7 @@ bool cata_tiles::draw_furniture( const tripoint_bub_ms &p, const lit_level ll, i
             return memorize_only
                    ? false
                    : draw_from_id_string( fname, TILE_CATEGORY::FURNITURE, empty_string, p, subtile,
-                                          rotation, lit, nv, height_3d );
+                                          rotation, lit, nv ? COLOR_OVERLAY::NIGHT_VISION : COLOR_OVERLAY::NONE, height_3d );
         }
     } else if( invisible[0] ) {
         // try drawing memory if invisible and not overridden
@@ -3519,7 +3530,7 @@ bool cata_tiles::draw_furniture( const tripoint_bub_ms &p, const lit_level ll, i
                    ? false
                    : draw_from_id_string(
                        mt.get_dec_id(), TILE_CATEGORY::FURNITURE, empty_string, p, mt.get_dec_subtile(),
-                       mt.get_dec_rotation(), lit_level::MEMORIZED, nv_goggles_activated, height_3d );
+                       mt.get_dec_rotation(), lit_level::MEMORIZED, calculate_color_overlay(), height_3d );
         }
     }
     return false;
@@ -3563,7 +3574,7 @@ bool cata_tiles::draw_trap( const tripoint_bub_ms &p, const lit_level ll, int &h
             return memorize_only
                    ? false
                    : draw_from_id_string( trname, TILE_CATEGORY::TRAP, empty_string, p, subtile,
-                                          rotation, ll, nv_goggles_activated, height_3d );
+                                          rotation, ll, calculate_color_overlay(), height_3d );
         }
     }
     if( overridden || ( !invisible[0] && neighborhood_overridden &&
@@ -3595,7 +3606,7 @@ bool cata_tiles::draw_trap( const tripoint_bub_ms &p, const lit_level ll, int &h
             return memorize_only
                    ? false
                    : draw_from_id_string( trname, TILE_CATEGORY::TRAP, empty_string, p, subtile,
-                                          rotation, lit, nv, height_3d );
+                                          rotation, lit, nv ? COLOR_OVERLAY::NIGHT_VISION : COLOR_OVERLAY::NONE, height_3d );
         }
     } else if( invisible[0] ) {
         // try drawing memory if invisible and not overridden
@@ -3606,7 +3617,7 @@ bool cata_tiles::draw_trap( const tripoint_bub_ms &p, const lit_level ll, int &h
                    : draw_from_id_string(
                        mt.get_dec_id(), TILE_CATEGORY::TRAP, empty_string, p, mt.get_dec_subtile(),
                        mt.get_dec_rotation(),
-                       lit_level::MEMORIZED, nv_goggles_activated, height_3d );
+                       lit_level::MEMORIZED, calculate_color_overlay(), height_3d );
         }
     }
     return false;
@@ -3625,7 +3636,7 @@ bool cata_tiles::draw_part_con( const tripoint_bub_ms &p, const lit_level ll, in
         return memorize_only
                ? false
                : draw_from_id_string( trname, TILE_CATEGORY::TRAP, empty_string, p, 0,
-                                      0, ll, nv_goggles_activated, height_3d );
+                                      0, ll, calculate_color_overlay(), height_3d );
     }
     return false;
 }
@@ -3649,7 +3660,7 @@ bool cata_tiles::draw_graffiti( const tripoint_bub_ms &p, const lit_level ll, in
                              to_upper_case( string_replace( remove_punctuations( here.graffiti_at( p ) ), " ",
                                             "_" ) ).substr( 0, 32 );
     return draw_from_id_string( tileset_ptr->find_tile_type( tile ) ? tile : "graffiti",
-                                TILE_CATEGORY::NONE, empty_string, p, 0, rotation, lit, false, height_3d );
+                                TILE_CATEGORY::NONE, empty_string, p, 0, rotation, lit, COLOR_OVERLAY::NONE, height_3d );
 }
 
 bool cata_tiles::draw_field_or_item( const tripoint_bub_ms &p, const lit_level ll, int &height_3d,
@@ -3695,7 +3706,7 @@ bool cata_tiles::draw_field_or_item( const tripoint_bub_ms &p, const lit_level l
 
                     // if we have found info on the item go through and draw its stuff
                     ret_draw_field = draw_from_id_string( sprite_to_draw, TILE_CATEGORY::FIELD, empty_string, p,
-                                                          subtile, rotation, ll, nv, height_3d, fe.get_field_intensity(), "", layer_var.offset );
+                                                          subtile, rotation, ll, nv ? COLOR_OVERLAY::NIGHT_VISION : COLOR_OVERLAY::NONE, height_3d, fe.get_field_intensity(), "", layer_var.offset );
                     break;
                 }
             }
@@ -3738,7 +3749,7 @@ bool cata_tiles::draw_field_or_item( const tripoint_bub_ms &p, const lit_level l
                         }
                         // if we have found info on the item go through and draw its stuff
                         draw_from_id_string( sprite_to_draw, TILE_CATEGORY::ITEM, layer_it_category, p, 0,
-                                             0, layer_lit, layer_nv, height_3d, 0, variant, layer_var.offset );
+                                             0, layer_lit, layer_nv ? COLOR_OVERLAY::NIGHT_VISION : COLOR_OVERLAY::NONE, height_3d, 0, variant, layer_var.offset );
 
                         // if the top item is already being layered don't draw it later
                         if( i.typeId() == tile.get_uppermost_item().typeId() ) {
@@ -3802,7 +3813,7 @@ bool cata_tiles::draw_field_or_item( const tripoint_bub_ms &p, const lit_level l
                 }
                 if( !has_drawn_field ) {
                     draw_from_id_string( fld.id().str(), TILE_CATEGORY::FIELD, empty_string,
-                                         p, subtile, rotation, ll, nv_goggles_activated, height_3d, intensity );
+                                         p, subtile, rotation, ll, calculate_color_overlay(), height_3d, intensity );
                 }
             }
         }
@@ -3832,7 +3843,7 @@ bool cata_tiles::draw_field_or_item( const tripoint_bub_ms &p, const lit_level l
             //get field intensity
             int intensity = fld_overridden ? 0 : here.field_at( p ).displayed_intensity();
             ret_draw_field = draw_from_id_string( fld.id().str(), TILE_CATEGORY::FIELD, empty_string,
-                                                  p, subtile, rotation, lit, false, height_3d, intensity );
+                                                  p, subtile, rotation, lit, COLOR_OVERLAY::NONE, height_3d, intensity );
         }
     }
 
@@ -3896,7 +3907,7 @@ bool cata_tiles::draw_field_or_item( const tripoint_bub_ms &p, const lit_level l
                 const bool nv = it_overridden ? false : nv_goggles_activated;
 
                 ret_draw_items = draw_from_id_string( disp_id, TILE_CATEGORY::ITEM, it_category, p, 0,
-                                                      0, lit, nv, height_3d, 0, variant );
+                                                      0, lit, nv ? COLOR_OVERLAY::NIGHT_VISION : COLOR_OVERLAY::NONE, height_3d, 0, variant );
                 if( ret_draw_items && hilite ) {
                     draw_item_highlight( p, height_3d );
                 }
@@ -3971,7 +3982,7 @@ bool cata_tiles::draw_vpart( const tripoint_bub_ms &p, lit_level ll, int &height
                                  ? false
                                  : draw_from_id_string( "vp_" + vd.id.str(), TILE_CATEGORY::VEHICLE_PART,
                                                         empty_string, p, subtile, rotation, ll,
-                                                        nv_goggles_activated, height_3d_temp, 0, vd.variant.id );
+                                                        calculate_color_overlay(), height_3d_temp, 0, vd.variant.id );
                 if( ret && vd.has_cargo ) {
                     draw_item_highlight( p, height_3d_temp );
                 }
@@ -3998,7 +4009,7 @@ bool cata_tiles::draw_vpart( const tripoint_bub_ms &p, lit_level ll, int &height
             const bool ret = memorize_only
                              ? false
                              : draw_from_id_string( vpname, TILE_CATEGORY::VEHICLE_PART, empty_string, p, subtile,
-                                                    rotation, lit_level::LIT, false, height_3d_temp );
+                                                    rotation, lit_level::LIT, COLOR_OVERLAY::NONE, height_3d_temp );
             if( ret && draw_highlight ) {
                 draw_item_highlight( p, height_3d_temp );
             }
@@ -4023,7 +4034,7 @@ bool cata_tiles::draw_vpart( const tripoint_bub_ms &p, lit_level ll, int &height
                    ? false
                    : draw_from_id_string(
                        std::string( tid ), TILE_CATEGORY::VEHICLE_PART, empty_string, p, t.get_dec_subtile(),
-                       t.get_dec_rotation(), lit_level::MEMORIZED, nv_goggles_activated, height_3d_temp, 0,
+                       t.get_dec_rotation(), lit_level::MEMORIZED, calculate_color_overlay(), height_3d_temp, 0,
                        std::string( tvar ) );
         }
     }
@@ -4098,7 +4109,7 @@ bool cata_tiles::draw_critter_at( const tripoint_bub_ms &p, lit_level ll, int &h
         const std::string &ent_subcategory = id.obj().species.empty() ?
                                              empty_string : id.obj().species.begin()->str();
         result = draw_from_id_string( chosen_id, TILE_CATEGORY::MONSTER, ent_subcategory, p,
-                                      corner, 0, lit_level::LIT, false, height_3d );
+                                      corner, 0, lit_level::LIT, calculate_color_overlay( *pcritter ), height_3d );
     } else if( !invisible[0] || always_visible ) {
         if( pcritter == nullptr ) {
             return false;
@@ -4112,7 +4123,7 @@ bool cata_tiles::draw_critter_at( const tripoint_bub_ms &p, lit_level ll, int &h
                 const enchant_cache::special_vision_descriptions special_vis_desc =
                     you.enchantment_cache->get_vision_description_struct( sees_with_special, d );
                 return draw_from_id_string( special_vis_desc.id, TILE_CATEGORY::NONE, empty_string, p, 0, 0,
-                                            lit_level::LIT, false, height_3d );
+                                            lit_level::LIT, calculate_color_overlay( critter ), height_3d );
             }
             return false;
         }
@@ -4162,13 +4173,13 @@ bool cata_tiles::draw_critter_at( const tripoint_bub_ms &p, lit_level ll, int &h
                     if( caster_mon != nullptr ) {
                         // caster is another monster
                         result = draw_from_id_string( caster_mon->type->id.str(), ent_category, ent_subcategory, p,
-                                                      subtile, rot_facing, ll, false, height_3d );
+                                                      subtile, rot_facing, ll, calculate_color_overlay( critter ), height_3d );
                     }
                 } else if( m->has_flag( mon_flag_COPY_AVATAR_LOOK ) ) {
                     draw_entity_with_overlays( *get_avatar().as_character(), p, ll, height_3d, m->facing );
                 } else {
                     result = draw_from_id_string( chosen_id, ent_category, ent_subcategory, p,
-                                                  subtile, rot_facing, ll, false, height_3d );
+                                                  subtile, rot_facing, ll, calculate_color_overlay( critter ), height_3d );
                 }
 
                 draw_entity_with_overlays( *m, p, ll, height_3d );
@@ -4202,7 +4213,7 @@ bool cata_tiles::draw_critter_at( const tripoint_bub_ms &p, lit_level ll, int &h
                 const enchant_cache::special_vision_descriptions special_vis_desc =
                     you.enchantment_cache->get_vision_description_struct( sees_with_special, d );
                 return draw_from_id_string( special_vis_desc.id, TILE_CATEGORY::NONE, empty_string, p,
-                                            0, 0, lit_level::LIT, false, height_3d );
+                                            0, 0, lit_level::LIT, calculate_color_overlay( *pcritter ), height_3d );
             } else {
                 return false;
             }
@@ -4218,7 +4229,7 @@ bool cata_tiles::draw_critter_at( const tripoint_bub_ms &p, lit_level ll, int &h
         }
         if( tileset_ptr->find_tile_type( draw_id ) ) {
             draw_from_id_string( draw_id, TILE_CATEGORY::NONE, empty_string, p, 0, 0,
-                                 lit_level::LIT, false, height_3d );
+                                 lit_level::LIT, calculate_color_overlay( *pcritter ), height_3d );
         }
     }
     return result;
@@ -4251,7 +4262,7 @@ bool cata_tiles::draw_critter_above( const tripoint_bub_ms &p, lit_level ll, int
 
     // Draw shadow
     if( draw_from_id_string( "shadow", TILE_CATEGORY::NONE, empty_string, p,
-                             0, 0, ll, false, height_3d ) && scan_p.z() - 1 > you.posz() && you.sees( here, critter ) ) {
+                             0, 0, ll, calculate_color_overlay(), height_3d ) && scan_p.z() - 1 > you.posz() && you.sees( here, critter ) ) {
 
         bool is_player = false;
         bool sees_player = false;
@@ -4283,7 +4294,7 @@ bool cata_tiles::draw_critter_above( const tripoint_bub_ms &p, lit_level ll, int
             }
             if( tileset_ptr->find_tile_type( draw_id ) ) {
                 draw_from_id_string( draw_id, TILE_CATEGORY::NONE, empty_string, p, 0, 0,
-                                     lit_level::LIT, false, height_3d );
+                                     lit_level::LIT, calculate_color_overlay(), height_3d );
             }
         }
         return true;
@@ -4316,7 +4327,7 @@ bool cata_tiles::draw_zone_mark( const tripoint_bub_ms &p, lit_level ll, int &he
 
         if( option && !option->get_mark().empty() ) {
             return draw_from_id_string( option->get_mark(), TILE_CATEGORY::NONE, empty_string, p,
-                                        0, 0, ll, nv_goggles_activated, height_3d );
+                                        0, 0, ll, calculate_color_overlay(), height_3d );
         }
     }
 
@@ -4337,7 +4348,7 @@ bool cata_tiles::draw_zombie_revival_indicators( const tripoint_bub_ms &pos, con
         for( item &i : here.i_at( pos ) ) {
             if( i.can_revive() ) {
                 return draw_from_id_string( ZOMBIE_REVIVAL_INDICATOR, TILE_CATEGORY::NONE,
-                                            empty_string, pos, 0, 0, lit_level::LIT, false, height_3d );
+                                            empty_string, pos, 0, 0, lit_level::LIT, COLOR_OVERLAY::NONE, height_3d );
             }
         }
     }
@@ -4392,9 +4403,52 @@ void cata_tiles::draw_zlevel_overlay( const tripoint_bub_ms &p, const lit_level 
     SetRenderDrawBlendMode( renderer, SDL_BLENDMODE_NONE );
 }
 
+COLOR_OVERLAY cata_tiles::calculate_color_overlay( const Creature &cr ) const
+{
+    if( nv_goggles_activated && get_option<bool>( "NV_GREEN_TOGGLE" ) ) {
+        return COLOR_OVERLAY::NIGHT_VISION;
+    } else if ( cr.has_monochrome_overlay() ) {
+        return COLOR_OVERLAY::MONOCHROME;
+    } else {
+        return COLOR_OVERLAY::NONE;
+    }
+}
+
+COLOR_OVERLAY cata_tiles::calculate_color_overlay( const monster &mon ) const
+{
+    if( nv_goggles_activated && get_option<bool>( "NV_GREEN_TOGGLE" ) ) {
+        return COLOR_OVERLAY::NIGHT_VISION;
+    } else if ( mon.has_monochrome_overlay() ) {
+        return COLOR_OVERLAY::MONOCHROME;
+    } else {
+        return COLOR_OVERLAY::NONE;
+    }
+}
+
+COLOR_OVERLAY cata_tiles::calculate_color_overlay( const Character &ch ) const
+{
+    if( nv_goggles_activated && get_option<bool>( "NV_GREEN_TOGGLE" ) ) {
+        return COLOR_OVERLAY::NIGHT_VISION;
+    } else if ( ch.has_monochrome_overlay() ) {
+        return COLOR_OVERLAY::MONOCHROME;
+    } else {
+        return COLOR_OVERLAY::NONE;
+    }
+}
+
+COLOR_OVERLAY cata_tiles::calculate_color_overlay( ) const
+{
+    if( nv_goggles_activated && get_option<bool>( "NV_GREEN_TOGGLE" ) ) {
+        return COLOR_OVERLAY::NIGHT_VISION;
+    } else {
+        return COLOR_OVERLAY::NONE;
+    }
+}
+
 void cata_tiles::draw_entity_with_overlays( const Character &ch, const tripoint_bub_ms &p,
         lit_level ll, int &height_3d, const FacingDirection facing_override )
 {
+    COLOR_OVERLAY color_overlay = calculate_color_overlay( ch );
     std::vector<trait_id> override_look_muts = ch.get_functioning_mutations( true,
     false, []( const mutation_branch & mut ) {
         return mut.override_look.has_value();
@@ -4417,10 +4471,10 @@ void cata_tiles::draw_entity_with_overlays( const Character &ch, const tripoint_
         }
         // depending on the toggle flip sprite left or right
         if( facing == FacingDirection::RIGHT ) {
-            draw_from_id_string( ent_name, TILE_CATEGORY::NONE, "", p, corner, 0, ll, false,
+            draw_from_id_string( ent_name, TILE_CATEGORY::NONE, "", p, corner, 0, ll, color_overlay,
                                  height_3d );
         } else if( facing == FacingDirection::LEFT ) {
-            draw_from_id_string( ent_name, TILE_CATEGORY::NONE, "", p, corner, -1, ll, false,
+            draw_from_id_string( ent_name, TILE_CATEGORY::NONE, "", p, corner, -1, ll, color_overlay,
                                  height_3d );
         }
     } else {
@@ -4434,10 +4488,10 @@ void cata_tiles::draw_entity_with_overlays( const Character &ch, const tripoint_
             category = TILE_CATEGORY::NONE;
         }
         if( facing == FacingDirection::RIGHT ) {
-            draw_from_id_string( override_look.id, category, "", p, corner, 0, ll, false,
+            draw_from_id_string( override_look.id, category, "", p, corner, 0, ll, color_overlay,
                                  height_3d );
         } else if( facing == FacingDirection::LEFT ) {
-            draw_from_id_string( override_look.id, category, "", p, corner, -1, ll, false,
+            draw_from_id_string( override_look.id, category, "", p, corner, -1, ll, color_overlay,
                                  height_3d );
         }
     }
@@ -4451,10 +4505,10 @@ void cata_tiles::draw_entity_with_overlays( const Character &ch, const tripoint_
             int overlay_height_3d = prev_height_3d;
             if( facing == FacingDirection::RIGHT ) {
                 draw_from_id_string( draw_id, TILE_CATEGORY::NONE, "", p, corner, /*rota:*/ 0, ll,
-                                     false, overlay_height_3d );
+                                     color_overlay, overlay_height_3d );
             } else if( facing == FacingDirection::LEFT ) {
                 draw_from_id_string( draw_id, TILE_CATEGORY::NONE, "", p, corner, /*rota:*/ -1, ll,
-                                     false, overlay_height_3d );
+                                     color_overlay, overlay_height_3d );
             }
             // the tallest height-having overlay is the one that counts
             height_3d = std::max( height_3d, overlay_height_3d );
@@ -4467,6 +4521,7 @@ void cata_tiles::draw_entity_with_overlays( const monster &mon, const tripoint_b
 {
     // TODO: move drawing the monster from draw_critter_at() here
 
+    COLOR_OVERLAY color_overlay = calculate_color_overlay( mon );
     std::vector<std::pair<std::string, std::string>> overlays = mon.get_overlay_ids();
     for( const std::pair<std::string, std::string> &overlay : overlays ) {
         std::string draw_id = overlay.first;
@@ -4474,10 +4529,10 @@ void cata_tiles::draw_entity_with_overlays( const monster &mon, const tripoint_b
             int overlay_height_3d = height_3d;
             if( mon.facing == FacingDirection::RIGHT ) {
                 draw_from_id_string( draw_id, TILE_CATEGORY::NONE, "", p, corner, /*rota:*/ 0, ll,
-                                     false, overlay_height_3d );
+                                     color_overlay, overlay_height_3d );
             } else if( mon.facing == FacingDirection::LEFT ) {
                 draw_from_id_string( draw_id, TILE_CATEGORY::NONE, "", p, corner, /*rota:*/ -1, ll,
-                                     false, overlay_height_3d );
+                                     color_overlay, overlay_height_3d );
             }
 
             height_3d = std::max( height_3d, overlay_height_3d );
@@ -4488,7 +4543,7 @@ void cata_tiles::draw_entity_with_overlays( const monster &mon, const tripoint_b
 bool cata_tiles::draw_item_highlight( const tripoint_bub_ms &pos, int &height_3d )
 {
     return draw_from_id_string( ITEM_HIGHLIGHT, TILE_CATEGORY::NONE, empty_string, pos, 0, 0,
-                                lit_level::LIT, false, height_3d );
+                                lit_level::LIT, COLOR_OVERLAY::NONE, height_3d );
 }
 
 std::shared_ptr<const tileset> tileset_cache::load_tileset( const std::string &tileset_id,
@@ -4775,27 +4830,27 @@ void cata_tiles::draw_explosion_frame()
         rotation = 0;
 
         draw_from_id_string( exp_name, exp_pos + point( -i, -i ),
-                             subtile, rotation++, lit_level::LIT, nv_goggles_activated );
+                             subtile, rotation++, lit_level::LIT, calculate_color_overlay() );
         draw_from_id_string( exp_name, exp_pos + point( -i, i ),
-                             subtile, rotation++, lit_level::LIT, nv_goggles_activated );
+                             subtile, rotation++, lit_level::LIT, calculate_color_overlay() );
         draw_from_id_string( exp_name, exp_pos + point( i, i ),
-                             subtile, rotation++, lit_level::LIT, nv_goggles_activated );
+                             subtile, rotation++, lit_level::LIT, calculate_color_overlay() );
         draw_from_id_string( exp_name, exp_pos + point( i, -i ),
-                             subtile, rotation, lit_level::LIT, nv_goggles_activated );
+                             subtile, rotation, lit_level::LIT, calculate_color_overlay() );
 
         subtile = edge;
         for( int j = 1 - i; j < 0 + i; j++ ) {
             rotation = 0;
             draw_from_id_string( exp_name, exp_pos + point( j, -i ),
-                                 subtile, rotation, lit_level::LIT, nv_goggles_activated );
+                                 subtile, rotation, lit_level::LIT, calculate_color_overlay() );
             draw_from_id_string( exp_name, exp_pos + point( j, i ),
-                                 subtile, rotation, lit_level::LIT, nv_goggles_activated );
+                                 subtile, rotation, lit_level::LIT, calculate_color_overlay() );
 
             rotation = 1;
             draw_from_id_string( exp_name, exp_pos + point( -i, j ),
-                                 subtile, rotation, lit_level::LIT, nv_goggles_activated );
+                                 subtile, rotation, lit_level::LIT, calculate_color_overlay() );
             draw_from_id_string( exp_name, exp_pos + point( i, j ),
-                                 subtile, rotation, lit_level::LIT, nv_goggles_activated );
+                                 subtile, rotation, lit_level::LIT, calculate_color_overlay() );
         }
     }
 }
@@ -4878,21 +4933,21 @@ void cata_tiles::draw_custom_explosion_frame()
         }
 
         draw_from_id_string( explosion_tile_id, p, subtile, rotation, lit_level::LIT,
-                             nv_goggles_activated );
+                             calculate_color_overlay() );
     }
 }
 void cata_tiles::draw_bullet_frame()
 {
     draw_from_id_string( bul_id, TILE_CATEGORY::BULLET, empty_string, bul_pos, 0, 0,
-                         lit_level::LIT, false );
+                         lit_level::LIT, COLOR_OVERLAY::NONE );
 }
 void cata_tiles::draw_hit_frame()
 {
     std::string hit_overlay = "animation_hit";
 
     draw_from_id_string( hit_entity_id, TILE_CATEGORY::HIT_ENTITY, empty_string, hit_pos, 0, 0,
-                         lit_level::LIT, false );
-    draw_from_id_string( hit_overlay, hit_pos, 0, 0, lit_level::LIT, false );
+                         lit_level::LIT, COLOR_OVERLAY::NONE );
+    draw_from_id_string( hit_overlay, hit_pos, 0, 0, lit_level::LIT, COLOR_OVERLAY::NONE );
 }
 void cata_tiles::draw_line()
 {
@@ -4904,22 +4959,22 @@ void cata_tiles::draw_line()
     static std::string line_overlay = "animation_line";
     if( !is_target_line || get_player_view().sees( here, line_pos ) ) {
         for( auto it = line_trajectory.begin(); it != line_trajectory.end() - 1; ++it ) {
-            draw_from_id_string( line_overlay, *it, 0, 0, lit_level::LIT, false );
+            draw_from_id_string( line_overlay, *it, 0, 0, lit_level::LIT, COLOR_OVERLAY::NONE );
         }
     }
 
-    draw_from_id_string( line_endpoint_id, line_trajectory.back(), 0, 0, lit_level::LIT, false );
+    draw_from_id_string( line_endpoint_id, line_trajectory.back(), 0, 0, lit_level::LIT, COLOR_OVERLAY::NONE );
 }
 void cata_tiles::draw_cursor()
 {
     for( const tripoint_bub_ms &p : cursors ) {
-        draw_from_id_string( "cursor", p, 0, 0, lit_level::LIT, false );
+        draw_from_id_string( "cursor", p, 0, 0, lit_level::LIT, COLOR_OVERLAY::NONE );
     }
 }
 void cata_tiles::draw_highlight()
 {
     for( const tripoint_bub_ms &p : highlights ) {
-        draw_from_id_string( "highlight", p, 0, 0, lit_level::LIT, false );
+        draw_from_id_string( "highlight", p, 0, 0, lit_level::LIT, COLOR_OVERLAY::NONE );
     }
 }
 void cata_tiles::draw_weather_frame()
@@ -4938,7 +4993,7 @@ void cata_tiles::draw_weather_frame()
         }
         const tripoint_bub_ms pos( point_bub_ms( p ), 0 );
         draw_from_id_string( weather_name, TILE_CATEGORY::WEATHER, empty_string, pos, 0, 0,
-                             lit_level::LIT, nv_goggles_activated );
+                             lit_level::LIT, calculate_color_overlay() );
     }
 }
 
@@ -4975,7 +5030,7 @@ void cata_tiles::draw_sct_frame( std::multimap<point, formatted_text> &overlay_s
                     if( tileset_ptr->find_tile_type( generic_id ) ) {
                         draw_from_id_string( generic_id, TILE_CATEGORY::NONE, empty_string,
                                              iD + tripoint_bub_ms( point_bub_ms( iOffset ), player_pos.z() ),
-                                             0, 0, lit_level::LIT, false );
+                                             0, 0, lit_level::LIT, COLOR_OVERLAY::NONE );
                     }
 
                     if( is_isometric() ) {
@@ -4995,7 +5050,7 @@ void cata_tiles::draw_zones_frame()
         for( int iX = zone_start.x(); iX <= zone_end.x(); ++iX ) {
             draw_from_id_string( "highlight", TILE_CATEGORY::NONE, empty_string,
                                  tripoint_bub_ms( iX, iY, player_pos.z() ) + zone_offset.xy(),
-                                 0, 0, lit_level::LIT, false );
+                                 0, 0, lit_level::LIT, COLOR_OVERLAY::NONE );
         }
     }
 
@@ -5010,7 +5065,7 @@ void cata_tiles::draw_async_anim()
         const std::string tile_id = anim.second;
         // Only draw if sprite found
         if( find_tile_looks_like( tile_id, TILE_CATEGORY::NONE, "" ) ) {
-            draw_from_id_string( tile_id, p, 0, 0, lit_level::LIT, nv_goggles_activated );
+            draw_from_id_string( tile_id, p, 0, 0, lit_level::LIT, calculate_color_overlay() );
         }
     }
 }
@@ -5026,11 +5081,11 @@ void cata_tiles::draw_footsteps_frame( const tripoint_bub_ms &center )
 
     for( const tripoint_bub_ms &pos : sounds::get_footstep_markers() ) {
         if( pos.z() > center.z() && tl_above ) {
-            draw_from_id_string( id_footstep_above, pos, 0, 0, lit_level::LIT, false );
+            draw_from_id_string( id_footstep_above, pos, 0, 0, lit_level::LIT, COLOR_OVERLAY::NONE );
         } else if( pos.z() < center.z() && tl_below ) {
-            draw_from_id_string( id_footstep_below, pos, 0, 0, lit_level::LIT, false );
+            draw_from_id_string( id_footstep_below, pos, 0, 0, lit_level::LIT, COLOR_OVERLAY::NONE );
         } else {
-            draw_from_id_string( id_footstep, pos, 0, 0, lit_level::LIT, false );
+            draw_from_id_string( id_footstep, pos, 0, 0, lit_level::LIT, COLOR_OVERLAY::NONE );
         }
     }
 }

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -279,7 +279,6 @@ void tileset::clear()
 {
     tile_values.clear();
     monochrome_tile_values.clear();
-    greenchrome_tile_values.clear();
     shadow_tile_values.clear();
     night_tile_values.clear();
     overexposed_tile_values.clear();
@@ -498,10 +497,9 @@ void tileset_cache::loader::create_textures_from_tile_atlas( const SDL_Surface_P
 
     /** perform color filter conversion here */
     using tiles_pixel_color_entry = std::tuple<std::vector<texture>*, std::string>;
-    std::array<tiles_pixel_color_entry, 7> tile_values_data = {{
+    std::array<tiles_pixel_color_entry, 6> tile_values_data = {{
             { std::make_tuple( &ts.tile_values, "color_pixel_none" ) },
             { std::make_tuple( &ts.monochrome_tile_values, "color_pixel_monochrome" ) },
-            { std::make_tuple( &ts.greenchrome_tile_values, "color_pixel_greenchrome" ) },
             { std::make_tuple( &ts.shadow_tile_values, "color_pixel_grayscale" ) },
             { std::make_tuple( &ts.night_tile_values, "color_pixel_nightvision" ) },
             { std::make_tuple( &ts.overexposed_tile_values, "color_pixel_overexposed" ) },
@@ -599,7 +597,6 @@ void tileset_cache::loader::load_tileset( const cata_path &img_path, const bool 
                                    ( tile_atlas->h / sprite_height );
     extend_vector_by( ts.tile_values, expected_tilecount );
     extend_vector_by( ts.monochrome_tile_values, expected_tilecount );
-    extend_vector_by( ts.greenchrome_tile_values, expected_tilecount );
     extend_vector_by( ts.shadow_tile_values, expected_tilecount );
     extend_vector_by( ts.night_tile_values, expected_tilecount );
     extend_vector_by( ts.overexposed_tile_values, expected_tilecount );
@@ -3051,7 +3048,7 @@ bool cata_tiles::draw_sprite_at(
         if( const texture *ptr = tileset_ptr->get_memory_tile( sprite_index ) ) {
             sprite_tex = ptr;
         }
-    } else if( color_overlay == COLOR_OVERLAY::NIGHT_VISION ) { // true will make character green too
+    } else if( color_overlay == COLOR_OVERLAY::NIGHT_VISION ) {
         if( ll != lit_level::LOW ) {
             if( const texture *ptr = tileset_ptr->get_overexposed_tile( sprite_index ) ) {
                 sprite_tex = ptr;
@@ -3090,6 +3087,12 @@ bool cata_tiles::draw_sprite_at(
                     tileset_ptr->get_tile_width() );
     destination.w = width * tile_width * tile.pixelscale / tileset_ptr->get_tile_width();
     destination.h = height * tile_height * tile.pixelscale / tileset_ptr->get_tile_height();
+
+    // if ( color_overlay == COLOR_OVERLAY::MONOCHROME ) {
+    //     // SDL_Texture sdl_texture = (sprite_tex).sdl_texture_ptr->get();
+    //     // SDL_SetTextureColorMod( sprite_tex->sdl_texture_ptr.get(), 127, 127, 127 );
+    // }
+
 
     if( rotate_sprite ) {
         if( rota == -1 ) {
@@ -3159,6 +3162,10 @@ bool cata_tiles::draw_sprite_at(
         // don't rotate, same as case 0 above
         ret = sprite_tex->render_copy_ex( renderer, &destination, 0, nullptr, SDL_FLIP_NONE );
     }
+
+        // SDL_SetTextureAlphaMod( sprite_tex->sdl_texture_ptr.get(), 255 );
+        // SDL_SetTextureColorMod( sprite_tex->sdl_texture_ptr.get(), 255, 255, 255 );
+        // SDL_SetTextureBlendMode( sprite_tex->sdl_texture_ptr.get(), SDL_BLENDMODE_BLEND );
 
     printErrorIf( ret != 0, "SDL_RenderCopyEx() failed" );
     // this reference passes all the way back up the call chain back to

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -82,6 +82,14 @@ enum class TILE_CATEGORY {
     last
 };
 
+// Possible color overlays that can modify how a sprite or tile should look
+enum class COLOR_OVERLAY {
+    NONE,
+    NIGHT_VISION,
+    MONOCHROME,
+    last
+};
+
 const std::unordered_map<std::string, TILE_CATEGORY> to_TILE_CATEGORY = {
     {"none", TILE_CATEGORY::NONE},
     {"vehicle_part", TILE_CATEGORY::VEHICLE_PART},
@@ -195,6 +203,8 @@ class tileset
         float tile_pixelscale = 1.0f;
 
         std::vector<texture> tile_values;
+        std::vector<texture> monochrome_tile_values;
+        std::vector<texture> greenchrome_tile_values;
         std::vector<texture> shadow_tile_values;
         std::vector<texture> night_tile_values;
         std::vector<texture> overexposed_tile_values;
@@ -255,6 +265,12 @@ class tileset
         }
         const texture *get_night_tile( const size_t index ) const {
             return get_if_available( index, night_tile_values );
+        }
+        const texture *get_monochrome_tile( const size_t index ) const {
+            return get_if_available( index, monochrome_tile_values );
+        }
+        const texture *get_greenchrome_tile( const size_t index ) const {
+            return get_if_available( index, greenchrome_tile_values );
         }
         const texture *get_shadow_tile( const size_t index ) const {
             return get_if_available( index, shadow_tile_values );
@@ -496,59 +512,59 @@ class cata_tiles
     private:
         bool draw_from_id_string_internal( const std::string &id, const tripoint_bub_ms &pos, int subtile,
                                            int rota,
-                                           lit_level ll, int retract, bool apply_night_vision_goggles, int &height_3d );
+                                           lit_level ll, int retract, COLOR_OVERLAY color_overlay, int &height_3d );
         bool draw_from_id_string_internal( const std::string &id, TILE_CATEGORY category,
                                            const std::string &subcategory, const tripoint_bub_ms &pos, int subtile, int rota,
-                                           lit_level ll, int retract, bool apply_night_vision_goggles, int &height_3d, int intensity_level,
+                                           lit_level ll, int retract, COLOR_OVERLAY color_overlay, int &height_3d, int intensity_level,
                                            const std::string &variant, const point &offset );
     protected:
         bool draw_from_id_string( const std::string &id, const tripoint_bub_ms &pos, int subtile, int rota,
                                   lit_level ll,
-                                  bool apply_night_vision_goggles );
+                                  COLOR_OVERLAY color_overlay );
         bool draw_from_id_string( const std::string &id, const tripoint_abs_omt &pos, int subtile, int rota,
                                   lit_level ll,
-                                  bool apply_night_vision_goggles ) {
+                                  COLOR_OVERLAY color_overlay ) {
             // A number of operations follow this pattern, i.e. tripoint_abs_omt coordinates are cast to tripoint_bub_ms and the call
             // is forwarded to the "normal" operation. This relies on the underlying logic being the same regardless of the coordinate
             // system and scale.
             return draw_from_id_string( id, tripoint_bub_ms( pos.raw() ), subtile, rota, ll,
-                                        apply_night_vision_goggles );
+                                        color_overlay );
         }
         bool draw_from_id_string( const std::string &id, TILE_CATEGORY category,
                                   const std::string &subcategory, const tripoint_bub_ms &pos, int subtile, int rota,
-                                  lit_level ll, bool apply_night_vision_goggles );
+                                  lit_level ll, COLOR_OVERLAY color_overlay );
         bool draw_from_id_string( const std::string &id, TILE_CATEGORY category,
                                   const std::string &subcategory, const tripoint_abs_omt &pos, int subtile, int rota,
-                                  lit_level ll, bool apply_night_vision_goggles ) {
+                                  lit_level ll, COLOR_OVERLAY color_overlay ) {
             return draw_from_id_string( id, category, subcategory, tripoint_bub_ms( pos.raw() ), subtile, rota,
-                                        ll, apply_night_vision_goggles );
+                                        ll, color_overlay );
         }
         bool draw_from_id_string( const std::string &id, TILE_CATEGORY category,
                                   const std::string &subcategory, const tripoint_bub_ms &pos, int subtile, int rota,
-                                  lit_level ll, bool apply_night_vision_goggles, int &height_3d );
+                                  lit_level ll, COLOR_OVERLAY color_overlay, int &height_3d );
         bool draw_from_id_string( const std::string &id, TILE_CATEGORY category,
                                   const std::string &subcategory, const tripoint_abs_omt &pos, int subtile, int rota,
-                                  lit_level ll, bool apply_night_vision_goggles, int &height_3d ) {
+                                  lit_level ll, COLOR_OVERLAY color_overlay, int &height_3d ) {
             return draw_from_id_string( id, category, subcategory, tripoint_bub_ms( pos.raw() ), subtile, rota,
-                                        ll, apply_night_vision_goggles, height_3d );
+                                        ll, color_overlay, height_3d );
         };
         bool draw_from_id_string( const std::string &id, TILE_CATEGORY category,
                                   const std::string &subcategory, const tripoint_bub_ms &pos, int subtile, int rota,
-                                  lit_level ll, bool apply_night_vision_goggles, int &height_3d, int intensity_level );
+                                  lit_level ll, COLOR_OVERLAY color_overlay, int &height_3d, int intensity_level );
         bool draw_from_id_string( const std::string &id, TILE_CATEGORY category,
                                   const std::string &subcategory, const tripoint_bub_ms &pos, int subtile, int rota,
-                                  lit_level ll, bool apply_night_vision_goggles, int &height_3d, int intensity_level,
+                                  lit_level ll, COLOR_OVERLAY color_overlay, int &height_3d, int intensity_level,
                                   const std::string &variant );
         bool draw_from_id_string( const std::string &id, TILE_CATEGORY category,
                                   const std::string &subcategory, const tripoint_bub_ms &pos, int subtile, int rota,
-                                  lit_level ll, bool apply_night_vision_goggles, int &height_3d, int intensity_level,
+                                  lit_level ll, COLOR_OVERLAY color_overlay, int &height_3d, int intensity_level,
                                   const std::string &variant, const point &offset );
         bool draw_sprite_at(
             const tile_type &tile, const weighted_int_list<std::vector<int>> &svlist,
             const point &, unsigned int loc_rand, bool rota_fg, int rota, lit_level ll,
-            bool apply_night_vision_goggles, int retract, int &height_3d, const point &offset );
+            COLOR_OVERLAY color_overlay, int retract, int &height_3d, const point &offset );
         bool draw_tile_at( const tile_type &tile, const point &, unsigned int loc_rand, int rota,
-                           lit_level ll, bool apply_night_vision_goggles, int retract, int &height_3d,
+                           lit_level ll, COLOR_OVERLAY color_overlay, int retract, int &height_3d,
                            const point &offset );
 
         /* Tile Picking */
@@ -582,6 +598,11 @@ class cata_tiles
         const memorized_tile &get_furniture_memory_at( const tripoint_abs_ms &p ) const;
         const memorized_tile &get_trap_memory_at( const tripoint_abs_ms &p ) const;
         const memorized_tile &get_vpart_memory_at( const tripoint_abs_ms &p ) const;
+
+        COLOR_OVERLAY calculate_color_overlay( const Creature &cr) const;
+        COLOR_OVERLAY calculate_color_overlay( const monster &mon) const;
+        COLOR_OVERLAY calculate_color_overlay( const Character &ch) const;
+        COLOR_OVERLAY calculate_color_overlay() const;
 
         /** Drawing Layers */
         bool would_apply_vision_effects( visibility_type visibility ) const;

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -136,10 +136,10 @@ class tile_lookup_res
 class texture
 {
     private:
-        std::shared_ptr<SDL_Texture> sdl_texture_ptr;
         SDL_Rect srcrect = { 0, 0, 0, 0 };
 
     public:
+        std::shared_ptr<SDL_Texture> sdl_texture_ptr;
         texture( std::shared_ptr<SDL_Texture> ptr,
                  const SDL_Rect &rect ) : sdl_texture_ptr( std::move( ptr ) ),
             srcrect( rect ) { }
@@ -204,7 +204,6 @@ class tileset
 
         std::vector<texture> tile_values;
         std::vector<texture> monochrome_tile_values;
-        std::vector<texture> greenchrome_tile_values;
         std::vector<texture> shadow_tile_values;
         std::vector<texture> night_tile_values;
         std::vector<texture> overexposed_tile_values;
@@ -268,9 +267,6 @@ class tileset
         }
         const texture *get_monochrome_tile( const size_t index ) const {
             return get_if_available( index, monochrome_tile_values );
-        }
-        const texture *get_greenchrome_tile( const size_t index ) const {
-            return get_if_available( index, greenchrome_tile_values );
         }
         const texture *get_shadow_tile( const size_t index ) const {
             return get_if_available( index, shadow_tile_values );

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -5848,6 +5848,13 @@ bool Character::is_immune_field( const field_type_id &fid ) const
     return Creature::is_immune_field( fid );
 }
 
+bool Character::has_monochrome_overlay() const
+{
+    return std::any_of( effects->begin(), effects->end(), [&]( const auto & elem ) {
+        return elem.first->has_monochrome_overlay();
+    } );
+}
+
 // FIXME: Relies on hardcoded damage type
 bool Character::is_elec_immune() const
 {

--- a/src/character.h
+++ b/src/character.h
@@ -2610,6 +2610,7 @@ class Character : public Creature, public visitable
         // checks if your character is immune to an effect or field based on field_immunity_data
         bool check_immunity_data( const field_immunity_data &ft ) const override;
         bool is_immune_field( const field_type_id &fid ) const override;
+        bool has_monochrome_overlay() const override;
         /** Returns true is the player is protected from electric shocks */
         bool is_elec_immune() const override;
         /** Returns true if the player is immune to this kind of effect */

--- a/src/creature.h
+++ b/src/creature.h
@@ -599,6 +599,10 @@ class Creature : public viewer
             return false;
         }
 
+        virtual bool has_monochrome_overlay() const {
+            return false;
+        }
+
         /** Returns multiplier on fall damage at low velocity (knockback/pit/1 z-level, not 5 z-levels) */
         virtual float fall_damage_mod() const = 0;
         /** Deals falling/collision damage with terrain/creature at pos */

--- a/src/effect.cpp
+++ b/src/effect.cpp
@@ -693,6 +693,10 @@ bool effect_type::is_show_in_info() const
 {
     return show_in_info;
 }
+bool effect_type::has_monochrome_overlay() const
+{
+    return monochrome_overlay;
+}
 bool effect_type::load_miss_msgs( const JsonObject &jo, std::string_view member )
 {
     return jo.read( member, miss_msgs );
@@ -1593,6 +1597,7 @@ void load_effect_type( const JsonObject &jo, std::string_view src )
     new_etype.main_parts_only = jo.get_bool( "main_parts_only", false );
     new_etype.show_in_info = jo.get_bool( "show_in_info", false );
     new_etype.show_intensity = jo.get_bool( "show_intensity", true );
+    new_etype.monochrome_overlay = jo.get_bool( "monochrome_overlay", false );
     new_etype.pkill_addict_reduces = jo.get_bool( "pkill_addict_reduces", false );
 
     new_etype.pain_sizing = jo.get_bool( "pain_sizing", false );

--- a/src/effect.h
+++ b/src/effect.h
@@ -149,6 +149,7 @@ class effect_type
                               int intensity ) const;
 
         bool is_show_in_info() const;
+        bool has_monochrome_overlay() const;
 
         /** Loading helper functions */
         void load_mod_data( const JsonObject &jo );
@@ -204,6 +205,8 @@ class effect_type
 
         // Determines if effect should show intensity value next to its name in EFFECTS tab.
         bool show_intensity = false;
+
+        bool monochrome_overlay = false;
 
         std::vector<trait_id> resist_traits;
         std::vector<efftype_id> resist_effects;

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -3969,6 +3969,13 @@ void monster::on_hit( map *here, Creature *source, bodypart_id,
     // TODO: Faction relations
 }
 
+bool monster::has_monochrome_overlay() const
+{
+    return std::any_of( effects->begin(), effects->end(), [&]( const auto & elem ) {
+        return elem.first->has_monochrome_overlay();
+    } );
+}
+
 int monster::get_hp_max( const bodypart_id & ) const
 {
     return type->hp;

--- a/src/monster.h
+++ b/src/monster.h
@@ -287,6 +287,7 @@ class monster : public Creature
 
         bool is_immune_field( const field_type_id &fid ) const override;
         bool check_immunity_data( const field_immunity_data &ft ) const override;
+        bool has_monochrome_overlay() const override;
 
         /**
          * Attempt to move to p.

--- a/src/sdl_utils.cpp
+++ b/src/sdl_utils.cpp
@@ -21,6 +21,8 @@ static color_pixel_function_map builtin_color_pixel_functions = {
     { "color_pixel_sepia_dark", color_pixel_sepia_dark },
     { "color_pixel_blue_dark", color_pixel_blue_dark },
     { "color_pixel_custom", color_pixel_custom },
+    { "color_pixel_monochrome", color_pixel_monochrome },
+    { "color_pixel_greenchrome", color_pixel_greenchrome },
     { "color_pixel_grayscale", color_pixel_grayscale },
     { "color_pixel_nightvision", color_pixel_nightvision },
     { "color_pixel_overexposed", color_pixel_overexposed },
@@ -72,6 +74,24 @@ SDL_Color mix_colors( const SDL_Color &first, const SDL_Color &second, int secon
         static_cast<Uint8>( std::min( ( first.b * first_percent + second.b * second_percent ) / 100, 0xFF ) ),
         static_cast<Uint8>( std::min( ( first.a * first_percent + second.a * second_percent ) / 100, 0xFF ) )
     };
+}
+
+inline SDL_Color color_pixel_monochrome( const SDL_Color &color )
+{
+    if( is_black( color ) ) {
+        return color;
+    }
+
+    const Uint8 av = average_pixel_color( color );
+
+    return { av, av, av, color.a };
+}
+
+inline SDL_Color color_pixel_greenchrome( const SDL_Color &color )
+{
+    const Uint8 av = average_pixel_color( color );
+
+    return { static_cast<Uint8>( av >> 2 ), av, static_cast<Uint8>( av >> 3), color.a };
 }
 
 inline SDL_Color color_pixel_grayscale( const SDL_Color &color )

--- a/src/sdl_utils.cpp
+++ b/src/sdl_utils.cpp
@@ -22,7 +22,6 @@ static color_pixel_function_map builtin_color_pixel_functions = {
     { "color_pixel_blue_dark", color_pixel_blue_dark },
     { "color_pixel_custom", color_pixel_custom },
     { "color_pixel_monochrome", color_pixel_monochrome },
-    { "color_pixel_greenchrome", color_pixel_greenchrome },
     { "color_pixel_grayscale", color_pixel_grayscale },
     { "color_pixel_nightvision", color_pixel_nightvision },
     { "color_pixel_overexposed", color_pixel_overexposed },
@@ -82,16 +81,9 @@ inline SDL_Color color_pixel_monochrome( const SDL_Color &color )
         return color;
     }
 
-    const Uint8 av = average_pixel_color( color );
+    const Uint8 av = 0.21 * color.r + 0.72 * color.g + 0.07 * color.b;
 
     return { av, av, av, color.a };
-}
-
-inline SDL_Color color_pixel_greenchrome( const SDL_Color &color )
-{
-    const Uint8 av = average_pixel_color( color );
-
-    return { static_cast<Uint8>( av >> 2 ), av, static_cast<Uint8>( av >> 3), color.a };
 }
 
 inline SDL_Color color_pixel_grayscale( const SDL_Color &color )

--- a/src/sdl_utils.h
+++ b/src/sdl_utils.h
@@ -33,6 +33,8 @@ inline Uint8 average_pixel_color( const SDL_Color &color )
     return 85 * ( color.r + color.g + color.b ) >> 8; // 85/256 ~ 1/3
 }
 
+SDL_Color color_pixel_monochrome( const SDL_Color &color );
+SDL_Color color_pixel_greenchrome( const SDL_Color &color );
 SDL_Color color_pixel_grayscale( const SDL_Color &color );
 SDL_Color color_pixel_nightvision( const SDL_Color &color );
 SDL_Color color_pixel_overexposed( const SDL_Color &color );

--- a/src/sdl_utils.h
+++ b/src/sdl_utils.h
@@ -34,7 +34,6 @@ inline Uint8 average_pixel_color( const SDL_Color &color )
 }
 
 SDL_Color color_pixel_monochrome( const SDL_Color &color );
-SDL_Color color_pixel_greenchrome( const SDL_Color &color );
 SDL_Color color_pixel_grayscale( const SDL_Color &color );
 SDL_Color color_pixel_nightvision( const SDL_Color &color );
 SDL_Color color_pixel_overexposed( const SDL_Color &color );

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -869,16 +869,16 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
             // light level is now used for choosing between grayscale filter and normal lit tiles.
             draw_from_id_string( id, category,
                                  category == TILE_CATEGORY::OVERMAP_TERRAIN ? "overmap_terrain" : "",
-                                 omp, subtile, rotation, ll, false, height_3d );
+                                 omp, subtile, rotation, ll, COLOR_OVERLAY::NONE, height_3d );
             if( !mx.is_empty() && mx->autonote ) {
                 draw_from_id_string( mx.str(), TILE_CATEGORY::MAP_EXTRA, "map_extra", omp,
-                                     0, 0, ll, false );
+                                     0, 0, ll, COLOR_OVERLAY::NONE );
             }
 
             if( draw_overlays && show_map_revealed ) {
                 auto it = revealed_highlights.find( omp );
                 if( it != revealed_highlights.end() ) {
-                    draw_from_id_string( "highlight", omp, 0, 0, lit_level::LIT, false );
+                    draw_from_id_string( "highlight", omp, 0, 0, lit_level::LIT, COLOR_OVERLAY::NONE );
                 }
             }
 
@@ -889,7 +889,7 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
                         auto mgroup_iter = mgroups.begin();
                         std::advance( mgroup_iter, rng( 0, mgroups.size() - 1 ) );
                         draw_from_id_string( ( *mgroup_iter )->type->defaultMonster.str(),
-                                             omp, 0, 0, lit_level::LIT, false );
+                                             omp, 0, 0, lit_level::LIT, COLOR_OVERLAY::NONE );
                     }
                 }
                 const int horde_size = overmap_buffer.get_horde_size( omp );
@@ -898,32 +898,32 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
                     if( find_tile_with_season( id ) ) {
                         // NOLINTNEXTLINE(cata-translate-string-literal)
                         draw_from_id_string( string_format( "overmap_horde_%d", horde_size < 10 ? horde_size : 10 ),
-                                             omp, 0, 0, lit_level::LIT, false );
+                                             omp, 0, 0, lit_level::LIT, COLOR_OVERLAY::NONE );
                     } else {
                         switch( horde_size ) {
                             case HORDE_VISIBILITY_SIZE:
                                 draw_from_id_string( "mon_zombie", omp, 0, 0, lit_level::LIT,
-                                                     false );
+                                                     COLOR_OVERLAY::NONE );
                                 break;
                             case HORDE_VISIBILITY_SIZE + 1:
                                 draw_from_id_string( "mon_zombie_tough", omp, 0, 0,
-                                                     lit_level::LIT, false );
+                                                     lit_level::LIT, COLOR_OVERLAY::NONE );
                                 break;
                             case HORDE_VISIBILITY_SIZE + 2:
                                 draw_from_id_string( "mon_zombie_brute", omp, 0, 0,
-                                                     lit_level::LIT, false );
+                                                     lit_level::LIT, COLOR_OVERLAY::NONE );
                                 break;
                             case HORDE_VISIBILITY_SIZE + 3:
                                 draw_from_id_string( "mon_zombie_hulk", omp, 0, 0,
-                                                     lit_level::LIT, false );
+                                                     lit_level::LIT, COLOR_OVERLAY::NONE );
                                 break;
                             case HORDE_VISIBILITY_SIZE + 4:
                                 draw_from_id_string( "mon_zombie_necro", omp, 0, 0,
-                                                     lit_level::LIT, false );
+                                                     lit_level::LIT, COLOR_OVERLAY::NONE );
                                 break;
                             default:
                                 draw_from_id_string( "mon_zombie_master", omp, 0, 0,
-                                                     lit_level::LIT, false );
+                                                     lit_level::LIT, COLOR_OVERLAY::NONE );
                                 break;
                         }
                     }
@@ -933,19 +933,19 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
             if( ( uistate.place_terrain || uistate.place_special ) &&
                 overmap_ui::is_generated_omt( omp.xy() ) ) {
                 // Highlight areas that already have been generated
-                draw_from_id_string( "highlight", omp, 0, 0, lit_level::LIT, false );
+                draw_from_id_string( "highlight", omp, 0, 0, lit_level::LIT, COLOR_OVERLAY::NONE );
             }
 
             if( draw_overlays && overmap_buffer.has_vehicle( omp ) ) {
                 const std::string tile_id = overmap_buffer.get_vehicle_tile_id( omp );
                 if( find_tile_looks_like( tile_id, TILE_CATEGORY::OVERMAP_NOTE, "" ) ) {
                     draw_from_id_string( tile_id, TILE_CATEGORY::OVERMAP_NOTE,
-                                         "overmap_note", omp, 0, 0, lit_level::LIT, false );
+                                         "overmap_note", omp, 0, 0, lit_level::LIT, COLOR_OVERLAY::NONE );
                 } else {
                     const std::string ter_sym = overmap_buffer.get_vehicle_ter_sym( omp );
                     std::string note_name = "note_" + ter_sym + "_cyan";
                     draw_from_id_string( note_name, TILE_CATEGORY::OVERMAP_NOTE,
-                                         "overmap_note", omp, 0, 0, lit_level::LIT, false );
+                                         "overmap_note", omp, 0, 0, lit_level::LIT, COLOR_OVERLAY::NONE );
                 }
             }
 
@@ -959,10 +959,10 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
 
                     std::string note_name = "note_" + ter_sym + "_" + string_from_color( ter_color );
                     draw_from_id_string( note_name, TILE_CATEGORY::OVERMAP_NOTE, "overmap_note",
-                                         omp, 0, 0, lit_level::LIT, false );
+                                         omp, 0, 0, lit_level::LIT, COLOR_OVERLAY::NONE );
                 } else if( overmap_buffer.is_marked_dangerous( omp ) ) {
                     draw_from_id_string( "note_X_red", TILE_CATEGORY::OVERMAP_NOTE, "overmap_note",
-                                         omp, 0, 0, lit_level::LIT, false );
+                                         omp, 0, 0, lit_level::LIT, COLOR_OVERLAY::NONE );
 
                 }
             }
@@ -977,7 +977,7 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
         int subtile;
         terrain.get_rotation_and_subtile( rotation, subtile );
         draw_from_id_string( id, global_omt_to_draw_position( center_pos ), subtile, rotation,
-                             lit_level::LOW, true );
+                             lit_level::LOW, COLOR_OVERLAY::NIGHT_VISION );
     }
     if( uistate.place_special ) {
         for( const overmap_special_terrain &s_ter : uistate.place_special->preview_terrains() ) {
@@ -992,7 +992,7 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
 
                 draw_from_id_string( id, TILE_CATEGORY::OVERMAP_TERRAIN, "overmap_terrain",
                                      global_omt_to_draw_position( center_pos + rp ), 0,
-                                     rotation, lit_level::LOW, true );
+                                     rotation, lit_level::LOW, COLOR_OVERLAY::NIGHT_VISION );
             }
         }
     }
@@ -1015,7 +1015,7 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
                                lit_level::LIT, height_3d );
     if( !fast_traveling ) {
         draw_from_id_string( "cursor", global_omt_to_draw_position( center_pos ), 0, 0, lit_level::LIT,
-                             false );
+                             COLOR_OVERLAY::NONE );
     }
 
     if( draw_overlays ) {
@@ -1023,7 +1023,7 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
         for( const tripoint_abs_omt &pos : you.omt_path ) {
             if( pos.z() == center_pos.z() ) {
                 draw_from_id_string( "highlight", global_omt_to_draw_position( pos ), 0, 0, lit_level::LIT,
-                                     false );
+                                     COLOR_OVERLAY::NONE );
             }
         }
 
@@ -1031,7 +1031,7 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
             for( const tripoint_abs_omt &pos : g->follower_path_to_show->omt_path ) {
                 if( pos.z() == center_pos.z() ) {
                     draw_from_id_string( "highlight", global_omt_to_draw_position( pos ), 0, 0, lit_level::LIT,
-                                         false );
+                                         COLOR_OVERLAY::NONE );
                 }
             }
         }
@@ -1041,7 +1041,7 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
                     get_mission_arrow( full_om_tile_area, center_pos );
         if( mission_arrow ) {
             draw_from_id_string( mission_arrow->second, global_omt_to_draw_position( mission_arrow->first ), 0,
-                                 0, lit_level::LIT, false );
+                                 0, lit_level::LIT, COLOR_OVERLAY::NONE );
         }
     }
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Xedra] Time Frozen Things are Gray"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Big visual improvement for both visuals and also easily telling which entities are frozen in time.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add a bool field in the effect params
Add another color function to convert tiles to monochrome
Pass an enum through drawing functions instead of a night vision bool that can choose between color functions

TODO:
- Pretty much rip out the existing infrastructure in favor of jsonized color functions
- Then make effect param take an arbitrary color function instead of just being a bool
- Extend color function to fields
- Add mutation param for another chronomancer negative
- There's a reason this is in draft

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Creatures:
![frozen creatures](https://github.com/user-attachments/assets/ac6d5b03-5745-4593-b74a-0ca71462f0c3)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
