### PR TITLE
[Hotfix] add boomer_bile and boomer_bile_adv to good uncrafts

### DIFF
--- a/data/mods/TEST_DATA/known_good_uncrafts.json
+++ b/data/mods/TEST_DATA/known_good_uncrafts.json
@@ -61,7 +61,9 @@
       "coal_lump",
       "albuterol",
       "liq_bandage",
-      "gasfilter_s"
+      "gasfilter_s",
+      "boomer_bile",
+      "boomer_bile_adv"
     ]
   }
 ]


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Two PRs were merged at once - one that added boomer_bile and boomer_bile_adv items #72271, and one that added uncrafting test #81830. Collision happened
#### Describe the solution
Add two items to good uncraft list
#### Describe alternatives you've considered
Some better way to catch pseudo items, tho reading definition of boomer_bile, i cannot see anything existing that can be used to detect it is being a pseudo item
https://github.com/CleverRaven/Cataclysm-DDA/blob/1efa6e8b2299633bec9ac0471c59e7bd8382b03d/data/json/monster_special_attacks/monster_ammo.json#L8-L24
#### Testing
CI