### PR TITLE
Fix deconstruction not deconstructing

### DIFF
--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -1578,10 +1578,10 @@ bool construct::check_deconstruct( const tripoint_bub_ms &p )
         if( here.has_flag_furn( ter_furn_flag::TFLAG_EASY_DECONSTRUCT, p ) ) {
             return false;
         }
-        return !!here.furn( p ).obj().deconstruct;
+        return !!here.furn( p ).obj().deconstruct || !here.furn( p ).obj().base_item.is_null();
     }
     // terrain can only be deconstructed when there is no furniture in the way
-    return !!here.ter( p ).obj().deconstruct;
+    return !!here.ter( p ).obj().deconstruct || !here.furn( p ).obj().base_item.is_null();
 }
 
 bool construct::check_up_OK( const tripoint_bub_ms & )
@@ -1808,11 +1808,11 @@ void construct::done_deconstruct( const tripoint_bub_ms &p, Character &player_ch
     // TODO: Make this the argument
     if( here.has_furn( p ) ) {
         const furn_t &f = here.furn( p ).obj();
-        if( !f.deconstruct && f.base_item.is_null() ) {
+        if( !f.has_disassembly() ) {
             add_msg( m_info, _( "That %s can not be disassembled!" ), f.name() );
             return;
         }
-        if( f.deconstruct->furn_set.str().empty() ) {
+        if( !f.deconstruct || f.deconstruct->furn_set.str().empty() ) {
             here.furn_set( p, furn_str_id::NULL_ID() );
         } else {
             here.furn_set( p, f.deconstruct->furn_set );

--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -570,6 +570,12 @@ void load_season_array( const JsonObject &jo, const std::string &key, const std:
     }
 }
 
+bool map_data_common_t::has_disassembly() const
+{
+    return !base_item.is_null() || ( deconstruct_info().has_value() &&
+                                     deconstruct_info().value().drop_group != Item_spawn_data_EMPTY_GROUP );
+}
+
 std::string map_data_common_t::name() const
 {
     return name_.translated();

--- a/src/mapdata.h
+++ b/src/mapdata.h
@@ -494,6 +494,7 @@ struct map_data_common_t {
     public:
         virtual ~map_data_common_t() = default;
         virtual std::optional<map_common_bash_info> bash_info() const = 0;
+        virtual std::optional<map_common_deconstruct_info> deconstruct_info() const = 0;
     protected:
         friend furn_t null_furniture_t();
         friend ter_t null_terrain_t();
@@ -516,6 +517,8 @@ struct map_data_common_t {
         bool has_curtains() const {
             return !( curtain_transform.is_empty() || curtain_transform.is_null() );
         }
+
+        bool has_disassembly() const;
 
         std::string name() const;
 
@@ -685,6 +688,9 @@ struct ter_t : map_data_common_t {
     std::optional<map_common_bash_info> bash_info() const override {
         return bash;
     }
+    std::optional<map_common_deconstruct_info> deconstruct_info() const override {
+        return deconstruct;
+    }
 
     static size_t count();
 
@@ -745,7 +751,9 @@ struct furn_t : map_data_common_t {
     std::optional<map_common_bash_info> bash_info() const override {
         return bash;
     }
-
+    std::optional<map_common_deconstruct_info> deconstruct_info() const override {
+        return deconstruct;
+    }
     static size_t count();
 
     bool is_movable() const;


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
I missed to update a few checks in #81669
Fix #81716
#### Describe the solution
Add missing checks
#### Describe alternatives you've considered
Actually make some function like "has deconstruction", maybe in the future
#### Testing
Walking to solar panel with tools now shows the construction disassembly properly
#### Additional context
i am fighting very annoying bug that i cannot figure out, the game throws
`invalid furniture id "null"`
at
`add_msg( _( "The %s is disassembled." ), f.name() );`
but then print the message totally fine, like it didn't just report `f` being a null, and it confuses me as hell
<img width="470" height="39" alt="image" src="https://github.com/user-attachments/assets/2e8ec1e4-6be1-4e38-acb2-b3142ffedd08" />
~~Upd: discord hive mind says it's UD, I'll try to address it in this PR or the next one~~
~~Upd2: i have no clue how to adress it~~ should be fixed now