### PR TITLE
Modernity?! In my Cataclysm?! (Professions: Books in smartphones, smartwatches)

### DIFF
--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -4389,15 +4389,10 @@
           { "item": "mbag" },
           { "item": "mag_animecon" },
           { "item": "cheeseburger" },
-          { "group": "charged_smart_phone", "contents-item": "mag_comic" },
+          { "group": "charged_smart_watch_adv", "contents-item": "mag_comic" },
+          { "group": "charged_smart_phone", "contents-item": "novel_fantasy" },
           { "group": "starter_wallet_full" },
-          { "item": "eink_tablet_pc", "charges": 150, "contents-item": "novel_fantasy" },
-          {
-            "item": "light_minus_battery_cell",
-            "ammo-item": "battery",
-            "charges": 50,
-            "container-item": "game_watch"
-          }
+          { "item": "eink_tablet_pc", "charges": 150, "contents-item": "tailor_japanese" }
         ]
       },
       "male": { "entries": [ { "item": "briefs" } ] },

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -3019,7 +3019,7 @@
           { "item": "badge_deputy" },
           { "item": "wristwatch" },
           { "item": "tacvest" },
-          { "group": "charged_two_way_radio", "contents-item": "novel_crime_midnight" },
+          { "group": "charged_two_way_radio" },
           { "group": "starter_wallet_full" },
           { "item": "glasses_bal", "custom-flags": [ "no_auto_equip" ] },
           { "group": "charged_powered_earmuffs" },

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -143,6 +143,18 @@
   {
     "type": "item_group",
     "subtype": "collection",
+    "id": "charged_smart_watch",
+    "entries": [ { "item": "smart_watch", "ammo-item": "battery", "charges": 20 } ]
+  },
+  {
+    "type": "item_group",
+    "subtype": "collection",
+    "id": "charged_smart_watch_adv",
+    "entries": [ { "item": "smart_watch_adv", "ammo-item": "battery", "charges": 30 } ]
+  },
+  {
+    "type": "item_group",
+    "subtype": "collection",
     "id": "charged_flashlight",
     "entries": [ { "item": "flashlight", "charges": 300 } ]
   },
@@ -720,7 +732,7 @@
           { "item": "pockknife" },
           { "item": "water_clean" },
           { "item": "wristwatch" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "guidebook" },
           { "group": "starter_wallet_full" },
           { "group": "charged_matches" }
         ]
@@ -748,10 +760,10 @@
           { "item": "pockknife" },
           { "item": "water_clean" },
           { "item": "wearable_camera" },
-          { "item": "wristwatch" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_watch_adv" },
+          { "group": "charged_smart_phone", "contents-item": "mag_tv" },
           { "group": "starter_wallet_full" },
-          { "group": "charged_laptop" },
+          { "group": "charged_laptop", "contents-item": "textbook_speech" },
           { "group": "charged_matches" }
         ]
       },
@@ -870,7 +882,7 @@
           { "item": "textbook_tailor" },
           { "item": "sf_watch" },
           { "item": "hairpin" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "mag_tailor" },
           { "group": "starter_wallet_full" },
           { "item": "tailors_kit", "ammo-item": "thread", "charges": 100 },
           { "item": "pants", "variant": "pants_black" }
@@ -903,7 +915,7 @@
         "entries": [
           { "item": "socks" },
           { "item": "dress_shoes" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "family_cookbook" },
           { "item": "knife_huge", "variant": "knife_butcher", "container-item": "sheath" },
           { "item": "hat_chef", "variant": "white_hat_chef" },
           { "item": "jacket_chef", "variant": "white_jacket_chef" },
@@ -941,7 +953,7 @@
         "entries": [
           { "item": "socks" },
           { "item": "sneakers" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "mag_cooking" },
           { "group": "starter_wallet_full" },
           { "item": "knife_huge", "variant": "knife_butcher", "container-item": "sheath" },
           { "item": "hat_chef", "variant": "white_hat_chef" },
@@ -1012,9 +1024,9 @@
           { "item": "coat_lab" },
           { "item": "gloves_rubber" },
           { "item": "glasses_safety" },
-          { "item": "wristwatch" },
+          { "group": "charged_smart_watch_adv" },
           { "item": "pants", "variant": "pants_gray" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "textbook_chemistry" },
           { "group": "starter_wallet_full" }
         ]
       },
@@ -1040,7 +1052,11 @@
     "items": {
       "both": {
         "items": [ "dress_shirt", "socks", "boots", "coat_lab", "gloves_rubber", "glasses_safety", "wristwatch" ],
-        "entries": [ { "group": "charged_smart_phone" }, { "group": "starter_wallet_full" }, { "item": "pants", "variant": "pants_gray" } ]
+        "entries": [
+          { "group": "charged_smart_phone", "contents-item": "adv_chemistry" },
+          { "group": "starter_wallet_full" },
+          { "item": "pants", "variant": "pants_gray" }
+        ]
       },
       "male": [ "briefs" ],
       "female": [ "bra", "panties" ]
@@ -1068,7 +1084,7 @@
           { "item": "wristwatch" },
           { "item": "mag_cars" },
           { "item": "goggles_welding", "custom-flags": [ "no_auto_equip" ] },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "manual_mechanics" },
           { "group": "starter_wallet_full" },
           { "item": "wrench", "container-item": "tool_belt" }
         ]
