### PR TITLE
Always show clean water on top of consume menu

### DIFF
--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -79,6 +79,8 @@ static const bionic_id bio_painkiller( "bio_painkiller" );
 static const flag_id json_flag_CALORIES_INTAKE( "CALORIES_INTAKE" );
 static const flag_id json_flag_CALORIE_BURN( "CALORIE_BURN" );
 
+static const itype_id itype_water_clean( "water_clean" );
+
 static const json_character_flag json_flag_MANUAL_CBM_INSTALLATION( "MANUAL_CBM_INSTALLATION" );
 static const json_character_flag json_flag_PAIN_IMMUNE( "PAIN_IMMUNE" );
 
@@ -831,7 +833,9 @@ class comestible_inventory_preset : public inventory_selector_preset
 
     protected:
         int get_order( const item_location &loc, const time_duration &time ) const {
-            if( loc->rotten() ) {
+            if( loc->typeId() == itype_water_clean ) {
+                return 0;
+            } else if( loc->rotten() ) {
                 if( you.has_trait( trait_SAPROPHAGE ) || you.has_trait( trait_SAPROVORE ) ) {
                     return 1;
                 } else {


### PR DESCRIPTION
#### Summary
Interface "Always show clean water on top of consume menu"

#### Purpose of change
Make clean water always appear on top of consumable menu, so players could satisfy character thirst faster

#### Describe alternatives you've considered
Make this setting optional

#### Additional context
<img width="1920" height="1030" alt="image" src="https://github.com/user-attachments/assets/e44d17ff-0f3f-4e2f-8816-e2e951b5c418" />
