### PR TITLE
add support for fault applying via itemgroup

### DIFF
--- a/doc/JSON/ITEM_SPAWN.md
+++ b/doc/JSON/ITEM_SPAWN.md
@@ -97,6 +97,7 @@ Each entry can have more values (shown above as `...`).  They allow further prop
 "artifact": <object>
 "event": <string>
 "snippets": <string>
+"faults": <object>
 ```
 
 `contents` is added as contents of the created item.  It is not checked if they can be put into the item.  This allows water, that contains a book, that contains a steel frame, that contains a corpse.
@@ -117,8 +118,6 @@ Each entry can have more values (shown above as `...`).  They allow further prop
 
 `event`: A reference to a holiday in the `holiday` enum. If specified, the entry only spawns during the specified real holiday. This works the same way as the seasonal title screens, where the holiday is checked against the current system's time. If the holiday matches, the item's spawn probability is taken from the `prob` field. Otherwise, the spawn probability becomes 0.
 
-`snippets`: If item uses `snippet_category` instead of description, and snippets contain ids, allow to pick a specific description of an item to spawn; see [JSON_INFO.md#snippets](JSON_INFO.md#snippets)
-
 Current possible values are:
 - "none" (Not event-based. Same as omitting the "event" field.)
 - "new_year"
@@ -127,6 +126,16 @@ Current possible values are:
 - "halloween"
 - "thanksgiving"
 - "christmas"
+
+`snippets`: If item uses `snippet_category` instead of description, and snippets contain ids, allow to pick a specific description of an item to spawn; see [JSON_INFO.md#snippets](JSON_INFO.md#snippets)
+
+`faults`: If item can have this fault or faults, it would be spawned with it applied. Possible values are:
+  `id`: array of fault id that should be applied, if possible
+  `chance`: chance to apply any of the faults. Default is 100, always apply
+For example:
+```json
+  { "group": "nested_ar10", "prob": 89, "faults": { "id": [ "fault_stovepipe" ], "chance": 50 } },
+```
 
 `artifact`: This object determines that the item or group that is spawned by this entry will become an artifact. Here is an example:
 ```jsonc

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -4641,6 +4641,15 @@ void Item_factory::add_entry( Item_group &ig, const JsonObject &obj,
         use_modifier = true;
     }
 
+    if( obj.has_object( "faults" ) ) {
+        JsonObject jo = obj.get_object( "faults" );
+        int chance = jo.get_int( "chance", 100 );
+        for( std::string ids : jo.get_array( "id" ) ) {
+            modifier.faults.emplace_back( fault_id( ids ), chance );
+        }
+        use_modifier = true;
+    }
+
     if( use_modifier ) {
         sptr->modifier.emplace( std::move( modifier ) );
     }

--- a/src/item_group.cpp
+++ b/src/item_group.cpp
@@ -517,6 +517,14 @@ void Item_modifier::modify( item &new_item, const std::string &context ) const
 
     new_item.set_itype_variant( variant );
 
+    if( !faults.empty() ) {
+        for( const std::pair<fault_id, int> f : faults ) {
+            if( x_in_y( f.second, 100 ) ) {
+                new_item.set_fault( f.first, false, false );
+            }
+        }
+    }
+
     {
         // create container here from modifier or from default to get max charges later
         std::optional<item> cont;

--- a/src/item_group.cpp
+++ b/src/item_group.cpp
@@ -518,7 +518,7 @@ void Item_modifier::modify( item &new_item, const std::string &context ) const
     new_item.set_itype_variant( variant );
 
     if( !faults.empty() ) {
-        for( const std::pair<fault_id, int> f : faults ) {
+        for( const std::pair<fault_id, int> &f : faults ) {
             if( x_in_y( f.second, 100 ) ) {
                 new_item.set_fault( f.first, false, false );
             }

--- a/src/item_group.h
+++ b/src/item_group.h
@@ -279,6 +279,11 @@ class Item_modifier
         std::string variant;
 
         /**
+        * add this faults to item, if possible
+        */
+        std::vector<std::pair<fault_id, int>> faults;
+
+        /**
          * Custom sub set of snippets to be randomly chosen from and then applied to the item.
          */
         std::vector<snippet_id> snippets;


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Fault power
#### Describe the solution
Add support for fault application via itemgroup, and add a chance field to it
#### Describe alternatives you've considered
Also add support for fault group - fault groups were made terribly, because i didn't expect they will be used for anything else.
#### Testing
Spawned gun with stovepipe applied
![image](https://github.com/user-attachments/assets/c58c3999-5044-4b25-b5e2-c2f4529dc970)
ar-10 specifically had 50% chance
![image](https://github.com/user-attachments/assets/b82e3e75-bfd9-4918-ba90-23c394a274bc)