### PR TITLE
[CrazyCataclysm] Kitchen Gun

### DIFF
--- a/data/mods/CrazyCataclysm/crazy_ammo_effects.json
+++ b/data/mods/CrazyCataclysm/crazy_ammo_effects.json
@@ -3,5 +3,23 @@
     "id": "EXPLOSIVE_HUGE",
     "type": "ammo_effect",
     "explosion": { "power": 1200 }
+  },
+  {
+    "id": "CLEAN_DUST",
+    "type": "ammo_effect",
+    "always_cast_spell": true,
+    "spell_data": { "id": "spell_clean_dust" }
+  },
+  {
+    "id": "CLEAN_SPLINTERS",
+    "type": "ammo_effect",
+    "always_cast_spell": true,
+    "spell_data": { "id": "spell_clean_splinters" }
+  },
+  {
+    "id": "CLEAN_BLOOD",
+    "type": "ammo_effect",
+    "always_cast_spell": true,
+    "spell_data": { "id": "spell_clean_blood" }
   }
 ]

--- a/data/mods/CrazyCataclysm/crazy_item_groups.json
+++ b/data/mods/CrazyCataclysm/crazy_item_groups.json
@@ -185,5 +185,12 @@
       { "item": "akmag90", "prob": 20 },
       { "group": "on_hand_762" }
     ]
+  },
+ {
+    "type": "item_group",
+    "id": "SUS_junk_drawer",
+    "copy-from": "SUS_junk_drawer",
+    "subtype": "collection",
+    "extend": { "entries": [ { "item": "kitchen_gun", "charges": [ 1, 3 ], "prob": 5 } ] }
   }
 ]

--- a/data/mods/CrazyCataclysm/crazy_item_groups.json
+++ b/data/mods/CrazyCataclysm/crazy_item_groups.json
@@ -186,7 +186,7 @@
       { "group": "on_hand_762" }
     ]
   },
- {
+  {
     "type": "item_group",
     "id": "SUS_junk_drawer",
     "copy-from": "SUS_junk_drawer",

--- a/data/mods/CrazyCataclysm/crazy_items.json
+++ b/data/mods/CrazyCataclysm/crazy_items.json
@@ -765,7 +765,7 @@
     "type": "ITEM",
     "subtypes": [ "GUN" ],
     "copy-from": "m9",
-    "name": { "str": "Kitchen Gun™" },
+    "name": { "str": "Kitchen Gun™", "str_pl": "Kitchen Guns™" },
     "description": "Say goodbye to daily stains and dirty surfaces with new Kitchen Gun!  Just aim at the dust, blood, or splinters, and then shoot it a bunch of times to clean it.  Blast the filth away with Kitchen Gun™!",
     "ammo_effects": [ "CLEAN_DUST", "CLEAN_SPLINTERS", "CLEAN_BLOOD" ]
   }

--- a/data/mods/CrazyCataclysm/crazy_items.json
+++ b/data/mods/CrazyCataclysm/crazy_items.json
@@ -759,5 +759,14 @@
         "description": "A large black and orange international bear brotherhood flag.  The flag displays seven horizontal stripes of colors ranging from black to brown representing the colors of different bear species, you can see a black bear paw in the upper right corner."
       }
     ]
+  },
+  {
+    "id": "kitchen_gun",
+    "type": "ITEM",
+    "subtypes": [ "GUN" ],
+    "copy-from": "m9",
+    "name": { "str": "Kitchen Gun™" },
+    "description": "Say goodbye to daily stains and dirty surfaces with new Kitchen Gun!  Just aim at the dust, blood, or splinters, and then shoot it a bunch of times to clean it.  Blast the filth away with Kitchen Gun™!",
+    "ammo_effects": [ "CLEAN_DUST", "CLEAN_SPLINTERS", "CLEAN_BLOOD" ]
   }
 ]

--- a/data/mods/CrazyCataclysm/crazy_spells.json
+++ b/data/mods/CrazyCataclysm/crazy_spells.json
@@ -29,5 +29,47 @@
     "effect_str": "mon_zombie_hulk",
     "targeted_monster_ids": [ "mon_zombie_dancer" ],
     "extra_effects": [ { "id": "remove_controlled_jackson", "hit_self": true } ]
+  },
+  {
+    "type": "SPELL",
+    "id": "spell_clean_dust",
+    "name": { "str": "Clean Dust" },
+    "description": { "str": "Cleans Dust.", "//~": "NO_I18N" },
+    "message": "",
+    "min_aoe": 3,
+    "max_aoe": 3,
+    "valid_targets": [ "ground", "field" ],
+    "flags": [ "IGNORE_WALLS", "NO_PROJECTILE", "NO_EXPLOSION_SFX" ],
+    "shape": "blast",
+    "effect": "remove_field",
+    "effect_str": "fd_dust"
+  },
+  {
+    "type": "SPELL",
+    "id": "spell_clean_splinters",
+    "name": { "str": "Clean Splinters", "//~": "NO_I18N" },
+    "description": { "str": "Clean splinters.", "//~": "NO_I18N" },
+    "message": "",
+    "min_aoe": 3,
+    "max_aoe": 3,
+    "valid_targets": [ "ground", "field" ],
+    "flags": [ "IGNORE_WALLS", "NO_PROJECTILE", "NO_EXPLOSION_SFX" ],
+    "shape": "blast",
+    "effect": "remove_field",
+    "effect_str": "fd_splinters"
+  },
+  {
+    "type": "SPELL",
+    "id": "spell_clean_blood",
+    "name": { "str": "Clean Blood", "//~": "NO_I18N" },
+    "description": { "str": "Cleans blood.", "//~": "NO_I18N" },
+    "message": "",
+    "min_aoe": 3,
+    "max_aoe": 3,
+    "valid_targets": [ "ground", "field" ],
+    "flags": [ "IGNORE_WALLS", "NO_PROJECTILE", "NO_EXPLOSION_SFX" ],
+    "shape": "blast",
+    "effect": "remove_field",
+    "effect_str": "fd_blood"
   }
 ]


### PR DESCRIPTION

#### Summary
None

#### Purpose of change

*Hi I'm Getusedto, say goodbye to daily stains and dirty surfaces with new Kitchen Gun!*

Adds a handgun that can clean out tiles from dust, splinters, and blood splatter. Bang Bang Bang!

#### Describe the solution

Adds the gun into crazycata and make it spawn very rarely in kitchen junk drawers.

#### Describe alternatives you've considered

Keep the silly to myself

#### Testing

https://github.com/user-attachments/assets/386cbea1-a3fa-430e-a05b-c08a59dc488b

![Screenshot_20250714_011130](https://github.com/user-attachments/assets/a0826ef9-597e-438b-8e72-5047ac9df822)



#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