@@ -1089,7 +1105,7 @@
     "items": {
       "both": {
         "items": [ "dress_shirt", "jeans", "socks", "boots_steel", "wristwatch" ],
-        "entries": [ { "group": "charged_smart_phone" }, { "group": "starter_wallet_full" } ]
+        "entries": [ { "group": "charged_smart_phone", "contents-item": "textbook_mechanics" }, { "group": "starter_wallet_full" } ]
       },
       "male": [ "boxer_shorts" ],
       "female": [ "bra", "boy_shorts" ]
@@ -1124,7 +1140,7 @@
           { "item": "switchblade" },
           { "item": "wristwatch" },
           { "item": "picklocks" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "mag_porn" },
           { "group": "starter_wallet_full" },
           { "item": "lighter", "charges": 100 }
         ]
@@ -1188,7 +1204,7 @@
           { "item": "helmet_ball" },
           { "item": "sports_drink" },
           { "item": "gum" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "book_fict_soft_sports_bunt" },
           { "group": "starter_wallet_full" },
           { "item": "bat", "custom-flags": [ "auto_wield" ] },
           { "item": "tshirt", "variant": "generic_tshirt" }
@@ -1219,7 +1235,7 @@
           { "item": "sports_drink" },
           { "item": "runner_bag" },
           { "item": "jersey", "variant": "sportsteam" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "book_nonf_hard_sports_hoop" },
           { "group": "starter_wallet_full" }
         ]
       },
@@ -1255,7 +1271,7 @@
           { "item": "knee_pads" },
           { "item": "sports_drink" },
           { "item": "jersey", "variant": "sportsteam" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "book_fict_soft_sports_tdsp" },
           { "group": "starter_wallet_full" },
           { "item": "pants", "variant": "pants_blue" }
         ]
@@ -1321,10 +1337,10 @@
           { "item": "socks_ankle" },
           { "item": "sneakers" },
           { "item": "sports_drink" },
-          { "item": "wristwatch" },
+          { "item": "fitness_band" },
           { "item": "fanny" },
           { "item": "sunglasses" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "book_nonf_hard_sports_bike" },
           { "group": "starter_wallet_full" }
         ]
       },
@@ -2071,7 +2087,7 @@
         "entries": [
           { "item": "pocketwatch" },
           { "item": "knife_small", "variant": "knife_steak" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "book_nonf_hard_homemk_handshome" },
           { "group": "starter_wallet_full" }
         ]
       },
@@ -2141,7 +2157,7 @@
           { "item": "vest" },
           { "item": "wristwatch" },
           { "item": "bracelet_friendship" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "novel_buddy" },
           { "group": "starter_wallet_full" },
           { "item": "knife_combat", "container-item": "sheath" },
           { "group": "modular_m4a1", "ammo-item": "556", "charges": 30, "contents-item": "shoulder_strap" },
@@ -2191,7 +2207,7 @@
           { "group": "charged_aspirin" },
           { "item": "stethoscope" },
           { "item": "pants", "variant": "pants_blue" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "textbook_firstaid" },
           { "group": "starter_wallet_full" },
           { "group": "full_1st_aid" }
         ]
@@ -2241,7 +2257,7 @@
         ],
         "entries": [
           { "item": "pants", "variant": "pants_blue" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "reference_firstaid1" },
           { "group": "starter_rich_wallet_full" },
           { "group": "full_1st_aid" }
         ]
@@ -2319,7 +2335,7 @@
         ],
         "entries": [
           { "item": "pants", "variant": "pants_blue" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "reference_firstaid1" },
           { "group": "starter_wallet_full" },
           { "group": "full_1st_aid" }
         ]
@@ -2362,7 +2378,7 @@
           { "item": "cestus" },
           { "item": "gold_watch" },
           { "item": "gold_ring" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "novel_crime2" },
           { "group": "starter_wallet_full" },
           { "item": "glock_19", "ammo-item": "9mm", "container-item": "holster", "charges": 15 },
           { "item": "glockmag", "ammo-item": "9mm", "charges": 15 },
@@ -2398,7 +2414,7 @@
           { "item": "hat_ball" },
           { "item": "wristwatch" },
           { "item": "leather_belt" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "novel_spy" },
           { "group": "starter_wallet_full" },
           { "group": "charged_flashlight" },
           { "item": "pants", "variant": "pants_black" },
@@ -2473,7 +2489,7 @@
           { "item": "stethoscope" },
           { "item": "pudding" },
           { "item": "pants", "variant": "pants_white" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "textbook_firstaid" },
           { "group": "starter_wallet_full" },
           { "item": "mask_dust", "variant": "white_mask_dust" }
         ]
@@ -2581,9 +2597,9 @@
           { "item": "socks" },
           { "item": "polo_shirt" },
           { "item": "boots" },
