### PR TITLE
More Sky island upgrades

### DIFF
--- a/data/mods/Sky_Island/EOCs.json
+++ b/data/mods/Sky_Island/EOCs.json
@@ -24,7 +24,67 @@
         "min_radius": 2,
         "max_radius": 10
       },
-      { "u_add_effect": "warpcloak", "intensity": 1, "duration": { "global_val": "invistime", "default": "3 s" } },
+      { "u_add_effect": "warpcloak", "intensity": 2, "duration": { "global_val": "invistime", "default": "3 s" } },
+      {
+        "run_eocs": [
+          {
+            "id": "EOC_PLAYER_WARPCLOAK_WATERWALK",
+            "condition": { "math": [ "landing_waterwalk == 1" ] },
+            "effect": [
+              {
+                "u_add_effect": "effect_warped_waterwalking_hidden",
+                "intensity": 1,
+                "duration": { "global_val": "var", "var_name": "invistime", "default": "3 s" }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "run_eocs": [
+          {
+            "id": "EOC_PLAYER_WARPCLOAK_FLIGHT",
+            "condition": { "math": [ "landing_flight == 1" ] },
+            "effect": [
+              {
+                "u_add_effect": "effect_warped_flight",
+                "intensity": 1,
+                "duration": { "global_val": "var", "var_name": "invistime", "default": "3 s" }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "run_eocs": [
+          {
+            "id": "EOC_PLAYER_WARPCLOAK_PHASING",
+            "condition": { "math": [ "landing_phase == 1" ] },
+            "effect": [
+              {
+                "u_add_effect": "effect_warped_phasing",
+                "intensity": 1,
+                "duration": { "global_val": "var", "var_name": "invistime", "default": "3 s" }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "run_eocs": [
+          {
+            "id": "EOC_PLAYER_START_CLAIRVOYANCE",
+            "condition": { "math": [ "scoutingclairvoyancetime >= 1" ] },
+            "effect": [
+              {
+                "u_add_effect": "effect_warped_super_clairvoyance",
+                "intensity": 1,
+                "duration": { "global_val": "var", "var_name": "scoutingclairvoyancetime", "default": "3 s" }
+              }
+            ]
+          }
+        ]
+      },
       {
         "u_run_npc_eocs": [
           {

--- a/data/mods/Sky_Island/EOCs.json
+++ b/data/mods/Sky_Island/EOCs.json
@@ -34,7 +34,7 @@
               {
                 "u_add_effect": "effect_warped_waterwalking_hidden",
                 "intensity": 1,
-                "duration": { "global_val": "var", "var_name": "invistime", "default": "3 s" }
+                "duration": { "global_val": "invistime", "default": "3 s" }
               }
             ]
           }
@@ -46,11 +46,7 @@
             "id": "EOC_PLAYER_WARPCLOAK_FLIGHT",
             "condition": { "math": [ "landing_flight == 1" ] },
             "effect": [
-              {
-                "u_add_effect": "effect_warped_flight",
-                "intensity": 1,
-                "duration": { "global_val": "var", "var_name": "invistime", "default": "3 s" }
-              }
+              { "u_add_effect": "effect_warped_flight", "intensity": 1, "duration": { "global_val": "invistime", "default": "3 s" } }
             ]
           }
         ]
@@ -61,11 +57,7 @@
             "id": "EOC_PLAYER_WARPCLOAK_PHASING",
             "condition": { "math": [ "landing_phase == 1" ] },
             "effect": [
-              {
-                "u_add_effect": "effect_warped_phasing",
-                "intensity": 1,
-                "duration": { "global_val": "var", "var_name": "invistime", "default": "3 s" }
-              }
+              { "u_add_effect": "effect_warped_phasing", "intensity": 1, "duration": { "global_val": "invistime", "default": "3 s" } }
             ]
           }
         ]
@@ -79,7 +71,7 @@
               {
                 "u_add_effect": "effect_warped_super_clairvoyance",
                 "intensity": 1,
-                "duration": { "global_val": "var", "var_name": "scoutingclairvoyancetime", "default": "3 s" }
+                "duration": { "global_val": "scoutingclairvoyancetime", "default": "3 s" }
               }
             ]
           }

--- a/data/mods/Sky_Island/dialog_statue.json
+++ b/data/mods/Sky_Island/dialog_statue.json
@@ -264,6 +264,29 @@
         "effect": [ { "assign_mission": "SKYISLAND_UPGRADE_sunblock" } ],
         "topic": "SKYISLAND_UPGRADES_TERRAFORM"
       },
+      {
+        "text": "Unlock: Personal Windblocker",
+        "condition": {
+          "and": [
+            { "not": { "u_has_mission": "SKYISLAND_UPGRADE_windblock" } },
+            { "not": { "u_has_trait": "mut_skyisland_windblock" } }
+          ]
+        },
+        "effect": [ { "assign_mission": "SKYISLAND_UPGRADE_windblock" } ],
+        "topic": "SKYISLAND_UPGRADES_TERRAFORM"
+      },
+      {
+        "text": "Unlock: Personal Temperature Adjustement",
+        "condition": {
+          "and": [
+            { "not": { "u_has_mission": "SKYISLAND_UPGRADE_personal_temperature_adaptation" } },
+            { "math": [ "skyisland_bunker_temperature_adaptation == 1" ] },
+            { "math": [ "skyisland_personal_temperature_adaptation == 0" ] }
+          ]
+        },
+        "effect": [ { "assign_mission": "SKYISLAND_UPGRADE_personal_temperature_adaptation" } ],
+        "topic": "SKYISLAND_UPGRADES_TERRAFORM"
+      },
       { "text": "Nevermind.", "topic": "SKYISLAND_UPGRADE" }
     ]
   },
@@ -315,6 +338,42 @@
         "topic": "SKYISLAND_UPGRADES_FEATURES"
       },
       {
+        "text": "Upgrade: Stability 5",
+        "condition": {
+          "and": [
+            { "not": { "u_has_mission": "SKYISLAND_UPGRADE_stability5" } },
+            { "math": [ "bonuspulses == 4" ] },
+            { "math": [ "islandrank >= 4" ] }
+          ]
+        },
+        "effect": [ { "assign_mission": "SKYISLAND_UPGRADE_stability5" } ],
+        "topic": "SKYISLAND_UPGRADES_FEATURES"
+      },
+      {
+        "text": "Upgrade: Stability 6",
+        "condition": {
+          "and": [
+            { "not": { "u_has_mission": "SKYISLAND_UPGRADE_stability6" } },
+            { "math": [ "bonuspulses == 5" ] },
+            { "math": [ "islandrank >= 4" ] }
+          ]
+        },
+        "effect": [ { "assign_mission": "SKYISLAND_UPGRADE_stability6" } ],
+        "topic": "SKYISLAND_UPGRADES_FEATURES"
+      },
+      {
+        "text": "Upgrade: Stability 7",
+        "condition": {
+          "and": [
+            { "not": { "u_has_mission": "SKYISLAND_UPGRADE_stability7" } },
+            { "math": [ "bonuspulses == 6" ] },
+            { "math": [ "islandrank >= 4" ] }
+          ]
+        },
+        "effect": [ { "assign_mission": "SKYISLAND_UPGRADE_stability7" } ],
+        "topic": "SKYISLAND_UPGRADES_FEATURES"
+      },
+      {
         "text": "Upgrade: Scouting 1",
         "condition": {
           "and": [ { "not": { "u_has_mission": "SKYISLAND_UPGRADE_scouting1" } }, { "math": [ "scoutingdistancetargets == 0" ] } ]
@@ -360,6 +419,66 @@
           ]
         },
         "effect": [ { "assign_mission": "SKYISLAND_UPGRADE_scouting5" } ],
+        "topic": "SKYISLAND_UPGRADES_FEATURES"
+      },
+      {
+        "text": "Upgrade: Scouting 6",
+        "condition": {
+          "and": [
+            { "not": { "u_has_mission": "SKYISLAND_UPGRADE_scouting6" } },
+            { "math": [ "scoutingdistancetargets == 7" ] },
+            { "math": [ "islandrank >= 4" ] }
+          ]
+        },
+        "effect": [ { "assign_mission": "SKYISLAND_UPGRADE_scouting6" } ],
+        "topic": "SKYISLAND_UPGRADES_FEATURES"
+      },
+      {
+        "text": "Upgrade: Scouting 7",
+        "condition": {
+          "and": [
+            { "not": { "u_has_mission": "SKYISLAND_UPGRADE_scouting7" } },
+            { "math": [ "scoutingdistancetargets == 8" ] },
+            { "math": [ "islandrank >= 4" ] }
+          ]
+        },
+        "effect": [ { "assign_mission": "SKYISLAND_UPGRADE_scouting7" } ],
+        "topic": "SKYISLAND_UPGRADES_FEATURES"
+      },
+      {
+        "text": "Upgrade: Scouting 8",
+        "condition": {
+          "and": [
+            { "not": { "u_has_mission": "SKYISLAND_UPGRADE_scouting8" } },
+            { "math": [ "scoutingdistancetargets == 7" ] },
+            { "math": [ "islandrank >= 4" ] }
+          ]
+        },
+        "effect": [ { "assign_mission": "SKYISLAND_UPGRADE_scouting8" } ],
+        "topic": "SKYISLAND_UPGRADES_FEATURES"
+      },
+      {
+        "text": "Upgrade: Scouting Clairvoyance",
+        "condition": {
+          "and": [
+            { "not": { "u_has_mission": "SKYISLAND_UPGRADE_scoutingclairvoyance1" } },
+            { "math": [ "scoutingdistancetargets == 4" ] },
+            { "math": [ "scoutingclairvoyancetime < 10" ] }
+          ]
+        },
+        "effect": [ { "assign_mission": "SKYISLAND_UPGRADE_scoutingclairvoyance1" } ],
+        "topic": "SKYISLAND_UPGRADES_FEATURES"
+      },
+      {
+        "text": "Upgrade: Scouting Clairvoyance 2",
+        "condition": {
+          "and": [
+            { "not": { "u_has_mission": "SKYISLAND_UPGRADE_scoutingclairvoyance2" } },
+            { "math": [ "scouting_clairvoyance == 1" ] },
+            { "math": [ "scoutingclairvoyancetime == 20" ] }
+          ]
+        },
+        "effect": [ { "assign_mission": "SKYISLAND_UPGRADE_scoutingclairvoyance2" } ],
         "topic": "SKYISLAND_UPGRADES_FEATURES"
       },
       {
@@ -411,6 +530,78 @@
         "topic": "SKYISLAND_UPGRADES_FEATURES"
       },
       {
+        "text": "Upgrade: Landing 6",
+        "condition": {
+          "and": [
+            { "not": { "u_has_mission": "SKYISLAND_UPGRADE_landing6" } },
+            { "math": [ "scoutingdistancelanding == 20" ] },
+            { "math": [ "islandrank >= 4" ] }
+          ]
+        },
+        "effect": [ { "assign_mission": "SKYISLAND_UPGRADE_landing6" } ],
+        "topic": "SKYISLAND_UPGRADES_FEATURES"
+      },
+      {
+        "text": "Upgrade: Landing 7",
+        "condition": {
+          "and": [
+            { "not": { "u_has_mission": "SKYISLAND_UPGRADE_landing7" } },
+            { "math": [ "scoutingdistancelanding == 24" ] },
+            { "math": [ "islandrank >= 4" ] }
+          ]
+        },
+        "effect": [ { "assign_mission": "SKYISLAND_UPGRADE_landing7" } ],
+        "topic": "SKYISLAND_UPGRADES_FEATURES"
+      },
+      {
+        "text": "Upgrade: Landing 8",
+        "condition": {
+          "and": [
+            { "not": { "u_has_mission": "SKYISLAND_UPGRADE_landing8" } },
+            { "math": [ "scoutingdistancelanding == 28" ] },
+            { "math": [ "islandrank >= 4" ] }
+          ]
+        },
+        "effect": [ { "assign_mission": "SKYISLAND_UPGRADE_landing8" } ],
+        "topic": "SKYISLAND_UPGRADES_FEATURES"
+      },
+      {
+        "text": "Upgrade: Landing Water-Walking",
+        "condition": {
+          "and": [
+            { "not": { "u_has_mission": "SKYISLAND_UPGRADE_landing_water_walking" } },
+            { "math": [ "landing_waterwalk == 0" ] },
+            { "math": [ "scoutingdistancelanding >= 16" ] }
+          ]
+        },
+        "effect": [ { "assign_mission": "SKYISLAND_UPGRADE_landing_water_walking" } ],
+        "topic": "SKYISLAND_UPGRADES_FEATURES"
+      },
+      {
+        "text": "Upgrade: Landing Flight",
+        "condition": {
+          "and": [
+            { "not": { "u_has_mission": "SKYISLAND_UPGRADE_landing_flight" } },
+            { "math": [ "landing_flight == 0" ] },
+            { "math": [ "scoutingdistancelanding >= 20" ] }
+          ]
+        },
+        "effect": [ { "assign_mission": "SKYISLAND_UPGRADE_landing_flight" } ],
+        "topic": "SKYISLAND_UPGRADES_FEATURES"
+      },
+      {
+        "text": "Upgrade: Landing Phasing",
+        "condition": {
+          "and": [
+            { "not": { "u_has_mission": "SKYISLAND_UPGRADE_landing_phase" } },
+            { "math": [ "landing_phase == 0" ] },
+            { "math": [ "scoutingdistancelanding >= 20" ] }
+          ]
+        },
+        "effect": [ { "assign_mission": "SKYISLAND_UPGRADE_landing_phase" } ],
+        "topic": "SKYISLAND_UPGRADES_FEATURES"
+      },
+      {
         "text": "Unlock: Slaughter Missions",
         "condition": { "and": [ { "not": { "u_has_mission": "SKYISLAND_UPGRADE_slaughter" } }, { "math": [ "slaughterunlocked == 0" ] } ] },
         "effect": [ { "assign_mission": "SKYISLAND_UPGRADE_slaughter" } ],
@@ -435,6 +626,30 @@
         "topic": "SKYISLAND_UPGRADES_FEATURES"
       },
       {
+        "text": "Unlock: Four Exits per Expedition",
+        "condition": {
+          "and": [
+            { "not": { "u_has_mission": "SKYISLAND_UPGRADE_exit3" } },
+            { "math": [ "bonusexits == 2" ] },
+            { "math": [ "islandrank >= 3" ] }
+          ]
+        },
+        "effect": [ { "assign_mission": "SKYISLAND_UPGRADE_exit3" } ],
+        "topic": "SKYISLAND_UPGRADES_FEATURES"
+      },
+      {
+        "text": "Unlock: Five Exits per Expedition",
+        "condition": {
+          "and": [
+            { "not": { "u_has_mission": "SKYISLAND_UPGRADE_exit4" } },
+            { "math": [ "bonusexits == 3" ] },
+            { "math": [ "islandrank >= 4" ] }
+          ]
+        },
+        "effect": [ { "assign_mission": "SKYISLAND_UPGRADE_exit4" } ],
+        "topic": "SKYISLAND_UPGRADES_FEATURES"
+      },
+      {
         "text": "Unlock: Expedition Missions",
         "condition": { "and": [ { "not": { "u_has_mission": "SKYISLAND_UPGRADE_bonusmissions1" } }, { "math": [ "bonusmissions == 0" ] } ] },
         "effect": [ { "assign_mission": "SKYISLAND_UPGRADE_bonusmissions1" } ],
@@ -456,6 +671,30 @@
           ]
         },
         "effect": [ { "assign_mission": "SKYISLAND_UPGRADE_bonusmissions3" } ],
+        "topic": "SKYISLAND_UPGRADES_FEATURES"
+      },
+      {
+        "text": "Unlock: Four Missions per Expedition",
+        "condition": {
+          "and": [
+            { "not": { "u_has_mission": "SKYISLAND_UPGRADE_bonusmissions4" } },
+            { "math": [ "bonusmissions == 3" ] },
+            { "math": [ "islandrank >= 3" ] }
+          ]
+        },
+        "effect": [ { "assign_mission": "SKYISLAND_UPGRADE_bonusmissions4" } ],
+        "topic": "SKYISLAND_UPGRADES_FEATURES"
+      },
+      {
+        "text": "Unlock: Five Missions per Expedition",
+        "condition": {
+          "and": [
+            { "not": { "u_has_mission": "SKYISLAND_UPGRADE_bonusmissions5" } },
+            { "math": [ "bonusmissions == 2" ] },
+            { "math": [ "islandrank >= 4" ] }
+          ]
+        },
+        "effect": [ { "assign_mission": "SKYISLAND_UPGRADE_bonusmissions5" } ],
         "topic": "SKYISLAND_UPGRADES_FEATURES"
       },
       {

--- a/data/mods/Sky_Island/effects.json
+++ b/data/mods/Sky_Island/effects.json
@@ -80,6 +80,9 @@
       "You are invisible for a very brief time.  Now's your chance to get to cover.  You're also incorporeal enough to not take fall damage, but hopefully that won't be relevant."
     ],
     "flags": [ "INVISIBLE", "FEATHER_FALL" ],
