### PR TITLE
Add hit field and destroy field for fungal terrain

### DIFF
--- a/data/json/fields/debris.json
+++ b/data/json/fields/debris.json
@@ -71,5 +71,110 @@
     "phase": "liquid",
     "display_field": true,
     "looks_like": "water"
+  },
+  {
+    "type": "field_type",
+    "id": "fd_spores",
+    "intensity_levels": [
+      {
+        "name": "spore dust",
+        "sym": "%",
+        "color": "light_gray",
+        "transparent": true,
+        "dangerous": false,
+        "concentration": 1,
+        "effects": [
+          {
+            "effect_id": "spores",
+            "min_duration": "1 minutes",
+            "max_duration": "10 minutes",
+            "intensity": 1,
+            "message": "You're covered in spores!",
+            "message_npc": "<npcname> is covered in spores!",
+            "message_type": "bad",
+            "immunity_data": {
+              "flags": [ "mycus" ],
+              "body_part_env_resistance": [ [ "head", 15 ], [ "torso", 15 ], [ "arm", 15 ], [ "hand", 15 ], [ "leg", 15 ], [ "foot", 15 ] ]
+            }
+          }
+        ]
+      },
+      {
+        "name": "spore dust and grime",
+        "sym": "%",
+        "color": "light_gray",
+        "transparent": true,
+        "dangerous": false,
+        "concentration": 1,
+        "effects": [
+          {
+            "effect_id": "spores",
+            "min_duration": "1 minutes",
+            "max_duration": "10 minutes",
+            "intensity": 1,
+            "message": "You're covered in spores!",
+            "message_npc": "<npcname> is covered in spores!",
+            "message_type": "bad",
+            "immunity_data": {
+              "flags": [ "mycus" ],
+              "body_part_env_resistance": [ [ "head", 15 ], [ "torso", 15 ], [ "arm", 15 ], [ "hand", 15 ], [ "leg", 15 ], [ "foot", 15 ] ]
+            }
+          }
+        ]
+      }
+    ],
+    "priority": 1,
+    "dirty_transparency_cache": false,
+    "display_items": true,
+    "display_field": true,
+    "description_affix": "covered_in",
+    "mopsafe": true,
+    "moppable": true,
+    "percent_spread": 75,
+    "half_life": "6 hours",
+    "phase": "gas",
+    "has_fume": true,
+    "looks_like": "t_open_air"
+  },
+  {
+    "type": "field_type",
+    "id": "fd_fungal_splinters",
+    "intensity_levels": [
+      {
+        "name": "fungal debris",
+        "sym": "%",
+        "color": "light_gray",
+        "transparent": true,
+        "dangerous": false,
+        "concentration": 1,
+        "effects": [
+          {
+            "effect_id": "spores",
+            "min_duration": "1 minutes",
+            "max_duration": "10 minutes",
+            "intensity": 1,
+            "message": "You're covered in spores!",
+            "message_npc": "<npcname> is covered in spores!",
+            "message_type": "bad",
+            "immunity_data": {
+              "flags": [ "mycus" ],
+              "body_part_env_resistance": [ [ "head", 15 ], [ "torso", 15 ], [ "arm", 15 ], [ "hand", 15 ], [ "leg", 15 ], [ "foot", 15 ] ]
+            }
+          }
+        ]
+      }
+    ],
+    "priority": 2,
+    "dirty_transparency_cache": false,
+    "display_items": true,
+    "display_field": true,
+    "description_affix": "covered_in",
+    "mopsafe": true,
+    "moppable": true,
+    "percent_spread": 50,
+    "half_life": "6 hours",
+    "phase": "gas",
+    "has_fume": true,
+    "looks_like": "fd_dust"
   }
 ]

--- a/data/json/fields/debris.json
+++ b/data/json/fields/debris.json
@@ -104,7 +104,7 @@
         "sym": "%",
         "color": "light_gray",
         "transparent": true,
