### PR TITLE
Tune and expand furniture bash fields

### DIFF
--- a/data/json/field_type.json
+++ b/data/json/field_type.json
@@ -1882,7 +1882,6 @@
     "display_field": true,
     "looks_like": "fd_smoke"
   },
-
   {
     "id": "fd_electricity_unlit",
     "type": "field_type",

--- a/data/json/field_type.json
+++ b/data/json/field_type.json
@@ -1882,21 +1882,7 @@
     "display_field": true,
     "looks_like": "fd_smoke"
   },
-  {
-    "id": "fd_mechanical_fluid",
-    "type": "field_type",
-    "intensity_levels": [
-      { "name": "mechanical fluid splatter", "color": "light_gray" },
-      { "name": "mechanical fluid stain" },
-      { "name": "puddle of mechanical fluid", "color": "dark_gray" }
-    ],
-    "description_affix": "covered_in",
-    "is_splattering": true,
-    "half_life": "10 days",
-    "phase": "liquid",
-    "display_field": true,
-    "looks_like": "fd_sludge"
-  },
+
   {
     "id": "fd_electricity_unlit",
     "type": "field_type",

--- a/data/json/fields/debris.json
+++ b/data/json/fields/debris.json
@@ -21,7 +21,6 @@
     "mopsafe": true,
     "moppable": true,
     "percent_spread": 20,
-    "half_life": "5 days",
     "phase": "gas",
     "looks_like": "t_open_air"
   },
@@ -37,8 +36,8 @@
     "mopsafe": true,
     "moppable": true,
     "percent_spread": 8,
-    "half_life": "7 days",
-    "phase": "gas"
+    "phase": "gas",
+    "looks_like": "fd_dust"
   },
   {
     "id": "fd_mechanical_fluid",
@@ -50,6 +49,8 @@
     ],
     "description_affix": "covered_in",
     "is_splattering": true,
+    "mopsafe": true,
+    "moppable": true,
     "half_life": "10 days",
     "phase": "liquid",
     "display_field": true,
@@ -64,7 +65,8 @@
       { "name": "puddle of dirty water", "color": "dark_gray" }
     ],
     "description_affix": "covered_in",
-    "is_splattering": true,
+    "mopsafe": true,
+    "moppable": true,
     "half_life": "2 hours",
     "phase": "liquid",
     "display_field": true,

--- a/data/json/fields/debris.json
+++ b/data/json/fields/debris.json
@@ -21,7 +21,9 @@
     "mopsafe": true,
     "moppable": true,
     "percent_spread": 20,
-    "phase": "gas"
+    "half_life": "5 days",
+    "phase": "gas",
+    "looks_like": "t_open_air"
   },
   {
     "type": "field_type",
@@ -35,6 +37,37 @@
     "mopsafe": true,
     "moppable": true,
     "percent_spread": 8,
+    "half_life": "7 days",
     "phase": "gas"
+  },
+  {
+    "id": "fd_mechanical_fluid",
+    "type": "field_type",
+    "intensity_levels": [
+      { "name": "mechanical fluid splatter", "color": "light_gray" },
+      { "name": "mechanical fluid stain" },
+      { "name": "puddle of mechanical fluid", "color": "dark_gray" }
+    ],
+    "description_affix": "covered_in",
+    "is_splattering": true,
+    "half_life": "10 days",
+    "phase": "liquid",
+    "display_field": true,
+    "looks_like": "fd_sludge"
+  },
+  {
+    "id": "fd_dirty_water",
+    "type": "field_type",
+    "intensity_levels": [
+      { "name": "dirty water splatter", "color": "light_gray" },
+      { "name": "dirty water stain" },
+      { "name": "puddle of dirty water", "color": "dark_gray" }
+    ],
+    "description_affix": "covered_in",
+    "is_splattering": true,
+    "half_life": "2 hours",
+    "phase": "liquid",
+    "display_field": true,
+    "looks_like": "water"
   }
 ]

