### PR TITLE
fix opened seals in fridges, add oat milk

### DIFF
--- a/data/json/itemgroups/SUS/fridges.json
+++ b/data/json/itemgroups/SUS/fridges.json
@@ -204,8 +204,8 @@
       },
       {
         "distribution": [
-          { "group": "sixpack_drinks_opened", "prob": 70 },
-          { "group": "sixpack_drinks_unopened", "prob": 15 },
+          { "group": "sixpack_bottles_random", "prob": 70 },
+          { "group": "sixpack_cans_random", "prob": 15 },
           { "group": "twoliter_bottle_random", "prob": 15 }
         ],
         "prob": 90
@@ -331,8 +331,8 @@
       { "prob": 3, "group": "stuffed_clams_box_small_1_inf" },
       {
         "distribution": [
-          { "group": "sixpack_drinks_unhealthy_opened", "prob": 70 },
-          { "group": "sixpack_drinks_unhealthy_unopened", "prob": 15 },
+          { "group": "sixpack_bottles_random_unhealthy", "prob": 70 },
+          { "group": "sixpack_cans_random_unhealthy", "prob": 15 },
           { "group": "twoliter_bottle_random", "prob": 15 }
         ],
         "prob": 70
@@ -664,8 +664,8 @@
       },
       {
         "distribution": [
-          { "group": "sixpack_drinks_opened", "prob": 70 },
-          { "group": "sixpack_drinks_unopened", "prob": 15 },
+          { "group": "sixpack_bottles_random", "prob": 70 },
+          { "group": "sixpack_cans_random", "prob": 15 },
           { "group": "twoliter_bottle_random", "prob": 15 }
         ],
         "prob": 20
@@ -723,7 +723,7 @@
     ]
   },
   {
-    "id": "sixpack_drinks_opened",
+    "id": "sixpack_bottles_random",
     "type": "item_group",
     "subtype": "distribution",
     "entries": [
@@ -776,11 +776,11 @@
         ],
         "prob": 50
       },
