### PR TITLE
[Mods] Traits that let you cast spells or other supernatural power suites are green

### DIFF
--- a/data/mods/Magiclysm/mutations/magic_classes/classes.json
+++ b/data/mods/Magiclysm/mutations/magic_classes/classes.json
@@ -9,7 +9,8 @@
     "purifiable": false,
     "valid": false,
     "cancels": [ "ANIMIST" ],
-    "spells_learned": [ [ "create_rune_magus", 0 ] ]
+    "spells_learned": [ [ "create_rune_magus", 0 ] ],
+    "flags": [ "ATTUNEMENT" ]
   },
   {
     "type": "mutation",
@@ -22,7 +23,8 @@
     "valid": false,
     "cancels": [ "MAGUS" ],
     "spells_learned": [ [ "create_rune_animist", 0 ] ],
-    "moncams": [ [ "mon_watcher_spirit", 30 ] ]
+    "moncams": [ [ "mon_watcher_spirit", 30 ] ],
+    "flags": [ "ATTUNEMENT" ]
   },
   {
     "type": "mutation",
@@ -35,7 +37,8 @@
     "valid": false,
     "enchantments": [ "KELVINIST" ],
     "cancels": [ "STORMSHAPER" ],
-    "spells_learned": [ [ "create_rune_kelvinist", 0 ] ]
+    "spells_learned": [ [ "create_rune_kelvinist", 0 ] ],
+    "flags": [ "ATTUNEMENT" ]
   },
   {
     "type": "mutation",
@@ -48,7 +51,8 @@
     "valid": false,
     "enchantments": [ "STORMSHAPER" ],
     "cancels": [ "KELVINIST" ],
-    "spells_learned": [ [ "create_rune_stormshaper", 0 ] ]
+    "spells_learned": [ [ "create_rune_stormshaper", 0 ] ],
+    "flags": [ "ATTUNEMENT" ]
   },
   {
     "type": "mutation",
@@ -60,7 +64,8 @@
     "purifiable": false,
     "valid": false,
     "cancels": [ "EARTHSHAPER" ],
-    "spells_learned": [ [ "create_rune_technomancer", 0 ] ]
+    "spells_learned": [ [ "create_rune_technomancer", 0 ] ],
+    "flags": [ "ATTUNEMENT" ]
   },
   {
     "type": "mutation",
@@ -72,7 +77,8 @@
     "purifiable": false,
     "valid": false,
     "cancels": [ "TECHNOMANCER" ],
-    "spells_learned": [ [ "create_rune_earthshaper", 0 ] ]
+    "spells_learned": [ [ "create_rune_earthshaper", 0 ] ],
+    "flags": [ "ATTUNEMENT" ]
   },
   {
     "type": "mutation",
@@ -84,7 +90,8 @@
     "purifiable": false,
     "valid": false,
     "cancels": [ "DRUID" ],
-    "spells_learned": [ [ "create_rune_biomancer", 0 ] ]
+    "spells_learned": [ [ "create_rune_biomancer", 0 ] ],
+    "flags": [ "ATTUNEMENT" ]
   },
   {
     "type": "mutation",
@@ -96,7 +103,7 @@
     "purifiable": false,
     "valid": false,
     "cancels": [ "BIOMANCER" ],
-    "flags": [ "TREE_COMMUNION_PLUS" ],
-    "spells_learned": [ [ "create_rune_druid", 0 ] ]
+    "spells_learned": [ [ "create_rune_druid", 0 ] ],
+    "flags": [ "ATTUNEMENT", "TREE_COMMUNION_PLUS" ]
   }
 ]

--- a/data/mods/Xedra_Evolved/mutations/classes.json
+++ b/data/mods/Xedra_Evolved/mutations/classes.json
@@ -19,7 +19,8 @@
     ],
     "vitamin_rates": [ [ "dreamer_vit", -1080 ] ],
     "//": "1 vit each 18 minutes, 80 per day, 12,5 days to full",
