### PR TITLE
Aftershock: Add mod achievements and lock challenge scenarios behind them.

### DIFF
--- a/data/mods/aftershock_exoplanet/achievements/achievements.json
+++ b/data/mods/aftershock_exoplanet/achievements/achievements.json
@@ -34,7 +34,7 @@
     "id": "afs_achievement_crashed_spaceship",
     "type": "achievement",
     "name": { "str": "Falling Star" },
-    "description": "Planet crosses into a giant scrapfield every few months, some old battlefield from when the discontinuity happened.  Locals make a great show of it, marks the start of the start of the great hunt.\n<color_c_dark_gray>  -\"The Highlands of Aztlan\" holodoc",
+    "description": "Planet crosses into a giant scrapfield every few months, some old battlefield from when the discontinuity happened.  Locals make a great show of it, marks the start of the great hunt.\n<color_c_dark_gray>  -\"The Highlands of Aztlan\" holodoc",
     "requirements": [
       {
         "event_statistic": "num_avatar_enters_crashed_ship",

--- a/data/mods/aftershock_exoplanet/achievements/achievements.json
+++ b/data/mods/aftershock_exoplanet/achievements/achievements.json
@@ -3,9 +3,9 @@
     "id": "afs_alien_dawn",
     "type": "achievement",
     "name": "Alien Dawn",
-    "description": "At night, both water and carbon dioxide freeze in the upper atmosphere, such that every dawn is accompanied by a procession of colorful haloes over the horizon.\n<color_c_dark_gray>  - Salus IV rediscovery report 02.11.2428, submitted by Cpt. Jean McAllister.",
+    "description": "At night, both water and carbon dioxide freeze in the upper atmosphere, such that every dawn is accompanied by a procession of colorful haloes over the horizon.\n<color_c_dark_gray>  - Salus IV rediscovery report 02.11.2428, submitted by Cpt.  Jean McAllister.",
     "time_constraint": { "since": "game_start", "is": ">=", "target": "1 day" },
-    "requirements": [ { "event_statistic": "num_avatar_wake_ups", "is": "anything", "description": "Wake up after a night on Salus IV" } ]
+    "requirements": [ { "event_statistic": "num_avatar_wake_ups", "is": "anything", "description": "Wake up after a night on Salus IV." } ]
   },
   {
     "id": "afs_achievement_discontinuity_weapon",
@@ -25,7 +25,7 @@
     "id": "afs_achievement_plasma_weapon",
     "type": "achievement",
     "name": { "str": "Sunfire" },
-    "description": "Now just watch this! [STATIC]\n<color_c_dark_gray>  - unattributed comms chatter from raid on UFS Golden Sunray.",
+    "description": "Now just watch this!  [STATIC]\n<color_c_dark_gray>  - unattributed comms chatter from raid on UFS Golden Sunray.",
     "requirements": [
       { "event_statistic": "num_avatar_wields_plasma_gun", "is": ">=", "target": 1, "description": "Obtain a plasma weapon" }
     ]
@@ -40,7 +40,7 @@
         "event_statistic": "num_avatar_enters_crashed_ship",
         "is": ">=",
         "target": 1,
-        "description": "Visit a crashed spaceship"
+        "description": "Visit a crashed spaceship."
       }
     ]
   },
@@ -68,7 +68,7 @@
         "event_statistic": "avatar_max_damage",
         "is": ">=",
         "target": 2500,
-        "description": "Recieve 2500 damage in a single attack and survive (optional)"
+        "description": "Recieve 2500 damage in a single attack and survive (optional)."
       }
     ]
   },
@@ -83,6 +83,21 @@
         "is": ">=",
         "target": 1,
         "description": "Cross a threshold using genetech templates."
+      }
+    ]
+  },
+  {
+    "id": "achievement_psion",
+    "type": "achievement",
+    "name": { "str": "The New Sun" },
+    "description": "There were among our men those who asked whether it was all not a dream.  How else could one explain the glimpse of things never heard of, never seen, and never even conceived of before.\n<color_c_dark_gray>  - recovered from the log of ESS Firebird.",
+    "requirements": [
+      {
+        "event_statistic": "avatar_last_gains_mutation",
+        "is": "==",
+        "target": [ "trait_id", "ESPER" ],
+        "description": "Gain psionic powers.",
+        "visible": "when_achievement_completed"
       }
     ]
   },

