### PR TITLE
Allow dragging furniture on/off vehicles

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -5136,7 +5136,9 @@ bool move_furniture_on_vehicle_activity_actor::move_furniture( Character &who ) 
         transfer_furniture( *vp, *vp_dest );
     } else {
         vp->part_with_feature( "FURNITURE_TIEDOWN", true )->part().unload_furniture( here, dest );
-        stop_grab( who );
+        if( avatar *a = dynamic_cast<avatar *>( &who ) ) {
+            a->grab( object_type::FURNITURE, who.grab_point );
+        }
     }
     if( shifting ) {
         tripoint_rel_ms d_sum = who.grab_point + dp;

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -1509,6 +1509,37 @@ class disassemble_activity_actor : public activity_actor
         static std::unique_ptr<activity_actor> deserialize( JsonValue &jsin );
 };
 
+class move_furniture_on_vehicle_activity_actor : public activity_actor
+{
+    private:
+        tripoint_rel_ms dp;
+        bool via_ramp;
+
+    public:
+        move_furniture_on_vehicle_activity_actor( const tripoint_rel_ms &dp, bool via_ramp ) :
+            dp( dp ), via_ramp( via_ramp ) {}
+        const activity_id &get_type() const override {
+            static const activity_id ACT_FURNITURE_MOVE( "ACT_FURNITURE_MOVE" );
+            return ACT_FURNITURE_MOVE;
+        }
+
+        bool can_move_furn_on_veh_to( map &, const tripoint_bub_ms & ) const;
+        // false = move player, true = don't move player
+        bool move_furniture( Character & ) const;
+
+        void start( player_activity &act, Character & ) override;
+        void do_turn( player_activity &, Character & ) override {}
+        void finish( player_activity &act, Character &who ) override;
+        void canceled( player_activity &act, Character &who ) override;
+
+        std::unique_ptr<activity_actor> clone() const override {
+            return std::make_unique<move_furniture_on_vehicle_activity_actor>( *this );
+        }
+
+        void serialize( JsonOut &jsout ) const override;
+        static std::unique_ptr<activity_actor> deserialize( JsonValue &jsin );
+};
+
 class move_furniture_activity_actor : public activity_actor
 {
     private:

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -3979,6 +3979,11 @@ bool cata_tiles::draw_vpart( const tripoint_bub_ms &p, lit_level ll, int &height
                 if( !roof ) {
                     height_3d = height_3d_temp;
                 }
+                if( ret && !vd.carried_furn.empty() ) {
+                    draw_from_id_string( vd.carried_furn,
+                                         TILE_CATEGORY::FURNITURE, empty_string, p, 0, angle_to_dir4( 0_degrees ), ll, nv_goggles_activated,
+                                         height_3d );
+                }
                 return ret;
             }
         }

