### PR TITLE
Fix potential crash shooting at driverless vehicle

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1272,7 +1272,8 @@ std::set<tripoint_bub_ms> map::get_moving_vehicle_targets( const Creature &z, in
         if( !v.v->is_moving() ) {
             continue;
         }
-        if( z.attitude_to( *v.v->get_driver( *this ) ) != Creature::Attitude::HOSTILE ) {
+        if( v.v->get_driver( *this ) != nullptr &&
+            z.attitude_to( *v.v->get_driver( *this ) ) != Creature::Attitude::HOSTILE ) {
             continue;
         }
         if( std::abs( v.pos.z() - zpos.z() ) > fov_3d_z_range ) {


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
https://github.com/CleverRaven/Cataclysm-DDA/pull/81711 introduces a nullptr dereference if a vehicle is moving within range of monster that fires at vehicles.

#### Describe the solution
Add nullptr check.

#### Testing
Spawn a turret, spawn a quad bike, and spawn a truck. Ram the quad bike with the truck in range of the turret.
