### PR TITLE
Aftershock: Survival heaters produce temporary AC

### DIFF
--- a/data/mods/aftershock_exoplanet/emit.json
+++ b/data/mods/aftershock_exoplanet/emit.json
@@ -25,7 +25,7 @@
   {
     "id": "afs_emit_survival_heater",
     "type": "emit",
-    "field": "fd_hot_airAC",
+    "field": "fd_hot_airAC_temporary",
     "qty": 60,
     "chance": 100
   },

--- a/data/mods/aftershock_exoplanet/field.json
+++ b/data/mods/aftershock_exoplanet/field.json
@@ -94,6 +94,16 @@
     "phase": "gas"
   },
   {
+    "id": "fd_hot_airAC_temporary",
+    "type": "field_type",
+    "intensity_levels": [ { "name": "air conditioner", "sym": "&", "convection_temperature_mod": 115 } ],
+    "priority": -1,
+    "display_field": false,
+    "percent_spread": 100,
+    "half_life": "120 seconds",
+    "phase": "gas"
+  },
+  {
     "id": "fd_elect_anomaly",
     "type": "field_type",
     "intensity_levels": [


### PR DESCRIPTION
#### Summary
Mods "Aftershock: Survival heaters produce temporary AC" 

#### Purpose of change
Fixes #81378

#### Describe the solution
Heaters now use temporary AC fields which decay in 120s and top out at a safer ~25C

#### Testing
Spawned a heater to check.
