### PR TITLE
Melee Weapon Tech Adjustment

### DIFF
--- a/data/json/techniques.json
+++ b/data/json/techniques.json
@@ -305,6 +305,24 @@
       "and": [
         { "math": [ "u_val('size') + 1 >= n_val('size')" ] },
         { "not": { "npc_has_effect": "stunned" } },
+        {
+          "and": [
+            { "not": { "npc_has_species": "ZOMBIE" } },
+            { "not": { "npc_has_species": "NETHER" } },
+            { "not": { "npc_has_species": "NETHER_EMANATION" } },
+            { "not": { "npc_has_species": "LEECH_PLANT" } },
+            { "not": { "npc_has_species": "MIGO" } },
+            { "not": { "npc_has_species": "SLIME" } },
+            { "not": { "npc_has_species": "FUNGUS" } },
+            { "not": { "npc_has_species": "PLANT" } },
+            { "not": { "npc_has_species": "ROBOT" } },
+            { "not": { "npc_has_species": "CYBORG" } },
+            { "not": { "npc_has_species": "HALLUCINATION" } },
+            { "not": { "npc_has_species": "HORROR" } },
+            { "not": { "npc_has_species": "ABERRATION" } },
+            { "not": { "npc_has_species": "KRAKEN" } }
+          ]
+        },
         { "or": [ { "npc_bodytype": "human" }, { "npc_bodytype": "angel" } ] }
       ]
     },


### PR DESCRIPTION

#### Summary
Balance "Adjust Precise Strike melee tech so it also cant stun what other stun-causing techs cant stun."

#### Purpose of change
I noticed how i can stun zeds with a cudgel, which is a bit odd considering the fact that they werent supposed to be stunnable, among other things.

#### Describe the solution

Give it the same species conditions as any other stun-causing melee techs.

#### Describe alternatives you've considered

Not doing so.

#### Testing
Hit a buncha monsters that is in the list of species conditions, see that it doesnt proc on them.
![Screenshot_20250701_071033](https://github.com/user-attachments/assets/557435b2-26ff-45ca-986f-93f8639bdd8d)

Hit a feral human with the cudgel and it does stun them.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
