### PR TITLE
Restore looks_like to Crabapple tree

### DIFF
--- a/data/json/furniture_and_terrain/terrain-flora.json
+++ b/data/json/furniture_and_terrain/terrain-flora.json
@@ -351,6 +351,7 @@
     "id": "t_tree_crabapple",
     "copy-from": "t_tree_fruit_abstract",
     "name": "crabapple tree",
+    "looks_like": "t_tree_hickory",
     "description": "This tree is a member of the 'Malus' genus, though unlike popular cultivars, its fruits are small and sour.  If you examined the branches more closely, you could probably find a few mature ones in autumn.",
     "transforms_into": "t_tree_crabapple_harvested",
     "harvest_by_season": [ { "seasons": [ "autumn" ], "id": "crabapple_harv" } ]


### PR DESCRIPTION
#### Summary
Bugfixes "Restore looks_like to Crabapple tree"

#### Purpose of change

#80991 removed the looks_like hickory tree line from the abstract tree.
TLDR: Crabapple looks_liked from abstract tree which looks_liked hickory tree.
Abstract tree no longer looks_like hickory Tree
Crabapple tree lost sprite and displayed as a 7.

#### Describe the solution

Add line to Crabapple tree giving it a looks_like hickory tree as it did before.  Simple.  I would have added it back to abstract but I assume there was a reason it was removed (although part of me thinks it was a mistake.)  I do not know if other trees have this issue.

#### Describe alternatives you've considered

Digging into if other trees have this issue.

#### Testing

We talked it through on the discord and puzzled out this was the issue.

#### Additional context

Blerg.  I should probably submit this to the release candidate, too.
