### PR TITLE
Let there be light: Board up a window with sturdy wooden shutters

### DIFF
--- a/data/json/construction/windows.json
+++ b/data/json/construction/windows.json
@@ -855,7 +855,7 @@
         { "id": "SAW_W", "level": 2 }
       ]
     ],
-    "components": [ [ [ "2x4", 7 ] ], [ [ "wood_panel", 4 ] ], [ [ "hinge", 4 ] ], [ [ "nuts_bolts", 8 ] ], [ [ "nails", 8, "LIST" ] ] ],
+    "components": [ [ [ "2x4", 7 ] ], [ [ "wood_panel", 4 ] ], [ [ "hinge", 4 ] ], [ [ "nuts_bolts", 8 ] ], [ [ "nails", 16, "LIST" ] ] ],
     "pre_flags": "BARRICADABLE_WINDOW",
     "post_terrain": "t_window_boarded_shutters_closed"
   },

--- a/data/json/construction/windows.json
+++ b/data/json/construction/windows.json
@@ -842,7 +842,7 @@
   {
     "type": "construction",
     "id": "constr_window_boarded_shutters",
-    "group": "board_up_window",
+    "group": "wooden_shutters",
     "//": "Bolt sturdy wood shutters onto a window",
     "category": "REINFORCE",
     "required_skills": [ [ "fabrication", 2 ] ],

--- a/data/json/construction/windows.json
+++ b/data/json/construction/windows.json
@@ -841,6 +841,26 @@
   },
   {
     "type": "construction",
+    "id": "constr_window_boarded_shutters",
+    "group": "board_up_window",
+    "//": "Bolt sturdy wood shutters onto a window",
+    "category": "REINFORCE",
+    "required_skills": [ [ "fabrication", 2 ] ],
+    "time": "30 m",
+    "qualities": [
+      [
+        { "id": "HAMMER", "level": 2 },
+        { "id": "WRENCH", "level": 1 },
+        { "id": "DRILL", "level": 1 },
+        { "id": "SAW_W", "level": 2 }
+      ]
+    ],
+    "components": [ [ [ "2x4", 7 ] ], [ [ "wood_panel", 4 ] ], [ [ "hinge", 4 ] ], [ [ "nuts_bolts", 8 ] ], [ [ "nails", 8, "LIST" ] ] ],
+    "pre_flags": "BARRICADABLE_WINDOW",
+    "post_terrain": "t_window_boarded_shutters_closed"
+  },
+  {
+    "type": "construction",
     "id": "constr_window_boarded_curtains",
     "group": "board_up_window",
     "//": "Board up window with curtains",

--- a/data/json/construction_group.json
+++ b/data/json/construction_group.json
@@ -11,6 +11,11 @@
   },
   {
     "type": "construction_group",
+    "id": "wooden_shutters",
+    "name": "Built Wooden Window Shutters"
+  },
+  {
+    "type": "construction_group",
     "id": "board_up_wood_door",
     "name": "Board Up Wood Door"
   },

--- a/data/json/furniture_and_terrain/terrain-windows.json
+++ b/data/json/furniture_and_terrain/terrain-windows.json
@@ -977,16 +977,7 @@
     "copy-from": "t_window_boarded_shutters_closed",
     "close": "t_window_boarded_shutters_closed",
     "open": "t_window_boarded_shutters_open_fully",
-    "flags": [
-      "TRANSPARENT",
-      "FLAMMABLE",
-      "NOITEM",
-      "REDUCE_SCENT",
-      "BLOCK_WIND",
-      "WINDOW",
-      "OPENCLOSE_INSIDE",
-      "SUPPORTS_ROOF"
-    ],
+    "flags": [ "TRANSPARENT", "FLAMMABLE", "NOITEM", "REDUCE_SCENT", "BLOCK_WIND", "WINDOW", "OPENCLOSE_INSIDE", "SUPPORTS_ROOF" ],
     "bash": {
       "str_min": 3,
       "str_max": 8,

--- a/data/json/furniture_and_terrain/terrain-windows.json
+++ b/data/json/furniture_and_terrain/terrain-windows.json
@@ -1002,11 +1002,7 @@
         { "item": "nuts_bolts", "count": [ 1, 4 ] }
       ]
     },
