### PR TITLE
Aftershock: Update cryosuit armor values

### DIFF
--- a/data/mods/aftershock_exoplanet/items/armor/winter_suits.json
+++ b/data/mods/aftershock_exoplanet/items/armor/winter_suits.json
@@ -9,7 +9,6 @@
     "weight": "7800 g",
     "volume": "14 L",
     "price": "4 kUSD",
-    "material": [ "nomex", "titanium" ],
     "symbol": "[",
     "looks_like": "robofac_enviro_suit",
     "color": "light_gray",
@@ -29,8 +28,8 @@
       { "covers": [ "hand_l", "hand_r" ], "coverage": 100, "encumbrance": 10 },
       {
         "material": [
-          { "type": "nylon", "covered_by_mat": 100, "thickness": 1.0 },
-          { "type": "nanoprinted_alloy", "covered_by_mat": 100, "thickness": 1.0 }
+          { "type": "plastic", "covered_by_mat": 100, "thickness": 1.0 },
+          { "type": "titanium", "covered_by_mat": 100, "thickness": 1.0 }
         ],
         "encumbrance": 6,
         "coverage": 100,
@@ -112,7 +111,7 @@
       {
         "material": [
           { "type": "nylon", "covered_by_mat": 100, "thickness": 1.0 },
-          { "type": "nanoprinted_alloy", "covered_by_mat": 100, "thickness": 1.0 }
+          { "type": "cotton", "covered_by_mat": 100, "thickness": 1.0 }
         ],
         "encumbrance": 6,
         "coverage": 100,
@@ -130,7 +129,7 @@
       }
     ],
     "warmth": 20,
-    "material_thickness": 2,
+    "material_thickness": 3,
     "valid_mods": [ "steel_padded" ],
     "environmental_protection": 2,
     "flags": [ "VARSIZE", "WATERPROOF", "POCKETS", "RAINPROOF", "STURDY", "OUTER" ],
@@ -284,7 +283,7 @@
     "description": "A dark orange bodyglove, hundreds of tubes curl over its surface, tracing the contours of human musculature.  Meant to control body temperature during prolonged cryopreservation, it could easily keep you comfortable in any earthly climate.  Use it to activate its climate control functionality.",
     "price": "15 kUSD",
     "price_postapoc": "1 kUSD 500 USD",
-    "material": [ "graphene_weave" ],
+    "material": [ "nylon", "cotton" ],
     "weight": "1250 g",
     "volume": "4500 ml",
     "charges_per_use": 5,


### PR DESCRIPTION
#### Summary
Mods "Aftershock: Update cryosuit armor values to be lower than light-armor"

#### Purpose of change
Cryosuits arent meant to function as armor, and they should have defensive values that only slightly mitigate the damage dies of the weakest meleee attacks.

#### Describe the solution
Tweak materials. Magellan suits remain slightly more protective than the rest.

#### Testing
Viewed the new values ingame.