--- a/data/json/fields/debris.json
+++ b/data/json/fields/debris.json
@@ -5,7 +5,7 @@
     "intensity_levels": [
       { "name": "dust", "sym": "%", "color": "brown", "transparent": true, "dangerous": false, "concentration": 1 },
       {
-        "name": "fountain of dust",
+        "name": "dust and grime",
         "sym": "%",
         "color": "brown",
         "transparent": true,
@@ -20,13 +20,13 @@
     "description_affix": "covered_in",
     "mopsafe": true,
     "moppable": true,
-    "percent_spread": 33,
+    "percent_spread": 20,
     "phase": "gas"
   },
   {
     "type": "field_type",
     "id": "fd_splinters",
-    "intensity_levels": [ { "name": "splinters", "sym": "%", "color": "brown", "transparent": true, "dangerous": false, "concentration": 1 } ],
+    "intensity_levels": [ { "name": "wood debris", "sym": "%", "color": "brown", "transparent": true, "dangerous": false, "concentration": 1 } ],
     "priority": 2,
     "dirty_transparency_cache": false,
     "display_items": true,

--- a/data/json/furniture_and_terrain/furniture-industrial.json
+++ b/data/json/furniture_and_terrain/furniture-industrial.json
@@ -21,7 +21,8 @@
         { "item": "metal_tank_little", "count": [ 0, 2 ] },
         { "item": "jerrycan", "count": [ 0, 2 ] },
         { "item": "metal_tank", "count": [ 0, 2 ] }
-      ]
+      ],
+      "destroyed_field": [ "fd_mechanical_fluid", 2 ]
     },
     "deconstruct": {
       "items": [
@@ -33,8 +34,7 @@
         { "item": "metal_tank", "count": [ 2, 4 ] },
         { "item": "motor_small", "count": 1 }
       ]
-    },
-    "destroyed_field": [ "fd_mechanical_fluid", 2 ]
+    }
   },
   {
     "type": "furniture",
@@ -58,7 +58,8 @@
         { "item": "lc_steel_chunk", "count": [ 1, 4 ] },
         { "item": "scrap", "count": [ 3, 7 ] },
         { "item": "pipe", "count": [ 0, 1 ] }
-      ]
+      ],
+      "destroyed_field": [ "fd_mechanical_fluid", 1 ]
     },
     "deconstruct": {
       "items": [
@@ -71,8 +72,7 @@
         { "item": "pipe_fittings", "count": [ 0, 1 ] },
         { "item": "frame", "count": [ 0, 1 ] }
       ]
-    },
-    "destroyed_field": [ "fd_mechanical_fluid", 1 ]
+    }
   },
   {
     "type": "furniture",
@@ -167,9 +167,9 @@
         { "item": "bearing", "charges": [ 2, 8 ] },
         { "item": "frame", "prob": 20 },
         { "item": "motor_small", "prob": 10 }
-      ]
-    },
-    "destroyed_field": [ "fd_mechanical_fluid", 1 ]
+      ],
+      "destroyed_field": [ "fd_mechanical_fluid", 1 ]
+    }
   },
   {
     "type": "furniture",
@@ -225,9 +225,9 @@
         { "item": "motor", "prob": 10 },
         { "item": "metal_tank", "prob": 20 },
         { "item": "motor_large", "prob": 5 }
-      ]
-    },
-    "destroyed_field": [ "fd_mechanical_fluid", 2 ]
+      ],
+      "destroyed_field": [ "fd_mechanical_fluid", 2 ]
+    }
   },
   {
     "type": "furniture",
@@ -470,8 +470,7 @@
         { "item": "power_supply", "count": [ 0, 2 ] },
         { "item": "metal_tank_little", "count": [ 0, 6 ] }
       ]