-    "prying": {
-      "result": "t_window_boarded_shutters_open_fully",
-      "duration": "30 seconds",
-      "message": "You pry the window open"
-    }
+    "prying": { "result": "t_window_boarded_shutters_open_fully", "duration": "30 seconds", "message": "You pry the window open" }
   },
   {
     "type": "terrain",

--- a/data/json/furniture_and_terrain/terrain-windows.json
+++ b/data/json/furniture_and_terrain/terrain-windows.json
@@ -881,11 +881,11 @@
       "sound_vol": 16,
       "sound_fail_vol": 10,
       "ter_set": "t_window_frame",
-      "items": [ { "item": "splinter", "count": [ 0, 2 ] }, { "item": "glass_shard", "count": [ 25, 42 ] } ]
+      "items": [ { "item": "splinter", "count": [ 10, 20 ] }, { "item": "glass_shard", "count": [ 25, 42 ] } ]
     },
     "prying": {
-      "result": "t_window_frame",
-      "duration": "30 seconds",
+      "result": "t_window",
+      "duration": "2 minutes",
       "message": "You pry the boards from the window.",
       "byproducts": [ { "item": "nail", "count": 8 }, { "item": "2x4", "count": 4 } ],
       "prying_data": { "prying_nails": true }
@@ -919,16 +919,114 @@
       "sound_vol": 14,
       "sound_fail_vol": 10,
       "ter_set": "t_window_empty",
-      "items": [ { "item": "splinter", "count": [ 0, 2 ] } ]
+      "items": [ { "item": "splinter", "count": [ 10, 20 ] } ]
     },
     "prying": {
       "result": "t_window_empty",
-      "duration": "30 seconds",
+      "duration": "2 minutes",
       "message": "You pry the boards from the window frame.",
       "byproducts": [ { "item": "nail", "count": 8 }, { "item": "2x4", "count": 4 } ],
       "prying_data": { "prying_nails": true }
     },
     "shoot": { "reduce_damage": [ 9, 21 ], "reduce_damage_laser": [ 5, 16 ], "destroy_damage": [ 10, 40 ] }