-          { "item": "wristwatch" },
+          { "group": "charged_smart_watch" },
           { "item": "sunglasses" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "novel_spy_comefly" },
           { "group": "starter_wallet_full" },
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] }
         ]
@@ -2624,7 +2640,7 @@
           { "item": "wristwatch" },
           { "item": "dogfood_dry", "count": 2, "container-item": "null", "entry-wrapper": "bag_plastic" },
           { "item": "baton" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "novel_crime_midnight" },
           { "group": "charged_two_way_radio" },
           { "group": "starter_wallet_full" },
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
@@ -2671,7 +2687,7 @@
           { "item": "knee_pads" },
           { "item": "elbow_pads" },
           { "item": "baton" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "novel_crime_midnight" },
           { "group": "charged_two_way_radio" },
           { "group": "starter_wallet_full" },
           { "group": "holster_supp_usp9", "container-item": "XL_holster" },
@@ -2751,7 +2767,7 @@
           { "item": "water_clean" },
           { "item": "wristwatch" },
           { "item": "mbag" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "book_fict_soft_satire_cats" },
           { "group": "starter_wallet_full" },
           { "group": "charged_matches" },
           { "item": "catfood_dry", "count": 10, "container-item": "null", "entry-wrapper": "bag_plastic" }
@@ -2790,7 +2806,7 @@
           { "item": "whistle" },
           { "item": "wristwatch" },
           { "item": "baton" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "novel_crime_midnight" },
           { "group": "starter_wallet_full" },
           { "group": "charged_two_way_radio" },
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
@@ -2829,7 +2845,7 @@
           { "item": "socks" },
           { "item": "dress_shoes" },
           { "group": "charged_cigs" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "novel_mystery" },
           { "group": "starter_wallet_full" },
           { "group": "charged_two_way_radio" },
           { "group": "charged_ref_lighter" },
@@ -3003,7 +3019,7 @@
           { "item": "badge_deputy" },
           { "item": "wristwatch" },
           { "item": "tacvest" },
-          { "group": "charged_two_way_radio" },
+          { "group": "charged_two_way_radio", "contents-item": "novel_crime_midnight" },
           { "group": "starter_wallet_full" },
           { "item": "glasses_bal", "custom-flags": [ "no_auto_equip" ] },
           { "group": "charged_powered_earmuffs" },
@@ -3097,7 +3113,7 @@
           { "item": "wristwatch" },
           { "item": "baton" },
           { "item": "leather_police_jacket", "variant": "leather_police_jacket" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "novel_crime_midnight" },
           { "group": "starter_wallet_full" },
           { "group": "charged_two_way_radio" },
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
@@ -3128,7 +3144,7 @@
           { "item": "dress_shoes" },
           { "item": "gold_watch" },
           { "item": "money_strap_fifty" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "manual_business" },
           { "group": "starter_rich_wallet_full" }
         ]
       },
@@ -3155,9 +3171,9 @@
           { "item": "jacket_leather" },
           { "item": "sunglasses" },
           { "item": "hat_boonie" },
-          { "item": "diving_watch" },
+          { "group": "charged_smart_watch_adv" },
           { "item": "caff_gum" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "book_archery" },
           { "group": "starter_wallet_full" },
           { "item": "rashguard", "variant": "black_rashguard_shirt" },
           { "item": "takedown_recurbow", "custom-flags": [ "no_auto_equip" ] },
@@ -3203,7 +3219,7 @@
           { "item": "bow_sight_pin" },
           { "item": "hat_hunting" },
           { "item": "wristwatch" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "manual_archery" },
           { "group": "starter_wallet_full" },
           { "item": "compbow_low", "custom-flags": [ "no_auto_equip" ] },
           { "item": "quiver", "contents-group": "quiver_bow_hunter" },
