### PR TITLE
[Xedra Evolved] Cabin cellars

### DIFF
--- a/data/json/mapgen/nested/cabin_cellar_nested.json
+++ b/data/json/mapgen/nested/cabin_cellar_nested.json
@@ -267,7 +267,7 @@
         "      "
       ],
       "palettes": [ "cabin_cellar" ],
-      "place_monster": [ { "group": "GROUP_ZOMBIE", "x": [ 0, 5 ], "y": [ 0, 5 ], "chance": 100, "repeat": [ 1, 6 ] } ]
+      "place_monster": [ { "group": "GROUP_VANILLA_DORMANT", "x": [ 0, 5 ], "y": [ 0, 5 ], "chance": 100, "repeat": [ 1, 6 ] } ]
     }
   },
   {

--- a/data/json/mapgen_palettes/cabin.json
+++ b/data/json/mapgen_palettes/cabin.json
@@ -182,7 +182,8 @@
       ".": { "param": "floor_types", "fallback": "t_dirtfloor" },
       "N": { "param": "floor_types", "fallback": "t_dirtfloor" },
       "R": { "param": "floor_types", "fallback": "t_dirtfloor" },
-      "c": { "param": "floor_types", "fallback": "t_dirtfloor" }
+      "c": { "param": "floor_types", "fallback": "t_dirtfloor" },
+      "t": { "param": "floor_types", "fallback": "t_dirtfloor" }
     },
     "furniture": { "R": "f_rack_wood", "t": "f_table", "c": "f_chair" }
   }

--- a/data/mods/Xedra_Evolved/furniture_and_terrain/furniture.json
+++ b/data/mods/Xedra_Evolved/furniture_and_terrain/furniture.json
@@ -371,7 +371,7 @@
     "id": "f_alembic",
     "//": "Just a copy from the Magiclysm one",
     "name": "standing alembic",
-    "looks_like": "f_still",
+    "looks_like": "f_alembic",
     "description": "A large glass and copper alembic for distilling alchemical concoctions.  It consists of a copper pot with rising spires of twisted glass draining into various removable bottles.",
     "symbol": "&",
     "color": "light_blue",
@@ -401,5 +401,17 @@
         { "item": "glass_shard", "count": [ 25, 50 ] }
       ]
     }
+  },
+  {
+    "type": "furniture",
+    "id": "f_xe_magic_circle",
+    "name": "magick circle",
+    "looks_like": "f_magic_circle",
+    "move_cost_mod": 0,
+    "symbol": "O",
+    "color": "red",
+    "required_str": -1,
+    "flags": [ "ALLOW_FIELD_EFFECT", "TRANSPARENT" ],
+    "description": "This is a rough magic circle, carved into the ground and decorated with blood, candles, and other small knick-knacks."
   }
 ]

