### PR TITLE
Make terrain able to have an underlying item for supplemental info

### DIFF
--- a/data/json/furniture_and_terrain/furniture-appliances.json
+++ b/data/json/furniture_and_terrain/furniture-appliances.json
@@ -95,25 +95,8 @@
     "max_volume": "120 L",
     "examine_action": { "type": "appliance_convert", "furn_set": "f_null", "item": "household_dishwasher" },
     "flags": [ "CONTAINER", "PLACE_ITEM", "BLOCKSDOOR", "FLAT_SURF", "MINEABLE", "EASY_DECONSTRUCT", "NO_SELF_CONNECT" ],
-    "deconstruct": { "items": [ { "item": "household_dishwasher", "count": 1 } ] },
-    "bash": {
-      "str_min": 18,
-      "str_max": 50,
-      "sound": "metal screeching!",
-      "sound_fail": "clang!",
-      "items": [
-        { "item": "scrap", "count": [ 2, 7 ] },
-        { "item": "mc_steel_chunk", "count": [ 0, 3 ] },
-        { "item": "sheet_metal_small", "count": [ 8, 12 ] },
-        { "item": "sheet_metal", "count": [ 1, 2 ] },
-        { "item": "cotton_patchwork", "count": [ 5, 10 ] },
-        { "item": "pipe_fittings", "count": [ 1, 3 ] },
-        { "item": "cable", "charges": [ 1, 15 ] },
-        { "item": "hose", "count": [ 0, 1 ] },
-        { "item": "cu_pipe", "count": [ 1, 4 ] },
-        { "item": "scrap_copper", "count": [ 0, 2 ] }
-      ]
-    }
+    "item": "household_dishwasher",
+    "bash": { "str_min": 18, "str_max": 50, "sound": "metal screeching!", "sound_fail": "clang!" }
   },
   {
     "type": "furniture",
@@ -212,24 +195,8 @@
     "max_volume": "135 L",
     "examine_action": { "type": "appliance_convert", "furn_set": "f_null", "item": "household_washing_machine" },
     "flags": [ "CONTAINER", "PLACE_ITEM", "BLOCKSDOOR", "FLAT_SURF", "MINEABLE", "EASY_DECONSTRUCT", "SMALL_HIDE" ],
-    "deconstruct": { "items": [ { "item": "household_washing_machine", "count": 1 } ] },
-    "bash": {
-      "str_min": 18,
-      "str_max": 50,
-      "sound": "metal screeching!",
-      "sound_fail": "clang!",
-      "items": [
-        { "item": "scrap", "count": [ 2, 7 ] },
-        { "item": "mc_steel_chunk", "count": [ 0, 3 ] },
-        { "item": "sheet_metal_small", "count": [ 8, 12 ] },
-        { "item": "sheet_metal", "count": [ 1, 4 ] },
-        { "item": "cable", "charges": [ 1, 15 ] },
-        { "item": "hose", "count": [ 0, 2 ] },
-        { "item": "pipe_fittings", "count": [ 1, 3 ] },
-        { "item": "cu_pipe", "count": [ 1, 4 ] },
-        { "item": "scrap_copper", "count": [ 0, 2 ] }
-      ]
-    }
+    "item": "household_washing_machine",
+    "bash": { "str_min": 18, "str_max": 50, "sound": "metal screeching!", "sound_fail": "clang!" }
   },
   {
     "type": "furniture",
@@ -254,22 +221,9 @@
       "SMALL_HIDE",
       "NO_SELF_CONNECT"
     ],
-    "deconstruct": { "items": [ { "item": "oven", "count": 1 } ] },
+    "item": "oven",
     "max_volume": "120 L",
-    "bash": {
-      "str_min": 8,
-      "str_max": 30,
-      "sound": "metal screeching!",
-      "sound_fail": "clang!",
-      "items": [
-        { "item": "sheet_metal", "count": [ 1, 4 ] },
-        { "item": "sheet_metal_small", "count": [ 8, 12 ] },
-        { "item": "mc_steel_chunk", "count": [ 0, 3 ] },
-        { "item": "scrap", "count": [ 0, 6 ] },
-        { "item": "element", "count": [ 1, 3 ] },
-        { "item": "cable", "charges": [ 1, 3 ] }
-      ]
-    },
+    "bash": { "str_min": 8, "str_max": 30, "sound": "metal screeching!", "sound_fail": "clang!" },
     "crafting_pseudo_item": "oven"
   },
   {
@@ -579,23 +533,8 @@
     "required_str": -1,
     "examine_action": { "type": "appliance_convert", "furn_set": "f_null", "item": "ground_solar_panel" },
     "flags": [ "TRANSPARENT" ],
-    "deconstruct": { "items": [ { "item": "ground_solar_panel", "count": 1 } ] },
-    "bash": {
-      "str_min": 10,
-      "str_max": 20,
-      "sound": "whack!",
-      "sound_fail": "clang!",
-      "items": [
-        { "item": "solar_cell", "count": [ 4, 20 ] },
-        { "item": "scrap", "count": [ 12, 24 ] },
-        { "item": "amplifier", "count": [ 0, 2 ] },
-        { "item": "cable", "charges": [ 40, 60 ] },
-        { "item": "power_supply", "count": [ 0, 2 ] },
-        { "item": "scrap", "count": [ 16, 24 ] },
-        { "item": "plastic_chunk", "count": [ 4, 8 ] },
-        { "item": "mc_steel_chunk", "count": 12 }
-      ]
-    }
+    "item": "ground_solar_panel",
+    "bash": { "str_min": 10, "str_max": 20, "sound": "whack!", "sound_fail": "clang!" }
   },
   {
     "type": "furniture",
@@ -606,23 +545,8 @@
     "symbol": "#",
     "color": "light_blue",
     "examine_action": { "type": "appliance_convert", "furn_set": "f_null", "item": "ground_solar_panel_v2" },
-    "deconstruct": { "items": [ { "item": "ground_solar_panel_v2", "count": 1 } ] },
-    "bash": {
-      "str_min": 10,
-      "str_max": 20,
-      "sound": "whack!",
-      "sound_fail": "clang!",
-      "items": [
-        { "item": "solar_cell_v2", "count": [ 4, 20 ] },
-        { "item": "scrap", "count": [ 12, 24 ] },
-        { "item": "amplifier", "count": [ 0, 2 ] },
-        { "item": "cable", "charges": [ 40, 60 ] },
-        { "item": "power_supply", "count": [ 0, 2 ] },
-        { "item": "scrap", "count": [ 16, 24 ] },
-        { "item": "plastic_chunk", "count": [ 4, 8 ] },
-        { "item": "mc_steel_chunk", "count": 12 }
-      ]
-    }
+    "item": "ground_solar_panel_v2",
+    "bash": { "str_min": 10, "str_max": 20, "sound": "whack!", "sound_fail": "clang!" }
   },
   {
     "type": "furniture",
@@ -635,22 +559,8 @@
     "required_str": 12,
     "examine_action": { "type": "appliance_convert", "furn_set": "f_null", "item": "oxygen_concentrator" },
     "flags": [ "OBSTACLE" ],
-    "deconstruct": { "items": [ { "item": "oxygen_concentrator", "count": 1 } ] },
-    "bash": {
-      "str_min": 35,
-      "str_max": 140,
-      "sound": "crunch!",
-      "sound_fail": "clang!",
-      "items": [
-        { "item": "plastic_chunk", "count": [ 4, 7 ] },
-        { "item": "mc_steel_chunk", "count": [ 3, 6 ] },
-        { "item": "sheet_metal_small", "count": [ 4, 8 ] },
-        { "item": "scrap", "count": [ 4, 7 ] },
-        { "item": "element", "count": [ 0, 2 ] },
-        { "item": "glass_shard", "prob": 50 },
-        { "item": "motor_small", "prob": 25 }
-      ]
-    }
+    "item": "oxygen_concentrator",
+    "bash": { "str_min": 35, "str_max": 140, "sound": "crunch!", "sound_fail": "clang!" }
   },
   {
     "type": "furniture",
@@ -663,18 +573,7 @@
     "required_str": 16,
     "examine_action": { "type": "appliance_convert", "furn_set": "f_null", "item": "hd_compressor_unit" },
     "flags": [ "OBSTACLE" ],
-    "deconstruct": { "items": [ { "item": "hd_compressor_unit", "count": 1 } ] },
-    "bash": {
-      "str_min": 45,
-      "str_max": 180,
-      "sound": "metal screeching!",
-      "sound_fail": "clang!",
-      "items": [
-        { "item": "plastic_chunk", "count": [ 1, 2 ] },
-        { "item": "scrap", "count": [ 6, 12 ] },
-        { "item": "mc_steel_chunk", "count": [ 8, 16 ] },
-        { "item": "sheet_metal_small", "count": [ 1, 4 ] }
-      ]
-    }
+    "item": "hd_compressor_unit",
+    "bash": { "str_min": 45, "str_max": 180, "sound": "metal screeching!", "sound_fail": "clang!" }
   }
 ]

--- a/data/json/furniture_and_terrain/furniture-barriers.json
+++ b/data/json/furniture_and_terrain/furniture-barriers.json
@@ -238,14 +238,8 @@
     "required_str": -1,
     "examine_action": "chainfence",
     "flags": [ "TRANSPARENT", "NOITEM", "THIN_OBSTACLE", "PERMEABLE", "FLAMMABLE_ASH", "CLIMBABLE", "EASY_DECONSTRUCT" ],
