### PR TITLE
Change outside cache to build from floor cache

### DIFF
--- a/doc/JSON/JSON_FLAGS.md
+++ b/doc/JSON/JSON_FLAGS.md
@@ -675,7 +675,6 @@ Can also be used as `pre_flags` for `construction`.
 - ```GROWTH_SEED``` This plant was just planted, not grown yet. Generic json flag, not all plants may use this!
 - ```HARVESTED``` Marks the harvested version of a terrain type (e.g. harvesting an apple tree turns it into a harvested tree, which later becomes an apple tree again).
 - ```HIDE_PLACE``` Creatures on this tile can't be seen by creatures not standing on adjacent tiles.
-- ```INDOORS``` Has a roof over it; blocks rain, sunlight, etc.
 - ```LADDER``` This piece of furniture that makes climbing easy.
 - ```LIQUIDCONT``` Furniture that contains liquid, allows for contents to be accessed in some checks even if `SEALED`.
 - ```LIQUID``` Terrain is liquid (e.g. water, lava, etc.), blocking movement without being a wall.

--- a/src/editmap.cpp
+++ b/src/editmap.cpp
@@ -798,12 +798,6 @@ void editmap::update_view_with_help( const std::string &txt, const std::string &
     if( vp ) {
         extras += _( " [vehicle]" );
     }
-    if( here.has_flag( ter_furn_flag::TFLAG_INDOORS, target ) ) {
-        extras += _( " [indoors]" );
-    }
-    if( here.has_flag( ter_furn_flag::TFLAG_SUPPORTS_ROOF, target ) ) {
-        extras += _( " [roof]" );
-    }
 
     mvwprintw( w_info, point( 1, off++ ), "%s %s", here.features( target ), extras ); // 12
 
@@ -965,17 +959,13 @@ static std::string describe( const T_t &t );
 template<>
 std::string describe( const ter_t &type )
 {
-    return string_format( _( "Move cost: %d\nIndoors: %s\nRoof: %s" ), type.movecost,
-                          type.has_flag( ter_furn_flag::TFLAG_INDOORS ) ? _( "Yes" ) : _( "No" ),
-                          type.has_flag( ter_furn_flag::TFLAG_SUPPORTS_ROOF ) ? _( "Yes" ) : _( "No" ) );
+    return string_format( _( "Move cost: %d" ), type.movecost );
 }
 
 template<>
 std::string describe( const furn_t &type )
 {
-    return string_format( _( "Move cost: %d\nIndoors: %s\nRoof: %s" ), type.movecost,
-                          type.has_flag( ter_furn_flag::TFLAG_INDOORS ) ? _( "Yes" ) : _( "No" ),
-                          type.has_flag( ter_furn_flag::TFLAG_SUPPORTS_ROOF ) ? _( "Yes" ) : _( "No" ) );
+    return string_format( _( "Move cost: %d" ), type.movecost );
 }
 
 template<>
@@ -1903,7 +1893,6 @@ void editmap::mapgen_preview( const real_coords &tc, uilist &gmenu )
             const point_rel_sm target_sub( target.x() / SEEX, target.y() / SEEY );
 
             here.set_transparency_cache_dirty( target.z() );
-            here.set_outside_cache_dirty( target.z() );
             here.set_floor_cache_dirty( target.z() );
             here.set_pathfinding_cache_dirty( target.z() );
 

--- a/src/fungal_effects.cpp
+++ b/src/fungal_effects.cpp
@@ -44,7 +44,6 @@ static const skill_id skill_melee( "melee" );
 static const species_id species_FUNGUS( "FUNGUS" );
 
 static const ter_str_id ter_t_fungus( "t_fungus" );
-static const ter_str_id ter_t_fungus_floor_in( "t_fungus_floor_in" );
 static const ter_str_id ter_t_fungus_floor_out( "t_fungus_floor_out" );
 static const ter_str_id ter_t_fungus_floor_sup( "t_fungus_floor_sup" );
 static const ter_str_id ter_t_fungus_mound( "t_fungus_mound" );
@@ -155,13 +154,8 @@ void fungal_effects::spread_fungus_one_tile( const tripoint_bub_ms &p, const int
             converted = true;
         }
     } else if( here.has_flag( ter_furn_flag::TFLAG_FLAT, p ) ) {
-        if( here.has_flag( ter_furn_flag::TFLAG_INDOORS, p ) ) {
-            if( x_in_y( growth * 10, 500 ) ) {
-                here.ter_set( p, ter_t_fungus_floor_in );
-                converted = true;
-            }
-        } else if( here.has_flag( ter_furn_flag::TFLAG_SUPPORTS_ROOF, p ) ) {
-            if( x_in_y( growth * 10, 1000 ) ) {
+        if( !here.is_outside( p ) || here.has_flag( ter_furn_flag::TFLAG_SUPPORTS_ROOF, p ) ) {
+            if( x_in_y( growth * 10, 750 ) ) {
                 here.ter_set( p, ter_t_fungus_floor_sup );
                 converted = true;
             }

--- a/src/level_cache.h
+++ b/src/level_cache.h
@@ -39,15 +39,14 @@ struct level_cache {
         // Cache of natural light level is useful if it needs to be in sync with the light cache.
         float natural_light_level_cache;
 
-        // if false, means tile is under the roof ("inside"), true means tile is "outside"
-        // "inside" tiles are protected from sun, rain, etc. (see ter_furn_flag::TFLAG_INDOORS flag)
-        cata::mdarray<bool, point_bub_ms> outside_cache;
-
         // true when vehicle below has "ROOF" or "OPAQUE" part, furniture below has ter_furn_flag::TFLAG_SUN_ROOF_ABOVE
         //      or terrain doesn't have ter_furn_flag::TFLAG_NO_FLOOR flag
         // false otherwise
         // i.e. true == has floor
         cata::mdarray<bool, point_bub_ms> floor_cache;
+
+        // if false, means tile is under (not necessarily directly) a floor as per floor_cache above
+        cata::mdarray<bool, point_bub_ms> outside_cache;
 
         // stores cached transparency of the tiles
         // units: "transparency" (see LIGHT_TRANSPARENCY_OPEN_AIR)

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -9854,8 +9854,14 @@ void map::build_outside_cache( const int zlev )
         debugmsg( "Tried to access level cache at z-level %d but it hasn't been populated", zlev + 1 );
     }
     const level_cache &ch_above = *ch_lazy_above;
-    const cata::mdarray<bool, point_bub_ms> &outside_cache_above = ch_above.outside_cache;
+    if( ch_lazy_above->floor_cache_dirty ) {
+        build_floor_cache( zlev + 1 );
+    }
+    if( ch_lazy_above->outside_cache_dirty ) {
+        build_outside_cache( zlev + 1 );
+    }
     const cata::mdarray<bool, point_bub_ms> &floor_cache_above = ch_above.floor_cache;
+    const cata::mdarray<bool, point_bub_ms> &outside_cache_above = ch_above.outside_cache;
 
 
     for( int smx = 0; smx < my_MAPSIZE; ++smx ) {

--- a/src/map.h
+++ b/src/map.h
@@ -1077,10 +1077,7 @@ class map
         }
 
         bool is_outside( const tripoint_bub_ms &p ) const;
-        bool is_outside( const tripoint_abs_ms &p ) const {
-            //TODO: Likely needs out of bubble handling that replicates floor cache logic at a tripoint_abs_ms scale and above
-            return is_outside( get_bub( p ) );
-        };
+        bool is_outside( const tripoint_abs_ms &p ) const;
         /**
          * Returns whether or not the terrain at the given location can be dived into
          * (by monsters that can swim or are aquatic or non-breathing).

--- a/src/map.h
+++ b/src/map.h
@@ -433,7 +433,6 @@ class map
 
         // invalidates seen cache for the whole zlevel unconditionally
         void set_seen_cache_dirty( int zlevel );
-        void set_outside_cache_dirty( int zlev );
         void set_floor_cache_dirty( int zlev );
         void set_pathfinding_cache_dirty( int zlev );
         void set_pathfinding_cache_dirty( const tripoint_bub_ms &p );
@@ -1078,6 +1077,10 @@ class map
         }
 
         bool is_outside( const tripoint_bub_ms &p ) const;
+        bool is_outside( const tripoint_abs_ms &p ) const {
+            //TODO: Likely needs out of bubble handling that replicates floor cache logic at a tripoint_abs_ms scale and above
+            return is_outside( get_bub( p ) );
+        };
         /**
          * Returns whether or not the terrain at the given location can be dived into
          * (by monsters that can swim or are aquatic or non-breathing).

--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -209,7 +209,6 @@ std::string enum_to_string<ter_furn_flag>( ter_furn_flag data )
         case ter_furn_flag::TFLAG_COLLAPSES: return "COLLAPSES";
         case ter_furn_flag::TFLAG_FLAMMABLE_ASH: return "FLAMMABLE_ASH";
         case ter_furn_flag::TFLAG_DESTROY_ITEM: return "DESTROY_ITEM";
-        case ter_furn_flag::TFLAG_INDOORS: return "INDOORS";
         case ter_furn_flag::TFLAG_LIQUIDCONT: return "LIQUIDCONT";
         case ter_furn_flag::TFLAG_FIRE_CONTAINER: return "FIRE_CONTAINER";
         case ter_furn_flag::TFLAG_FLAMMABLE_HARD: return "FLAMMABLE_HARD";

--- a/src/mapdata.h
+++ b/src/mapdata.h
@@ -200,7 +200,6 @@ struct plant_data {
  * ALARMED - Sets off an alarm if smashed
  * SUPPORTS_ROOF - Used as a boundary for roof construction
  * MINEABLE - Able to broken with the jackhammer/pickaxe, but does not necessarily support a roof
- * INDOORS - Has roof over it; blocks rain, sunlight, etc.
  * COLLAPSES - Has a roof that can collapse
  * FLAMMABLE_ASH - Burns to ash rather than rubble.
  * REDUCE_SCENT - Reduces scent even more, only works if also bashable
@@ -259,7 +258,6 @@ enum class ter_furn_flag : int {
     TFLAG_COLLAPSES,
     TFLAG_FLAMMABLE_ASH,
     TFLAG_DESTROY_ITEM,
-    TFLAG_INDOORS,
     TFLAG_LIQUIDCONT,
     TFLAG_FIRE_CONTAINER,
     TFLAG_FLAMMABLE_HARD,
@@ -391,9 +389,6 @@ struct connect_group {
     public:
         connect_group_id id;
         int index;
-        std::set<ter_furn_flag> group_flags;
-        std::set<ter_furn_flag> connects_to_flags;
-        std::set<ter_furn_flag> rotates_to_flags;
 
         static void load( const JsonObject &jo );
         static void reset();

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -737,7 +737,8 @@ static void GENERATOR_aftershock_ruin( map &md, const tripoint_abs_omt &p )
                 !one_in( 5 ) ? md.ter_set( current_tile.xy(),
                                            ter_t_wall_prefab_metal ) : md.ter_set( current_tile.xy(), ter_t_metal_floor );
             }
-            if( md.has_flag_ter( ter_furn_flag::TFLAG_INDOORS, current_tile ) ) {
+            //BEFOREMERGE: I haven't checked if outside cache is rebuilt before this
+            if( !md.is_outside( current_tile ) ) {
                 if( !one_in( 4 ) ) {
                     p.z() == 0 ? md.ter_set( current_tile.xy(),
                                              ter_t_snow_metal_floor ) : md.ter_set( current_tile.xy(), ter_t_snow );

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -303,8 +303,7 @@ static bool tile_can_have_blood( map &md, const tripoint_bub_ms &current_tile,
         return md.has_flag_ter( ter_furn_flag::TFLAG_WALL, current_tile ) &&
                !md.has_flag_ter( ter_furn_flag::TFLAG_NATURAL_UNDERGROUND, current_tile );
     } else {
-        if( !md.has_flag_ter( ter_furn_flag::TFLAG_INDOORS, current_tile ) &&
-            x_in_y( days_since_cataclysm, 30 ) ) {
+        if( md.is_outside( current_tile ) && x_in_y( days_since_cataclysm, 30 ) ) {
             // Placement of blood outdoors scales down over the course of 30 days until no further blood is placed.
             return false;
         }
@@ -625,12 +624,12 @@ static void GENERATOR_pre_burn( map &md,
             if( md.has_flag_ter( ter_furn_flag::TFLAG_WALL, current_tile ) ) {
                 // burnt wall
                 md.ter_set( current_tile.xy(), ter_t_wall_burnt );
-            } else if( md.has_flag_ter( ter_furn_flag::TFLAG_INDOORS, current_tile ) ||
+            } else if( !md.is_outside( current_tile ) ||
                        md.has_flag_ter( ter_furn_flag::TFLAG_DOOR, current_tile ) ) {
                 // if we're indoors but we're not a wall, then we must be a floor.
                 // doorways also get burned to the ground.
                 md.ter_set( current_tile.xy(), ter_t_floor_burnt );
-            } else if( !md.has_flag_ter( ter_furn_flag::TFLAG_INDOORS, current_tile ) ) {
+            } else if( md.is_outside( current_tile ) ) {
                 // if we're outside on ground level, burn it to dirt.
                 if( current_tile.z() == 0 ) {
                     md.ter_set( current_tile.xy(), ter_t_dirt );

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -4071,8 +4071,8 @@ bool monster::will_join_horde( int size )
     if( mha == MHA_ALWAYS ) {
         return true;
     }
-    if( get_map().has_flag( ter_furn_flag::TFLAG_INDOORS, pos_bub() ) &&
-        ( mha == MHA_OUTDOORS || mha == MHA_OUTDOORS_AND_LARGE ) ) {
+    if( ( mha == MHA_OUTDOORS || mha == MHA_OUTDOORS_AND_LARGE ) &&
+        get_map().is_outside( pos_abs() ) ) {
         return false;
     }
     if( size < 3 && ( mha == MHA_LARGE || mha == MHA_OUTDOORS_AND_LARGE ) ) {

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -1500,7 +1500,7 @@ bool vehicle::check_heli_ascend( map &here, Character &p ) const
         const tripoint_bub_ms pos = here.get_bub( pt );
         tripoint_bub_ms above( pos + tripoint::above );
         const optional_vpart_position ovp = here.veh_at( above );
-        if( here.has_flag_ter_or_furn( ter_furn_flag::TFLAG_INDOORS, pos ) ||
+        if( here.has_floor( above ) ||
             here.impassable_ter_furn( above ) ||
             ovp ||
             creatures.creature_at( above ) ) {

--- a/tests/gates_test.cpp
+++ b/tests/gates_test.cpp
@@ -220,9 +220,9 @@ TEST_CASE( "character_should_lose_moves_when_opening_or_closing_doors_or_windows
         REQUIRE( here.ter_set( pos, ter_concrete_floor ) );
         REQUIRE( here.ter_set( pos + tripoint::above, ter_flat_roof ) );
 
-        // mark map cache as dirty and rebuild it so that map starts
+        // rebuild map cache so that map starts
         // recognizing that tile player is standing on is indoors
-        here.set_outside_cache_dirty( pos.z() );
+        here.build_floor_cache( pos.z() + 1 );
         here.build_outside_cache( pos.z() );
         REQUIRE_FALSE( here.is_outside( pos ) );
 

--- a/tests/npc_behavior_rules_test.cpp
+++ b/tests/npc_behavior_rules_test.cpp
@@ -105,7 +105,7 @@ TEST_CASE( "NPC-rules-close-doors", "[npc_rules]" )
     /* Close doors rule
     * Target is a chair in a room fully enclosed by concrete walls
     * We have a straight line path to the target, but in the way are several vexing trials!
-    * An open door, a closed door, and a locked door (unlockable from adjacent INDOORS tile).
+    * An open door, a closed door, and a locked door (unlockable from adjacent !is_outside tile).
     * We must open them all, *and* close them behind us!
     */
     const ally_rule rule_to_test = ally_rule::close_doors;
@@ -124,7 +124,8 @@ TEST_CASE( "NPC-rules-close-doors", "[npc_rules]" )
             break;
         }
     }
-    here.set_outside_cache_dirty( door_unlock_position.z() );
+    here.set_floor_cache_dirty( door_unlock_position.z() + 1 );
+    here.build_floor_cache( door_unlock_position.z() + 1 );
     here.build_outside_cache( door_unlock_position.z() );
     REQUIRE( !here.is_outside( door_unlock_position ) );
 
@@ -194,9 +195,10 @@ TEST_CASE( "NPC-rules-avoid-locks", "[npc_rules]" )
     }
     tripoint_bub_ms door_unlock_position = door_position + point::south;
     tripoint_bub_ms past_the_door = door_position + point::north;
-    here.set_outside_cache_dirty( door_position.z() );
+    here.set_floor_cache_dirty( door_position.z() + 1 );
+    here.build_floor_cache( door_position.z() + 1 );
     here.build_outside_cache( door_position.z() );
-    REQUIRE( !here.is_outside( door_unlock_position ) );
+    REQUIRE( !here.is_outside( door_position ) );
 
     test_subject->update_path( door_unlock_position, true, true );
     REQUIRE( !test_subject->path.empty() ); // we can reach the unlock position


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Infrastructure "Obsolete pre-zlevel INDOORS flag in favour of determining indoors from floor cache"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Third part of removing INDOORS flag https://github.com/CleverRaven/Cataclysm-DDA/issues/82056
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Changes outside_cache so anywhere below a floor_cache floor is marked as inside and removes the x/y propagation effect.
This does mean it's now fundamentally different to what it was before, but checking through the things using it I couldn't find anywhere this would be objectively worse, and anything that actively cares about neighbours should just check for them itself.
Changes vehicle's is_sm_tile_outside to use the outside_cache when in bubble and mimic build_floor_cache -> build_outside_cache logic for outside of bubble
Leaves INDOORS flags in the JSON for a followup PR as loading/validation allow non C++ specified flags (I have a branch removing the flags ready to go I just don't want to make reviewing this more awkward)

Will attempt to add unit tests
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
This can be dirtied much more efficiently but it's not super expensive to build and I'd rather do a fairly minimal change to catch bugs before trying to optimise it.
An absolute crap ton of outbounds coords are being passed to the bub version of is_outside that want reviewing on a case by case, I don't want to deal with that here though.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
In bubble values appear to be as expected, not tested out of bubble yet
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
From the very funky test results I think something might be wrong '^^
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