-    },
-    "destroyed_field": [ "fd_mechanical_fluid", 1 ]
+    }
   },
   {
     "type": "furniture",
@@ -521,9 +520,9 @@
         { "item": "amplifier", "prob": 40 },
         { "item": "plastic_chunk", "count": [ 2, 8 ] },
         { "item": "scrap", "count": [ 3, 8 ] }
-      ]
-    },
-    "destroyed_field": [ "fd_mechanical_fluid", 1 ]
+      ],
+      "destroyed_field": [ "fd_mechanical_fluid", 1 ]
+    }
   },
   {
     "type": "furniture",

--- a/data/json/furniture_and_terrain/furniture-industrial.json
+++ b/data/json/furniture_and_terrain/furniture-industrial.json
@@ -33,7 +33,8 @@
         { "item": "metal_tank", "count": [ 2, 4 ] },
         { "item": "motor_small", "count": 1 }
       ]
-    }
+    },
+    "destroyed_field": [ "fd_mechanical_fluid", 2 ]
   },
   {
     "type": "furniture",
@@ -70,7 +71,8 @@
         { "item": "pipe_fittings", "count": [ 0, 1 ] },
         { "item": "frame", "count": [ 0, 1 ] }
       ]
-    }
+    },
+    "destroyed_field": [ "fd_mechanical_fluid", 1 ]
   },
   {
     "type": "furniture",
@@ -166,7 +168,8 @@
         { "item": "frame", "prob": 20 },
         { "item": "motor_small", "prob": 10 }
       ]
-    }
+    },
+    "destroyed_field": [ "fd_mechanical_fluid", 1 ]
   },
   {
     "type": "furniture",
@@ -223,7 +226,8 @@
         { "item": "metal_tank", "prob": 20 },
         { "item": "motor_large", "prob": 5 }
       ]
-    }
+    },
+    "destroyed_field": [ "fd_mechanical_fluid", 2 ]
   },
   {
     "type": "furniture",
@@ -278,8 +282,8 @@
         { "item": "2x4", "count": 2 },
         { "item": "nail", "charges": [ 2, 5 ] }
       ],
-      "hit_field": [ "fd_dust", 2 ],
-      "destroyed_field": [ "fd_splinters", 1 ]
+      "hit_field": [ "fd_dust", 3 ],
+      "destroyed_field": [ "fd_mechanical_fluid", 1 ]
     }
   },
   {
@@ -466,7 +470,8 @@
         { "item": "power_supply", "count": [ 0, 2 ] },
         { "item": "metal_tank_little", "count": [ 0, 6 ] }
       ]
-    }
+    },
+    "destroyed_field": [ "fd_mechanical_fluid", 1 ]
   },
   {
     "type": "furniture",
@@ -517,7 +522,8 @@
         { "item": "plastic_chunk", "count": [ 2, 8 ] },
         { "item": "scrap", "count": [ 3, 8 ] }
       ]
-    }
+    },
+    "destroyed_field": [ "fd_mechanical_fluid", 1 ]
   },
   {
     "type": "furniture",

--- a/data/json/furniture_and_terrain/furniture-medical.json
+++ b/data/json/furniture_and_terrain/furniture-medical.json
@@ -43,7 +43,8 @@
         { "item": "amplifier", "prob": 25 },
         { "item": "plastic_chunk", "count": [ 4, 10 ], "prob": 50 },
         { "item": "scrap", "count": [ 2, 6 ], "prob": 50 }
-      ]
+      ],
+      "destroyed_field": [ "fd_mechanical_fluid", 1 ]
     }
   },
   {
@@ -81,8 +82,7 @@
         { "item": "sheet_cotton", "count": [ 3, 4 ] },
         { "item": "cotton_patchwork", "count": [ 3, 4 ] }
       ],
