### PR TITLE
Change u_profession condition

### DIFF
--- a/data/mods/Magiclysm/effect_on_conditions/game_start.json
+++ b/data/mods/Magiclysm/effect_on_conditions/game_start.json
@@ -4,7 +4,7 @@
     "id": "EOC_DRUID_SHIFTER_GIVE_FORM",
     "eoc_type": "EVENT",
     "required_event": "game_start",
-    "condition": { "u_profession": "shifter_druid" },
+    "condition": { "u_has_profession": "shifter_druid" },
     "effect": [ { "run_eocs": "EOC_DRUID_SHIFTER_GIVE_FORM_2", "time_in_future": 0 } ]
   },
   {

--- a/data/mods/Xedra_Evolved/eocs/initialization.json
+++ b/data/mods/Xedra_Evolved/eocs/initialization.json
@@ -37,7 +37,7 @@
     "id": "EOC_INVENTOR_START_RECIPES",
     "eoc_type": "EVENT",
     "required_event": "game_avatar_new",
-    "condition": { "compare_string": [ "xe_inventor", { "context_val": "avatar_profession" } ] },
+    "condition": { "u_has_profession": "xe_inventor" },
     "effect": [
       { "u_roll_remainder": [ "software_math_inventor", "software_electronics_reference_inventor" ], "type": "recipe" },
       { "u_roll_remainder": [ "inventor_leg_weight", "inventor_jump_boots" ], "type": "recipe" },
@@ -49,7 +49,7 @@
     "id": "EOC_DREAMSMITH_START_RECIPES",
     "eoc_type": "EVENT",
     "required_event": "game_avatar_new",
-    "condition": { "compare_string": [ "xe_dreamsmith", { "context_val": "avatar_profession" } ] },
+    "condition": { "u_has_profession": "xe_dreamsmith" },
     "effect": [
       { "u_roll_remainder": [ "forged_dreamstuff_ingot" ], "type": "recipe" },
       { "u_roll_remainder": [ "dreamdross_bo", "dreamdross_knife", "dreamdross_club" ], "type": "recipe" },

--- a/data/mods/Xedra_Evolved/eocs/profession_eocs.json
+++ b/data/mods/Xedra_Evolved/eocs/profession_eocs.json
@@ -4,7 +4,7 @@
     "id": "EOC_XE_XE_OPERATIVE_MAGIC_SQUARES_BOOK_UNDERSTANDING",
     "eoc_type": "EVENT",
     "required_event": "game_start",
-    "condition": { "u_profession": "xe_hedge_mage_magic_squares" },
+    "condition": { "u_has_profession": "xe_hedge_mage_magic_squares" },
     "effect": [ { "math": [ "u_deciphered_spellbook_hedge_abramelin_the_mage = 1" ] } ]
   }
 ]

--- a/doc/JSON/EFFECT_ON_CONDITION.md
+++ b/doc/JSON/EFFECT_ON_CONDITION.md
@@ -608,9 +608,9 @@ Check if two variables are `yes`
 "compare_string": [ "yes", { "context_val": "some_context_should_be_yes" }, { "context_val": "some_another_context_also_should_be_yes" } ]
 ```
 
-### `u_profession`
+### `u_has_profession`, `npc_has_profession`
 - type: string or [variable object](#variable-object)
-- Return true if player character has the given profession id or its "hobby" subtype
+- Return true if alpha / beta talker has the given profession id or its "hobby" subtype
 
 #### Valid talkers:
 
@@ -619,14 +619,21 @@ Check if two variables are `yes`
 | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ | ❌ |
 
 #### Examples
-True if the character has selected Heist Driver profession at the character creation
+True if the talker has the Heist Driver profession
 ```jsonc
-{ "u_profession": "heist_driver" }
+{ "u_has_profession": "heist_driver" }
 ```
 
-True if the character has selected Fishing background at the character creation
+Print a message if the character selected Fisher profession or the Fishing background at character creation
 ```jsonc
-{ "u_profession": "fishing" }
+{
+  "type": "effect_on_condition",
+  "id": "EOC_MSG_IF_FISHER",
+  "eoc_type": "EVENT",
+  "required_event": "game_start",
+  "condition": { "or": [ { "u_has_profession": "fisher" }, { "u_has_profession": "fishing" } ] },
+  "effect": { "u_message": "Good morning. Nice day for fishing ain't it?" }
+}
 ```
 
 ### `u_has_strength`, `npc_has_strength`, `u_has_dexterity`, `npc_has_dexterity`, `u_has_intelligence`, `npc_has_intelligence`, `u_has_perception`, `npc_has_perception`
@@ -1705,7 +1712,7 @@ Every event EOC passes context vars with each of their key value pairs that the 
 | gains_proficiency | | { "character", `character_id` },<br/> { "proficiency", `proficiency_id` }, | character / NONE |
 | gains_skill_level | | { "character", `character_id` },<br/> { "skill", `skill_id` },<br/> { "new_level", `int` }, | character / NONE |
 | game_avatar_death | Triggers during bury screen with ASCII grave art is displayed (when avatar dies, obviously) | { "avatar_id", `character_id` },<br/> { "avatar_name", `string` },<br/> { "avatar_is_male", `bool` },<br/> { "is_suicide", `bool` },<br/> { "last_words", `string` }, | avatar / NONE |
-| game_avatar_new | Triggers when new character is controlled and during new game character initialization  | { "is_new_game", `bool` },<br/> { "is_debug", `bool` },<br/> { "avatar_id", `character_id` },<br/> { "avatar_name", `string` },<br/> { "avatar_is_male", `bool` },<br/> { "avatar_profession", `profession_id` },<br/> { "avatar_custom_profession", `string` }, | avatar / NONE |
+| game_avatar_new | Triggers when new character is controlled and during new game character initialization  | { "is_new_game", `bool` },<br/> { "is_debug", `bool` },<br/> { "avatar_id", `character_id` },<br/> { "avatar_name", `string` },<br/> { "avatar_is_male", `bool` },<br/> { "avatar_custom_profession", `string` }, | avatar / NONE |
 | game_load | Triggers only when loading a saved game (not a new game!) | { "cdda_version", `string` }, | avatar / NONE |
 | game_begin | Triggered during game load and new game start | { "cdda_version", `string` }, | avatar / NONE |
 | game_over | Triggers after fully accepting death, epilogues etc. have played (probably not useable for eoc purposes?) | { "total_time_played", `chrono_seconds` }, | avatar / NONE |

--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -60,7 +60,6 @@
 #include "pathfinding.h"
 #include "pimpl.h"
 #include "point.h"
-#include "profession.h"
 #include "ranged.h"
 #include "recipe.h"
 #include "ret_val.h"

--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -183,9 +183,8 @@ void avatar::control_npc( npc &np, const bool debug )
     g->update_map( *this, z_level_changed );
     character_mood_face( true );
 
-    profession_id prof_id = prof ? prof->ident() : profession::generic()->ident();
-    get_event_bus().send<event_type::game_avatar_new>( /*is_new_game=*/false, debug,
-            getID(), name, male, prof_id, custom_profession );
+    get_event_bus().send<event_type::game_avatar_new>( /*is_new_game=*/false, debug, getID(), name,
+            custom_profession );
 }
 
 void avatar::control_npc_menu( const bool debug )

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -597,16 +597,40 @@ conditional_t::func f_is_trait_purifiable( const JsonObject &jo, std::string_vie
 conditional_t::func f_has_visible_trait( const JsonObject &jo, std::string_view member,
         bool is_npc )
 {
-    str_or_var trait_to_check = get_str_or_var( jo.get_member( member ), member, true );
-    return [trait_to_check, is_npc]( const_dialogue const & d ) {
+    str_or_var trait_to_check_var = get_str_or_var( jo.get_member( member ), member, true );
+    return [trait_to_check_var, is_npc]( const_dialogue const & d ) {
         const_talker const *observer = d.const_actor( !is_npc );
         const_talker const *observed = d.const_actor( is_npc );
         int visibility_cap = observer->get_const_character()->get_mutation_visibility_cap(
                                  observed->get_const_character() );
-        bool observed_has = observed->has_trait( trait_id( trait_to_check.evaluate( d ) ) );
-        const mutation_branch &mut_branch = trait_id( trait_to_check.evaluate( d ) ).obj();
+        const trait_id trait_to_check( trait_to_check_var.evaluate( d ) );
+        bool observed_has = observed->has_trait( trait_to_check );
+        const mutation_branch &mut_branch = trait_to_check.obj();
         bool is_visible = mut_branch.visibility > 0 && mut_branch.visibility >= visibility_cap;
         return observed_has && is_visible;
+    };
+}
+
+conditional_t::func f_has_profession( const JsonObject &jo, std::string_view member, bool is_npc )
+{
+    str_or_var prof_to_check_var = get_str_or_var( jo.get_member( member ), member, true );
+    return [prof_to_check_var, is_npc ]( const_dialogue const & d ) {
+        const Character *ch = d.const_actor( is_npc )->get_const_character();
+        const profession *prof_present = ch->prof;
+        const profession_id prof_to_check( prof_to_check_var.evaluate( d ) );
+        if( !!prof_present ) {
+            if( prof_present->get_profession_id() == prof_to_check ) {
+                return true;
+            }
+        }
+        if( prof_to_check->is_hobby() ) {
+            for( const profession *hob : ch->get_hobbies() ) {
+                if( hob->get_profession_id() == prof_to_check ) {
+                    return true;
+                }
+            }
+        }
+        return false;
     };
 }
 
@@ -740,28 +764,6 @@ conditional_t::func f_u_safe_mode_trigger( const JsonObject &jo, std::string_vie
         const int card_dir = static_cast<int>( io::string_to_enum<cardinal_direction>( dir.evaluate(
                 d ) ) );
         return get_avatar().get_mon_visible().dangerous[card_dir];
-    };
-}
-
-conditional_t::func f_u_profession( const JsonObject &jo, std::string_view member )
-{
-    str_or_var u_profession = get_str_or_var( jo.get_member( member ), member, true );
-    return [u_profession]( const_dialogue const & d ) {
-        const profession *prof = get_player_character().get_profession();
-        std::set<const profession *> hobbies = get_player_character().get_hobbies();
-        if( prof->get_profession_id() == profession_id( u_profession.evaluate( d ) ) ) {
-            return true;
-        } else if( profession_id( u_profession.evaluate( d ) )->is_hobby() ) {
-            for( const profession *hob : hobbies ) {
-                if( hob->get_profession_id() == profession_id( u_profession.evaluate( d ) ) ) {
-                    return true;
-                }
-                break;
-            }
-            return false;
-        } else {
-            return false;
-        }
     };
 }
 
@@ -2499,6 +2501,7 @@ parsers = {
     {"u_has_trait", "npc_has_trait", jarg::member, &conditional_fun::f_has_trait },
     { "u_is_trait_purifiable", "npc_is_trait_purifiable", jarg::member, &conditional_fun::f_is_trait_purifiable},
     {"u_has_visible_trait", "npc_has_visible_trait", jarg::member, &conditional_fun::f_has_visible_trait },
+    {"u_has_profession", "npc_has_profession", jarg::string, &conditional_fun::f_has_profession },
     {"u_has_martial_art", "npc_has_martial_art", jarg::member, &conditional_fun::f_has_martial_art },
     {"u_using_martial_art", "npc_using_martial_art", jarg::member, &conditional_fun::f_using_martial_art },
     {"u_has_proficiency", "npc_has_proficiency", jarg::member, &conditional_fun::f_has_proficiency },
@@ -2511,7 +2514,6 @@ parsers = {
     {"u_has_mission", jarg::string, &conditional_fun::f_u_has_mission },
     {"u_monsters_in_direction", jarg::string, &conditional_fun::f_u_monsters_in_direction },
     {"u_safe_mode_trigger", jarg::member, &conditional_fun::f_u_safe_mode_trigger },
-    {"u_profession", jarg::string, &conditional_fun::f_u_profession },
     {"u_has_strength", "npc_has_strength", jarg::member | jarg::array, &conditional_fun::f_has_strength },
     {"u_has_dexterity", "npc_has_dexterity", jarg::member | jarg::array, &conditional_fun::f_has_dexterity },
     {"u_has_intelligence", "npc_has_intelligence", jarg::member | jarg::array, &conditional_fun::f_has_intelligence },

--- a/src/event.h
+++ b/src/event.h
@@ -696,10 +696,9 @@ struct event_spec<event_type::gains_skill_level> {
 
 template<>
 struct event_spec<event_type::game_avatar_death> {
-    static constexpr std::array<std::pair<const char *, cata_variant_type>, 5> fields = {{
+    static constexpr std::array<std::pair<const char *, cata_variant_type>, 4> fields = {{
             { "avatar_id", cata_variant_type::character_id },
             { "avatar_name", cata_variant_type::string },
-            { "avatar_is_male", cata_variant_type::bool_ },
             { "is_suicide", cata_variant_type::bool_ },
             { "last_words", cata_variant_type::string },
         }
@@ -708,13 +707,11 @@ struct event_spec<event_type::game_avatar_death> {
 
 template<>
 struct event_spec<event_type::game_avatar_new> {
-    static constexpr std::array<std::pair<const char *, cata_variant_type>, 7> fields = {{
+    static constexpr std::array<std::pair<const char *, cata_variant_type>, 5> fields = {{
             { "is_new_game", cata_variant_type::bool_ },
             { "is_debug", cata_variant_type::bool_ },
             { "avatar_id", cata_variant_type::character_id },
             { "avatar_name", cata_variant_type::string },
-            { "avatar_is_male", cata_variant_type::bool_ },
-            { "avatar_profession", cata_variant_type::profession_id },
             { "avatar_custom_profession", cata_variant_type::string },
         }
     };

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1165,7 +1165,7 @@ bool game::start_game()
 
     get_event_bus().send<event_type::game_start>( getVersionString() );
     get_event_bus().send<event_type::game_avatar_new>( /*is_new_game=*/true, /*is_debug=*/false,
-            u.getID(), u.name, u.male, u.prof->ident(), u.custom_profession );
+            u.getID(), u.name, u.custom_profession );
     time_played_at_last_load = std::chrono::seconds( 0 );
     time_of_last_load = std::chrono::steady_clock::now();
     tripoint_abs_omt abs_omt = u.pos_abs_omt();
@@ -3048,8 +3048,7 @@ void end_screen_data::draw_end_screen_ui()
     }
     avatar &u = get_avatar();
     const bool is_suicide = g->uquit == QUIT_SUICIDE;
-    get_event_bus().send<event_type::game_avatar_death>( u.getID(), u.name, u.male, is_suicide,
-            p_impl.text );
+    get_event_bus().send<event_type::game_avatar_death>( u.getID(), u.name, is_suicide, p_impl.text );
 }
 
 void end_screen_ui_impl::draw_controls()

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -4683,17 +4683,15 @@ void stats_tracker::deserialize( const JsonObject &jo )
                 // retroactively insert current avatar, if different from starting avatar
                 // we don't know when they took over, so just use current time point
                 if( u.getID() != gs_data["avatar_id"].get<cata_variant_type::character_id>() ) {
-                    profession_id prof_id = u.prof ? u.prof->ident() : profession::generic()->ident();
                     get_event_bus().send( cata::event::make<event_type::game_avatar_new>( false, false,
-                                          u.getID(), u.name, u.male, prof_id, u.custom_profession ) );
+                                          u.getID(), u.name, u.custom_profession ) );
                 }
             } else {
                 // last ditch effort for really old saves that don't even have event_type::game_start
                 // treat current avatar as the starting avatar; abuse is_new_game=false to flag such cases
-                profession_id prof_id = u.prof ? u.prof->ident() : profession::generic()->ident();
                 std::swap( calendar::turn, calendar::start_of_game );
                 get_event_bus().send( cata::event::make<event_type::game_avatar_new>( false, false,
-                                      u.getID(), u.name, u.male, prof_id, u.custom_profession ) );
+                                      u.getID(), u.name, u.custom_profession ) );
                 std::swap( calendar::turn, calendar::start_of_game );
             }
         }

--- a/tests/memorial_test.cpp
+++ b/tests/memorial_test.cpp
@@ -19,7 +19,6 @@
 #include "memorial_logger.h"
 #include "mutation.h"
 #include "player_helpers.h"
-#include "profession.h"
 #include "stats_tracker.h"
 #include "type_id.h"
 
@@ -223,12 +222,11 @@ TEST_CASE( "memorials", "[memorial]" )
         m, b, "Reached skill level 8 in vehicles.", ch, skill_driving, 8 );
 
     check_memorial<event_type::game_avatar_death>(
-        m, b, u_name + " was killed.\nLast words: last_words", ch, u_name, player_character.male, false,
-        "last_words" );
+        m, b, u_name + " was killed.\nLast words: last_words", ch, u_name, false, "last_words" );
 
     check_memorial<event_type::game_avatar_new>(
         m, b, u_name + " began their journey into the Cataclysm.", true, false, ch, u_name,
-        player_character.male, player_character.prof->ident(), player_character.custom_profession );
+        player_character.custom_profession );
 
     check_memorial<event_type::installs_cbm>(
         m, b, "Installed bionic: Alarm System.", ch, cbm );

--- a/tests/stats_tracker_test.cpp
+++ b/tests/stats_tracker_test.cpp
@@ -204,8 +204,8 @@ TEST_CASE( "stats_tracker_event_time_bounds", "[stats]" )
 static void send_game_start( event_bus &b, const character_id &u_id )
 {
     b.send<event_type::game_start>( "VERION_STRING" );
-    b.send<event_type::game_avatar_new>( /*is_new_game=*/true, /*is_debug=*/false, u_id,
-            "Avatar name", /*is_male=*/false, profession_id::NULL_ID(), "CUSTOM_PROFESSION" );
+    b.send<event_type::game_avatar_new>( /*is_new_game=*/true, /*is_debug=*/false, u_id, "Avatar name",
+            "CUSTOM_PROFESSION" );
 }
 
 TEST_CASE( "stats_tracker_with_event_statistics", "[stats]" )


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
u_profession sounds like it acts on the alpha talker when it is avatar only regardless of talkers
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Change it to u_has_profession/npc_has_profession that works with all character talkers
Update the few EOCs using it or trying to achieve it and remove a couple of redundant context variables passed with events
Update docs

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Tested with the fishing example with and without the profession and background with expected results
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
