### PR TITLE
Move debug options to debug menu

### DIFF
--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -2964,43 +2964,7 @@
   },
   {
     "type": "keybinding",
-    "name": "View scent map",
-    "category": "DEFAULTMODE",
-    "id": "debug_scent"
-  },
-  {
-    "type": "keybinding",
-    "name": "View scent type",
-    "category": "DEFAULTMODE",
-    "id": "debug_scent_type"
-  },
-  {
-    "type": "keybinding",
-    "name": "View temperature map (using map font)",
-    "category": "DEFAULTMODE",
-    "id": "debug_temp"
-  },
-  {
-    "type": "keybinding",
-    "name": "View visibility map",
-    "category": "DEFAULTMODE",
-    "id": "debug_visibility"
-  },
-  {
-    "type": "keybinding",
-    "name": "View lighting map",
-    "category": "DEFAULTMODE",
-    "id": "debug_lighting"
-  },
-  {
-    "type": "keybinding",
-    "name": "View radiation map",
-    "category": "DEFAULTMODE",
-    "id": "debug_radiation"
-  },
-  {
-    "type": "keybinding",
-    "name": "Toggle hour timer",
+    "name": "Debug Toggle hour timer",
     "category": "DEFAULTMODE",
     "id": "debug_hour_timer"
   },

--- a/src/action.cpp
+++ b/src/action.cpp
@@ -339,22 +339,6 @@ std::string action_ident( action_id act )
             return "help";
         case ACTION_DEBUG:
             return "debug";
-        case ACTION_DISPLAY_SCENT:
-            return "debug_scent";
-        case ACTION_DISPLAY_SCENT_TYPE:
-            return "debug_scent_type";
-        case ACTION_DISPLAY_TEMPERATURE:
-            return "debug_temp";
-        case ACTION_DISPLAY_VEHICLE_AI:
-            return "debug_vehicle_ai";
-        case ACTION_DISPLAY_VISIBILITY:
-            return "debug_visibility";
-        case ACTION_DISPLAY_TRANSPARENCY:
-            return "debug_transparency";
-        case ACTION_DISPLAY_LIGHTING:
-            return "debug_lighting";
-        case ACTION_DISPLAY_RADIATION:
-            return "debug_radiation";
         case ACTION_DISPLAY_NPC_ATTACK_POTENTIAL:
             return "debug_npc_attack_potential";
         case ACTION_TOGGLE_HOUR_TIMER:
@@ -472,12 +456,6 @@ bool can_action_change_worldstate( const action_id act )
         // Debug Functions
         case ACTION_TOGGLE_FULLSCREEN:
         case ACTION_DEBUG:
-        case ACTION_DISPLAY_SCENT:
-        case ACTION_DISPLAY_SCENT_TYPE:
-        case ACTION_DISPLAY_TEMPERATURE:
-        case ACTION_DISPLAY_VEHICLE_AI:
-        case ACTION_DISPLAY_VISIBILITY:
-        case ACTION_DISPLAY_LIGHTING:
         case ACTION_DISPLAY_RADIATION:
         case ACTION_DISPLAY_NPC_ATTACK_POTENTIAL:
         case ACTION_DISPLAY_TRANSPARENCY:

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -4204,9 +4204,11 @@ void debug()
             ui::omap::display_scents();
             break;
         case debug_menu_index::DISPLAY_SCENTS_LOCAL:
-            g->display_toggle_overlay( ACTION_DISPLAY_SCENT );
+            g->display_scent(); // sets anything that needs to be set
+            g->display_toggle_overlay( ACTION_DISPLAY_SCENT ); // turns it on.
             break;
         case debug_menu_index::DISPLAY_SCENTS_TYPE_LOCAL:
+            g->display_scent();
             g->display_toggle_overlay( ACTION_DISPLAY_SCENT_TYPE );
             break;
         case debug_menu_index::DISPLAY_NPC_ATTACK:
