### PR TITLE
[Magiclysm] Adjust elven vision based on light level

### DIFF
--- a/data/mods/Magiclysm/effects/effects.json
+++ b/data/mods/Magiclysm/effects/effects.json
@@ -2341,6 +2341,13 @@
   },
   {
     "type": "effect_type",
+    "id": "effect_magiclysm_craft_in_darkness",
+    "name": [ "" ],
+    "desc": [ "" ],
+    "flags": [ "CRAFT_IN_DARKNESS" ]
+  },
+  {
+    "type": "effect_type",
     "id": "effect_vulcanist_no_smoke_or_blisters",
     "name": [ "" ],
     "desc": [ "" ],

--- a/data/mods/Magiclysm/mutations/mutation_paths/fantasy_species.json
+++ b/data/mods/Magiclysm/mutations/mutation_paths/fantasy_species.json
@@ -392,7 +392,8 @@
       },
       {
         "condition": { "and": [ { "not": "u_is_outside" }, { "math": [ "u_val('fine_detail_vision_mod') <= 7" ] } ] },
-        "values": [ { "value": "NIGHT_VIS", "add": 6 } ]
+        "values": [ { "value": "NIGHT_VIS", "add": 6 } ],
+        "ench_effects": [ { "effect": "effect_magiclysm_craft_in_darkness", "intensity": 1 } ]
       }
     ]
   },

