### PR TITLE
Fix camp blueprint autocalc

### DIFF
--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -2537,6 +2537,84 @@ void finalize_constructions()
     finalized = true;
 }
 
+// Using BFS to find the shortest route to create target terrain from empty or base terrain,
+std::vector<construction_id> find_build_sequence( std::string target_id,
+        std::function<bool( construction const & )> const &filter,
+        std::function<bool( construction const & )> const &can_build )
+{
+    // make a post_terrain->construction multimap for speedy search
+    std::unordered_multimap<std::string, const construction *> construction_map;
+    for( const auto &cons : constructions ) {
+        if( !filter( cons ) ) {
+            continue;
+        }
+        construction_map.insert( { cons.post_terrain, &cons } );
+    }
+
+    std::queue<std::string> terrain_queue;
+    std::unordered_map<std::string, std::pair<const construction *, std::string>>
+            parent; // pre, cons , post
+    std::unordered_set<std::string> visited;
+
+    terrain_queue.push( target_id );
+    visited.insert( target_id );
+    std::string base_terrain; // Does this route require base_ter as pre_terrain or not
+    bool found = false;
+    while( !terrain_queue.empty() && !found ) {
+        std::string cur_terrain = terrain_queue.front();
+        terrain_queue.pop();
+
+        // find all constructions whose post_terrain == cur_terrain
+        const auto &range = construction_map.equal_range( cur_terrain );
+        const auto &it = parent.find( cur_terrain );
+        if( it != parent.end() ) {
+            const auto& [cons_ptr, next_terrain] = it->second;
+            if( can_build( *cons_ptr ) ) {
+                base_terrain = cur_terrain;
+                break;
+            }
+        }
+
+        for( auto it = range.first; it != range.second; ++it ) {
+            const auto &cons = it->second;
+            // Does this construction require a pre_terrain or not
+            std::string pre_terrain = cons->pre_terrain.size() == 0 ? "" : *( cons->pre_terrain.begin() );
+
+            // skip visited terrain
+            if( visited.find( pre_terrain ) != visited.end() ) {
+                continue;
+            }
+            // keep record that this pre_terrain turns into cur_terrain through cons
+            visited.insert( pre_terrain );
+            parent[pre_terrain] = std::make_pair( cons, cur_terrain );
+            terrain_queue.push( pre_terrain );
+
+            // success
+            if( can_build( *cons ) ) {
+                found = true;
+                base_terrain = pre_terrain;
+                break;
+            }
+        }
+    }
+    // reconstruct the route from base_ter or empty string
+    std::string current_terrain = base_terrain;
+    // count == 0 means we cannot find a valid route to construct this terrain from the ground up
+    // thus skip it.
+    if( !found ) {
+        return {};
+    }
+    std::vector<construction_id> ret;
+    // go through the parent chain until we find target_terrain
+    while( current_terrain != target_id ) {
+        auto it = parent.find( current_terrain );
+        const auto& [cons_ptr, next_terrain] = it->second;
+        ret.push_back( cons_ptr->id );
+        current_terrain = next_terrain;
+    }
+    return ret;
+}
+
 build_reqs get_build_reqs_for_furn_ter_ids(
     const std::pair<std::map<ter_id, int>, std::map<furn_id, int>> &changed_ids )
 {
@@ -2549,107 +2627,40 @@ build_reqs get_build_reqs_for_furn_ter_ids(
     }
     std::map<construction_id, int> total_builds;
 
-    // iteratively recurse through the pre-terrains until the pre-terrain is empty, adding
-    // the constructions to the total_builds map
-    const auto add_builds = [&total_builds, &base_ter]( const construction & build, int count ) {
-        if( total_builds.find( build.id ) == total_builds.end() ) {
-            total_builds[build.id] = 0;
-        }
-        total_builds[build.id] += count;
-        if( build.pre_terrain.size() > 1 ) {
-            debugmsg( "get_build_reqs_for_furn_ter_ids tried to get reqs for %s which has multiple pre_terrain",
-                      build.str_id.str() );
+    // find the shortest route to create target terrain from empty or base terrain,
+    // adding the constructions to the total_builds map
+    const auto add_builds = [&total_builds, &base_ter]( const std::string & target_id, int count ) {
+
+        std::vector<construction_id> construction_chain = find_build_sequence( target_id, [](
+        construction const & cons ) {
+            return !( cons.post_terrain.empty() || cons.pre_terrain.size() > 1 ||
+                      cons.category == construction_category_REPAIR ||
+                      cons.category == construction_category_DECONSTRUCT );
+        }, [&base_ter]( construction const & cons ) {
+            return cons.pre_terrain.empty() || *cons.pre_terrain.begin() == base_ter.id().str();
+        } );
+
+        // count == 0 means we cannot find a valid route to construct this terrain from the ground up
+        // thus skip it.
+        if( construction_chain.size() == 0 ) {
             return;
         }
-        std::string build_pre_ter = build.pre_terrain.empty() ? "" : *build.pre_terrain.begin();
-        while( !build_pre_ter.empty() ) {
-            bool found_pre = false;
-            // only consider DECORATE constructions if there's no other way to build the target
-            // this will allow painting walls, but will skip un-painting walls as a way to make a wall
-            for( bool allow_decorate : {
-                     false, true
-                 } ) {
-                for( const construction &pre_build : constructions ) {
-                    if( ( pre_build.category == construction_category_DECORATE ) != allow_decorate ) {
-                        continue;
-                    }
-                    if( pre_build.category == construction_category_REPAIR ||
-                        pre_build.category == construction_category_DECONSTRUCT ) {
-                        continue;
-                    }
-                    std::string pre_build_pre_terrain = pre_build.pre_terrain.empty() ? "" : *
-                                                        pre_build.pre_terrain.begin();
-                    if( ( pre_build.post_terrain.empty() ||
-                          ( !pre_build.post_is_furniture &&
-                            ter_id( pre_build.post_terrain ) != base_ter ) ) &&
-                        ( pre_build.pre_terrain.empty() ||
-                          ( pre_build.post_is_furniture &&
-                            ter_id( pre_build_pre_terrain ) == base_ter ) ) &&
-                        pre_build.post_terrain == build_pre_ter &&
-                        pre_build_pre_terrain != build.post_terrain ) {
-                        if( pre_build.pre_terrain.size() > 1 ) {
-                            debugmsg( "get_build_reqs_for_furn_ter_ids tried to recurse into %s which has multiple pre_terrain",
-                                      pre_build.str_id.str() );
-                            return;
-                        }
-                        if( total_builds.find( pre_build.id ) == total_builds.end() ) {
-                            total_builds[pre_build.id] = 0;
-                        }
-                        total_builds[pre_build.id] += count;
-                        build_pre_ter = pre_build_pre_terrain;
-                        found_pre = true;
-                        break;
-                    }
-                }
-                if( found_pre ) {
-                    break;
-                }
+        for( const construction_id con_id : construction_chain ) {
+            if( total_builds.find( con_id ) == total_builds.end() ) {
+                total_builds[con_id] = 0;
             }
-            if( !found_pre ) {
-                break;
-            }
+            total_builds[con_id] += count;
         }
     };
 
     // go through the list of terrains and add their constructions and any pre-constructions
     // to the map of total builds
     for( const auto &ter_data : changed_ids.first ) {
-        bool found = false;
-        // only consider DECORATE constructions if there's no other way to build the target
-        // this will allow painting walls, but will skip un-painting walls as a way to make a wall
-        for( bool allow_decorate : {
-                 false, true
-             } ) {
-            for( const construction &build : constructions ) {
-                if( build.post_terrain.empty() || build.post_is_furniture ||
-                    build.category == construction_category_REPAIR ||
-                    build.category == construction_category_DECONSTRUCT ||
-                    ( build.category == construction_category_DECORATE ) != allow_decorate ) {
-                    continue;
-                }
-                if( ter_id( build.post_terrain ) == ter_data.first ) {
-                    add_builds( build, ter_data.second );
-                    found = true;
-                    break;
-                }
-            }
-            if( found ) {
-                break;
-            }
-        }
+        add_builds( ter_data.first.id().str(), ter_data.second );
     }
     // same, but for furniture
     for( const auto &furn_data : changed_ids.second ) {
-        for( const construction &build : constructions ) {
-            if( build.post_terrain.empty() || !build.post_is_furniture ||
-                build.category == construction_category_REPAIR ) {
-                continue;
-            }
-            if( furn_id( build.post_terrain ) == furn_data.first ) {
-                add_builds( build, furn_data.second );
-                break;
-            }
-        }
+        add_builds( furn_data.first.id().str(), furn_data.second );
     }
 
     for( const auto &build_data : total_builds ) {

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -3,10 +3,12 @@
 #include <algorithm>
 #include <array>
 #include <cstddef>
-#include <initializer_list>
 #include <iterator>
 #include <memory>
 #include <numeric>
+#include <queue>
+#include <unordered_map>
+#include <unordered_set>
 #include <utility>
 
 #include "action.h"

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -86,7 +86,6 @@ static const activity_id ACT_MULTIPLE_CONSTRUCTION( "ACT_MULTIPLE_CONSTRUCTION" 
 static const construction_category_id construction_category_ALL( "ALL" );
 static const construction_category_id construction_category_APPLIANCE( "APPLIANCE" );
 static const construction_category_id construction_category_DECONSTRUCT( "DECONSTRUCT" );
-static const construction_category_id construction_category_DECORATE( "DECORATE" );
 static const construction_category_id construction_category_FILTER( "FILTER" );
 static const construction_category_id construction_category_REPAIR( "REPAIR" );
 
@@ -2540,13 +2539,13 @@ void finalize_constructions()
 }
 
 // Using BFS to find the shortest route to create target terrain from empty or base terrain,
-std::vector<construction_id> find_build_sequence( std::string target_id,
+std::vector<construction_id> find_build_sequence( const std::string &target_id,
         std::function<bool( construction const & )> const &filter,
         std::function<bool( construction const & )> const &can_build )
 {
     // make a post_terrain->construction multimap for speedy search
     std::unordered_multimap<std::string, const construction *> construction_map;
-    for( const auto &cons : constructions ) {
+    for( construction const &cons : constructions ) {
         if( !filter( cons ) ) {
             continue;
         }
@@ -2578,9 +2577,9 @@ std::vector<construction_id> find_build_sequence( std::string target_id,
         }
 
         for( auto it = range.first; it != range.second; ++it ) {
-            const auto &cons = it->second;
+            const construction *cons = it->second;
             // Does this construction require a pre_terrain or not
-            std::string pre_terrain = cons->pre_terrain.size() == 0 ? "" : *( cons->pre_terrain.begin() );
+            std::string pre_terrain = cons->pre_terrain.empty() ? "" : *cons->pre_terrain.begin();
 
             // skip visited terrain
             if( visited.find( pre_terrain ) != visited.end() ) {
@@ -2644,7 +2643,7 @@ build_reqs get_build_reqs_for_furn_ter_ids(
 
         // count == 0 means we cannot find a valid route to construct this terrain from the ground up
         // thus skip it.
-        if( construction_chain.size() == 0 ) {
+        if( construction_chain.empty() ) {
             return;
         }
         for( const construction_id con_id : construction_chain ) {

--- a/src/construction.h
+++ b/src/construction.h
@@ -133,7 +133,7 @@ std::vector<construction *> constructions_by_filter( std::function<bool( constru
         const &filter );
 void check_constructions();
 void finalize_constructions();
-std::vector<construction_id> find_build_sequence( std::string target_id,
+std::vector<construction_id> find_build_sequence( const std::string &target_id,
         std::function<bool( construction const & )> const &filter,
         std::function<bool( construction const & )> const &can_build );
 #endif // CATA_SRC_CONSTRUCTION_H

--- a/src/construction.h
+++ b/src/construction.h
@@ -133,5 +133,7 @@ std::vector<construction *> constructions_by_filter( std::function<bool( constru
         const &filter );
 void check_constructions();
 void finalize_constructions();
-
+std::vector<construction_id> find_build_sequence( std::string target_id,
+        std::function<bool( construction const & )> const &filter,
+        std::function<bool( construction const & )> const &can_build );
 #endif // CATA_SRC_CONSTRUCTION_H

--- a/tests/act_build_test.cpp
+++ b/tests/act_build_test.cpp
@@ -60,14 +60,14 @@ static const itype_id itype_test_multitool( "test_multitool" );
 static const itype_id itype_wearable_atomic_light( "wearable_atomic_light" );
 
 static const ter_str_id ter_t_dirt( "t_dirt" );
+static const ter_str_id ter_t_floor( "t_floor" );
 static const ter_str_id ter_t_metal_grate_window( "t_metal_grate_window" );
 static const ter_str_id ter_t_railroad_rubble( "t_railroad_rubble" );
+static const ter_str_id ter_t_thconc_floor( "t_thconc_floor" );
+static const ter_str_id ter_t_wall_wood( "t_wall_wood" );
 static const ter_str_id ter_t_window_boarded_noglass( "t_window_boarded_noglass" );
 static const ter_str_id ter_t_window_empty( "t_window_empty" );
-static const ter_str_id ter_t_thconc_floor( "t_thconc_floor" );
-static const ter_str_id ter_t_floor( "t_floor" );
 static const ter_str_id ter_t_window_no_curtains( "t_window_no_curtains" );
-static const ter_str_id ter_t_wall_wood( "t_wall_wood" );
 
 static const zone_type_id zone_type_CONSTRUCTION_BLUEPRINT( "CONSTRUCTION_BLUEPRINT" );
 static const zone_type_id zone_type_LOOT_UNSORTED( "LOOT_UNSORTED" );

--- a/tests/act_build_test.cpp
+++ b/tests/act_build_test.cpp
@@ -39,17 +39,17 @@
 
 static const activity_id ACT_MULTIPLE_CONSTRUCTION( "ACT_MULTIPLE_CONSTRUCTION" );
 
-
-static const construction_str_id construction_constr_thconc_floor( "constr_thconc_floor" );
+static const construction_str_id construction_constr_floor( "constr_floor" );
 static const construction_str_id
 construction_constr_ov_smreb_cage_thconc_floor( "constr_ov_smreb_cage_thconc_floor" );
 static const construction_str_id construction_constr_pit_shallow( "constr_pit_shallow" );
-static const construction_str_id construction_constr_floor( "constr_floor" );
-static const construction_str_id
-construction_constr_window_no_curtains( "constr_window_no_curtains" );
-static const construction_str_id construction_constr_window_empty( "constr_window_empty" );
+static const construction_str_id construction_constr_thconc_floor( "constr_thconc_floor" );
 static const construction_str_id construction_constr_wall_wood( "constr_wall_wood" );
 static const construction_str_id construction_constr_wall_half( "constr_wall_half" );
+static const construction_str_id construction_constr_window_empty( "constr_window_empty" );
+static const construction_str_id
+construction_constr_window_no_curtains( "constr_window_no_curtains" );
+
 static const faction_id faction_free_merchants( "free_merchants" );
 
 static const itype_id itype_bow_saw( "bow_saw" );

--- a/tests/act_build_test.cpp
+++ b/tests/act_build_test.cpp
@@ -10,6 +10,7 @@
 
 #include "activity_handlers.h"
 #include "avatar.h"
+#include "build_reqs.h"
 #include "calendar.h"
 #include "cata_catch.h"
 #include "character.h"

--- a/tests/act_build_test.cpp
+++ b/tests/act_build_test.cpp
@@ -39,6 +39,17 @@
 
 static const activity_id ACT_MULTIPLE_CONSTRUCTION( "ACT_MULTIPLE_CONSTRUCTION" );
 
+
+static const construction_str_id construction_constr_thconc_floor( "constr_thconc_floor" );
+static const construction_str_id
+construction_constr_ov_smreb_cage_thconc_floor( "constr_ov_smreb_cage_thconc_floor" );
+static const construction_str_id construction_constr_pit_shallow( "constr_pit_shallow" );
+static const construction_str_id construction_constr_floor( "constr_floor" );
+static const construction_str_id
+construction_constr_window_no_curtains( "constr_window_no_curtains" );
+static const construction_str_id construction_constr_window_empty( "constr_window_empty" );
+static const construction_str_id construction_constr_wall_wood( "constr_wall_wood" );
+static const construction_str_id construction_constr_wall_half( "constr_wall_half" );
 static const faction_id faction_free_merchants( "free_merchants" );
 
 static const itype_id itype_bow_saw( "bow_saw" );
@@ -53,6 +64,10 @@ static const ter_str_id ter_t_metal_grate_window( "t_metal_grate_window" );
 static const ter_str_id ter_t_railroad_rubble( "t_railroad_rubble" );
 static const ter_str_id ter_t_window_boarded_noglass( "t_window_boarded_noglass" );
 static const ter_str_id ter_t_window_empty( "t_window_empty" );
+static const ter_str_id ter_t_thconc_floor( "t_thconc_floor" );
+static const ter_str_id ter_t_floor( "t_floor" );
+static const ter_str_id ter_t_window_no_curtains( "t_window_no_curtains" );
+static const ter_str_id ter_t_wall_wood( "t_wall_wood" );
 
 static const zone_type_id zone_type_CONSTRUCTION_BLUEPRINT( "CONSTRUCTION_BLUEPRINT" );
 static const zone_type_id zone_type_LOOT_UNSORTED( "LOOT_UNSORTED" );
@@ -331,23 +346,7 @@ TEST_CASE( "npc_act_multiple_construction", "[npc][zones][activities][constructi
 
 TEST_CASE( "camp_blueprint_autocalc", "[camp][construction]" )
 {
-    static const ter_str_id ter_t_thconc_floor( "t_thconc_floor" );
-    static const construction_str_id construction_constr_thconc_floor( "constr_thconc_floor" );
-    static const construction_str_id
-    construction_constr_ov_smreb_cage_thconc_floor( "constr_ov_smreb_cage_thconc_floor" );
-    static const construction_str_id construction_constr_pit_shallow( "constr_pit_shallow" );
 
-    static const ter_str_id ter_t_floor( "t_floor" );
-    static const construction_str_id construction_constr_floor( "constr_floor" );
-
-    static const ter_str_id ter_t_window_no_curtains( "t_window_no_curtains" );
-    static const construction_str_id
-    construction_constr_window_no_curtains( "constr_window_no_curtains" );
-    static const construction_str_id construction_constr_window_empty( "constr_window_empty" );
-
-    static const ter_str_id ter_t_wall_wood( "t_wall_wood" );
-    static const construction_str_id construction_constr_wall_wood( "constr_wall_wood" );
-    static const construction_str_id construction_constr_wall_half( "constr_wall_half" );
 
     build_reqs total_reqs;
     const auto add_build = [&total_reqs]( const construction_str_id & con_id ) {
@@ -358,7 +357,7 @@ TEST_CASE( "camp_blueprint_autocalc", "[camp][construction]" )
 
     WHEN( "ter_t_thconc_floor" ) {
         std::pair<std::map<ter_id, int>, std::map<furn_id, int>> changed_ids = { {{ter_t_thconc_floor.id(), 1}}, {} };
-        auto auto_build_reqs = get_build_reqs_for_furn_ter_ids( changed_ids );
+        build_reqs auto_build_reqs = get_build_reqs_for_furn_ter_ids( changed_ids );
         total_reqs.time = 0;
         total_reqs.raw_reqs.clear();
 
@@ -373,7 +372,7 @@ TEST_CASE( "camp_blueprint_autocalc", "[camp][construction]" )
     }
     WHEN( "ter_t_floor" ) {
         std::pair<std::map<ter_id, int>, std::map<furn_id, int>> changed_ids = { { {ter_t_floor.id(), 1}}, {} };
-        auto auto_build_reqs = get_build_reqs_for_furn_ter_ids( changed_ids );
+        build_reqs auto_build_reqs = get_build_reqs_for_furn_ter_ids( changed_ids );
         total_reqs.time = 0;
         total_reqs.raw_reqs.clear();
 
@@ -386,7 +385,7 @@ TEST_CASE( "camp_blueprint_autocalc", "[camp][construction]" )
     }
     WHEN( "ter_t_window_no_curtains" ) {
         std::pair<std::map<ter_id, int>, std::map<furn_id, int>> changed_ids = { {{ter_t_window_no_curtains.id(), 1}}, {} };
-        auto auto_build_reqs = get_build_reqs_for_furn_ter_ids( changed_ids );
+        build_reqs auto_build_reqs = get_build_reqs_for_furn_ter_ids( changed_ids );
         total_reqs.time = 0;
         total_reqs.raw_reqs.clear();
 
@@ -400,7 +399,7 @@ TEST_CASE( "camp_blueprint_autocalc", "[camp][construction]" )
     }
     WHEN( "ter_t_wall_wood" ) {
         std::pair<std::map<ter_id, int>, std::map<furn_id, int>> changed_ids = { { {ter_t_wall_wood.id(), 1}}, {} };
-        auto auto_build_reqs = get_build_reqs_for_furn_ter_ids( changed_ids );
+        build_reqs auto_build_reqs = get_build_reqs_for_furn_ter_ids( changed_ids );
         total_reqs.time = 0;
         total_reqs.raw_reqs.clear();
 

--- a/tests/act_build_test.cpp
+++ b/tests/act_build_test.cpp
@@ -327,3 +327,88 @@ TEST_CASE( "npc_act_multiple_construction", "[npc][zones][activities][constructi
     u.set_fac( faction_free_merchants );
     run_test_case( u );
 }
+
+TEST_CASE( "camp_blueprint_autocalc", "[camp][construction]" )
+{
+    static const ter_str_id ter_t_thconc_floor( "t_thconc_floor" );
+    static const construction_str_id construction_constr_thconc_floor( "constr_thconc_floor" );
+    static const construction_str_id
+    construction_constr_ov_smreb_cage_thconc_floor( "constr_ov_smreb_cage_thconc_floor" );
+    static const construction_str_id construction_constr_pit_shallow( "constr_pit_shallow" );
+
+    static const ter_str_id ter_t_floor( "t_floor" );
+    static const construction_str_id construction_constr_floor( "constr_floor" );
+
+    static const ter_str_id ter_t_window_no_curtains( "t_window_no_curtains" );
+    static const construction_str_id
+    construction_constr_window_no_curtains( "constr_window_no_curtains" );
+    static const construction_str_id construction_constr_window_empty( "constr_window_empty" );
+
+    static const ter_str_id ter_t_wall_wood( "t_wall_wood" );
+    static const construction_str_id construction_constr_wall_wood( "constr_wall_wood" );
+    static const construction_str_id construction_constr_wall_half( "constr_wall_half" );
+
+    build_reqs total_reqs;
+    const auto add_build = [&total_reqs]( const construction_str_id & con_id ) {
+        const construction &build = con_id.obj();
+        total_reqs.time += build.time;
+        total_reqs.raw_reqs[build.requirements] += 1;
+    };
+
+    WHEN( "ter_t_thconc_floor" ) {
+        std::pair<std::map<ter_id, int>, std::map<furn_id, int>> changed_ids = { {{ter_t_thconc_floor.id(), 1}}, {} };
+        auto auto_build_reqs = get_build_reqs_for_furn_ter_ids( changed_ids );
+        total_reqs.time = 0;
+        total_reqs.raw_reqs.clear();
+
+        add_build( construction_constr_thconc_floor );
+        add_build( construction_constr_ov_smreb_cage_thconc_floor );
+        add_build( construction_constr_pit_shallow );
+
+        CHECK( total_reqs.time == auto_build_reqs.time );
+        for( const auto &req : total_reqs.raw_reqs ) {
+            CHECK( req.second == auto_build_reqs.raw_reqs[req.first] );
+        }
+    }
+    WHEN( "ter_t_floor" ) {
+        std::pair<std::map<ter_id, int>, std::map<furn_id, int>> changed_ids = { { {ter_t_floor.id(), 1}}, {} };
+        auto auto_build_reqs = get_build_reqs_for_furn_ter_ids( changed_ids );
+        total_reqs.time = 0;
+        total_reqs.raw_reqs.clear();
+
+        add_build( construction_constr_floor );
+
+        CHECK( total_reqs.time == auto_build_reqs.time );
+        for( const auto &req : total_reqs.raw_reqs ) {
+            CHECK( req.second == auto_build_reqs.raw_reqs[req.first] );
+        }
+    }
+    WHEN( "ter_t_window_no_curtains" ) {
+        std::pair<std::map<ter_id, int>, std::map<furn_id, int>> changed_ids = { {{ter_t_window_no_curtains.id(), 1}}, {} };
+        auto auto_build_reqs = get_build_reqs_for_furn_ter_ids( changed_ids );
+        total_reqs.time = 0;
+        total_reqs.raw_reqs.clear();
+
+        add_build( construction_constr_window_no_curtains );
+        add_build( construction_constr_window_empty );
+
+        CHECK( total_reqs.time == auto_build_reqs.time );
+        for( const auto &req : total_reqs.raw_reqs ) {
+            CHECK( req.second == auto_build_reqs.raw_reqs[req.first] );
+        }
+    }
+    WHEN( "ter_t_wall_wood" ) {
+        std::pair<std::map<ter_id, int>, std::map<furn_id, int>> changed_ids = { { {ter_t_wall_wood.id(), 1}}, {} };
+        auto auto_build_reqs = get_build_reqs_for_furn_ter_ids( changed_ids );
+        total_reqs.time = 0;
+        total_reqs.raw_reqs.clear();
+
+        add_build( construction_constr_wall_wood );
+        add_build( construction_constr_wall_half );
+        CHECK( total_reqs.time == auto_build_reqs.time );
+        for( const auto &req : total_reqs.raw_reqs ) {
+            CHECK( req.second == auto_build_reqs.raw_reqs[req.first] );
+        }
+    }
+
+}

--- a/tests/act_build_test.cpp
+++ b/tests/act_build_test.cpp
@@ -44,8 +44,8 @@ static const construction_str_id
 construction_constr_ov_smreb_cage_thconc_floor( "constr_ov_smreb_cage_thconc_floor" );
 static const construction_str_id construction_constr_pit_shallow( "constr_pit_shallow" );
 static const construction_str_id construction_constr_thconc_floor( "constr_thconc_floor" );
-static const construction_str_id construction_constr_wall_wood( "constr_wall_wood" );
 static const construction_str_id construction_constr_wall_half( "constr_wall_half" );
+static const construction_str_id construction_constr_wall_wood( "constr_wall_wood" );
 static const construction_str_id construction_constr_window_empty( "constr_window_empty" );
 static const construction_str_id
 construction_constr_window_no_curtains( "constr_window_no_curtains" );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Fix camp blueprint autocalc"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fix #81634

There are a few problems with the original implementation:
1. It doesn't treat `REINFORCE` category like `DECORATE` category, so `t_window_no_curtains` is constructed through removing duct tape from taped windows.
2. The filter is too strict to correctly compute the pre_terrain requirements for terrains like `t_thconc_floor` , see the issue for details.
3. After removing the strict filter, the recursion still doesn't stop when there's a construction whose pre_terrain is `t_dirt`. Instead, it tries to construct `t_dirt` by constructing then destructing `t_rubber_mulch`, creating weird requirement for `shredded_rubber`.
4. The most prominent of all, I cannot figure out a way to determine that a shallow pit shouldn't be constructed by `constr_exhume`. This construction needs a non-construct-able terrain `t_grave` as pre_terrain, just like some blueprint mapgen creates `t_dirtmound` that cannot be constructed. To make the latter case work, non-construct-able terrain should be considered as cost nothing and construct-able. So does `t_grave`. This consequently makes `constr_exhume` a valid way to dig a shallow pit.

Problem 1,2 and 3 can be fixed by patching the original implementation, but problem 4 cannot. Therefore, we must compare different approaches to build a terrain.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Using BFS to find the shortest route to create target terrain from empty or base terrain ( in this case, `t_dirt` ).

First, I construct a multimap that uses `post_terrain` as key and construction pointer as value. The original implementation and many other cases doesn't consider constructions that don't have a `post_terrain`.

I only excluded `REPAIR` and `DESTRUCT` categories. I don't think `DECORATE` category needs a special case, as the shortest way to construct a wall from the ground up shouldn't contain taking paint off a painted wall.

Then I find the list of constructions that can create target terrain. Using their pre_terrain (if exists) as new target terrain, recursively repeat the look up process. Stores the relations of pre_terrain, post_terrain and construction in a unordered_map, basically forming a graph. When I find a construction that has no pre_terrain or has `t_dirt` as pre_terrain, stop.

Finally, reconstruct the route by searching in that unordered_map (graph).

Make it a standalone function so that zone construction might be able to reuse it ( not in this pr )


<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Patch the original method: not able to solve all problems.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Added one test unit. 

Basecamp upgrade requirement seems good:

![图片](https://github.com/user-attachments/assets/088cbbca-e41f-4979-9a38-c44b6a7412aa)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
