### PR TITLE
Aftershock: Cryosuit Audit and UI elements.

### DIFF
--- a/data/mods/aftershock_exoplanet/EOC/cryosuit_eocs.json
+++ b/data/mods/aftershock_exoplanet/EOC/cryosuit_eocs.json
@@ -1,0 +1,77 @@
+[
+  {
+    "type": "SPELL",
+    "id": "afs_cryosuit_ui_spell",
+    "//": "Triggered by enchantment added to all cryosuits. ",
+    "name": { "str": "updates the cryosuit UI", "//~": "NO_I18N" },
+    "description": { "str": "EOCs the player.", "//~": "NO_I18N" },
+    "valid_targets": [ "self", "hostile", "ally" ],
+    "max_level": 1,
+    "flags": [ "SILENT", "NO_EXPLOSION_SFX" ],
+    "base_casting_time": 75,
+    "shape": "blast",
+    "min_range": 0,
+    "min_aoe": 1,
+    "max_aoe": 1,
+    "effect": "effect_on_condition",
+    "effect_str": "afs_cryosuit_ui_eoc"
+  },
+  {
+    "id": "afs_cryosuit_ui_eoc",
+    "//": "Sends warnings and updates the sidebar power gauge.",
+    "type": "effect_on_condition",
+    "effect": [
+      {
+        "//": "No need to check for anything since only worn active cryosuits can call this.",
+        "u_run_inv_eocs": "all",
+        "search_data": [ { "worn_only": true, "flags": [ "ACTIVE_CRYOSUIT" ] } ],
+        "true_eocs": [
+          {
+            "id": "_update_ui",
+            "effect": [
+              { "math": [ "u_cryosuit_power = n_val('power_percentage')" ] },
+              {
+                "if": {
+                  "and": [
+                    { "math": [ "u_cryosuit_power < 5" ] },
+                    { "math": [ "u_cryosuit_power > 0" ] },
+                    { "not": { "u_has_effect": "afs_cryosuit_warning" } }
+                  ]
+                },
+                "then": [
+                  { "if": { "u_has_effect": "sleep" }, "then": { "u_lose_effect": "sleep" } },
+                  {
+                    "u_message": "Your cryosuit sounds a critical power warning!",
+                    "type": "warning",
+                    "popup": true,
+                    "popup_w_interrupt_query": true,
+                    "interrupt_type": "eoc"
+                  },
+                  { "u_add_effect": "afs_cryosuit_warning", "duration": "15 minutes" }
+                ],
+                "else": {
+                  "if": { "and": [ { "math": [ "u_cryosuit_power < 15" ] }, { "not": { "u_has_effect": "afs_cryosuit_warning" } } ] },
+                  "then": [
+                    { "if": { "u_has_effect": "sleep" }, "then": { "u_lose_effect": "sleep" } },
+                    {
+                      "u_message": "Your cryosuit sounds a low power warning!",
+                      "type": "warning",
+                      "popup": true,
+                      "popup_w_interrupt_query": true,
+                      "interrupt_type": "eoc"
+                    },
+                    { "u_add_effect": "afs_cryosuit_warning", "duration": "45 minutes" }
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "afs_cryosuit_warning",
+    "type": "effect_type"
+  }
+]

--- a/data/mods/aftershock_exoplanet/flags.json
+++ b/data/mods/aftershock_exoplanet/flags.json
@@ -39,6 +39,10 @@
     "info": "This item is capable of projecting a Riemann protective shield."
   },
   {
+    "id": "ACTIVE_CRYOSUIT",
+    "type": "json_flag"
+  },
+  {
     "id": "HIVE_MIND",
     "type": "monster_flag",
     "//": "This monster is part of a hive mind"

--- a/data/mods/aftershock_exoplanet/items/armor/winter_masks.json
+++ b/data/mods/aftershock_exoplanet/items/armor/winter_masks.json
@@ -14,22 +14,12 @@
     "material": [ "plastic", "titanium" ],
     "symbol": "[",
     "color": "dark_gray",
-    "charges_per_use": 1,
-    "use_action": {
-      "type": "transform",
-      "msg": "You activate your %s.",
-      "target": "afs_magellan_suit_helmet_on",
-      "active": true,
-      "need_charges": 1,
-      "need_charges_msg": "The %s's batteries are dead."
-    },
     "armor": [
       { "covers": [ "head" ], "coverage": 100, "encumbrance": 25 },
       { "covers": [ "eyes" ], "rigid_layer_only": true, "coverage": 100, "encumbrance": 5 },
       { "covers": [ "mouth" ], "rigid_layer_only": true, "coverage": 100, "encumbrance": 15 }
     ],
-    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 1000 } } ],
-    "warmth": 10,
+    "warmth": 50,
     "material_thickness": 1,
     "environmental_protection": 1,
     "flags": [
@@ -44,37 +34,21 @@
       "RECHARGE",
       "NO_RELOAD",
       "NO_UNLOAD",
+      "GAS_PROOF",
+      "WATCH",
+      "ALARMCLOCK",
+      "THERMOMETER",
+      "HYGROMETER",
+      "PARTIAL_DEAF",
       "SOFT"
     ],
     "melee_damage": { "bash": 7 },
-    "tool_ammo": "battery",
-    "passive_effects": [ { "id": "afs_ench_climate_control_warm" } ]
-  },
-  {
-    "id": "afs_magellan_suit_helmet_on",
-    "copy-from": "afs_magellan_suit_helmet",
-    "type": "ITEM",
-    "subtypes": [ "TOOL", "ARMOR" ],
-    "name": { "str": "Magellan helmet CA. (on)", "str_pl": "Magellan helmets CA. (on)" },
-    "looks_like": "helmet_motor",
-    "description": "The temperature control units and augmented reality overlays of this high-tech garment are currently active, and continuously draining battery power.  Use it to turn them off.",
-    "power_draw": "8170 mW",
-    "warmth": 150,
-    "revert_to": "afs_magellan_suit_helmet",
-    "use_action": {
-      "type": "transform",
-      "ammo_scale": 0,
-      "menu_text": "Turn off",
-      "msg": "Your %s deactivates.",
-      "target": "afs_magellan_suit_helmet"
-    },
-    "extend": { "flags": [ "GAS_PROOF", "WATCH", "ALARMCLOCK", "THERMOMETER", "HYGROMETER", "PARTIAL_DEAF", "TRADER_AVOID" ] },
-    "environmental_protection": 15
+    "passive_effects": [ { "id": "afs_ench_climate_control_warm_helmet" } ]
   },
   {
     "id": "afs_frontier_cryomask",
     "type": "ITEM",
-    "subtypes": [ "TOOL", "ARMOR", "ARTIFACT" ],
+    "subtypes": [ "ARMOR", "ARTIFACT" ],
     "category": "armor",
     "looks_like": "helmet_motor",
     "name": { "str": "frontier cryomask" },
@@ -86,52 +60,15 @@
     "material": [ "plastic", "nomex" ],
     "symbol": "[",
     "color": "dark_gray",
-    "charges_per_use": 1,
-    "use_action": {
-      "type": "transform",
-      "msg": "You activate your %s.",
-      "target": "afs_frontier_cryomask_on",
-      "active": true,
-      "need_charges": 1,
-      "need_charges_msg": "The %s's batteries are dead."
-    },
     "armor": [
       { "covers": [ "eyes" ], "rigid_layer_only": true, "coverage": 100, "encumbrance": 15 },
       { "covers": [ "mouth" ], "rigid_layer_only": true, "coverage": 100, "encumbrance": 20 }
     ],
-    "pocket_data": [
-      {
-        "pocket_type": "MAGAZINE_WELL",
-        "rigid": true,
-        "flag_restriction": [ "BATTERY_HEAVY" ],
-        "default_magazine": "afs_heavy_suit_battery_cell"
-      }
-    ],
-    "warmth": 5,
+    "warmth": 50,
     "material_thickness": 2,
     "environmental_protection": 2,
     "flags": [ "VARSIZE", "WATERPROOF", "RAINPROOF", "STURDY", "SUN_GLASSES", "OUTER", "SOFT" ],
     "melee_damage": { "bash": 7 },
-    "tool_ammo": "battery",
-    "passive_effects": [ { "id": "afs_ench_climate_control_warm" } ]
-  },
-  {
-    "id": "afs_frontier_cryomask_on",
-    "copy-from": "afs_frontier_cryomask",
-    "type": "ITEM",
-    "subtypes": [ "TOOL", "ARMOR" ],
-    "name": { "str": "frontier cryomask (on)", "str_pl": "frontier cryomasks (on)" },
-    "looks_like": "helmet_motor",
-    "description": "The heater of this high-tech garment is currently active, and continuously draining battery power.  Use it to turn the heat off.",
-    "power_draw": "6944 mW",
-    "warmth": 150,
-    "revert_to": "afs_frontier_cryomask",
-    "use_action": {
-      "type": "transform",
-      "ammo_scale": 0,
-      "menu_text": "Turn off",
-      "msg": "Your %s deactivates.",
-      "target": "afs_frontier_cryomask"
-    }
+    "passive_effects": [ { "id": "afs_ench_climate_control_warm_helmet" } ]
   }
 ]

--- a/data/mods/aftershock_exoplanet/items/armor/winter_suits.json
+++ b/data/mods/aftershock_exoplanet/items/armor/winter_suits.json
@@ -58,7 +58,7 @@
       "NO_UNLOAD"
     ],
     "tool_ammo": "battery",
-    "passive_effects": [ { "id": "afs_ench_climate_control_warm" } ]
+    "passive_effects": [ { "id": "afs_ench_climate_control_warm" }, { "id": "afs_ench_cryo_ui" } ]
   },
   {
     "id": "afs_magellan_suit_on",
@@ -78,7 +78,8 @@
       "menu_text": "Turn off",
       "msg": "Your %s deactivates.",
       "target": "afs_magellan_suit"
-    }
+    },
+    "extend": { "flags": [ "ACTIVE_CRYOSUIT" ] }
   },
   {
     "id": "afs_frontier_cryo",
@@ -148,6 +149,7 @@
     "power_draw": "6944 mW",
     "warmth": 150,
     "revert_to": "afs_frontier_cryo",
+    "extend": { "flags": [ "ACTIVE_CRYOSUIT" ] },
     "use_action": {
       "type": "transform",
       "ammo_scale": 0,
@@ -182,6 +184,8 @@
     "armor": [
       { "covers": [ "head" ], "coverage": 100, "encumbrance": 2 },
       { "covers": [ "torso" ], "coverage": 100, "encumbrance": 2 },
+      { "covers": [ "eyes" ], "coverage": 100, "encumbrance": 2 },
+      { "covers": [ "mouth" ], "coverage": 100, "encumbrance": 2 },
       { "covers": [ "leg_l", "leg_r" ], "coverage": 100, "encumbrance": 2 },
       { "covers": [ "arm_l", "arm_r" ], "coverage": 100, "encumbrance": 2 },
       { "covers": [ "hand_l", "hand_r" ], "coverage": 100, "encumbrance": 2 },
@@ -230,7 +234,8 @@
       "menu_text": "Turn off",
       "msg": "Your %s deactivates.",
       "target": "afs_combat_cryo"
-    }
+    },
+    "extend": { "flags": [ "ACTIVE_CRYOSUIT" ] }
   },
   {
     "id": "afs_combat_cryo_xl",
@@ -240,6 +245,14 @@
     "copy-from": "afs_combat_cryo",
     "description": "A sleek black undersuit criss-crossed with the tubing of a heat regulation unit.  Insulation is kept at a minimum to allow for combat mobility, and the suit is quite power hungry as a result.  Despite the name, it's minimally protective and designed to be worn under a set of armor.  Made to fit the uplifted, the heavily augmented, or similarly sized individuals.",
     "proportional": { "weight": 1.25, "volume": 1.13, "price": 1.25 },
+    "use_action": {
+      "type": "transform",
+      "msg": "You activate your %s.",
+      "target": "afs_combat_cryo_on_xl",
+      "active": true,
+      "need_charges": 1,
+      "need_charges_msg": "The %s's batteries are dead."
+    },
     "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
@@ -249,7 +262,15 @@
     "name": { "str": "combat cryo suit (on)", "str_pl": "combat cryo suits (on)" },
     "copy-from": "afs_combat_cryo_on",
     "proportional": { "weight": 1.25, "volume": 1.13, "price": 1.25 },
-    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
+    "revert_to": "afs_combat_cryo_xl",
+    "use_action": {
+      "type": "transform",
+      "ammo_scale": 0,
+      "menu_text": "Turn off",
+      "msg": "Your %s deactivates.",
+      "target": "afs_combat_cryo_xl"
+    },
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL", "ACTIVE_CRYOSUIT" ] }
   },
   {
     "id": "afs_cryopod_bodyglove",
@@ -307,6 +328,7 @@
     "looks_like": "afs_cryopod_bodyglove",
     "description": "A dark orange bodyglove, hundreds of tubes curl over its surface, tracing the contours of human musculature.  Meant to control body temperature during prolonged cryopreservation, it could easily keep you comfortable in any earthly climate.  The temperature control units of this high-tech garment are currently active, and continuously draining battery power.  Use it to turn them off.",
     "power_draw": "90 W",
+    "warmth": 150,
     "revert_to": "afs_cryopod_bodyglove",
     "use_action": {
       "type": "transform",
@@ -315,6 +337,16 @@
       "msg": "Your %s deactivates.",
       "target": "afs_cryopod_bodyglove"
     },
-    "flags": [ "VARSIZE", "SKINTIGHT", "RAINPROOF", "STURDY", "WATERPROOF", "PADDED", "THERMOMETER", "HYGROMETER" ]
+    "flags": [
+      "VARSIZE",
+      "SKINTIGHT",
+      "RAINPROOF",
+      "STURDY",
+      "WATERPROOF",
+      "PADDED",
+      "THERMOMETER",
+      "HYGROMETER",
+      "ACTIVE_CRYOSUIT"
+    ]
   }
 ]

