### PR TITLE
Fix workflow title string used to allow basic build to run on draft PRs

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -220,7 +220,7 @@ jobs:
         CCACHE_NOCOMPRESS: true
         SKIP: >-
           ${{
-          ( github.event.pull_request.draft == true && matrix.title != 'Basic Build and Test (Clang 13, Ubuntu, Curses)' ) ||
+          ( github.event.pull_request.draft == true && matrix.title != 'Basic Build and Test (Clang oldest supported, Ubuntu, Curses)' ) ||
           ( matrix.dont_skip_data_only_changes == 0 && needs.skip-duplicates.outputs.should_skip_code == 'true' ) ||
           ( matrix.dont_skip_data_only_changes != 0 && needs.skip-duplicates-mods.outputs.should_skip_data == 'true' )
           }}


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
I broke build-skipping-for-drafts-except-basic-build when I renamed the basic build and updated the runner verions.

#### Describe the solution
Fix the string

#### Describe alternatives you've considered
Burn github integration to the ground.

#### Testing
Marking this draft, basic build should run.

#### Additional context
We discovered comparing bare strings was stupid in like the 70's, WTH github infra?