### PR TITLE
add more calculations for Offense stat in chargen

### DIFF
--- a/src/player_difficulty.cpp
+++ b/src/player_difficulty.cpp
@@ -31,6 +31,8 @@ static const itype_id itype_bat( "bat" );
 static const itype_id itype_knife_combat( "knife_combat" );
 static const itype_id itype_machete( "machete" );
 static const itype_id itype_m4_carbine( "modular_m4_carbine" );
+static const itype_id itype_glock_19( "glock_19" );
+static const itype_id itype_m203( "m203" );
 
 static const profession_id profession_unemployed( "unemployed" );
 
@@ -207,12 +209,16 @@ double player_difficulty::calc_dps_value( const Character &u )
     item early_bashing = item( itype_bat );
 
     // idk some standard ranged weapons i guess
-    item standard_rifle = item( modular_m4_carbine );
+    item standard_rifle = item( itype_m4_carbine );
+    item standard_handgun = item( itype_glock19 );
+    item standard_launcher = item( itype_m203 );
 
     double baseline = std::max( u.weapon_value( early_piercing ),
                                 u.weapon_value( early_cutting ) );
     baseline = std::max( baseline, u.weapon_value( early_bashing ) );
-    baseline = std::max( baseline, u.weapon_value( modular_m4_carbine, nullptr ) );
+    baseline = std::max( baseline, u.weapon_value( standard_rifle, nullptr ) );
+    baseline = std::max( baseline, u.weapon_value( standard_handgun, nullptr ) );
+    baseline = std::max( baseline, u.weapon_value( standard_launcher, nullptr ) );
 
     // check any other items the character has on them
     if( u.prof ) {

--- a/src/player_difficulty.cpp
+++ b/src/player_difficulty.cpp
@@ -216,9 +216,9 @@ double player_difficulty::calc_dps_value( const Character &u )
     double baseline = std::max( u.weapon_value( early_piercing ),
                                 u.weapon_value( early_cutting ) );
     baseline = std::max( baseline, u.weapon_value( early_bashing ) );
-    baseline = std::max( baseline, u.weapon_value( standard_rifle, 10 ) );
-    baseline = std::max( baseline, u.weapon_value( standard_handgun, 10 ) );
     baseline = std::max( baseline, u.weapon_value( standard_launcher, 3 ) );
+    baseline = std::max( baseline, u.weapon_value( standard_rifle, 30 ) );
+    baseline = std::max( baseline, u.weapon_value( standard_handgun, 30 ) );
 
     // check any other items the character has on them
     if( u.prof ) {

--- a/src/player_difficulty.cpp
+++ b/src/player_difficulty.cpp
@@ -210,15 +210,15 @@ double player_difficulty::calc_dps_value( const Character &u )
 
     // idk some standard ranged weapons i guess
     item standard_rifle = item( itype_m4_carbine );
-    item standard_handgun = item( itype_glock19 );
+    item standard_handgun = item( itype_glock_19 );
     item standard_launcher = item( itype_m203 );
 
     double baseline = std::max( u.weapon_value( early_piercing ),
                                 u.weapon_value( early_cutting ) );
     baseline = std::max( baseline, u.weapon_value( early_bashing ) );
-    baseline = std::max( baseline, u.weapon_value( standard_rifle, nullptr ) );
-    baseline = std::max( baseline, u.weapon_value( standard_handgun, nullptr ) );
-    baseline = std::max( baseline, u.weapon_value( standard_launcher, nullptr ) );
+    baseline = std::max( baseline, u.weapon_value( standard_rifle, 10 ) );
+    baseline = std::max( baseline, u.weapon_value( standard_handgun, 10 ) );
+    baseline = std::max( baseline, u.weapon_value( standard_launcher, 3 ) );
 
     // check any other items the character has on them
     if( u.prof ) {

--- a/src/player_difficulty.cpp
+++ b/src/player_difficulty.cpp
@@ -30,6 +30,7 @@ static const damage_type_id damage_bash( "bash" );
 static const itype_id itype_bat( "bat" );
 static const itype_id itype_knife_combat( "knife_combat" );
 static const itype_id itype_machete( "machete" );
+static const itype_id itype_m4_carbine( "modular_m4_carbine" );
 
 static const profession_id profession_unemployed( "unemployed" );
 
@@ -205,9 +206,13 @@ double player_difficulty::calc_dps_value( const Character &u )
     item early_cutting = item( itype_machete );
     item early_bashing = item( itype_bat );
 
+    // idk some standard ranged weapons i guess
+    item standard_rifle = item( modular_m4_carbine );
+
     double baseline = std::max( u.weapon_value( early_piercing ),
                                 u.weapon_value( early_cutting ) );
     baseline = std::max( baseline, u.weapon_value( early_bashing ) );
+    baseline = std::max( baseline, u.weapon_value( modular_m4_carbine, nullptr ) );
 
     // check any other items the character has on them
     if( u.prof ) {


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Fixes #81383

#### Describe the solution
- I (aim to) add more ranged weapons to calculate. However, I'm not too sure about the ideal testing weapons for each type, so I'll leave it in draft for now.
- In addition, I (may) also try and deal with the ugly workarounds found in the [`weapon_value`](https://github.com/CleverRaven/Cataclysm-DDA/blob/0c6847d9e6dec75eee63dab33f08a0e6e182dabc/src/melee.cpp#L2736) function. I'm currently trying to understand it alongside {melee, gun}_value. 

#### Describe alternatives you've considered
NONE

#### Testing
Not yet.

#### Additional context
Uhm it's 2025, how am I supposed to burn & tear it then rebuild a "glorious" castle?