-        "dangerous": false,
+        "dangerous": true,
         "concentration": 1,
         "effects": [
           {
@@ -145,23 +145,8 @@
         "sym": "%",
         "color": "light_gray",
         "transparent": true,
-        "dangerous": false,
-        "concentration": 1,
-        "effects": [
-          {
-            "effect_id": "spores",
-            "min_duration": "1 minutes",
-            "max_duration": "10 minutes",
-            "intensity": 1,
-            "message": "You're covered in spores!",
-            "message_npc": "<npcname> is covered in spores!",
-            "message_type": "bad",
-            "immunity_data": {
-              "flags": [ "mycus" ],
-              "body_part_env_resistance": [ [ "head", 15 ], [ "torso", 15 ], [ "arm", 15 ], [ "hand", 15 ], [ "leg", 15 ], [ "foot", 15 ] ]
-            }
-          }
-        ]
+        "dangerous": true,
+        "concentration": 1
       }
     ],
     "priority": 2,

--- a/data/json/furniture_and_terrain/terrain-fungal.json
+++ b/data/json/furniture_and_terrain/terrain-fungal.json
@@ -10,7 +10,15 @@
     "coverage": 40,
     "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "FUNGUS", "SHRUB", "SHORT", "GRAZER_INEDIBLE" ],
     "examine_action": "shrub_marloss",
-    "bash": { "str_min": 4, "str_max": 60, "sound": "crunch.", "sound_fail": "poof!", "ter_set": "t_fungus" }
+    "bash": {
+      "str_min": 4,
+      "str_max": 60,
+      "sound": "crunch.",
+      "sound_fail": "poof!",
+      "ter_set": "t_fungus",
+      "hit_field": [ "fd_spores", 1 ],
+      "destroyed_field": [ "fd_fungal_splinters", 1 ]
+    }
   },
   {
     "type": "terrain",
@@ -27,7 +35,9 @@
       "ter_set": "t_null",
       "str_min": 20,
       "str_max": 400,
-      "str_min_supported": 50
+      "str_min_supported": 50,
+      "hit_field": [ "fd_spores", 1 ],
+      "destroyed_field": [ "fd_fungal_splinters", 1 ]
     }
   },
   {
@@ -41,7 +51,15 @@
     "move_cost": 2,
     "connect_groups": "INDOORFLOOR",
     "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "FUNGUS" ],
-    "bash": { "sound": "smash", "ter_set": "t_null", "str_min": 20, "str_max": 400, "str_min_supported": 50 }
+    "bash": {
+      "sound": "smash",
+      "ter_set": "t_null",
+      "str_min": 20,
+      "str_max": 400,
+      "str_min_supported": 50,
+      "hit_field": [ "fd_spores", 1 ],
+      "destroyed_field": [ "fd_fungal_splinters", 1 ]
+    }
   },
   {
     "type": "terrain",
@@ -53,7 +71,15 @@
     "color": "light_gray",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "SUPPORTS_ROOF", "FLAT", "FUNGUS" ],
-    "bash": { "sound": "smash", "ter_set": "t_null", "str_min": 20, "str_max": 400, "str_min_supported": 50 }
+    "bash": {
+      "sound": "smash",
+      "ter_set": "t_null",
+      "str_min": 20,
+      "str_max": 400,
+      "str_min_supported": 50,
+      "hit_field": [ "fd_spores", 1 ],
+      "destroyed_field": [ "fd_fungal_splinters", 1 ]
+    }
   },
   {
     "type": "terrain",
@@ -65,7 +91,15 @@
     "color": "light_gray",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "FLAT", "FUNGUS" ],
