### PR TITLE
Add nested cellars to cabins

### DIFF
--- a/data/json/itemgroups/Locations_MapExtras/cabin_cellars.json
+++ b/data/json/itemgroups/Locations_MapExtras/cabin_cellars.json
@@ -1,0 +1,45 @@
+[
+  {
+    "type": "item_group",
+    "subtype": "distribution",
+    "id": "cabin_nested_cellar_boxed_junk",
+    "//": "various types of stored items in boxes or empty boxes for the nested cabin cellar",
+    "//2": "Two itemgroups are necessary because on_overflow can only be specified on top-level itemgroups",
+    "entries": [
+      { "group": "cabin_nested_cellar_boxed_junk_wood", "prob": 1 },
+      { "group": "cabin_nested_cellar_boxed_junk_cardboard", "prob": 1 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "subtype": "distribution",
+    "id": "cabin_nested_cellar_boxed_junk_wood",
+    "on_overflow": "spill",
+    "container-item": "box_large_wood",
+    "entries": [
+      { "item": "null", "prob": 50 },
+      { "group": "clothing_hunting", "count": [ 2, 4 ], "prob": 10 },
+      { "group": "clothing_hunting", "count": [ 2, 4 ], "prob": 10 },
+      { "group": "camping", "count": [ 2, 4 ], "prob": 10 },
+      { "group": "camping", "count": [ 2, 4 ], "prob": 10 },
+      { "group": "hiking", "count": [ 2, 4 ], "prob": 10 },
+      { "group": "hiking", "count": [ 2, 4 ], "prob": 10 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "subtype": "distribution",
+    "id": "cabin_nested_cellar_boxed_junk_cardboard",
+    "on_overflow": "spill",
+    "container-item": "box_large",
+    "entries": [
+      { "item": "null", "prob": 50 },
+      { "group": "clothing_hunting", "count": [ 2, 4 ], "prob": 10 },
+      { "group": "clothing_hunting", "count": [ 2, 4 ], "prob": 10 },
+      { "group": "camping", "count": [ 2, 4 ], "prob": 10 },
+      { "group": "camping", "count": [ 2, 4 ], "prob": 10 },
+      { "group": "hiking", "count": [ 2, 4 ], "prob": 10 },
+      { "group": "hiking", "count": [ 2, 4 ], "prob": 10 }
+    ]
+  }
+]

--- a/data/json/mapgen/cabin.json
+++ b/data/json/mapgen/cabin.json
@@ -261,7 +261,8 @@
         "*************.~.********"
       ],
       "palettes": [ { "distribution": [ [ "cabin_palette", 1 ], [ "cabin_palette_abandoned", 1 ] ] } ],
-      "terrain": { "0": "t_region_soil", "b": "t_region_groundcover" }
+      "terrain": { "0": "t_region_soil", "b": "t_region_groundcover" },
+      "place_nested": [ { "chunks": [ [ "null", 2 ], [ "cabin_cellar_stairs", 1 ] ], "x": 12, "y": 7 } ]
     }
   },
   {
@@ -331,7 +332,8 @@
         "************************"
       ],
       "palettes": [ { "distribution": [ [ "cabin_palette", 1 ], [ "cabin_palette_abandoned", 1 ] ] } ],
-      "terrain": { "0": "t_region_soil", "z": "t_region_soil" }
+      "terrain": { "0": "t_region_soil", "z": "t_region_soil" },
+      "place_nested": [ { "chunks": [ [ "null", 2 ], [ "cabin_cellar_stairs", 1 ] ], "x": 3, "y": 9 } ]
     }
   },
   {
@@ -400,7 +402,8 @@
         "************************",
         "************************"
       ],
-      "palettes": [ { "distribution": [ [ "cabin_palette", 1 ], [ "cabin_palette_abandoned", 1 ] ] } ]
+      "palettes": [ { "distribution": [ [ "cabin_palette", 1 ], [ "cabin_palette_abandoned", 1 ] ] } ],
+      "place_nested": [ { "chunks": [ [ "null", 2 ], [ "cabin_cellar_stairs", 1 ] ], "x": 6, "y": 6 } ]
     }
   },
   {
@@ -469,7 +472,8 @@
         "************************",
         "************************"
       ],
