### PR TITLE
Aftershock: Humaniforms can execute humanoid monsters

### DIFF
--- a/data/mods/Aftershock/mobs/robots.json
+++ b/data/mods/Aftershock/mobs/robots.json
@@ -305,8 +305,7 @@
       "NO_BREATHE",
       "PRIORITIZE_TARGETS",
       "GOODHEARING",
-      "PATH_AVOID_DANGER",
-      "HIT_AND_RUN"
+      "PATH_AVOID_DANGER"
     ],
     "//": "Much lower armor than usual since this is a player allied robot only.",
     "armor": { "bash": 8, "cut": 10, "bullet": 15 }

--- a/data/mods/aftershock_exoplanet/monster_attacks/monster_attacks.json
+++ b/data/mods/aftershock_exoplanet/monster_attacks/monster_attacks.json
@@ -15,12 +15,58 @@
   {
     "type": "monster_attack",
     "attack_type": "melee",
+    "id": "android_drop",
+    "cooldown": 10,
+    "move_cost": 100,
+    "hitsize_min": 4,
+    "attack_upper": false,
+    "condition": {
+      "and": [
+        { "not": { "npc_has_effect": "downed" } },
+        { "math": [ "u_val('size') + 1 >= n_val('size')" ] },
+        { "not": { "u_has_effect": "afs_android_crawling" } }
+      ]
+    },
+    "damage_max_instance": [ { "damage_type": "bash", "amount": 18, "armor_penetration": 15 } ],
+    "effects_require_dmg": true,
+    "hit_dmg_u": "%1$s lifts you with its arm and slams you into the ground!",
+    "hit_dmg_npc": "%1$s effortlessly lifts <npcname> before slamming them into the ground!",
+    "no_dmg_msg_u": "%1$s tries to grab you, but finds no grip on your armor!",
+    "no_dmg_msg_npc": "%1$s tries to grab <npcname>, but finds no grip on their armor!",
+    "miss_msg_u": "%s reaches for you with its arm, but you slip out of the way!",
+    "miss_msg_npc": "%s tries to grab <npcname>, but they slip out of the way!",
+    "effects": [ { "id": "downed", "duration": 3 } ]
+  },
+  {
+    "type": "monster_attack",
+    "attack_type": "melee",
     "id": "android_crush",
     "cooldown": 5,
     "move_cost": 80,
     "damage_max_instance": [ { "damage_type": "bash", "amount": 30, "armor_penetration": 15 } ],
+    "condition": { "and": [ { "npc_has_effect": "downed" }, { "not": { "u_has_effect": "afs_android_crawling" } }, "npc_is_character" ] },
+    "min_mul": 0.3,
+    "hit_dmg_u": "%1$s crushes your %2$s with a vicious stomp!",
+    "hit_dmg_npc": "%1$s crushes <npcname> underfoot!",
+    "no_dmg_msg_u": "%1$s's attempt to crush your %2$s is deflected by your armor.",
+    "no_dmg_msg_npc": "%1$s's attempt to crush <npcname> is deflected by their armor.",
+    "miss_msg_u": "You roll out of the way of %1$s's stomp!",
+    "miss_msg_npc": "<npcname> rolls out of the way of %1$s's stomp!"
+  },
+  {
+    "type": "monster_attack",
+    "attack_type": "melee",
+    "id": "android_crush_monster",
+    "cooldown": 1,
+    "move_cost": 80,
+    "damage_max_instance": [ { "damage_type": "bash", "amount": 1200, "armor_penetration": 15 } ],
     "condition": {
-      "and": [ { "u_has_flag": "GRAB_FILTER" }, { "npc_has_effect": "downed" }, { "u_has_effect": "afs_android_crawling" } ]
+      "and": [
+        { "npc_has_effect": "downed" },
+        { "not": { "u_has_effect": "afs_android_crawling" } },
+        "npc_is_monster",
+        { "math": [ "u_val('size') + 1 >= n_val('size')" ] }
+      ]
     },
     "min_mul": 0.3,
     "hit_dmg_u": "%1$s crushes your %2$s with a vicious stomp!",

--- a/data/mods/aftershock_exoplanet/monsters/robots.json
+++ b/data/mods/aftershock_exoplanet/monsters/robots.json
@@ -268,7 +268,7 @@
     "id": "afs_mon_sentinel_lx",
     "type": "MONSTER",
     "name": { "str": "Wraitheon Sentinel-lx", "str_pl": "Wraitheon Sentinels-lx" },
-    "description": "Its exterior plates are sable and gold, this luxurious variant of a Wraitheon drone was once kept as a bodyguard by society's wealthiest.  Still with its wrist sword extended, it resembles an ancient knight, standing an eternal watch.",
+    "description": "Clad in sable and gold armor, this luxurious combat humaniform is intended to serve as a bodyguard to society's wealthiest.  Still with its wrist sword extended, it resembles an ancient knight, standing an eternal watch.",
     "default_faction": "WraitheonRobotics",
     "species": [ "ROBOT" ],
     "diff": 10,
@@ -276,6 +276,7 @@
     "weight": "81500 g",
     "hp": 200,
     "speed": 100,
+    "bleed_rate": 0,
     "material": [ "steel" ],
     "symbol": "R",
     "color": "light_gray",
@@ -285,20 +286,22 @@
     "melee_dice": 4,
     "melee_dice_sides": 5,
     "melee_dice_ap": 4,
-    "melee_damage": [ { "damage_type": "cut", "amount": 5 } ],
+    "melee_damage": [ { "damage_type": "cut", "amount": 10 } ],
     "dodge": 8,
     "vision_day": 6,
     "vision_night": 6,
     "path_settings": { "max_dist": 6, "avoid_traps": true, "avoid_sharp": true },
     "revert_to_itype": "bot_sentinel_lx",
     "special_attacks": [
+      { "id": "android_crush", "cooldown": 1 },
+      { "id": "android_crush_monster", "cooldown": 1 },
+      { "id": "android_drop", "cooldown": 2 },
       [ "SMASH", 20 ],
-      [ "TAZER", 5 ],
       {
         "type": "gun",
         "cooldown": 15,
         "gun_type": "afs_sentinel_laser_mon",
-        "ranges": [ [ 0, 12, "DEFAULT" ] ],
+        "ranges": [ [ 3, 12, "DEFAULT" ] ],
         "targeting_sound": "\"Dispatching hostile with lethal force.\"",
         "require_targeting_npc": true,
         "require_targeting_monster": true,
@@ -316,8 +319,7 @@
       "NO_BREATHE",
       "PRIORITIZE_TARGETS",
       "GOODHEARING",
-      "PATH_AVOID_DANGER",
-      "HIT_AND_RUN"
+      "PATH_AVOID_DANGER"
     ],
     "//": "Much lower armor than usual since this is a player allied robot only.",
     "armor": { "bash": 8, "cut": 10, "bullet": 15 }
@@ -690,6 +692,7 @@
     "melee_dice": 4,
     "melee_dice_sides": 5,
     "melee_dice_ap": 4,
+    "bleed_rate": 0,
     "starting_ammo": { "afs_7.50mm_caseless": 90 },
     "vision_day": 50,
     "vision_night": 50,
@@ -716,15 +719,15 @@
         "targeting_sound": "\"Hostile Detected.\"",
         "targeting_volume": 10
       },
-      { "id": "grab", "cooldown": 7 },
       {
         "id": "smash",
         "throw_strength": 48,
         "cooldown": 30,
         "condition": { "not": { "u_has_effect": "afs_android_crawling" } }
       },
-      { "id": "android_crush", "cooldown": 3 },
-      { "id": "leg_sweep", "cooldown": 2 }
+      { "id": "android_crush", "cooldown": 1 },
+      { "id": "android_crush_monster", "cooldown": 1 },
+      { "id": "android_drop", "cooldown": 2 }
     ],
     "extend": { "flags": [ "DROPS_AMMO" ] },
     "broken_itype": "broken_imaginifer",


### PR DESCRIPTION
#### Summary
Mods "Aftershock: Humaniforms can execute humanoid monsters"

#### Purpose of change
Combat androids should be incredibly vicious melee fighters, and indeed they are when fighting player.  However the way their attacks were structured made them completely inefectual at fighting even basic moxies, since its dealt in big bursts that are easily countered by hp regen, and not constant DPS.


#### Describe the solution
First I dropped the grab requirement from the groundslam in favor of simply checking for relative size.
Then I added a special instant-kill move that they can use on similarily sized monsters with the grounded effect.

Pic of the combo: 
<img width="949" height="797" alt="imagen" src="https://github.com/user-attachments/assets/59a93505-d369-4197-9b12-25c4d7323de5" />

They consistently win melee fights with monsters as expected from a million dollar combat machine.

#### Testing
See pic.

#### Additional context
It'd be cool to have different snippets describing how the execution is performed, unfortunately it isnt possible.