@@ -3248,7 +3264,7 @@
           { "item": "jacket_flannel" },
           { "item": "hat_hunting" },
           { "item": "wristwatch" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "book_archery" },
           { "group": "starter_wallet_full" },
           {
             "item": "compcrossbow",
@@ -3295,7 +3311,7 @@
           { "item": "hat_hunting" },
           { "item": "wristwatch" },
           { "item": "back_holster" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "manual_shotgun" },
           { "group": "starter_wallet_full" },
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
           {
@@ -3342,7 +3358,7 @@
           { "item": "hat_hunting" },
           { "item": "wristwatch" },
           { "item": "back_holster" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "manual_rifle" },
           { "group": "starter_wallet_full" },
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
           {
@@ -3390,7 +3406,7 @@
           { "item": "hat_hunting" },
           { "item": "wristwatch" },
           { "item": "back_holster" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "manual_rifle" },
           { "group": "starter_wallet_full" },
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
           {
@@ -3468,7 +3484,7 @@
           { "item": "boots_steel" },
           { "item": "multitool" },
           { "item": "wristwatch" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "carpentry_book" },
           { "group": "starter_wallet_full" },
           { "item": "nailgun", "ammo-item": "nail", "charges": 20 },
           { "item": "nail", "charges": 180 },
@@ -3500,7 +3516,7 @@
           { "item": "wristwatch" },
           { "item": "gloves_work" },
           { "item": "hat_ball" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "novel_road" },
           { "group": "starter_wallet_full" },
           { "item": "pants", "variant": "pants_gray" },
           { "item": "tank_top", "variant": "tank_top_generic" }
@@ -3527,9 +3543,9 @@
           { "item": "socks" },
           { "item": "jeans" },
           { "item": "longshirt" },
-          { "item": "wristwatch" },
+          { "group": "charged_smart_watch" },
           { "item": "water_clean" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "novel_road" },
           { "group": "starter_wallet_full" }
         ]
       },
@@ -3582,7 +3598,7 @@
           { "item": "morphine" },
           { "item": "adrenaline_injector" },
           { "group": "full_1st_aid" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "textbook_firstaid" },
           { "group": "starter_wallet_full" },
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
           { "item": "halligan", "container-item": "fireman_belt" }
@@ -3612,13 +3628,13 @@
           { "item": "socks" },
           { "item": "boots" },
           { "item": "multitool" },
-          { "item": "wristwatch" },
+          { "group": "charged_smart_watch" },
           { "item": "mbag" },
           { "item": "water_clean" },
           { "item": "gloves_work" },
           { "item": "hammer" },
           { "item": "hat_ball" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "carpentry_book" },
           { "group": "starter_wallet_full" },
           { "group": "charged_electrical_measuring" },
           { "item": "pants", "variant": "pants_black" }
@@ -3689,7 +3705,7 @@
           { "item": "kevlar" },
           { "item": "baton" },
           { "item": "wristwatch" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "novel_crime_midnight" },
           { "group": "starter_wallet_full" },
           { "group": "charged_two_way_radio" },
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
@@ -3788,7 +3804,7 @@
           { "item": "vest" },
           { "item": "water_clean" },
           { "item": "whistle_multitool" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "survival_book" },
           { "group": "starter_wallet_full" },
           { "group": "charged_flashlight" },
           { "group": "charged_two_way_radio" },
@@ -3861,7 +3877,7 @@
           { "item": "sneakers" },
           { "item": "socks" },
           { "item": "knife_small", "variant": "knife_steak" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "book_fict_soft_ya_pbbr" },
           { "group": "starter_wallet_full" },
           { "item": "tshirt", "variant": "generic_tshirt" },
           { "item": "pants", "variant": "pants_black" }
@@ -3888,10 +3904,10 @@
           { "item": "socks" },
           { "item": "boots" },
           { "item": "tool_belt" },
-          { "item": "wristwatch" },
+          { "group": "charged_smart_watch" },
           { "item": "mbag" },
           { "item": "solder_wire" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "manual_electronics" },
           { "group": "starter_wallet_full" },
           { "group": "charged_flashlight" },
           { "group": "charged_soldering_iron" },
@@ -3919,9 +3935,10 @@
     "skills": [ { "level": 5, "name": "electronics" } ],
     "items": {
       "both": {
-        "items": [ "dress_shirt", "socks", "dress_shoes", "wristwatch", "file" ],
+        "items": [ "dress_shirt", "socks", "dress_shoes", "file" ],
         "entries": [
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_watch" },
+          { "group": "charged_smart_phone", "contents-item": "textbook_electronics" },
           { "group": "starter_wallet_full" },
           { "item": "pants", "variant": "pants_black" }
         ]
@@ -3947,13 +3964,14 @@
           { "item": "mbag" },
           { "item": "caffeine", "count": 10, "container-item": "null", "entry-wrapper": "bottle_plastic_small" },
           { "item": "caff_gum", "count": 3 },
-          { "item": "memory_card" },
-          { "item": "usb_drive" },
+          { "item": "memory_card", "contents-item": "textbook_computer" },
+          { "item": "usb_drive", "contents-item": "SICP" },
           { "item": "portable_game", "charges": 150 },
           { "item": "pants", "variant": "pants_gray" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_watch_adv", "contents-item": "efile_map" },
+          { "group": "charged_smart_phone", "contents-item": "hackerman_computer" },
           { "group": "starter_wallet_full" },
-          { "group": "charged_laptop" }
+          { "group": "charged_laptop", "contents-item": "software_hacking" }
         ]
       },
       "male": { "entries": [ { "item": "briefs" } ] },
@@ -3978,7 +3996,7 @@
           { "item": "socks" },
           { "item": "wristwatch" },
           { "item": "fun_survival" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "novel_road" },
           { "group": "starter_wallet_full" },
           { "item": "tshirt", "variant": "generic_tshirt" }
         ]
@@ -4006,7 +4024,7 @@
           { "item": "textbook_speech" },
           { "item": "story_book" },
           { "item": "howto_computer" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "mag_news" },
           { "group": "starter_wallet_full" },
           { "item": "tshirt", "variant": "generic_tshirt" },
           { "item": "jeans" }
@@ -4049,7 +4067,7 @@
           { "item": "leather_police_jacket" },
           { "item": "wristwatch" },
           { "item": "multitool" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "book_nonf_hard_sports_bike" },
           { "group": "starter_wallet_full" },
           { "item": "sheath", "contents-item": "knife_trench" },
           { "item": "leg_bag", "variant": "black_leg_bag" }
@@ -4073,7 +4091,7 @@
           { "item": "socks" },
           { "item": "knit_scarf" },
           { "item": "dance_shoes" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "book_nonf_hard_dodge_tlwd" },
           { "group": "starter_wallet_full" }
         ]
       },
