### PR TITLE
"hard" meta progression requirements for mods

### DIFF
--- a/doc/JSON/JSON_INFO.md
+++ b/doc/JSON/JSON_INFO.md
@@ -1964,6 +1964,7 @@ The following properties (mandatory, except if noted otherwise) are supported:
     "CBMs": [ "bio_fuel_cell_blood" ],                         // (optional) Array of starting implanted CMBs
     "traits": [ "PROF_CHURL", "ILLITERATE" ],                  // (optional) Array of starting traits/mutations. For further information, see mutations.json and MUTATIONS.md. Note: "trait" is also supported, used for a single trait/mutation ID (legacy!)
     "requirement": "achievement_survive_28_days",              // (optional) String of an achievement ID required to unlock this profession
+    "hard_requirement": true,                                  // (optional) Defaults false. Whether or not the requirement ignores the metaprogression setting and is always required. Intended for use by mods.
     "effect_on_conditions": [ "scenario_assassin_conv" ],      // (optional) eoc id, inline eoc, or multiple of them, that would run when scenario starts
     "spells": [                                                // (optional) Array of starting spell IDs the character knows upon creation. For further information, see MAGIC.md
       { "id": "magic_missile", "level": 4 },
@@ -4058,6 +4059,12 @@ Add a map special to the starting location, see JSON_FLAGS for the possible spec
 (optional, an achievement ID)
 
 The achievement you need to do to access this scenario
+
+## `hard_requirement`
+
+(optional, bool)
+
+Defaults false. Whether or not the requirement ignores the metaprogression setting and is always required. Intended for use by mods.
 
 ## `reveal_locale`
 

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -2276,8 +2276,14 @@ static std::string assemble_profession_details( const avatar &u, const input_con
 
     if( sorted_profs[cur_id]->get_requirement().has_value() ) {
         assembled += "\n" + colorize( _( "Profession requirements:" ), COL_HEADER ) + "\n";
-        assembled += string_format( _( "Complete \"%s\"\n" ),
-                                    sorted_profs[cur_id]->get_requirement().value()->name() );
+        ret_val<void> can_pick_prof = sorted_profs[cur_id]->can_pick();
+        if( can_pick_prof.success() ) {
+            assembled += colorize( string_format( _( "Completed \"%s\"\n" ),
+                                                  sorted_profs[cur_id]->get_requirement().value()->name() ),
+                                   c_green ) + "\n";
+        } else { // fail, can't pick so display ret_val's reason
+            assembled += colorize( can_pick_prof.str(), c_red ) + "\n";
+        }
     }
     //Profession story
     assembled += "\n" + colorize( _( "Profession story:" ), COL_HEADER ) + "\n";
@@ -3506,12 +3512,13 @@ static std::string assemble_scenario_details( const avatar &u, const input_conte
             assembled += colorize( scenUnavailable, c_red ) + "\n";
         }
         if( scenRequirement.has_value() ) {
-            nc_color requirement_color = c_red;
-            if( current_scenario->can_pick().success() ) {
-                requirement_color = c_green;
+            ret_val<void> can_pick_scenario = current_scenario->can_pick();
+            if( can_pick_scenario.success() ) {
+                assembled += colorize( string_format( _( "Completed \"%s\"" ), scenRequirement.value()->name() ),
+                                       c_green ) + "\n";
+            } else { // fail, can't pick so display ret_val's reason
+                assembled += colorize( can_pick_scenario.str(), c_red ) + "\n";
             }
-            assembled += colorize( string_format( _( "Complete \"%s\"" ), scenRequirement.value()->name() ),
-                                   requirement_color ) + "\n";
         }
     }
 

--- a/src/profession.h
+++ b/src/profession.h
@@ -67,6 +67,8 @@ class profession
 
         // does this profession require a specific achiement to unlock
         std::optional<achievement_id> _requirement;
+        // does this profession require the requirement even when metaprogression is disabled?
+        bool hard_requirement = false;
 
         std::vector<addiction> _starting_addictions;
         std::vector<bionic_id> _starting_CBMs;
@@ -144,6 +146,7 @@ class profession
         std::vector<effect_on_condition_id> get_eocs() const;
         //returns the profession id
         profession_id get_profession_id() const;
+        bool has_hard_requirement() const;
 
         /**
          * Check if this type of profession has a certain flag set.

--- a/src/scenario.cpp
+++ b/src/scenario.cpp
@@ -102,6 +102,12 @@ void scenario::load( const JsonObject &jo, std::string_view )
     optional( jo, was_loaded, "missions", _missions, string_id_reader<::mission_type> {} );
 
     optional( jo, was_loaded, "requirement", _requirement );
+    optional( jo, was_loaded, "hard_requirement", hard_requirement, false );
+
+    if( hard_requirement && !_requirement ) {
+        jo.throw_error_at( "hard_requirement",
+                           "Cannot have hard requirement when object has no requirements" );
+    }
 
     optional( jo, was_loaded, "reveal_locale", reveal_locale, true );
     optional( jo, was_loaded, "distance_initial_visibility", distance_initial_visibility, 15 );
@@ -509,6 +515,11 @@ bool scenario::scenario_traits_conflict_with_profession_traits( const profession
     return false;
 }
 
+bool scenario::has_hard_requirement() const
+{
+    return hard_requirement;
+}
+
 const profession *scenario::weighted_random_profession() const
 {
     // Strategy: 1/3 of the time, return the generic profession (if it's permitted).
@@ -662,18 +673,23 @@ ret_val<void> scenario::can_afford( const scenario &current_scenario, const int 
 
 ret_val<void> scenario::can_pick() const
 {
+    const bool meta_progression = get_option<bool>( "META_PROGRESS" );
     // if meta progression is disabled then skip this
     if( get_past_achievements().is_completed( achievement_achievement_arcade_mode ) ||
-        !get_option<bool>( "META_PROGRESS" ) ) {
+        ( !meta_progression && !has_hard_requirement() ) ) {
         return ret_val<void>::make_success();
     }
 
     if( _requirement ) {
         const bool has_req = get_past_achievements().is_completed(
                                  _requirement.value()->id );
+        std::string fail_msg = _( "You must complete the achievement \"%s\" to unlock this scenario." );
+        if( !meta_progression ) {
+            fail_msg += _( "\nThis scenario can only be unlocked through achievements." );
+        }
         if( !has_req ) {
             return ret_val<void>::make_failure(
-                       _( "You must complete the achievement \"%s\" to unlock this scenario." ),
+                       fail_msg,
                        _requirement.value()->name() );
         }
     }

--- a/src/scenario.h
+++ b/src/scenario.h
@@ -60,6 +60,8 @@ class scenario
 
         // does this scenario require a specific achiement to unlock
         std::optional<achievement_id> _requirement;
+        // does this scenario require the requirement even when metaprogression is disabled?
+        bool hard_requirement = false;
 
         bool reveal_locale = true;
         int distance_initial_visibility = 0;
@@ -106,6 +108,7 @@ class scenario
 
         std::optional<achievement_id> get_requirement() const;
 
+        bool has_hard_requirement() const;
         bool get_reveal_locale() const;
         bool get_distance_initial_visibility() const;
 


### PR DESCRIPTION
#### Summary
Mods "Mods can have 'hard' requirements for meta progression"

#### Purpose of change

Requested by @John-Candlebury for Aftershock Exoplanet.

<img width="844" height="611" alt="image" src="https://github.com/user-attachments/assets/c86dff74-4ef7-49cb-8d1f-a732bdb9c301" />



#### Describe the solution
Requirements can optionally be "hard" on a per-unlock basis, making them ignore the meta progression.

Put some basic guard rails in so if people use the value the wrong way it'll error helpfully and point out the problem.

Fix a bug where the return values of scenario::can_pick() and profession::can_pick() were being dropped, leading to dead strings that didn't appear anywhere. (This is separated out into its own commit)

#### Describe alternatives you've considered
I jokingly suggested to Candlebury that they override the meta progression option in their mod, but that would be bad. Everytime the mod would be loaded it would force the option to that setting even if the user created a new world without Aftershock Exoplanet enabled (until the user manually changed it back).

For debugging purposes this currently allows the "arcade" achievement to bypass even the "hard" requirements, but I considered also making it check debug_menu::is_debug_character().

#### Testing
<img width="2552" height="1399" alt="image" src="https://github.com/user-attachments/assets/2407dbc2-fc38-4483-a39d-c46c4351f64a" />



#### Additional context

