### PR TITLE
Fix 0.I blocker error when swapping in vehicle

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5636,8 +5636,8 @@ bool game::swap_critters( Creature &a, Creature &b )
         }
     }
 
-    if( other_npc && here.veh_at( other_npc_pos ).part_with_feature( VPFLAG_BOARDABLE, true ) ) {
-        here.board_vehicle( other_npc_pos, other_npc );
+    if( other_npc && here.veh_at( other_npc->pos_bub() ).part_with_feature( VPFLAG_BOARDABLE, true ) ) {
+        here.board_vehicle( other_npc->pos_bub(), other_npc );
     }
     return true;
 }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1401,8 +1401,9 @@ void map::board_vehicle( const tripoint_bub_ms &pos, Character *p )
     }
     if( vp->part().has_flag( vp_flag::passenger_flag ) ) {
         Character *psg = vp->vehicle().get_passenger( vp->part_index() );
-        debugmsg( "map::board_vehicle: passenger (%s) is already there",
-                  psg ? psg->get_name() : "<null>" );
+        debugmsg( "map::board_vehicle: %s failed to board passenger (%s) is already there",
+                  p ? p->get_name() : "<null_boarder>",
+                  psg ? psg->get_name() : "<null_passenger>" );
         unboard_vehicle( pos );
     }
     vp->part().set_flag( vp_flag::passenger_flag );


### PR DESCRIPTION
#### Summary
Bugfixes "Fix error when swapping position with NPC in vehicle"

#### Purpose of change
* Fixes #80923

#### Describe the solution
Correctly try to board the NPC at its new position, not its old one.

Also updated the debugmsg for more clarity

#### Describe alternatives you've considered


#### Testing
load saves from linked issue, swap swap swap

#### Additional context
I tried blaming to figure out how we introduced this error, but this whole function is an absolute dumpster fire. I am going to refactor it in a separate PR.