### PR TITLE
Cannot trap a monster and use it as an infinite training dummy

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -2070,7 +2070,6 @@ void Character::on_dodge( Creature *source, float difficulty, float training_lev
         recoil = std::min( MAX_RECOIL, recoil );
     }
 
-    // Even if we are not to train still call practice to prevent skill rust
     difficulty = std::max( difficulty, 0.0f );
 
     // If training_level is set, treat that as the difficulty instead
@@ -2078,7 +2077,10 @@ void Character::on_dodge( Creature *source, float difficulty, float training_lev
         difficulty = training_level;
     }
 
-    practice( skill_dodge, difficulty * 2, difficulty );
+    if( source && source->times_combatted_player <= 100 ) {
+        source->times_combatted_player++;
+        practice( skill_dodge, difficulty * 2, difficulty );
+    }
     martial_arts_data->ma_ondodge_effects( *this );
 
     // For adjacent attackers check for techniques usable upon successful dodge

--- a/src/creature.h
+++ b/src/creature.h
@@ -1284,6 +1284,9 @@ class Creature : public viewer
         // This is done this way in order to not destroy focus since `do_aim` is on a per-move basis.
         int archery_aim_counter = 0;
 
+        // This tracks how many times the creature has trained any opponent's skill in melee/weapon skill/dodging in combat.
+        short times_combatted_player = 0;
+
         // Find the body part with the biggest hitsize - we will treat this as the center of mass for targeting
         bodypart_id get_max_hitsize_bodypart() const;
         // Select a bodypart depending on the attack's hitsize/limb restrictions

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -683,6 +683,13 @@ bool Character::melee_attack_abstract( Creature &t, bool allow_special,
 
     const int skill_training_cap = t.is_monster() ? t.as_monster()->type->melee_training_cap :
                                    MAX_SKILL;
+    // Practice melee and relevant weapon skill (if any) except when using CQB bionic, if the creature is a hallucination, if the creature cannot move,
+    // if the creature cannot take damage, or if the monster has already trained someone an excessive number of times.
+    const bool can_train_melee = !has_active_bionic( bio_cqb ) &&
+                                 !t.is_hallucination() &&
+                                 !t.has_flag( json_flag_CANNOT_MOVE ) &&
+                                 !t.has_flag( json_flag_CANNOT_TAKE_DAMAGE ) &&
+                                 t.times_combatted_player <= 100;
     Character &player_character = get_player_character();
     if( !hits ) {
         int stumble_pen = stumble( *this, cur_weapon );
@@ -720,10 +727,8 @@ bool Character::melee_attack_abstract( Creature &t, bool allow_special,
             }
         }
 
-        // Practice melee and relevant weapon skill (if any) except when using CQB bionic, if the creature is a hallucination, or if the creature cannot move and take damage.
-        if( !has_active_bionic( bio_cqb ) && !t.is_hallucination() &&
-            !( t.has_flag( json_flag_CANNOT_MOVE ) &&
-               t.has_flag( json_flag_CANNOT_TAKE_DAMAGE ) ) ) {
+        if( can_train_melee ) {
+            t.times_combatted_player++;
             melee_train( *this, 2, std::min( 5, skill_training_cap ), cur_weap, attack_vector_id::NULL_ID() );
         }
 
@@ -902,10 +907,8 @@ bool Character::melee_attack_abstract( Creature &t, bool allow_special,
             int dam = dealt_dam.total_damage();
             melee::melee_stats.damage_amount += dam;
 
-            // Practice melee and relevant weapon skill (if any) except when using CQB bionic, if the creature is a hallucination, or if the creature cannot move and take damage.
-            if( !has_active_bionic( bio_cqb ) && !t.is_hallucination() &&
-                !( t.has_flag( json_flag_CANNOT_MOVE ) &&
-                   t.has_flag( json_flag_CANNOT_TAKE_DAMAGE ) ) ) {
+            if( can_train_melee ) {
+                t.times_combatted_player++;
                 melee_train( *this, 5, std::min( 10, skill_training_cap ), cur_weap, vector_id );
             }
 

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -2615,6 +2615,7 @@ void monster::load( const JsonObject &data )
     biosig_timer = time_point( data.get_int( "biosig_timer", -1 ) );
 
     data.read( "udder_timer", udder_timer );
+    data.read( "times_combatted_player", times_combatted_player );
 
     horde_attraction = static_cast<monster_horde_attraction>( data.get_int( "horde_attraction", 0 ) );
 
@@ -2701,6 +2702,7 @@ void monster::store( JsonOut &json ) const
     json.member( "biosignatures", biosignatures );
     json.member( "biosig_timer", biosig_timer );
     json.member( "udder_timer", udder_timer );
+    json.member( "times_combatted_player", times_combatted_player );
 
     if( horde_attraction > MHA_NULL && horde_attraction < NUM_MONSTER_HORDE_ATTRACTION ) {
         json.member( "horde_attraction", horde_attraction );

--- a/tests/melee_test.cpp
+++ b/tests/melee_test.cpp
@@ -339,6 +339,17 @@ TEST_CASE( "Melee_skill_training_caps", "[melee], [melee_training_cap], [skill]"
         dude.melee_attack_abstract( zed, false, matec_id( "" ) );
         CHECK( level.knowledgeExperience( true ) == prev_xp );
     }
+    SECTION( "Using a monster as a training dummy will not cause further skill gain" ) {
+        zed.times_combatted_player = 101;
+        dude.set_skill_level( skill_melee, 0 );
+        dude.set_knowledge_level( skill_melee, 0 );
+        const int prev_xp = level.knowledgeExperience( true );
+        dude.melee_attack_abstract( zed, false, matec_id( "" ) );
+        CHECK( level.knowledgeLevel() == 0 );
+        CHECK( level.level() == 0 );
+        CHECK( level.knowledgeExperience( true ) == 0 );
+        CHECK( level.knowledgeExperience( true ) == prev_xp );
+    }
 }
 
 static void check_damage_from_test_fire( const std::string &mon_id, int expected_resist,


### PR DESCRIPTION
#### Summary
Bugfixes "Cannot trap a monster and use it as an infinite training dummy"

#### Purpose of change
People doing their best to optimize all the fun out of the game

#### Describe the solution
Fun is mandatory. A single monster can only train a person's skill so much. Once they've been pincushioned a hundred times you don't learn anything from stabbing them again.

Also applies to dodging their attacks.

#### Describe alternatives you've considered


#### Testing
I have added a section to our existing tests to cover this.

#### Additional context

This only applies to melee(+ weapon skill) and dodge training, ranged attacks aren't checked. But that could be added if needed.