### PR TITLE
[MoM] Remove double minus 100 from awakening calculations

### DIFF
--- a/data/mods/MindOverMatter/effectoncondition/conditions_for_eocs.json
+++ b/data/mods/MindOverMatter/effectoncondition/conditions_for_eocs.json
@@ -184,7 +184,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_CONDITION_AWAKENING_X_IN_Y_CHANCE",
-    "condition": { "x_in_y_chance": { "x": { "math": [ "100 - u_awakening_reducer" ] }, "y": 100 } },
+    "condition": { "x_in_y_chance": { "x": { "math": [ "u_awakening_reducer" ] }, "y": 100 } },
     "effect": [  ]
   },
   {

--- a/data/mods/MindOverMatter/effectoncondition/eoc_awakening.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_awakening.json
@@ -13,6 +13,7 @@
     "id": "EOC_PSI_AWAKENING_BIOKINESIS_FINALIZATION",
     "effect": [
       { "math": [ "u_awakening_countup", "+=", "1" ] },
+      { "math": [ "u_awakening_reducer = (matrix_awakening_odds(u_awakening_countup))" ] },
       { "u_lose_trait": "ALWAYS_GAIN_PSIONICS" },
       { "u_add_trait": "BIOKINETIC" },
       { "u_add_trait": "BIOKIN_NEEDS" },
@@ -26,6 +27,7 @@
     "id": "EOC_PSI_AWAKENING_CLAIRSENTIENCE_FINALIZATION",
     "effect": [
       { "math": [ "u_awakening_countup", "+=", "1" ] },
+      { "math": [ "u_awakening_reducer = (matrix_awakening_odds(u_awakening_countup))" ] },
       { "u_lose_trait": "ALWAYS_GAIN_PSIONICS" },
       { "u_add_trait": "CLAIRSENTIENT" },
       { "u_add_trait": "CLAIR_SENSES" },
@@ -39,6 +41,7 @@
     "id": "EOC_PSI_AWAKENING_ELECTROKINESIS_FINALIZATION",
     "effect": [
       { "math": [ "u_awakening_countup", "+=", "1" ] },
+      { "math": [ "u_awakening_reducer = (matrix_awakening_odds(u_awakening_countup))" ] },
       { "u_lose_trait": "ALWAYS_GAIN_PSIONICS" },
       { "u_add_trait": "ELECTROKINETIC" },
       { "u_add_trait": "ELECTRO_SHIELD" },
@@ -52,6 +55,7 @@
     "id": "EOC_PSI_AWAKENING_PHOTOKINESIS_FINALIZATION",
     "effect": [
       { "math": [ "u_awakening_countup", "+=", "1" ] },
+      { "math": [ "u_awakening_reducer = (matrix_awakening_odds(u_awakening_countup))" ] },
       { "u_lose_trait": "ALWAYS_GAIN_PSIONICS" },
       { "u_add_trait": "PHOTOKINETIC" },
       { "u_add_trait": "PHOTO_EYES" },
@@ -65,6 +69,7 @@
     "id": "EOC_PSI_AWAKENING_PYROKINESIS_FINALIZATION",
     "effect": [
       { "math": [ "u_awakening_countup", "+=", "1" ] },
+      { "math": [ "u_awakening_reducer = (matrix_awakening_odds(u_awakening_countup))" ] },
       { "u_lose_trait": "ALWAYS_GAIN_PSIONICS" },
       { "u_add_trait": "PYROKINETIC" },
       { "u_add_trait": "PYROKIN_ADAPTATION" },
@@ -78,6 +83,7 @@
     "id": "EOC_PSI_AWAKENING_TELEKINESIS_FINALIZATION",
     "effect": [
       { "math": [ "u_awakening_countup", "+=", "1" ] },
+      { "math": [ "u_awakening_reducer = (matrix_awakening_odds(u_awakening_countup))" ] },
       { "u_lose_trait": "ALWAYS_GAIN_PSIONICS" },
       { "u_add_trait": "TELEKINETIC" },
       { "u_add_trait": "TELEKINETIC_GRAB_POCKETS" },
@@ -91,6 +97,7 @@
     "id": "EOC_PSI_AWAKENING_TELEPATHY_FINALIZATION",
     "effect": [
       { "math": [ "u_awakening_countup", "+=", "1" ] },
+      { "math": [ "u_awakening_reducer = (matrix_awakening_odds(u_awakening_countup))" ] },
       { "u_lose_trait": "ALWAYS_GAIN_PSIONICS" },
       { "u_add_trait": "TELEPATH" },
       { "u_add_trait": "TELEPATHIC_SUGGESTION" },
@@ -104,6 +111,7 @@
     "id": "EOC_PSI_AWAKENING_TELEPORTATION_FINALIZATION",
     "effect": [
       { "math": [ "u_awakening_countup", "+=", "1" ] },
+      { "math": [ "u_awakening_reducer = (matrix_awakening_odds(u_awakening_countup))" ] },
       { "u_lose_trait": "ALWAYS_GAIN_PSIONICS" },
       { "u_add_trait": "TELEPORTER" },
       { "u_add_trait": "TELEPORTER_PROTECT" },
@@ -116,6 +124,7 @@
     "id": "EOC_PSI_AWAKENING_VITAKINESIS_FINALIZATION",
     "effect": [
       { "math": [ "u_awakening_countup", "+=", "1" ] },
+      { "math": [ "u_awakening_reducer = (matrix_awakening_odds(u_awakening_countup))" ] },
       { "u_lose_trait": "ALWAYS_GAIN_PSIONICS" },
       { "u_add_trait": "VITAKINETIC" },
       { "u_add_trait": "VITAKINETIC_HEALTH" },

--- a/data/mods/MindOverMatter/jmath.json
+++ b/data/mods/MindOverMatter/jmath.json
@@ -127,13 +127,13 @@
     "type": "jmath_function",
     "id": "matrix_awakening_odds",
     "num_args": 1,
-    "return": "100 - (100 * (e ^ ( ( _0 - max( (u_has_trait('MORE_PSI_ALPHA') * 0.75), 0) ) / -1.7) ) )"
+    "return": "100 * (e ^ ( ( _0 - max( (u_has_trait('MORE_PSI_ALPHA') * 0.75), 0) ) / -1.7) )"
   },
   {
     "type": "jmath_function",
     "id": "portal_storm_awakening_odds",
     "num_args": 1,
-    "return": "100 - (100 * (e ^ ( ( _0 - max( (u_has_trait('MORE_PSI_ALPHA') * 0.75), 0) ) / -3) ) )"
+    "return": "100 * (e ^ ( ( _0 - max( (u_has_trait('MORE_PSI_ALPHA') * 0.75), 0) ) / -3) )"
   },
   {
     "type": "jmath_function",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[MoM] Remove double minus 100 from awakening calculations"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

When I first wrote the awakening calculations, it took the odds that you didn't awaken ( 100 - odds to awaken), and then reversed that to calculate whether you did awaken ( 100 - chance to awaken, out of 100). 

Originally it was replicated in a bunch of places and a lot of work to change, but over time I've gotten it to two places, so we don't need it anymore.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

 Remove both 100 -
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Awakened a few times and checked variables, they were set appropriately. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