-      "hit_field": [ "fd_dust", 2 ],
-      "destroyed_field": [ "fd_splinters", 1 ]
+      "destroyed_field": [ "fd_mechanical_fluid", 1 ]
     }
   },
   {
@@ -113,7 +113,8 @@
         { "item": "hose", "count": [ 0, 2 ] },
         { "item": "cu_pipe", "count": [ 1, 4 ] },
         { "item": "scrap_copper", "count": [ 0, 2 ] }
-      ]
+      ],
+      "destroyed_field": [ "fd_mechanical_fluid", 1 ]
     }
   },
   {
@@ -156,7 +157,8 @@
         { "item": "hose", "count": [ 0, 2 ] },
         { "item": "cu_pipe", "count": [ 1, 4 ] },
         { "item": "scrap_copper", "count": [ 0, 2 ] }
-      ]
+      ],
+      "destroyed_field": [ "fd_mechanical_fluid", 1 ]
     }
   },
   {
@@ -201,7 +203,8 @@
         { "item": "cu_pipe", "count": [ 2, 4 ] },
         { "item": "scrap_copper", "count": [ 1, 2 ] },
         { "item": "motor_tiny", "prob": 25 }
-      ]
+      ],
+      "destroyed_field": [ "fd_mechanical_fluid", 1 ]
     }
   },
   {
@@ -288,7 +291,8 @@
         { "item": "pipe", "count": 1 },
         { "item": "glass_shard", "count": [ 25, 100 ] },
         { "item": "cable", "charges": [ 1, 2 ] }
-      ]
+      ],
+      "destroyed_field": [ "fd_mechanical_fluid", 1 ]
     }
   },
   {
@@ -327,7 +331,8 @@
         { "item": "sheet_metal", "count": [ 1, 4 ] },
         { "item": "element", "count": [ 1, 3 ] },
         { "item": "cable", "charges": [ 1, 15 ] }
-      ]
+      ],
+      "destroyed_field": [ "fd_mechanical_fluid", 1 ]
     }
   },
   {
@@ -429,7 +434,8 @@
         { "item": "hose", "count": [ 0, 1 ] },
         { "item": "e_scrap", "count": [ 5, 10 ] },
         { "item": "plastic_chunk", "count": [ 0, 2 ] }
-      ]
+      ],
+      "destroyed_field": [ "fd_mechanical_fluid", 2 ]
     }
   },
   {
@@ -473,7 +479,8 @@
         { "item": "hose", "count": [ 0, 1 ] },
         { "item": "e_scrap", "count": [ 5, 10 ] },
         { "item": "plastic_chunk", "count": [ 0, 2 ] }
-      ]
+      ],
+      "destroyed_field": [ "fd_mechanical_fluid", 2 ]
     }
   },
   {
@@ -513,7 +520,8 @@
         { "item": "cable", "charges": [ 1, 15 ] },
         { "item": "e_scrap", "count": [ 5, 10 ] },
         { "item": "plastic_chunk", "count": [ 0, 2 ] }
-      ]
+      ],
+      "destroyed_field": [ "fd_mechanical_fluid", 2 ]
     }
   },
   {
@@ -552,7 +560,8 @@
         { "item": "cable", "charges": [ 1, 15 ] },
         { "item": "e_scrap", "count": [ 5, 10 ] },
         { "item": "plastic_chunk", "count": [ 0, 2 ] }
-      ]
+      ],
+      "destroyed_field": [ "fd_mechanical_fluid", 2 ]
     }
   },
   {
@@ -590,7 +599,8 @@
         { "item": "cable", "charges": [ 1, 15 ] },
         { "item": "e_scrap", "count": [ 5, 10 ] },
         { "item": "plastic_chunk", "count": [ 0, 2 ] }
-      ]
+      ],
+      "destroyed_field": [ "fd_mechanical_fluid", 1 ]
     }
   },
   {
@@ -630,7 +640,8 @@
         { "item": "cable", "charges": [ 1, 15 ] },
         { "item": "e_scrap", "count": [ 5, 10 ] },
         { "item": "plastic_chunk", "count": [ 0, 2 ] }
-      ]
+      ],
+      "destroyed_field": [ "fd_mechanical_fluid", 2 ]
     }
   },
   {
@@ -670,7 +681,8 @@
         { "item": "cable", "charges": [ 1, 15 ] },
         { "item": "e_scrap", "count": [ 5, 10 ] },
         { "item": "plastic_chunk", "count": [ 0, 2 ] }
-      ]
+      ],
+      "destroyed_field": [ "fd_mechanical_fluid", 2 ]
     }
   },
   {
@@ -750,7 +762,8 @@
         { "item": "hose", "count": [ 0, 1 ] },
         { "item": "e_scrap", "count": [ 5, 10 ] },
         { "item": "plastic_chunk", "count": [ 0, 2 ] }
-      ]
+      ],
+      "destroyed_field": [ "fd_mechanical_fluid", 1 ]
     }
   },
   {
@@ -793,7 +806,8 @@
         { "item": "hose", "count": [ 0, 1 ] },
         { "item": "e_scrap", "count": [ 5, 10 ] },
         { "item": "plastic_chunk", "count": [ 0, 2 ] }
-      ]
+      ],
+      "destroyed_field": [ "fd_mechanical_fluid", 3 ]
     }
   },
   {
@@ -836,7 +850,8 @@
         { "item": "hose", "count": [ 0, 1 ] },
         { "item": "e_scrap", "count": [ 5, 10 ] },
         { "item": "plastic_chunk", "count": [ 0, 2 ] }
-      ]
+      ],
+      "destroyed_field": [ "fd_mechanical_fluid", 1 ]
     }
   },
   {
@@ -939,7 +954,8 @@
         { "item": "mc_steel_chunk", "count": [ 0, 3 ] },
         { "item": "sheet_metal", "count": [ 1, 3 ] },
         { "item": "cable", "charges": [ 1, 15 ] }
-      ]
+      ],
+      "destroyed_field": [ "fd_mechanical_fluid", 1 ]
     }
   },
   {
@@ -979,7 +995,8 @@
         { "item": "cable", "charges": [ 1, 15 ] },
         { "item": "e_scrap", "count": [ 5, 10 ] },
         { "item": "plastic_chunk", "count": [ 0, 2 ] }
-      ]
+      ],
+      "destroyed_field": [ "fd_mechanical_fluid", 1 ]
     }
   },
   {
@@ -1019,7 +1036,8 @@
         { "item": "cable", "charges": [ 1, 15 ] },
         { "item": "e_scrap", "count": [ 2, 4 ] },
         { "item": "plastic_chunk", "count": [ 0, 2 ] }
-      ]
+      ],
+      "destroyed_field": [ "fd_mechanical_fluid", 1 ]
     }
   },
   {

--- a/data/json/furniture_and_terrain/furniture-plumbing.json
+++ b/data/json/furniture_and_terrain/furniture-plumbing.json
@@ -23,7 +23,8 @@
         { "item": "water_faucet", "prob": 50 },
         { "item": "pipe_fittings", "count": [ 0, 2 ] },
         { "item": "ceramic_shard", "count": [ 6, 18 ] }
-      ]
+      ],
+      "destroyed_field": [ "fd_dirty_water", 1 ]
     }
   },
   {
@@ -50,7 +51,8 @@
         { "item": "pipe_fittings", "count": [ 0, 2 ] },
         { "item": "ceramic_shard", "count": [ 2, 6 ] },
         { "item": "glass_shard", "count": [ 8, 16 ] }
-      ]
+      ],
+      "destroyed_field": [ "fd_dirty_water", 1 ]
     }
   },
   {
@@ -77,7 +79,8 @@
         { "item": "water_faucet", "prob": 50 },
         { "item": "pipe_fittings", "count": [ 0, 2 ] },
         { "item": "ceramic_shard", "count": [ 2, 8 ] }
-      ]
+      ],
+      "destroyed_field": [ "fd_dirty_water", 2 ]
     }
   },
   {
@@ -97,7 +100,8 @@
         { "item": "water_faucet", "prob": 50 },
         { "item": "pipe_fittings", "count": [ 0, 2 ] },
         { "item": "30gal_barrel", "prob": 60 }
-      ]
+      ],
+      "destroyed_field": [ "fd_dirty_water", 5 ]
     },
     "//COMMENT": "Currently only used in NPC faction camps. Note that this is an infinite source of water if you use it elsewhere.",
     "examine_action": "water_source"
