### PR TITLE
Add tests for bashing creates fields

### DIFF
--- a/data/mods/TEST_DATA/fields.json
+++ b/data/mods/TEST_DATA/fields.json
@@ -24,6 +24,40 @@
     "display_field": true
   },
   {
+    "id": "fd_bash_bothfield",
+    "type": "field_type",
+    "copy-from": "fd_bash_nofield",
+    "bash": { "str_min": 4, "str_max": 100, "hit_field": [ "fd_marker1", 1 ], "destroyed_field": [ "fd_marker2", 1 ] }
+  },
+  {
+    "id": "fd_bash_destroyfield",
+    "type": "field_type",
+    "copy-from": "fd_bash_nofield",
+    "bash": { "str_min": 4, "str_max": 100, "destroyed_field": [ "fd_marker1", 2 ] }
+  },
+  {
+    "id": "fd_bash_hitfield",
+    "type": "field_type",
+    "copy-from": "fd_bash_nofield",
+    "bash": { "str_min": 4, "str_max": 100, "hit_field": [ "fd_marker2", 1 ] }
+  },
+  {
+    "id": "fd_bash_nofield",
+    "type": "field_type",
+    "intensity_levels": [ { "name": "1", "sym": "1" } ],
+    "bash": { "str_min": 4, "str_max": 100 }
+  },
+  {
+    "id": "fd_marker1",
+    "type": "field_type",
+    "intensity_levels": [ { "name": "1", "sym": "1" }, { "name": "2", "sym": "2" } ]
+  },
+  {
+    "id": "fd_marker2",
+    "type": "field_type",
+    "intensity_levels": [ { "name": "1", "sym": "1" }, { "name": "2", "sym": "2" } ]
+  },
+  {
     "id": "fd_test",
     "type": "field_type",
     "intensity_levels": [

--- a/data/mods/TEST_DATA/furniture.json
+++ b/data/mods/TEST_DATA/furniture.json
@@ -121,6 +121,69 @@
   },
   {
     "type": "furniture",
+    "id": "test_f_bash_nofield",
+    "name": "Bash nofield furniture",
+    "description": "Testing fields produced on bash",
+    "symbol": "f",
+    "color": "blue",
+    "bash": { "str_min": 4, "str_max": 100, "sound": "Tests testing!", "sound_fail": "Tests testing!" },
+    "move_cost_mod": 1,
+    "required_str": 8
+  },
+  {
+    "type": "furniture",
+    "id": "test_f_bash_hitfield",
+    "name": "Bash hit field furniture",
+    "description": "Testing fields produced on bash",
+    "symbol": "f",
+    "color": "blue",
+    "bash": {
+      "str_min": 4,
+      "str_max": 100,
+      "sound": "Tests testing!",
+      "sound_fail": "Tests testing!",
+      "hit_field": [ "fd_marker1", 2 ]
+    },
+    "move_cost_mod": 1,
+    "required_str": 8
+  },
+  {
+    "type": "furniture",
+    "id": "test_f_bash_destroyfield",
+    "name": "Bash destroy field furniture",
+    "description": "Testing fields produced on bash",
+    "symbol": "f",
+    "color": "blue",
+    "bash": {
+      "str_min": 4,
+      "str_max": 100,
+      "sound": "Tests testing!",
+      "sound_fail": "Tests testing!",
+      "destroyed_field": [ "fd_marker1", 1 ]
+    },
+    "move_cost_mod": 1,
+    "required_str": 8
+  },
+  {
+    "type": "furniture",
+    "id": "test_f_bash_bothfield",
+    "name": "Bash both field furniture",
+    "description": "Testing fields produced on bash",
+    "symbol": "f",
+    "color": "blue",
+    "bash": {
+      "str_min": 4,
+      "str_max": 100,
+      "sound": "Tests testing!",
+      "sound_fail": "Tests testing!",
+      "hit_field": [ "fd_marker2", 1 ],
+      "destroyed_field": [ "fd_marker1", 2 ]
+    },
+    "move_cost_mod": 1,
+    "required_str": 8
+  },
+  {
+    "type": "furniture",
     "id": "test_f_bash_persist",
     "name": "Bash persistence furniture",
     "description": "Testing that bashing data does not persist when furniture changes",

--- a/data/mods/TEST_DATA/terrain.json
+++ b/data/mods/TEST_DATA/terrain.json
@@ -27,6 +27,64 @@
   },
   {
     "type": "terrain",
+    "id": "test_t_bash_nofield",
+    "name": "Bash nofield",
+    "description": "Testing fields produced on bash",
+    "symbol": "f",
+    "color": "blue",
+    "bash": { "ter_set": "t_null", "str_min": 4, "str_max": 100, "sound": "Tests testing!", "sound_fail": "Tests testing!" }
+  },
+  {
+    "type": "terrain",
+    "id": "test_t_bash_hitfield",
+    "name": "Bash hit field",
+    "description": "Testing fields produced on bash",
+    "symbol": "f",
+    "color": "blue",
+    "bash": {
+      "ter_set": "t_null",
+      "str_min": 4,
+      "str_max": 100,
+      "sound": "Tests testing!",
+      "sound_fail": "Tests testing!",
+      "hit_field": [ "fd_marker2", 1 ]
+    }
+  },
+  {
+    "type": "terrain",
+    "id": "test_t_bash_destroyfield",
+    "name": "Bash destroy field",
+    "description": "Testing fields produced on bash",
+    "symbol": "f",
+    "color": "blue",
+    "bash": {
+      "ter_set": "t_null",
+      "str_min": 4,
+      "str_max": 100,
+      "sound": "Tests testing!",
+      "sound_fail": "Tests testing!",
+      "destroyed_field": [ "fd_marker2", 2 ]
+    }
+  },
+  {
+    "type": "terrain",
+    "id": "test_t_bash_bothfield",
+    "name": "Bash both field",
+    "description": "Testing fields produced on bash",
+    "symbol": "f",
+    "color": "blue",
+    "bash": {
+      "ter_set": "t_null",
+      "str_min": 4,
+      "str_max": 100,
+      "sound": "Tests testing!",
+      "sound_fail": "Tests testing!",
+      "hit_field": [ "fd_marker1", 2 ],
+      "destroyed_field": [ "fd_marker2", 1 ]
+    }
+  },
+  {
+    "type": "terrain",
     "id": "test_t_hacksaw1",
     "name": "Hacksaw Test Terrain 1",
     "description": "Hacksaw terrain with valid data.",


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Test new feature.

#### Describe the solution
Add tests for furniture and terrain. Also added tests for fields, but map::bash doesn't bash fields.

#### Testing
See CI.