### PR TITLE
Add assertion to skill rust test about excessive rust speed

### DIFF
--- a/tests/skill_test.cpp
+++ b/tests/skill_test.cpp
@@ -39,6 +39,7 @@ TEST_CASE( "skill_rust_occurs", "[character][skill]" )
         INFO( skill.ident().str() );
         // Rust is about 1% per day with a one day grace period
         CHECK( guy.get_skill_level( skill.ident() ) < 2.f );
+        CHECK( guy.get_skill_level( skill.ident() ) > 1.5f );
         CHECK( guy.get_knowledge_level( skill.ident() ) == 2 );
         CHECK( guy.get_skill_level_object( skill.ident() ).isRusty() );
     }


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Noticed the skill rust check only asserted that rust had occurred, not that it was fairly minimal.

#### Describe the solution
Added a loose assertion that skill rust isn't much faster than expected.