### PR TITLE
Add BULLETPROOF flag for monsters immune to ballistic damage, apply to Magiclysm's will o' wisps

### DIFF
--- a/data/json/damage_types.json
+++ b/data/json/damage_types.json
@@ -83,7 +83,7 @@
     "mon_difficulty": true,
     "name": "ballistic",
     "material_required": true,
-    "immune_flags": { "character": [ "BULLET_IMMUNE" ] }
+    "immune_flags": { "character": [ "BULLET_IMMUNE" ], "monster": [ "BULLETPROOF" ] }
   },
   {
     "id": "bullet",

--- a/data/json/monsters/monster_flags.json
+++ b/data/json/monsters/monster_flags.json
@@ -200,6 +200,11 @@
     "//": "Causes monster to leave a low intensity, 1 tile sludge pool approximately every other tile when moving"
   },
   {
+    "id": "BULLETPROOF",
+    "type": "monster_flag",
+    "//": "Immune to ballistic damage"
+  },
+  {
     "id": "COLDPROOF",
     "type": "monster_flag",
     "//": "Immune to cold damage"

--- a/data/mods/Magiclysm/monsters/monsters.json
+++ b/data/mods/Magiclysm/monsters/monsters.json
@@ -265,6 +265,7 @@
     "species": [ "MAGICAL_BEAST" ],
     "volume": "1500 ml",
     "weight": "136 g",
+    "diff": 5,
     "hp": 20,
     "speed": 160,
     "luminance": 16,
@@ -296,7 +297,6 @@
         "monster_message": "%1$s glitters in an eerie pattern."
       }
     ],
-    "armor": { "bullet": 9999 },
     "flags": [
       "SEES",
       "HEARS",
@@ -304,6 +304,7 @@
       "KEEP_DISTANCE",
       "PATH_AVOID_DANGER",
       "ELECTRIC",
+      "BULLETPROOF",
       "BIOLOGICALPROOF",
       "HARDTOSHOOT",
       "PLASTIC",

--- a/doc/JSON/JSON_FLAGS.md
+++ b/doc/JSON/JSON_FLAGS.md
@@ -1100,6 +1100,7 @@ Used to describe monster characteristics and set their properties and abilities.
 - ```BILE_BLOOD``` Makes monster bleed bile.
 - ```BIOLOGICALPROOF``` Immune to biological damage.
 - ```BORES``` Tunnels through just about anything (15x bash multiplier e.g. dark wyrms' bash skill 12 -> 180).
+- ```BULLETPROOF``` Immune to ballistic damage.
 - ```CAMOUFLAGE``` Stays invisible up to (current Perception, + base Perception if the character has the Spotting proficiency) tiles away, even in broad daylight.  Monsters see it from the lower of `vision_day` and `vision_night` ranges.
 - ```CANPLAY``` This creature can be played with if it's a pet.
 - ```CAN_BE_CULLED``` This animal can be culled if it's a pet.


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Balance "Add BULLETPROOF flag for monsters immune to ballistic damage, apply to Magiclysm's will o' wisps"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Got a report that thanks to will o' wisps having 9999 ballistic armor, they had a difficulty of 4019, which made them show up as fatally dangerous and threw everything that uses exp (like Stats Through Kills) out of whack. 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add the `BULLETPROOF` flag to make monsters immune to ballistic damage. Apply it to the will o' wisp and remove its ballistic armor. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<img width="352" height="155" alt="Untitled" src="https://github.com/user-attachments/assets/eb113737-b801-4bd5-8238-d3c19959434d" />

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

I repeat my conviction that some Nether monsters should be immune to bullets but this isn't the PR for that. 
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
