### PR TITLE
Allow NPC to dress really quietly on game start (and during mutations)

### DIFF
--- a/src/character.h
+++ b/src/character.h
@@ -2027,7 +2027,8 @@ class Character : public Creature, public visitable
          * If do_calc_encumbrance is false, don't recalculate encumbrance, caller must call it eventually.
          */
         std::optional<std::list<item>::iterator>
-        wear_item( const item &to_wear, bool interactive = true, bool do_calc_encumbrance = true );
+        wear_item( const item &to_wear, bool interactive = true, bool do_calc_encumbrance = true,
+                   bool do_sort_items = true, bool quiet = false );
 
         /** Returns the amount of item `type' that is currently worn */
         int  amount_worn( const itype_id &id ) const;

--- a/src/character_attire.cpp
+++ b/src/character_attire.cpp
@@ -434,7 +434,7 @@ void outfit::recalc_ablative_blocking( const Character *guy )
 }
 
 std::optional<std::list<item>::iterator> Character::wear_item( const item &to_wear,
-        bool interactive, bool do_calc_encumbrance )
+        bool interactive, bool do_calc_encumbrance, bool do_sort_items, bool quiet )
 {
     invalidate_inventory_validity_cache();
     invalidate_leak_level_cache();
@@ -446,7 +446,7 @@ std::optional<std::list<item>::iterator> Character::wear_item( const item &to_we
         return std::nullopt;
     }
 
-    return worn.wear_item( *this, to_wear, interactive, do_calc_encumbrance );
+    return worn.wear_item( *this, to_wear, interactive, do_calc_encumbrance, do_sort_items, quiet );
 }
 
 int Character::amount_worn( const itype_id &id ) const

--- a/src/character_attire.cpp
+++ b/src/character_attire.cpp
@@ -352,27 +352,29 @@ std::optional<std::list<item>::iterator> outfit::wear_item( Character &guy, cons
         }
         guy.mod_moves( -guy.item_wear_cost( to_wear ) );
 
-        for( const bodypart_id &bp : guy.get_all_body_parts() ) {
-            if( to_wear.covers( bp ) && guy.encumb( bp ) >= 40 && !quiet ) {
+        if( !quiet ) {
+            for( const bodypart_id &bp : guy.get_all_body_parts() ) {
+                if( to_wear.covers( bp ) && guy.encumb( bp ) >= 40 ) {
+                    guy.add_msg_if_player( m_warning,
+                                           bp == body_part_eyes ?
+                                           _( "Your %s are very encumbered!  %s" ) : _( "Your %s is very encumbered!  %s" ),
+                                           body_part_name( bp ), encumb_text( bp ) );
+                }
+            }
+            if( !was_deaf && guy.is_deaf() ) {
+                guy.add_msg_if_player( m_info, _( "You're deafened!" ) );
+            }
+            if( supertinymouse && !to_wear.has_flag( flag_UNDERSIZE ) ) {
                 guy.add_msg_if_player( m_warning,
-                                       bp == body_part_eyes ?
-                                       _( "Your %s are very encumbered!  %s" ) : _( "Your %s is very encumbered!  %s" ),
-                                       body_part_name( bp ), encumb_text( bp ) );
+                                       _( "This %s is too big to wear comfortably!  Maybe it could be refitted." ),
+                                       to_wear.tname() );
+            } else if( !supertinymouse && to_wear.has_flag( flag_UNDERSIZE ) ) {
+                guy.add_msg_if_player( m_warning,
+                                       _( "This %s is too small to wear comfortably!  Maybe it could be refitted." ),
+                                       to_wear.tname() );
             }
         }
-        if( !was_deaf && guy.is_deaf() && !quiet ) {
-            guy.add_msg_if_player( m_info, _( "You're deafened!" ) );
-        }
-        if( supertinymouse && !to_wear.has_flag( flag_UNDERSIZE ) && !quiet ) {
-            guy.add_msg_if_player( m_warning,
-                                   _( "This %s is too big to wear comfortably!  Maybe it could be refitted." ),
-                                   to_wear.tname() );
-        } else if( !supertinymouse && to_wear.has_flag( flag_UNDERSIZE ) && !quiet ) {
-            guy.add_msg_if_player( m_warning,
-                                   _( "This %s is too small to wear comfortably!  Maybe it could be refitted." ),
-                                   to_wear.tname() );
-        }
-    } else if( guy.is_npc() && get_player_view().sees( here, guy ) && !quiet ) {
+    } else if( !quiet && guy.is_npc() && get_player_view().sees( here, guy ) ) {
         guy.add_msg_if_npc( _( "<npcname> puts on their %s." ), to_wear.tname() );
     }
 

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -583,7 +583,7 @@ void Character::mutation_effect( const trait_id &mut, const bool worn_destroyed_
 
     for( const itype_id &armor : branch.integrated_armor ) {
         item tmparmor( armor );
-        wear_item( tmparmor, false );
+        wear_item( tmparmor, false, true, true, true );
     }
 
     remove_worn_items_with( [&]( item & armor ) {

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -914,7 +914,7 @@ void starting_clothes( npc &who, const npc_class_id &type, bool male )
         }
         if( who.can_wear( it ).success() ) {
             it.on_wear( who );
-            who.worn.wear_item( who, it, false, false );
+            who.worn.wear_item( who, it, false, false, true, true );
             it.set_owner( who );
         }
     }


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Follow-up on https://github.com/CleverRaven/Cataclysm-DDA/pull/56108

#### Describe the solution

Added some missed parameters to function calls, so npc would wear their starting items and mutation-related armor quietly.

I've also rearranged the code, so a single check for quiet parameter would guard multiple relatively expensive checks.

#### Testing

1. Start nearby NPCs (e.g. in refugee center).
2. Do not see any messages about NPCs dressing up in the log.
