### PR TITLE
Fix scenarios that change starting year doing so incorrectly on first load

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -795,6 +795,12 @@ void game::setup()
 
         load_core_data();
     }
+
+    // invalidate calendar caches in case we were previously playing
+    // a different world
+    calendar::set_eternal_season( ::get_option<bool>( "ETERNAL_SEASON" ) );
+    calendar::set_season_length( ::get_option<int>( "SEASON_LENGTH" ) );
+
     world_generator->get_mod_manager().check_mods_list( world_generator->active_world );
     load_world_modfiles();
     // Panel manager needs JSON data to be loaded before init
@@ -806,11 +812,6 @@ void game::setup()
     next_mission_id = 1;
     uquit = QUIT_NO;   // We haven't quit the game
     bVMonsterLookFire = true;
-
-    // invalidate calendar caches in case we were previously playing
-    // a different world
-    calendar::set_eternal_season( ::get_option<bool>( "ETERNAL_SEASON" ) );
-    calendar::set_season_length( ::get_option<int>( "SEASON_LENGTH" ) );
 
     calendar::set_eternal_night( ::get_option<std::string>( "ETERNAL_TIME_OF_DAY" ) == "night" );
     calendar::set_eternal_day( ::get_option<std::string>( "ETERNAL_TIME_OF_DAY" ) == "day" );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -799,7 +799,7 @@ void game::setup()
     // invalidate calendar caches in case we were previously playing
     // a different world
     calendar::set_eternal_season( ::get_option<bool>( "ETERNAL_SEASON" ) );
-	// must be called before load_world_modfiles() #81904
+    // must be called before load_world_modfiles() #81904
     calendar::set_season_length( ::get_option<int>( "SEASON_LENGTH" ) );
 
     world_generator->get_mod_manager().check_mods_list( world_generator->active_world );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -799,6 +799,7 @@ void game::setup()
     // invalidate calendar caches in case we were previously playing
     // a different world
     calendar::set_eternal_season( ::get_option<bool>( "ETERNAL_SEASON" ) );
+	// must be called before load_world_modfiles() #81904
     calendar::set_season_length( ::get_option<int>( "SEASON_LENGTH" ) );
 
     world_generator->get_mod_manager().check_mods_list( world_generator->active_world );

