### PR TITLE
note that you cannot repair fault_blade_cracked, fix it's weight

### DIFF
--- a/data/json/faults/fault_groups_melee.json
+++ b/data/json/faults/fault_groups_melee.json
@@ -29,7 +29,7 @@
     "group": [
       { "fault": "fault_blade_rolled_edge", "weight": 100 },
       { "fault": "fault_blade_chipped", "weight": 100 },
-      { "fault": "fault_blade_cracked", "weight": 100 },
+      { "fault": "fault_blade_cracked", "weight": 50 },
       { "fault": "fault_blade_broken", "weight": 3 },
       { "fault": "fault_blade_broken_half", "weight": 8 },
       { "fault": "fault_blade_broken_tip", "weight": 50 },
@@ -43,7 +43,7 @@
     "group": [
       { "fault": "fault_blade_rolled_edge", "weight": 100 },
       { "fault": "fault_blade_chipped", "weight": 100 },
-      { "fault": "fault_blade_cracked", "weight": 100 },
+      { "fault": "fault_blade_cracked", "weight": 50 },
       { "fault": "fault_blade_broken", "weight": 3 },
       { "fault": "fault_blade_broken_half", "weight": 8 }
     ]

--- a/data/json/faults/faults_melee.json
+++ b/data/json/faults/faults_melee.json
@@ -21,7 +21,7 @@
     "fault_type": "mechanical_damage",
     "name": { "str": "Crack" },
     "degradation_mod": 50,
-    "description": "There is a deep crack on the blade.  A sure sign that the entire sword will break apart sooner or later."
+    "description": "There is a deep crack on the blade.  A sure sign that the entire sword will break apart sooner or later.  Any attempt to repair it would only further damage the blade, so the days for this %s are numbered."
   },
   {
     "type": "fault",


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Someone at discord was confused how to fix the crack on a blade. After a bit more investigation, i remembered it is the one you cannot repair.
#### Describe the solution
Add the information that it cannot be repaired.
Also fix the cracked blade weight being 100 instead of generally picked 50.
#### Additional context
Someone need to visit and check weights for faults, they were added with a very simple guesstimation and might be very wrong