### PR TITLE
Aftershock: Add a food vendor to the spaceport.

### DIFF
--- a/data/mods/Aftershock/items/comestibles/flesh.json
+++ b/data/mods/Aftershock/items/comestibles/flesh.json
@@ -14,6 +14,7 @@
     "id": "afs_jerky",
     "copy-from": "jerky",
     "name": { "str_sp": "meat flakes" },
+    "price_postapoc": "1 USD 50 cent",
     "description": "Transparent thin hexagonal cuts of dried meat.  Conspicuously uniform in both looks and texture."
   },
   {

--- a/data/mods/aftershock_exoplanet/itemgroups/food_groups.json
+++ b/data/mods/aftershock_exoplanet/itemgroups/food_groups.json
@@ -83,8 +83,10 @@
     "subtype": "distribution",
     "id": "afs_stored_meats",
     "entries": [
-      { "item": "afs_synthetic_meat", "prob": 10, "container-item": "afs_foil_bag" },
-      { "item": "afs_jerky", "prob": 40, "container-item": "afs_foil_bag" }
+      { "item": "meat", "variant": "synth", "prob": 10, "container-item": "afs_foil_bag" },
+      { "item": "fish", "variant": "synth", "prob": 10, "container-item": "afs_foil_bag" },
+      { "item": "fish", "variant": "insect", "prob": 10, "container-item": "afs_foil_bag" },
+      { "item": "ajerky", "variant": "synth", "prob": 40, "container-item": "afs_foil_bag" }
     ]
   },
   {
@@ -134,7 +136,7 @@
     "subtype": "collection",
     "//": "This group was created automatically and may contain errors.",
     "container-item": "afs_foil_bag",
-    "entries": [ { "item": "afs_kelp", "count": 9 } ]
+    "entries": [ { "item": "kelp_sugar", "count": 9 } ]
   },
   {
     "type": "item_group",

--- a/data/mods/aftershock_exoplanet/itemgroups/food_groups.json
+++ b/data/mods/aftershock_exoplanet/itemgroups/food_groups.json
@@ -86,7 +86,7 @@
       { "item": "meat", "variant": "synth", "prob": 10, "container-item": "afs_foil_bag" },
       { "item": "fish", "variant": "synth", "prob": 10, "container-item": "afs_foil_bag" },
       { "item": "fish", "variant": "insect", "prob": 10, "container-item": "afs_foil_bag" },
-      { "item": "ajerky", "variant": "synth", "prob": 40, "container-item": "afs_foil_bag" }
+      { "item": "jerky", "variant": "synth", "prob": 40, "container-item": "afs_foil_bag" }
     ]
   },
   {

--- a/data/mods/aftershock_exoplanet/items/comestibles/flesh.json
+++ b/data/mods/aftershock_exoplanet/items/comestibles/flesh.json
@@ -1,25 +1,40 @@
 [
   {
     "type": "ITEM",
-    "subtypes": [ "COMESTIBLE" ],
-    "id": "afs_synthetic_meat",
+    "id": "meat",
     "copy-from": "meat",
-    "name": { "str_sp": "synthetic meat" },
-    "description": "A cut of vat grown lean meat, genetically similar to beef.  Conspicuously uniform in both looks and texture.",
+    "subtypes": [ "COMESTIBLE" ],
+    "comestible_type": "FOOD",
+    "variants": [
+      {
+        "id": "synth",
+        "name": { "str_sp": "synthetic meat" },
+        "description": "A cut of vat grown lean meat, genetically similar to beef.  Conspicuously uniform in both looks and texture."
+      }
+    ],
     "parasites": 0
   },
   {
     "type": "ITEM",
+    "id": "jerky",
     "subtypes": [ "COMESTIBLE" ],
-    "id": "afs_jerky",
+    "comestible_type": "FOOD",
     "copy-from": "jerky",
-    "name": { "str_sp": "meat flakes" },
-    "description": "Transparent thin hexagonal cuts of dried meat.  Conspicuously uniform in both looks and texture."
+    "price_postapoc": "1 USD 25 cent",
+    "variants": [
+      {
+        "id": "synth",
+        "name": { "str_sp": "meat flakes" },
+        "description": "Transparent thin hexagonal cuts of dried meat.  Conspicuously uniform in both looks and texture."
+      }
+    ]
   },
   {
     "type": "ITEM",
     "id": "fish",
     "copy-from": "fish",
+    "subtypes": [ "COMESTIBLE" ],
+    "comestible_type": "FOOD",
     "variants": [
       {
         "id": "synth",
@@ -35,8 +50,20 @@
   },
   {
     "type": "ITEM",
+    "id": "alien_jerky",
+    "copy-from": "jerky",
     "subtypes": [ "COMESTIBLE" ],
-    "id": "curry_meat",
+    "comestible_type": "FOOD",
+    "name": { "str_sp": "dried alien meat" },
+    "price_postapoc": "1 USD 50 cent",
+    "description": "Thin and long strips of white, almost sickly pale meat, clearly belonging to some sort of alien creature.  It has a very strong taste, and is quite chewy.",
+    "fun": 0,
+    "quench": -7
+  },
+  {
+    "type": "ITEM",
+    "subtypes": [ "COMESTIBLE" ],
+    "id": "afs_soup_meat",
     "looks_like": "soup_meat",
     "name": { "str_sp": "ramen" },
     "conditional_names": [ { "type": "COMPONENT_ID_SUBSTRING", "condition": "mutant", "name": { "str_sp": "frontier ramen" } } ],
@@ -50,7 +77,7 @@
     "calories": 381,
     "description": "Ramen's adaptability to dried and preserved ingredients make it a staple in the culinary landscapes of frontier outposts and shipping crews alike.  Any spaceport worth visiting has a local ramen tradition of its own, and here the dish is slightly acidic, with a sweet aftertaste produced by the break-down of alien proteins.",
     "price": "14 USD",
-    "price_postapoc": "14 USD",
+    "price_postapoc": "2 USD 25 cent",
     "material": [ { "type": "water", "portion": 50 }, { "type": "flesh", "portion": 25 }, { "type": "veggy", "portion": 25 } ],
     "volume": "250 ml",
     "phase": "liquid",
@@ -58,6 +85,25 @@
     "flags": [ "EATEN_HOT", "USE_EAT_VERB" ],
     "vitamins": [ [ "vitC", 30 ], [ "calcium", 5 ], [ "iron", 28 ], [ "meat_allergen", 1 ], [ "veggy_allergen", 1 ] ],
     "fun": 8
+  },
+  {
+    "id": "afs_streetfood_meat",
+    "copy-from": "flesh",
+    "weight": "275 g",
+    "volume": "250 ml",
+    "spoils_in": "1 day",
+    "type": "ITEM",
+    "subtypes": [ "COMESTIBLE" ],
+    "comestible_type": "FOOD",
+    "name": { "str_sp": "starport roast" },
+    "description": "Streetfood from the Salus spaceport.  White strips of meat, grilled and served with a heavy dressing of sour sauce.  Who knows where it came from, but it tastes pretty good.",
+    "price": "8 USD",
+    "price_postapoc": "3 USD 50 cent",
+    "fun": 5,
+    "parasites": 0,
+    "calories": 652,
+    "vitamins": [ [ "calcium", 2 ], [ "iron", 12 ], [ "meat_allergen", 1 ] ],
+    "flags": [ "EATEN_HOT", "NUTRIENT_OVERRIDE" ]
   },
   {
     "type": "ITEM",

--- a/data/mods/aftershock_exoplanet/items/comestibles/veggies.json
+++ b/data/mods/aftershock_exoplanet/items/comestibles/veggies.json
@@ -2,7 +2,7 @@
   {
     "type": "ITEM",
     "subtypes": [ "COMESTIBLE" ],
-    "id": "afs_kelp",
+    "id": "kelp_sugar",
     "copy-from": "spinach",
     "name": { "str_sp": "kelp" },
     "description": "Thin wafers of kelp, the essential greens of frontier cuisine.  These were probably grown in some farm ship or another.",
@@ -24,7 +24,7 @@
     "calories": 165,
     "description": "Most ramen served in the frontier is already vegan through the use of synthetic meat and other meat substitutes.  This variant simply doesn't pretend to include any meat at all.  Slightly spicy.",
     "price": "12 USD",
-    "price_postapoc": "12 USD",
+    "price_postapoc": "1 USD 75 cent",
     "material": [ "veggy" ],
     "volume": "500 ml",
     "charges": 2,
@@ -32,6 +32,24 @@
     "flags": [ "EATEN_HOT", "USE_EAT_VERB" ],
     "vitamins": [ [ "vitC", 4 ], [ "calcium", 1 ], [ "iron", 5 ], [ "veggy_allergen", 1 ] ],
     "fun": 1
+  },
+  {
+    "id": "afs_streetfood_veggy",
+    "copy-from": "flesh",
+    "weight": "275 g",
+    "volume": "250 ml",
+    "spoils_in": "5 day",
+    "type": "ITEM",
+    "subtypes": [ "COMESTIBLE" ],
+    "name": { "str_sp": "starport yeast cake" },
+    "description": "Streetfood from the Salus spaceport.  A large square of fried dough topped with red sauce.",
+    "price": "8 USD",
+    "price_postapoc": "1 USD 50 cent",
+    "fun": 3,
+    "parasites": 0,
+    "calories": 125,
+    "vitamins": [ [ "vitC", 4 ], [ "calcium", 1 ], [ "iron", 5 ], [ "veggy_allergen", 1 ] ],
+    "flags": [ "EATEN_HOT" ]
   },
   {
     "id": "afs_kibble",

--- a/data/mods/aftershock_exoplanet/items/obsolete.json
+++ b/data/mods/aftershock_exoplanet/items/obsolete.json
@@ -160,5 +160,17 @@
     "//": "remove after 0.J",
     "id": "afs_frontier_cryomask_on",
     "replace": "afs_frontier_cryomask"
+  },
+  {
+    "type": "MIGRATION",
+    "//": "remove after 0.J",
+    "id": "afs_magellan_suit_helmet_on",
+    "replace": "jerky"
+  },
+  {
+    "type": "MIGRATION",
+    "//": "remove after 0.J",
+    "id": "afs_jerky",
+    "replace": "meat"
   }
 ]

--- a/data/mods/aftershock_exoplanet/maps/mapgen/shuttlepad_salvors.json
+++ b/data/mods/aftershock_exoplanet/maps/mapgen/shuttlepad_salvors.json
@@ -29,7 +29,7 @@
         " |ΩΩÖÖÖÖ×Ω|‘ ℗¾℗‘‘‘‘‘‘‘ À╫ ‘‘‘ ‘ ╫℗℗ÀÀ‘‘‘‘ä¦ìì·#",
         " |||####|||    ℗   ℗¾‘‘‘ ╫╫╫╫‘╫╫╫╫½¾‘‘‘‘‘Ψä¦¦··#",
         "   ℗℗℗℗℗            ℗‘‘‘   ω‘‘℗¾¼¼‘‘‘╡ÅÅ╡‘ á¦·ú¦",
-        "    ℗    Χ            ‘‘℗℗¾¿‘℗ ‘‘‘‘‘‘╡Æ∙È‘ 2¦ûó¦",
+        "    ℗    Χ            ‘‘℗℗¾¿‘℗ ‘‘‘‘‘‘╡ÆθÈ‘ 2¦ûó¦",
         "      ℗℗ ℗℗   ℗℗℗℗    ‘‘‘‘‘‘‘‘‘‘‘‘‘‘‘╡Éõ╡‘‘½╡╡¦¦",
         "    ---##------##---  ℗‘‘‘Ù‘‘‘‘Ù‘ Ψ ‘‘ ‘‘ ‘â╡ûø¦",
         "    -Υ.³³..ΦΦ..ΦΦ%©-  ¾‘‘¼╡----¦Á2 ‘ ‘Ù¦$$$$¦ýù¦",
@@ -78,7 +78,8 @@
         "χ": { "class": "uica_ground_soldier" },
         "ϋ": { "class": "uica_vehicle_merchant" },
         "ի": { "class": "salvor_camp_solo" },
-        "λ": { "class": "salvor_fabricator" }
+        "λ": { "class": "salvor_fabricator" },
+        "θ": { "class": "salvor_street_food" }
       },
       "monster": {
         "ψ": { "monster": "mon_uica_tankbot" },
@@ -162,6 +163,7 @@
         "è": "t_strconc_floor",
         "é": "t_strconc_floor_olight",
         "ê": "t_thconc_floor_no_roof",
+        "θ": "t_thconc_floor_no_roof",
         "ë": "t_thconc_floor_no_roof",
         "ì": "t_thconc_floor_no_roof",
         "í": "t_thconc_floor_no_roof",

--- a/data/mods/aftershock_exoplanet/npcs/Salvor_Market/salvor_street_food.json
+++ b/data/mods/aftershock_exoplanet/npcs/Salvor_Market/salvor_street_food.json
@@ -1,0 +1,108 @@
+[
+  {
+    "type": "npc_class",
+    "id": "NC_SALVOR_STREET_FOOD",
+    "name": { "str": "hawker " },
+    "job_description": "A vendor selling street food.",
+    "common": false,
+    "traits": [ { "group": "NPC_starting_traits" }, { "group": "Appearance_demographics" } ],
+    "bonus_str": { "rng": [ 2, 3 ] },
+    "bonus_dex": { "rng": [ 0, 2 ] },
+    "bonus_int": { "rng": [ -2, 0 ] },
+    "bonus_per": { "rng": [ 1, 3 ] },
+    "worn_override": "NC_SALVOR_STREET_FOOD_worn",
+    "carry_override": "EMPTY_GROUP",
+    "weapon_override": "EMPTY_GROUP",
+    "skills": [
+      { "skill": "speech", "bonus": { "rng": [ 4, 5 ] } },
+      { "skill": "survival", "bonus": { "rng": [ 2, 6 ] } },
+      { "skill": "cooking", "bonus": { "rng": [ 3, 5 ] } }
+    ],
+    "shopkeeper_item_group": [ { "group": "afs_street_dry_food", "rigid": true } ],
+    "shopkeeper_price_rules": [ { "group": "afs_street_vendor_food", "markup": 10 }, { "group": "afs_street_dry_food", "markup": 10 } ]
+  },
+  {
+    "type": "npc",
+    "id": "salvor_street_food",
+    "name_unique": "Trés Landwell",
+    "name_suffix": "hawker",
+    "gender": "male",
+    "age": 39,
+    "height": 160,
+    "class": "NC_SALVOR_STREET_FOOD",
+    "attitude": 0,
+    "mission": 3,
+    "chat": "NC_SALVOR_STREET_FOOD",
+    "faction": "UICA"
+  },
+  {
+    "type": "item_group",
+    "id": "NC_SALVOR_STREET_FOOD_worn",
+    "subtype": "collection",
+    "ammo": 100,
+    "magazine": 100,
+    "items": [ { "item": "afs_frontier_cryo" }, { "item": "apron_plastic" }, { "item": "afs_frontier_cryomask" } ]
+  },
+  {
+    "type": "item_group",
+    "id": "afs_street_vendor_food",
+    "subtype": "collection",
+    "items": [
+      { "item": "afs_streetfood_meat", "count": [ 2, 3 ], "container-item": "ceramic_bowl", "custom-flags": [ "HOT" ] },
+      {
+        "item": "afs_streetfood_veggy",
+        "count": [ 2, 3 ],
+        "container-item": "ceramic_bowl",
+        "custom-flags": [ "HOT" ]
+      },
+      { "item": "afs_soup_meat", "count": [ 2, 3 ], "container-item": "ceramic_bowl", "custom-flags": [ "HOT" ] },
+      { "item": "afs_soup_veggy", "count": [ 2, 3 ], "container-item": "ceramic_bowl", "custom-flags": [ "HOT" ] }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "afs_street_dry_food",
+    "subtype": "collection",
+    "items": [ { "item": "alien_jerky", "count": [ 6, 13 ] } ]
+  },
+  {
+    "id": [ "NC_SALVOR_STREET_FOOD", "NC_SALVOR_STREET_FOOD_SAFE" ],
+    "type": "talk_topic",
+    "dynamic_line": "&The food stall is a colorful array of various dishes, and the smell of spices and cooked meats cuts easily through the frozen air.  The vendor  is busy preparing a meal when you approach.\n\"Oh steemd do you see anything you like?\"",
+    "speaker_effect": {
+      "effect": [
+        { "npc_location_variable": { "context_val": "vendor_loc" } },
+        { "mapgen_update": "streetfood_reset", "target_var": { "context_val": "vendor_loc" } }
+      ]
+    },
+    "responses": [
+      { "text": "I'll have whatever it is you're cooking.", "topic": "TALK_DONE", "effect": [ "start_trade" ] },
+      { "text": "Are these things safe to eat?", "topic": "NC_SALVOR_STREET_FOOD_SAFE" }
+    ]
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "streetfood_reset_nest",
+    "object": {
+      "mapgensize": [ 1, 1 ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
+      "rows": [ "Ω" ],
+      "terrain": { "Ω": "t_thconc_floor_no_roof" },
+      "furniture": { "Ω": "f_oven" },
+      "items": { "Ω": { "item": "afs_street_vendor_food" } }
+    }
+  },
+  {
+    "type": "mapgen",
+    "update_mapgen_id": "streetfood_reset",
+    "object": {
+      "place_nested": [ { "chunks": [ "streetfood_reset_nest" ], "x": 15, "y": 22 } ],
+      "faction_owner": [ { "id": "UICA", "x": 15, "y": 22 } ]
+    }
+  },
+  {
+    "id": [ "NC_SALVOR_STREET_FOOD_SAFE" ],
+    "type": "talk_topic",
+    "dynamic_line": "&The vendor chuckles at your question, wiping his hands on his apron.\nSafe?  Yes very safe steemd,  snow dry and clean steemd.  In home we do not have so much snow, but here it is very good for food."
+  }
+]

--- a/data/mods/aftershock_exoplanet/npcs/Salvor_Market/salvor_street_food.json
+++ b/data/mods/aftershock_exoplanet/npcs/Salvor_Market/salvor_street_food.json
@@ -103,6 +103,6 @@
   {
     "id": [ "NC_SALVOR_STREET_FOOD_SAFE" ],
     "type": "talk_topic",
-    "dynamic_line": "&The vendor chuckles at your question, wiping his hands on his apron.\nSafe?  Yes very safe steemd,  snow dry and clean steemd.  In home we do not have so much snow, but here it is very good for food."
+    "dynamic_line": "&The vendor chuckles at your question, wiping his hands on his apron.\nSafe?  Yes very safe steemd, snow dry and clean steemd.  In home we do not have so much snow, but here it is very good for food."
   }
 ]

--- a/data/mods/aftershock_exoplanet/requirements.json
+++ b/data/mods/aftershock_exoplanet/requirements.json
@@ -58,7 +58,7 @@
     "id": "meat_raw_steak",
     "type": "requirement",
     "//": "An unbroken slab of raw meat.  For when scraps just aren't good enough.",
-    "extend": { "components": [ [ [ "frost_human_flesh", 1 ], [ "afs_synthetic_meat", 1 ], [ "alien_flesh", 1 ] ] ] }
+    "extend": { "components": [ [ [ "frost_human_flesh", 1 ], [ "alien_flesh", 1 ] ] ] }
   },
   {
     "id": "meat_red_raw",
@@ -94,9 +94,7 @@
     "id": "meat_cooked",
     "type": "requirement",
     "//": "meat you'd put on a sandwich",
-    "extend": {
-      "components": [ [ [ "alien_flesh_cooked", 1 ], [ "alien_meat_scrap_cooked", 10 ], [ "frost_human_cooked", 1 ], [ "afs_jerky", 1 ] ] ]
-    }
+    "extend": { "components": [ [ [ "alien_flesh_cooked", 1 ], [ "alien_meat_scrap_cooked", 10 ], [ "frost_human_cooked", 1 ] ] ] }
   },
   {
     "id": "human_meat",
@@ -109,17 +107,5 @@
     "type": "requirement",
     "//": "Cooked meat that non-cannibals would be unhappy eating.",
     "extend": { "components": [ [ [ "frost_human_cooked", 1 ] ] ] }
-  },
-  {
-    "id": "veggy_any_fresh_uncooked",
-    "type": "requirement",
-    "//": "Any type of edible raw fat.",
-    "extend": { "components": [ [ [ "afs_kelp", 1 ] ] ] }
-  },
-  {
-    "id": "veggy_green",
-    "type": "requirement",
-    "//": "Any type of edible raw fat.",
-    "extend": { "components": [ [ [ "afs_kelp", 1 ] ] ] }
   }
 ]


### PR DESCRIPTION
#### Summary
Mods "Aftershock: Add a food vendor to the spaceport."

#### Purpose of change
Add a vendor selling streetfood to the surface, so you dont feel compelled to eat centuries old food (you just do it cause its cheaper)

#### Describe the solution
New NPC pretty barebones for now.

#### Testing
Bought some food.
