### PR TITLE
Fix Powdered Milk Not Giving Calories

### DIFF
--- a/data/json/items/comestibles/dairy.json
+++ b/data/json/items/comestibles/dairy.json
@@ -437,7 +437,6 @@
     "material": [ "powder", "milk" ],
     "primary_material": "powder",
     "volume": "62 ml",
-    "cooks_like": "milk",
     "flags": [ "EDIBLE_FROZEN" ],
     "vitamins": [ [ "vitC", 1 ], [ "calcium", 7 ], [ "milk_allergen", 1 ] ],
     "fun": -5,


### PR DESCRIPTION
#### Summary
Bugfixes "Powdered Milk Now Gives its Calories"

#### Purpose of change

#80956 pointed out that powdered milk would not give its calories when used in recipes. This doesn't make sense.  IE: Powdered Milk + Water should come out to contain the amount of calories in Powdered milk.

#### Describe the solution

Removed cooks_like from powdered milk.  

It does not require cooks_like, as powdered milk's entry already contains all the data required to allow it to be cooked and processed in recipes on its own.  For comparison, powdered eggs contain the same fields of data as powdered milk, yet powdered milk had cooks_like.

For whatever reason, cooks_like was preventing the calories and vitamins from being inherited.  This is a new-ish field (I've never seen cooks_like before researching today) and I don't know why specifically it borked.

But in this situation, removing cooks_like allowed powdered milk to once again give its calories properly.  It seems like a win all around unless I'm missing something.

#### Describe alternatives you've considered

Not messing with it, or alternatively trying to figure out what's going on with cooks_like.  It effectively replaces powdered milk in the recipe with regular milk and this should not lead to the problems encountered.  But it did, preventing calories and vitamins from being inherited.  I could have dug into that, but I didn't.

Regardless, this entry does not need cooks_like, so removing it seems fine.

#### Testing

I tested a variety of recipes that used powdered milk to verify they do not inherit the calories or vitamins like they should have been.
Viewed the entries, blah blah, figured out the difference was cooks_like and removed it.
Observed that calories and vitamins are now inherited properly.
Checked a variety of recipes to verify that removing cooks_like didn't break anything.  If it did, I didn't see the issue.

#### Additional context

closes #80956 

cooks_like SEEMS like a neat and handy thing to have.  But... if a food item's entry already contains all the data the game needs in order to use the item in recipes, why do we need to replace it with another item? 

What I mean is, this powdered milk entry, as far as I could tell, contains all the important data needed to be used directly in a recipe.  Why then do we replace it with regular milk by using cooks_like?  It being powdered doesn't seem to affect the quench or morale in a negative way, nothing that I saw like that?


Aaaanyway, really hoping there's not some hidden secret thing that I'm missing that will make me look like a moron and have to close the PR.