-    "deconstruct": { "items": [ { "item": "long_pole", "count": 1 } ] },
-    "bash": {
-      "str_min": 5,
-      "str_max": 12,
-      "sound": "whump!",
-      "sound_fail": "whack!",
-      "items": [ { "item": "long_pole", "count": [ 0, 1 ] } ]
-    }
+    "item": "long_pole",
+    "bash": { "str_min": 5, "str_max": 12, "sound": "whump!", "sound_fail": "whack!" }
   },
   {
     "type": "furniture",

--- a/data/json/furniture_and_terrain/furniture-decorative.json
+++ b/data/json/furniture_and_terrain/furniture-decorative.json
@@ -130,14 +130,13 @@
     "required_str": 5,
     "flags": [ "PLACE_ITEM", "TRANSPARENT", "FLAMMABLE", "EASY_DECONSTRUCT" ],
     "deployed_item": "mannequin",
-    "deconstruct": { "items": [ { "item": "mannequin", "count": 1 } ] },
+    "item": "mannequin",
     "examine_action": "deployed_furniture",
     "bash": {
       "str_min": 6,
       "str_max": 40,
       "sound": "smash!",
       "sound_fail": "whump.",
-      "items": [ { "item": "splinter", "count": [ 9, 12 ] } ],
       "hit_field": [ "fd_dust", 2 ],
       "destroyed_field": [ "fd_splinters", 1 ]
     }
@@ -224,20 +223,8 @@
     "required_str": 1,
     "examine_action": { "type": "appliance_convert", "furn_set": "f_null", "item": "standing_lamp" },
     "flags": [ "TRANSPARENT", "BLOCKSDOOR", "PLACE_ITEM", "EASY_DECONSTRUCT" ],
-    "deconstruct": { "items": [ { "item": "standing_lamp", "count": 1 } ] },
-    "bash": {
-      "str_min": 12,
-      "str_max": 40,
-      "sound": "metal screeching!",
-      "sound_fail": "bonk!",
-      "items": [
-        { "item": "scrap", "count": [ 1, 3 ] },
-        { "item": "cable", "charges": [ 0, 1 ] },
-        { "item": "e_scrap", "count": [ 0, 1 ] },
-        { "item": "glass_shard", "count": [ 0, 8 ] },
-        { "item": "pipe", "count": [ 0, 1 ] }
-      ]
-    }
+    "item": "standing_lamp",
+    "bash": { "str_min": 12, "str_max": 40, "sound": "metal screeching!", "sound_fail": "bonk!" }
   },
   {
     "type": "furniture",

--- a/data/json/furniture_and_terrain/furniture-fireplaces.json
+++ b/data/json/furniture_and_terrain/furniture-fireplaces.json
@@ -79,19 +79,9 @@
     "crafting_pseudo_item": "fake_fireplace",
     "flags": [ "PLACE_ITEM", "TRANSPARENT", "FIRE_CONTAINER", "EASY_DECONSTRUCT" ],
     "deployed_item": "brazier",
-    "deconstruct": { "items": [ { "item": "brazier", "count": 1 } ] },
+    "item": "brazier",
     "examine_action": "fireplace",
-    "bash": {
-      "str_min": 8,
-      "str_max": 30,
-      "sound": "metal screeching!",
-      "sound_fail": "clang!",
-      "items": [
-        { "item": "scrap", "count": [ 5, 15 ] },
-        { "item": "lc_steel_chunk", "count": [ 2, 6 ] },
-        { "item": "sheet_metal_small", "count": [ 2, 6 ] }
-      ]
-    }
+    "bash": { "str_min": 8, "str_max": 30, "sound": "metal screeching!", "sound_fail": "clang!" }
   },
   {
     "type": "furniture",
@@ -108,19 +98,9 @@
     "crafting_pseudo_item": "fake_fireplace",
     "flags": [ "PLACE_ITEM", "TRANSPARENT", "FIRE_CONTAINER", "EASY_DECONSTRUCT" ],
     "deployed_item": "makeshift_brazier",
-    "deconstruct": { "items": [ { "item": "makeshift_brazier", "count": 1 } ] },
+    "item": "makeshift_brazier",
     "examine_action": "fireplace",
-    "bash": {
-      "str_min": 8,
-      "str_max": 30,
-      "sound": "metal screeching!",
-      "sound_fail": "clang!",
-      "items": [
-        { "item": "scrap", "count": [ 3, 6 ] },
-        { "item": "lc_steel_chunk", "count": [ 1, 3 ] },
-        { "item": "sheet_metal_small", "count": [ 1, 3 ] }
-      ]
-    }
+    "bash": { "str_min": 8, "str_max": 30, "sound": "metal screeching!", "sound_fail": "clang!" }
   },
   {
     "type": "furniture",
@@ -134,20 +114,10 @@
     "required_str": 4,
     "flags": [ "PLACE_ITEM", "TRANSPARENT", "FIRE_CONTAINER", "EASY_DECONSTRUCT" ],
     "deployed_item": "hobo_stove",
-    "deconstruct": { "items": [ { "item": "hobo_stove", "count": 1 } ] },
+    "item": "hobo_stove",
     "examine_action": "fireplace",
     "max_volume": "680 ml",
-    "bash": {
-      "str_min": 8,
-      "str_max": 30,
-      "sound": "metal screeching!",
-      "sound_fail": "clang!",
-      "items": [
-        { "item": "scrap", "count": [ 2, 4 ] },
-        { "item": "lc_steel_chunk", "count": [ 1, 2 ] },
-        { "item": "sheet_metal_small", "count": [ 1, 2 ] }
-      ]
-    }
+    "bash": { "str_min": 8, "str_max": 30, "sound": "metal screeching!", "sound_fail": "clang!" }
   },
   {
     "type": "furniture",
@@ -187,19 +157,9 @@
     "required_str": 8,
     "flags": [ "PLACE_ITEM", "TRANSPARENT", "FIRE_CONTAINER", "EASY_DECONSTRUCT" ],
     "deployed_item": "55gal_firebarrel",
-    "deconstruct": { "items": [ { "item": "55gal_firebarrel", "count": 1 } ] },
+    "item": "55gal_firebarrel",
     "examine_action": "fireplace",
-    "bash": {
-      "str_min": 8,
-      "str_max": 30,
-      "sound": "metal screeching!",
-      "sound_fail": "clang!",
-      "items": [
-        { "item": "scrap", "count": [ 8, 20 ] },
-        { "item": "sheet_metal_small", "count": [ 3, 10 ] },
-        { "item": "sheet_metal", "count": [ 0, 1 ] }
-      ]
-    }
+    "bash": { "str_min": 8, "str_max": 30, "sound": "metal screeching!", "sound_fail": "clang!" }
   },
   {
     "type": "furniture",
@@ -214,15 +174,9 @@
     "required_str": 8,
     "flags": [ "PLACE_ITEM", "TRANSPARENT", "FIRE_CONTAINER", "EASY_DECONSTRUCT" ],
     "deployed_item": "30gal_firebarrel",
-    "deconstruct": { "items": [ { "item": "30gal_firebarrel", "count": 1 } ] },
+    "item": "30gal_firebarrel",
     "examine_action": "fireplace",
-    "bash": {
-      "str_min": 8,
-      "str_max": 30,
-      "sound": "metal screeching!",
-      "sound_fail": "clang!",
-      "items": [ { "item": "scrap", "count": [ 5, 15 ] }, { "item": "sheet_metal_small", "count": [ 1, 9 ] } ]
-    }
+    "bash": { "str_min": 8, "str_max": 30, "sound": "metal screeching!", "sound_fail": "clang!" }
   },
   {
     "id": "f_firering",

--- a/data/json/furniture_and_terrain/furniture-industrial.json
+++ b/data/json/furniture_and_terrain/furniture-industrial.json
@@ -116,9 +116,9 @@
     "required_str": 2,
     "deployed_item": "xedra_antenna",
     "examine_action": "deployed_furniture",
+    "item": "xedra_antenna",
     "flags": [ "TRANSPARENT", "FLAMMABLE", "MOUNTABLE", "CAN_SIT" ],
-    "max_volume": "600 L",
-    "deconstruct": { "items": [ { "item": "xedra_antenna", "count": 1 } ] }
+    "max_volume": "600 L"
   },
   {
     "type": "furniture",

--- a/data/json/furniture_and_terrain/furniture-medical.json
+++ b/data/json/furniture_and_terrain/furniture-medical.json
@@ -97,23 +97,13 @@
     "required_str": 16,
     "looks_like": "f_washer",
     "flags": [ "CONTAINER", "PLACE_ITEM", "BLOCKSDOOR", "FLAT_SURF", "EASY_DECONSTRUCT" ],
-    "deconstruct": { "items": [ { "item": "autoclave", "count": 1 } ] },
+    "item": "autoclave",
     "examine_action": "autoclave_empty",
     "bash": {
       "str_min": 40,
       "str_max": 80,
       "sound": "metal screeching!",
       "sound_fail": "clang!",
-      "items": [
-        { "item": "scrap", "count": [ 2, 7 ] },
-        { "item": "mc_steel_chunk", "count": [ 0, 3 ] },
-        { "item": "sheet_metal_small", "count": [ 8, 12 ] },
-        { "item": "sheet_metal", "count": [ 1, 4 ] },
-        { "item": "cable", "charges": [ 1, 15 ] },
-        { "item": "hose", "count": [ 0, 2 ] },
-        { "item": "cu_pipe", "count": [ 1, 4 ] },
-        { "item": "scrap_copper", "count": [ 0, 2 ] }
-      ],
       "destroyed_field": [ "fd_mechanical_fluid", 1 ]
     }
   },

--- a/data/json/furniture_and_terrain/furniture-plumbing.json
+++ b/data/json/furniture_and_terrain/furniture-plumbing.json
@@ -147,23 +147,12 @@
     "//": "keg_capacity assumed to be from model XE36S06ST45U0 water heater <https://images.thdstatic.com/catalog/pdfImages/2d/2d7ed116-1a8c-439d-b7fe-a62a0a98f806.pdf>",
     "examine_action": "keg",
     "keg_capacity": "100 L",
-    "deconstruct": { "items": [ { "item": "household_water_heater", "count": 1 } ] },
+    "item": "household_water_heater",
     "bash": {
       "str_min": 18,
       "str_max": 50,
       "sound": "metal screeching!",
       "sound_fail": "clang!",
-      "items": [
-        { "item": "scrap", "count": [ 2, 7 ] },
-        { "item": "lc_steel_chunk", "count": [ 0, 3 ] },
-        { "item": "sheet_metal", "count": [ 2, 6 ] },
-        { "item": "cable", "charges": [ 1, 15 ] },
-        { "item": "hose", "count": [ 0, 2 ] },
-        { "item": "cu_pipe", "count": [ 1, 4 ] },
-        { "item": "scrap_copper", "count": [ 0, 2 ] },
-        { "item": "water_faucet", "count": [ 0, 1 ] },
-        { "item": "material_aluminium_ingot", "count": 2 }
-      ],
       "destroyed_field": [ "fd_dirty_water", 4 ]
     }
   },
@@ -182,23 +171,12 @@
     "//": "keg_capacity assumed to be from model XG55T06EC50UO water heater <https://images.thdstatic.com/catalog/pdfImages/7e/7e7928b1-8b4f-472a-8ee8-b48eb1e7932a.pdf>",
     "examine_action": "keg",
     "keg_capacity": "200 L",
-    "deconstruct": { "items": [ { "item": "household_water_heater_family", "count": 1 } ] },
+    "item": "household_water_heater_family",
     "bash": {
       "str_min": 18,
       "str_max": 50,
       "sound": "metal screeching!",
       "sound_fail": "clang!",
-      "items": [
-        { "item": "scrap", "count": [ 4, 14 ] },
-        { "item": "lc_steel_chunk", "count": [ 1, 6 ] },
-        { "item": "sheet_metal", "count": [ 4, 12 ] },
-        { "item": "cable", "charges": [ 1, 15 ] },
-        { "item": "hose", "count": [ 1, 4 ] },
-        { "item": "cu_pipe", "count": [ 1, 8 ] },
-        { "item": "scrap_copper", "count": [ 1, 4 ] },
-        { "item": "water_faucet", "count": [ 0, 1 ] },
-        { "item": "material_aluminium_ingot", "count": 4 }
-      ],
       "destroyed_field": [ "fd_dirty_water", 4 ]
     }
   },
@@ -215,23 +193,12 @@
     "required_str": -1,
     "examine_action": { "type": "appliance_convert", "furn_set": "f_null", "item": "stationary_water_purifier" },
     "flags": [ "EASY_DECONSTRUCT", "SMALL_HIDE" ],
-    "deconstruct": { "items": [ { "item": "stationary_water_purifier", "count": 1 } ] },
+    "item": "stationary_water_purifier",
     "bash": {
       "str_min": 15,
       "str_max": 50,
       "sound": "metal screeching!",
       "sound_fail": "clang!",
-      "items": [
-        { "item": "scrap", "count": [ 2, 7 ] },
-        { "item": "lc_steel_chunk", "count": [ 0, 3 ] },
-        { "item": "sheet_metal_small", "count": [ 8, 12 ] },
-        { "item": "sheet_metal", "count": [ 1, 2 ] },
-        { "item": "cable", "charges": [ 1, 15 ] },
-        { "item": "hose", "count": [ 0, 1 ] },
-        { "item": "e_scrap", "count": [ 5, 10 ] },
-        { "item": "plastic_chunk", "count": [ 0, 2 ] },
-        { "item": "cu_pipe", "count": [ 1, 3 ] }
-      ],
       "destroyed_field": [ "fd_dirty_water", 4 ]
     }
   }

--- a/data/json/furniture_and_terrain/furniture-recreation.json
+++ b/data/json/furniture_and_terrain/furniture-recreation.json
@@ -154,22 +154,12 @@
     "required_str": 12,
     "examine_action": { "type": "appliance_convert", "furn_set": "f_null", "item": "arcade_machine" },
     "flags": [ "BLOCKSDOOR", "TRANSPARENT", "EASY_DECONSTRUCT", "SMALL_HIDE" ],
-    "deconstruct": { "items": [ { "item": "arcade_machine", "count": 1 } ] },
+    "item": "arcade_machine",
     "bash": {
       "str_min": 6,
       "str_max": 35,
       "sound": "smash!",
       "sound_fail": "whump!",
-      "items": [
-        { "item": "splinter", "count": [ 0, 6 ] },
-        { "item": "television", "prob": 50 },
-        { "item": "2x4", "count": [ 2, 6 ] },
-        { "item": "nail", "charges": [ 4, 10 ] },
-        { "item": "cable", "charges": [ 4, 10 ] },
-        { "item": "circuit", "count": [ 0, 4 ] },
-        { "item": "power_supply", "prob": 50 },
-        { "item": "RAM", "count": [ 0, 2 ] }
-      ],
       "hit_field": [ "fd_dust", 2 ],
       "destroyed_field": [ "fd_splinters", 1 ]
     }
@@ -433,19 +423,12 @@
     "//": "While heavy, most large pianos have casters for relatively easy movement.",
     "flags": [ "FLAMMABLE", "ORGANIC", "BLOCKSDOOR", "EASY_DECONSTRUCT", "SMALL_HIDE" ],
     "examine_action": { "type": "effect_on_condition", "effect_on_conditions": [ "EOC_PLAY_PIANO" ] },
-    "deconstruct": { "items": [ { "item": "piano", "count": 1 } ] },
+    "item": "piano",
     "bash": {
       "str_min": 12,
       "str_max": 40,
       "sound": "a suffering piano!",
       "sound_fail": "kerchang.",
-      "items": [
-        { "item": "2x4", "count": [ 4, 8 ] },
-        { "item": "qt_wire", "count": [ 0, 5 ] },
-        { "item": "nail", "charges": [ 6, 12 ] },
-        { "item": "splinter", "count": 1 },
-        { "item": "plastic_chunk", "count": [ 1, 5 ] }
-      ],
       "hit_field": [ "fd_dust", 2 ],
       "destroyed_field": [ "fd_splinters", 1 ]
     }
@@ -607,17 +590,12 @@
     "required_str": -1,
     "flags": [ "TRANSPARENT", "FLAMMABLE", "EASY_DECONSTRUCT" ],
     "crafting_pseudo_item": "pseudo_training_dummy_light",
-    "deconstruct": { "items": [ { "item": "training_dummy_light", "count": 1 } ] },
+    "item": "training_dummy_light",
     "bash": {
       "str_min": 25,
       "str_max": 75,
       "sound": "smash!",
       "sound_fail": "whump.",
-      "items": [
-        { "item": "2x4", "count": [ 2, 4 ] },
-        { "item": "nail", "charges": [ 5, 18 ] },
-        { "item": "splinter", "count": [ 5, 17 ] }
-      ],
       "hit_field": [ "fd_dust", 2 ],
       "destroyed_field": [ "fd_splinters", 1 ]
     }
@@ -633,18 +611,12 @@
     "required_str": -1,
     "flags": [ "TRANSPARENT", "FLAMMABLE", "EASY_DECONSTRUCT" ],
     "crafting_pseudo_item": "pseudo_training_dummy_heavy",
