### PR TITLE
Basecamp fixes/refactor and allow tags/snippets in camp labels

### DIFF
--- a/src/basecamp.cpp
+++ b/src/basecamp.cpp
@@ -133,6 +133,7 @@ basecamp_map &basecamp_map::operator=( const basecamp_map & )
 basecamp::basecamp( const std::string &name_, const tripoint_abs_omt &omt_pos_ ): name( name_ ),
     omt_pos( omt_pos_ )
 {
+    parse_tags( name, get_player_character(), get_player_character() );
 }
 
 basecamp::basecamp( const std::string &name_, const tripoint_abs_ms &bb_pos_,
@@ -140,6 +141,7 @@ basecamp::basecamp( const std::string &name_, const tripoint_abs_ms &bb_pos_,
                     const std::map<point_rel_omt, expansion_data> &expansions_ )
     : directions( directions_ ), name( name_ ), bb_pos( bb_pos_ ), expansions( expansions_ )
 {
+    parse_tags( name, get_player_character(), get_player_character() );
 }
 
 std::string basecamp::board_name() const
@@ -690,6 +692,7 @@ void basecamp::query_new_name( bool force )
 void basecamp::set_name( const std::string &new_name )
 {
     name = new_name;
+    parse_tags( name, get_player_character(), get_player_character() );
 }
 
 /*
@@ -906,7 +909,7 @@ void basecamp::handle_takeover_by( faction_id new_owner, bool violent_takeover )
         if( checked_camp->get_owner() == get_owner() ) {
             add_msg_debug( debugmode::DF_CAMPS,
                            "Camp %s at %s is owned by %s, adding it to plunder calculations.",
-                           checked_camp->name, checked_camp->camp_omt_pos().to_string_writable(), get_owner()->name );
+                           checked_camp->camp_name(), checked_camp->camp_omt_pos().to_string_writable(), get_owner()->name );
             num_of_owned_camps++;
         }
     }

--- a/src/basecamp.h
+++ b/src/basecamp.h
@@ -198,7 +198,6 @@ class basecamp
         std::vector<std::vector<ui_mission_id>> hidden_missions;
         std::vector<tripoint_abs_omt> fortifications;
         std::vector<expansion_salt_water_pipe *> salt_water_pipes;
-        std::string name;
         void faction_display( const catacurses::window &fac_w, int width ) const;
 
         //change name of camp
@@ -499,6 +498,8 @@ class basecamp
         // lazy re-evaluation of available camp resources
         void reset_camp_resources( map &here );
         void add_resource( const itype_id &camp_resource );
+        // Translated name w/ parse_tags evaluated
+        std::string name;
         // omt pos
         tripoint_abs_omt omt_pos;
         std::vector<npc_ptr> assigned_npcs; // NOLINT(cata-serialize)

--- a/src/basecamp.h
+++ b/src/basecamp.h
@@ -204,7 +204,7 @@ class basecamp
         void set_name( const std::string &new_name );
         void query_new_name( bool force = false );
         // remove the camp without safety checks; use abandon_camp() for in-game
-        void remove_camp( const tripoint_abs_omt &omt_pos ) const;
+        void remove_camp() const;
         // remove the camp from an in-game context
         void abandon_camp();
         void scan_pseudo_items();

--- a/src/basecamp.h
+++ b/src/basecamp.h
@@ -204,7 +204,8 @@ class basecamp
         void set_name( const std::string &new_name );
         void query_new_name( bool force = false );
         // remove the camp without safety checks; use abandon_camp() for in-game
-        void remove_camp() const;
+        // normally always removes from overmap, but when mass-removing via overmap::clear_camps() we don't so we can iterate it properly
+        void remove_camp( bool remove_from_overmap = true ) const;
         // remove the camp from an in-game context
         void abandon_camp();
         void scan_pseudo_items();

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -2156,7 +2156,7 @@ void basecamp::remove_camp( const tripoint_abs_omt &omt_pos ) const
     std::set<tripoint_abs_omt> &known_camps = get_player_character().camps;
     known_camps.erase( omt_pos );
 
-    overmap_buffer.remove_camp( *this );
+    overmap_buffer.remove_camp( omt_pos.xy() );
 
     map &here = get_map();
     const tripoint_abs_sm sm_pos = coords::project_to<coords::sm>( omt_pos );

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -2151,12 +2151,14 @@ void basecamp::start_upgrade( const mission_id &miss_id )
     }
 }
 
-void basecamp::remove_camp() const
+void basecamp::remove_camp( bool remove_from_overmap ) const
 {
     std::set<tripoint_abs_omt> &known_camps = get_player_character().camps;
     known_camps.erase( omt_pos );
 
-    overmap_buffer.remove_camp( omt_pos.xy() );
+    if( remove_from_overmap ) {
+        overmap_buffer.remove_camp( omt_pos.xy() );
+    }
 
     map &here = get_map();
     tripoint_bub_ms pos_bub;

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -2151,7 +2151,7 @@ void basecamp::start_upgrade( const mission_id &miss_id )
     }
 }
 
-void basecamp::remove_camp( const tripoint_abs_omt &omt_pos ) const
+void basecamp::remove_camp() const
 {
     std::set<tripoint_abs_omt> &known_camps = get_player_character().camps;
     known_camps.erase( omt_pos );
@@ -2159,11 +2159,18 @@ void basecamp::remove_camp( const tripoint_abs_omt &omt_pos ) const
     overmap_buffer.remove_camp( omt_pos.xy() );
 
     map &here = get_map();
-    const tripoint_abs_sm sm_pos = coords::project_to<coords::sm>( omt_pos );
-    const tripoint_abs_ms ms_pos = coords::project_to<coords::ms>( sm_pos );
-    // We cannot use bb_pos here, because bb_pos may be {0,0,0} if you haven't examined the bulletin board on camp ever.
-    // here.remove_submap_camp( here.getlocal( bb_pos ) );
-    here.remove_submap_camp( here.get_bub( ms_pos ) );
+    tripoint_bub_ms pos_bub;
+    // bb_pos may be {0,0,0} if you haven't examined the bulletin board on camp ever
+    if( bb_pos != tripoint_abs_ms::zero ) {
+        pos_bub = here.get_bub( bb_pos );
+    } else {
+        const tripoint_abs_sm sm_pos = coords::project_to<coords::sm>( omt_pos );
+        const tripoint_abs_ms ms_pos = coords::project_to<coords::ms>( sm_pos );
+        pos_bub = here.get_bub( ms_pos );
+    }
+    if( here.inbounds( pos_bub ) ) {
+        here.remove_submap_camp( pos_bub );
+    }
 }
 
 void basecamp::abandon_camp()
@@ -2182,7 +2189,7 @@ void basecamp::abandon_camp()
     }
     // We must send this message early, before the name is erased.
     add_msg( m_info, _( "You abandon %s." ), name );
-    remove_camp( omt_pos );
+    remove_camp();
 }
 
 void basecamp::scan_pseudo_items()

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -725,15 +725,10 @@ void talk_function::start_camp( npc &p )
 
     for( const auto &om_near : om_building_region( omt_pos, 3 ) ) {
         const oter_id &om_type = oter_id( om_near.first );
-        if( is_ot_match( "faction_base", om_type, ot_match_type::contains ) ) {
-            tripoint_abs_omt const &building_omt_pos = om_near.second;
-            std::vector<basecamp> const &camps = overmap_buffer.get_om_global( building_omt_pos ).om->camps;
-            if( std::any_of( camps.cbegin(), camps.cend(), [&building_omt_pos]( const basecamp & camp ) {
-            return camp.camp_omt_pos() == building_omt_pos;
-            } ) ) {
-                popup( _( "You are too close to another camp!" ) );
-                return;
-            }
+        if( is_ot_match( "faction_base", om_type, ot_match_type::contains ) ||
+            overmap_buffer.has_camp( om_near.second ) ) {
+            popup( _( "You are too close to another camp!" ) );
+            return;
         }
     }
     const recipe &making = camp_type.obj();
@@ -765,7 +760,7 @@ void talk_function::basecamp_mission( npc &p )
     }
     basecamp *bcp = *temp_camp;
     if( !bcp->allowed_access_by( p ) ) {
-        popup( _( "%s isn't under your control!" ), bcp->name );
+        popup( _( "%s isn't under your control!" ), bcp->camp_name() );
         return;
     }
     bcp->set_by_radio( get_avatar().dialogue_by_radio );

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -6727,20 +6727,6 @@ computer *map::computer_at( const tripoint_bub_ms &p )
     return sm->get_computer( l );
 }
 
-bool map::point_within_camp( const tripoint_abs_ms &point_check ) const
-{
-    const tripoint_abs_omt omt_check( coords::project_to<coords::omt>( point_check ) );
-    const point_abs_omt p = omt_check.xy();
-    for( int x2 = -2; x2 < 2; x2++ ) {
-        for( int y2 = -2; y2 < 2; y2++ ) {
-            if( std::optional<basecamp *> bcp = overmap_buffer.find_camp( p + point( x2, y2 ) ) ) {
-                return ( *bcp )->point_within_camp( omt_check );
-            }
-        }
-    }
-    return false;
-}
-
 void map::remove_submap_camp( const tripoint_bub_ms &p )
 {
     submap *const current_submap = get_submap_at( p );

--- a/src/map.h
+++ b/src/map.h
@@ -1609,7 +1609,6 @@ class map
                        bool need_validate = true );
         void remove_submap_camp( const tripoint_bub_ms & );
         basecamp hoist_submap_camp( const tripoint_bub_ms &p );
-        bool point_within_camp( const tripoint_abs_ms &point_check ) const;
         // Graffiti
         bool has_graffiti_at( const tripoint_bub_ms &p ) const;
         const std::string &graffiti_at( const tripoint_bub_ms &p ) const;

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -2498,14 +2498,10 @@ bool npc::is_leader() const
 
 bool npc::within_boundaries_of_camp() const
 {
-    const point_abs_omt p( pos_abs_omt().xy() );
-    for( int x2 = -3; x2 < 3; x2++ ) {
-        for( int y2 = -3; y2 < 3; y2++ ) {
-            const point_abs_omt nearby = p + point( x2, y2 );
-            std::optional<basecamp *> bcp = overmap_buffer.find_camp( nearby );
-            if( bcp ) {
-                return true;
-            }
+    for( const point_abs_omt &p : closest_points_first( pos_abs_omt().xy(), 0, 3 ) ) {
+        std::optional<basecamp *> bcp = overmap_buffer.find_camp( p );
+        if( bcp ) {
+            return true;
         }
     }
     return false;

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -2496,17 +2496,6 @@ bool npc::is_leader() const
     return attitude == NPCATT_LEAD;
 }
 
-bool npc::within_boundaries_of_camp() const
-{
-    for( const point_abs_omt &p : closest_points_first( pos_abs_omt().xy(), 0, 3 ) ) {
-        std::optional<basecamp *> bcp = overmap_buffer.find_camp( p );
-        if( bcp ) {
-            return true;
-        }
-    }
-    return false;
-}
-
 bool npc::is_enemy() const
 {
     return attitude == NPCATT_KILL || attitude == NPCATT_FLEE || attitude == NPCATT_FLEE_TEMP;

--- a/src/npc.h
+++ b/src/npc.h
@@ -916,7 +916,6 @@ class npc : public Character
         bool is_guarding() const;
         // Has a guard patrol mission
         bool is_patrolling() const;
-        bool within_boundaries_of_camp() const;
         /** is performing a player_activity */
         bool has_player_activity() const;
         bool is_travelling() const;

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -3387,7 +3387,8 @@ void npc::worker_downtime()
                 if( here.has_flag_furn( ter_furn_flag::TFLAG_CAN_SIT, elem ) && !creatures.creature_at( elem ) &&
                     could_move_onto( elem ) && !!assigned_camp ) {
                     std::optional<basecamp *> camp = overmap_buffer.find_camp( assigned_camp->xy() );
-                    if( !!camp && camp->point_within_camp( here.get_abs( elem ) ) ) {
+                    if( !!camp && !!( *camp ) &&
+                        ( *camp )->point_within_camp( project_to<coords::omt>( here.get_abs( elem ) ) ) ) {
                         // this one will do
                         chair_pos = here.get_abs( elem );
                         return;

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -3385,11 +3385,13 @@ void npc::worker_downtime()
         if( !is_mounted() ) {
             for( const tripoint_bub_ms &elem : here.points_in_radius( pos_bub(), 30 ) ) {
                 if( here.has_flag_furn( ter_furn_flag::TFLAG_CAN_SIT, elem ) && !creatures.creature_at( elem ) &&
-                    could_move_onto( elem ) &&
-                    here.point_within_camp( here.get_abs( elem ) ) ) {
-                    // this one will do
-                    chair_pos = here.get_abs( elem );
-                    return;
+                    could_move_onto( elem ) && !!assigned_camp ) {
+                    std::optional<basecamp *> camp = overmap_buffer.find_camp( assigned_camp->xy() );
+                    if( !!camp && camp->point_within_camp( here.get_abs( elem ) ) ) {
+                        // this one will do
+                        chair_pos = here.get_abs( elem );
+                        return;
+                    }
                 }
             }
         }

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -7380,9 +7380,10 @@ void overmap::remove_camp( const point_abs_omt &p )
 
 void overmap::clear_camps()
 {
-    for( const std::pair<const point_abs_omt, basecamp> &camp : camps ) {
-        // ::remove_camp is called in this
-        camp.second.remove_camp();
+    auto iter = camps.begin();
+    while( iter != camps.end() ) {
+        iter->second.remove_camp( false );
+        iter = camps.erase( iter );
     }
 }
 

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -7351,14 +7351,31 @@ shared_ptr_fast<npc> overmap::find_npc_by_unique_id( const std::string &id ) con
     return nullptr;
 }
 
+void overmap::add_camp( const point_abs_omt &p, const basecamp &camp )
+{
+    //TODO: After 0.I stable this should debugmsg on failed emplace
+    //auto it = camps.emplace( p, camp );
+    //if( !it.second ) {
+    //  debugmsg( "Tried to add a basecamp %s at %s when basecamp %s is already present", camp.camp_name(), p.to_string(), it.first->second.camp_name() );
+    //}
+    camps.emplace( p, camp );
+}
+
 std::optional<basecamp *> overmap::find_camp( const point_abs_omt &p )
 {
-    for( basecamp &v : camps ) {
-        if( v.camp_omt_pos().xy() == p ) {
-            return &v;
-        }
+    const auto it = camps.find( p );
+    if( it != camps.end() ) {
+        return &( it->second );
     }
     return std::nullopt;
+}
+
+void overmap::remove_camp( const point_abs_omt &p )
+{
+    const auto it = camps.find( p );
+    if( it != camps.end() ) {
+        camps.erase( it );
+    }
 }
 
 bool overmap::is_omt_generated( const tripoint_om_omt &loc ) const

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -7378,6 +7378,14 @@ void overmap::remove_camp( const point_abs_omt &p )
     }
 }
 
+void overmap::clear_camps()
+{
+    for( const std::pair<const point_abs_omt, basecamp> &camp : camps ) {
+        // ::remove_camp is called in this
+        camp.second.remove_camp();
+    }
+}
+
 bool overmap::is_omt_generated( const tripoint_om_omt &loc ) const
 {
     if( !inbounds( loc ) ) {

--- a/src/overmap.h
+++ b/src/overmap.h
@@ -447,7 +447,7 @@ class overmap
         // Fill in any gaps in city_tiles that don't connect to the map edge
         void flood_fill_city_tiles();
         std::multimap<tripoint_om_sm, mongroup> zg; // NOLINT(cata-serialize)
-        std::map<point_om_omt, basecamp> camps;
+        std::map<point_abs_omt, basecamp> camps;
     public:
         /** Unit test enablers to check if a given mongroup is present. */
         bool mongroup_check( const mongroup &candidate ) const;
@@ -459,7 +459,12 @@ class overmap
         std::vector<city> cities;
         std::vector<overmap_river_node> rivers;
         std::map<string_id<overmap_connection>, std::vector<tripoint_om_omt>> connections_out;
+        void add_camp( const point_abs_omt &p, const basecamp &camp );
         std::optional<basecamp *> find_camp( const point_abs_omt &p );
+        const std::map<point_abs_omt, basecamp> &get_camps() const {
+            return camps;
+        }
+        void remove_camp( const point_abs_omt &p );
         /// Adds the npc to the contained list of npcs ( @ref npcs ).
         void insert_npc( const shared_ptr_fast<npc> &who );
         /// Removes the npc and returns it ( or returns nullptr if not found ).

--- a/src/overmap.h
+++ b/src/overmap.h
@@ -447,6 +447,7 @@ class overmap
         // Fill in any gaps in city_tiles that don't connect to the map edge
         void flood_fill_city_tiles();
         std::multimap<tripoint_om_sm, mongroup> zg; // NOLINT(cata-serialize)
+        std::map<point_om_omt, basecamp> camps;
     public:
         /** Unit test enablers to check if a given mongroup is present. */
         bool mongroup_check( const mongroup &candidate ) const;
@@ -455,7 +456,6 @@ class overmap
         // TODO: make private
         std::vector<radio_tower> radios;
         std::map<int, om_vehicle> vehicles;
-        std::vector<basecamp> camps;
         std::vector<city> cities;
         std::vector<overmap_river_node> rivers;
         std::map<string_id<overmap_connection>, std::vector<tripoint_om_omt>> connections_out;

--- a/src/overmap.h
+++ b/src/overmap.h
@@ -461,6 +461,7 @@ class overmap
         std::map<string_id<overmap_connection>, std::vector<tripoint_om_omt>> connections_out;
         void add_camp( const point_abs_omt &p, const basecamp &camp );
         std::optional<basecamp *> find_camp( const point_abs_omt &p );
+        void clear_camps();
         const std::map<point_abs_omt, basecamp> &get_camps() const {
             return camps;
         }

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -335,11 +335,11 @@ static void draw_camp_labels( const catacurses::window &w, const tripoint_abs_om
              project_to<coords::sm>( center ), sm_radius ) ) {
         const point_abs_omt camp_pos( element.camp->camp_omt_pos().xy() );
         const point screen_pos( ( camp_pos - center.xy() ).raw() + screen_center_pos );
-        const int text_width = utf8_width( element.camp->name, true );
+        const int text_width = utf8_width( element.camp->camp_name(), true );
         const int text_x_min = screen_pos.x - text_width / 2;
         const int text_x_max = text_x_min + text_width;
         const int text_y = screen_pos.y;
-        const std::string camp_name = element.camp->name;
+        const std::string camp_name = element.camp->camp_name();
         if( text_x_min < 0 ||
             text_x_max > win_x_max ||
             text_y < 0 ||

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -737,12 +737,11 @@ void overmapbuffer::move_vehicle( vehicle *veh, const point_abs_ms &old_msp )
     }
 }
 
-void overmapbuffer::remove_camp( const basecamp &camp )
+void overmapbuffer::remove_camp( const point_abs_omt &p )
 {
-    const point_abs_omt omt = camp.camp_omt_pos().xy();
-    const overmap_with_local_coords om_loc = get_existing_om_global( omt );
+    const overmap_with_local_coords om_loc = get_existing_om_global( p );
     if( !!om_loc.om ) {
-        om_loc.om->remove_camp( omt );
+        om_loc.om->remove_camp( p );
     }
 }
 

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -1442,6 +1442,14 @@ std::optional<basecamp *> overmapbuffer::find_camp( const point_abs_omt &p )
     return std::nullopt;
 }
 
+void overmapbuffer::clear_camps( const point_abs_omt &p )
+{
+    const overmap_with_local_coords om_loc = get_existing_om_global( p );
+    if( !!om_loc.om ) {
+        om_loc.om->clear_camps();
+    }
+}
+
 void overmapbuffer::insert_npc( const shared_ptr_fast<npc> &who )
 {
     cata_assert( who );

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -507,18 +507,8 @@ bool overmapbuffer::has_camp( const tripoint_abs_omt &p )
         return false;
     }
 
-    const overmap_with_local_coords om_loc = get_existing_om_global( p );
-    if( !om_loc ) {
-        return false;
-    }
-
-    for( const basecamp &v : om_loc.om->camps ) {
-        if( v.camp_omt_pos().xy() == p.xy() ) {
-            return true;
-        }
-    }
-
-    return false;
+    const auto camp = find_camp( p.xy() );
+    return !!camp;
 }
 
 bool overmapbuffer::has_vehicle( const tripoint_abs_omt &p )
@@ -750,13 +740,9 @@ void overmapbuffer::move_vehicle( vehicle *veh, const point_abs_ms &old_msp )
 void overmapbuffer::remove_camp( const basecamp &camp )
 {
     const point_abs_omt omt = camp.camp_omt_pos().xy();
-    const overmap_with_local_coords om_loc = get_om_global( omt );
-    std::vector<basecamp> &camps = om_loc.om->camps;
-    for( auto it = camps.begin(); it != camps.end(); ++it ) {
-        if( it->camp_omt_pos().xy() == omt ) {
-            camps.erase( it );
-            return;
-        }
+    const overmap_with_local_coords om_loc = get_existing_om_global( omt );
+    if( !!om_loc.om ) {
+        om_loc.om->remove_camp( omt );
     }
 }
 
@@ -794,7 +780,7 @@ void overmapbuffer::add_camp( const basecamp &camp )
 {
     const point_abs_omt omt = camp.camp_omt_pos().xy();
     const overmap_with_local_coords om_loc = get_om_global( omt );
-    om_loc.om->camps.push_back( camp );
+    om_loc.om->add_camp( omt, camp );
 }
 
 om_vision_level overmapbuffer::seen( const tripoint_abs_omt &p )
@@ -1447,14 +1433,11 @@ shared_ptr_fast<npc> overmapbuffer::find_npc_by_unique_id( const std::string &un
 
 std::optional<basecamp *> overmapbuffer::find_camp( const point_abs_omt &p )
 {
-    for( auto &it : overmaps ) {
-        const point_abs_omt p2( p );
-        for( int x2 = p2.x() - 3; x2 < p2.x() + 3; x2++ ) {
-            for( int y2 = p2.y() - 3; y2 < p2.y() + 3; y2++ ) {
-                if( std::optional<basecamp *> camp = it.second->find_camp( point_abs_omt( x2, y2 ) ) ) {
-                    return camp;
-                }
-            }
+    const overmap_with_local_coords om_loc = get_existing_om_global( p );
+    if( !!om_loc.om ) {
+        std::optional<basecamp *> camp = om_loc.om->find_camp( p );
+        if( !!camp ) {
+            return camp;
         }
     }
     return std::nullopt;
@@ -1607,14 +1590,16 @@ std::vector<camp_reference> overmapbuffer::get_camps_near( const tripoint_abs_sm
 {
     std::vector<camp_reference> result;
     for( overmap *om : get_overmaps_near( location, radius ) ) {
-        result.reserve( result.size() + om->camps.size() );
-        std::transform( om->camps.begin(), om->camps.end(), std::back_inserter( result ),
-        [&]( basecamp & element ) {
-            const tripoint_abs_omt camp_pt = element.camp_omt_pos();
+        const std::map<point_abs_omt, basecamp> &camps = om->get_camps();
+        result.reserve( result.size() + camps.size() );
+        std::transform( camps.begin(), camps.end(), std::back_inserter( result ),
+        [&]( auto & element ) {
+            const tripoint_abs_omt camp_pt = element.second.camp_omt_pos();
             const tripoint_abs_sm camp_sm = project_to<coords::sm>( camp_pt );
             const int distance = rl_dist( camp_sm, location );
 
-            return camp_reference{ &element, camp_sm, distance };
+            //This is very ugly but element.second is const and camps should be private and we overmap can't access camp_reference as it would be circular
+            return camp_reference{ om->find_camp( camp_pt.xy() ).value(), camp_sm, distance };
         } );
     }
     std::sort( result.begin(), result.end(), []( const camp_reference & lhs,

--- a/src/overmapbuffer.h
+++ b/src/overmapbuffer.h
@@ -281,6 +281,8 @@ class overmapbuffer
         void add_camp( const basecamp &camp );
 
         std::optional<basecamp *> find_camp( const point_abs_omt &p );
+        // Remove all basecamps in the inbound overmap
+        void clear_camps( const point_abs_omt &p );
         /**
          * Get all npcs in a area with given radius around given central point.
          * All z-levels are considered.

--- a/src/overmapbuffer.h
+++ b/src/overmapbuffer.h
@@ -270,7 +270,7 @@ class overmapbuffer
         /**
          * Remove basecamp
          */
-        void remove_camp( const basecamp &camp );
+        void remove_camp( const point_abs_omt &p );
         /**
          * Remove the vehicle from being tracked in the overmap.
          */

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -674,22 +674,10 @@ void overmap::unserialize( const JsonObject &jsobj )
             }
         } else if( name == "camps" ) {
             JsonArray camps_json = om_member;
-            if( version < ?? ? ) {
-                for( JsonObject camp_json : camps_json ) {
-                    basecamp new_camp;
-                    new_camp.deserialize( camp_json );
-                    camps.push_back( new_camp );
-                }
-            } else {
-                JsonArray camps_json = om_member;
-                for( JsonObject pos_camp : camps_json ) {
-                    point_om_omt p;
-                    basecamp new_camp;
-                    pos_camp.read( "pos", p );
-                    JsonObject camp_json = pos_camp.get_member( "camp" );
-                    new_camp.deserialize( camp_json );
-                    camps.emplace( pos, new_camp );
-                }
+            for( JsonObject camp_json : camps_json ) {
+                basecamp new_camp;
+                new_camp.deserialize( camp_json );
+                add_camp( new_camp.camp_omt_pos().xy(), new_camp );
             }
         } else if( name == "overmap_special_placements" ) {
             JsonArray special_placements_json = om_member;
@@ -1404,10 +1392,7 @@ void overmap::serialize( std::ostream &fout ) const
     json.member( "camps" );
     json.start_array();
     for( const auto &i : camps ) {
-        json.start_object();
-        json.member( "pos", i->first );
-        json.member( "camp", i->second );
-        json.end_object();
+        json.write( i.second );
     }
     json.end_array();
     fout << std::endl;

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -674,10 +674,22 @@ void overmap::unserialize( const JsonObject &jsobj )
             }
         } else if( name == "camps" ) {
             JsonArray camps_json = om_member;
-            for( JsonObject camp_json : camps_json ) {
-                basecamp new_camp;
-                new_camp.deserialize( camp_json );
-                camps.push_back( new_camp );
+            if( version < ?? ? ) {
+                for( JsonObject camp_json : camps_json ) {
+                    basecamp new_camp;
+                    new_camp.deserialize( camp_json );
+                    camps.push_back( new_camp );
+                }
+            } else {
+                JsonArray camps_json = om_member;
+                for( JsonObject pos_camp : camps_json ) {
+                    point_om_omt p;
+                    basecamp new_camp;
+                    pos_camp.read( "pos", p );
+                    JsonObject camp_json = pos_camp.get_member( "camp" );
+                    new_camp.deserialize( camp_json );
+                    camps.emplace( pos, new_camp );
+                }
             }
         } else if( name == "overmap_special_placements" ) {
             JsonArray special_placements_json = om_member;
@@ -1391,8 +1403,11 @@ void overmap::serialize( std::ostream &fout ) const
 
     json.member( "camps" );
     json.start_array();
-    for( const basecamp &i : camps ) {
-        json.write( i );
+    for( const auto &i : camps ) {
+        json.start_object();
+        json.member( "pos", i->first );
+        json.member( "camp", i->second );
+        json.end_object();
     }
     json.end_array();
     fout << std::endl;

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -455,10 +455,10 @@ void overmap::unserialize( const JsonObject &jsobj )
             omt_stack_arguments_map.emplace( p );
         }
     }
+    std::vector<tripoint_abs_omt> camps_to_place;
     // Extract layers first so predecessor deduplication can happen.
     if( jsobj.has_member( "layers" ) ) {
         std::unordered_map<tripoint_om_omt, std::string> oter_id_migrations;
-        std::vector<tripoint_abs_omt> camps_to_place;
         JsonArray layers_json = jsobj.get_array( "layers" );
 
         for( int z = 0; z < OVERMAP_LAYERS; ++z ) {
@@ -500,7 +500,7 @@ void overmap::unserialize( const JsonObject &jsobj )
             }
         }
         migrate_oter_ids( oter_id_migrations );
-        migrate_camps( camps_to_place );
+        // Don't do camps_to_place migration attempt yet bc we haven't deserialised existing camps
     }
     for( JsonMember om_member : jsobj ) {
         const std::string name = om_member.name();
@@ -798,6 +798,7 @@ void overmap::unserialize( const JsonObject &jsobj )
             }
         }
     }
+    migrate_camps( camps_to_place );
 }
 
 // throws std::exception

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -1089,7 +1089,7 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
             const tripoint_abs_omt camp_center = project_to<coords::omt>( camp.abs_sm_pos );
             if( overmap_buffer.seen_more_than( camp_center, om_vision_level::outlines ) &&
                 overmap_area.contains( camp_center ) ) {
-                label_bg( camp.abs_sm_pos, camp.camp->name );
+                label_bg( camp.abs_sm_pos, camp.camp->camp_name() );
             }
         }
     }

--- a/tests/faction_camp_test.cpp
+++ b/tests/faction_camp_test.cpp
@@ -39,6 +39,7 @@ TEST_CASE( "camp_calorie_counting", "[camp]" )
     clear_map();
     map &m = get_map();
     const tripoint_abs_ms zone_loc = m.get_abs( tripoint_bub_ms{ 5, 5, 0 } );
+    REQUIRE( m.inbounds( zone_loc ) );
     mapgen_place_zone( zone_loc, zone_loc, zone_type_CAMP_FOOD, your_fac, {},
                        "food" );
     mapgen_place_zone( zone_loc, zone_loc, zone_type_CAMP_STORAGE, your_fac, {},
@@ -47,6 +48,7 @@ TEST_CASE( "camp_calorie_counting", "[camp]" )
     const tripoint_abs_omt this_omt = project_to<coords::omt>( zone_loc );
     m.add_camp( this_omt, "faction_camp" );
     std::optional<basecamp *> bcp = overmap_buffer.find_camp( this_omt.xy() );
+    REQUIRE( !!bcp );
     basecamp *test_camp = *bcp;
     test_camp->set_owner( your_fac );
     WHEN( "a base item is added to larder" ) {
@@ -155,5 +157,6 @@ TEST_CASE( "camp_calorie_counting", "[camp]" )
 
         CHECK( camp_faction->food_supply().kcal() == 0 );
     }
+    overmap_buffer.clear_camps( this_omt.xy() );
 }
 // TODO: Tests for: Check calorie display at various activity levels, camp crafting works as expected (consumes inputs, returns outputs+byproducts, costs calories)

--- a/tests/map_helpers.cpp
+++ b/tests/map_helpers.cpp
@@ -1,11 +1,9 @@
 #include "map_helpers.h"
 
 #include <memory>
-#include <optional>
 #include <vector>
 
 #include "avatar.h"
-#include "basecamp.h"
 #include "calendar.h"
 #include "cata_catch.h"
 #include "character.h"
@@ -130,14 +128,7 @@ void clear_zones()
 
 void clear_basecamps()
 {
-    std::optional<basecamp *> camp;
-    do {
-        const tripoint_abs_omt &avatar_pos = get_avatar().pos_abs_omt();
-        camp = overmap_buffer.find_camp( avatar_pos.xy() );
-        if( camp && *camp != nullptr ) {
-            ( **camp ).remove_camp( avatar_pos );
-        }
-    } while( camp );
+    overmap_buffer.clear_camps( get_avatar().pos_abs_omt().xy() );
 }
 
 void clear_map( int zmin, int zmax )


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully.
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results can be either seen under the "Files changed" section of a PR or in the check's details.

Rules for suggested pull requests:
- If possible, limit yourself to small changes, 500 strings at max. Exceptions are adding or changing maps, and changes, that won't work unless they are done in a single run (even then there can be ways) - violating it puts a lot of unnecessary work on our merge team.
- Do not scope creep. If you make a pull request "Add new gun", please do not make anything more than adding the gun and following changes, like changing the stats of the gun, removing other guns from itemgroups or tweaking zombie horse stats - violating it makes future search and debugging stuff much harder, since PR name is not related to what is changed in the game. "Who the hell removed the quest item from drop in location X in PR, that adds a new plushie" - this may be a quote from a person who was affected by scope creep
- Do not make omnibus PRs. Meaning do not make a single PR, that fixes ten different, not related issues, at once, even if they are all one string - same as previously mentioned scope creep, it doesn't help to search the changes when debugging, despite all power of git blame tool

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
4. Infrastructure "JSON-ize slot machines"
5. Bugfixes "Crafting GUI: show how much recipe makes for non-charge items"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Currently NPC camp migration labels are being attempted before serialised camps are deserialised resulting in them always being placed
Milopetilo wants snippets to work with labels for something they're working on
All kind of whacky poorly scoped code that I felt the need to touch what I were directly affecting
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
NPC camp migrations are attempted after camp deserialisation
Non const camp name is private
Non const camps is private and is now a map keyed by point_abs_omt to make finding a camp less ugly and allow debugmsging on placing another camp in the same point once we're past 0.I stable
This deduplicates the problem for existing saves without need for explicit migration
overmapbuffer::find_camp is now exact, it was made to check a range here c3dfa49 but double dipped in being ranged leading to it checking more than it should have. As far as I can see nowhere is expecting this to be non-exact anymore bc we track NPC's assigned camp location
Makes get_camps_near more accurate than all the camps in an om in range
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Having the test clear camps only clear camps in the reality bubble
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Tested snippets by changing `"camp_name": "Tacoma"` to `"camp_name": "<mypronoun> <balthazar_affix> Tacoma"` with
```
  {
    "type": "snippet",
    "category": "<balthazar_affix>",
    "text": [ "alpha", "beta", "gamma", "delta", "lambda", "omega", "terra", "nova", "apex", "thor" ]
  },
```
Worked as expected including after save/load

Tested duped camps by making a save with high occurance Cabin_Lapin and save loading a few times on master at which point there were 7 original camps and 14 unwanted extra migration ones in one of the overmap savefiles. Loaded/saved on this branch and now there were only 7 total as expected.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
I'm not certain that submap camps are even set anywhere? Everything is in such a tangled web of basecamp/map/overmap/overmapbuffer/submap I could just be missing it tho
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
