### PR TITLE
[XE] Remove melee training cap from a certain boss.

### DIFF
--- a/data/mods/Xedra_Evolved/monsters/anathema.json
+++ b/data/mods/Xedra_Evolved/monsters/anathema.json
@@ -34,7 +34,6 @@
     "bleed_rate": 0,
     "vision_day": 5,
     "vision_night": 85,
-    "melee_training_cap": 0,
     "path_settings": {
       "max_dist": 45,
       "allow_open_doors": true,


### PR DESCRIPTION
#### Summary
Mods "[XE] Remove melee training cap from a certain boss."

#### Purpose of change

For some unknown reason, the Vampire Anathema as a melee training cap of zero, despite their massive skill.

This PR fixes that.

#### Describe the solution

Remove the line.

#### Describe alternatives you've considered

Also make it look like the armored axe-wielding feral, but the Anathema doesn't work well with a face-showing sprite. They must be guaranteed to be fully armor-clad but said feral only has 50% odds of having a sprite with a helmet.

#### Testing

The line is removed.

#### Additional context