### PR TITLE
Add bus variant with bike rack

### DIFF
--- a/data/json/vehicle_groups.json
+++ b/data/json/vehicle_groups.json
@@ -103,7 +103,8 @@
       [ "fridge_van", 300 ],
       [ "security_van", 500 ],
       [ "schoolbus", 100 ],
-      [ "bus", 500 ],
+      [ "bus", 300 ],
+      [ "bus_rack", 200 ],
       [ "bus_tour", 50 ],
       [ "rv", 500 ],
       [ "limousine", 200 ],
@@ -311,7 +312,8 @@
       [ "aapc-mg", 100 ],
       [ "aapc-gl", 50 ],
       [ "schoolbus", 50 ],
-      [ "bus", 350 ],
+      [ "bus", 225 ],
+      [ "bus_rack", 125 ],
       [ "bus_tour", 25 ],
       [ "rv", 800 ],
       [ "limousine", 200 ],
@@ -1379,7 +1381,7 @@
   {
     "type": "vehicle_group",
     "id": "buses",
-    "vehicles": [ [ "bus", 1000 ], [ "schoolbus", 100 ], [ "bus_tour", 50 ] ]
+    "vehicles": [ [ "bus", 900 ], [ "bus_rack", 100 ], [ "schoolbus", 100 ], [ "bus_tour", 50 ] ]
   },
   {
     "id": "VETS",

--- a/data/json/vehicles/vans_busses.json
+++ b/data/json/vehicles/vans_busses.json
@@ -2258,6 +2258,19 @@
     ]
   },
   {
+    "id": "bus_rack",
+    "type": "vehicle",
+    "copy-from": "bus",
+    "name": "Bus with Bike Rack",
+    "parts": [
+      { "x": 2, "y": -1, "parts": [ "bike_rack" ] },
+      { "x": 2, "y": 0, "parts": [ "bike_rack" ] },
+      { "x": 2, "y": 1, "parts": [ "bike_rack" ] },
+      { "x": 2, "y": 2, "parts": [ "bike_rack" ] },
+      { "x": 2, "y": 3, "parts": [ "bike_rack" ] }
+    ]
+  },
+  {
     "id": "bus_tour",
     "type": "vehicle",
     "name": "Tour Bus",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Content "Bus variant with bike rack"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
Many transit buses have a rack on the front for a bike.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
Add a variant vehicle that copies from `bus` and adds a bike rack. Change 10-40% of `bus` to be `bus_rack` in various vehicle spawn groups depending on context.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->
Spawned a bus_rack, confirmed it behaves as expected.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
Transit bus front bike racks usually hold 2-3 bikes, but the game doesn't support that yet.

Tour bus rear bike racks usually hold 3-5 bikes, ditto. I opted not to add these at all since they are uncommon in New England.

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
