### PR TITLE
WIP: eliminate an extra buffer copy on every frame

### DIFF
--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -43,8 +43,6 @@ enum class direction : unsigned int;
 enum class lit_level : int;
 enum class visibility_type : int;
 
-extern void set_displaybuffer_rendertarget();
-
 /** Structures */
 struct tile_type {
     // fg and bg are both a weighted list of lists of sprite IDs

--- a/src/pixel_minimap.cpp
+++ b/src/pixel_minimap.cpp
@@ -451,7 +451,7 @@ void pixel_minimap::render( const tripoint_bub_ms &center )
     render_critters( center );
 
     //set display buffer to main screen
-    set_displaybuffer_rendertarget();
+    SetRenderTarget( renderer, NULL );
     //paint intermediate texture to screen
     RenderCopy( renderer, main_tex, &main_tex_clip_rect, &screen_clip_rect );
 }

--- a/src/pixel_minimap.cpp
+++ b/src/pixel_minimap.cpp
@@ -451,7 +451,7 @@ void pixel_minimap::render( const tripoint_bub_ms &center )
     render_critters( center );
 
     //set display buffer to main screen
-    SetRenderTarget( renderer, NULL );
+    SetRenderTarget( renderer, nullptr );
     //paint intermediate texture to screen
     RenderCopy( renderer, main_tex, &main_tex_clip_rect, &screen_clip_rect );
 }

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -234,7 +234,7 @@ static void InitSDL()
 static bool SetupRenderTarget()
 {
     SetRenderDrawBlendMode( renderer, SDL_BLENDMODE_NONE );
-    if( printErrorIf( SDL_SetRenderTarget( renderer.get(), NULL ) != 0,
+    if( printErrorIf( SDL_SetRenderTarget( renderer.get(), nullptr ) != 0,
                       "SDL_SetRenderTarget failed" ) ) {
         return false;
     }

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -134,7 +134,6 @@ static Font_Ptr overmap_font;
 static SDL_Window_Ptr window;
 static SDL_Renderer_Ptr renderer;
 static SDL_PixelFormat_Ptr format;
-static SDL_Texture_Ptr display_buffer;
 static GeometryRenderer_Ptr geometry;
 #if defined(__ANDROID__)
 static SDL_Texture_Ptr touch_joystick;
@@ -235,12 +234,7 @@ static void InitSDL()
 static bool SetupRenderTarget()
 {
     SetRenderDrawBlendMode( renderer, SDL_BLENDMODE_NONE );
-    display_buffer.reset( SDL_CreateTexture( renderer.get(), SDL_PIXELFORMAT_ARGB8888,
-                          SDL_TEXTUREACCESS_TARGET, WindowWidth / scaling_factor, WindowHeight / scaling_factor ) );
-    if( printErrorIf( !display_buffer, "Failed to create window buffer" ) ) {
-        return false;
-    }
-    if( printErrorIf( SDL_SetRenderTarget( renderer.get(), display_buffer.get() ) != 0,
+    if( printErrorIf( SDL_SetRenderTarget( renderer.get(), NULL ) != 0,
                       "SDL_SetRenderTarget failed" ) ) {
         return false;
     }
@@ -382,7 +376,6 @@ static void WinCreate()
             dbg( D_ERROR ) <<
                            "Failed to initialize display buffer under accelerated rendering, falling back to software rendering.";
             software_renderer = true;
-            display_buffer.reset();
             renderer.reset();
         }
     }
@@ -452,7 +445,6 @@ static void WinDestroy()
     gamepad::quit();
     geometry.reset();
     format.reset();
-    display_buffer.reset();
     renderer.reset();
     ::window.reset();
 }
@@ -545,18 +537,6 @@ void refresh_display()
         return;
     }
 
-    // Select default target (the window), copy rendered buffer
-    // there, present it, select the buffer as target again.
-    SetRenderTarget( renderer, nullptr );
-    ClearScreen();
-#if defined(__ANDROID__)
-    SDL_Rect dstrect = get_android_render_rect( TERMINAL_WIDTH * fontwidth,
-                       TERMINAL_HEIGHT * fontheight );
-    RenderCopy( renderer, display_buffer, NULL, &dstrect );
-#else
-    RenderCopy( renderer, display_buffer, nullptr, nullptr );
-#endif
-
 #if defined(__ANDROID__)
     draw_terminal_size_preview();
     if( g ) {
@@ -565,7 +545,7 @@ void refresh_display()
     draw_virtual_joystick();
 #endif
     SDL_RenderPresent( renderer.get() );
-    SetRenderTarget( renderer, display_buffer );
+    ClearScreen();
 }
 
 // only update if the set interval has elapsed
@@ -577,12 +557,6 @@ static void try_sdl_update()
     } else {
         needupdate = true;
     }
-}
-
-//for resetting the render target after updating texture caches in cata_tiles.cpp
-void set_displaybuffer_rendertarget()
-{
-    SetRenderTarget( renderer, display_buffer );
 }
 
 void clear_window_area( const catacurses::window &win_ )


### PR DESCRIPTION
#### Summary
Performance "Do double buffering correctly, avoiding an extra buffer copy"

#### Purpose of change

Speed

#### Describe the solution

Instead of drawing the whole game to a texture then copying that texture to the main window every frame, simply draw to the main window and let double–buffering do its thing.

There is a slight downside to this patch, however. We’re still not drawing non-ImGui UI elements when they are underneath ImGui UI elements, so anything using ImGui ends up drawn on top of a blank screen.

#### Additional context

Before:
![Screenshot 2025-07-03 at 11-06-06 release-tiles-s on orod-na-thon (perf version 6 15 4-200 fc42 x86_64) – Linux 6 15 3-200 fc42 x86_64 – 7_3_2025 6 04 04 PM UTC – Firefox Profiler](https://github.com/user-attachments/assets/e5300525-dc2d-4042-b8a8-878f56c01a32)

After:
![Screenshot 2025-07-03 at 11-21-24 release-tiles-s on orod-na-thon (perf version 6 15 4-200 fc42 x86_64) – Linux 6 15 3-200 fc42 x86_64 – 7_3_2025 6 19 52 PM UTC – Firefox Profiler](https://github.com/user-attachments/assets/02804d1f-76e2-4677-9d3a-b84c02b7b3ef)
