### PR TITLE
print related info for bash and deconstruction of ter furn with base item

### DIFF
--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -2109,13 +2109,13 @@ void construct::do_turn_deconstruct( const tripoint_bub_ms &p, Character &who )
         std::string tname;
         if( here.has_furn( p ) ) {
             const furn_t &f = here.furn( p ).obj();
-            if( f.deconstruct ) {
-                deconstruct_query( f.deconstruct->potential_deconstruct_items( f.name() ) );
+            if( f.deconstruct || !f.base_item.is_null() ) {
+                deconstruct_query( f.deconstruct->potential_deconstruct_items( f ) );
             }
         } else {
             const ter_t &t = here.ter( p ).obj();
-            if( t.deconstruct ) {
-                deconstruct_query( t.deconstruct->potential_deconstruct_items( t.name() ) );
+            if( t.deconstruct || !t.base_item.is_null() ) {
+                deconstruct_query( t.deconstruct->potential_deconstruct_items( t ) );
             }
         }
         if( cancel_construction ) {

--- a/src/mapdata.h
+++ b/src/mapdata.h
@@ -37,6 +37,7 @@ const int NUM_TERCONN = 256;
 connect_group get_connect_group( const std::string &name );
 
 template <typename E> struct enum_traits;
+struct map_data_common_t;
 
 struct map_common_bash_info { //TODO: Half of this shouldn't be common
         // min str(*) required to bash
@@ -64,7 +65,8 @@ struct map_common_bash_info { //TODO: Half of this shouldn't be common
         std::pair<field_type_str_id, int> destroyed_field; // field spawned on successful bash
         void load( const JsonObject &jo, bool was_loaded, const std::string &context );
         void check( const std::string &id ) const;
-        std::string potential_bash_items( const std::string &ter_furn_name ) const;
+        // todo: move it to map_data_common_t
+        std::string potential_bash_items( const map_data_common_t &ter_furn ) const;
     public:
         virtual ~map_common_bash_info() = default;
 };
@@ -106,7 +108,8 @@ struct map_common_deconstruct_info {
         virtual void check( const std::string &id ) const;
     public:
         virtual ~map_common_deconstruct_info() = default;
-        std::string potential_deconstruct_items( const std::string &ter_furn_name ) const;
+        // todo: move it to map_data_common_t
+        std::string potential_deconstruct_items( const map_data_common_t &ter_furn ) const;
 };
 struct map_ter_deconstruct_info : map_common_deconstruct_info {
     ter_str_id ter_set = ter_str_id::NULL_ID();


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Sudden continuation of #81669
#### Describe the solution
Actually print the information about what we gonna bash
#### Testing
<img width="541" height="436" alt="image" src="https://github.com/user-attachments/assets/aacfcbeb-9068-4017-a97a-cd3c6baab4b6" />
<img width="505" height="133" alt="image" src="https://github.com/user-attachments/assets/972b1e43-43ab-4140-afae-4e8544c5a7e1" />

#### Additional context

wise man once said ☝️
<img width="468" height="54" alt="image" src="https://github.com/user-attachments/assets/16a6ddbb-5ae5-4548-8c51-c06525fd842a" />

there is a potential issue of bash info saying "drops 10 sheets" but actually drop 8 sheet and 48 small sheets, but i think it's a low priority problem