### PR TITLE
can_contain: calculate pocket volume once (huge speed up in special cases)

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -10731,18 +10731,17 @@ ret_val<void> item::can_contain( const item &it, int &copies_remaining, const bo
             const bool ignore_nested_rigidity =
                 !pkt->settings.accepts_item( it ) ||
                 !pkt->get_pocket_data()->get_flag_restrictions().empty() || pkt->is_holster();
+            units::volume remaining_volume = pkt->remaining_volume();
             for( const item *internal_it : pkt->all_items_top() ) {
-                if( parent_it.where() != item_location::type::invalid && internal_it == parent_it.get_item() ) {
-                    continue;
-                }
-                if( !internal_it->is_container() ) {
-                    continue;
-                }
+                const int copies_remaining_before = copies_remaining;
                 auto ret = internal_it->can_contain( it, copies_remaining, true, ignore_nested_rigidity,
                                                      ignore_pkt_settings, ignore_non_container_pocket, parent_it,
-                                                     pkt->remaining_volume() );
+                                                     remaining_volume );
                 if( copies_remaining <= 0 ) {
                     return ret;
+                }
+                if( copies_remaining_before != copies_remaining ) {
+                    remaining_volume = pkt->remaining_volume();
                 }
             }
         }


### PR DESCRIPTION

#### Summary
Performance "can_contain: calculate pocket volume once (huge speed up in special cases)"

#### Purpose of change

 - With 500 plastic bags, it speeds up the "Pick up from all nearby tiles" menu display from 15s to 1s.
 - Originally, I wanted to delete duplicate code, but it was a working optimisation attempt from #60414.

#### Describe the solution

 - Calculate the remaining pocket volume once, not once for all items in said pocket.
 - Also, remove the original optimisation.

#### Describe alternatives you've considered

Keep the original optimisation too. There is no need; I didn't even try. See line 10734 in the new code in testing, it would save at most 10% performance while keeping more complicated code.

#### Testing

1. I tested opening the "Pick up from all nearby tiles" on save from the original issue #60277. The original optimisation can be found here #60414.
2. There was not a big difference, so I added 500 plastic bags to the player's inventory. This slowed the master version to a halt (15 seconds), while the newly optimised version remained somewhat speedy (1 second).

Before:
<img width="977" height="355" alt="image" src="https://github.com/user-attachments/assets/f2afa937-2135-45c5-9440-772780fb4352" />

After:
<img width="957" height="351" alt="image" src="https://github.com/user-attachments/assets/11303c71-f4a7-45a9-9be4-e31daa1e9151" />

#### Additional context

I don't know where the `copies_remaining_before != copies_remaining` is needed. I didn't hit it during testing.