+    "max_intensity": 2,
+    "int_dur_factor": "10 s",
+    "decay_messages": [ [ "Your warpcloak is about to fade away.", "bad" ] ],
     "remove_message": "You fully materialize.  You're not invisible anymore!"
   },
   {
@@ -90,5 +93,41 @@
     "rating": "good",
     "remove_message": "You can no longer walk on the water.",
     "flags": [ "ITEM_WATERPROOFING", "WATERWALKING" ]
+  },
+  {
+    "type": "effect_type",
+    "id": "effect_warped_waterwalking_hidden",
+    "//": "hidden message-less version of warped waterwalking, so the player won't get extra messages as it's all part of the warpcloak.",
+    "name": [ "" ],
+    "desc": [ "" ],
+    "rating": "good",
+    "flags": [ "ITEM_WATERPROOFING", "WATERWALKING" ]
+  },
+  {
+    "type": "effect_type",
+    "id": "effect_warped_flight",
+    "name": [ "" ],
+    "desc": [ "" ],
+    "rating": "good",
+    "flags": [ "LEVITATION", "CLIMB_FLYING" ]
+  },
+  {
+    "type": "effect_type",
+    "id": "effect_warped_phasing",
+    "name": [ "" ],
+    "desc": [ "" ],
+    "rating": "good",
+    "enchantments": [ { "condition": "always", "values": [ { "value": "PHASE_DISTANCE", "add": 1 } ] } ]
+  },
+  {
+    "id": "effect_warped_super_clairvoyance",
+    "type": "effect_type",
+    "name": [ "Warped Omniscience" ],
+    "desc": [ "Nothing escapes your sight." ],
+    "apply_message": "Your vision expands until you see everything.",
+    "remove_message": "Your sight returns to normal.",
+    "rating": "good",
+    "show_intensity": false,
+    "flags": [ "SUPER_CLAIRVOYANCE" ]
   }
 ]

--- a/data/mods/Sky_Island/effects.json
+++ b/data/mods/Sky_Island/effects.json
@@ -117,7 +117,7 @@
     "name": [ "" ],
     "desc": [ "" ],
     "rating": "good",
-    "enchantments": [ { "condition": "always", "values": [ { "value": "PHASE_DISTANCE", "add": 1 } ] } ]
+    "enchantments": [ { "values": [ { "value": "PHASE_DISTANCE", "add": 1 } ] } ]
   },
   {
     "id": "effect_warped_super_clairvoyance",

--- a/data/mods/Sky_Island/itemgroups/requirements.json
+++ b/data/mods/Sky_Island/itemgroups/requirements.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "any_badge",
+    "type": "requirement",
+    "//": "For when a recipe calls for a badge.",
+    "components": [
+      [
+        [ "badge_fbi", 1 ],
+        [ "badge_swat", 1 ],
+        [ "badge_deputy", 1 ],
+        [ "badge_doctor", 1 ],
+        [ "badge_marshal", 1 ],
+        [ "badge_foodkid", 1 ],
+        [ "badge_detective", 1 ],
+        [ "badge_cardboard", 1 ],
+        [ "badge_detective", 1 ]
+      ]
+    ]
+  },
+  {
+    "id": "any_tiara",
+    "type": "requirement",
+    "//": "For when a recipe calls for a tiara.",
+    "components": [
+      [
+        [ "ruby_silver_tiara", 1 ],
+        [ "onyx_silver_tiara", 1 ],
+        [ "opal_gold_tiara", 1 ],
+        [ "ruby_gold_tiara", 1 ],
+        [ "onyx_gold_tiara", 1 ],
+        [ "pearl_gold_tiara", 1 ],
+        [ "opal_silver_tiara", 1 ],
+        [ "garnet_gold_tiara", 1 ],
+        [ "peridot_gold_tiara", 1 ],
+        [ "pearl_silver_tiara", 1 ],
+        [ "emerald_gold_tiara", 1 ],
+        [ "citrine_gold_tiara", 1 ],
+        [ "diamond_gold_tiara", 1 ],
+        [ "onyx_platinum_tiara", 1 ],
+        [ "ruby_platinum_tiara", 1 ],
+        [ "opal_platinum_tiara", 1 ],
+        [ "garnet_silver_tiara", 1 ],
+        [ "sapphire_gold_tiara", 1 ],
+        [ "amethyst_gold_tiara", 1 ],
+        [ "pearl_platinum_tiara", 1 ],
+        [ "citrine_silver_tiara", 1 ],
+        [ "peridot_silver_tiara", 1 ],
+        [ "emerald_silver_tiara", 1 ],
+        [ "diamond_silver_tiara", 1 ],
+        [ "blue_topaz_gold_tiara", 1 ],
+        [ "tourmaline_gold_tiara", 1 ],
+        [ "sapphire_silver_tiara", 1 ],
+        [ "aquamarine_gold_tiara", 1 ],
+        [ "garnet_platinum_tiara", 1 ],
+        [ "amethyst_silver_tiara", 1 ],
+        [ "diamond_platinum_tiara", 1 ],
+        [ "citrine_platinum_tiara", 1 ],
+        [ "alexandrite_gold_tiara", 1 ],
+        [ "emerald_platinum_tiara", 1 ],
+        [ "peridot_platinum_tiara", 1 ],
+        [ "blue_topaz_silver_tiara", 1 ],
+        [ "tourmaline_silver_tiara", 1 ],
+        [ "amethyst_platinum_tiara", 1 ],
+        [ "sapphire_platinum_tiara", 1 ],
+        [ "aquamarine_silver_tiara", 1 ],
+        [ "alexandrite_silver_tiara", 1 ],
+        [ "blue_topaz_platinum_tiara", 1 ],
+        [ "aquamarine_platinum_tiara", 1 ],
+        [ "tourmaline_platinum_tiara", 1 ],
+        [ "alexandrite_platinum_tiara", 1 ]
+      ]
+    ]
+  }
+]

--- a/data/mods/Sky_Island/items.json
+++ b/data/mods/Sky_Island/items.json
@@ -618,5 +618,34 @@
         "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "head", "foot_l", "foot_r", "mouth", "eyes" ]
       }
     ]
+  },
+  {
+    "id": "sky_island_windblock",
+    "type": "ARMOR",
+    "name": { "str": "Personal Windblock" },
+    "description": "The island is protecting you against the winds as long as you are on it.",
+    "weight": "1 g",
+    "volume": "1 ml",
+    "symbol": "o",
+    "color": "blue",
+    "material": [ "alien_resin_windblock" ],
+    "flags": [
+      "AURA",
+      "SEMITANGIBLE",
+      "OVERSIZE",
+      "TRADER_AVOID",
+      "NO_TAKEOFF",
+      "NONCONDUCTIVE",
+      "UNBREAKABLE",
+      "ALLOWS_NATURAL_ATTACKS"
+    ],
+    "max_worn": 1,
+    "armor": [
+      {
+        "encumbrance": 0,
+        "coverage": 100,
+        "covers": [ "leg_l", "leg_r", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "head", "foot_l", "foot_r", "mouth", "eyes" ]
+      }
+    ]
   }
 ]

