### PR TITLE
[MoM] Overhaul Premonition, add Sense Hostility power

### DIFF
--- a/data/mods/MindOverMatter/PowerDescriptionSpoilers.md
+++ b/data/mods/MindOverMatter/PowerDescriptionSpoilers.md
@@ -338,7 +338,7 @@ This is natural painkiller and so has natural effects (reduces speed slightly)<b
 *Stamina Cost*: 5500, minus 145 per level to a minimum of 2750<br />
 *Channeling Time*: 150 moves, minus 9 moves per level to a minimum of 70<br />
 *Effects*: Gaze a short time into the future to predict enemy movements.  Grants a 25% chance to avoid any damage from an attack plus 1.5% per power level to a maximum of a 70% chance, prevents the psion from being grabbed, and applies the HARDTOHIT flag.  It also increases your effective dodge skill by 1 per 2 power levels.<br />
-*Prerequisites*: Premonition 10 *or* Speed Reader 10 *or* Discern Weakness 6, Clairyovance 6<br />
+*Prerequisites*: Premonition 10 *or* Sense Hostility 5, Speed Reader 10 *or* Discern Weakness 6, Clairyovance 6<br />
 </details>
 <details>
 <summary><h3>Intuitive Artisan (C)</h3></summary>

--- a/data/mods/MindOverMatter/PowerDescriptionSpoilers.md
+++ b/data/mods/MindOverMatter/PowerDescriptionSpoilers.md
@@ -246,11 +246,11 @@ This is natural painkiller and so has natural effects (reduces speed slightly)<b
 <summary><h3>Premonition (C)</h3></summary>
 
 *Difficulty*: 2<br />
-*Target*: All enemies within 2 squares per power level<br />
-*Duration*: 2 minutes to 8 minutes 10 seconds, plus 45 seconds to 1 minutes 15 seconds minutes per level<br />
+*Target*: Self<br />
+*Duration*: 19 minutes and 34 seconds to 37 minutes and 12 seconds, plus 5 minutes and 3 seconds seconds to 16 minutes and 42 seconds per level<br />
 *Stamina Cost*: 2250, minus 85 per level to a minimum of 850<br />
 *Channeling Time*: 85 moves, minus 7 moves per level to a minimum of 25<br />
-*Effects*: Reveal the location of all hostile enemies (NPCs who are currently hostile and creatures with aggression 10 or greater) within the power's range. Premonition does not reveal exactly what sort of enemy is out there, only that something is.<br />
+*Effects*: Open the psion's senses up to nearby dangers or other disturbances, allowing them to sense nearby motion as well as other more esoteric sources of danger (such as receiving an advance warning before a portal storm).  The psion cannot tell the exact location of the danger, only that it's nearby.<br />
 *Prerequisites*: Heightened Senses 6<br />
 </details>
 <details>
@@ -307,6 +307,16 @@ This is natural painkiller and so has natural effects (reduces speed slightly)<b
 *Channeling Time*: 200 moves, minus 6 moves per level to a minimum of 125<br />
 *Effects*: Increase the psion's range with ranged weapons by 1 square per 4 power levels, reduces weapon dispersion by 2.5% per power level to a maximum of 60%, and increases your chance to hit weakpoints with ranged weapons by 10% plus 8% per power level.<br />
 *Prerequisites*: Discern Weakness 7<br />
+</details>
+<summary><h3>Sense Hostility (C)</h3></summary>
+
+*Difficulty*: 5<br />
+*Target*: All hostile creatures within 2 squares per power level<br />
+*Duration*: 2 minutes to 8 minutes 10 seconds, plus 45 seconds to 1 minutes 15 seconds minutes per level<br />
+*Stamina Cost*: 6500, minus 120 per level to a minimum of 3150<br />
+*Channeling Time*: 85 moves, minus 7 moves per level to a minimum of 25<br />
+*Effects*: Reveal the location of all hostile enemies (NPCs who are currently hostile and creatures with aggression 10 or greater) within the power's range. Sense Danger does not reveal exactly what sort of enemy is out there, only that something is.<br />
+*Prerequisites*: Heightened Senses 8, Premonition 6, Aura Sight 5<br />
 </details>
 <details>
 <summary><h3>Clairyovance</h3></summary>

--- a/data/mods/MindOverMatter/effectoncondition/eoc_learn_recipes.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_learn_recipes.json
@@ -150,6 +150,7 @@
           "EOC_CHECK_GAMEBEGIN_CLAIR_RECIPE_SPOT_WEAKNESS",
           "EOC_CHECK_GAMEBEGIN_CLAIR_RECIPE_AURA_SIGHT",
           "EOC_CHECK_GAMEBEGIN_CLAIR_RECIPE_RANGED_ENHANCE",
+          "EOC_CHECK_GAMEBEGIN_CLAIR_RECIPE_SENSE_HOSTILE_CREATURES",
           "EOC_CHECK_GAMEBEGIN_CLAIR_RECIPE_VOYANCE",
           "EOC_CHECK_GAMEBEGIN_CLAIR_RECIPE_DODGE_POWER",
           "EOC_CHECK_GAMEBEGIN_CLAIR_RECIPE_CRAFT_BONUS",
