### PR TITLE
fix autopulping pulping corpses that do not need to be pulped, fix pulp time being 0 in some cases

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -8737,7 +8737,7 @@ void pulp_activity_actor::start( player_activity &act, Character &you )
                     // Don't smash non-rezing corpses or random items
                     continue;
                 }
-                if( corpse.damage() < corpse.max_damage() ) {
+                if( corpse.can_revive() ) {
                     item_location corpse_loc( map_cursor( here.get_bub( pos_abs ) ), &corpse );
                     corpses.push_back( corpse_loc );
                 }
@@ -8779,6 +8779,10 @@ void pulp_activity_actor::do_turn( player_activity &act, Character &you )
 
 bool pulp_activity_actor::can_pulp( item &corpse, Character &you )
 {
+
+    if( !corpse.can_revive() ) {
+        return false;
+    }
 
     const mtype *corpse_mtype = corpse.get_mtype();
     if( corpse_mtype == nullptr ) {


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Fix #81566
#### Describe the solution
time_to_pulp and min_time_to_pulp could be 0 in some cases, prevent it
function that harvested corpses for pulping didn't include all the variables it should've check, so does pulping activity itself, now it uses can_revive() general check
also some cosmetic changes in debug output
#### Testing
Lot of pulping