@@ -4219,10 +4221,10 @@ void debug()
             g->display_toggle_overlay( ACTION_DISPLAY_VEHICLE_AI );
             break;
         case debug_menu_index::DISPLAY_VISIBILITY:
-            g->display_toggle_overlay( ACTION_DISPLAY_VISIBILITY );
+            g->display_visibility();
             break;
         case debug_menu_index::DISPLAY_LIGHTING:
-            g->display_toggle_overlay( ACTION_DISPLAY_LIGHTING );
+            g->display_lighting();
             break;
         case debug_menu_index::DISPLAY_RADIATION:
             g->display_toggle_overlay( ACTION_DISPLAY_RADIATION );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -13366,20 +13366,6 @@ void game::display_scent()
     }
 }
 
-void game::display_temperature()
-{
-    if( use_tiles ) {
-        display_toggle_overlay( ACTION_DISPLAY_TEMPERATURE );
-    }
-}
-
-void game::display_vehicle_ai()
-{
-    if( use_tiles ) {
-        display_toggle_overlay( ACTION_DISPLAY_VEHICLE_AI );
-    }
-}
-
 void game::display_visibility()
 {
     if( use_tiles ) {
@@ -13461,20 +13447,6 @@ void game::display_lighting()
             ( static_cast<size_t>( lighting_menu.ret ) < lighting_menu_strings.size() ) ) {
             g->displaying_lighting_condition = lighting_menu.ret;
         }
-    }
-}
-
-void game::display_radiation()
-{
-    if( use_tiles ) {
-        display_toggle_overlay( ACTION_DISPLAY_RADIATION );
-    }
-}
-
-void game::display_transparency()
-{
-    if( use_tiles ) {
-        display_toggle_overlay( ACTION_DISPLAY_TRANSPARENCY );
     }
 }
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -8174,26 +8174,6 @@ look_around_result game::look_around(
                 u.set_destination( *try_route );
                 continue;
             }
-        } else if( action == "debug_scent" || action == "debug_scent_type" ) {
-            if( !MAP_SHARING::isCompetitive() || MAP_SHARING::isDebugger() ) {
-                display_scent();
-            }
-        } else if( action == "debug_temp" ) {
-            if( !MAP_SHARING::isCompetitive() || MAP_SHARING::isDebugger() ) {
-                display_temperature();
-            }
-        } else if( action == "debug_lighting" ) {
-            if( !MAP_SHARING::isCompetitive() || MAP_SHARING::isDebugger() ) {
-                display_lighting();
-            }
-        } else if( action == "debug_transparency" ) {
-            if( !MAP_SHARING::isCompetitive() || MAP_SHARING::isDebugger() ) {
-                display_transparency();
-            }
-        } else if( action == "debug_radiation" ) {
-            if( !MAP_SHARING::isCompetitive() || MAP_SHARING::isDebugger() ) {
-                display_radiation();
-            }
         } else if( action == "debug_hour_timer" ) {
             toggle_debug_hour_timer();
         } else if( action == "EXTENDED_DESCRIPTION" ) {
@@ -13349,9 +13329,7 @@ void game::display_toggle_overlay( const action_id action )
 
 void game::display_scent()
 {
-    if( use_tiles ) {
-        display_toggle_overlay( ACTION_DISPLAY_SCENT );
-    } else {
+    if( !use_tiles ) {
         int div = 0;
         if( !query_int( div, false, _( "Set scent map sensitivity to?" ) ) || div != 0 ) {
             return;
@@ -13392,6 +13370,7 @@ void game::display_visibility()
                 displaying_visibility_creature = creature;
             }
         } else {
+            popup( _( "No support for curses mode" ) );
             displaying_visibility_creature = nullptr;
         }
     }
@@ -13447,6 +13426,8 @@ void game::display_lighting()
             ( static_cast<size_t>( lighting_menu.ret ) < lighting_menu_strings.size() ) ) {
             g->displaying_lighting_condition = lighting_menu.ret;
         }
+    } else {
+        popup( _( "No support for curses mode" ) );
     }
 }
 

