### PR TITLE
Fix dust mopping

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -3613,7 +3613,7 @@ bool map::mop_spills( const tripoint_bub_ms &p )
 
     field &fld = field_at( p );
     for( const auto &it : fld ) {
-        if( it.first->phase == phase_id::LIQUID ) {
+        if( it.first->phase == phase_id::LIQUID || it.first->moppable ) {
             remove_field( p, it.first );
             retval = true;
         }


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Fix https://github.com/CleverRaven/Cataclysm-DDA/issues/81592

#### Describe the solution
Add the moppable check to the function that removes fields too.

#### Testing
Smash a bench, spawn a mop, clean up remains.