### PR TITLE
Update PR template for brevity

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,32 +1,28 @@
 <!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
-Leave the headings unless they don't apply to your PR.
+You must have the below headings. Comments like this may be safely removed, if you want.
 
-Please read carefully.
-Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
-The results can be either seen under the "Files changed" section of a PR or in the check's details.
+If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.
 
-Rules for suggested pull requests:
-- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
-- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
-- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool
-
-NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->
+Guidelines for pull requests:
+-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
+-A good rule of thumb is that most pull requests are less than 500 lines of changes.
+-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
+-->
 
 #### Summary
 Category "Brief description"
+
 <!-- This section should consist of exactly one line, edit the one above.
-1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
+1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
 2. Replace the text inside the quotes with a brief description of your changes.
 Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
-Examples:
+Some examples:
 1. None
 2. Features "In-game Armor sprite change"
 3. Interface "Show crafting failure chances in the crafting interface"
-4. Infrastructure "JSON-ize slot machines"
-5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
 For more on the meaning of each category, see:
 https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
-If approved and merged, your summary will be added to the project changelog:
+If merged, your summary will be added to the project changelog:
 https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->
 
 #### Purpose of change


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Our PR template remains extremely verbose, and difficult to parse. Let's not scare away our promising new contributors will walls of text, okay?

![image](https://github.com/user-attachments/assets/c5940b85-b209-46b4-afa6-4dde2618fcee)


#### Describe the solution
Trim trim trim

The major changes were to the guidelines. Since those were intended to be 'bullet points' but dragged on for entire paragraphs they weren't really doing their job. I have rewritten them to hopefully convey the essence of what we want (no mega PRs) while not requiring people to read through all the exceptions. Contributors do not want to read through all this and mentally classify whether their PR is "mapgen" or "a new item" or whatever, they just need a rule of thumb. The rule of thumb is 500 lines of changes.

I removed some misleading statements, such as "automatic stylistic and consistency checks will be performed on the PR's changes"... those do not need to be looked for, and will not be automatically applied. If suggested by the github-actions bot, the author will already be notified. So we don't need to burden them with this knowledge when opening their PR.

Similarly I removed the statement about allowing edits and access to secrets. It is pretty rare that we need to push someone's branch and the option is already enabled by default. So we don't need a statement for this very rare occurrence.

We had 5 examples of changelog entries, I shortened it to 3. (One for the special case 'None', and then two separate category entries so people can compare between the two to understand).

I changed the comment about headings to reinforce that the headings must be kept. Removing some headings will cause the PR summary bot to fail, which is just confusing to contributors. The suggestion to remove headings is a footgun, get rid of it.


#### Describe alternatives you've considered
Can't we use the proper template, like bug reports do?

Maybe we should move the copyright notice to the top, that feels more appropriate. But that's the last thing contributors *actually* want to read, so putting it first means less chance they'll read the guidelines...

#### Testing
No changes to the game

#### Additional context
Fun fact: This PR uses the old template. Not sure how that works, github!