### PR TITLE
Use the more typical name for China instead of an archaic one.

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1368,7 +1368,7 @@ std::vector<options_manager::id_and_option> options_manager::get_lang_options()
             { "sr", R"(Српски)" },
             { "tr", R"(Türkçe)" },
             { "uk_UA", R"(Українська)" },
-            { "zh_CN", R"(中文 (天朝))" },
+            { "zh_CN", R"(中文 (中国))" },
             { "zh_TW", R"(中文 (台灣))" },
         }
     };


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
As mentioned in #82067 we seem to be using an unusual archaic name for China in locale selection.

#### Describe the solution
Use the standard modern name 中国 instead.

#### Describe alternatives you've considered
Strangely enough there are numerous candidates for the country name,  as far as I can tell this is the dominant one.