### PR TITLE
[Magiclysm] Rework attunement requirements

### DIFF
--- a/data/mods/Magiclysm/effect_on_conditions/attunement_choices.json
+++ b/data/mods/Magiclysm/effect_on_conditions/attunement_choices.json
@@ -2010,7 +2010,7 @@
     },
     "effect": [
       {
-        "u_message": "The altar does not respond to your touch.  While you know many spells, your knowledge of them is stil too shallow.",
+        "u_message": "The altar does not respond to your touch.  While you know many spells, your knowledge of them is still too shallow.",
         "type": "bad"
       }
     ]

--- a/data/mods/Magiclysm/effect_on_conditions/attunement_choices.json
+++ b/data/mods/Magiclysm/effect_on_conditions/attunement_choices.json
@@ -515,6 +515,7 @@
       "and": [
         { "u_has_trait": "STORMSHAPER" },
         { "u_has_trait": "TECHNOMANCER" },
+        { "not": { "u_has_trait": "ARTIFICER" } },
         {
           "not": {
             "u_has_any_trait": [
@@ -563,6 +564,7 @@
       "and": [
         { "u_has_trait": "ANIMIST" },
         { "u_has_trait": "TECHNOMANCER" },
+        { "not": { "u_has_trait": "ALCHEMIST" } },
         {
           "not": {
             "u_has_any_trait": [
@@ -609,6 +611,7 @@
       "and": [
         { "u_has_trait": "BIOMANCER" },
         { "u_has_trait": "TECHNOMANCER" },
+        { "not": { "u_has_trait": "BIOTEK" } },
         {
           "not": {
             "u_has_any_trait": [
@@ -657,6 +660,7 @@
       "and": [
         { "u_has_trait": "BIOMANCER" },
         { "u_has_trait": "ANIMIST" },
+        { "not": { "u_has_trait": "BLOOD_MAGE" } },
         {
           "not": {
             "u_has_any_trait": [
@@ -703,6 +707,7 @@
       "and": [
         { "u_has_trait": "KELVINIST" },
         { "u_has_trait": "TECHNOMANCER" },
+        { "not": { "u_has_trait": "BOREAL_MAGE" } },
         {
           "not": {
             "u_has_any_trait": [
@@ -751,6 +756,7 @@
       "and": [
         { "u_has_trait": "DRUID" },
         { "u_has_trait": "KELVINIST" },
+        { "not": { "u_has_trait": "CLEANSING_FLAME" } },
         {
           "not": {
             "u_has_any_trait": [
@@ -799,6 +805,7 @@
       "and": [
         { "u_has_trait": "DRUID" },
         { "u_has_trait": "TECHNOMANCER" },
+        { "not": { "u_has_trait": "CRUSADER" } },
         {
           "not": {
             "u_has_any_trait": [
@@ -845,6 +852,7 @@
       "and": [
         { "u_has_trait": "BIOMANCER" },
         { "u_has_trait": "EARTHSHAPER" },
+        { "not": { "u_has_trait": "EARTH_ELEMENTAL" } },
         {
           "not": {
             "u_has_any_trait": [
@@ -891,6 +899,7 @@
       "and": [
         { "u_has_trait": "BIOMANCER" },
         { "u_has_trait": "KELVINIST" },
+        { "not": { "u_has_trait": "FIRE_ELEMENTAL" } },
         {
           "not": {
             "u_has_any_trait": [
@@ -939,6 +948,7 @@
       "and": [
         { "u_has_trait": "MAGUS" },
         { "u_has_trait": "STORMSHAPER" },
+        { "not": { "u_has_trait": "FORCE_MAGE" } },
         {
           "not": {
             "u_has_any_trait": [
@@ -987,6 +997,7 @@
       "and": [
         { "u_has_trait": "DRUID" },
         { "u_has_trait": "EARTHSHAPER" },
+        { "not": { "u_has_trait": "GAIAS_CHOSEN" } },
         {
           "not": {
             "u_has_any_trait": [
@@ -1033,6 +1044,7 @@
       "and": [
         { "u_has_trait": "EARTHSHAPER" },
         { "u_has_trait": "KELVINIST" },
+        { "not": { "u_has_trait": "GLACIER_MAGE" } },
         {
           "not": {
             "u_has_any_trait": [
@@ -1085,6 +1097,7 @@
       "and": [
         { "u_has_trait": "ANIMIST" },
         { "u_has_trait": "EARTHSHAPER" },
+        { "not": { "u_has_trait": "GOLEMANCER" } },
         {
           "not": {
             "u_has_any_trait": [
@@ -1131,6 +1144,7 @@
       "and": [
         { "u_has_trait": "EARTHSHAPER" },
         { "u_has_trait": "MAGUS" },
+        { "not": { "u_has_trait": "GRAVITY_MAGE" } },
         {
           "not": {
             "u_has_any_trait": [
@@ -1177,6 +1191,7 @@
       "and": [
         { "u_has_trait": "BIOMANCER" },
         { "u_has_trait": "KELVINIST" },
+        { "not": { "u_has_trait": "ICE_ELEMENTAL" } },
         {
           "not": {
             "u_has_any_trait": [
@@ -1225,6 +1240,7 @@
       "and": [
         { "u_has_trait": "MAGUS" },
         { "u_has_trait": "TECHNOMANCER" },
+        { "not": { "u_has_trait": "ILLUSIONIST" } },
         {
           "not": {
             "u_has_any_trait": [
@@ -1271,6 +1287,7 @@
       "and": [
         { "u_has_trait": "EARTHSHAPER" },
         { "u_has_trait": "STORMSHAPER" },
+        { "not": { "u_has_trait": "MAGNETISM_MAGE" } },
         {
           "not": {
             "u_has_any_trait": [
@@ -1319,6 +1336,7 @@
       "and": [
         { "u_has_trait": "KELVINIST" },
         { "u_has_trait": "TECHNOMANCER" },
+        { "not": { "u_has_trait": "OVERCLOCKER" } },
         {
           "not": {
             "u_has_any_trait": [
@@ -1367,6 +1385,7 @@
       "and": [
         { "u_has_trait": "KELVINIST" },
         { "u_has_trait": "MAGUS" },
+        { "not": { "u_has_trait": "PERMAFROST_MAGE" } },
         {
           "not": {
             "u_has_any_trait": [
@@ -1415,6 +1434,7 @@
       "and": [
         { "u_has_trait": "ANIMIST" },
         { "u_has_trait": "STORMSHAPER" },
+        { "not": { "u_has_trait": "RADIATION_MAGE" } },
         {
           "not": {
             "u_has_any_trait": [
@@ -1467,6 +1487,7 @@
       "and": [
         { "u_has_trait": "ANIMIST" },
         { "u_has_trait": "DRUID" },
+        { "not": { "u_has_trait": "SHAMAN" } },
         {
           "not": {
             "u_has_any_trait": [
@@ -1515,6 +1536,7 @@
       "and": [
         { "u_has_trait": "BIOMANCER" },
         { "u_has_trait": "MAGUS" },
+        { "not": { "u_has_trait": "SHAPESHIFTER" } },
         {
           "not": {
             "u_has_any_trait": [
@@ -1561,6 +1583,7 @@
       "and": [
         { "u_has_trait": "ANIMIST" },
         { "u_has_trait": "KELVINIST" },
+        { "not": { "u_has_trait": "SOULFIRE" } },
         {
           "not": {
             "u_has_any_trait": [
@@ -1613,6 +1636,7 @@
       "and": [
         { "u_has_trait": "BIOMANCER" },
         { "u_has_trait": "STORMSHAPER" },
+        { "not": { "u_has_trait": "STORM_ELEMENTAL" } },
         {
           "not": {
             "u_has_any_trait": [
@@ -1661,6 +1685,7 @@
       "and": [
         { "u_has_trait": "DRUID" },
         { "u_has_trait": "STORMSHAPER" },
+        { "not": { "u_has_trait": "STORMCALLER" } },
         {
           "not": {
             "u_has_any_trait": [
@@ -1709,6 +1734,7 @@
       "and": [
         { "u_has_trait": "KELVINIST" },
         { "u_has_trait": "MAGUS" },
+        { "not": { "u_has_trait": "SUN_MAGE" } },
         {
           "not": {
             "u_has_any_trait": [
@@ -1757,6 +1783,7 @@
       "and": [
         { "u_has_trait": "DRUID" },
         { "u_has_trait": "KELVINIST" },
+        { "not": { "u_has_trait": "TUNDRA_MAGE" } },
         {
           "not": {
             "u_has_any_trait": [
@@ -1809,6 +1836,7 @@
       "and": [
         { "u_has_trait": "ANIMIST" },
         { "u_has_trait": "KELVINIST" },
+        { "not": { "u_has_trait": "VOID_MAGE" } },
         {
           "not": {
             "u_has_any_trait": [
@@ -1857,6 +1885,7 @@
       "and": [
         { "u_has_trait": "EARTHSHAPER" },
         { "u_has_trait": "KELVINIST" },
+        { "not": { "u_has_trait": "VULCANIST" } },
         {
           "not": {
             "u_has_any_trait": [
@@ -1905,6 +1934,7 @@
       "and": [
         { "u_has_trait": "DRUID" },
         { "u_has_trait": "MAGUS" },
+        { "not": { "u_has_trait": "WITHER_MAGE" } },
         {
           "not": {
             "u_has_any_trait": [

--- a/data/mods/Magiclysm/effect_on_conditions/attunement_choices.json
+++ b/data/mods/Magiclysm/effect_on_conditions/attunement_choices.json
@@ -1168,6 +1168,400 @@
   },
   {
     "type": "effect_on_condition",
+    "id": "EOC_GIVE_ATTUNEMENT_SOULFIRE",
+    "condition": {
+      "and": [
+        { "u_has_trait": "ANIMIST" },
+        { "u_has_trait": "KELVINIST" },
+        {
+          "not": {
+            "u_has_any_trait": [
+              "ARTIFICER",
+              "ALCHEMIST",
+              "BLOOD_MAGE",
+              "BOREAL_MAGE",
+              "CLEANSING_FLAME",
+              "FIRE_ELEMENTAL",
+              "FORCE_MAGE",
+              "GLACIER_MAGE",
+              "GOLEMANCER",
+              "GRAVITY_MAGE",
+              "OVERCLOCKER",
+              "ICE_ELEMENTAL",
+              "ILLUSIONIST",
+              "MAGNETISM_MAGE",
+              "PERMAFROST_MAGE",
+              "RADIATION_MAGE",
+              "SHAMAN",
+              "SHAPESHIFTER",
+              "STORM_ELEMENTAL",
+              "STORMCALLER",
+              "SUN_MAGE",
+              "TUNDRA_MAGE",
+              "VOID_MAGE",
+              "VULCANIST",
+              "WITHER_MAGE",
+              "MAGIC_EMPTY"
+            ]
+          }
+        },
+        { "math": [ "u_spell_count('school': 'ANIMIST') >= _required_spell_count" ] },
+        { "math": [ "u_spell_count('school': 'KELVINIST') >= _required_spell_count" ] },
+        { "math": [ "u_spell_level_sum('school': 'ANIMIST') >= _required_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'KELVINIST') >= _required_spell_levels" ] },
+        { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
+      ]
+    },
+    "effect": [
+      { "u_add_trait": "SOUL_PRESSURE_OFF" },
+      { "u_add_trait": "SOULFIRE" },
+      { "run_eocs": "EOC_ATTUNEMENT_SUCCESS_MESSAGE" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_GIVE_ATTUNEMENT_STORM_ELEMENTAL",
+    "condition": {
+      "and": [
+        { "u_has_trait": "BIOMANCER" },
+        { "u_has_trait": "STORMSHAPER" },
+        {
+          "not": {
+            "u_has_any_trait": [
+              "ARTIFICER",
+              "BIOTEK",
+              "BLOOD_MAGE",
+              "BOREAL_MAGE",
+              "CRUSADER",
+              "CLEANSING_FLAME",
+              "EARTH_ELEMENTAL",
+              "FIRE_ELEMENTAL",
+              "FORCE_MAGE",
+              "GAIAS_CHOSEN",
+              "GLACIER_MAGE",
+              "OVERCLOCKER",
+              "ICE_ELEMENTAL",
+              "MAGNETISM_MAGE",
+              "PERMAFROST_MAGE",
+              "RADIATION_MAGE",
+              "SHAMAN",
+              "SHAPESHIFTER",
+              "STORMCALLER",
+              "SUN_MAGE",
+              "TUNDRA_MAGE",
+              "VOID_MAGE",
+              "VULCANIST",
+              "SOULFIRE",
+              "WITHER_MAGE",
+              "MAGIC_EMPTY"
+            ]
+          }
+        },
+        { "math": [ "u_spell_count('school': 'BIOMANCER') >= _required_spell_count" ] },
+        { "math": [ "u_spell_count('school': 'STORMSHAPER') >= _required_spell_count" ] },
+        { "math": [ "u_spell_level_sum('school': 'BIOMANCER') >= _required_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'STORMSHAPER') >= _required_spell_levels" ] },
+        { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
+      ]
+    },
+    "effect": [ { "u_add_trait": "STORM_ELEMENTAL" }, { "run_eocs": "EOC_ATTUNEMENT_SUCCESS_MESSAGE" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_GIVE_ATTUNEMENT_STORMCALLER",
+    "condition": {
+      "and": [
+        { "u_has_trait": "DRUID" },
+        { "u_has_trait": "STORMSHAPER" },
+        {
+          "not": {
+            "u_has_any_trait": [
+              "ARTIFICER",
+              "BIOTEK",
+              "BLOOD_MAGE",
+              "BOREAL_MAGE",
+              "CRUSADER",
+              "CLEANSING_FLAME",
+              "EARTH_ELEMENTAL",
+              "FIRE_ELEMENTAL",
+              "FORCE_MAGE",
+              "GAIAS_CHOSEN",
+              "GLACIER_MAGE",
+              "OVERCLOCKER",
+              "ICE_ELEMENTAL",
+              "MAGNETISM_MAGE",
+              "PERMAFROST_MAGE",
+              "RADIATION_MAGE",
+              "SHAMAN",
+              "SHAPESHIFTER",
+              "STORM_ELEMENTAL",
+              "SUN_MAGE",
+              "TUNDRA_MAGE",
+              "VOID_MAGE",
+              "VULCANIST",
+              "SOULFIRE",
+              "WITHER_MAGE",
+              "MAGIC_EMPTY"
+            ]
+          }
+        },
+        { "math": [ "u_spell_count('school': 'DRUID') >= _required_spell_count" ] },
+        { "math": [ "u_spell_count('school': 'STORMSHAPER') >= _required_spell_count" ] },
+        { "math": [ "u_spell_level_sum('school': 'DRUID') >= _required_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'STORMSHAPER') >= _required_spell_levels" ] },
+        { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
+      ]
+    },
+    "effect": [ { "u_add_trait": "STORMCALLER" }, { "run_eocs": "EOC_ATTUNEMENT_SUCCESS_MESSAGE" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_GIVE_ATTUNEMENT_SUN_MAGE",
+    "condition": {
+      "and": [
+        { "u_has_trait": "KELVINIST" },
+        { "u_has_trait": "MAGUS" },
+        {
+          "not": {
+            "u_has_any_trait": [
+              "ARTIFICER",
+              "ALCHEMIST",
+              "BLOOD_MAGE",
+              "BOREAL_MAGE",
+              "CLEANSING_FLAME",
+              "FIRE_ELEMENTAL",
+              "FORCE_MAGE",
+              "GLACIER_MAGE",
+              "GOLEMANCER",
+              "GRAVITY_MAGE",
+              "OVERCLOCKER",
+              "ICE_ELEMENTAL",
+              "ILLUSIONIST",
+              "MAGNETISM_MAGE",
+              "PERMAFROST_MAGE",
+              "RADIATION_MAGE",
+              "SHAMAN",
+              "SHAPESHIFTER",
+              "STORM_ELEMENTAL",
+              "STORMCALLER",
+              "TUNDRA_MAGE",
+              "VOID_MAGE",
+              "VULCANIST",
+              "SOULFIRE",
+              "WITHER_MAGE",
+              "MAGIC_EMPTY"
+            ]
+          }
+        },
+        { "math": [ "u_spell_count('school': 'KELVINIST') >= _required_spell_count" ] },
+        { "math": [ "u_spell_count('school': 'MAGUS') >= _required_spell_count" ] },
+        { "math": [ "u_spell_level_sum('school': 'KELVINIST') >= _required_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'MAGUS') >= _required_spell_levels" ] },
+        { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
+      ]
+    },
+    "effect": [ { "u_add_trait": "SUN_MAGE" }, { "run_eocs": "EOC_ATTUNEMENT_SUCCESS_MESSAGE" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_GIVE_ATTUNEMENT_TUNDRA_MAGE",
+    "condition": {
+      "and": [
+        { "u_has_trait": "DRUID" },
+        { "u_has_trait": "KELVINIST" },
+        {
+          "not": {
+            "u_has_any_trait": [
+              "ARTIFICER",
+              "BIOTEK",
+              "BLOOD_MAGE",
+              "BOREAL_MAGE",
+              "CRUSADER",
+              "CLEANSING_FLAME",
+              "EARTH_ELEMENTAL",
+              "FIRE_ELEMENTAL",
+              "FORCE_MAGE",
+              "GAIAS_CHOSEN",
+              "GLACIER_MAGE",
+              "OVERCLOCKER",
+              "ICE_ELEMENTAL",
+              "MAGNETISM_MAGE",
+              "PERMAFROST_MAGE",
+              "RADIATION_MAGE",
+              "SHAMAN",
+              "SHAPESHIFTER",
+              "STORM_ELEMENTAL",
+              "STORMCALLER",
+              "SUN_MAGE",
+              "VOID_MAGE",
+              "VULCANIST",
+              "SOULFIRE",
+              "WITHER_MAGE",
+              "MAGIC_EMPTY"
+            ]
+          }
+        },
+        { "math": [ "u_spell_count('school': 'DRUID') >= _required_spell_count" ] },
+        { "math": [ "u_spell_count('school': 'KELVINIST') >= _required_spell_count" ] },
+        { "math": [ "u_spell_level_sum('school': 'DRUID') >= _required_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'KELVINIST') >= _required_spell_levels" ] },
+        { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
+      ]
+    },
+    "effect": [
+      { "u_add_trait": "FREEZING_AURA_OFF" },
+      { "u_add_trait": "TUNDRA_MAGE" },
+      { "run_eocs": "EOC_ATTUNEMENT_SUCCESS_MESSAGE" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_GIVE_ATTUNEMENT_VOID_MAGE",
+    "condition": {
+      "and": [
+        { "u_has_trait": "ANIMIST" },
+        { "u_has_trait": "KELVINIST" },
+        {
+          "not": {
+            "u_has_any_trait": [
+              "ARTIFICER",
+              "ALCHEMIST",
+              "BLOOD_MAGE",
+              "BOREAL_MAGE",
+              "CLEANSING_FLAME",
+              "FIRE_ELEMENTAL",
+              "FORCE_MAGE",
+              "GLACIER_MAGE",
+              "GOLEMANCER",
+              "GRAVITY_MAGE",
+              "OVERCLOCKER",
+              "ICE_ELEMENTAL",
+              "ILLUSIONIST",
+              "MAGNETISM_MAGE",
+              "PERMAFROST_MAGE",
+              "RADIATION_MAGE",
+              "SHAMAN",
+              "SHAPESHIFTER",
+              "STORM_ELEMENTAL",
+              "STORMCALLER",
+              "SUN_MAGE",
+              "TUNDRA_MAGE",
+              "VULCANIST",
+              "SOULFIRE",
+              "WITHER_MAGE",
+              "MAGIC_EMPTY"
+            ]
+          }
+        },
+        { "math": [ "u_spell_count('school': 'ANIMIST') >= _required_spell_count" ] },
+        { "math": [ "u_spell_count('school': 'KELVINIST') >= _required_spell_count" ] },
+        { "math": [ "u_spell_level_sum('school': 'ANIMIST') >= _required_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'KELVINIST') >= _required_spell_levels" ] },
+        { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
+      ]
+    },
+    "effect": [ { "u_add_trait": "VOID_MAGE" }, { "run_eocs": "EOC_ATTUNEMENT_SUCCESS_MESSAGE" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_GIVE_ATTUNEMENT_VULCANIST",
+    "condition": {
+      "and": [
+        { "u_has_trait": "EARTHSHAPER" },
+        { "u_has_trait": "KELVINIST" },
+        {
+          "not": {
+            "u_has_any_trait": [
+              "ARTIFICER",
+              "ALCHEMIST",
+              "BIOTEK",
+              "BOREAL_MAGE",
+              "CRUSADER",
+              "CLEANSING_FLAME",
+              "EARTH_ELEMENTAL",
+              "FIRE_ELEMENTAL",
+              "FORCE_MAGE",
+              "GAIAS_CHOSEN",
+              "GLACIER_MAGE",
+              "GOLEMANCER",
+              "GRAVITY_MAGE",
+              "OVERCLOCKER",
+              "ICE_ELEMENTAL",
+              "ILLUSIONIST",
+              "MAGNETISM_MAGE",
+              "PERMAFROST_MAGE",
+              "RADIATION_MAGE",
+              "STORM_ELEMENTAL",
+              "STORMCALLER",
+              "SUN_MAGE",
+              "TUNDRA_MAGE",
+              "VOID_MAGE",
+              "SOULFIRE",
+              "MAGIC_EMPTY"
+            ]
+          }
+        },
+        { "math": [ "u_spell_count('school': 'EARTHSHAPER') >= _required_spell_count" ] },
+        { "math": [ "u_spell_count('school': 'KELVINIST') >= _required_spell_count" ] },
+        { "math": [ "u_spell_level_sum('school': 'EARTHSHAPER') >= _required_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'KELVINIST') >= _required_spell_levels" ] },
+        { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
+      ]
+    },
+    "effect": [ { "u_add_trait": "VULCANIST" }, { "run_eocs": "EOC_ATTUNEMENT_SUCCESS_MESSAGE" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_GIVE_ATTUNEMENT_WITHER_MAGE",
+    "condition": {
+      "and": [
+        { "u_has_trait": "DRUID" },
+        { "u_has_trait": "MAGUS" },
+        {
+          "not": {
+            "u_has_any_trait": [
+              "ALCHEMIST",
+              "BIOTEK",
+              "BLOOD_MAGE",
+              "CRUSADER",
+              "CLEANSING_FLAME",
+              "EARTH_ELEMENTAL",
+              "FIRE_ELEMENTAL",
+              "FORCE_MAGE",
+              "GAIAS_CHOSEN",
+              "GOLEMANCER",
+              "GRAVITY_MAGE",
+              "ICE_ELEMENTAL",
+              "ILLUSIONIST",
+              "PERMAFROST_MAGE",
+              "RADIATION_MAGE",
+              "SHAMAN",
+              "SHAPESHIFTER",
+              "STORM_ELEMENTAL",
+              "STORMCALLER",
+              "SUN_MAGE",
+              "TUNDRA_MAGE",
+              "VOID_MAGE",
+              "SOULFIRE",
+              "MAGIC_EMPTY"
+            ]
+          }
+        },
+        { "math": [ "u_spell_count('school': 'DRUID') >= _required_spell_count" ] },
+        { "math": [ "u_spell_count('school': 'MAGUS') >= _required_spell_count" ] },
+        { "math": [ "u_spell_level_sum('school': 'DRUID') >= _required_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'MAGUS') >= _required_spell_levels" ] },
+        { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
+      ]
+    },
+    "effect": [
+      { "u_add_trait": "TOXIC_AURA_OFF" },
+      { "u_add_trait": "WITHER_MAGE" },
+      { "run_eocs": "EOC_ATTUNEMENT_SUCCESS_MESSAGE" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
     "id": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY",
     "condition": {
       "or": [

--- a/data/mods/Magiclysm/effect_on_conditions/attunement_choices.json
+++ b/data/mods/Magiclysm/effect_on_conditions/attunement_choices.json
@@ -974,6 +974,200 @@
   },
   {
     "type": "effect_on_condition",
+    "id": "EOC_GIVE_ATTUNEMENT_PERMAFROST_MAGE",
+    "condition": {
+      "and": [
+        { "u_has_trait": "KELVINIST" },
+        { "u_has_trait": "MAGUS" },
+        {
+          "not": {
+            "u_has_any_trait": [
+              "ARTIFICER",
+              "ALCHEMIST",
+              "BLOOD_MAGE",
+              "BOREAL_MAGE",
+              "CLEANSING_FLAME",
+              "FIRE_ELEMENTAL",
+              "FORCE_MAGE",
+              "GLACIER_MAGE",
+              "GOLEMANCER",
+              "GRAVITY_MAGE",
+              "OVERCLOCKER",
+              "ICE_ELEMENTAL",
+              "ILLUSIONIST",
+              "MAGNETISM_MAGE",
+              "RADIATION_MAGE",
+              "SHAMAN",
+              "SHAPESHIFTER",
+              "STORM_ELEMENTAL",
+              "STORMCALLER",
+              "SUN_MAGE",
+              "TUNDRA_MAGE",
+              "VOID_MAGE",
+              "VULCANIST",
+              "SOULFIRE",
+              "WITHER_MAGE",
+              "MAGIC_EMPTY"
+            ]
+          }
+        },
+        { "math": [ "u_spell_count('school': 'KELVINIST') >= _required_spell_count" ] },
+        { "math": [ "u_spell_count('school': 'MAGUS') >= _required_spell_count" ] },
+        { "math": [ "u_spell_level_sum('school': 'KELVINIST') >= _required_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'MAGUS') >= _required_spell_levels" ] },
+        { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
+      ]
+    },
+    "effect": [ { "u_add_trait": "PERMAFROST_MAGE" }, { "run_eocs": "EOC_ATTUNEMENT_SUCCESS_MESSAGE" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_GIVE_ATTUNEMENT_RADIATION_MAGE",
+    "condition": {
+      "and": [
+        { "u_has_trait": "ANIMIST" },
+        { "u_has_trait": "STORMSHAPER" },
+        {
+          "not": {
+            "u_has_any_trait": [
+              "ARTIFICER",
+              "ALCHEMIST",
+              "BLOOD_MAGE",
+              "BOREAL_MAGE",
+              "CLEANSING_FLAME",
+              "FIRE_ELEMENTAL",
+              "FORCE_MAGE",
+              "GLACIER_MAGE",
+              "GOLEMANCER",
+              "GRAVITY_MAGE",
+              "OVERCLOCKER",
+              "ICE_ELEMENTAL",
+              "ILLUSIONIST",
+              "MAGNETISM_MAGE",
+              "PERMAFROST_MAGE",
+              "SHAMAN",
+              "SHAPESHIFTER",
+              "STORM_ELEMENTAL",
+              "STORMCALLER",
+              "SUN_MAGE",
+              "TUNDRA_MAGE",
+              "VOID_MAGE",
+              "VULCANIST",
+              "SOULFIRE",
+              "WITHER_MAGE",
+              "MAGIC_EMPTY"
+            ]
+          }
+        },
+        { "math": [ "u_spell_count('school': 'ANIMIST') >= _required_spell_count" ] },
+        { "math": [ "u_spell_count('school': 'STORMSHAPER') >= _required_spell_count" ] },
+        { "math": [ "u_spell_level_sum('school': 'ANIMIST') >= _required_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'STORMSHAPER') >= _required_spell_levels" ] },
+        { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
+      ]
+    },
+    "effect": [
+      { "u_add_trait": "CLAIRVOYANCE_OFF" },
+      { "u_add_trait": "RADIATION_MAGE" },
+      { "run_eocs": "EOC_ATTUNEMENT_SUCCESS_MESSAGE" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_GIVE_ATTUNEMENT_SHAMAN",
+    "condition": {
+      "and": [
+        { "u_has_trait": "ANIMIST" },
+        { "u_has_trait": "DRUID" },
+        {
+          "not": {
+            "u_has_any_trait": [
+              "ARTIFICER",
+              "ALCHEMIST",
+              "BLOOD_MAGE",
+              "BOREAL_MAGE",
+              "CLEANSING_FLAME",
+              "FIRE_ELEMENTAL",
+              "FORCE_MAGE",
+              "GLACIER_MAGE",
+              "GOLEMANCER",
+              "GRAVITY_MAGE",
+              "OVERCLOCKER",
+              "ICE_ELEMENTAL",
+              "ILLUSIONIST",
+              "MAGNETISM_MAGE",
+              "RADIATION_MAGE",
+              "SHAMAN",
+              "SHAPESHIFTER",
+              "STORM_ELEMENTAL",
+              "STORMCALLER",
+              "SUN_MAGE",
+              "TUNDRA_MAGE",
+              "VOID_MAGE",
+              "VULCANIST",
+              "SOULFIRE",
+              "WITHER_MAGE",
+              "MAGIC_EMPTY"
+            ]
+          }
+        },
+        { "math": [ "u_spell_count('school': 'ANIMIST') >= _required_spell_count" ] },
+        { "math": [ "u_spell_count('school': 'DRUID') >= _required_spell_count" ] },
+        { "math": [ "u_spell_level_sum('school': 'ANIMIST') >= _required_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'DRUID') >= _required_spell_levels" ] },
+        { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
+      ]
+    },
+    "effect": [ { "u_add_trait": "MIND_READ_OFF" }, { "u_add_trait": "SHAMAN" }, { "run_eocs": "EOC_ATTUNEMENT_SUCCESS_MESSAGE" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_GIVE_ATTUNEMENT_SHAPESHIFTER",
+    "condition": {
+      "and": [
+        { "u_has_trait": "BIOMANCER" },
+        { "u_has_trait": "MAGUS" },
+        {
+          "not": {
+            "u_has_any_trait": [
+              "ALCHEMIST",
+              "BIOTEK",
+              "BLOOD_MAGE",
+              "CRUSADER",
+              "CLEANSING_FLAME",
+              "EARTH_ELEMENTAL",
+              "FIRE_ELEMENTAL",
+              "FORCE_MAGE",
+              "GAIAS_CHOSEN",
+              "GOLEMANCER",
+              "GRAVITY_MAGE",
+              "ICE_ELEMENTAL",
+              "ILLUSIONIST",
+              "PERMAFROST_MAGE",
+              "RADIATION_MAGE",
+              "SHAMAN",
+              "STORM_ELEMENTAL",
+              "STORMCALLER",
+              "SUN_MAGE",
+              "TUNDRA_MAGE",
+              "VOID_MAGE",
+              "SOULFIRE",
+              "WITHER_MAGE",
+              "MAGIC_EMPTY"
+            ]
+          }
+        },
+        { "math": [ "u_spell_count('school': 'BIOMANCER') >= _required_spell_count" ] },
+        { "math": [ "u_spell_count('school': 'MAGUS') >= _required_spell_count" ] },
+        { "math": [ "u_spell_level_sum('school': 'BIOMANCER') >= _required_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'MAGUS') >= _required_spell_levels" ] },
+        { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
+      ]
+    },
+    "effect": [ { "u_add_trait": "SHAPESHIFTER" }, { "run_eocs": "EOC_ATTUNEMENT_SUCCESS_MESSAGE" } ]
+  },
+  {
+    "type": "effect_on_condition",
     "id": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY",
     "condition": {
       "or": [

--- a/data/mods/Magiclysm/effect_on_conditions/attunement_choices.json
+++ b/data/mods/Magiclysm/effect_on_conditions/attunement_choices.json
@@ -3,8 +3,8 @@
     "type": "effect_on_condition",
     "id": "EOC_CHECK_ATTUNEMENTS",
     "effect": [
-      { "math": [ "_required_spell_count = 10" ] },
-      { "math": [ "_required_spell_levels = 150" ] },
+      { "math": [ "_required_spell_count = 12" ] },
+      { "math": [ "_required_spell_levels = 200" ] },
       {
         "run_eoc_selector": [
           "EOC_GIVE_ATTUNEMENT_ARTIFICER",

--- a/data/mods/Magiclysm/effect_on_conditions/attunement_choices.json
+++ b/data/mods/Magiclysm/effect_on_conditions/attunement_choices.json
@@ -5,6 +5,8 @@
     "effect": [
       { "math": [ "_required_spell_count = 12" ] },
       { "math": [ "_required_spell_levels = 200" ] },
+      { "run_eoc": "EOC_CHECK_ATTUNEMENT_CHECK_SPELL_LEVELS" },
+      { "run_eoc": "EOC_CHECK_ATTUNEMENT_CHECK_SPELL_COUNT" },
       {
         "run_eoc_selector": [
           "EOC_GIVE_ATTUNEMENT_ARTIFICER",
@@ -1558,6 +1560,429 @@
       { "u_add_trait": "TOXIC_AURA_OFF" },
       { "u_add_trait": "WITHER_MAGE" },
       { "run_eocs": "EOC_ATTUNEMENT_SUCCESS_MESSAGE" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_CANT_GIVE_ATTUNEMENT_NOT_A_MAGE",
+    "condition": {
+      "not": {
+        "u_has_any_trait": [ "ANIMIST", "BIOMANCER", "DRUID", "EARTHSHAPER", "KELVINIST", "MAGUS", "STORMSHAPER", "TECHNOMANCER" ]
+      }
+    },
+    "effect": [ { "u_message": "The altar does not respond to your touch.  Only a mage can unlock its secrets.", "type": "neutral" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_CHECK_ATTUNEMENT_CHECK_SPELL_LEVELS",
+    "//": "FIXME: some better way of handling this",
+    "condition": {
+      "and": [
+        {
+          "and": [
+            { "math": [ "u_spell_count('school': 'ANIMIST') < _required_spell_count" ] },
+            { "math": [ "u_spell_count('school': 'BIOMANCER') < _required_spell_count" ] }
+          ]
+        },
+        {
+          "and": [
+            { "math": [ "u_spell_count('school': 'ANIMIST') < _required_spell_count" ] },
+            { "math": [ "u_spell_count('school': 'DRUID') < _required_spell_count" ] }
+          ]
+        },
+        {
+          "and": [
+            { "math": [ "u_spell_count('school': 'ANIMIST') < _required_spell_count" ] },
+            { "math": [ "u_spell_count('school': 'EARTHSHAPER') < _required_spell_count" ] }
+          ]
+        },
+        {
+          "and": [
+            { "math": [ "u_spell_count('school': 'ANIMIST') < _required_spell_count" ] },
+            { "math": [ "u_spell_count('school': 'KELVINIST') < _required_spell_count" ] }
+          ]
+        },
+        {
+          "and": [
+            { "math": [ "u_spell_count('school': 'ANIMIST') < _required_spell_count" ] },
+            { "math": [ "u_spell_count('school': 'MAGUS') < _required_spell_count" ] }
+          ]
+        },
+        {
+          "and": [
+            { "math": [ "u_spell_count('school': 'ANIMIST') < _required_spell_count" ] },
+            { "math": [ "u_spell_count('school': 'STORMSHAPER') < _required_spell_count" ] }
+          ]
+        },
+        {
+          "and": [
+            { "math": [ "u_spell_count('school': 'ANIMIST') < _required_spell_count" ] },
+            { "math": [ "u_spell_count('school': 'TECHNOMANCER') < _required_spell_count" ] }
+          ]
+        },
+        {
+          "and": [
+            { "math": [ "u_spell_count('school': 'BIOMANCER') < _required_spell_count" ] },
+            { "math": [ "u_spell_count('school': 'DRUID') < _required_spell_count" ] }
+          ]
+        },
+        {
+          "and": [
+            { "math": [ "u_spell_count('school': 'BIOMANCER') < _required_spell_count" ] },
+            { "math": [ "u_spell_count('school': 'EARTHSHAPER') < _required_spell_count" ] }
+          ]
+        },
+        {
+          "and": [
+            { "math": [ "u_spell_count('school': 'BIOMANCER') < _required_spell_count" ] },
+            { "math": [ "u_spell_count('school': 'KELVINIST') < _required_spell_count" ] }
+          ]
+        },
+        {
+          "and": [
+            { "math": [ "u_spell_count('school': 'BIOMANCER') < _required_spell_count" ] },
+            { "math": [ "u_spell_count('school': 'MAGUS') < _required_spell_count" ] }
+          ]
+        },
+        {
+          "and": [
+            { "math": [ "u_spell_count('school': 'BIOMANCER') < _required_spell_count" ] },
+            { "math": [ "u_spell_count('school': 'STORMSHAPER') < _required_spell_count" ] }
+          ]
+        },
+        {
+          "and": [
+            { "math": [ "u_spell_count('school': 'BIOMANCER') < _required_spell_count" ] },
+            { "math": [ "u_spell_count('school': 'TECHNOMANCER') < _required_spell_count" ] }
+          ]
+        },
+        {
+          "and": [
+            { "math": [ "u_spell_count('school': 'DRUID') < _required_spell_count" ] },
+            { "math": [ "u_spell_count('school': 'EARTHSHAPER') < _required_spell_count" ] }
+          ]
+        },
+        {
+          "and": [
+            { "math": [ "u_spell_count('school': 'DRUID') < _required_spell_count" ] },
+            { "math": [ "u_spell_count('school': 'KELVINIST') < _required_spell_count" ] }
+          ]
+        },
+        {
+          "and": [
+            { "math": [ "u_spell_count('school': 'DRUID') < _required_spell_count" ] },
+            { "math": [ "u_spell_count('school': 'MAGUS') < _required_spell_count" ] }
+          ]
+        },
+        {
+          "and": [
+            { "math": [ "u_spell_count('school': 'DRUID') < _required_spell_count" ] },
+            { "math": [ "u_spell_count('school': 'STORMSHAPER') < _required_spell_count" ] }
+          ]
+        },
+        {
+          "and": [
+            { "math": [ "u_spell_count('school': 'DRUID') < _required_spell_count" ] },
+            { "math": [ "u_spell_count('school': 'TECHNOMANCER') < _required_spell_count" ] }
+          ]
+        },
+        {
+          "and": [
+            { "math": [ "u_spell_count('school': 'EARTHSHAPER') < _required_spell_count" ] },
+            { "math": [ "u_spell_count('school': 'KELVINIST') < _required_spell_count" ] }
+          ]
+        },
+        {
+          "and": [
+            { "math": [ "u_spell_count('school': 'EARTHSHAPER') < _required_spell_count" ] },
+            { "math": [ "u_spell_count('school': 'MAGUS') < _required_spell_count" ] }
+          ]
+        },
+        {
+          "and": [
+            { "math": [ "u_spell_count('school': 'EARTHSHAPER') < _required_spell_count" ] },
+            { "math": [ "u_spell_count('school': 'STORMSHAPER') < _required_spell_count" ] }
+          ]
+        },
+        {
+          "and": [
+            { "math": [ "u_spell_count('school': 'EARTHSHAPER') < _required_spell_count" ] },
+            { "math": [ "u_spell_count('school': 'TECHNOMANCER') < _required_spell_count" ] }
+          ]
+        },
+        {
+          "and": [
+            { "math": [ "u_spell_count('school': 'KELVINIST') < _required_spell_count" ] },
+            { "math": [ "u_spell_count('school': 'MAGUS') < _required_spell_count" ] }
+          ]
+        },
+        {
+          "and": [
+            { "math": [ "u_spell_count('school': 'KELVINIST') < _required_spell_count" ] },
+            { "math": [ "u_spell_count('school': 'STORMSHAPER') < _required_spell_count" ] }
+          ]
+        },
+        {
+          "and": [
+            { "math": [ "u_spell_count('school': 'KELVINIST') < _required_spell_count" ] },
+            { "math": [ "u_spell_count('school': 'TECHNOMANCER') < _required_spell_count" ] }
+          ]
+        },
+        {
+          "and": [
+            { "math": [ "u_spell_count('school': 'MAGUS') < _required_spell_count" ] },
+            { "math": [ "u_spell_count('school': 'STORMSHAPER') < _required_spell_count" ] }
+          ]
+        },
+        {
+          "and": [
+            { "math": [ "u_spell_count('school': 'MAGUS') < _required_spell_count" ] },
+            { "math": [ "u_spell_count('school': 'TECHNOMANCER') < _required_spell_count" ] }
+          ]
+        },
+        {
+          "and": [
+            { "math": [ "u_spell_count('school': 'STORMSHAPER') < _required_spell_count" ] },
+            { "math": [ "u_spell_count('school': 'TECHNOMANCER') < _required_spell_count" ] }
+          ]
+        }
+      ]
+    },
+    "effect": [
+      {
+        "if": {
+          "u_has_any_trait": [ "ANIMIST", "BIOMANCER", "DRUID", "EARTHSHAPER", "KELVINIST", "MAGUS", "STORMSHAPER", "TECHNOMANCER" ]
+        },
+        "then": { "math": [ "_required_spell_count_is_met = 0" ] },
+        "else": { "math": [ "_required_spell_count_is_met = -1" ] }
+      }
+    ],
+    "false_effect": [ { "math": [ "_required_spell_count_is_met = 1" ] } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_CANT_GIVE_ATTUNEMENT_NOT_ENOUGH_SPELLS",
+    "condition": { "math": [ "_required_spell_count_is_met == 0" ] },
+    "effect": [
+      {
+        "u_message": "The altar does not respond to your touch.  You need more breadth in your spell selection before you can attempt attunement.",
+        "type": "bad"
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_CANT_GIVE_ATTUNEMENT_NOT_ENOUGH_SPELL_LEVELS",
+    "//": "FIXME: some better way of handling this",
+    "condition": {
+      "and": [
+        {
+          "and": [
+            { "math": [ "u_spell_level_sum('school': 'ANIMIST') < _required_spell_levels" ] },
+            { "math": [ "u_spell_level_sum('school': 'BIOMANCER') < _required_spell_levels" ] }
+          ]
+        },
+        {
+          "and": [
+            { "math": [ "u_spell_level_sum('school': 'ANIMIST') < _required_spell_levels" ] },
+            { "math": [ "u_spell_level_sum('school': 'DRUID') < _required_spell_levels" ] }
+          ]
+        },
+        {
+          "and": [
+            { "math": [ "u_spell_level_sum('school': 'ANIMIST') < _required_spell_levels" ] },
+            { "math": [ "u_spell_level_sum('school': 'EARTHSHAPER') < _required_spell_levels" ] }
+          ]
+        },
+        {
+          "and": [
+            { "math": [ "u_spell_level_sum('school': 'ANIMIST') < _required_spell_levels" ] },
+            { "math": [ "u_spell_level_sum('school': 'KELVINIST') < _required_spell_levels" ] }
+          ]
+        },
+        {
+          "and": [
+            { "math": [ "u_spell_level_sum('school': 'ANIMIST') < _required_spell_levels" ] },
+            { "math": [ "u_spell_level_sum('school': 'MAGUS') < _required_spell_levels" ] }
+          ]
+        },
+        {
+          "and": [
+            { "math": [ "u_spell_level_sum('school': 'ANIMIST') < _required_spell_levels" ] },
+            { "math": [ "u_spell_level_sum('school': 'STORMSHAPER') < _required_spell_levels" ] }
+          ]
+        },
+        {
+          "and": [
+            { "math": [ "u_spell_level_sum('school': 'ANIMIST') < _required_spell_levels" ] },
+            { "math": [ "u_spell_level_sum('school': 'TECHNOMANCER') < _required_spell_levels" ] }
+          ]
+        },
+        {
+          "and": [
+            { "math": [ "u_spell_level_sum('school': 'BIOMANCER') < _required_spell_levels" ] },
+            { "math": [ "u_spell_level_sum('school': 'DRUID') < _required_spell_levels" ] }
+          ]
+        },
+        {
+          "and": [
+            { "math": [ "u_spell_level_sum('school': 'BIOMANCER') < _required_spell_levels" ] },
+            { "math": [ "u_spell_level_sum('school': 'EARTHSHAPER') < _required_spell_levels" ] }
+          ]
+        },
+        {
+          "and": [
+            { "math": [ "u_spell_level_sum('school': 'BIOMANCER') < _required_spell_levels" ] },
+            { "math": [ "u_spell_level_sum('school': 'KELVINIST') < _required_spell_levels" ] }
+          ]
+        },
+        {
+          "and": [
+            { "math": [ "u_spell_level_sum('school': 'BIOMANCER') < _required_spell_levels" ] },
+            { "math": [ "u_spell_level_sum('school': 'MAGUS') < _required_spell_levels" ] }
+          ]
+        },
+        {
+          "and": [
+            { "math": [ "u_spell_level_sum('school': 'BIOMANCER') < _required_spell_levels" ] },
+            { "math": [ "u_spell_level_sum('school': 'STORMSHAPER') < _required_spell_levels" ] }
+          ]
+        },
+        {
+          "and": [
+            { "math": [ "u_spell_level_sum('school': 'BIOMANCER') < _required_spell_levels" ] },
+            { "math": [ "u_spell_level_sum('school': 'TECHNOMANCER') < _required_spell_levels" ] }
+          ]
+        },
+        {
+          "and": [
+            { "math": [ "u_spell_level_sum('school': 'DRUID') < _required_spell_levels" ] },
+            { "math": [ "u_spell_level_sum('school': 'EARTHSHAPER') < _required_spell_levels" ] }
+          ]
+        },
+        {
+          "and": [
+            { "math": [ "u_spell_level_sum('school': 'DRUID') < _required_spell_levels" ] },
+            { "math": [ "u_spell_level_sum('school': 'KELVINIST') < _required_spell_levels" ] }
+          ]
+        },
+        {
+          "and": [
+            { "math": [ "u_spell_level_sum('school': 'DRUID') < _required_spell_levels" ] },
+            { "math": [ "u_spell_level_sum('school': 'MAGUS') < _required_spell_levels" ] }
+          ]
+        },
+        {
+          "and": [
+            { "math": [ "u_spell_level_sum('school': 'DRUID') < _required_spell_levels" ] },
+            { "math": [ "u_spell_level_sum('school': 'STORMSHAPER') < _required_spell_levels" ] }
+          ]
+        },
+        {
+          "and": [
+            { "math": [ "u_spell_level_sum('school': 'DRUID') < _required_spell_levels" ] },
+            { "math": [ "u_spell_level_sum('school': 'TECHNOMANCER') < _required_spell_levels" ] }
+          ]
+        },
+        {
+          "and": [
+            { "math": [ "u_spell_level_sum('school': 'EARTHSHAPER') < _required_spell_levels" ] },
+            { "math": [ "u_spell_level_sum('school': 'KELVINIST') < _required_spell_levels" ] }
+          ]
+        },
+        {
+          "and": [
+            { "math": [ "u_spell_level_sum('school': 'EARTHSHAPER') < _required_spell_levels" ] },
+            { "math": [ "u_spell_level_sum('school': 'MAGUS') < _required_spell_levels" ] }
+          ]
+        },
+        {
+          "and": [
+            { "math": [ "u_spell_level_sum('school': 'EARTHSHAPER') < _required_spell_levels" ] },
+            { "math": [ "u_spell_level_sum('school': 'STORMSHAPER') < _required_spell_levels" ] }
+          ]
+        },
+        {
+          "and": [
+            { "math": [ "u_spell_level_sum('school': 'EARTHSHAPER') < _required_spell_levels" ] },
+            { "math": [ "u_spell_level_sum('school': 'TECHNOMANCER') < _required_spell_levels" ] }
+          ]
+        },
+        {
+          "and": [
+            { "math": [ "u_spell_level_sum('school': 'KELVINIST') < _required_spell_levels" ] },
+            { "math": [ "u_spell_level_sum('school': 'MAGUS') < _required_spell_levels" ] }
+          ]
+        },
+        {
+          "and": [
+            { "math": [ "u_spell_level_sum('school': 'KELVINIST') < _required_spell_levels" ] },
+            { "math": [ "u_spell_level_sum('school': 'STORMSHAPER') < _required_spell_levels" ] }
+          ]
+        },
+        {
+          "and": [
+            { "math": [ "u_spell_level_sum('school': 'KELVINIST') < _required_spell_levels" ] },
+            { "math": [ "u_spell_level_sum('school': 'TECHNOMANCER') < _required_spell_levels" ] }
+          ]
+        },
+        {
+          "and": [
+            { "math": [ "u_spell_level_sum('school': 'MAGUS') < _required_spell_levels" ] },
+            { "math": [ "u_spell_level_sum('school': 'STORMSHAPER') < _required_spell_levels" ] }
+          ]
+        },
+        {
+          "and": [
+            { "math": [ "u_spell_level_sum('school': 'MAGUS') < _required_spell_levels" ] },
+            { "math": [ "u_spell_level_sum('school': 'TECHNOMANCER') < _required_spell_levels" ] }
+          ]
+        },
+        {
+          "and": [
+            { "math": [ "u_spell_level_sum('school': 'STORMSHAPER') < _required_spell_levels" ] },
+            { "math": [ "u_spell_level_sum('school': 'TECHNOMANCER') < _required_spell_levels" ] }
+          ]
+        }
+      ]
+    },
+    "effect": [
+      {
+        "if": {
+          "u_has_any_trait": [ "ANIMIST", "BIOMANCER", "DRUID", "EARTHSHAPER", "KELVINIST", "MAGUS", "STORMSHAPER", "TECHNOMANCER" ]
+        },
+        "then": { "math": [ "_required_spell_levels_is_met = 0" ] },
+        "else": { "math": [ "_required_spell_levels_is_met = -1" ] }
+      }
+    ],
+    "false_effect": [ { "math": [ "_required_spell_levels_is_met = 1" ] } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_CANT_GIVE_ATTUNEMENT_NOT_ENOUGH_SPELL_LEVELS",
+    "condition": { "math": [ "_required_spell_levels_is_met == 0" ] },
+    "effect": [
+      {
+        "u_message": "The altar does not respond to your touch.  While you know many spells, your knowledge of them is stil too shallow.",
+        "type": "bad"
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_CANT_GIVE_ATTUNEMENT_NOT_ENOUGH_PROFICIENCIES",
+    "condition": {
+      "and": [
+        { "math": [ "_required_spell_count_is_met == 1" ] },
+        { "math": [ "_required_spell_levels_is_met == 1" ] },
+        { "not": { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" } }
+      ]
+    },
+    "effect": [
+      {
+        "u_message": "The altar does not respond to your touch.  While your knowledge of spells is considerable, your understanding of the fundamentals of spellcasting needs work.",
+        "type": "bad"
+      }
     ]
   },
   {

--- a/data/mods/Magiclysm/effect_on_conditions/attunement_choices.json
+++ b/data/mods/Magiclysm/effect_on_conditions/attunement_choices.json
@@ -5,8 +5,8 @@
     "effect": [
       { "math": [ "_required_spell_count = 12" ] },
       { "math": [ "_required_spell_levels = 200" ] },
-      { "run_eoc": "EOC_CHECK_ATTUNEMENT_CHECK_SPELL_LEVELS" },
-      { "run_eoc": "EOC_CHECK_ATTUNEMENT_CHECK_SPELL_COUNT" },
+      { "run_eocs": "EOC_CHECK_ATTUNEMENT_CHECK_SPELL_LEVELS" },
+      { "run_eocs": "EOC_CHECK_ATTUNEMENT_CHECK_SPELL_COUNT" },
       {
         "run_eoc_selector": [
           "EOC_GIVE_ATTUNEMENT_ARTIFICER",
@@ -1753,7 +1753,7 @@
         "if": {
           "u_has_any_trait": [ "ANIMIST", "BIOMANCER", "DRUID", "EARTHSHAPER", "KELVINIST", "MAGUS", "STORMSHAPER", "TECHNOMANCER" ]
         },
-        "then": { "math": [ "_required_spell_count_is_met = 0" ] },
+        "then": { "math": [ "_required_spell_count_is_met = -2" ] },
         "else": { "math": [ "_required_spell_count_is_met = -1" ] }
       }
     ],
@@ -1762,7 +1762,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_CANT_GIVE_ATTUNEMENT_NOT_ENOUGH_SPELLS",
-    "condition": { "math": [ "_required_spell_count_is_met == 0" ] },
+    "condition": { "math": [ "_required_spell_count_is_met == -2" ] },
     "effect": [
       {
         "u_message": "The altar does not respond to your touch.  You need more breadth in your spell selection before you can attempt attunement.",
@@ -1772,7 +1772,7 @@
   },
   {
     "type": "effect_on_condition",
-    "id": "EOC_CANT_GIVE_ATTUNEMENT_NOT_ENOUGH_SPELL_LEVELS",
+    "id": "EOC_CHECK_ATTUNEMENT_CHECK_SPELL_COUNT",
     "//": "FIXME: some better way of handling this",
     "condition": {
       "and": [
@@ -1951,7 +1951,7 @@
         "if": {
           "u_has_any_trait": [ "ANIMIST", "BIOMANCER", "DRUID", "EARTHSHAPER", "KELVINIST", "MAGUS", "STORMSHAPER", "TECHNOMANCER" ]
         },
-        "then": { "math": [ "_required_spell_levels_is_met = 0" ] },
+        "then": { "math": [ "_required_spell_levels_is_met = -2" ] },
         "else": { "math": [ "_required_spell_levels_is_met = -1" ] }
       }
     ],
@@ -1960,7 +1960,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_CANT_GIVE_ATTUNEMENT_NOT_ENOUGH_SPELL_LEVELS",
-    "condition": { "math": [ "_required_spell_levels_is_met == 0" ] },
+    "condition": { "math": [ "_required_spell_levels_is_met == -2" ] },
     "effect": [
       {
         "u_message": "The altar does not respond to your touch.  While you know many spells, your knowledge of them is stil too shallow.",

--- a/data/mods/Magiclysm/effect_on_conditions/attunement_choices.json
+++ b/data/mods/Magiclysm/effect_on_conditions/attunement_choices.json
@@ -2,11 +2,394 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_CHECK_ATTUNEMENTS",
+    "//": "These need to be u_variables because they don't carry down into the EoC-selector's options otherwise",
     "effect": [
-      { "math": [ "_required_spell_count = 12" ] },
-      { "math": [ "_required_spell_levels = 200" ] },
-      { "run_eocs": "EOC_CHECK_ATTUNEMENT_CHECK_SPELL_LEVELS" },
-      { "run_eocs": "EOC_CHECK_ATTUNEMENT_CHECK_SPELL_COUNT" },
+      { "math": [ "u_required_attunement_spell_count = 12" ] },
+      { "math": [ "u_required_attunement_spell_levels = 200" ] },
+      {
+        "if": {
+          "or": [
+            {
+              "and": [
+                { "math": [ "u_spell_count('school': 'ANIMIST') >= u_required_attunement_spell_count" ] },
+                { "math": [ "u_spell_count('school': 'BIOMANCER') >= u_required_attunement_spell_count" ] }
+              ]
+            },
+            {
+              "and": [
+                { "math": [ "u_spell_count('school': 'ANIMIST') >= u_required_attunement_spell_count" ] },
+                { "math": [ "u_spell_count('school': 'DRUID') >= u_required_attunement_spell_count" ] }
+              ]
+            },
+            {
+              "and": [
+                { "math": [ "u_spell_count('school': 'ANIMIST') >= u_required_attunement_spell_count" ] },
+                { "math": [ "u_spell_count('school': 'EARTHSHAPER') >= u_required_attunement_spell_count" ] }
+              ]
+            },
+            {
+              "and": [
+                { "math": [ "u_spell_count('school': 'ANIMIST') >= u_required_attunement_spell_count" ] },
+                { "math": [ "u_spell_count('school': 'KELVINIST') >= u_required_attunement_spell_count" ] }
+              ]
+            },
+            {
+              "and": [
+                { "math": [ "u_spell_count('school': 'ANIMIST') >= u_required_attunement_spell_count" ] },
+                { "math": [ "u_spell_count('school': 'MAGUS') >= u_required_attunement_spell_count" ] }
+              ]
+            },
+            {
+              "and": [
+                { "math": [ "u_spell_count('school': 'ANIMIST') >= u_required_attunement_spell_count" ] },
+                { "math": [ "u_spell_count('school': 'STORMSHAPER') >= u_required_attunement_spell_count" ] }
+              ]
+            },
+            {
+              "and": [
+                { "math": [ "u_spell_count('school': 'ANIMIST') >= u_required_attunement_spell_count" ] },
+                { "math": [ "u_spell_count('school': 'TECHNOMANCER') >= u_required_attunement_spell_count" ] }
+              ]
+            },
+            {
+              "and": [
+                { "math": [ "u_spell_count('school': 'BIOMANCER') >= u_required_attunement_spell_count" ] },
+                { "math": [ "u_spell_count('school': 'DRUID') >= u_required_attunement_spell_count" ] }
+              ]
+            },
+            {
+              "and": [
+                { "math": [ "u_spell_count('school': 'BIOMANCER') >= u_required_attunement_spell_count" ] },
+                { "math": [ "u_spell_count('school': 'EARTHSHAPER') >= u_required_attunement_spell_count" ] }
+              ]
+            },
+            {
+              "and": [
+                { "math": [ "u_spell_count('school': 'BIOMANCER') >= u_required_attunement_spell_count" ] },
+                { "math": [ "u_spell_count('school': 'KELVINIST') >= u_required_attunement_spell_count" ] }
+              ]
+            },
+            {
+              "and": [
+                { "math": [ "u_spell_count('school': 'BIOMANCER') >= u_required_attunement_spell_count" ] },
+                { "math": [ "u_spell_count('school': 'MAGUS') >= u_required_attunement_spell_count" ] }
+              ]
+            },
+            {
+              "and": [
+                { "math": [ "u_spell_count('school': 'BIOMANCER') >= u_required_attunement_spell_count" ] },
+                { "math": [ "u_spell_count('school': 'STORMSHAPER') >= u_required_attunement_spell_count" ] }
+              ]
+            },
+            {
+              "and": [
+                { "math": [ "u_spell_count('school': 'BIOMANCER') >= u_required_attunement_spell_count" ] },
+                { "math": [ "u_spell_count('school': 'TECHNOMANCER') >= u_required_attunement_spell_count" ] }
+              ]
+            },
+            {
+              "and": [
+                { "math": [ "u_spell_count('school': 'DRUID') >= u_required_attunement_spell_count" ] },
+                { "math": [ "u_spell_count('school': 'EARTHSHAPER') >= u_required_attunement_spell_count" ] }
+              ]
+            },
+            {
+              "and": [
+                { "math": [ "u_spell_count('school': 'DRUID') >= u_required_attunement_spell_count" ] },
+                { "math": [ "u_spell_count('school': 'KELVINIST') >= u_required_attunement_spell_count" ] }
+              ]
+            },
+            {
+              "and": [
+                { "math": [ "u_spell_count('school': 'DRUID') >= u_required_attunement_spell_count" ] },
+                { "math": [ "u_spell_count('school': 'MAGUS') >= u_required_attunement_spell_count" ] }
+              ]
+            },
+            {
+              "and": [
+                { "math": [ "u_spell_count('school': 'DRUID') >= u_required_attunement_spell_count" ] },
+                { "math": [ "u_spell_count('school': 'STORMSHAPER') >= u_required_attunement_spell_count" ] }
+              ]
+            },
+            {
+              "and": [
+                { "math": [ "u_spell_count('school': 'DRUID') >= u_required_attunement_spell_count" ] },
+                { "math": [ "u_spell_count('school': 'TECHNOMANCER') >= u_required_attunement_spell_count" ] }
+              ]
+            },
+            {
+              "and": [
+                { "math": [ "u_spell_count('school': 'EARTHSHAPER') >= u_required_attunement_spell_count" ] },
+                { "math": [ "u_spell_count('school': 'KELVINIST') >= u_required_attunement_spell_count" ] }
+              ]
+            },
+            {
+              "and": [
+                { "math": [ "u_spell_count('school': 'EARTHSHAPER') >= u_required_attunement_spell_count" ] },
+                { "math": [ "u_spell_count('school': 'MAGUS') >= u_required_attunement_spell_count" ] }
+              ]
+            },
+            {
+              "and": [
+                { "math": [ "u_spell_count('school': 'EARTHSHAPER') >= u_required_attunement_spell_count" ] },
+                { "math": [ "u_spell_count('school': 'STORMSHAPER') >= u_required_attunement_spell_count" ] }
+              ]
+            },
+            {
+              "and": [
+                { "math": [ "u_spell_count('school': 'EARTHSHAPER') >= u_required_attunement_spell_count" ] },
+                { "math": [ "u_spell_count('school': 'TECHNOMANCER') >= u_required_attunement_spell_count" ] }
+              ]
+            },
+            {
+              "and": [
+                { "math": [ "u_spell_count('school': 'KELVINIST') >= u_required_attunement_spell_count" ] },
+                { "math": [ "u_spell_count('school': 'MAGUS') >= u_required_attunement_spell_count" ] }
+              ]
+            },
+            {
+              "and": [
+                { "math": [ "u_spell_count('school': 'KELVINIST') >= u_required_attunement_spell_count" ] },
+                { "math": [ "u_spell_count('school': 'STORMSHAPER') >= u_required_attunement_spell_count" ] }
+              ]
+            },
+            {
+              "and": [
+                { "math": [ "u_spell_count('school': 'KELVINIST') >= u_required_attunement_spell_count" ] },
+                { "math": [ "u_spell_count('school': 'TECHNOMANCER') >= u_required_attunement_spell_count" ] }
+              ]
+            },
+            {
+              "and": [
+                { "math": [ "u_spell_count('school': 'MAGUS') >= u_required_attunement_spell_count" ] },
+                { "math": [ "u_spell_count('school': 'STORMSHAPER') >= u_required_attunement_spell_count" ] }
+              ]
+            },
+            {
+              "and": [
+                { "math": [ "u_spell_count('school': 'MAGUS') >= u_required_attunement_spell_count" ] },
+                { "math": [ "u_spell_count('school': 'TECHNOMANCER') >= u_required_attunement_spell_count" ] }
+              ]
+            },
+            {
+              "and": [
+                { "math": [ "u_spell_count('school': 'STORMSHAPER') >= u_required_attunement_spell_count" ] },
+                { "math": [ "u_spell_count('school': 'TECHNOMANCER') >= u_required_attunement_spell_count" ] }
+              ]
+            }
+          ]
+        },
+        "then": [
+          {
+            "if": {
+              "u_has_any_trait": [ "ANIMIST", "BIOMANCER", "DRUID", "EARTHSHAPER", "KELVINIST", "MAGUS", "STORMSHAPER", "TECHNOMANCER" ]
+            },
+            "then": { "math": [ "u_required_attunement_spell_count_is_met = 1" ] },
+            "else": { "math": [ "u_required_attunement_spell_count_is_met = -1" ] }
+          }
+        ],
+        "else": [
+          {
+            "if": {
+              "u_has_any_trait": [ "ANIMIST", "BIOMANCER", "DRUID", "EARTHSHAPER", "KELVINIST", "MAGUS", "STORMSHAPER", "TECHNOMANCER" ]
+            },
+            "then": { "math": [ "u_required_attunement_spell_count_is_met = -2" ] },
+            "else": { "math": [ "u_required_attunement_spell_count_is_met = -1" ] }
+          }
+        ]
+      },
+      {
+        "if": {
+          "or": [
+            {
+              "and": [
+                { "math": [ "u_spell_level_sum('school': 'ANIMIST') >= u_required_attunement_spell_levels" ] },
+                { "math": [ "u_spell_level_sum('school': 'BIOMANCER') >= u_required_attunement_spell_levels" ] }
+              ]
+            },
+            {
+              "and": [
+                { "math": [ "u_spell_level_sum('school': 'ANIMIST') >= u_required_attunement_spell_levels" ] },
+                { "math": [ "u_spell_level_sum('school': 'DRUID') >= u_required_attunement_spell_levels" ] }
+              ]
+            },
+            {
+              "and": [
+                { "math": [ "u_spell_level_sum('school': 'ANIMIST') >= u_required_attunement_spell_levels" ] },
+                { "math": [ "u_spell_level_sum('school': 'EARTHSHAPER') >= u_required_attunement_spell_levels" ] }
+              ]
+            },
+            {
+              "and": [
+                { "math": [ "u_spell_level_sum('school': 'ANIMIST') >= u_required_attunement_spell_levels" ] },
+                { "math": [ "u_spell_level_sum('school': 'KELVINIST') >= u_required_attunement_spell_levels" ] }
+              ]
+            },
+            {
+              "and": [
+                { "math": [ "u_spell_level_sum('school': 'ANIMIST') >= u_required_attunement_spell_levels" ] },
+                { "math": [ "u_spell_level_sum('school': 'MAGUS') >= u_required_attunement_spell_levels" ] }
+              ]
+            },
+            {
+              "and": [
+                { "math": [ "u_spell_level_sum('school': 'ANIMIST') >= u_required_attunement_spell_levels" ] },
+                { "math": [ "u_spell_level_sum('school': 'STORMSHAPER') >= u_required_attunement_spell_levels" ] }
+              ]
+            },
+            {
+              "and": [
+                { "math": [ "u_spell_level_sum('school': 'ANIMIST') >= u_required_attunement_spell_levels" ] },
+                { "math": [ "u_spell_level_sum('school': 'TECHNOMANCER') >= u_required_attunement_spell_levels" ] }
+              ]
+            },
+            {
+              "and": [
+                { "math": [ "u_spell_level_sum('school': 'BIOMANCER') >= u_required_attunement_spell_levels" ] },
+                { "math": [ "u_spell_level_sum('school': 'DRUID') >= u_required_attunement_spell_levels" ] }
+              ]
+            },
+            {
+              "and": [
+                { "math": [ "u_spell_level_sum('school': 'BIOMANCER') >= u_required_attunement_spell_levels" ] },
+                { "math": [ "u_spell_level_sum('school': 'EARTHSHAPER') >= u_required_attunement_spell_levels" ] }
+              ]
+            },
+            {
+              "and": [
+                { "math": [ "u_spell_level_sum('school': 'BIOMANCER') >= u_required_attunement_spell_levels" ] },
+                { "math": [ "u_spell_level_sum('school': 'KELVINIST') >= u_required_attunement_spell_levels" ] }
+              ]
+            },
+            {
+              "and": [
+                { "math": [ "u_spell_level_sum('school': 'BIOMANCER') >= u_required_attunement_spell_levels" ] },
+                { "math": [ "u_spell_level_sum('school': 'MAGUS') >= u_required_attunement_spell_levels" ] }
+              ]
+            },
+            {
+              "and": [
+                { "math": [ "u_spell_level_sum('school': 'BIOMANCER') >= u_required_attunement_spell_levels" ] },
+                { "math": [ "u_spell_level_sum('school': 'STORMSHAPER') >= u_required_attunement_spell_levels" ] }
+              ]
+            },
+            {
+              "and": [
+                { "math": [ "u_spell_level_sum('school': 'BIOMANCER') >= u_required_attunement_spell_levels" ] },
+                { "math": [ "u_spell_level_sum('school': 'TECHNOMANCER') >= u_required_attunement_spell_levels" ] }
+              ]
+            },
+            {
+              "and": [
+                { "math": [ "u_spell_level_sum('school': 'DRUID') >= u_required_attunement_spell_levels" ] },
+                { "math": [ "u_spell_level_sum('school': 'EARTHSHAPER') >= u_required_attunement_spell_levels" ] }
+              ]
+            },
+            {
+              "and": [
+                { "math": [ "u_spell_level_sum('school': 'DRUID') >= u_required_attunement_spell_levels" ] },
+                { "math": [ "u_spell_level_sum('school': 'KELVINIST') >= u_required_attunement_spell_levels" ] }
+              ]
+            },
+            {
+              "and": [
+                { "math": [ "u_spell_level_sum('school': 'DRUID') >= u_required_attunement_spell_levels" ] },
+                { "math": [ "u_spell_level_sum('school': 'MAGUS') >= u_required_attunement_spell_levels" ] }
+              ]
+            },
+            {
+              "and": [
+                { "math": [ "u_spell_level_sum('school': 'DRUID') >= u_required_attunement_spell_levels" ] },
+                { "math": [ "u_spell_level_sum('school': 'STORMSHAPER') >= u_required_attunement_spell_levels" ] }
+              ]
+            },
+            {
+              "and": [
+                { "math": [ "u_spell_level_sum('school': 'DRUID') >= u_required_attunement_spell_levels" ] },
+                { "math": [ "u_spell_level_sum('school': 'TECHNOMANCER') >= u_required_attunement_spell_levels" ] }
+              ]
+            },
+            {
+              "and": [
+                { "math": [ "u_spell_level_sum('school': 'EARTHSHAPER') >= u_required_attunement_spell_levels" ] },
+                { "math": [ "u_spell_level_sum('school': 'KELVINIST') >= u_required_attunement_spell_levels" ] }
+              ]
+            },
+            {
+              "and": [
+                { "math": [ "u_spell_level_sum('school': 'EARTHSHAPER') >= u_required_attunement_spell_levels" ] },
+                { "math": [ "u_spell_level_sum('school': 'MAGUS') >= u_required_attunement_spell_levels" ] }
+              ]
+            },
+            {
+              "and": [
+                { "math": [ "u_spell_level_sum('school': 'EARTHSHAPER') >= u_required_attunement_spell_levels" ] },
+                { "math": [ "u_spell_level_sum('school': 'STORMSHAPER') >= u_required_attunement_spell_levels" ] }
+              ]
+            },
+            {
+              "and": [
+                { "math": [ "u_spell_level_sum('school': 'EARTHSHAPER') >= u_required_attunement_spell_levels" ] },
+                { "math": [ "u_spell_level_sum('school': 'TECHNOMANCER') >= u_required_attunement_spell_levels" ] }
+              ]
+            },
+            {
+              "and": [
+                { "math": [ "u_spell_level_sum('school': 'KELVINIST') >= u_required_attunement_spell_levels" ] },
+                { "math": [ "u_spell_level_sum('school': 'MAGUS') >= u_required_attunement_spell_levels" ] }
+              ]
+            },
+            {
+              "and": [
+                { "math": [ "u_spell_level_sum('school': 'KELVINIST') >= u_required_attunement_spell_levels" ] },
+                { "math": [ "u_spell_level_sum('school': 'STORMSHAPER') >= u_required_attunement_spell_levels" ] }
+              ]
+            },
+            {
+              "and": [
+                { "math": [ "u_spell_level_sum('school': 'KELVINIST') >= u_required_attunement_spell_levels" ] },
+                { "math": [ "u_spell_level_sum('school': 'TECHNOMANCER') >= u_required_attunement_spell_levels" ] }
+              ]
+            },
+            {
+              "and": [
+                { "math": [ "u_spell_level_sum('school': 'MAGUS') >= u_required_attunement_spell_levels" ] },
+                { "math": [ "u_spell_level_sum('school': 'STORMSHAPER') >= u_required_attunement_spell_levels" ] }
+              ]
+            },
+            {
+              "and": [
+                { "math": [ "u_spell_level_sum('school': 'MAGUS') >= u_required_attunement_spell_levels" ] },
+                { "math": [ "u_spell_level_sum('school': 'TECHNOMANCER') >= u_required_attunement_spell_levels" ] }
+              ]
+            },
+            {
+              "and": [
+                { "math": [ "u_spell_level_sum('school': 'STORMSHAPER') >= u_required_attunement_spell_levels" ] },
+                { "math": [ "u_spell_level_sum('school': 'TECHNOMANCER') >= u_required_attunement_spell_levels" ] }
+              ]
+            }
+          ]
+        },
+        "then": [
+          {
+            "if": {
+              "u_has_any_trait": [ "ANIMIST", "BIOMANCER", "DRUID", "EARTHSHAPER", "KELVINIST", "MAGUS", "STORMSHAPER", "TECHNOMANCER" ]
+            },
+            "then": { "math": [ "u_required_spell_levels_is_met = 1" ] },
+            "else": { "math": [ "u_required_spell_levels_is_met = -1" ] }
+          }
+        ],
+        "else": [
+          {
+            "if": {
+              "u_has_any_trait": [ "ANIMIST", "BIOMANCER", "DRUID", "EARTHSHAPER", "KELVINIST", "MAGUS", "STORMSHAPER", "TECHNOMANCER" ]
+            },
+            "then": { "math": [ "u_required_spell_levels_is_met = -2" ] },
+            "else": { "math": [ "u_required_spell_levels_is_met = -1" ] }
+          }
+        ]
+      },
       {
         "run_eoc_selector": [
           "EOC_GIVE_ATTUNEMENT_ARTIFICER",
@@ -42,7 +425,8 @@
           "EOC_CANT_GIVE_ATTUNEMENT_NOT_A_MAGE",
           "EOC_CANT_GIVE_ATTUNEMENT_NOT_ENOUGH_SPELLS",
           "EOC_CANT_GIVE_ATTUNEMENT_NOT_ENOUGH_SPELL_LEVELS",
-          "EOC_CANT_GIVE_ATTUNEMENT_NOT_ENOUGH_PROFICIENCIES"
+          "EOC_CANT_GIVE_ATTUNEMENT_NOT_ENOUGH_PROFICIENCIES",
+          "EOC_NONE"
         ],
         "title": "You reach out to touch the attunement altar.",
         "names": [
@@ -79,7 +463,8 @@
           "Touch the altar",
           "Touch the altar",
           "Touch the altar",
-          "Touch the altar"
+          "Touch the altar",
+          "Back away"
         ],
         "descriptions": [
           "<trait_description:ARTIFICER>",
@@ -115,7 +500,8 @@
           "Touch the altar",
           "Touch the altar",
           "Touch the altar",
-          "Touch the altar"
+          "Touch the altar",
+          "Leave the altar alone"
         ],
         "allow_cancel": true,
         "hide_failing": true
@@ -161,10 +547,10 @@
             ]
           }
         },
-        { "math": [ "u_spell_count('school': 'STORMSHAPER') >= _required_spell_count" ] },
-        { "math": [ "u_spell_count('school': 'TECHNOMANCER') >= _required_spell_count" ] },
-        { "math": [ "u_spell_level_sum('school': 'STORMSHAPER') >= _required_spell_levels" ] },
-        { "math": [ "u_spell_level_sum('school': 'TECHNOMANCER') >= _required_spell_levels" ] },
+        { "math": [ "u_spell_count('school': 'STORMSHAPER') >= u_required_attunement_spell_count" ] },
+        { "math": [ "u_spell_count('school': 'TECHNOMANCER') >= u_required_attunement_spell_count" ] },
+        { "math": [ "u_spell_level_sum('school': 'STORMSHAPER') >= u_required_attunement_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'TECHNOMANCER') >= u_required_attunement_spell_levels" ] },
         { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
       ]
     },
@@ -207,10 +593,10 @@
             ]
           }
         },
-        { "math": [ "u_spell_count('school': 'ANIMIST') >= _required_spell_count" ] },
-        { "math": [ "u_spell_count('school': 'TECHNOMANCER') >= _required_spell_count" ] },
-        { "math": [ "u_spell_level_sum('school': 'ANIMIST') >= _required_spell_levels" ] },
-        { "math": [ "u_spell_level_sum('school': 'TECHNOMANCER') >= _required_spell_levels" ] },
+        { "math": [ "u_spell_count('school': 'ANIMIST') >= u_required_attunement_spell_count" ] },
+        { "math": [ "u_spell_count('school': 'TECHNOMANCER') >= u_required_attunement_spell_count" ] },
+        { "math": [ "u_spell_level_sum('school': 'ANIMIST') >= u_required_attunement_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'TECHNOMANCER') >= u_required_attunement_spell_levels" ] },
         { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
       ]
     },
@@ -255,10 +641,10 @@
             ]
           }
         },
-        { "math": [ "u_spell_count('school': 'BIOMANCER') >= _required_spell_count" ] },
-        { "math": [ "u_spell_count('school': 'TECHNOMANCER') >= _required_spell_count" ] },
-        { "math": [ "u_spell_level_sum('school': 'BIOMANCER') >= _required_spell_levels" ] },
-        { "math": [ "u_spell_level_sum('school': 'TECHNOMANCER') >= _required_spell_levels" ] },
+        { "math": [ "u_spell_count('school': 'BIOMANCER') >= u_required_attunement_spell_count" ] },
+        { "math": [ "u_spell_count('school': 'TECHNOMANCER') >= u_required_attunement_spell_count" ] },
+        { "math": [ "u_spell_level_sum('school': 'BIOMANCER') >= u_required_attunement_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'TECHNOMANCER') >= u_required_attunement_spell_levels" ] },
         { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
       ]
     },
@@ -301,10 +687,10 @@
             ]
           }
         },
-        { "math": [ "u_spell_count('school': 'BIOMANCER') >= _required_spell_count" ] },
-        { "math": [ "u_spell_count('school': 'ANIMIST') >= _required_spell_count" ] },
-        { "math": [ "u_spell_level_sum('school': 'BIOMANCER') >= _required_spell_levels" ] },
-        { "math": [ "u_spell_level_sum('school': 'ANIMIST') >= _required_spell_levels" ] },
+        { "math": [ "u_spell_count('school': 'BIOMANCER') >= u_required_attunement_spell_count" ] },
+        { "math": [ "u_spell_count('school': 'ANIMIST') >= u_required_attunement_spell_count" ] },
+        { "math": [ "u_spell_level_sum('school': 'BIOMANCER') >= u_required_attunement_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'ANIMIST') >= u_required_attunement_spell_levels" ] },
         { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
       ]
     },
@@ -349,10 +735,10 @@
             ]
           }
         },
-        { "math": [ "u_spell_count('school': 'KELVINIST') >= _required_spell_count" ] },
-        { "math": [ "u_spell_count('school': 'TECHNOMANCER') >= _required_spell_count" ] },
-        { "math": [ "u_spell_level_sum('school': 'KELVINIST') >= _required_spell_levels" ] },
-        { "math": [ "u_spell_level_sum('school': 'TECHNOMANCER') >= _required_spell_levels" ] },
+        { "math": [ "u_spell_count('school': 'KELVINIST') >= u_required_attunement_spell_count" ] },
+        { "math": [ "u_spell_count('school': 'TECHNOMANCER') >= u_required_attunement_spell_count" ] },
+        { "math": [ "u_spell_level_sum('school': 'KELVINIST') >= u_required_attunement_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'TECHNOMANCER') >= u_required_attunement_spell_levels" ] },
         { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
       ]
     },
@@ -397,10 +783,10 @@
             ]
           }
         },
-        { "math": [ "u_spell_count('school': 'DRUID') >= _required_spell_count" ] },
-        { "math": [ "u_spell_count('school': 'KELVINIST') >= _required_spell_count" ] },
-        { "math": [ "u_spell_level_sum('school': 'DRUID') >= _required_spell_levels" ] },
-        { "math": [ "u_spell_level_sum('school': 'KELVINIST') >= _required_spell_levels" ] },
+        { "math": [ "u_spell_count('school': 'DRUID') >= u_required_attunement_spell_count" ] },
+        { "math": [ "u_spell_count('school': 'KELVINIST') >= u_required_attunement_spell_count" ] },
+        { "math": [ "u_spell_level_sum('school': 'DRUID') >= u_required_attunement_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'KELVINIST') >= u_required_attunement_spell_levels" ] },
         { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
       ]
     },
@@ -443,10 +829,10 @@
             ]
           }
         },
-        { "math": [ "u_spell_count('school': 'DRUID') >= _required_spell_count" ] },
-        { "math": [ "u_spell_count('school': 'TECHNOMANCER') >= _required_spell_count" ] },
-        { "math": [ "u_spell_level_sum('school': 'DRUID') >= _required_spell_levels" ] },
-        { "math": [ "u_spell_level_sum('school': 'TECHNOMANCER') >= _required_spell_levels" ] },
+        { "math": [ "u_spell_count('school': 'DRUID') >= u_required_attunement_spell_count" ] },
+        { "math": [ "u_spell_count('school': 'TECHNOMANCER') >= u_required_attunement_spell_count" ] },
+        { "math": [ "u_spell_level_sum('school': 'DRUID') >= u_required_attunement_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'TECHNOMANCER') >= u_required_attunement_spell_levels" ] },
         { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
       ]
     },
@@ -489,10 +875,10 @@
             ]
           }
         },
-        { "math": [ "u_spell_count('school': 'BIOMANCER') >= _required_spell_count" ] },
-        { "math": [ "u_spell_count('school': 'EARTHSHAPER') >= _required_spell_count" ] },
-        { "math": [ "u_spell_level_sum('school': 'BIOMANCER') >= _required_spell_levels" ] },
-        { "math": [ "u_spell_level_sum('school': 'EARTHSHAPER') >= _required_spell_levels" ] },
+        { "math": [ "u_spell_count('school': 'BIOMANCER') >= u_required_attunement_spell_count" ] },
+        { "math": [ "u_spell_count('school': 'EARTHSHAPER') >= u_required_attunement_spell_count" ] },
+        { "math": [ "u_spell_level_sum('school': 'BIOMANCER') >= u_required_attunement_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'EARTHSHAPER') >= u_required_attunement_spell_levels" ] },
         { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
       ]
     },
@@ -537,10 +923,10 @@
             ]
           }
         },
-        { "math": [ "u_spell_count('school': 'BIOMANCER') >= _required_spell_count" ] },
-        { "math": [ "u_spell_count('school': 'KELVINIST') >= _required_spell_count" ] },
-        { "math": [ "u_spell_level_sum('school': 'BIOMANCER') >= _required_spell_levels" ] },
-        { "math": [ "u_spell_level_sum('school': 'KELVINIST') >= _required_spell_levels" ] },
+        { "math": [ "u_spell_count('school': 'BIOMANCER') >= u_required_attunement_spell_count" ] },
+        { "math": [ "u_spell_count('school': 'KELVINIST') >= u_required_attunement_spell_count" ] },
+        { "math": [ "u_spell_level_sum('school': 'BIOMANCER') >= u_required_attunement_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'KELVINIST') >= u_required_attunement_spell_levels" ] },
         { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
       ]
     },
@@ -585,10 +971,10 @@
             ]
           }
         },
-        { "math": [ "u_spell_count('school': 'MAGUS') >= _required_spell_count" ] },
-        { "math": [ "u_spell_count('school': 'STORMSHAPER') >= _required_spell_count" ] },
-        { "math": [ "u_spell_level_sum('school': 'MAGUS') >= _required_spell_levels" ] },
-        { "math": [ "u_spell_level_sum('school': 'STORMSHAPER') >= _required_spell_levels" ] },
+        { "math": [ "u_spell_count('school': 'MAGUS') >= u_required_attunement_spell_count" ] },
+        { "math": [ "u_spell_count('school': 'STORMSHAPER') >= u_required_attunement_spell_count" ] },
+        { "math": [ "u_spell_level_sum('school': 'MAGUS') >= u_required_attunement_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'STORMSHAPER') >= u_required_attunement_spell_levels" ] },
         { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
       ]
     },
@@ -631,10 +1017,10 @@
             ]
           }
         },
-        { "math": [ "u_spell_count('school': 'DRUID') >= _required_spell_count" ] },
-        { "math": [ "u_spell_count('school': 'EARTHSHAPER') >= _required_spell_count" ] },
-        { "math": [ "u_spell_level_sum('school': 'DRUID') >= _required_spell_levels" ] },
-        { "math": [ "u_spell_level_sum('school': 'EARTHSHAPER') >= _required_spell_levels" ] },
+        { "math": [ "u_spell_count('school': 'DRUID') >= u_required_attunement_spell_count" ] },
+        { "math": [ "u_spell_count('school': 'EARTHSHAPER') >= u_required_attunement_spell_count" ] },
+        { "math": [ "u_spell_level_sum('school': 'DRUID') >= u_required_attunement_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'EARTHSHAPER') >= u_required_attunement_spell_levels" ] },
         { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
       ]
     },
@@ -679,10 +1065,10 @@
             ]
           }
         },
-        { "math": [ "u_spell_count('school': 'EARTHSHAPER') >= _required_spell_count" ] },
-        { "math": [ "u_spell_count('school': 'KELVINIST') >= _required_spell_count" ] },
-        { "math": [ "u_spell_level_sum('school': 'EARTHSHAPER') >= _required_spell_levels" ] },
-        { "math": [ "u_spell_level_sum('school': 'KELVINIST') >= _required_spell_levels" ] },
+        { "math": [ "u_spell_count('school': 'EARTHSHAPER') >= u_required_attunement_spell_count" ] },
+        { "math": [ "u_spell_count('school': 'KELVINIST') >= u_required_attunement_spell_count" ] },
+        { "math": [ "u_spell_level_sum('school': 'EARTHSHAPER') >= u_required_attunement_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'KELVINIST') >= u_required_attunement_spell_levels" ] },
         { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
       ]
     },
@@ -729,10 +1115,10 @@
             ]
           }
         },
-        { "math": [ "u_spell_count('school': 'ANIMIST') >= _required_spell_count" ] },
-        { "math": [ "u_spell_count('school': 'EARTHSHAPER') >= _required_spell_count" ] },
-        { "math": [ "u_spell_level_sum('school': 'ANIMIST') >= _required_spell_levels" ] },
-        { "math": [ "u_spell_level_sum('school': 'EARTHSHAPER') >= _required_spell_levels" ] },
+        { "math": [ "u_spell_count('school': 'ANIMIST') >= u_required_attunement_spell_count" ] },
+        { "math": [ "u_spell_count('school': 'EARTHSHAPER') >= u_required_attunement_spell_count" ] },
+        { "math": [ "u_spell_level_sum('school': 'ANIMIST') >= u_required_attunement_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'EARTHSHAPER') >= u_required_attunement_spell_levels" ] },
         { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
       ]
     },
@@ -775,10 +1161,10 @@
             ]
           }
         },
-        { "math": [ "u_spell_count('school': 'EARTHSHAPER') >= _required_spell_count" ] },
-        { "math": [ "u_spell_count('school': 'MAGUS') >= _required_spell_count" ] },
-        { "math": [ "u_spell_level_sum('school': 'EARTHSHAPER') >= _required_spell_levels" ] },
-        { "math": [ "u_spell_level_sum('school': 'MAGUS') >= _required_spell_levels" ] },
+        { "math": [ "u_spell_count('school': 'EARTHSHAPER') >= u_required_attunement_spell_count" ] },
+        { "math": [ "u_spell_count('school': 'MAGUS') >= u_required_attunement_spell_count" ] },
+        { "math": [ "u_spell_level_sum('school': 'EARTHSHAPER') >= u_required_attunement_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'MAGUS') >= u_required_attunement_spell_levels" ] },
         { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
       ]
     },
@@ -823,10 +1209,10 @@
             ]
           }
         },
-        { "math": [ "u_spell_count('school': 'BIOMANCER') >= _required_spell_count" ] },
-        { "math": [ "u_spell_count('school': 'KELVINIST') >= _required_spell_count" ] },
-        { "math": [ "u_spell_level_sum('school': 'BIOMANCER') >= _required_spell_levels" ] },
-        { "math": [ "u_spell_level_sum('school': 'KELVINIST') >= _required_spell_levels" ] },
+        { "math": [ "u_spell_count('school': 'BIOMANCER') >= u_required_attunement_spell_count" ] },
+        { "math": [ "u_spell_count('school': 'KELVINIST') >= u_required_attunement_spell_count" ] },
+        { "math": [ "u_spell_level_sum('school': 'BIOMANCER') >= u_required_attunement_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'KELVINIST') >= u_required_attunement_spell_levels" ] },
         { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
       ]
     },
@@ -869,10 +1255,10 @@
             ]
           }
         },
-        { "math": [ "u_spell_count('school': 'MAGUS') >= _required_spell_count" ] },
-        { "math": [ "u_spell_count('school': 'TECHNOMANCER') >= _required_spell_count" ] },
-        { "math": [ "u_spell_level_sum('school': 'MAGUS') >= _required_spell_levels" ] },
-        { "math": [ "u_spell_level_sum('school': 'TECHNOMANCER') >= _required_spell_levels" ] },
+        { "math": [ "u_spell_count('school': 'MAGUS') >= u_required_attunement_spell_count" ] },
+        { "math": [ "u_spell_count('school': 'TECHNOMANCER') >= u_required_attunement_spell_count" ] },
+        { "math": [ "u_spell_level_sum('school': 'MAGUS') >= u_required_attunement_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'TECHNOMANCER') >= u_required_attunement_spell_levels" ] },
         { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
       ]
     },
@@ -917,10 +1303,10 @@
             ]
           }
         },
-        { "math": [ "u_spell_count('school': 'EARTHSHAPER') >= _required_spell_count" ] },
-        { "math": [ "u_spell_count('school': 'STORMSHAPER') >= _required_spell_count" ] },
-        { "math": [ "u_spell_level_sum('school': 'EARTHSHAPER') >= _required_spell_levels" ] },
-        { "math": [ "u_spell_level_sum('school': 'STORMSHAPER') >= _required_spell_levels" ] },
+        { "math": [ "u_spell_count('school': 'EARTHSHAPER') >= u_required_attunement_spell_count" ] },
+        { "math": [ "u_spell_count('school': 'STORMSHAPER') >= u_required_attunement_spell_count" ] },
+        { "math": [ "u_spell_level_sum('school': 'EARTHSHAPER') >= u_required_attunement_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'STORMSHAPER') >= u_required_attunement_spell_levels" ] },
         { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
       ]
     },
@@ -965,10 +1351,10 @@
             ]
           }
         },
-        { "math": [ "u_spell_count('school': 'KELVINIST') >= _required_spell_count" ] },
-        { "math": [ "u_spell_count('school': 'TECHNOMANCER') >= _required_spell_count" ] },
-        { "math": [ "u_spell_level_sum('school': 'KELVINIST') >= _required_spell_levels" ] },
-        { "math": [ "u_spell_level_sum('school': 'TECHNOMANCER') >= _required_spell_levels" ] },
+        { "math": [ "u_spell_count('school': 'KELVINIST') >= u_required_attunement_spell_count" ] },
+        { "math": [ "u_spell_count('school': 'TECHNOMANCER') >= u_required_attunement_spell_count" ] },
+        { "math": [ "u_spell_level_sum('school': 'KELVINIST') >= u_required_attunement_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'TECHNOMANCER') >= u_required_attunement_spell_levels" ] },
         { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
       ]
     },
@@ -1013,10 +1399,10 @@
             ]
           }
         },
-        { "math": [ "u_spell_count('school': 'KELVINIST') >= _required_spell_count" ] },
-        { "math": [ "u_spell_count('school': 'MAGUS') >= _required_spell_count" ] },
-        { "math": [ "u_spell_level_sum('school': 'KELVINIST') >= _required_spell_levels" ] },
-        { "math": [ "u_spell_level_sum('school': 'MAGUS') >= _required_spell_levels" ] },
+        { "math": [ "u_spell_count('school': 'KELVINIST') >= u_required_attunement_spell_count" ] },
+        { "math": [ "u_spell_count('school': 'MAGUS') >= u_required_attunement_spell_count" ] },
+        { "math": [ "u_spell_level_sum('school': 'KELVINIST') >= u_required_attunement_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'MAGUS') >= u_required_attunement_spell_levels" ] },
         { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
       ]
     },
@@ -1061,10 +1447,10 @@
             ]
           }
         },
-        { "math": [ "u_spell_count('school': 'ANIMIST') >= _required_spell_count" ] },
-        { "math": [ "u_spell_count('school': 'STORMSHAPER') >= _required_spell_count" ] },
-        { "math": [ "u_spell_level_sum('school': 'ANIMIST') >= _required_spell_levels" ] },
-        { "math": [ "u_spell_level_sum('school': 'STORMSHAPER') >= _required_spell_levels" ] },
+        { "math": [ "u_spell_count('school': 'ANIMIST') >= u_required_attunement_spell_count" ] },
+        { "math": [ "u_spell_count('school': 'STORMSHAPER') >= u_required_attunement_spell_count" ] },
+        { "math": [ "u_spell_level_sum('school': 'ANIMIST') >= u_required_attunement_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'STORMSHAPER') >= u_required_attunement_spell_levels" ] },
         { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
       ]
     },
@@ -1113,10 +1499,10 @@
             ]
           }
         },
-        { "math": [ "u_spell_count('school': 'ANIMIST') >= _required_spell_count" ] },
-        { "math": [ "u_spell_count('school': 'DRUID') >= _required_spell_count" ] },
-        { "math": [ "u_spell_level_sum('school': 'ANIMIST') >= _required_spell_levels" ] },
-        { "math": [ "u_spell_level_sum('school': 'DRUID') >= _required_spell_levels" ] },
+        { "math": [ "u_spell_count('school': 'ANIMIST') >= u_required_attunement_spell_count" ] },
+        { "math": [ "u_spell_count('school': 'DRUID') >= u_required_attunement_spell_count" ] },
+        { "math": [ "u_spell_level_sum('school': 'ANIMIST') >= u_required_attunement_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'DRUID') >= u_required_attunement_spell_levels" ] },
         { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
       ]
     },
@@ -1159,10 +1545,10 @@
             ]
           }
         },
-        { "math": [ "u_spell_count('school': 'BIOMANCER') >= _required_spell_count" ] },
-        { "math": [ "u_spell_count('school': 'MAGUS') >= _required_spell_count" ] },
-        { "math": [ "u_spell_level_sum('school': 'BIOMANCER') >= _required_spell_levels" ] },
-        { "math": [ "u_spell_level_sum('school': 'MAGUS') >= _required_spell_levels" ] },
+        { "math": [ "u_spell_count('school': 'BIOMANCER') >= u_required_attunement_spell_count" ] },
+        { "math": [ "u_spell_count('school': 'MAGUS') >= u_required_attunement_spell_count" ] },
+        { "math": [ "u_spell_level_sum('school': 'BIOMANCER') >= u_required_attunement_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'MAGUS') >= u_required_attunement_spell_levels" ] },
         { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
       ]
     },
@@ -1207,10 +1593,10 @@
             ]
           }
         },
-        { "math": [ "u_spell_count('school': 'ANIMIST') >= _required_spell_count" ] },
-        { "math": [ "u_spell_count('school': 'KELVINIST') >= _required_spell_count" ] },
-        { "math": [ "u_spell_level_sum('school': 'ANIMIST') >= _required_spell_levels" ] },
-        { "math": [ "u_spell_level_sum('school': 'KELVINIST') >= _required_spell_levels" ] },
+        { "math": [ "u_spell_count('school': 'ANIMIST') >= u_required_attunement_spell_count" ] },
+        { "math": [ "u_spell_count('school': 'KELVINIST') >= u_required_attunement_spell_count" ] },
+        { "math": [ "u_spell_level_sum('school': 'ANIMIST') >= u_required_attunement_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'KELVINIST') >= u_required_attunement_spell_levels" ] },
         { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
       ]
     },
@@ -1259,10 +1645,10 @@
             ]
           }
         },
-        { "math": [ "u_spell_count('school': 'BIOMANCER') >= _required_spell_count" ] },
-        { "math": [ "u_spell_count('school': 'STORMSHAPER') >= _required_spell_count" ] },
-        { "math": [ "u_spell_level_sum('school': 'BIOMANCER') >= _required_spell_levels" ] },
-        { "math": [ "u_spell_level_sum('school': 'STORMSHAPER') >= _required_spell_levels" ] },
+        { "math": [ "u_spell_count('school': 'BIOMANCER') >= u_required_attunement_spell_count" ] },
+        { "math": [ "u_spell_count('school': 'STORMSHAPER') >= u_required_attunement_spell_count" ] },
+        { "math": [ "u_spell_level_sum('school': 'BIOMANCER') >= u_required_attunement_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'STORMSHAPER') >= u_required_attunement_spell_levels" ] },
         { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
       ]
     },
@@ -1307,10 +1693,10 @@
             ]
           }
         },
-        { "math": [ "u_spell_count('school': 'DRUID') >= _required_spell_count" ] },
-        { "math": [ "u_spell_count('school': 'STORMSHAPER') >= _required_spell_count" ] },
-        { "math": [ "u_spell_level_sum('school': 'DRUID') >= _required_spell_levels" ] },
-        { "math": [ "u_spell_level_sum('school': 'STORMSHAPER') >= _required_spell_levels" ] },
+        { "math": [ "u_spell_count('school': 'DRUID') >= u_required_attunement_spell_count" ] },
+        { "math": [ "u_spell_count('school': 'STORMSHAPER') >= u_required_attunement_spell_count" ] },
+        { "math": [ "u_spell_level_sum('school': 'DRUID') >= u_required_attunement_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'STORMSHAPER') >= u_required_attunement_spell_levels" ] },
         { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
       ]
     },
@@ -1355,10 +1741,10 @@
             ]
           }
         },
-        { "math": [ "u_spell_count('school': 'KELVINIST') >= _required_spell_count" ] },
-        { "math": [ "u_spell_count('school': 'MAGUS') >= _required_spell_count" ] },
-        { "math": [ "u_spell_level_sum('school': 'KELVINIST') >= _required_spell_levels" ] },
-        { "math": [ "u_spell_level_sum('school': 'MAGUS') >= _required_spell_levels" ] },
+        { "math": [ "u_spell_count('school': 'KELVINIST') >= u_required_attunement_spell_count" ] },
+        { "math": [ "u_spell_count('school': 'MAGUS') >= u_required_attunement_spell_count" ] },
+        { "math": [ "u_spell_level_sum('school': 'KELVINIST') >= u_required_attunement_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'MAGUS') >= u_required_attunement_spell_levels" ] },
         { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
       ]
     },
@@ -1403,10 +1789,10 @@
             ]
           }
         },
-        { "math": [ "u_spell_count('school': 'DRUID') >= _required_spell_count" ] },
-        { "math": [ "u_spell_count('school': 'KELVINIST') >= _required_spell_count" ] },
-        { "math": [ "u_spell_level_sum('school': 'DRUID') >= _required_spell_levels" ] },
-        { "math": [ "u_spell_level_sum('school': 'KELVINIST') >= _required_spell_levels" ] },
+        { "math": [ "u_spell_count('school': 'DRUID') >= u_required_attunement_spell_count" ] },
+        { "math": [ "u_spell_count('school': 'KELVINIST') >= u_required_attunement_spell_count" ] },
+        { "math": [ "u_spell_level_sum('school': 'DRUID') >= u_required_attunement_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'KELVINIST') >= u_required_attunement_spell_levels" ] },
         { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
       ]
     },
@@ -1455,10 +1841,10 @@
             ]
           }
         },
-        { "math": [ "u_spell_count('school': 'ANIMIST') >= _required_spell_count" ] },
-        { "math": [ "u_spell_count('school': 'KELVINIST') >= _required_spell_count" ] },
-        { "math": [ "u_spell_level_sum('school': 'ANIMIST') >= _required_spell_levels" ] },
-        { "math": [ "u_spell_level_sum('school': 'KELVINIST') >= _required_spell_levels" ] },
+        { "math": [ "u_spell_count('school': 'ANIMIST') >= u_required_attunement_spell_count" ] },
+        { "math": [ "u_spell_count('school': 'KELVINIST') >= u_required_attunement_spell_count" ] },
+        { "math": [ "u_spell_level_sum('school': 'ANIMIST') >= u_required_attunement_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'KELVINIST') >= u_required_attunement_spell_levels" ] },
         { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
       ]
     },
@@ -1503,10 +1889,10 @@
             ]
           }
         },
-        { "math": [ "u_spell_count('school': 'EARTHSHAPER') >= _required_spell_count" ] },
-        { "math": [ "u_spell_count('school': 'KELVINIST') >= _required_spell_count" ] },
-        { "math": [ "u_spell_level_sum('school': 'EARTHSHAPER') >= _required_spell_levels" ] },
-        { "math": [ "u_spell_level_sum('school': 'KELVINIST') >= _required_spell_levels" ] },
+        { "math": [ "u_spell_count('school': 'EARTHSHAPER') >= u_required_attunement_spell_count" ] },
+        { "math": [ "u_spell_count('school': 'KELVINIST') >= u_required_attunement_spell_count" ] },
+        { "math": [ "u_spell_level_sum('school': 'EARTHSHAPER') >= u_required_attunement_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'KELVINIST') >= u_required_attunement_spell_levels" ] },
         { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
       ]
     },
@@ -1549,10 +1935,10 @@
             ]
           }
         },
-        { "math": [ "u_spell_count('school': 'DRUID') >= _required_spell_count" ] },
-        { "math": [ "u_spell_count('school': 'MAGUS') >= _required_spell_count" ] },
-        { "math": [ "u_spell_level_sum('school': 'DRUID') >= _required_spell_levels" ] },
-        { "math": [ "u_spell_level_sum('school': 'MAGUS') >= _required_spell_levels" ] },
+        { "math": [ "u_spell_count('school': 'DRUID') >= u_required_attunement_spell_count" ] },
+        { "math": [ "u_spell_count('school': 'MAGUS') >= u_required_attunement_spell_count" ] },
+        { "math": [ "u_spell_level_sum('school': 'DRUID') >= u_required_attunement_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'MAGUS') >= u_required_attunement_spell_levels" ] },
         { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
       ]
     },
@@ -1574,195 +1960,8 @@
   },
   {
     "type": "effect_on_condition",
-    "id": "EOC_CHECK_ATTUNEMENT_CHECK_SPELL_LEVELS",
-    "//": "FIXME: some better way of handling this",
-    "condition": {
-      "and": [
-        {
-          "and": [
-            { "math": [ "u_spell_count('school': 'ANIMIST') < _required_spell_count" ] },
-            { "math": [ "u_spell_count('school': 'BIOMANCER') < _required_spell_count" ] }
-          ]
-        },
-        {
-          "and": [
-            { "math": [ "u_spell_count('school': 'ANIMIST') < _required_spell_count" ] },
-            { "math": [ "u_spell_count('school': 'DRUID') < _required_spell_count" ] }
-          ]
-        },
-        {
-          "and": [
-            { "math": [ "u_spell_count('school': 'ANIMIST') < _required_spell_count" ] },
-            { "math": [ "u_spell_count('school': 'EARTHSHAPER') < _required_spell_count" ] }
-          ]
-        },
-        {
-          "and": [
-            { "math": [ "u_spell_count('school': 'ANIMIST') < _required_spell_count" ] },
-            { "math": [ "u_spell_count('school': 'KELVINIST') < _required_spell_count" ] }
-          ]
-        },
-        {
-          "and": [
-            { "math": [ "u_spell_count('school': 'ANIMIST') < _required_spell_count" ] },
-            { "math": [ "u_spell_count('school': 'MAGUS') < _required_spell_count" ] }
-          ]
-        },
-        {
-          "and": [
-            { "math": [ "u_spell_count('school': 'ANIMIST') < _required_spell_count" ] },
-            { "math": [ "u_spell_count('school': 'STORMSHAPER') < _required_spell_count" ] }
-          ]
-        },
-        {
-          "and": [
-            { "math": [ "u_spell_count('school': 'ANIMIST') < _required_spell_count" ] },
-            { "math": [ "u_spell_count('school': 'TECHNOMANCER') < _required_spell_count" ] }
-          ]
-        },
-        {
-          "and": [
-            { "math": [ "u_spell_count('school': 'BIOMANCER') < _required_spell_count" ] },
-            { "math": [ "u_spell_count('school': 'DRUID') < _required_spell_count" ] }
-          ]
-        },
-        {
-          "and": [
-            { "math": [ "u_spell_count('school': 'BIOMANCER') < _required_spell_count" ] },
-            { "math": [ "u_spell_count('school': 'EARTHSHAPER') < _required_spell_count" ] }
-          ]
-        },
-        {
-          "and": [
-            { "math": [ "u_spell_count('school': 'BIOMANCER') < _required_spell_count" ] },
-            { "math": [ "u_spell_count('school': 'KELVINIST') < _required_spell_count" ] }
-          ]
-        },
-        {
-          "and": [
-            { "math": [ "u_spell_count('school': 'BIOMANCER') < _required_spell_count" ] },
-            { "math": [ "u_spell_count('school': 'MAGUS') < _required_spell_count" ] }
-          ]
-        },
-        {
-          "and": [
-            { "math": [ "u_spell_count('school': 'BIOMANCER') < _required_spell_count" ] },
-            { "math": [ "u_spell_count('school': 'STORMSHAPER') < _required_spell_count" ] }
-          ]
-        },
-        {
-          "and": [
-            { "math": [ "u_spell_count('school': 'BIOMANCER') < _required_spell_count" ] },
-            { "math": [ "u_spell_count('school': 'TECHNOMANCER') < _required_spell_count" ] }
-          ]
-        },
-        {
-          "and": [
-            { "math": [ "u_spell_count('school': 'DRUID') < _required_spell_count" ] },
-            { "math": [ "u_spell_count('school': 'EARTHSHAPER') < _required_spell_count" ] }
-          ]
-        },
-        {
-          "and": [
-            { "math": [ "u_spell_count('school': 'DRUID') < _required_spell_count" ] },
-            { "math": [ "u_spell_count('school': 'KELVINIST') < _required_spell_count" ] }
-          ]
-        },
-        {
-          "and": [
-            { "math": [ "u_spell_count('school': 'DRUID') < _required_spell_count" ] },
-            { "math": [ "u_spell_count('school': 'MAGUS') < _required_spell_count" ] }
-          ]
-        },
-        {
-          "and": [
-            { "math": [ "u_spell_count('school': 'DRUID') < _required_spell_count" ] },
-            { "math": [ "u_spell_count('school': 'STORMSHAPER') < _required_spell_count" ] }
-          ]
-        },
-        {
-          "and": [
-            { "math": [ "u_spell_count('school': 'DRUID') < _required_spell_count" ] },
-            { "math": [ "u_spell_count('school': 'TECHNOMANCER') < _required_spell_count" ] }
-          ]
-        },
-        {
-          "and": [
-            { "math": [ "u_spell_count('school': 'EARTHSHAPER') < _required_spell_count" ] },
-            { "math": [ "u_spell_count('school': 'KELVINIST') < _required_spell_count" ] }
-          ]
-        },
-        {
-          "and": [
-            { "math": [ "u_spell_count('school': 'EARTHSHAPER') < _required_spell_count" ] },
-            { "math": [ "u_spell_count('school': 'MAGUS') < _required_spell_count" ] }
-          ]
-        },
-        {
-          "and": [
-            { "math": [ "u_spell_count('school': 'EARTHSHAPER') < _required_spell_count" ] },
-            { "math": [ "u_spell_count('school': 'STORMSHAPER') < _required_spell_count" ] }
-          ]
-        },
-        {
-          "and": [
-            { "math": [ "u_spell_count('school': 'EARTHSHAPER') < _required_spell_count" ] },
-            { "math": [ "u_spell_count('school': 'TECHNOMANCER') < _required_spell_count" ] }
-          ]
-        },
-        {
-          "and": [
-            { "math": [ "u_spell_count('school': 'KELVINIST') < _required_spell_count" ] },
-            { "math": [ "u_spell_count('school': 'MAGUS') < _required_spell_count" ] }
-          ]
-        },
-        {
-          "and": [
-            { "math": [ "u_spell_count('school': 'KELVINIST') < _required_spell_count" ] },
-            { "math": [ "u_spell_count('school': 'STORMSHAPER') < _required_spell_count" ] }
-          ]
-        },
-        {
-          "and": [
-            { "math": [ "u_spell_count('school': 'KELVINIST') < _required_spell_count" ] },
-            { "math": [ "u_spell_count('school': 'TECHNOMANCER') < _required_spell_count" ] }
-          ]
-        },
-        {
-          "and": [
-            { "math": [ "u_spell_count('school': 'MAGUS') < _required_spell_count" ] },
-            { "math": [ "u_spell_count('school': 'STORMSHAPER') < _required_spell_count" ] }
-          ]
-        },
-        {
-          "and": [
-            { "math": [ "u_spell_count('school': 'MAGUS') < _required_spell_count" ] },
-            { "math": [ "u_spell_count('school': 'TECHNOMANCER') < _required_spell_count" ] }
-          ]
-        },
-        {
-          "and": [
-            { "math": [ "u_spell_count('school': 'STORMSHAPER') < _required_spell_count" ] },
-            { "math": [ "u_spell_count('school': 'TECHNOMANCER') < _required_spell_count" ] }
-          ]
-        }
-      ]
-    },
-    "effect": [
-      {
-        "if": {
-          "u_has_any_trait": [ "ANIMIST", "BIOMANCER", "DRUID", "EARTHSHAPER", "KELVINIST", "MAGUS", "STORMSHAPER", "TECHNOMANCER" ]
-        },
-        "then": { "math": [ "_required_spell_count_is_met = -2" ] },
-        "else": { "math": [ "_required_spell_count_is_met = -1" ] }
-      }
-    ],
-    "false_effect": [ { "math": [ "_required_spell_count_is_met = 1" ] } ]
-  },
-  {
-    "type": "effect_on_condition",
     "id": "EOC_CANT_GIVE_ATTUNEMENT_NOT_ENOUGH_SPELLS",
-    "condition": { "math": [ "_required_spell_count_is_met == -2" ] },
+    "condition": { "math": [ "u_required_attunement_spell_count_is_met == -2" ] },
     "effect": [
       {
         "u_message": "The altar does not respond to your touch.  You need more breadth in your spell selection before you can attempt attunement.",
@@ -1772,195 +1971,13 @@
   },
   {
     "type": "effect_on_condition",
-    "id": "EOC_CHECK_ATTUNEMENT_CHECK_SPELL_COUNT",
-    "//": "FIXME: some better way of handling this",
+    "id": "EOC_CANT_GIVE_ATTUNEMENT_NOT_ENOUGH_SPELL_LEVELS",
     "condition": {
       "and": [
-        {
-          "and": [
-            { "math": [ "u_spell_level_sum('school': 'ANIMIST') < _required_spell_levels" ] },
-            { "math": [ "u_spell_level_sum('school': 'BIOMANCER') < _required_spell_levels" ] }
-          ]
-        },
-        {
-          "and": [
-            { "math": [ "u_spell_level_sum('school': 'ANIMIST') < _required_spell_levels" ] },
-            { "math": [ "u_spell_level_sum('school': 'DRUID') < _required_spell_levels" ] }
-          ]
-        },
-        {
-          "and": [
-            { "math": [ "u_spell_level_sum('school': 'ANIMIST') < _required_spell_levels" ] },
-            { "math": [ "u_spell_level_sum('school': 'EARTHSHAPER') < _required_spell_levels" ] }
-          ]
-        },
-        {
-          "and": [
-            { "math": [ "u_spell_level_sum('school': 'ANIMIST') < _required_spell_levels" ] },
-            { "math": [ "u_spell_level_sum('school': 'KELVINIST') < _required_spell_levels" ] }
-          ]
-        },
-        {
-          "and": [
-            { "math": [ "u_spell_level_sum('school': 'ANIMIST') < _required_spell_levels" ] },
-            { "math": [ "u_spell_level_sum('school': 'MAGUS') < _required_spell_levels" ] }
-          ]
-        },
-        {
-          "and": [
-            { "math": [ "u_spell_level_sum('school': 'ANIMIST') < _required_spell_levels" ] },
-            { "math": [ "u_spell_level_sum('school': 'STORMSHAPER') < _required_spell_levels" ] }
-          ]
-        },
-        {
-          "and": [
-            { "math": [ "u_spell_level_sum('school': 'ANIMIST') < _required_spell_levels" ] },
-            { "math": [ "u_spell_level_sum('school': 'TECHNOMANCER') < _required_spell_levels" ] }
-          ]
-        },
-        {
-          "and": [
-            { "math": [ "u_spell_level_sum('school': 'BIOMANCER') < _required_spell_levels" ] },
-            { "math": [ "u_spell_level_sum('school': 'DRUID') < _required_spell_levels" ] }
-          ]
-        },
-        {
-          "and": [
-            { "math": [ "u_spell_level_sum('school': 'BIOMANCER') < _required_spell_levels" ] },
-            { "math": [ "u_spell_level_sum('school': 'EARTHSHAPER') < _required_spell_levels" ] }
-          ]
-        },
-        {
-          "and": [
-            { "math": [ "u_spell_level_sum('school': 'BIOMANCER') < _required_spell_levels" ] },
-            { "math": [ "u_spell_level_sum('school': 'KELVINIST') < _required_spell_levels" ] }
-          ]
-        },
-        {
-          "and": [
-            { "math": [ "u_spell_level_sum('school': 'BIOMANCER') < _required_spell_levels" ] },
-            { "math": [ "u_spell_level_sum('school': 'MAGUS') < _required_spell_levels" ] }
-          ]
-        },
-        {
-          "and": [
-            { "math": [ "u_spell_level_sum('school': 'BIOMANCER') < _required_spell_levels" ] },
-            { "math": [ "u_spell_level_sum('school': 'STORMSHAPER') < _required_spell_levels" ] }
-          ]
-        },
-        {
-          "and": [
-            { "math": [ "u_spell_level_sum('school': 'BIOMANCER') < _required_spell_levels" ] },
-            { "math": [ "u_spell_level_sum('school': 'TECHNOMANCER') < _required_spell_levels" ] }
-          ]
-        },
-        {
-          "and": [
-            { "math": [ "u_spell_level_sum('school': 'DRUID') < _required_spell_levels" ] },
-            { "math": [ "u_spell_level_sum('school': 'EARTHSHAPER') < _required_spell_levels" ] }
-          ]
-        },
-        {
-          "and": [
-            { "math": [ "u_spell_level_sum('school': 'DRUID') < _required_spell_levels" ] },
-            { "math": [ "u_spell_level_sum('school': 'KELVINIST') < _required_spell_levels" ] }
-          ]
-        },
-        {
-          "and": [
-            { "math": [ "u_spell_level_sum('school': 'DRUID') < _required_spell_levels" ] },
-            { "math": [ "u_spell_level_sum('school': 'MAGUS') < _required_spell_levels" ] }
-          ]
-        },
-        {
-          "and": [
-            { "math": [ "u_spell_level_sum('school': 'DRUID') < _required_spell_levels" ] },
-            { "math": [ "u_spell_level_sum('school': 'STORMSHAPER') < _required_spell_levels" ] }
-          ]
-        },
-        {
-          "and": [
-            { "math": [ "u_spell_level_sum('school': 'DRUID') < _required_spell_levels" ] },
-            { "math": [ "u_spell_level_sum('school': 'TECHNOMANCER') < _required_spell_levels" ] }
-          ]
-        },
-        {
-          "and": [
-            { "math": [ "u_spell_level_sum('school': 'EARTHSHAPER') < _required_spell_levels" ] },
-            { "math": [ "u_spell_level_sum('school': 'KELVINIST') < _required_spell_levels" ] }
-          ]
-        },
-        {
-          "and": [
-            { "math": [ "u_spell_level_sum('school': 'EARTHSHAPER') < _required_spell_levels" ] },
-            { "math": [ "u_spell_level_sum('school': 'MAGUS') < _required_spell_levels" ] }
-          ]
-        },
-        {
-          "and": [
-            { "math": [ "u_spell_level_sum('school': 'EARTHSHAPER') < _required_spell_levels" ] },
-            { "math": [ "u_spell_level_sum('school': 'STORMSHAPER') < _required_spell_levels" ] }
-          ]
-        },
-        {
-          "and": [
-            { "math": [ "u_spell_level_sum('school': 'EARTHSHAPER') < _required_spell_levels" ] },
-            { "math": [ "u_spell_level_sum('school': 'TECHNOMANCER') < _required_spell_levels" ] }
-          ]
-        },
-        {
-          "and": [
-            { "math": [ "u_spell_level_sum('school': 'KELVINIST') < _required_spell_levels" ] },
-            { "math": [ "u_spell_level_sum('school': 'MAGUS') < _required_spell_levels" ] }
-          ]
-        },
-        {
-          "and": [
-            { "math": [ "u_spell_level_sum('school': 'KELVINIST') < _required_spell_levels" ] },
-            { "math": [ "u_spell_level_sum('school': 'STORMSHAPER') < _required_spell_levels" ] }
-          ]
-        },
-        {
-          "and": [
-            { "math": [ "u_spell_level_sum('school': 'KELVINIST') < _required_spell_levels" ] },
-            { "math": [ "u_spell_level_sum('school': 'TECHNOMANCER') < _required_spell_levels" ] }
-          ]
-        },
-        {
-          "and": [
-            { "math": [ "u_spell_level_sum('school': 'MAGUS') < _required_spell_levels" ] },
-            { "math": [ "u_spell_level_sum('school': 'STORMSHAPER') < _required_spell_levels" ] }
-          ]
-        },
-        {
-          "and": [
-            { "math": [ "u_spell_level_sum('school': 'MAGUS') < _required_spell_levels" ] },
-            { "math": [ "u_spell_level_sum('school': 'TECHNOMANCER') < _required_spell_levels" ] }
-          ]
-        },
-        {
-          "and": [
-            { "math": [ "u_spell_level_sum('school': 'STORMSHAPER') < _required_spell_levels" ] },
-            { "math": [ "u_spell_level_sum('school': 'TECHNOMANCER') < _required_spell_levels" ] }
-          ]
-        }
+        { "math": [ "u_required_attunement_spell_count_is_met == 1" ] },
+        { "math": [ "u_required_spell_levels_is_met == -2" ] }
       ]
     },
-    "effect": [
-      {
-        "if": {
-          "u_has_any_trait": [ "ANIMIST", "BIOMANCER", "DRUID", "EARTHSHAPER", "KELVINIST", "MAGUS", "STORMSHAPER", "TECHNOMANCER" ]
-        },
-        "then": { "math": [ "_required_spell_levels_is_met = -2" ] },
-        "else": { "math": [ "_required_spell_levels_is_met = -1" ] }
-      }
-    ],
-    "false_effect": [ { "math": [ "_required_spell_levels_is_met = 1" ] } ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "EOC_CANT_GIVE_ATTUNEMENT_NOT_ENOUGH_SPELL_LEVELS",
-    "condition": { "math": [ "_required_spell_levels_is_met == -2" ] },
     "effect": [
       {
         "u_message": "The altar does not respond to your touch.  While you know many spells, your knowledge of them is stil too shallow.",
@@ -1973,8 +1990,8 @@
     "id": "EOC_CANT_GIVE_ATTUNEMENT_NOT_ENOUGH_PROFICIENCIES",
     "condition": {
       "and": [
-        { "math": [ "_required_spell_count_is_met == 1" ] },
-        { "math": [ "_required_spell_levels_is_met == 1" ] },
+        { "math": [ "u_required_attunement_spell_count_is_met == 1" ] },
+        { "math": [ "u_required_spell_levels_is_met == 1" ] },
         { "not": { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" } }
       ]
     },

--- a/data/mods/Magiclysm/effect_on_conditions/attunement_choices.json
+++ b/data/mods/Magiclysm/effect_on_conditions/attunement_choices.json
@@ -42,7 +42,7 @@
           "EOC_CANT_GIVE_ATTUNEMENT_NOT_ENOUGH_SPELL_LEVELS",
           "EOC_CANT_GIVE_ATTUNEMENT_NOT_ENOUGH_PROFICIENCIES"
         ],
-        "title": "Pick an Attunement to show the world your Worth.",
+        "title": "You reach out to touch the attunement altar.",
         "names": [
           "<trait_name:ARTIFICER>",
           "<trait_name:ALCHEMIST>",
@@ -204,7 +204,101 @@
         { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
       ]
     },
-    "effect": [ { "u_add_trait": "ARTIFICER" }, { "run_eocs": "EOC_ATTUNEMENT_SUCCESS_MESSAGE" } ]
+    "effect": [ { "u_add_trait": "ALCHEMIST" }, { "run_eocs": "EOC_ATTUNEMENT_SUCCESS_MESSAGE" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_GIVE_ATTUNEMENT_BIOTEK",
+    "condition": {
+      "and": [
+        { "u_has_trait": "BIOMANCER" },
+        { "u_has_trait": "TECHNOMANCER" },
+        {
+          "not": {
+            "u_has_any_trait": [
+              "ARTIFICER",
+              "ALCHEMIST",
+              "BLOOD_MAGE",
+              "BOREAL_MAGE",
+              "CRUSADER",
+              "CLEANSING_FLAME",
+              "EARTH_ELEMENTAL",
+              "FIRE_ELEMENTAL",
+              "GAIAS_CHOSEN",
+              "GLACIER_MAGE",
+              "GOLEMANCER",
+              "GRAVITY_MAGE",
+              "OVERCLOCKER",
+              "ICE_ELEMENTAL",
+              "ILLUSIONIST",
+              "MAGNETISM_MAGE",
+              "SHAMAN",
+              "SHAPESHIFTER",
+              "STORM_ELEMENTAL",
+              "STORMCALLER",
+              "TUNDRA_MAGE",
+              "VOID_MAGE",
+              "VULCANIST",
+              "SOULFIRE",
+              "WITHER_MAGE",
+              "MAGIC_EMPTY"
+            ]
+          }
+        },
+        { "math": [ "u_spell_count('school': 'BIOMANCER') >= _required_spell_count" ] },
+        { "math": [ "u_spell_count('school': 'TECHNOMANCER') >= _required_spell_count" ] },
+        { "math": [ "u_spell_level_sum('school': 'BIOMANCER') >= _required_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'TECHNOMANCER') >= _required_spell_levels" ] },
+        { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
+      ]
+    },
+    "effect": [ { "u_add_trait": "BIOTEK" }, { "run_eocs": "EOC_ATTUNEMENT_SUCCESS_MESSAGE" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_GIVE_ATTUNEMENT_BLOOD_MAGE",
+    "condition": {
+      "and": [
+        { "u_has_trait": "BIOMANCER" },
+        { "u_has_trait": "ANIMIST" },
+        {
+          "not": {
+            "u_has_any_trait": [
+              "ALCHEMIST",
+              "BIOTEK",
+              "CRUSADER",
+              "CLEANSING_FLAME",
+              "EARTH_ELEMENTAL",
+              "FIRE_ELEMENTAL",
+              "FORCE_MAGE",
+              "GAIAS_CHOSEN",
+              "GOLEMANCER",
+              "GRAVITY_MAGE",
+              "ICE_ELEMENTAL",
+              "ILLUSIONIST",
+              "PERMAFROST_MAGE",
+              "RADIATION_MAGE",
+              "SHAMAN",
+              "SHAPESHIFTER",
+              "STORM_ELEMENTAL",
+              "STORMCALLER",
+              "SUN_MAGE",
+              "TUNDRA_MAGE",
+              "VOID_MAGE",
+              "SOULFIRE",
+              "WITHER_MAGE",
+              "MAGIC_EMPTY"
+            ]
+          }
+        },
+        { "math": [ "u_spell_count('school': 'BIOMANCER') >= _required_spell_count" ] },
+        { "math": [ "u_spell_count('school': 'ANIMIST') >= _required_spell_count" ] },
+        { "math": [ "u_spell_level_sum('school': 'BIOMANCER') >= _required_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'ANIMIST') >= _required_spell_levels" ] },
+        { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
+      ]
+    },
+    "effect": [ { "u_add_trait": "BLOOD_MAGE" }, { "run_eocs": "EOC_ATTUNEMENT_SUCCESS_MESSAGE" } ]
   },
   {
     "type": "effect_on_condition",

--- a/data/mods/Magiclysm/effect_on_conditions/attunement_choices.json
+++ b/data/mods/Magiclysm/effect_on_conditions/attunement_choices.json
@@ -1,0 +1,236 @@
+[
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_CHECK_ATTUNEMENTS",
+    "effect": [
+      { "math": [ "_required_spell_count = 10" ] },
+      { "math": [ "_required_spell_levels = 150" ] },
+      {
+        "run_eoc_selector": [
+          "EOC_GIVE_ATTUNEMENT_ARTIFICER",
+          "EOC_GIVE_ATTUNEMENT_ALCHEMIST",
+          "EOC_GIVE_ATTUNEMENT_BIOTEK",
+          "EOC_GIVE_ATTUNEMENT_BLOOD_MAGE",
+          "EOC_GIVE_ATTUNEMENT_BOREAL_MAGE",
+          "EOC_GIVE_ATTUNEMENT_CLEANSING_FLAME",
+          "EOC_GIVE_ATTUNEMENT_CRUSADER",
+          "EOC_GIVE_ATTUNEMENT_EARTH_ELEMENTAL",
+          "EOC_GIVE_ATTUNEMENT_FIRE_ELEMENTAL",
+          "EOC_GIVE_ATTUNEMENT_FORCE_MAGE",
+          "EOC_GIVE_ATTUNEMENT_GAIAS_CHOSEN",
+          "EOC_GIVE_ATTUNEMENT_GLACIER_MAGE",
+          "EOC_GIVE_ATTUNEMENT_GOLEMANCER",
+          "EOC_GIVE_ATTUNEMENT_GRAVITY_MAGE",
+          "EOC_GIVE_ATTUNEMENT_ICE_ELEMENTAL",
+          "EOC_GIVE_ATTUNEMENT_ILLUSIONIST",
+          "EOC_GIVE_ATTUNEMENT_MAGNETISM_MAGE",
+          "EOC_GIVE_ATTUNEMENT_OVERCLOCKER",
+          "EOC_GIVE_ATTUNEMENT_PERMAFROST_MAGE",
+          "EOC_GIVE_ATTUNEMENT_RADIATION_MAGE",
+          "EOC_GIVE_ATTUNEMENT_SHAMAN",
+          "EOC_GIVE_ATTUNEMENT_SHAPESHIFTER",
+          "EOC_GIVE_ATTUNEMENT_SOULFIRE",
+          "EOC_GIVE_ATTUNEMENT_STORM_ELEMENTAL",
+          "EOC_GIVE_ATTUNEMENT_STORMCALLER",
+          "EOC_GIVE_ATTUNEMENT_SUN_MAGE",
+          "EOC_GIVE_ATTUNEMENT_TUNDRA_MAGE",
+          "EOC_GIVE_ATTUNEMENT_VOID_MAGE",
+          "EOC_GIVE_ATTUNEMENT_VULCANIST",
+          "EOC_GIVE_ATTUNEMENT_WITHER_MAGE",
+          "EOC_CANT_GIVE_ATTUNEMENT_NOT_A_MAGE",
+          "EOC_CANT_GIVE_ATTUNEMENT_NOT_ENOUGH_SPELLS",
+          "EOC_CANT_GIVE_ATTUNEMENT_NOT_ENOUGH_SPELL_LEVELS",
+          "EOC_CANT_GIVE_ATTUNEMENT_NOT_ENOUGH_PROFICIENCIES"
+        ],
+        "title": "Pick an Attunement to show the world your Worth.",
+        "names": [
+          "<trait_name:ARTIFICER>",
+          "<trait_name:ALCHEMIST>",
+          "<trait_name:BIOTEK>",
+          "<trait_name:BLOOD_MAGE>",
+          "<trait_name:BOREAL_MAGE>",
+          "<trait_name:CLEANSING_FLAME>",
+          "<trait_name:CRUSADER>",
+          "<trait_name:EARTH_ELEMENTAL>",
+          "<trait_name:FIRE_ELEMENTAL>",
+          "<trait_name:FORCE_MAGE>",
+          "<trait_name:GAIAS_CHOSEN>",
+          "<trait_name:GLACIER_MAGE>",
+          "<trait_name:GOLEMANCER>",
+          "<trait_name:GRAVITY_MAGE>",
+          "<trait_name:OVERCLOCKER>",
+          "<trait_name:ICE_ELEMENTAL>",
+          "<trait_name:ILLUSIONIST>",
+          "<trait_name:MAGNETISM_MAGE>",
+          "<trait_name:PERMAFROST_MAGE>",
+          "<trait_name:RADIATION_MAGE>",
+          "<trait_name:SHAMAN>",
+          "<trait_name:SHAPESHIFTER>",
+          "<trait_name:SOULFIRE>",
+          "<trait_name:STORM_ELEMENTAL>",
+          "<trait_name:STORMCALLER>",
+          "<trait_name:SUN_MAGE>",
+          "<trait_name:TUNDRA_MAGE>",
+          "<trait_name:VOID_MAGE>",
+          "<trait_name:VULCANIST>",
+          "<trait_name:WITHER_MAGE>"
+        ],
+        "descriptions": [
+          "<trait_description:ARTIFICER>",
+          "<trait_description:ALCHEMIST>",
+          "<trait_description:BIOTEK>",
+          "<trait_description:BLOOD_MAGE>",
+          "<trait_description:BOREAL_MAGE>",
+          "<trait_description:CLEANSING_FLAME>",
+          "<trait_description:CRUSADER>",
+          "<trait_description:EARTH_ELEMENTAL>",
+          "<trait_description:FIRE_ELEMENTAL>",
+          "<trait_description:FORCE_MAGE>",
+          "<trait_description:GAIAS_CHOSEN>",
+          "<trait_description:GLACIER_MAGE>",
+          "<trait_description:GOLEMANCER>",
+          "<trait_description:GRAVITY_MAGE>",
+          "<trait_description:OVERCLOCKER>",
+          "<trait_description:ICE_ELEMENTAL>",
+          "<trait_description:ILLUSIONIST>",
+          "<trait_description:MAGNETISM_MAGE>",
+          "<trait_description:PERMAFROST_MAGE>",
+          "<trait_description:RADIATION_MAGE>",
+          "<trait_description:SHAMAN>",
+          "<trait_description:SHAPESHIFTER>",
+          "<trait_description:SOULFIRE>",
+          "<trait_description:STORM_ELEMENTAL>",
+          "<trait_description:STORMCALLER>",
+          "<trait_description:SUN_MAGE>",
+          "<trait_description:TUNDRA_MAGE>",
+          "<trait_description:VOID_MAGE>",
+          "<trait_description:VULCANIST>",
+          "<trait_description:WITHER_MAGE>"
+        ],
+        "allow_cancel": true,
+        "hide_failing": true
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_GIVE_ATTUNEMENT_ARTIFICER",
+    "condition": {
+      "and": [
+        { "u_has_trait": "STORMSHAPER" },
+        { "u_has_trait": "TECHNOMANCER" },
+        {
+          "not": {
+            "u_has_any_trait": [
+              "ALCHEMIST",
+              "BIOTEK",
+              "BOREAL_MAGE",
+              "CRUSADER",
+              "CLEANSING_FLAME",
+              "EARTH_ELEMENTAL",
+              "FIRE_ELEMENTAL",
+              "FORCE_MAGE",
+              "GAIAS_CHOSEN",
+              "GLACIER_MAGE",
+              "GOLEMANCER",
+              "GRAVITY_MAGE",
+              "OVERCLOCKER",
+              "ICE_ELEMENTAL",
+              "ILLUSIONIST",
+              "MAGNETISM_MAGE",
+              "PERMAFROST_MAGE",
+              "RADIATION_MAGE",
+              "STORM_ELEMENTAL",
+              "STORMCALLER",
+              "SUN_MAGE",
+              "TUNDRA_MAGE",
+              "VOID_MAGE",
+              "VULCANIST",
+              "SOULFIRE",
+              "MAGIC_EMPTY"
+            ]
+          }
+        },
+        { "math": [ "u_spell_count('school': 'STORMSHAPER') >= _required_spell_count" ] },
+        { "math": [ "u_spell_count('school': 'TECHNOMANCER') >= _required_spell_count" ] },
+        { "math": [ "u_spell_level_sum('school': 'STORMSHAPER') >= _required_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'TECHNOMANCER') >= _required_spell_levels" ] },
+        { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
+      ]
+    },
+    "effect": [ { "u_add_trait": "ARTIFICER" }, { "run_eocs": "EOC_ATTUNEMENT_SUCCESS_MESSAGE" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_GIVE_ATTUNEMENT_ALCHEMIST",
+    "condition": {
+      "and": [
+        { "u_has_trait": "ANIMIST" },
+        { "u_has_trait": "TECHNOMANCER" },
+        {
+          "not": {
+            "u_has_any_trait": [
+              "ARTIFICER",
+              "BIOTEK",
+              "BLOOD_MAGE",
+              "BOREAL_MAGE",
+              "CRUSADER",
+              "EARTH_ELEMENTAL",
+              "FORCE_MAGE",
+              "GAIAS_CHOSEN",
+              "GLACIER_MAGE",
+              "GOLEMANCER",
+              "GRAVITY_MAGE",
+              "OVERCLOCKER",
+              "ILLUSIONIST",
+              "MAGNETISM_MAGE",
+              "PERMAFROST_MAGE",
+              "RADIATION_MAGE",
+              "SHAMAN",
+              "SHAPESHIFTER",
+              "SUN_MAGE",
+              "VOID_MAGE",
+              "VULCANIST",
+              "SOULFIRE",
+              "WITHER_MAGE",
+              "MAGIC_EMPTY"
+            ]
+          }
+        },
+        { "math": [ "u_spell_count('school': 'ANIMIST') >= _required_spell_count" ] },
+        { "math": [ "u_spell_count('school': 'TECHNOMANCER') >= _required_spell_count" ] },
+        { "math": [ "u_spell_level_sum('school': 'ANIMIST') >= _required_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'TECHNOMANCER') >= _required_spell_levels" ] },
+        { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
+      ]
+    },
+    "effect": [ { "u_add_trait": "ARTIFICER" }, { "run_eocs": "EOC_ATTUNEMENT_SUCCESS_MESSAGE" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY",
+    "condition": {
+      "or": [
+        { "u_has_proficiency": "prof_magic_evocation_master" },
+        { "u_has_proficiency": "prof_magic_channel_master" },
+        { "u_has_proficiency": "prof_magic_summon_master" },
+        { "u_has_proficiency": "prof_magic_enhancement_master" },
+        { "u_has_proficiency": "prof_magic_enervation_master" },
+        { "u_has_proficiency": "prof_magic_conveyance_master" },
+        { "u_has_proficiency": "prof_magic_restoration_master" },
+        { "u_has_proficiency": "prof_magic_transformation_master" }
+      ]
+    },
+    "effect": [  ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_ATTUNEMENT_SUCCESS_MESSAGE",
+    "effect": [
+      {
+        "u_message": "As you touch the altar, you feel your ley lines twitch before they reconfigure themselves into new patterns.  Power flows through your body in a torrent along the new channels.  You have attained attunement.",
+        "type": "good"
+      }
+    ]
+  }
+]

--- a/data/mods/Magiclysm/effect_on_conditions/attunement_choices.json
+++ b/data/mods/Magiclysm/effect_on_conditions/attunement_choices.json
@@ -73,7 +73,11 @@
           "<trait_name:TUNDRA_MAGE>",
           "<trait_name:VOID_MAGE>",
           "<trait_name:VULCANIST>",
-          "<trait_name:WITHER_MAGE>"
+          "<trait_name:WITHER_MAGE>",
+          "Touch the altar",
+          "Touch the altar",
+          "Touch the altar",
+          "Touch the altar"
         ],
         "descriptions": [
           "<trait_description:ARTIFICER>",
@@ -105,7 +109,11 @@
           "<trait_description:TUNDRA_MAGE>",
           "<trait_description:VOID_MAGE>",
           "<trait_description:VULCANIST>",
-          "<trait_description:WITHER_MAGE>"
+          "<trait_description:WITHER_MAGE>",
+          "Touch the altar",
+          "Touch the altar",
+          "Touch the altar",
+          "Touch the altar"
         ],
         "allow_cancel": true,
         "hide_failing": true
@@ -302,6 +310,336 @@
   },
   {
     "type": "effect_on_condition",
+    "id": "EOC_GIVE_ATTUNEMENT_BOREAL_MAGE",
+    "condition": {
+      "and": [
+        { "u_has_trait": "KELVINIST" },
+        { "u_has_trait": "TECHNOMANCER" },
+        {
+          "not": {
+            "u_has_any_trait": [
+              "ARTIFICER",
+              "ALCHEMIST",
+              "BIOTEK",
+              "CRUSADER",
+              "CLEANSING_FLAME",
+              "EARTH_ELEMENTAL",
+              "FIRE_ELEMENTAL",
+              "FORCE_MAGE",
+              "GAIAS_CHOSEN",
+              "GLACIER_MAGE",
+              "GOLEMANCER",
+              "GRAVITY_MAGE",
+              "OVERCLOCKER",
+              "ICE_ELEMENTAL",
+              "ILLUSIONIST",
+              "MAGNETISM_MAGE",
+              "PERMAFROST_MAGE",
+              "RADIATION_MAGE",
+              "STORM_ELEMENTAL",
+              "STORMCALLER",
+              "SUN_MAGE",
+              "TUNDRA_MAGE",
+              "VOID_MAGE",
+              "VULCANIST",
+              "SOULFIRE",
+              "MAGIC_EMPTY"
+            ]
+          }
+        },
+        { "math": [ "u_spell_count('school': 'KELVINIST') >= _required_spell_count" ] },
+        { "math": [ "u_spell_count('school': 'TECHNOMANCER') >= _required_spell_count" ] },
+        { "math": [ "u_spell_level_sum('school': 'KELVINIST') >= _required_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'TECHNOMANCER') >= _required_spell_levels" ] },
+        { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
+      ]
+    },
+    "effect": [ { "u_add_trait": "BOREAL_MAGE" }, { "run_eocs": "EOC_ATTUNEMENT_SUCCESS_MESSAGE" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_GIVE_ATTUNEMENT_CLEANSING_FLAME",
+    "condition": {
+      "and": [
+        { "u_has_trait": "DRUID" },
+        { "u_has_trait": "KELVINIST" },
+        {
+          "not": {
+            "u_has_any_trait": [
+              "ARTIFICER",
+              "BIOTEK",
+              "BLOOD_MAGE",
+              "BOREAL_MAGE",
+              "CRUSADER",
+              "EARTH_ELEMENTAL",
+              "FIRE_ELEMENTAL",
+              "FORCE_MAGE",
+              "GAIAS_CHOSEN",
+              "GLACIER_MAGE",
+              "OVERCLOCKER",
+              "ICE_ELEMENTAL",
+              "MAGNETISM_MAGE",
+              "PERMAFROST_MAGE",
+              "RADIATION_MAGE",
+              "SHAMAN",
+              "SHAPESHIFTER",
+              "STORM_ELEMENTAL",
+              "STORMCALLER",
+              "SUN_MAGE",
+              "TUNDRA_MAGE",
+              "VOID_MAGE",
+              "VULCANIST",
+              "SOULFIRE",
+              "WITHER_MAGE",
+              "MAGIC_EMPTY"
+            ]
+          }
+        },
+        { "math": [ "u_spell_count('school': 'DRUID') >= _required_spell_count" ] },
+        { "math": [ "u_spell_count('school': 'KELVINIST') >= _required_spell_count" ] },
+        { "math": [ "u_spell_level_sum('school': 'DRUID') >= _required_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'KELVINIST') >= _required_spell_levels" ] },
+        { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
+      ]
+    },
+    "effect": [ { "u_add_trait": "CLEANSING_FLAME" }, { "run_eocs": "EOC_ATTUNEMENT_SUCCESS_MESSAGE" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_GIVE_ATTUNEMENT_CRUSADER",
+    "condition": {
+      "and": [
+        { "u_has_trait": "DRUID" },
+        { "u_has_trait": "TECHNOMANCER" },
+        {
+          "not": {
+            "u_has_any_trait": [
+              "ARTIFICER",
+              "ALCHEMIST",
+              "BIOTEK",
+              "BLOOD_MAGE",
+              "BOREAL_MAGE",
+              "CLEANSING_FLAME",
+              "EARTH_ELEMENTAL",
+              "FIRE_ELEMENTAL",
+              "GAIAS_CHOSEN",
+              "GLACIER_MAGE",
+              "GOLEMANCER",
+              "GRAVITY_MAGE",
+              "OVERCLOCKER",
+              "ICE_ELEMENTAL",
+              "ILLUSIONIST",
+              "MAGNETISM_MAGE",
+              "SHAMAN",
+              "SHAPESHIFTER",
+              "STORM_ELEMENTAL",
+              "STORMCALLER",
+              "TUNDRA_MAGE",
+              "VULCANIST",
+              "WITHER_MAGE",
+              "MAGIC_EMPTY"
+            ]
+          }
+        },
+        { "math": [ "u_spell_count('school': 'DRUID') >= _required_spell_count" ] },
+        { "math": [ "u_spell_count('school': 'TECHNOMANCER') >= _required_spell_count" ] },
+        { "math": [ "u_spell_level_sum('school': 'DRUID') >= _required_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'TECHNOMANCER') >= _required_spell_levels" ] },
+        { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
+      ]
+    },
+    "effect": [ { "u_add_trait": "CRUSADER" }, { "run_eocs": "EOC_ATTUNEMENT_SUCCESS_MESSAGE" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_GIVE_ATTUNEMENT_EARTH_ELEMENTAL",
+    "condition": {
+      "and": [
+        { "u_has_trait": "BIOMANCER" },
+        { "u_has_trait": "EARTHSHAPER" },
+        {
+          "not": {
+            "u_has_any_trait": [
+              "ARTIFICER",
+              "ALCHEMIST",
+              "BIOTEK",
+              "BLOOD_MAGE",
+              "BOREAL_MAGE",
+              "CRUSADER",
+              "CLEANSING_FLAME",
+              "FIRE_ELEMENTAL",
+              "GAIAS_CHOSEN",
+              "GLACIER_MAGE",
+              "GOLEMANCER",
+              "GRAVITY_MAGE",
+              "OVERCLOCKER",
+              "ICE_ELEMENTAL",
+              "ILLUSIONIST",
+              "MAGNETISM_MAGE",
+              "SHAMAN",
+              "SHAPESHIFTER",
+              "STORM_ELEMENTAL",
+              "STORMCALLER",
+              "TUNDRA_MAGE",
+              "VULCANIST",
+              "WITHER_MAGE",
+              "MAGIC_EMPTY"
+            ]
+          }
+        },
+        { "math": [ "u_spell_count('school': 'BIOMANCER') >= _required_spell_count" ] },
+        { "math": [ "u_spell_count('school': 'EARTHSHAPER') >= _required_spell_count" ] },
+        { "math": [ "u_spell_level_sum('school': 'BIOMANCER') >= _required_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'EARTHSHAPER') >= _required_spell_levels" ] },
+        { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
+      ]
+    },
+    "effect": [ { "u_add_trait": "EARTH_ELEMENTAL" }, { "run_eocs": "EOC_ATTUNEMENT_SUCCESS_MESSAGE" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_GIVE_ATTUNEMENT_FIRE_ELEMENTAL",
+    "condition": {
+      "and": [
+        { "u_has_trait": "BIOMANCER" },
+        { "u_has_trait": "KELVINIST" },
+        {
+          "not": {
+            "u_has_any_trait": [
+              "ARTIFICER",
+              "BIOTEK",
+              "BLOOD_MAGE",
+              "BOREAL_MAGE",
+              "CRUSADER",
+              "CLEANSING_FLAME",
+              "EARTH_ELEMENTAL",
+              "FORCE_MAGE",
+              "GAIAS_CHOSEN",
+              "GLACIER_MAGE",
+              "OVERCLOCKER",
+              "ICE_ELEMENTAL",
+              "MAGNETISM_MAGE",
+              "PERMAFROST_MAGE",
+              "RADIATION_MAGE",
+              "SHAMAN",
+              "SHAPESHIFTER",
+              "STORM_ELEMENTAL",
+              "STORMCALLER",
+              "SUN_MAGE",
+              "TUNDRA_MAGE",
+              "VOID_MAGE",
+              "VULCANIST",
+              "SOULFIRE",
+              "WITHER_MAGE",
+              "MAGIC_EMPTY"
+            ]
+          }
+        },
+        { "math": [ "u_spell_count('school': 'BIOMANCER') >= _required_spell_count" ] },
+        { "math": [ "u_spell_count('school': 'KELVINIST') >= _required_spell_count" ] },
+        { "math": [ "u_spell_level_sum('school': 'BIOMANCER') >= _required_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'KELVINIST') >= _required_spell_levels" ] },
+        { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
+      ]
+    },
+    "effect": [ { "u_add_trait": "FIRE_ELEMENTAL" }, { "run_eocs": "EOC_ATTUNEMENT_SUCCESS_MESSAGE" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_GIVE_ATTUNEMENT_FORCE_MAGE",
+    "condition": {
+      "and": [
+        { "u_has_trait": "MAGUS" },
+        { "u_has_trait": "STORMSHAPER" },
+        {
+          "not": {
+            "u_has_any_trait": [
+              "ARTIFICER",
+              "ALCHEMIST",
+              "BLOOD_MAGE",
+              "BOREAL_MAGE",
+              "CLEANSING_FLAME",
+              "FIRE_ELEMENTAL",
+              "GLACIER_MAGE",
+              "GOLEMANCER",
+              "GRAVITY_MAGE",
+              "OVERCLOCKER",
+              "ICE_ELEMENTAL",
+              "ILLUSIONIST",
+              "MAGNETISM_MAGE",
+              "PERMAFROST_MAGE",
+              "RADIATION_MAGE",
+              "SHAMAN",
+              "SHAPESHIFTER",
+              "STORM_ELEMENTAL",
+              "STORMCALLER",
+              "SUN_MAGE",
+              "TUNDRA_MAGE",
+              "VOID_MAGE",
+              "VULCANIST",
+              "SOULFIRE",
+              "WITHER_MAGE",
+              "MAGIC_EMPTY"
+            ]
+          }
+        },
+        { "math": [ "u_spell_count('school': 'MAGUS') >= _required_spell_count" ] },
+        { "math": [ "u_spell_count('school': 'STORMSHAPER') >= _required_spell_count" ] },
+        { "math": [ "u_spell_level_sum('school': 'MAGUS') >= _required_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'STORMSHAPER') >= _required_spell_levels" ] },
+        { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
+      ]
+    },
+    "effect": [ { "u_add_trait": "FORCE_MAGE" }, { "run_eocs": "EOC_ATTUNEMENT_SUCCESS_MESSAGE" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_GIVE_ATTUNEMENT_GAIAS_CHOSEN",
+    "condition": {
+      "and": [
+        { "u_has_trait": "DRUID" },
+        { "u_has_trait": "EARTHSHAPER" },
+        {
+          "not": {
+            "u_has_any_trait": [
+              "ARTIFICER",
+              "ALCHEMIST",
+              "BIOTEK",
+              "BLOOD_MAGE",
+              "BOREAL_MAGE",
+              "CRUSADER",
+              "CLEANSING_FLAME",
+              "EARTH_ELEMENTAL",
+              "FIRE_ELEMENTAL",
+              "GLACIER_MAGE",
+              "GOLEMANCER",
+              "GRAVITY_MAGE",
+              "OVERCLOCKER",
+              "ICE_ELEMENTAL",
+              "ILLUSIONIST",
+              "MAGNETISM_MAGE",
+              "SHAMAN",
+              "SHAPESHIFTER",
+              "STORM_ELEMENTAL",
+              "STORMCALLER",
+              "TUNDRA_MAGE",
+              "VULCANIST",
+              "WITHER_MAGE",
+              "MAGIC_EMPTY"
+            ]
+          }
+        },
+        { "math": [ "u_spell_count('school': 'DRUID') >= _required_spell_count" ] },
+        { "math": [ "u_spell_count('school': 'EARTHSHAPER') >= _required_spell_count" ] },
+        { "math": [ "u_spell_level_sum('school': 'DRUID') >= _required_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'EARTHSHAPER') >= _required_spell_levels" ] },
+        { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
+      ]
+    },
+    "effect": [ { "u_add_trait": "GAIAS_CHOSEN" }, { "run_eocs": "EOC_ATTUNEMENT_SUCCESS_MESSAGE" } ]
+  },
+  {
+    "type": "effect_on_condition",
     "id": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY",
     "condition": {
       "or": [
@@ -322,7 +660,7 @@
     "id": "EOC_ATTUNEMENT_SUCCESS_MESSAGE",
     "effect": [
       {
-        "u_message": "As you touch the altar, you feel your ley lines twitch before they reconfigure themselves into new patterns.  Power flows through your body in a torrent along the new channels.  You have attained attunement.",
+        "u_message": "As you touch the altar, you feel your ley lines twitch before they reconfigure themselves into new patterns.  Power flows through your body in a torrent along the new channels.  You have attained attunement, the rarest of all magical accomplishments.",
         "type": "good"
       }
     ]

--- a/data/mods/Magiclysm/effect_on_conditions/attunement_choices.json
+++ b/data/mods/Magiclysm/effect_on_conditions/attunement_choices.json
@@ -58,10 +58,10 @@
           "<trait_name:GLACIER_MAGE>",
           "<trait_name:GOLEMANCER>",
           "<trait_name:GRAVITY_MAGE>",
-          "<trait_name:OVERCLOCKER>",
           "<trait_name:ICE_ELEMENTAL>",
           "<trait_name:ILLUSIONIST>",
           "<trait_name:MAGNETISM_MAGE>",
+          "<trait_name:OVERCLOCKER>",
           "<trait_name:PERMAFROST_MAGE>",
           "<trait_name:RADIATION_MAGE>",
           "<trait_name:SHAMAN>",
@@ -94,10 +94,10 @@
           "<trait_description:GLACIER_MAGE>",
           "<trait_description:GOLEMANCER>",
           "<trait_description:GRAVITY_MAGE>",
-          "<trait_description:OVERCLOCKER>",
           "<trait_description:ICE_ELEMENTAL>",
           "<trait_description:ILLUSIONIST>",
           "<trait_description:MAGNETISM_MAGE>",
+          "<trait_description:OVERCLOCKER>",
           "<trait_description:PERMAFROST_MAGE>",
           "<trait_description:RADIATION_MAGE>",
           "<trait_description:SHAMAN>",
@@ -637,6 +637,340 @@
       ]
     },
     "effect": [ { "u_add_trait": "GAIAS_CHOSEN" }, { "run_eocs": "EOC_ATTUNEMENT_SUCCESS_MESSAGE" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_GIVE_ATTUNEMENT_GLACIER_MAGE",
+    "condition": {
+      "and": [
+        { "u_has_trait": "EARTHSHAPER" },
+        { "u_has_trait": "KELVINIST" },
+        {
+          "not": {
+            "u_has_any_trait": [
+              "ARTIFICER",
+              "ALCHEMIST",
+              "BIOTEK",
+              "BOREAL_MAGE",
+              "CRUSADER",
+              "CLEANSING_FLAME",
+              "EARTH_ELEMENTAL",
+              "FIRE_ELEMENTAL",
+              "FORCE_MAGE",
+              "GAIAS_CHOSEN",
+              "GOLEMANCER",
+              "GRAVITY_MAGE",
+              "OVERCLOCKER",
+              "ICE_ELEMENTAL",
+              "ILLUSIONIST",
+              "MAGNETISM_MAGE",
+              "PERMAFROST_MAGE",
+              "RADIATION_MAGE",
+              "STORM_ELEMENTAL",
+              "STORMCALLER",
+              "SUN_MAGE",
+              "TUNDRA_MAGE",
+              "VOID_MAGE",
+              "VULCANIST",
+              "SOULFIRE",
+              "MAGIC_EMPTY"
+            ]
+          }
+        },
+        { "math": [ "u_spell_count('school': 'EARTHSHAPER') >= _required_spell_count" ] },
+        { "math": [ "u_spell_count('school': 'KELVINIST') >= _required_spell_count" ] },
+        { "math": [ "u_spell_level_sum('school': 'EARTHSHAPER') >= _required_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'KELVINIST') >= _required_spell_levels" ] },
+        { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
+      ]
+    },
+    "effect": [
+      { "u_add_trait": "FROZEN_PRESSURE_OFF" },
+      { "u_add_trait": "GLACIER_MAGE" },
+      { "run_eocs": "EOC_ATTUNEMENT_SUCCESS_MESSAGE" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_GIVE_ATTUNEMENT_GOLEMANCER",
+    "condition": {
+      "and": [
+        { "u_has_trait": "ANIMIST" },
+        { "u_has_trait": "EARTHSHAPER" },
+        {
+          "not": {
+            "u_has_any_trait": [
+              "ARTIFICER",
+              "ALCHEMIST",
+              "BIOTEK",
+              "BLOOD_MAGE",
+              "BOREAL_MAGE",
+              "CRUSADER",
+              "EARTH_ELEMENTAL",
+              "FORCE_MAGE",
+              "GAIAS_CHOSEN",
+              "GLACIER_MAGE",
+              "GRAVITY_MAGE",
+              "OVERCLOCKER",
+              "ILLUSIONIST",
+              "MAGNETISM_MAGE",
+              "PERMAFROST_MAGE",
+              "RADIATION_MAGE",
+              "SHAMAN",
+              "SHAPESHIFTER",
+              "SUN_MAGE",
+              "VOID_MAGE",
+              "VULCANIST",
+              "SOULFIRE",
+              "WITHER_MAGE",
+              "MAGIC_EMPTY"
+            ]
+          }
+        },
+        { "math": [ "u_spell_count('school': 'ANIMIST') >= _required_spell_count" ] },
+        { "math": [ "u_spell_count('school': 'EARTHSHAPER') >= _required_spell_count" ] },
+        { "math": [ "u_spell_level_sum('school': 'ANIMIST') >= _required_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'EARTHSHAPER') >= _required_spell_levels" ] },
+        { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
+      ]
+    },
+    "effect": [ { "u_add_trait": "GOLEMANCER" }, { "run_eocs": "EOC_ATTUNEMENT_SUCCESS_MESSAGE" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_GIVE_ATTUNEMENT_GRAVITY_MAGE",
+    "condition": {
+      "and": [
+        { "u_has_trait": "EARTHSHAPER" },
+        { "u_has_trait": "MAGUS" },
+        {
+          "not": {
+            "u_has_any_trait": [
+              "ARTIFICER",
+              "ALCHEMIST",
+              "BIOTEK",
+              "BLOOD_MAGE",
+              "BOREAL_MAGE",
+              "CRUSADER",
+              "EARTH_ELEMENTAL",
+              "FORCE_MAGE",
+              "GAIAS_CHOSEN",
+              "GLACIER_MAGE",
+              "GOLEMANCER",
+              "OVERCLOCKER",
+              "ILLUSIONIST",
+              "MAGNETISM_MAGE",
+              "PERMAFROST_MAGE",
+              "RADIATION_MAGE",
+              "SHAMAN",
+              "SHAPESHIFTER",
+              "SUN_MAGE",
+              "VOID_MAGE",
+              "VULCANIST",
+              "SOULFIRE",
+              "WITHER_MAGE",
+              "MAGIC_EMPTY"
+            ]
+          }
+        },
+        { "math": [ "u_spell_count('school': 'EARTHSHAPER') >= _required_spell_count" ] },
+        { "math": [ "u_spell_count('school': 'MAGUS') >= _required_spell_count" ] },
+        { "math": [ "u_spell_level_sum('school': 'EARTHSHAPER') >= _required_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'MAGUS') >= _required_spell_levels" ] },
+        { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
+      ]
+    },
+    "effect": [ { "u_add_trait": "GRAVITY_MAGE" }, { "run_eocs": "EOC_ATTUNEMENT_SUCCESS_MESSAGE" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_GIVE_ATTUNEMENT_ICE_ELEMENTAL",
+    "condition": {
+      "and": [
+        { "u_has_trait": "BIOMANCER" },
+        { "u_has_trait": "KELVINIST" },
+        {
+          "not": {
+            "u_has_any_trait": [
+              "ARTIFICER",
+              "BIOTEK",
+              "BLOOD_MAGE",
+              "BOREAL_MAGE",
+              "CRUSADER",
+              "CLEANSING_FLAME",
+              "EARTH_ELEMENTAL",
+              "FIRE_ELEMENTAL",
+              "FORCE_MAGE",
+              "GAIAS_CHOSEN",
+              "GLACIER_MAGE",
+              "OVERCLOCKER",
+              "MAGNETISM_MAGE",
+              "PERMAFROST_MAGE",
+              "RADIATION_MAGE",
+              "SHAMAN",
+              "SHAPESHIFTER",
+              "STORM_ELEMENTAL",
+              "STORMCALLER",
+              "SUN_MAGE",
+              "TUNDRA_MAGE",
+              "VOID_MAGE",
+              "VULCANIST",
+              "SOULFIRE",
+              "WITHER_MAGE",
+              "MAGIC_EMPTY"
+            ]
+          }
+        },
+        { "math": [ "u_spell_count('school': 'BIOMANCER') >= _required_spell_count" ] },
+        { "math": [ "u_spell_count('school': 'KELVINIST') >= _required_spell_count" ] },
+        { "math": [ "u_spell_level_sum('school': 'BIOMANCER') >= _required_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'KELVINIST') >= _required_spell_levels" ] },
+        { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
+      ]
+    },
+    "effect": [ { "u_add_trait": "ICE_ELEMENTAL" }, { "run_eocs": "EOC_ATTUNEMENT_SUCCESS_MESSAGE" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_GIVE_ATTUNEMENT_ILLUSIONIST",
+    "condition": {
+      "and": [
+        { "u_has_trait": "MAGUS" },
+        { "u_has_trait": "TECHNOMANCER" },
+        {
+          "not": {
+            "u_has_any_trait": [
+              "ARTIFICER",
+              "ALCHEMIST",
+              "BIOTEK",
+              "BLOOD_MAGE",
+              "BOREAL_MAGE",
+              "CRUSADER",
+              "EARTH_ELEMENTAL",
+              "FORCE_MAGE",
+              "GAIAS_CHOSEN",
+              "GLACIER_MAGE",
+              "GOLEMANCER",
+              "GRAVITY_MAGE",
+              "OVERCLOCKER",
+              "MAGNETISM_MAGE",
+              "PERMAFROST_MAGE",
+              "RADIATION_MAGE",
+              "SHAMAN",
+              "SHAPESHIFTER",
+              "SUN_MAGE",
+              "VOID_MAGE",
+              "VULCANIST",
+              "SOULFIRE",
+              "WITHER_MAGE",
+              "MAGIC_EMPTY"
+            ]
+          }
+        },
+        { "math": [ "u_spell_count('school': 'MAGUS') >= _required_spell_count" ] },
+        { "math": [ "u_spell_count('school': 'TECHNOMANCER') >= _required_spell_count" ] },
+        { "math": [ "u_spell_level_sum('school': 'MAGUS') >= _required_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'TECHNOMANCER') >= _required_spell_levels" ] },
+        { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
+      ]
+    },
+    "effect": [ { "u_add_trait": "ILLUSIONIST" }, { "run_eocs": "EOC_ATTUNEMENT_SUCCESS_MESSAGE" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_GIVE_ATTUNEMENT_MAGNETISM_MAGE",
+    "condition": {
+      "and": [
+        { "u_has_trait": "EARTHSHAPER" },
+        { "u_has_trait": "STORMSHAPER" },
+        {
+          "not": {
+            "u_has_any_trait": [
+              "ARTIFICER",
+              "ALCHEMIST",
+              "BIOTEK",
+              "BOREAL_MAGE",
+              "CRUSADER",
+              "CLEANSING_FLAME",
+              "EARTH_ELEMENTAL",
+              "FIRE_ELEMENTAL",
+              "FORCE_MAGE",
+              "GAIAS_CHOSEN",
+              "GLACIER_MAGE",
+              "GOLEMANCER",
+              "GRAVITY_MAGE",
+              "OVERCLOCKER",
+              "ICE_ELEMENTAL",
+              "ILLUSIONIST",
+              "PERMAFROST_MAGE",
+              "RADIATION_MAGE",
+              "STORM_ELEMENTAL",
+              "STORMCALLER",
+              "SUN_MAGE",
+              "TUNDRA_MAGE",
+              "VOID_MAGE",
+              "VULCANIST",
+              "SOULFIRE",
+              "MAGIC_EMPTY"
+            ]
+          }
+        },
+        { "math": [ "u_spell_count('school': 'EARTHSHAPER') >= _required_spell_count" ] },
+        { "math": [ "u_spell_count('school': 'STORMSHAPER') >= _required_spell_count" ] },
+        { "math": [ "u_spell_level_sum('school': 'EARTHSHAPER') >= _required_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'STORMSHAPER') >= _required_spell_levels" ] },
+        { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
+      ]
+    },
+    "effect": [ { "u_add_trait": "MAGNETISM_MAGE" }, { "run_eocs": "EOC_ATTUNEMENT_SUCCESS_MESSAGE" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_GIVE_ATTUNEMENT_OVERCLOCKER",
+    "condition": {
+      "and": [
+        { "u_has_trait": "KELVINIST" },
+        { "u_has_trait": "TECHNOMANCER" },
+        {
+          "not": {
+            "u_has_any_trait": [
+              "ARTIFICER",
+              "ALCHEMIST",
+              "BIOTEK",
+              "BOREAL_MAGE",
+              "CRUSADER",
+              "CLEANSING_FLAME",
+              "EARTH_ELEMENTAL",
+              "FIRE_ELEMENTAL",
+              "FORCE_MAGE",
+              "GAIAS_CHOSEN",
+              "GLACIER_MAGE",
+              "GOLEMANCER",
+              "GRAVITY_MAGE",
+              "ICE_ELEMENTAL",
+              "ILLUSIONIST",
+              "MAGNETISM_MAGE",
+              "PERMAFROST_MAGE",
+              "RADIATION_MAGE",
+              "STORM_ELEMENTAL",
+              "STORMCALLER",
+              "SUN_MAGE",
+              "TUNDRA_MAGE",
+              "VOID_MAGE",
+              "VULCANIST",
+              "SOULFIRE",
+              "MAGIC_EMPTY"
+            ]
+          }
+        },
+        { "math": [ "u_spell_count('school': 'KELVINIST') >= _required_spell_count" ] },
+        { "math": [ "u_spell_count('school': 'TECHNOMANCER') >= _required_spell_count" ] },
+        { "math": [ "u_spell_level_sum('school': 'KELVINIST') >= _required_spell_levels" ] },
+        { "math": [ "u_spell_level_sum('school': 'TECHNOMANCER') >= _required_spell_levels" ] },
+        { "test_eoc": "EOC_CONDITION_ATTUNEMENT_CHECK_PROFICIENCY_MASTERY" }
+      ]
+    },
+    "effect": [ { "u_add_trait": "OVERCLOCKER" }, { "run_eocs": "EOC_ATTUNEMENT_SUCCESS_MESSAGE" } ]
   },
   {
     "type": "effect_on_condition",

--- a/data/mods/Magiclysm/furniture_and_terrain/furniture.json
+++ b/data/mods/Magiclysm/furniture_and_terrain/furniture.json
@@ -234,7 +234,7 @@
     "coverage": 40,
     "looks_like": "t_pedestal_temple",
     "required_str": 30,
-    "examine_action": "attunement_altar",
+    "examine_action": { "type": "effect_on_condition", "effect_on_conditions": [ "EOC_CHECK_ATTUNEMENTS" ] },
     "description": "An ancient stone plinth covered in symbols that appear to be combinations and variations of the eight magic classes.  Eight depressions are on the top with the original symbols of the classes, each look as though they can hold an item.",
     "bash": {
       "str_min": 30,


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Magiclysm] Rework attunement requirements"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Attunements are supposed to be extremely rare but at the moment you can get them in a couple weeks of spamming magic and reading books. 

Also, this will JSONify the requirements, which is better than hardcoding. 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Rework the Attunement Altar to call an EoC that checks the requirements. At the moment, there's no way other than to check the requiements for each attunement individually (GuardianDII attempted this previously and stalled out due to that), so the EoC is extremely long, but in the future hopefully we'll be able to reduce it somewhat.

The new requirements are:

1. Twelve spells in each school linked to the attunement.
2. Two-hundred total levels of spells in each school linked to the attunement.
3. At least one Master-level spellcasting proficiency. 

Existing requirements (attunements preventing taking other attunements etc) are still in place.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

If you're not a mage, the altar tells you.
If you are a mage but don't know enough spells, the altar tells you.
If you know enough spells but don't know them well enough, the altar tells you.
If you know them well enough but don't have any master proficiencies, the altar tells you.
If you have all of that, you get your choice of attunement.
You cannot take conflicting attunements. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
