### PR TITLE
Add map_is_outside condition

### DIFF
--- a/data/mods/Xedra_Evolved/mutations/paraclesians/paraclesian_fae_bans.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/paraclesian_fae_bans.json
@@ -371,10 +371,7 @@
     "eoc_type": "EVENT",
     "required_event": "character_wakes_up",
     "condition": {
-      "and": [
-        { "or": [ { "u_has_trait": "THRESH_SYLPH" }, { "u_has_trait": "SYLPH_DEX_BONUS_2" } ] },
-        { "or": [ { "not": "u_is_outside" }, { "u_is_on_terrain_with_flag": "INDOORS" } ] }
-      ]
+      "and": [ { "or": [ { "u_has_trait": "THRESH_SYLPH" }, { "u_has_trait": "SYLPH_DEX_BONUS_2" } ] }, { "not": "u_is_outside" } ]
     },
     "effect": [
       { "run_eocs": "EOC_PARACLESIAN_BROKE_FAE_BAN" },

--- a/data/mods/Xedra_Evolved/mutations/playable_changeling_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/playable_changeling_eocs.json
@@ -815,7 +815,7 @@
         "true_eocs": [
           {
             "id": "EOC_BROWNIE_INDOOR_BLINK_SUCCESS",
-            "condition": { "map_terrain_with_flag": "INDOORS", "loc": { "context_val": "brownie_teleport" } },
+            "condition": { "not": { "map_is_outside": { "context_val": "brownie_teleport" } } },
             "effect": [
               { "u_teleport": { "context_val": "brownie_teleport" } },
               { "u_message": "You carefully slip through the cracks.", "type": "good" }

--- a/data/mods/Xedra_Evolved/spells/changeling_seasonal_magic_winter_eocs.json
+++ b/data/mods/Xedra_Evolved/spells/changeling_seasonal_magic_winter_eocs.json
@@ -254,7 +254,7 @@
       {
         "if": { "math": [ "has_var(_changeling_winter_hail_attack_location)" ] },
         "then": {
-          "if": { "not": { "map_terrain_with_flag": "INDOORS", "loc": { "context_val": "changeling_winter_hail_attack_location" } } },
+          "if": { "map_is_outside": { "context_val": "changeling_winter_hail_attack_location" } },
           "then": [
             {
               "u_cast_spell": { "id": "changeling_winter_hail_attack_spell_bash_damage" },

--- a/doc/JSON/EFFECT_ON_CONDITION.md
+++ b/doc/JSON/EFFECT_ON_CONDITION.md
@@ -1281,6 +1281,10 @@ Runs a query, allowing you to pick specific tile around. When picked, stores coo
 - type: location string or [variable object](#variable-object)
 - return true if the location is in the bounds of a city at or above z-1
 
+### `map_is_outside`
+- type: location string or [variable object](#variable-object)
+- return true if the location is outside. Currently always returns false if the location is outside the reality bubble.
+
 #### Valid talkers:
 
 No talker is needed.

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -1877,6 +1877,20 @@ conditional_t::func f_map_in_city( const JsonObject &jo, std::string_view member
     };
 }
 
+conditional_t::func f_map_is_outside( const JsonObject &jo, std::string_view member )
+{
+    var_info loc_var = read_var_info( jo.get_member( member ) );
+    return [loc_var]( const_dialogue const & d ) {
+        map &here = get_map();
+        tripoint_bub_ms loc = here.get_bub( read_var_value( loc_var, d ).tripoint() );
+        if( here.inbounds( loc ) ) {
+            return !here.is_outside( loc );
+        }
+        //TODO: Make work outside of reality bubble?
+        return false;
+    };
+}
+
 conditional_t::func f_mod_is_loaded( const JsonObject &jo, std::string_view member )
 {
     str_or_var compared_mod = get_str_or_var( jo.get_member( member ), member, true );
@@ -2595,6 +2609,7 @@ parsers = {
     {"map_terrain_id", jarg::member, &conditional_fun::f_map_ter_furn_id },
     {"map_furniture_id", jarg::member, &conditional_fun::f_map_ter_furn_id },
     {"map_field_id", jarg::member, &conditional_fun::f_map_ter_furn_id },
+    {"map_is_outside", jarg::member, &conditional_fun::f_map_is_outside },
     {"map_in_city", jarg::member, &conditional_fun::f_map_in_city },
     {"mod_is_loaded", jarg::member, &conditional_fun::f_mod_is_loaded },
     {"u_has_faction_trust", jarg::member | jarg::array, &conditional_fun::f_has_faction_trust },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
First part of removing INDOORS flag #82056
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Also removes a redundant check for INDOORS flag while already checking u_is_outside
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Combining this with the PR removing the flag/dealing with the cache but that PR will be messy enough without niche issues like this
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Tested with this EOC with expected results
```json
{
    "type": "effect_on_condition",
    "id": "EOC_TEST_CHECK_IF_OUTSIDE",
    "effect": [
      {
        "u_query_tile": "line_of_sight",
        "target_var": { "context_val": "test_outside" },
        "range": 30,
        "z_level": true,
        "message": "Select target."
      },
      {
        "if": { "math": [ "has_var(_test_outside)" ] },
        "then": {
          "if": { "map_is_outside": { "context_val": "test_outside" } },
          "then": [ { "u_message": "The selected point is outside.", "type": "good" } ],
          "else": { "u_message": "The selected point is not outside.", "type": "bad" }
        },
        "else": { "u_message": "Cancelled" }
      }
    ]
  }
```
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Will update doc with however the cache works when changed and might extend to work outside reality bubble at that point (it would need to replicate the caches new logic at a point_abs_ms scope)
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