-    "deconstruct": { "items": [ { "item": "training_dummy_heavy", "count": 1 } ] },
+    "item": "training_dummy_heavy",
     "bash": {
       "str_min": 75,
       "str_max": 150,
       "sound": "smash!",
       "sound_fail": "thump!",
-      "items": [
-        { "item": "2x4", "count": [ 2, 4 ] },
-        { "item": "nail", "charges": [ 5, 18 ] },
-        { "item": "splinter", "count": [ 5, 17 ] },
-        { "item": "scrap", "count": [ 15, 60 ] }
-      ],
       "hit_field": [ "fd_dust", 2 ],
       "destroyed_field": [ "fd_splinters", 1 ]
     }
@@ -660,18 +632,8 @@
     "required_str": 5,
     "flags": [ "TRANSPARENT", "FLAMMABLE", "EASY_DECONSTRUCT" ],
     "crafting_pseudo_item": "pseudo_archery_target_box",
-    "deconstruct": { "items": [ { "item": "archery_target_box", "count": 1 } ] },
-    "bash": {
-      "str_min": 4,
-      "str_max": 12,
-      "sound": "whish!",
-      "sound_fail": "whish.",
-      "items": [
-        { "item": "cardboard", "count": [ 20, 80 ] },
-        { "item": "sheet_cotton", "count": [ 6, 21 ] },
-        { "item": "cotton_patchwork", "count": [ 2, 7 ] }
-      ]
-    }
+    "item": "archery_target_box",
+    "bash": { "str_min": 4, "str_max": 12, "sound": "whish!", "sound_fail": "whish." }
   },
   {
     "type": "furniture",

--- a/data/json/furniture_and_terrain/furniture-seats.json
+++ b/data/json/furniture_and_terrain/furniture-seats.json
@@ -44,7 +44,7 @@
     "floor_bedding_warmth": 500,
     "bonus_fire_warmth_feet": 1000,
     "required_str": 7,
-    "deconstruct": { "items": [ { "item": "armchair", "count": 1 } ] },
+    "item": "armchair",
     "flags": [
       "TRANSPARENT",
       "FLAMMABLE_ASH",
@@ -60,13 +60,6 @@
       "str_max": 40,
       "sound": "smash!",
       "sound_fail": "whump.",
-      "items": [
-        { "item": "wooden_post_short", "count": [ 0, 3 ] },
-        { "item": "nuts_bolts", "charges": [ 2, 8 ] },
-        { "item": "splinter", "count": [ 5, 35 ] },
-        { "item": "sheet_cotton", "count": [ 6, 10 ] },
-        { "item": "cotton_patchwork", "count": [ 2, 7 ] }
-      ],
       "hit_field": [ "fd_dust", 2 ],
       "destroyed_field": [ "fd_splinters", 1 ]
     }
@@ -126,17 +119,12 @@
     "bonus_fire_warmth_feet": 1000,
     "required_str": 4,
     "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "ORGANIC", "MOUNTABLE", "CAN_SIT", "EASY_DECONSTRUCT", "ALIGN_WORKBENCH" ],
-    "deconstruct": { "items": [ { "item": "chair_wood", "count": 1 } ] },
+    "item": "chair_wood",
     "bash": {
       "str_min": 6,
       "str_max": 25,
       "sound": "smash!",
       "sound_fail": "whump.",
-      "items": [
-        { "item": "wooden_post_short", "count": 1 },
-        { "item": "nuts_bolts", "charges": [ 2, 10 ] },
-        { "item": "splinter", "count": [ 1, 10 ] }
-      ],
       "hit_field": [ "fd_dust", 2 ],
       "destroyed_field": [ "fd_splinters", 1 ]
     }
@@ -195,14 +183,13 @@
     "bonus_fire_warmth_feet": 1000,
     "required_str": 3,
     "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "ORGANIC", "MOUNTABLE", "CAN_SIT", "EASY_DECONSTRUCT", "ALIGN_WORKBENCH" ],
-    "deconstruct": { "items": [ { "item": "stool_wood", "count": 1 } ] },
+    "item": "stool_wood",
     "max_volume": "875 L",
     "bash": {
       "str_min": 6,
       "str_max": 20,
       "sound": "smash!",
       "sound_fail": "whump.",
-      "items": [ { "item": "nuts_bolts", "charges": [ 1, 5 ] }, { "item": "splinter", "count": [ 3, 10 ] } ],
       "hit_field": [ "fd_dust", 2 ],
       "destroyed_field": [ "fd_splinters", 1 ]
     }
@@ -225,19 +212,8 @@
     "examine_action": "deployed_furniture",
     "flags": [ "TRANSPARENT", "SHORT", "CAN_SIT", "EASY_DECONSTRUCT", "ALIGN_WORKBENCH" ],
     "max_volume": "875 L",
-    "deconstruct": { "items": [ { "item": "camp_chair", "count": 1 } ] },
-    "bash": {
-      "str_min": 6,
-      "str_max": 20,
-      "sound": "metal screeching!",
-      "sound_fail": "crash!",
-      "items": [
-        { "item": "lc_steel_chunk", "count": 1 },
-        { "item": "scrap", "charges": [ 3, 20 ] },
-        { "item": "sheet_cotton", "count": [ 0, 1 ] },
-        { "item": "cotton_patchwork", "count": [ 3, 10 ] }
-      ]
-    }
+    "item": "camp_chair",
+    "bash": { "str_min": 6, "str_max": 20, "sound": "metal screeching!", "sound_fail": "crash!" }
   },
   {
     "type": "furniture",
@@ -255,13 +231,12 @@
     "required_str": 5,
     "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "ORGANIC", "MOUNTABLE", "SHORT", "CAN_SIT", "EASY_DECONSTRUCT", "ALIGN_WORKBENCH" ],
     "max_volume": "750 L",
-    "deconstruct": { "items": [ { "item": "stool_log", "count": 1 } ] },
+    "item": "stool_log",
     "bash": {
       "str_min": 12,
       "str_max": 40,
       "sound": "smash!",
       "sound_fail": "whump.",
-      "items": [ { "item": "splinter", "count": [ 2, 30 ] } ],
       "hit_field": [ "fd_dust", 2 ],
       "destroyed_field": [ "fd_splinters", 1 ]
     }
@@ -284,17 +259,12 @@
     "examine_action": "deployed_furniture",
     "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "ORGANIC", "SHORT", "EASY_DECONSTRUCT", "CAN_SIT" ],
     "max_volume": "750 L",
-    "deconstruct": { "items": [ { "item": "deck_chair", "count": 1 } ] },
+    "item": "deck_chair",
     "bash": {
       "str_min": 5,
       "str_max": 25,
       "sound": "smash!",
       "sound_fail": "whump.",
-      "items": [
-        { "item": "splinter", "count": [ 2, 10 ] },
-        { "item": "nuts_bolts", "charges": [ 1, 6 ] },
-        { "item": "sheet_cotton", "count": 1 }
-      ],
       "hit_field": [ "fd_dust", 2 ],
       "destroyed_field": [ "fd_splinters", 1 ]
     }
@@ -410,18 +380,8 @@
     "floor_bedding_warmth": -1000,
     "bonus_fire_warmth_feet": 1000,
     "flags": [ "TRANSPARENT", "MOUNTABLE", "SHORT", "CAN_SIT", "EASY_DECONSTRUCT", "ALIGN_WORKBENCH" ],
-    "deconstruct": { "items": [ { "item": "barstool", "count": 1 } ] },
-    "bash": {
-      "str_min": 10,
-      "str_max": 45,
-      "sound": "metal screeching!",
-      "sound_fail": "crash!",
-      "items": [
-        { "item": "leather", "count": [ 1, 4 ] },
-        { "item": "lc_steel_chunk", "count": [ 1, 14 ] },
-        { "item": "scrap", "charges": [ 10, 65 ] }
-      ]
-    }
+    "item": "barstool",
+    "bash": { "str_min": 10, "str_max": 45, "sound": "metal screeching!", "sound_fail": "crash!" }
   },
   {
     "type": "furniture",
@@ -441,14 +401,8 @@
     "examine_action": "deployed_furniture",
     "flags": [ "TRANSPARENT", "FLAMMABLE", "EASY_DECONSTRUCT", "CAN_SIT", "ALIGN_WORKBENCH" ],
     "max_volume": "750 L",
-    "deconstruct": { "items": [ { "item": "chair_folding", "count": 1 } ] },
-    "bash": {
-      "str_min": 5,
-      "str_max": 15,
-      "sound": "smash!",
-      "sound_fail": "whump.",
-      "items": [ { "item": "plastic_chunk", "count": [ 3, 12 ] }, { "item": "scrap", "charges": [ 5, 25 ] } ]
-    }
+    "item": "chair_folding",
+    "bash": { "str_min": 5, "str_max": 15, "sound": "smash!", "sound_fail": "whump." }
   },
   {
     "type": "furniture",
@@ -465,13 +419,12 @@
     "bonus_fire_warmth_feet": 1000,
     "required_str": 5,
     "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "ORGANIC", "MOUNTABLE", "CAN_SIT", "EASY_DECONSTRUCT", "ALIGN_WORKBENCH" ],
-    "deconstruct": { "items": [ { "item": "chair_plywood", "count": 1 } ] },
+    "item": "chair_plywood",
     "bash": {
       "str_min": 7,
       "str_max": 25,
       "sound": "smash!",
       "sound_fail": "whump.",
-      "items": [ { "item": "splinter", "count": [ 1, 10 ] }, { "item": "scrap", "charges": [ 10, 30 ] } ],
       "hit_field": [ "fd_dust", 2 ],
       "destroyed_field": [ "fd_splinters", 1 ]
     }
@@ -491,17 +444,12 @@
     "bonus_fire_warmth_feet": 1000,
     "required_str": 4,
     "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "ORGANIC", "MOUNTABLE", "CAN_SIT", "EASY_DECONSTRUCT", "ALIGN_WORKBENCH" ],
-    "deconstruct": { "items": [ { "item": "chair_wood_black", "count": 1 } ] },
+    "item": "chair_wood_black",
     "bash": {
       "str_min": 6,
       "str_max": 25,
       "sound": "smash!",
       "sound_fail": "whump.",
-      "items": [
-        { "item": "wooden_post_short", "count": 1 },
-        { "item": "nuts_bolts", "charges": [ 2, 10 ] },
-        { "item": "splinter", "count": [ 1, 10 ] }
-      ],
       "hit_field": [ "fd_dust", 2 ],
       "destroyed_field": [ "fd_splinters", 1 ]
     }
@@ -521,17 +469,12 @@
     "bonus_fire_warmth_feet": 1000,
     "required_str": 4,
     "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "ORGANIC", "MOUNTABLE", "CAN_SIT", "EASY_DECONSTRUCT", "ALIGN_WORKBENCH" ],
-    "deconstruct": { "items": [ { "item": "chair_wood_white", "count": 1 } ] },
+    "item": "chair_wood_white",
     "bash": {
       "str_min": 6,
       "str_max": 25,
       "sound": "smash!",
       "sound_fail": "whump.",
-      "items": [
-        { "item": "wooden_post_short", "count": 1 },
-        { "item": "nuts_bolts", "charges": [ 2, 10 ] },
-        { "item": "splinter", "count": [ 1, 10 ] }
-      ],
       "hit_field": [ "fd_dust", 2 ],
       "destroyed_field": [ "fd_splinters", 1 ]
     }
@@ -571,14 +514,8 @@
     "comfort": 6,
     "floor_bedding_warmth": 500,
     "required_str": 10,
-    "deconstruct": { "items": [ { "item": "beanbag", "count": 1 } ] },
+    "item": "beanbag",
     "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "CAN_SIT", "UNSTABLE" ],
-    "bash": {
-      "str_min": 12,
-      "str_max": 40,
-      "sound": "smash!",
-      "sound_fail": "whump.",
-      "items": [ { "item": "sheet_nylon", "count": 8 }, { "item": "plastic_chunk", "count": [ 10, 20 ] } ]
-    }
+    "bash": { "str_min": 12, "str_max": 40, "sound": "smash!", "sound_fail": "whump." }
   }
 ]

--- a/data/json/furniture_and_terrain/furniture-sleep.json
+++ b/data/json/furniture_and_terrain/furniture-sleep.json
@@ -213,14 +213,8 @@
     "deployed_item": "mattress",
     "examine_action": "deployed_furniture",
     "flags": [ "TRANSPARENT", "SHORT", "FLAMMABLE_ASH", "PLACE_ITEM", "ORGANIC", "MOUNTABLE", "EASY_DECONSTRUCT" ],
