### PR TITLE
[MoM] Add Flashbang Photokinetic power

### DIFF
--- a/data/mods/MindOverMatter/PowerDescriptionSpoilers.md
+++ b/data/mods/MindOverMatter/PowerDescriptionSpoilers.md
@@ -729,6 +729,17 @@ Powers causing photokinetic damage have a 40% chance to blind the target for 3 s
 *Prerequisites*: Chameleoflage 8, Lucent Barrier 5<br />
 </details>
 <details>
+<summary><h3>Flashbang</h3></summary>
+
+*Difficulty*: 4<br />
+*Target*: An area of effect with radius 2 squares, plus 1 square per 2 power levels to a maximum of 30 squares, at a range of 3 squares plus 0.7 squares per power level to a maximum of 50 squares<br />
+*Duration*: Instant<br />
+*Stamina Cost*: 4500, minus 120 per level to a minimum of 1750<br />
+*Channeling Time*: 135 moves, minus 5.5 moves per level to a minimum of 50<br />
+*Effects*: Wrap the psion in illusions, concealing any mutations or visible bionics they may have. NPCs will react to them better, and certain people who might refuse to talk to a mutant will be happy to talk to them.  Their total Ugliness is reduced by 60% plus 1.5% per level, to a maximum of 100% Ugliness reduction.<br />
+*Prerequisites*: Field of Light 9 *or* Photon Beam 5, Illuminate 6<br />
+</details>
+<details>
 <summary><h3>Lucid Shadows</h3></summary>
 
 *Difficulty*: 5<br />
@@ -803,7 +814,7 @@ Powers causing photokinetic damage have a 40% chance to blind the target for 3 s
 *Stamina Cost*: 6500, minus 95 per level to a minimum of 3250<br />
 *Channeling Time*: 125 moves, minus 7.5 moves per level to a minimum of 25<br />
 *Effects*: Begin glowing brighter than a floodlight, illuminating the ground out to XXXX squares and gaining a +4 dodge bonus as enemies have a hard time targeting the psion.  When hit or when attacking enemies, there is a 33% chance the psion will unleash an even brighter flash that blinds everyone within 5 squares plus 1.2 squares per power level for between 5 and 20 seconds.<br />
-*Prerequisites*: Field of Light 12, Star Flash 6 *or* Lucent Barrier 10<br />
+*Prerequisites*: Field of Light 12 *or* Flashbang 7, Star Flash 6 *or* Lucent Barrier 10<br />
 </details>
 <details>
 <summary><h3>Luminous Disintegration</h3></summary>

--- a/data/mods/MindOverMatter/effectoncondition/eoc_learn_recipes.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_learn_recipes.json
@@ -433,6 +433,7 @@
           "EOC_CHECK_GAMEBEGIN_PHOTOKIN_RECIPE_RAD_IMMUNITY",
           "EOC_CHECK_GAMEBEGIN_PHOTOKIN_RECIPE_LIGHT_ARMS",
           "EOC_CHECK_GAMEBEGIN_PHOTOKIN_RECIPE_HIDE_UGLY",
+          "EOC_CHECK_GAMEBEGIN_PHOTOKIN_RECIPE_FLASH_BANG",
           "EOC_CHECK_GAMEBEGIN_PHOTOKIN_RECIPE_LIGHT_IMAGE",
           "EOC_CHECK_GAMEBEGIN_PHOTOKIN_RECIPE_RADIO",
           "EOC_CHECK_GAMEBEGIN_PHOTOKIN_RECIPE_STERILIZE_FOOD",
