### PR TITLE
stop spawning exactly half empty bags of food

### DIFF
--- a/data/json/itemgroups/Food/food.json
+++ b/data/json/itemgroups/Food/food.json
@@ -48,13 +48,13 @@
       { "item": "dry_corn", "prob": 1 },
       { "item": "dry_fruit", "prob": 10 },
       { "prob": 40, "group": "oatmeal_box_small_4" },
-      { "prob": 15, "group": "fruit_leather_bag_plastic_5" },
+      { "prob": 15, "group": "fruit_leather_bag_plastic_full" },
       { "item": "salted_fish", "prob": 15 },
-      { "prob": 40, "group": "dry_beans_bag_plastic_6" },
-      { "prob": 30, "group": "dry_lentils_bag_plastic_2" },
-      { "prob": 40, "group": "dry_rice_bag_plastic_3" },
+      { "prob": 40, "group": "dry_beans_bag_plastic_full" },
+      { "prob": 30, "group": "dry_lentils_bag_plastic_full" },
+      { "prob": 40, "group": "dry_rice_bag_plastic_full" },
       { "item": "freeze_dried_meal", "prob": 10 },
-      { "prob": 40, "group": "gelatin_powder_bag_plastic_25" },
+      { "prob": 40, "group": "gelatin_powder_bag_plastic_full" },
       { "prob": 15, "group": "chem_agar_bottle_plastic_small_50" },
       { "item": "gelatin_dessert_powder", "prob": 40 },
       { "group": "instant_gravy", "prob": 4 }
@@ -242,8 +242,8 @@
       { "prob": 20, "group": "cocoa_powder_various" },
       { "prob": 20, "group": "milk_cocoa_powder_various" },
       { "prob": 30, "group": "cornmeal_box_small_10" },
-      { "prob": 20, "group": "tortilla_corn_bag_plastic_12" },
-      { "prob": 20, "group": "tortilla_flour_bag_plastic_12" },
+      { "prob": 20, "group": "tortilla_corn_bag_plastic_full" },
+      { "prob": 20, "group": "tortilla_flour_bag_plastic_full" },
       { "prob": 20, "group": "powder_eggs_bottle_plastic_small_16" },
       { "prob": 12, "group": "protein_powder_bottle_plastic_small_1_9" },
       { "item": "dry_meat", "prob": 10 },
@@ -277,9 +277,9 @@
       { "item": "catfood", "prob": 5, "container-item": "can_food" },
       { "prob": 8, "group": "fish_pickled_jar_glass_sealed_2" },
       { "item": "lutefisk", "prob": 1 },
-      { "prob": 40, "group": "dry_beans_bag_plastic_6" },
-      { "prob": 40, "group": "dry_lentils_bag_plastic_2" },
-      { "prob": 40, "group": "dry_rice_bag_plastic_3" },
+      { "prob": 40, "group": "dry_beans_bag_plastic_full" },
+      { "prob": 40, "group": "dry_lentils_bag_plastic_full" },
+      { "prob": 40, "group": "dry_rice_bag_plastic_full" },
       { "prob": 6, "group": "meat_pickled_jar_glass_sealed_2" },
       { "prob": 2, "group": "kitchen_sealed_3L_jar" },
       { "group": "big_canned_food", "prob": 1 },
@@ -525,7 +525,7 @@
       { "prob": 55, "group": "pretzels_bag_plastic_3" },
       { "item": "jerky", "prob": 55 },
       { "prob": 55, "group": "porkstick_bag_plastic_4" },
-      { "prob": 50, "group": "nachos_bag_plastic_3" },
+      { "prob": 50, "group": "nachos_bag_plastic_full" },
       { "prob": 40, "group": "chocpretzels_bag_plastic_3" },
       { "prob": 25, "group": "popcorn_bag_plastic_4" },
       { "prob": 35, "group": "popcorn2_bag_plastic_4" },
@@ -561,7 +561,7 @@
       { "prob": 10, "group": "pepper_various" },
       { "item": "syrup", "prob": 10 },
       { "item": "coffee_syrup", "prob": 10 },
-      { "prob": 25, "group": "fruit_leather_bag_plastic_5" },
+      { "prob": 25, "group": "fruit_leather_bag_plastic_full" },
       { "item": "kernels", "prob": 25 },
       { "prob": 20, "group": "pine_nuts_bag_plastic_4" },
       { "group": "teabag_box", "prob": 10 },
@@ -580,7 +580,7 @@
       { "prob": 15, "group": "granola_bag_plastic_4" },
       { "prob": 8, "group": "mintpatties_bag_plastic_3" },
       { "prob": 8, "group": "choco_coffee_beans_bag_plastic_5" },
-      { "prob": 15, "group": "fruit_leather_bag_plastic_5" },
+      { "prob": 15, "group": "fruit_leather_bag_plastic_full" },
       { "prob": 20, "group": "pine_nuts_bag_plastic_4" }
     ]
   },