-    "deconstruct": { "items": [ { "item": "mattress", "count": 1 } ] },
-    "bash": {
-      "str_min": 8,
-      "str_max": 30,
-      "sound": "rrrrip!",
-      "sound_fail": "whump.",
-      "items": [ { "item": "sheet_cotton", "count": [ 5, 6 ] }, { "item": "cotton_patchwork", "count": [ 8, 15 ] } ]
-    }
+    "item": "mattress",
+    "bash": { "str_min": 8, "str_max": 30, "sound": "rrrrip!", "sound_fail": "whump." }
   },
   {
     "type": "furniture",
@@ -238,18 +232,8 @@
     "deployed_item": "down_mattress",
     "examine_action": "deployed_furniture",
     "flags": [ "TRANSPARENT", "SHORT", "FLAMMABLE_ASH", "PLACE_ITEM", "ORGANIC", "MOUNTABLE" ],
-    "deconstruct": { "items": [ { "item": "down_mattress", "count": 1 } ] },
-    "bash": {
-      "str_min": 8,
-      "str_max": 30,
-      "sound": "rrrrip!",
-      "sound_fail": "whump.",
-      "items": [
-        { "item": "sheet_cotton", "count": 1 },
-        { "item": "cotton_patchwork", "count": [ 10, 15 ] },
-        { "item": "down_feather", "count": [ 45, 55 ] }
-      ]
-    }
+    "item": "down_mattress",
+    "bash": { "str_min": 8, "str_max": 30, "sound": "rrrrip!", "sound_fail": "whump." }
   },
   {
     "type": "furniture",
@@ -263,21 +247,9 @@
     "comfort": 4,
     "floor_bedding_warmth": -1400,
     "required_str": -1,
-    "deconstruct": { "items": [ { "item": "hammock", "count": 1 } ] },
+    "item": "hammock",
     "flags": [ "TRANSPARENT", "FLAMMABLE", "PLACE_ITEM", "ORGANIC", "CAN_SIT", "EASY_DECONSTRUCT" ],
-    "bash": {
-      "str_min": 4,
-      "str_max": 14,
-      "sound": "rrrrip!",
-      "sound_fail": "slap!",
-      "sound_vol": 6,
-      "sound_fail_vol": 3,
-      "items": [
-        { "item": "sheet_cotton", "count": [ 2, 3 ] },
-        { "item": "cotton_patchwork", "count": [ 12, 14 ] },
-        { "item": "rope_makeshift_6", "count": [ 2, 3 ] }
-      ]
-    }
+    "bash": { "str_min": 4, "str_max": 14, "sound": "rrrrip!", "sound_fail": "slap!", "sound_vol": 6, "sound_fail_vol": 3 }
   },
   {
     "type": "furniture",
@@ -291,17 +263,9 @@
     "comfort": 4,
     "floor_bedding_warmth": -1500,
     "required_str": -1,
-    "deconstruct": { "items": [ { "item": "hammock_net", "count": 1 } ] },
+    "item": "hammock_net",
     "flags": [ "TRANSPARENT", "FLAMMABLE", "PLACE_ITEM", "ORGANIC", "CAN_SIT", "EASY_DECONSTRUCT" ],
-    "bash": {
-      "str_min": 2,
-      "str_max": 10,
-      "sound": "rrrrip!",
-      "sound_fail": "slap!",
-      "sound_vol": 6,
-      "sound_fail_vol": 3,
-      "items": [ { "item": "string_36", "count": [ 12, 16 ] }, { "item": "rope_makeshift_6", "count": [ 2, 3 ] } ]
-    }
+    "bash": { "str_min": 2, "str_max": 10, "sound": "rrrrip!", "sound_fail": "slap!", "sound_vol": 6, "sound_fail_vol": 3 }
   },
   {
     "type": "furniture",

--- a/data/json/furniture_and_terrain/furniture-storage.json
+++ b/data/json/furniture_and_terrain/furniture-storage.json
@@ -225,18 +225,12 @@
     "comfort": 1,
     "floor_bedding_warmth": 200,
     "required_str": 3,
-    "deconstruct": { "items": [ { "item": "box_large", "count": 1 } ] },
+    "item": "box_large",
     "max_volume": "324 L",
     "deployed_item": "box_large",
     "examine_action": "deployed_furniture",
     "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "PLACE_ITEM", "ORGANIC", "EASY_DECONSTRUCT", "HIDE_PLACE", "NO_SIGHT", "CONTAINER" ],
-    "bash": {
-      "str_min": 2,
-      "str_max": 15,
-      "sound": "crumple!",
-      "sound_fail": "thud.",
-      "items": [ { "item": "cardboard", "count": [ 150, 180 ] } ]
-    }
+    "bash": { "str_min": 2, "str_max": 15, "sound": "crumple!", "sound_fail": "thud." }
   },
   {
     "type": "furniture",
@@ -251,18 +245,12 @@
     "comfort": 1,
     "floor_bedding_warmth": 200,
     "required_str": 3,
-    "deconstruct": { "items": [ { "item": "box_large_reinforced", "count": 1 } ] },
+    "item": "box_large_reinforced",
     "max_volume": "324 L",
     "deployed_item": "box_large_reinforced",
     "examine_action": "deployed_furniture",
     "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "PLACE_ITEM", "ORGANIC", "EASY_DECONSTRUCT", "HIDE_PLACE", "NO_SIGHT", "CONTAINER" ],
-    "bash": {
-      "str_min": 3,
-      "str_max": 16,
-      "sound": "crumple!",
-      "sound_fail": "thud.",
-      "items": [ { "item": "cardboard", "count": [ 300, 360 ] } ]
-    }
+    "bash": { "str_min": 3, "str_max": 16, "sound": "crumple!", "sound_fail": "thud." }
   },
   {
     "type": "furniture",
@@ -803,14 +791,8 @@
     "required_str": 5,
     "max_volume": "40 L",
     "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "CONTAINER", "PLACE_ITEM", "MOUNTABLE", "SHORT", "SMALL_HIDE", "EASY_DECONSTRUCT" ],
-    "bash": {
-      "str_min": 1,
-      "str_max": 1,
-      "sound": "smash!",
-      "sound_fail": "whump.",
-      "items": [ { "item": "trashcan", "count": 1, "damage": [ 2, 4 ] } ]
-    },
-    "deconstruct": { "items": [ { "item": "trashcan", "count": 1 } ] }
+    "bash": { "str_min": 1, "str_max": 1, "sound": "smash!", "sound_fail": "whump." },
+    "item": "trashcan"
   },
   {
     "type": "furniture",
@@ -1472,20 +1454,12 @@
     "flags": [ "NOITEM", "SEALED", "ALLOW_FIELD_EFFECT", "TRANSPARENT", "FLAMMABLE", "CONTAINER", "LIQUIDCONT", "EASY_DECONSTRUCT" ],
     "examine_action": "keg",
     "keg_capacity": "11250 ml",
-    "deconstruct": { "items": [ { "item": "churn", "count": 1 } ] },
+    "item": "churn",
     "bash": {
       "str_min": 12,
       "str_max": 50,
       "sound": "smash!",
       "sound_fail": "whump.",
-      "items": [
-        { "item": "2x4", "count": [ 6, 12 ] },
-        { "item": "nail", "charges": [ 4, 8 ] },
-        { "item": "water_faucet", "prob": 50 },
-        { "item": "sheet_metal_small", "count": [ 6, 12 ] },
-        { "item": "scrap", "count": [ 10, 20 ] },
-        { "item": "splinter", "count": [ 1, 20 ] }
-      ],
       "hit_field": [ "fd_dust", 2 ],
       "destroyed_field": [ "fd_splinters", 1 ]
     }
@@ -1614,20 +1588,8 @@
     "deployed_item": "foot_locker",
     "examine_action": "deployed_furniture",
     "max_volume": "68208 ml",
-    "deconstruct": { "items": [ { "item": "foot_locker", "count": 1 } ] },
-    "bash": {
-      "str_min": 12,
-      "str_max": 40,
-      "sound": "metal screeching!",
-      "sound_fail": "clang!",
-      "items": [
-        { "item": "sheet_metal_small", "count": [ 3, 8 ] },
-        { "item": "lock", "count": [ 0, 1 ] },
-        { "item": "scrap", "charges": [ 3, 15 ] },
-        { "item": "hinge", "count": [ 0, 2 ] },
-        { "item": "nuts_bolts", "charges": [ 2, 8 ] }
-      ]
-    }
+    "item": "foot_locker",
+    "bash": { "str_min": 12, "str_max": 40, "sound": "metal screeching!", "sound_fail": "clang!" }
   },
   {
     "type": "furniture",
@@ -1644,20 +1606,8 @@
     "deployed_item": "foot_locker_aluminum",
     "examine_action": "deployed_furniture",
     "max_volume": "67669 ml",
-    "deconstruct": { "items": [ { "item": "foot_locker_aluminum", "count": 1 } ] },
-    "bash": {
-      "str_min": 12,
-      "str_max": 40,
-      "sound": "metal screeching!",
-      "sound_fail": "clang!",
-      "items": [
-        { "item": "material_aluminium_ingot", "count": [ 3, 8 ] },
-        { "item": "lock", "count": [ 0, 1 ] },
-        { "item": "scrap_aluminum", "count": [ 3, 15 ] },
-        { "item": "hinge", "count": [ 0, 2 ] },
-        { "item": "nuts_bolts", "charges": [ 2, 8 ] }
-      ]
-    }
+    "item": "foot_locker_aluminum",
+    "bash": { "str_min": 12, "str_max": 40, "sound": "metal screeching!", "sound_fail": "clang!" }
   },
   {
     "type": "furniture",
@@ -1673,18 +1623,8 @@
     "flags": [ "CONTAINER", "PLACE_ITEM", "LIQUIDCONT", "NOITEM", "SEALED", "EASY_DECONSTRUCT" ],
     "examine_action": "keg",
     "keg_capacity": "1635 L",
-    "deconstruct": { "items": [ { "item": "432gal_drum_rubber", "count": 1 } ] },
-    "bash": {
-      "str_min": 90,
-      "str_max": 150,
-      "sound": "metal screeching!",
-      "sound_fail": "clang!",
-      "items": [
-        { "item": "rubber_tire_chunk", "count": [ 40, 60 ] },
-        { "item": "scrap", "count": [ 50, 80 ] },
-        { "item": "water_faucet", "count": [ 0, 2 ] }
-      ]
-    }
+    "item": "432gal_drum_rubber",
+    "bash": { "str_min": 90, "str_max": 150, "sound": "metal screeching!", "sound_fail": "clang!" }
   },
   {
     "type": "furniture",
@@ -1761,6 +1701,6 @@
     "coverage": 1000,
     "required_str": 10,
     "flags": [ "CONTAINER", "FIRE_CONTAINER", "PLACE_ITEM" ],
-    "deconstruct": { "items": [ { "item": "exodii_kiln", "count": 1 } ] }
+    "item": "exodii_kiln"
   }
 ]

--- a/data/json/furniture_and_terrain/furniture-surfaces.json
+++ b/data/json/furniture_and_terrain/furniture-surfaces.json
@@ -159,20 +159,8 @@
     "looks_like": "f_lab_bench",
     "crafting_pseudo_item": "large_surface_pseudo",
     "flags": [ "TRANSPARENT", "PLACE_ITEM", "MOUNTABLE", "FLAT_SURF", "EASY_DECONSTRUCT", "SMALL_HIDE" ],
-    "deconstruct": { "items": [ { "item": "workbench", "count": 1 } ] },
-    "bash": {
-      "str_min": 35,
-      "str_max": 80,
-      "sound": "metal screeching!",
-      "sound_fail": "clang!",
-      "items": [
-        { "item": "pipe", "count": [ 4, 6 ] },
-        { "item": "sheet_metal", "count": [ 0, 1 ] },
-        { "item": "sheet_metal_small", "count": [ 12, 24 ] },
-        { "item": "mc_steel_chunk", "count": [ 4, 8 ] },
-        { "item": "scrap", "count": [ 12, 24 ] }
-      ]
-    },
+    "item": "workbench",
+    "bash": { "str_min": 35, "str_max": 80, "sound": "metal screeching!", "sound_fail": "clang!" },
     "examine_action": "workbench",
     "workbench": { "multiplier": 1.2, "mass": 500000, "volume": "200 L" }
   },
@@ -188,14 +176,8 @@
     "deployed_item": "leather_tarp",
     "crafting_pseudo_item": "large_surface_pseudo",
     "flags": [ "TRANSPARENT", "SHORT", "FLAT_SURF", "CAN_SIT" ],
-    "deconstruct": { "items": [ { "item": "leather_tarp", "count": 1 } ] },
-    "bash": {
-      "str_min": 5,
-      "str_max": 10,
-      "sound": "smash!",
-      "sound_fail": "whump.",
-      "items": [ { "item": "leather_tarp", "count": [ 1, 1 ] } ]
-    },
+    "item": "leather_tarp",
+    "bash": { "str_min": 5, "str_max": 10, "sound": "smash!", "sound_fail": "whump." },
     "examine_action": "workbench",
     "workbench": { "multiplier": 0.85, "mass": 500000, "volume": "500 L" }
   },
@@ -211,14 +193,8 @@
     "deployed_item": "plastic_sheet",
     "crafting_pseudo_item": "large_surface_pseudo",
     "flags": [ "TRANSPARENT", "SHORT", "FLAT_SURF", "CAN_SIT" ],
-    "deconstruct": { "items": [ { "item": "plastic_sheet", "count": 1 } ] },
-    "bash": {
-      "str_min": 5,
-      "str_max": 10,
-      "sound": "whuff!",
-      "sound_fail": "crinkle.",
-      "items": [ { "item": "plastic_sheet", "count": 1 } ]
-    },
+    "item": "plastic_sheet",
+    "bash": { "str_min": 5, "str_max": 10, "sound": "whuff!", "sound_fail": "crinkle." },
     "examine_action": "workbench",
     "workbench": { "multiplier": 0.85, "mass": 500000, "volume": "500 L" }
   },
