### PR TITLE
Add E_STORABLE_EXCLUSIVE flag

### DIFF
--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -2363,6 +2363,11 @@
     "//": "Any item that can be an electronic file"
   },
   {
+    "id": "E_STORABLE_EXCLUSIVE",
+    "type": "json_flag",
+    "//": "Any item that can ONLY be an electronic file"
+  },
+  {
     "id": "E_COPIABLE",
     "type": "json_flag",
     "//": "Any item that can be electronically copied and scanned"

--- a/data/json/items/software.json
+++ b/data/json/items/software.json
@@ -1,7 +1,7 @@
 [
   {
     "id": "abstract_software",
-    "copy-from": "abstract_efile",
+    "copy-from": "abstract_efile_exclusive",
     "type": "ITEM",
     "category": "software",
     "name": { "str_sp": "abstract software", "//~": "NO_I18N" },
@@ -113,6 +113,17 @@
     "variables": { "browsed": "false" }
   },
   {
+    "abstract": "abstract_efile_exclusive",
+    "copy-from": "abstract_efile",
+    "type": "ITEM",
+    "symbol": "o",
+    "name": { "str": "abstract e-only electronic file", "//~": "NO_I18N" },
+    "description": { "str": "abstract e-only electronic file", "//~": "NO_I18N" },
+    "ememory_size": "1 KB",
+    "delete": { "flags": [ "E_STORABLE" ] },
+    "extend": { "flags": [ "E_STORABLE_EXCLUSIVE" ] }
+  },
+  {
     "abstract": "abstract_efile_copiable",
     "copy-from": "abstract_efile",
     "type": "ITEM",
@@ -121,6 +132,17 @@
     "description": { "str": "abstract copiable electronic file", "//~": "NO_I18N" },
     "ememory_size": "1 KB",
     "extend": { "flags": [ "E_COPIABLE" ] }
+  },
+  {
+    "abstract": "abstract_efile_exclusive_copiable",
+    "copy-from": "abstract_efile",
+    "type": "ITEM",
+    "symbol": "o",
+    "name": { "str": "abstract copiable electronic file", "//~": "NO_I18N" },
+    "description": { "str": "abstract copiable electronic file", "//~": "NO_I18N" },
+    "ememory_size": "1 KB",
+    "delete": { "flags": [ "E_STORABLE" ] },
+    "extend": { "flags": [ "E_COPIABLE", "E_STORABLE_EXCLUSIVE" ] }
   },
   {
     "abstract": "abstract_efile_read",
@@ -136,7 +158,7 @@
   },
   {
     "id": "efile_junk",
-    "copy-from": "abstract_efile",
+    "copy-from": "abstract_efile_exclusive",
     "type": "ITEM",
     "symbol": "o",
     "name": "junk file",
@@ -146,7 +168,7 @@
   },
   {
     "id": "efile_lore",
-    "copy-from": "abstract_efile",
+    "copy-from": "abstract_efile_exclusive",
     "type": "ITEM",
     "symbol": "o",
     "name": "questionable media file",
@@ -156,7 +178,7 @@
   },
   {
     "id": "efile_map",
-    "copy-from": "abstract_efile",
+    "copy-from": "abstract_efile_exclusive",
     "type": "ITEM",
     "symbol": "o",
     "name": "map cache",
@@ -167,13 +189,14 @@
   },
   {
     "abstract": "abstract_efile_recipes",
-    "copy-from": "abstract_efile_copiable",
+    "copy-from": "abstract_efile_exclusive_copiable",
     "type": "ITEM",
     "symbol": "o",
     "name": { "str": "abstract recipe catalog", "//~": "NO_I18N" },
     "description": { "str": "for any collection of recipes", "//~": "NO_I18N" },
     "ememory_size": "4 MB",
-    "extend": { "flags": [ "E_FILE_COLLECTION" ] },
+    "delete": { "flags": [ "E_STORABLE" ] },
+    "extend": { "flags": [ "E_FILE_COLLECTION", "E_STORABLE_EXCLUSIVE" ] },
     "variables": { "browsed": "false" }
   },
   {
@@ -227,7 +250,7 @@
   },
   {
     "id": "efile_photos",
-    "copy-from": "abstract_efile_copiable",
+    "copy-from": "abstract_efile_exclusive_copiable",
     "type": "ITEM",
     "symbol": "o",
     "name": { "str": "photo gallery", "str_pl": "photo galleries" },

--- a/doc/JSON/JSON_FLAGS.md
+++ b/doc/JSON/JSON_FLAGS.md
@@ -793,7 +793,8 @@ These flags can be applied via JSON item definition to most items.  Not to be co
 - ```DURABLE_MELEE``` Item is made to hit stuff and it does it well, so it's considered to be a lot tougher than other weapons made of the same materials.
 - ```E_COPIABLE``` This item can be scanned onto an electronic device and can be electronically copied.
 - ```E_FILE_COLLECTION``` This item represents a combinable collection of files. Does not imply E_COPIABLE.
-- ```E_STORABLE``` This item can be stored on an electronic device.
+- ```E_STORABLE``` This item can be stored on an in-game electronic device.
+- ```E_STORABLE_EXCLUSIVE``` This item can ONLY be stored on an in-game electronic device; it may only be handled electronically.
 - ```ELECTRONIC``` This item contain sensitive electronics which can be fried by nearby EMP blast.
 - ```FAKE_MILL``` Item is a fake item, to denote a partially milled product by @ref Item::process_fake_mill, where conditions for its removal are set.
 - ```FAKE_SMOKE``` Item is a fake item generating smoke, recognizable by @ref item::process_fake_smoke, where conditions for its removal are set.

--- a/src/flag.cpp
+++ b/src/flag.cpp
@@ -118,6 +118,7 @@ const flag_id flag_EXO_UNDERLAYER( "EXO_UNDERLAYER" );
 const flag_id flag_E_COPIABLE( "E_COPIABLE" );
 const flag_id flag_E_FILE_COLLECTION( "E_FILE_COLLECTION" );
 const flag_id flag_E_STORABLE( "E_STORABLE" );
+const flag_id flag_E_STORABLE_EXCLUSIVE( "E_STORABLE_EXCLUSIVE" );
 const flag_id flag_FAKE_MILL( "FAKE_MILL" );
 const flag_id flag_FAKE_SMOKE( "FAKE_SMOKE" );
 const flag_id flag_FELINE( "FELINE" );

--- a/src/flag.h
+++ b/src/flag.h
@@ -117,6 +117,7 @@ extern const flag_id flag_ELECTRIC_IMMUNE;
 extern const flag_id flag_ELECTRONIC;
 extern const flag_id flag_ENERGY_SHIELD;
 extern const flag_id flag_E_STORABLE;
+extern const flag_id flag_E_STORABLE_EXCLUSIVE;
 extern const flag_id flag_ETHEREAL_ITEM;
 extern const flag_id flag_EXO_ARM_PLATE;
 extern const flag_id flag_EXO_BOOT_PLATE;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -8939,7 +8939,12 @@ bool item::is_estorage_usable( const Character &who ) const
 
 bool item::is_estorable() const
 {
-    return has_flag( flag_E_STORABLE ) || is_book();
+    return has_flag( flag_E_STORABLE ) || has_flag( flag_E_STORABLE_EXCLUSIVE ) || is_book();
+}
+
+bool item::is_estorable_exclusive() const
+{
+    return has_flag( flag_E_STORABLE_EXCLUSIVE );
 }
 
 bool item::is_browsed() const

--- a/src/item.h
+++ b/src/item.h
@@ -358,6 +358,7 @@ class item : public visitable
         /** Above, along with checks for power, browsed, use action */
         bool is_estorage_usable( const Character &who ) const;
         bool is_estorable() const;
+        bool is_estorable_exclusive() const;
         bool is_browsed() const;
         void set_browsed( bool browsed );
         /** @return if item can be copied as an e-file */

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -904,7 +904,7 @@ std::pair<item_location, item_pocket *> item_contents::best_pocket( const item &
             continue;
         }
         if( !pocket.is_type( pocket_type::CONTAINER ) &&
-            !( pocket.is_type( pocket_type::E_FILE_STORAGE ) && it.is_estorable() ) ) {
+            !( pocket.is_type( pocket_type::E_FILE_STORAGE ) && it.is_estorable_exclusive() ) ) {
             // best pocket is for picking stuff up.
             // containers are the only pockets that are available for such...
             // unless it's an e-device spawning with contents; we can do this here because


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "add E_STORABLE_EXCLUSIVE flag"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

- Fix #81778

Alternatively, why you shouldn't leave a PR in draft for over a month. In #81123, there were two C++ changes made.

This one I think was fine because we want crafted `E_STORABLE` items to be spawned into their desired containers:
https://github.com/CleverRaven/Cataclysm-DDA/blob/2a24989f244a561be1a87f9cd1cea1633fa0a8c8/src/item.cpp#L1311

And this one made it so that any item with the `E_STORABLE` flag can be put into a `E_FILE_STORAGE` pocket, which is not intended behavior. A book is `E_STORABLE`, but it should go into `CONTAINER` unless explicitly spawned into an e-device.
https://github.com/CleverRaven/Cataclysm-DDA/blob/2a24989f244a561be1a87f9cd1cea1633fa0a8c8/src/item_contents.cpp#L906-L907

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add and apply `E_STORABLE_EXCLUSIVE` flag for items that should _only_ exist on e-devices, handle the above case using `is_estorable_exclusive` function. 

The `item_contents::best_pocket` for `E_STORABLE_EXCLUSIVE` is always `E_FILE_STORAGE`; the `item_contents::best_pocket` for `E_STORABLE` is `CONTAINER` by default unless spawned into `E_FILE_STORAGE`.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

- Spawned and wore a messenger bag, put a smartphone in it, picked up a copy of "Under the Hood" and it went into the bag and not the phone. Doing this before this PR would put the book directly into the phone.
- Tried the above with backpack, jeans, same results.
- Tried picking up a bunch of books with a bunch of phones in a messenger bag, none of the books went into phones.
- Verified that MatheMAX was still crafted correctly in XEDRA: Evolved.
- Moved files around on e-devices, scanned some books.
- Passed all tests locally

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

This absolutely needs to be backported, but maybe wait a week to make sure there aren't any further regressions.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
