### PR TITLE
Vampirism updates to account for new base blood need.

### DIFF
--- a/data/mods/Xedra_Evolved/mutations/mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/mutations.json
@@ -1522,11 +1522,11 @@
     "id": "VAMPIRE_WEAKNESS_MORE_BLOOD",
     "name": { "str": "Vampiric weakness: blood drain" },
     "points": -1,
-    "description": "You thirst for blood is more intense than usual.  You now need twice as much blood to prevent blood starvation.",
+    "description": "You thirst for blood is more intense than usual.  You now need much more blood to prevent blood starvation.",
     "starting_trait": false,
     "valid": false,
     "purifiable": false,
-    "vitamin_rates": [ [ "human_blood_vitamin", 60 ] ]
+    "vitamin_rates": [ [ "human_blood_vitamin", 120 ] ]
   },
   {
     "type": "mutation",

--- a/data/mods/Xedra_Evolved/mutations/vampire_trait_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/vampire_trait_eocs.json
@@ -1680,7 +1680,7 @@
     "name": [ "Torpor" ],
     "desc": [ "Thanks to your torpor you are healing and recovering quickly" ],
     "rating": "good",
-    "vitamins": [ { "vitamin": "human_blood_vitamin", "rate": [ [ 1, 1 ] ], "tick": [ "3 m" ] } ],
+    "vitamins": [ { "vitamin": "human_blood_vitamin", "rate": [ [ 1, 1 ] ], "tick": [ "8 m" ] } ],
     "flags": [ "DEAF", "BLIND" ],
     "enchantments": [
       {

--- a/data/mods/Xedra_Evolved/mutations/vampire_trait_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/vampire_trait_eocs.json
@@ -2765,7 +2765,7 @@
     "type": "effect_on_condition",
     "id": "EOC_ANATHEMA_MIND_CHAOS",
     "//": "Checks the variable every time the player drinks vampire blood with the weakness.  If the effect triggers, it gives a random mental negative.  If if cannot give one, it gives a negative effect for a while.  If the effect doesn't trigger, it increments the variable.",
-    "//2": "It doesn't give nyctophobia and pyrophobia for obvious reasons.",
+    "//2": "It doesn't give nyctophobia and pyromania for obvious reasons.",
     "condition": { "x_in_y_chance": { "x": { "math": [ "u_counter_anathema_mind_chaos" ] }, "y": 100 } },
     "effect": [
       {


### PR DESCRIPTION
#### Summary
Mods "Vampirism updates to account for new base blood need."

#### Purpose of change

The new base blood need resulted in torpor being a net positive blood-wise, which is not intended.

I've also noticed other details to fix.

#### Describe the solution

Make torpor give less blood, resulting in a slowed but still negative blood drain.

The blood drain weakness has been adjusted to result in a tripled base blood need. 

The note about the blood-muddled mind EOC now properly refers to pyromania.

#### Describe alternatives you've considered

Letting vampires ignore their need for blood by sleeping in a certain way.

#### Testing

Values are changed.

#### Additional context
