### PR TITLE
Clarify refusal message when faction trust isn't high enough

### DIFF
--- a/doc/JSON/NPCs.md
+++ b/doc/JSON/NPCs.md
@@ -95,7 +95,7 @@ Format:
 - `"condition"` : (_optional_) Checked alongside trust with the avatar as alpha and the evaluating NPC as beta. See [Player or NPC conditions](#player-or-npc-conditions).
 - `"strict"` : (_optional_) If true, items in this group will not be available for restocking unless the conditions are met. (Defaults to false)
 - `"rigid"` : (_optional_) By default, item groups will be continually iterated until they reach a certain value or size threshold for the NPC. Rigid groups are instead guaranteed to populate a single time if they can, and will not include duplicate reruns. (Defaults to false)
-- `"refusal"` : (_optional_) message to display in UIs (ex: trade UI) when conditions are not met. Defaults to `"<npcname> does not trust you enough"`
+- `"refusal"` : (_optional_) message to display in UIs (ex: trade UI) when conditions are not met. Defaults to `"<npc_faction> faction does not trust you enough."`
 
 #### Shopkeeper consumption rates
 Controls consumption of shopkeeper's stock of items (simulates purchase by other people besides they player).
@@ -354,6 +354,9 @@ Field | Used for...
 `<mywp>` | displays npc's wielded item
 `<u_name>` | displays avatar's name
 `<npc_name>` | displays npc's name
+`<npcname>` | DO NOT USE, DEPRECATED - This will not work in parse_tags! It is listed here so you don't confuse it with with the very similar <npc_name>.
+`<u_faction>` | displays name of the faction for `u` (usually avatar, but can vary if you've changed talker context). If no faction, uses their display name instead.
+`<npc_faction>` | displays name of the faction for `npc` (usually npc, but can vary if you've changed talker context). If no faction, uses their display name instead.
 `<ammo>` | displays avatar's ammo
 `<current_activity>` | displays npc's current activity
 `<punc>` | displays a random punctuation from: `.`, `…`, `!`

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -2892,7 +2892,9 @@ class bionic_install_surgeon_preset : public inventory_selector_preset
                 ret_val<void> const refusal =
                     you.as_npc()->wants_to_sell( loc, price );
                 if( !refusal.success() ) {
-                    return you.replace_with_npc_name( refusal.str() );
+                    std::string refused_text = refusal.str();
+                    parse_tags( refused_text, you, pa );
+                    return refused_text;
                 }
             }
             const ret_val<void> installable = pa.is_installable( loc.get_item(), false );

--- a/src/npc_class.cpp
+++ b/src/npc_class.cpp
@@ -209,7 +209,7 @@ bool shopkeeper_item_group::can_restock( npc const &guy ) const
 std::string shopkeeper_item_group::get_refusal() const
 {
     if( refusal.empty() ) {
-        return _( "<npcname> does not trust you enough" );
+        return _( "<npc_faction> faction does not trust you enough." );
     }
 
     return refusal.translated();

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -2320,6 +2320,16 @@ int topic_category( const talk_topic &the_topic )
     return -1; // Not grouped with other topics
 }
 
+static std::string faction_or_fallback( const_talker const &guy )
+{
+    faction *fac = guy.get_faction();
+    if( !fac ) {
+        return guy.get_name();
+    }
+    // Note: Check for translation, don't just return raw name.
+    return _( fac->name );
+}
+
 void parse_tags( std::string &phrase, const Character &u, const Creature &me,
                  const itype_id &item_type )
 {
@@ -2393,6 +2403,10 @@ void parse_tags( std::string &phrase, const_talker const &u, const_talker const 
             phrase.replace( fa, l, u.get_name() );
         } else if( tag == "<npc_name>" ) {
             phrase.replace( fa, l, me.get_name() );
+        } else if( tag == "<u_faction>" ) {
+            phrase.replace( fa, l, faction_or_fallback( u ) );
+        } else if( tag == "<npc_faction>" ) {
+            phrase.replace( fa, l, faction_or_fallback( me ) );
         } else if( tag == "<ammo>" ) {
             if( !me_weapon || !me_weapon->is_gun() ) {
                 phrase.replace( fa, l, _( "BADAMMO" ) );

--- a/src/trade_ui.cpp
+++ b/src/trade_ui.cpp
@@ -71,10 +71,12 @@ std::string trade_preset::get_denial( const item_location &loc ) const
         npc const &np = *_u.as_npc();
         ret_val<void> const ret = np.wants_to_sell( loc, price );
         if( !ret.success() ) {
-            if( ret.str().empty() ) {
+            std::string refused_text = ret.str();
+            if( refused_text.empty() ) {
                 return string_format( _( "%s does not want to sell this" ), np.get_name() );
             }
-            return np.replace_with_npc_name( ret.str() );
+            parse_tags( refused_text, _trader, _u );
+            return refused_text;
         }
     } else if( _trader.is_npc() ) {
         npc const &np = *_trader.as_npc();


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
When a NPC refuses to sell something it is most often because the faction's trust is not high enough to meet the `trust` requirement of the item. (Default requirement is 0, so negative trust will make this show up a lot)

<img width="976" height="951" alt="guh" src="https://github.com/user-attachments/assets/cc3ef853-7a94-4984-b64b-d1e66660d3f6" />

You can however check how much the **trader** trusts you(the player) with dialogue options. So it is confusing to see "Smokes, Merchant does not trust you enough" when the dialogue window says he has 9999999 trust with you.*

This has been the case for quite a while but since adding NPC camps (and making those NPCs care about property) many players have been rude guests and gotten themselves untrusted. Hence, it is reasonably straightforward for a player to encounter this message and we need to resolve it.

*There is a similar 'issue' with Rubik in that Rubik, the premiere exodii merchant, uses faction trust. Players have noticed Rubik's trust will be a high value according to the game, but the message "Rubik doesn't trust you enough" incorrectly suggests that *Rubik's* trust is what matters.

#### Describe the solution
Update the message to mention the faction's name instead of the trader's name.

To do this I had to make two new talk tags, `<u_faction>` and `<npc_faction>` which return their related faction's names. I also plumbed to see where else shopkeeper_item_group::get_refusal() might show up.

#### Describe alternatives you've considered
Just replacing `<npcname>` with %s and using the faction's name as an argument?

#### Testing
<img width="2560" height="1400" alt="image" src="https://github.com/user-attachments/assets/b96587e7-98a3-4286-b034-9fd56d367692" />


#### Additional context
I'm unsure whether this should be backported. It provides some important clarity, but it's possible I've missed someplace where it might be displayed.

I have unilaterally declared `<npcname>` to be deprecated because have two similar tags do the same thing but be different tags is bad and confusing and we should be using parse_tags everywhere anyway.
﻿