--- a/src/enums.h
+++ b/src/enums.h
@@ -273,6 +273,7 @@ enum class object_type : int {
     FIELD,     // field.h; field_entry
     TERRAIN,   // Not a real object
     FURNITURE, // Not a real object
+    FURNITURE_ON_VEHICLE, // least real
     NUM_OBJECT_TYPES,
 };
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -11637,15 +11637,28 @@ bool game::can_move_furniture( tripoint_bub_ms fdest, const tripoint_rel_ms &dp 
     bool is_ramp_or_road = here.has_flag( ter_furn_flag::TFLAG_RAMP_DOWN, fdest ) ||
                            here.has_flag( ter_furn_flag::TFLAG_RAMP_UP, fdest ) ||
                            here.has_flag( ter_furn_flag::TFLAG_ROAD, fdest );
-    return  here.passable( fdest ) &&
-            creatures.creature_at<npc>( fdest ) == nullptr &&
-            creatures.creature_at<monster>( fdest ) == nullptr &&
-            ( !pulling_furniture || is_empty( u.pos_bub() + dp ) ) &&
-            ( !has_floor || here.has_flag( ter_furn_flag::TFLAG_FLAT, fdest ) ||
-              is_ramp_or_road ) &&
-            !here.has_furn( fdest ) &&
-            !here.veh_at( fdest ) &&
-            ( !has_floor || here.tr_at( fdest ).is_null() );
+    if( !here.passable( fdest ) ) {
+        return false;
+    }
+    if( creatures.creature_at<npc>( fdest ) != nullptr ||
+        creatures.creature_at<monster>( fdest ) != nullptr ) {
+        return false;
+    }
+    if( !( !pulling_furniture || is_empty( u.pos_bub() + dp ) ) &&
+        ( !has_floor || here.has_flag( ter_furn_flag::TFLAG_FLAT, fdest ) ||
+          is_ramp_or_road ) ) {
+        return false;
+    }
+    if( here.has_furn( fdest ) ) {
+        return false;
+    }
+    if( here.veh_at( fdest ) ) {
+        return false;
+    }
+    if( !( !has_floor || here.tr_at( fdest ).is_null() ) ) {
+        return false;
+    }
+    return true;
 }
 
 int game::grabbed_furn_move_time( const tripoint_rel_ms &dp )

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -10693,7 +10693,7 @@ bool game::walk_move( const tripoint_bub_ms &dest_loc, const bool via_ramp,
             add_msg( m_warning, _( "You move into the %s, releasing it." ), grabbed_vehicle->name );
             u.grab( object_type::NONE );
         }
-    } else if( grabbed ) {
+    } else if( grabbed && u.get_grab_type() != object_type::FURNITURE_ON_VEHICLE ) {
         // We were grabbing something WEIRD, let's pretend we weren't
         grabbed = false;
     }
@@ -11950,6 +11950,11 @@ bool game::grabbed_move( const tripoint_rel_ms &dp, const bool via_ramp )
 
     if( u.get_grab_type() == object_type::FURNITURE ) {
         u.assign_activity( move_furniture_activity_actor( dp, via_ramp ) );
+        return true;
+    }
+
+    if( u.get_grab_type() == object_type::FURNITURE_ON_VEHICLE ) {
+        u.assign_activity( move_furniture_on_vehicle_activity_actor( dp, via_ramp ) );
         return true;
     }
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -11866,6 +11866,11 @@ bool game::grabbed_furn_move( const tripoint_rel_ms &dp )
         here.furn_set( fpos, furn_str_id::NULL_ID(), true );
         here.veh_at( fdest )->vehicle().invalidate_mass();
         add_msg( _( "You load the furniture onto the vehicle." ) );
+        tripoint_rel_ms new_grab_pt( fdest - ( u.pos_bub() +
+                                               ( shifting_furniture ? tripoint_rel_ms::zero : dp ) ) );
+        if( std::abs( new_grab_pt.x() ) < 2 && std::abs( new_grab_pt.y() ) < 2 ) {
+            u.grab( object_type::FURNITURE_ON_VEHICLE, new_grab_pt );
+        }
         return shifting_furniture;
     } else {
         // Actually move the furniture.

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -770,6 +770,15 @@ static void grab()
                 return;
             }
         }
+        if( vp->has_loaded_furniture() ) {
+            furn_str_id furn( vp->part_with_feature( "FURNITURE_TIEDOWN",
+                              true )->part().get_base().get_var( "tied_down_furniture" ) );
+            if( query_yn( _( "Grab %s on %s?" ), furn->name(), veh_name ) ) {
+                you.grab( object_type::FURNITURE_ON_VEHICLE, grabp - you.pos_bub() );
+                add_msg( m_info, _( "You grab the %s loaded on the %s." ), furn->name(), veh_name );
+                return;
+            }
+        }
         //solid vehicles can't be grabbed while boarded
         const optional_vpart_position vp_boarded = here.veh_at( you.pos_bub() );
         if( vp_boarded ) {

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -7158,6 +7158,11 @@ bool map::draw_maptile( const catacurses::window &w, const tripoint_bub_ms &p,
                                                 player_character.grab_point ) ) ) ) {
             memory_sym = sym;
         }
