### PR TITLE
simplify vpart_info::has_control_req

### DIFF
--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -1174,10 +1174,9 @@ time_duration vpart_info::get_unfolding_time() const
     return unfolding_time;
 }
 
-bool vpart_info::has_control_req() const
+bool vpart_info::has_control_req( vp_control_req control ) const
 {
-    return !control_air.proficiencies.empty() || !control_air.skills.empty() ||
-           !control_land.proficiencies.empty() || !control_land.skills.empty();
+    return !control.proficiencies.empty() || !control.skills.empty();
 }
 
 std::string vpart_variant::get_label() const

--- a/src/veh_type.h
+++ b/src/veh_type.h
@@ -314,7 +314,7 @@ class vpart_info
         time_duration get_unfolding_time() const;
 
         /** Returns whether or not the vehicle this part installed requires something to control */
-        bool has_control_req() const;
+        bool has_control_req( vp_control_req control ) const;
 
     private:
         std::set<std::string> flags;

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -6780,7 +6780,7 @@ void vehicle::refresh( const bool remove_fakes )
         if( vpi.has_flag( VPFLAG_CABLE_PORTS ) || vpi.has_flag( VPFLAG_APPLIANCE ) ) {
             cable_ports.push_back( p );
         }
-        if( vpi.has_control_req() ) {
+        if( vpi.has_control_req( vpi.control_air ) && vpi.has_control_req( vpi.control_land ) ) {
             control_req_parts.push_back( p );
         }
     }


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
I feel the check can be simplified a bit.

#### Describe the solution
As the title suggests.

#### Describe alternatives you've considered
- Just dump the whole function entirely, but it'll be too long to read
- I'm thinking of adding `terrain` type of argument that will remove the need for duplicate `can_control_*` functions. It's beyond my expertise — sadly.

#### Testing
Should work

#### Additional context
This is a result of me obsessively reading the same PR again and again just to have more understanding of the code.