--- a/data/mods/Sky_Island/items.json
+++ b/data/mods/Sky_Island/items.json
@@ -621,7 +621,8 @@
   },
   {
     "id": "sky_island_windblock",
-    "type": "ARMOR",
+    "type": "ITEM",
+    "subtypes": [ "ARMOR" ],
     "name": { "str": "Personal Windblock" },
     "description": "The island is protecting you against the winds as long as you are on it.",
     "weight": "1 g",

--- a/data/mods/Sky_Island/material.json
+++ b/data/mods/Sky_Island/material.json
@@ -1,0 +1,10 @@
+[
+  {
+    "type": "material",
+    "id": "alien_resin_windblock",
+    "//": "Identical to regular resins but also fully blocks winds.",
+    "name": "Resin",
+    "copy-from": "alien_resin",
+    "wind_resist": 100
+  }
+]

--- a/data/mods/Sky_Island/mutations.json
+++ b/data/mods/Sky_Island/mutations.json
@@ -40,9 +40,9 @@
   {
     "type": "mutation",
     "id": "mut_skyisland_sunblock",
-    "name": { "str": "Personal Sunblock" },
+    "name": { "str": "Personal Sunblock", "//~": "NO_I18N" },
+    "description": { "str": "As long as you are on the island, the sun cannot affect you.", "//~": "NO_I18N" },
     "points": 0,
-    "description": "As long as you are on the island, the sun cannot affect you.",
     "valid": false,
     "player_display": false,
     "purifiable": false,
@@ -51,12 +51,50 @@
   {
     "type": "mutation",
     "id": "mut_skyisland_sunblock_real",
-    "name": { "str": "Personal sunblock real" },
+    "name": { "str": "Personal Sunblock", "//~": "NO_I18N" },
+    "description": { "str": "As long as you are on the island, the sun cannot affect you.", "//~": "NO_I18N" },
     "points": 0,
-    "description": "As long as you are on the island, the sun cannot affect you.",
     "valid": false,
     "player_display": false,
     "purifiable": false,
     "integrated_armor": [ "sky_island_sunblock" ]
+  },
+  {
+    "type": "mutation",
+    "id": "mut_skyisland_windblock",
+    "name": { "str": "Personal Windblock", "//~": "NO_I18N" },
+    "description": { "str": "As long as you are on the island, the winds cannot affect you.", "//~": "NO_I18N" },
+    "points": 0,
+    "valid": false,
+    "player_display": false,
+    "purifiable": false,
+    "enchantments": [ { "condition": { "not": { "u_has_trait": "awayfromhome" } }, "mutations": [ "mut_skyisland_windblock_real" ] } ]
+  },
+  {
+    "type": "mutation",
+    "id": "mut_skyisland_windblock_real",
+    "name": { "str": "Personal Windblock Real", "//~": "NO_I18N" },
+    "description": { "str": "As long as you are on the island, the winds cannot affect you.", "//~": "NO_I18N" },
+    "points": 0,
+    "valid": false,
+    "player_display": false,
+    "purifiable": false,
+    "integrated_armor": [ "sky_island_windblock" ]
+  },
+  {
+    "type": "mutation",
+    "id": "mut_skyisland_personal_temperature_adaptation",
+    "name": { "str": "Personal Temperature Adaptation", "//~": "NO_I18N" },
+    "description": { "str": "As long as you are on the island, temperature cannot affect you.", "//~": "NO_I18N" },
+    "points": 0,
+    "valid": false,
+    "player_display": false,
+    "purifiable": false,
+    "enchantments": [
+      {
+        "condition": { "not": { "u_has_trait": "awayfromhome" } },
+        "values": [ { "value": "CLIMATE_CONTROL_HEAT", "add": 999 }, { "value": "CLIMATE_CONTROL_CHILL", "add": 999 } ]
+      }
+    ]
   }
 ]

--- a/data/mods/Sky_Island/upgrade_missions.json
+++ b/data/mods/Sky_Island/upgrade_missions.json
@@ -326,6 +326,349 @@
     ]
   },
   {
+    "id": "SKYISLAND_UPGRADE_scouting6",
+    "type": "mission_definition",
+    "name": "Upgrade: Scouting 6",
+    "description": "Completing this mission will unlock a permanent upgrade for all future expeditions.\n\nCraft a warpforged telescope from sensors and telescopes.  The Heart of the Island has already placed the recipe inside your mind.\n\nEFFECT: Reveals a huge amount of the map around exit points and mission targets.",
+    "goal": "MGOAL_FIND_ITEM",
+    "item": "upgradekey_scouting6",
+    "count": 1,
+    "difficulty": 0,
+    "value": 0,
+    "has_generic_rewards": false,
+    "start": {
+      "effect": [
+        { "u_learn_recipe": "upgradekey_scouting6" },
+        {
+          "u_message": "Somehow, you understand the statue is calling out for something that can strengthen its power.\nA new recipe has been learned.  Craft this artifact to permanently upgrade the island.\n\nEFFECT: Reveals a huge amount of the map around exit points and mission targets.",
+          "popup": true
+        }
+      ]
+    },
+    "end": {
+      "effect": [
+        { "math": [ "scoutingdistancetargets = 14" ] },
+        { "u_forget_recipe": "upgradekey_scouting6" },
+        {
+          "u_message": "Your vision expands.  Future missions and exits will provide a huge scouting radius.",
+          "type": "mixed"
+        }
+      ]
+    }
+  },
+  {
+    "id": "upgradekey_scouting6",
+    "type": "GENERIC",
+    "category": "spare_parts",
+    "name": { "str_sp": "Warpforged Telescope" },
+    "description": "This strange metaphysical artifact will empower the island and unlock a permanent upgrade for all future runs.  Will be used automatically upon crafting, and can only be used once.\n\nASSOCIATED UPGRADE: Scouting 6",
+    "volume": "25000 ml",
+    "weight": "15000 g",
+    "longest_side": "90 cm",
+    "material": [ "stone" ],
+    "symbol": "V",
+    "color": "white"
+  },
+  {
+    "result": "upgradekey_scouting6",
+    "type": "recipe",
+    "activity_level": "NO_EXERCISE",
+    "category": "CC_WARP",
+    "subcategory": "CSC_WARP_UPGRADES",
+    "skill_used": "survival",
+    "difficulty": 0,
+    "time": "15 m",
+    "flags": [ "SECRET", "BLIND_EASY" ],
+    "reversible": false,
+    "tools": [ [ [ "fakeitem_statue", -1 ] ] ],
+    "components": [
+      [ [ "tele_sight", 1 ] ],
+      [ [ "cantilever_small", 1 ] ],
+      [ [ "survivor_scope", 3 ] ],
+      [ [ "warptoken", 16 ] ],
+      [ [ "plastic_chunk", 20 ] ],
+      [ [ "beeper", 1 ], [ "stereo", 1 ], [ "chimes", 1 ] ],
+      [ [ "radio", 1 ] ]
+    ]
+  },
+  {
+    "id": "SKYISLAND_UPGRADE_scouting7",
+    "type": "mission_definition",
+    "name": "Upgrade: Scouting 7",
+    "description": "Completing this mission will unlock a permanent upgrade for all future expeditions.\n\nCraft an Agglomerated Oculus from ocular enhancements and petrified eyes.  The Heart of the Island has already placed the recipe inside your mind.\n\nEFFECT: Reveals a huge amount of the map around exit points and mission targets.",
+    "goal": "MGOAL_FIND_ITEM",
+    "item": "upgradekey_scouting7",
+    "count": 1,
+    "difficulty": 0,
+    "value": 0,
+    "has_generic_rewards": false,
+    "start": {
+      "effect": [
+        { "u_learn_recipe": "upgradekey_scouting7" },
+        {
+          "u_message": "Somehow, you understand the statue is calling out for something that can strengthen its power.\nA new recipe has been learned.  Craft this artifact to permanently upgrade the island.\n\nEFFECT: Reveals a huge amount of the map around exit points and mission targets.",
+          "popup": true
+        }
+      ]
+    },
+    "end": {
+      "effect": [
+        { "math": [ "scoutingdistancetargets = 18" ] },
+        { "u_forget_recipe": "upgradekey_scouting7" },
+        {
+          "u_message": "Your vision expands.  Future missions and exits will provide a huge scouting radius.",
+          "type": "mixed"
+        }
+      ]
+    }
+  },
+  {
+    "id": "upgradekey_scouting7",
+    "type": "GENERIC",
+    "category": "spare_parts",
+    "name": { "str_sp": "Agglomerated Oculus" },
+    "description": "This strange metaphysical artifact will empower the island and unlock a permanent upgrade for all future runs.  Will be used automatically upon crafting, and can only be used once.\n\nASSOCIATED UPGRADE: Scouting 5",
+    "volume": "25000 ml",
+    "weight": "15000 g",
+    "longest_side": "90 cm",
+    "material": [ "stone" ],
+    "symbol": "V",
+    "color": "white"
+  },
+  {
+    "result": "upgradekey_scouting7",
+    "type": "recipe",
+    "activity_level": "NO_EXERCISE",
+    "category": "CC_WARP",
+    "subcategory": "CSC_WARP_UPGRADES",
+    "skill_used": "survival",
+    "difficulty": 0,
+    "time": "15 m",
+    "flags": [ "SECRET", "BLIND_EASY" ],
+    "reversible": false,
+    "tools": [ [ [ "fakeitem_statue", -1 ] ] ],
+    "//": "The components below allow all CBMs that enhances eyes or vision.",
+    "//2": "Two petrified eyes in a sky island run is a daunting task, so the other components are easier to find to compensate.",
+    "components": [
+      [
+        [ "bio_eye_optic", 1 ],
+        [ "bio_armor_eyes", 1 ],
+        [ "bio_ar", 1 ],
+        [ "bio_eye_enhancer", 1 ],
+        [ "bio_infrared", 1 ],
+        [ "bio_night_vision", 1 ]
+      ],
+      [ [ "steroid_eyedrops", 50 ], [ "eyedrops", 50 ] ],
+      [ [ "warptoken", 20 ] ],
+      [ [ "petrified_eye", 2 ] ],
+      [ [ "magic_8_ball", 3 ] ],
+      [ [ "steel_lump", 10 ] ]
+    ]
+  },
+  {
+    "id": "SKYISLAND_UPGRADE_scouting8",
+    "type": "mission_definition",
+    "name": "Upgrade: Scouting 8",
+    "description": "Completing this mission will unlock a permanent upgrade for all future expeditions.\n\nCraft the Other Eye of the Island from outworldly sensors and esoteric notes.  The Heart of the Island has already placed the recipe inside your mind.\n\nEFFECT: Reveals a huge amount of the map around exit points and mission targets.",
+    "goal": "MGOAL_FIND_ITEM",
+    "item": "upgradekey_scouting8",
+    "count": 1,
+    "difficulty": 0,
+    "value": 0,
+    "has_generic_rewards": false,
+    "start": {
+      "effect": [
+        { "u_learn_recipe": "upgradekey_scouting8" },
+        {
+          "u_message": "Somehow, you understand the statue is calling out for something that can strengthen its power.\nA new recipe has been learned.  Craft this artifact to permanently upgrade the island.\n\nEFFECT: Reveals a huge amount of the map around exit points and mission targets.",
+          "popup": true
+        }
+      ]
+    },
+    "end": {
+      "effect": [
+        { "math": [ "scoutingdistancetargets = 22" ] },
+        { "u_forget_recipe": "upgradekey_scouting8" },
+        {
+          "u_message": "Your vision expands.  Future missions and exits will provide a huge scouting radius.",
+          "type": "mixed"
+        }
+      ]
+    }
+  },
+  {
+    "id": "upgradekey_scouting8",
+    "type": "GENERIC",
+    "category": "spare_parts",
+    "name": { "str": "Other Eye of the Island" },
+    "description": "This strange metaphysical artifact will empower the island and unlock a permanent upgrade for all future runs.  Will be used automatically upon crafting, and can only be used once.\n\nASSOCIATED UPGRADE: Scouting 8",
+    "volume": "25000 ml",
+    "weight": "15000 g",
+    "longest_side": "90 cm",
+    "material": [ "stone" ],
+    "symbol": "V",
+    "color": "white"
+  },
+  {
+    "result": "upgradekey_scouting8",
+    "type": "recipe",
+    "activity_level": "NO_EXERCISE",
+    "category": "CC_WARP",
+    "subcategory": "CSC_WARP_UPGRADES",
+    "skill_used": "survival",
+    "difficulty": 0,
+    "time": "15 m",
+    "flags": [ "SECRET", "BLIND_EASY" ],
+    "reversible": false,
+    "tools": [ [ [ "fakeitem_statue", -1 ] ] ],
+    "//": "Yrax sensors are very hard to find, so the other components are few to compensate.",
+    "components": [
+      [ [ "exodii_sensor", 3 ] ],
+      [ [ "self_monitoring_module", 2 ] ],
+      [ [ "yrax_sensor", 1 ] ],
+      [ [ "warptoken", 24 ] ],
+      [ [ "book_newage_witchcraftadv", 1 ] ],
+      [ [ "gold_small", 100 ] ]
+    ]
+  },
+  {
+    "id": "SKYISLAND_UPGRADE_scoutingclairvoyance1",
+    "type": "mission_definition",
+    "name": "Upgrade: Scouting Clairvoyance 1",
+    "description": "Completing this mission will unlock a permanent upgrade for all future expeditions.\n\nCraft the Higher Viewpoint from notes on the psychic and things that belong to the dead.  The Heart of the Island has already placed the recipe inside your mind.\n\nEFFECT: See everything near you for a short time when beginning a mission.",
+    "goal": "MGOAL_FIND_ITEM",
+    "item": "upgradekey_scoutingclairvoyance1",
+    "count": 1,
+    "difficulty": 0,
+    "value": 0,
+    "has_generic_rewards": false,
+    "start": {
+      "effect": [
+        { "u_learn_recipe": "upgradekey_scoutingclairvoyance1" },
+        {
+          "u_message": "Somehow, you understand the statue is calling out for something that can strengthen its power.\nA new recipe has been learned.  Craft this artifact to permanently upgrade the island.\n\nEFFECT: See everything near you for a short time when beginning a mission.",
+          "popup": true
+        }
+      ]
+    },
+    "end": {
+      "effect": [
+        { "math": [ "scoutingclairvoyancetime = 20" ] },
+        { "u_forget_recipe": "upgradekey_scoutingclairvoyance1" },
+        {
+          "u_message": "Your vision expands.  You will see everything near you for a short time when beginning a mission.",
+          "type": "mixed"
+        }
+      ]
+    }
+  },
+  {
+    "id": "upgradekey_scoutingclairvoyance1",
+    "type": "GENERIC",
+    "category": "spare_parts",
+    "name": { "str": "Higher Viewpoint" },
+    "description": "This strange metaphysical artifact will empower the island and unlock a permanent upgrade for all future runs.  Will be used automatically upon crafting, and can only be used once.\n\nASSOCIATED UPGRADE: Scouting Clairvoyance 1",
+    "volume": "25000 ml",
+    "weight": "15000 g",
+    "longest_side": "90 cm",
+    "material": [ "stone" ],
+    "symbol": "V",
+    "color": "white"
+  },
+  {
+    "result": "upgradekey_scoutingclairvoyance1",
+    "type": "recipe",
+    "activity_level": "NO_EXERCISE",
+    "category": "CC_WARP",
+    "subcategory": "CSC_WARP_UPGRADES",
+    "skill_used": "survival",
+    "difficulty": 0,
+    "time": "15 m",
+    "flags": [ "SECRET", "BLIND_EASY" ],
+    "reversible": false,
+    "tools": [ [ [ "fakeitem_statue", -1 ] ] ],
+    "//": "The clay urn is craftable, the porcelain urn is 100% likely to be found in retirement centers and a crystal urn can be found in one mansion out of two.",
+    "components": [
+      [ [ "book_newage_inpsychic", 1 ], [ "book_newage_beyondveil", 1 ] ],
+      [ [ "clay_urn", 1 ] ],
+      [ [ "porcelain_urn", 1 ] ],
+      [ [ "crystal_urn", 1 ] ],
+      [ [ "warptoken", 16 ] ],
+      [ [ "corpse_ash", 3000 ] ]
+    ]
+  },
+  {
+    "id": "SKYISLAND_UPGRADE_scoutingclairvoyance2",
+    "type": "mission_definition",
+    "name": "Upgrade: Scouting Clairvoyance 2",
+    "description": "Completing this mission will unlock a permanent upgrade for all future expeditions.\n\nCraft the All-Seeing Effigy from the remains of the observers and detection tools.  The Heart of the Island has already placed the recipe inside your mind.\n\nEFFECT: See everything near you at the start of a mission of a longer time.",
+    "goal": "MGOAL_FIND_ITEM",
+    "item": "upgradekey_scoutingclairvoyance2",
+    "count": 1,
+    "difficulty": 0,
+    "value": 0,
+    "has_generic_rewards": false,
+    "start": {
+      "effect": [
+        { "u_learn_recipe": "upgradekey_scoutingclairvoyance2" },
+        {
+          "u_message": "Somehow, you understand the statue is calling out for something that can strengthen its power.\nA new recipe has been learned.  Craft this artifact to permanently upgrade the island.\n\nEFFECT: See everything near you at the start of a mission of a longer time.",
+          "popup": true
+        }
+      ]
+    },
+    "end": {
+      "effect": [
+        { "math": [ "scoutingclairvoyancetime = 60" ] },
+        { "u_forget_recipe": "upgradekey_scoutingclairvoyance2" },
+        {
+          "u_message": "Your vision expands.  You will see everything near you for a longer time at the beginning of a mission.",
+          "type": "mixed"
+        }
+      ]
+    }
+  },
+  {
+    "id": "upgradekey_scoutingclairvoyance2",
+    "type": "GENERIC",
+    "category": "spare_parts",
+    "name": { "str_sp": "All-Seeing Effigy" },
+    "description": "This strange metaphysical artifact will empower the island and unlock a permanent upgrade for all future runs.  Will be used automatically upon crafting, and can only be used once.\n\nASSOCIATED UPGRADE: Scouting Clairvoyance 2",
+    "volume": "25000 ml",
+    "weight": "15000 g",
+    "longest_side": "90 cm",
+    "material": [ "stone" ],
+    "symbol": "V",
+    "color": "white"
+  },
+  {
+    "result": "upgradekey_scoutingclairvoyance2",
+    "type": "recipe",
+    "activity_level": "NO_EXERCISE",
+    "category": "CC_WARP",
+    "subcategory": "CSC_WARP_UPGRADES",
+    "skill_used": "survival",
+    "difficulty": 0,
+    "time": "15 m",
+    "flags": [ "SECRET", "BLIND_EASY" ],
+    "reversible": false,
+    "tools": [ [ [ "fakeitem_statue", -1 ] ] ],
+    "components": [
+      [
+        [ "broken_lab_security_drone_BM", 5 ],
+        [ "broken_lab_security_drone_YM", 5 ],
+        [ "broken_lab_security_drone_GR", 5 ],
+        [ "broken_lab_security_drone_GM", 5 ],
+        [ "broken_lab_security_drone_BM2", 5 ]
+      ],
+      [ [ "pathfinding_module", 5 ] ],
+      [ [ "warptoken", 22 ] ],
+      [ [ "light_detector", 5 ] ],
+      [ [ "emf_detector", 1 ] ],
+      [ [ "geiger_off", 1 ] ]
+    ]
+  },
+  {
     "id": "SKYISLAND_UPGRADE_landing1",
     "type": "mission_definition",
     "name": "Upgrade: Landing 1",
@@ -658,6 +1001,405 @@
     ]
   },
   {
+    "id": "SKYISLAND_UPGRADE_landing6",
+    "type": "mission_definition",
+    "name": "Upgrade: Landing 6",
+    "description": "Completing this mission will unlock a permanent upgrade for all future expeditions.\n\nCraft the Familiarity Gemstone from maps and flags.  The Heart of the Island has already placed the recipe inside your mind.\n\nEFFECT: Reveal a huge section of the map around your landing point, and increase the warpcloak invisibility grace period at the start of each expedition to 130 seconds.",
+    "goal": "MGOAL_FIND_ITEM",
+    "item": "upgradekey_landing6",
+    "count": 1,
+    "difficulty": 0,
+    "value": 0,
+    "has_generic_rewards": false,
+    "start": {
+      "effect": [
+        { "u_learn_recipe": "upgradekey_landing6" },
+        {
+          "u_message": "Somehow, you understand the statue is calling out for something that can strengthen its power.\nA new recipe has been learned.  Craft this artifact to permanently upgrade the island.\n\nEFFECT: Reveal a huge section of the map around your landing point, and increase the warpcloak invisibility grace period at the start of each expedition to 130 seconds.",
+          "popup": true
+        }
+      ]
+    },
+    "end": {
+      "effect": [
+        { "math": [ "scoutingdistancelanding = 32" ] },
+        { "math": [ "invistime = 130" ] },
+        { "u_forget_recipe": "upgradekey_landing6" },
+        {
+          "u_message": "Your focus tightens.  Landing points will reveal more of the map, and your warpcloak will last 130 seconds at the beginning of every expedition.",
+          "type": "mixed"
+        }
+      ]
+    }
+  },
+  {
+    "id": "upgradekey_landing6",
+    "type": "GENERIC",
+    "category": "spare_parts",
+    "name": { "str": "Familiarity Gemstone" },
+    "description": "This strange metaphysical artifact will empower the island and unlock a permanent upgrade for all future runs.  Will be used automatically upon crafting, and can only be used once.\n\nASSOCIATED UPGRADE: Landing 6",
+    "volume": "25000 ml",
+    "weight": "15000 g",
+    "longest_side": "90 cm",
+    "material": [ "stone" ],
+    "symbol": "V",
+    "color": "white"
+  },
+  {
+    "result": "upgradekey_landing6",
+    "type": "recipe",
+    "activity_level": "NO_EXERCISE",
+    "category": "CC_WARP",
+    "subcategory": "CSC_WARP_UPGRADES",
+    "skill_used": "survival",
+    "difficulty": 0,
+    "time": "15 m",
+    "flags": [ "SECRET", "BLIND_EASY" ],
+    "reversible": false,
+    "tools": [ [ [ "fakeitem_statue", -1 ] ] ],
+    "components": [
+      [ [ "pride_flag", 6 ], [ "national_flag", 6 ], [ "american_flag", 6 ], [ "state_flag", 6 ] ],
+      [ [ "warptoken", 16 ] ],
+      [
+        [ "roadmap", 6 ],
+        [ "subwaystationmap", 6 ],
+        [ "survivormap", 6 ],
+        [ "trailmap", 6 ],
+        [ "touristmap", 6 ],
+        [ "restaurantmap", 6 ]
+      ],
+      [ [ "labmap", 5 ], [ "id_science_visitor_1", 5 ] ]
+    ]
+  },
+  {
+    "id": "SKYISLAND_UPGRADE_landing7",
+    "type": "mission_definition",
+    "name": "Upgrade: Landing 7",
+    "description": "Completing this mission will unlock a permanent upgrade for all future expeditions.\n\nCraft the Warm Welcome from painkillers and winter clothes.  The Heart of the Island has already placed the recipe inside your mind.\n\nEFFECT: Reveal a huge section of the map around your landing point, and increase the warpcloak invisibility grace period at the start of each expedition to 140 seconds.",
+    "goal": "MGOAL_FIND_ITEM",
+    "item": "upgradekey_landing7",
+    "count": 1,
+    "difficulty": 0,
+    "value": 0,
+    "has_generic_rewards": false,
+    "start": {
+      "effect": [
+        { "u_learn_recipe": "upgradekey_landing7" },
+        {
+          "u_message": "Somehow, you understand the statue is calling out for something that can strengthen its power.\nA new recipe has been learned.  Craft this artifact to permanently upgrade the island.\n\nEFFECT: Reveal a huge section of the map around your landing point, and increase the warpcloak invisibility grace period at the start of each expedition to 140 seconds.",
+          "popup": true
+        }
+      ]
+    },
+    "end": {
+      "effect": [
+        { "math": [ "scoutingdistancelanding = 40" ] },
+        { "math": [ "invistime = 140" ] },
+        { "u_forget_recipe": "upgradekey_landing7" },
+        {
+          "u_message": "Your focus tightens.  Landing points will reveal more of the map, and your warpcloak will last 140 seconds at the beginning of every expedition.",
+          "type": "mixed"
+        }
+      ]
+    }
+  },
+  {
+    "id": "upgradekey_landing7",
+    "type": "GENERIC",
+    "category": "spare_parts",
+    "name": { "str": "Warm Welcome" },
+    "description": "This strange metaphysical artifact will empower the island and unlock a permanent upgrade for all future runs.  Will be used automatically upon crafting, and can only be used once.\n\nASSOCIATED UPGRADE: Landing 7",
+    "volume": "25000 ml",
+    "weight": "15000 g",
+    "longest_side": "90 cm",
+    "material": [ "stone" ],
+    "symbol": "V",
+    "color": "white"
+  },
+  {
+    "result": "upgradekey_landing7",
+    "type": "recipe",
+    "activity_level": "NO_EXERCISE",
+    "category": "CC_WARP",
+    "subcategory": "CSC_WARP_UPGRADES",
+    "skill_used": "survival",
+    "difficulty": 0,
+    "time": "15 m",
+    "flags": [ "SECRET", "BLIND_EASY" ],
+    "reversible": false,
+    "tools": [ [ [ "fakeitem_statue", -1 ] ] ],
+    "components": [
+      [ [ "oxycodone", 200 ], [ "tramadol", 200 ] ],
+      [ [ "poppy_pain", 20 ], [ "morphine", 10 ] ],
+      [ [ "warptoken", 20 ] ],
+      [ [ "thermal_suit", 5 ] ],
+      [ [ "coat_winter", 5 ] ],
+      [ [ "plastic_jack_o_lantern", 1 ] ]
+    ]
+  },
+  {
+    "id": "SKYISLAND_UPGRADE_landing8",
+    "type": "mission_definition",
+    "name": "Upgrade: Landing 8",
+    "description": "Completing this mission will unlock a permanent upgrade for all future expeditions.\n\nCraft the Emissary's Herald from insignias and proofs of authority.  The Heart of the Island has already placed the recipe inside your mind.\n\nEFFECT: Reveal a huge section of the map around your landing point, and increase the warpcloak invisibility grace period at the start of each expedition to 150 seconds.",
+    "goal": "MGOAL_FIND_ITEM",
+    "item": "upgradekey_landing8",
+    "count": 1,
+    "difficulty": 0,
+    "value": 0,
+    "has_generic_rewards": false,
+    "start": {
+      "effect": [
+        { "u_learn_recipe": "upgradekey_landing8" },
+        {
+          "u_message": "Somehow, you understand the statue is calling out for something that can strengthen its power.\nA new recipe has been learned.  Craft this artifact to permanently upgrade the island.\n\nEFFECT: Reveal a huge section of the map around your landing point, and increase the warpcloak invisibility grace period at the start of each expedition to 150 seconds.",
+          "popup": true
+        }
+      ]
+    },
+    "end": {
+      "effect": [
+        { "math": [ "scoutingdistancelanding = 48" ] },
+        { "math": [ "invistime = 150" ] },
+        { "u_forget_recipe": "upgradekey_landing8" },
+        {
+          "u_message": "Your focus tightens.  Landing points will reveal more of the map, and your warpcloak will last 150 seconds at the beginning of every expedition.",
+          "type": "mixed"
+        }
+      ]
+    }
+  },
+  {
+    "id": "upgradekey_landing8",
+    "type": "GENERIC",
+    "category": "spare_parts",
+    "name": { "str": "Emissary's Herald" },
+    "description": "This strange metaphysical artifact will empower the island and unlock a permanent upgrade for all future runs.  Will be used automatically upon crafting, and can only be used once.\n\nASSOCIATED UPGRADE: Landing 8",
+    "volume": "25000 ml",
+    "weight": "15000 g",
+    "longest_side": "90 cm",
+    "material": [ "stone" ],
+    "symbol": "V",
+    "color": "white"
+  },
+  {
+    "result": "upgradekey_landing8",
+    "type": "recipe",
+    "activity_level": "NO_EXERCISE",
+    "category": "CC_WARP",
+    "subcategory": "CSC_WARP_UPGRADES",
+    "skill_used": "survival",
+    "difficulty": 0,
+    "time": "15 m",
+    "flags": [ "SECRET", "BLIND_EASY" ],
+    "reversible": false,
+    "tools": [ [ [ "fakeitem_statue", -1 ] ] ],
+    "components": [
+      [ [ "any_badge", 3, "LIST" ] ],
+      [ [ "warptoken", 24 ] ],
+      [ [ "jade_brooch", 3 ] ],
+      [ [ "any_tiara", 6, "LIST" ] ],
+      [ [ "bronze_medal", 1 ], [ "silver_medal", 1 ], [ "gold_medal", 1 ], [ "service_medal", 1 ] ],
+      [ [ "suit", 1 ] ],
+      [ [ "ring_signet", 3 ] ]
+    ]
+  },
+  {
+    "id": "SKYISLAND_UPGRADE_landing_water_walking",
+    "type": "mission_definition",
+    "name": "Upgrade: Landing Boost: Waterwalking",
+    "description": "Completing this mission will unlock a permanent upgrade for all future expeditions.\n\nCraft a Cloaking Buoyancy from things from water and things that float.  The Heart of the Island has already placed the recipe inside your mind.\n\nEFFECT: While under the effect of the warpcloak, you can walk on water.",
+    "goal": "MGOAL_FIND_ITEM",
+    "item": "upgradekey_landing_waterwalking",
+    "count": 1,
+    "difficulty": 0,
+    "value": 0,
+    "has_generic_rewards": false,
+    "start": {
+      "effect": [
+        { "u_learn_recipe": "upgradekey_landing_waterwalking" },
+        {
+          "u_message": "Somehow, you understand the statue is calling out for something that can strengthen its power.\nA new recipe has been learned.  Craft this artifact to permanently upgrade the island.\n\nEFFECT: While under the effect of the warpcloak, you can walk on water.",
+          "popup": true
+        }
+      ]
+    },
+    "end": {
+      "effect": [
+        { "math": [ "landing_waterwalk = 1" ] },
+        { "u_forget_recipe": "upgradekey_landing_waterwalking" },
+        {
+          "u_message": "You feel the warp ripple around you.  While under the effect of the warpcloak, you can walk on water.",
+          "type": "mixed"
+        }
+      ]
+    }
+  },
+  {
+    "id": "upgradekey_landing_waterwalking",
+    "type": "GENERIC",
+    "category": "spare_parts",
+    "name": { "str_sp": "Cloaking Buoyancy" },
+    "description": "This strange metaphysical artifact will empower the island and unlock a permanent upgrade for all future runs.  Will be used automatically upon crafting, and can only be used once.\n\nASSOCIATED UPGRADE: Landing Boost: Waterwalking.",
+    "volume": "25000 ml",
+    "weight": "15000 g",
+    "longest_side": "90 cm",
+    "material": [ "stone" ],
+    "symbol": "V",
+    "color": "white"
+  },
+  {
+    "result": "upgradekey_landing_waterwalking",
+    "type": "recipe",
+    "activity_level": "NO_EXERCISE",
+    "category": "CC_WARP",
+    "subcategory": "CSC_WARP_UPGRADES",
+    "skill_used": "survival",
+    "difficulty": 0,
+    "time": "15 m",
+    "flags": [ "SECRET", "BLIND_EASY" ],
+    "reversible": false,
+    "tools": [ [ [ "fakeitem_statue", -1 ] ] ],
+    "components": [
+      [ [ "flotation_vest_ms", 1 ], [ "flotation_vest", 1 ], [ "armor_samurai", 1 ], [ "armor_junk_plate", 1 ] ],
+      [ [ "warp_waterwalking_stone", 5 ] ],
+      [ [ "folded_inflatable_boat", 1 ] ],
+      [ [ "stationary_water_purifier", 1 ] ],
+      [ [ "soup_fish", 10 ] ]
+    ]
+  },
+  {
+    "id": "SKYISLAND_UPGRADE_landing_flight",
+    "type": "mission_definition",
+    "name": "Upgrade: Landing Boost: Flight",
+    "description": "Completing this mission will unlock a permanent upgrade for all future expeditions.\n\nCraft an Inverted Gravity Bubble from things that used to fly and things that could make someone fly.  The Heart of the Island has already placed the recipe inside your mind.\n\nEFFECT: While under the effect of the warpcloak, you can fly.",
+    "goal": "MGOAL_FIND_ITEM",
+    "item": "upgradekey_landing_flight",
+    "count": 1,
+    "difficulty": 0,
+    "value": 0,
+    "has_generic_rewards": false,
+    "start": {
+      "effect": [
+        { "u_learn_recipe": "upgradekey_landing_flight" },
+        {
+          "u_message": "Somehow, you understand the statue is calling out for something that can strengthen its power.\nA new recipe has been learned.  Craft this artifact to permanently upgrade the island.\n\nEFFECT: While under the effect of the warpcloak, you can fly.",
+          "popup": true
+        }
+      ]
+    },
+    "end": {
+      "effect": [
+        { "math": [ "landing_flight = 1" ] },
+        { "u_forget_recipe": "upgradekey_landing_flight" },
+        {
+          "u_message": "You feel the warp ripple around you.  While under the effect of the warpcloak, you can fly.",
+          "type": "mixed"
+        }
+      ]
+    }
+  },
+  {
+    "id": "upgradekey_landing_flight",
+    "type": "GENERIC",
+    "category": "spare_parts",
+    "name": { "str": "Inverted Gravity Bubble" },
+    "description": "This strange metaphysical artifact will empower the island and unlock a permanent upgrade for all future runs.  Will be used automatically upon crafting, and can only be used once.\n\nASSOCIATED UPGRADE: Landing Boost: Flight.",
+    "volume": "25000 ml",
+    "weight": "15000 g",
+    "longest_side": "90 cm",
+    "material": [ "stone" ],
+    "symbol": "V",
+    "color": "white"
+  },
+  {
+    "result": "upgradekey_landing_flight",
+    "type": "recipe",
+    "activity_level": "NO_EXERCISE",
+    "category": "CC_WARP",
+    "subcategory": "CSC_WARP_UPGRADES",
+    "skill_used": "survival",
+    "difficulty": 0,
+    "time": "15 m",
+    "flags": [ "SECRET", "BLIND_EASY" ],
+    "reversible": false,
+    "tools": [ [ [ "fakeitem_statue", -1 ] ] ],
+    "components": [
+      [ [ "mutant_bug_hydrogen_sacs", 300 ] ],
+      [ [ "warptoken", 16 ] ],
+      [ [ "book_fict_soft_ya_hilo", 1 ] ],
+      [ [ "iv_mutagen_bird", 2 ] ],
+      [ [ "feather", 100 ], [ "down_feather", 100 ] ],
+      [ [ "meth", 10 ] ]
+    ]
+  },
+  {
+    "id": "SKYISLAND_UPGRADE_landing_phase",
+    "type": "mission_definition",
+    "name": "Upgrade: Landing Boost: Phasing",
+    "description": "Completing this mission will unlock a permanent upgrade for all future expeditions.\n\nCraft the Universal Access Pass from different tools granting access to restricted areas.  The Heart of the Island has already placed the recipe inside your mind.\n\nEFFECT: While under the effect of the warpcloak, you can pass through non-thick walls.",
+    "goal": "MGOAL_FIND_ITEM",
+    "item": "upgradekey_landing_phase",
+    "count": 1,
+    "difficulty": 0,
+    "value": 0,
+    "has_generic_rewards": false,
+    "start": {
+      "effect": [
+        { "u_learn_recipe": "upgradekey_landing_phase" },
+        {
+          "u_message": "Somehow, you understand the statue is calling out for something that can strengthen its power.\nA new recipe has been learned.  Craft this artifact to permanently upgrade the island.\n\nEFFECT: While under the effect of the warpcloak, you can pass through non-thick walls.",
+          "popup": true
+        }
+      ]
+    },
+    "end": {
+      "effect": [
+        { "math": [ "landing_phase = 1" ] },
+        { "u_forget_recipe": "upgradekey_landing_phase" },
+        {
+          "u_message": "You feel the warp ripple around you.  While under the effect of the warpcloak, you can pass through non-thick walls.",
+          "type": "mixed"
+        }
+      ]
+    }
+  },
+  {
+    "id": "upgradekey_landing_phase",
+    "type": "GENERIC",
+    "category": "spare_parts",
+    "name": { "str_sp": "Universal Access Pass" },
+    "description": "This strange metaphysical artifact will empower the island and unlock a permanent upgrade for all future runs.  Will be used automatically upon crafting, and can only be used once.\n\nASSOCIATED UPGRADE: Landing Boost: Phasing.",
+    "volume": "25000 ml",
+    "weight": "15000 g",
+    "longest_side": "90 cm",
+    "material": [ "stone" ],
+    "symbol": "V",
+    "color": "white"
+  },
+  {
+    "result": "upgradekey_landing_phase",
+    "type": "recipe",
+    "activity_level": "NO_EXERCISE",
+    "category": "CC_WARP",
+    "subcategory": "CSC_WARP_UPGRADES",
+    "skill_used": "survival",
+    "difficulty": 0,
+    "time": "15 m",
+    "flags": [ "SECRET", "BLIND_EASY" ],
+    "reversible": false,
+    "tools": [ [ [ "fakeitem_statue", -1 ] ] ],
+    "components": [
+      [ [ "altered_keyring", 1 ], [ "bio_probability_travel", 1 ], [ "bio_teleport", 1 ], [ "teleporter", 3 ] ],
+      [ [ "phase_immersion_suit", 1 ] ],
+      [ [ "warptoken", 22 ] ],
+      [ [ "book_lockpick", 1 ] ],
+      [ [ "crude_picklock", 25 ] ],
+      [ [ "picklocks", 1 ] ],
+      [ [ "colander_steel", 5 ] ]
+    ]
+  },
+  {
     "id": "SKYISLAND_UPGRADE_stability1",
     "type": "mission_definition",
     "name": "Upgrade: Stability 1",
@@ -933,6 +1675,202 @@
     ]
   },
   {
+    "id": "SKYISLAND_UPGRADE_stability5",
+    "type": "mission_definition",
+    "name": "Upgrade: Stability 5",
+    "description": "Completing this mission will unlock a permanent upgrade for all future expeditions.\n\nCraft the Explorer's Ward from things helping to withstand harsh conditions.  The Heart of the Island has already placed the recipe inside your mind.\n\nEFFECT: You will begin every expedition with the ability to withstand 13 pulses instead of the default 8, allowing you to stay out 62.5% longer before warpsickness takes over.",
+    "goal": "MGOAL_FIND_ITEM",
+    "item": "upgradekey_stability4",
+    "count": 1,
+    "difficulty": 0,
+    "value": 0,
+    "has_generic_rewards": false,
+    "start": {
+      "effect": [
+        { "u_learn_recipe": "upgradekey_stability5" },
+        {
+          "u_message": "Somehow, you understand the statue is calling out for something that can strengthen its power.\nA new recipe has been learned.  Craft this artifact to permanently upgrade the island.\n\nEFFECT: You will begin every expedition with the ability to withstand 13 pulses instead of the default 8, allowing you to stay out 62.5% longer before warpsickness takes over.",
+          "popup": true
+        }
+      ]
+    },
+    "end": {
+      "effect": [
+        { "math": [ "bonuspulses = 5" ] },
+        { "u_forget_recipe": "upgradekey_stability5" },
+        {
+          "u_message": "Your resistance to the chaos of the warpstream increases.  In every future expedition, you will be able to endure an additional warp pulse and stay earthside longer.",
+          "type": "mixed"
+        }
+      ]
+    }
+  },
+  {
+    "id": "upgradekey_stability5",
+    "type": "GENERIC",
+    "category": "spare_parts",
+    "name": { "str": "Explorer's Ward" },
+    "description": "This strange metaphysical artifact will empower the island and unlock a permanent upgrade for all future runs.  Will be used automatically upon crafting, and can only be used once.\n\nASSOCIATED UPGRADE: Stability 5",
+    "volume": "25000 ml",
+    "weight": "15000 g",
+    "longest_side": "90 cm",
+    "material": [ "stone" ],
+    "symbol": "V",
+    "color": "white"
+  },
+  {
+    "result": "upgradekey_stability5",
+    "type": "recipe",
+    "activity_level": "NO_EXERCISE",
+    "category": "CC_WARP",
+    "subcategory": "CSC_WARP_UPGRADES",
+    "skill_used": "survival",
+    "difficulty": 0,
+    "time": "15 m",
+    "flags": [ "SECRET", "BLIND_EASY" ],
+    "reversible": false,
+    "tools": [ [ [ "fakeitem_statue", -1 ] ] ],
+    "components": [
+      [ [ "ballistic_vest_heavy", 2 ] ],
+      [ [ "warptoken", 30 ] ],
+      [ [ "alien_pod_resin", 5 ] ],
+      [ [ "oxygen_tank", 5 ], [ "scuba_tank", 5 ] ],
+      [ [ "iv_mutagen_medical", 1 ] ],
+      [ [ "caviar_egg_sandwich", 1 ] ]
+    ]
+  },
+  {
+    "id": "SKYISLAND_UPGRADE_stability6",
+    "type": "mission_definition",
+    "name": "Upgrade: Stability 6",
+    "description": "Completing this mission will unlock a permanent upgrade for all future expeditions.\n\nCraft an Island-Bound Armor from various armors from this world and from others.  The Heart of the Island has already placed the recipe inside your mind.\n\nEFFECT: You will begin every expedition with the ability to withstand 14 pulses instead of the default 8, allowing you to stay out 75% longer before warpsickness takes over.",
+    "goal": "MGOAL_FIND_ITEM",
+    "item": "upgradekey_stability6",
+    "count": 1,
+    "difficulty": 0,
+    "value": 0,
+    "has_generic_rewards": false,
+    "start": {
+      "effect": [
+        { "u_learn_recipe": "upgradekey_stability6" },
+        {
+          "u_message": "Somehow, you understand the statue is calling out for something that can strengthen its power.\nA new recipe has been learned.  Craft this artifact to permanently upgrade the island.\n\nEFFECT: You will begin every expedition with the ability to withstand 14 pulses instead of the default 8, allowing you to stay out 75% longer before warpsickness takes over.",
+          "popup": true
+        }
+      ]
+    },
+    "end": {
+      "effect": [
+        { "math": [ "bonuspulses = 6" ] },
+        { "u_forget_recipe": "upgradekey_stability6" },
+        {
+          "u_message": "Your resistance to the chaos of the warpstream increases.  In every future expedition, you will be able to endure an additional warp pulse and stay earthside longer.",
+          "type": "mixed"
+        }
+      ]
+    }
+  },
+  {
+    "id": "upgradekey_stability6",
+    "type": "GENERIC",
+    "category": "spare_parts",
+    "name": { "str": "Island-Bound Armor" },
+    "description": "This strange metaphysical artifact will empower the island and unlock a permanent upgrade for all future runs.  Will be used automatically upon crafting, and can only be used once.\n\nASSOCIATED UPGRADE: Stability 6",
+    "volume": "25000 ml",
+    "weight": "15000 g",
+    "longest_side": "90 cm",
+    "material": [ "stone" ],
+    "symbol": "V",
+    "color": "white"
+  },
+  {
+    "result": "upgradekey_stability6",
+    "type": "recipe",
+    "activity_level": "NO_EXERCISE",
+    "category": "CC_WARP",
+    "subcategory": "CSC_WARP_UPGRADES",
+    "skill_used": "survival",
+    "difficulty": 0,
+    "time": "15 m",
+    "flags": [ "SECRET", "BLIND_EASY" ],
+    "reversible": false,
+    "tools": [ [ [ "fakeitem_statue", -1 ] ] ],
+    "components": [
+      [ [ "warptoken", 35 ] ],
+      [ [ "helmet_acidchitin", 1 ], [ "helmet_bronze", 1 ] ],
+      [ [ "armor_acidchitin", 1 ], [ "cuirass_bronze", 1 ] ],
+      [ [ "armguard_acidchitin", 1 ], [ "armguard_bronze", 1 ] ],
+      [ [ "legguard_acidchitin", 1 ], [ "legguard_bronze", 1 ] ],
+      [ [ "hard_steel_armor", 1 ], [ "migo_plate", 1 ], [ "migo_sideplate", 1 ] ]
+    ]
+  },
+  {
+    "id": "SKYISLAND_UPGRADE_stability7",
+    "type": "mission_definition",
+    "name": "Upgrade: Stability 7",
+    "description": "Completing this mission will unlock a permanent upgrade for all future expeditions.\n\nCraft the Triune Anchor from the corpse of a yugg and rare ressources.  The Heart of the Island has already placed the recipe inside your mind.\n\nEFFECT: You will begin every expedition with the ability to withstand 15 pulses instead of the default 8, allowing you to stay out 87.5% longer before warpsickness takes over.",
+    "goal": "MGOAL_FIND_ITEM",
+    "item": "upgradekey_stability7",
+    "count": 1,
+    "difficulty": 0,
+    "value": 0,
+    "has_generic_rewards": false,
+    "start": {
+      "effect": [
+        { "u_learn_recipe": "upgradekey_stability7" },
+        {
+          "u_message": "Somehow, you understand the statue is calling out for something that can strengthen its power.\nA new recipe has been learned.  Craft this artifact to permanently upgrade the island.\n\nEFFECT: You will begin every expedition with the ability to withstand 15 pulses instead of the default 8, allowing you to stay out 87.5% longer before warpsickness takes over.",
+          "popup": true
+        }
+      ]
+    },
+    "end": {
+      "effect": [
+        { "math": [ "bonuspulses = 7" ] },
+        { "u_forget_recipe": "upgradekey_stability7" },
+        {
+          "u_message": "Your resistance to the chaos of the warpstream increases.  In every future expedition, you will be able to endure an additional warp pulse and stay earthside longer.",
+          "type": "mixed"
+        }
+      ]
+    }
+  },
+  {
+    "id": "upgradekey_stability7",
+    "type": "GENERIC",
+    "category": "spare_parts",
+    "name": { "str": "Triune Anchor" },
+    "description": "This strange metaphysical artifact will empower the island and unlock a permanent upgrade for all future runs.  Will be used automatically upon crafting, and can only be used once.\n\nASSOCIATED UPGRADE: Stability 7",
+    "volume": "25000 ml",
+    "weight": "15000 g",
+    "longest_side": "90 cm",
+    "material": [ "stone" ],
+    "symbol": "V",
+    "color": "white"
+  },
+  {
+    "result": "upgradekey_stability7",
+    "type": "recipe",
+    "activity_level": "NO_EXERCISE",
+    "category": "CC_WARP",
+    "subcategory": "CSC_WARP_UPGRADES",
+    "skill_used": "survival",
+    "difficulty": 0,
+    "time": "15 m",
+    "flags": [ "SECRET", "BLIND_EASY" ],
+    "reversible": false,
+    "tools": [ [ [ "fakeitem_statue", -1 ] ] ],
+    "components": [
+      [ [ "corpse_yugg_jade", 1 ], [ "corpse_yugg_rubber", 1 ], [ "corpse_yugg_mutflesh", 1 ] ],
+      [ [ "warptoken", 40 ] ],
+      [ [ "wine_marloss", 1 ] ],
+      [ [ "resonance_measurement_device", 1 ], [ "nre_recorder", 1 ] ],
+      [ [ "pure_meth", 6 ] ],
+      [ [ "friday", 1 ], [ "spirit_island", 1 ] ],
+      [ [ "violin_golden", 1 ] ]
+    ]
+  },
+  {
     "id": "SKYISLAND_UPGRADE_slaughter",
     "type": "mission_definition",
     "name": "Unlock: Slaughter Missions",
@@ -1121,6 +2059,134 @@
       [ [ "roller_shoes_off", 1 ], [ "folded_skateboard_generic", 1 ] ],
       [ [ "fire_ax", 1 ], [ "crash_axe", 1 ] ],
       [ [ "halligan", 1 ], [ "ny_hook", 1 ] ]
+    ]
+  },
+  {
+    "id": "SKYISLAND_UPGRADE_exit3",
+    "type": "mission_definition",
+    "name": "Unlock: Four Exits per Expedition",
+    "description": "Completing this mission will unlock a permanent upgrade for all future expeditions.\n\nCraft a Thrice-Sided Door from locks and doormats.  The Heart of the Island has already placed the recipe inside your mind.\n\nEFFECT: Every expedition will now have four different locations you can exit from.",
+    "goal": "MGOAL_FIND_ITEM",
+    "item": "upgradekey_exit3",
+    "count": 1,
+    "difficulty": 0,
+    "value": 0,
+    "has_generic_rewards": false,
+    "start": {
+      "effect": [
+        { "u_learn_recipe": "upgradekey_exit3" },
+        {
+          "u_message": "Somehow, you understand the statue is calling out for something that can strengthen its power.\nA new recipe has been learned.  Craft this artifact to permanently upgrade the island.\n\nEFFECT: Every expedition will now have four different locations you can exit from.",
+          "popup": true
+        }
+      ]
+    },
+    "end": {
+      "effect": [
+        { "math": [ "bonusexits = 3" ] },
+        { "u_forget_recipe": "upgradekey_exit3" },
+        {
+          "u_message": "Again you see in blindness, and before you stretches a vast invisible labyrinth beneath an empty sky.  You race forward, tracing paths spoken to you in dreams, and an origami spiderweb crumples and breathes out underfoot.  At last, at the seashell's center, lies the cornucopia's smallest door.\nWhen at last you open your eyes, you find yourself where you began, unmoved, yet changed.\n\nIn every future expedition, you will now be able to find four different locations you can exit from.",
+          "type": "mixed"
+        }
+      ]
+    }
+  },
+  {
+    "id": "upgradekey_exit3",
+    "type": "GENERIC",
+    "category": "spare_parts",
+    "name": { "str": "Thrice-Sided Door" },
+    "description": "This strange metaphysical artifact will empower the island and unlock a permanent upgrade for all future runs.  Will be used automatically upon crafting, and can only be used once.\n\nASSOCIATED UPGRADE: Four Exits per Expedition",
+    "volume": "25000 ml",
+    "weight": "15000 g",
+    "longest_side": "90 cm",
+    "material": [ "stone" ],
+    "symbol": "V",
+    "color": "white"
+  },
+  {
+    "result": "upgradekey_exit3",
+    "type": "recipe",
+    "activity_level": "NO_EXERCISE",
+    "category": "CC_WARP",
+    "subcategory": "CSC_WARP_UPGRADES",
+    "skill_used": "survival",
+    "difficulty": 0,
+    "time": "15 m",
+    "flags": [ "SECRET", "BLIND_EASY" ],
+    "reversible": false,
+    "tools": [ [ [ "fakeitem_statue", -1 ] ] ],
+    "components": [
+      [ [ "doormat", 5 ] ],
+      [ [ "warptoken", 3 ] ],
+      [ [ "oven_door", 2 ], [ "door_lock", 5 ] ],
+      [ [ "vehicle_dashboard", 1 ], [ "vehicle_controls", 1 ] ],
+      [ [ "indoor_volleyball", 1 ] ]
+    ]
+  },
+  {
+    "id": "SKYISLAND_UPGRADE_exit4",
+    "type": "mission_definition",
+    "name": "Unlock: Five Exits per Expedition",
+    "description": "Completing this mission will unlock a permanent upgrade for all future expeditions.\n\nCraft an Intangible Door Stopper from door hinges and breaching tools.  The Heart of the Island has already placed the recipe inside your mind.\n\nEFFECT: Every expedition will now have four different locations you can exit from.",
+    "goal": "MGOAL_FIND_ITEM",
+    "item": "upgradekey_exit4",
+    "count": 1,
+    "difficulty": 0,
+    "value": 0,
+    "has_generic_rewards": false,
+    "start": {
+      "effect": [
+        { "u_learn_recipe": "upgradekey_exit4" },
+        {
+          "u_message": "Somehow, you understand the statue is calling out for something that can strengthen its power.\nA new recipe has been learned.  Craft this artifact to permanently upgrade the island.\n\nEFFECT: Every expedition will now have four different locations you can exit from.",
+          "popup": true
+        }
+      ]
+    },
+    "end": {
+      "effect": [
+        { "math": [ "bonusexits = 4" ] },
+        { "u_forget_recipe": "upgradekey_exit4" },
+        {
+          "u_message": "Again you see in blindness, and before you stretches a vast invisible labyrinth beneath an empty sky.  You race forward, tracing paths spoken to you in dreams, and an origami spiderweb crumples and breathes out underfoot.  At last, at the seashell's center, lies the cornucopia's smallest door.\nWhen at last you open your eyes, you find yourself where you began, unmoved, yet changed.\n\nIn every future expedition, you will now be able to find five different locations you can exit from.",
+          "type": "mixed"
+        }
+      ]
+    }
+  },
+  {
+    "id": "upgradekey_exit4",
+    "type": "GENERIC",
+    "category": "spare_parts",
+    "name": { "str": "Intangible Door Stopper" },
+    "description": "This strange metaphysical artifact will empower the island and unlock a permanent upgrade for all future runs.  Will be used automatically upon crafting, and can only be used once.\n\nASSOCIATED UPGRADE: Five Exits per Expedition",
+    "volume": "25000 ml",
+    "weight": "15000 g",
+    "longest_side": "90 cm",
+    "material": [ "stone" ],
+    "symbol": "V",
+    "color": "white"
+  },
+  {
+    "result": "upgradekey_exit4",
+    "type": "recipe",
+    "activity_level": "NO_EXERCISE",
+    "category": "CC_WARP",
+    "subcategory": "CSC_WARP_UPGRADES",
+    "skill_used": "survival",
+    "difficulty": 0,
+    "time": "15 m",
+    "flags": [ "SECRET", "BLIND_EASY" ],
+    "reversible": false,
+    "tools": [ [ [ "fakeitem_statue", -1 ] ] ],
+    "components": [
+      [ [ "bite_suit", 1 ] ],
+      [ [ "warptoken", 5 ] ],
+      [ [ "carpentry_book", 1 ], [ "textbook_carpentry", 1 ] ],
+      [ [ "hinge", 20 ] ],
+      [ [ "remington_870_breacher", 1 ], [ "shotgun_d", 3 ] ]
     ]
   },
   {
@@ -1337,6 +2403,138 @@
       [ [ "aquamarine", 1 ] ],
       [ [ "alexandrite", 1 ] ]
     ]