@@ -4203,7 +4221,7 @@
           { "item": "wristwatch" },
           { "group": "rolling_cigs" },
           { "item": "backpack" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "textbook_traps" },
           { "group": "starter_wallet_full" },
           { "group": "charged_matches" },
           { "item": "knife_hunting", "container-item": "sheath" }
@@ -4233,7 +4251,7 @@
           { "item": "fire_gauntlets" },
           { "item": "wristwatch" },
           { "item": "hammer" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "reference_fabrication1" },
           { "group": "starter_wallet_full" }
         ]
       },
@@ -4260,7 +4278,7 @@
           { "item": "wristwatch" },
           { "item": "apron_leather" },
           { "item": "chisel" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "jewelry_book" },
           { "group": "starter_wallet_full" }
         ]
       },
@@ -4371,9 +4389,9 @@
           { "item": "mbag" },
           { "item": "mag_animecon" },
           { "item": "cheeseburger" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "mag_comic" },
           { "group": "starter_wallet_full" },
-          { "item": "eink_tablet_pc", "charges": 150 },
+          { "item": "eink_tablet_pc", "charges": 150, "contents-item": "novel_fantasy" },
           {
             "item": "light_minus_battery_cell",
             "ammo-item": "battery",
@@ -4395,7 +4413,13 @@
     "npc_background": "BG_survival_story_EVACUEE",
     "points": -1,
     "items": {
-      "both": { "entries": [ { "item": "ring_wedding" }, { "group": "charged_smart_phone" }, { "group": "starter_wallet_full" } ] },
+      "both": {
+        "entries": [
+          { "item": "ring_wedding" },
+          { "group": "charged_smart_phone", "contents-item": "book_nonf_soft_wedding_coolring" },
+          { "group": "starter_wallet_full" }
+        ]
+      },
       "male": {
         "entries": [
           { "item": "tux" },
@@ -4442,7 +4466,7 @@
           { "group": "weed_pack" },
           { "group": "rolling_cigs" },
           { "item": "wristwatch" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "novel_coa" },
           { "group": "starter_wallet_full" },
           { "group": "charged_mp3" },
           { "group": "charged_ref_lighter" },
@@ -4515,7 +4539,7 @@
           { "item": "dress_shoes" },
           { "group": "rolling_cigs" },
           { "item": "wristwatch" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "novel_coa" },
           { "group": "starter_wallet_full" },
           { "group": "charged_mp3" },
           { "group": "charged_ref_lighter" }
@@ -4777,7 +4801,7 @@
           { "item": "briefcase" },
           { "item": "money_strap_fifty" },
           { "item": "file", "count": [ 1, 4 ] },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "book_nonf_soft_speech_naillaw" },
           { "group": "starter_rich_wallet_full" }
         ]
       },
@@ -4799,7 +4823,7 @@
           { "item": "socks" },
           { "item": "dress_shoes" },
           { "item": "holybook_bible1" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "holybook_catechism2" },
           { "group": "starter_wallet_full" },
           { "item": "holy_symbol", "variant": "cross_necklace" }
         ]
@@ -4824,7 +4848,7 @@
           { "item": "socks" },
           { "item": "dress_shoes" },
           { "item": "holybook_bible4" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "holybook_catechism1" },
           { "group": "starter_wallet_full" },
           { "item": "holy_symbol", "variant": "cross_necklace" }
         ]
@@ -4868,7 +4892,7 @@
           { "item": "tabi_dress" },
           { "item": "geta" },
           { "item": "holybook_kojiki" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "holybook_nihon" },
           { "group": "starter_wallet_full" },
           { "item": "holy_symbol", "variant": "shinto_necklace" },
           { "item": "pants", "variant": "pants_white" }
@@ -4894,7 +4918,7 @@
           { "item": "samghati" },
           { "item": "flip_flops" },
           { "item": "holybook_sutras" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "holybook_navayana" },
           { "group": "starter_wallet_full" },
           { "item": "holy_symbol", "variant": "buddhist_necklace" }
         ]
@@ -4918,7 +4942,7 @@
           { "item": "socks" },
           { "item": "lowtops" },
           { "item": "holybook_quran" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "holybook_hadith" },
           { "group": "starter_wallet_full" },
           { "item": "tshirt", "variant": "generic_tshirt" },
           { "item": "holy_symbol", "variant": "muslim_necklace" },
@@ -4948,7 +4972,7 @@
           { "item": "tallit_gadol" },
           { "item": "dress_shoes" },
           { "item": "holybook_talmud" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "holybook_siddur" },
           { "group": "starter_wallet_full" },
           { "item": "holy_symbol", "variant": "jewish_necklace" },
           { "item": "pants", "variant": "pants_black" }
