### PR TITLE
prepper food in bugout bags

### DIFF
--- a/data/json/itemgroups/stashes.json
+++ b/data/json/itemgroups/stashes.json
@@ -262,6 +262,7 @@
     "entries": [
       { "item": "freeze_dried_meal", "count": 4 },
       { "group": "MRE", "count": 1 },
+      { "group": "jerky_ziploc", "count": 2 },
       { "group": "pemmican_ziploc", "count": 2 },
       { "group": "canned_staples_1l" },
       { "item": "protein_bar_evac", "count": 6 }
@@ -275,6 +276,7 @@
     "entries": [
       { "group": "MRE", "count": 4 },
       { "group": "freeze_dried_meal_box_8", "count": 4 },
+      { "group": "jerky_ziploc_gallon_irradiated", "count": 2 },
       { "group": "pemmican_ziploc_gallon", "count": 2 },
       { "group": "pemmican_ziploc_gallon_irradiated", "count": 2 },
       { "group": "hardtack_ziploc_gallon", "count": 2 },
@@ -476,6 +478,20 @@
       { "group": "can_spam_can_medium_6", "count": 2 },
       { "item": "can_tuna", "count": 4 }
     ]
+  },
+  {
+    "type": "item_group",
+    "id": "jerky_ziploc",
+    "subtype": "collection",
+    "container-item": "bag_zipper",
+    "entries": [ { "item": "jerky", "container-item": "null", "count": -1 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "jerky_ziploc_gallon_irradiated",
+    "subtype": "collection",
+    "container-item": "bag_zipper_gallon",
+    "entries": [ { "item": "jerky", "container-item": "null", "count": -1, "custom-flags": [ "IRRADIATED" ] } ]
   },
   {
     "type": "item_group",

--- a/data/json/itemgroups/stashes.json
+++ b/data/json/itemgroups/stashes.json
@@ -266,6 +266,7 @@
       { "group": "freeze_dried_meal_box_8", "count": 4 },
       { "group": "pemmican_ziploc_gallon", "count": 2 },
       { "group": "pemmican_ziploc_gallon_irradiated", "count": 2 },
+      { "group": "hardtack_ziploc_gallon", "count": 2 },
       { "group": "can_beans_can_food_big_12", "count": 3 },
       { "group": "protein_bar_box_small", "count": 4 }
     ]
@@ -485,6 +486,13 @@
     "subtype": "collection",
     "container-item": "bag_zipper_gallon",
     "entries": [ { "item": "pemmican", "container-item": "null", "count": 37, "custom-flags": [ "IRRADIATED" ] } ]
+  },
+  {
+    "type": "item_group",
+    "id": "hardtack_ziploc_gallon",
+    "subtype": "collection",
+    "container-item": "bag_zipper_gallon",
+    "entries": [ { "item": "hardtack", "count": 64 } ]
   },
   {
     "type": "item_group",

--- a/data/json/itemgroups/stashes.json
+++ b/data/json/itemgroups/stashes.json
@@ -262,6 +262,7 @@
     "entries": [
       { "item": "freeze_dried_meal", "count": 4 },
       { "group": "MRE", "count": 1 },
+      { "group": "peanuts_ziploc", "count": 2 },
       { "group": "jerky_ziploc", "count": 2 },
       { "group": "pemmican_ziploc", "count": 2 },
       { "group": "canned_staples_1l" },
@@ -478,6 +479,13 @@
       { "group": "can_spam_can_medium_6", "count": 2 },
       { "item": "can_tuna", "count": 4 }
     ]
+  },
+  {
+    "type": "item_group",
+    "id": "peanuts_ziploc",
+    "subtype": "collection",
+    "container-item": "bag_zipper",
+    "entries": [ { "item": "peanut_shelled", "container-item": "null", "count": -1 } ]
   },
   {
     "type": "item_group",

--- a/data/json/itemgroups/stashes.json
+++ b/data/json/itemgroups/stashes.json
@@ -266,6 +266,8 @@
       { "group": "jerky_ziploc", "count": 2 },
       { "group": "pemmican_ziploc", "count": 2 },
       { "group": "canned_staples_1l" },
+      { "group": "dry_lentils_bag_plastic_full", "count": 2 },
+      { "group": "dry_rice_bag_plastic_full", "count": 2 },
       { "item": "protein_bar_evac", "count": 6 }
     ]
   },

