### PR TITLE
Aftershock: Lasers cant use UPS, cant be mounted in vehicle.

### DIFF
--- a/data/mods/aftershock_exoplanet/items/gun/laser.json
+++ b/data/mods/aftershock_exoplanet/items/gun/laser.json
@@ -14,7 +14,7 @@
     "dispersion": 500,
     "energy_drain": "25 kJ",
     "ammo_effects": [ "LASER", "BEANBAG" ],
-    "flags": [ "NEVER_JAMS", "NO_UNLOAD", "NON_FOULING", "NEEDS_NO_LUBE", "USE_UPS" ],
+    "flags": [ "NEVER_JAMS", "NO_UNLOAD", "NON_FOULING", "NEEDS_NO_LUBE", "USE_UPS", "NO_TURRET" ],
     "melee_damage": { "bash": 10 }
   },
   {
@@ -30,7 +30,7 @@
     "energy_drain": "30 kJ",
     "modes": [ [ "MULTI", "trilaser", 3 ] ],
     "ammo_effects": [ "LASER" ],
-    "flags": [ "NEVER_JAMS", "NO_UNLOAD", "NON_FOULING", "NEEDS_NO_LUBE", "USE_UPS" ]
+    "flags": [ "NEVER_JAMS", "NO_UNLOAD", "NON_FOULING", "NEEDS_NO_LUBE", "USE_UPS", "NO_TURRET" ]
   },
   {
     "id": "afs_sentinel_laser_mon",
@@ -76,7 +76,7 @@
       [ "underbarrel mount", 1 ]
     ],
     "ammo_effects": [ "LASER", "IGNITE" ],
