### PR TITLE
Adds inflatable sumo suit

### DIFF
--- a/data/json/items/armor/suits_clothes.json
+++ b/data/json/items/armor/suits_clothes.json
@@ -830,6 +830,41 @@
     ]
   },
   {
+    "id": "inflatable_suit_off",
+    "type": "ITEM",
+    "subtypes": [ "ARMOR" ],
+    "name": { "str": "inflatable costume (off)" },
+    "description": "An inflatable costume.  It is turned off.",
+    "weight": "300 g",
+    "volume": "1 L",
+    "price": "50 USD",
+    "price_postapoc": "1 USD",
+    "material": [ "lycra" ],
+    "symbol": "[",
+    "color": "brown",
+    "armor": [ { "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ], "coverage": 100, "encumbrance": 8 } ],
+    "pocket_data": [
+      {
+        "pocket_type": "MAGAZINE_WELL",
+        "rigid": true,
+        "flag_restriction": [ "BATTERY_LIGHT" ],
+        "default_magazine": "light_battery_cell"
+      }
+    ],
+    "warmth": 8,
+    "material_thickness": 1,
+    "flags": [ "OUTER", "ELECTRONIC" ],
+    "variant_type": "generic",
+    "variants": [
+      {
+        "id": "sumo_suit_off",
+        "name": { "str": "inflatable sumo suit (off)" },
+        "description": "A cartoonish inflatable sumo suit. It's turned off and hangs limp.",
+        "weight": 100
+      }
+    ]
+  },
+  {
     "id": "wool_suit",
     "type": "ITEM",
     "subtypes": [ "ARMOR" ],


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Content "Adds an inflatable sumo suit"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

I can't believe there aren't inflatable suits in this game!

#### Describe the solution

Adds an inflatable sumo suit that you can turn on and off. When it's on, it will give you little protection, and when it's hit it will deflate.

#### Describe alternatives you've considered

N\A

#### Testing

Draft. Loads in game so far

#### Additional context

n/a


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
