### PR TITLE
don’t call std::pow for squaring numbers

### DIFF
--- a/src/point.cpp
+++ b/src/point.cpp
@@ -41,7 +41,9 @@ point point::rotate( int turns, const point &dim ) const
 
 float point::distance( const point &rhs ) const
 {
-    return std::sqrt( static_cast<float>( std::pow( x - rhs.x, 2 ) + std::pow( y - rhs.y, 2 ) ) );
+    float dx = x - rhs.x;
+    float dy = y - rhs.y;
+    return std::sqrt( dx * dx + dy * dy );
 }
 
 int point::distance_manhattan( const point &rhs ) const


### PR DESCRIPTION
#### Summary
Performance "don’t call std::pow for squaring numbers"
#### Purpose of change

Speed.

#### Testing

Everything still looks right.

#### Additional context
Before:
![Screenshot 2025-07-02 at 14-08-04 tiles-sound-loc on orod-na-thon (perf version 6 15 4-200 fc42 x86_64) – Linux 6 15 3-200 fc42 x86_64 – 7_2_2025 8 57 20 PM UTC – Firefox Profiler](https://github.com/user-attachments/assets/00df5a01-32d8-4496-a821-ab10cf940032)

After:
![Screenshot 2025-07-02 at 14-13-13 tiles-sound-loc on orod-na-thon (perf version 6 15 4-200 fc42 x86_64) – Linux 6 15 3-200 fc42 x86_64 – 7_2_2025 9 02 10 PM UTC – Firefox Profiler](https://github.com/user-attachments/assets/4f59c12e-e247-48d3-a687-2322e596b183)

These profiles were taken specifically to measure the performance of drawing the world map. I used debug commands to reveal a 3×3 grid of overmaps, then zoomed all the way out. The frame rate drops to about 1, so clearly there is room for improvement. This is merely the easiest improvement, not the biggest.