### PR TITLE
Aftershock: Disable A shadow event.

### DIFF
--- a/data/mods/aftershock_exoplanet/game_balance.json
+++ b/data/mods/aftershock_exoplanet/game_balance.json
@@ -7,6 +7,16 @@
     "effect": [  ]
   },
   {
+    "type": "effect_on_condition",
+    "id": "EOC_LIEUTENANT_SPAWN_SHADOW",
+    "recurrence": [ "15 minutes", "9 hours" ],
+    "global": true,
+    "run_for_npcs": false,
+    "condition": { "test_eoc": "EOC_SHADOW_SPAWN_CONDITIONS" },
+    "effect": [  ],
+    "false_effect": [  ]
+  },
+  {
     "type": "EXTERNAL_OPTION",
     "name": "GENERIC_PROFESSION_ID",
     "stype": "string_input",


### PR DESCRIPTION

#### Summary
None

#### Purpose of change
The monster was already blacklisted, but the messages could still trigger and warn you about unexistent dangers. This gets rid of those.

#### Describe the solution
Replace the EOC with an empty one

#### Testing
Game loads.