### PR TITLE
Aftershock: Port Augustmoon sells nanomaterial

### DIFF
--- a/data/mods/aftershock_exoplanet/items/items.json
+++ b/data/mods/aftershock_exoplanet/items/items.json
@@ -16,6 +16,16 @@
   },
   {
     "type": "ITEM",
+    "subtypes": [ "AMMO" ],
+    "id": "nanomaterial",
+    "copy-from": "nanomaterial",
+    "price": "2750 USD",
+    "price_postapoc": "2750 USD",
+    "name": { "str": "nanomaterial canister" },
+    "description": "A steel canister containing carbon, iron, titanium, copper, and other elements in specifically engineered atomic-scale configurations.  Feedstock for most modern industrial processes, a nanofabricator can assemble them into usable items."
+  },
+  {
+    "type": "ITEM",
     "id": "afs_radiobeacon",
     "name": { "str": "broken distress beacon" },
     "description": "Truly putting the 'distress' in 'distress beacon,' this one has a huge hole in the front.  It will not be alerting anyone today.  Perhaps you could disassemble it for scrap.",

--- a/data/mods/aftershock_exoplanet/npcs/Augustmoon_Salvors/augustmoon_tool_trader.json
+++ b/data/mods/aftershock_exoplanet/npcs/Augustmoon_Salvors/augustmoon_tool_trader.json
@@ -33,6 +33,7 @@
       { "group": "afs_tools_portable_power", "count": [ 1, 2 ] },
       { "group": "afs_tools_structural_repair", "count": [ 1, 3 ] },
       { "group": "afs_tools_programing", "count": [ 1, 1 ] },
+      { "item": "nanomaterial", "prob": 66, "count": [ 2, 3 ] },
       { "group": "afs_tools_scavenging", "count": [ 6, 12 ] },
       { "group": "afs_tools_pocket", "count": [ 5, 10 ] },
       { "item": "afs_thermos", "count": [ 2, 3 ] },
@@ -88,6 +89,7 @@
     "ammo": 100,
     "magazine": 100,
     "items": [
+      { "item": "nanomaterial", "prob": 66, "count": [ 2, 3 ] },
       [ "electrohack", 20 ],
       [ "control_laptop", 20 ],
       [ "folding_solar_panel_v2", 20 ],


### PR DESCRIPTION
#### Summary
Mods "Aftershock: Port Augustmoon sells nanomaterial"
 
#### Purpose of change
There's nanofabricators aboard port augustmoon, but using them isnt very easy because nanomaterial is very rare in SALUS IV. Lets let the tool trader sell it at a very high price for now.

#### Describe the solution
Trade lists and price adjustments.

#### Testing
Checked the tool trader stock.
