### PR TITLE
make faults able to alter item encumbrance

### DIFF
--- a/doc/JSON/JSON_INFO.md
+++ b/doc/JSON/JSON_INFO.md
@@ -1607,6 +1607,8 @@ Faults can be defined for more specialized damage of an item.
   "price_modifier": 0.4, // (Optional, double) Defaults to 1 if not specified. A multiplier on the price of an item when this fault is present. Values above 1.0 will increase the item's value.
   "melee_damage_mod": [ { "damage_id": "cut", "add": -5, "multiply": 0.8 } ], // (Optional) alters the melee damage of this type for item, if fault of this type is presented. `damage_id` is mandatory, `add` is 0 by default, `multiply` is 1 by default
   "armor_mod": [ { "damage_id": "cut", "add": -5, "multiply": 0.8 } ], // (Optional) Same as armor_mod, changes the protection value of damage type of the faulted item if it's presented
+  "encumbrance_add": 20,  // if armor, item encumbrance will be modified by this amount, in this case +20 encumbrance
+  "encumbrance_mult": 1.3, // if armor, item encumbrance will be multiplied by this amount, in this case 1.3x as much (100-> 130)
   "block_faults": [ "fault_handle_chipping", "fault_handle_cracked" ], // Faults, that cannot be applied if this fault is already presented on item. If there is already such a fault, it will be removed. Can't have chipped blade if the blade is gone
   "flags": [ "JAMMED_GUN" ] // optional flags, see below
 }

--- a/src/fault.cpp
+++ b/src/fault.cpp
@@ -193,6 +193,16 @@ bool fault::affected_by_degradation() const
     return affected_by_degradation_;
 }
 
+double fault::encumb_mod_flat() const
+{
+    return encumbrance_mod_flat_;
+}
+
+double fault::encumb_mod_mult() const
+{
+    return encumbrance_mod_mult_;
+}
+
 std::string fault::type() const
 {
     return type_;
@@ -227,6 +237,8 @@ void fault::load( const JsonObject &jo, std::string_view )
     optional( jo, was_loaded, "price_modifier", price_modifier, 1.0 );
     optional( jo, was_loaded, "degradation_mod", degradation_mod_, 0 );
     optional( jo, was_loaded, "affected_by_degradation", affected_by_degradation_, false );
+    optional( jo, was_loaded, "encumbrance_add", encumbrance_mod_flat_, 0 );
+    optional( jo, was_loaded, "encumbrance_mult", encumbrance_mod_mult_, 1.f );
 
     if( jo.has_array( "melee_damage_mod" ) ) {
         for( JsonObject jo_f : jo.get_array( "melee_damage_mod" ) ) {

--- a/src/fault.h
+++ b/src/fault.h
@@ -88,6 +88,8 @@ class fault
         // int is additive (default 0), float is multiplier (default 1)
         std::vector<std::tuple<int, float, damage_type_id>> armor_mod() const;
         bool affected_by_degradation() const;
+        double encumb_mod_flat() const;
+        double encumb_mod_mult() const;
         bool has_flag( const std::string &flag ) const;
         const std::set<fault_id> &get_block_faults() const;
 
@@ -112,6 +114,8 @@ class fault
         int degradation_mod_ = 0;
         std::vector<std::tuple<int, float, damage_type_id>> melee_damage_mod_;
         std::vector<std::tuple<int, float, damage_type_id>> armor_mod_;
+        int encumbrance_mod_flat_ = 0;
+        float encumbrance_mod_mult_ = 1.f;
         // todo add tool_quality_mod_; axe with no handle won't axe
         bool affected_by_degradation_ = false;
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -8420,6 +8420,16 @@ int item::get_encumber( const Character &p, const bodypart_id &bodypart,
 
     encumber += static_cast<int>( std::ceil( get_clothing_mod_val( clothing_mod_type_encumbrance ) ) );
 
+    if( !faults.empty() ) {
+        int add = 0;
+        float mult = 1.f;
+        for( const fault_id fault : faults ) {
+            add += fault->encumb_mod_flat();
+            mult *= fault->encumb_mod_mult();
+        }
+        encumber = std::max( 0.f, ( encumber + add ) * mult );
+    }
+
     return encumber;
 }
 


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Fault power
#### Describe the solution
Make faults able to alter the item encumbrance
#### Describe alternatives you've considered
Some different way to alter item encumbrance than this one
#### Testing
![image](https://github.com/user-attachments/assets/a99a30cd-9377-4389-80e1-86274854ad3d)
![image](https://github.com/user-attachments/assets/ebf82c7d-b0c9-446d-baa8-a7623d4fec38)