-    "bash": { "sound": "SMASH!", "ter_set": "t_null", "str_min": 20, "str_max": 400, "str_min_supported": 50 }
+    "bash": {
+      "sound": "SMASH!",
+      "ter_set": "t_null",
+      "str_min": 20,
+      "str_max": 400,
+      "str_min_supported": 50,
+      "hit_field": [ "fd_spores", 1 ],
+      "destroyed_field": [ "fd_fungal_splinters", 1 ]
+	}
   },
   {
     "type": "terrain",
@@ -79,7 +113,15 @@
     "connect_groups": "WALL",
     "connects_to": "WALL",
     "flags": [ "FLAMMABLE_ASH", "NOITEM", "SUPPORTS_ROOF", "FUNGUS", "WALL", "REDUCE_SCENT", "MINEABLE" ],
-    "bash": { "str_min": 30, "str_max": 180, "sound": "crunch!", "sound_fail": "poof!", "ter_set": "t_fungus" }
+     "bash": {
+      "str_min": 30,
+      "str_max": 180,
+      "sound": "crunch!",
+      "sound_fail": "poof!",
+      "ter_set": "t_fungus",
+      "hit_field": [ "fd_spores", 1 ],
+      "destroyed_field": [ "fd_fungal_splinters", 1 ]
+    }
   },
   {
     "type": "terrain",
@@ -93,7 +135,15 @@
     "connect_groups": "WALL",
     "connects_to": "WALL",
     "flags": [ "FLAMMABLE_ASH", "NOITEM", "SUPPORTS_ROOF", "FUNGUS", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "MINEABLE" ],
-    "bash": { "str_min": 30, "str_max": 180, "sound": "crunch!", "sound_fail": "poof!", "ter_set": "t_fungus" }
+    "bash": {
+      "str_min": 30,
+      "str_max": 180,
+      "sound": "crunch!",
+      "sound_fail": "poof!",
+      "ter_set": "t_fungus",
+      "hit_field": [ "fd_spores", 1 ],
+      "destroyed_field": [ "fd_fungal_splinters", 1 ]
+    }
   },
   {
     "type": "terrain",
@@ -104,7 +154,15 @@
     "color": "light_gray",
     "move_cost": 4,
     "flags": [ "TRANSPARENT", "THIN_OBSTACLE", "FLAMMABLE_ASH", "FUNGUS", "MOUNTABLE" ],
-    "bash": { "str_min": 10, "str_max": 70, "sound": "crunch!", "sound_fail": "poof!", "ter_set": "t_fungus" }
+    "bash": {
+      "str_min": 10,
+      "str_max": 70,
+      "sound": "crunch!",
+      "sound_fail": "poof!",
+      "ter_set": "t_fungus",
+      "hit_field": [ "fd_spores", 1 ],
+      "destroyed_field": [ "fd_fungal_splinters", 1 ]
+    }
   },
   {
     "type": "terrain",
@@ -126,7 +184,15 @@
       "SHORT",
       "GRAZER_INEDIBLE"
     ],
-    "bash": { "str_min": 4, "str_max": 60, "sound": "crunch.", "sound_fail": "poof!", "ter_set": "t_fungus" }
+    "bash": {
+      "str_min": 4,
+      "str_max": 60,
+      "sound": "crunch.",
+      "sound_fail": "poof!",
+      "ter_set": "t_fungus",
+      "hit_field": [ "fd_spores", 1 ],
+      "destroyed_field": [ "fd_fungal_splinters", 1 ]
+    }
   },
   {
     "type": "terrain",

--- a/data/json/furniture_and_terrain/terrain-fungal.json
+++ b/data/json/furniture_and_terrain/terrain-fungal.json
@@ -99,7 +99,7 @@
       "str_min_supported": 50,
       "hit_field": [ "fd_spores", 1 ],
       "destroyed_field": [ "fd_fungal_splinters", 1 ]
-	}
+    }
   },
   {
     "type": "terrain",

--- a/data/json/furniture_and_terrain/terrain-fungal.json
+++ b/data/json/furniture_and_terrain/terrain-fungal.json
@@ -113,7 +113,7 @@
     "connect_groups": "WALL",
     "connects_to": "WALL",
     "flags": [ "FLAMMABLE_ASH", "NOITEM", "SUPPORTS_ROOF", "FUNGUS", "WALL", "REDUCE_SCENT", "MINEABLE" ],
-     "bash": {
+    "bash": {
       "str_min": 30,
       "str_max": 180,
       "sound": "crunch!",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Features "Adds lingering fields of spores after fungal terrain is destroyed."

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Simple visual addition, makes it so that spore dust and fungal debris linger in the air, or on the ground when a fungal tile is destroyed. Mostly cosmetic, similar to #81565 .
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add a spore dust and splinter field to every fungal terrain that should do so. Doesn't run the risk of infinitely growing flames, or infinitely growing fungal bedding.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Seems to be the easiest (and simplest) method of creating this specific effect, so I don't believe there are any alternatives.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
various field testing, number tweaks and more so it actually has a visual impact. Shouldn't cause too much lag, besides what lag fungal stuff already causes.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
<img width="990" height="942" alt="image" src="https://github.com/user-attachments/assets/09a74067-c935-4bff-bc7a-d330a325912a" />
example of what happens when burning a field of fungal ground.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