--- a/data/mods/aftershock_exoplanet/items/item_enchants.json
+++ b/data/mods/aftershock_exoplanet/items/item_enchants.json
@@ -78,6 +78,22 @@
     "description": "Assists with learning and study."
   },
   {
+    "id": "afs_ench_cryo_ui",
+    "type": "enchantment",
+    "has": "WORN",
+    "condition": "ACTIVE",
+    "intermittent_activation": { "effects": [ { "frequency": "120 seconds", "spell_effects": [ { "id": "afs_cryosuit_ui_spell" } ] } ] }
+  },
+  {
+    "id": "afs_ench_climate_control_warm_helmet",
+    "type": "enchantment",
+    "has": "WORN",
+    "name": { "str": "Cold Climate Control Helmet" },
+    "description": "You are wearing equipment that helps handle harsh climates.",
+    "condition": { "u_has_worn_with_flag": "ACTIVE_CRYOSUIT" },
+    "values": [ { "value": "CLIMATE_CONTROL_HEAT", "add": 75 } ]
+  },
+  {
     "id": "afs_ench_climate_control_warm",
     "type": "enchantment",
     "name": { "str": "Cold Climate Control" },

--- a/data/mods/aftershock_exoplanet/items/obsolete.json
+++ b/data/mods/aftershock_exoplanet/items/obsolete.json
@@ -148,5 +148,17 @@
     "//": "remove after 0.I",
     "id": "40mmEMP_act",
     "replace": "40x46mm_m433"
+  },
+  {
+    "type": "MIGRATION",
+    "//": "remove after 0.J",
+    "id": "afs_magellan_suit_helmet_on",
+    "replace": "afs_magellan_suit_helmet"
+  },
+  {
+    "type": "MIGRATION",
+    "//": "remove after 0.J",
+    "id": "afs_frontier_cryomask_on",
+    "replace": "afs_frontier_cryomask"
   }
 ]

