### PR TITLE
Aftershock: Small price updates for vendors

### DIFF
--- a/data/mods/aftershock_exoplanet/items/armor/exosuit/exosuit_melee.json
+++ b/data/mods/aftershock_exoplanet/items/armor/exosuit/exosuit_melee.json
@@ -37,6 +37,8 @@
     "ascii_picture": "halberd",
     "description": "This is an oversized axe made from scraps of salvaged metal.  While not as versatile or durable as the boarding axe, it still packs a punch.",
     "weight": "9250 g",
+    "price": "60 USD",
+    "price_postapoc": "60 USD",
     "volume": "2750 ml",
     "longest_side": "120 cm",
     "techniques": [ "WBLOCK_1", "BRUTAL", "SWEEP" ],

--- a/data/mods/aftershock_exoplanet/items/containers.json
+++ b/data/mods/aftershock_exoplanet/items/containers.json
@@ -45,7 +45,7 @@
     "volume": "1250 ml",
     "longest_side": "32 cm",
     "price": "175 USD ",
-    "price_postapoc": "1 USD",
+    "price_postapoc": "175 USD",
     "material": [ "steel" ],
     "symbol": "I",
     "color": "green",

--- a/data/mods/aftershock_exoplanet/items/gun/shot.json
+++ b/data/mods/aftershock_exoplanet/items/gun/shot.json
@@ -15,7 +15,8 @@
       [ "sights", 1 ],
       [ "underbarrel mount", 1 ]
     ],
-    "price": "150 USD",
+    "price": "510 USD",
+    "price_postapoc": "510 USD",
     "variants": [
       {
         "id": "vatforged",
@@ -53,7 +54,8 @@
       [ "sights", 1 ],
       [ "underbarrel mount", 1 ]
     ],
-    "price": "3 kUSD",
+    "price": "4 kUSD",
+    "price_postapoc": "4 kUSD",
     "built_in_mods": [ "afs_magnetic_choke", "afs_shotgun_gauss" ]
   },
   {
@@ -76,6 +78,8 @@
     "dispersion": 125,
     "durability": 7,
     "min_cycle_recoil": 1250,
+    "price": "2510 USD",
+    "price_postapoc": "2510 USD",
     "modes": [ [ "DEFAULT", "single", 1 ], [ "AUTO", "2 rd.", 2 ] ],
     "barrel_volume": "500 ml",
     "valid_mod_locations": [
@@ -99,6 +103,8 @@
     "name": { "str": "Drotik Shotpistol" },
     "description": "A massive TSKBEM-designed 'sidearm' intended for exosuits and uplifts, the Drotik aka 'Dart' is a large revolver firing 12ga shells.",
     "weight": "2250 g",
+    "price": "1510 USD",
+    "price_postapoc": "1510 USD",
     "volume": "1450 ml",
     "longest_side": "475 mm",
     "min_strength": 14,


### PR DESCRIPTION
#### Summary
Mods "Aftershock: Small price updates for vendors"

#### Purpose of change

Fixes incredibly cheap prices for: 
- Modded Shotguns (<$10)
- Radio Thermoses ($1)
- Boarding axes. (FREE??)


#### Describe the solution
Just set prices correctly.

#### Describe alternatives you've considered
Die because theres like a million of these updates I need to do.

#### Testing
Visited the stores.