### PR TITLE
Add PERMEABLE to various terrain

### DIFF
--- a/data/json/furniture_and_terrain/terrain-manufactured.json
+++ b/data/json/furniture_and_terrain/terrain-manufactured.json
@@ -1369,7 +1369,7 @@
     "looks_like": "t_pit",
     "move_cost": 0,
     "connect_groups": "INDOORFLOOR",
-    "flags": [ "TRANSPARENT", "CONTAINER", "PLACE_ITEM", "INDOORS" ],
+    "flags": [ "TRANSPARENT", "PERMEABLE", "CONTAINER", "PLACE_ITEM", "INDOORS" ],
     "deconstruct": { "ter_set": "t_pit", "items": [ { "item": "rock", "count": 40 }, { "item": "stick", "count": [ 16, 16 ] } ] },
     "bash": {
       "str_min": 18,

--- a/data/json/furniture_and_terrain/terrain-mechanisms.json
+++ b/data/json/furniture_and_terrain/terrain-mechanisms.json
@@ -134,7 +134,7 @@
     "symbol": "6",
     "color": "white",
     "move_cost": 0,
-    "flags": [ "TRANSPARENT", "NOITEM", "COLLAPSES", "THIN_OBSTACLE" ],
+    "flags": [ "TRANSPARENT", "PERMEABLE", "NOITEM", "COLLAPSES", "THIN_OBSTACLE" ],
     "examine_action": "controls_gate",
     "bash": {
       "str_min": 18,
@@ -153,7 +153,7 @@
     "symbol": "6",
     "color": "white",
     "move_cost": 0,
-    "flags": [ "TRANSPARENT", "NOITEM", "COLLAPSES", "THIN_OBSTACLE" ],
+    "flags": [ "TRANSPARENT", "PERMEABLE", "NOITEM", "COLLAPSES", "THIN_OBSTACLE" ],
     "examine_action": "controls_gate",
     "bash": {
       "str_min": 18,

--- a/data/json/furniture_and_terrain/terrain-railroads.json
+++ b/data/json/furniture_and_terrain/terrain-railroads.json
@@ -562,7 +562,7 @@
         { "item": "power_supply", "count": [ 0, 1 ] }
       ]
     },
-    "flags": [ "TRANSPARENT", "NOITEM" ]
+    "flags": [ "TRANSPARENT", "PERMEABLE", "NOITEM" ]
   },
   {
     "id": "t_crossbuck_wood",
@@ -586,7 +586,7 @@
       "hit_field": [ "fd_dust", 2 ],
       "destroyed_field": [ "fd_splinters", 1 ]
     },
-    "flags": [ "TRANSPARENT", "NOITEM" ]
+    "flags": [ "TRANSPARENT", "PERMEABLE", "NOITEM" ]
   },
   {
     "id": "t_crossbuck_metal",
@@ -604,7 +604,7 @@
       "sound_fail": "clang.",
       "items": [ { "item": "pipe", "count": [ 2, 3 ] }, { "item": "scrap", "count": [ 0, 2 ] } ]
     },
