### PR TITLE
Display decimals for low speed values

### DIFF
--- a/src/display.cpp
+++ b/src/display.cpp
@@ -945,10 +945,11 @@ std::pair<std::string, nc_color> display::vehicle_cruise_text_color( const Chara
     // Text color indicates how much the engine is straining beyond its safe velocity.
     vehicle *veh = display::vehicle_driven( u );
     if( veh ) {
-        int target = static_cast<int>( convert_velocity( veh->cruise_velocity, VU_VEHICLE ) );
-        int current = static_cast<int>( convert_velocity( veh->velocity, VU_VEHICLE ) );
+        const double target = convert_velocity( veh->cruise_velocity, VU_VEHICLE );
+        const double current = convert_velocity( veh->velocity, VU_VEHICLE );
         const std::string units = get_option<std::string> ( "USE_METRIC_SPEEDS" );
-        vel_text = string_format( "%d < %d %s", target, current, units );
+        vel_text = string_format( "%s < %s %s", three_digit_display( target ),
+                                  three_digit_display( current ), units );
 
         const float strain = veh->strain( here );
         if( strain <= 0 ) {

--- a/src/units_utility.cpp
+++ b/src/units_utility.cpp
@@ -1,5 +1,6 @@
 #include "units_utility.h"
 
+#include <clocale>
 #include <string>
 
 #include "cata_utility.h"
@@ -399,4 +400,23 @@ double round_with_places( double value, int decimal_places )
 {
     const double multiplier = std::pow( 10.0, decimal_places );
     return std::round( value * multiplier ) / multiplier;
+}
+
+std::string three_digit_display( const double value )
+{
+    const bool neg = value < 0;
+    const double abs_value = abs( value );
+    if( abs_value == 0 ) {
+        return "0";
+    }
+    if( abs_value >= 10 ) {
+        return string_format( "%.0f", value );
+    }
+    if( abs_value >= 1 ) {
+        return string_format( "%.1f", value );
+    }
+
+    return string_format( "%s%c%02d", neg ? "-" : "",
+                          *std::localeconv()->decimal_point,
+                          static_cast<int>( abs_value * 100 ) );
 }

--- a/src/units_utility.h
+++ b/src/units_utility.h
@@ -148,3 +148,14 @@ std::string unit_to_string( const units::length &unit, bool compact = false );
 /** utility function to round with specified decimal places */
 double round_with_places( double value, int decimal_places );
 #endif // CATA_SRC_UNITS_UTILITY_H
+
+/**
+ * convert a float @value to a string to be displayed in up to 3 characters
+ * negative numbers have an extra character for the -
+ * 0 renders as 0
+ * values >= 1000 render as more than 3 characters
+ * values >= 10 render as integers
+ * values < 10 and >= 1.0 render with one decimal place
+ * values < 1 and > 0 render with two decimal places and no leading zero
+*/
+std::string three_digit_display( double value );

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -2464,36 +2464,36 @@ void veh_interact::display_stats( map &here ) const
     bool is_ground = !veh->wheelcache.empty() || !is_boat;
     bool is_aircraft = veh->is_rotorcraft( here ) && veh->is_flying_in_air();
 
-    const auto vel_to_int = []( const double vel ) {
-        return static_cast<int>( convert_velocity( vel, VU_VEHICLE ) );
+    const auto vel_to_str = []( const double vel ) {
+        return three_digit_display( convert_velocity( vel, VU_VEHICLE ) );
     };
 
     int i = 0;
     if( is_aircraft ) {
         fold_and_print( *win[i], point( 0, row[i] ), getmaxx( *win[i] ), c_light_gray,
-                        _( "Air Safe/Top speed: <color_light_green>%3d</color>/<color_light_red>%3d</color> %s" ),
-                        vel_to_int( veh->safe_rotor_velocity( here, false ) ),
-                        vel_to_int( veh->max_rotor_velocity( here, false ) ),
+                        _( "Air Safe/Top speed: <color_light_green>%3s</color>/<color_light_red>%3s</color> %s" ),
+                        vel_to_str( veh->safe_rotor_velocity( here, false ) ),
+                        vel_to_str( veh->max_rotor_velocity( here, false ) ),
                         velocity_units( VU_VEHICLE ) );
         i += 1;
         fold_and_print( *win[i], point( 0, row[i] ), getmaxx( *win[i] ), c_light_gray,
-                        _( "Air acceleration: <color_light_blue>%3d</color> %s/s" ),
-                        vel_to_int( veh->rotor_acceleration( here, false ) ),
+                        _( "Air acceleration: <color_light_blue>%3s</color> %s/s" ),
+                        vel_to_str( veh->rotor_acceleration( here, false ) ),
                         velocity_units( VU_VEHICLE ) );
         i += 1;
     } else {
         if( is_ground ) {
             fold_and_print( *win[i], point( 0, row[i] ), getmaxx( *win[i] ), c_light_gray,
-                            _( "Safe/Top speed: <color_light_green>%3d</color>/<color_light_red>%3d</color> %s" ),
-                            vel_to_int( veh->safe_ground_velocity( here, false ) ),
-                            vel_to_int( veh->max_ground_velocity( here, false ) ),
+                            _( "Safe/Top speed: <color_light_green>%3s</color>/<color_light_red>%3s</color> %s" ),
+                            vel_to_str( veh->safe_ground_velocity( here, false ) ),
+                            vel_to_str( veh->max_ground_velocity( here, false ) ),
                             velocity_units( VU_VEHICLE ) );
             i += 1;
             // TODO: extract accelerations units to its own function
             fold_and_print( *win[i], point( 0, row[i] ), getmaxx( *win[i] ), c_light_gray,
                             //~ /t means per turn
-                            _( "Acceleration: <color_light_blue>%3d</color> %s/s" ),
-                            vel_to_int( veh->ground_acceleration( here, false ) ),
+                            _( "Acceleration: <color_light_blue>%3s</color> %s/s" ),
+                            vel_to_str( veh->ground_acceleration( here, false ) ),
                             velocity_units( VU_VEHICLE ) );
             i += 1;
         } else {
@@ -2501,16 +2501,16 @@ void veh_interact::display_stats( map &here ) const
         }
         if( is_boat ) {
             fold_and_print( *win[i], point( 0, row[i] ), getmaxx( *win[i] ), c_light_gray,
-                            _( "Water Safe/Top speed: <color_light_green>%3d</color>/<color_light_red>%3d</color> %s" ),
-                            vel_to_int( veh->safe_water_velocity( here, false ) ),
-                            vel_to_int( veh->max_water_velocity( here, false ) ),
+                            _( "Water Safe/Top speed: <color_light_green>%3s</color>/<color_light_red>%3s</color> %s" ),
+                            vel_to_str( veh->safe_water_velocity( here, false ) ),
+                            vel_to_str( veh->max_water_velocity( here, false ) ),
                             velocity_units( VU_VEHICLE ) );
             i += 1;
             // TODO: extract accelerations units to its own function
             fold_and_print( *win[i], point( 0, row[i] ), getmaxx( *win[i] ), c_light_gray,
                             //~ /t means per turn
-                            _( "Water acceleration: <color_light_blue>%3d</color> %s/s" ),
-                            vel_to_int( veh->water_acceleration( here, false ) ),
+                            _( "Water acceleration: <color_light_blue>%3s</color> %s/s" ),
+                            vel_to_str( veh->water_acceleration( here, false ) ),
                             velocity_units( VU_VEHICLE ) );
             i += 1;
         } else {

--- a/src/vehicle_display.cpp
+++ b/src/vehicle_display.cpp
@@ -487,23 +487,24 @@ void vehicle::print_speed_gauge( map &here, const catacurses::window &win, const
                        ( strain <= 0.2 ? c_yellow :
                          ( strain <= 0.4 ? c_light_red : c_red ) );
     // Get cruising (target) velocity, and current (actual) velocity
-    int t_speed = static_cast<int>( convert_velocity( cruise_velocity, VU_VEHICLE ) );
-    int c_speed = static_cast<int>( convert_velocity( velocity, VU_VEHICLE ) );
-    auto ndigits = []( int value ) {
-        return value == 0 ? 1 :
-               ( value > 0 ?
-                 static_cast<int>( std::log10( static_cast<double>( std::abs( value ) ) ) ) + 1 :
-                 static_cast<int>( std::log10( static_cast<double>( std::abs( value ) ) ) ) + 2 );
+    const double t_speed = convert_velocity( cruise_velocity, VU_VEHICLE );
+    const double c_speed = convert_velocity( velocity, VU_VEHICLE );
+    auto ndigits = []( double value ) {
+        return ( value < 0 ? 1 : 0 ) +
+               ( value == 0 ? 1 :
+                 ( ( value < 1000 && value > -1000 ) ? 3 :
+                   static_cast<int>( std::log10( static_cast<double>( std::abs( value ) ) ) ) + 1 ) );
     };
     const std::string type = get_option<std::string> ( "USE_METRIC_SPEEDS" );
     int t_offset = ndigits( t_speed );
     int c_offset = ndigits( c_speed );
 
     // Target cruising velocity in green
-    mvwprintz( win, p, c_light_green, "%d", t_speed );
+    mvwprintz( win, p, c_light_green, "%s", three_digit_display( t_speed ) );
     mvwprintz( win, p + point( t_offset + spacing, 0 ), c_light_gray, "<" );
     // Current velocity in color indicating engine strain
-    mvwprintz( win, p + point( t_offset + 1 + 2 * spacing, 0 ), col_vel, "%d", c_speed );
+    mvwprintz( win, p + point( t_offset + 1 + 2 * spacing, 0 ), col_vel, "%s",
+               three_digit_display( c_speed ) );
     // Units of speed (mph, km/h, t/t)
     mvwprintz( win, p + point( t_offset  + c_offset + 1 + 3 * spacing, 0 ), c_light_gray, type );
 }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Interface "Display decimals for low speed values"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
A lot of rounding and truncation happens when converting speed units which get displayed as integers. This can result in a vehicle changing speed or acceleration by a non-trivial amount without the displayed values changing. For example a vehicle with very low acceleration might take multiple turns to reach 1 tile per turn, and currently we display 0t/t for all of those turns even though the speed is constantly increasing.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
All of the existing places we display speed are designed for up to 3 characters, 4 for negative values. This is enough space for values between 1 and 10 to have one decimal place, and values below 1 to have two decimal places without a leading zero, without taking up more than the planned amount of space. That is what this PR does.
Examples:
```
  0
.01
.99
1.0
9.9
 10
100
1000
```


#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

I am playing with this PR. I have used a variety of ground and water vehicles. I have not yet tested in an aircraft. Through various maneuvers and vehicle modifications and unit config changes I've observed fractional values in every position.

I have not found anywhere that `vehicle::print_speed_gauge` is used so I have not been able to test it.

Four digit speeds (>=1000 in any unit) are already problematic and this PR should not change how they are displayed. I have not found a way to test this.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
The most noticeable change produced by this PR is that the first cruise control (target speed) increment in metric displays as 6.4 kph instead of 6 kph.

I intentionally omitted the necessary extra arithmetic and logic to avoid displaying `.00`; if someone can manage to get a vehicle going less than .01 but still more than 0 velocity units, I'll be rather impressed.


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
