### PR TITLE
Penalize melee fighting from on a vehicle, expecially while driving.

### DIFF
--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -412,6 +412,19 @@ float Character::hit_roll() const
         hit -= 2.0f;
     }
 
+    // Greatly impaired accuracy when in a vehicle.
+    // TODO: mitigating factors like "standing on top of a vehicle" instead of "in a vehicle".
+    map &here = get_map();
+    const optional_vpart_position vp_there = here.veh_at( pos_abs() );
+    if( vp_there ) {
+        hit -= 10;
+        vehicle &boarded_vehicle = vp_there->vehicle();
+        if( boarded_vehicle.player_in_control( here, *this ) ) {
+            hit -= 10;
+        }
+        hit -= std::abs( boarded_vehicle.forward_velocity() );
+    }
+
     hit *= get_modifier( character_modifier_melee_attack_roll_mod );
 
     return melee::melee_hit_range( hit );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
I was reminded once again that melee kiting while on a skateboard or bicycle is something our system accidentally makes into a great option since we don't do anything to represent your lack of leverage and bodily mobility that makes this a terrible idea.

#### Describe the solution
Throw some severe melee accuracy penalties at occupying and operating a vehicle, especially if it's in motion.

#### Describe alternatives you've considered
Ideally this would also hit leverage and striking power etc, but this is better than nothing.

#### Additional context
Balance feedback is welcome, but please put a bit more thought into it than "this is too high".