### PR TITLE
Forbid nesting chains over 12 in AIM to prevent save corruption.

### DIFF
--- a/src/item_location.cpp
+++ b/src/item_location.cpp
@@ -1107,6 +1107,19 @@ pocket_constraint item_location::get_pocket_constraints_recursive( const item_po
     return ret;
 }
 
+/**
+ * Return length of the longest nesting chain.
+ * For A > B > C, return 2.
+ */
+static int DFS_nesting( const item *it )
+{
+    int max_nest = 0;
+    for( const item *son : it->all_items_top() ) {
+        max_nest = std::max( max_nest, 1 + DFS_nesting( son ) );
+    }
+    return max_nest;
+}
+
 ret_val<void> item_location::parents_can_contain_recursive( item *it ) const
 {
     item_pocket *parent_pocket;
@@ -1119,8 +1132,10 @@ ret_val<void> item_location::parents_can_contain_recursive( item *it ) const
     const item_pocket *current_pocket = get_item()->get_standard_pockets().front();
     const pocket_data *current_pocket_data = current_pocket->get_pocket_data();
 
+    int recursion_depth = DFS_nesting( it );
     //Repeat until top-most container reached
     while( current_location.has_parent() ) {
+        ++recursion_depth;
         parent_pocket = current_location.parent_pocket();
 
         //Ignore volume and length after innermost rigid container
@@ -1146,6 +1161,10 @@ ret_val<void> item_location::parents_can_contain_recursive( item *it ) const
         current_pocket = parent_pocket;
         current_pocket_data = current_pocket->get_pocket_data();
         current_location = current_location.parent_item();
+    }
+    // Deep nesting would lead to stack overflow error on loading
+    if( recursion_depth > 10 ) {
+        return ret_val<void>::make_failure( _( "containers are nested too deeply" ) );
     }
     return ret_val<void>::make_success();
 }


### PR DESCRIPTION
#### Summary
Bugfixes "Forbid nesting chains over 12 in AIM to prevent save corruption."

#### Purpose of change

 - Fix #81946

#### Describe the solution

Whenever putting an item inside another, check that the longest nesting chain is no longer than 12. (`A > B > C > ... > L`)

#### Describe alternatives you've considered

1. Make it possible to nest deeper than 12. See #81946 for implementation.
2. Caching the result, but it might be fast enough without it. See #81946 for flashed-out idea.

#### Testing

Tried to construct a chain of `short rope` (`SR`) longer than 12 (`SR > SR > SR > ... > SR`)
1. By putting `SR` into `SR > ... > SR` (len 12).
2. By putting `SR > ... > SR` (len 12) into `SR`.
3. By putting `SR > SR` into `SR > ... > SR` (len 11).

All these failed. So I obtained only a chain of length 12 or shorter.

I tested that having a chain of length 13 or bigger does trigger the error (leading to a crash, if the chain is wielded) mentioned in #81946.

Tested interfaces (crossed work, others don't):
 - [x] AIM
 - [ ] Store previously wielded `SR > SR...` (DOESN'T WORK)
 - [x] examine item > `i`nsert OR `v` insert menu
 - [ ] examine item > `v` manage pockets - future PR

#### Additional context

