### PR TITLE
Flashbang stuff

### DIFF
--- a/doc/JSON/EFFECT_ON_CONDITION.md
+++ b/doc/JSON/EFFECT_ON_CONDITION.md
@@ -4309,8 +4309,11 @@ Creates an explosion at talker position or at passed coordinate
 | --- | --- | --- | --- | 
 | "u_explosion", / "npc_explosion" | **mandatory** | explosion_data | copies the `explosion` field from `"type": "ammo_effect"`, but allows to use variables; defines what type of explosion is occuring. |
 | "target_var" | optional | [variable object](#variable-object) | if used, explosion will occur where the variable point to | 
-| "emp_blast" | optional | bool | if used, the emp blast would appear at the center of the explosion (only at the center, no matter the size of explosion.  If you want the explosion to have an area, see examples below) | 
-| "scrambler_blast" | optional | bool | if used, the scrambler blast would appear at the center of the explosion (only at the center, no matter the size of explosion) |
+| "emp_blast" | optional | bool | if used, the emp blast would appear at the center of the explosion (only at the center, no matter the size of explosion.  If you want the explosion to have an area, see examples below). Default false | 
+| "scrambler_blast" | optional | bool | if used, the scrambler blast would appear at the center of the explosion (only at the center, no matter the size of explosion). Default false |
+| "flashbang" | optional | bool | if used, the flashbang explosion happens. Default false |
+| "flashbang_avatar_is_immune" | optional | bool | if used with `flashbang`, the flashbang explosion won't affect the avatar (to protect alpha/beta talker, if they are not an avatar, other means need to be used, like FLASH_PROTECTION flag for character and FLASHBANGPROOF flag for monster ) |
+| "flashbang_radius" | optional | int, duration or [variable object](#variable-object) | if used with `flashbang`, the flashbang explosion would be this big. Doesn't affect flashbang loudness. Default is 8 |
 
 ##### Valid talkers:
 
@@ -4334,6 +4337,27 @@ You pick a tile using u_query_omt, then the explosion is caused at this position
       }
     ]
   }
+```
+
+You pick a tile using `u_query_tile`, pass it to `u_explosion`, with a flashbang on and `flashbang_radius` being input manually
+```jsonc
+  {
+    "type": "effect_on_condition",
+    "id": "AAAAAAAAAAAA",
+    "effect": [
+      { "u_query_tile": "anywhere", "target_var": { "context_val": "pos" }, "message": "Select point to detonate." },
+      {
+        "if": { "math": [ "has_var(_pos)" ] },
+        "then": {
+          "u_explosion": { },
+          "flashbang": true,
+          "flashbang_radius": { "math": [ "num_input('flashbang radius?', 8)" ] },
+          "target_var": { "context_val": "pos" }
+        },
+        "else": { "u_message": "Canceled" }
+      }
+    ]
+  },
 ```
 
 `u_map_run_eocs` runs 5 tiles around alpha talker, applying EMP effect on all the tiles

--- a/doc/JSON/MAGIC.md
+++ b/doc/JSON/MAGIC.md
@@ -179,7 +179,7 @@ Effect                 | Description
 `effect_on_condition`  | Runs the `effect_on_condition` from `effect_str` on all valid targets.  The EOC will be centered on the player, with the NPC as caster and a context val location variable `spell_location` for the target primarily useful if the target isn't a creature.
 `emit`                 | Causes an `emit` at the target.
 `explosion`            | Causes an explosion centered on the target.  Uses damage() for power and factor aoe()/10.
-`flashbang`            | Causes a flashbang effect is centered on the target.  Uses damage() for power and factor aoe()/10.
+`flashbang`            | Causes a flashbang effect, centered on the target.  AoE affects the flashbang radius.
 `fungalize`            | Fungalizes the target.
 `guilt`                | Target gets the guilt morale as if it killed the caster.
 `map`                  | Maps out the overmap centered on the player, to a radius of aoe().

--- a/src/explosion.h
+++ b/src/explosion.h
@@ -96,7 +96,7 @@ void _make_explosion( map *m, const Creature *source, const tripoint_bub_ms &p,
                       const explosion_data &ex );
 
 /** Triggers a flashbang explosion at p. */
-void flashbang( const tripoint_bub_ms &p, bool player_immune = false );
+void flashbang( const tripoint_bub_ms &p, bool player_immune = false, int radius = 8 );
 /** Triggers a resonance cascade at p. */
 void resonance_cascade( const tripoint_bub_ms &p );
 /** Triggers a scrambler blast at p. */

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -1469,7 +1469,7 @@ void spell_effect::explosion( const spell &sp, Creature &caster, const tripoint_
 void spell_effect::flashbang( const spell &sp, Creature &caster, const tripoint_bub_ms &target )
 {
     explosion_handler::flashbang( target, caster.is_avatar() &&
-                                  !sp.is_valid_target( spell_target::self ) );
+                                  !sp.is_valid_target( spell_target::self ), sp.aoe( caster ) );
 }
 
 void spell_effect::mod_moves( const spell &sp, Creature &caster, const tripoint_bub_ms &target )

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -4517,10 +4517,13 @@ talk_effect_fun_t::func f_explosion( const JsonObject &jo, std::string_view memb
 
     bool emp_blast = jo.get_bool( "emp_blast", false );
     bool scrambler_blast = jo.get_bool( "scrambler_blast", false );
+    bool flashbang = jo.get_bool( "flashbang", false );
+    bool flashbang_avatar_is_immune = jo.get_bool( "flashbang_avatar_is_immune", false );
+    dbl_or_var flashbang_radius = get_dbl_or_var( jo, "flashbang_radius", false, 8 );
 
     return [target_var, dov_power, dov_distance_factor, dov_max_noise, fire, dov_shrapnel_casing_mass,
                         dov_shrapnel_fragment_mass, dov_shrapnel_recovery, dov_shrapnel_drop, emp_blast, scrambler_blast,
-                is_npc, &here]( dialogue const & d ) {
+                flashbang, flashbang_avatar_is_immune, flashbang_radius, is_npc, &here]( dialogue const & d ) {
         tripoint_bub_ms target_pos;
         if( target_var.has_value() ) {
             tripoint_abs_ms abs_ms = read_var_value( *target_var, d ).tripoint();
@@ -4547,6 +4550,10 @@ talk_effect_fun_t::func f_explosion( const JsonObject &jo, std::string_view memb
         }
         if( scrambler_blast ) {
             explosion_handler::scrambler_blast( target_pos );
+        }
+        if( flashbang ) {
+            explosion_handler::flashbang( target_pos, flashbang_avatar_is_immune,
+                                          flashbang_radius.evaluate( d ) );
         }
     };
 }


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Storm asked, who am i to reject the request
#### Describe the solution
Make flashbang scale it's explosion radius instead of always being 8 tiles
While at it, try to make it better by also affecting npcs
While at it, make it **LOUD** (instead of noise 12, akin to you talking, it's 120, akin to a rifle shot)
Make spells scale flashbang radius with aoe
Expose flashbang to eoc
#### Describe alternatives you've considered
Just obliterate it from orbit, it's pretty weird thing
Actually improve it, get rid of imaginary numbers, tweak checks to make sense, make one actually go blind and dazed for more than three milliseconds after using it
#### Testing
Made EoC to test flashbangs
Nothing crashes, random migo i found on the road seems to be affected by it as expected
#### Additional context
think fast chucklenuts