+  },
+  {
+    "id": "SKYISLAND_UPGRADE_bonusmissions4",
+    "type": "mission_definition",
+    "name": "Unlock: Four Missions per Expedition",
+    "description": "Completing this mission will unlock a permanent upgrade for all future expeditions.\n\nCraft a Petrified Duty's Call from old money and a spiral stone.  The Heart of the Island has already placed the recipe inside your mind.\n\nEFFECT: Every expedition will now have 4 different randomly assigned missions, increasing the possibility for earning warp shards.  Completing a mission also extends the time left on current expedition by 1 warp pulse.",
+    "goal": "MGOAL_FIND_ITEM",
+    "item": "upgradekey_bonusmissions4",
+    "count": 1,
+    "difficulty": 0,
+    "value": 0,
+    "has_generic_rewards": false,
+    "start": {
+      "effect": [
+        { "u_learn_recipe": "upgradekey_bonusmissions4" },
+        {
+          "u_message": "Somehow, you understand the statue is calling out for something that can strengthen its power.\nA new recipe has been learned.  Craft this artifact to permanently upgrade the island.\n\nEFFECT: Every expedition will now have 4 different randomly assigned missions, increasing the possibility for earning warp shards.  Completing a mission also extends the time left on current expedition by 1 warp pulse.",
+          "popup": true
+        }
+      ]
+    },
+    "end": {
+      "effect": [
+        { "math": [ "bonusmissions = 4" ] },
+        { "u_forget_recipe": "upgradekey_bonusmissions4" },
+        {
+          "u_message": "Some disrupt the warpstream by their very existence, a problem you will solve through violence.\nIn every future expedition, you will now be given 4 random missions.",
+          "type": "mixed"
+        }
+      ]
+    }
+  },
+  {
+    "id": "upgradekey_bonusmissions4",
+    "type": "GENERIC",
+    "category": "spare_parts",
+    "name": { "str": "Petrified Duty's Call" },
+    "description": "This strange metaphysical artifact will empower the island and unlock a permanent upgrade for all future runs.  Will be used automatically upon crafting, and can only be used once.\n\nASSOCIATED UPGRADE: Four Missions per Expedition",
+    "volume": "25000 ml",
+    "weight": "15000 g",
+    "longest_side": "90 cm",
+    "material": [ "stone" ],
+    "symbol": "V",
+    "color": "white"
+  },
+  {
+    "result": "upgradekey_bonusmissions4",
+    "type": "recipe",
+    "activity_level": "NO_EXERCISE",
+    "category": "CC_WARP",
+    "subcategory": "CSC_WARP_UPGRADES",
+    "skill_used": "survival",
+    "difficulty": 0,
+    "time": "15 m",
+    "flags": [ "SECRET", "BLIND_EASY" ],
+    "reversible": false,
+    "tools": [ [ [ "fakeitem_statue", -1 ] ] ],
+    "components": [
+      [ [ "warptoken", 8 ] ],
+      [ [ "money_bundle_one", 2 ] ],
+      [ [ "money_bundle_two", 2 ] ],
+      [ [ "money_bundle_five", 2 ] ],
+      [ [ "money_bundle_ten", 2 ] ],
+      [ [ "money_bundle_twenty", 2 ] ],
+      [ [ "money_bundle_fifty", 2 ] ],
+      [ [ "money_bundle_hundred", 2 ] ],
+      [ [ "spiral_stone", 1 ] ]
+    ]
+  },
+  {
+    "id": "SKYISLAND_UPGRADE_bonusmissions5",
+    "type": "mission_definition",
+    "name": "Unlock: Five Missions per Expedition",
+    "description": "Completing this mission will unlock a permanent upgrade for all future expeditions.\n\nCraft the Oath of the Island's Enforcer from massive amounts of ink.  The Heart of the Island has already placed the recipe inside your mind.\n\nEFFECT: Every expedition will now have 53 different randomly assigned missions, increasing the possibility for earning warp shards.  Completing a mission also extends the time left on current expedition by 1 warp pulse.",
+    "goal": "MGOAL_FIND_ITEM",
+    "item": "upgradekey_bonusmissions5",
+    "count": 1,
+    "difficulty": 0,
+    "value": 0,
+    "has_generic_rewards": false,
+    "start": {
+      "effect": [
+        { "u_learn_recipe": "upgradekey_bonusmissions5" },
+        {
+          "u_message": "Somehow, you understand the statue is calling out for something that can strengthen its power.\nA new recipe has been learned.  Craft this artifact to permanently upgrade the island.\n\nEFFECT: Every expedition will now have 5 different randomly assigned missions, increasing the possibility for earning warp shards.  Completing a mission also extends the time left on current expedition by 1 warp pulse.",
+          "popup": true
+        }
+      ]
+    },
+    "end": {
+      "effect": [
+        { "math": [ "bonusmissions = 5" ] },
+        { "u_forget_recipe": "upgradekey_bonusmissions5" },
+        {
+          "u_message": "Your mmind fills with many transgressors that the Island has marked or will mark for death.  Carrying the Island's sentences is your responsibility, a duty you've accepted in full.\nIn every future expedition, you will now be given 5 random missions.",
+          "type": "mixed"
+        }
+      ]
+    }
+  },
+  {
+    "id": "upgradekey_bonusmissions5",
+    "type": "GENERIC",
+    "category": "spare_parts",
+    "name": { "str": "Oath of the Island's Enforcer" },
+    "description": "This strange metaphysical artifact will empower the island and unlock a permanent upgrade for all future runs.  Will be used automatically upon crafting, and can only be used once.\n\nASSOCIATED UPGRADE: Five Missions per Expedition",
+    "volume": "25000 ml",
+    "weight": "15000 g",
+    "longest_side": "90 cm",
+    "material": [ "stone" ],
+    "symbol": "V",
+    "color": "white"
+  },
+  {
+    "result": "upgradekey_bonusmissions5",
+    "type": "recipe",
+    "activity_level": "NO_EXERCISE",
+    "category": "CC_WARP",
+    "subcategory": "CSC_WARP_UPGRADES",
+    "skill_used": "survival",
+    "difficulty": 0,
+    "time": "15 m",
+    "flags": [ "SECRET", "BLIND_EASY" ],
+    "reversible": false,
+    "tools": [
+      [ [ "fakeitem_statue", -1 ] ],
+      [ [ "black_pen", 5000 ] ],
+      [ [ "blue_pen", 5000 ] ],
+      [ [ "red_pen", 5000 ] ],
+      [ [ "green_pen", 5000 ] ]
+    ],
+    "components": [ [ [ "warptoken", 10 ] ], [ [ "paper", 1 ] ] ]
   },
   {
     "id": "SKYISLAND_UPGRADE_hardmissions1",
@@ -3895,6 +5093,143 @@
       [ [ "umbrella", 1 ], [ "teleumbrella", 1 ] ],
       [ [ "sundress", 1 ] ],
       [ [ "glass_shard", 176 ] ]
+    ]
+  },
+  {
+    "id": "SKYISLAND_UPGRADE_windblock",
+    "type": "mission_definition",
+    "name": "Upgrade: Personal windblock",
+    "description": "Completing this mission will unlock a permanent upgrade for all future expeditions.\n\nCraft a Wind Redirector from wind-blocking clothes and creams.  The Heart of the Island has already placed the recipe inside your mind.\n\nEFFECT: The winds cannot affect you while on the island.",
+    "goal": "MGOAL_FIND_ITEM",
+    "item": "upgradekey_windblock",
+    "count": 1,
+    "difficulty": 0,
+    "value": 0,
+    "has_generic_rewards": false,
+    "start": {
+      "effect": [
+        { "u_learn_recipe": "upgradekey_windblock" },
+        {
+          "u_message": "Somehow, you understand the statue is calling out for something that can strengthen its power.\nA new recipe has been learned.  Craft this artifact to permanently upgrade the island.\n\nEFFECT: The winds cannot affect you while on the island.",
+          "popup": true
+        }
+      ]
+    },
+    "end": {
+      "effect": [
+        { "u_add_trait": "mut_skyisland_windblock" },
+        { "u_forget_recipe": "upgradekey_windblock" },
+        { "math": [ "windblock = 1" ] },
+        {
+          "u_message": "The winds shift a little.  As long as you are on the island, they will not touch you.",
+          "type": "mixed"
+        }
+      ]
+    }
+  },
+  {
+    "id": "upgradekey_windblock",
+    "type": "GENERIC",
+    "category": "spare_parts",
+    "name": { "str": "Wind Redirector" },
+    "description": "This strange metaphysical artifact will make the island protect you from the winds while you are not earthside.  Will be used automatically upon crafting, and can only be used once.\n\nASSOCIATED UPGRADE: personal windblock.",
+    "volume": "25000 ml",
+    "weight": "15000 g",
+    "longest_side": "90 cm",
+    "material": [ "stone" ],
+    "symbol": "V",
+    "color": "white"
+  },
+  {
+    "result": "upgradekey_windblock",
+    "type": "recipe",
+    "activity_level": "NO_EXERCISE",
+    "category": "CC_WARP",
+    "subcategory": "CSC_WARP_UPGRADES",
+    "//": "Intended to be a midgame craft, as the winds are a good motivator to drive early exploration.",
+    "skill_used": "survival",
+    "difficulty": 0,
+    "time": "15 m",
+    "flags": [ "SECRET", "BLIND_EASY" ],
+    "reversible": false,
+    "tools": [ [ [ "fakeitem_statue", -1 ] ] ],
+    "components": [
+      [ [ "jacket_windbreaker", 3 ] ],
+      [ [ "survival_book", 1 ] ],
+      [ [ "milk_cream", 5 ], [ "moisturizer", 5 ], [ "bristol_sherry", 5 ] ],
+      [ [ "any_tallow", 24, "LIST" ] ]
+    ]
+  },
+  {
+    "id": "SKYISLAND_UPGRADE_personal_temperature_adaptation",
+    "type": "mission_definition",
+    "name": "Upgrade: Personal temperature adjustement",
+    "description": "Completing this mission will unlock a permanent upgrade for all future expeditions.\n\nCraft a Climate Self-Injector from temperature-controlling devices and various parts.  The Heart of the Island has already placed the recipe inside your mind.\n\nEFFECT: Temperature cannot affect you while on the island.",
+    "goal": "MGOAL_FIND_ITEM",
+    "item": "upgradekey_windblock",
+    "count": 1,
+    "difficulty": 0,
+    "value": 0,
+    "has_generic_rewards": false,
+    "start": {
+      "effect": [
+        { "u_learn_recipe": "upgradekey_temperature_control" },
+        {
+          "u_message": "Somehow, you understand the statue is calling out for something that can strengthen its power.\nA new recipe has been learned.  Craft this artifact to permanently upgrade the island.\n\nEFFECT: Temperature cannot affect you while on the island.",
+          "popup": true
+        }
+      ]
+    },
+    "end": {
+      "effect": [
+        { "u_add_trait": "mut_skyisland_personal_temperature_adaptation" },
+        { "u_forget_recipe": "upgradekey_temperature_control" },
+        { "math": [ "temperature_adaptation = 1" ] },
+        {
+          "u_message": "Your skin shimmer for a second.  As long as you are on the island, you won't be affected by temperature.",
+          "type": "mixed"
+        }
+      ]
+    }
+  },
+  {
+    "id": "upgradekey_temperature_control",
+    "type": "GENERIC",
+    "category": "spare_parts",
+    "name": { "str": "Climate Self-Injector" },
+    "description": "This strange metaphysical artifact will make the island protect you from temperature while you are not earthside.  Will be used automatically upon crafting, and can only be used once.\n\nASSOCIATED UPGRADE: personal temperature adaptation.",
+    "volume": "25000 ml",
+    "weight": "15000 g",
+    "longest_side": "90 cm",
+    "material": [ "stone" ],
+    "symbol": "V",
+    "color": "white"
+  },
+  {
+    "result": "upgradekey_temperature_control",
+    "type": "recipe",
+    "activity_level": "NO_EXERCISE",
+    "category": "CC_WARP",
+    "subcategory": "CSC_WARP_UPGRADES",
+    "//": "Intended to be a lategame craft, something the player focuses on as winter draws near.",
+    "skill_used": "survival",
+    "difficulty": 0,
+    "time": "15 m",
+    "flags": [ "SECRET", "BLIND_EASY" ],
+    "reversible": false,
+    "tools": [ [ [ "fakeitem_statue", -1 ] ] ],
+    "components": [
+      [
+        [ "thermal_outfit", 20 ],
+        [ "thermal_suit", 20 ],
+        [ "bio_climate", 1 ],
+        [ "bio_heatsink", 1 ],
+        [ "exodii_ac_kit", 3 ]
+      ],
+      [ [ "mountable_cooler", 3 ], [ "condensor_coil", 30 ], [ "evaporator_coil", 30 ] ],
+      [ [ "mountable_heater", 3 ], [ "element", 30 ] ],
+      [ [ "air_compressor", 1 ], [ "1l_gold", 1 ] ],
+      [ [ "railroad_track_item", 1 ] ]
     ]
   }
 ]

