### PR TITLE
Add dolphin shorts, simplify hot pants definitions + small changes

### DIFF
--- a/data/json/items/armor/legs_clothes.json
+++ b/data/json/items/armor/legs_clothes.json
@@ -191,9 +191,9 @@
     "id": "hot_pants",
     "type": "ITEM",
     "subtypes": [ "ARMOR" ],
-    "name": { "str_sp": "hot pants" },
+    "name": { "str_sp": "short shorts" },
     "description": "A simple pair of short shorts.",
-    "weight": "92 g",
+    "weight": "125 g",
     "volume": "250 ml",
     "price": "25 USD",
     "price_postapoc": "50 cent",
@@ -202,46 +202,188 @@
     "looks_like": "boxer_briefs",
     "color": "light_red",
     "material_thickness": 0.1,
-    "flags": [ "VARSIZE", "WATER_FRIENDLY", "SKINTIGHT" ],
-    "armor": [ { "coverage": 75, "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_hip_l", "leg_hip_r" ] } ]
+    "flags": [ "VARSIZE", "SKINTIGHT" ],
+    "armor": [ { "coverage": 75, "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_hip_l", "leg_hip_r" ] } ],
+    "variant_type": "generic",
+    "variants": [
+      {
+        "id": "purple",
+        "name": { "str_sp": "purple short shorts" },
+        "color": "magenta",
+        "description": "These ones are purple.",
+        "append": true,
+        "weight": 10
+      },
+      {
+        "id": "blue",
+        "name": { "str_sp": "blue short shorts" },
+        "color": "blue",
+        "description": "These ones are colored blue.",
+        "append": true,
+        "weight": 10
+      },
+      {
+        "id": "yellow",
+        "name": { "str_sp": "yellow short shorts" },
+        "color": "yellow",
+        "description": "These ones are colored yellow.",
+        "append": true,
+        "weight": 10
+      },
+      {
+        "id": "green",
+        "name": { "str_sp": "green short shorts" },
+        "color": "green",
+        "description": "These ones are colored green.",
+        "append": true,
+        "weight": 10
+      },
+      {
+        "id": "pink",
+        "name": { "str_sp": "pink short shorts" },
+        "color": "magenta",
+        "description": "These ones are colored pink.",
+        "append": true,
+        "weight": 10
+      },
+      {
+        "id": "cyan",
+        "name": { "str_sp": "cyan short shorts" },
+        "color": "cyan",
+        "description": "These ones are colored cyan.",
+        "append": true,
+        "weight": 10
+      },
+      {
+        "id": "black",
+        "name": { "str_sp": "black short shorts" },
+        "color": "dark_gray",
+        "description": "These ones are colored black.",
+        "append": true,
+        "weight": 10
+      },
+      {
+        "id": "white",
+        "name": { "str_sp": "white short shorts" },
+        "color": "light_gray",
+        "description": "These ones are colored white.",
+        "append": true,
+        "weight": 10
+      },
+      {
+        "id": "brown",
+        "name": { "str_sp": "brown short shorts" },
+        "color": "brown",
+        "description": "These ones are colored brown.",
+        "append": true,
+        "weight": 10
+      },
+      {
+        "id": "red",
+        "name": { "str_sp": "red short shorts" },
+        "description": "These ones are red.",
+        "append": true,
+        "weight": 10
+      },
+      {
+        "id": "dolphin_purple",
+        "name": { "str_sp": "purple dolphin shorts" },
+        "color": "magenta",
+        "description": "Athletic shorts with a characteristic white hem.  These ones are purple, perfect to play some strategy games in.",
+        "append": true
+      },
+      {
+        "id": "dolphin_red",
+        "name": { "str_sp": "red dolphin shorts" },
+        "description": "Athletic shorts with a characteristic white hem.  These ones are colored red.",
+        "color": "red",
+        "append": true
+      },
+      {
+        "id": "dolphin_blue",
+        "name": { "str_sp": "blue dolphin shorts" },
+        "color": "blue",
+        "description": "Athletic shorts with a characteristic white hem.  These ones are colored blue.",
+        "append": true
+      },
+      {
+        "id": "dolphin_yellow",
+        "name": { "str_sp": "yellow dolphin shorts" },
+        "color": "yellow",
+        "description": "Athletic shorts with a characteristic white hem.  These ones are colored yellow.",
+        "append": true
+      },
+      {
+        "id": "dolphin_green",
+        "name": { "str_sp": "green dolphin shorts" },
+        "color": "green",
+        "description": "Athletic shorts with a characteristic white hem.  These ones are colored green.",
+        "append": true
+      },
+      {
+        "id": "dolphin_pink",
+        "name": { "str_sp": "pink dolphin shorts" },
+        "color": "magenta",
+        "description": "Athletic shorts with a characteristic white hem.  These ones are colored pink.",
+        "append": true
+      },
+      {
+        "id": "dolphin_cyan",
+        "name": { "str_sp": "cyan dolphin shorts" },
+        "color": "cyan",
+        "description": "Athletic shorts with a characteristic white hem.  These ones are colored cyan.",
+        "append": true
+      },
+      {
+        "id": "dolphin_black",
+        "name": { "str_sp": "black dolphin shorts" },
+        "color": "dark_gray",
+        "description": "Athletic shorts with a characteristic white hem.  These ones are colored black.",
+        "append": true
+      },
+      {
+        "id": "dolphin_white",
+        "name": { "str_sp": "white dolphin shorts" },
+        "color": "light_gray",
+        "description": "Athletic shorts with a characteristic white hem.  These ones are colored white.",
+        "append": true
+      },
+      {
+        "id": "dolphin_brown",
+        "name": { "str_sp": "brown dolphin shorts" },
+        "color": "brown",
+        "description": "Athletic shorts with a characteristic white hem.  These ones are colored brown.",
+        "append": true
+      }
+    ]
   },
   {
-    "id": "hot_pants_fur",
     "type": "ITEM",
     "subtypes": [ "ARMOR" ],
+    "id": "hot_pants_leather",
+    "copy-from": "hot_pants",
+    "proportional": { "weight": 2.2 },
+    "name": { "str_sp": "leather hot pants" },
+    "description": "A simple pair of leather short shorts.",
+    "material": [ "leather" ],
+    "looks_like": "hot_pants",
+    "color": "brown",
+    "warmth": 5,
+    "material_thickness": 0.1
+  },
+  {
+    "type": "ITEM",
+    "subtypes": [ "ARMOR" ],
+    "id": "hot_pants_fur",
+    "copy-from": "hot_pants",
+    "proportional": { "weight": 2.2 },
     "name": { "str_sp": "fur hot pants" },
     "description": "A simple pair of fur short shorts.",
-    "weight": "118 g",
-    "volume": "250 ml",
-    "price": "55 USD",
-    "price_postapoc": "1 USD",
     "material": [ "fur" ],
-    "symbol": "[",
     "looks_like": "hot_pants_leather",
     "color": "brown",
     "warmth": 10,
-    "material_thickness": 0.2,
-    "flags": [ "VARSIZE", "SKINTIGHT" ],
-    "armor": [ { "coverage": 75, "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_hip_l", "leg_hip_r" ] } ]
-  },
-  {
-    "id": "hot_pants_leather",
-    "type": "ITEM",
-    "subtypes": [ "ARMOR" ],
-    "name": { "str_sp": "leather hot pants" },
-    "description": "A simple pair of leather short shorts.",
-    "weight": "106 g",
-    "volume": "250 ml",
-    "price": "25 USD",
-    "price_postapoc": "50 cent",
-    "material": [ "leather" ],
-    "symbol": "[",
-    "looks_like": "hot_pants",
-    "color": "dark_gray",
-    "warmth": 5,
-    "material_thickness": 0.1,
-    "flags": [ "VARSIZE", "SKINTIGHT" ],
-    "armor": [ { "coverage": 75, "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_hip_l", "leg_hip_r" ] } ]
+    "material_thickness": 0.2
   },
   {
     "id": "jeans",

--- a/data/json/recipes/armor/legs.json
+++ b/data/json/recipes/armor/legs.json
@@ -233,7 +233,6 @@
     "activity_level": "LIGHT_EXERCISE",
     "category": "CC_ARMOR",
     "subcategory": "CSC_ARMOR_LEGS",
-    "//": "zero Encumbrance, without elastic, at skill 2? seems tricky",
     "skill_used": "tailor",
     "difficulty": 2,
     "time": "3 h",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

1. We don't have dolphin shorts despite those being quite popular, especially in some communities.
2. No one calls these garments "hot pants" anymore or at least it's way more popular to simply call them "short shorts" or even "booty shorts".
3. The definitions for leather and fur short shorts are quite redundant.
4. There's a "WATER_FRIENDLY" flag there for no apparent reason, short shorts are not particularly made to swim or go in water in.
5. The crafting recipe include an irrelevant comment.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

1. Add dolphin short variants alongside color variants for the "base" version.
2. Rename the item.
3. Copy-from the leather and fur versions, proportionally changing the weight to account for density, see additional context though.
4. Remove the flag.
5. Remove the comment.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Spawned them, worn them, no issue.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
I used another cotton density to calculate the weight but got more weight, dunno what's happening there but #82032 probably needs to be merged first anyway. Also, the purple dolphin shorts description includes a reference, I can remove it if it's unwelcome.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
