### PR TITLE
[Xedra Evolved] Add bloodthorne druid safehouse

### DIFF
--- a/data/mods/Xedra_Evolved/itemgroups/itemgroups.json
+++ b/data/mods/Xedra_Evolved/itemgroups/itemgroups.json
@@ -540,5 +540,16 @@
     "//": "This group was created automatically and may contain errors.",
     "container-item": "wrapper_wyld",
     "entries": [ { "item": "wyld_candy", "container-item": "null", "count": 20 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "portable_non_flashlight_light_sources",
+    "subtype": "distribution",
+    "entries": [
+      { "item": "candle", "prob": 3, "charges": [ 5, 50 ] },
+      { "item": "gasoline_lantern", "prob": 5, "charges": [ 0, -1 ] },
+      { "item": "electric_lantern", "prob": 8, "charges": [ 0, 100 ] },
+      { "item": "oil_lamp", "prob": 5, "charges": [ 0, -1 ] }
+    ]
   }
 ]

--- a/data/mods/Xedra_Evolved/items/book_lore.json
+++ b/data/mods/Xedra_Evolved/items/book_lore.json
@@ -307,5 +307,20 @@
       { "u_learn_recipe": "anathema_blood_catalyst_unready" },
       { "u_add_var": "you_know_vampire_anathema_recipe", "value": "yes" }
     ]
+  },
+  {
+    "type": "ITEM",
+    "id": "note_snippet_bloodthorne_druid",
+    "name": { "str": "druidic notes", "str_pl": "copies of druidic notes" },
+    "category": "books",
+    "description": "Some notes taken on paper with pen or pencil.  Some parts of them catch your eye.",
+    "snippet_category": "note_bloodthorne_druid",
+    "weight": "15 g",
+    "color": "white",
+    "symbol": ",",
+    "material": [ "paper" ],
+    "volume": "50 ml",
+    "flags": [ "TRADER_AVOID" ],
+    "copy-from": "file"
   }
 ]

--- a/data/mods/Xedra_Evolved/mapgen/cabins/bloodthorne_druid_safehouse.json
+++ b/data/mods/Xedra_Evolved/mapgen/cabins/bloodthorne_druid_safehouse.json
@@ -43,6 +43,7 @@
         "W": "t_wooden_well"
       },
       "furniture": { "£": "f_magic_brambles", "€": [ [ "f_diesel_generator", 2 ], [ "f_null", 1 ] ] },
