### PR TITLE
update bugout bags

### DIFF
--- a/data/json/itemgroups/Drugs_Tobacco_Alcohol/drugs.json
+++ b/data/json/itemgroups/Drugs_Tobacco_Alcohol/drugs.json
@@ -107,43 +107,43 @@
     "id": "adhesive_bandages_box_full",
     "type": "item_group",
     "subtype": "collection",
-    "container-item": "box_small",
+    "container-item": "box_paper_small",
     "items": [ { "item": "adhesive_bandages", "prob": 100, "count": 20 } ]
   },
   {
     "id": "adhesive_bandages_box_used",
     "type": "item_group",
     "subtype": "collection",
-    "container-item": "box_small",
+    "container-item": "box_paper_small",
     "items": [ { "item": "adhesive_bandages", "prob": 100, "count": [ 1, 20 ] } ]
   },
   {
     "id": "alcohol_wipes_box_full",
     "type": "item_group",
     "subtype": "collection",
-    "container-item": "box_small",
+    "container-item": "box_paper_small",
     "items": [ { "item": "alcohol_wipes", "prob": 100, "count": 40 } ]
   },
   {
     "id": "alcohol_wipes_box_used",
     "type": "item_group",
     "subtype": "collection",
-    "container-item": "box_small",
+    "container-item": "box_paper_small",
     "items": [ { "item": "alcohol_wipes", "prob": 100, "count": [ 1, 40 ] } ]
   },
   {
     "id": "cotton_ball_bag_full",
     "type": "item_group",
     "subtype": "collection",
-    "container-item": "bag_plastic",
-    "items": [ { "item": "cotton_ball", "prob": 100, "count": 10 } ]
+    "container-item": "bag_plastic_small",
+    "items": [ { "item": "cotton_ball", "count": 20 } ]
   },
   {
     "id": "cotton_ball_bag_used",
     "type": "item_group",
     "subtype": "collection",
-    "container-item": "bag_plastic",
-    "items": [ { "item": "cotton_ball", "prob": 100, "count": [ 1, 10 ] } ]
+    "container-item": "bag_plastic_small",
+    "items": [ { "item": "cotton_ball", "count": [ 1, -1 ] } ]
   },
   {
     "id": "tampon_box_full",

--- a/data/json/itemgroups/Locations_MapExtras/locations.json
+++ b/data/json/itemgroups/Locations_MapExtras/locations.json
@@ -1666,6 +1666,7 @@
     "subtype": "distribution",
     "entries": [
       { "group": "tools_medical", "prob": 100 },
+      { "item": "bag_body_bag", "prob": 5 },
       { "group": "drugs_emergency", "prob": 50 },
       { "prob": 10, "group": "quikclot_bag_plastic_1_6" },
       { "item": "badge_doctor", "prob": 2 }

--- a/data/json/itemgroups/stashes.json
+++ b/data/json/itemgroups/stashes.json
@@ -145,10 +145,10 @@
     "subtype": "collection",
     "entries": [
       { "group": "bugout_meds_easy", "prob": 90 },
-      { "group": "bugout_first_aid", "prob": 20 },
+      { "group": "full_1st_aid", "prob": 20 },
       { "group": "guns_pistol_common", "prob": 45 },
       { "group": "bugout_tools", "prob": 50 },
-      { "group": "bugout_food_easy", "prob": 50 },
+      { "group": "bugout_food_easy", "count": [ 1, 2 ], "prob": 60 },
       { "group": "bugout_water", "prob": 50 },
       { "group": "bugout_bad_pack", "prob": 100 }
     ]
@@ -161,14 +161,16 @@
     "subtype": "collection",
     "on_overflow": "spill",
     "entries": [
-      { "group": "bugout_first_aid", "prob": 90 },
+      { "group": "bugout_meds_prepper", "count": [ 1, 2 ], "prob": 75 },
+      { "group": "bugout_first_aid", "prob": 80 },
       { "group": "bugout_gun", "prob": 50 },
-      { "group": "bugout_tools", "prob": 60 },
+      { "group": "bugout_tools", "prob": 80 },
       { "group": "bugout_food_easy", "prob": 25, "count": [ 1, 4 ] },
-      { "group": "bugout_food_1l", "prob": 75, "count": [ 2, 6 ] },
-      { "group": "bugout_food_9l", "prob": 15, "count": [ 1, 2 ] },
-      { "group": "bugout_water", "prob": 50, "count": [ 1, 2 ] },
+      { "group": "bugout_food_1l", "prob": 80, "count": [ 2, 6 ] },
+      { "group": "bugout_food_9l", "prob": 40, "count": [ 1, 2 ] },
+      { "group": "bugout_water", "prob": 90, "count": [ 1, 2 ] },
       { "group": "bugout_extras", "prob": 100, "count": [ 1, 4 ] },
+      { "group": "prepper_maps", "prob": 80 },
       { "group": "civilian_armor", "prob": 35 }
     ]
   },
@@ -180,6 +182,7 @@
     "subtype": "collection",
     "on_overflow": "spill",
     "entries": [
+      { "group": "bugout_meds_prepper", "count": [ 2, 4 ], "prob": 80 },
       { "group": "bugout_first_aid", "count": 1, "prob": 90 },
       { "group": "guns_pistol_common", "prob": 70 },
       { "group": "bugout_long_gun", "prob": 20 },
@@ -187,9 +190,11 @@
       { "group": "bugout_food_easy", "prob": 25, "count": [ 1, 2 ] },
       { "group": "bugout_food_1l", "prob": 50, "count": [ 2, 4 ] },
       { "group": "bugout_food_9l", "prob": 90, "count": [ 2, 4 ] },
-      { "group": "bugout_water", "prob": 90, "count": [ 1, 3 ] },
-      { "group": "bugout_extras", "prob": 100, "count": [ 2, 6 ] },
+      { "group": "bugout_water", "prob": 20, "count": [ 1, 2 ] },
+      { "group": "used_survival_kit", "prob": 60 },
+      { "group": "bugout_extras", "prob": 100, "count": [ 4, 12 ] },
       { "group": "civilian_armor", "count": 2, "prob": 35 },
+      { "group": "prepper_maps", "prob": 100 },
       { "group": "bugout_large_extras", "prob": 40 }
     ]
   },
