### PR TITLE
Make autodrive less restricted

### DIFF
--- a/data/json/overmap/overmap_terrain/overmap_terrain_agricultural.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_agricultural.json
@@ -35,6 +35,17 @@
   },
   {
     "type": "overmap_terrain",
+    "abstract": "generic_rural_field",
+    "copy-from": "generic_open_land",
+    "name": "field",
+    "sym": "#",
+    "color": "i_brown",
+    "vision_levels": "farm_field",
+    "travel_cost_type": "field",
+    "extend": { "flags": [ "SOURCE_FOOD", "SOURCE_SAFETY", "RISK_LOW", "SOURCE_FARMING" ] }
+  },
+  {
+    "type": "overmap_terrain",
     "id": "sugar_house",
     "copy-from": "generic_rural_building",
     "name": "sugar house",
@@ -94,9 +105,7 @@
       "farm_8",
       "farm_9"
     ],
-    "copy-from": "generic_rural_building",
-    "vision_levels": "farm_field",
-    "travel_cost_type": "field",
+    "copy-from": "generic_rural_field",
     "name": "farm field"
   },
   {
@@ -142,11 +151,8 @@
       "farmland_turn_inside",
       "farmland_U"
     ],
-    "copy-from": "generic_rural_building",
+    "copy-from": "generic_rural_field",
     "name": "farm field",
-    "vision_levels": "farm_field",
-    "travel_cost_type": "field",
-    "see_cost": "none",
     "extras": "agricultural",
     "looks_like": "farm_5",
     "spawns": { "group": "GROUP_FOREST", "population": [ 0, 2 ], "chance": 15 }
@@ -154,12 +160,9 @@
   {
     "type": "overmap_terrain",
     "id": [ "hayfield_straight", "hayfield_turnL", "hayfield_turnR", "hayfield_end" ],
-    "copy-from": "generic_rural_building",
+    "copy-from": "generic_rural_field",
     "name": "hay field",
     "color": "brown",
-    "vision_levels": "farm_field",
-    "travel_cost_type": "field",
-    "see_cost": "none",
     "extras": "agricultural",
     "looks_like": "ranch_camp_76",
     "spawns": { "group": "GROUP_FOREST", "population": [ 0, 2 ], "chance": 15 }
@@ -441,8 +444,7 @@
       "splitrail_fence_DR",
       "splitrail_fence_inner"
     ],
-    "copy-from": "generic_rural_building",
-    "travel_cost_type": "field",
+    "copy-from": "generic_rural_field",
     "name": "pasture",
     "sym": "#",
     "color": "brown"
@@ -479,9 +481,8 @@
       "paddock_end_DL",
       "paddock_end_DR"
     ],
-    "copy-from": "generic_rural_building",
+    "copy-from": "generic_rural_field",
     "name": "paddock",
-    "travel_cost_type": "field",
     "sym": "#",
     "color": "white"
   },
@@ -764,9 +765,8 @@
   {
     "type": "overmap_terrain",
     "id": "yard",
-    "copy-from": "generic_rural_building",
+    "copy-from": "generic_rural_field",
     "name": "yard",
-    "travel_cost_type": "field",
     "color": "brown"
   },
   {

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -953,6 +953,7 @@ overmap_path_params overmap_path_params::for_land_vehicle( float offroad_coeff, 
         ret.set_cost( oter_travel_cost_type::water, boat_params.get_cost( oter_travel_cost_type::water ) );
         ret.set_cost( oter_travel_cost_type::shore, boat_params.get_cost( oter_travel_cost_type::shore ) );
     }
+    ret.allow_diagonal = true;
     return ret;
 }
 
@@ -961,6 +962,7 @@ overmap_path_params overmap_path_params::for_watercraft()
     overmap_path_params ret;
     ret.set_cost( oter_travel_cost_type::water, 8 ); // limited by vehicle autodrive speed
     ret.set_cost( oter_travel_cost_type::shore, 16 );
+    ret.allow_diagonal = true;
     return ret;
 }
 
@@ -968,6 +970,7 @@ overmap_path_params overmap_path_params::for_aircraft()
 {
     overmap_path_params ret;
     ret.set_cost( oter_travel_cost_type::air, 8 ); // limited by vehicle autodrive speed
+    ret.allow_diagonal = true;
     return ret;
 }
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Make autodrive less restricted.

#### Describe the solution

1. Allowed diagonal paths for vehicle auto-drive (I believe air and water should especially benefit from it).
2. Inherited farm field-like overmap terrains from a new abstract that has same travel costs as open land.