+      "place_item": [ { "item": "plant_imbuement", "x": 10, "y": 8, "chance": 65 } ],
       "place_nested": [
         {
           "chunks": [ [ "roof_6x6_garden_3", 25 ], [ "roof_6x6_greenhouse_bloodthorne", 25 ], [ "roof_6x6_garden_2", 25 ] ],

--- a/data/mods/Xedra_Evolved/mapgen/cabins/bloodthorne_druid_safehouse.json
+++ b/data/mods/Xedra_Evolved/mapgen/cabins/bloodthorne_druid_safehouse.json
@@ -49,7 +49,7 @@
           "x": 2,
           "y": 17
         },
-        { "chunks": [ "bloodthorne_druid_10x10_basement_stairs" ], "x": 5, "y": 8 },
+        { "chunks": [ "bloodthorne_druid_11x11_basement_stairs" ], "x": 5, "y": 7 },
         { "chunks": [ "bloodthorne_druid_safehouse_bathroom_roof" ], "x": 15, "y": 4 }
       ],
       "place_monster": [

--- a/data/mods/Xedra_Evolved/mapgen/cabins/bloodthorne_druid_safehouse.json
+++ b/data/mods/Xedra_Evolved/mapgen/cabins/bloodthorne_druid_safehouse.json
@@ -1,0 +1,61 @@
+[
+  {
+    "om_terrain": "cabin_6",
+    "weight": 250,
+    "type": "mapgen",
+    "object": {
+      "fill_ter": "t_floor",
+      "rows": [
+        "*£££££*££££.~.£££££££*££",
+        "££***£££***.~.******££££",
+        "£*********..~..*******££",
+        "£*******....~....******£",
+        "££******.#w#+#w####****£",
+        "*£******.wb    + T#***££",
+        "*£***....#b  ct# 5#.***£",
+        "££***.##w###=###+##.***£",
+        "£**...#15SFR &#  D#.***£",
+        "£**...w2     R# BBw.**££",
+        "£*....w3 CC   + BB#.**£*",
+        "££....#y ll   #####%**£*",
+        "£~~~~~+       +  D#.**££",
+        "£.....#cttc#+## BBw.***£",
+        "£**...#cttc# R# BB#.***£",
+        "£***..##ww##+###w##.**££",
+        "££**................**££",
+        "£*......**********.****£",
+        "£*......*********...***£",
+        "£*......*********.W.**££",
+        "£*......*********...**££",
+        "£*......**************£*",
+        "££......**£££****££££££*",
+        "*££££££££££*££££££**££**"
+      ],
+      "palettes": [ "cabin_palette" ],
+      "terrain": {
+        "*": [
+          [ "t_region_tree", 1 ],
+          [ "t_region_tree_evergreen", 1 ],
+          [ "t_region_shrub", 5 ],
+          [ "t_region_groundcover_forest", 10 ],
+          [ "t_region_groundcover", 25 ]
+        ],
+        "W": "t_wooden_well"
+      },
+      "furniture": { "£": "f_magic_brambles" },
+      "place_nested": [
+        {
+          "chunks": [ [ "roof_6x6_garden_3", 25 ], [ "roof_6x6_greenhouse_bloodthorne", 25 ], [ "roof_6x6_garden_2", 25 ] ],
+          "x": 2,
+          "y": 17
+        },
+        { "chunks": [ "bloodthorne_druid_9x9_basement_stairs" ], "x": 6, "y": 9 }
+      ],
+      "place_monster": [
+        { "monster": "mon_thornhound", "x": 3, "y": 3, "chance": 50 },
+        { "monster": "mon_thornhound", "x": 19, "y": 3, "chance": 50 },
+        { "monster": "mon_thornhound", "x": 18, "y": 19, "chance": 50 }
+      ]
+    }
+  }
+]

--- a/data/mods/Xedra_Evolved/mapgen/cabins/bloodthorne_druid_safehouse.json
+++ b/data/mods/Xedra_Evolved/mapgen/cabins/bloodthorne_druid_safehouse.json
@@ -43,7 +43,10 @@
         "W": "t_wooden_well"
       },
       "furniture": { "£": "f_magic_brambles", "€": [ [ "f_diesel_generator", 2 ], [ "f_null", 1 ] ] },
-      "place_item": [ { "item": "plant_imbuement", "x": 10, "y": 8, "chance": 65 } ],
+      "place_item": [
+        { "item": "plant_imbuement", "x": 10, "y": 8, "chance": 65 },
+        { "item": "alchemy_recipe_plant_imbuement", "x": 13, "y": 11, "chance": 50 }
+      ],
       "place_nested": [
         {
           "chunks": [ [ "roof_6x6_garden_3", 25 ], [ "roof_6x6_greenhouse_bloodthorne", 25 ], [ "roof_6x6_garden_2", 25 ] ],

--- a/data/mods/Xedra_Evolved/mapgen/cabins/bloodthorne_druid_safehouse.json
+++ b/data/mods/Xedra_Evolved/mapgen/cabins/bloodthorne_druid_safehouse.json
@@ -49,7 +49,7 @@
           "x": 2,
           "y": 17
         },
-        { "chunks": [ "bloodthorne_druid_9x9_basement_stairs" ], "x": 6, "y": 9 },
+        { "chunks": [ "bloodthorne_druid_10x10_basement_stairs" ], "x": 5, "y": 8 },
         { "chunks": [ "bloodthorne_druid_safehouse_bathroom_roof" ], "x": 15, "y": 4 }
       ],
       "place_monster": [

--- a/data/mods/Xedra_Evolved/mapgen/cabins/bloodthorne_druid_safehouse.json
+++ b/data/mods/Xedra_Evolved/mapgen/cabins/bloodthorne_druid_safehouse.json
@@ -1,7 +1,7 @@
 [
   {
     "om_terrain": "cabin_6",
-    "weight": 250,
+    "weight": 450,
     "type": "mapgen",
     "object": {
       "fill_ter": "t_floor",
@@ -17,7 +17,7 @@
         "£**...#15SFR &#  D#.***£",
         "£**...w2     R# BBw.**££",
         "£*....w3 CC   + BB#.**£*",
-        "££....#y ll   #####%**£*",
+        "££...€#y ll  A#####%**£*",
         "£~~~~~+       +  D#.**££",
         "£.....#cttc#+## BBw.***£",
         "£**...#cttc# R# BB#.***£",
@@ -42,19 +42,20 @@
         ],
         "W": "t_wooden_well"
       },
-      "furniture": { "£": "f_magic_brambles" },
+      "furniture": { "£": "f_magic_brambles", "€": [ [ "f_diesel_generator", 2 ], [ "f_null", 1 ] ] },
       "place_nested": [
         {
           "chunks": [ [ "roof_6x6_garden_3", 25 ], [ "roof_6x6_greenhouse_bloodthorne", 25 ], [ "roof_6x6_garden_2", 25 ] ],
           "x": 2,
           "y": 17
         },
-        { "chunks": [ "bloodthorne_druid_9x9_basement_stairs" ], "x": 6, "y": 9 }
+        { "chunks": [ "bloodthorne_druid_9x9_basement_stairs" ], "x": 6, "y": 9 },
+        { "chunks": [ "bloodthorne_druid_safehouse_bathroom_roof" ], "x": 15, "y": 4 }
       ],
       "place_monster": [
         { "monster": "mon_thornhound", "x": 3, "y": 3, "chance": 50 },
         { "monster": "mon_thornhound", "x": 19, "y": 3, "chance": 50 },
-        { "monster": "mon_thornhound", "x": 18, "y": 19, "chance": 50 }
+        { "monster": "mon_thornhound", "x": 18, "y": 17, "chance": 50 }
       ]
     }
   }