@@ -4979,7 +5003,7 @@
           { "item": "leathersandals" },
           { "item": "holy_symbol" },
           { "item": "wristwatch" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "holybook_gita" },
           { "group": "starter_wallet_full" },
           { "item": "tshirt", "variant": "generic_tshirt" }
         ]
@@ -5008,9 +5032,9 @@
           { "item": "flyer" },
           { "item": "flyer" },
           { "item": "holy_symbol" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "holybook_confession" },
           { "group": "starter_wallet_full" },
-          { "group": "charged_laptop" },
+          { "group": "charged_laptop", "contents-item": "holybook_catechism" },
           { "item": "holy_symbol", "variant": "cross_necklace" },
           { "item": "pants", "variant": "pants_black" }
         ]
@@ -5144,7 +5168,7 @@
           { "item": "money_strap_one" },
           { "item": "wristwatch" },
           { "item": "mbag" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "novel_coa" },
           { "group": "starter_wallet_full" },
           { "item": "tshirt", "variant": "generic_tshirt" }
         ]
@@ -5181,7 +5205,7 @@
           { "item": "fedora" },
           { "item": "wristwatch" },
           { "item": "spiral_stone" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "novel_adventure" },
           { "group": "starter_wallet_full" },
           { "group": "speedloaders_s&w619_special" },
           { "item": "sw_619", "ammo-item": "38_special", "charges": 7, "container-item": "holster" },
@@ -5216,7 +5240,7 @@
           { "item": "wristwatch" },
           { "item": "newest_newspaper", "count": [ 5, 10 ] },
           { "item": "folded_bicycle" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "novel_coa" },
           { "group": "starter_wallet_full" },
           { "item": "pants", "variant": "pants_blue" }
         ]
@@ -5432,7 +5456,7 @@
           { "item": "pockknife" },
           { "item": "wristwatch" },
           { "item": "leather_belt" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "novel_spy" },
           { "group": "starter_wallet_full" },
           { "group": "charged_flashlight" },
           { "group": "charged_tazer" },
@@ -5589,7 +5613,7 @@
           { "item": "flintlock_ammo", "charges": 15 },
           { "item": "vinegar", "container-item": "bottle_plastic_small" },
           { "item": "lamp_oil", "container-item": "bottle_plastic_small" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "tall_tales" },
           { "group": "starter_wallet_full" },
           { "group": "charged_matches" }
         ]
@@ -5632,7 +5656,7 @@
           { "item": "salt", "count": 100, "container-item": "null", "entry-wrapper": "bag_plastic" },
           { "item": "needle_wood", "ammo-item": "thread", "charges": 200 },
           { "item": "oil_lamp", "charges": 750 },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "book_nonf_hard_homemk_handshome" },
           { "group": "starter_wallet_full" },
           { "group": "charged_matches" }
         ]
@@ -5661,7 +5685,7 @@
           { "item": "roller_blades" },
           { "item": "wristwatch" },
           { "item": "sports_drink" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "book_fict_soft_ya_rwya" },
           { "group": "starter_wallet_full" }
         ]
       },
@@ -5694,7 +5718,7 @@
           { "item": "folded_skateboard_generic" },
           { "item": "wristwatch" },
           { "item": "sports_drink" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "book_fict_soft_ya_rwya" },
           { "group": "starter_wallet_full" }
         ]
       },
@@ -5734,7 +5758,7 @@
           { "item": "marble" },
           { "item": "marble" },
           { "item": "slingshot" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "mag_melee" },
           { "group": "starter_wallet_full" },
           { "group": "charged_matches" }
         ]
@@ -5773,7 +5797,7 @@
           { "item": "water_clean" },
           { "item": "scissors" },
           { "item": "magnifying_glass" },
-          { "item": "wristwatch" },
+          { "group": "charged_smart_watch_adv", "contents-item": "atomic_survival" },
           { "item": "whistle" },
           { "group": "charged_cell_phone" },
           { "group": "starter_wallet_full" },
@@ -5806,7 +5830,7 @@
           { "item": "lowtops" },
           { "item": "slingpack" },
           { "item": "juice" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "manual_dodge" },
           { "group": "starter_wallet_full" },
           { "item": "tshirt", "variant": "generic_tshirt" }
         ]
@@ -5836,7 +5860,7 @@
           { "item": "backpack" },
           { "item": "basic_chemistry" },
           { "item": "wristwatch" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "basic_chemistry" },
           { "group": "starter_wallet_full" },
           { "item": "tshirt", "variant": "generic_tshirt" }
         ]
@@ -5867,7 +5891,7 @@
           { "item": "backpack" },
           { "item": "mag_electronics" },
           { "item": "wristwatch" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "mag_gaming" },
           { "group": "starter_wallet_full" }
         ]
       },
@@ -5896,7 +5920,7 @@
           { "item": "tieclip" },
           { "item": "poetry_book" },
           { "item": "wristwatch" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "book_nonf_hard_psych_grconres" },
           { "group": "starter_wallet_full" },
           { "item": "permanent_marker", "charges": 500 },
           { "item": "pants", "variant": "pants_black" }
