### PR TITLE
Refactor game::swap_critters() 

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5636,8 +5636,8 @@ bool game::swap_critters( Creature &a, Creature &b )
         }
     }
 
-    if( other_npc && here.veh_at( other_npc_pos ).part_with_feature( VPFLAG_BOARDABLE, true ) ) {
-        here.board_vehicle( other_npc_pos, other_npc );
+    if( other_npc && here.veh_at( other_npc->pos_bub() ).part_with_feature( VPFLAG_BOARDABLE, true ) ) {
+        here.board_vehicle( other_npc->pos_bub(), other_npc );
     }
     return true;
 }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5556,88 +5556,123 @@ bool game::swap_critters( Creature &a, Creature &b )
 {
     map &here = get_map();
 
-    const tripoint_bub_ms a_pos = a.pos_bub( );
-    const tripoint_bub_ms b_pos = b.pos_bub( );
+    Creature *lhs = &a;
+    Creature *rhs = &b;
 
-    if( &a == &b ) {
+    if( rhs->as_character() && !lhs->as_character() ) {
+        std::swap( lhs, rhs ); // LHS will always be a character if either is a character
+    }
+
+    // Possible options:
+    // LHS and RHS are both monsters
+    // LHS is character, RHS is monster
+    // LHS is character, RHS is character
+    // This is simply to make it easier to follow the code.
+
+    const tripoint_bub_ms lhs_cached_pos = lhs->pos_bub( );
+    const tripoint_bub_ms rhs_cached_pos = rhs->pos_bub( );
+
+    if( lhs == rhs ) {
         // No need to do anything, but print a debugmsg anyway
-        debugmsg( "Tried to swap %s with itself", a.disp_name() );
+        debugmsg( "Tried to swap %s with itself", lhs->disp_name() );
         return true;
     }
     creature_tracker &creatures = get_creature_tracker();
-    if( creatures.creature_at( a_pos ) != &a ) {
-        if( creatures.creature_at( a_pos ) == nullptr ) {
+    if( creatures.creature_at( lhs_cached_pos ) != &a ) {
+        if( creatures.creature_at( lhs_cached_pos ) == nullptr ) {
             debugmsg( "Tried to swap %s and %s when the latter isn't present at its own location %s.",
-                      b.disp_name(), a.disp_name(), a_pos.to_string() );
+                      rhs->disp_name(), lhs->disp_name(), lhs_cached_pos.to_string() );
         } else {
             debugmsg( "Tried to swap when it would cause a collision between %s and %s.",
-                      b.disp_name(), creatures.creature_at( a_pos )->disp_name() );
+                      rhs->disp_name(), creatures.creature_at( lhs_cached_pos )->disp_name() );
         }
         return false;
     }
-    if( creatures.creature_at( b_pos ) != &b ) {
-        if( creatures.creature_at( b_pos ) == nullptr ) {
+    if( creatures.creature_at( rhs_cached_pos ) != &b ) {
+        if( creatures.creature_at( rhs_cached_pos ) == nullptr ) {
             debugmsg( "Tried to swap %s and %s when the latter isn't present at its own location %s.",
-                      a.disp_name(), b.disp_name(), b_pos.to_string() );
+                      lhs->disp_name(), rhs->disp_name(), rhs_cached_pos.to_string() );
         } else {
             debugmsg( "Tried to swap when it would cause a collision between %s and %s.",
-                      a.disp_name(), creatures.creature_at( b_pos )->disp_name() );
+                      lhs->disp_name(), creatures.creature_at( rhs_cached_pos )->disp_name() );
         }
         return false;
     }
-    // Simplify by "sorting" the arguments
-    // Only the first argument can be u
-    // If swapping player/npc with a monster, monster is second
-    bool a_first = a.is_avatar() ||
-                   ( a.is_npc() && !b.is_avatar() );
-    Creature &first  = a_first ? a : b;
-    Creature &second = a_first ? b : a;
-    // Possible options:
-    // both first and second are monsters
-    // second is a monster, first is a player or an npc
-    // first is a player, second is an npc
-    // both first and second are npcs
-    if( first.is_monster() ) {
-        monster *m1 = dynamic_cast< monster * >( &first );
-        monster *m2 = dynamic_cast< monster * >( &second );
-        if( m1 == nullptr || m2 == nullptr || m1 == m2 ) {
+
+    if( lhs->is_monster() ) { // then we have two monsters.
+        monster *lhs_as_mon = dynamic_cast< monster * >( lhs );
+        monster *rhs_as_mon = dynamic_cast< monster * >( rhs );
+        if( lhs_as_mon == nullptr || rhs_as_mon == nullptr || lhs_as_mon == rhs_as_mon ) {
             debugmsg( "Couldn't swap two monsters" );
             return false;
         }
 
-        critter_tracker->swap_positions( *m1, *m2 );
+        critter_tracker->swap_positions( *lhs_as_mon, *rhs_as_mon );
         return true;
     }
 
-    Character *u_or_npc = dynamic_cast< Character * >( &first );
-    // Issue https://github.com/CleverRaven/Cataclysm-DDA/issues/80245
-    // second can be a monster, in that case other_npc will be NULL
-    Character *other_npc = dynamic_cast< Character * >( &second );
-    const tripoint_bub_ms u_or_npc_pos = u_or_npc->pos_bub( );
-    const tripoint_bub_ms other_npc_pos = second.pos_bub( );
+    // If we've reached here, LHS must be a character. RHS *might* be a character.
+    Character *lhs_as_char = static_cast< Character * >( lhs );
 
-    if( u_or_npc->in_vehicle ) {
-        here.unboard_vehicle( u_or_npc_pos );
-    }
-
-    if( other_npc && other_npc->in_vehicle ) {
-        here.unboard_vehicle( other_npc_pos );
-    }
-
-    tripoint_bub_ms temp = second.pos_bub( );
-    second.setpos( here, first.pos_bub( ) );
-
-    if( first.is_avatar() ) {
-        walk_move( temp );
-    } else {
-        first.setpos( here, temp );
-        if( here.veh_at( u_or_npc_pos ).part_with_feature( VPFLAG_BOARDABLE, true ) ) {
-            here.board_vehicle( u_or_npc_pos, u_or_npc );
+    // Case: character swaps with monster.
+    if( rhs->as_monster() ) {
+        if( lhs_as_char->in_vehicle ) { // unboard lhs always...
+            here.unboard_vehicle( lhs_cached_pos );
+        }
+        // Go ahead and move rhs, so the destination is clear
+        rhs->setpos( here, lhs_cached_pos );
+        if( lhs->as_avatar() ) {
+            walk_move( rhs_cached_pos ); // Does vehicle boarding! Do not double board! DON'T DO IT! >:(
+            return true;
+        } else {
+            if( here.veh_at( rhs_cached_pos ).part_with_feature( VPFLAG_BOARDABLE, true ) ) {
+                here.board_vehicle( rhs_cached_pos, lhs_as_char );
+            }
+            lhs->setpos( here, rhs_cached_pos );
+            return true;
         }
     }
 
-    if( other_npc && here.veh_at( other_npc->pos_bub() ).part_with_feature( VPFLAG_BOARDABLE, true ) ) {
-        here.board_vehicle( other_npc->pos_bub(), other_npc );
+    // If we've reached here, both LHS and RHS are characters. So we need to do some real juggling...
+    Character *rhs_as_char = static_cast< Character * >( rhs );
+
+    // Make sure we're both unboarded.
+    if( lhs_as_char->in_vehicle ) {
+        here.unboard_vehicle( lhs_cached_pos );
+    }
+    if( rhs_as_char->in_vehicle ) {
+        here.unboard_vehicle( rhs_cached_pos );
+    }
+
+    if( lhs->as_avatar() ) {
+        if( here.veh_at( lhs_cached_pos ).part_with_feature( VPFLAG_BOARDABLE, true ) ) {
+            here.board_vehicle( lhs_cached_pos, rhs_as_char ); // sets position!
+        } else {
+            rhs->setpos( here, lhs_cached_pos );
+        }
+        walk_move( rhs_cached_pos ); // boards if needed!
+        return true;
+    } else if( rhs->as_avatar() ) {
+        if( here.veh_at( rhs_cached_pos ).part_with_feature( VPFLAG_BOARDABLE, true ) ) {
+            here.board_vehicle( rhs_cached_pos, lhs_as_char );
+        } else {
+            lhs->setpos( here, rhs_cached_pos );
+        }
+        walk_move( lhs_cached_pos );
+        return true;
+    }
+    // Two NPCs, oh boy!
+    // LHS movement
+    if( here.veh_at( rhs_cached_pos ).part_with_feature( VPFLAG_BOARDABLE, true ) ) {
+        here.board_vehicle( rhs_cached_pos, lhs_as_char );
+    } else {
+        lhs->setpos( here, rhs_cached_pos );
+    }
+    // RHS movement
+    if( here.veh_at( lhs_cached_pos ).part_with_feature( VPFLAG_BOARDABLE, true ) ) {
+        here.board_vehicle( lhs_cached_pos, rhs_as_char );
+    } else {
+        rhs->setpos( here, lhs_cached_pos );
     }
     return true;
 }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5647,33 +5647,27 @@ bool game::swap_critters( Creature &a, Creature &b )
     if( lhs->as_avatar() ) {
         if( here.veh_at( lhs_cached_pos ).part_with_feature( VPFLAG_BOARDABLE, true ) ) {
             here.board_vehicle( lhs_cached_pos, rhs_as_char ); // sets position!
-        } else {
-            rhs->setpos( here, lhs_cached_pos );
         }
+        rhs->setpos( here, lhs_cached_pos ); // If board vehicle didn't move us, harmless otherwise.
         walk_move( rhs_cached_pos ); // boards if needed!
         return true;
     } else if( rhs->as_avatar() ) {
         if( here.veh_at( rhs_cached_pos ).part_with_feature( VPFLAG_BOARDABLE, true ) ) {
             here.board_vehicle( rhs_cached_pos, lhs_as_char );
-        } else {
-            lhs->setpos( here, rhs_cached_pos );
         }
+        lhs->setpos( here, rhs_cached_pos );
         walk_move( lhs_cached_pos );
         return true;
     }
-    // Two NPCs, oh boy!
-    // LHS movement
+    // Two NPCs, oh boy! no walk_move() here.
     if( here.veh_at( rhs_cached_pos ).part_with_feature( VPFLAG_BOARDABLE, true ) ) {
         here.board_vehicle( rhs_cached_pos, lhs_as_char );
-    } else {
-        lhs->setpos( here, rhs_cached_pos );
     }
-    // RHS movement
     if( here.veh_at( lhs_cached_pos ).part_with_feature( VPFLAG_BOARDABLE, true ) ) {
         here.board_vehicle( lhs_cached_pos, rhs_as_char );
-    } else {
-        rhs->setpos( here, lhs_cached_pos );
     }
+    lhs->setpos( here, rhs_cached_pos );
+    rhs->setpos( here, lhs_cached_pos );
     return true;
 }
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1401,8 +1401,9 @@ void map::board_vehicle( const tripoint_bub_ms &pos, Character *p )
     }
     if( vp->part().has_flag( vp_flag::passenger_flag ) ) {
         Character *psg = vp->vehicle().get_passenger( vp->part_index() );
-        debugmsg( "map::board_vehicle: passenger (%s) is already there",
-                  psg ? psg->get_name() : "<null>" );
+        debugmsg( "map::board_vehicle: %s failed to board passenger (%s) is already there",
+                  p ? p->get_name() : "<null_boarder>",
+                  psg ? psg->get_name() : "<null_passenger>" );
         unboard_vehicle( pos );
     }
     vp->part().set_flag( vp_flag::passenger_flag );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
The existing game::swap_critters() function is an absurdly convoluted wave of variables, reassignments, and type casting.

#### Describe the solution
Refactor. Intended to follow simple LHS/RHS convention, no special casing. Always evaluating left to right.

Swap variables **only once** and only then immediately at the start, so it's obvious what is going on. For example we're working with the bog-standard `lhs` and `rhs` and never `u_or_npc_pos`. We set this at the start as `lhs_cached_pos` and never, ever change it. The position is always LHS's position and it's always the position it had at the start of the function, we never have to question whether it's their current position or whether it's a player or npc or what. It's simply `lhs`.

Append the necessary casts with extremely simple, obvious names. e.g. `lhs` casted to character is `lhs_as_char`.

Built on top of #82113

#### Describe alternatives you've considered
Why does map::board_vehicle also setpos()?!

Why does walk_move() also board_vehicle()?!

Maybe we need some kind of `maybe_board_if_vehicle_there( /*bool also_do_movement=*/ true )`

#### Testing
Got some friendly NPCs and friendly cats in and out of vehicles

Swap swap swap swap swap swap all around, no errors or issues noticed. Called some of the NPCs to follow me, not sure if any NPC<-->NPC swaps happened but those are the simplest code so I'm not too worried.

Could still use more testing.

#### Additional context