--- a/data/mods/Xedra_Evolved/mapgen/nested/bloodthorne_druid.json
+++ b/data/mods/Xedra_Evolved/mapgen/nested/bloodthorne_druid.json
@@ -1,0 +1,71 @@
+[
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "roof_6x6_greenhouse_bloodthorne",
+    "object": {
+      "mapgensize": [ 6, 6 ],
+      "rotation": [ 0, 3 ],
+      "rows": [
+        "%#++#%",
+        "%1__1%",
+        "#1__1#",
+        "#1__1#",
+        "%1__1%",
+        "%####%"
+      ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
+      "terrain": {
+        "_": "t_railroad_rubble",
+        "#": "t_reinforced_glass_shutter_open",
+        "+": "t_reinforced_door_glass_c",
+        "%": "t_reinforced_glass_shutter",
+        "$": "t_wall_glass"
+      },
+      "furniture": { "S": "f_statue" },
+      "sealed_item": { "1": { "item": { "item": "seed_rose" }, "furniture": "f_planter_mature" } },
+      "place_nested": [ { "chunks": [ "roof_6x6_greenhouse_roof" ], "x": 0, "y": 0, "z": 1 } ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "bloodthorne_druid_9x9_basement_stairs",
+    "object": {
+      "mapgensize": [ 9, 9 ],
+      "rotation": [ 0, 0 ],
+      "rows": [
+        "         ",
+        "         ",
+        "         ",
+        "         ",
+        "         ",
+        "         ",
+        "         ",
+        "       T ",
+        "         "
+      ],
+      "terrain": { "T": "t_wood_stairs_down" },
+      "place_nested": [ { "chunks": [ "bloodthorne_druid_9x9_basement" ], "x": 0, "y": 0, "z": -1 } ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "bloodthorne_druid_9x9_basement",
+    "object": {
+      "mapgensize": [ 9, 9 ],
+      "rotation": [ 0, 0 ],
+      "rows": [
+        "---------",
+        "-       -",
+        "-       -",
+        "-       -",
+        "-       -",
+        "-       -",
+        "-       -",
+        "-      T-",
+        "---------"
+      ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
+      "terrain": { "T": "t_wood_stairs_up", "-": "t_wall_wood", " ": "t_dirtfloor" }
+    }
+  }
+]

--- a/data/mods/Xedra_Evolved/mapgen/nested/bloodthorne_druid.json
+++ b/data/mods/Xedra_Evolved/mapgen/nested/bloodthorne_druid.json
@@ -61,49 +61,53 @@
   },
   {
     "type": "mapgen",
-    "nested_mapgen_id": "bloodthorne_druid_9x9_basement_stairs",
+    "nested_mapgen_id": "bloodthorne_druid_10x10_basement_stairs",
     "object": {
-      "mapgensize": [ 9, 9 ],
+      "mapgensize": [ 10, 10 ],
       "rotation": [ 0, 0 ],
       "rows": [
-        "         ",
-        "         ",
-        "         ",
-        "         ",
-        "         ",
-        "         ",
-        "         ",
-        "       T ",
-        "         "
+        "          ",
+        "          ",
+        "          ",
+        "          ",
+        "          ",
+        "          ",
+        "          ",
+        "          ",
+        "        T ",
+        "          "
       ],
       "terrain": { "T": "t_wood_stairs_down" },
-      "place_nested": [ { "chunks": [ "bloodthorne_druid_9x9_basement" ], "x": 0, "y": 0, "z": -1 } ]
+      "place_nested": [ { "chunks": [ "bloodthorne_druid_10x10_basement" ], "x": 0, "y": 0, "z": -1 } ]
     }
   },
   {
     "type": "mapgen",
-    "nested_mapgen_id": "bloodthorne_druid_9x9_basement",
+    "nested_mapgen_id": "bloodthorne_druid_10x10_basement",
     "object": {
-      "mapgensize": [ 9, 9 ],
+      "mapgensize": [ 10, 10 ],
       "rotation": [ 0, 0 ],
       "rows": [
-        "---------",
-        "-   | tt-",
-        "-||+| ct-",
-        "-      t-",
-        "-   -   -",
-        "-R      -",
-        "-R      -",
-        "-RRR   T-",
-        "---------"
+        "#---------",
+        "#-   |-tt-",
+        "#-||+|-ct-",
+        "#-    - t-",
+        "#---d--  -",
+        "#-R      -",
+        "#-R      -",
+        "#-RRR    -",
+        "#-------T-",
+        "#######---"
       ],
       "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
       "terrain": {
+        "#": "t_soil",
         "T": "t_wood_stairs_up",
         "-": "t_wall_wood",
         " ": "t_dirtfloor",
         "|": "t_bars",
         "+": "t_door_bar_locked",
+        "d": "t_door_c",
         "R": "t_dirtfloor",
         "t": "t_dirtfloor",
         "c": "t_dirtfloor"

--- a/data/mods/Xedra_Evolved/mapgen/nested/bloodthorne_druid.json
+++ b/data/mods/Xedra_Evolved/mapgen/nested/bloodthorne_druid.json
@@ -61,43 +61,45 @@
   },
   {
     "type": "mapgen",
-    "nested_mapgen_id": "bloodthorne_druid_10x10_basement_stairs",
+    "nested_mapgen_id": "bloodthorne_druid_11x11_basement_stairs",
     "object": {
-      "mapgensize": [ 10, 10 ],
+      "mapgensize": [ 11, 11 ],
       "rotation": [ 0, 0 ],
       "rows": [
-        "          ",
-        "          ",
-        "          ",
-        "          ",
-        "          ",
-        "          ",
-        "          ",
-        "          ",
-        "        T ",
-        "          "
+        "           ",
+        "           ",
+        "           ",
+        "           ",
+        "           ",
+        "           ",
+        "           ",
+        "           ",
+        "           ",
+        "        T  ",
+        "           "
       ],
       "terrain": { "T": "t_wood_stairs_down" },
-      "place_nested": [ { "chunks": [ "bloodthorne_druid_10x10_basement" ], "x": 0, "y": 0, "z": -1 } ]
+      "place_nested": [ { "chunks": [ "bloodthorne_druid_11x11_basement" ], "x": 0, "y": 0, "z": -1 } ]
     }
   },
   {
     "type": "mapgen",
-    "nested_mapgen_id": "bloodthorne_druid_10x10_basement",
+    "nested_mapgen_id": "bloodthorne_druid_11x11_basement",
     "object": {
-      "mapgensize": [ 10, 10 ],
+      "mapgensize": [ 11, 11 ],
       "rotation": [ 0, 0 ],
       "rows": [
-        "#---------",
-        "#-   |-tt-",
-        "#-||+|-ct-",
-        "#-    - t-",
-        "#---d--  -",
-        "#-R      -",
-        "#-R      -",
-        "#-RRR    -",
-        "#-------T-",
-        "#######---"
+        "#---------#",
+        "#-   |-tt-#",
+        "#-||+|-ct-#",
+        "#-    - t-#",
+        "#---d--  -#",
+        "#-R      -#",
+        "#-R      -#",
+        "#-RRR    -#",
+        "#------- -#",
+        "#######-T-#",
+        "#######---#"
       ],
       "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
       "terrain": {

--- a/data/mods/Xedra_Evolved/mapgen/nested/bloodthorne_druid.json
+++ b/data/mods/Xedra_Evolved/mapgen/nested/bloodthorne_druid.json
@@ -28,6 +28,39 @@
   },
   {
     "type": "mapgen",
+    "nested_mapgen_id": "bloodthorne_druid_safehouse_bathroom_roof",
+    "object": {
+      "mapgensize": [ 4, 4 ],
+      "rotation": [ 0, 0 ],
+      "rows": [
+        "    ",
+        "    ",
+        "    ",
+        "    "
+      ],
+      "terrain": { "T": "t_wood_stairs_down" },
+      "place_nested": [ { "chunks": [ "bloodthorne_druid_safehouse_bathroom_roof_z1" ], "x": 0, "y": 0, "z": 1 } ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "bloodthorne_druid_safehouse_bathroom_roof_z1",
+    "object": {
+      "mapgensize": [ 4, 4 ],
+      "rotation": [ 0, 0 ],
+      "rows": [
+        "----",
+        "...-",
+        "...-",
+        "...-"
+      ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
+      "palettes": [ "roof_palette" ],
+      "terrain": { ".": "t_tar_flat_roof" }
+    }
+  },
+  {
+    "type": "mapgen",
     "nested_mapgen_id": "bloodthorne_druid_9x9_basement_stairs",
     "object": {
       "mapgensize": [ 9, 9 ],
@@ -55,17 +88,48 @@
       "rotation": [ 0, 0 ],
       "rows": [
         "---------",
-        "-       -",
-        "-       -",
-        "-       -",
-        "-       -",
-        "-       -",
-        "-       -",
-        "-      T-",
+        "-   | tt-",
+        "-||+| ct-",
+        "-      t-",
+        "-   -   -",
+        "-R      -",
+        "-R      -",
+        "-RRR   T-",
         "---------"
       ],
       "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
-      "terrain": { "T": "t_wood_stairs_up", "-": "t_wall_wood", " ": "t_dirtfloor" }
+      "terrain": {
+        "T": "t_wood_stairs_up",
+        "-": "t_wall_wood",
+        " ": "t_dirtfloor",
+        "|": "t_bars",
+        "+": "t_door_bar_locked",
+        "R": "t_dirtfloor",
+        "t": "t_dirtfloor",
+        "c": "t_dirtfloor"
+      },
+      "furniture": { "R": "f_rack_wood", "t": "f_table", "c": "f_chair" },
+      "items": {
+        "R": [
+          { "item": "veggy_pickled_jar_3l_glass_sealed_12", "chance": 15, "repeat": [ 1, 2 ] },
+          { "item": "apple_canned_jar_3l_glass_sealed_24", "chance": 15 },
+          { "item": "fish_pickled_jar_3l_glass_sealed_12", "chance": 15, "repeat": [ 1, 2 ] },
+          { "item": "meat_pickled_jar_3l_glass_sealed_12", "chance": 15 },
+          { "item": "veggy_canned_jar_3l_glass_sealed_12", "chance": 15, "repeat": [ 1, 2 ] },
+          { "item": "can_tomato_jar_3l_glass_sealed_24", "chance": 15, "repeat": [ 1, 2 ] },
+          { "item": "meat_canned_jar_3l_glass_sealed_12", "chance": 15 },
+          { "item": "flour_bag_paper_full", "chance": 60, "repeat": [ 1, 2 ] },
+          { "item": "kitchen_sack", "chance": 60, "repeat": [ 0, 2 ] }
+        ]
+      },
+      "place_item": [
+        { "item": "silver_locket", "x": 7, "y": 1, "chance": 5 },
+        { "item": "vacutainer", "x": 7, "y": 2, "chance": 85 },
+        { "item": "note_snippet_bloodthorne_druid", "x": 7, "y": 1, "chance": 80 },
+        { "item": "note_snippet_bloodthorne_druid", "x": 6, "y": 1, "chance": 45 }
+      ],
+      "place_items": [ { "item": "portable_non_flashlight_light_sources", "x": 8, "y": 0 } ],
+      "place_monster": [ { "monster": "mon_vampire_feral", "x": 2, "y": 1, "chance": 70 } ]
     }
   }
 ]

--- a/data/mods/Xedra_Evolved/monsters/bloodthorne.json
+++ b/data/mods/Xedra_Evolved/monsters/bloodthorne.json
@@ -5,7 +5,7 @@
     "name": { "str_sp": "Thornhound" },
     "description": "An animated tangle of thorns in the rough shape of a large dog, with several vines waving in the air like an anemone's tentacles.  Three glowing green spots are visible on what might be the head.",
     "default_faction": "factionless",
-    "species": [ "PLANT" ],
+    "species": [ "PLANT", "THORNBEAST" ],
     "volume": "62500 ml",
     "weight": "81500 g",
     "bodytype": "dog",

--- a/data/mods/Xedra_Evolved/monsters/bloodthorne.json
+++ b/data/mods/Xedra_Evolved/monsters/bloodthorne.json
@@ -4,7 +4,7 @@
     "type": "MONSTER",
     "name": { "str_sp": "Thornhound" },
     "description": "An animated tangle of thorns in the rough shape of a large dog, with several vines waving in the air like an anemone's tentacles.  Three glowing green spots are visible on what might be the head.",
-    "default_faction": "factionless",
+    "default_faction": "thornbeast",
     "species": [ "PLANT", "THORNBEAST" ],
     "volume": "62500 ml",
     "weight": "81500 g",

--- a/data/mods/Xedra_Evolved/monsters/bloodthorne.json
+++ b/data/mods/Xedra_Evolved/monsters/bloodthorne.json
@@ -19,6 +19,7 @@
     "melee_skill": 6,
     "melee_dice": 2,
     "melee_dice_sides": 4,
+    "attack_cost": 160,
     "dodge": 3,
     "vision_day": 35,
     "vision_night": 6,

--- a/data/mods/Xedra_Evolved/monsters/monfaction.json
+++ b/data/mods/Xedra_Evolved/monsters/monfaction.json
@@ -13,7 +13,7 @@
     "base_faction": "zombie",
     "neutral": [ "zombie" ],
     "by_mood": [ "nether", "nightmares" ],
-    "hate": [ "changeling" ]
+    "hate": [ "changeling", "thornbeast" ]
   },
   {
     "type": "MONSTER_FACTION",
@@ -28,7 +28,7 @@
     "base_faction": "changeling",
     "neutral": [ "small_animal", "fish" ],
     "by_mood": [ "nether", "nightmares", "ierde", "undine", "sylph", "salamander" ],
-    "hate": [ "zombie", "homullus" ]
+    "hate": [ "zombie", "homullus", "thornbeast" ]
   },
   {
     "type": "MONSTER_FACTION",
@@ -70,6 +70,12 @@
     "neutral": [ "small_animal", "fish" ],
     "by_mood": [ "nether", "nightmares", "homullus", "arvore", "undine", "salamander" ],
     "hate": [ "zombie", "ierde" ]
+  },
+  {
+    "type": "MONSTER_FACTION",
+    "name": "thornbeast",
+    "by_mood": [ "zombie", "nether", "nightmares" ],
+    "hate": [ "arvore", "vampire" ]
   },
   {
     "type": "MONSTER_FACTION",

--- a/data/mods/Xedra_Evolved/monsters/species.json
+++ b/data/mods/Xedra_Evolved/monsters/species.json
@@ -62,6 +62,11 @@
   },
   {
     "type": "SPECIES",
+    "id": "THORNBEAST",
+    "description": "A magickally-animated mass of thorns, born to kill vampires"
+  },
+  {
+    "type": "SPECIES",
     "id": "RENFIELD",
     "description": "a variety of creatures that have partaken of the unholy blood of the vampyr",
     "fear_triggers": [ "FIRE" ]

--- a/data/mods/Xedra_Evolved/mutations/bloodthorne_druid_traits.json
+++ b/data/mods/Xedra_Evolved/mutations/bloodthorne_druid_traits.json
@@ -22,6 +22,7 @@
       }
     ],
     "no_cbm_on_bp": [ "torso", "head", "eyes", "mouth", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
+    "anger_relations": [ [ "THORNBEAST", -100 ] ],
     "flags": [ "ATTUNEMENT", "TREE_COMMUNION_PLUS" ]
   },
   {

--- a/data/mods/Xedra_Evolved/snippets/bloodthorne_note_snippets.json
+++ b/data/mods/Xedra_Evolved/snippets/bloodthorne_note_snippets.json
@@ -6,7 +6,7 @@
       {
         "id": "xe_bloodthorn_note_01",
         "name": "Meditations",
-        "text": "The elders want me to write down what I feel during weekly meditations but I don't see the point.  I've never been good at concentrating.  I go out into the forest and I sit and pretty soon there's some bugs crawling on or my back itches or I get a cramp on my leg and it breaks my concentration.  I've gotten pretty used to the heartvines moving, that's not the problem, it's the *other* stuff I can't get past.\n\nIt's weird, right?  You'd think that having a plant in my blood would be all I can think about but I got used to it in a week.  ̶A̶n̶y̶t̶h̶i̶n̶g̶ ̶i̶f̶ ̶I̶ ̶c̶a̶n̶  No, not yet.  I have to find the thing that did it, then I'll write it all down.  Now I just have to stop getting those cricks in my heck when I'm looking up through the leaves."
+        "text": "The elders want me to write down what I feel during weekly meditations but I don't see the point.  I've never been good at concentrating.  I go out into the forest and I sit and pretty soon there's some bugs crawling on me or my back itches or I get a cramp in my leg and it breaks my concentration.  I've gotten pretty used to the heartvines moving, that's not the problem, it's the *other* stuff I can't get past.\n\nIt's weird, right?  You'd think that having a plant in my blood would be all I can think about but I got used to it in a week.  ̶A̶n̶y̶t̶h̶i̶n̶g̶ ̶i̶f̶ ̶I̶ ̶c̶a̶n̶  No, not yet.  I have to find the thing that did it, then I'll write it all down.  Now I just have to stop getting those cricks in my neck when I'm looking up through the leaves."
       },
       {
         "id": "xe_bloodthorn_note_02",

--- a/data/mods/Xedra_Evolved/snippets/bloodthorne_note_snippets.json
+++ b/data/mods/Xedra_Evolved/snippets/bloodthorne_note_snippets.json
@@ -1,0 +1,18 @@
+[
+  {
+    "type": "snippet",
+    "category": "note_bloodthorne_druid",
+    "text": [
+      {
+        "id": "xe_bloodthorn_note_01",
+        "name": "Meditations",
+        "text": "The elders want me to write down what I feel during weekly meditations but I don't see the point.  I've never been good at concentrating.  I go out into the forest and I sit and pretty soon there's some bugs crawling on or my back itches or I get a cramp on my leg and it breaks my concentration.  I've gotten pretty used to the heartvines moving, that's not the problem, it's the *other* stuff I can't get past.\n\nIt's weird, right?  You'd think that having a plant in my blood would be all I can think about but I got used to it in a week.  ̶A̶n̶y̶t̶h̶i̶n̶g̶ ̶i̶f̶ ̶I̶ ̶c̶a̶n̶  No, not yet.  I have to find the thing that did it, then I'll write it all down.  Now I just have to stop getting those cricks in my heck when I'm looking up through the leaves."
+      },
+      {
+        "id": "xe_bloodthorn_note_02",
+        "name": "blood draws",
+        "text": "Day 1: 1L.  Day 7: 1L.  Day 9: 1L.  Day 10: 3L donated blood provided.  Day 15: 1L.  Day 18: 1L.  Day 19: 3L donated blood provided.\n\nWe've been doing this for who knows how long and we still don't understand basic principles like \"How much do we get out based on what we put in?\"    Animal blood doesn't work, though, that's a constant.  We've tried cows, sheep, dogs, cats, pigs, rats, bats, everything we could think of and it just spat it all out.  Only human blood will do.\n\nI don't know why the elders allow this.  All the leeches need to die."
+      }
+    ]
+  }
+]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[Xedra Evolved] Add bloodthorne druid safehouse"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

More bloodthorne druid content
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add the bloodthorne druid safehouse, a variant on `cabin_6`. Thanks to new nest power, I can add a cellar with some supplies entirely through nests!

<img width="784" height="774" alt="Untitled" src="https://github.com/user-attachments/assets/18e4c67a-3823-48d0-83e6-a06920beaf15" />
You can see the cellar stairs there below the cabin. 

(# is a wall of brambles, T are thornhounds)

At the moment there's not a ton of bloodthorne-specific things here, but it's a base to add more.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Everything looks good
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Nested cellars worked out pretty well.  I think I'm going to add some to the base cabins so there's a chance at root cellars
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
