### PR TITLE
Somewhat relax shooting_at_terrain test passing criteria (Revive #79772)

### DIFF
--- a/src/ballistics.cpp
+++ b/src/ballistics.cpp
@@ -442,6 +442,10 @@ void projectile_attack( dealt_projectile_attack &attack, const projectile &proj_
 
         for( size_t i = 1; i < traj_len && ( has_momentum || stream ); ++i ) {
             tp = t_copy[i];
+            if( !here->inbounds( tp ) ) {
+                debugmsg( "Shot along %s out-of-bounds", tp.to_string() );
+                break;
+            }
             int distance = rl_dist( source, tp );
             // no spread at point-blank, skip point-blank calculate
             if( !first && distance <= 1 ) {

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -4438,6 +4438,10 @@ void map::crush( const tripoint_bub_ms &p )
 }
 double map::shoot( const tripoint_bub_ms &p, projectile &proj, const bool hit_items )
 {
+    if( !inbounds( p ) ) {
+        debugmsg( "Called map::shoot on out-of-bounds tile %s", p.to_string() );
+        return 0;
+    }
     // TODO: make bashing better a destroying, worse at penetrating
     std::map<damage_type_id, float> dmg_by_type {};
     damage_instance &impact = proj.multishot ? proj.shot_impact : proj.impact;

--- a/tests/map_bash_test.cpp
+++ b/tests/map_bash_test.cpp
@@ -202,7 +202,7 @@ static void shoot_at_terrain( std::function<void()> &setup, npc &shooter,
         aim_pos = wall_pos;
     }
 
-    int num_trials = 10;
+    int num_trials = 20;
     int broken_count = 0;
     for( int i = 0; i < num_trials; i++ ) {
         // Place a terrain
@@ -224,9 +224,9 @@ static void shoot_at_terrain( std::function<void()> &setup, npc &shooter,
         broken_count += here.ter( wall_pos ) != id;
     }
     if( expected_to_break ) {
-        CHECK( broken_count > 0.7 * num_trials );
+        CHECK( broken_count > 0.8 * num_trials );
     } else {
-        CHECK( broken_count < 0.3 * num_trials );
+        CHECK( broken_count < 0.2 * num_trials );
     }
 
 }
@@ -239,13 +239,19 @@ TEST_CASE( "shooting_at_terrain", "[rng][map][bash][ranged]" )
     standard_npc shooter( "Shooter", { 10, 10, 0 } );
     shooter.set_body();
     shooter.worn.wear_item( shooter, item( itype_backpack ), false, false );
+    SECTION( "birdshot vs brick wall near" ) {
+        std::function<void()> setup = [&shooter]() {
+            arm_shooter( shooter, itype_mossberg_590, {}, itype_shot_bird );
+        };
+        shoot_at_terrain( setup, shooter, "t_brick_wall",
+                          shooter.pos_bub() + point::east, false );
+    }
     // Broken. See https://github.com/CleverRaven/Cataclysm-DDA/issues/79770
     //SECTION( "birdshot vs adobe wall point blank" ) {
     //    shoot_at_terrain( shooter, itype_mossberg_590, itype_shot_bird,
     //                      "t_adobe_brick_wall", shooter.pos_bub() + point::east, false );
     //}
     SECTION( "birdshot vs adobe wall near" ) {
-        //arm_shooter( shooter, gun, {}, ammo );
         std::function<void()> setup = [&shooter]() {
             arm_shooter( shooter, itype_mossberg_590, {}, itype_shot_bird );
         };

--- a/tests/map_bash_test.cpp
+++ b/tests/map_bash_test.cpp
@@ -1,3 +1,4 @@
+#include <functional>
 #include <map>
 #include <optional>
 #include <string>
@@ -191,33 +192,46 @@ TEST_CASE( "map_bash_ephemeral_persistence", "[map][bash]" )
     }
 }
 
-static void shoot_at_terrain( npc &shooter, const std::string &ter_str, tripoint_bub_ms wall_pos,
+static void shoot_at_terrain( std::function<void()> &setup, npc &shooter,
+                              const std::string &ter_str, tripoint_bub_ms wall_pos,
                               bool expected_to_break, tripoint_bub_ms aim_pos = tripoint_bub_ms::zero )
 {
     map &here = get_map();
-    // Place a terrain
     ter_str_id id{ ter_str };
     if( aim_pos == tripoint_bub_ms::zero ) {
         aim_pos = wall_pos;
     }
-    here.ter_set( wall_pos, id );
-    REQUIRE( here.ter( wall_pos ) == id );
-    // This is a workaround for nonsense where you can't shoot terrain or furniture unless it
-    // obscures sight, specifically map::is_transparent() must return false.
-    here.build_map_cache( 0, true );
 
-    // Shoot it a bunch
-    for( int i = 0; i < 9; ++i ) {
-        shooter.recoil = 0;
-        shooter.set_moves( 100 );
-        shooter.fire_gun( aim_pos );
+    int num_trials = 10;
+    int broken_count = 0;
+    for( int i = 0; i < num_trials; i++ ) {
+        // Place a terrain
+        here.ter_set( wall_pos, id );
+        REQUIRE( here.ter( wall_pos ) == id );
+        // This is a workaround for nonsense where you can't shoot terrain or furniture unless it
+        // obscures sight, specifically map::is_transparent() must return false.
+        here.build_map_cache( 0, true );
+
+        setup();
+        // Shoot it a bunch
+        for( int i = 0; i < 9; ++i ) {
+            shooter.recoil = 0;
+            shooter.set_moves( 100 );
+            shooter.fire_gun( aim_pos );
+        }
+        // is it gone?
+        INFO( here.ter( wall_pos ).id().str() );
+        broken_count += here.ter( wall_pos ) != id;
     }
-    // is it gone?
-    INFO( here.ter( wall_pos ).id().str() );
-    CHECK( ( here.ter( wall_pos ) != id ) == expected_to_break );
+    if( expected_to_break ) {
+        CHECK( broken_count > 0.7 * num_trials );
+    } else {
+        CHECK( broken_count < 0.3 * num_trials );
+    }
+
 }
 
-TEST_CASE( "shooting_at_terrain", "[map][bash][ranged]" )
+TEST_CASE( "shooting_at_terrain", "[rng][map][bash][ranged]" )
 {
     clear_map();
 
@@ -225,38 +239,57 @@ TEST_CASE( "shooting_at_terrain", "[map][bash][ranged]" )
     standard_npc shooter( "Shooter", { 10, 10, 0 } );
     shooter.set_body();
     shooter.worn.wear_item( shooter, item( itype_backpack ), false, false );
-    SECTION( "birdshot vs adobe wall point blank" ) {
-        arm_shooter( shooter, itype_mossberg_590, {}, itype_shot_bird );
-        shoot_at_terrain( shooter, "t_adobe_brick_wall", shooter.pos_bub() + point::east, false );
-    }
+    // Broken. See https://github.com/CleverRaven/Cataclysm-DDA/issues/79770
+    //SECTION( "birdshot vs adobe wall point blank" ) {
+    //    shoot_at_terrain( shooter, itype_mossberg_590, itype_shot_bird,
+    //                      "t_adobe_brick_wall", shooter.pos_bub() + point::east, false );
+    //}
     SECTION( "birdshot vs adobe wall near" ) {
-        arm_shooter( shooter, itype_mossberg_590, {}, itype_shot_bird );
-        shoot_at_terrain( shooter, "t_adobe_brick_wall", shooter.pos_bub() + point::east * 2, false );
+        //arm_shooter( shooter, gun, {}, ammo );
+        std::function<void()> setup = [&shooter]() {
+            arm_shooter( shooter, itype_mossberg_590, {}, itype_shot_bird );
+        };
+        shoot_at_terrain( setup, shooter, "t_adobe_brick_wall",
+                          shooter.pos_bub() + point::east * 2, false );
     }
     SECTION( "birdshot vs opaque glass door point blank" ) {
-        arm_shooter( shooter, itype_mossberg_590, {}, itype_shot_bird );
-        shoot_at_terrain( shooter, "test_t_door_glass_opaque_c", shooter.pos_bub() + point::east, true );
+        std::function<void()> setup = [&shooter]() {
+            arm_shooter( shooter, itype_mossberg_590, {}, itype_shot_bird );
+        };
+        shoot_at_terrain( setup, shooter, "test_t_door_glass_opaque_c",
+                          shooter.pos_bub() + point::east, true );
     }
     SECTION( "birdshot vs opaque glass door near" ) {
-        arm_shooter( shooter, itype_mossberg_590, {}, itype_shot_bird );
-        shoot_at_terrain( shooter, "test_t_door_glass_opaque_c", shooter.pos_bub() + point::east * 2,
-                          false );
+        std::function<void()> setup = [&shooter]() {
+            arm_shooter( shooter, itype_mossberg_590, {}, itype_shot_bird );
+        };
+        shoot_at_terrain( setup, shooter, "test_t_door_glass_opaque_c",
+                          shooter.pos_bub() + point::east * 2, false );
     }
     SECTION( "birdshot vs door near" ) {
-        arm_shooter( shooter, itype_mossberg_590, {}, itype_shot_bird );
-        shoot_at_terrain( shooter, "t_door_c", shooter.pos_bub() + point::east * 2, false );
+        std::function<void()> setup = [&shooter]() {
+            arm_shooter( shooter, itype_mossberg_590, {}, itype_shot_bird );
+        };
+        shoot_at_terrain( setup, shooter, "t_door_c",
+                          shooter.pos_bub() + point::east * 2, false );
     }
     // I thought I saw some failures based on whether an unseen monster was present,
     // But I think it was just shooting at door wthout a 100% chance to break it and getting unlucky.
     SECTION( "birdshot through door at nothing" ) {
-        arm_shooter( shooter, itype_mossberg_590, {}, itype_shot_bird );
-        shoot_at_terrain( shooter, "t_door_c", shooter.pos_bub() + point::east, true,
+        std::function<void()> setup = [&shooter]() {
+            arm_shooter( shooter, itype_mossberg_590, {}, itype_shot_bird );
+        };
+        shoot_at_terrain( setup, shooter, "t_door_c",
+                          shooter.pos_bub() + point::east, true,
                           shooter.pos_bub() + point::east * 2 );
     }
     SECTION( "birdshot through door at monster" ) {
-        arm_shooter( shooter, itype_mossberg_590, {}, itype_shot_bird );
-        spawn_test_monster( "mon_zombie", shooter.pos_bub() + point::east * 2 );
-        shoot_at_terrain( shooter, "t_door_c", shooter.pos_bub() + point::east, true,
+        std::function<void()> setup = [&shooter]() {
+            arm_shooter( shooter, itype_mossberg_590, {}, itype_shot_bird );
+            spawn_test_monster( "mon_zombie", shooter.pos_bub() + point::east * 2 );
+        };
+        shoot_at_terrain( setup, shooter, "t_door_c",
+                          shooter.pos_bub() + point::east, true,
                           shooter.pos_bub() + point::east * 2 );
     }
     // TODO: If we get a feature where damage accumulates a test for it would go here.

--- a/tests/map_bash_test.cpp
+++ b/tests/map_bash_test.cpp
@@ -241,7 +241,7 @@ TEST_CASE( "shooting_at_terrain", "[rng][map][bash][ranged]" )
     clear_map();
 
     // Make a shooter
-    standard_npc shooter( "Shooter", { 10, 10, 0 } );
+    standard_npc shooter( "Shooter", { 30, 30, 0 } );
     shooter.set_body();
     shooter.worn.wear_item( shooter, item( itype_backpack ), false, false );
     SECTION( "birdshot vs brick wall near" ) {


### PR DESCRIPTION
#### Summary
Infrastructure "Make shooting_at_terrain test less flaky"

#### Purpose of change
Test failure on https://github.com/CleverRaven/Cataclysm-DDA/pull/81424

#### Describe the solution
Original work done by @moxian in https://github.com/CleverRaven/Cataclysm-DDA/pull/79772

Nothing added yet.

#### Testing
CI.