### PR TITLE
Revert accidental 100x increase in gunshop quantities

### DIFF
--- a/data/json/regional_map_settings.json
+++ b/data/json/regional_map_settings.json
@@ -1086,7 +1086,7 @@
         "gym_fitness": 200,
         "gym_fitness_1": 200,
         "s_liquor": 500,
-        "s_gun_a": 120000,
+        "s_gun_a": 1200,
         "s_gun_b": 300,
         "s_clothes": 450,
         "s_clothes_1": 200,


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
#81619 increased the gunshop rate 100 times for test purposes, but never reverted it, and went unnoticed
#### Describe the solution
Revert
#### Describe alternatives you've considered
Consider making the game to be in Texas