@@ -499,6 +500,12 @@
     "id": "EOC_CHECK_GAMEBEGIN_PHOTOKIN_RECIPE_HIDE_UGLY",
     "condition": { "and": [ { "u_has_trait": "PHOTOKINETIC" }, { "math": [ "u_spell_level('photokinetic_hide_ugly') >= 0" ] } ] },
     "effect": [ { "u_learn_recipe": "practice_photokinetic_hide_ugly" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_CHECK_GAMEBEGIN_PHOTOKIN_RECIPE_FLASH_BANG",
+    "condition": { "and": [ { "u_has_trait": "PHOTOKINETIC" }, { "math": [ "u_spell_level('photokinetic_flash_bang') >= 0" ] } ] },
+    "effect": [ { "u_learn_recipe": "practice_photokinetic_flash_bang" } ]
   },
   {
     "type": "effect_on_condition",

--- a/data/mods/MindOverMatter/powers/learning_eocs/photokinesis.json
+++ b/data/mods/MindOverMatter/powers/learning_eocs/photokinesis.json
@@ -304,6 +304,50 @@
   },
   {
     "type": "effect_on_condition",
+    "id": "EOC_PHOTOKIN_LEARNING_FLASH_BANG",
+    "recurrence": [
+      { "math": [ "jmath_photokinesis_learning_eocs_modifiers(global_tier_two_power_learning_time_low)" ] },
+      { "math": [ "jmath_photokinesis_learning_eocs_modifiers(global_tier_two_power_learning_time_high)" ] }
+    ],
+    "condition": {
+      "and": [
+        { "u_has_trait": "PHOTOKINETIC" },
+        { "math": [ "u_vitamin('vitamin_psi_learning_counter') == 1" ] },
+        {
+          "or": [
+            { "test_eoc": "EOC_CONDITION_ODDS_OF_RANDOM_TIER_TWO_POWER_INSIGHT" },
+            {
+              "and": [
+                {
+                  "or": [
+                    { "math": [ "u_spell_level('photokinetic_create_light') >= 9" ] },
+                    { "math": [ "u_spell_level('photokinetic_light_beam') >= 5" ] }
+                  ]
+                },
+                { "math": [ "u_spell_level('photokinetic_light_up_enemy') >= 6" ] }
+              ]
+            }
+          ]
+        },
+        { "test_eoc": "EOC_PSI_LEARNING_BANNED_EFFECTS" },
+        { "math": [ "u_spell_level('photokinetic_flash_bang') <= 0" ] },
+        { "not": { "u_know_recipe": "practice_photokinetic_flash_bang" } }
+      ]
+    },
+    "deactivate_condition": {
+      "or": [ { "not": { "u_has_trait": "PHOTOKINETIC" } }, { "math": [ "u_spell_level('photokinetic_flash_bang') >= 1" ] } ]
+    },
+    "effect": [
+      { "math": [ "u_vitamin('vitamin_psi_learning_counter') = 0" ] },
+      { "u_learn_recipe": "practice_photokinetic_flash_bang" },
+      {
+        "u_message": "Use of your powers has led to an insight.  You could create a large amount of light and allow it to burst out all at once, creating something similar to a flashbang effect, if you can figure out the technique.",
+        "popup": true
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
     "id": "EOC_PHOTOKIN_LEARNING_LIGHT_IMAGE",
     "recurrence": [
       { "math": [ "jmath_photokinesis_learning_eocs_modifiers(global_tier_two_power_learning_time_low)" ] },
@@ -590,7 +634,12 @@
             { "test_eoc": "EOC_CONDITION_ODDS_OF_RANDOM_TIER_THREE_POWER_INSIGHT" },
             {
               "and": [
-                { "math": [ "u_spell_level('photokinetic_create_light') >= 12" ] },
+                {
+                  "or": [
+                    { "math": [ "u_spell_level('photokinetic_create_light') >= 12" ] },
+                    { "math": [ "u_spell_level('photokinetic_flash_bang') >= 7" ] }
+                  ]
+                },
                 {
                   "or": [
                     { "math": [ "u_spell_level('photokinetic_light_flash') >= 6" ] },

--- a/data/mods/MindOverMatter/powers/photokinesis.json
+++ b/data/mods/MindOverMatter/powers/photokinesis.json
@@ -464,6 +464,45 @@
     }
   },
   {
+    "id": "photokinetic_flash_bang",
+    "type": "SPELL",
+    "name": "[Ψ]Flashbang",
+    "description": "Create a concentration of photons and EM radiation and then allow them to burst outward, creating a bright flash of light accompanied by a loud sound, producing a flashbang effect.",
+    "message": "The air bursts into a eye-searing flash accompanied by a loud bang!",
+    "teachable": false,
+    "valid_targets": [ "ally", "ground", "hostile" ],
+    "spell_class": "PHOTOKINETIC",
+    "magic_type": "mom_psionics",
+    "skill": "metaphysics",
+    "flags": [ "PSIONIC", "NO_HANDS", "NO_LEGS" ],
+    "max_level": { "math": [ "int_to_level(1)" ] },
+    "difficulty": 4,
+    "effect": "flashbang",
+    "shape": "blast",
+    "min_range": {
+      "math": [
+        "min( ( ( (u_spell_level('photokinetic_flash_bang') * 0.7) + 3) * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling), 50)"
+      ]
+    },
+    "max_range": 50,
+    "min_aoe": {
+      "math": [
+        "min( ( ( (u_spell_level('photokinetic_flash_bang') * 0.5) + 2) * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling), 30)"
+      ]
+    },
+    "max_aoe": {
+      "math": [
+        "min( ( ( (u_spell_level('photokinetic_flash_bang') * 0.5) + 2) * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling), 30)"
+      ]
+    },
+    "base_energy_cost": 4500,
+    "final_energy_cost": 1750,
+    "energy_increment": -120,
+    "base_casting_time": 135,
+    "final_casting_time": 50,
+    "casting_time_increment": -5.5
+  },
+  {
     "id": "photokinetic_light_image",
     "type": "SPELL",
     "name": "[Ψ]Lucid Shadows",

--- a/data/mods/MindOverMatter/recipes/practice/photokinesis_practice.json
+++ b/data/mods/MindOverMatter/recipes/practice/photokinesis_practice.json
@@ -19,6 +19,7 @@
       "practice_photokinetic_rad_immunity",
       "practice_photokinetic_light_arms",
       "practice_photokinetic_hide_ugly",
+      "practice_photokinetic_flash_bang",
       "practice_photokinetic_light_image",
       "practice_photokinetic_radio",
       "practice_photokinetic_sterilize_food",
@@ -456,6 +457,60 @@
     "condition": {
       "and": [
         { "compare_string": [ "photokinetic_light_arms", { "u_val": "latest_studied_power_name" } ] },
+        { "test_eoc": "EOC_CONDITION_PSI_REQUIRED_FOR_LEARNING_NEW_POWER" }
+      ]
+    },
+    "effect": [ { "run_eocs": "EOC_PRACTICE_PSIONICS_FINAL_LEARNING_CHECK" } ]
+  },
+  {
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "name": "contemplation: flashbang",
+    "id": "practice_photokinetic_flash_bang",
+    "description": "Contemplate your powers and improve your ability to create a burst of light that will blind and deafen anyone nearby.\n\nPower Difficulty: 4",
+    "category": "CC_*",
+    "subcategory": "CSC_*_NESTED",
+    "skill_used": "metaphysics",
+    "difficulty": 0,
+    "time": "0 s",
+    "autolearn": false,
+    "proficiencies": [ { "proficiency": "prof_contemplation_photokinesis", "required": false } ],
+    "tools": [
+      [ [ "matrix_crystal_drained", -1 ], [ "black_nether_crystal_pseudo_tool", -1 ], [ "matrix_crystal_photokinesis", -1 ] ]
+    ],
+    "components": [ [ [ "matrix_crystal_photokin_dust", 1 ] ] ],
+    "flags": [ "SECRET", "BLIND_EASY", "NO_MANIP", "AFFECTED_BY_PAIN", "NO_BENCH", "NO_ENCHANTMENT" ],
+    "result_eocs": [
+      {
+        "id": "EOC_PRACTICE_PHOTOKIN_FLASH_BANG",
+        "condition": { "u_has_trait": "PHOTOKINETIC" },
+        "effect": [
+          { "set_string_var": "photokinetic_flash_bang", "target_var": { "u_val": "latest_studied_power_name" } },
+          { "run_eocs": "EOC_PSI_STUDYING_PHOTOKIN_POWER_SETUP" },
+          {
+            "if": { "math": [ "u_spell_level('photokinetic_flash_bang') >= 1" ] },
+            "then": { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] },
+            "else": [
+              { "run_eocs": [ "EOC_PSI_STUDYING_POWER_INITIAL_SETUP", "EOC_PSI_PRACTICE_FOCUS_MOD" ] },
+              {
+                "run_eocs": "EOC_PRACTICE_PHOTOKIN_FLASH_BANG_LEARNING",
+                "time_in_future": [
+                  { "math": [ "learn_new_power_lower_time_bound(u_latest_studied_power_difficulty)" ] },
+                  { "math": [ "learn_new_power_upper_time_bound(u_latest_studied_power_difficulty)" ] }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PRACTICE_PHOTOKIN_FLASH_BANG_LEARNING",
+    "condition": {
+      "and": [
+        { "compare_string": [ "photokinetic_flash_bang", { "u_val": "latest_studied_power_name" } ] },
         { "test_eoc": "EOC_CONDITION_PSI_REQUIRED_FOR_LEARNING_NEW_POWER" }
       ]
     },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[MoM] Add Flashbang Photokinetic power"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Guardian added the capability because I asked, so I must prove that it was worth his time.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add the Difficulty 4 Flashbang Photokinetic power, which creates a flashbang. Simple, big light, big boom.

It's not super-effective (flashbangs stun targets based on their distance from the edge and around 1 second per square), so it's not really possible to flashbang a group of zombies and then run unless you have a corner to duck around, but that's true of flashbang grenades as well. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Contemplated flashbang, learned flashbang, flashbanged some zombies.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
