### PR TITLE
fix f_player_see erroring if talker is not presented

### DIFF
--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -1368,12 +1368,11 @@ conditional_t::func f_player_see( bool is_npc )
     const map &here = get_map();
 
     return [is_npc, &here]( const_dialogue const & d ) {
-        const Creature *c = d.const_actor( is_npc )->get_const_creature();
-        if( c ) {
+        if( d.has_actor( is_npc ) ) {
+            const Creature *c = d.const_actor( is_npc )->get_const_creature();
             return get_player_view().sees( here, *c );
-        } else {
-            return get_player_view().sees( here,  d.const_actor( is_npc )->pos_bub( here ) );
         }
+        return false;
     };
 }
 


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Fix #80911
Supersede #81218
#### Describe the solution
Guard player_see_u / player_see_npc with check that verify talker is presented, if not, return false (if it's not presented, you cannot see it)
Also simple cleanup of a function
#### Testing
Debug killing yugg do not error anymore