--- a/data/mods/Xedra_Evolved/itemgroups/nests_itemgroups.json
+++ b/data/mods/Xedra_Evolved/itemgroups/nests_itemgroups.json
@@ -2,6 +2,64 @@
   {
     "type": "item_group",
     "subtype": "distribution",
+    "id": "hedge_magick_materials",
+    "items": [
+      { "item": "mortar_pestle", "prob": 40 },
+      {
+        "item": "corpse_ash",
+        "prob": 15,
+        "container-item": "null",
+        "entry-wrapper": "jug_plastic",
+        "count": [ 5, 10 ]
+      },
+      { "item": "ash", "prob": 15, "container-item": "null", "entry-wrapper": "jug_plastic", "count": [ 10, 20 ] },
+      {
+        "item": "wild_herbs",
+        "prob": 75,
+        "container-item": "null",
+        "entry-wrapper": "bag_zipper",
+        "count": [ 20, 80 ]
+      },
+      {
+        "distribution": [
+          { "item": "alder_bark", "prob": 1, "count": [ 2, 5 ] },
+          { "item": "tanbark", "prob": 1, "count": [ 2, 5 ] },
+          { "item": "birchbark", "prob": 1, "count": [ 2, 5 ] },
+          { "item": "willowbark", "prob": 1, "count": [ 2, 5 ] }
+        ],
+        "prob": 40
+      },
+      {
+        "distribution": [
+          { "item": "leaves", "prob": 1, "count": [ 5, 10 ] },
+          { "item": "grape_leaves", "prob": 1, "count": [ 5, 10 ] },
+          { "item": "young_leaves", "prob": 1, "count": [ 5, 10 ] },
+          { "item": "chicory_leaves", "prob": 1, "count": [ 5, 10 ] },
+          { "item": "wintergreen_leaves", "prob": 1, "count": [ 5, 10 ] }
+        ],
+        "prob": 40
+      },
+      {
+        "distribution": [
+          { "item": "leather", "prob": 2, "count": [ 1, 5 ] },
+          { "item": "thread", "prob": 5, "count": [ 5, 50 ] },
+          { "item": "sinew", "prob": 1, "count": [ 2, 20 ] },
+          { "item": "plant_fibre", "prob": 1, "count": [ 3, 30 ] },
+          { "item": "yarn", "prob": 5, "count": [ 5, 50 ] },
+          { "item": "plant_fibre", "prob": 1, "count": [ 5, 50 ] },
+          { "item": "yarn", "prob": 5, "count": [ 5, 50 ] }
+        ],
+        "prob": 25
+      },
+      { "item": "salt", "count": [ 10, 50 ], "prob": 15, "entry-wrapper": "bag_zipper", "container-item": "null" },
+      { "item": "candle", "prob": 75, "charges": [ 10, -1 ] },
+      { "item": "copper", "prob": 15, "count": [ 5, 10 ] },
+      { "item": "scrap_dreamdross", "prob": 10, "count": [ 5, 10 ] }
+    ]
+  },
+  {
+    "type": "item_group",
+    "subtype": "distribution",
     "id": "alchemical_materials",
     "items": [
       { "item": "chemistry_set", "prob": 25 },

--- a/data/mods/Xedra_Evolved/mapgen/nested/cabin_cellars.json
+++ b/data/mods/Xedra_Evolved/mapgen/nested/cabin_cellars.json
@@ -1,0 +1,23 @@
+[
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "cabin_6x6_cellar_nested_spiders",
+    "weight": 250,
+    "//": "A cellar overlay for XE goblin spiders.  Won't you come out to play?",
+    "object": {
+      "mapgensize": [ 6, 6 ],
+      "rotation": [ 0, 0 ],
+      "rows": [
+        "      ",
+        "      ",
+        "      ",
+        "      ",
+        "      ",
+        "      "
+      ],
+      "palettes": [ "cabin_cellar" ],
+      "place_fields": [ { "field": "fd_web", "x": [ 0, 5 ], "y": [ 0, 5 ], "repeat": [ 10, 20 ] } ],
+      "place_monster": [ { "group": "GROUP_GOBLIN_SPIDER", "x": [ 0, 5 ], "y": [ 0, 5 ], "chance": 100, "repeat": [ 3, 4 ] } ]
+    }
+  }
+]

--- a/data/mods/Xedra_Evolved/mapgen/nested/cabin_cellars.json
+++ b/data/mods/Xedra_Evolved/mapgen/nested/cabin_cellars.json
@@ -1,6 +1,60 @@
 [
   {
     "type": "mapgen",
+    "nested_mapgen_id": "cabin_6x6_cellar_nested",
+    "//": "A cellar with a setup for hedge magick",
+    "weight": 250,
+    "object": {
+      "mapgensize": [ 6, 6 ],
+      "rotation": [ 0, 0 ],
+      "rows": [
+        "BB  tt",
+        "     t",
+        "  OO  ",
+        "  OO  ",
+        "      ",
+        "      "
+      ],
+      "palettes": [ "cabin_cellar" ],
+      "furniture": { "O": "f_xe_magic_circle", "B": "f_bookcase" },
+      "items": {
+        "B": [
+          { "item": "esoteric_books", "chance": 80, "repeat": [ 1, 2 ] },
+          { "item": "hedge_magic_books", "chance": 50, "repeat": [ 1, 2 ] }
+        ],
+        "t": [ { "item": "hedge_magick_materials", "chance": 80, "repeat": [ 2, 4 ] } ]
+      },
+      "place_fields": [ { "field": "fd_dust", "x": [ 0, 5 ], "y": [ 0, 5 ], "repeat": [ 10, 20 ] } ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "cabin_6x6_cellar_nested_zombies",
+    "//": "A cellar overlay for a feral vampire.",
+    "weight": 200,
+    "object": {
+      "mapgensize": [ 6, 6 ],
+      "rotation": [ 0, 0 ],
+      "rows": [
+        "      ",
+        "      ",
+        "      ",
+        "      ",
+        "      ",
+        "      "
+      ],
+      "palettes": [ "cabin_cellar" ],
+      "place_loot": [
+        { "item": "sleeping_bag", "x": 1, "y": 3, "chance": 100, "repeat": [ 1, 2 ] },
+        { "group": "stash_food", "x": [ 2, 3 ], "y": [ 2, 4 ], "chance": 30, "repeat": [ 2, 3 ] },
+        { "group": "roof_holdout", "x": [ 2, 3 ], "y": [ 2, 4 ], "chance": 70, "repeat": [ 2, 4 ] }
+      ],
+      "place_fields": [ { "field": "fd_blood", "x": [ 0, 5 ], "y": [ 0, 5 ], "repeat": [ 1, 4 ] } ],
+      "place_monster": [ { "monster": "mon_vampire_feral", "x": [ 0, 5 ], "y": [ 0, 5 ], "chance": 100 } ]
+    }
+  },
+  {
+    "type": "mapgen",
     "nested_mapgen_id": "cabin_6x6_cellar_nested_spiders",
     "weight": 250,
     "//": "A cellar overlay for XE goblin spiders.  Won't you come out to play?",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[Xedra Evolved] Cabin cellars"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Now that cabins have nested cellars, mods can add nests
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add three nests for XE cellars.

- Hedge magick nest. Has some magickal supplies, magic circles, and the chance of hedge magick study books. 
- Feral vampire: A version of the zombie overlay. Has a feral vampire holed up in there.
- Goblin spiders: A version of the spider overlay. 

I also changed the vanilla zombie overlay to spawn dormant zombies instead of active ones. They're just chilling down there until you interrupt them. 

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing


<img width="571" height="698" alt="Untitled" src="https://github.com/user-attachments/assets/f9e064f4-f348-45bf-83f2-ead665ae1a24" />

Hedge magick cellar with the vampire overlay

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