--- a/data/json/itemgroups/stashes.json
+++ b/data/json/itemgroups/stashes.json
@@ -144,7 +144,8 @@
     "//": "a light bugout, stuff people would have on hand, not super full",
     "subtype": "collection",
     "entries": [
-      { "group": "bugout_first_aid", "prob": 50 },
+      { "group": "bugout_meds_easy", "prob": 90 },
+      { "group": "bugout_first_aid", "prob": 20 },
       { "group": "guns_pistol_common", "prob": 45 },
       { "group": "bugout_tools", "prob": 50 },
       { "group": "bugout_food_easy", "prob": 50 },
@@ -190,6 +191,16 @@
       { "group": "bugout_extras", "prob": 100, "count": [ 2, 6 ] },
       { "group": "civilian_armor", "count": 2, "prob": 35 },
       { "group": "bugout_large_extras", "prob": 40 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "bugout_meds_easy",
+    "subtype": "collection",
+    "//": "Everything vaguely medical on hand quickly shoved into the bag.",
+    "entries": [
+      { "group": "adhesive_bandages_box_used", "count": [ 1, 2 ], "prob": 95 },
+      { "group": "SUS_bathroom_medicine", "prob": 80 }
     ]
   },
   {

--- a/data/json/itemgroups/stashes.json
+++ b/data/json/itemgroups/stashes.json
@@ -141,7 +141,8 @@
     "entries": [
       { "group": "bugout_first_aid", "prob": 50 },
       { "group": "guns_pistol_common", "prob": 45 },
-      { "group": "bugout_food", "prob": 50 },
+      { "group": "bugout_tools", "prob": 50 },
+      { "group": "bugout_food_easy", "prob": 50 },
       { "group": "bugout_water", "prob": 50 },
       { "group": "bugout_bad_pack", "prob": 100 }
     ]
@@ -149,14 +150,17 @@
   {
     "id": "medium_bugout",
     "type": "item_group",
-    "//": "a medium bugout, stuff people would have had if preppers, or they had forsight",
+    "//": "a medium bugout, stuff people would have had if preppers, or they had foresight",
     "container-item": "backpack_hiking",
     "subtype": "collection",
     "on_overflow": "spill",
     "entries": [
       { "group": "bugout_first_aid", "prob": 90 },
       { "group": "bugout_gun", "prob": 50 },
-      { "group": "bugout_food", "prob": 50, "count": [ 1, 2 ] },
+      { "group": "bugout_tools", "prob": 60 },
+      { "group": "bugout_food_easy", "prob": 25, "count": [ 1, 4 ] },
+      { "group": "bugout_food_1l", "prob": 75, "count": [ 2, 6 ] },
+      { "group": "bugout_food_9l", "prob": 15, "count": [ 1, 2 ] },
       { "group": "bugout_water", "prob": 50, "count": [ 1, 2 ] },
       { "group": "bugout_extras", "prob": 100, "count": [ 1, 4 ] },
       { "group": "civilian_armor", "prob": 35 }
@@ -173,8 +177,11 @@
       { "group": "bugout_first_aid", "count": 1, "prob": 90 },
       { "group": "guns_pistol_common", "prob": 70 },
       { "group": "bugout_long_gun", "prob": 20 },
-      { "group": "bugout_food", "prob": 50, "count": [ 1, 3 ] },
-      { "group": "bugout_water", "prob": 50, "count": [ 1, 3 ] },
+      { "group": "bugout_tools", "prob": 80 },
+      { "group": "bugout_food_easy", "prob": 25, "count": [ 1, 2 ] },
+      { "group": "bugout_food_1l", "prob": 50, "count": [ 2, 4 ] },
+      { "group": "bugout_food_9l", "prob": 90, "count": [ 2, 4 ] },
+      { "group": "bugout_water", "prob": 90, "count": [ 1, 3 ] },
       { "group": "bugout_extras", "prob": 100, "count": [ 2, 6 ] },
       { "group": "civilian_armor", "count": 2, "prob": 35 },
       { "group": "bugout_large_extras", "prob": 40 }
@@ -210,14 +217,51 @@
   },
   {
     "type": "item_group",
-    "id": "bugout_food",
-    "subtype": "distribution",
-    "//": "food of some kind.",
+    "id": "bugout_tools",
+    "subtype": "collection",
     "entries": [
-      { "group": "MRE", "count": 2, "prob": 100 },
-      { "group": "bugout_cans", "prob": 100 },
-      { "item": "protein_bar_evac", "count": 1, "prob": 100 },
+      { "item": "fork", "count": [ 1, 2 ], "prob": 95 },
+      { "item": "knife_butter", "count": [ 1, 2 ], "prob": 90 },
+      { "item": "spoon", "count": [ 1, 2 ], "prob": 90 },
+      { "item": "can_opener", "prob": 80 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "bugout_food_easy",
+    "subtype": "distribution",
+    "//": "food easily found in a hurry.",
+    "entries": [
+      { "group": "canned_staples_1l", "count": [ 2, 6 ], "prob": 100 },
+      { "group": "pasta", "count": [ 2, 6 ], "prob": 100 },
       { "group": "snacks", "count": 4, "prob": 100 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "bugout_food_1l",
+    "subtype": "distribution",
+    "//": "about 1L worth of food with long shelf life",
+    "entries": [
+      { "item": "freeze_dried_meal", "count": 4 },
+      { "group": "MRE", "count": 1 },
+      { "group": "pemmican_ziploc", "count": 2 },
+      { "group": "canned_staples_1l" },
+      { "item": "protein_bar_evac", "count": 6 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "bugout_food_9l",
+    "subtype": "distribution",
+    "//": "about 9L/2 gallons worth of food with long shelf life",
+    "entries": [
+      { "group": "MRE", "count": 4 },
+      { "group": "freeze_dried_meal_box_8", "count": 4 },
+      { "group": "pemmican_ziploc_gallon", "count": 2 },
+      { "group": "pemmican_ziploc_gallon_irradiated", "count": 2 },
+      { "group": "can_beans_can_food_big_12", "count": 3 },
+      { "group": "protein_bar_box_small", "count": 4 }
     ]
   },
   {
@@ -239,13 +283,6 @@
       { "item": "rehydration_drink", "count": 1, "prob": 50 },
       { "item": "sports_drink", "count": 1, "prob": 50 }
     ]
-  },
-  {
-    "type": "item_group",
-    "id": "bugout_cans",
-    "subtype": "collection",
-    "//": "cans and a can opener.",
-    "entries": [ { "group": "big_canned_food", "count": 2, "prob": 100 }, { "item": "can_opener", "prob": 100 } ]
   },
   {
     "type": "item_group",
@@ -358,7 +395,8 @@
       { "group": "bugout_toys", "prob": 50 },
       { "group": "bugout_child_snacks", "prob": 100 },
       { "group": "bugout_water", "prob": 75 },
-      { "group": "bugout_cans", "prob": 33 },
+      { "group": "bugout_tools", "prob": 40 },
+      { "group": "bugout_food_easy", "prob": 33 },
       { "item": "toothbrush_plain", "prob": 10 },
       { "item": "childnote", "prob": 33 }
     ]
@@ -398,6 +436,49 @@
       { "prob": 30, "group": "cookies_box_snack_1_4" },
       { "group": "toastems", "prob": 15 }
     ]
+  },
+  {
+    "type": "item_group",
+    "id": "freeze_dried_meal_box_8",
+    "subtype": "collection",
+    "container-item": "box_small",
+    "entries": [ { "item": "freeze_dried_meal", "count": 8 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "canned_staples_1l",
+    "subtype": "distribution",
+    "//": "1L of calorie dense canned food, not things like tomatoes or pineapples",
+    "entries": [
+      { "group": "can_beans_can_medium_2", "count": 2 },
+      { "group": "pork_beans_can_medium_2", "count": 2 },
+      { "group": "can_chicken_can_medium_2", "count": 2 },
+      { "group": "chili_can_medium_2", "count": 2 },
+      { "group": "ravioli_can_medium_2", "count": 2 },
+      { "group": "can_spam_can_medium_6", "count": 2 },
+      { "item": "can_tuna", "count": 4 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "pemmican_ziploc",
+    "subtype": "collection",
+    "container-item": "bag_zipper",
+    "entries": [ { "item": "pemmican", "container-item": "null", "count": 4 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "pemmican_ziploc_gallon",
+    "subtype": "collection",
+    "container-item": "bag_zipper_gallon",
+    "entries": [ { "item": "pemmican", "container-item": "null", "count": 37 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "pemmican_ziploc_gallon_irradiated",
+    "subtype": "collection",
+    "container-item": "bag_zipper_gallon",
+    "entries": [ { "item": "pemmican", "container-item": "null", "count": 37, "custom-flags": [ "IRRADIATED" ] } ]
   },
   {
     "type": "item_group",

--- a/data/json/itemgroups/stashes.json
+++ b/data/json/itemgroups/stashes.json
@@ -6,7 +6,7 @@
     "//": "This itemgroup is intended to represent a stash of long-lasting food and water supplies that a survivor may have scavenged",
     "items": [
       { "group": "pantry_liquids", "prob": 30, "count": [ 1, 3 ] },
-      { "group": "pasta", "prob": 50, "count": [ 1, 5 ] },
+      { "group": "groce_pasta", "prob": 50, "count": [ 1, 5 ] },
       { "group": "cannedfood", "prob": 50, "count": [ 1, 6 ] },
       { "group": "big_canned_food", "prob": 25, "count": [ 1, 3 ] },
       { "group": "dry_goods", "prob": 30, "count": [ 1, 4 ] },
@@ -238,7 +238,8 @@
     "//": "food easily found in a hurry.",
     "entries": [
       { "group": "canned_staples_1l", "count": [ 2, 6 ], "prob": 100 },
-      { "group": "pasta", "count": [ 2, 6 ], "prob": 100 },
+      { "group": "groce_pasta", "count": [ 2, 6 ], "prob": 100 },
+      { "group": "dollar_food", "count": [ 2, 6 ], "prob": 100 },
       { "group": "snacks", "count": 4, "prob": 100 }
     ]
   },

--- a/data/json/itemgroups/stashes.json
+++ b/data/json/itemgroups/stashes.json
@@ -98,7 +98,12 @@
     "//": "randomized assortment of possible bugout bags people would have as the apocalypse ramped up",
     "entries": [
       {
-        "distribution": [ { "group": "small_bugout_bag_1" }, { "group": "small_bugout_bag_2" }, { "group": "small_bugout_bag_3" } ],
+        "distribution": [
+          { "group": "small_bugout_bag_1" },
+          { "group": "small_bugout_bag_2" },
+          { "group": "small_bugout_bag_3" },
+          { "group": "small_bugout_bag_4" }
+        ],
         "prob": 50
       },
       { "group": "medium_bugout", "prob": 40 },

--- a/data/json/items/containers/containers.json
+++ b/data/json/items/containers/containers.json
@@ -449,7 +449,7 @@
         "transparent": true,
         "magazine_well": "50 ml",
         "max_contains_volume": "4500 ml",
-        "max_contains_weight": "3000 g",
+        "max_contains_weight": "5000 g",
         "max_item_length": "29 cm",
         "spoil_multiplier": 0.8,
         "moves": 600

--- a/data/json/mapgen/nested/strip_mall_nested.json
+++ b/data/json/mapgen/nested/strip_mall_nested.json
@@ -1004,7 +1004,7 @@
         ".": { "item": "SUS_trash_floor", "chance": 5 },
         "m": { "item": "bed", "chance": 75 },
         "w": { "item": "stash_wood", "chance": 100, "repeat": [ 2, 3 ] },
-        "T": [ { "item": "bugout_food", "chance": 25 }, { "item": "guns_pistol_common", "chance": 25 } ],
+        "T": [ { "item": "bugout_food_9l", "chance": 25 }, { "item": "guns_pistol_common", "chance": 25 } ],
         "b": [
           { "item": "small_bugout", "chance": 30 },
           { "item": "medium_bugout", "chance": 20 },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Content "More prepper food, meds in bugout bags"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

The 55L+ sized backpack seemed somewhat empty for belonging to a prepper.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

Add more long shelf life food, and pack calorie-dense foods instead of big 3L cans of tomatoes.

Remove the chance of non-preppers having MREs or protein rations on them, add `groce_pasta` instead.

Pack eating utencils and adhesive bandaids, too.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
