### PR TITLE
Update the rules for sealing

### DIFF
--- a/src/item_group.cpp
+++ b/src/item_group.cpp
@@ -21,6 +21,7 @@
 #include "item_components.h"
 #include "item_contents.h"
 #include "item_factory.h"
+#include "item_pocket.h"
 #include "itype.h"
 #include "iuse.h"
 #include "iuse_actor.h"

--- a/src/item_group.cpp
+++ b/src/item_group.cpp
@@ -709,7 +709,7 @@ void Item_modifier::modify( item &new_item, const std::string &context ) const
             // but i do not see where to fit it elsewhere
 
             bool any_sealed = false;
-            for( const auto &pocket : new_item.get_contents().get_all_contained_pockets() ) {
+            for( const item_pocket &pocket : new_item.get_contents().get_all_contained_pockets() ) {
                 if( pocket->sealable() ) {
                     any_sealed = true;
                     break;

--- a/src/item_group.cpp
+++ b/src/item_group.cpp
@@ -709,7 +709,7 @@ void Item_modifier::modify( item &new_item, const std::string &context ) const
             // but i do not see where to fit it elsewhere
 
             bool any_sealed = false;
-            for( const item_pocket &pocket : new_item.get_contents().get_all_contained_pockets() ) {
+            for( const item_pocket *pocket : new_item.get_contents().get_all_contained_pockets() ) {
                 if( pocket->sealable() ) {
                     any_sealed = true;
                     break;

--- a/src/item_group.cpp
+++ b/src/item_group.cpp
@@ -702,7 +702,22 @@ void Item_modifier::modify( item &new_item, const std::string &context ) const
                 new_item.put_in( it, pk_type );
             }
         }
-        if( sealed ) {
+        // sealed is true by default, but it gives nothing to seal ammunition or glue (at least yet)
+        if( sealed && new_item.is_comestible() ) {
+            // I don't like we validate sealing at itemgroup spawn
+            // but i do not see where to fit it elsewhere
+
+            bool any_sealed = false;
+            for( const auto &pocket : new_item.get_contents().get_all_contained_pockets() ) {
+                if( pocket->sealable() ) {
+                    any_sealed = true;
+                    break;
+                }
+            }
+            if( !any_sealed ) {
+                debugmsg( "in %s: item %s tries to spawn sealed, but has no sealed_data to actually be sealed.",
+                          context, new_item.typeId().c_str() );
+            }
             new_item.seal();
         }
     }

--- a/src/item_pocket.cpp
+++ b/src/item_pocket.cpp
@@ -2036,6 +2036,10 @@ bool item_pocket::empty() const
 
 bool item_pocket::full( bool allow_bucket ) const
 {
+    if( contents.empty() ) {
+        return false;
+    }
+
     if( !allow_bucket && will_spill() ) {
         return true;
     }
@@ -2052,7 +2056,23 @@ bool item_pocket::full( bool allow_bucket ) const
         return false;
     }
 
-    return remaining_volume() == 0_ml;
+    if( remaining_volume() == 0_ml ) {
+        return true;
+    }
+
+    if( remaining_capacity_for_item( contents.front() ) == 0 ) {
+        bool has_only_one_type = true;
+        // maybe there is a better way?
+        for( const item &it : contents ) {
+            if( it.type->id != contents.front().type->id ) {
+                has_only_one_type = false;
+                break;
+            }
+        }
+        return has_only_one_type;
+    }
+
+    return false;
 }
 
 bool item_pocket::rigid() const


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Attempt to adress #81781
#### Describe the solution
Make only containers that contain comestibles of one type sealable
Instead of checking if total space left in pocket is 0_ml, also check if you cannot fit any more of the same item inside - for container with 100 ml, you can seal 3 items 30 ml of volume each, since you cannot fit any more of it into the container. You cannot seal if it's only 2 items tho
Catch cases where we try to spawn comestible in non-sealable containers, but want them sealed
#### Testing
made squeeze_tube sealable, put red sause into it. All instances that spawned with 4 charges are sealed, the rest are not:
<img width="696" height="281" alt="image" src="https://github.com/user-attachments/assets/048e10bf-4140-4a6a-b3ad-13a40c8f40b8" />
#### Additional context
Kind of a dillema, since `sealed` is always true unless otherwise is specified, a lot of food spawn sealed because of it, meaning adding `"sealed": true` to itemgroup is pointless double dipping
However i cannot find how to catch it meaningfully