### PR TITLE
Assign name to Protein Wrapper

### DIFF
--- a/data/json/items/containers/containers.json
+++ b/data/json/items/containers/containers.json
@@ -3461,6 +3461,7 @@
   {
     "id": "wrapper_pr",
     "type": "ITEM",
+    "name": { "str": "wrapper" },
     "copy-from": "wrapper_bar",
     "ascii_picture": "wrapper_pr",
     "description": {


### PR DESCRIPTION
#### Summary
Bugfixes "Assign name to protein wrapper"


#### Purpose of change
Protein ration wrappers were displaying as blank (unnamed) items in game.  Don't want that.  Screenshots below.


#### Describe the solution
Add a name field to the entry.  It copy-from's a different wrapper, but either name isn't copy-from'd or copy-from is borked.  Assigning the name in the entry is just one line, can't imagine it's a big deal.

#### Describe alternatives you've considered
None, really.  This is my third or so copy-from affected change and the last two I was discouraged from doing those because it may be an issue with copy-from code.  But this one was the name field, which I just don't know if that's supposed to be copied or not.  So the most sense to me was to add the name.

#### Testing
They have name now.  Magic.

#### Additional context
Possible backport?  I don't know when this issue began.
Screenshot displaying the blank name in inventory and lack of info in item entry.
<img width="1326" height="685" alt="image" src="https://github.com/user-attachments/assets/02fbe618-8a08-4904-af29-4af3c7751c48" />