--- a/data/mods/aftershock_exoplanet/ui.json
+++ b/data/mods/aftershock_exoplanet/ui.json
@@ -4,35 +4,35 @@
     "copy-from": "legacy_classic_sidebar",
     "type": "widget",
     "id": "legacy_classic_sidebar",
-    "extend": { "widgets": [ "shield_layout" ] }
+    "extend": { "widgets": [ "cryosuit_power", "shield_layout" ] }
   },
   {
     "//": "Extend with the danger widget",
     "copy-from": "legacy_compact_sidebar",
     "type": "widget",
     "id": "legacy_compact_sidebar",
-    "extend": { "widgets": [ "shield_layout" ] }
+    "extend": { "widgets": [ "cryosuit_power", "shield_layout" ] }
   },
   {
     "//": "Extend with the danger widget",
     "copy-from": "legacy_labels_narrow_sidebar",
     "type": "widget",
     "id": "legacy_labels_narrow_sidebar",
-    "extend": { "widgets": [ "shield_layout" ] }
+    "extend": { "widgets": [ "cryosuit_power", "shield_layout" ] }
   },
   {
     "//": "Extend with the danger widget",
     "copy-from": "legacy_labels_sidebar",
     "type": "widget",
     "id": "legacy_labels_sidebar",
-    "extend": { "widgets": [ "shield_layout" ] }
+    "extend": { "widgets": [ "cryosuit_power", "shield_layout" ] }
   },
   {
     "//": "Extend with the danger widget",
     "copy-from": "structured_sidebar",
     "type": "widget",
     "id": "structured_sidebar",
-    "extend": { "widgets": [ "shield_layout" ] }
+    "extend": { "widgets": [ "cryosuit_power", "shield_layout" ] }
   },
   {
     "id": "shield_layout",
@@ -322,5 +322,80 @@
     "style": "text",
     "string": "",
     "flags": [ "W_LABEL_NONE", "W_NO_PADDING" ]
+  },
+  {
+    "id": "cryosuit_power",
+    "style": "layout",
+    "label": "CRYOSUIT",
+    "label_align": "right",
+    "text_align": "right",
+    "flags": [ "W_DISABLED_WHEN_EMPTY" ],
+    "widgets": [ "cryosuit_power_graph" ],
+    "type": "widget"
+  },
+  {
+    "id": "cryosuit_power_graph",
+    "type": "widget",
+    "style": "text",
+    "label": "CRYOSUIT POWER",
+    "width": 19,
+    "clauses": [
+      {
+        "id": "empty",
+        "text": "<color_red>      OFFLINE      </color>",
+        "condition": { "not": { "u_has_worn_with_flag": "ACTIVE_CRYOSUIT" } }
+      },
+      {
+        "id": "full10",
+        "text": { "str": "<color_red>▇ ▇ ▇ ▇ ▇ ▇ ▇ ▇ ▇ ▇</color>", "//~": "NO_I18N" },
+        "condition": { "math": [ "u_cryosuit_power", ">=", "90" ] }
+      },
+      {
+        "id": "full9",
+        "text": { "str": "<color_red>▇ ▇ ▇ ▇ ▇ ▇ ▇ ▇ ▇  </color>", "//~": "NO_I18N" },
+        "condition": { "math": [ "u_cryosuit_power", ">=", "80" ] }
+      },
+      {
+        "id": "full8",
+        "text": { "str": "<color_red>▇ ▇ ▇ ▇ ▇ ▇ ▇ ▇    </color>", "//~": "NO_I18N" },
+        "condition": { "math": [ "u_cryosuit_power", ">=", "70" ] }
+      },
+      {
+        "id": "full7",
+        "text": { "str": "<color_red>▇ ▇ ▇ ▇ ▇ ▇ ▇      </color>", "//~": "NO_I18N" },
+        "condition": { "math": [ "u_cryosuit_power", ">=", "60" ] }
+      },
+      {
+        "id": "full6",
+        "text": { "str": "<color_red>▇ ▇ ▇ ▇ ▇ ▇        </color>", "//~": "NO_I18N" },
+        "condition": { "math": [ "u_cryosuit_power", ">=", "50" ] }
+      },
+      {
+        "id": "full5",
+        "text": { "str": "<color_red>▇ ▇ ▇ ▇ ▇          </color>", "//~": "NO_I18N" },
+        "condition": { "math": [ "u_cryosuit_power", ">=", "40" ] }
+      },
+      {
+        "id": "full4",
+        "text": { "str": "<color_red>▇ ▇ ▇ ▇            </color>", "//~": "NO_I18N" },
+        "condition": { "math": [ "u_cryosuit_power", ">=", "30" ] }
+      },
+      {
+        "id": "full3",
+        "text": { "str": "<color_red>▇ ▇ ▇              </color>", "//~": "NO_I18N" },
+        "condition": { "math": [ "u_cryosuit_power", ">=", "20" ] }
+      },
+      {
+        "id": "full2",
+        "text": { "str": "<color_red>▇ ▇                </color>", "//~": "NO_I18N" },
+        "condition": { "math": [ "u_cryosuit_power", ">=", "10" ] }
+      },
+      {
+        "id": "full1",
+        "text": { "str": "<color_red>▇                  </color>", "//~": "NO_I18N" },
+        "condition": { "math": [ "u_cryosuit_power", ">", "0" ] }
+      }
+    ],
+    "flags": [ "W_NO_PADDING" ]
   }
 ]


### PR DESCRIPTION
#### Summary
Mods "Aftershock: Create cryosuit UI elements and power warnings."

#### Purpose of change
Implement the suggestions from: #81034

Cryosuits are pretty important for survival and you should really get warinings about when they are low on power so you can swap activities and not freeze to death. I also added a power gauge to the sidebar that tells you the remaining battery of your cryosuit without needing to check the inventory.

To simplify implementation, all the cryosuit helmets no longer need batteries to function, they will instead work only if you are wearing an active cryosuit.

Closes  #81034

#### Describe the solution
Eoc stuff.

#### Testing
Used all the cryosuits to verify they worked.
