### PR TITLE
Fix debugmsg on portal storm end

### DIFF
--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -7779,7 +7779,7 @@ talk_effect_fun_t::func f_trigger_event( const JsonObject &jo, std::string_view 
         args_str.reserve( args.size() );
         std::transform( args.cbegin(), args.cend(),
         std::back_inserter( args_str ), [&d]( str_or_var const & sov ) {
-            return sov.evaluate( d );
+            return sov.evaluate( d, true );
         } );
         get_event_bus().send( cata::event::make_dyn( type, args_str ) );
     };


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Fix https://github.com/CleverRaven/Cataclysm-DDA/issues/81768

#### Describe the solution
f_trigger_event uses all string arguments, but `u_counter_portal_storm_counter` is a double. Ensure that the variables are converted to strings for the event arguments.

#### Testing
Start a portal storm by setting the time ahead one season and waiting a few turns, then wait until it ends.

#### Additional context
This should be backported.