+        if( !vd.carried_furn.empty() ) {
+            furn_str_id furn( vd.carried_furn );
+            sym = furn->symbol();
+            tercol = furn->color();
+        }
     }
 
     if( param.memorize() && memory_cache_ter_is_dirty( p ) ) {

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -733,6 +733,7 @@ class vpart_display
         const vpart_id &id;
         const vpart_variant &variant;
         nc_color color = c_black;
+        std::string carried_furn;
         char32_t symbol = ' '; // symbol in unicode
         int symbol_curses = ' '; // symbol converted to curses ACS encoding if needed
         bool is_broken = false;

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -383,6 +383,9 @@ struct vehicle_part {
         /** Try to set fault returning false if specified fault cannot occur with this item */
         bool fault_set( const fault_id &f );
 
+        void load_furniture( map &here, const tripoint_bub_ms &from );
+        void unload_furniture( map &here, const tripoint_bub_ms &to );
+
         /**
          *  Get NPC currently assigned to this part (seat, turret etc)?
          *  @note checks crew member is alive and currently allied to the player

--- a/src/vehicle_display.cpp
+++ b/src/vehicle_display.cpp
@@ -41,7 +41,8 @@ vpart_display::vpart_display()
 
 vpart_display::vpart_display( const vehicle_part &vp )
     : id( vp.info().id )
-    , variant( vp.info().variants.at( vp.variant ) ) {}
+    , variant( vp.info().variants.at( vp.variant ) )
+    , carried_furn( vp.get_base().get_var( "tied_down_furniture" ) ) {}
 
 std::string vpart_display::get_tileset_id() const
 {

--- a/src/vehicle_part.cpp
+++ b/src/vehicle_part.cpp
@@ -546,6 +546,15 @@ bool vpart_position::can_load_furniture() const
     return true;
 }
 
+bool vpart_position::has_loaded_furniture() const
+{
+    std::optional<vpart_reference> loader = part_with_feature( "FURNITURE_TIEDOWN", true );
+    if( !loader.has_value() ) {
+        return false;
+    }
+    return loader->part().get_base().has_var( "tied_down_furniture" );
+}
+
 void vehicle_part::load_furniture( map &here, const tripoint_bub_ms &from )
 {
     if( base.has_var( "tied_down_furniture" ) ) {

--- a/src/vpart_position.h
+++ b/src/vpart_position.h
@@ -100,6 +100,7 @@ class vpart_position
         void form_inventory( map &here, inventory &inv ) const;
 
         bool can_load_furniture() const;
+        bool has_loaded_furniture() const;
 
         tripoint_bub_ms pos_bub( const map &here ) const;
         tripoint_abs_ms pos_abs() const;

--- a/src/vpart_position.h
+++ b/src/vpart_position.h
@@ -99,6 +99,8 @@ class vpart_position
         // Forms inventory for inventory::form_from_map
         void form_inventory( map &here, inventory &inv ) const;
 
+        bool can_load_furniture() const;
+
         tripoint_bub_ms pos_bub( const map &here ) const;
         tripoint_abs_ms pos_abs() const;
         /**


### PR DESCRIPTION
#### Summary
Features "Allow pushing/pulling furniture directly onto and off of vehicles that can load them"

#### Purpose of change
Make https://github.com/CleverRaven/Cataclysm-DDA/pull/81501 more seamless.

#### Describe the solution
Allow dragging furniture onto vehicle tiles that can load furniture, and instead load them onto the vehicle when this is attempted.

Add some `vehicle_part` functions to somewhat simplify loading/unloading furniture, and refactor the code to use them.

#### Describe alternatives you've considered
~~Allowing a grab to continue while on vehicle tiles that can store furniture, allowing moving within the vehicle: too complicated.~~

#### Testing
![gif of a character loading a bookcase onto a truck by dragging it](https://github.com/user-attachments/assets/6cc3a69d-4cb1-4e06-8c4c-c0ce5981108e)
