### PR TITLE
Stop using pre-apoc price as a fallback for postapoc price

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -6110,7 +6110,7 @@ void item::final_info( std::vector<iteminfo> &info, const iteminfo_query *parts,
                            iteminfo::is_decimal | iteminfo::no_newline,
                            static_cast<double>( price_preapoc ) / 100 );
     }
-    if( price_preapoc != price_postapoc && parts->test( iteminfo_parts::BASE_BARTER ) ) {
+    if( parts->test( iteminfo_parts::BASE_BARTER ) ) {
         const std::string space = "  ";
         info.emplace_back( "BASE", space + _( "Barter value: " ), _( "$<num>" ),
                            iteminfo::is_decimal,

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -387,10 +387,6 @@ void Item_factory::finalize_pre( itype &obj )
         obj.category_force = calc_category( obj );
     }
 
-    // use pre-Cataclysm price as default if post-cataclysm price unspecified
-    if( obj.price_post < 0_cent ) {
-        obj.price_post = obj.price;
-    }
     // use base volume if integral volume unspecified
     if( obj.integral_volume < 0_ml ) {
         obj.integral_volume = obj.volume;
@@ -4075,7 +4071,7 @@ void itype::load( const JsonObject &jo, std::string_view src )
     optional( jo, was_loaded, "volume", volume );
     optional( jo, was_loaded, "longest_side", longest_side, -1_mm );
     optional( jo, was_loaded, "price", price, not_negative_money, 0_cent );
-    optional( jo, was_loaded, "price_postapoc", price_post, not_negative_money, -1_cent );
+    optional( jo, was_loaded, "price_postapoc", price_post, not_negative_money, 0_cent );
     optional( jo, was_loaded, "stackable", stackable_ );
     optional( jo, was_loaded, "integral_volume", integral_volume, not_negative_volume, -1_ml );
     optional( jo, was_loaded, "integral_longest_side", integral_longest_side, not_negative_length,

--- a/src/itype.h
+++ b/src/itype.h
@@ -1515,7 +1515,7 @@ struct itype {
         units::money price = 0_cent;
 
         /** Value after the Cataclysm, dependent upon practical usages. Price given is for a default-sized stack. */
-        units::money price_post = -1_cent;
+        units::money price_post = 0_cent;
 
         // TODO: Add some very basic unweildiness calc for non specified to_hit?
         int m_to_hit = -2;  // To-hit bonus for melee combat, see GAME_BALANCE.md#to-hit-value

--- a/tests/iteminfo_test.cpp
+++ b/tests/iteminfo_test.cpp
@@ -450,26 +450,6 @@ TEST_CASE( "item_price_and_barter_value", "[iteminfo][price]" )
                "--\n"
                "Price: $<color_c_yellow>75.00</color>  Barter value: $<color_c_yellow>3.00</color>\n" );
     }
-
-    SECTION( "item with same price and barter value shows only price" ) {
-        item nuts( itype_test_pine_nuts );
-        REQUIRE( nuts.price( false ) == 136 );
-        REQUIRE( nuts.price( true ) == 136 );
-
-        CHECK( item_info_str( nuts, price_barter ) ==
-               "--\n"
-               "Price: $<color_c_yellow>1.36</color>" );
-    }
-
-    SECTION( "item with no price or barter value" ) {
-        item rock( itype_test_rock );
-        REQUIRE( rock.price( false ) == 0 );
-        REQUIRE( rock.price( true ) == 0 );
-
-        CHECK( item_info_str( rock, price_barter ) ==
-               "--\n"
-               "Price: $<color_c_yellow>0.00</color>" );
-    }
 }
 
 // Related JSON fields:


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
For a while pre-apoc price was used as a fallback for post-apoc price, which resulted in quite a few items to have absurdly high price
#### Describe the solution
Remove fallbacking
Also print the price even if it's the same as pre-apoc price, to avoid confusion
#### Describe alternatives you've considered
Also rename the option from `Price` and `Barter value` to something more explanatory
#### Testing
Compiled, checked marijuana, it prints both prices now