--- a/src/game.h
+++ b/src/game.h
@@ -1081,17 +1081,15 @@ class game
         void display_faction_epilogues();
         void disp_NPC_epilogues();  // Display NPC endings
 
+    public:
         /* Debug functions */
         // currently displayed overlay (none is displayed if empty)
         std::optional<action_id> displaying_overlays; // NOLINT(cata-serialize)
         void display_scent();   // Displays the scent map
-        void display_temperature();    // Displays temperature map
-        void display_vehicle_ai(); // Displays vehicle autopilot AI overlay
         void display_visibility(); // Displays visibility map
         void display_lighting(); // Displays lighting conditions heat map
-        void display_radiation(); // Displays radiation map
-        void display_transparency(); // Displays transparency map
 
+    private:
         // prints the IRL time in ms of the last full in-game hour
         class debug_hour_timer
         {

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -3044,56 +3044,8 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
             set_next_option( "AUTO_PICKUP" );
             break;
 
-        case ACTION_DISPLAY_SCENT:
-        case ACTION_DISPLAY_SCENT_TYPE:
-            if( MAP_SHARING::isCompetitive() && !MAP_SHARING::isDebugger() ) {
-                break;    //don't do anything when sharing and not debugger
-            }
-            display_scent();
-            break;
-
-        case ACTION_DISPLAY_TEMPERATURE:
-            if( MAP_SHARING::isCompetitive() && !MAP_SHARING::isDebugger() ) {
-                break;    //don't do anything when sharing and not debugger
-            }
-            display_temperature();
-            break;
-        case ACTION_DISPLAY_VEHICLE_AI:
-            if( MAP_SHARING::isCompetitive() && !MAP_SHARING::isDebugger() ) {
-                break;    //don't do anything when sharing and not debugger
-            }
-            display_vehicle_ai();
-            break;
-        case ACTION_DISPLAY_VISIBILITY:
-            if( MAP_SHARING::isCompetitive() && !MAP_SHARING::isDebugger() ) {
-                break;    //don't do anything when sharing and not debugger
-            }
-            display_visibility();
-            break;
-
-        case ACTION_DISPLAY_LIGHTING:
-            if( MAP_SHARING::isCompetitive() && !MAP_SHARING::isDebugger() ) {
-                break;    //don't do anything when sharing and not debugger
-            }
-            display_lighting();
-            break;
-
-        case ACTION_DISPLAY_RADIATION:
-            if( MAP_SHARING::isCompetitive() && !MAP_SHARING::isDebugger() ) {
-                break;    //don't do anything when sharing and not debugger
-            }
-            display_radiation();
-            break;
-
         case ACTION_TOGGLE_HOUR_TIMER:
             toggle_debug_hour_timer();
-            break;
-
-        case ACTION_DISPLAY_TRANSPARENCY:
-            if( MAP_SHARING::isCompetitive() && !MAP_SHARING::isDebugger() ) {
-                break;    //don't do anything when sharing and not debugger
-            }
-            display_transparency();
             break;
 
         case ACTION_TOGGLE_DEBUG_MODE:


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
These debug options are just lying around unlabeled, and people managed to confuse them for intended gameplay options. (Somehow.)

#### Describe the solution
Move them exclusively to the debug menu.
These options are all already toggles there, but some of the specific stuff happens only through the top-level keybinding (WHY???) so work needs to be done to hook it up properly.


Debug hour timer just got renamed because it can actually be useful as a top-level keybind.

#### Describe alternatives you've considered


#### Testing
Went through the overlays one by one, toggled them on through debug menu. They seemed to put up stuff that made sense. (Scent map only showed scents near the evac shelter where I had just started, temperature map said everything was 8C, etc.)

Display NPC attack stuff crashed after failing to find NC_NONE, seems to be existing issue since no code changes were done there.

#### Additional context