@@ -205,16 +210,42 @@
   },
   {
     "type": "item_group",
-    "id": "bugout_first_aid",
-    "subtype": "distribution",
-    "//": "a form of first aid.",
+    "id": "bugout_meds_prepper",
+    "subtype": "collection",
+    "//": "A pessimist planning for a catastrophe, excluding serious first aid items.",
     "entries": [
-      { "group": "full_ifak", "prob": 50 },
-      { "group": "used_ifak", "prob": 50 },
-      { "group": "full_1st_aid", "prob": 50 },
-      { "group": "used_1st_aid", "prob": 50 },
-      { "prob": 50, "group": "homeopathic_pills_bottle_plastic_pill_supplement_20" },
-      { "group": "full_ipok", "prob": 50 }
+      { "group": "adhesive_bandages_box_full", "count": 1, "prob": 80 },
+      { "group": "alcohol_wipes_box_full", "count": 1, "prob": 50 },
+      { "group": "cotton_ball_bag_full", "count": 1, "prob": 60 },
+      { "item": "liq_bandage_spray", "count": 1, "prob": 30 },
+      { "group": "vitc_tablet_bottle_full", "count": 1, "prob": 30 },
+      { "item": "calcium_tablet", "count": [ 30, -1 ], "prob": 30 },
+      { "item": "gummy_vitamins", "count": [ 30, -1 ], "container-item": "bottle_plastic", "prob": 20 },
+      { "item": "antibiotics", "count": [ 30, -1 ], "prob": 30 },
+      { "item": "iodine", "count": [ 30, -1 ], "prob": 30 },
+      { "item": "prussian_blue", "count": [ 12, -1 ], "prob": 20 },
+      { "item": "antifungal", "count": [ 30, -1 ], "prob": 10 },
+      { "item": "antiparasitic", "count": [ 30, -1 ], "prob": 10 },
+      { "item": "homeopathic_pills", "count": [ 30, -1 ], "prob": 10 },
+      { "group": "drugs_analgesic", "count": [ 1, 2 ], "prob": 40 },
+      { "group": "drugs_misc", "count": [ 1, 2 ], "prob": 5 },
+      { "group": "drugs_rare", "count": [ 1, 2 ], "prob": 5 },
+      { "item": "wrapped_rad_badge", "count": [ 1, 4 ], "prob": 5 },
+      { "group": "jar_weed", "count": 1, "prob": 25 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "bugout_first_aid",
+    "subtype": "collection",
+    "//": "First aid supplies, if you had time to prepare.",
+    "entries": [
+      { "distribution": [ { "group": "full_1st_aid", "prob": 50 }, { "group": "used_1st_aid", "prob": 50 } ], "prob": 90 },
+      {
+        "distribution": [ { "group": "full_ifak", "prob": 70 }, { "group": "used_ifak", "prob": 20 }, { "group": "full_ipok", "prob": 10 } ],
+        "prob": 70
+      },
+      { "group": "tools_medical", "count": [ 1, 4 ], "prob": 50 }
     ]
   },
   {
@@ -234,11 +265,44 @@
   {
     "type": "item_group",
     "id": "bugout_tools",
+    "//": "hastily-gathered items for eating and survival.",
     "subtype": "collection",
     "entries": [
       { "item": "fork", "count": [ 1, 2 ], "prob": 95 },
       { "item": "knife_butter", "count": [ 1, 2 ], "prob": 90 },
+      { "item": "knife_small", "count": [ 1, 2 ], "prob": 80 },
       { "item": "spoon", "count": [ 1, 2 ], "prob": 90 },
+      { "distribution": [ { "item": "tin_plate", "prob": 40 }, { "item": "plastic_plate", "prob": 60 } ], "prob": 50 },
+      {
+        "distribution": [
+          { "item": "bottle_metal", "prob": 50 },
+          { "item": "thermos", "prob": 50 },
+          { "item": "canteen", "prob": 20 },
+          { "item": "2lcanteen", "prob": 20 },
+          { "item": "camelbak", "prob": 10 }
+        ],
+        "prob": 80
+      },
+      { "group": "tools_lighting", "prob": 80 },
+      { "item": "teleumbrella", "prob": 50 },
+      {
+        "distribution": [
+          { "item": "knife_large", "prob": 120 },
+          { "item": "knife_cleaver", "prob": 30 },
+          { "item": "boxcutter", "prob": 60 },
+          { "item": "xacto", "prob": 60 },
+          { "item": "knife_swissarmy", "prob": 60 },
+          { "item": "pockknife", "prob": 10 },
+          { "item": "switchblade", "prob": 10 },
+          { "item": "knife_folding", "prob": 10 },
+          { "item": "utility_knife_folding", "prob": 5 },
+          { "item": "scalpel", "prob": 5 }
+        ],
+        "prob": 20
+      },
+      { "item": "roadmap", "prob": 5 },
+      { "item": "trailmap", "prob": 5 },
+      { "item": "whistle", "prob": 50 },
       { "item": "can_opener", "prob": 80 }
     ]
   },
@@ -268,6 +332,9 @@
       { "group": "canned_staples_1l" },
       { "group": "dry_lentils_bag_plastic_full", "count": 2 },
       { "group": "dry_rice_bag_plastic_full", "count": 2 },
+      { "group": "flatbread_bag_plastic_full", "count": 2 },
+      { "item": "peanutbutter", "count": 2 },
+      { "item": "jam_fruit", "count": 2 },
       { "item": "protein_bar_evac", "count": 6 }
     ]
   },
@@ -291,20 +358,13 @@
     "type": "item_group",
     "id": "bugout_water",
     "subtype": "distribution",
-    "//": "a form of water.",
+    "//": "a form of water, up to 3L or a gallon.",
     "entries": [
-      {
-        "distribution": [
-          { "item": "2lcanteen", "prob": 50 },
-          { "item": "camelbak", "prob": 25 },
-          { "item": "canteen", "prob": 70 },
-          { "item": "bottle_metal", "prob": 70 }
-        ],
-        "prob": 50
-      },
-      { "item": "water_mineral", "count": 1, "prob": 50 },
-      { "item": "rehydration_drink", "count": 1, "prob": 50 },
-      { "item": "sports_drink", "count": 1, "prob": 50 }
+      { "item": "water_clean", "count": [ 2, 6 ], "prob": 60 },
+      { "item": "water_clean", "charges": -1, "container-item": "jug_plastic", "prob": 20 },
+      { "item": "water_mineral", "count": [ 2, 6 ], "prob": 40 },
+      { "item": "sports_drink", "count": [ 2, 6 ], "prob": 40 },
+      { "item": "rehydration_drink", "count": [ 2, 6 ], "prob": 5 }
     ]
   },
   {
@@ -313,9 +373,11 @@
     "subtype": "distribution",
     "//": "extra useful items for inside a bugout bag.",
     "entries": [
+      { "item": "radio", "prob": 25 },
       { "group": "gear_survival", "count": 2, "prob": 50 },
       { "group": "hiking", "count": 2, "prob": 75 },
-      { "group": "bugout_bad_pack", "prob": 100 }
+      { "group": "tools_hunting", "count": 2, "prob": 75 },
+      { "group": "bugout_bad_pack", "prob": 150 }
     ]
   },
   {
@@ -331,9 +393,13 @@
     "subtype": "distribution",
     "//": "an item that wouldn't be super useful to the player, recreational items and such.",
     "entries": [
+      { "item": "towel", "count": 1, "prob": 50 },
+      { "group": "pet_food", "count": [ 1, 2 ], "prob": 20 },
       { "group": "SUS_book", "prob": 50 },
       { "group": "games", "prob": 20 },
       { "group": "bugout_memento", "prob": 50 },
+      { "group": "jewelry_front", "count": [ 1, 4 ], "prob": 40 },
+      { "group": "jewelry_safe", "count": [ 4, 12 ], "prob": 10 },
       { "group": "tampon_box_full", "prob": 20 },
       { "group": "menstrual_pad_box_full", "prob": 20 }
     ]
@@ -420,6 +486,7 @@
       { "group": "bugout_water", "prob": 75 },
       { "group": "bugout_tools", "prob": 40 },
       { "group": "bugout_food_easy", "prob": 33 },
+      { "group": "lunchbox_with_contents", "prob": 67 },
       { "item": "toothbrush_plain", "prob": 10 },
       { "item": "childnote", "prob": 33 }
     ]