@@ -234,14 +210,8 @@
     "deployed_item": "fiber_mat",
     "crafting_pseudo_item": "large_surface_pseudo",
     "flags": [ "TRANSPARENT", "SHORT", "FLAT_SURF", "CAN_SIT" ],
-    "deconstruct": { "items": [ { "item": "fiber_mat", "count": 1 } ] },
-    "bash": {
-      "str_min": 5,
-      "str_max": 10,
-      "sound": "smash!",
-      "sound_fail": "whump.",
-      "items": [ { "item": "fiber_mat", "count": [ 1, 1 ] } ]
-    },
+    "item": "fiber_mat",
+    "bash": { "str_min": 5, "str_max": 10, "sound": "smash!", "sound_fail": "whump." },
     "examine_action": "workbench",
     "workbench": { "multiplier": 0.85, "mass": 500000, "volume": "500 L" }
   },
@@ -259,18 +229,8 @@
     "looks_like": "f_table",
     "crafting_pseudo_item": "medium_surface_pseudo",
     "flags": [ "TRANSPARENT", "MOUNTABLE", "SHORT", "FLAT_SURF", "SMALL_HIDE" ],
-    "deconstruct": { "items": [ { "item": "tourist_table", "count": 1 } ] },
-    "bash": {
-      "str_min": 16,
-      "str_max": 50,
-      "sound": "metal screeching!",
-      "sound_fail": "clang!",
-      "items": [
-        { "item": "scrap", "count": [ 4, 8 ] },
-        { "item": "pipe", "count": [ 1, 3 ] },
-        { "item": "sheet_metal_small", "count": [ 4, 8 ] }
-      ]
-    },
+    "item": "tourist_table",
+    "bash": { "str_min": 16, "str_max": 50, "sound": "metal screeching!", "sound_fail": "clang!" },
     "examine_action": "workbench",
     "workbench": { "multiplier": 1.05, "mass": 100000, "volume": "35 L" }
   },
@@ -319,18 +279,12 @@
     "required_str": 5,
     "crafting_pseudo_item": "medium_surface_pseudo",
     "flags": [ "TRANSPARENT", "FLAMMABLE", "ORGANIC", "MOUNTABLE", "SHORT", "FLAT_SURF", "SMALL_HIDE", "EASY_DECONSTRUCT" ],
-    "deconstruct": { "items": [ { "item": "v_table", "count": 1 } ] },
+    "item": "v_table",
     "bash": {
       "str_min": 12,
       "str_max": 50,
       "sound": "smash!",
       "sound_fail": "whump.",
-      "items": [
-        { "item": "2x4", "count": [ 1, 3 ] },
-        { "item": "wood_panel", "prob": 30 },
-        { "item": "nail", "charges": [ 4, 8 ] },
-        { "item": "splinter", "count": [ 3, 6 ] }
-      ],
       "hit_field": [ "fd_dust", 2 ],
       "destroyed_field": [ "fd_splinters", 1 ]
     },

--- a/data/json/furniture_and_terrain/furniture-tools.json
+++ b/data/json/furniture_and_terrain/furniture-tools.json
@@ -162,15 +162,9 @@
     "required_str": -1,
     "crafting_pseudo_item": "fake_forge",
     "flags": [ "TRANSPARENT", "SEALED", "CONTAINER", "NOITEM", "EASY_DECONSTRUCT", "AMMOTYPE_RELOAD" ],
-    "deconstruct": { "items": [ { "item": "char_forge", "count": 1 } ] },
+    "item": "char_forge",
     "examine_action": "reload_furniture",