-    "spells_learned": [ [ "create_dream_dross", 0 ], [ "dreamer_artifact", 0 ], [ "return_critters", 0 ] ]
+    "spells_learned": [ [ "create_dream_dross", 0 ], [ "dreamer_artifact", 0 ], [ "return_critters", 0 ] ],
+    "flags": [ "ATTUNEMENT" ]
   },
   {
     "type": "mutation",
@@ -32,7 +33,8 @@
     "valid": false,
     "enchantments": [ "BONUS_EATER" ],
     "cancels": [ "DREAMER" ],
-    "spells_learned": [ [ "eat_dreamdross", 0 ] ]
+    "spells_learned": [ [ "eat_dreamdross", 0 ] ],
+    "flags": [ "ATTUNEMENT" ]
   },
   {
     "type": "mutation",
@@ -44,7 +46,8 @@
     "purifiable": false,
     "valid": false,
     "enchantments": [ "BONUS_DREAMSMITH" ],
-    "cancels": [ "INVENTOR" ]
+    "cancels": [ "INVENTOR" ],
+    "flags": [ "ATTUNEMENT" ]
   },
   {
     "type": "mutation",
@@ -57,7 +60,8 @@
     "valid": false,
     "enchantments": [ "BONUS_INVENTOR" ],
     "cancels": [ "DREAMSMITH" ],
-    "vitamin_rates": [ [ "creative_spark", -64800 ] ]
+    "vitamin_rates": [ [ "creative_spark", -64800 ] ],
+    "flags": [ "ATTUNEMENT" ]
   },
   {
     "type": "mutation",
@@ -68,6 +72,7 @@
     "starting_trait": false,
     "purifiable": false,
     "valid": false,
-    "spells_learned": [ [ "hedge_luck_spell", 0 ] ]
+    "spells_learned": [ [ "hedge_luck_spell", 0 ] ],
+    "flags": [ "ATTUNEMENT" ]
   }
 ]

--- a/doc/JSON/JSON_FLAGS.md
+++ b/doc/JSON/JSON_FLAGS.md
@@ -332,6 +332,7 @@ Character flags can be `trait_id`, `json_flag_id` or `flag_id`.  Some of these a
 - ```ACID_IMMUNE``` You are immune to acid damage.
 - ```ALARMCLOCK``` You always can set alarms.
 - ```ALBINO``` Cause you to have painful sunburns.
+- ```ATTUNEMENT``` Turns a mutation with this flag green on the list.  Currently used in mods for mutations that grant spellcasting or other supernatural powers.
 - ```BARKY``` Makes you considered to be made of bark for the purposes of making blistering harder.
 - ```BASH_IMMUNE``` You are immune to bashing damage.
 - ```BG_OTHER_SURVIVORS_STORY``` Given to NPC when it has other survival story.
@@ -379,6 +380,7 @@ Character flags can be `trait_id`, `json_flag_id` or `flag_id`.  Some of these a
 - ```HARDTOHIT``` Whenever something attacks you, RNG gets rolled twice, and you get the better result.
 - ```HEATSINK``` You are resistant to extreme heat.
 - ```HEAT_IMMUNE``` Immune to very hot temperatures.
+- ```HERITAGE``` Turns a mutation with this flag light cyan on the list.  Currently used in mods for mutations that indicate non-human ancestry.
 - ```HUGE``` Changes your size to `creature_size::huge`.  Checked last of the size category flags, if no size flags are found your size defaults to `creature_size::medium`.
 - ```HYPEROPIC``` You are far-sighted: close combat is hampered and reading is impossible without glasses.
 - ```IMMUNE_HEARING_DAMAGE``` Immune to hearing damage from loud sounds.


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[Mods] Traits that let you cast spells or other supernatural power suites are green"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Extension of #81751 across other mods. 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add the ATTUNEMENT flag to Animist, Biomancer, etc from Magiclysm and Dreamer, Eater of Dreams, etc from XE. 

#81763 already adds it to Esper for Aftershock

Also document the way ATTUNEMENT and HERITAGE are used and their effects on color.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
