### PR TITLE
Display time as months and days instead of time into season

### DIFF
--- a/data/json/npcs/cabin_chemist/chemist_npc.json
+++ b/data/json/npcs/cabin_chemist/chemist_npc.json
@@ -143,7 +143,7 @@
   {
     "type": "talk_topic",
     "id": "TALK_NPC_CABIN_CHEMIST_ASK_INTERVAL",
-    "dynamic_line": "Unfortunately, I'm still gathering resources and cooking new stuff.  Maybe ask again after <interval>.",
+    "dynamic_line": "Unfortunately, I'm still gathering resources and cooking new stuff.  Maybe ask again after <restock_time_point>.",
     "responses": [ { "text": "Alright.  thanks nonetheless.", "topic": "TALK_NPC_CABIN_CHEMIST_INTRO" } ]
   },
   {

--- a/data/json/npcs/campus/great_library_librarian_talk.json
+++ b/data/json/npcs/campus/great_library_librarian_talk.json
@@ -60,8 +60,8 @@
     "id": "TALK_GREAT_LIBRARY_LIBRARIAN_AskedRestock",
     "type": "talk_topic",
     "dynamic_line": [
-      "It can be hard to predict the way things are now, but I am expecting new materials around <interval>.",
-      "I am expecting some new materials <interval>, hopefully some good escapism."
+      "It can be hard to predict the way things are now, but I am expecting new materials around <restock_time_point>.",
+      "I am expecting some new materials around <restock_time_point>, hopefully some good escapism."
     ],
     "responses": [
       { "text": "<done_conversation_section>", "topic": "TALK_GREAT_LIBRARY_LIBRARIAN_Talk" },

--- a/data/json/npcs/exodii/exodii_merchant_talk.json
+++ b/data/json/npcs/exodii/exodii_merchant_talk.json
@@ -340,8 +340,8 @@
     "id": "TALK_EXODII_MERCHANT_AskedRestock",
     "type": "talk_topic",
     "dynamic_line": {
-      "//~": "HEH, you can't get enough of old Rubik's merchandise, eh?  Sure as hell, come back in <interval>.",
-      "str": "HEH, ye c'nnae get enough o' ol' Rubik's merchandise, eh?  Sure as 'ell, come back in <interval>."
+      "//~": "HEH, you can't get enough of old Rubik's merchandise, eh?  Sure as hell, come back after <restock_time_point>.",
+      "str": "HEH, ye c'nnae get enough o' ol' Rubik's merchandise, eh?  Sure as 'ell, come back after <restock_time_point>."
     },
     "responses": [
       { "text": "<done_conversation_section>", "topic": "TALK_EXODII_MERCHANT_Talk" },

--- a/data/json/npcs/godco/members/NPC_Kostas_Walsman.json
+++ b/data/json/npcs/godco/members/NPC_Kostas_Walsman.json
@@ -168,8 +168,8 @@
     "id": "TALK_GODCO_Kostas_Interval",
     "type": "talk_topic",
     "dynamic_line": [
-      "I'm afraid I haven't gone out there for a while, maybe come back in <interval>.  These are all I have, care to take a look?",
-      "Sorry these are all I have.  However I'll be back from my next run in <interval>.  Care to take a look in the meanwhile?"
+      "I'm afraid I haven't gone out there for a while, maybe come back on <restock_time_point>.  These are all I have, care to take a look?",
+      "Sorry these are all I have.  However I'll be back from my next run on <restock_time_point>.  Care to take a look in the meanwhile?"
     ],
     "responses": [
       { "text": "Alright, I'll take a look.", "effect": "start_trade", "topic": "TALK_GODCO_Kostas_1" },

--- a/data/json/npcs/godco/visitors/TALK_CARAVAN_MERCHANT_PREDATORY.json
+++ b/data/json/npcs/godco/visitors/TALK_CARAVAN_MERCHANT_PREDATORY.json
@@ -96,7 +96,7 @@
   {
     "type": "talk_topic",
     "id": "TALK_CARAVAN_MERCHANT_PREDATORY_askinterval",
-    "dynamic_line": "Well, not right now.  Try again after around <interval>.",
+    "dynamic_line": "Well, not right now.  Try again after around <restock_time_point>.",
     "responses": [ { "text": "Okay.  About other things…", "topic": "TALK_CARAVAN_MERCHANT_PREDATORY_2" } ]
   },
   {

--- a/data/json/npcs/isherwood_farm/NPC_Claire_Isherwood.json
+++ b/data/json/npcs/isherwood_farm/NPC_Claire_Isherwood.json
@@ -166,7 +166,7 @@
   {
     "type": "talk_topic",
     "id": "TALK_ISHERWOOD_CLAIRE_RESTOCK",
-    "dynamic_line": "Around <interval>.",
+    "dynamic_line": "Around <restock_time_point>.",
     "responses": [ { "text": "Alright then, bye.", "topic": "TALK_DONE" } ]
   },
   {

--- a/data/json/npcs/isherwood_farm/NPC_Eddie_Isherwood.json
+++ b/data/json/npcs/isherwood_farm/NPC_Eddie_Isherwood.json
@@ -233,7 +233,7 @@
   {
     "type": "talk_topic",
     "id": "TALK_ISHERWOOD_EDDIE_RESTOCK",
-    "dynamic_line": "If the cows don't get anything nasty it should be around <interval>.",
+    "dynamic_line": "If the cows don't get anything nasty it should be around <restock_time_point>.",
     "responses": [ { "text": "Cheers, bye.", "topic": "TALK_DONE" } ]
   },
   {

--- a/data/json/npcs/isherwood_farm/NPC_Jack_Isherwood.json
+++ b/data/json/npcs/isherwood_farm/NPC_Jack_Isherwood.json
@@ -211,7 +211,7 @@
   {
     "type": "talk_topic",
     "id": "TALK_ISHERWOOD_JACK_RESTOCK",
-    "dynamic_line": "Around <interval>.",
+    "dynamic_line": "Around <restock_time_point>.",
     "responses": [ { "text": "Alright then, bye.", "topic": "TALK_DONE" } ]
   },
   {

--- a/data/json/npcs/isolated_road/isolated_road_cody_dialogue.json
+++ b/data/json/npcs/isolated_road/isolated_road_cody_dialogue.json
@@ -205,7 +205,7 @@
   {
     "id": "TALK_BLACKSMITH_RESTOCK",
     "type": "talk_topic",
-    "dynamic_line": "With how the things are goin'?  <interval>.",
+    "dynamic_line": "With how the things are goin'? <restock_time_point>.",
     "responses": [ { "text": "I'll leave you to your work then.  <end_talking_bye>", "topic": "TALK_DONE" } ]
   },
   {

--- a/data/json/npcs/isolated_road/isolated_road_jay_dialogue.json
+++ b/data/json/npcs/isolated_road/isolated_road_jay_dialogue.json
@@ -97,7 +97,7 @@
   {
     "id": "TALK_GUNSMITH_RESTOCK",
     "type": "talk_topic",
-    "dynamic_line": "Next series of currency gotta be ready in around <interval>, fresh off the print!",
+    "dynamic_line": "Next series of currency gotta be ready around <restock_time_point>, fresh off the print!",
     "responses": [ { "text": "I'll make sure to take a look.  <end_talking_bye>", "topic": "TALK_DONE" } ]
   },
   {

--- a/data/json/npcs/lumbermill_employees/TALK_lumbermill_merchant.json
+++ b/data/json/npcs/lumbermill_employees/TALK_lumbermill_merchant.json
@@ -75,7 +75,7 @@
   {
     "type": "talk_topic",
     "id": "TALK_LUMBERMILL_RESTOCK",
-    "dynamic_line": "Workers will bring in a new shipment of lumber in <interval>."
+    "dynamic_line": "Workers will bring in a new shipment of lumber on <restock_time_point>."
   },
   {
     "type": "talk_topic",

--- a/data/json/npcs/refugee_center/surface_staff/Smokes/free_merchant_shopkeep_talk.json
+++ b/data/json/npcs/refugee_center/surface_staff/Smokes/free_merchant_shopkeep_talk.json
@@ -76,8 +76,8 @@
     "id": "TALK_FREE_MERCHANTS_MERCHANT_AskedRestock",
     "type": "talk_topic",
     "dynamic_line": [
-      "Next shipment should arrive in around <interval>.",
-      "Stick around for <interval>, there will surely be something you'd like."
+      "Next shipment should arrive in around <restock_time_point>.",
+      "Stick around 'til <restock_time_point>, there will surely be something you'd like."
     ],
     "responses": [
       { "text": "<done_conversation_section>", "topic": "TALK_FREE_MERCHANTS_MERCHANT_Talk" },

--- a/data/json/npcs/robofac/ROBOFAC_SURFACE_FREEMERCHANT.json
+++ b/data/json/npcs/robofac/ROBOFAC_SURFACE_FREEMERCHANT.json
@@ -119,7 +119,7 @@
   {
     "id": "TALK_ROBOFAC_FREE_MERCHANT_INTERVAL",
     "type": "talk_topic",
-    "dynamic_line": "Around <interval>, if the caravan doesn't run into trouble.",
+    "dynamic_line": "Around <restock_time_point>, if the caravan doesn't run into trouble.",
     "responses": [ { "text": "Thanks for the info, bye.", "topic": "TALK_DONE" } ]
   }
 ]

--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom.json
@@ -1069,8 +1069,8 @@
     "id": "TALK_ROBOFAC_INTERCOM_ASK_INTERVAL",
     "type": "talk_topic",
     "dynamic_line": [
-      "We have no other disposable equipment right now.  You'll have to come back in <interval>.",
-      "No. Come back in <interval>."
+      "We have no other disposable equipment right now.  You'll have to come back on <restock_time_point>.",
+      "No. Come back on <restock_time_point>."
     ],
     "responses": [ { "text": "Right…", "topic": "TALK_ROBOFAC_INTERCOM_SERVICES" } ]
   }

--- a/data/json/npcs/scrap_trader/scrap_trader.json
+++ b/data/json/npcs/scrap_trader/scrap_trader.json
@@ -363,7 +363,7 @@
   {
     "id": "TALK_SCRAP_TRADER_ASK_INTERVAL",
     "type": "talk_topic",
-    "dynamic_line": "Nope, although I have a really good claim by the river.  Gonna go fetch them soon, be right back in <interval>.",
+    "dynamic_line": "Nope, although I have a really good claim by the river.  Gonna go fetch them soon, be right back on <restock_time_point>.",
     "responses": [ { "text": "Well, good luck.", "topic": "TALK_NPC_SCRAP_TRADER" } ]
   }
 ]

--- a/data/json/npcs/tacoma_ranch/NPC_ranch_scavenger.json
+++ b/data/json/npcs/tacoma_ranch/NPC_ranch_scavenger.json
@@ -42,7 +42,7 @@
   {
     "type": "talk_topic",
     "id": "TALK_RANCH_SCAVENGER_ASK_RESTOCK",
-    "dynamic_line": "Nope, current run hasn't returned yet.  Come back in <interval>.  You might find something you like.",
+    "dynamic_line": "Nope, current run hasn't returned yet.  Come back on <restock_time_point>.  You might find something you like.",
     "responses": [ { "text": "Alright, thanks.", "topic": "TALK_RANCH_SCAVENGER_1" } ]
   },
   {

--- a/data/mods/Magiclysm/npc/TALK_FORGE_ARDELIA.json
+++ b/data/mods/Magiclysm/npc/TALK_FORGE_ARDELIA.json
@@ -88,7 +88,7 @@
   {
     "id": "TALK_FORGE_LIBRARIAN_ASK_INTERVAL",
     "type": "talk_topic",
-    "dynamic_line": "It shouldn't take Valzain too long to read what he desires from what I have out.  Check back in <interval> and I should have some new books set out.",
+    "dynamic_line": "It shouldn't take Valzain too long to read what he desires from what I have out.  Check back on <restock_time_point> and I should have some new books set out.",
     "responses": [ { "text": "Safe readings.", "topic": "TALK_FORGE_LORD_LIBRARIAN" } ]
   }
 ]

--- a/data/mods/Magiclysm/npc/TALK_FORGE_HELEN_TAVREL.json
+++ b/data/mods/Magiclysm/npc/TALK_FORGE_HELEN_TAVREL.json
@@ -129,7 +129,7 @@
         "Not even trying to ask me that undercover?  By the seventeen seas, officers of the law really ARE made worse these days.",
         "The end of times is here and that's what you're worried about?  You should get your priorities straight."
       ],
-      "no": "Well you obviously aren't an officer so here's the deal.  There's a mighty fine galleon making land in <interval>, I'm certain to have something good by then."
+      "no": "Well you obviously aren't an officer so here's the deal.  There's a mighty fine galleon making land on <restock_time_point>, I'm certain to have something good by then."
     },
     "responses": [ { "text": "May the seas be ever in your favor.", "topic": "TALK_FORGE_LORD_REAGENT" } ]
   }

--- a/data/mods/Magiclysm/npc/TALK_FORGE_MERCHANT.json
+++ b/data/mods/Magiclysm/npc/TALK_FORGE_MERCHANT.json
@@ -153,7 +153,7 @@
   {
     "id": "TALK_FORGE_LORD_ASK_INTERVAL",
     "type": "talk_topic",
-    "dynamic_line": "My minions are busy putting the final touches on a few exciting projects, check back in <interval> and see what's new.",
+    "dynamic_line": "My minions are busy putting the final touches on a few exciting projects, check back on <restock_time_point> and see what's new.",
     "responses": [ { "text": "May your hammers be accurate.", "topic": "TALK_FORGE_LORD" } ]
   }
 ]

--- a/data/mods/translate-dialogue/exodii_merchant_talk.json
+++ b/data/mods/translate-dialogue/exodii_merchant_talk.json
@@ -68,9 +68,9 @@
     "type": "talk_topic",
     "dynamic_line": {
       "concatenate": [
-        "HEH, ye c'nnae get enough o' ol' Rubik's merchandise, eh?  Sure as 'ell, come back in <interval>.",
+        "HEH, ye c'nnae get enough o' ol' Rubik's merchandise, eh?  Sure as 'ell, come back on <restock_time_point>.",
         "\"\n\n[TRANSLATE:] \"",
-        "HEH, you can't get enough of old Rubik's merchandise, eh?  Sure as hell, come back in <interval>."
+        "HEH, you can't get enough of old Rubik's merchandise, eh?  Sure as hell, come back on <restock_time_point>."
       ]
     }
   },

--- a/doc/JSON/NPCs.md
+++ b/doc/JSON/NPCs.md
@@ -364,6 +364,7 @@ Certain entries like the snippets above are taken from the game state as opposed
 | `<topic_item_my_total_price>`                 | beta           | gets replaced with the total price for talk_topic's referenced item in beta talker's inventory
 | `<topic_item_your_total_price>`               | alpha          | gets replaced with the total price for talk_topic's referenced item in alpha talker's inventory
 | `<interval>`                                  | beta           | gets replaced with the time remaining until the beta talker restocks
+| `<restock_time_point>`                        | beta           | displays the date of next restock of the beta talker
 | `<u_val:VAR>`                                 | alpha          | gets replaced with the user variable VAR
 | `<npc_val:VAR>`                               | beta           | gets replaced with the npc variable VAR
 | `<context_val:VAR>`                           | N/A            | gets replaced with the context variable VAR

--- a/src/calendar.cpp
+++ b/src/calendar.cpp
@@ -925,7 +925,8 @@ std::string to_string( month m )
     return _( months[static_cast<int>( m )] );
 }
 
-std::string get_diary_time_since_str( const time_duration &turn_diff, time_accuracy acc )
+std::string get_diary_time_since_str( const time_duration &turn_diff, time_accuracy acc,
+                                      bool include_postfix )
 {
     const int days = to_days<int>( turn_diff );
     const int hours = to_hours<int>( turn_diff ) % 24;
@@ -965,8 +966,12 @@ std::string get_diary_time_since_str( const time_duration &turn_diff, time_accur
             break;
 
     }
+    if( include_postfix ) {
+        //~ %1$s is xx days, %2$s is xx hours, %3$s is xx minutes
+        return string_format( _( "%1$s%2$s%3$s since last entry" ), days_text, hours_text, minutes_text );
+    }
     //~ %1$s is xx days, %2$s is xx hours, %3$s is xx minutes
-    return string_format( _( "%1$s%2$s%3$s since last entry" ), days_text, hours_text, minutes_text );
+    return string_format( _( "%1$s%2$s%3$s" ), days_text, hours_text, minutes_text );
 }
 
 std::string get_diary_time_str( const time_point &turn, time_accuracy acc )

--- a/src/calendar.h
+++ b/src/calendar.h
@@ -606,7 +606,8 @@ std::string to_string_time_of_day( const time_point &p );
 /** Time approximation based on the player's timekeeping capability, formatted for diary pages **/
 std::string get_diary_time_str( const time_point &turn, time_accuracy acc );
 /** Time approximation based on the player's timekeeping capability, formatted for diary pages **/
-std::string get_diary_time_since_str( const time_duration &turn_diff, time_accuracy acc );
+std::string get_diary_time_since_str( const time_duration &turn_diff, time_accuracy acc,
+                                      bool include_postfix = true );
 /** Returns the default duration of a lunar month (duration between syzygies) */
 time_duration lunar_month();
 /** Returns the current phase of the moon. */

--- a/src/calendar.h
+++ b/src/calendar.h
@@ -113,6 +113,10 @@ void set_season_length( int dur );
 
 void set_location( float latitude, float longitude );
 
+// time from the start of the year to calendar::turn_zero
+time_duration turn_zero_offset();
+int years_since_cataclysm( time_point );
+
 /// @returns relative length of game season to real life season.
 float season_ratio();
 
@@ -570,7 +574,7 @@ inline time_duration time_past_midnight( const time_point &p )
 
 inline time_duration time_past_new_year( const time_point &p )
 {
-    return ( p - calendar::turn_zero ) % calendar::year_length();
+    return ( p - calendar::turn_zero + calendar::turn_zero_offset() ) % calendar::year_length();
 }
 
 template<typename T>
@@ -664,6 +668,27 @@ enum class weekdays : int {
 };
 
 weekdays day_of_week( const time_point &p );
+std::string to_string( const weekdays &d );
+
+enum class month : int {
+    JANUARY = 0,
+    FEBRUARY,
+    MARCH,
+    APRIL,
+    MAY,
+    JUNE,
+    JULY,
+    AUGUST,
+    SEPTEMBER,
+    OCTOBER,
+    NOVEMBER,
+    DECEMBER,
+    UNKNOWN
+};
+
+std::pair<month, int> month_and_day( time_point );
+std::string to_string( month m );
+
 
 // To support the eternal season option we create a strong typedef of timepoint
 // which is a season_effective_time.  This converts a regular time to a time

--- a/src/diary.h
+++ b/src/diary.h
@@ -65,6 +65,18 @@ struct diary_page {
     std::vector<proficiency_id> learning_profs;
     /*maximal power level the character has*/
     units::energy max_power_level;
+
+    virtual std::string entry_name() const;
+    virtual bool is_summary() const {
+        return false;
+    }
+};
+
+struct diary_page_summary : public diary_page {
+    std::string entry_name() const override;
+    bool is_summary() const override {
+        return true;
+    }
 };
 
 /// <summary>
@@ -106,6 +118,10 @@ class diary
         void serialize( JsonOut &jsout );
 
     private:
+        void add_summary_page();
+        void open_summary_page();
+        time_accuracy time_acc() const;
+
         /*Uses editor window class to edit the text.*/
         void edit_page_ui( const std::function<catacurses::window()> &create_window );
         /*set page to be be shown in ui*/

--- a/src/diary_ui.cpp
+++ b/src/diary_ui.cpp
@@ -256,7 +256,7 @@ void diary::show_diary_ui( diary *c_diary )
         print_list_scrollable( &w_pages, c_diary->get_pages_list(), &selected[window_mode::PAGE_WIN],
                                currwin == window_mode::PAGE_WIN, true, report_color_error::yes );
         center_print( w_pages, 0, c_light_gray, string_format( _( "pages: %d" ),
-                      c_diary->get_pages_list().size() ) );
+                      c_diary->get_pages_list().size() - 1 ) );
 
         wnoutrefresh( w_pages );
     } );
