### PR TITLE
[Mods] Mutually-exclusive supernatural heritage traits are light cyan

### DIFF
--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -2500,6 +2500,11 @@
     "info": "You can ascend straight up even with no physical surface to climb on."
   },
   {
+    "id": "HERITAGE",
+    "type": "json_flag",
+    "info": "You have nonhuman ancestry or are not human"
+  },
+  {
     "id": "TREE_COMMUNION_PLUS",
     "type": "json_flag",
     "info": "You gain greatly enhanced effects from the Mycorrhizal Communion mutation"

--- a/data/mods/Magiclysm/mutations/mutation_paths/fantasy_species.json
+++ b/data/mods/Magiclysm/mutations/mutation_paths/fantasy_species.json
@@ -1,5 +1,9 @@
 [
   {
+    "type": "mutation_type",
+    "id": "HERITAGE"
+  },
+  {
     "type": "mutation_category",
     "id": "SPECIES_DWARF",
     "name": "Dwarf",
@@ -157,16 +161,15 @@
   {
     "type": "mutation",
     "id": "DWARVEN_BUILD",
-    "name": { "str": "Dwarven Build" },
+    "name": { "str": "Dwarf" },
     "//": "Slightly better version of STOCKY_TROGLO since dwarves are born this way",
-    "types": [ "SIZE" ],
+    "types": [ "HERITAGE" ],
     "purifiable": false,
     "mixed_effect": true,
     "points": 1,
     "visibility": 3,
     "ugliness": 0,
     "description": "Dwarves are smaller than humans, the better to deal with confined spaces underground, but as solid as the mountains (+2 STR, -1 DEX).",
-    "flags": [ "SMALL" ],
     "category": [ "SPECIES_DWARF" ],
     "enchantments": [
       {
@@ -177,7 +180,8 @@
           { "value": "WEIGHT", "multiply": 0.2 }
         ]
       }
-    ]
+    ],
+    "flags": [ "HERITAGE", "SMALL" ]
   },
   {
     "type": "mutation",
@@ -301,9 +305,9 @@
   {
     "type": "mutation",
     "id": "ELVEN_BUILD",
-    "name": { "str": "Elven Build" },
+    "name": { "str": "Elf" },
     "//": "Opposite of Dwarven Build!",
-    "types": [ "SIZE" ],
+    "types": [ "HERITAGE" ],
     "purifiable": false,
     "mixed_effect": true,
     "points": 1,
@@ -322,7 +326,8 @@
           { "value": "WEIGHT", "multiply": -0.15 }
         ]
       }
-    ]
+    ],
+    "flags": [ "HERITAGE" ]
   },
   {
     "type": "mutation",
@@ -492,8 +497,8 @@
   {
     "type": "mutation",
     "id": "GOBLIN_BUILD",
-    "name": { "str": "Goblin Build" },
-    "types": [ "SIZE" ],
+    "name": { "str": "Goblin" },
+    "types": [ "HERITAGE" ],
     "purifiable": false,
     "mixed_effect": true,
     "points": 1,
@@ -501,7 +506,6 @@
     "ugliness": 5,
     "description": "Goblins are much smaller than humans, often no more than half the height.  You have a harder time carrying things and can't eat as much, but you're better at dodging and make very little noise when you move.",
     "category": [ "SPECIES_GOBLIN" ],
-    "flags": [ "TINY" ],
     "anger_relations": [ [ "WARG", -90 ] ],
     "spells_learned": [ [ "goblin_tame_warg_spell", 1 ] ],
     "enchantments": [
@@ -516,7 +520,8 @@
           { "value": "CARRY_WEIGHT", "multiply": 0.7 }
         ]
       }
-    ]
+    ],
+    "flags": [ "HERITAGE", "TINY" ]
   },
   {
     "type": "mutation",
@@ -595,8 +600,8 @@
   {
     "type": "mutation",
     "id": "LIZARDFOLK_BUILD",
-    "name": { "str": "Lizardfolk Build" },
-    "types": [ "SIZE" ],
+    "name": { "str": "Lizardfolk" },
+    "types": [ "HERITAGE" ],
     "purifiable": false,
     "mixed_effect": true,
     "points": 1,
@@ -604,7 +609,6 @@
     "ugliness": 0,
     "description": "Lizardfolk are taller and stronger than humans but not much thicker and are surprisingly fast for their size (+1 STR, +1 DEX).",
     "category": [ "SPECIES_LIZARDFOLK" ],
-    "flags": [ "LARGE" ],
     "enchantments": [
       {
         "values": [
@@ -615,7 +619,8 @@
           { "value": "CARRY_WEIGHT", "multiply": 0.05 }
         ]
       }
-    ]
+    ],
+    "flags": [ "HERITAGE", "LARGE" ]
   },
   {
     "type": "mutation",
@@ -727,8 +732,8 @@
   {
     "type": "mutation",
     "id": "RAVENFOLK_BUILD",
-    "name": { "str": "Ravenfolk Build" },
-    "types": [ "SIZE" ],
+    "name": { "str": "Ravenfolk" },
+    "types": [ "HERITAGE" ],
     "purifiable": false,
     "mixed_effect": true,
     "points": 1,
@@ -736,7 +741,8 @@
     "ugliness": 1,
     "description": "Ravenfolk are about the same size as humans, though their feathers and wings obviously set them apart.",
     "category": [ "SPECIES_RAVENFOLK" ],
-    "enchantments": [ { "values": [ { "value": "WEIGHT", "multiply": -0.25 } ] } ]
+    "enchantments": [ { "values": [ { "value": "WEIGHT", "multiply": -0.25 } ] } ],
+    "flags": [ "HERITAGE" ]
   },
   {
     "type": "mutation",

--- a/data/mods/Xedra_Evolved/mutations/chronomancer_traits.json
+++ b/data/mods/Xedra_Evolved/mutations/chronomancer_traits.json
@@ -13,7 +13,8 @@
     "vitamin_rates": [ [ "xedra_chronomancer_insight", -86400 ] ],
     "active": true,
     "activated_eocs": [ "EOC_XEDRA_CHRONOMANCER_OPEN_INSIGHT_MENU" ],
-    "activation_msg": ""
+    "activation_msg": "",
+    "flags": [ "ATTUNEMENT" ]
   },
   {
     "type": "mutation",

--- a/data/mods/Xedra_Evolved/mutations/mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/mutations.json
@@ -208,7 +208,7 @@
       { "condition": "ALWAYS", "ench_effects": [ { "effect": "effect_lilin_vampire_immune", "intensity": 1 } ] }
     ],
     "//": "Dhampirs not getting Cannibal is deliberate.  The struggle over their own humanity is a core part of the dhampir theme.",
-    "flags": [ "HEMOVORE", "ATTUNEMENT" ],
+    "flags": [ "HEMOVORE", "HERITAGE" ],
     "cancels": [ "DREAMER", "DREAMSMITH", "EATER", "INVENTOR" ]
   },
   {

--- a/data/mods/Xedra_Evolved/mutations/mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/mutations.json
@@ -208,7 +208,7 @@
       { "condition": "ALWAYS", "ench_effects": [ { "effect": "effect_lilin_vampire_immune", "intensity": 1 } ] }
     ],
     "//": "Dhampirs not getting Cannibal is deliberate.  The struggle over their own humanity is a core part of the dhampir theme.",