-    "bash": {
-      "str_min": 4,
-      "str_max": 8,
-      "sound": "crunch!",
-      "sound_fail": "whump.",
-      "items": [ { "item": "char_forge", "count": 1 } ]
-    }
+    "bash": { "str_min": 30, "str_max": 80, "sound": "crunch!", "sound_fail": "whump." }
   },
   {
     "type": "furniture",
@@ -185,15 +179,9 @@
     "required_str": -1,
     "crafting_pseudo_item": "fake_forge",
     "flags": [ "TRANSPARENT", "SEALED", "CONTAINER", "NOITEM", "EASY_DECONSTRUCT", "AMMOTYPE_RELOAD" ],
-    "deconstruct": { "items": [ { "item": "char_forge", "count": 1 } ] },
+    "item": "char_forge",
     "examine_action": "reload_furniture",
-    "bash": {
-      "str_min": 4,
-      "str_max": 8,
-      "sound": "crunch!",
-      "sound_fail": "whump.",
-      "items": [ { "item": "char_forge", "count": 1 } ]
-    }
+    "bash": { "str_min": 30, "str_max": 80, "sound": "crunch!", "sound_fail": "whump." }
   },
   {
     "type": "furniture",
@@ -208,15 +196,9 @@
     "required_str": -1,
     "crafting_pseudo_item": "fake_forge",
     "flags": [ "TRANSPARENT", "SEALED", "CONTAINER", "NOITEM", "EASY_DECONSTRUCT", "AMMOTYPE_RELOAD" ],
-    "deconstruct": { "items": [ { "item": "char_forge", "count": 1 } ] },
+    "item": "char_forge",
     "examine_action": "reload_furniture",
-    "bash": {
-      "str_min": 4,
-      "str_max": 8,
-      "sound": "crunch!",
-      "sound_fail": "whump.",
-      "items": [ { "item": "char_forge", "count": 1 } ]
-    }
+    "bash": { "str_min": 30, "str_max": 80, "sound": "crunch!", "sound_fail": "whump." }
   },
   {
     "type": "furniture",
@@ -230,9 +212,9 @@
     "coverage": 30,
     "required_str": 10,
     "crafting_pseudo_item": "fake_anvil",
-    "deconstruct": { "items": [ { "item": "anvil", "count": 1 } ] },
+    "item": "anvil",
     "flags": [ "TRANSPARENT", "NOITEM", "EASY_DECONSTRUCT" ],
-    "bash": { "str_min": 4, "str_max": 8, "sound": "crunch!", "sound_fail": "whump.", "items": [ { "item": "anvil", "count": 1 } ] }
+    "bash": { "str_min": 130, "str_max": 500, "sound": "crunch!", "sound_fail": "whump." }
   },
   {
     "type": "furniture",
@@ -246,15 +228,9 @@
     "coverage": 30,
     "required_str": 10,
     "crafting_pseudo_item": "fake_anvil",
-    "deconstruct": { "items": [ { "item": "anvil_bronze", "count": 1 } ] },
+    "item": "anvil_bronze",
     "flags": [ "TRANSPARENT", "NOITEM", "EASY_DECONSTRUCT" ],
-    "bash": {
-      "str_min": 4,
-      "str_max": 8,
-      "sound": "crunch!",
-      "sound_fail": "whump.",
-      "items": [ { "item": "anvil_bronze", "count": 1 } ]
-    }
+    "bash": { "str_min": 110, "str_max": 450, "sound": "crunch!", "sound_fail": "whump." }
   },
   {
     "type": "furniture",
@@ -268,15 +244,9 @@
     "coverage": 30,
     "required_str": 20,
     "crafting_pseudo_item": "fake_anvil_heavy",
-    "deconstruct": { "items": [ { "item": "anvil_heavy", "count": 1 } ] },
+    "item": "anvil_heavy",
     "flags": [ "TRANSPARENT", "NOITEM", "EASY_DECONSTRUCT" ],
-    "bash": {
-      "str_min": 4,
-      "str_max": 8,
-      "sound": "crunch!",
-      "sound_fail": "whump.",
-      "items": [ { "item": "anvil_heavy", "count": 1 } ]
-    }
+    "bash": { "str_min": 190, "str_max": 800, "sound": "crunch!", "sound_fail": "whump." }
   },
   {
     "type": "furniture",
@@ -290,15 +260,9 @@
     "coverage": 30,
     "required_str": 10,
     "crafting_pseudo_item": "fake_anvil",
-    "deconstruct": { "items": [ { "item": "anvil_crude", "count": 1 } ] },
+    "item": "anvil_crude",
     "flags": [ "TRANSPARENT", "NOITEM", "EASY_DECONSTRUCT" ],
-    "bash": {
-      "str_min": 4,
-      "str_max": 8,
-      "sound": "crunch!",
-      "sound_fail": "whump.",
-      "items": [ { "item": "anvil_crude", "count": 1 } ]
-    }
+    "bash": { "str_min": 120, "str_max": 480, "sound": "crunch!", "sound_fail": "whump." }
   },
   {
     "type": "furniture",
@@ -356,9 +320,9 @@
     "coverage": 40,
     "required_str": -1,
     "crafting_pseudo_item": "still",
-    "deconstruct": { "items": [ { "item": "still", "count": 1 } ] },
+    "item": "still",
     "flags": [ "TRANSPARENT", "NOITEM", "EASY_DECONSTRUCT" ],
-    "bash": { "str_min": 4, "str_max": 8, "sound": "crunch!", "sound_fail": "whump.", "items": [ { "item": "still", "count": 1 } ] }
+    "bash": { "str_min": 60, "str_max": 150, "sound": "crunch!", "sound_fail": "whump." }
   },
   {
     "type": "furniture",
@@ -371,18 +335,13 @@
     "coverage": 40,
     "required_str": -1,
     "crafting_pseudo_item": "screw_press",
-    "deconstruct": { "items": [ { "item": "screw_press_tool", "count": 1 } ] },
+    "item": "screw_press_tool",
     "flags": [ "TRANSPARENT", "NOITEM", "EASY_DECONSTRUCT" ],
     "bash": {
       "str_min": 4,
       "str_max": 8,
       "sound": "crunch!",
       "sound_fail": "whump.",
-      "items": [
-        { "item": "wood_beam", "count": [ 0, 2 ] },
-        { "item": "2x4", "count": [ 2, 6 ] },
-        { "item": "splinter", "count": [ 5, 20 ] }
-      ],
       "hit_field": [ "fd_dust", 2 ],
       "destroyed_field": [ "fd_splinters", 1 ]
     }
@@ -449,18 +408,8 @@
     "max_volume": "200 L",
     "crafting_pseudo_item": "fake_char_kiln",
     "flags": [ "CONTAINER", "FIRE_CONTAINER", "PLACE_ITEM" ],
-    "deconstruct": { "items": [ { "item": "char_kiln", "count": 1 } ] },
-    "bash": {
-      "str_min": 12,
-      "str_max": 40,
-      "sound": "metal screeching!",
-      "sound_fail": "clang!",
-      "items": [
-        { "item": "mc_steel_lump", "count": [ 2, 12 ] },
-        { "item": "mc_steel_chunk", "count": [ 4, 15 ] },
-        { "item": "pipe", "count": [ 0, 1 ] }
-      ]
-    }
+    "item": "char_kiln",
+    "bash": { "str_min": 12, "str_max": 40, "sound": "metal screeching!", "sound_fail": "clang!" }
   },
   {
     "type": "furniture",
@@ -474,19 +423,9 @@
     "coverage": 40,
     "required_str": -1,
     "examine_action": "kiln_full",
-    "deconstruct": { "items": [ { "item": "char_kiln", "count": 1 } ] },
+    "item": "char_kiln",
     "flags": [ "NOITEM", "SEALED", "CONTAINER", "FIRE_CONTAINER", "SUPPRESS_SMOKE", "PLACE_ITEM" ],
-    "bash": {
-      "str_min": 12,
-      "str_max": 40,
-      "sound": "metal screeching!",
-      "sound_fail": "clang!",
-      "items": [
-        { "item": "mc_steel_lump", "count": [ 2, 12 ] },
-        { "item": "mc_steel_chunk", "count": [ 4, 15 ] },
-        { "item": "pipe", "count": [ 0, 1 ] }
-      ]
-    }
+    "bash": { "str_min": 12, "str_max": 40, "sound": "metal screeching!", "sound_fail": "clang!" }
   },
   {
     "type": "furniture",
@@ -556,18 +495,8 @@
     "max_volume": "200 L",
     "flags": [ "CONTAINER", "FIRE_CONTAINER", "PLACE_ITEM", "EASY_DECONSTRUCT" ],
     "examine_action": { "type": "appliance_convert", "furn_set": "f_null", "item": "arc_furnace" },
-    "deconstruct": { "items": [ { "item": "arc_furnace", "count": 1 } ] },
-    "bash": {
-      "str_min": 18,
-      "str_max": 40,
-      "sound": "metal screeching!",
-      "sound_fail": "clang!",
-      "items": [
-        { "item": "scrap", "count": [ 2, 4 ] },
-        { "item": "ch_steel_chunk", "count": [ 0, 3 ] },
-        { "item": "pipe", "count": [ 0, 4 ] }
-      ]
-    },
+    "item": "arc_furnace",
+    "bash": { "str_min": 18, "str_max": 40, "sound": "metal screeching!", "sound_fail": "clang!" },
     "crafting_pseudo_item": "fake_arc_furnace"
   },
   {
@@ -755,14 +684,8 @@
     "flags": [ "TRANSPARENT", "SEALED", "ALLOW_FIELD_EFFECT", "CONTAINER", "NOITEM", "EASY_DECONSTRUCT", "MINEABLE" ],
     "crafting_pseudo_item": "fake_char_smoker",
     "examine_action": "smoker_options",
-    "deconstruct": { "items": [ { "item": "metal_smoking_rack", "count": 1 } ] },
-    "bash": {
-      "str_min": 18,
-      "str_max": 50,
-      "sound": "metal screeching!",
-      "sound_fail": "clang!",
-      "items": [ { "item": "scrap", "count": 4 }, { "item": "pipe", "count": [ 3, 5 ] } ]
-    }
+    "item": "metal_smoking_rack",
+    "bash": { "str_min": 18, "str_max": 50, "sound": "metal screeching!", "sound_fail": "clang!" }
   },
   {
     "type": "furniture",
@@ -778,14 +701,8 @@
     "flags": [ "TRANSPARENT", "SEALED", "ALLOW_FIELD_EFFECT", "CONTAINER", "NOITEM", "EASY_DECONSTRUCT", "MINEABLE" ],
     "crafting_pseudo_item": "fake_char_smoker",
     "examine_action": "smoker_options",
-    "deconstruct": { "items": [ { "item": "metal_smoking_rack", "count": 1 } ] },
-    "bash": {
-      "str_min": 18,
-      "str_max": 50,
-      "sound": "metal screeching!",
-      "sound_fail": "clang!",
-      "items": [ { "item": "scrap", "count": 4 }, { "item": "pipe", "count": [ 3, 5 ] } ]
-    }
+    "item": "metal_smoking_rack",
+    "bash": { "str_min": 18, "str_max": 50, "sound": "metal screeching!", "sound_fail": "clang!" }
   },
   {
     "type": "furniture",
@@ -895,18 +812,8 @@
     "coverage": 40,
     "required_str": 10,
     "flags": [ "TRANSPARENT", "EASY_DECONSTRUCT" ],
-    "bash": {
-      "str_min": 40,
-      "str_max": 150,
-      "sound_fail": "clang!",
-      "items": [
-        { "item": "pipe", "count": [ 0, 1 ] },
-        { "item": "ch_steel_chunk", "count": [ 2, 4 ] },
-        { "item": "ch_steel_lump", "count": [ 1, 2 ] },
-        { "item": "scrap", "count": [ 2, 4 ] }
-      ]
-    },
-    "deconstruct": { "items": [ { "item": "beverly_shear", "count": 1 } ] },
+    "bash": { "str_min": 40, "str_max": 150, "sound_fail": "clang!" },
+    "item": "beverly_shear",
     "crafting_pseudo_item": "fake_beverly_shear"
   },
   {
@@ -922,19 +829,8 @@
     "required_str": 10,
     "examine_action": { "type": "appliance_convert", "furn_set": "f_null", "item": "drill_press" },
     "flags": [ "BLOCKSDOOR", "EASY_DECONSTRUCT" ],
-    "deconstruct": { "items": [ { "item": "drill_press", "count": 1 } ] },
-    "bash": {
-      "str_min": 40,
-      "str_max": 150,
-      "sound_fail": "clang!",
-      "items": [
-        { "item": "cable", "charges": [ 0, 4 ] },
-        { "item": "scrap", "count": [ 8, 12 ] },
-        { "item": "ch_steel_chunk", "count": [ 2, 4 ] },
-        { "item": "plastic_chunk", "count": [ 4, 10 ] },
-        { "item": "steel_plate", "count": [ 2, 4 ] }
-      ]
-    }
+    "item": "drill_press",
+    "bash": { "str_min": 40, "str_max": 150, "sound_fail": "clang!" }
   },
   {
     "type": "furniture",
@@ -976,19 +872,8 @@
     "required_str": 10,
     "examine_action": { "type": "appliance_convert", "furn_set": "f_null", "item": "tablesaw" },
     "flags": [ "BLOCKSDOOR", "TRANSPARENT", "MOUNTABLE", "EASY_DECONSTRUCT" ],
-    "deconstruct": { "items": [ { "item": "tablesaw", "count": 1 } ] },
-    "bash": {
-      "str_min": 40,
-      "str_max": 150,
-      "sound_fail": "clang!",
-      "items": [
-        { "item": "cable", "charges": [ 0, 4 ] },
-        { "item": "scrap", "count": [ 8, 12 ] },
-        { "item": "ch_steel_chunk", "count": [ 2, 4 ] },
-        { "item": "plastic_chunk", "count": [ 4, 10 ] },
-        { "item": "steel_plate", "count": [ 2, 4 ] }
-      ]
-    }
+    "item": "tablesaw",
+    "bash": { "str_min": 40, "str_max": 150, "sound_fail": "clang!" }
   },
   {
     "type": "furniture",
@@ -1003,19 +888,8 @@
     "required_str": 10,
     "examine_action": { "type": "appliance_convert", "furn_set": "f_null", "item": "mitresaw" },
     "flags": [ "BLOCKSDOOR", "TRANSPARENT", "EASY_DECONSTRUCT" ],
-    "deconstruct": { "items": [ { "item": "mitresaw", "count": 1 } ] },
-    "bash": {
-      "str_min": 40,
-      "str_max": 150,
-      "sound_fail": "clang!",
-      "items": [
-        { "item": "cable", "charges": [ 0, 4 ] },
-        { "item": "scrap", "count": [ 8, 12 ] },
-        { "item": "ch_steel_chunk", "count": [ 2, 4 ] },
-        { "item": "plastic_chunk", "count": [ 4, 10 ] },
-        { "item": "steel_plate", "count": [ 2, 4 ] }
-      ]
-    }
+    "item": "mitresaw",
+    "bash": { "str_min": 40, "str_max": 150, "sound_fail": "clang!" }
   },
   {
     "type": "furniture",
@@ -1030,19 +904,8 @@
     "required_str": 10,
     "examine_action": { "type": "appliance_convert", "furn_set": "f_null", "item": "bandsaw" },
     "flags": [ "BLOCKSDOOR", "EASY_DECONSTRUCT" ],
-    "deconstruct": { "items": [ { "item": "bandsaw", "count": 1 } ] },
-    "bash": {
-      "str_min": 40,
-      "str_max": 150,
-      "sound_fail": "clang!",
-      "items": [
-        { "item": "cable", "charges": [ 0, 4 ] },
-        { "item": "scrap", "count": [ 8, 12 ] },
-        { "item": "mc_steel_chunk", "count": [ 2, 4 ] },
-        { "item": "plastic_chunk", "count": [ 4, 10 ] },
-        { "item": "steel_plate", "count": [ 2, 4 ] }
-      ]
-    }
+    "item": "bandsaw",
+    "bash": { "str_min": 40, "str_max": 150, "sound_fail": "clang!" }
   },
   {
     "type": "furniture",
@@ -1057,19 +920,8 @@
     "required_str": 14,
     "examine_action": { "type": "appliance_convert", "furn_set": "f_null", "item": "router" },
     "flags": [ "BLOCKSDOOR", "TRANSPARENT", "MOUNTABLE", "EASY_DECONSTRUCT" ],
-    "deconstruct": { "items": [ { "item": "router", "count": 1 } ] },
-    "bash": {
-      "str_min": 40,
-      "str_max": 150,
-      "sound_fail": "clang!",
-      "items": [
-        { "item": "cable", "charges": [ 0, 4 ] },
-        { "item": "scrap", "count": [ 8, 12 ] },
-        { "item": "mc_steel_chunk", "count": [ 2, 4 ] },
-        { "item": "plastic_chunk", "count": [ 4, 10 ] },
-        { "item": "steel_plate", "count": [ 2, 4 ] }
-      ]
-    }
+    "item": "router",
+    "bash": { "str_min": 40, "str_max": 150, "sound_fail": "clang!" }
   },
   {
     "type": "furniture",
@@ -1084,19 +936,8 @@
     "required_str": 12,
     "examine_action": { "type": "appliance_convert", "furn_set": "f_null", "item": "planer" },
     "flags": [ "BLOCKSDOOR", "EASY_DECONSTRUCT" ],
-    "deconstruct": { "items": [ { "item": "planer", "count": 1 } ] },
-    "bash": {
-      "str_min": 40,
-      "str_max": 150,
-      "sound_fail": "clang!",
-      "items": [
-        { "item": "cable", "charges": [ 0, 4 ] },
-        { "item": "scrap", "count": [ 8, 12 ] },
-        { "item": "mc_steel_chunk", "count": [ 2, 4 ] },
-        { "item": "plastic_chunk", "count": [ 4, 10 ] },
-        { "item": "steel_plate", "count": [ 2, 4 ] }
-      ]
-    }
+    "item": "planer",
+    "bash": { "str_min": 40, "str_max": 150, "sound_fail": "clang!" }
   },
   {
     "type": "furniture",
@@ -1111,19 +952,8 @@
     "required_str": 14,
     "examine_action": { "type": "appliance_convert", "furn_set": "f_null", "item": "jointer" },
     "flags": [ "BLOCKSDOOR", "TRANSPARENT", "MOUNTABLE", "EASY_DECONSTRUCT" ],
-    "deconstruct": { "items": [ { "item": "jointer", "count": 1 } ] },
-    "bash": {
-      "str_min": 40,
-      "str_max": 150,
-      "sound_fail": "clang!",
-      "items": [
-        { "item": "cable", "charges": [ 0, 4 ] },
-        { "item": "scrap", "count": [ 8, 12 ] },
-        { "item": "mc_steel_chunk", "count": [ 2, 4 ] },
-        { "item": "plastic_chunk", "count": [ 4, 10 ] },
-        { "item": "steel_plate", "count": [ 2, 4 ] }
-      ]
-    }
+    "item": "jointer",
+    "bash": { "str_min": 40, "str_max": 150, "sound_fail": "clang!" }
   },
   {
     "type": "furniture",
@@ -1138,22 +968,8 @@
     "required_str": 16,
     "examine_action": { "type": "appliance_convert", "furn_set": "f_null", "item": "catalytic_cracking_reactor" },
     "flags": [ "BLOCKSDOOR", "EASY_DECONSTRUCT" ],
-    "bash": {
-      "str_min": 40,
-      "str_max": 150,
-      "sound_fail": "clang!",
-      "items": [
-        { "item": "element", "count": [ 4, 8 ] },
-        { "item": "55gal_drum", "count": [ 3, 5 ] },
-        { "item": "pipe", "count": [ 2, 5 ] },
-        { "item": "thermometer", "count": [ 1, 4 ] },
-        { "item": "well_pump", "count": [ 0, 1 ] },
-        { "item": "laptop", "count": [ 0, 1 ] },
-        { "item": "pump_complex", "count": [ 0, 3 ] },
-        { "item": "cable", "count": [ 3, 8 ] }
-      ]
-    },
-    "deconstruct": { "items": [ { "item": "catalytic_cracking_reactor", "count": 1 } ] }
+    "bash": { "str_min": 40, "str_max": 150, "sound_fail": "clang!" },
+    "item": "catalytic_cracking_reactor"
   },
   {
     "type": "furniture",
@@ -1168,19 +984,8 @@
     "required_str": 16,
     "examine_action": { "type": "appliance_convert", "furn_set": "f_null", "item": "hydraulic_press" },
     "flags": [ "BLOCKSDOOR", "EASY_DECONSTRUCT" ],
-    "bash": {
-      "str_min": 40,
-      "str_max": 150,
-      "sound_fail": "clang!",
-      "items": [
-        { "item": "cable", "charges": [ 0, 4 ] },
-        { "item": "scrap", "count": [ 8, 12 ] },
-        { "item": "ch_steel_chunk", "count": [ 2, 4 ] },
-        { "item": "ch_steel_lump", "count": [ 1, 2 ] },
-        { "item": "steel_plate", "count": [ 1, 2 ] }
-      ]
-    },
-    "deconstruct": { "items": [ { "item": "hydraulic_press", "count": 1 } ] }
+    "bash": { "str_min": 40, "str_max": 150, "sound_fail": "clang!" },
+    "item": "hydraulic_press"
   },
   {
     "type": "furniture",
@@ -1229,23 +1034,8 @@
     "required_str": 12,
     "examine_action": { "type": "appliance_convert", "furn_set": "f_null", "item": "air_compressor" },
     "flags": [ "BLOCKSDOOR", "EASY_DECONSTRUCT" ],
-    "deconstruct": { "items": [ { "item": "air_compressor", "count": 1 } ] },
-    "bash": {
-      "str_min": 18,
-      "str_max": 50,
-      "sound": "metal screeching!",
-      "sound_fail": "clang!",
-      "items": [
-        { "item": "scrap", "count": [ 2, 7 ] },
-        { "item": "mc_steel_chunk", "count": [ 0, 3 ] },
-        { "item": "sheet_metal_small", "count": [ 8, 12 ] },
-        { "item": "sheet_metal", "count": [ 1, 2 ] },
-        { "item": "cable", "charges": [ 1, 15 ] },
-        { "item": "hose", "count": [ 0, 1 ] },
-        { "item": "e_scrap", "count": [ 5, 10 ] },
-        { "item": "plastic_chunk", "count": [ 0, 2 ] }
-      ]
-    }
+    "item": "air_compressor",
+    "bash": { "str_min": 18, "str_max": 50, "sound": "metal screeching!", "sound_fail": "clang!" }
   },
   {
     "type": "furniture",
@@ -1260,18 +1050,8 @@
     "coverage": 30,
     "required_str": 10,
     "flags": [ "BLOCKSDOOR", "EASY_DECONSTRUCT" ],
-    "deconstruct": { "items": [ { "item": "manual_tire_changer", "count": 1 } ] },
-    "bash": {
-      "str_min": 18,
-      "str_max": 50,
-      "sound": "metal screeching!",
-      "sound_fail": "clang!",
-      "items": [
-        { "item": "scrap", "count": [ 2, 7 ] },
-        { "item": "mc_steel_chunk", "count": [ 0, 3 ] },
-        { "item": "plastic_chunk", "count": [ 0, 2 ] }
-      ]
-    },
+    "item": "manual_tire_changer",
+    "bash": { "str_min": 18, "str_max": 50, "sound": "metal screeching!", "sound_fail": "clang!" },
     "crafting_pseudo_item": "fake_tire_changer"
   },
   {
@@ -1512,14 +1292,8 @@
     "examine_action": "deployed_furniture",
     "flags": [ "PLACE_ITEM", "TRANSPARENT", "MOUNTABLE", "ALLOW_FIELD_EFFECT", "BUTCHER_EQ" ],
     "crafting_pseudo_item": "fake_butcher_rack",
-    "deconstruct": { "items": [ { "item": "metal_butcher_rack", "count": 1 } ] },
-    "bash": {
-      "str_min": 18,
-      "str_max": 50,
-      "sound": "metal screeching!",
-      "sound_fail": "clang!",
-      "items": [ { "item": "scrap", "count": [ 1, 3 ] }, { "item": "pipe", "count": [ 1, 3 ] } ]
-    }
+    "item": "metal_butcher_rack",
+    "bash": { "str_min": 18, "str_max": 50, "sound": "metal screeching!", "sound_fail": "clang!" }
   },
   {
     "id": "f_hanging_meathook",
@@ -1546,19 +1320,8 @@
     "required_str": -1,
     "examine_action": "quern_examine",
     "flags": [ "SEALED", "ALLOW_FIELD_EFFECT", "CONTAINER", "NOITEM", "BLOCKSDOOR" ],
-    "deconstruct": { "items": [ { "item": "wind_mill", "count": 1 } ] },
-    "bash": {
-      "str_min": 16,
-      "str_max": 50,
-      "sound": "metal screeching!",
-      "sound_fail": "clang!",
-      "items": [
-        { "item": "scrap", "count": [ 4, 8 ] },
-        { "item": "pipe", "count": [ 1, 3 ] },
-        { "item": "sheet_metal_small", "count": [ 4, 8 ] },
-        { "item": "rock", "count": [ 8, 15 ] }
-      ]
-    }
+    "item": "wind_mill",
+    "bash": { "str_min": 16, "str_max": 50, "sound": "metal screeching!", "sound_fail": "clang!" }
   },
   {
     "type": "furniture",
@@ -1572,19 +1335,8 @@
     "required_str": -1,
     "examine_action": "quern_examine",
     "flags": [ "SEALED", "ALLOW_FIELD_EFFECT", "CONTAINER", "NOITEM", "BLOCKSDOOR" ],
-    "deconstruct": { "items": [ { "item": "wind_mill", "count": 1 } ] },
-    "bash": {
-      "str_min": 16,
-      "str_max": 50,
-      "sound": "metal screeching!",
-      "sound_fail": "clang!",
-      "items": [
-        { "item": "scrap", "count": [ 4, 8 ] },
-        { "item": "pipe", "count": [ 1, 3 ] },
-        { "item": "sheet_metal_small", "count": [ 4, 8 ] },
-        { "item": "rock", "count": [ 8, 15 ] }
-      ]
-    }
+    "item": "wind_mill",
+    "bash": { "str_min": 16, "str_max": 50, "sound": "metal screeching!", "sound_fail": "clang!" }
   },
   {
     "type": "furniture",
@@ -1597,20 +1349,12 @@
     "required_str": -1,
     "examine_action": "quern_examine",
     "flags": [ "SEALED", "ALLOW_FIELD_EFFECT", "CONTAINER", "NOITEM", "BLOCKSDOOR" ],
-    "deconstruct": { "items": [ { "item": "water_mill", "count": 1 } ] },
+    "item": "water_mill",
     "bash": {
       "str_min": 12,
       "str_max": 50,
       "sound": "smash!",
       "sound_fail": "whump.",
-      "items": [
-        { "item": "2x4", "count": [ 1, 5 ] },
-        { "item": "nail", "charges": [ 5, 15 ] },
-        { "item": "splinter", "count": [ 20, 30 ] },
-        { "item": "sheet_metal_small", "count": [ 2, 3 ] },
-        { "item": "scrap", "count": [ 3, 5 ] },
-        { "item": "rock", "count": [ 8, 15 ] }
-      ],
       "hit_field": [ "fd_dust", 2 ],
       "destroyed_field": [ "fd_splinters", 1 ]
     }
@@ -1627,20 +1371,12 @@
     "required_str": -1,
     "examine_action": "quern_examine",
     "flags": [ "SEALED", "ALLOW_FIELD_EFFECT", "CONTAINER", "NOITEM", "BLOCKSDOOR" ],
-    "deconstruct": { "items": [ { "item": "water_mill", "count": 1 } ] },
+    "item": "water_mill",
     "bash": {
       "str_min": 12,
       "str_max": 50,
       "sound": "smash!",
       "sound_fail": "whump.",
-      "items": [
-        { "item": "2x4", "count": [ 1, 5 ] },
-        { "item": "nail", "charges": [ 5, 15 ] },
-        { "item": "splinter", "count": [ 20, 30 ] },
-        { "item": "sheet_metal_small", "count": [ 2, 3 ] },
-        { "item": "scrap", "count": [ 3, 5 ] },
-        { "item": "rock", "count": [ 8, 15 ] }
-      ],
       "hit_field": [ "fd_dust", 2 ],
       "destroyed_field": [ "fd_splinters", 1 ]
     }
@@ -1919,7 +1655,7 @@
     "flags": [ "TRANSPARENT", "EASY_DECONSTRUCT", "NOCOLLIDE" ],
     "examine_action": "deployed_furniture",
     "deployed_item": "rope_30",
-    "deconstruct": { "items": [ { "item": "rope_30", "count": 1 } ] },
+    "item": "rope_30",
     "crafting_pseudo_item": "fake_lift_light"
   },
   {

--- a/data/json/furniture_and_terrain/furniture_military.json
+++ b/data/json/furniture_and_terrain/furniture_military.json
@@ -10,8 +10,8 @@
     "coverage": 15,
     "required_str": 10,
     "flags": [ "SHORT", "FLAT_SURF" ],
-    "bash": { "str_min": 1, "str_max": 1, "items": [ { "item": "mortar_m224", "count": 1 } ] },
-    "deconstruct": { "items": [ { "item": "mortar_m224", "count": 1 } ] },
+    "bash": { "str_min": 40, "str_max": 70 },
+    "item": "mortar_m224",
     "//range": [
       "charge; muzzle velocity; min range, max range",
       "0, 210, 70,  400 ",

--- a/data/json/furniture_and_terrain/furniture_refrigeration.json
+++ b/data/json/furniture_and_terrain/furniture_refrigeration.json
@@ -34,14 +34,13 @@
     "required_str": 10,
     "examine_action": { "type": "appliance_convert", "furn_set": "f_null", "item": "minifridge" },
     "flags": [ "PLACE_ITEM", "BLOCKSDOOR", "NO_SELF_CONNECT", "EASY_DECONSTRUCT", "SMALL_HIDE" ],
-    "deconstruct": { "items": [ { "item": "minifridge", "count": 1 } ] },
+    "item": "minifridge",
     "max_volume": "96 L",
     "bash": {
       "str_min": 12,
       "str_max": 50,
       "sound": "metal screeching!",
       "sound_fail": "clang!",
-      "items": [ { "group": "minifridge_destroyed" } ],
       "destroyed_field": [ "fd_mechanical_fluid", 1 ]
     }
   },
@@ -58,14 +57,13 @@
     "required_str": 10,
     "examine_action": { "type": "appliance_convert", "furn_set": "f_null", "item": "glass_fridge" },
     "flags": [ "PLACE_ITEM", "BLOCKSDOOR", "NO_SELF_CONNECT", "EASY_DECONSTRUCT", "SMALL_HIDE" ],
-    "deconstruct": { "items": [ { "item": "glass_fridge", "count": 1 } ] },
+    "item": "glass_fridge",
     "max_volume": "347 L",
     "bash": {
       "str_min": 12,
       "str_max": 50,
       "sound": "metal screeching!",
       "sound_fail": "clang!",
-      "items": [ { "group": "glass_fridge_destroyed" } ],
       "destroyed_field": [ "fd_mechanical_fluid", 1 ]
     }
   },
