### PR TITLE
Fix tools being consumed on processing

### DIFF
--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -206,6 +206,10 @@
     "conflicts": [ "PARTIAL_DEAF" ]
   },
   {
+    "id": "DESTROY_ON_CHARGE_USE",
+    "type": "json_flag"
+  },
+  {
     "id": "OVERHEATS",
     "type": "json_flag",
     "info": "Continuously firing this weapon will cause it to <bad>overheat</bad> and <info>can potentially damage it</info>."

--- a/data/json/items/comestibles/med.json
+++ b/data/json/items/comestibles/med.json
@@ -566,6 +566,7 @@
     "use_action": [
       {
         "type": "effect_on_conditions",
+        "consume": true,
         "menu_text": "Apply contact lenses",
         "description": "You can use this to mitigate your nearsightedness.",
         "effect_on_conditions": [
@@ -593,6 +594,7 @@
     "use_action": [
       {
         "type": "effect_on_conditions",
+        "consume": true,
         "menu_text": "Apply contact lenses",
         "description": "You can use this to mitigate your nearsightedness.",
         "effect_on_conditions": [
@@ -618,6 +620,7 @@
     "use_action": [
       {
         "type": "effect_on_conditions",
+        "consume": true,
         "menu_text": "Apply contact lenses",
         "description": "You can use this to mitigate your nearsightedness.",
         "effect_on_conditions": [
@@ -643,6 +646,7 @@
     "use_action": [
       {
         "type": "effect_on_conditions",
+        "consume": true,
         "menu_text": "Apply contact lenses",
         "description": "You can use this to mitigate your nearsightedness.",
         "effect_on_conditions": [
@@ -668,6 +672,7 @@
     "use_action": [
       {
         "type": "effect_on_conditions",
+        "consume": true,
         "menu_text": "Apply contact lenses",
         "description": "You can use this to mitigate your farsightedness.",
         "effect_on_conditions": [
@@ -690,6 +695,7 @@
     "use_action": [
       {
         "type": "effect_on_conditions",
+        "consume": true,
         "menu_text": "Apply contact lenses",
         "description": "You can use this to mitigate your farsightedness.",
         "effect_on_conditions": [
@@ -712,6 +718,7 @@
     "use_action": [
       {
         "type": "effect_on_conditions",
+        "consume": true,
         "menu_text": "Apply contact lenses",
         "description": "You can use this to mitigate your farsightedness.",
         "effect_on_conditions": [
@@ -734,6 +741,7 @@
     "use_action": [
       {
         "type": "effect_on_conditions",
+        "consume": true,
         "menu_text": "Apply contact lenses",
         "description": "You can use this to mitigate your farsightedness.",
         "effect_on_conditions": [
@@ -756,6 +764,7 @@
     "use_action": [
       {
         "type": "effect_on_conditions",
+        "consume": true,
         "menu_text": "Apply contact lenses",
         "description": "You can use this to mitigate your nearsightedness or farsightedness.",
         "effect_on_conditions": [
@@ -781,6 +790,7 @@
     "use_action": [
       {
         "type": "effect_on_conditions",
+        "consume": true,
         "menu_text": "Apply contact lenses",
         "description": "You can use this to mitigate your nearsightedness or farsightedness.",
         "effect_on_conditions": [
@@ -812,6 +822,7 @@
     "use_action": [
       {
         "type": "effect_on_conditions",
+        "consume": true,
         "menu_text": "Apply contact lenses",
         "description": "You can use this to mitigate your nearsightedness or farsightedness.",
         "effect_on_conditions": [
@@ -837,6 +848,7 @@
     "use_action": [
       {
         "type": "effect_on_conditions",
+        "consume": true,
         "menu_text": "Apply contact lenses",
         "description": "You can use this to mitigate your nearsightedness or farsightedness.",
         "effect_on_conditions": [
@@ -868,6 +880,7 @@
     "use_action": [
       {
         "type": "effect_on_conditions",
+        "consume": true,
         "menu_text": "Apply contact lenses",
         "description": "You can use this to mitigate your the bright light discomfort.",
         "effect_on_conditions": [
@@ -890,6 +903,7 @@
     "use_action": [
       {
         "type": "effect_on_conditions",
+        "consume": true,
         "menu_text": "Apply contact lenses",
         "description": "You can use this to mitigate the bright light discomfort.",
         "effect_on_conditions": [

--- a/data/json/items/comestibles/serums.json
+++ b/data/json/items/comestibles/serums.json
@@ -13,6 +13,7 @@
     "use_action": [
       {
         "type": "effect_on_conditions",
+        "consume": true,
         "menu_text": "Inject",
         "description": "Inject the liquid.",
         "effect_on_conditions": [

--- a/data/json/items/corpses/inactive_bots.json
+++ b/data/json/items/corpses/inactive_bots.json
@@ -735,7 +735,12 @@
     "material": [ "steel", "ceramic" ],
     "symbol": ",",
     "color": "cyan",
-    "use_action": { "type": "effect_on_conditions", "menu_text": "Activate", "effect_on_conditions": [ "yrax_trifacet_activation" ] },
+    "use_action": {
+      "type": "effect_on_conditions",
+      "consume": true,
+      "menu_text": "Activate",
+      "effect_on_conditions": [ "yrax_trifacet_activation" ]
+    },
     "flags": [ "SINGLE_USE" ]
   },
   {
@@ -752,7 +757,12 @@
     "volume": "119 L",
     "weight": "221 kg",
     "flags": [ "TRADER_AVOID", "NO_REPAIR", "SINGLE_USE" ],
-    "use_action": { "type": "effect_on_conditions", "menu_text": "Activate", "effect_on_conditions": [ "yrax_triakis_activation" ] }
+    "use_action": {
+      "type": "effect_on_conditions",
+      "consume": true,
+      "menu_text": "Activate",
+      "effect_on_conditions": [ "yrax_triakis_activation" ]
+    }
   },
   {
     "id": "bot_golden_monolith",
@@ -771,6 +781,7 @@
     "flags": [ "TRADER_AVOID", "NO_REPAIR", "SINGLE_USE" ],
     "use_action": {
       "type": "effect_on_conditions",
+      "consume": true,
       "menu_text": "Activate",
       "effect_on_conditions": [ "yrax_golden_monolith_activation" ]
     }
@@ -795,7 +806,12 @@
     "techniques": [ "RAPID" ],
     "qualities": [ [ "CUT", 1 ], [ "BUTCHER", 8 ] ],
     "flags": [ "TRADER_AVOID", "NO_REPAIR", "ALLOWS_BODY_BLOCK", "SHEATH_KNIFE", "SINGLE_USE" ],
-    "use_action": { "type": "effect_on_conditions", "menu_text": "Activate", "effect_on_conditions": [ "yrax_delta_activation" ] }
+    "use_action": {
+      "type": "effect_on_conditions",
+      "consume": true,
+      "menu_text": "Activate",
+      "effect_on_conditions": [ "yrax_delta_activation" ]
+    }
   },
   {
     "id": "bot_lab_security_drone_GR",

--- a/data/json/items/nether.json
+++ b/data/json/items/nether.json
@@ -7,6 +7,7 @@
     "color": "magenta",
     "use_action": {
       "type": "effect_on_conditions",
+      "consume": true,
       "description": "Seems like a targeted spatial distortion.",
       "effect_on_conditions": [ "EOC_PORTAL_STORM_CELL" ]
     },
@@ -25,6 +26,7 @@
     "copy-from": "escape_stone",
     "use_action": {
       "type": "effect_on_conditions",
+      "consume": true,
       "description": "Seems like a random spatial distortion.",
       "effect_on_conditions": [ "EOC_PORTAL_TELEPORT_UNSTABLE_RIFT" ]
     },
@@ -39,6 +41,7 @@
     "copy-from": "escape_stone",
     "use_action": {
       "type": "effect_on_conditions",
+      "consume": true,
       "description": "Seems like it could calm local conditions.",
       "effect_on_conditions": [ "EOC_CANCEL_PORTAL_STORM" ]
     },

--- a/data/json/items/tool/electronics.json
+++ b/data/json/items/tool/electronics.json
@@ -295,7 +295,6 @@
       },
       { "type": "link_up", "cable_length": 4, "charge_rate": "10 W" }
     ],
-    "tick_action": [ "EPIC_MUSIC" ],
     "//": "LIGHT_10 is the bare minimum for reading without penalties",
     "faults": [ { "fault_group": "electronic_general" } ],
     "flags": [ "NO_UNLOAD", "NO_RELOAD", "WATCH", "WATER_BREAK", "ELECTRONIC", "LIGHT_10", "TRADER_AVOID" ]
@@ -650,7 +649,6 @@
       },
       { "type": "link_up", "cable_length": 5, "charge_rate": "140 W" }
     ],
-    "tick_action": [ "EPIC_MUSIC" ],
     "faults": [ { "fault_group": "electronic_general" } ],
     "flags": [ "NO_UNLOAD", "NO_RELOAD", "WATCH", "LIGHT_10", "TRADER_AVOID", "WATER_BREAK", "ELECTRONIC", "ALLOWS_REMOTE_USE" ]
   },

--- a/data/json/items/tool/explosives.json
+++ b/data/json/items/tool/explosives.json
@@ -739,7 +739,7 @@
     "symbol": "*",
     "color": "light_gray",
     "tick_action": [ "MOLOTOV_LIT" ],
-    "flags": [ "LIGHT_15", "TRADER_AVOID", "NPC_THROW_NOW", "NO_REPAIR", "WATER_EXTINGUISH" ],
+    "flags": [ "LIGHT_15", "TRADER_AVOID", "NPC_THROW_NOW", "NO_REPAIR", "WATER_EXTINGUISH", "DESTROY_ON_CHARGE_USE" ],
     "melee_damage": { "bash": 5 }
   },
   {

--- a/data/json/items/tool/med.json
+++ b/data/json/items/tool/med.json
@@ -441,6 +441,7 @@
     "use_action": [
       {
         "type": "effect_on_conditions",
+        "consume": true,
         "menu_text": "Infuse saline",
         "description": "You can use it to mitigate the consequences of blood loss.  Require health care 3 and some disinfectant.",
         "effect_on_conditions": [
@@ -469,6 +470,7 @@
     "use_action": [
       {
         "type": "effect_on_conditions",
+        "consume": true,
         "menu_text": "Infuse saline",
         "description": "You can use it to mitigate the consequences of blood loss.  Require health care 4.",
         "effect_on_conditions": [
@@ -497,6 +499,7 @@
     "use_action": [
       {
         "type": "effect_on_conditions",
+        "consume": true,
         "menu_text": "Infuse saline",
         "description": "You can use it to mitigate the consequences of blood loss.  Require health care 4.",
         "effect_on_conditions": [
@@ -525,6 +528,7 @@
     "use_action": [
       {
         "type": "effect_on_conditions",
+        "consume": true,
         "menu_text": "Infuse saline",
         "description": "You can use it to mitigate the consequences of blood loss.  Require health care 4.",
         "effect_on_conditions": [

--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -1215,7 +1215,6 @@
     "color": "light_gray",
     "charges_per_use": 1,
     "use_action": [ "CAMERA", "PORTABLE_GAME", "EBOOKSAVE", "E_FILE_DEVICE" ],
-    "tick_action": [ "EPIC_MUSIC" ],
     "pocket_data": [
       {
         "pocket_type": "MAGAZINE_WELL",

--- a/data/mods/BombasticPerks/perkdata/flawless_memory.json
+++ b/data/mods/BombasticPerks/perkdata/flawless_memory.json
@@ -9,7 +9,6 @@
     "charges_per_use": 0,
     "etransfer_rate": "30 MB",
     "use_action": [ "CAMERA", "PORTABLE_GAME", "EBOOKSAVE", "E_FILE_DEVICE" ],
-    "tick_action": [ "EPIC_MUSIC" ],
     "pocket_data": [
       {
         "pocket_type": "E_FILE_STORAGE",

--- a/data/mods/MindOverMatter/items/matrix_crystals.json
+++ b/data/mods/MindOverMatter/items/matrix_crystals.json
@@ -15,6 +15,7 @@
     "flags": [ "MATRIX_CRYSTAL_BIOKINESIS" ],
     "use_action": {
       "type": "effect_on_conditions",
+      "consume": true,
       "description": "The pink glow calls to you.",
       "effect_on_conditions": [ "EOC_BIOKIN_MATRIX_AWAKENING" ]
     }
@@ -54,6 +55,7 @@
     "flags": [ "MATRIX_CRYSTAL_CLAIRSENTIENCE" ],
     "use_action": {
       "type": "effect_on_conditions",
+      "consume": true,
       "description": "The gray glow calls to you.",
       "effect_on_conditions": [ "EOC_CLAIR_MATRIX_AWAKENING" ]
     }
@@ -85,6 +87,7 @@
     "flags": [ "MATRIX_CRYSTAL_ELECTROKINESIS" ],
     "use_action": {
       "type": "effect_on_conditions",
+      "consume": true,
       "description": "The cyan glow calls to you.",
       "effect_on_conditions": [ "EOC_ELECTRO_MATRIX_AWAKENING" ]
     }
@@ -116,6 +119,7 @@
     "flags": [ "MATRIX_CRYSTAL_PHOTOKINESIS" ],
     "use_action": {
       "type": "effect_on_conditions",
+      "consume": true,
       "description": "The golden glow calls to you.",
       "effect_on_conditions": [ "EOC_PHOTOKIN_MATRIX_AWAKENING" ]
     }
@@ -147,6 +151,7 @@
     "flags": [ "MATRIX_CRYSTAL_PYROKINESIS" ],
     "use_action": {
       "type": "effect_on_conditions",
+      "consume": true,
       "description": "The red glow calls to you.",
       "effect_on_conditions": [ "EOC_PYROKIN_MATRIX_AWAKENING" ]
     }
@@ -178,6 +183,7 @@
     "flags": [ "MATRIX_CRYSTAL_TELEKINESIS" ],
     "use_action": {
       "type": "effect_on_conditions",
+      "consume": true,
       "description": "The yellow glow calls to you.",
       "effect_on_conditions": [ "EOC_TELEKIN_MATRIX_AWAKENING" ]
     }
@@ -209,6 +215,7 @@
     "flags": [ "MATRIX_CRYSTAL_TELEPATHY" ],
     "use_action": {
       "type": "effect_on_conditions",
+      "consume": true,
       "description": "The white glow calls to you.",
       "effect_on_conditions": [ "EOC_TEEP_MATRIX_AWAKENING" ]
     }
@@ -240,6 +247,7 @@
     "flags": [ "MATRIX_CRYSTAL_TELEPORTATION" ],
     "use_action": {
       "type": "effect_on_conditions",
+      "consume": true,
       "description": "The blue glow calls to you.",
       "effect_on_conditions": [ "EOC_TELEPORT_MATRIX_AWAKENING" ]
     }
@@ -271,6 +279,7 @@
     "flags": [ "MATRIX_CRYSTAL_VITAKINESIS" ],
     "use_action": {
       "type": "effect_on_conditions",
+      "consume": true,
       "description": "The green glow calls to you.",
       "effect_on_conditions": [ "EOC_VITAKIN_MATRIX_AWAKENING" ]
     }
@@ -306,6 +315,7 @@
     "looks_like": "art_crystal",
     "use_action": {
       "type": "effect_on_conditions",
+      "consume": true,
       "description": "The faint light calls to you.",
       "effect_on_conditions": [ "EOC_DRAINED_MATRIX" ]
     }
@@ -337,6 +347,7 @@
     "flags": [ "MATRIX_CRYSTAL_CORUSCATING" ],
     "use_action": {
       "type": "effect_on_conditions",
+      "consume": true,
       "description": "The coruscating light calls to you.",
       "effect_on_conditions": [ "EOC_CORUSCATING_MATRIX" ]
     }

--- a/data/mods/MindOverMatter/items/tools/nether_items.json
+++ b/data/mods/MindOverMatter/items/tools/nether_items.json
@@ -7,6 +7,7 @@
     "color": "magenta",
     "use_action": {
       "type": "effect_on_conditions",
+      "consume": true,
       "description": "Seems like chaos in solid form.",
       "effect_on_conditions": [ "EOC_CAUSE_PORTAL_STORM" ]
     },

--- a/data/mods/Sky_Island/items.json
+++ b/data/mods/Sky_Island/items.json
@@ -271,7 +271,12 @@
     "type": "ITEM",
     "subtypes": [ "TOOL" ],
     "name": { "str": "homeward mote" },
-    "use_action": { "type": "effect_on_conditions", "description": "A hasty escape.", "effect_on_conditions": [ "EOC_homewardmote" ] },
+    "use_action": {
+      "type": "effect_on_conditions",
+      "consume": true,
+      "description": "A hasty escape.",
+      "effect_on_conditions": [ "EOC_homewardmote" ]
+    },
     "description": "Though visibly little more than a glowing dustbunny, this strange ethereal mote of warp essence reveals, on closer inspection, something more.  A tiny, twisting, half-visible thread of shimmering bluish-purple trails away into the sky and far out of sight, unimpeded by any obstacles.\n\nTaking this rare and valuable artifact with you on an expedition is essentially buying life insurance.  If you die with this mote in your inventory, you will instead be restored to full health and brought home, WITH all items and equipment carried.  But this effect will only last for a single expedition.  Even if you extract safely, any and all motes carried on your person when you return home will be DESTROYED.",
     "weight": "15 g",
     "volume": "5 ml",
@@ -454,6 +459,7 @@
     "ammo_type": "components",
     "use_action": {
       "type": "effect_on_conditions",
+      "consume": true,
       "description": "Return to the sky.",
       "effect_on_conditions": [ "EOC_WARPED_ENEMY_CHECK_RETURN" ]
     }
@@ -493,6 +499,7 @@
     "ammo_type": "components",
     "use_action": {
       "type": "effect_on_conditions",
+      "consume": true,
       "description": "Cross the waters.",
       "effect_on_conditions": [ "EOC_WARPED_WATERWALKING" ]
     }

--- a/data/mods/Xedra_Evolved/items/ethereal_items.json
+++ b/data/mods/Xedra_Evolved/items/ethereal_items.json
@@ -246,7 +246,12 @@
     ],
     "max_worn": 1,
     "armor": [ { "encumbrance": 0, "coverage": 0, "covers": [ "hand_r" ] } ],
-    "use_action": { "type": "effect_on_conditions", "description": "Jump.", "effect_on_conditions": [ "EOC_WINCH_TELEPORT" ] }
+    "use_action": {
+      "type": "effect_on_conditions",
+      "consume": true,
+      "description": "Jump.",
+      "effect_on_conditions": [ "EOC_WINCH_TELEPORT" ]
+    }
   },
   {
     "id": "magic_light",

--- a/data/mods/Xedra_Evolved/items/hedge_magic_items.json
+++ b/data/mods/Xedra_Evolved/items/hedge_magic_items.json
@@ -312,6 +312,7 @@
     "extend": { "flags": [ "HEDGE_ENCHANTED" ] },
     "use_action": {
       "type": "effect_on_conditions",
+      "consume": true,
       "description": "Activate the charm using the magic square.",
       "effect_on_conditions": [
         {
@@ -334,6 +335,7 @@
     "extend": { "flags": [ "HEDGE_ENCHANTED" ] },
     "use_action": {
       "type": "effect_on_conditions",
+      "consume": true,
       "description": "Activate the charm using the magic square.",
       "effect_on_conditions": [
         {
@@ -359,6 +361,7 @@
     "extend": { "flags": [ "HEDGE_ENCHANTED" ] },
     "use_action": {
       "type": "effect_on_conditions",
+      "consume": true,
       "description": "Activate the charm using the magic square.",
       "effect_on_conditions": [
         {
@@ -381,6 +384,7 @@
     "extend": { "flags": [ "HEDGE_ENCHANTED" ] },
     "use_action": {
       "type": "effect_on_conditions",
+      "consume": true,
       "description": "Activate the charm using the magic square.",
       "effect_on_conditions": [
         {
@@ -415,6 +419,7 @@
     "extend": { "flags": [ "HEDGE_ENCHANTED" ] },
     "use_action": {
       "type": "effect_on_conditions",
+      "consume": true,
       "description": "Activate the charm using the magic square.",
       "effect_on_conditions": [
         {
@@ -437,6 +442,7 @@
     "extend": { "flags": [ "HEDGE_ENCHANTED" ] },
     "use_action": {
       "type": "effect_on_conditions",
+      "consume": true,
       "description": "Activate the charm using the magic square.",
       "effect_on_conditions": [
         {

--- a/data/mods/Xedra_Evolved/items/inventor/armor.json
+++ b/data/mods/Xedra_Evolved/items/inventor/armor.json
@@ -465,8 +465,7 @@
         "need_charges": 0,
         "type": "transform"
       }
-    ],
-    "tick_action": [ "EPIC_MUSIC" ]
+    ]
   },
   {
     "type": "ITEM",

--- a/data/mods/Xedra_Evolved/items/tools.json
+++ b/data/mods/Xedra_Evolved/items/tools.json
@@ -255,6 +255,7 @@
     "color": "magenta",
     "use_action": {
       "type": "effect_on_conditions",
+      "consume": true,
       "description": "Complete the ritual.",
       "effect_on_conditions": [ "EOC_CHECK_TO_SUMMON_REVENANT" ],
       "//": "until the day EoCs can be affected with need_wielding, they won't have it to allow the game to start"

--- a/data/mods/aftershock_exoplanet/items/tools.json
+++ b/data/mods/aftershock_exoplanet/items/tools.json
@@ -540,7 +540,6 @@
       "menu_text": "Turn off",
       "type": "transform"
     },
-    "tick_action": [ "EPIC_MUSIC" ],
     "flags": [ "WATCH", "LIGHT_10", "TRADER_AVOID" ]
   },
   {
@@ -630,7 +629,6 @@
       "type": "transform"
     },
     "flags": [ "WATCH", "TRADER_AVOID" ],
-    "tick_action": [ "EPIC_MUSIC" ],
     "passive_effects": [
       {
         "has": "WORN",

--- a/data/mods/deadly_bites/items.json
+++ b/data/mods/deadly_bites/items.json
@@ -15,6 +15,7 @@
     "container": "bottle_plastic_pill_prescription",
     "use_action": {
       "type": "effect_on_conditions",
+      "consume": true,
       "description": "Reduces the effect of certain viral infections.",
       "effect_on_conditions": [ "EOC_CONSUMED_ANTIVIRAL" ]
     },

--- a/doc/JSON/ITEM.md
+++ b/doc/JSON/ITEM.md
@@ -1405,6 +1405,7 @@ The contents of `use_action` fields can either be a string indicating a built-in
 },
 "use_action": {
   "type": "effect_on_conditions",          // Activate effect_on_conditions
+  "consume": true,                         // defaults false: whether the iuse function should return 1 and attempt to consume the item
   "menu_text": "Infuse saline",            // (optional) Text displayed in the activation screen. Defaults to "Activate item"
   "description": "This debugs the game",   // Usage description
   "effect_on_conditions": [ "test_cond" ]  // IDs of the effect_on_conditions to activate

--- a/src/flag.cpp
+++ b/src/flag.cpp
@@ -84,6 +84,7 @@ const flag_id flag_CUT_IMMUNE( "CUT_IMMUNE" );
 const flag_id flag_DANGEROUS( "DANGEROUS" );
 const flag_id flag_DEAF( "DEAF" );
 const flag_id flag_DECAYS_IN_AIR( "DECAYS_IN_AIR" );
+const flag_id flag_DESTROY_ON_CHARGE_USE( "DESTROY_ON_CHARGE_USE" );
 const flag_id flag_DIAMOND( "DIAMOND" );
 const flag_id flag_DIG_TOOL( "DIG_TOOL" );
 const flag_id flag_DIMENSIONAL_ANCHOR( "DIMENSIONAL_ANCHOR" );

--- a/src/flag.h
+++ b/src/flag.h
@@ -97,6 +97,7 @@ extern const flag_id flag_CUT_IMMUNE;
 extern const flag_id flag_DANGEROUS;
 extern const flag_id flag_DEAF;
 extern const flag_id flag_DECAYS_IN_AIR;
+extern const flag_id flag_DESTROY_ON_CHARGE_USE;
 extern const flag_id flag_DIAMOND;
 extern const flag_id flag_DIG_TOOL;
 extern const flag_id flag_DIMENSIONAL_ANCHOR;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -14826,12 +14826,15 @@ bool item::process_tool( Character *carrier, const tripoint_bub_ms &pos )
         }
     }
 
-    // Complicated safety net in case an item with charges slipped through.
-    const int num_to_destroy = type->tick( carrier, *this, pos );
-    if( num_to_destroy < 0 || num_to_destroy > 1 ) {
+    // FIXME: some iuse functions return 1+ expecting to be destroyed (molotovs), others
+    // to use charges, and others just because?
+    // allow some items to opt into requesting destruction
+    const int charges_used = type->tick( carrier, *this, pos );
+    const bool destroy = has_flag( flag_DESTROY_ON_CHARGE_USE );
+    if( !destroy && charges_used > 0 ) {
         debugmsg( "Item %s consumes charges via tick_action, but should not", tname() );
     }
-    return num_to_destroy; // Implicit conversion to bool!
+    return destroy && charges_used > 0;
 }
 
 bool item::process_blackpowder_fouling( Character *carrier )

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -1976,7 +1976,6 @@ void Item_factory::init()
     add_iuse( "ECIG", &iuse::ecig );
     add_iuse( "EHANDCUFFS", &iuse::ehandcuffs );
     add_iuse( "EHANDCUFFS_TICK", &iuse::ehandcuffs_tick );
-    add_iuse( "EPIC_MUSIC", &iuse::epic_music );
     add_iuse( "EBOOKSAVE", &iuse::ebooksave );
     add_iuse( "EMF_PASSIVE_ON", &iuse::emf_passive_on );
     add_iuse( "EXTINGUISHER", &iuse::extinguisher );

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -5655,18 +5655,6 @@ void item::extended_photo_def::serialize( JsonOut &jsout ) const
     jsout.end_object();
 }
 
-std::optional<int> iuse::epic_music( Character *p, item *it, const tripoint_bub_ms &pos )
-{
-    if( !it->get_var( "EIPC_MUSIC_ON" ).empty() &&
-        it->ammo_sufficient( p ) ) {
-
-        //the more varied music, the better max mood.
-        const int songs = it->get_var( "EIPC_MUSIC", 0 );
-        play_music( p, pos, 8, std::min( 25, songs ) );
-    }
-    return std::nullopt;
-}
-
 std::optional<int> iuse::efiledevice( Character *p, item *it, const tripoint_bub_ms & )
 {
     //restrictions

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -2695,7 +2695,7 @@ std::optional<int> iuse::radio_tick( Character *, item *it, const tripoint_bub_m
                                              0 );
         }
     }
-    return 1;
+    return 0;
 }
 
 std::optional<int> iuse::radio_on( Character *, item *it, const tripoint_bub_ms & )
@@ -2751,7 +2751,7 @@ std::optional<int> iuse::noise_emitter_on( Character *, item *, const tripoint_b
 {
     sounds::sound( pos, 30, sounds::sound_t::alarm, _( "KXSHHHHRRCRKLKKK!" ), true, "tool",
                    "noise_emitter" );
-    return 1;
+    return 0;
 }
 
 std::optional<int> iuse::emf_passive_on( Character *, item *, const tripoint_bub_ms &pos )
@@ -2769,7 +2769,7 @@ std::optional<int> iuse::emf_passive_on( Character *, item *, const tripoint_bub
         sounds::sound( pos, 6, sounds::sound_t::alarm, _( "BEEEEE-CHHHHHHH-eeEEEEEEE-CHHHHHHHHHHHH" ), true,
                        "tool", "emf_detector" );
         // skip continuing to check for locations
-        return 1;
+        return 0;
     }
 
     for( const tripoint_bub_ms &loc : closest_points_first( pos, max ) ) {
@@ -2802,10 +2802,10 @@ std::optional<int> iuse::emf_passive_on( Character *, item *, const tripoint_bub
                                "emf_detector" );
             }
             // skip continuing to check for locations
-            return 1;
+            return 0;
         }
     }
-    return 1;
+    return 0;
 }
 
 std::optional<int> iuse::ma_manual( Character *p, item *it, const tripoint_bub_ms & )
@@ -3292,7 +3292,7 @@ std::optional<int> iuse::geiger_active( Character *, item *, const tripoint_bub_
 {
     const int rads = get_map().get_radiation( pos );
     if( rads == 0 ) {
-        return 1;
+        return 0;
     }
     std::string description = rads > 50 ? _( "buzzing" ) :
                               rads > 25 ? _( "rapid clicking" ) : _( "clicking" );
@@ -3302,7 +3302,7 @@ std::optional<int> iuse::geiger_active( Character *, item *, const tripoint_bub_
     sounds::sound( pos, 6, sounds::sound_t::alarm, description, true, "tool", sound_var );
     if( !get_avatar().can_hear( pos, 6 ) ) {
         // can not hear it, but may have alarmed other creatures
-        return 1;
+        return 0;
     }
     if( rads > 50 ) {
         add_msg( m_warning, _( "The geiger counter buzzes intensely." ) );
@@ -3319,7 +3319,7 @@ std::optional<int> iuse::geiger_active( Character *, item *, const tripoint_bub_
     } else {
         add_msg( _( "The geiger counter clicks once." ) );
     }
-    return 1;
+    return 0;
 }
 
 std::optional<int> iuse::teleport( Character *p, item *it, const tripoint_bub_ms & )
@@ -3958,7 +3958,7 @@ std::optional<int> iuse::mp3_on( Character *p, item *, const tripoint_bub_ms &po
     // mp3 player in inventory, we can listen
     play_music( p, pos, 0, 20 );
     music::activate_music_id( music::music_id::mp3 );
-    return 1;
+    return 0;
 }
 
 std::optional<int> iuse::mp3_deactivate( Character *p, item *it, const tripoint_bub_ms & )
@@ -4025,7 +4025,7 @@ std::optional<int> iuse::dive_tank( Character *p, item *it, const tripoint_bub_m
         it->convert( *it->type->revert_to ).active = false;
     }
 
-    return 1;
+    return 0;
 }
 
 std::optional<int> iuse::dive_tank_activate( Character *p, item *it, const tripoint_bub_ms & )
@@ -6893,7 +6893,7 @@ std::optional<int> iuse::ehandcuffs_tick( Character *p, item *it, const tripoint
         it->ammo_unset();
         it->active = false;
         add_msg( m_good, _( "%s automatically turned off!" ), it->tname() );
-        return 1;
+        return 0;
     }
 
     if( !p ) {
@@ -6901,7 +6901,7 @@ std::optional<int> iuse::ehandcuffs_tick( Character *p, item *it, const tripoint
         sounds::sound( pos, 2, sounds::sound_t::combat, "Click.", true, "tools", "handcuffs" );
         it->unset_flag( flag_NO_UNWIELD );
         it->active = false;
-        return 1;
+        return 0;
     }
 
     if( it->charges == 0 ) {
@@ -6913,7 +6913,7 @@ std::optional<int> iuse::ehandcuffs_tick( Character *p, item *it, const tripoint
             add_msg( m_good, _( "%s on your wrists opened!" ), it->tname() );
         }
 
-        return 1;
+        return 0;
     }
 
     if( p->has_active_bionic( bio_shock ) && p->get_power_level() >= bio_shock->power_trigger &&
@@ -6926,7 +6926,7 @@ std::optional<int> iuse::ehandcuffs_tick( Character *p, item *it, const tripoint
         add_msg( m_good, _( "The %s crackle with electricity from your bionic, then come off your hands!" ),
                  it->tname() );
 
-        return 1;
+        return 0;
     }
 
     if( calendar::once_every( 1_minutes ) ) {
@@ -6960,11 +6960,11 @@ std::optional<int> iuse::ehandcuffs_tick( Character *p, item *it, const tripoint
         it->set_var( "HANDCUFFS_X", pos.x() );
         it->set_var( "HANDCUFFS_Y", pos.y() );
 
-        return 1;
+        return 0;
 
     }
 
-    return 1;
+    return 0;
 }
 
 std::optional<int> iuse::ehandcuffs( Character *, item *it, const tripoint_bub_ms & )
@@ -7182,7 +7182,7 @@ std::optional<int> iuse::radiocontrol_tick( Character *p, item *it, const tripoi
         avatar &player = get_avatar();
         it->active = false;
         player.remove_value( "remote_controlling" );
-        return 1;
+        return 0;
     }
     if( !it->ammo_sufficient( p ) ) {
         it->active = false;
@@ -7191,7 +7191,7 @@ std::optional<int> iuse::radiocontrol_tick( Character *p, item *it, const tripoi
         it->active = false;
     }
 
-    return 1;
+    return 0;
 }
 
 std::optional<int> iuse::radiocontrol( Character *p, item *it, const tripoint_bub_ms & )
@@ -7399,7 +7399,7 @@ std::optional<int> iuse::remoteveh_tick( Character *p, item *it, const tripoint_
         g->setremoteveh( nullptr );
     }
 
-    return 1;
+    return 0;
 }
 
 std::optional<int> iuse::remoteveh( Character *p, item *it, const tripoint_bub_ms &pos )

--- a/src/iuse.h
+++ b/src/iuse.h
@@ -105,7 +105,6 @@ std::optional<int> dive_tank( Character *, item *, const tripoint_bub_ms & );
 std::optional<int> dog_whistle( Character *, item *, const tripoint_bub_ms & );
 std::optional<int> ehandcuffs( Character *, item *, const tripoint_bub_ms & );
 std::optional<int> ehandcuffs_tick( Character *, item *, const tripoint_bub_ms & );
-std::optional<int> epic_music( Character *, item *, const tripoint_bub_ms & );
 std::optional<int> emf_passive_on( Character *, item *, const tripoint_bub_ms & );
 std::optional<int> extinguisher( Character *, item *, const tripoint_bub_ms & );
 std::optional<int> fill_pit( Character *, item *, const tripoint_bub_ms & );

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -2366,7 +2366,7 @@ std::optional<int> fireweapon_on_actor::use( Character *p, item &it,
         p->add_msg_if_player( "%s", noise_message );
     }
 
-    return 1;
+    return 0;
 }
 
 void manualnoise_actor::load( const JsonObject &obj, const std::string & )

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -6083,6 +6083,7 @@ std::unique_ptr<iuse_actor> effect_on_conditions_actor::clone() const
 
 void effect_on_conditions_actor::load( const JsonObject &obj, const std::string &src )
 {
+    optional( obj, false, "consume", consume, false );
     obj.read( "description", description );
     obj.read( "menu_text", menu_text );
     need_worn = obj.get_bool( "need_worn", false );
@@ -6154,8 +6155,11 @@ std::optional<int> effect_on_conditions_actor::use( Character *p, item &it,
     // it will not properly decrement any item of type `comestible` if consumed via the `E` `Consume item` menu.
     // Therefore, it is not advised to use items of type `comestible` with a `use_action` of type
     // `effect_on_conditions` until/unless this section is properly updated to actually consume said item.
-    if( p && !p->has_item( it ) ) {
-        return 0;
+    if( consume ) {
+        if( p && !p->has_item( it ) ) {
+            return 0;
+        }
+        return 1;
     }
-    return 1;
+    return 0;
 }

--- a/src/iuse_actor.h
+++ b/src/iuse_actor.h
@@ -1271,6 +1271,7 @@ class effect_on_conditions_actor : public iuse_actor
         explicit effect_on_conditions_actor( const std::string &type = "effect_on_conditions" ) :
             iuse_actor(
                 type ) {}
+        bool consume;
 
         ~effect_on_conditions_actor() override = default;
         void load( const JsonObject &obj, const std::string &src ) override;


### PR DESCRIPTION
#### Summary
Bugfixes "Fix EOC actor consuming tools on processing"

#### Purpose of change
Fixes https://github.com/CleverRaven/Cataclysm-DDA/issues/81719

#### Describe the solution
Allow the individual actors to specify whether or not they want to consume. Update all actors.

#### Testing
Spawn a chainsaw, activate it. It does not disappear.  Apply contact lenses, they are used.

#### Additional context
Why is there not a make noise iuse actor? These do not need a whole EOC for that.