@@ -1034,27 +1034,24 @@
   },
   {
     "type": "item_group",
-    "id": "fruit_leather_bag_plastic_5",
+    "id": "fruit_leather_bag_plastic_full",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_plastic_small",
-    "entries": [ { "item": "fruit_leather", "container-item": "null", "count": 5 } ]
+    "entries": [ { "item": "fruit_leather", "container-item": "null", "count": 10 } ]
   },
   {
     "type": "item_group",
-    "id": "dry_lentils_bag_plastic_2",
+    "id": "dry_lentils_bag_plastic_full",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_plastic_small",
-    "entries": [ { "item": "dry_lentils", "container-item": "null", "count": 2 } ]
+    "entries": [ { "item": "dry_lentils", "container-item": "null", "count": 4 } ]
   },
   {
     "type": "item_group",
-    "id": "gelatin_powder_bag_plastic_25",
+    "id": "gelatin_powder_bag_plastic_full",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_plastic_small",
-    "entries": [ { "item": "gelatin_powder", "container-item": "null", "count": 25 } ]
+    "entries": [ { "item": "gelatin_powder", "container-item": "null", "count": 50 } ]
   },
   {
     "type": "item_group",

--- a/data/json/itemgroups/SUS/fridges.json
+++ b/data/json/itemgroups/SUS/fridges.json
@@ -1503,7 +1503,7 @@
       { "group": "pie_meat_box_small_8", "prob": 10 },
       { "group": "pie_maple_box_small_8", "prob": 10 },
       { "group": "bologna_bag_plastic_10", "prob": 15 },
-      { "group": "fruit_leather_bag_plastic_5", "prob": 15 },
+      { "group": "fruit_leather_bag_plastic_full", "prob": 15 },
       { "group": "frozen_dinner_box_small_2", "prob": 25 },
       { "group": "pizza_veggy_box_small_4", "prob": 5 },
       { "group": "pizza_cheese_box_small_4", "prob": 5 },

--- a/data/json/itemgroups/food_service.json
+++ b/data/json/itemgroups/food_service.json
@@ -698,8 +698,8 @@
       { "item": "hot_sauce", "prob": 25 },
       { "prob": 60, "group": "sugar_various_full" },
       { "prob": 15, "group": "artificial_sweetener_box_small_71" },
-      { "prob": 65, "group": "dry_rice_bag_plastic_3" },
-      { "prob": 5, "group": "dry_wild_rice_bag_plastic_3" },
+      { "prob": 65, "group": "dry_rice_bag_plastic_full" },
+      { "prob": 5, "group": "dry_wild_rice_bag_plastic_full" },
       { "prob": 5, "group": "chem_citric_acid_bottle_glass_50" }
     ]
   },
@@ -1354,7 +1354,7 @@
         ],
         "prob": 60
       },
-      { "prob": 30, "group": "nachos_bowl_plastic_3" },
+      { "prob": 30, "group": "nachos_bowl_plastic_full" },
       { "item": "hot_sauce", "prob": 40 }
     ]
   },