@@ -82,14 +80,13 @@
     "required_str": 10,
     "examine_action": { "type": "appliance_convert", "furn_set": "f_null", "item": "glass_fridge_double" },
     "flags": [ "PLACE_ITEM", "BLOCKSDOOR", "NO_SELF_CONNECT", "EASY_DECONSTRUCT", "SMALL_HIDE" ],
-    "deconstruct": { "items": [ { "item": "glass_fridge_double", "count": 1 } ] },
+    "item": "glass_fridge_double",
     "max_volume": "991 L",
     "bash": {
       "str_min": 12,
       "str_max": 50,
       "sound": "metal screeching!",
       "sound_fail": "clang!",
-      "items": [ { "group": "glass_fridge_double_destroyed" } ],
       "destroyed_field": [ "fd_mechanical_fluid", 1 ]
     }
   },
@@ -106,14 +103,13 @@
     "required_str": 10,
     "examine_action": { "type": "appliance_convert", "furn_set": "f_null", "item": "heavy_duty_fridge" },
     "flags": [ "PLACE_ITEM", "BLOCKSDOOR", "NO_SELF_CONNECT", "EASY_DECONSTRUCT", "SMALL_HIDE" ],
-    "deconstruct": { "items": [ { "item": "heavy_duty_fridge", "count": 1 } ] },
+    "item": "heavy_duty_fridge",
     "max_volume": "700 L",
     "bash": {
       "str_min": 12,
       "str_max": 50,
       "sound": "metal screeching!",
       "sound_fail": "clang!",
-      "items": [ { "group": "heavy_duty_fridge_destroyed" } ],
       "destroyed_field": [ "fd_mechanical_fluid", 1 ]
     }
   },
@@ -130,14 +126,13 @@
     "required_str": 10,
     "examine_action": { "type": "appliance_convert", "furn_set": "f_null", "item": "display_fridge" },
     "flags": [ "PLACE_ITEM", "BLOCKSDOOR", "NO_SELF_CONNECT", "EASY_DECONSTRUCT", "SMALL_HIDE" ],
-    "deconstruct": { "items": [ { "item": "display_fridge", "count": 1 } ] },
+    "item": "display_fridge",
     "max_volume": "600 L",
     "bash": {
       "str_min": 12,
       "str_max": 50,
       "sound": "metal screeching!",
       "sound_fail": "clang!",
-      "items": [ { "group": "display_fridge_destroyed" } ],
       "destroyed_field": [ "fd_mechanical_fluid", 1 ]
     }
   },
@@ -154,14 +149,13 @@
     "required_str": 10,
     "examine_action": { "type": "appliance_convert", "furn_set": "f_null", "item": "minifreezer" },
     "flags": [ "CONTAINER", "PLACE_ITEM", "BLOCKSDOOR", "MINEABLE", "NO_SELF_CONNECT", "EASY_DECONSTRUCT", "SMALL_HIDE" ],
-    "deconstruct": { "items": [ { "item": "minifreezer", "count": 1 } ] },
+    "item": "minifreezer",
     "max_volume": "90 L",
     "bash": {
       "str_min": 18,
       "str_max": 50,
       "sound": "metal screeching!",
       "sound_fail": "clang!",
-      "items": [ { "group": "minifreezer_destroyed" } ],
       "destroyed_field": [ "fd_mechanical_fluid", 1 ]
     }
   },
@@ -178,14 +172,13 @@
     "required_str": 10,
     "examine_action": { "type": "appliance_convert", "furn_set": "f_null", "item": "chest_minifreezer" },
     "flags": [ "CONTAINER", "PLACE_ITEM", "BLOCKSDOOR", "MINEABLE", "NO_SELF_CONNECT", "EASY_DECONSTRUCT", "SMALL_HIDE" ],
-    "deconstruct": { "items": [ { "item": "chest_minifreezer", "count": 1 } ] },
+    "item": "chest_minifreezer",
     "max_volume": "99 L",
     "bash": {
       "str_min": 18,
       "str_max": 50,
       "sound": "metal screeching!",
       "sound_fail": "clang!",
-      "items": [ { "group": "chest_minifreezer_destroyed" } ],
       "destroyed_field": [ "fd_mechanical_fluid", 1 ]
     }
   },
@@ -202,14 +195,13 @@
     "required_str": 10,
     "examine_action": { "type": "appliance_convert", "furn_set": "f_null", "item": "chest_freezer" },
     "flags": [ "CONTAINER", "PLACE_ITEM", "BLOCKSDOOR", "MINEABLE", "NO_SELF_CONNECT", "EASY_DECONSTRUCT", "SMALL_HIDE" ],
