### PR TITLE
rename strict -> strict_boiling to match docs

### DIFF
--- a/src/item_location.cpp
+++ b/src/item_location.cpp
@@ -1233,9 +1233,9 @@ bool item_location::can_reload_with( const item_location &ammo, bool now ) const
     return reloadable->can_reload_with( *ammo, now );
 }
 
-int item_location::get_quality( const std::string &quality, bool strict ) const
+int item_location::get_quality( const std::string &quality, bool strict_boiling ) const
 {
     const item_location tool = *this;
     quality_id qualityid( quality );
-    return tool->get_quality_nonrecursive( qualityid, strict );
+    return tool->get_quality_nonrecursive( qualityid, strict_boiling );
 }

--- a/src/item_location.h
+++ b/src/item_location.h
@@ -174,9 +174,9 @@ class item_location
         /**
         * returns the item's level of the specified quality.
         * @param quality the name of quality to check the level of
-        * @param boiling true if the item is required to be empty to have the boiling quality
+        * @param strict_boiling True if containers must be empty to have BOIL quality
         */
-        int get_quality( const std::string &quality, bool strict ) const;
+        int get_quality( const std::string &quality, bool strict_boiling ) const;
 
     private:
         class impl;


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Doc said `@param boiling` the code had `bool strict`.

#### Describe the solution

Rename param to `bool strict_boiling` and reflect that in the docs. The new description is from `item::get_quality_nonrecursive`, why make something different?

#### Describe alternatives you've considered

#### Testing

Compiles.

#### Additional context