-      "palettes": [ { "distribution": [ [ "cabin_palette", 1 ], [ "cabin_palette_abandoned", 1 ] ] } ]
+      "palettes": [ { "distribution": [ [ "cabin_palette", 1 ], [ "cabin_palette_abandoned", 1 ] ] } ],
+      "place_nested": [ { "chunks": [ [ "null", 2 ], [ "cabin_cellar_stairs", 1 ] ], "x": 5, "y": 8 } ]
     }
   },
   {

--- a/data/json/mapgen/cabin.json
+++ b/data/json/mapgen/cabin.json
@@ -922,5 +922,40 @@
       ],
       "set": [ { "point": "trap", "id": "tr_beartrap", "x": 3, "y": 7 }, { "point": "trap", "id": "tr_shotgun_1", "x": 18, "y": 8 } ]
     }
+  },
+  {
+    "type": "mapgen",
+    "om_terrain": [ "cabin_cellar" ],
+    "//": "Used to clear out space to allow cellars to spawn without problems.",
+    "object": {
+      "fill_ter": "t_soil",
+      "rows": [
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        "
+      ],
+      "terrain": { " ": "t_soil" }
+    }
   }
 ]

--- a/data/json/mapgen/nested/cabin_cellar_nested.json
+++ b/data/json/mapgen/nested/cabin_cellar_nested.json
@@ -306,8 +306,20 @@
         "      "
       ],
       "palettes": [ "cabin_cellar" ],
+      "ter_furn_transforms": { " ": { "transform": "fungalize" } },
       "place_fields": [ { "field": "fd_fungal_haze", "x": [ 0, 5 ], "y": [ 0, 5 ], "repeat": [ 10, 20 ] } ],
       "place_monster": [ { "monster": "mon_zombie_fungus", "x": [ 0, 5 ], "y": [ 0, 5 ], "chance": 85 } ]
     }
+  },
+  {
+    "type": "ter_furn_transform",
+    "id": "fungalize",
+    "terrain": [ { "result": [ [ "t_fungus", 2 ], [ "t_fungus_floor_sup", 1 ] ], "valid_flags": [ "FLAT" ] } ],
+    "furniture": [
+      {
+        "result": [ [ "f_fungal_mass", 1 ], [ "f_fungal_tangle", 1 ], [ "f_fungal_clump", 1 ] ],
+        "valid_flags": [ "ORGANIC" ]
+      }
+    ]
   }
 ]