--- a/data/mods/Magiclysm/mutations/mutation_paths/fantasy_species.json
+++ b/data/mods/Magiclysm/mutations/mutation_paths/fantasy_species.json
@@ -368,8 +368,26 @@
         "values": [ { "value": "NIGHT_VIS", "add": 20 } ]
       },
       {
-        "condition": { "and": [ "u_is_outside", { "not": { "is_weather": "clear" } }, { "not": { "is_weather": "sunny" } } ] },
+        "condition": {
+          "and": [
+            "u_is_outside",
+            { "not": { "is_weather": "clear" } },
+            { "not": { "is_weather": "sunny" } },
+            { "math": [ "moon_phase() != 0" ] }
+          ]
+        },
         "values": [ { "value": "NIGHT_VIS", "add": 10 } ]
+      },
+      {
+        "condition": {
+          "and": [
+            "u_is_outside",
+            { "not": { "is_weather": "clear" } },
+            { "not": { "is_weather": "sunny" } },
+            { "math": [ "moon_phase() == 0" ] }
+          ]
+        },
+        "values": [ { "value": "NIGHT_VIS", "add": 2 } ]
       },
       {
         "condition": { "and": [ { "not": "u_is_outside" }, { "math": [ "u_val('fine_detail_vision_mod') <= 7" ] } ] },

--- a/data/mods/Magiclysm/mutations/mutation_paths/fantasy_species.json
+++ b/data/mods/Magiclysm/mutations/mutation_paths/fantasy_species.json
@@ -365,11 +365,11 @@
     "enchantments": [
       {
         "condition": { "and": [ "u_is_outside", { "or": [ { "is_weather": "clear" }, { "is_weather": "sunny" } ] } ] },
-        "values": [ { "value": "NIGHT_VIS", "add": 15 } ]
+        "values": [ { "value": "NIGHT_VIS", "add": 20 } ]
       },
       {
         "condition": { "and": [ "u_is_outside", { "not": { "is_weather": "clear" } }, { "not": { "is_weather": "sunny" } } ] },
-        "values": [ { "value": "NIGHT_VIS", "add": 8 } ]
+        "values": [ { "value": "NIGHT_VIS", "add": 10 } ]
       },
       {
         "condition": { "and": [ { "not": "u_is_outside" }, { "math": [ "u_val('fine_detail_vision_mod') <= 7" ] } ] },

--- a/data/mods/Magiclysm/mutations/mutation_paths/fantasy_species.json
+++ b/data/mods/Magiclysm/mutations/mutation_paths/fantasy_species.json
@@ -365,7 +365,7 @@
     "enchantments": [
       {
         "condition": { "and": [ "u_is_outside", { "or": [ { "is_weather": "clear" }, { "is_weather": "sunny" } ] } ] },
-        "values": [ { "value": "NIGHT_VIS", "add": 20 } ]
+        "values": [ { "value": "NIGHT_VIS", "add": 20 }, { "value": "OVERMAP_SIGHT", "add": 6 } ]
       },
       {
         "condition": {
@@ -376,7 +376,7 @@
             { "math": [ "moon_phase() != 0" ] }
           ]
         },
-        "values": [ { "value": "NIGHT_VIS", "add": 10 } ]
+        "values": [ { "value": "NIGHT_VIS", "add": 10 }, { "value": "OVERMAP_SIGHT", "add": 2 } ]
       },
       {
         "condition": {

--- a/data/mods/Magiclysm/mutations/mutation_paths/fantasy_species.json
+++ b/data/mods/Magiclysm/mutations/mutation_paths/fantasy_species.json
@@ -365,7 +365,8 @@
     "enchantments": [
       {
         "condition": { "and": [ "u_is_outside", { "or": [ { "is_weather": "clear" }, { "is_weather": "sunny" } ] } ] },
-        "values": [ { "value": "NIGHT_VIS", "add": 20 }, { "value": "OVERMAP_SIGHT", "add": 6 } ]
+        "values": [ { "value": "NIGHT_VIS", "add": 20 }, { "value": "OVERMAP_SIGHT", "add": 6 } ],
+        "ench_effects": [ { "effect": "effect_magiclysm_craft_in_darkness", "intensity": 1 } ]
       },
       {
         "condition": {

--- a/data/mods/Magiclysm/mutations/mutation_paths/fantasy_species.json
+++ b/data/mods/Magiclysm/mutations/mutation_paths/fantasy_species.json
@@ -362,26 +362,18 @@
     "description": "Like a cat, elven eyes are well-attuned to low levels of light, able to pick up even the slightest glimmer.  You have greatly-enhanced night vision.  However, you have no additional vision while in complete darkness.",
     "types": [ "EYES" ],
     "category": [ "SPECIES_ELF" ],
-    "enchantments": [ 
-      { 
+    "enchantments": [
+      {
         "condition": { "and": [ "u_is_outside", { "or": [ { "is_weather": "clear" }, { "is_weather": "sunny" } ] } ] },
-        "values": [
-          { "value": "NIGHT_VIS", "add": 15 } 
-        ]
+        "values": [ { "value": "NIGHT_VIS", "add": 15 } ]
       },
-       { 
-        "condition":  { "and": [ "u_is_outside", { "not": { "is_weather": "clear" } }, { "not": { "is_weather": "sunny" } } ] },
-    
-        "values": [
-          { "value": "NIGHT_VIS", "add": 8 } 
-        ]
+      {
+        "condition": { "and": [ "u_is_outside", { "not": { "is_weather": "clear" } }, { "not": { "is_weather": "sunny" } } ] },
+        "values": [ { "value": "NIGHT_VIS", "add": 8 } ]
       },
-   { 
-        "condition":  { "and": [ { "not": "u_is_outside" }, { "math": [ "u_val('fine_detail_vision_mod') <= 7" ] } ] },
-    
-        "values": [
-          { "value": "NIGHT_VIS", "add": 6 } 
-        ]
+      {
+        "condition": { "and": [ { "not": "u_is_outside" }, { "math": [ "u_val('fine_detail_vision_mod') <= 7" ] } ] },
+        "values": [ { "value": "NIGHT_VIS", "add": 6 } ]
       }
     ]
   },

--- a/data/mods/Magiclysm/mutations/mutation_paths/fantasy_species.json
+++ b/data/mods/Magiclysm/mutations/mutation_paths/fantasy_species.json
@@ -359,10 +359,31 @@
     "id": "ELVEN_SIGHT",
     "name": { "str": "Elvensight" },
     "points": 2,
-    "description": "Like a cat, elven eyes are well-attuned to low levels of light, able to pick up even the slightest glimmer.  You have greatly-enhanced night vision.",
+    "description": "Like a cat, elven eyes are well-attuned to low levels of light, able to pick up even the slightest glimmer.  You have greatly-enhanced night vision.  However, you have no additional vision while in complete darkness.",
     "types": [ "EYES" ],
     "category": [ "SPECIES_ELF" ],
-    "enchantments": [ { "values": [ { "value": "NIGHT_VIS", "add": 5 } ] } ]
+    "enchantments": [ 
+      { 
+        "condition": { "and": [ "u_is_outside", { "or": [ { "is_weather": "clear" }, { "is_weather": "sunny" } ] } ] },
+        "values": [
+          { "value": "NIGHT_VIS", "add": 15 } 
+        ]
+      },
+       { 
+        "condition":  { "and": [ "u_is_outside", { "not": { "is_weather": "clear" } }, { "not": { "is_weather": "sunny" } } ] },
+    
+        "values": [
+          { "value": "NIGHT_VIS", "add": 8 } 
+        ]
+      },
+   { 
+        "condition":  { "and": [ { "not": "u_is_outside" }, { "math": [ "u_val('fine_detail_vision_mod') <= 7" ] } ] },
+    
+        "values": [
+          { "value": "NIGHT_VIS", "add": 6 } 
+        ]
+      }
+    ]
   },
   {
     "type": "mutation",

--- a/data/mods/Magiclysm/mutations/mutation_paths/fantasy_species.json
+++ b/data/mods/Magiclysm/mutations/mutation_paths/fantasy_species.json
@@ -373,7 +373,7 @@
             "u_is_outside",
             { "not": { "is_weather": "clear" } },
             { "not": { "is_weather": "sunny" } },
-            { "math": [ "moon_phase() != 0" ] }
+            { "and": [ { "math": [ "moon_phase() >= 2" ] }, { "math": [ "moon_phase() < 7" ] } ] }
           ]
         },
         "values": [ { "value": "NIGHT_VIS", "add": 10 }, { "value": "OVERMAP_SIGHT", "add": 2 } ]
@@ -384,7 +384,7 @@
             "u_is_outside",
             { "not": { "is_weather": "clear" } },
             { "not": { "is_weather": "sunny" } },
-            { "math": [ "moon_phase() == 0" ] }
+            { "or": [ { "math": [ "moon_phase() <= 1" ] }, { "math": [ "moon_phase() == 7" ] } ] }
           ]
         },
         "values": [ { "value": "NIGHT_VIS", "add": 2 } ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[Magiclysm] Adjust elven vision based on light level"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Giving elves great night vision at all times is boring and steps on goblins' toes. 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Adjust elven night vision based on conditions:

**Outside on a clear night**:
<img width="1708" height="1356" alt="Untitled" src="https://github.com/user-attachments/assets/8041397e-ebab-4e6c-ac68-bdae898ac9b0" />

At this level, elves can craft.

**Outside on a cloudy night:**
<img width="871" height="881" alt="Untitled" src="https://github.com/user-attachments/assets/75d85fcf-3722-44b5-9309-c59d4cac3fc7" />

**Outside at night in fog:**

<img width="589" height="556" alt="Untitled" src="https://github.com/user-attachments/assets/775105de-e2ed-4a4d-b0f6-356bad91b273" />

**Indoors when there's some light (through windows etc):**

<img width="670" height="661" alt="Untitled" src="https://github.com/user-attachments/assets/f0603d08-4b06-4228-b2a3-57981b965fd5" />

At this level (which is basically "indoors during the day near a curtained window"), elves can craft.

**Indoors when there's no light:**

<img width="290" height="229" alt="Untitled" src="https://github.com/user-attachments/assets/9eec147e-857b-4eda-b73a-5e4895d03fdd" />

Vision reduced during the new/crescent moon if it's cloudy as well (i.e., if there's no/minimal moon or starlight to see by).

Elves need actual light to read, the same as everyone else.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

See photos above.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

One disadvantage is your enhanced night vision cuts off the instant you step indoors at night if it's dark enough, but the gradient elsewhere is way better and more interesting.

If you're an elf and you want to see in pitch darkness, use magic. 
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
