### PR TITLE
Backport molotov fixes to 0.I

### DIFF
--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -206,6 +206,10 @@
     "conflicts": [ "PARTIAL_DEAF" ]
   },
   {
+    "id": "DESTROY_ON_CHARGE_USE",
+    "type": "json_flag"
+  },
+  {
     "id": "OVERHEATS",
     "type": "json_flag",
     "info": "Continuously firing this weapon will cause it to <bad>overheat</bad> and <info>can potentially damage it</info>."

--- a/data/json/items/tool/explosives.json
+++ b/data/json/items/tool/explosives.json
@@ -739,7 +739,7 @@
     "symbol": "*",
     "color": "light_gray",
     "tick_action": [ "MOLOTOV_LIT" ],
-    "flags": [ "LIGHT_15", "TRADER_AVOID", "NPC_THROW_NOW", "NO_REPAIR", "WATER_EXTINGUISH" ],
+    "flags": [ "LIGHT_15", "TRADER_AVOID", "NPC_THROW_NOW", "NO_REPAIR", "WATER_EXTINGUISH", "DESTROY_ON_CHARGE_USE" ],
     "melee_damage": { "bash": 5 }
   },
   {

--- a/src/flag.cpp
+++ b/src/flag.cpp
@@ -84,6 +84,7 @@ const flag_id flag_CUT_IMMUNE( "CUT_IMMUNE" );
 const flag_id flag_DANGEROUS( "DANGEROUS" );
 const flag_id flag_DEAF( "DEAF" );
 const flag_id flag_DECAYS_IN_AIR( "DECAYS_IN_AIR" );
+const flag_id flag_DESTROY_ON_CHARGE_USE( "DESTROY_ON_CHARGE_USE" );
 const flag_id flag_DIAMOND( "DIAMOND" );
 const flag_id flag_DIG_TOOL( "DIG_TOOL" );
 const flag_id flag_DIMENSIONAL_ANCHOR( "DIMENSIONAL_ANCHOR" );

--- a/src/flag.h
+++ b/src/flag.h
@@ -97,6 +97,7 @@ extern const flag_id flag_CUT_IMMUNE;
 extern const flag_id flag_DANGEROUS;
 extern const flag_id flag_DEAF;
 extern const flag_id flag_DECAYS_IN_AIR;
+extern const flag_id flag_DESTROY_ON_CHARGE_USE;
 extern const flag_id flag_DIAMOND;
 extern const flag_id flag_DIG_TOOL;
 extern const flag_id flag_DIMENSIONAL_ANCHOR;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -14826,8 +14826,12 @@ bool item::process_tool( Character *carrier, const tripoint_bub_ms &pos )
         }
     }
 
-    type->tick( carrier, *this, pos );
-    return false;
+    // Complicated safety net in case an item with charges slipped through.
+    const int num_to_destroy = type->tick( carrier, *this, pos );
+    if( num_to_destroy < 0 || num_to_destroy > 1 ) {
+        debugmsg( "Item %s consumes charges via tick_action, but should not", tname() );
+    }
+    return num_to_destroy; // Implicit conversion to bool!
 }
 
 bool item::process_blackpowder_fouling( Character *carrier )

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -14826,12 +14826,15 @@ bool item::process_tool( Character *carrier, const tripoint_bub_ms &pos )
         }
     }
 
-    // Complicated safety net in case an item with charges slipped through.
-    const int num_to_destroy = type->tick( carrier, *this, pos );
-    if( num_to_destroy < 0 || num_to_destroy > 1 ) {
+    // FIXME: some iuse functions return 1+ expecting to be destroyed (molotovs), others
+    // to use charges, and others just because?
+    // allow some items to opt into requesting destruction
+    const int charges_used = type->tick( carrier, *this, pos );
+    const bool destroy = has_flag( flag_DESTROY_ON_CHARGE_USE );
+    if( !destroy && charges_used > 0 ) {
         debugmsg( "Item %s consumes charges via tick_action, but should not", tname() );
     }
-    return num_to_destroy; // Implicit conversion to bool!
+    return destroy && charges_used > 0;
 }
 
 bool item::process_blackpowder_fouling( Character *carrier )

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -14831,9 +14831,6 @@ bool item::process_tool( Character *carrier, const tripoint_bub_ms &pos )
     // allow some items to opt into requesting destruction
     const int charges_used = type->tick( carrier, *this, pos );
     const bool destroy = has_flag( flag_DESTROY_ON_CHARGE_USE );
-    if( !destroy && charges_used > 0 ) {
-        debugmsg( "Item %s consumes charges via tick_action, but should not", tname() );
-    }
     return destroy && charges_used > 0;
 }
 


### PR DESCRIPTION
#### Summary
Bugfixes "Fix molotovs exploding multiple times"

#### Purpose of change
Backport of https://github.com/CleverRaven/Cataclysm-DDA/pull/81661 and partial backport of https://github.com/CleverRaven/Cataclysm-DDA/pull/81731

#### Describe the solution
Remove molotovs on request per RenechCDDA's PR, and cherry-pick the behavior from my PR that makes this removal only apply when a flag requesting it is present. _Remove_ the debug message when an iuse tries to return > 0 charges used in a tick function, preserving the behavior for other items before the molotov fix.

#### Describe alternatives you've considered
Full backport of https://github.com/CleverRaven/Cataclysm-DDA/pull/81731

#### Testing
Throw a molotov, it does not create all raging fires.
Activate other items, such as an mp3 player, or a chainsaw. They work properly and do not disappear.