@@ -124,7 +128,8 @@
         { "item": "cu_pipe", "prob": 50 },
         { "item": "ceramic_shard", "count": [ 2, 8 ] },
         { "item": "wax_paraffin", "count": 1 }
-      ]
+      ],
+      "destroyed_field": [ "fd_dirty_water", 4 ]
     }
   },
   {
@@ -158,7 +163,8 @@
         { "item": "scrap_copper", "count": [ 0, 2 ] },
         { "item": "water_faucet", "count": [ 0, 1 ] },
         { "item": "material_aluminium_ingot", "count": 2 }
-      ]
+      ],
+      "destroyed_field": [ "fd_dirty_water", 4 ]
     }
   },
   {
@@ -192,7 +198,8 @@
         { "item": "scrap_copper", "count": [ 1, 4 ] },
         { "item": "water_faucet", "count": [ 0, 1 ] },
         { "item": "material_aluminium_ingot", "count": 4 }
-      ]
+      ],
+      "destroyed_field": [ "fd_dirty_water", 4 ]
     }
   },
   {
@@ -224,7 +231,8 @@
         { "item": "e_scrap", "count": [ 5, 10 ] },
         { "item": "plastic_chunk", "count": [ 0, 2 ] },
         { "item": "cu_pipe", "count": [ 1, 3 ] }
-      ]
+      ],
+      "destroyed_field": [ "fd_dirty_water", 4 ]
     }
   }
 ]