+  },
+  {
+    "type": "terrain",
+    "id": "t_window_boarded_shutters_closed",
+    "name": "window with makeshift shutters",
+    "description": "A glass window with a heavy makeshift shutter bolted into the window frame, with a wooden bar to close it from the inside.  It's fairly sturdy when closed.",
+    "symbol": "=",
+    "copy-from": "t_window_boarded",
+    "flags": [ "FLAMMABLE", "NOITEM", "REDUCE_SCENT", "BLOCK_WIND", "WINDOW", "OPENCLOSE_INSIDE", "SUPPORTS_ROOF" ],
+    "open": "t_window_boarded_shutters_open",
+    "deconstruct": {
+      "ter_set": "t_window",
+      "items": [
+        { "item": "2x4", "count": 7 },
+        { "item": "nail", "charges": [ 6, 8 ] },
+        { "item": "wood_panel", "count": 4 },
+        { "item": "hinge", "count": 4 },
+        { "item": "nuts_bolts", "count": 8 }
+      ]
+    },
+    "bash": {
+      "str_min": 3,
+      "str_max": 30,
+      "sound": "crash!",
+      "sound_fail": "wham!",
+      "sound_vol": 16,
+      "sound_fail_vol": 10,
+      "ter_set": "t_window_frame",
+      "items": [
+        { "item": "splinter", "count": [ 10, 25 ] },
+        { "item": "glass_shard", "count": [ 25, 42 ] },
+        { "item": "hinge", "count": [ 0, 3 ] },
+        { "item": "nuts_bolts", "count": [ 1, 4 ] }
+      ]
+    },
+    "prying": {
+      "result": "t_window",
+      "duration": "5 minutes",
+      "message": "You pry the shutters off the window.",
+      "items": [
+        { "item": "2x4", "count": 7 },
+        { "item": "nail", "charges": [ 7, 9 ] },
+        { "item": "wood_panel", "count": [ 2, 4 ] },
+        { "item": "hinge", "count": [ 0, 3 ] },
+        { "item": "nuts_bolts", "count": [ 1, 4 ] }
+      ],
+      "prying_data": { "prying_nails": true }
+    },
+    "shoot": { "reduce_damage": [ 10, 25 ], "reduce_damage_laser": [ 5, 20 ], "destroy_damage": [ 10, 40 ] }
+  },
+  {
+    "type": "terrain",
+    "id": "t_window_boarded_shutters_open",
+    "name": "window with open makeshift shutters",
+    "description": "A glass window with a heavy makeshift shutter bolted into the window frame, with a wooden bar to close it from the inside.  The shutters are currently open, and offer no more defense than any glass window.",
+    "symbol": "/",
+    "coverage": 70,
+    "copy-from": "t_window_boarded_shutters_closed",
+    "close": "t_window_boarded_shutters_closed",
+    "open": "t_window_boarded_shutters_open_fully",
+    "flags": [
+      "TRANSPARENT",
+      "FLAMMABLE",
+      "NOITEM",
+      "REDUCE_SCENT",
+      "BLOCK_WIND",
+      "WINDOW",
+      "BARRICADABLE_WINDOW",
+      "OPENCLOSE_INSIDE",
+      "SUPPORTS_ROOF"
+    ],
+    "bash": {
+      "str_min": 3,
+      "str_max": 8,
+      "sound": "glass shattering!",
+      "sound_fail": "wham!",
+      "sound_vol": 16,
+      "sound_fail_vol": 10,
+      "ter_set": "t_window_frame",
+      "items": [
+        { "item": "splinter", "count": [ 10, 25 ] },
+        { "item": "glass_shard", "count": [ 25, 42 ] },
+        { "item": "hinge", "count": [ 0, 3 ] },
+        { "item": "nuts_bolts", "count": [ 1, 4 ] }
+      ]
+    }
+  },
+  {
+    "type": "terrain",
+    "id": "t_window_boarded_shutters_open_fully",
+    "name": "window with open makeshift shutters",
+    "description": "A glass window with a heavy makeshift shutter bolted into the window frame, with a wooden bar to close it from the inside.  Both the shutters and the window glass are wide open, offering no defense.",
+    "symbol": "0",
+    "move_cost": 5,
+    "coverage": 70,
+    "copy-from": "t_window_boarded_shutters_open",
+    "close": "t_window_boarded_shutters_open",
+    "flags": [ "TRANSPARENT", "FLAMMABLE", "NOITEM", "WINDOW", "OPENCLOSE_INSIDE", "SUPPORTS_ROOF", "PERMEABLE" ]
   },
   {
     "type": "terrain",

--- a/data/json/furniture_and_terrain/terrain-windows.json
+++ b/data/json/furniture_and_terrain/terrain-windows.json
@@ -970,6 +970,7 @@
     "type": "terrain",
     "id": "t_window_boarded_shutters_open",
     "name": "window with open makeshift shutters",
+    "looks_like": "t_window",
     "description": "A glass window with a heavy makeshift shutter bolted into the window frame, with a wooden bar to close it from the inside.  The shutters are currently open, and offer no more defense than any glass window.",
     "symbol": "/",
     "coverage": 70,
@@ -983,7 +984,6 @@
       "REDUCE_SCENT",
       "BLOCK_WIND",
       "WINDOW",
-      "BARRICADABLE_WINDOW",
       "OPENCLOSE_INSIDE",
       "SUPPORTS_ROOF"
     ],
@@ -1008,6 +1008,7 @@
     "type": "terrain",
     "id": "t_window_boarded_shutters_open_fully",
     "name": "window with open makeshift shutters",