@@ -5923,7 +5947,7 @@
           { "item": "dress_shoes" },
           { "item": "wristwatch" },
           { "item": "camera_bag" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "book_nonf_hard_homemk_nyparti" },
           { "group": "starter_wallet_full" },
           { "item": "camera_pro", "charges": 300 },
           { "item": "pants", "variant": "pants_black" }
@@ -5957,8 +5981,8 @@
           { "item": "socks_ankle" },
           { "item": "sneakers" },
           { "item": "runner_bag" },
-          { "item": "wristwatch" },
-          { "group": "charged_smart_phone" },
+          { "item": "fitness_band" },
+          { "group": "charged_smart_phone", "contents-item": "book_fict_hard_sports_uni" },
           { "group": "starter_wallet_full" },
           { "item": "tank_top", "variant": "tank_top_generic" }
         ]
@@ -6027,7 +6051,7 @@
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
           { "item": "dynamite", "count": 8 },
           { "item": "dynamite", "count": 4 },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "mag_launcher" },
           { "group": "starter_wallet_full" }
         ]
       },
@@ -6051,8 +6075,8 @@
           { "item": "socks_ankle" },
           { "item": "sneakers" },
           { "item": "runner_bag" },
-          { "item": "wristwatch" },
-          { "group": "charged_smart_phone" },
+          { "item": "fitness_band" },
+          { "group": "charged_smart_phone", "contents-item": "mag_dodge" },
           { "group": "starter_wallet_full" }
         ]
       },
@@ -6083,7 +6107,7 @@
           { "item": "roadmap" },
           { "item": "touristmap" },
           { "item": "wristwatch" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "novel_road" },
           { "group": "starter_rich_wallet_full" },
           { "item": "camera", "charges": 300 },
           { "item": "pants", "variant": "pants_black" }
@@ -6123,7 +6147,7 @@
           { "item": "bucket" },
           { "item": "shovel" },
           { "item": "wristwatch" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "mag_survival" },
           { "group": "starter_wallet_full" }
         ]
       },
@@ -6149,6 +6173,7 @@
           { "item": "tabi_dress" },
           { "item": "geta" },
           { "item": "bellywrap" },
+          { "group": "charged_smart_phone", "contents-item": "novel_samurai" },
           { "item": "bokken_inferior", "container-item": "scabbard" }
         ]
       },
@@ -6184,7 +6209,7 @@
           { "item": "fencing_epee" },
           { "item": "duffelbag" },
           { "item": "fencing_mask", "custom-flags": [ "no_auto_equip" ] },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "mag_stabbing" },
           { "group": "starter_wallet_full" }
         ]
       },
@@ -6213,7 +6238,7 @@
           { "item": "file" },
           { "item": "cigar" },
           { "group": "charged_ref_lighter" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "paperback_romance_circuses" },
           { "group": "starter_rich_wallet_full" }
         ]
       },
@@ -6250,7 +6275,7 @@
           { "item": "cattlefodder" },
           { "group": "charged_cigs" },
           { "item": "rope_30" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "novel_western" },
           { "group": "starter_wallet_full" }
         ]
       },
@@ -6284,7 +6309,7 @@
           { "item": "wristwatch" },
           { "item": "gloves_work" },
           { "item": "mbag" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "carpentry_book" },
           { "group": "starter_wallet_full" },
           { "group": "charged_matches" },
           { "group": "charged_soldering_iron" }
@@ -6321,7 +6346,7 @@
           { "item": "plectrum" },
           { "item": "joint" },
           { "item": "towel", "custom-flags": [ "no_auto_equip" ] },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "novel_tragedy" },
           { "group": "starter_wallet_full" }
         ]
       },
@@ -6383,7 +6408,7 @@
           { "item": "duster" },
           { "item": "badge_deputy" },
           { "item": "novel_western" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "book_fict_soft_west_vride" },
           { "group": "starter_wallet_full" },
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
           { "item": "whiskey", "container-item": "bottle_glass" },
@@ -6412,14 +6437,14 @@
     "items": {
       "both": {
         "entries": [
-          { "item": "gold_watch" },
+          { "group": "charged_smart_watch_adv" },
           { "item": "sunglasses" },
           { "item": "water_mineral" },
           { "item": "money_strap_twenty" },
           { "group": "charged_cigs" },
           { "item": "mag_porn" },
           { "group": "charged_ref_lighter" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "novel_coa" },
           { "group": "starter_rich_wallet_full" }
         ]
       },
@@ -6861,7 +6886,7 @@
           { "item": "lowtops" },
           { "item": "pockknife" },
           { "item": "diving_watch" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "manual_pistol" },
           { "group": "starter_wallet_full" },
           { "item": "holster", "contents-group": "holster_supp_57" },
           { "item": "suppressor" },
@@ -6946,7 +6971,7 @@
           { "group": "charged_aspirin" },
           { "item": "adrenaline_injector" },
           { "item": "adhesive_bandages", "count": 8 },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "textbook_firstaid" },
           { "group": "starter_wallet_full" },
           { "item": "pants", "variant": "pants_blue" }
         ]
