### PR TITLE
[XE] Vampire cathedrals contain captives the vampires feed from.

### DIFF
--- a/data/mods/Xedra_Evolved/mapgen/vampire_cathedral.json
+++ b/data/mods/Xedra_Evolved/mapgen/vampire_cathedral.json
@@ -58,7 +58,7 @@
       "terrain": { ",": "t_linoleum_gray", " ": "t_soil", "n": "t_rock_floor", "@": "t_rock_floor", "_": "t_rock_floor" },
       "place_item": [ { "item": "small_relic", "x": 21, "y": 36 } ],
       "place_npcs": [ { "class": "xe_vampire_mentor", "x": 21, "y": 30 } ],
-      "place_monster": [ { "monster": "mon_civilian_bloodbag", "x": [ 20, 22 ], "y": [ 35, 37 ], "pack_size": [ 2, 5 ] } ],
+      "place_monster": [ { "monster": "mon_civilian_bloodbag", "x": [ 19 ], "y": [ 36 ], "pack_size": [ 2, 5 ] } ],
       "place_monsters": [
         { "monster": "GROUP_VAMPIRES_MIXED", "x": [ 0, 23 ], "y": [ 0, 23 ], "density": 0.1 },
         { "monster": "GROUP_VAMPIRES_MIXED", "x": [ 24, 47 ], "y": [ 0, 23 ], "density": 0.1 },

--- a/data/mods/Xedra_Evolved/mapgen/vampire_cathedral.json
+++ b/data/mods/Xedra_Evolved/mapgen/vampire_cathedral.json
@@ -58,6 +58,7 @@
       "terrain": { ",": "t_linoleum_gray", " ": "t_soil", "n": "t_rock_floor", "@": "t_rock_floor", "_": "t_rock_floor" },
       "place_item": [ { "item": "small_relic", "x": 21, "y": 36 } ],
       "place_npcs": [ { "class": "xe_vampire_mentor", "x": 21, "y": 30 } ],
+      "place_monster": [ { "monster": "mon_civilian_bloodbag", "x": [ 20, 22 ], "y": [ 35, 37 ], "pack_size": [ 2, 5 ] } ],
       "place_monsters": [
         { "monster": "GROUP_VAMPIRES_MIXED", "x": [ 0, 23 ], "y": [ 0, 23 ], "density": 0.1 },
         { "monster": "GROUP_VAMPIRES_MIXED", "x": [ 24, 47 ], "y": [ 0, 23 ], "density": 0.1 },

--- a/data/mods/Xedra_Evolved/monsters/bloodsuckers.json
+++ b/data/mods/Xedra_Evolved/monsters/bloodsuckers.json
@@ -725,6 +725,6 @@
     "default_faction": "vampire",
     "//": "Vampire faction so they aren't killed by the vampires.  They're food, not foe.",
     "//2": "Being fed and locked does wonders to keep them alive, so they don't die over time like the other civilians.",
-    "upgrades": false,
+    "upgrades": false
   }
 ]

--- a/data/mods/Xedra_Evolved/monsters/bloodsuckers.json
+++ b/data/mods/Xedra_Evolved/monsters/bloodsuckers.json
@@ -722,6 +722,7 @@
     "name": { "str": "petrified person" },
     "copy-from": "mon_civilian_stationary",
     "description": "They just stand there, staring into the void, with a vacant expression on their face.  A multitude of small puncture scars can be seen on their neck.",
+    "default_faction": "vampire",
     "//": "Vampire faction so they aren't killed by the vampires.  They're food, not foe.",
     "//2": "Being fed and locked does wonders to keep them alive, so they don't die over time like the other civilians.",
     "upgrades": false,

--- a/data/mods/Xedra_Evolved/monsters/bloodsuckers.json
+++ b/data/mods/Xedra_Evolved/monsters/bloodsuckers.json
@@ -715,5 +715,15 @@
     "special_attacks": [ { "type": "bite", "cooldown": 15 } ],
     "fear_triggers": [ "SOUND", "PLAYER_CLOSE" ],
     "flags": [ "SEES", "SMELLS", "HEARS", "GOODHEARING", "WARM", "FLIES", "HIT_AND_RUN", "ANIMAL", "PATH_AVOID_DANGER" ]
+  },
+  {
+    "id": "mon_civilian_bloodbag",
+    "type": "MONSTER",
+    "name": { "str": "petrified person" },
+    "copy-from": "mon_civilian_stationary",
+    "description": "They just stand there, staring into the void, with a vacant expression on their face.  A multitude of small puncture scars can be seen on their neck.",
+    "//": "Vampire faction so they aren't killed by the vampires.  They're food, not foe.",
+    "//2": "Being fed and locked does wonders to keep them alive, so they don't die over time like the other civilians.",
+    "upgrades": false,
   }
 ]

--- a/data/mods/Xedra_Evolved/monsters/bloodsuckers.json
+++ b/data/mods/Xedra_Evolved/monsters/bloodsuckers.json
@@ -719,7 +719,7 @@
   {
     "id": "mon_civilian_bloodbag",
     "type": "MONSTER",
-    "name": { "str": "petrified person" },
+    "name": { "str": "enthralled victim" },
     "copy-from": "mon_civilian_stationary",
     "description": "They just stand there, staring into the void, with a vacant expression on their face.  A multitude of small puncture scars can be seen on their neck.",
     "default_faction": "vampire",


### PR DESCRIPTION
#### Summary
Mods "[XE] Vampire cathedrals contain captives the vampires feed from."

#### Purpose of change

The blank bodies locked in a cage in the vampire cathedral were removed for their tendency to escape and kill the mentor.

This PR fills the cage once more, this time with non-aggressive humans that have a 100% chance to spawn inside the cage.

#### Describe the solution

Add a petrified person variant that won't be attacked by vampires and won't die over time like the other civilians.
Add them in the vampire cathedral's cage.

#### Describe alternatives you've considered

Readd the blanks, but their blood won't feed vampires anymore and horrors from beneath and beyond are probably harder to find than regular humans on near-regular earth.

#### Testing

<img width="776" height="555" alt="bags" src="https://github.com/user-attachments/assets/c792830e-1a36-405c-af0b-b9a73e391952" />

#### Additional context
I'm open to a better name than "petrified person". I considered "bloodbag", but that feels like something vampires would call them, not like something the usually-non-vampire player would.