### PR TITLE
Fix mod loading

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -795,7 +795,7 @@ void game::setup()
 
         load_core_data();
     }
-    world_generator->get_mod_manager().load_mods_list( world_generator->active_world );
+    world_generator->get_mod_manager().check_mods_list( world_generator->active_world );
     load_world_modfiles();
     // Panel manager needs JSON data to be loaded before init
     panel_manager::get_manager().init();

--- a/src/mod_manager.h
+++ b/src/mod_manager.h
@@ -134,6 +134,7 @@ class mod_manager
          * world.
          */
         void load_mods_list( WORLD *world ) const;
+        void check_mods_list( WORLD *world ) const;
         const t_mod_list &get_default_mods() const;
         bool set_default_mods( const t_mod_list &mods );
         const std::vector<mod_id> &get_usable_mods() const {

--- a/src/worldfactory.cpp
+++ b/src/worldfactory.cpp
@@ -394,6 +394,7 @@ void worldfactory::init()
         for( auto &world_sav_file : world_sav_files ) {
             all_worlds[worldname]->world_saves.push_back( save_t::from_base_path( world_sav_file ) );
         }
+        mman->load_mods_list( all_worlds[worldname].get() );
 
         // load options into the world
         if( !all_worlds[worldname]->load_options() ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Fix mod loading"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes #81541 (and the other more severe related issues in the comments hopefully)
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Move loading all worlds modlists back to where it was pre-#81521 and split the checking off to perform after migrations have been loaded
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Outside of the ability to see the worlds active mods on the menu which should be done on an as wanted basis imo I don't understand why all the worlds lists are loaded but fixing this borking saves is more important than tracking down whatever isn't feeding through this
~~Constructing a new vector here is ugly but heathazed me found it easiest~~ Nvm heathazed me also thought it was ugly
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
The portions of the linked issue I can repro appear fixed
Mod migrations still work as intended

If anyone else that could repro some part of the issue and has a build environment setup more testing would be appreciated esp when I flat out can't repro the actual save breaking issue
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