-      { "group": "sixpack_drinks_unhealthy_opened", "prob": 525 }
+      { "group": "sixpack_bottles_random_unhealthy", "prob": 525 }
     ]
   },
   {
-    "id": "sixpack_drinks_unhealthy_opened",
+    "id": "sixpack_bottles_random_unhealthy",
     "type": "item_group",
     "subtype": "distribution",
     "entries": [
@@ -920,7 +920,7 @@
     ]
   },
   {
-    "id": "sixpack_drinks_unopened",
+    "id": "sixpack_cans_random",
     "type": "item_group",
     "subtype": "distribution",
     "entries": [
@@ -929,11 +929,11 @@
       { "item": "cranberry_juice", "count": [ 1, 6 ], "prob": 50 },
       { "item": "juice", "count": [ 1, 6 ], "prob": 50 },
       { "item": "lemonade", "count": [ 1, 6 ], "prob": 50 },
-      { "group": "sixpack_drinks_unhealthy_unopened", "prob": 540 }
+      { "group": "sixpack_cans_random_unhealthy", "prob": 540 }
     ]
   },
   {
-    "id": "sixpack_drinks_unhealthy_unopened",
+    "id": "sixpack_cans_random_unhealthy",
     "type": "item_group",
     "subtype": "distribution",
     "entries": [

--- a/data/json/itemgroups/SUS/fridges.json
+++ b/data/json/itemgroups/SUS/fridges.json
@@ -22,8 +22,8 @@
       {
         "distribution": [
           { "item": "milk", "charges": [ 1, -1 ], "prob": 89, "container-item": "jug_plastic", "sealed": false },
-          { "item": "almond_milk", "charges": [ 1, -1 ], "prob": 3, "container-item": "jug_plastic", "sealed": false },
-          { "item": "soy_milk", "charges": [ 1, -1 ], "prob": 3, "container-item": "jug_plastic", "sealed": false },
+          { "item": "almond_milk", "charges": [ 1, -1 ], "prob": 3, "container-item": "carton_milk", "sealed": false },
+          { "item": "soy_milk", "charges": [ 1, -1 ], "prob": 3, "container-item": "carton_milk", "sealed": false },
           { "item": "milk_choc", "charges": [ 1, -1 ], "prob": 5, "container-item": "jug_plastic", "sealed": false }
         ],
         "prob": 95
@@ -378,8 +378,11 @@
       { "group": "fresh_produce", "count": [ 1, 8 ], "prob": 50 },
       {
         "distribution": [
-          { "item": "almond_milk", "charges": [ 1, -1 ], "prob": 50, "container-item": "jug_plastic", "sealed": false },
-          { "item": "soy_milk", "charges": [ 1, -1 ], "prob": 50, "container-item": "jug_plastic", "sealed": false }
+          { "item": "almond_milk", "charges": [ 1, -1 ], "prob": 50, "container-item": "carton_milk", "sealed": false },
+          { "item": "hazelnut_milk", "charges": [ 1, -1 ], "prob": 5, "sealed": false },
+          { "item": "oat_milk", "charges": [ 1, -1 ], "prob": 30, "container-item": "carton_milk", "sealed": false },
+          { "item": "soy_milk", "charges": [ 1, -1 ], "prob": 10, "container-item": "carton_milk", "sealed": false },
+          { "item": "walnut_milk", "charges": [ 1, -1 ], "prob": 5, "container-item": "carton_milk", "sealed": false }
         ],
         "prob": 95
       },
@@ -403,49 +406,49 @@
           {
             "collection": [
               { "item": "water_clean", "charges": 1, "container-item": "bottle_plastic", "prob": 50, "sealed": false },
-              { "item": "water_clean", "container-item": "bottle_plastic", "count": [ 1, 6 ], "sealed": false }
+              { "item": "water_clean", "container-item": "bottle_plastic", "count": [ 1, 6 ] }
             ],
             "prob": 90
           },
           {
             "collection": [
               { "item": "water_mineral", "container-item": "bottle_plastic", "charges": 1, "prob": 50, "sealed": false },
-              { "item": "water_mineral", "container-item": "bottle_plastic", "count": [ 1, 6 ], "sealed": false }
+              { "item": "water_mineral", "container-item": "bottle_plastic", "count": [ 1, 6 ] }
             ],
             "prob": 70
           },
           {
             "collection": [
               { "item": "oj", "container-item": "bottle_plastic", "charges": 1, "prob": 50, "sealed": false },
-              { "item": "oj", "container-item": "bottle_plastic", "count": [ 1, 6 ], "sealed": false }
+              { "item": "oj", "container-item": "bottle_plastic", "count": [ 1, 6 ] }
             ],
             "prob": 50
           },
           {
             "collection": [
               { "item": "pineapple_juice", "container-item": "bottle_plastic", "charges": 1, "prob": 50, "sealed": false },
-              { "item": "pineapple_juice", "container-item": "bottle_plastic", "count": [ 1, 6 ], "sealed": false }
+              { "item": "pineapple_juice", "container-item": "bottle_plastic", "count": [ 1, 6 ] }
             ],
             "prob": 50
           },
           {
             "collection": [
               { "item": "cranberry_juice", "container-item": "bottle_plastic", "charges": 1, "prob": 50, "sealed": false },
-              { "item": "cranberry_juice", "container-item": "bottle_plastic", "count": [ 1, 6 ], "sealed": false }
+              { "item": "cranberry_juice", "container-item": "bottle_plastic", "count": [ 1, 6 ] }
             ],
             "prob": 50
           },
           {
             "collection": [
               { "item": "juice", "container-item": "bottle_plastic", "charges": 1, "prob": 50, "sealed": false },
-              { "item": "juice", "container-item": "bottle_plastic", "count": [ 1, 6 ], "sealed": false }
+              { "item": "juice", "container-item": "bottle_plastic", "count": [ 1, 6 ] }
             ],
             "prob": 50
           },
           {
             "collection": [
               { "item": "sports_drink", "container-item": "bottle_plastic", "charges": 1, "prob": 50, "sealed": false },
-              { "item": "sports_drink", "container-item": "bottle_plastic", "count": [ 1, 6 ], "sealed": false }
+              { "item": "sports_drink", "container-item": "bottle_plastic", "count": [ 1, 6 ] }
             ],
             "prob": 30
           }
@@ -494,8 +497,8 @@
       {
         "distribution": [
           { "item": "milk", "charges": [ 1, -1 ], "prob": 94, "container-item": "jug_plastic", "sealed": false },
-          { "item": "almond_milk", "charges": [ 1, -1 ], "prob": 3, "container-item": "jug_plastic", "sealed": false },
-          { "item": "soy_milk", "charges": [ 1, -1 ], "prob": 3, "container-item": "jug_plastic", "sealed": false }
+          { "item": "almond_milk", "charges": [ 1, -1 ], "prob": 3, "container-item": "carton_milk", "sealed": false },
+          { "item": "soy_milk", "charges": [ 1, -1 ], "prob": 3, "container-item": "carton_milk", "sealed": false }
         ],
         "prob": 20
       },
@@ -727,49 +730,49 @@
       {
         "collection": [
           { "item": "water_clean", "charges": 1, "container-item": "bottle_plastic", "prob": 50, "sealed": false },
-          { "item": "water_clean", "container-item": "bottle_plastic", "count": [ 1, 6 ], "sealed": false }
+          { "item": "water_clean", "container-item": "bottle_plastic", "count": [ 1, 6 ] }
         ],
         "prob": 90
       },
       {
         "collection": [
           { "item": "water_mineral", "container-item": "bottle_plastic", "charges": 1, "prob": 50, "sealed": false },
-          { "item": "water_mineral", "container-item": "bottle_plastic", "count": [ 1, 6 ], "sealed": false }
+          { "item": "water_mineral", "container-item": "bottle_plastic", "count": [ 1, 6 ] }
         ],
         "prob": 70
       },
       {
         "collection": [
           { "item": "oj", "container-item": "bottle_plastic", "charges": 1, "prob": 50, "sealed": false },
-          { "item": "oj", "container-item": "bottle_plastic", "count": [ 1, 6 ], "sealed": false }
+          { "item": "oj", "container-item": "bottle_plastic", "count": [ 1, 6 ] }
         ],
         "prob": 50
       },
       {
         "collection": [
           { "item": "pineapple_juice", "container-item": "bottle_plastic", "charges": 1, "prob": 50, "sealed": false },
-          { "item": "pineapple_juice", "container-item": "bottle_plastic", "count": [ 1, 6 ], "sealed": false }
+          { "item": "pineapple_juice", "container-item": "bottle_plastic", "count": [ 1, 6 ] }
         ],
         "prob": 50
       },
       {
         "collection": [
           { "item": "cranberry_juice", "container-item": "bottle_plastic", "charges": 1, "prob": 50, "sealed": false },
-          { "item": "cranberry_juice", "container-item": "bottle_plastic", "count": [ 1, 6 ], "sealed": false }
+          { "item": "cranberry_juice", "container-item": "bottle_plastic", "count": [ 1, 6 ] }
         ],
         "prob": 50
       },
       {
         "collection": [
           { "item": "juice", "container-item": "bottle_plastic", "charges": 1, "prob": 50, "sealed": false },
-          { "item": "juice", "container-item": "bottle_plastic", "count": [ 1, 6 ], "sealed": false }
+          { "item": "juice", "container-item": "bottle_plastic", "count": [ 1, 6 ] }
         ],
         "prob": 50
       },
       {
         "collection": [
           { "item": "lemonade", "container-item": "bottle_plastic", "charges": 1, "prob": 50, "sealed": false },
-          { "item": "lemonade", "container-item": "bottle_plastic", "count": [ 1, 6 ], "sealed": false }
+          { "item": "lemonade", "container-item": "bottle_plastic", "count": [ 1, 6 ] }
         ],
         "prob": 50
       },
@@ -784,133 +787,133 @@
       {
         "collection": [
           { "item": "cola", "container-item": "bottle_plastic", "charges": 1, "prob": 50, "sealed": false },
-          { "item": "cola", "container-item": "bottle_plastic", "count": [ 1, 6 ], "sealed": false }
+          { "item": "cola", "container-item": "bottle_plastic", "count": [ 1, 6 ] }
         ],
         "prob": 70
       },
       {
         "collection": [
           { "item": "rootbeer", "container-item": "bottle_plastic", "charges": 1, "prob": 50, "sealed": false },
-          { "item": "rootbeer", "container-item": "bottle_plastic", "count": [ 1, 6 ], "sealed": false }
+          { "item": "rootbeer", "container-item": "bottle_plastic", "count": [ 1, 6 ] }
         ],
         "prob": 65
       },
       {
         "collection": [
           { "item": "tonic_water", "container-item": "bottle_plastic", "charges": 1, "prob": 50, "sealed": false },
-          { "item": "tonic_water", "container-item": "bottle_plastic", "count": [ 1, 6 ], "sealed": false }
+          { "item": "tonic_water", "container-item": "bottle_plastic", "count": [ 1, 6 ] }
         ],
         "prob": 20
       },
       {
         "collection": [
           { "item": "sports_drink", "container-item": "bottle_plastic", "charges": 1, "prob": 50, "sealed": false },
-          { "item": "sports_drink", "container-item": "bottle_plastic", "count": [ 1, 6 ], "sealed": false }
+          { "item": "sports_drink", "container-item": "bottle_plastic", "count": [ 1, 6 ] }
         ],
         "prob": 30
       },
       {
         "collection": [
           { "item": "choc_drink", "container-item": "bottle_plastic", "charges": 1, "prob": 50, "sealed": false },
-          { "item": "choc_drink", "container-item": "bottle_plastic", "count": [ 1, 6 ], "sealed": false }
+          { "item": "choc_drink", "container-item": "bottle_plastic", "count": [ 1, 6 ] }
         ],
         "prob": 30
       },
       {
         "collection": [
           { "item": "purple_drink", "container-item": "bottle_plastic", "charges": 1, "prob": 50, "sealed": false },
-          { "item": "purple_drink", "container-item": "bottle_plastic", "count": [ 1, 6 ], "sealed": false }
+          { "item": "purple_drink", "container-item": "bottle_plastic", "count": [ 1, 6 ] }
         ],
         "prob": 35
       },
       {
         "collection": [
           { "item": "creamsoda", "container-item": "bottle_plastic", "charges": 1, "prob": 50, "sealed": false },
-          { "item": "creamsoda", "container-item": "bottle_plastic", "count": [ 1, 6 ], "sealed": false }
+          { "item": "creamsoda", "container-item": "bottle_plastic", "count": [ 1, 6 ] }
         ],
         "prob": 35
       },
       {
         "collection": [
           { "item": "lemonlime", "charges": 1, "container-item": "bottle_plastic", "prob": 50, "sealed": false },
-          { "item": "lemonlime", "container-item": "bottle_plastic", "count": [ 1, 6 ], "sealed": false }
+          { "item": "lemonlime", "container-item": "bottle_plastic", "count": [ 1, 6 ] }
         ],
         "prob": 35
       },
       {
         "collection": [
           { "item": "orangesoda", "charges": 1, "container-item": "bottle_plastic", "prob": 50, "sealed": false },
-          { "item": "orangesoda", "container-item": "bottle_plastic", "count": [ 1, 6 ], "sealed": false }
+          { "item": "orangesoda", "container-item": "bottle_plastic", "count": [ 1, 6 ] }
         ],
         "prob": 20
       },
       {
         "collection": [
           { "item": "crispycran", "charges": 1, "container-item": "bottle_plastic", "prob": 50, "sealed": false },
-          { "item": "crispycran", "container-item": "bottle_plastic", "count": [ 1, 6 ], "sealed": false }
+          { "item": "crispycran", "container-item": "bottle_plastic", "count": [ 1, 6 ] }
         ],
         "prob": 20
       },
       {
         "collection": [
           { "item": "colamdew", "charges": 1, "container-item": "bottle_plastic", "prob": 50, "sealed": false },
-          { "item": "colamdew", "container-item": "bottle_plastic", "count": [ 1, 6 ], "sealed": false }
+          { "item": "colamdew", "container-item": "bottle_plastic", "count": [ 1, 6 ] }
         ],
         "prob": 35
       },
       {
         "collection": [
           { "item": "zerocola", "charges": 1, "container-item": "bottle_plastic", "prob": 50, "sealed": false },
-          { "item": "zerocola", "container-item": "bottle_plastic", "count": [ 1, 6 ], "sealed": false }
+          { "item": "zerocola", "container-item": "bottle_plastic", "count": [ 1, 6 ] }
         ],
         "prob": 20
       },
       {
         "collection": [
           { "item": "zeroorange", "charges": 1, "container-item": "bottle_plastic", "prob": 50, "sealed": false },
-          { "item": "zeroorange", "container-item": "bottle_plastic", "count": [ 1, 6 ], "sealed": false }
+          { "item": "zeroorange", "container-item": "bottle_plastic", "count": [ 1, 6 ] }
         ],
         "prob": 20
       },
       {
         "collection": [
           { "item": "zerotropical", "charges": 1, "container-item": "bottle_plastic", "prob": 50, "sealed": false },
-          { "item": "zerotropical", "container-item": "bottle_plastic", "count": [ 1, 6 ], "sealed": false }
+          { "item": "zerotropical", "container-item": "bottle_plastic", "count": [ 1, 6 ] }
         ],
         "prob": 20
       },
       {
         "collection": [
           { "item": "zeromdew", "charges": 1, "container-item": "bottle_plastic", "prob": 50, "sealed": false },
-          { "item": "zeromdew", "container-item": "bottle_plastic", "count": [ 1, 6 ], "sealed": false }
+          { "item": "zeromdew", "container-item": "bottle_plastic", "count": [ 1, 6 ] }
         ],
         "prob": 20
       },
       {
         "collection": [
           { "item": "foodplace_zero_drink", "charges": 1, "container-item": "bottle_plastic", "prob": 50, "sealed": false },
-          { "item": "foodplace_zero_drink", "container-item": "bottle_plastic", "count": [ 1, 6 ], "sealed": false }
+          { "item": "foodplace_zero_drink", "container-item": "bottle_plastic", "count": [ 1, 6 ] }
         ],
         "prob": 5
       },
       {
         "collection": [
           { "item": "sparkling", "charges": 1, "container-item": "bottle_plastic", "prob": 50, "sealed": false },
-          { "item": "sparkling", "container-item": "bottle_plastic", "count": [ 1, 6 ], "sealed": false }
+          { "item": "sparkling", "container-item": "bottle_plastic", "count": [ 1, 6 ] }
         ],
         "prob": 15
       },
       {
         "collection": [
           { "item": "sparkling_peach", "charges": 1, "container-item": "bottle_plastic", "prob": 50, "sealed": false },
-          { "item": "sparkling_peach", "container-item": "bottle_plastic", "count": [ 1, 6 ], "sealed": false }
+          { "item": "sparkling_peach", "container-item": "bottle_plastic", "count": [ 1, 6 ] }
         ],
         "prob": 15
       },
       {
         "collection": [
           { "item": "sparkling_pomegranate", "charges": 1, "container-item": "bottle_plastic", "prob": 50, "sealed": false },
-          { "item": "sparkling_pomegranate", "container-item": "bottle_plastic", "count": [ 1, 6 ], "sealed": false }
+          { "item": "sparkling_pomegranate", "container-item": "bottle_plastic", "count": [ 1, 6 ] }
         ],
         "prob": 15
       }
@@ -973,13 +976,12 @@
       { "item": "melon", "prob": 2 },
       { "item": "kiwi", "prob": 2, "count": [ 1, 3 ] },
       { "item": "milk", "charges": [ 1, -1 ], "prob": 20, "container-item": "jug_plastic", "sealed": false },
-      { "item": "milk", "charges": [ 1, -1 ], "prob": 55, "container-item": "bottle_twoliter", "sealed": false },
-      { "item": "almond_milk", "charges": [ 1, -1 ], "prob": 1, "container-item": "jug_plastic", "sealed": false },
-      { "item": "almond_milk", "charges": [ 1, -1 ], "prob": 3, "container-item": "bottle_twoliter", "sealed": false },
-      { "item": "soy_milk", "charges": [ 1, -1 ], "prob": 2, "container-item": "jug_plastic", "sealed": false },
-      { "item": "soy_milk", "charges": [ 1, -1 ], "prob": 6, "container-item": "bottle_twoliter", "sealed": false },
+      { "item": "milk", "charges": [ 1, -1 ], "prob": 55, "container-item": "carton_milk", "sealed": false },
+      { "item": "almond_milk", "charges": [ 1, -1 ], "prob": 12, "container-item": "carton_milk", "sealed": false },
+      { "item": "oat_milk", "charges": [ 1, -1 ], "prob": 8, "container-item": "carton_milk", "sealed": false },
+      { "item": "soy_milk", "charges": [ 1, -1 ], "prob": 6, "container-item": "carton_milk", "sealed": false },
       { "item": "milk_choc", "charges": [ 1, -1 ], "prob": 2, "container-item": "jug_plastic", "sealed": false },
-      { "item": "milk_choc", "charges": [ 1, -1 ], "prob": 6, "container-item": "bottle_twoliter", "sealed": false },
+      { "item": "milk_choc", "charges": [ 1, -1 ], "prob": 6, "container-item": "carton_milk", "sealed": false },
       { "item": "horchata", "charges": [ 1, -1 ], "prob": 3, "container-item": "bottle_plastic", "sealed": false },
       { "prob": 40, "group": "cheese_bag_plastic" },
       { "item": "cottage_cheese", "prob": 9 },

--- a/data/json/itemgroups/SUS/fridges.json
+++ b/data/json/itemgroups/SUS/fridges.json
@@ -1004,8 +1004,8 @@
       { "prob": 6, "group": "sandwich_pbj_wrapper_1_inf" },
       { "prob": 6, "group": "fish_sandwich_wrapper_1_inf" },
       { "group": "softdrinks_canned", "count": [ 1, 5 ], "prob": 75 },
-      { "item": "water_clean", "container-item": "bottle_plastic", "prob": 65, "count": [ 1, 3 ], "sealed": false },
-      { "item": "water_mineral", "container-item": "bottle_plastic", "prob": 35, "count": [ 1, 2 ], "sealed": false }
+      { "item": "water_clean", "container-item": "bottle_plastic", "prob": 65, "count": [ 1, 3 ] },
+      { "item": "water_mineral", "container-item": "bottle_plastic", "prob": 35, "count": [ 1, 2 ] }
     ]
   },
   {
@@ -1022,7 +1022,7 @@
       { "group": "preserved_food", "count": [ 3, 6 ], "prob": 40 },
       { "group": "softdrinks_canned", "count": [ 3, 7 ], "prob": 75 },
       { "group": "alcohol_bottled_canned", "count": [ 2, 4 ], "prob": 30 },
-      { "item": "water_clean", "container-item": "bottle_plastic", "prob": 65, "count": [ 2, 6 ], "sealed": false }
+      { "item": "water_clean", "container-item": "bottle_plastic", "prob": 65, "count": [ 2, 6 ] }
     ]
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Seal unopened soda six-packs in fridges"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#44640 added `"sealed": false` to too many things.

Milk in a 2-liter bottle and soy milk in a gallon jug is very unlikely. This JSON pre-dates the addition of #50706

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

Set unopened containers to sealed.  Spawn smaller amounts of milk in cartons not bottles.  Add oat milk to break room fridges. Adjust spawns to make trendier milks slightly more common than soy milk.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

#81812

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
