### PR TITLE
NPCs can handle liquids from crafting

### DIFF
--- a/src/butchery.cpp
+++ b/src/butchery.cpp
@@ -872,12 +872,13 @@ bool butchery_drops_harvest( butchery_data bt, Character &you )
                     obj.remove_fault( flt );
                 }
 
-                // TODO: smarter NPC liquid handling
                 // If we're not bleeding the animal we don't care about the blood being wasted
-                if( you.is_npc() || action != butcher_type::BLEED ) {
+                if( action != butcher_type::BLEED ) {
                     drop_on_map( you, item_drop_reason::deliberate, { obj }, &here, corpse_loc );
-                } else {
+                } else if( you.is_avatar() ) {
                     liquid_handler::handle_all_liquid( obj, 1 );
+                } else {
+                    liquid_handler::handle_npc_liquid( obj, you );
                 }
             } else if( drop->count_by_charges() ) {
                 std::vector<item> objs = create_charge_items( drop, roll, entry, &corpse_item, you );

--- a/src/handle_liquid.h
+++ b/src/handle_liquid.h
@@ -6,6 +6,7 @@
 #include "item_location.h"
 #include "point.h"
 
+class Character;
 class item;
 class monster;
 class vehicle;
@@ -42,6 +43,14 @@ namespace liquid_handler
  * `true` indicates some charges have been transferred (but not necessarily all of them).
  */
 void handle_all_liquid( item liquid, int radius, const item *avoid = nullptr );
+
+/**
+ * Store any liquids produced during an NPC activity (e.g. crafting or disassembly) into
+ * nearby containers. Will spill on the ground if no suitable containers are found.
+ * Does not consume moves (the move cost is presumed to be covered by the activity that
+ * produced the liquid).
+ */
+void handle_npc_liquid( item liquid, Character &who );
 
 /**
  * Consume / handle as much of the liquid as possible in varying ways. This function can

--- a/src/recipe.cpp
+++ b/src/recipe.cpp
@@ -21,7 +21,6 @@
 #include "debug.h"
 #include "effect_on_condition.h"
 #include "enum_traits.h"
-#include "enums.h"
 #include "flag.h"
 #include "flexbuffer_json.h"
 #include "game_constants.h"
@@ -1334,18 +1333,8 @@ std::function<bool( const item & )> recipe::get_component_filter(
     };
 }
 
-bool recipe::npc_can_craft( std::string &reason ) const
+bool recipe::npc_can_craft( std::string & ) const
 {
-    if( result()->phase != phase_id::SOLID ) {
-        reason = _( "Ordering NPC to craft non-solid item is currently only implemented for camps." );
-        return false;
-    }
-    for( const auto& [bp, _] : get_byproducts() ) {
-        if( bp->phase != phase_id::SOLID ) {
-            reason = _( "Ordering NPC to craft non-solid item is currently only implemented for camps." );
-            return false;
-        }
-    }
     return true;
 }
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Features "NPCs can handle liquids from crafting"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Currently NPCs are not able to work on crafting recipes that have liquid products or byproducts, but can otherwise handle any other recipe. Additionally, when NPCs disassemble items that yield liquids (car batteries, engines) they drop the liquids on the ground.
This PR enables NPCs to stash liquids produced by crafting/disassembly/butchery into nearby containers and removes the limitation on crafting recipes that yield liquids.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Implement the function `liquid_handler::handle_npc_liquid()` and call that instead of `liquid_handler::handle_all_liquid()` when the character performing the action is an NPC.
NPCs will attempt to stash liquids in containers found in a 1-tile radius (including vehicle storage and their own inventory), in this order:
- containers that are partially filled with the same liquid
- spill-proof containers on the ground or in furniture/vehicle cargo
- spillable containers (e.g. buckets)
- spill-proof containers in personal inventory

NPCs will attempt to minimize the number of containers used, while also attempting to reduce waste (i.e. not using a drum if a bottle is enough). If they run out of available containers they will spill any remaining liquid on the ground.
Note that unlike `handle_all_liquid()`, the NPC-specific function does not consume extra movement points -- it is presumed that the pouring of liquids is done as part of the activity that generated them.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

- Various different priority schemes for choosing containers. I picked something that seems reasonable to me.
- Adding support for liquid-containing furniture. Maybe a future PR.
- Increasing the search radius beyond 1 tile. Makes the code more complicated due to reachability checks. Maybe a future PR.
- Simulating the pouring actions. This makes the code significantly more complicated.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

- Start a new game, gain debug mutations, find a safe spot, spawn and recruit an NPC
- Build a workbench, a water source (well), build/spawn a shopping cart, place a large battery and spawn + connect a hotplate
- Spawn some containers (bottles, pots, buckets, jerrycans, gallon jugs) and a car battery
- Position the NPC next to the workbench and the shopping cart
- Ask the NPC to craft different amounts of clean water and place containers around them
- Wait for the crafting to finish and observe that they prioritize filling containers in the order described above
- Put the car battery in a disassembly zone next to the NPC, ask them to work on disassembly
- Wait for the disassembly to finish and observe that the sulfuric acid gets stored instead of dropped
- Repeat when there are no [empty] containers near the NPC and verify that they drop the clean water / acid on the floor
- Repeat with a few containers, not enough to store all the crafted water and verify that the containers get filled and the excess gets spilled on the floor
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