--- a/data/json/furniture_and_terrain/furniture_refrigeration.json
+++ b/data/json/furniture_and_terrain/furniture_refrigeration.json
@@ -17,7 +17,8 @@
       "str_max": 50,
       "sound": "metal screeching!",
       "sound_fail": "clang!",
-      "items": [ { "group": "apartment_fridge_destroyed" }, { "group": "apartment_freezer_destroyed" } ]
+      "items": [ { "group": "apartment_fridge_destroyed" }, { "group": "apartment_freezer_destroyed" } ],
+      "destroyed_field": [ "fd_mechanical_fluid", 1 ]
     }
   },
   {
@@ -40,7 +41,8 @@
       "str_max": 50,
       "sound": "metal screeching!",
       "sound_fail": "clang!",
-      "items": [ { "group": "minifridge_destroyed" } ]
+      "items": [ { "group": "minifridge_destroyed" } ],
+      "destroyed_field": [ "fd_mechanical_fluid", 1 ]
     }
   },
   {
@@ -63,7 +65,8 @@
       "str_max": 50,
       "sound": "metal screeching!",
       "sound_fail": "clang!",
-      "items": [ { "group": "glass_fridge_destroyed" } ]
+      "items": [ { "group": "glass_fridge_destroyed" } ],
+      "destroyed_field": [ "fd_mechanical_fluid", 1 ]
     }
   },
   {
@@ -86,7 +89,8 @@
       "str_max": 50,
       "sound": "metal screeching!",
       "sound_fail": "clang!",
-      "items": [ { "group": "glass_fridge_double_destroyed" } ]
+      "items": [ { "group": "glass_fridge_double_destroyed" } ],
+      "destroyed_field": [ "fd_mechanical_fluid", 1 ]
     }
   },
   {
@@ -109,7 +113,8 @@
       "str_max": 50,
       "sound": "metal screeching!",
       "sound_fail": "clang!",
-      "items": [ { "group": "heavy_duty_fridge_destroyed" } ]
+      "items": [ { "group": "heavy_duty_fridge_destroyed" } ],
+      "destroyed_field": [ "fd_mechanical_fluid", 1 ]
     }
   },
   {
@@ -132,7 +137,8 @@
       "str_max": 50,
       "sound": "metal screeching!",
       "sound_fail": "clang!",
-      "items": [ { "group": "display_fridge_destroyed" } ]
+      "items": [ { "group": "display_fridge_destroyed" } ],
+      "destroyed_field": [ "fd_mechanical_fluid", 1 ]
     }
   },
   {
@@ -155,7 +161,8 @@
       "str_max": 50,
       "sound": "metal screeching!",
       "sound_fail": "clang!",
-      "items": [ { "group": "minifreezer_destroyed" } ]
+      "items": [ { "group": "minifreezer_destroyed" } ],
+      "destroyed_field": [ "fd_mechanical_fluid", 1 ]
     }
   },
   {
@@ -178,7 +185,8 @@
       "str_max": 50,
       "sound": "metal screeching!",
       "sound_fail": "clang!",
-      "items": [ { "group": "chest_minifreezer_destroyed" } ]
+      "items": [ { "group": "chest_minifreezer_destroyed" } ],
+      "destroyed_field": [ "fd_mechanical_fluid", 1 ]
     }
   },
   {
@@ -201,7 +209,8 @@
       "str_max": 50,
       "sound": "metal screeching!",
       "sound_fail": "clang!",
-      "items": [ { "group": "chest_freezer_destroyed" } ]
+      "items": [ { "group": "chest_freezer_destroyed" } ],
+      "destroyed_field": [ "fd_mechanical_fluid", 1 ]
     }
   },
   {
@@ -224,7 +233,8 @@
       "str_max": 50,
       "sound": "metal screeching!",
       "sound_fail": "clang!",
-      "items": [ { "group": "heavy_duty_freezer_destroyed" } ]
+      "items": [ { "group": "heavy_duty_freezer_destroyed" } ],
+      "destroyed_field": [ "fd_mechanical_fluid", 1 ]
     }
   },
   {
@@ -247,7 +257,8 @@
       "str_max": 50,
       "sound": "metal screeching!",
       "sound_fail": "clang!",
-      "items": [ { "group": "glass_freezer_destroyed" } ]
+      "items": [ { "group": "glass_freezer_destroyed" } ],
+      "destroyed_field": [ "fd_mechanical_fluid", 1 ]
     }
   },
   {
@@ -270,7 +281,8 @@
       "str_max": 50,
       "sound": "metal screeching!",
       "sound_fail": "clang!",
-      "items": [ { "group": "display_freezer_destroyed" } ]
+      "items": [ { "group": "display_freezer_destroyed" } ],
+      "destroyed_field": [ "fd_mechanical_fluid", 1 ]
     }
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

