### PR TITLE
Fix NPC rules checkbox CONFIRM key double toggle

### DIFF
--- a/src/npctalk_rules.cpp
+++ b/src/npctalk_rules.cpp
@@ -283,20 +283,16 @@ void follower_rules_ui_impl::rules_transfer_popup( bool &exporting_rules, bool &
 
 template<typename T>
 void follower_rules_ui_impl::checkbox( int rule_number, const T &this_rule,
-                                       input_event &assigned_hotkey, const input_event &pressed_key )
+                                       input_event &assigned_hotkey, const input_event &pressed_key, bool confirm_toggle )
 {
     ImGui::PushID( rule_number );
     print_hotkey( assigned_hotkey );
     bool rule_enabled = guy->rules.has_flag( this_rule.rule );
-    std::string rules_text;
-    if( rule_enabled ) {
-        rules_text = this_rule.rule_true_text;
-    } else {
-        rules_text = this_rule.rule_false_text;
-    }
+    std::string rules_text = rule_enabled ? this_rule.rule_true_text : this_rule.rule_false_text;
     rules_text = string_format( "%s###CHECK", get_parsed( rules_text ) );
     bool clicked = ImGui::Checkbox( rules_text.c_str(), &rule_enabled );
-    bool typed = pressed_key == assigned_hotkey;
+    bool typed = ( pressed_key == assigned_hotkey ) ||
+                 ( confirm_toggle && ImGui::GetActiveID() == ImGui::GetID( rule_number ) );
     bool changed = typed || clicked;
     if( typed ) {
         ImGui::SetKeyboardFocusHere( -1 );
@@ -347,6 +343,7 @@ void follower_rules_ui_impl::draw_controls()
         return;
     }
 
+    bool confirm_toggle = false;
     // ImGui only captures arrow keys by default, we want to also capture the numpad and hjkl
     if( last_action == "QUIT" ) {
         return;
@@ -363,7 +360,7 @@ void follower_rules_ui_impl::draw_controls()
         ImGui::NavMoveRequestSubmit( ImGuiDir_Right, ImGuiDir_Right, ImGuiNavMoveFlags_None,
                                      ImGuiScrollFlags_None );
     } else if( last_action == "CONFIRM" ) {
-        ImGui::ActivateItemByID( ImGui::GetFocusID() );
+        confirm_toggle = true;
     }
 
     ImGui::SetWindowSize( ImVec2( window_width, window_height ), ImGuiCond_Once );
@@ -414,7 +411,7 @@ void follower_rules_ui_impl::draw_controls()
     /* Handle all of our regular, boolean rules */
     for( const std::pair<const std::string, ally_rule_data> &rule_data : ally_rule_strs ) {
         assigned_hotkey = input_ptr->next_unassigned_hotkey( hotkeys, assigned_hotkey );
-        checkbox( rule_number, rule_data.second, assigned_hotkey, pressed_key );
+        checkbox( rule_number, rule_data.second, assigned_hotkey, pressed_key, confirm_toggle );
         rule_number += 1;
     }
 

--- a/src/npctalk_rules.h
+++ b/src/npctalk_rules.h
@@ -51,7 +51,7 @@ class follower_rules_ui_impl : public cataimgui::window
         // makes a checkbox for the rule
         template<typename T>
         void checkbox( int rule_number, const T &this_rule, input_event &assigned_hotkey,
-                       const input_event &pressed_key );
+                       const input_event &pressed_key, bool confirm_toggle );
 
         // makes one radio button per option in the map
         template<typename T>


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "fix NPC rules checkbox CONFIRM key double toggle"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Pressing CONFIRM on the selected checkbox in the NPC rules menu toggles the selection twice, shown at the start of this video:

https://github.com/user-attachments/assets/a03db492-a35e-484a-a973-b2399b84eabc

Hotkeys and the mouse still work, as shown later in the video.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Remove activating the checkbox on pressing CONFIRM, instead add a parameter specifically for toggling via `CONFIRM`.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

After reading about ImGui, I don't think that the hotkey implementation is great, but I don't want to redesign the entire rules window right now.

#### Testing

Pressed hotkey, pressed CONFIRM, clicked with mouse, all toggle the rule exactly once as intended. Made sure that the NPC rule is actually set by toggling 4 spaces -> 2 spaces.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
