### PR TITLE
migrate "longarm bag" item

### DIFF
--- a/data/json/items/armor/storage.json
+++ b/data/json/items/armor/storage.json
@@ -2971,37 +2971,6 @@
     "armor": [ { "encumbrance": [ 0, 0 ], "covers": [ "torso" ], "specifically_covers": [ "torso_hanging_back" ] } ]
   },
   {
-    "id": "long_duffelbag",
-    "type": "ITEM",
-    "subtypes": [ "ARMOR" ],
-    "name": { "str": "longarm bag" },
-    "description": "A long duffel bag.  Provides storage for long arms and rifles.  Quite cumbersome.",
-    "weight": "1203 g",
-    "volume": "12 L",
-    "price": "180 USD",
-    "price_postapoc": "8 USD",
-    "material": [ "canvas" ],
-    "symbol": "[",
-    "looks_like": "rucksack",
-    "color": "green",
-    "pocket_data": [
-      {
-        "pocket_type": "CONTAINER",
-        "max_contains_volume": "50 L",
-        "max_contains_weight": "80 kg",
-        "max_item_length": "150 cm",
-        "magazine_well": "10 L",
-        "moves": 300
-      }
-    ],
-    "warmth": 8,
-    "material_thickness": 1,
-    "flags": [ "BELTED", "WATER_FRIENDLY" ],
-    "armor": [
-      { "encumbrance": [ 8, 42 ], "coverage": 100, "covers": [ "torso" ], "specifically_covers": [ "torso_hanging_back" ] }
-    ]
-  },
-  {
     "id": "rifle_case_soft",
     "type": "ITEM",
     "subtypes": [ "ARMOR" ],

--- a/data/json/obsoletion_and_migration_0.I/migration_items.json
+++ b/data/json/obsoletion_and_migration_0.I/migration_items.json
@@ -2686,5 +2686,10 @@
     "type": "MIGRATION",
     "id": "e_combatsaw_on",
     "replace": "elec_chainsaw_on"
+  },
+  {
+    "type": "MIGRATION",
+    "id": "long_duffelbag",
+    "replace": "duffelbag"
   }
 ]

--- a/data/json/recipes/armor/storage.json
+++ b/data/json/recipes/armor/storage.json
@@ -2365,20 +2365,6 @@
     "components": [ [ [ "strap_large", 2, "LIST" ] ] ]
   },
   {
-    "result": "long_duffelbag",
-    "type": "recipe",
-    "activity_level": "LIGHT_EXERCISE",
-    "category": "CC_ARMOR",
-    "subcategory": "CSC_ARMOR_STORAGE",
-    "skill_used": "tailor",
-    "difficulty": 2,
-    "time": "10 h",
-    "autolearn": true,
-    "reversible": true,
-    "using": [ [ "tailoring_canvas_patchwork", 32 ], [ "fastener_large", 2 ], [ "waterproofing_plastic_sheets", 4 ] ],
-    "proficiencies": [ { "proficiency": "prof_closures" }, { "proficiency": "prof_closures_waterproofing" } ]
-  },
-  {
     "result": "rifle_case_soft",
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",

--- a/tests/reload_time_test.cpp
+++ b/tests/reload_time_test.cpp
@@ -19,7 +19,7 @@
 static const itype_id itype_ammo_pouch( "ammo_pouch" );
 static const itype_id itype_arrow_wood( "arrow_wood" );
 static const itype_id itype_backpack( "backpack" );
-static const itype_id itype_long_duffelbag( "long_duffelbag" );
+static const itype_id itype_duffelbag( "duffelbag" );
 static const itype_id itype_longbow( "longbow" );
 static const itype_id itype_pants( "pants" );
 static const itype_id itype_pebble( "pebble" );
@@ -113,7 +113,7 @@ TEST_CASE( "reload_from_inventory_times", "[reload],[inventory],[balance]" )
     }
     SECTION( "reloading a bow" ) {
         SECTION( "from a duffel bag" ) {
-            check_reload_time( itype_longbow, itype_arrow_wood, itype_long_duffelbag, 410 );
+            check_reload_time( itype_longbow, itype_arrow_wood, itype_duffelbag, 410 );
         }
         SECTION( "from a quiver" ) {
             check_reload_time( itype_longbow, itype_arrow_wood, itype_quiver, 130 );

--- a/tests/reload_time_test.cpp
+++ b/tests/reload_time_test.cpp
@@ -19,7 +19,7 @@
 static const itype_id itype_ammo_pouch( "ammo_pouch" );
 static const itype_id itype_arrow_wood( "arrow_wood" );
 static const itype_id itype_backpack( "backpack" );
-static const itype_id itype_duffelbag( "duffelbag" );
+static const itype_id itype_backpack_giant( "backpack_giant" );
 static const itype_id itype_longbow( "longbow" );
 static const itype_id itype_pants( "pants" );
 static const itype_id itype_pebble( "pebble" );
@@ -112,8 +112,8 @@ TEST_CASE( "reload_from_inventory_times", "[reload],[inventory],[balance]" )
         }
     }
     SECTION( "reloading a bow" ) {
-        SECTION( "from a duffel bag" ) {
-            check_reload_time( itype_longbow, itype_arrow_wood, itype_duffelbag, 410 );
+        SECTION( "from a giant novelty backpack" ) {
+            check_reload_time( itype_longbow, itype_arrow_wood, itype_backpack_giant, 410 );
         }
         SECTION( "from a quiver" ) {
             check_reload_time( itype_longbow, itype_arrow_wood, itype_quiver, 130 );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Content "Obsolete longarm bags"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

A longarm bag does not exist. The *term* "longarm bag" does not exist. The term looks like an awkward name coined in #42386 for its invention of a duffelbag intended to hold rifles without using the word "rifle." But in real life rifles are generally held in rifle cases (added a few months later in #43466). And no real duffelbag with that volume capacity has 1 extremely long length dimension like this item does (50L but 150 cm long?).

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

Replace it with a duffelbag.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

The `duffelbag` is currently larger than the `long_duffelbag` ever was, though not with the same absurd length. #81101

#81553

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
