### PR TITLE
Fix highway segments generating over highway specials

### DIFF
--- a/data/json/mapgen/highway/highway.json
+++ b/data/json/mapgen/highway/highway.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "mapgen",
-    "om_terrain": [ "hw_reserved", "hw_reserved_water", "hw_reserved_ramp" ],
+    "om_terrain": [ "hw_reserved", "hw_reserved_water" ],
     "object": { "fallback_predecessor_mapgen": "open_air" }
   },
   {

--- a/data/json/overmap/overmap_terrain/overmap_terrain_special.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_special.json
@@ -191,12 +191,6 @@
   },
   {
     "type": "overmap_terrain",
-    "id": "hw_reserved_ramp",
-    "//": "for placing adjacent to bridgeheads for z = 1 ramp detection",
-    "copy-from": "hw_reserved"
-  },
-  {
-    "type": "overmap_terrain",
     "abstract": "generic_road",
     "copy-from": "road_abstract"
   },

--- a/data/json/overmap/special_locations.json
+++ b/data/json/overmap/special_locations.json
@@ -112,11 +112,6 @@
   },
   {
     "type": "overmap_location",
-    "id": "highway_ramp",
-    "terrains": [ "hw_reserved_ramp" ]
-  },
-  {
-    "type": "overmap_location",
     "id": "forest_trail",
     "terrains": [ "forest_trail" ]
   },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "fix highway segments generating over highway specials"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Courtesy of @Zetsumei45 on Discord:

Missing ramp:
<img width="1789" height="1186" alt="image" src="https://github.com/user-attachments/assets/fc18956b-2123-4023-b1dc-b8a416eb34b5" />

Rails generating over rest area special:
<img width="1745" height="1192" alt="image3" src="https://github.com/user-attachments/assets/7862d2e6-95e4-48c4-a1ef-7fb1ea36d8f6" />

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

While placing highway segments, only the intrahighway point was checked for highway specials instead of all of the placed segment's points; this was corrected.

For the missing ramp, I'm not entirely sure this will solve the issue, but ramps could hypothetically place on `z = base_z + 1`, so force them to place at `z = base_z`.

Removes unused OMT `hw_reserved_ramp`

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Checked rest areas and diamond interchanges, looks good.

If you see more missing ramps, please report an issue.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Probably going to do a deep dive into weird road/bridge behavior.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