@@ -461,6 +528,20 @@
     ]
   },
   {
+    "id": "prepper_maps",
+    "type": "item_group",
+    "//": "collected over the years by someone who anticipated the Internet going down",
+    "subtype": "collection",
+    "entries": [
+      { "item": "roadmap", "prob": 99 },
+      { "item": "trailmap", "prob": 90 },
+      { "item": "urbexmap", "prob": 25 },
+      { "item": "subwaystationmap", "prob": 75 },
+      { "item": "subwaymap", "prob": 10 },
+      { "item": "sewermap", "prob": 10 }
+    ]
+  },
+  {
     "type": "item_group",
     "id": "freeze_dried_meal_box_8",
     "subtype": "collection",
@@ -479,6 +560,7 @@
       { "group": "chili_can_medium_2", "count": 2 },
       { "group": "ravioli_can_medium_2", "count": 2 },
       { "group": "can_spam_can_medium_6", "count": 2 },
+      { "item": "milk_evap", "count": 2 },
       { "item": "can_tuna", "count": 4 }
     ]
   },

--- a/data/json/itemgroups/tools.json
+++ b/data/json/itemgroups/tools.json
@@ -559,8 +559,7 @@
       [ "stethoscope", 50 ],
       [ "syringe", 50 ],
       [ "thermometer", 50 ],
-      [ "vacutainer", 50 ],
-      [ "bag_body_bag", 10 ]
+      [ "vacutainer", 50 ]
     ]
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Content "Add meds, maps in bugout bags"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

If a prepper expects the Internet to go down, he's going to stockpile maps.

Cotton balls also shouldn't spawn in 6L bags, and band-aids and alcohol wipes shouldn't spawn in cereal boxes.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

Add prepper meds and maps.

Move the bulky body bag #28803 out of the medical tools itemgroup, so it doesn't turn up when that group gets used in a space-constrained place like a bugout bag (or other unintended places outside an ambulance).

Remove the chance of a non-prepper packing an IFAK pouch.

Add more bad items of dubious use like a stash of valuables and pet food. But also add a chance of a radio.

Add plates, umbrellas, and flashlights.

Packing 1 single water bottle didn't make sense so add more water, but shed water weight from the heavy bugout bag, implying a reliance on a supply of purifying tablets instead.

Pack a child's lunchbox.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
