### PR TITLE
Explain that degraded items are degraded

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -5236,6 +5236,11 @@ void item::repair_info( std::vector<iteminfo> &info, const iteminfo_query *parts
         if( !repairs_with.empty() ) {
             info.emplace_back( "DESCRIPTION", string_format( _( "<bold>With</bold> %s." ), repairs_with ) );
         }
+        if( degradation() > 0 && damage() == degradation() ) {
+            info.emplace_back( "DESCRIPTION",
+                               string_format(
+                                   _( "<color_c_red>Degraded and cannot be repaired beyond the current level.</color>" ) ) );
+        }
     } else {
         info.emplace_back( "DESCRIPTION", _( "* This item is <bad>not repairable</bad>." ) );
     }

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -1143,7 +1143,7 @@ void veh_interact::do_repair( map &here )
                 msg = _( "You can't repair stuff while driving." );
                 return false;
             case task_reason::INVALID_TARGET:
-                msg = _( "There are no damaged parts on this vehicle." );
+                msg = _( "There are no parts which can be repaired on this vehicle." );
                 return false;
             default:
                 break;

--- a/src/vehicle_display.cpp
+++ b/src/vehicle_display.cpp
@@ -293,6 +293,12 @@ void vehicle::print_vparts_descs( const catacurses::window &win, int max_y, int 
                                            vp.carried_name() );
             new_lines += 1;
         }
+        if( vp.degradation() > 0 && vp.damage() == vp.degradation() ) {
+            // Some untranslated padding and a linebreak for formatting here, but we re-use the same string from item::repair_info()
+            possible_msg += string_format( "   %s\n",
+                                           _( "<color_c_red>Degraded and cannot be repaired beyond the current level.</color>" ) );
+            new_lines += 1;
+        }
 
         possible_msg += "</color>\n";
         if( lines + new_lines <= max_y ) {


### PR DESCRIPTION
#### Summary
Interface "Explain that degraded items are degraded"

#### Purpose of change
The degradation mechanic remains opaque and people don't understand why they suddenly cannot repair an item.

#### Describe the solution
Add some info. On the vehicle summary and iteminfo repair sections it will say something if the part has been repaired to its maximum extent.

Also changed the message when there are no repairable parts, because it was just plain wrong nowadays. `There are no damaged parts on this vehicle.` ---> `There are no parts which can be repaired on this vehicle.`

#### Describe alternatives you've considered
Put a different line in if degradation is > 0 but it's not fully repaired? IDK

#### Testing
Item:
<img width="393" height="112" alt="image" src="https://github.com/user-attachments/assets/ac434abf-bfac-4be1-925f-82d3f5f386a2" />

Vehicle summary:
<img width="2560" height="1400" alt="image" src="https://github.com/user-attachments/assets/b1e31461-77b8-4788-89c0-9dc452b8518a" />


#### Additional context