--- a/data/mods/aftershock_exoplanet/achievements/achievements.json
+++ b/data/mods/aftershock_exoplanet/achievements/achievements.json
@@ -1,5 +1,92 @@
 [
   {
+    "id": "afs_alien_dawn",
+    "type": "achievement",
+    "name": "Alien Dawn",
+    "description": "At night, both water and carbon dioxide freeze in the upper atmosphere, such that every dawn is accompanied by a procession of colorful haloes over the horizon.\n<color_c_dark_gray>  - Salus IV rediscovery report 02.11.2428, submitted by Cpt. Jean McAllister.",
+    "time_constraint": { "since": "game_start", "is": ">=", "target": "1 day" },
+    "requirements": [ { "event_statistic": "num_avatar_wake_ups", "is": "anything", "description": "Wake up after a night on Salus IV" } ]
+  },
+  {
+    "id": "afs_achievement_discontinuity_weapon",
+    "type": "achievement",
+    "name": { "str": "A civilized Age" },
+    "description": "Mostly, it makes me feel very small, like when I was a kid playing with my father's tools.\n<color_c_dark_gray>  - \"Life in the Tenellus Frontier\", interview with mercenary captain, c2514.",
+    "requirements": [
+      {
+        "event_statistic": "num_avatar_wields_archeotech_gun",
+        "is": ">=",
+        "target": 1,
+        "description": "Wield a weapon from the Late Hyperspace Age."
+      }
+    ]
+  },
+  {
+    "id": "afs_achievement_plasma_weapon",
+    "type": "achievement",
+    "name": { "str": "Sunfire" },
+    "description": "Now just watch this! [STATIC]\n<color_c_dark_gray>  - unattributed comms chatter from raid on UFS Golden Sunray.",
+    "requirements": [
+      { "event_statistic": "num_avatar_wields_plasma_gun", "is": ">=", "target": 1, "description": "Obtain a plasma weapon" }
+    ]
+  },
+  {
+    "id": "afs_achievement_crashed_spaceship",
+    "type": "achievement",
+    "name": { "str": "Falling Star" },
+    "description": "Planet crosses into a giant scrapfield every few months, some old battlefield from when the discontinuity happened.  Locals make a great show of it, marks the start of the start of the great hunt.\n<color_c_dark_gray>  -\"The Highlands of Aztlan\" holodoc",
+    "requirements": [
+      {
+        "event_statistic": "num_avatar_enters_crashed_ship",
+        "is": ">=",
+        "target": 1,
+        "description": "Visit a crashed spaceship"
+      }
+    ]
+  },
+  {
+    "id": "afs_achievement_ruins",
+    "type": "achievement",
+    "name": { "str": "Boneyards" },
+    "description": "We had those at home too, on summer days we'd chase frogs through the pipes and into the coolant chambers deep below them.  I remember the em-lights still glittering in the immense halls, it was like a secret night sky sealed away.\n<color_c_dark_gray>  - overheard in Port Augustmoon.",
+    "requirements": [ { "event_statistic": "num_avatar_enters_ruins", "is": ">=", "target": 1, "description": "Visit a ruin" } ]
+  },
+  {
+    "id": "afs_achievement_many_ruins",
+    "type": "achievement",
+    "name": { "str": "Ruins of Orion" },
+    "description": "I try not to think about what it actually means, none of us do really.  Otherwise it would drive us mad with grief.  [Laughs] Still drives some mad though, I guess.\n<color_c_dark_gray>  - \"Life in the Tenellus Frontier\", interview with salvor guild journeyman, c2514.",
+    "requirements": [ { "event_statistic": "num_avatar_enters_ruins", "is": ">=", "target": 50, "description": "Visit many ruins." } ]
+  },
+  {
+    "id": "afs_achievement_discontinous",
+    "type": "achievement",
+    "name": { "str": "Discontinous" },
+    "description": "[ ERROR: Outside Hypernet Range ]",
+    "requirements": [
+      {
+        "event_statistic": "avatar_max_damage",
+        "is": ">=",
+        "target": 2500,
+        "description": "Recieve 2500 damage in a single attack and survive (optional)"
+      }
+    ]
+  },
+  {
+    "id": "afs_achievement_chimera",
+    "type": "achievement",
+    "name": { "str": "Chimera" },
+    "description": "Unexplained, instinctual urges might rarely manifest after bio-modification.  In such cases we recommend the following self-centering techniques…\n<color_c_dark_gray>  - Aftercare brochure, Mercurial Genomics ltd.",
+    "requirements": [
+      {
+        "event_statistic": "num_crosses_mutation_threshold",
+        "is": ">=",
+        "target": 1,
+        "description": "Cross a threshold using genetech templates."
+      }
+    ]
+  },
+  {
     "id": "achievement_kill_moxie",
     "type": "achievement",
     "name": "Breaking the Ice",

--- a/data/mods/aftershock_exoplanet/achievements/statistics.json
+++ b/data/mods/aftershock_exoplanet/achievements/statistics.json
@@ -6,6 +6,91 @@
     "value_constraints": { "species": { "equals": [ "species_id", "MOXIE" ] } }
   },
   {
+    "id": "avatar_enters_crashed_ship",
+    "type": "event_transformation",
+    "event_transformation": "avatar_enters_oter_type",
+    "value_constraints": {
+      "oter_type_id": { "equals_any": [ "oter_type_str_id", [ "afs_crashed_cargo_shuttle", "afs_crashed_cargo_shuttle_wraitheon" ] ] }
+    }
+  },
+  {
+    "id": "num_avatar_enters_crashed_ship",
+    "type": "event_statistic",
+    "stat_type": "count",
+    "event_transformation": "avatar_enters_crashed_ship",
+    "description": { "str": "crashed ship visited", "str_pl": "crashed ships visited" }
+  },
+  {
+    "id": "avatar_enters_ruins",
+    "type": "event_transformation",
+    "event_transformation": "avatar_enters_oter_type",
+    "value_constraints": {
+      "oter_type_id": {
+        "equals_any": [
+          "oter_type_str_id",
+          [
+            "afs_formless_ruins_dynamic",
+            "afs_formless_ruins_aeolian",
+            "afs_formless_ruins_industrial",
+            "afs_formless_ruins_pipe"
+          ]
+        ]
+      }
+    }
+  },
+  {
+    "id": "num_avatar_enters_ruins",
+    "type": "event_statistic",
+    "stat_type": "count",
+    "event_transformation": "avatar_enters_ruins",
+    "description": { "str": "ruin visited", "str_pl": "ruins visited" }
+  },
+  {
+    "id": "avatar_wields_archeotech_gun",
+    "type": "event_transformation",
+    "event_transformation": "avatar_wields_item",
+    "value_constraints": { "itype": { "equals_any": [ "itype_id", [ "afs_archeotech_laspistol", "afs_electro_anomaly_rifle" ] ] } },
+    "drop_fields": [ "itype" ]
+  },
+  {
+    "id": "num_avatar_wields_archeotech_gun",
+    "type": "event_statistic",
+    "stat_type": "count",
+    "event_transformation": "avatar_wields_archeotech_gun"
+  },
+  {
+    "id": "avatar_max_damage",
+    "type": "event_statistic",
+    "stat_type": "maximum",
+    "field": "damage",
+    "event_transformation": "avatar_takes_damage",
+    "description": { "str_sp": "maximum damage taken in a single instant." }
+  },
+  {
+    "id": "avatar_wields_plasma_gun",
+    "type": "event_transformation",
+    "event_transformation": "avatar_wields_item",
+    "value_constraints": {
+      "itype": {
+        "equals_any": [ "itype_id", [ "afs_magnadrive_230k", "afs_pam-41", "afs_plasma_torch_gun", "afs_makeshift_fusion_guns" ] ]
+      }
+    },
+    "drop_fields": [ "itype" ]
+  },
+  {
+    "id": "num_avatar_wields_plasma_gun",
+    "type": "event_statistic",
+    "stat_type": "count",
+    "event_transformation": "avatar_wields_plasma_gun"
+  },
+  {
+    "id": "avatar_wields_prediscontinuity_weapon",
+    "type": "event_transformation",
+    "event_transformation": "avatar_wields_item",
+    "value_constraints": { "itype": { "equals": [ "itype_id", "crowbar" ] } },
+    "drop_fields": [ "itype" ]
+  },
+  {
     "id": "num_avatar_moxie_kills",
     "type": "event_statistic",
     "stat_type": "count",

--- a/data/mods/aftershock_exoplanet/achievements/statistics.json
+++ b/data/mods/aftershock_exoplanet/achievements/statistics.json
@@ -72,7 +72,7 @@
     "event_transformation": "avatar_wields_item",
     "value_constraints": {
       "itype": {
-        "equals_any": [ "itype_id", [ "afs_magnadrive_230k", "afs_pam-41", "afs_plasma_torch_gun", "afs_makeshift_fusion_guns" ] ]
+        "equals_any": [ "itype_id", [ "afs_magnadrive_230k", "afs_pam-41", "afs_plasma_torch_gun", "afs_makeshift_fusion_gun" ] ]
       }
     },
     "drop_fields": [ "itype" ]

--- a/data/mods/aftershock_exoplanet/scenarios.json
+++ b/data/mods/aftershock_exoplanet/scenarios.json
@@ -7,6 +7,8 @@
     "description": "During the riots and chaos, you hid in a robot dispatch center hoping the robots would protect you, but they may prove more dangerous than the zombies.",
     "allowed_locs": [ "sloc_robot_dispatch" ],
     "flags": [ "CITY_START" ],
+    "requirement": "afs_achievement_many_ruins",
+    "hard_requirement": true,
     "start_name": "Robot Dispatch"
   },
   {
@@ -74,6 +76,8 @@
       "afs_esper_inheritance"
     ],
     "surround_groups": [ [ "GROUP_PIRATE__BOT_AMBUSH", 70.0 ] ],
+    "requirement": "afs_achievement_crashed_spaceship",
+    "hard_requirement": true,
     "flags": [ "LONE_START" ]
   },
   {
@@ -147,6 +151,8 @@
     "points": -2,
     "description": "You've already been modified mutagenically but now you were all ready for a bionic implant or three - the bill footed by the corp, of course - when everything went pear-shaped and all you could hear from the other rooms was screaming.  For a few hours, at least.  Now all you can hear is shuffling, crackling, the occasional gurgling, burbling moan, and heavy, wet thumps.  Hopefully your surgery was registered as an elective because you've elected to get the heck out of here!",
     "forced_traits": [ "ELECTRORECEPTORS", "NIGHTVISION3", "LIGHTSTEP" ],
+    "requirement": "afs_achievement_chimera",
+    "hard_requirement": true,
     "allowed_locs": [ "sloc_afs_augmentation_clinic_n3" ]
   },
   {
@@ -160,7 +166,9 @@
     "flags": [ "LONE_START", "HELI_CRASH" ],
     "start_name": "Crashing Ship",
     "whitelist_hobbies": true,
-    "hobbies": [ "afs_speed_freak", "afs_armament_license", "afs_spacer", "afs_leadership", "afs_earthling", "afs_esper_inheritance" ],
+    "requirement": "afs_achievement_crashed_spaceship",
+    "hard_requirement": true,
+    "hobbies": [ "afs_speed_freak", "afs_armament_license", "afs_spacer", "afs_leadership", "afs_earthling" ],
     "eoc": [ "EOC_CRASHING_SHIP_SETUP" ]
   },
   {
@@ -176,7 +184,19 @@
     "start_name": "Lost on the Surface",
     "reveal_locale": false,
     "whitelist_hobbies": true,
-    "hobbies": [ "afs_armament_license", "afs_spacer", "afs_leadership", "afs_earthling" ],
+    "hobbies": [
+      "afs_armament_license",
+      "afs_spacer",
+      "afs_leadership",
+      "afs_earthling",
+      "afs_physical_stat_genemod",
+      "afs_mental_stat_genemod",
+      "afs_health_genemod",
+      "afs_efficiency_genemod",
+      "afs_beauty_genemod"
+    ],
+    "requirement": "afs_achievement_chimera",
+    "hard_requirement": true,
     "eoc": [ "EOC_ESPER_SCENARIO_SETUP" ]
   },
   {
@@ -202,6 +222,8 @@
       "afs_esper_inheritance"
     ],
     "flags": [ "LONE_START" ],
+    "requirement": "afs_achievement_crashed_spaceship",
+    "hard_requirement": true,
     "start_name": "Escape Pod"
   }
 ]


### PR DESCRIPTION
#### Summary
Mods "Aftershock: Add mod achievements and lock challenge scenarios behind them."

#### Purpose of change
Lots of players select the challenge scenarios for their first playthroughs, which leads to them repeatedly dying without gaining any understanding of how the mod works and how to survive in it.

This locks all the scenarios where you can't easily procure a cryosuit and its fuel behind achievements.

#### Describe the solution
Add achievements to the mod and hardlock several scenarios behind them.

The achievements aren't very hard, mostly they require exploration of the surface.

#### Testing
Loads. Still need to build to test it works.

#### Additional context

Backporting this to prevent aftershock stable players from shooting themselves on the foot.