--- a/data/json/mapgen/nested/cabin_cellar_nested.json
+++ b/data/json/mapgen/nested/cabin_cellar_nested.json
@@ -1,0 +1,313 @@
+[
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "cabin_cellar_stairs",
+    "object": {
+      "mapgensize": [ 10, 10 ],
+      "rotation": [ 0, 0 ],
+      "rows": [
+        "          ",
+        "          ",
+        "          ",
+        "          ",
+        "          ",
+        "          ",
+        "          ",
+        "          ",
+        "       >  ",
+        "          "
+      ],
+      "palettes": [ "cabin_cellar" ],
+      "place_nested": [ { "chunks": [ "cabin_cellar" ], "x": 0, "y": 0, "z": -1 } ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "cabin_cellar",
+    "object": {
+      "mapgensize": [ 10, 10 ],
+      "rotation": [ 0, 0 ],
+      "rows": [
+        "#--------#",
+        "#-......-#",
+        "#-......-#",
+        "#-......-#",
+        "#-......-#",
+        "#-......-#",
+        "#-......-#",
+        "#------.-#",
+        "######-<-#",
+        "######---#"
+      ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
+      "palettes": [ "cabin_cellar" ],
+      "place_nested": [
+        { "chunks": [ "cabin_6x6_cellar_nested" ], "x": 2, "y": 1 },
+        {
+          "chunks": [
+            [ "null", 90 ],
+            [ "cabin_6x6_cellar_nested_zombies", 15 ],
+            [ "cabin_6x6_cellar_nested_spiders", 5 ],
+            [ "cabin_6x6_cellar_nested_mycus", 1 ]
+          ],
+          "x": 2,
+          "y": 1
+        }
+      ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "cabin_6x6_cellar_nested",
+    "//": "A cellar filled with various bits of hobby equipment for hiking, hunting, or camping",
+    "object": {
+      "mapgensize": [ 6, 6 ],
+      "rotation": [ 0, 0 ],
+      "rows": [
+        "NNNNNN",
+        "Nnnnn ",
+        "Nn    ",
+        "Nn nn ",
+        "Nn nn ",
+        "N     "
+      ],
+      "palettes": [ "cabin_cellar" ],
+      "nested": {
+        "N": { "chunks": [ [ "cabin_cellar_1x1_junk_box", 20 ], [ "null", 5 ] ] },
+        "n": { "chunks": [ [ "cabin_cellar_1x1_junk_box", 1 ], [ "null", 1 ] ] }
+      },
+      "place_fields": [ { "field": "fd_dust", "x": [ 0, 5 ], "y": [ 0, 5 ], "repeat": [ 10, 20 ] } ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "cabin_cellar_1x1_junk_box",
+    "object": {
+      "mapgensize": [ 1, 1 ],
+      "rotation": [ 0, 0 ],
+      "rows": [ " " ],
+      "place_items": [ { "item": "cabin_nested_cellar_boxed_junk", "x": 0, "y": 0 } ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "cabin_6x6_cellar_nested",
+    "//": "A cellar filled with preserved food",
+    "weight": 900,
+    "object": {
+      "mapgensize": [ 6, 6 ],
+      "rotation": [ 0, 0 ],
+      "rows": [
+        "      ",
+        " R  R ",
+        " R  R ",
+        " R  R ",
+        " R  R ",
+        "      "
+      ],
+      "palettes": [ "cabin_cellar" ],
+      "items": { "R": { "item": "preserved_food", "chance": 80, "repeat": [ 1, 4 ] } },
+      "place_fields": [ { "field": "fd_dust", "x": [ 0, 5 ], "y": [ 0, 5 ], "repeat": [ 10, 20 ] } ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "cabin_6x6_cellar_nested",
+    "//": "A cellar that's totally empty",
+    "weight": 600,
+    "object": {
+      "mapgensize": [ 6, 6 ],
+      "rotation": [ 0, 0 ],
+      "rows": [
+        "      ",
+        "      ",
+        "      ",
+        "      ",
+        "      ",
+        "      "
+      ],
+      "palettes": [ "cabin_cellar" ],
+      "place_fields": [ { "field": "fd_dust", "x": [ 0, 5 ], "y": [ 0, 5 ], "repeat": [ 10, 20 ] } ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "cabin_6x6_cellar_nested",
+    "//": "A cellar with booze.  Drink up!",
+    "weight": 500,
+    "object": {
+      "mapgensize": [ 6, 6 ],
+      "rotation": [ 0, 0 ],
+      "rows": [
+        "R     ",
+        "R   c ",
+        "R ctt ",
+        "R ctt ",
+        "   c  ",
+        "      "
+      ],
+      "palettes": [ "cabin_cellar" ],
+      "items": { "R": { "item": "liquor_and_spirits", "chance": 80, "repeat": [ 1, 4 ] } },
+      "place_item": [
+        { "item": "bottle_glass", "x": 3, "y": 2, "chance": 80 },
+        { "item": "bottle_glass", "x": 3, "y": 3, "chance": 80 },
+        { "item": "bottle_glass", "x": 4, "y": 2, "chance": 80 },
+        { "item": "bottle_glass", "x": 4, "y": 3, "chance": 80 },
+        { "item": "deck_of_cards", "x": 4, "y": 3, "chance": 50 }
+      ],
+      "place_nested": [ { "chunks": [ [ "null", 2 ], [ "cabin_cellar_2x2_moonshine_still", 1 ] ], "x": 1, "y": 0 } ],
+      "place_fields": [ { "field": "fd_dust", "x": [ 0, 5 ], "y": [ 0, 5 ], "repeat": [ 10, 20 ] } ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "cabin_6x6_cellar_nested",
+    "//": "A cellar with stored furniture",
+    "weight": 450,
+    "object": {
+      "mapgensize": [ 6, 6 ],
+      "rotation": [ 0, 0 ],
+      "rows": [
+        "ttttcc",
+        "ttcccc",
+        "      ",
+        "      ",
+        "      ",
+        "      "
+      ],
+      "palettes": [ "cabin_cellar" ],
+      "place_item": [
+        { "item": "tourist_table", "x": 0, "y": 2, "chance": 50 },
+        { "item": "tourist_table", "x": 1, "y": 2, "chance": 50 },
+        { "item": "box_large_wood", "x": 0, "y": 3, "chance": 50 },
+        { "item": "box_large_wood", "x": 0, "y": 4, "chance": 50 },
+        { "item": "box_large_wood", "x": 0, "y": 5, "chance": 50 },
+        { "item": "box_large_wood", "x": 1, "y": 3, "chance": 50 },
+        { "item": "box_large_wood", "x": 1, "y": 4, "chance": 50 },
+        { "item": "box_large_wood", "x": 1, "y": 5, "chance": 50 }
+      ],
+      "place_fields": [ { "field": "fd_dust", "x": [ 0, 5 ], "y": [ 0, 5 ], "repeat": [ 10, 20 ] } ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "cabin_cellar_2x2_moonshine_still",
+    "object": {
+      "mapgensize": [ 2, 2 ],
+      "rotation": [ 0, 0 ],
+      "rows": [
+        "SV",
+        "  "
+      ],
+      "furniture": { "S": "f_still", "V": "f_fvat_empty" }
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "cabin_6x6_cellar_nested",
+    "//": "A cellar that's totally empty and also has no dust.  Mysterious!",
+    "weight": 50,
+    "object": {
+      "mapgensize": [ 6, 6 ],
+      "rotation": [ 0, 0 ],
+      "rows": [
+        "      ",
+        "      ",
+        "      ",
+        "      ",
+        "      ",
+        "      "
+      ],
+      "palettes": [ "cabin_cellar" ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "cabin_6x6_cellar_nested",
+    "//": "A cellar with bones on a table and candles on the floor around it.  What happened here?",
+    "weight": 25,
+    "object": {
+      "mapgensize": [ 6, 6 ],
+      "rotation": [ 0, 0 ],
+      "rows": [
+        "      ",
+        "      ",
+        "  tt  ",
+        "  tt  ",
+        "      ",
+        "      "
+      ],
+      "palettes": [ "cabin_cellar" ],
+      "place_item": [
+        { "item": "bone", "x": 2, "y": 2, "repeat": [ 1, 2 ] },
+        { "item": "bone", "x": 3, "y": 2, "repeat": [ 1, 2 ] },
+        { "item": "bone", "x": 2, "y": 3, "repeat": [ 1, 2 ] },
+        { "item": "bone", "x": 3, "y": 3, "repeat": [ 1, 2 ] },
+        { "item": "candle", "x": 1, "y": 1, "chance": 95 },
+        { "item": "candle", "x": 4, "y": 1, "chance": 95 },
+        { "item": "candle", "x": 1, "y": 4, "chance": 95 },
+        { "item": "candle", "x": 4, "y": 4, "chance": 95 }
+      ],
+      "place_fields": [ { "field": "fd_dust", "x": [ 0, 5 ], "y": [ 0, 5 ], "repeat": [ 10, 20 ] } ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "cabin_6x6_cellar_nested_zombies",
+    "//": "A cellar overlay for zombies.  It is the zombie apocalypse, after all.",
+    "object": {
+      "mapgensize": [ 6, 6 ],
+      "rotation": [ 0, 0 ],
+      "rows": [
+        "      ",
+        "      ",
+        "      ",
+        "      ",
+        "      ",
+        "      "
+      ],
+      "palettes": [ "cabin_cellar" ],
+      "place_monster": [ { "group": "GROUP_ZOMBIE", "x": [ 0, 5 ], "y": [ 0, 5 ], "chance": 100, "repeat": [ 1, 6 ] } ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "cabin_6x6_cellar_nested_spiders",
+    "//": "A cellar overlay for spiders.  Spiders!!",
+    "object": {
+      "mapgensize": [ 6, 6 ],
+      "rotation": [ 0, 0 ],
+      "rows": [
+        "      ",
+        "      ",
+        "      ",
+        "      ",
+        "      ",
+        "      "
+      ],
+      "palettes": [ "cabin_cellar" ],
+      "place_fields": [ { "field": "fd_web", "x": [ 0, 5 ], "y": [ 0, 5 ], "repeat": [ 10, 20 ] } ],
+      "place_monster": [ { "group": "GROUP_SPIDER_BASEMENT", "x": [ 0, 5 ], "y": [ 0, 5 ], "chance": 100, "repeat": [ 3, 4 ] } ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "cabin_6x6_cellar_nested_mycus",
+    "//": "A cellar overlay with a mycus infestation.  Pouf!",
+    "object": {
+      "mapgensize": [ 6, 6 ],
+      "rotation": [ 0, 0 ],
+      "rows": [
+        "      ",
+        "      ",
+        "      ",
+        "      ",
+        "      ",
+        "      "
+      ],
+      "palettes": [ "cabin_cellar" ],
+      "place_fields": [ { "field": "fd_fungal_haze", "x": [ 0, 5 ], "y": [ 0, 5 ], "repeat": [ 10, 20 ] } ],
+      "place_monster": [ { "monster": "mon_zombie_fungus", "x": [ 0, 5 ], "y": [ 0, 5 ], "chance": 85 } ]
+    }
+  }
+]

--- a/data/json/mapgen_palettes/cabin.json
+++ b/data/json/mapgen_palettes/cabin.json
@@ -161,5 +161,29 @@
       "T": { "item": "SUS_toilet", "chance": 50 }
     },
     "toilets": { "T": {  } }
+  },
+  {
+    "type": "palette",
+    "id": "cabin_cellar",
+    "parameters": {
+      "floor_types": {
+        "type": "ter_str_id",
+        "default": {
+          "distribution": [ [ "t_dirtfloor", 500 ], [ "t_floor", 100 ], [ "t_concrete", 100 ], [ "t_water_sh_underground", 1 ] ]
+        }
+      },
+      "wall_types": { "type": "ter_str_id", "default": { "distribution": [ [ "t_wall_wood", 10 ], [ "t_sconc_wall", 1 ] ] } }
+    },
+    "terrain": {
+      ">": "t_wood_stairs_down",
+      "<": "t_wood_stairs_up",
+      "#": "t_soil",
+      "-": { "param": "wall_types", "fallback": "t_wall_wood" },
+      ".": { "param": "floor_types", "fallback": "t_dirtfloor" },
+      "N": { "param": "floor_types", "fallback": "t_dirtfloor" },
+      "R": { "param": "floor_types", "fallback": "t_dirtfloor" },
+      "c": { "param": "floor_types", "fallback": "t_dirtfloor" }
+    },
+    "furniture": { "R": "f_rack_wood", "t": "f_table", "c": "f_chair" }
   }
 ]

--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -676,7 +676,11 @@
   {
     "type": "overmap_special",
     "id": "Cabin_3",
-    "overmaps": [ { "point": [ 0, 0, 0 ], "overmap": "cabin_3_north" }, { "point": [ 0, 0, 1 ], "overmap": "cabin_roof_3_north" } ],
+    "overmaps": [
+      { "point": [ 0, 0, 0 ], "overmap": "cabin_3_north" },
+      { "point": [ 0, 0, 1 ], "overmap": "cabin_roof_3_north" },
+      { "point": [ 0, 0, -1 ], "overmap": "special_earth" }
+    ],
     "connections": [ { "point": [ 0, -1, 0 ], "terrain": "forest_trail", "connection": "forest_trail" } ],
     "locations": [ "forest" ],
     "city_distance": [ 25, -1 ],
@@ -687,7 +691,11 @@
   {
     "type": "overmap_special",
     "id": "Cabin_4",
-    "overmaps": [ { "point": [ 0, 0, 0 ], "overmap": "cabin_4_north" }, { "point": [ 0, 0, 1 ], "overmap": "cabin_roof_4_north" } ],
+    "overmaps": [
+      { "point": [ 0, 0, 0 ], "overmap": "cabin_4_north" },
+      { "point": [ 0, 0, 1 ], "overmap": "cabin_roof_4_north" },
+      { "point": [ 0, 0, -1 ], "overmap": "special_earth" }
+    ],
     "connections": [ { "point": [ 0, -1, 0 ], "terrain": "forest_trail", "connection": "forest_trail" } ],
     "locations": [ "forest" ],
     "city_distance": [ 25, -1 ],
@@ -698,7 +706,11 @@
   {
     "type": "overmap_special",
     "id": "Cabin_5",
-    "overmaps": [ { "point": [ 0, 0, 0 ], "overmap": "cabin_5_north" }, { "point": [ 0, 0, 1 ], "overmap": "cabin_roof_5_north" } ],
+    "overmaps": [
+      { "point": [ 0, 0, 0 ], "overmap": "cabin_5_north" },
+      { "point": [ 0, 0, 1 ], "overmap": "cabin_roof_5_north" },
+      { "point": [ 0, 0, -1 ], "overmap": "special_earth" }
+    ],
     "connections": [ { "point": [ 0, -1, 0 ], "terrain": "forest_trail", "connection": "forest_trail" } ],
     "locations": [ "forest" ],
     "city_distance": [ 25, -1 ],
@@ -709,7 +721,11 @@
   {
     "type": "overmap_special",
     "id": "Cabin_6",
-    "overmaps": [ { "point": [ 0, 0, 0 ], "overmap": "cabin_6_north" }, { "point": [ 0, 0, 1 ], "overmap": "cabin_roof_6_north" } ],
+    "overmaps": [
+      { "point": [ 0, 0, 0 ], "overmap": "cabin_6_north" },
+      { "point": [ 0, 0, 1 ], "overmap": "cabin_roof_6_north" },
+      { "point": [ 0, 0, -1 ], "overmap": "special_earth" }
+    ],
     "connections": [ { "point": [ 0, -1, 0 ], "terrain": "forest_trail", "connection": "forest_trail" } ],
     "locations": [ "forest" ],
     "city_distance": [ 25, -1 ],

--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -679,7 +679,7 @@
     "overmaps": [
       { "point": [ 0, 0, 0 ], "overmap": "cabin_3_north" },
       { "point": [ 0, 0, 1 ], "overmap": "cabin_roof_3_north" },
-      { "point": [ 0, 0, -1 ], "overmap": "special_earth" }
+      { "point": [ 0, 0, -1 ], "overmap": "cabin_cellar_north" }
     ],
     "connections": [ { "point": [ 0, -1, 0 ], "terrain": "forest_trail", "connection": "forest_trail" } ],
     "locations": [ "forest" ],
@@ -694,7 +694,7 @@
     "overmaps": [
       { "point": [ 0, 0, 0 ], "overmap": "cabin_4_north" },
       { "point": [ 0, 0, 1 ], "overmap": "cabin_roof_4_north" },
-      { "point": [ 0, 0, -1 ], "overmap": "special_earth" }
+      { "point": [ 0, 0, -1 ], "overmap": "cabin_cellar_north" }
     ],
     "connections": [ { "point": [ 0, -1, 0 ], "terrain": "forest_trail", "connection": "forest_trail" } ],
     "locations": [ "forest" ],
@@ -709,7 +709,7 @@
     "overmaps": [
       { "point": [ 0, 0, 0 ], "overmap": "cabin_5_north" },
       { "point": [ 0, 0, 1 ], "overmap": "cabin_roof_5_north" },
-      { "point": [ 0, 0, -1 ], "overmap": "special_earth" }
+      { "point": [ 0, 0, -1 ], "overmap": "cabin_cellar_north" }
     ],
     "connections": [ { "point": [ 0, -1, 0 ], "terrain": "forest_trail", "connection": "forest_trail" } ],
     "locations": [ "forest" ],
@@ -724,7 +724,7 @@
     "overmaps": [
       { "point": [ 0, 0, 0 ], "overmap": "cabin_6_north" },
       { "point": [ 0, 0, 1 ], "overmap": "cabin_roof_6_north" },
-      { "point": [ 0, 0, -1 ], "overmap": "special_earth" }
+      { "point": [ 0, 0, -1 ], "overmap": "cabin_cellar_north" }
     ],
     "connections": [ { "point": [ 0, -1, 0 ], "terrain": "forest_trail", "connection": "forest_trail" } ],
     "locations": [ "forest" ],

--- a/data/json/overmap/overmap_terrain/overmap_terrain.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain.json
@@ -312,6 +312,16 @@
   },
   {
     "type": "overmap_terrain",
+    "id": [ "cabin_cellar" ],
+    "vision_levels": "underground_dirt",
+    "name": "cabin cellar",
+    "looks_like": "special_earth",
+    "sym": "C",
+    "color": "brown",
+    "see_cost": "opaque"
+  },
+  {
+    "type": "overmap_terrain",
     "id": [ "cabin_lakeside", "cabin_lakeside1", "cabin_lakeside2", "cabin_lakeside3", "cabin_lakeside4", "cabin_lakeside5" ],
     "name": "lakeside cabin",
     "copy-from": "cabin"


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Content "Add nested cellars to cabins"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Standing-Storm vanilla PR! What??!

While working on #81714 I realized that it's possible to add nested cellars to existing buildings without messing with overmap mapgen, and I thought that would be a good feature for vanilla cabins.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add a the possibility (currently 33% chance) of a root cellar/small cellar in `cabin_3`, `cabin_4`, `cabin_5`, and `cabin_6`. `cabin_7` has a pond right nearby so I left it out, and `cabin_1` and `cabin_2` are both larger and have more storage so have less need for one.

The current spawns are (listed by spawn weight)

- 1000: Some boxes filled with hiking, hunting, or camping equipment, taken from the appropriate itemgroups.
- 900: Preserved foods, taken from the `preserved_food` itemgroup
- 600: Totally empty
- 500: Filled with booze and a small table with maybe some playing cards on it. 33% chance of a moonshine setup (still and vat)
- 450: Furniture storage, just tables and chairs and boxes.
- 50: Totally empty but, unlike all previous entries, has _no dust_...
- 25: Spooky setpiece--a table with some animal bones on it and candles around it. 

There's also three overlays that can spawn on top of this. One just adds zombies, one adds spiders and webs, and the last adds a fungal zombie and fungal haze.

The `cabin_cellar` palette is parameterized, so the walls are usually wood and the floor is usually dirt, but there's also wood floors, concrete, and a small chance of a cellar being flooded. 

The cellar is nested under the id `cabin_6x6_cellar_nested`, so it's easy for mods to add their own weird cellars to the pool. 

<details>
<summary>Images: </summary>

Cabins:

<img width="397" height="374" alt="Untitled" src="https://github.com/user-attachments/assets/1843415d-4026-4fb5-b5f8-925304f46c02" />

<img width="549" height="445" alt="Untitled" src="https://github.com/user-attachments/assets/45c9f72f-9fc8-4f2c-befa-4f0bf5a28d78" />

<img width="634" height="569" alt="Untitled" src="https://github.com/user-attachments/assets/9654d658-d56f-44d3-8d34-f17697d38204" />


Cellars:

<img width="291" height="342" alt="Untitled" src="https://github.com/user-attachments/assets/4ccd8af5-3230-4044-8c77-1bb987521dc6" />

<img width="291" height="342" alt="Untitled" src="https://github.com/user-attachments/assets/2546f5ec-a09f-471b-a34e-2dcea33a81da" />

<img width="299" height="353" alt="Untitled" src="https://github.com/user-attachments/assets/fe37b337-a365-47c9-8cf4-66e0b354f674" />

<img width="277" height="332" alt="Untitled" src="https://github.com/user-attachments/assets/f22b29d3-1516-4d0a-9e5c-ea3733810c6c" />

<img width="284" height="343" alt="Untitled" src="https://github.com/user-attachments/assets/5192edc8-0602-4afd-8569-ef6fd8ae283c" />

<img width="358" height="259" alt="Untitled" src="https://github.com/user-attachments/assets/05447b68-f597-4b64-9eb5-465674faa86b" />

<img width="277" height="305" alt="Untitled" src="https://github.com/user-attachments/assets/a4b63c37-0a4c-41dd-88de-4fc6f92ce239" />

</details>

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Spawned a bunch of cabins, messed with spawn weights, teleported around.

Fungalization achieved, check the pictures 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