@@ -1420,16 +1420,16 @@
     "subtype": "collection",
     "entries": [
       { "group": "pantry_liquids", "prob": 30 },
-      { "prob": 50, "count": [ 1, 3 ], "group": "tortilla_corn_bag_plastic_12" },
-      { "prob": 50, "count": [ 1, 3 ], "group": "tortilla_flour_bag_plastic_12" },
+      { "prob": 50, "count": [ 1, 3 ], "group": "tortilla_corn_bag_plastic_full" },
+      { "prob": 50, "count": [ 1, 3 ], "group": "tortilla_flour_bag_plastic_full" },
       { "item": "sauce_red", "prob": 30 },
-      { "prob": 60, "count": [ 1, 3 ], "group": "nachos_bag_plastic_3" },
+      { "prob": 60, "count": [ 1, 3 ], "group": "nachos_bag_plastic_full" },
       { "prob": 40, "group": "cheese_hard_wrapper_8" },
       { "prob": 20, "count": [ 1, 3 ], "group": "can_beans_can_medium_2" },
-      { "prob": 60, "count": [ 1, 3 ], "group": "dry_beans_bag_plastic_6" },
+      { "prob": 60, "count": [ 1, 3 ], "group": "dry_beans_bag_plastic_full" },
       { "item": "dry_mushroom", "prob": 40, "count": [ 1, 3 ] },
-      { "prob": 20, "count": [ 3, 9 ], "group": "flatbread_bag_plastic_2" },
-      { "prob": 60, "count": [ 1, 3 ], "group": "dry_rice_bag_plastic_3" },
+      { "prob": 20, "count": [ 3, 9 ], "group": "flatbread_bag_plastic_full" },
+      { "prob": 60, "count": [ 1, 3 ], "group": "dry_rice_bag_plastic_full" },
       { "group": "SUS_spice_collection", "prob": 70 },
       { "group": "big_canned_food", "prob": 20, "count": [ 1, 2 ] },
       { "group": "dry_goods", "prob": 30 }
@@ -2454,19 +2454,17 @@
   },
   {
     "type": "item_group",
-    "id": "dry_rice_bag_plastic_3",
+    "id": "dry_rice_bag_plastic_full",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_plastic_small",
-    "entries": [ { "item": "dry_rice", "container-item": "null", "count": 3 } ]
+    "entries": [ { "item": "dry_rice", "container-item": "null", "count": 6 } ]
   },
   {
     "type": "item_group",
-    "id": "dry_wild_rice_bag_plastic_3",
+    "id": "dry_wild_rice_bag_plastic_full",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_plastic_small",
-    "entries": [ { "item": "dry_wild_rice", "container-item": "null", "count": 3 } ]
+    "entries": [ { "item": "dry_wild_rice", "container-item": "null", "count": 6 } ]
   },
   {
     "type": "item_group",
@@ -2799,50 +2797,44 @@
   },
   {
     "type": "item_group",
-    "id": "nachos_bowl_plastic_3",
+    "id": "nachos_bowl_plastic_full",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bowl_plastic",
-    "entries": [ { "item": "nachos", "container-item": "null", "count": 3 } ]
+    "entries": [ { "item": "nachos", "container-item": "null", "count": 9 } ]
   },
   {
     "type": "item_group",
-    "id": "tortilla_corn_bag_plastic_12",
+    "id": "tortilla_corn_bag_plastic_full",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_plastic_small",
-    "entries": [ { "item": "tortilla_corn", "container-item": "null", "count": 12 } ]
+    "entries": [ { "item": "tortilla_corn", "container-item": "null", "count": 25 } ]
   },
   {
     "type": "item_group",
-    "id": "tortilla_flour_bag_plastic_12",
+    "id": "tortilla_flour_bag_plastic_full",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_plastic_small",
-    "entries": [ { "item": "tortilla_flour", "container-item": "null", "count": 12 } ]
+    "entries": [ { "item": "tortilla_flour", "container-item": "null", "count": 25 } ]
   },
   {
     "type": "item_group",
-    "id": "nachos_bag_plastic_3",
+    "id": "nachos_bag_plastic_full",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_plastic_small",
-    "entries": [ { "item": "nachos", "container-item": "null", "count": 3 } ]
+    "entries": [ { "item": "nachos", "container-item": "null", "count": 6 } ]
   },
   {
     "type": "item_group",
-    "id": "dry_beans_bag_plastic_6",
+    "id": "dry_beans_bag_plastic_full",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_plastic_small",
-    "entries": [ { "item": "dry_beans", "container-item": "null", "count": 6 } ]
+    "entries": [ { "item": "dry_beans", "container-item": "null", "count": 12 } ]
   },
   {
     "type": "item_group",
-    "id": "flatbread_bag_plastic_2",
+    "id": "flatbread_bag_plastic_full",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_plastic_small",
-    "entries": [ { "item": "flatbread", "container-item": "null", "count": 2 } ]
+    "entries": [ { "item": "flatbread", "container-item": "null", "count": 8 } ]
   }
 ]

--- a/data/json/mapgen/military/mil_base/mil_base_z0.json
+++ b/data/json/mapgen/military/mil_base/mil_base_z0.json
@@ -527,7 +527,7 @@
         { "group": "MRE", "x": [ 49, 55 ], "y": [ 53, 54 ], "chance": 75, "repeat": 1500 },
         { "group": "MRE", "x": [ 49, 55 ], "y": 48, "chance": 75, "repeat": 750 },
         { "group": "groce_pasta", "x": [ 44, 46 ], "y": 54, "chance": 75, "repeat": [ 50, 150 ] },
-        { "group": "dry_beans_bag_plastic_6", "x": [ 41, 43 ], "y": 54, "chance": 75, "repeat": [ 50, 150 ] },
+        { "group": "dry_beans_bag_plastic_full", "x": [ 41, 43 ], "y": 54, "chance": 75, "repeat": [ 50, 150 ] },
         { "group": "big_canned_food", "x": [ 36, 40 ], "y": 54, "chance": 75, "repeat": [ 50, 150 ] },
         { "group": "oatmeal_box_small_4", "x": [ 45, 46 ], "y": 53, "chance": 75, "repeat": [ 50, 150 ] },
         { "group": "flour_bag_paper", "x": [ 43, 44 ], "y": 53, "chance": 75, "repeat": [ 50, 150 ] },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Balance "spawn full bags of food"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

spawning almost exactly 250ml worth of food (the volume the food happened to have before comestible charges were removed) doesn't make sense compared to just filling the 500 ml container the food is sold in (`bag_plastic_small`).

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

Increase the amounts, rename the itemgroups to convey they represent a full bag.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Also adding whole new itemgroups with randomization to their amounts to represent being used up. That would really benefit from #81352

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