--- a/src/scenario.cpp
+++ b/src/scenario.cpp
@@ -115,8 +115,6 @@ void scenario::load( const JsonObject &jo, std::string_view )
     optional( jo, was_loaded, "eoc", _eoc, auto_flags_reader<effect_on_condition_id> {} );
 
     if( !was_loaded ) {
-        const time_duration year_length = time_duration::from_days( get_option<int>( "SEASON_LENGTH" ) ) *
-                                          4;
 
         int _start_of_cataclysm_hour = 0;
         // The cataclysm started 5 days before game start
@@ -134,7 +132,7 @@ void scenario::load( const JsonObject &jo, std::string_view )
                                       1_hours * _start_of_cataclysm_hour +
                                       1_days * ( _start_of_cataclysm_day - 1 ) +
                                       1_days * get_option<int>( "SEASON_LENGTH" ) * _start_of_cataclysm_season +
-                                      year_length * ( _start_of_cataclysm_year - 1 )
+                                      calendar::year_length() * ( _start_of_cataclysm_year - 1 )
                                       ;
 
         int _start_of_game_hour = 8;
@@ -152,7 +150,7 @@ void scenario::load( const JsonObject &jo, std::string_view )
                                  1_hours * _start_of_game_hour +
                                  1_days * ( _start_of_game_day - 1 ) +
                                  1_days * get_option<int>( "SEASON_LENGTH" ) * _start_of_game_season +
-                                 year_length * ( _start_of_game_year - 1 )
+                                 calendar::year_length() * ( _start_of_game_year - 1 )
                                  ;
 
         reset_calendar();

--- a/src/scenario.cpp
+++ b/src/scenario.cpp
@@ -115,6 +115,7 @@ void scenario::load( const JsonObject &jo, std::string_view )
     optional( jo, was_loaded, "eoc", _eoc, auto_flags_reader<effect_on_condition_id> {} );
 
     if( !was_loaded ) {
+    	const time_duration year_length = time_duration::from_days( get_option<int>( "SEASON_LENGTH" ) ) * 4;
 
         int _start_of_cataclysm_hour = 0;
         // The cataclysm started 5 days before game start
@@ -132,7 +133,7 @@ void scenario::load( const JsonObject &jo, std::string_view )
                                       1_hours * _start_of_cataclysm_hour +
                                       1_days * ( _start_of_cataclysm_day - 1 ) +
                                       1_days * get_option<int>( "SEASON_LENGTH" ) * _start_of_cataclysm_season +
-                                      calendar::year_length() * ( _start_of_cataclysm_year - 1 )
+                                      year_length * ( _start_of_cataclysm_year - 1 )
                                       ;
 
         int _start_of_game_hour = 8;
@@ -150,7 +151,7 @@ void scenario::load( const JsonObject &jo, std::string_view )
                                  1_hours * _start_of_game_hour +
                                  1_days * ( _start_of_game_day - 1 ) +
                                  1_days * get_option<int>( "SEASON_LENGTH" ) * _start_of_game_season +
-                                 calendar::year_length() * ( _start_of_game_year - 1 )
+                                 year_length * ( _start_of_game_year - 1 )
                                  ;
 
         reset_calendar();

--- a/src/scenario.cpp
+++ b/src/scenario.cpp
@@ -115,7 +115,8 @@ void scenario::load( const JsonObject &jo, std::string_view )
     optional( jo, was_loaded, "eoc", _eoc, auto_flags_reader<effect_on_condition_id> {} );
 
     if( !was_loaded ) {
-    	const time_duration year_length = time_duration::from_days( get_option<int>( "SEASON_LENGTH" ) ) * 4;
+        const time_duration year_length = time_duration::from_days( get_option<int>( "SEASON_LENGTH" ) ) *
+                                          4;
 
         int _start_of_cataclysm_hour = 0;
         // The cataclysm started 5 days before game start


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Fix incorrect date from starting year scenarios on first load"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes #81287

The Next Summer scenario, and any other scenario that changes the start year of the game or the cataclysm to anything higher than 1 (in vanilla, just Brave New World), load an incorrect date whenever you create a character after first opening the game but load properly if you abort and create another one.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
`scenario::load()` uses `calendar::year_length()`, which ultimately relies on `cur_season_length`, to calculate the game and cataclysm start dates. In `game::setup()`, the call to load modfiles (which calls `scenario::load()`) happens before the call to set `cur_season_length`, so when `calendar::year_length()` gets used on a first load, it uses `cur_season_length`'s default value of 1 which causes the incorrect date bug. 

In `tests/test_main.cpp` the call to set `cur_season_length` *is* before the call to load modfiles, so that's why the bug isn't present in the test suite and doesn't get caught by`tests/start_date_test.cpp`.

My solution is to use the option for SEASON_LENGTH instead of `calendar::year_length()` to calculate the date in `scenario::load()`, which has the benefit of making the scenarios load correctly regardless of when `cur_season_length` is set. `scenario::load()` does this for the day and season parts of the calculation already. 

I also moved the season set calls before the calls to load modfiles to make it consistent with `tests/test_main.cpp` and in case anything else relies on `cur_season_length` being set.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
I considered just moving the season set calls, which also fixes the bug, but I think this solution is better for the reasons above.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Open game with existing world
Create custom character
Select The Next Summer (and Brave New World) scenarios
See that start of game is correct


Open game with no worlds 
Create custom character
Select The Next Summer (and Brave New World) scenarios
See that start of game is correct

Both are incorrect before changes.
Both are correct after change including without moving season set calls before load modfiles call.

Also tried moving the season set calls to happen after the load modfiles call in `tests/test_main.cpp` which caused `tests/start_date_test.cpp` to properly fail.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->
