### PR TITLE
JSON: Allow serializing/deserializing std::maps with tripoints as keys

### DIFF
--- a/src/coordinates.h
+++ b/src/coordinates.h
@@ -220,6 +220,10 @@ class coord_point_ob : public
             return *this == invalid;
         }
 
+        static coord_point_ob from_string( const std::string &s ) {
+            return coord_point_ob( Point::from_string( s ) );
+        }
+
         static constexpr bool is_inbounds = false;
         using this_as_tripoint = coord_point_ob<tripoint, Origin, Scale>;
         using this_as_point = coord_point_ob<point, Origin, Scale>;

--- a/src/json.h
+++ b/src/json.h
@@ -81,6 +81,13 @@ struct key_from_json_string<Enum, std::enable_if_t<std::is_enum_v<Enum>>> {
     }
 };
 
+template<typename T>
+struct key_from_json_string<T, std::void_t<decltype( std::declval<T &>().to_string_writable() )>> {
+    T operator()( const std::string &s ) {
+        return T::from_string( s );
+    }
+};
+
 struct number_sci_notation {
     bool negative = false;
     // AKA the significand
@@ -853,6 +860,12 @@ class JsonOut
         template<typename T>
         void write_as_string( const int_id<T> &s ) {
             write( s.id() );
+        }
+
+        template <typename T>
+        auto write_as_string( const T &value ) -> decltype( std::declval<T &>().to_string_writable(),
+                void() ) {
+            write( value.to_string_writable() );
         }
 
         template<typename T, typename U>

--- a/tests/json_test.cpp
+++ b/tests/json_test.cpp
@@ -962,6 +962,30 @@ TEST_CASE( "item_colony_ser_deser", "[json][item]" )
     }
 }
 
+TEST_CASE( "serialize_map_with_point_key", "[json]" )
+{
+    SECTION( "empty map" ) {
+        std::map<tripoint, int> empty;
+        test_serialization( empty, "{}" );
+    }
+    SECTION( "map with one element" ) {
+        std::map<tripoint, int> one_element;
+        one_element.emplace( tripoint( 4, 3, 2 ), 7 );
+        test_serialization( one_element, "{\"(4,3,2)\":7}" );
+    }
+    SECTION( "map with two elements" ) {
+        std::map<tripoint, int> two_element;
+        two_element.emplace( tripoint( 1, 2, 3 ), 4 );
+        two_element.emplace( tripoint( 8, 7, 6 ), 5 );
+        test_serialization( two_element, "{\"(1,2,3)\":4,\"(8,7,6)\":5}" );
+    }
+    SECTION( "map with typed tripoint" ) {
+        std::map<tripoint_abs_omt, float> typed;
+        typed.emplace( tripoint_abs_omt( 8, 8, 0 ), 2.5f );
+        test_serialization( typed, "{\"(8,8,0)\":2.500000}" );
+    }
+}
+
 TEST_CASE( "serialize_optional", "[json]" )
 {
     SECTION( "simple_empty_optional" ) {


### PR DESCRIPTION
#### Summary
Infrastructure "Allow serializing/deserializing std::maps with tripoint keys"

#### Purpose of change
There's several places in the codebase where maps require special serialize/deserialize handling because the limited set of keys supported.

#### Describe the solution
Expand the set of allowed types to include tripoints by adding a key_from_json_string specialization for types with a to_string_writeable function, that writes the value as a string suitable for serialization/deserialization.

Also add a JsonOut::write_as_string specialization for types with this to_string writeable, as these are required for deserialization/serialization respectively.

Add a limited set of test cases for this. There could be more, but the rest should be covered by more specific test cases.

Also add a <typed_tripoint>::from_string, as is necessary for the key_from_json_string specialization to easily encompass more than untyped points.

#### Describe alternatives you've considered
A different serialize/deserialize syntax for maps with keys that are not trivially convertible to strings, as an array of `[ key, value ]` pairs.
I think this is worth doing, but it is not necessary for tripoints.

#### Testing
See test cases.

#### Additional context
I would appreciate review from someone who is more experienced with SFINAE.

I believe all existing cases use the array of key/pair syntax and so are non-trivial to migrate to this new format.