### PR TITLE
Fix 0.I blocker zombies always(100%) trying to bash cramped vehicle space

### DIFF
--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -1761,8 +1761,10 @@ bool monster::bash_at( const tripoint_bub_ms &p )
         return false;
     }
 
+    // Note: Cramped space preventing movement is currently 'turned off', so the chance for them bashing is purposefully low
+    // This variable remains for maintenance purposes and the 1-in-1000 chance to prevent clang from complaining.
     const bool cramped = will_be_cramped_in_vehicle_tile( here, here.get_abs( p ) );
-    bool try_bash = !can_move_to( p ) || one_in( 3 ) || cramped;
+    bool try_bash = !can_move_to( p ) || one_in( 3 ) || ( cramped && one_in( 1000 ) );
     if( !try_bash ) {
         return false;
     }
@@ -1771,7 +1773,7 @@ bool monster::bash_at( const tripoint_bub_ms &p )
         return false;
     }
 
-    if( !( here.is_bashable_furn( p ) || here.veh_at( p ).obstacle_at_part() || cramped ) ) {
+    if( !( here.is_bashable_furn( p ) || here.veh_at( p ).obstacle_at_part() ) ) {
         // if the only thing here is road or flat, rarely bash it
         bool flat_ground = here.has_flag( ter_furn_flag::TFLAG_ROAD, p ) ||
                            here.has_flag( ter_furn_flag::TFLAG_FLAT, p );


### PR DESCRIPTION
#### Summary
Bugfixes "Fix zombies always(100%) trying to bash cramped vehicle space"

#### Purpose of change
* Fixes 0.I blocker #81934

#### Describe the solution
In ##74004 I added logic to make monsters try to bash a cramped vehicle space because previously they would never do so, just endlessly milling about staring at you over a seat filled with rocks.

The problem is that they **always** try to, instead of moving onto the tile. And shortly after that PR we made too-cramped spaces not restrict movement anyway.

#### Describe alternatives you've considered
Reduce the bash chance to 1-in-1000.

Keep it there in case we turn the system back on, with a little note to explain.

#### Testing
<img width="2560" height="1400" alt="image" src="https://github.com/user-attachments/assets/2d33f699-3381-4389-a2ce-5649cfdee154" />


#### Additional context
