### PR TITLE
Make 'A shadow?' always visible.

### DIFF
--- a/data/json/monsters/singularities.json
+++ b/data/json/monsters/singularities.json
@@ -93,7 +93,7 @@
       "ALL_SEEING",
       "ALWAYS_SEES_YOU",
       "HAS_MIND",
-      "NIGHT_INVISIBILITY",
+      "ALWAYS_VISIBLE",
       "NO_FUNG_DMG",
       "FILTHY",
       "STUN_IMMUNE",


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
* Follow-up to #80746

There are still scenarios where people don't see it and believe that amalgamations spawn out of thin air.

#### Describe the solution
Make sure it's always seen. Add the ALWAYS_VISIBLE flag.

#### Describe alternatives you've considered
ALWAYS_VISIBLE forces it to even be rendered through walls. This is not a huge problem as most times the act of entering any place with walls (an INDOORS) would cause it to despawn. We could instead make a new flag which still respects LOS but ignores lighting.

I just don't feel like dealing with the LOS code so I'm using the existing flag instead.

#### Testing
I have not tested this change.

For reviewers/mergers I suggest forcibly spawning it at night and making sure there aren't any scenarios where you can't see this thing. This is the same flag as the portal 'person' uses, so I believe we should be covered.

#### Additional context

