### PR TITLE
fix Start Vehicle Construction cancelling

### DIFF
--- a/src/character.h
+++ b/src/character.h
@@ -3733,7 +3733,8 @@ class Character : public Creature, public visitable
         // Selects one entry in components using select_item_component and consumes those items.
         std::list<item> consume_items( const std::vector<item_comp> &components, int batch = 1,
                                        const std::function<bool( const item & )> &filter = return_true<item>,
-                                       const std::function<bool( const itype_id & )> &select_ind = return_false<itype_id> );
+                                       const std::function<bool( const itype_id & )> &select_ind = return_false<itype_id>,
+                                       const bool can_cancel = false );
         bool consume_software_container( const itype_id &software_id );
         comp_selection<tool_comp>
         select_tool_component( const std::vector<tool_comp> &tools, int batch, read_only_visitable &map_inv,

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -1313,7 +1313,11 @@ void place_construction( std::vector<construction_group_str_id> const &groups )
     } else {
         // Use up the components
         for( const std::vector<item_comp> &it : con.requirements->get_components() ) {
-            std::list<item> tmp = player_character.consume_items( it, 1, is_crafting_component );
+            std::list<item> tmp = player_character.consume_items( it, 1, is_crafting_component,
+                                  return_false<itype_id>, true );
+            if( tmp.empty() ) {
+                return;
+            }
             used.splice( used.end(), tmp );
         }
     }

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -2192,11 +2192,13 @@ In that case, consider using select_item_component with 1 pre-created map invent
 to consume_items */
 std::list<item> Character::consume_items( const std::vector<item_comp> &components, int batch,
         const std::function<bool( const item & )> &filter,
-        const std::function<bool( const itype_id & )> &select_ind )
+        const std::function<bool( const itype_id & )> &select_ind,
+        const bool can_cancel )
 {
     inventory map_inv;
     map_inv.form_from_map( pos_bub(), PICKUP_RANGE, this );
-    comp_selection<item_comp> sel = select_item_component( components, batch, map_inv, false, filter );
+    comp_selection<item_comp> sel = select_item_component( components, batch, map_inv, can_cancel,
+                                    filter );
     return consume_items( sel, batch, filter, select_ind( sel.comp.type ) );
 }
 


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Fix #62961
#### Describe the solution
select_item_component() support cancelling, but it was force disabled. Edit consume_items() to support an optional argument `can_cancel`, pass it as `consume_items() -> select_item_component()`, bail out if list is empty
#### Testing
Reproduced steps in issue, cancelled as expected