### PR TITLE
[XE/Sky Island] The island also gives the recipe to reshuffle vampire weaknesses.

### DIFF
--- a/data/mods/Sky_Island/mod_interactions/xedra_evolved/eocs.json
+++ b/data/mods/Sky_Island/mod_interactions/xedra_evolved/eocs.json
@@ -143,7 +143,25 @@
       { "u_remove_item_with": "upgradekey_bloodgift_research" },
       { "u_forget_recipe": "upgradekey_bloodgift_research" },
       { "u_learn_recipe": "xe_vampire_blood_gift_research" },
-      { "u_message": "You learn how to expand your blood gifts.", "type": "good" }
+      { "u_learn_recipe": "xe_vampire_blood_weaknesses_reshuffle" },
+      { "u_message": "You learn how to expand your blood gifts and reshuffle your weaknesses.", "type": "good" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_UPDATE_KNOWN_RECIPES",
+    "eoc_type": "EVENT",
+    "required_event": "game_load",
+    "//": "If a player only has the learn recipe, they also gain the reshuffle.  They're always gained together and this will ensure those who update aren't locked out of reshuffling.",
+    "condition": {
+      "and": [
+        { "u_know_recipe": "xe_vampire_blood_gift_research" },
+        { "not": { "u_know_recipe": "xe_vampire_blood_weaknesses_reshuffle" } }
+      ]
+    },
+    "effect": [
+      { "u_learn_recipe": "xe_vampire_blood_weaknesses_reshuffle" },
+      { "u_message": "You can now reshuffle your weaknesses.", "type": "popup" }
     ]
   }
 ]

--- a/data/mods/Sky_Island/mod_interactions/xedra_evolved/recipes.json
+++ b/data/mods/Sky_Island/mod_interactions/xedra_evolved/recipes.json
@@ -94,7 +94,7 @@
     "type": "ITEM",
     "category": "spare_parts",
     "name": { "str": "Key of Vampiric Knowledge" },
-    "description": "This strange metaphysical artifact will allow you to spend your blood to obtain new blood gifts.\n\nAs per the previous vampiric amplificator, you have to decide to use the crafted item for its effect to apply.",
+    "description": "This strange metaphysical artifact will allow you to spend your blood to obtain new blood gifts and reshuffle your weaknesses.\n\nAs per the previous vampiric amplificator, you have to decide to use the crafted item for its effect to apply.",
     "volume": "250 ml",
     "weight": "150 g",
     "longest_side": "9 cm",


### PR DESCRIPTION

#### Summary
Mods "[XE/Sky Island] The island also gives the recipe to reshuffle vampire weaknesses."

#### Purpose of change

Sky island contains a path to vampiric power that accounts for the nigh-impossibility to do the mentor's quests with the island's restrictions.

Since there is now a new vampire-related recipe, the island will give it too to prevent punishing those who use its recipes.

#### Describe the solution

The recipe that unlocks the ability to research vampire gifts also unlocks the reshuffle recipe.

Also add a game_load eoc that grants the reshuffle recipe if the player has the learn recipe, for those who update their save. They're always gained together.

#### Describe alternatives you've considered

Penalize those who use the island's recipes.

#### Testing

Used the key, gained both recipes.

#### Additional context

It is intended that the island doesn't give the Anathema recipe, the same way it doesn't give mutagen recipes.

Spawning the Anathema is straightforward unlike doing long quests and repeated NPC interaction in a mode where encountering the same NPC again is pure luck.