### PR TITLE
[XEDRA Evolved] Humaniform Mi-go

### DIFF
--- a/data/mods/Xedra_Evolved/monsters/migo.json
+++ b/data/mods/Xedra_Evolved/monsters/migo.json
@@ -43,6 +43,66 @@
       "PRIORITIZE_TARGETS",
       "CORNERED_FIGHTER"
     ],
+    "upgrades": { "into_group": "GROUP_XE_MIGO_EVO", "half_life": 40 },
     "armor": { "bash": 10, "cut": 16, "stab": 10, "bullet": 10, "electric": 3, "acid": 20 }
+  },
+  {
+    "id": "mon_mi_go_humanoid",
+    "type": "MONSTER",
+    "name": { "str": "humaniform mi-go" },
+    "description": "A pink alien that used to be a mi-go before turning into this facsimile of a human person.  Whatever compromises they went with to create this form has made them lighter and no taller than an average man's waist, they 'wear' clothes made out of waxy thin pink flesh, and the only mi-go parts left intact are their lobster-like claws and their useless pair of ribbed, membranous wings.  Whether they used the form for diplomacy with the humans or just the general curiousity of the humanoid shape, they still pack a punch despite the diminutive form.",
+    "default_faction": "mi-go",
+    "bodytype": "human",
+    "species": [ "MIGO" ],
+    "volume": "31250 ml",
+    "weight": "60 kg",
+    "hp": 125,
+    "speed": 140,
+    "material": [ "mi-go_flesh" ],
+    "symbol": "&",
+    "color": "pink",
+    "aggression": 20,
+    "morale": 30,
+    "melee_skill": 5,
+    "melee_dice": 4,
+    "melee_dice_sides": 6,
+    "melee_damage": [ { "damage_type": "cut", "amount": 6 } ],
+    "dodge": 4,
+    "bleed_rate": 75,
+    "vision_day": 50,
+    "vision_night": 20,
+    "weakpoint_sets": [ "wps_mi-go", "wps_humanoid_child_body", "wps_natural_armor" ],
+    "families": [ "prof_wp_mi-go_basic", "prof_wp_mi-go_advanced", "prof_wp_nat_armored", "prof_wp_child" ],
+    "harvest": "mi-go",
+    "path_settings": { "max_dist": 50, "allow_open_doors": true, "avoid_traps": true, "avoid_sharp": true, "avoid_dangerous_fields": true },
+    "scents_ignored": [ "sc_fetid" ],
+    "special_attacks": [
+      [ "PARROT", 50 ],
+      { "id": "scratch", "damage_max_instance": [ { "damage_type": "cut", "amount": 23, "armor_multiplier": 0.8 } ] }
+    ],
+    "flags": [
+      "SEES",
+      "SMELLS",
+      "HEARS",
+      "WARM",
+      "HAS_MIND",
+      "BASHES",
+      "POISON",
+      "NO_BREATHE",
+      "ARTHROPOD_BLOOD",
+      "PATH_AVOID_DANGER",
+      "CAN_OPEN_DOORS",
+      "PRIORITIZE_TARGETS",
+      "CORNERED_FIGHTER"
+    ],
+    "upgrades": { "into_group": "GROUP_XE_MIGO_EVO", "half_life": 40 },
+    "armor": { "bash": 4, "cut": 6, "bullet": 7, "electric": 2 }
+  },
+  {
+    "id": "mon_mi_go",
+    "type": "MONSTER",
+    "copy-from": "mon_mi_go",
+    "name": { "str": "mi-go" },
+    "upgrades": { "into_group": "GROUP_XE_MIGO_EVO", "half_life": 40 }
   }
 ]

--- a/data/mods/Xedra_Evolved/monsters/migo.json
+++ b/data/mods/Xedra_Evolved/monsters/migo.json
@@ -50,7 +50,7 @@
     "id": "mon_mi_go_humanoid",
     "type": "MONSTER",
     "name": { "str": "humaniform mi-go" },
-    "description": "A pink alien that used to be a mi-go before turning into this facsimile of a human person.  Whatever compromises they went with to create this form has made them lighter and no taller than an average man's waist, they 'wear' clothes made out of waxy thin pink flesh, and the only mi-go parts left intact are their lobster-like claws and their useless pair of ribbed, membranous wings.  Whether they used the form for diplomacy with the humans or just the general curiousity of the humanoid shape, they still pack a punch despite the diminutive form.",
+    "description": "A pink alien that used to be a mi-go before turning into this facsimile of a human person.  Whatever compromises they went with to create this form has made them lighter and no taller than an average man's waist, they 'wear' clothes made out of waxy thin pink flesh, and the only mi-go parts left intact are their lobster-like claws and their useless pair of ribbed, membranous wings.  Whether they used the form for diplomacy with the humans or just the general curiosity of the humanoid shape, they still pack a punch despite the diminutive form.",
     "default_faction": "mi-go",
     "bodytype": "human",
     "species": [ "MIGO" ],

--- a/data/mods/Xedra_Evolved/monsters/monstergroup.json
+++ b/data/mods/Xedra_Evolved/monsters/monstergroup.json
@@ -347,7 +347,10 @@
   {
     "type": "monstergroup",
     "id": "GROUP_MI-GO_BASE_COMMON",
-    "monsters": [ { "monster": "mon_mi_go_stalking_warper", "weight": 50, "cost_multiplier": 2, "starts": "35 days" } ]
+    "monsters": [
+      { "monster": "mon_mi_go_stalking_warper", "weight": 50, "cost_multiplier": 2, "starts": "35 days" },
+      { "monster": "mon_mi_go_humanoid", "weight": 50, "cost_multiplier": 2, "starts": "35 days" }
+    ]
   },
   {
     "type": "monstergroup",
@@ -431,5 +434,10 @@
       { "monster": "mon_zombie_monochrome_2", "weight": 225 },
       { "monster": "mon_zombie_monochrome_3", "weight": 100 }
     ]
+  },
+  {
+    "type": "monstergroup",
+    "id": "GROUP_XE_MIGO_EVO",
+    "monsters": [ { "monster": "mon_mi_go" }, { "monster": "mon_mi_go_humanoid" }, { "monster": "mon_mi_go_stalking_warper" } ]
   }
 ]


### PR DESCRIPTION

#### Summary
None

#### Purpose of change
Adds a mi-go, now in human form as the potential basic mi-go and stalking warper's "evolution" (which i like to hand wave it as migo trying out different form to see if it works for their particular situation)

I already made it basically confirmed in my previous XE loading screen, might as well add it.
#### Describe the solution
Adds the jsons for it


#### Describe alternatives you've considered
Keeping Migo-chan to myself

#### Testing
![Screenshot_20250719_044537](https://github.com/user-attachments/assets/48e73863-ef9b-4644-b003-a37ca212e50d)


#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
