### PR TITLE
Fix molotovs processing too many times

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -14826,8 +14826,12 @@ bool item::process_tool( Character *carrier, const tripoint_bub_ms &pos )
         }
     }
 
-    type->tick( carrier, *this, pos );
-    return false;
+    // Complicated safety net in case an item with charges slipped through.
+    const int num_to_destroy = type->tick( carrier, *this, pos );
+    if( num_to_destroy < 0 || num_to_destroy > 1 ) {
+        debugmsg( "Item %s consumes charges via tick_action, but should not", tname() );
+    }
+    return num_to_destroy; // Implicit conversion to bool!
 }
 
 bool item::process_blackpowder_fouling( Character *carrier )


### PR DESCRIPTION
#### Summary
Bugfixes "Fix molotovs processing too many times"

#### Purpose of change
Here's a short demonstration video. Notice that after I throw the molotov it remains on the ground, and after passing a turn the flames get bigger (?!).

https://github.com/user-attachments/assets/cbb6b394-0779-4899-aa85-1cfc3ee95fdc

The lit molotov is an active item and therefore processing every turn, but it never gets deleted. Instead, it gets destroyed by the action of the fire. (When exactly the fire destroys it is variable, but it will always 'tick' at least twice).

This is because we're discarding the return value of itype::tick().

#### Describe the solution
Build a stupid safety net and don't discard the return value. Properly destroy the item.

#### Describe alternatives you've considered
~~DELETE CHARGES~~ working on that...

add_field should probably be refactored at some point so that it doesn't increase the intensity of existing fields. This is not [the first time](https://github.com/CleverRaven/Cataclysm-DDA/pull/77149) that overload has caused issues. I can imagine it's only going to keep causing issues. If we absolutely need to keep that behavior it should be separated out into a specific function, like `add_or_mod_field()` which explicitly names what it does.

#### Testing
Spawn molotov, light molotov, throw molotov. Notice that not every field is a raging fire. Notice that the lit molotov does not remain on the ground.

#### Additional context
