### PR TITLE
Debug mode persists through save/load

### DIFF
--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -208,6 +208,7 @@ bool debug_has_error_been_observed()
     return error_observed;
 }
 
+// saved in game::serialize
 bool debug_mode = false;
 
 namespace debugmode

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -94,6 +94,7 @@ void game::serialize_json( std::ostream &fout )
     // basic game state information.
     json.member( "savegame_loading_version", savegame_version );
     json.member( "turn", calendar::turn );
+    json.member( "debug_mode", debug_mode );
     json.member( "calendar_start", calendar::start_of_cataclysm );
     json.member( "game_start", calendar::start_of_game );
     json.member( "initial_season", static_cast<int>( calendar::initial_season ) );
@@ -239,6 +240,7 @@ void game::unserialize_impl( const JsonObject &data )
     point_abs_om com;
 
     data.read( "turn", tmpturn );
+    data.read( "debug_mode", debug_mode );
     data.read( "calendar_start", tmpcalstart );
     calendar::initial_season = static_cast<season_type>( data.get_int( "initial_season",
                                static_cast<int>( SPRING ) ) );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Debug mode is used to determine some of our persistent debugging effects, like debug options on the overmap view. It has greatly annoyed me having to toggle it back on every time.

#### Describe the solution
Thanks to Kevin Granade for pointing out that this could be serialized on the game object without being part of the game object. I simply assumed that had to be the case - but it's not. So we can just save/load this otherwise-unelated boolean to/from the game object.

Note: This does NOT save any debug mode filters.

#### Describe alternatives you've considered
Full custom save state for debug mode and its filters

#### Testing
Load an old save from before the patch --> Doesn't explode, debug mode is off when checked (it was not saved without the patch) --> Enable debug mode, save and reload, debug mode is still on. Perfection.

#### Additional context

