### PR TITLE
print correct ammo damage in wielding menu

### DIFF
--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -1918,7 +1918,13 @@ class weapon_inventory_preset: public inventory_selector_preset
                                                 );
                         }
                     }
-                    const int ammo_damage = damage.total_damage();
+
+                    int ammo_damage;
+                    if( loc->barrel_length().value() > 0 ) {
+                        ammo_damage = damage.di_considering_length( loc->barrel_length() ).total_damage();
+                    } else {
+                        ammo_damage = damage.total_damage();
+                    }
 
                     return string_format( "%s<color_light_gray>+</color>%s <color_light_gray>=</color> %s",
                                           get_damage_string( basic_damage, true ),


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
wielding menu `ammo_damage` value printed only ammo assigned damage, without checking the barrel length, whereas item info menu printed ammo damage including the barrel length
Fix #79573
#### Describe the solution
make wielding menu print ammo damage affected by barrel length
#### Describe alternatives you've considered
Move it to a single function?
#### Testing
<img width="1388" height="909" alt="image" src="https://github.com/user-attachments/assets/31049a5b-d498-4a7f-9e8f-cb0835c2efb4" />
<img width="941" height="95" alt="image" src="https://github.com/user-attachments/assets/10c56fa4-4bb5-42b8-ac76-72ad6214a065" />