--- a/data/mods/Sky_Island/upgrade_missions.json
+++ b/data/mods/Sky_Island/upgrade_missions.json
@@ -358,7 +358,7 @@
   },
   {
     "id": "upgradekey_scouting6",
-    "type": "GENERIC",
+    "type": "ITEM",
     "category": "spare_parts",
     "name": { "str_sp": "Warpforged Telescope" },
     "description": "This strange metaphysical artifact will empower the island and unlock a permanent upgrade for all future runs.  Will be used automatically upon crafting, and can only be used once.\n\nASSOCIATED UPGRADE: Scouting 6",
@@ -424,7 +424,7 @@
   },
   {
     "id": "upgradekey_scouting7",
-    "type": "GENERIC",
+    "type": "ITEM",
     "category": "spare_parts",
     "name": { "str_sp": "Agglomerated Oculus" },
     "description": "This strange metaphysical artifact will empower the island and unlock a permanent upgrade for all future runs.  Will be used automatically upon crafting, and can only be used once.\n\nASSOCIATED UPGRADE: Scouting 5",
@@ -498,7 +498,7 @@
   },
   {
     "id": "upgradekey_scouting8",
-    "type": "GENERIC",
+    "type": "ITEM",
     "category": "spare_parts",
     "name": { "str": "Other Eye of the Island" },
     "description": "This strange metaphysical artifact will empower the island and unlock a permanent upgrade for all future runs.  Will be used automatically upon crafting, and can only be used once.\n\nASSOCIATED UPGRADE: Scouting 8",
@@ -564,7 +564,7 @@
   },
   {
     "id": "upgradekey_scoutingclairvoyance1",
-    "type": "GENERIC",
+    "type": "ITEM",
     "category": "spare_parts",
     "name": { "str": "Higher Viewpoint" },
     "description": "This strange metaphysical artifact will empower the island and unlock a permanent upgrade for all future runs.  Will be used automatically upon crafting, and can only be used once.\n\nASSOCIATED UPGRADE: Scouting Clairvoyance 1",
@@ -630,7 +630,7 @@
   },
   {
     "id": "upgradekey_scoutingclairvoyance2",
-    "type": "GENERIC",
+    "type": "ITEM",
     "category": "spare_parts",
     "name": { "str_sp": "All-Seeing Effigy" },
     "description": "This strange metaphysical artifact will empower the island and unlock a permanent upgrade for all future runs.  Will be used automatically upon crafting, and can only be used once.\n\nASSOCIATED UPGRADE: Scouting Clairvoyance 2",
@@ -1034,7 +1034,7 @@
   },
   {
     "id": "upgradekey_landing6",
-    "type": "GENERIC",
+    "type": "ITEM",
     "category": "spare_parts",
     "name": { "str": "Familiarity Gemstone" },
     "description": "This strange metaphysical artifact will empower the island and unlock a permanent upgrade for all future runs.  Will be used automatically upon crafting, and can only be used once.\n\nASSOCIATED UPGRADE: Landing 6",
@@ -1105,7 +1105,7 @@
   },
   {
     "id": "upgradekey_landing7",
-    "type": "GENERIC",
+    "type": "ITEM",
     "category": "spare_parts",
     "name": { "str": "Warm Welcome" },
     "description": "This strange metaphysical artifact will empower the island and unlock a permanent upgrade for all future runs.  Will be used automatically upon crafting, and can only be used once.\n\nASSOCIATED UPGRADE: Landing 7",
@@ -1171,7 +1171,7 @@
   },
   {
     "id": "upgradekey_landing8",
-    "type": "GENERIC",
+    "type": "ITEM",
     "category": "spare_parts",
     "name": { "str": "Emissary's Herald" },
     "description": "This strange metaphysical artifact will empower the island and unlock a permanent upgrade for all future runs.  Will be used automatically upon crafting, and can only be used once.\n\nASSOCIATED UPGRADE: Landing 8",
@@ -1237,7 +1237,7 @@
   },
   {
     "id": "upgradekey_landing_waterwalking",
-    "type": "GENERIC",
+    "type": "ITEM",
     "category": "spare_parts",
     "name": { "str_sp": "Cloaking Buoyancy" },
     "description": "This strange metaphysical artifact will empower the island and unlock a permanent upgrade for all future runs.  Will be used automatically upon crafting, and can only be used once.\n\nASSOCIATED UPGRADE: Landing Boost: Waterwalking.",
@@ -1301,7 +1301,7 @@
   },
   {
     "id": "upgradekey_landing_flight",
-    "type": "GENERIC",
+    "type": "ITEM",
     "category": "spare_parts",
     "name": { "str": "Inverted Gravity Bubble" },
     "description": "This strange metaphysical artifact will empower the island and unlock a permanent upgrade for all future runs.  Will be used automatically upon crafting, and can only be used once.\n\nASSOCIATED UPGRADE: Landing Boost: Flight.",
@@ -1366,7 +1366,7 @@
   },
   {
     "id": "upgradekey_landing_phase",
-    "type": "GENERIC",
+    "type": "ITEM",
     "category": "spare_parts",
     "name": { "str_sp": "Universal Access Pass" },
     "description": "This strange metaphysical artifact will empower the island and unlock a permanent upgrade for all future runs.  Will be used automatically upon crafting, and can only be used once.\n\nASSOCIATED UPGRADE: Landing Boost: Phasing.",
@@ -1707,7 +1707,7 @@
   },
   {
     "id": "upgradekey_stability5",
-    "type": "GENERIC",
+    "type": "ITEM",
     "category": "spare_parts",
     "name": { "str": "Explorer's Ward" },
     "description": "This strange metaphysical artifact will empower the island and unlock a permanent upgrade for all future runs.  Will be used automatically upon crafting, and can only be used once.\n\nASSOCIATED UPGRADE: Stability 5",
@@ -1772,7 +1772,7 @@
   },
   {
     "id": "upgradekey_stability6",
-    "type": "GENERIC",
+    "type": "ITEM",
     "category": "spare_parts",
     "name": { "str": "Island-Bound Armor" },
     "description": "This strange metaphysical artifact will empower the island and unlock a permanent upgrade for all future runs.  Will be used automatically upon crafting, and can only be used once.\n\nASSOCIATED UPGRADE: Stability 6",
@@ -1837,7 +1837,7 @@
   },
   {
     "id": "upgradekey_stability7",
-    "type": "GENERIC",
+    "type": "ITEM",
     "category": "spare_parts",
     "name": { "str": "Triune Anchor" },
     "description": "This strange metaphysical artifact will empower the island and unlock a permanent upgrade for all future runs.  Will be used automatically upon crafting, and can only be used once.\n\nASSOCIATED UPGRADE: Stability 7",
@@ -2094,7 +2094,7 @@
   },
   {
     "id": "upgradekey_exit3",
-    "type": "GENERIC",
+    "type": "ITEM",
     "category": "spare_parts",
     "name": { "str": "Thrice-Sided Door" },
     "description": "This strange metaphysical artifact will empower the island and unlock a permanent upgrade for all future runs.  Will be used automatically upon crafting, and can only be used once.\n\nASSOCIATED UPGRADE: Four Exits per Expedition",
@@ -2158,7 +2158,7 @@
   },
   {
     "id": "upgradekey_exit4",
-    "type": "GENERIC",
+    "type": "ITEM",
     "category": "spare_parts",
     "name": { "str": "Intangible Door Stopper" },
     "description": "This strange metaphysical artifact will empower the island and unlock a permanent upgrade for all future runs.  Will be used automatically upon crafting, and can only be used once.\n\nASSOCIATED UPGRADE: Five Exits per Expedition",
@@ -2437,7 +2437,7 @@
   },
   {
     "id": "upgradekey_bonusmissions4",
-    "type": "GENERIC",
+    "type": "ITEM",
     "category": "spare_parts",
     "name": { "str": "Petrified Duty's Call" },
     "description": "This strange metaphysical artifact will empower the island and unlock a permanent upgrade for all future runs.  Will be used automatically upon crafting, and can only be used once.\n\nASSOCIATED UPGRADE: Four Missions per Expedition",
@@ -2505,7 +2505,7 @@
   },
   {
     "id": "upgradekey_bonusmissions5",
-    "type": "GENERIC",
+    "type": "ITEM",
     "category": "spare_parts",
     "name": { "str": "Oath of the Island's Enforcer" },
     "description": "This strange metaphysical artifact will empower the island and unlock a permanent upgrade for all future runs.  Will be used automatically upon crafting, and can only be used once.\n\nASSOCIATED UPGRADE: Five Missions per Expedition",
@@ -5129,7 +5129,7 @@
   },
   {
     "id": "upgradekey_windblock",
-    "type": "GENERIC",
+    "type": "ITEM",
     "category": "spare_parts",
     "name": { "str": "Wind Redirector" },
     "description": "This strange metaphysical artifact will make the island protect you from the winds while you are not earthside.  Will be used automatically upon crafting, and can only be used once.\n\nASSOCIATED UPGRADE: personal windblock.",
@@ -5184,7 +5184,7 @@
       "effect": [
         { "u_add_trait": "mut_skyisland_personal_temperature_adaptation" },
         { "u_forget_recipe": "upgradekey_temperature_control" },
-        { "math": [ "temperature_adaptation = 1" ] },
+        { "math": [ "skyisland_personal_temperature_adaptation = 1" ] },
         {
           "u_message": "Your skin shimmer for a second.  As long as you are on the island, you won't be affected by temperature.",
           "type": "mixed"
@@ -5194,7 +5194,7 @@
   },
   {
     "id": "upgradekey_temperature_control",
-    "type": "GENERIC",
+    "type": "ITEM",
     "category": "spare_parts",
     "name": { "str": "Climate Self-Injector" },
     "description": "This strange metaphysical artifact will make the island protect you from temperature while you are not earthside.  Will be used automatically upon crafting, and can only be used once.\n\nASSOCIATED UPGRADE: personal temperature adaptation.",


### PR DESCRIPTION
#### Summary
Mods "More Sky island upgrades"

#### Purpose of change

I worked on #80049 months ago, but stopped because the NPC-related changes refused to work.

Turned out that the other upgrades are perfectly functionnal, so I'm adding them.

#### Describe the solution

Add the following upgrades:

- [x] +3 stability upgrade tiers.

- [x] +3 scouting upgrade tiers.

- [x] +3 landing upgrade tiers.

- [x] +2 exit amount upgrade tiers.

- [x] +2 mission amount upgrade tiers.

- [x] Three upgrades to add a new property to the warpcloak (water-walking, flight, 1-tile phasing).

- [x] Two upgrades to gain a short-lived super clairvoyance when starting a mission.

- [x] A craft to make the winds not affect you while on the island.

- [x] A post-bunker-climate-control craft to always be at confortable temperature while on the island.

I also added a warning about the cloak expiring in a few seconds due to the flight and phase.

#### Describe alternatives you've considered

Trim the old PR instead of making a new one. Judging by the amount of lines I had to change from modified Json nomenclature, a new PR was the right call.

#### Testing

Gain upgrades. All of them.

Everything works as intended.

The windblocker gives messages about cold winds, but not getting these require not being cold, even if you're effectively wind-proof. Not being cold comes with a subsequent upgrade.

#### Additional context

Attuning a NPC to the island is a desired feature, but it'll have to wait.