### PR TITLE
Allow installation of CBMs into NPCs even when they aren't immediately useable

### DIFF
--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -142,7 +142,6 @@ static const itype_id itype_water_clean( "water_clean" );
 static const json_character_flag json_flag_BIONIC_ARMOR_INTERFACE( "BIONIC_ARMOR_INTERFACE" );
 static const json_character_flag json_flag_BIONIC_FAULTY( "BIONIC_FAULTY" );
 static const json_character_flag json_flag_BIONIC_GUN( "BIONIC_GUN" );
-static const json_character_flag json_flag_BIONIC_NPC_USABLE( "BIONIC_NPC_USABLE" );
 static const json_character_flag json_flag_BIONIC_POWER_SOURCE( "BIONIC_POWER_SOURCE" );
 static const json_character_flag json_flag_BIONIC_TOGGLED( "BIONIC_TOGGLED" );
 static const json_character_flag json_flag_BIONIC_WEAPON( "BIONIC_WEAPON" );
@@ -2337,8 +2336,6 @@ ret_val<void> Character::is_installable( const item *it, const bool by_autodoc )
     return has_bionic( b );
     } ) ) {
         return ret_val<void>::make_failure( _( "Superior version installed." ) );
-    } else if( is_npc() && !bid->has_flag( json_flag_BIONIC_NPC_USABLE ) ) {
-        return ret_val<void>::make_failure( _( "CBM not compatible with patient." ) );
     }
 
     return ret_val<void>::make_success( std::string() );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Turns out you can't install CBMs into a NPC if they don't have the BIONIC_NPC_USABLE flag.

Given that we can freely swap control back and forth nowadays, this limitation serves no purpose.

#### Describe the solution
Remove the block.

There's already a notice in the iteminfo window if a CBM in question is usable by NPCs.

#### Describe alternatives you've considered
Add a query_yn "warning" before installation proceeds, but it would be very immersion breaking.

#### Testing
<img width="893" height="688" alt="image" src="https://github.com/user-attachments/assets/9d4fcae1-27ab-4968-8316-5c7f0720836a" />


#### Additional context