-    "flags": [ "TRANSPARENT", "NOITEM" ]
+    "flags": [ "TRANSPARENT", "PERMEABLE", "NOITEM" ]
   },
   {
     "id": "t_railroad_track_small",

--- a/data/json/furniture_and_terrain/terrain-walls.json
+++ b/data/json/furniture_and_terrain/terrain-walls.json
@@ -176,7 +176,17 @@
     "connect_groups": [ "INDOORFLOOR", "WALL" ],
     "connects_to": "WALL",
     "roof": "t_flat_roof",
-    "flags": [ "TRANSPARENT", "FLAMMABLE", "PLACE_ITEM", "INDOORS", "AUTO_WALL_SYMBOL", "THIN_OBSTACLE", "MOUNTABLE", "SHORT" ],
+    "flags": [
+      "TRANSPARENT",
+      "PERMEABLE",
+      "FLAMMABLE",
+      "PLACE_ITEM",
+      "INDOORS",
+      "AUTO_WALL_SYMBOL",
+      "THIN_OBSTACLE",
+      "MOUNTABLE",
+      "SHORT"
+    ],
     "deconstruct": { "ter_set": "t_floor", "items": [ { "item": "2x4", "count": 5 }, { "item": "nail", "charges": 20 } ] },
     "bash": {
       "str_min": 8,
@@ -2106,7 +2116,17 @@
     "move_cost": 0,
     "coverage": 60,
     "examine_action": "chainfence",
-    "flags": [ "TRANSPARENT", "NOITEM", "REDUCE_SCENT", "MOUNTABLE", "MINEABLE", "THIN_OBSTACLE", "CLIMBABLE", "BURROWABLE" ],
+    "flags": [
+      "TRANSPARENT",
+      "NOITEM",
+      "REDUCE_SCENT",
+      "MOUNTABLE",
+      "MINEABLE",
+      "THIN_OBSTACLE",
+      "CLIMBABLE",
+      "BURROWABLE",
+      "PERMEABLE"
+    ],
     "connect_groups": "WALL",
     "connects_to": "WALL",
     "bash": {

--- a/doc/JSON/JSON_FLAGS.md
+++ b/doc/JSON/JSON_FLAGS.md
@@ -24,7 +24,7 @@
   - [Generic](#generic)
   - [Guns](#guns)
     - [Firing modes](#firing-modes)
-    - [Gun Faults](#gun-faults)
+    - [Gun faults](#gun-faults)
   - [Magazines](#magazines)
   - [Magic](#magic)
   - [Mapgen](#mapgen)
@@ -38,12 +38,12 @@
     - [Monster Groups](#monster-groups)
       - [Seasons](#seasons)
       - [Time of day](#time-of-day)
-    - [Sizes](#sizes)
     - [Special attacks](#special-attacks)
   - [Mutations](#mutations)
   - [Overmap](#overmap)
     - [Overmap connections](#overmap-connections)
     - [Overmap specials](#overmap-specials)
+      - [City buildings](#city-buildings)
     - [Overmap terrains](#overmap-terrains)
   - [Recipes](#recipes)
     - [Crafting recipes](#crafting-recipes)
@@ -57,7 +57,7 @@
   - [Technical flags](#technical-flags)
   - [Techniques](#techniques)
   - [Tools](#tools)
-    - [`use_action`](#use_action)
+    - [`use_action`](#use_action-1)
   - [Traps](#traps)
   - [Vehicles](#vehicles)
     - [Fuel types](#fuel-types)
@@ -674,7 +674,7 @@ List of known flags, used in both `furniture` and `terrain`.  Some work for both
 - ```NO_SPOIL``` Items placed in this tile do not spoil.
 - ```OPENCLOSE_INSIDE``` If it's a door (with an 'open' or 'close' field), it can only be opened or closed if you're inside.
 - ```PAINFUL``` May cause a small amount of pain.
-- ```PERMEABLE``` Permeable for gases.
+- ```PERMEABLE``` Permeable for gases. Implied for passable terrain, only needed on impassable.
 - ```PICKABLE``` This terrain/furniture could be picked with lockpicks.
 - ```PIT_FILLABLE``` This terrain can be filled with dirt like a shallow pit.
 - ```PLACE_ITEM``` Valid terrain for `place_item()` to put items on.


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Allow gas to permeate through various non-solid terrain"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
I noticed gas failing to cross a field stone half wall and discovered it is lacking the PERMEABLE flag, as are many other terrains that seem like they should allow gas to pass.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
Added PERMEABLE flag to various half walls, partially built walls, sign posts, winches, etc.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->
I've checked the behavior at a field stone half wall but not all the others.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
There are a lot more terrains seemingly deserving of PERMEABLE in special maps and mod maps but I didn't touch those because I wasn't sure if they had specific balance concerns.

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