@@ -6988,7 +7013,7 @@
           { "item": "syringe" },
           { "item": "morphine" },
           { "item": "adrenaline_injector" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "textbook_firstaid" },
           { "group": "starter_wallet_full" },
           { "group": "full_1st_aid" },
           { "item": "pants", "variant": "pants_blue" },
@@ -7101,7 +7126,7 @@
           { "item": "granola" },
           { "item": "granola" },
           { "item": "granola" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "textbook_firstaid" },
           { "group": "starter_wallet_full" }
         ]
       },
@@ -7129,8 +7154,8 @@
           { "item": "socks" },
           { "item": "motorbike_boots" },
           { "item": "gloves_leather" },
-          { "item": "wristwatch" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_watch_adv", "contents-item": "novel_road" },
+          { "group": "charged_smart_phone", "contents-item": "decoy_anarch" },
           { "group": "starter_wallet_full" }
         ]
       }
@@ -7164,7 +7189,7 @@
           { "item": "wristwatch" },
           { "item": "glasses_safety" },
           { "item": "scalpel" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "atomic_survival" },
           { "group": "starter_wallet_full" },
           { "item": "mask_filter", "ammo-item": "gasfilter_sm", "charges": 100 }
         ]
@@ -7271,7 +7296,7 @@
           { "item": "tool_belt" },
           { "item": "glasses_safety" },
           { "item": "camera_bag" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "book_nonf_hard_phil_mdlogic" },
           { "group": "starter_wallet_full" },
           { "group": "charged_flashlight" },
           { "item": "pants", "variant": "pants_gray" },
@@ -7399,6 +7424,7 @@
           { "item": "pom_poms" },
           { "item": "socks_ankle" },
           { "item": "sneakers" },
+          { "item": "fitness_band" },
           { "item": "tank_top", "variant": "tank_top_cheerleader" }
         ]
       },
@@ -7421,8 +7447,8 @@
         "entries": [
           { "item": "american_flag" },
           { "item": "socks" },
-          { "item": "wristwatch" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_watch" },
+          { "group": "charged_smart_phone", "contents-item": "book_fict_soft_swash_searovers" },
           { "group": "starter_wallet_full" },
           { "item": "mask_dust", "variant": "flag_mask_dust" }
         ]
@@ -7463,7 +7489,7 @@
         "entries": [
           { "item": "american_flag" },
           { "item": "slippers" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "novel_war" },
           { "group": "starter_wallet_full" },
           { "item": "mask_dust", "variant": "flag_mask_dust" },
           { "item": "chestrig", "variant": "flag_chestrig", "contents-group": "mags_ruger_arr" },
@@ -7511,7 +7537,7 @@
           { "item": "boots_western" },
           { "item": "sunglasses" },
           { "item": "rope_30" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "book_fict_soft_west_vaq" },
           { "group": "starter_wallet_full" },
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
           { "item": "sw_619", "ammo-item": "357mag_jhp", "charges": 7 },
@@ -7837,7 +7863,7 @@
           { "item": "slingpack" },
           { "item": "leather_belt" },
           { "item": "urbexmap" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "book_fict_soft_ya_rwya" },
           { "group": "starter_wallet_full" },
           { "item": "pants", "variant": "pants_black" },
           { "item": "camera_pro", "charges": 300 },
@@ -7871,7 +7897,7 @@
           { "item": "socks" },
           { "item": "tie_clipon" },
           { "item": "dress_shoes" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "book_anthology_an" },
           { "group": "starter_wallet_full" },
           { "group": "charged_penblack" },
           { "item": "pants", "variant": "pants_black" },
@@ -7917,7 +7943,7 @@
           { "item": "hat_hunting" },
           { "item": "wristwatch" },
           { "item": "back_holster" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "textbook_survival" },
           { "group": "starter_wallet_full" },
           { "item": "sheath", "contents-item": "knife_hunting" },
           { "item": "tank_top", "variant": "tank_top_camo" }
@@ -7948,7 +7974,7 @@
           { "item": "socks" },
           { "item": "sneakers" },
           { "item": "hammer" },
-          { "group": "charged_smart_phone" },
+          { "group": "charged_smart_phone", "contents-item": "novel_road" },
           { "group": "starter_wallet_full" }
         ]
       },


### PR DESCRIPTION
#### Summary
Content "Professions now start with relevant books in their smartphones/laptops and some even with smartwatches"

#### Purpose of change
I was reading the changes made in #81798 when I remembered that our professions also haven't been updated to reflect the current trend in technology, they don't use smartwatches at all, and they don't read books in their phones/computers! D; This could not continue as it is!

#### Describe the solution
Spending a lot of time searching random books that would fit with our random professions, either by relevant skill, or by them being recreational books that contain topics related to the professions (A biker with a book about bikers, or the sports professions with books with main characters of their respective sports).

#### Describe alternatives you've considered
To not like fun?

#### Testing
None yet.

#### Additional context
I should spend less time in these random PRs that get in my head by random reasons hahaha.