https://github.com/CleverRaven/Cataclysm-DDA/pull/81565 adds the ability to spawn fields when furniture is struck or bashed. It needs a little bit of tuning and can be expanded for some interesting uses.

#### Describe the solution
- Slightly reduces the spread on dust to avoid it getting a little out of hand.
- Gives dust a "looks_like" of t_open_air, so that if a tileset lacks this tile it doesn't get spammed as this is normally a transparent png.
- causes a wide range of furniture to drop mechanical fluid when bashed. This is the 'blood' of machines but as it will now be seen more often when smashing fridges and things, I've moved it to debris
- Adds a dirty water field to plumbing fixtures and a few other things. This will dry up in a while if ignored. It would be reasonable to make it slippery. Another option here would be to drop water as an item, but as far as I know that never dries up so the field is a little nicer.
- Adjusts the name of the field from "fountain of dust" to "dust and grime" since it is meant to linger.

#### Describe alternatives you've considered

The "field on bash" effect is hugely useful in the building of hostile terrain in the future. I will definitely be using it in the labyrinth. It could easily be applied to a lot of mi-go terrain right away but I would like to keep things small for now.

A lot of the dust release from furniture could probably be dropped in intensity, but I left it for now to see how it goes with the reduced spread.

I considered adding a half-life to dust and splinters, but I don't know if that will impact performance. let's see first how they are with lower visibility.

#### Testing
It do what it say it do! This fridge left behind a puddle.
![image](https://github.com/user-attachments/assets/755c33c9-8290-4916-b70d-299be67ad451)

t_open_air is a decent filler due to its relative low visual weight
![image](https://github.com/user-attachments/assets/2f619050-7196-47d0-a5e4-6ab6a6c3c50a)


#### Additional context

https://github.com/I-am-Erk/CDDA-Tilesets/pull/2698 will not be part of mainline for a month, but if you're running ultica you could download it once this merges and get a subtle tile for this effect, but this PR should make it less intrusive until you do.