-    "deconstruct": { "items": [ { "item": "chest_freezer", "count": 1 } ] },
+    "item": "chest_freezer",
     "max_volume": "350 L",
     "bash": {
       "str_min": 18,
       "str_max": 50,
       "sound": "metal screeching!",
       "sound_fail": "clang!",
-      "items": [ { "group": "chest_freezer_destroyed" } ],
       "destroyed_field": [ "fd_mechanical_fluid", 1 ]
     }
   },
@@ -226,14 +218,13 @@
     "required_str": 10,
     "examine_action": { "type": "appliance_convert", "furn_set": "f_null", "item": "heavy_duty_freezer" },
     "flags": [ "CONTAINER", "PLACE_ITEM", "BLOCKSDOOR", "MINEABLE", "NO_SELF_CONNECT", "EASY_DECONSTRUCT", "SMALL_HIDE" ],
-    "deconstruct": { "items": [ { "item": "heavy_duty_freezer", "count": 1 } ] },
+    "item": "heavy_duty_freezer",
     "max_volume": "745 L",
     "bash": {
       "str_min": 18,
       "str_max": 50,
       "sound": "metal screeching!",
       "sound_fail": "clang!",
-      "items": [ { "group": "heavy_duty_freezer_destroyed" } ],
       "destroyed_field": [ "fd_mechanical_fluid", 1 ]
     }
   },
@@ -250,14 +241,13 @@
     "required_str": 10,
     "examine_action": { "type": "appliance_convert", "furn_set": "f_null", "item": "glass_freezer" },
     "flags": [ "CONTAINER", "PLACE_ITEM", "BLOCKSDOOR", "MINEABLE", "NO_SELF_CONNECT", "EASY_DECONSTRUCT", "SMALL_HIDE" ],
-    "deconstruct": { "items": [ { "item": "glass_freezer", "count": 1 } ] },
+    "item": "glass_freezer",
     "max_volume": "400 L",
     "bash": {
       "str_min": 18,
       "str_max": 50,
       "sound": "metal screeching!",
       "sound_fail": "clang!",
-      "items": [ { "group": "glass_freezer_destroyed" } ],
       "destroyed_field": [ "fd_mechanical_fluid", 1 ]
     }
   },
@@ -274,14 +264,13 @@
     "required_str": 10,
     "examine_action": { "type": "appliance_convert", "furn_set": "f_null", "item": "display_freezer" },
     "flags": [ "CONTAINER", "PLACE_ITEM", "BLOCKSDOOR", "MINEABLE", "NO_SELF_CONNECT", "EASY_DECONSTRUCT", "SMALL_HIDE" ],
-    "deconstruct": { "items": [ { "item": "display_freezer", "count": 1 } ] },
+    "item": "display_freezer",
     "max_volume": "320 L",
     "bash": {
       "str_min": 18,
       "str_max": 50,
       "sound": "metal screeching!",
       "sound_fail": "clang!",
-      "items": [ { "group": "display_freezer_destroyed" } ],
       "destroyed_field": [ "fd_mechanical_fluid", 1 ]
     }
   }

--- a/data/json/furniture_and_terrain/special_use/bullet_trailer.json
+++ b/data/json/furniture_and_terrain/special_use/bullet_trailer.json
@@ -277,14 +277,8 @@
     "coverage": 15,
     "required_str": 6,
     "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "MOUNTABLE", "EASY_DECONSTRUCT" ],
-    "deconstruct": { "items": [ { "item": "toilet_travel", "count": 1 } ] },
-    "bash": {
-      "str_min": 6,
-      "str_max": 15,
-      "sound": "plastic cracking!",
-      "sound_fail": "whump!",
-      "items": [ { "item": "plastic_chunk", "count": [ 4, 8 ] } ]
-    }
+    "item": "toilet_travel",
+    "bash": { "str_min": 6, "str_max": 15, "sound": "plastic cracking!", "sound_fail": "whump!" }
   },
   {
     "type": "furniture",

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -1807,7 +1807,7 @@ void construct::done_deconstruct( const tripoint_bub_ms &p, Character &player_ch
     // TODO: Make this the argument
     if( here.has_furn( p ) ) {
         const furn_t &f = here.furn( p ).obj();
-        if( !f.deconstruct ) {
+        if( !f.deconstruct && f.base_item.is_null() ) {
             add_msg( m_info, _( "That %s can not be disassembled!" ), f.name() );
             return;
         }
@@ -1818,8 +1818,13 @@ void construct::done_deconstruct( const tripoint_bub_ms &p, Character &player_ch
         }
         add_msg( _( "The %s is disassembled." ), f.name() );
         item &item_here = here.i_at( p ).size() != 1 ? null_item_reference() : here.i_at( p ).only_item();
-        const std::vector<item *> drop = here.spawn_items( p,
-                                         item_group::items_from( f.deconstruct->drop_group, calendar::turn ) );
+        std::vector<item *> drop;
+        if( !f.base_item.is_null() ) {
+            here.spawn_item( p, f.base_item );
+        } else {
+            drop = here.spawn_items( p, item_group::items_from( f.deconstruct->drop_group, calendar::turn ) );
+        }
+
         if( f.deconstruct->skill.has_value() ) {
             deconstruction_practice_skill( f.deconstruct->skill.value() );
         }
@@ -1858,7 +1863,13 @@ void construct::done_deconstruct( const tripoint_bub_ms &p, Character &player_ch
         }
         here.ter_set( p, t.deconstruct->ter_set );
         add_msg( _( "The %s is disassembled." ), t.name() );
-        here.spawn_items( p, item_group::items_from( t.deconstruct->drop_group, calendar::turn ) );
+
+        if( !t.base_item.is_null() ) {
+            here.spawn_item( p, t.base_item );
+        } else {
+            here.spawn_items( p, item_group::items_from( t.deconstruct->drop_group, calendar::turn ) );
+        }
+
         if( t.deconstruct->skill.has_value() ) {
             deconstruction_practice_skill( t.deconstruct->skill.value() );
         }

--- a/src/map.h
+++ b/src/map.h
@@ -2076,6 +2076,10 @@ class map
         ter_str_id get_roof( const tripoint_bub_ms &p, bool allow_air ) const;
 
     public:
+
+        // handles all the bash results of specific terrain or furniture
+        void drop_bash_results( const map_data_common_t &ter_furn, const tripoint_bub_ms &p );
+
         void process_items();
         // All active items connected to the power_grid with their connection points.
         std::vector<item_reference> item_network_connections( vehicle *power_grid );

--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -898,6 +898,11 @@ void map_data_common_t::unset_rotates_to( const std::vector<std::string> &connec
     set_groups( rotate_to_groups, connect_groups_vec, true );
 }
 
+std::vector<item_comp> map_data_common_t::get_uncraft_components() const
+{
+    return item( base_item ).get_uncraft_components();
+}
+
 void map_data_common_t::set_groups( std::bitset<NUM_TERCONN> &bits,
                                     const std::vector<std::string> &connect_groups_vec, bool unset )
 {
@@ -1127,6 +1132,7 @@ void map_data_common_t::load( const JsonObject &jo, const std::string &src )
         shoot->load( jo, "shoot", was_loaded );
     }
 
+    optional( jo, was_loaded, "item", base_item, itype_id::NULL_ID() );
 }
 
 bool ter_t::is_null() const
@@ -1272,6 +1278,20 @@ void ter_t::check() const
         deconstruct->check( id.c_str() );
     }
 
+    if( !base_item.is_null() && bash.has_value() &&
+        bash.value().drop_group != Item_spawn_data_EMPTY_GROUP ) {
+        // in the future, maybe, if base_item would be used more widely,
+        // there would be a reason to not error about it or make some boolean to permit it
+        // but right now let's treat it as a bug
+        debugmsg( R"(terrain %s defines "bash"->"items", but "item" is presented, which is unnecessary - bash result would be picked from %s uncrafting recipe.)",
+                  id.c_str(), base_item.c_str() );
+    }
+
+    if( !base_item.is_null() && deconstruct.has_value() && !deconstruct.value().drop_group.is_null() ) {
+        debugmsg( R"(terrain %s defines "deconstruct"->"items", but "item" is presented, which is unnecessary - deconstruction would be set as %s.)",
+                  id.c_str(), base_item.c_str() );
+    }
+
     if( !transforms_into.is_valid() ) {
         debugmsg( "invalid transforms_into %s for %s", transforms_into.c_str(), id.c_str() );
     }
@@ -1414,6 +1434,17 @@ void furn_t::check() const
     }
     if( deconstruct ) {
         deconstruct->check( id.c_str() );
+    }
+
+    if( !base_item.is_null() && bash.has_value() &&
+        bash.value().drop_group != Item_spawn_data_EMPTY_GROUP ) {
+        debugmsg( R"(furniture %s defines "bash"->"items", but "item" is presented, which is unnecessary - bash result would be picked from %s uncrafting recipe.)",
+                  id.c_str(), base_item.c_str() );
+    }
+
+    if( !base_item.is_null() && deconstruct.has_value() && !deconstruct.value().drop_group.is_null() ) {
+        debugmsg( R"(furniture %s defines "deconstruct"->"items", but "item" is presented, which is unnecessary - deconstruction would be set as %s.)",
+                  id.c_str(), base_item.c_str() );
     }
 
     if( !open.is_valid() ) {

--- a/src/mapdata.h
+++ b/src/mapdata.h
@@ -19,6 +19,7 @@
 #include "enum_bitset.h"
 #include "game_constants.h"
 #include "iexamine.h"
+#include "requirements.h"
 #include "translation.h"
 #include "type_id.h"
 #include "units.h"
@@ -491,7 +492,7 @@ struct map_data_common_t {
 
     public:
         virtual ~map_data_common_t() = default;
-
+        virtual std::optional<map_common_bash_info> bash_info() const = 0;
     protected:
         friend furn_t null_furniture_t();
         friend ter_t null_terrain_t();
@@ -570,6 +571,10 @@ struct map_data_common_t {
             }
         };
 
+        // underlying item of this furniture. Underlying item of a freezer is freezer
+        // todo: use it as substitute as crafting pseudo item
+        itype_id base_item = itype_id::NULL_ID();
+
         bool transparent = false;
 
         const std::set<std::string> &get_flags() const {
@@ -605,6 +610,9 @@ struct map_data_common_t {
         // Set target group to rotate towards
         void set_rotates_to( const std::vector<std::string> &connect_groups_vec );
         void unset_rotates_to( const std::vector<std::string> &connect_groups_vec );
+
+        // grabs an item and return a default components from uncraft of this item
+        std::vector<item_comp> get_uncraft_components() const;
 
         // Set groups helper function
         void set_groups( std::bitset<NUM_TERCONN> &bits, const std::vector<std::string> &connect_groups_vec,
@@ -673,6 +681,10 @@ struct ter_t : map_data_common_t {
 
     ter_t();
 
+    std::optional<map_common_bash_info> bash_info() const override {
+        return bash;
+    }
+
     static size_t count();
 
     bool is_null() const;
@@ -728,6 +740,10 @@ struct furn_t : map_data_common_t {
     std::vector<const itype *> crafting_ammo_item_types() const;
 
     furn_t();
+
+    std::optional<map_common_bash_info> bash_info() const override {
+        return bash;
+    }
 
     static size_t count();
 

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -3583,7 +3583,7 @@ class jmapgen_terrain : public jmapgen_piece_with_has_vehicle_collision
                             } else {
                                 dat.m.furn_set( p, furn_bash->furn_set );
                             }
-                            dat.m.spawn_items( p, item_group::items_from( furn_bash->drop_group, calendar::turn ) );
+                            dat.m.drop_bash_results( f, p );
                         } else {
                             break;
                         }

--- a/tests/iexamine_test.cpp
+++ b/tests/iexamine_test.cpp
@@ -10,7 +10,7 @@
 
 TEST_CASE( "mapdata_examine" )
 {
-    map_data_common_t data;
+    ter_t data;
     data.set_examine( iexamine_functions{iexamine::always_true, iexamine::water_source} );
 
     CHECK( data.has_examine( iexamine::water_source ) );


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Less json churn
Also step 0.5 for #70501
#### Describe the solution
Make furniture be able to define itype_id attached to furniture
Use item attached for deconstruction (just our item) and bash results (components of item uncraft recipe)
Potential TODOs:
- [ ] go to map_common_bash_info::potential_bash_items() and make it show bash result properly
- [ ] ~~remove display_freezer_destroyed, glass_freezer_destroyed, heavy_duty_freezer_destroyed, chest_freezer_destroyed, chest_minifreezer_destroyed, minifreezer_destroyed, display_fridge_destroyed, heavy_duty_fridge_destroyed, glass_fridge_double_destroyed, glass_fridge_destroyed, minifridge_destroyed itemgroups as not needed anymore~~ still needed as they are used as bash result for appliances? maybe vehicles need to get the same treatment?
#### Describe alternatives you've considered
Not doing it?
Think how to make bash and deconstruct results overridable, but also prevent a blind copypaste by users
#### Testing
Compiled, bashed terrain and furniture, it still can be bashed, it still drops what we expect, bashing furniture with item defined drops the components as it was desired