### PR TITLE
Finalize requirement data for fault fixes

### DIFF
--- a/src/fault.cpp
+++ b/src/fault.cpp
@@ -326,6 +326,7 @@ void fault_fix::finalize()
     for( const fault_id &fid : faults_removed ) {
         const_cast<fault &>( *fid ).fixes.emplace( id );
     }
+    requirements->finalize();
 }
 
 void fault_fix::check() const


### PR DESCRIPTION
#### Summary
Bugfixes "Fix fault fix requirements requesting undefined-boiling_water_heat"

#### Purpose of change
Fixes https://github.com/CleverRaven/Cataclysm-DDA/issues/80702

#### Describe the solution
Requirements require being finalized to convert all the requirement ids into nested groups of item ids. Fault fixes did not do this, and so would treat requirement ids such as 'boiling_water_heat' as item ids.

#### Testing
Follow reproduction steps in the issue.
<img width="649" height="383" alt="image of the fault fix menu, showing the requirements for boiling_water_heat are populated. A coffeemaker (250 charges) is the only available option, but several more heating devices are listed." src="https://github.com/user-attachments/assets/6414c2b4-40c9-4fa6-aa46-42308b9d43aa" />