@@ -360,7 +360,7 @@ void diary::show_diary_ui( diary *c_diary )
         } else if( action == "VIEW_SCORES" ) {
             show_scores_ui();
         } else if( action == "DELETE PAGE" ) {
-            if( !c_diary->pages.empty() ) {
+            if( c_diary->pages.size() > 1 ) {
                 if( query_yn( _( "Really delete Page?" ) ) ) {
                     c_diary->delete_page();
                     if( selected[window_mode::PAGE_WIN] >= static_cast<int>( c_diary->pages.size() ) ) {
@@ -382,6 +382,9 @@ void diary::show_diary_ui( diary *c_diary )
 
 void diary::edit_page_ui( const std::function<catacurses::window()> &create_window )
 {
+    if( get_page_ptr()->is_summary() ) {
+        return;
+    }
     // Modify the stored text so the new text is displayed after exiting from
     // the editor window and before confirming or canceling the y/n query.
     std::string &new_text = get_page_ptr()->m_text;

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -186,9 +186,10 @@ std::string display::time_approx()
 
 std::string display::date_string()
 {
-    const std::string season = calendar::name_season( season_of_year( calendar::turn ) );
-    const int day_num = day_of_season<int>( calendar::turn ) + 1;
-    return string_format( _( "%s, day %d" ), season, day_num );
+    const std::pair<month, int> month_day = month_and_day( calendar::turn );
+    const weekdays day = day_of_week( calendar::turn );
+    return string_format( _( "%s, %s %d" ), to_string( day ), to_string( month_day.first ),
+                          month_day.second );
 }
 
 std::string display::time_string( const Character &u )

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -186,9 +186,15 @@ std::string display::time_approx()
 
 std::string display::date_string()
 {
+    if( calendar::year_length() != 364_days || !get_option<bool>( "SHOW_MONTHS" ) ) {
+        const std::string season = calendar::name_season( season_of_year( calendar::turn ) );
+        const int day_num = day_of_season<int>( calendar::turn ) + 1;
+        return string_format( _( "%s, day %d" ), season, day_num );
+    }
     const std::pair<month, int> month_day = month_and_day( calendar::turn );
     const weekdays day = day_of_week( calendar::turn );
-    return string_format( _( "%s, %s %d" ), to_string( day ), to_string( month_day.first ),
+    //~ 1: day (Monday,Tuesday,etc) 2: Month, 3: day of Month .e.g. Thursday, March 8
+    return string_format( _( "%1$s, %2$s %3$d" ), to_string( day ), to_string( month_day.first ),
                           month_day.second );
 }
 

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -2178,6 +2178,11 @@ void npc::shop_restock()
     distribute_items_to_npc_zones( ret, *this );
 }
 
+time_point npc::restock_time() const
+{
+    return restock + myclass->get_shop_restock_interval();
+}
+
 std::string npc::get_restock_interval() const
 {
     time_duration const restock_remaining =

--- a/src/npc.h
+++ b/src/npc.h
@@ -938,6 +938,7 @@ class npc : public Character
 
         // Re-roll the inventory of a shopkeeper
         void shop_restock();
+        time_point restock_time() const;
         std::string get_restock_interval() const;
         bool is_shopkeeper() const;
         // Use and assessment of items

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -103,6 +103,7 @@
 #include "npctalk.h"
 #include "npctalk_rules.h"
 #include "npctrade.h"
+#include "options.h"
 #include "output.h"
 #include "overmap_ui.h"
 #include "overmapbuffer.h"
@@ -2444,6 +2445,21 @@ void parse_tags( std::string &phrase, const_talker const &u, const_talker const 
             const npc *guy = dynamic_cast<const npc *>( me_chr );
             std::string restock_interval = guy ? guy->get_restock_interval() : _( "a few days" );
             phrase.replace( fa, l, restock_interval );
+        } else if( tag == "<restock_time_point>" ) {
+            const npc *guy = dynamic_cast<const npc *>( me_chr );
+            if( guy == nullptr ) {
+                phrase.replace( fa, l, _( "the future" ) );
+            } else if( get_option<bool>( "SHOW_MONTHS" ) && calendar::year_length() ==  364_days ) {
+                std::pair<month, int> month_day = month_and_day( guy->restock_time() );
+                //~ 1 is month, 2 is day
+                phrase.replace( fa, l, string_format( pgettext( "month and day", "%1$s %2$d" ),
+                                                      to_string( month_day.first ), month_day.second ) );
+            } else {
+                //~ 1 is season, 2 is day
+                phrase.replace( fa, l, string_format( pgettext( "season and day", "%1$s %2$d" ),
+                                                      calendar::name_season( season_of_year( guy->restock_time() ) ),
+                                                      day_of_season<int>( guy->restock_time() ) ) );
+            }
         } else if( tag.find( "<u_val:" ) == 0 ) {
             //adding a user variable to the string
             std::string var = tag.substr( tag.find( ':' ) + 1 );

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1828,6 +1828,9 @@ void options_manager::add_options_interface()
             { "24h", to_translation( "24h" ) }
         },
         "12h" );
+        add( "SHOW_MONTHS", page_id, to_translation( "Show day/month" ),
+             to_translation( "Show day/month instead of season in time displays." ),
+             true );
         add( "SHOW_VITAMIN_MASS", page_id, to_translation( "Show vitamin masses" ),
              to_translation( "Display the masses of vitamins in addition to units/RDA values in item descriptions." ),
              true );

--- a/src/weather.cpp
+++ b/src/weather.cpp
@@ -469,7 +469,7 @@ void handle_weather_effects( const weather_type_id &w )
     get_weather().lightning_active = false;
 }
 
-static std::string to_string( const weekdays &d )
+std::string to_string( const weekdays &d )
 {
     static const std::array<std::string, 7> weekday_names = {{
             translate_marker( "Sunday" ), translate_marker( "Monday" ),

--- a/tests/calendar_test.cpp
+++ b/tests/calendar_test.cpp
@@ -1,7 +1,13 @@
+#include <array>
+#include <stddef.h>
 #include <string>
+#include <utility>
+#include <vector>
 
 #include "calendar.h"
 #include "cata_catch.h"
+#include "cata_scope_helpers.h"
+#include "string_formatter.h"
 
 TEST_CASE( "time_duration_to_string", "[calendar][nogame]" )
 {
@@ -41,4 +47,115 @@ TEST_CASE( "time_duration_to_string_eternal_season", "[calendar][nogame]" )
     CHECK( to_string( 3650_days ) == "521 weeks and 3 days" );
     calendar::set_eternal_season( false );
     REQUIRE( calendar::season_from_default_ratio() == Approx( 1.0f ) );
+}
+
+TEST_CASE( "months_and_days_over_time", "[calendar]" )
+{
+    std::vector<std::pair<month, int>> date;
+    date.reserve( 364 );
+    for( int i = 0; i < 12; ++i ) {
+        for( int j = 0; j < ( ( i % 3 == 0 ) ? 31 : 30 ); ++j ) {
+            date.emplace_back( static_cast<month>( i ), j + 1 );
+        }
+    }
+    std::array<weekdays, 7> days;
+    for( int i = 0; i < 7; ++i ) {
+        days[i] = static_cast<weekdays>( i );
+    }
+
+    // jan, feb, first 19 days of mar
+    size_t date_idx = 31 + 30 + 20;
+    std::pair<month, int> month_day = month_and_day( calendar::turn_zero );
+    REQUIRE( month_day.first == month::MARCH );
+    REQUIRE( month_day.second == 21 );
+    CAPTURE( month_and_day( calendar::start_of_game ).first );
+    CAPTURE( month_and_day( calendar::start_of_game ).second );
+    REQUIRE( date[date_idx] == month_and_day( calendar::start_of_game ) );
+
+    // game starts on a thursday
+    restore_on_out_of_scope restore_game_start( calendar::start_of_game );
+    calendar::start_of_game = calendar::turn_zero;
+    size_t day_idx = static_cast<size_t>( weekdays::THURSDAY );
+    REQUIRE( day_of_week( calendar::start_of_game ) == days[day_idx] );
+
+    time_point turn = calendar::turn_zero;
+    int years_since_cataclysm = 0;
+    // ensure it's correct for the next ten years
+    for( int i = 0; i <= 364 * 10; ++i ) {
+        date_idx = ( date_idx + 1 ) % date.size();
+        day_idx = ( day_idx + 1 ) % days.size();
+        turn += 1_days;
+
+        std::pair<month, int> month_day = month_and_day( turn );
+        weekdays day = day_of_week( turn );
+        INFO( string_format( "Month %d, day %d (weekday %d)", month_day.first, month_day.second, day ) );
+        INFO( string_format( "expect month %d day %d (weekday %d)", date[date_idx].first,
+                             date[date_idx].second, days[day_idx] ) );
+
+        REQUIRE( month_day == date[date_idx] );
+        REQUIRE( day == days[day_idx] );
+
+        if( month_day == std::make_pair( month::JANUARY, 1 ) ) {
+            years_since_cataclysm += 1;
+        }
+        CHECK( years_since_cataclysm == calendar::years_since_cataclysm( turn ) );
+    }
+    CHECK( calendar::years_since_cataclysm( turn ) == 10 );
+}
+
+TEST_CASE( "seasons_over_time", "[calendar]" )
+{
+    int season_length_days = GENERATE( 91, 73 );
+    on_out_of_scope restore_season_length( []() {
+        calendar::set_season_length( 91 );
+    } );
+    CAPTURE( season_length_days );
+    calendar::set_season_length( season_length_days );
+    // to match the other test
+    restore_on_out_of_scope restore_game_start( calendar::start_of_game );
+    calendar::start_of_game = calendar::turn_zero;
+
+    time_point turn = calendar::turn_zero;
+
+    REQUIRE( day_of_season<int>( turn ) == 0 );
+    REQUIRE( season_of_year( turn ) == SPRING );
+
+    int years_since_cataclysm = 0;
+    // next ten years
+    for( int i = 0; i <= season_length_days * 4 * 10; ++i ) {
+        turn += 1_days;
+        int day = day_of_season<int>( turn );
+        season_type season = season_of_year( turn );
+
+        INFO( string_format( "%s %d", calendar::name_season( season ), day ) );
+        REQUIRE( day == to_days<int>( turn - calendar::turn_zero ) % season_length_days );
+        REQUIRE( season == static_cast<season_type>( ( to_days<int>( turn - calendar::turn_zero ) /
+                 season_length_days ) % 4 ) );
+
+        if( season == WINTER && day == season_length_days - to_days<int>( calendar::turn_zero_offset() ) ) {
+            years_since_cataclysm += 1;
+        }
+        INFO( string_format( "year offset: %s", to_string( calendar::turn_zero_offset() ) ) );
+        CHECK( years_since_cataclysm == calendar::years_since_cataclysm( turn ) );
+    }
+    CHECK( calendar::years_since_cataclysm( turn ) == 10 );
+}
+
+TEST_CASE( "time_point_to_string", "[calendar]" )
+{
+    REQUIRE( calendar::year_length() == 364_days );
+
+    CHECK( to_string( calendar::turn_zero + 7_days ) == "Year 1, Mar 28 12:00:00AM" );
+    CHECK( to_string( calendar::turn_zero + 9_days ) == "Year 1, Mar 30 12:00:00AM" );
+    CHECK( to_string( calendar::turn_zero + 10_days ) == "Year 1, Apr 1 12:00:00AM" );
+    CHECK( to_string( calendar::turn_zero + 30_days + 4_days ) == "Year 1, Apr 25 12:00:00AM" );
+    CHECK( to_string( calendar::turn_zero + 91_days ) == "Year 1, Jun 21 12:00:00AM" );
+    CHECK( to_string( calendar::turn_zero + 91_days + 30_days ) == "Year 1, Jul 21 12:00:00AM" );
+    CHECK( to_string( calendar::turn_zero + 91_days * 2 + 27_days ) == "Year 1, Oct 18 12:00:00AM" );
+    CHECK( to_string( calendar::turn_zero + 91_days * 3 ) == "Year 1, Dec 21 12:00:00AM" );
+    CHECK( to_string( calendar::turn_zero + 364_days - calendar::turn_zero_offset() - 1_days ) ==
+           "Year 1, Dec 30 12:00:00AM" );
+    CHECK( to_string( calendar::turn_zero + 364_days - calendar::turn_zero_offset() ) ==
+           "Year 2, Jan 1 12:00:00AM" );
+    CHECK( to_string( calendar::turn_zero + 364_days ) == "Year 2, Mar 21 12:00:00AM" );
 }

--- a/tests/memorial_test.cpp
+++ b/tests/memorial_test.cpp
@@ -335,7 +335,7 @@ TEST_CASE( "memorial_log_dumping", "[memorial]" )
     const std::string expected_output =
         "| Year 1, Spring, day 0 0800.00 | refugee center | "
         "Apolonia Trout began their journey into the Cataclysm." + eol +
-        "| Year 1, Spring, day 1 4:20:14 AM | forest | Used the debug menu (ENABLE_ACHIEVEMENTS)."
+        "| Year 1, Mar 21 4:20:14 AM | forest | Used the debug menu (ENABLE_ACHIEVEMENTS)."
         + eol;
 
     memorial_logger logger;

--- a/tests/stats_tracker_test.cpp
+++ b/tests/stats_tracker_test.cpp
@@ -702,7 +702,7 @@ TEST_CASE( "achievements_tracker", "[stats]" )
         } else {
             CHECK( a.ui_text_for( &*a_kill_in_first_minute ) ==
                    "<color_c_red>Rude awakening</color>\n"
-                   "  <color_c_red>Failed Year 1, Spring, day 61 0810.00</color>\n"
+                   "  <color_c_red>Failed Year 1, May 20 0810.00</color>\n"
                    "  <color_c_yellow>0/1 monster killed</color>\n" );
         }
 
@@ -726,34 +726,34 @@ TEST_CASE( "achievements_tracker", "[stats]" )
         if( time_since_game_start < 1_minutes ) {
             CHECK( a.ui_text_for( achievements_completed.at( a_kill_zombie ) ) ==
                    "<color_c_light_green>One down, billions to go…</color>\n"
-                   "  <color_c_light_green>Completed Year 1, Spring, day 61 0800.30</color>\n"
+                   "  <color_c_light_green>Completed Year 1, May 20 0800.30</color>\n"
                    "  <color_c_green>1/1 zombie killed</color>\n" );
             CHECK( a.ui_text_for( achievements_completed.at( a_kill_in_first_minute ) ) ==
                    "<color_c_light_green>Rude awakening</color>\n"
-                   "  <color_c_light_green>Completed Year 1, Spring, day 61 0800.30</color>\n"
+                   "  <color_c_light_green>Completed Year 1, May 20 0800.30</color>\n"
                    "  <color_c_green>1/1 monster killed</color>\n" );
         } else {
             CHECK( a.ui_text_for( achievements_completed.at( a_kill_zombie ) ) ==
                    "<color_c_light_green>One down, billions to go…</color>\n"
-                   "  <color_c_light_green>Completed Year 1, Spring, day 61 0810.00</color>\n"
+                   "  <color_c_light_green>Completed Year 1, May 20 0810.00</color>\n"
                    "  <color_c_green>1/1 zombie killed</color>\n" );
             CHECK( !achievements_completed.count( a_kill_in_first_minute ) );
             CHECK( a.ui_text_for( &*a_kill_in_first_minute ) ==
                    "<color_c_red>Rude awakening</color>\n"
-                   "  <color_c_red>Failed Year 1, Spring, day 61 0810.00</color>\n"
+                   "  <color_c_red>Failed Year 1, May 20 0810.00</color>\n"
                    "  <color_c_yellow>0/1 monster killed</color>\n" );
         }
 
         if( time_since_game_start < 1_minutes ) {
             CHECK( a.ui_text_for( &*c_pacifist ) ==
                    "<color_c_red>Pacifist</color>\n"
-                   "  <color_c_red>Failed Year 1, Spring, day 61 0800.30</color>\n"
+                   "  <color_c_red>Failed Year 1, May 20 0800.30</color>\n"
                    "  <color_c_yellow>Kill no monsters</color>\n"
                    "  <color_c_green>Kill no characters</color>\n" );
         } else {
             CHECK( a.ui_text_for( &*c_pacifist ) ==
                    "<color_c_red>Pacifist</color>\n"
-                   "  <color_c_red>Failed Year 1, Spring, day 61 0810.00</color>\n"
+                   "  <color_c_red>Failed Year 1, May 20 0810.00</color>\n"
                    "  <color_c_yellow>Kill no monsters</color>\n"
                    "  <color_c_green>Kill no characters</color>\n" );
         }
@@ -772,21 +772,21 @@ TEST_CASE( "achievements_tracker", "[stats]" )
         if( time_since_game_start < 1_minutes ) {
             CHECK( a.ui_text_for( achievements_completed.at( a_kill_zombie ) ) ==
                    "<color_c_light_green>One down, billions to go…</color>\n"
-                   "  <color_c_light_green>Completed Year 1, Spring, day 61 0800.30</color>\n"
+                   "  <color_c_light_green>Completed Year 1, May 20 0800.30</color>\n"
                    "  <color_c_green>1/1 zombie killed</color>\n" );
             CHECK( a.ui_text_for( achievements_completed.at( a_kill_in_first_minute ) ) ==
                    "<color_c_light_green>Rude awakening</color>\n"
-                   "  <color_c_light_green>Completed Year 1, Spring, day 61 0800.30</color>\n"
+                   "  <color_c_light_green>Completed Year 1, May 20 0800.30</color>\n"
                    "  <color_c_green>1/1 monster killed</color>\n" );
         } else {
             CHECK( a.ui_text_for( achievements_completed.at( a_kill_zombie ) ) ==
                    "<color_c_light_green>One down, billions to go…</color>\n"
-                   "  <color_c_light_green>Completed Year 1, Spring, day 61 0810.00</color>\n"
+                   "  <color_c_light_green>Completed Year 1, May 20 0810.00</color>\n"
                    "  <color_c_green>1/1 zombie killed</color>\n" );
             CHECK( !achievements_completed.count( a_kill_in_first_minute ) );
             CHECK( a.ui_text_for( &*a_kill_in_first_minute ) ==
                    "<color_c_red>Rude awakening</color>\n"
-                   "  <color_c_red>Failed Year 1, Spring, day 61 0810.00</color>\n"
+                   "  <color_c_red>Failed Year 1, May 20 0810.00</color>\n"
                    "  <color_c_yellow>0/1 monster killed</color>\n" );
         }
     }

--- a/tests/sun_test.cpp
+++ b/tests/sun_test.cpp
@@ -289,26 +289,26 @@ TEST_CASE( "sunrise_and_sunset", "[sun][sunrise][sunset][equinox][solstice]" )
 
     SECTION( "spring equinox is day 1 of spring" ) {
         // Actual sunrise and sunset on March 21st 2001 are 0545 and 1757
-        CHECK( "Year 1, Spring, day 1 5:57:58 AM" == to_string( sunrise( spring ) ) );
-        CHECK( "Year 1, Spring, day 1 6:16:07 PM" == to_string( sunset( spring ) ) );
+        CHECK( "Year 1, Mar 21 5:57:58 AM" == to_string( sunrise( spring ) ) );
+        CHECK( "Year 1, Mar 21 6:16:07 PM" == to_string( sunset( spring ) ) );
     }
 
     SECTION( "summer solstice is day 1 of summer" ) {
         // Actual sunrise and sunset on June 21st 2001 are 0407 and 1924
-        CHECK( "Year 1, Summer, day 1 4:22:20 AM" == to_string( sunrise( summer ) ) );
-        CHECK( "Year 1, Summer, day 1 7:41:38 PM" == to_string( sunset( summer ) ) );
+        CHECK( "Year 1, Jun 21 4:22:20 AM" == to_string( sunrise( summer ) ) );
+        CHECK( "Year 1, Jun 21 7:41:38 PM" == to_string( sunset( summer ) ) );
     }
 
     SECTION( "autumn equinox is day 1 of autumn" ) {
         // Actual sunrise and sunset on September 22nd 2001 are 0531 and 1741
-        CHECK( "Year 1, Autumn, day 1 5:45:33 AM" == to_string( sunrise( autumn ) ) );
-        CHECK( "Year 1, Autumn, day 1 5:59:37 PM" == to_string( sunset( autumn ) ) );
+        CHECK( "Year 1, Sep 21 5:45:33 AM" == to_string( sunrise( autumn ) ) );
+        CHECK( "Year 1, Sep 21 5:59:37 PM" == to_string( sunset( autumn ) ) );
     }
 
     SECTION( "winter solstice is day 1 of winter" ) {
         // Actual sunrise and sunset on December 21st 2001 are 0710 and 1614
-        CHECK( "Year 1, Winter, day 1 7:25:07 AM" == to_string( sunrise( winter ) ) );
-        CHECK( "Year 1, Winter, day 1 4:31:46 PM" == to_string( sunset( winter ) ) );
+        CHECK( "Year 1, Dec 21 7:25:07 AM" == to_string( sunrise( winter ) ) );
+        CHECK( "Year 1, Dec 21 4:31:46 PM" == to_string( sunset( winter ) ) );
     }
 
     SECTION( "spring sunrise gets earlier" ) {

--- a/tests/weather_test.cpp
+++ b/tests/weather_test.cpp
@@ -113,6 +113,7 @@ TEST_CASE( "weather_realism", "[weather]" )
 // https://gist.github.com/Kodiologist/e2f1e6685e8fd865650f97bb6a67ad07
 {
     for( unsigned int seed : seeds ) {
+        CAPTURE( seed );
         year_of_weather_data data = collect_weather_data( seed );
 
         // Check the mean absolute difference between the highs or lows
@@ -130,9 +131,10 @@ TEST_CASE( "weather_realism", "[weather]" )
         CHECK( mean_of_ranges <= 25 );
 
         // Check that summer and winter temperatures are very different.
-        size_t half = data.highs.size() / 4;
-        double summer_low = data.lows[half];
-        double winter_high = data.highs[0];
+        size_t summer_idx = data.lows.size() / 4;
+        size_t winter_idx = 5 * data.highs.size() / 6;
+        double summer_low = data.lows[summer_idx];
+        double winter_high = data.highs[winter_idx];
         {
             CAPTURE( summer_low );
             CAPTURE( winter_high );


### PR DESCRIPTION
#### Summary
Features "Show time in months/days"

Built on https://github.com/CleverRaven/Cataclysm-DDA/pull/81492

#### Purpose of change
I think it's more immersive to display the time in months/days.

#### Describe the solution
Because years after the cataclysm are 364 days, and I don't want to do gross calendar math, the structure of the months/days have changed a little:

Seasons remain the same, and the first day of each season is on the 21th of the month. The first full month of a season has 31 days, all other months have 30.

| Month     | Day   | Season |
|-----------|-------|--------|
| January   | 1-31  | Winter |
| February  | 1-30  | Winter |
| March     | 1-20  | Winter |
| March     | 21-30 | Spring |
| April     | 1-31  | Spring |
| May       | 1-30  | Spring |
| June      | 1-20  | Spring |
| June      | 21-30 | Summer |
| July      | 1-31  | Summer |
| August    | 1-30  | Summer |
| September | 1-20  | Summer |
| September | 21-30 | Autumn |
| October   | 1-31  | Autumn |
| November  | 1-30  | Autumn |
| December  | 1-20  | Autumn |
| December  | 21-30 | Winter |

Because calendar::turn_zero is the first day of spring (March 21), some code was needed to add an appropriate offset to ensure the year transitions on Dec 30 -> Jan 1.

Settings for season length other than 91 will not show months.

#### Describe alternatives you've considered
December has 34 days, all other months have 30.

Using the long forms of the month names.

Changing it to display year 0 instead of year 1 (it's 0 years since the cataclysm).

This makes it so you need to know the dates seasons change on to know when they are, and I'd be happy to take suggestions on how to make season change times more visible.

~~I'm very upset October 31 does not exist and I am strongly considering making the first full month of each season have 31 days to fix it.~~

#### Testing

See tests.

#### Additional context
![Image of sidebar showing a game that has just started. The date field says Thursday, May 19](https://github.com/user-attachments/assets/c9d1f9ad-d1b8-4500-bdf1-c1b40ff828f5)
![Image of the date section on the sidebar. It says Sunday, Jun 20](https://github.com/user-attachments/assets/09300cbd-c00d-4957-a9b5-f7e4e48c8d1c)
![Image of the time stamp of a diary entry. It says Year 1, Jun 20, and the time](https://github.com/user-attachments/assets/d6ee4106-d685-43eb-909e-d88281ef8d77)
![Image of the time stamp of a diary entry. It says Year 1, Dec 22](https://github.com/user-attachments/assets/df09c3d9-1702-45b9-8d4d-3240e53023b4)
![Image of the time stamp of a diary entry. It says Year 2, Jan 1, 10 days since last entry.](https://github.com/user-attachments/assets/4eafb10f-1e73-4e9e-98ce-ef4379587690)
![Image of the pages section of a diary. It has entries on Year 1, Jun 20, Year 1, Dec 22, and Year 2, Jan 1](https://github.com/user-attachments/assets/03e4381f-08a3-4b7f-857b-8d39c9e1cec3)