@@ -203,6 +204,12 @@
     "id": "EOC_CHECK_GAMEBEGIN_CLAIR_RECIPE_RANGED_ENHANCE",
     "condition": { "and": [ { "u_has_trait": "CLAIRSENTIENT" }, { "math": [ "u_spell_level('clair_ranged_enhance') >= 0" ] } ] },
     "effect": [ { "u_learn_recipe": "practice_clair_ranged_enhance" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_CHECK_GAMEBEGIN_CLAIR_RECIPE_SENSE_HOSTILE_CREATURES",
+    "condition": { "and": [ { "u_has_trait": "CLAIRSENTIENT" }, { "math": [ "u_spell_level('clair_sense_hostile_creatures') >= 0" ] } ] },
+    "effect": [ { "u_learn_recipe": "practice_clair_sense_hostile_creatures" } ]
   },
   {
     "type": "effect_on_condition",

--- a/data/mods/MindOverMatter/effectoncondition/eoc_premonition_instances.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_premonition_instances.json
@@ -8,12 +8,7 @@
         "run_eocs": [
           {
             "id": "EOC_LIEUTENANT_SPAWN_SHADOW_PREMONITION",
-            "condition": {
-              "or": [
-                { "math": [ "u_spell_level('clair_danger_sense') >= 1" ] },
-                { "math": [ "u_spell_level('clair_danger_sense_knack') >= 1" ] }
-              ]
-            },
+            "condition": { "u_has_any_effect": [ "effect_clair_premonition", "effect_clair_sense_hostile_creatures" ] },
             "effect": [
               {
                 "u_message": "The darkness takes on a palpable sense of menace.  Something terrible is coming.",
@@ -21,8 +16,28 @@
                 "popup": true
               },
               {
-                "run_eocs": "EOC_LIEUTENANT_SPAWN_SHADOW_NOW",
-                "time_in_future": { "math": [ "( (u_spell_level('clair_danger_sense') + u_spell_level('clair_danger_sense_knack') ) * 5) + 10" ] }
+                "if": {
+                  "and": [ { "u_has_effect": "effect_clair_premonition" }, { "u_has_effect": "effect_clair_sense_hostile_creatures" } ]
+                },
+                "then": {
+                  "run_eocs": "EOC_LIEUTENANT_SPAWN_SHADOW_NOW",
+                  "time_in_future": {
+                    "math": [
+                      "( (u_spell_level('clair_danger_sense') + u_spell_level('clair_danger_sense_knack') ) * 5) + ( u_spell_level('clair_sense_hostile_creatures') * 10) + 10"
+                    ]
+                  }
+                }
+              },
+              {
+                "if": { "u_has_effect": "effect_clair_premonition" },
+                "then": {
+                  "run_eocs": "EOC_LIEUTENANT_SPAWN_SHADOW_NOW",
+                  "time_in_future": { "math": [ "( (u_spell_level('clair_danger_sense') + u_spell_level('clair_danger_sense_knack') ) * 5) + 10" ] }
+                },
+                "else": {
+                  "run_eocs": "EOC_LIEUTENANT_SPAWN_SHADOW_NOW",
+                  "time_in_future": { "math": [ "( u_spell_level('clair_sense_hostile_creatures') * 10) + 10" ] }
+                }
               }
             ],
             "false_effect": [ { "run_eocs": [ "EOC_LIEUTENANT_SPAWN_SHADOW_NOW" ] } ]
@@ -51,12 +66,7 @@
         "run_eocs": [
           {
             "id": "EOC_CAUSE_EARLY_PORTAL_STORM_PREMONITION",
-            "condition": {
-              "or": [
-                { "math": [ "u_spell_level('clair_danger_sense') >= 1" ] },
-                { "math": [ "u_spell_level('clair_danger_sense_knack') >= 1" ] }
-              ]
-            },
+            "condition": { "u_has_effect": "effect_clair_premonition" },
             "effect": [
               {
                 "u_message": "The air hums like a wire stretched taut and on the verge of breaking.  Any moment, something is going to snap.",
@@ -115,12 +125,7 @@
         "run_eocs": [
           {
             "id": "EOC_BANDIT_ASSASSIN_1_PREMONITION",
-            "condition": {
-              "or": [
-                { "math": [ "u_spell_level('clair_danger_sense') >= 1" ] },
-                { "math": [ "u_spell_level('clair_danger_sense_knack') >= 1" ] }
-              ]
-            },
+            "condition": { "u_has_any_effect": [ "effect_clair_premonition", "effect_clair_sense_hostile_creatures" ] },
             "effect": [
               {
                 "u_message": "You feel hostile eyes watching you and rapidly getting closer.  Someone has it in for you.",
@@ -128,8 +133,28 @@
                 "popup": true
               },
               {
-                "run_eocs": "EOC_BANDIT_ASSASSIN_1_ACTUAL_FAR",
-                "time_in_future": { "math": [ "( (u_spell_level('clair_danger_sense') + u_spell_level('clair_danger_sense_knack') ) * 4) + 5" ] }
+                "if": {
+                  "and": [ { "u_has_effect": "effect_clair_premonition" }, { "u_has_effect": "effect_clair_sense_hostile_creatures" } ]
+                },
+                "then": {
+                  "run_eocs": "EOC_BANDIT_ASSASSIN_1_ACTUAL_FAR",
+                  "time_in_future": {
+                    "math": [
+                      "( (u_spell_level('clair_danger_sense') + u_spell_level('clair_danger_sense_knack') ) * 4) + ( u_spell_level('clair_sense_hostile_creatures') * 8) + 5"
+                    ]
+                  }
+                }
+              },
+              {
+                "if": { "u_has_effect": "effect_clair_premonition" },
+                "then": {
+                  "run_eocs": "EOC_BANDIT_ASSASSIN_1_ACTUAL_FAR",
+                  "time_in_future": { "math": [ "( (u_spell_level('clair_danger_sense') + u_spell_level('clair_danger_sense_knack') ) * 4) + 5" ] }
+                },
+                "else": {
+                  "run_eocs": "EOC_BANDIT_ASSASSIN_1_ACTUAL_FAR",
+                  "time_in_future": { "math": [ "( u_spell_level('clair_sense_hostile_creatures') * 8) + 5" ] }
+                }
               }
             ],
             "false_effect": [ { "run_eocs": [ "EOC_BANDIT_ASSASSIN_1_ACTUAL_NEAR" ] } ]
@@ -193,12 +218,7 @@
         "run_eocs": [
           {
             "id": "EOC_BANDIT_ASSASSIN_2_PREMONITION",
-            "condition": {
-              "or": [
-                { "math": [ "u_spell_level('clair_danger_sense') >= 1" ] },
-                { "math": [ "u_spell_level('clair_danger_sense_knack') >= 1" ] }
-              ]
-            },
+            "condition": { "u_has_any_effect": [ "effect_clair_premonition", "effect_clair_sense_hostile_creatures" ] },
             "effect": [
               {
                 "u_message": "You feel hostile eyes watching you and rapidly getting closer.  Someone has it in for you.",
@@ -206,11 +226,31 @@
                 "popup": true
               },
               {
-                "run_eocs": "EOC_BANDIT_ASSASSIN_2_ACTUAL_NEAR",
-                "time_in_future": { "math": [ "( (u_spell_level('clair_danger_sense') + u_spell_level('clair_danger_sense_knack') ) * 4) + 5" ] }
+                "if": {
+                  "and": [ { "u_has_effect": "effect_clair_premonition" }, { "u_has_effect": "effect_clair_sense_hostile_creatures" } ]
+                },
+                "then": {
+                  "run_eocs": "EOC_BANDIT_ASSASSIN_2_ACTUAL_FAR",
+                  "time_in_future": {
+                    "math": [
+                      "( (u_spell_level('clair_danger_sense') + u_spell_level('clair_danger_sense_knack') ) * 4) + ( u_spell_level('clair_sense_hostile_creatures') * 8) + 5"
+                    ]
+                  }
+                }
+              },
+              {
+                "if": { "u_has_effect": "effect_clair_premonition" },
+                "then": {
+                  "run_eocs": "EOC_BANDIT_ASSASSIN_2_ACTUAL_FAR",
+                  "time_in_future": { "math": [ "( (u_spell_level('clair_danger_sense') + u_spell_level('clair_danger_sense_knack') ) * 4) + 5" ] }
+                },
+                "else": {
+                  "run_eocs": "EOC_BANDIT_ASSASSIN_2_ACTUAL_FAR",
+                  "time_in_future": { "math": [ "( u_spell_level('clair_sense_hostile_creatures') * 8) + 5" ] }
+                }
               }
             ],
-            "false_effect": [ { "run_eocs": [ "EOC_BANDIT_ASSASSIN_2_ACTUAL_FAR" ] } ]
+            "false_effect": [ { "run_eocs": [ "EOC_BANDIT_ASSASSIN_2_ACTUAL_NEAR" ] } ]
           }
         ]
       }
@@ -272,12 +312,7 @@
         "run_eocs": [
           {
             "id": "EOC_BANDIT_ASSASSIN_3_PREMONITION",
-            "condition": {
-              "or": [
-                { "math": [ "u_spell_level('clair_danger_sense') >= 1" ] },
-                { "math": [ "u_spell_level('clair_danger_sense_knack') >= 1" ] }
-              ]
-            },
+            "condition": { "u_has_any_effect": [ "effect_clair_premonition", "effect_clair_sense_hostile_creatures" ] },
             "effect": [
               {
                 "u_message": "You feel several sets of hostile eyes watching you and rapidly getting closer.  Someone has it in for you.",
@@ -285,11 +320,31 @@
                 "popup": true
               },
               {
-                "run_eocs": "EOC_BANDIT_ASSASSIN_3_ACTUAL_NEAR",
-                "time_in_future": { "math": [ "( (u_spell_level('clair_danger_sense') + u_spell_level('clair_danger_sense_knack') ) * 4) + 5" ] }
+                "if": {
+                  "and": [ { "u_has_effect": "effect_clair_premonition" }, { "u_has_effect": "effect_clair_sense_hostile_creatures" } ]
+                },
+                "then": {
+                  "run_eocs": "EOC_BANDIT_ASSASSIN_3_ACTUAL_FAR",
+                  "time_in_future": {
+                    "math": [
+                      "( (u_spell_level('clair_danger_sense') + u_spell_level('clair_danger_sense_knack') ) * 4) + ( u_spell_level('clair_sense_hostile_creatures') * 8) + 5"
+                    ]
+                  }
+                }
+              },
+              {
+                "if": { "u_has_effect": "effect_clair_premonition" },
+                "then": {
+                  "run_eocs": "EOC_BANDIT_ASSASSIN_3_ACTUAL_FAR",
+                  "time_in_future": { "math": [ "( (u_spell_level('clair_danger_sense') + u_spell_level('clair_danger_sense_knack') ) * 4) + 5" ] }
+                },
+                "else": {
+                  "run_eocs": "EOC_BANDIT_ASSASSIN_3_ACTUAL_FAR",
+                  "time_in_future": { "math": [ "( u_spell_level('clair_sense_hostile_creatures') * 8) + 5" ] }
+                }
               }
             ],
-            "false_effect": [ { "run_eocs": [ "EOC_BANDIT_ASSASSIN_3_ACTUAL_FAR" ] } ]
+            "false_effect": [ { "run_eocs": [ "EOC_BANDIT_ASSASSIN_3_ACTUAL_NEAR" ] } ]
           }
         ]
       }
@@ -351,12 +406,7 @@
         "run_eocs": [
           {
             "id": "EOC_OLD_GUARD_ASSASSIN_PREMONITION",
-            "condition": {
-              "or": [
-                { "math": [ "u_spell_level('clair_danger_sense') >= 1" ] },
-                { "math": [ "u_spell_level('clair_danger_sense_knack') >= 1" ] }
-              ]
-            },
+            "condition": { "u_has_any_effect": [ "effect_clair_premonition", "effect_clair_sense_hostile_creatures" ] },
             "effect": [
               {
                 "u_message": "You feel several sets of hostile eyes watching you and rapidly getting closer.  Someone has it in for you.",
@@ -364,11 +414,31 @@
                 "popup": true
               },
               {
-                "run_eocs": "EOC_OLD_GUARD_ASSASSIN_ACTUAL_NEAR",
-                "time_in_future": { "math": [ "( (u_spell_level('clair_danger_sense') + u_spell_level('clair_danger_sense_knack') ) * 4) + 5" ] }
+                "if": {
+                  "and": [ { "u_has_effect": "effect_clair_premonition" }, { "u_has_effect": "effect_clair_sense_hostile_creatures" } ]
+                },
+                "then": {
+                  "run_eocs": "EOC_OLD_GUARD_ASSASSIN_ACTUAL_FAR",
+                  "time_in_future": {
+                    "math": [
+                      "( (u_spell_level('clair_danger_sense') + u_spell_level('clair_danger_sense_knack') ) * 4) + ( u_spell_level('clair_sense_hostile_creatures') * 8) + 5"
+                    ]
+                  }
+                }
+              },
+              {
+                "if": { "u_has_effect": "effect_clair_premonition" },
+                "then": {
+                  "run_eocs": "EOC_OLD_GUARD_ASSASSIN_ACTUAL_FAR",
+                  "time_in_future": { "math": [ "( (u_spell_level('clair_danger_sense') + u_spell_level('clair_danger_sense_knack') ) * 4) + 5" ] }
+                },
+                "else": {
+                  "run_eocs": "EOC_OLD_GUARD_ASSASSIN_ACTUAL_FAR",
+                  "time_in_future": { "math": [ "( u_spell_level('clair_sense_hostile_creatures') * 8) + 5" ] }
+                }
               }
             ],
-            "false_effect": [ { "run_eocs": [ "EOC_OLD_GUARD_ASSASSIN_ACTUAL_FAR" ] } ]
+            "false_effect": [ { "run_eocs": [ "EOC_OLD_GUARD_ASSASSIN_ACTUAL_NEAR" ] } ]
           }
         ]
       }

--- a/data/mods/MindOverMatter/effects/effects_psionic.json
+++ b/data/mods/MindOverMatter/effects/effects_psionic.json
@@ -1051,29 +1051,23 @@
   {
     "type": "effect_type",
     "id": "effect_clair_premonition",
-    "name": [ "Sensing Danger" ],
-    "desc": [ "You know there's something out there." ],
+    "name": [ "Premonition" ],
+    "desc": [ "You are preternaturally aware of nearby movement and possible dangers." ],
     "apply_message": "",
-    "remove_message": "The sense of danger fades away, but you know the danger remains.",
+    "remove_message": "Your preternatural awareness fades.",
     "rating": "good",
     "max_duration": "7 days",
     "max_intensity": 58,
     "enchantments": [
       {
-        "special_vision": [
+        "values": [
           {
-            "condition": {
-              "or": [
-                { "and": [ { "not": "npc_is_character" }, { "math": [ "n_val('anger') >= 10" ] } ] },
-                { "and": [ "npc_is_character", "npc_hostile" ] }
-              ]
-            },
-            "distance": {
+            "value": "MOTION_ALARM",
+            "add": {
               "math": [
-                "( ( ( u_spell_level('clair_danger_sense') + u_spell_level('clair_danger_sense_knack') ) * 2) * (scaling_factor(u_val('intelligence') ) ) ) * u_nether_attunement_power_scaling"
+                "max( ( ( 3 + ( ( u_spell_level('clair_danger_sense') + u_spell_level('clair_danger_sense_knack') ) * 0.5  ) * (scaling_factor(u_val('intelligence') ) ) ) * u_nether_attunement_power_scaling), 25)"
               ]
-            },
-            "descriptions": [ { "id": "moving_creature", "symbol": "?", "color": "c_white", "text": "You sense a danger here." } ]
+            }
           }
         ]
       }
@@ -1201,6 +1195,36 @@
     "dur_add_perc": 10,
     "int_dur_factor": "109 s",
     "enchantments": [ "enchant_clair_sense_rads" ]
+  },
+  {
+    "type": "effect_type",
+    "id": "effect_clair_sense_hostile_creatures",
+    "name": [ "Sense Hostility" ],
+    "desc": [ "You will know when there's something out there that means you harm." ],
+    "apply_message": "",
+    "remove_message": "The sense of dangerous creatures fades away, but you know the danger remains.",
+    "rating": "good",
+    "max_duration": "7 days",
+    "enchantments": [
+      {
+        "special_vision": [
+          {
+            "condition": {
+              "or": [
+                { "and": [ { "not": "npc_is_character" }, { "math": [ "n_val('anger') >= 10" ] } ] },
+                { "and": [ "npc_is_character", "npc_hostile" ] }
+              ]
+            },
+            "distance": {
+              "math": [
+                "( ( u_spell_level('clair_sense_hostile_creatures') * 2) * (scaling_factor(u_val('intelligence') ) ) ) * u_nether_attunement_power_scaling"
+              ]
+            },
+            "descriptions": [ { "id": "moving_creature", "symbol": "?", "color": "c_white", "text": "You sense a danger here." } ]
+          }
+        ]
+      }
+    ]
   },
   {
     "type": "effect_type",

--- a/data/mods/MindOverMatter/npcs/dialogue/Rubik.json
+++ b/data/mods/MindOverMatter/npcs/dialogue/Rubik.json
@@ -82,21 +82,33 @@
     "type": "talk_topic",
     "responses": [
       {
-        "text": "[Premonition] *Determine if <npc_name> is a threat*",
+        "text": "[Premonition] *Check for anything amiss*",
         "topic": "TALK_EXODII_MERCHANT_danger_sense",
         "condition": {
           "or": [
             { "math": [ "u_spell_level('clair_danger_sense') >= 2" ] },
-            { "math": [ "u_spell_level('knack_clair_danger_sense') >= 8" ] }
+            { "math": [ "u_spell_level('clair_danger_sense_knack') >= 8" ] }
           ]
         }
+      },
+      {
+        "text": "[Sense Hostility] *Determine if <npc_name> is a threat*",
+        "topic": "TALK_EXODII_MERCHANT_sense_hostility",
+        "condition": { "math": [ "u_spell_level('clair_sense_hostile_creatures') >= 1" ] }
       }
     ]
   },
   {
     "id": [ "TALK_EXODII_MERCHANT_danger_sense" ],
     "type": "talk_topic",
-    "dynamic_line": "&You extend your senses, alert for danger, and are surprised that at the result.  There is danger here, but it's muted, and certainly Rubik doesn't bear you any malice.  If any place is safe in the hell that the Earth has become, this is it.",
+    "dynamic_line": "&You extend your senses, alert for danger, and are surprised at the result.  There is danger here, but it's muted, and certainly Rubik doesn't seem to bear you any malice.  If any place is safe in the hell that the Earth has become, this is it.",
+    "responses": [ { "text": "…", "topic": "TALK_EXODII_MERCHANT_Talk" } ]
+  },
+  {
+    "id": [ "TALK_EXODII_MERCHANT_sense_hostility" ],
+    "type": "talk_topic",
+    "//": "TODO: Change this depending on how much Rubik trusts the PC.",
+    "dynamic_line": "&You extend your senses, probing at Rubik's attitude, and come away with a sense of relief.  Rubik certainly doesn't plan any violent action at this moment.",
     "responses": [ { "text": "…", "topic": "TALK_EXODII_MERCHANT_Talk" } ]
   },
   {

--- a/data/mods/MindOverMatter/npcs/dialogue/portal_future_you.json
+++ b/data/mods/MindOverMatter/npcs/dialogue/portal_future_you.json
@@ -4,7 +4,7 @@
     "type": "talk_topic",
     "responses": [
       {
-        "text": "[Premonition] *Determine if the voice is a threat*",
+        "text": "[Premonition] *Check for anything amiss*",
         "topic": "TALK_PORTAL_STORM_DANGER_SENSE_FAIL",
         "condition": {
           "or": [
@@ -24,7 +24,7 @@
         }
       },
       {
-        "text": "[Premonition 8+] *Determine if the voice is a threat*",
+        "text": "[Premonition 8+] *Check for anything amiss*",
         "topic": "TALK_PORTAL_STORM_DANGER_SENSE_SUCCEED",
         "condition": {
           "or": [
@@ -32,6 +32,11 @@
             { "math": [ "u_spell_level('clair_danger_sense') > 11" ] }
           ]
         }
+      },
+      {
+        "text": "[Sense Hostility] *Determine if the voice is a threat*",
+        "topic": "TALK_PORTAL_STORM_DANGER_sense_hostility",
+        "condition": { "math": [ "u_spell_level('clair_sense_hostile_creatures') >= 4" ] }
       }
     ]
   },
@@ -67,7 +72,13 @@
   {
     "id": [ "TALK_PORTAL_STORM_DANGER_SENSE_SUCCEED" ],
     "type": "talk_topic",
-    "dynamic_line": "&You extend your senses, alert for danger.  Shutting out the ever-present danger of the post-Cataclysmic world and the portal storm, you focus on the voice.  There is danger there, but not directly.  Whatever the outcome of its offer, it is not meant as a trap.",
+    "dynamic_line": "&You extend your senses, alert for danger.  Shutting out the ever-present danger of the post-Cataclysmic world and the portal storm, you focus on your immediate surroundings.  There is danger there, but not directly.  Whatever the outcome of its offer, it is not meant as a trap.",
+    "responses": [ { "text": "*Close your inner eye*", "topic": "TALK_PORTAL_STORM_CONVERSATION" } ]
+  },
+  {
+    "id": [ "TALK_PORTAL_STORM_DANGER_sense_hostility" ],
+    "type": "talk_topic",
+    "dynamic_line": "&You focus on the voice, trying to determine its intentions, and are surprised.  The voice, at least, does not mean you any harm.\n\nAs you withdraw your senses, however, you can't help but realize that in these circumstances, that doesn't necessarily mean you won't come to any harm.",
     "responses": [ { "text": "*Close your inner eye*", "topic": "TALK_PORTAL_STORM_CONVERSATION" } ]
   },
   {

--- a/data/mods/MindOverMatter/npcs/dialogue/refugee_guards_generic.json
+++ b/data/mods/MindOverMatter/npcs/dialogue/refugee_guards_generic.json
@@ -4,7 +4,7 @@
     "type": "talk_topic",
     "responses": [
       {
-        "text": "[Premonition] *Determine if <npc_name> is a threat*",
+        "text": "[Premonition] *Check for anything amiss*",
         "topic": "TALK_GUARD_GENERIC_REFUGEE_danger_sense",
         "condition": {
           "or": [
@@ -12,6 +12,11 @@
             { "math": [ "u_spell_level('clair_danger_sense_knack') >= 8" ] }
           ]
         }
+      },
+      {
+        "text": "[Sense Hostility] *Determine if <npc_name> is a threat*",
+        "topic": "TALK_GUARD_GENERIC_REFUGEE_sense_hostility",
+        "condition": { "math": [ "u_spell_level('clair_sense_hostile_creatures') >= 1" ] }
       },
       {
         "text": "[Telepathy] *Read <npc_name>'s mind*",
@@ -22,6 +27,12 @@
   },
   {
     "id": [ "TALK_GUARD_GENERIC_REFUGEE_danger_sense" ],
+    "type": "talk_topic",
+    "dynamic_line": "&You open your senses to any dangers.  You have a faint sense of foreboding, but that's it.",
+    "responses": [ { "text": "…", "topic": "TALK_GUARD" } ]
+  },
+  {
+    "id": [ "TALK_GUARD_GENERIC_REFUGEE_sense_hostility" ],
     "type": "talk_topic",
     "dynamic_line": "&A quick check reveals nothing out of the ordinary.  To <npc_name>, you're just another face in the crowd.",
     "responses": [ { "text": "…", "topic": "TALK_GUARD" } ]

--- a/data/mods/MindOverMatter/npcs/dialogue/refugee_guards_traitor.json
+++ b/data/mods/MindOverMatter/npcs/dialogue/refugee_guards_traitor.json
@@ -4,7 +4,7 @@
     "type": "talk_topic",
     "responses": [
       {
-        "text": "[Premonition] *Determine if <npc_name> is a threat*",
+        "text": "[Premonition] *Check for anything amiss*",
         "topic": "TALK_EVAC_GUARD3_danger_sense",
         "condition": {
           "or": [
@@ -12,6 +12,11 @@
             { "math": [ "u_spell_level('clair_danger_sense_knack') >= 8" ] }
           ]
         }
+      },
+      {
+        "text": "[Sense Hostility] *Determine if <npc_name> is a threat*",
+        "topic": "TALK_EVAC_GUARD3_sense_hostility",
+        "condition": { "math": [ "u_spell_level('clair_sense_hostile_creatures') >= 1" ] }
       },
       {
         "text": "[Telepathy] *Read <npc_name>'s mind*",
@@ -27,6 +32,12 @@
   },
   {
     "id": [ "TALK_EVAC_GUARD3_danger_sense" ],
+    "type": "talk_topic",
+    "dynamic_line": "&You open up your senses and the hair on the back of your neck immediately stands up.  Something could go very wrong for you at any moment.",
+    "responses": [ { "text": "…", "topic": "TALK_EVAC_GUARD3" } ]
+  },
+  {
+    "id": [ "TALK_EVAC_GUARD3_sense_hostility" ],
     "type": "talk_topic",
     "dynamic_line": "&You barely open up your senses before you're met with an overpowering sense of menace.  <npc_name> isn't planning to kill you at this exact second but that could change at any moment.",
     "responses": [ { "text": "…", "topic": "TALK_EVAC_GUARD3" } ]

--- a/data/mods/MindOverMatter/powers/clairsentience.json
+++ b/data/mods/MindOverMatter/powers/clairsentience.json
@@ -79,7 +79,7 @@
     "id": "clair_danger_sense",
     "type": "SPELL",
     "name": "[Ψ]Premonition (C)",
-    "description": "You can sense the presence of the things that wish to do you harm.\n\nThis power <color_yellow>is maintained by concentration</color> and <color_red>may fail</color> if <color_yellow>concentration is interrupted</color>.",
+    "description": "You can sense nearby movement and sometimes gain an advance warning of dangerous events.\n\nThis power <color_yellow>is maintained by concentration</color> and <color_red>may fail</color> if <color_yellow>concentration is interrupted</color>.",
     "message": "",
     "teachable": false,
     "valid_targets": [ "self" ],
@@ -94,12 +94,12 @@
     "shape": "blast",
     "min_duration": {
       "math": [
-        "( ( (u_spell_level('clair_danger_sense') + u_spell_level('clair_danger_sense_knack') ) * 4500) + 12000) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling"
+        "( ( (u_spell_level('clair_danger_sense') + u_spell_level('clair_danger_sense_knack') ) * 30300) + 117400) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling"
       ]
     },
     "max_duration": {
       "math": [
-        "( ( (u_spell_level('clair_danger_sense') + u_spell_level('clair_danger_sense_knack') ) * 7500) + 49000) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling"
+        "( ( (u_spell_level('clair_danger_sense') + u_spell_level('clair_danger_sense_knack') ) * 100200) + 223200) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling"
       ]
     },
     "base_energy_cost": {
@@ -335,6 +335,44 @@
     "base_casting_time": {
       "math": [
         "u_effect_intensity('effect_clair_ranged_enhance') > -1 ? 10 : max((200 -(u_spell_level('clair_ranged_enhance') * 6)), 125)"
+      ]
+    }
+  },
+  {
+    "id": "clair_sense_hostile_creatures",
+    "type": "SPELL",
+    "name": "[Ψ]Sense Hostility (C)",
+    "description": "You can sense the presence of the things that wish to do you harm.\n\nThis power <color_yellow>is maintained by concentration</color> and <color_red>may fail</color> if <color_yellow>concentration is interrupted</color>.",
+    "message": "",
+    "teachable": false,
+    "valid_targets": [ "self" ],
+    "spell_class": "CLAIRSENTIENT",
+    "magic_type": "mom_psionics",
+    "skill": "metaphysics",
+    "flags": [ "PSIONIC", "SILENT", "NO_HANDS", "NO_LEGS", "RANDOM_DURATION", "NO_EXPLOSION_SFX" ],
+    "difficulty": 5,
+    "max_level": { "math": [ "int_to_level(1)" ] },
+    "effect": "effect_on_condition",
+    "effect_str": "EOC_CLAIR_SENSE_HOSTILE_CREATURES_INITIATE",
+    "shape": "blast",
+    "min_duration": {
+      "math": [
+        "( ( (u_spell_level('clair_sense_hostile_creatures') + u_spell_level('clair_sense_hostile_creatures_knack') ) * 4500) + 12000) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling"
+      ]
+    },
+    "max_duration": {
+      "math": [
+        "( ( (u_spell_level('clair_sense_hostile_creatures') + u_spell_level('clair_sense_hostile_creatures_knack') ) * 7500) + 49000) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling"
+      ]
+    },
+    "base_energy_cost": {
+      "math": [
+        "u_effect_intensity('effect_clair_sense_hostile_creatures') > -1 ? 0 : max( (6500 - ( (u_spell_level('clair_sense_hostile_creatures') + u_spell_level('clair_sense_hostile_creatures_knack') ) * 120)), 3150)"
+      ]
+    },
+    "base_casting_time": {
+      "math": [
+        "u_effect_intensity('effect_clair_sense_hostile_creatures') > -1 ? 10 : max( (85 - ( (u_spell_level('clair_sense_hostile_creatures') + u_spell_level('clair_sense_hostile_creatures_knack') ) * 7)), 25)"
       ]
     }
   },

--- a/data/mods/MindOverMatter/powers/clairsentience_concentration_eocs.json
+++ b/data/mods/MindOverMatter/powers/clairsentience_concentration_eocs.json
@@ -267,7 +267,7 @@
     "id": "EOC_CLAIR_DANGER_SENSE_INITIATE",
     "condition": { "not": { "u_has_effect": "effect_clair_premonition" } },
     "effect": [
-      { "u_message": "You open your senses to the dangers of the world.", "type": "good" },
+      { "u_message": "You become preternaturally aware of possible dangers.", "type": "good" },
       { "run_eocs": "EOC_POWER_MAINTENANCE_PLUS_ONE" },
       { "u_add_effect": "effect_clair_premonition", "duration": "PERMANENT" },
       {
@@ -275,12 +275,12 @@
         "time_in_future": [
           {
             "math": [
-              "( (u_spell_level('clair_danger_sense') * 45) + 120) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling"
+              "( ( (u_spell_level('clair_danger_sense') + u_spell_level('clair_danger_sense_knack') ) * 303.00) + 1174.00) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling"
             ]
           },
           {
             "math": [
-              "( (u_spell_level('clair_danger_sense') * 75) + 490) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling"
+              "( ( (u_spell_level('clair_danger_sense') + u_spell_level('clair_danger_sense_knack') ) * 1002.00) + 2232.00) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling"
             ]
           }
         ]
@@ -306,19 +306,18 @@
         "then": { "math": [ "u_spell_exp('clair_danger_sense')", "+=", "psionic_power_experience_formula()" ] },
         "else": { "math": [ "u_spell_exp('clair_danger_sense_knack')", "+=", "psionic_power_experience_formula()" ] }
       },
-      { "math": [ "u_spell_exp('clair_danger_sense')", "+=", "psionic_power_experience_formula()" ] },
       { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
       {
         "run_eocs": "EOC_CLAIR_DANGER_SENSE_DRAIN",
         "time_in_future": [
           {
             "math": [
-              "( (u_spell_level('clair_danger_sense') * 45) + 120) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling"
+              "( ( (u_spell_level('clair_danger_sense') + u_spell_level('clair_danger_sense_knack') ) * 303.00) + 1174.00) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling"
             ]
           },
           {
             "math": [
-              "( (u_spell_level('clair_danger_sense') * 75) + 490) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling"
+              "( ( (u_spell_level('clair_danger_sense') + u_spell_level('clair_danger_sense_knack') ) * 1002.00) + 2232.00) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling"
             ]
           }
         ]
@@ -381,6 +380,65 @@
           {
             "math": [
               "( (u_spell_level('clair_ranged_enhance') * 25) + 640) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling"
+            ]
+          }
+        ]
+      }
+    ],
+    "false_effect": [  ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_CLAIR_SENSE_HOSTILE_CREATURES_INITIATE",
+    "condition": { "not": { "u_has_effect": "effect_clair_sense_hostile_creatures" } },
+    "effect": [
+      { "u_message": "You open your senses to the dangers of the world.", "type": "good" },
+      { "run_eocs": "EOC_POWER_MAINTENANCE_PLUS_ONE" },
+      { "u_add_effect": "effect_clair_sense_hostile_creatures", "duration": "PERMANENT" },
+      {
+        "run_eocs": "EOC_CLAIR_SENSE_HOSTILE_CREATURES_DRAIN",
+        "time_in_future": [
+          {
+            "math": [
+              "( (u_spell_level('clair_sense_hostile_creatures') * 45) + 120) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling"
+            ]
+          },
+          {
+            "math": [
+              "( (u_spell_level('clair_sense_hostile_creatures') * 75) + 490) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling"
+            ]
+          }
+        ]
+      }
+    ],
+    "false_effect": [ { "run_eocs": "EOC_CLAIR_REMOVE_SENSE_HOSTILE_CREATURES" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_CLAIR_REMOVE_SENSE_HOSTILE_CREATURES",
+    "condition": { "u_has_effect": "effect_clair_sense_hostile_creatures" },
+    "effect": [ { "run_eocs": "EOC_POWER_MAINTENANCE_MINUS_ONE" }, { "u_lose_effect": "effect_clair_sense_hostile_creatures" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_CLAIR_SENSE_HOSTILE_CREATURES_DRAIN",
+    "condition": { "u_has_effect": "effect_clair_sense_hostile_creatures" },
+    "effect": [
+      { "math": [ "u_latest_channeled_power_difficulty = 5" ] },
+      { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
+      { "math": [ "u_spell_exp('clair_sense_hostile_creatures')", "+=", "psionic_power_experience_formula()" ] },
+      { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
+      {
+        "run_eocs": "EOC_CLAIR_SENSE_HOSTILE_CREATURES_DRAIN",
+        "time_in_future": [
+          {
+            "math": [
+              "( (u_spell_level('clair_sense_hostile_creatures') * 45) + 120) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling"
+            ]
+          },
+          {
+            "math": [
+              "( (u_spell_level('clair_sense_hostile_creatures') * 75) + 490) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling"
             ]
           }
         ]

--- a/data/mods/MindOverMatter/powers/learning_eocs/clairsentience.json
+++ b/data/mods/MindOverMatter/powers/learning_eocs/clairsentience.json
@@ -26,7 +26,7 @@
       { "math": [ "u_vitamin('vitamin_psi_learning_counter') = 0" ] },
       { "u_learn_recipe": "practice_clair_danger_sense" },
       {
-        "u_message": "Use of your powers has led to an insight.  You could expand your senses into the esoteric, gaining a sense of , if you can figure out the proper technique.",
+        "u_message": "Use of your powers has led to an insight.  You could expand your senses into the esoteric, gaining a feel for nearby movement and the overall danger of a situation, if you can figure out the proper technique.",
         "popup": true
       }
     ]

--- a/data/mods/MindOverMatter/powers/learning_eocs/clairsentience.json
+++ b/data/mods/MindOverMatter/powers/learning_eocs/clairsentience.json
@@ -26,7 +26,7 @@
       { "math": [ "u_vitamin('vitamin_psi_learning_counter') = 0" ] },
       { "u_learn_recipe": "practice_clair_danger_sense" },
       {
-        "u_message": "Use of your powers has led to an insight.  You could expand your senses for what is out of place, looking for anything that means harm to you, if you can figure out the proper technique.",
+        "u_message": "Use of your powers has led to an insight.  You could expand your senses into the esoteric, gaining a sense of , if you can figure out the proper technique.",
         "popup": true
       }
     ]
@@ -167,6 +167,46 @@
       { "u_learn_recipe": "practice_clair_ranged_enhance" },
       {
         "u_message": "Use of your powers has led to an insight.  You could greatly enhance your vision, making ranged combat much easier as you're able to pinpoint exactly where to shoot, if you can figure out the technique.",
+        "popup": true
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_CLAIR_LEARNING_SENSE_HOSTILE_CREATURES",
+    "recurrence": [
+      { "math": [ "jmath_clairsentience_learning_eocs_modifiers(global_tier_two_power_learning_time_low)" ] },
+      { "math": [ "jmath_clairsentience_learning_eocs_modifiers(global_tier_two_power_learning_time_high)" ] }
+    ],
+    "condition": {
+      "and": [
+        { "u_has_trait": "CLAIRSENTIENT" },
+        { "math": [ "u_vitamin('vitamin_psi_learning_counter') == 1" ] },
+        {
+          "or": [
+            { "test_eoc": "EOC_CONDITION_ODDS_OF_RANDOM_TIER_TWO_POWER_INSIGHT" },
+            {
+              "and": [
+                { "math": [ "u_spell_level('clair_better_senses') >= 8" ] },
+                { "math": [ "u_spell_level('clair_danger_sense') >= 6" ] },
+                { "math": [ "u_spell_level('clair_aura_sight') >= 5" ] }
+              ]
+            }
+          ]
+        },
+        { "test_eoc": "EOC_PSI_LEARNING_BANNED_EFFECTS" },
+        { "math": [ "u_spell_level('clair_sense_hostile_creatures') <= 0" ] },
+        { "not": { "u_know_recipe": "practice_clair_sense_hostile_creatures" } }
+      ]
+    },
+    "deactivate_condition": {
+      "or": [ { "not": { "u_has_trait": "CLAIRSENTIENT" } }, { "math": [ "u_spell_level('clair_sense_hostile_creatures') >= 1" ] } ]
+    },
+    "effect": [
+      { "math": [ "u_vitamin('vitamin_psi_learning_counter') = 0" ] },
+      { "u_learn_recipe": "practice_clair_sense_hostile_creatures" },
+      {
+        "u_message": "Use of your powers has led to an insight.  You have a general sense of possible dangers already, but you could refine it, you could focus and learn the exact location of those that seek to do you harm, if you can figure out the proper technique.",
         "popup": true
       }
     ]

--- a/data/mods/MindOverMatter/powers/learning_eocs/clairsentience.json
+++ b/data/mods/MindOverMatter/powers/learning_eocs/clairsentience.json
@@ -273,6 +273,11 @@
                 {
                   "or": [
                     { "math": [ "u_spell_level('clair_danger_sense') >= 10" ] },
+                    { "math": [ "u_spell_level('clair_sense_hostile_creatures') >= 10" ] }
+                  ]
+                },
+                {
+                  "or": [
                     { "math": [ "u_spell_level('clair_speed_reading') >= 10" ] },
                     { "math": [ "u_spell_level('clair_spot_weakness') >= 6" ] }
                   ]

--- a/data/mods/MindOverMatter/recipes/practice/clairsentient_practice.json
+++ b/data/mods/MindOverMatter/recipes/practice/clairsentient_practice.json
@@ -17,6 +17,7 @@
       "practice_clair_sense_rads",
       "practice_clair_spot_weakness",
       "practice_clair_ranged_enhance",
+      "practice_clair_sense_hostile_creatures",
       "practice_clair_voyance",
       "practice_clair_dodge_power",
       "practice_clair_craft_bonus",
@@ -409,6 +410,64 @@
     "condition": {
       "and": [
         { "compare_string": [ "clair_ranged_enhance", { "u_val": "latest_studied_power_name" } ] },
+        { "test_eoc": "EOC_CONDITION_PSI_REQUIRED_FOR_LEARNING_NEW_POWER" }
+      ]
+    },
+    "effect": [ { "run_eocs": "EOC_PRACTICE_PSIONICS_FINAL_LEARNING_CHECK" } ]
+  },
+  {
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "name": "contemplation: sense hostility",
+    "id": "practice_clair_sense_hostile_creatures",
+    "description": "Contemplate your powers and improve your ability to determine nearby creatures' hostility even if you can't see them with your physical senses.\n\nPower Difficulty: 5",
+    "category": "CC_*",
+    "subcategory": "CSC_*_NESTED",
+    "skill_used": "metaphysics",
+    "difficulty": 0,
+    "time": "0 s",
+    "autolearn": false,
+    "proficiencies": [ { "proficiency": "prof_contemplation_clairsentience", "required": false } ],
+    "tools": [
+      [
+        [ "matrix_crystal_drained", -1 ],
+        [ "black_nether_crystal_pseudo_tool", -1 ],
+        [ "matrix_crystal_clairsentience", -1 ]
+      ]
+    ],
+    "components": [ [ [ "matrix_crystal_clair_dust", 1 ] ] ],
+    "flags": [ "SECRET", "BLIND_EASY", "NO_MANIP", "AFFECTED_BY_PAIN", "NO_BENCH", "NO_ENCHANTMENT" ],
+    "result_eocs": [
+      {
+        "id": "EOC_PRACTICE_CLAIR_SENSE_HOSTILE_CREATURES",
+        "condition": { "u_has_trait": "CLAIRSENTIENT" },
+        "effect": [
+          { "set_string_var": "clair_sense_hostile_creatures", "target_var": { "u_val": "latest_studied_power_name" } },
+          { "run_eocs": "EOC_PSI_STUDYING_CLAIR_POWER_SETUP" },
+          {
+            "if": { "math": [ "u_spell_level('clair_sense_hostile_creatures') >= 1" ] },
+            "then": { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] },
+            "else": [
+              { "run_eocs": [ "EOC_PSI_STUDYING_POWER_INITIAL_SETUP", "EOC_PSI_PRACTICE_FOCUS_MOD" ] },
+              {
+                "run_eocs": "EOC_PRACTICE_CLAIR_SENSE_HOSTILE_CREATURES_LEARNING",
+                "time_in_future": [
+                  { "math": [ "learn_new_power_lower_time_bound(u_latest_studied_power_difficulty)" ] },
+                  { "math": [ "learn_new_power_upper_time_bound(u_latest_studied_power_difficulty)" ] }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PRACTICE_CLAIR_SENSE_HOSTILE_CREATURES_LEARNING",
+    "condition": {
+      "and": [
+        { "compare_string": [ "clair_sense_hostile_creatures", { "u_val": "latest_studied_power_name" } ] },
         { "test_eoc": "EOC_CONDITION_PSI_REQUIRED_FOR_LEARNING_NEW_POWER" }
       ]
     },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[MoM] Overhaul Premonition, add Sense Hostility power"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Premonition letting you know exactly where all your enemies are at Difficulty 2 is a little too good. Also, we have the MOTION_ALARM enchant now.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Overhaul Premonition--it now uses the MOTION_ALARM enchant, alerting you that something is nearby but not exactly where it is. Premonition is your classic Spidey Sense, the idea that something is a little odd but without specifics. It lasts much longer than the previous version of Premonition before requiring maintenance. 

Add Sense Hostility, a Difficulty 5 power that tells you _exactly_ where those dangerous targets are. It works the same way the old Premonition power worked.

Rework the various elements dependent on Premonition, such as dialogue and early warning. Sense Hostility gives you better early warning if there's a specific danger to you personally (like when assassins are after you) but provides no warning at all against impersonal danger like a portal storm. I also noticed that you were getting these warnings if you had the powers at all, even if they weren't active, so I fixed that--now you need Premonition or Sense Hostility running to be warned.

I'd like Premonition to give you a bonus to avoid traps but that will take C++.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Learned Sense Hostility and used it, contemplated Sense Hostility, used Premonition. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

This is partially motivated by me wanting to get moving on adding Sibyls (precogs) to Aftershock. 

Discovered that MOTION_ALARM doesn't trigger on NPC movement when making this, which seems like a problem. 

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
