### PR TITLE
Update Cranberry's mission

### DIFF
--- a/data/json/npcs/robofac/NPC_Cranberry_Foster.json
+++ b/data/json/npcs/robofac/NPC_Cranberry_Foster.json
@@ -742,9 +742,9 @@
     "has_generic_rewards": false,
     "dialogue": {
       "describe": "…",
-      "offer": "Well… a little while ago, I set up a radio transmitter in the radio tower not far from here, but it stopped transmitting.  I went over there and encountered some crazy stuff you wouldn't believe if you didn't see it yourself:  Some 'plants' moving around, replicating, and attacking me with lightning bolts.  Luckily, the environmental suit I've got from our employers protected me from damage, but fried my electronics.  If you're willing to back me up to eradicate them, I'll owe you a favor.",
+      "offer": "Well… a little while ago, I set up a radio transmitter in the radio tower not far from here, but it stopped transmitting.  I went over there and encountered some crazy stuff you wouldn't believe if you didn't see it yourself:  Some 'plants' moving around, replicating, and attacking me with lightning bolts.  Luckily, the environmental suit I've got from our employers protected me from damage, but fried my electronics.  If you're willing to back me up to eradicate them, I'll owe you a favor.  However, I suggest you turn the mission down and come back when you think you've got sufficient gear.",
       "accepted": "Alright, let's be off, if you think you've got sufficient gear.  You don't mind taking point, right?",
-      "rejected": "Well, thanks for offering.",
+      "rejected": "Well, thanks for offering.  I hope you'll be able to come back when you've gotten hold of protective gear.",
       "advice": "Get hold of an environmental suit of your own, unless you've got some other protection against electric shocks.  Bring a good weapon and some ammo as well; no idea what insanity <the_cataclysm> has brought us this time, beyond what I saw during my brief encounter.",
       "inquire": "You think we fixed the problem?",
       "success": "Sure seems like it.  What even was that…?  Eh, doesn't matter.  Let's go back to the Hub; hopefully the tower's working now.",

--- a/data/json/npcs/robofac/NPC_Cranberry_Foster.json
+++ b/data/json/npcs/robofac/NPC_Cranberry_Foster.json
@@ -742,10 +742,10 @@
     "has_generic_rewards": false,
     "dialogue": {
       "describe": "…",
-      "offer": "Well… a little while ago, I set up a radio transmitter in the radio tower not far from here, but apparently it's stopped transmitting.  If you're willing to back me up while I check it out, I'll owe you a favor.",
-      "accepted": "Alright, let's be off.  You don't mind taking point, right?",
+      "offer": "Well… a little while ago, I set up a radio transmitter in the radio tower not far from here, but it stopped transmitting.  I went over there and encountered some crazy stuff you wouldn't believe if you didn't see it yourself:  Some 'plants' moving around, replicating, and attacking me with lightning bolts.  Luckily, the environmental suit I've got from our employers protected me from damage, but fried my electronics.  If you're willing to back me up to eradicate them, I'll owe you a favor.",
+      "accepted": "Alright, let's be off, if you think you've got sufficient gear.  You don't mind taking point, right?",
       "rejected": "Well, thanks for offering.",
-      "advice": "I'm sure we'll figure it out once there.  Bring a good weapon and some ammo just in case, if you can; no idea what insanity <the_cataclysm> has brought us this time.",
+      "advice": "Get hold of an environmental suit of your own, unless you've got some other protection against electric shocks.  Bring a good weapon and some ammo as well; no idea what insanity <the_cataclysm> has brought us this time, beyond what I saw during my brief encounter.",
       "inquire": "You think we fixed the problem?",
       "success": "Sure seems like it.  What even was that…?  Eh, doesn't matter.  Let's go back to the Hub; hopefully the tower's working now.",
       "success_lie": "*frowns at you.  \"I've been with you this whole time, dude.  C'mon.",

--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom.json
@@ -123,7 +123,7 @@
     "type": "item_group",
     "id": "NC_ROBOFAC_INTERCOM_trade_envirosuit",
     "subtype": "collection",
-    "entries": [ { "item": "robofac_enviro_suit", "count": 1, "prob": 25 } ]
+    "entries": [ { "item": "robofac_enviro_suit", "count": 1, "prob": 100 } ]
   },
   {
     "id": "robofac_blacklist",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fix #81733 by changing Cranberry's mission dialog so it gives you a chance to get the protective gear required by the quest.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
- An adjustment of the dialog.
- Changed the trade spawn chance for the suit from 25 -> 100% to ensure you can actually get the required gear without having to wait until the RNG trade inventory refresh finally gives you access to it. Note that the trade offer for the gear expires with the Light Retrieval quest, so if you performed that quest without buying the gear you're may be in for a waiting game otherwise.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
- It would be better if there was a way to get the mission and advice and then back out/put the quest on hold, but the standard quest dialog structure doesn't support that.
- Find a way to make the environment suit spawn chance depend on whether you've taken up the offer to buy it as part of the Light Retrieval quest.
- Find a way to move the spawning of Cranberry to after the Light Retrieval mission that's backwards compatible with saves where it's already spawned. I will need help to find the syntax for that, though.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Teleported to Hub01 and talked with Cranberry, going through the changed dialog to verify it was changed.
Talked to the intercom and saw the existing inventory was unchanged (no suit), but debug waited a week and saw it showed up (weak verification of 25% -> 100% chance, but I think it's enough).

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Placing this in draft until the spawning of Cranberry can be moved without duplication in existing saves where it's spawned but Light Retrieval hasn't been completed.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