+    "looks_like": "t_window_open",
     "description": "A glass window with a heavy makeshift shutter bolted into the window frame, with a wooden bar to close it from the inside.  Both the shutters and the window glass are wide open, offering no defense.",
     "symbol": "0",
     "move_cost": 5,

--- a/data/json/furniture_and_terrain/terrain-windows.json
+++ b/data/json/furniture_and_terrain/terrain-windows.json
@@ -943,14 +943,14 @@
       "ter_set": "t_window",
       "items": [
         { "item": "2x4", "count": 7 },
-        { "item": "nail", "charges": [ 6, 8 ] },
+        { "item": "nail", "charges": [ 10, 16 ] },
         { "item": "wood_panel", "count": 4 },
         { "item": "hinge", "count": 4 },
         { "item": "nuts_bolts", "count": 8 }
       ]
     },
     "bash": {
-      "str_min": 3,
+      "str_min": 6,
       "str_max": 30,
       "sound": "crash!",
       "sound_fail": "wham!",
@@ -970,7 +970,7 @@
       "message": "You pry the shutters off the window.",
       "items": [
         { "item": "2x4", "count": 7 },
-        { "item": "nail", "charges": [ 7, 9 ] },
+        { "item": "nail", "charges": [ 14, 16 ] },
         { "item": "wood_panel", "count": [ 2, 4 ] },
         { "item": "hinge", "count": [ 0, 3 ] },
         { "item": "nuts_bolts", "count": [ 1, 4 ] }

--- a/data/json/furniture_and_terrain/terrain-windows.json
+++ b/data/json/furniture_and_terrain/terrain-windows.json
@@ -964,19 +964,6 @@
         { "item": "nuts_bolts", "count": [ 1, 4 ] }
       ]
     },
-    "prying": {
-      "result": "t_window",
-      "duration": "5 minutes",
-      "message": "You pry the shutters off the window.",
-      "items": [
-        { "item": "2x4", "count": 7 },
-        { "item": "nail", "charges": [ 14, 16 ] },
-        { "item": "wood_panel", "count": [ 2, 4 ] },
-        { "item": "hinge", "count": [ 0, 3 ] },
-        { "item": "nuts_bolts", "count": [ 1, 4 ] }
-      ],
-      "prying_data": { "prying_nails": true }
-    },
     "shoot": { "reduce_damage": [ 10, 25 ], "reduce_damage_laser": [ 5, 20 ], "destroy_damage": [ 10, 40 ] }
   },
   {
@@ -1014,6 +1001,11 @@
         { "item": "hinge", "count": [ 0, 3 ] },
         { "item": "nuts_bolts", "count": [ 1, 4 ] }
       ]
+    },
+    "prying": {
+      "result": "t_window_boarded_shutters_open_fully",
+      "duration": "30 seconds",
+      "message": "You pry the window open"
     }
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Content "Build sturdy wooden shutters for your windows"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

My kid is playing DDA, and has noticed that we lack an intermediate solution between "window with curtains" and "reinforced window with metal shutters" that is easier to build but can still be opened to let light in for crafting.

#### Describe the solution

Adds sturdy wooden shutters that you can bar from the inside. These are a little sturdier than a boarded up window as the frame is bolted onto the window frame itself, but only a little. However, they can be opened to let the light in, and opened further to let in the fresh summer breeze. Delightful!

Requires a fair bit more skill and supplies than just boarding up a window, for I think obvious reasons.

While I was in there I noticed some nonsense in the boarded up window definitions, particularly the yield of splinters when bashed, and touched that up.

#### Describe alternatives you've considered

I thought of a few janky ways to make a lower grade version of this, but it was too fraught with pitfalls. Do it right or not at all folks!


#### Testing
![image](https://github.com/user-attachments/assets/40d87253-c68d-4ed5-99a1-81c1c44f5cc9)
![image](https://github.com/user-attachments/assets/69319cd6-45c8-433c-8c8f-43a5fcf807c4)


#### Additional context

Give me a bit and I'll have this kid making their own PRs.