-    "flags": [ "HEMOVORE" ],
+    "flags": [ "HEMOVORE", "ATTUNEMENT" ],
     "cancels": [ "DREAMER", "DREAMSMITH", "EATER", "INVENTOR" ]
   },
   {

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/paraclesian_mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/paraclesian_mutations.json
@@ -47,7 +47,7 @@
     "empathize_with": [ "IERDE" ],
     "no_empathize_with": [ "HUMAN" ],
     "no_cbm_on_bp": [ "torso", "head", "eyes", "mouth", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
-    "flags": [ "ATTUNEMENT" ]
+    "flags": [ "HERITAGE" ]
   },
   {
     "type": "mutation",
@@ -97,7 +97,7 @@
     "empathize_with": [ "ARVORE" ],
     "no_empathize_with": [ "HUMAN" ],
     "no_cbm_on_bp": [ "torso", "head", "eyes", "mouth", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
-    "flags": [ "TREE_COMMUNION_PLUS", "ARVORE_POLLEN_IMMUNE", "ATTUNEMENT" ],
+    "flags": [ "TREE_COMMUNION_PLUS", "ARVORE_POLLEN_IMMUNE", "HERITAGE" ],
     "enchantments": [
       {
         "condition": {
@@ -169,7 +169,7 @@
     "empathize_with": [ "SALAMANDER" ],
     "no_empathize_with": [ "HUMAN" ],
     "no_cbm_on_bp": [ "torso", "head", "eyes", "mouth", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
-    "flags": [ "ATTUNEMENT" ]
+    "flags": [ "HERITAGE" ]
   },
   {
     "type": "mutation",
@@ -229,7 +229,7 @@
     "empathize_with": [ "UNDINE" ],
     "no_empathize_with": [ "HUMAN" ],
     "no_cbm_on_bp": [ "torso", "head", "eyes", "mouth", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
-    "flags": [ "ATTUNEMENT" ]
+    "flags": [ "HERITAGE" ]
   },
   {
     "type": "mutation",
@@ -276,7 +276,7 @@
     "description": "A spirit of the image of humans given life.",
     "empathize_with": [ "HOMULLUS" ],
     "anger_relations": [ [ "HOMULLUS", -20 ], [ "ARVORE", 20 ] ],
-    "flags": [ "ATTUNEMENT" ]
+    "flags": [ "HERITAGE" ]
   },
   {
     "type": "mutation",
@@ -326,7 +326,7 @@
     "empathize_with": [ "SYLPH" ],
     "no_empathize_with": [ "HUMAN" ],
     "no_cbm_on_bp": [ "torso", "head", "eyes", "mouth", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
-    "flags": [ "ATTUNEMENT" ]
+    "flags": [ "HERITAGE" ]
   },
   {
     "type": "mutation",

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/paraclesian_mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/paraclesian_mutations.json
@@ -8,7 +8,6 @@
     "starting_trait": false,
     "valid": false,
     "purifiable": false,
-    "profession": true,
     "points": 2,
     "ignored_by": [ "IERDE" ],
     "cancels": [
@@ -47,7 +46,8 @@
     "vitamin_rates": [ [ "mutagen_human", 1 ] ],
     "empathize_with": [ "IERDE" ],
     "no_empathize_with": [ "HUMAN" ],
-    "no_cbm_on_bp": [ "torso", "head", "eyes", "mouth", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ]
+    "no_cbm_on_bp": [ "torso", "head", "eyes", "mouth", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
+    "flags": [ "ATTUNEMENT" ]
   },
   {
     "type": "mutation",
@@ -58,7 +58,6 @@
     "valid": false,
     "starting_trait": false,
     "purifiable": false,
-    "profession": true,
     "points": 2,
     "ignored_by": [ "ARVORE" ],
     "cancels": [
@@ -98,7 +97,7 @@
     "empathize_with": [ "ARVORE" ],
     "no_empathize_with": [ "HUMAN" ],
     "no_cbm_on_bp": [ "torso", "head", "eyes", "mouth", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
-    "flags": [ "TREE_COMMUNION_PLUS", "ARVORE_POLLEN_IMMUNE" ],
+    "flags": [ "TREE_COMMUNION_PLUS", "ARVORE_POLLEN_IMMUNE", "ATTUNEMENT" ],
     "enchantments": [
       {
         "condition": {
@@ -131,7 +130,6 @@
     "valid": false,
     "starting_trait": false,
     "purifiable": false,
-    "profession": true,
     "points": 2,
     "ignored_by": [ "SALAMANDER" ],
     "cancels": [
@@ -170,7 +168,8 @@
     "vitamin_rates": [ [ "mutagen_human", 1 ] ],
     "empathize_with": [ "SALAMANDER" ],
     "no_empathize_with": [ "HUMAN" ],
-    "no_cbm_on_bp": [ "torso", "head", "eyes", "mouth", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ]
+    "no_cbm_on_bp": [ "torso", "head", "eyes", "mouth", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
+    "flags": [ "ATTUNEMENT" ]
   },
   {
     "type": "mutation",
@@ -181,7 +180,6 @@
     "valid": false,
     "starting_trait": false,
     "purifiable": false,
-    "profession": true,
     "points": 2,
     "enchantments": [
       {
@@ -230,7 +228,8 @@
     "vitamin_rates": [ [ "mutagen_human", 1 ] ],
     "empathize_with": [ "UNDINE" ],
     "no_empathize_with": [ "HUMAN" ],
-    "no_cbm_on_bp": [ "torso", "head", "eyes", "mouth", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ]
+    "no_cbm_on_bp": [ "torso", "head", "eyes", "mouth", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
+    "flags": [ "ATTUNEMENT" ]
   },
   {
     "type": "mutation",
@@ -241,7 +240,6 @@
     "valid": false,
     "starting_trait": false,
     "purifiable": false,
-    "profession": true,
     "points": 2,
     "ignored_by": [ "HOMULLUS" ],
     "cancels": [
@@ -277,7 +275,8 @@
     "vitamin_rates": [ [ "mutagen_human", 1 ] ],
     "description": "A spirit of the image of humans given life.",
     "empathize_with": [ "HOMULLUS" ],
-    "anger_relations": [ [ "HOMULLUS", -20 ], [ "ARVORE", 20 ] ]
+    "anger_relations": [ [ "HOMULLUS", -20 ], [ "ARVORE", 20 ] ],
+    "flags": [ "ATTUNEMENT" ]
   },
   {
     "type": "mutation",
@@ -288,7 +287,6 @@
     "valid": false,
     "starting_trait": false,
     "purifiable": false,
-    "profession": true,
     "points": 2,
     "ignored_by": [ "SYLPH" ],
     "cancels": [
@@ -327,7 +325,8 @@
     "vitamin_rates": [ [ "mutagen_human", 1 ] ],
     "empathize_with": [ "SYLPH" ],
     "no_empathize_with": [ "HUMAN" ],
-    "no_cbm_on_bp": [ "torso", "head", "eyes", "mouth", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ]
+    "no_cbm_on_bp": [ "torso", "head", "eyes", "mouth", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
+    "flags": [ "ATTUNEMENT" ]
   },
   {
     "type": "mutation",

--- a/data/mods/Xedra_Evolved/mutations/playable_changeling.json
+++ b/data/mods/Xedra_Evolved/mutations/playable_changeling.json
@@ -201,7 +201,8 @@
           }
         ]
       }
-    ]
+    ],
+    "flags": [ "ATTUNEMENT" ]
   },
   {
     "type": "mutation",

--- a/data/mods/Xedra_Evolved/mutations/playable_changeling.json
+++ b/data/mods/Xedra_Evolved/mutations/playable_changeling.json
@@ -202,7 +202,7 @@
         ]
       }
     ],
-    "flags": [ "ATTUNEMENT" ]
+    "flags": [ "HERITAGE" ]
   },
   {
     "type": "mutation",

--- a/data/mods/Xedra_Evolved/mutations/shapeshifters.json
+++ b/data/mods/Xedra_Evolved/mutations/shapeshifters.json
@@ -39,7 +39,7 @@
       [ "mutagen_ursine", 1 ]
     ],
     "no_cbm_on_bp": [ "torso", "head", "eyes", "mouth", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
-    "flags": [ "MEND_ALL" ],
+    "flags": [ "MEND_ALL", "ATTUNEMENT" ],
     "enchantments": [ { "values": [ { "value": "REGEN_HP", "multiply": 0.25 }, { "value": "REGEN_HP_AWAKE", "multiply": 0.1 } ] } ],
     "cancels": [ "DREAMER", "DREAMSMITH", "EATER", "INVENTOR" ]
   },

--- a/data/mods/Xedra_Evolved/mutations/shapeshifters.json
+++ b/data/mods/Xedra_Evolved/mutations/shapeshifters.json
@@ -39,7 +39,7 @@
       [ "mutagen_ursine", 1 ]
     ],
     "no_cbm_on_bp": [ "torso", "head", "eyes", "mouth", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
-    "flags": [ "MEND_ALL", "ATTUNEMENT" ],
+    "flags": [ "MEND_ALL", "HERITAGE" ],
     "enchantments": [ { "values": [ { "value": "REGEN_HP", "multiply": 0.25 }, { "value": "REGEN_HP_AWAKE", "multiply": 0.1 } ] } ],
     "cancels": [ "DREAMER", "DREAMSMITH", "EATER", "INVENTOR" ]
   },

--- a/data/mods/Xedra_Evolved/mutations/xe_lilin.json
+++ b/data/mods/Xedra_Evolved/mutations/xe_lilin.json
@@ -54,7 +54,8 @@
     ],
     "activated_eocs": [ "EOC_LILIN_SPEND_RUACH_FOR_POWERS" ],
     "activation_msg": "You dedicate some ruach to increasing your power.",
-    "cancels": [ "DREAMER", "DREAMSMITH", "EATER", "INVENTOR" ]
+    "cancels": [ "DREAMER", "DREAMSMITH", "EATER", "INVENTOR" ],
+    "flags": [ "ATTUNEMENT" ]
   },
   {
     "type": "mutation",

--- a/data/mods/Xedra_Evolved/mutations/xe_lilin.json
+++ b/data/mods/Xedra_Evolved/mutations/xe_lilin.json
@@ -55,7 +55,7 @@
     "activated_eocs": [ "EOC_LILIN_SPEND_RUACH_FOR_POWERS" ],
     "activation_msg": "You dedicate some ruach to increasing your power.",
     "cancels": [ "DREAMER", "DREAMSMITH", "EATER", "INVENTOR" ],
-    "flags": [ "ATTUNEMENT" ]
+    "flags": [ "HERITAGE" ]
   },
   {
     "type": "mutation",

--- a/data/mods/Xedra_Evolved/mutations/xe_playable_gracken.json
+++ b/data/mods/Xedra_Evolved/mutations/xe_playable_gracken.json
@@ -47,7 +47,7 @@
     "cancels": [ "DREAMER", "DREAMSMITH", "EATER", "INVENTOR" ],
     "empathize_with": [ "GRACKEN" ],
     "no_empathize_with": [ "HUMAN" ],
-    "flags": [ "ATTUNEMENT" ],
+    "flags": [ "HERITAGE" ],
     "no_cbm_on_bp": [ "torso", "head", "eyes", "mouth", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ]
   },
   {

--- a/data/mods/Xedra_Evolved/mutations/xe_playable_gracken.json
+++ b/data/mods/Xedra_Evolved/mutations/xe_playable_gracken.json
@@ -40,7 +40,6 @@
     "valid": false,
     "starting_trait": false,
     "purifiable": false,
-    "profession": true,
     "points": 2,
     "description": "A traveler from another dimension.  A dimension of shadows with few bright lights.  Once your species matures, they gain the ability to create new alterations to their body from ingredients harvested from their kills, shadowstuff and magickal essence.",
     "types": [ "HERITAGE" ],
@@ -48,6 +47,7 @@
     "cancels": [ "DREAMER", "DREAMSMITH", "EATER", "INVENTOR" ],
     "empathize_with": [ "GRACKEN" ],
     "no_empathize_with": [ "HUMAN" ],
+    "flags": [ "ATTUNEMENT" ],
     "no_cbm_on_bp": [ "torso", "head", "eyes", "mouth", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ]
   },
   {

--- a/src/mutation_data.cpp
+++ b/src/mutation_data.cpp
@@ -792,7 +792,7 @@ nc_color mutation_branch::get_display_color() const
     if( flags.count( json_character_flag( "ATTUNEMENT" ) ) ) {
         return c_green;
     } else if( flags.count( json_character_flag( "HERITAGE" ) ) ) {
-        return c_light_cyan; 
+        return c_light_cyan;
     } else if( threshold || profession ) {
         return c_white;
     } else if( debug ) {

--- a/src/mutation_data.cpp
+++ b/src/mutation_data.cpp
@@ -22,7 +22,6 @@
 #include "json.h"
 #include "localized_comparator.h"
 #include "magic_enchantment.h"
-#include "make_static.h"
 #include "memory_fast.h"
 #include "npc.h"
 #include "string_formatter.h"

--- a/src/mutation_data.cpp
+++ b/src/mutation_data.cpp
@@ -791,12 +791,10 @@ nc_color mutation_branch::get_display_color() const
 {
     if( flags.count( json_flag_ATTUNEMENT ) ) {
         return c_green;
-    } else if( flags.count( json_flag_HERITAGE ) ) {
+    } else if( flags.count( json_flag_HERITAGE ) || debug ) {
         return c_light_cyan;
     } else if( threshold || profession ) {
         return c_white;
-    } else if( debug ) {
-        return c_light_cyan;
     } else if( mixed_effect ) {
         return c_pink;
     } else if( points > 0 ) {

--- a/src/mutation_data.cpp
+++ b/src/mutation_data.cpp
@@ -31,6 +31,9 @@
 #include "uilist.h"
 #include "weighted_list.h"
 
+static const json_character_flag json_flag_ATTUNEMENT( "ATTUNEMENT" );
+static const json_character_flag json_flag_HERITAGE( "HERITAGE" );
+
 static const mutation_category_id mutation_category_ANY( "ANY" );
 
 static const trait_group::Trait_group_tag Trait_group_EMPTY_GROUP( "EMPTY_GROUP" );
@@ -787,10 +790,10 @@ void mutation_branch::check_consistency()
 
 nc_color mutation_branch::get_display_color() const
 {
-    if( flags.count( STATIC( json_character_flag( "ATTUNEMENT" ) ) ) ) {
+    if( flags.count( json_character_flag( "ATTUNEMENT" ) ) ) {
         return c_green;
-    } else if( flags.count( STATIC( json_character_flag( "HERITAGE" ) ) ) ) {
-        return c_light_cyan;
+    } else if( flags.count( json_character_flag( "HERITAGE" ) ) ) {
+        return c_light_cyan; 
     } else if( threshold || profession ) {
         return c_white;
     } else if( debug ) {

--- a/src/mutation_data.cpp
+++ b/src/mutation_data.cpp
@@ -792,7 +792,7 @@ nc_color mutation_branch::get_display_color() const
     if( flags.count( STATIC( json_character_flag( "ATTUNEMENT" ) ) ) ) {
         return c_green;
     } else if( flags.count( STATIC( json_character_flag( "HERITAGE" ) ) ) ) {
-        return c_cyan;
+        return c_light_cyan;
     } else if( threshold || profession ) {
         return c_white;
     } else if( debug ) {

--- a/src/mutation_data.cpp
+++ b/src/mutation_data.cpp
@@ -31,6 +31,8 @@
 #include "uilist.h"
 #include "weighted_list.h"
 
+static const json_character_flag json_flag_HERITAGE( "HERITAGE" );
+
 static const mutation_category_id mutation_category_ANY( "ANY" );
 
 static const trait_group::Trait_group_tag Trait_group_EMPTY_GROUP( "EMPTY_GROUP" );
@@ -789,6 +791,8 @@ nc_color mutation_branch::get_display_color() const
 {
     if( flags.count( STATIC( json_character_flag( "ATTUNEMENT" ) ) ) ) {
         return c_green;
+    } else if( flags.count( STATIC( json_character_flag( "HERITAGE" ) ) ) ) {
+        return c_light_blue;
     } else if( threshold || profession ) {
         return c_white;
     } else if( debug ) {

--- a/src/mutation_data.cpp
+++ b/src/mutation_data.cpp
@@ -792,7 +792,7 @@ nc_color mutation_branch::get_display_color() const
     if( flags.count( STATIC( json_character_flag( "ATTUNEMENT" ) ) ) ) {
         return c_green;
     } else if( flags.count( STATIC( json_character_flag( "HERITAGE" ) ) ) ) {
-        return c_light_blue;
+        return c_cyan;
     } else if( threshold || profession ) {
         return c_white;
     } else if( debug ) {

--- a/src/mutation_data.cpp
+++ b/src/mutation_data.cpp
@@ -789,9 +789,9 @@ void mutation_branch::check_consistency()
 
 nc_color mutation_branch::get_display_color() const
 {
-    if( flags.count( json_character_flag( "ATTUNEMENT" ) ) ) {
+    if( flags.count( json_flag_ATTUNEMENT ) ) {
         return c_green;
-    } else if( flags.count( json_character_flag( "HERITAGE" ) ) ) {
+    } else if( flags.count( json_flag_HERITAGE ) ) {
         return c_light_cyan; 
     } else if( threshold || profession ) {
         return c_white;

--- a/src/mutation_data.cpp
+++ b/src/mutation_data.cpp
@@ -31,8 +31,6 @@
 #include "uilist.h"
 #include "weighted_list.h"
 
-static const json_character_flag json_flag_HERITAGE( "HERITAGE" );
-
 static const mutation_category_id mutation_category_ANY( "ANY" );
 
 static const trait_group::Trait_group_tag Trait_group_EMPTY_GROUP( "EMPTY_GROUP" );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[Mods] Mutually-exclusive supernatural/fantasy heritage traits are light cyan"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Use the interface to make special heritage traits show as obviously special. 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Implement the HERITAGE flag and apply it to relevant traits, representing some kind of non-human ancestry. The following traits are now light cyan. You can never get more than one of these, so it will really stand out:

Magiclysm

- Elf
- Dwarf
- Goblin
- Lizardfolk
- Ravenfolk

("Build" removed from the end of all of these)

XE
- Gracken
- Lilit
- Changeling
- The Paraclesian traits (Root and Branch, Born of the Air, Child of Dolls, etc)
- Dhampir
- Natural Shapeshifter

In addition, in XE the Living Paradox trait is green (it's more a magical attunement than a heritage type even though it's tagged HERITAGE to make it exclusive with other supernatural powers) and the Heartvines trait for bloodthorne druids remains green

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<img width="228" height="187" alt="Untitled" src="https://github.com/user-attachments/assets/82b85e57-7992-4850-89b9-14d7b1f322d5" />

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
