### PR TITLE
fix set_random_fault_of_type() ignoring fault type

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -7852,7 +7852,7 @@ void item::set_random_fault_of_type( const std::string &fault_type, bool force, 
 
     weighted_int_list<fault_id> faults_by_type;
     for( const weighted_object<int, fault_id> &f : type->faults ) {
-        if( can_have_fault( f.obj ) ) {
+        if( f.obj.obj().type() == fault_type && can_have_fault( f.obj ) ) {
             faults_by_type.add( f.obj, f.weight );
         }
 


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Fix #81208
Young gdll was an idiot, and made set_random_fault_of_type() function that did not actually checked the fault it tries to apply is of type or not
#### Describe the solution
Actually check if the fault applied is of type
#### Testing
I made a debug stanag magazine for 5000 rounds, damaged the gun, i shoot 800 rounds, i got three billion jams, i got no blackpowder fault applied