-    "flags": [ "NO_UNLOAD", "NON_FOULING", "NEEDS_NO_LUBE", "USE_UPS" ],
+    "flags": [ "NO_UNLOAD", "NON_FOULING", "NEEDS_NO_LUBE", "USE_UPS", "NO_TURRET" ],
     "melee_damage": { "bash": 4 }
   },
   {
@@ -86,7 +86,7 @@
     "copy-from": "laser_cannon_xray",
     "name": { "str": "mounted x-ray cannon" },
     "energy_drain": "0 kJ",
-    "flags": [ "NEVER_JAMS", "NO_UNLOAD", "NON_FOULING", "NEEDS_NO_LUBE", "NO_TURRET" ]
+    "flags": [ "NEVER_JAMS", "NO_UNLOAD", "NON_FOULING", "NEEDS_NO_LUBE", "NO_TURRET", "NO_TURRET" ]
   },
   {
     "id": "laser_rifle_cheap",
@@ -112,7 +112,7 @@
     "reload": 500,
     "valid_mod_locations": [ [ "sights", 1 ], [ "sling", 1 ], [ "stock", 1 ], [ "underbarrel", 1 ] ],
     "ammo_effects": [ "LASER" ],
-    "flags": [ "NEVER_JAMS", "NON_FOULING", "NEEDS_NO_LUBE" ],
+    "flags": [ "NEVER_JAMS", "NON_FOULING", "NEEDS_NO_LUBE", "NO_TURRET" ],
     "ammo_to_fire": 0,
     "energy_drain": "20 kJ",
     "pocket_data": [
@@ -142,7 +142,8 @@
     "overheat_threshold": 150,
     "range": 15,
     "modes": [ [ "DEFAULT", "pulse", 1 ], [ "BURST", "2s sequence", 2 ], [ "AUTO", "3s sequence", 3 ] ],
-    "delete": { "flags": [ "NO_UNLOAD", "NO_RELOAD" ] },
+    "extend": { "flags": [ "NO_TURRET" ] },
+    "delete": { "flags": [ "NO_UNLOAD", "NO_RELOAD", "USE_UPS" ] },
     "ammo_to_fire": 0,
     "energy_drain": "10 kJ",
     "valid_mod_locations": [ [ "emitter", 1 ], [ "grip", 1 ], [ "lens", 1 ], [ "rail", 1 ], [ "sights", 1 ], [ "stock", 1 ], [ "underbarrel", 1 ] ],
@@ -206,7 +207,8 @@
     "modes": [ [ "DEFAULT", "pulse", 1 ], [ "BURST", "2s sequence", 2 ] ],
     "ammo_to_fire": 0,
     "ammo_effects": [ "IGNITE", "DAZZLE_BEAM", "PLASMA_BUBBLE" ],
-    "delete": { "flags": [ "NO_UNLOAD", "NO_RELOAD" ] },
+    "extend": { "flags": [ "NO_TURRET" ] },
+    "delete": { "flags": [ "NO_UNLOAD", "NO_RELOAD", "USE_UPS" ] },
     "energy_drain": "30 kJ",
     "built_in_mods": [ "afs_holo_aim_assist" ],
     "valid_mod_locations": [ [ "emitter", 1 ], [ "grip", 1 ], [ "lens", 1 ], [ "rail", 1 ], [ "sights", 1 ], [ "stock", 1 ], [ "underbarrel", 1 ] ],
@@ -299,7 +301,8 @@
     "ranged_damage": { "damage_type": "afs_laser", "amount": 10 },
     "range": 15,
     "ammo_to_fire": 0,
-    "delete": { "flags": [ "NO_UNLOAD", "NO_RELOAD" ] },
+    "extend": { "flags": [ "NO_TURRET" ] },
+    "delete": { "flags": [ "NO_UNLOAD", "NO_RELOAD", "USE_UPS" ] },
     "energy_drain": "5 kJ",
     "valid_mod_locations": [ [ "emitter", 1 ], [ "grip", 1 ], [ "lens", 1 ], [ "rail", 1 ], [ "sights", 1 ], [ "stock", 1 ], [ "underbarrel", 1 ] ],
     "pocket_data": [
@@ -324,7 +327,8 @@
     "price_postapoc": "1 kUSD",
     "ammo": [ "battery" ],
     "ammo_to_fire": 0,
-    "delete": { "flags": [ "NO_UNLOAD", "NO_RELOAD" ] },
+    "extend": { "flags": [ "NO_TURRET" ] },
+    "delete": { "flags": [ "NO_UNLOAD", "NO_RELOAD", "USE_UPS" ] },
     "energy_drain": "120 kJ",
     "modes": [ [ "DEFAULT", "pulse", 1 ], [ "BURST", "2s sequence", 2 ] ],
     "ranged_damage": { "damage_type": "afs_laser", "amount": 25, "armor_penetration": 4 },
@@ -363,7 +367,7 @@
     "ammo_to_fire": 0,
     "energy_drain": "30 kJ",
     "ammo_effects": [ "LASER", "ROBOT_DAZZLE" ],
-    "flags": [ "NEVER_JAMS", "NON_FOULING", "NEEDS_NO_LUBE", "FRAGILE" ],
+    "flags": [ "NEVER_JAMS", "NON_FOULING", "NEEDS_NO_LUBE", "FRAGILE", "NO_TURRET" ],
     "pocket_data": [
       {
         "pocket_type": "MAGAZINE_WELL",
@@ -385,7 +389,8 @@
     "price_postapoc": "1500 USD",
     "ammo": [ "battery" ],
     "ammo_to_fire": 0,
-    "delete": { "flags": [ "NO_UNLOAD", "NO_RELOAD" ] },
+    "extend": { "flags": [ "NO_TURRET" ] },
+    "delete": { "flags": [ "NO_UNLOAD", "NO_RELOAD", "USE_UPS" ] },
     "energy_drain": "75 kJ",
     "pocket_data": [
       {


### PR DESCRIPTION
#### Summary
Mods "Aftershock: Lasers can only use power cartridges, cant be mounted in vehicle."

#### Purpose of change
Lasers arent inteded to use direct vehicle power, because their stats are too good to be balanced that way and they trivialize everything. This is the reason for why they use power cartridge magazines and not straight grid/ups power.

Making them unable to draw grid power fealt clunky code wise, so they just cant be mounted now.
#### Describe the solution
Add flags that control such behavior

#### Describe alternatives you've considered
Make lasers use MJ worth of energy every shot, and get rid of the abstracted difference in charge values.  but I personally find such big numbers unseeming and hard to track in the UI. (ALSO I think the base unit of power is milijoules so we start getting dangerously close to int max)


#### Testing
Loads.

#### Additional context
I'll add some vehicle lasers drawing power at the 10Mj range in the future.