### PR TITLE
Aftershock: Augstmoon vendors sell more tools.

### DIFF
--- a/data/mods/aftershock_exoplanet/npcs/Augustmoon_Salvors/augustmoon_gun_trader.json
+++ b/data/mods/aftershock_exoplanet/npcs/Augustmoon_Salvors/augustmoon_gun_trader.json
@@ -38,7 +38,10 @@
     "items": [
       { "group": "afs_civilian_armory", "count": [ 14, 28 ] },
       { "group": "augustmoon_shop_money" },
-      { "item": "UPS_OFF", "charges": 1000, "count": 1 }
+      { "item": "UPS_OFF", "charges": 1000, "count": 1 },
+      { "item": "small_repairkit", "count": 1 },
+      { "item": "large_repairkit", "count": 1 },
+      { "item": "chem_acetone", "count": [ 1, 2 ] }
     ]
   },
   {

--- a/data/mods/aftershock_exoplanet/npcs/Augustmoon_Salvors/augustmoon_tool_trader.json
+++ b/data/mods/aftershock_exoplanet/npcs/Augustmoon_Salvors/augustmoon_tool_trader.json
@@ -36,12 +36,15 @@
       { "group": "afs_tools_scavenging", "count": [ 6, 12 ] },
       { "group": "afs_tools_pocket", "count": [ 5, 10 ] },
       { "item": "afs_thermos", "count": [ 2, 3 ] },
-      { "item": "multi_cooker", "count": [ 1, 1 ] },
+      { "item": "multi_cooker", "count": 1 },
+      { "item": "water_purifier", "count": 1 },
       { "item": "afs_40g_plasma_civ", "count": [ 2, 5 ] },
       { "item": "afs_heavy_suit_battery_cell", "count": [ 2, 5 ] },
       { "group": "afs_tools_welding_consumable", "count": [ 6, 8 ] },
+      { "group": "pur_tablets_bottle_plastic_small_50", "count": [ 1, 2 ] },
       { "group": "afs_augustmoon_batteries_disposable", "count": [ 5, 10 ] },
       { "group": "afs_augustmoon_batteries_rechargeable", "count": [ 2, 3 ], "prob": 20 },
+      { "item": "ammonia_liquid", "count": [ 2, 4 ] },
       { "group": "augustmoon_shop_money" }
     ]
   },


### PR DESCRIPTION
#### Summary
Mods "Aftershock: Augstmoon vendors sell more tools."
 
#### Purpose of change
Add some more missing tools to the station store.

#### Describe the solution
The gunsmith now sells firearm maintenance tools and supplies. The tool vendor sells water purification tools and guaranteed fuel for the jetpack.

#### Testing
Loaded and visited the stores.

#### Additional context
This game has too many tools lol.