### PR TITLE
Avatar-only traits/professions for chargen

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -990,7 +990,7 @@
     "enchantments": [ { "values": [ { "value": "CONSUME_TIME_MOD", "multiply": 0.5 } ] } ],
     "description": "You've been taught proper table manners from your early childhood on; now, you can't even think about eating without being seated at a table and taking your time.  Eating without a table and chair frustrates you, but eating like a civilized person gives you a bigger morale bonus.",
     "starting_trait": true,
-    "random_at_chargen": false,
+    "chargen_allow_npc": false,
     "valid": false
   },
   {
@@ -1325,7 +1325,7 @@
     "points": 2,
     "description": "For your whole life you've been forbidden from indulging in your peculiar tastes.  Now the world's ended, and you'll be damned if anyone is going to tell you that you can't eat people.",
     "starting_trait": true,
-    "random_at_chargen": false,
+    "chargen_allow_npc": false,
     "valid": false,
     "cancels": [ "VEGETARIAN", "VEGAN", "HERBIVORE", "RUMINANT", "GRAZER" ],
     "flags": [ "CANNIBAL" ]
@@ -1337,7 +1337,7 @@
     "points": 1,
     "description": "You're convinced that these things that look vaguely human from elsewhere are definitely not people.  Therefore it's okay to eat them, right?",
     "starting_trait": true,
-    "random_at_chargen": false,
+    "chargen_allow_npc": false,
     "valid": false,
     "cancels": [ "VEGETARIAN", "VEGAN", "HERBIVORE", "RUMINANT", "GRAZER", "CANNIBAL" ],
     "flags": [ "STRICT_HUMANITARIAN" ]
@@ -1349,7 +1349,7 @@
     "points": 2,
     "description": "You don't feel any strong feelings for your fellow man.",
     "starting_trait": true,
-    "random_at_chargen": false,
+    "chargen_allow_npc": false,
     "valid": false,
     "social_modifiers": { "lie": -5, "persuade": -5 },
     "types": [ "HUMAN_EMPATHY" ],
@@ -1914,7 +1914,7 @@
     "vitamin_cost": 160,
     "description": "You suffer from a minor chemical imbalance, whether mental or physical.  Minor changes to your internal chemistry will manifest themselves on occasion, such as hunger, sleepiness, narcotic effects, etc.",
     "starting_trait": true,
-    "random_at_chargen": false,
+    "chargen_allow_npc": false,
     "category": [ "SLIME", "MEDICAL", "CHIMERA", "ELFA" ]
   },
   {
@@ -1961,7 +1961,7 @@
     "vitamin_cost": 160,
     "description": "Ever since the sky first broke, you have felt unwell, your head split by alien thoughts.  You will periodically suffer from delusions, ranging from minor effects to full visual hallucinations.  Some of these effects may be controlled through the use of antipsychotics.",
     "starting_trait": true,
-    "random_at_chargen": false,
+    "chargen_allow_npc": false,
     "category": [ "MEDICAL" ]
   },
   {
@@ -1972,7 +1972,7 @@
     "vitamin_cost": 160,
     "description": "You randomly fall asleep without any reason.",
     "starting_trait": true,
-    "random_at_chargen": false,
+    "chargen_allow_npc": false,
     "category": [ "MEDICAL" ]
   },
   {
@@ -9063,7 +9063,7 @@
     "vitamin_cost": 160,
     "description": "You have an unhealthy obsession with fire, and you get anxious if you don't light them every now and then or stand near them often.  However, you gain a mood bonus from doing so.",
     "starting_trait": true,
-    "random_at_chargen": false
+    "chargen_allow_npc": false
   },
   {
     "type": "mutation",

--- a/data/mods/CrazyCataclysm/crazy_mutations.json
+++ b/data/mods/CrazyCataclysm/crazy_mutations.json
@@ -7,7 +7,7 @@
     "description": "You're naturally quite lucky!",
     "starting_trait": true,
     "valid": false,
-    "random_at_chargen": false,
+    "chargen_allow_npc": false,
     "cancels": [ "UNLUCKY" ]
   },
   {
@@ -18,7 +18,7 @@
     "description": "You're naturally quite unlucky.",
     "starting_trait": true,
     "valid": false,
-    "random_at_chargen": false,
+    "chargen_allow_npc": false,
     "cancels": [ "LUCKY" ]
   }
 ]

--- a/doc/JSON/JSON_INFO.md
+++ b/doc/JSON/JSON_INFO.md
@@ -1936,6 +1936,7 @@ The following properties (mandatory, except if noted otherwise) are supported:
     "points": 0,                                               // Point cost of profession. Positive values cost points and negative values grant points. Has no effect as of 0.G
     "starting_cash": 500000,                                   // (optional) Int value for the starting bank balance.
     "npc_background": "BG_survival_story_LAB",                 // (optional) BG_trait_group ID, provides list of background stories. (see BG_trait_groups.json)
+	"chargen_allow_npc": false,                                // (optional) when false, removes this profession as an option for generated NPCs (default: true)
     "addictions": [ { "intensity": 10, "type": "nicotine" } ], // (optional) Array of addictions. Requires "type" as the string ID of the addiction (see JSON_FLAGS.md) and "intensity"
     "skills": [ { "name": "archery", "level": 2 } ],           // (optional) Array of starting skills. Requires "name" as the string ID of the skill (see skills.json) and "level", which is a value added to the skill level after character creation
     "missions": [ "MISSION_LAST_DELIVERY" ],                   // (optional) Array of starting mission IDs

--- a/doc/JSON/MUTATIONS.md
+++ b/doc/JSON/MUTATIONS.md
@@ -125,7 +125,7 @@ Note that **all new traits that can be obtained through mutation must be purifia
   "mixed_effect": false,                      // Whether the trait has both positive and negative effects.  This is purely declarative and is only used for the user interface (default: false).
   "description": "Nothing gets you down!",    // In-game description. Supports snippets and u/global variables
   "starting_trait": true,                     // Can be selected at character creation (default: false).
-  "random_at_chargen": false,                 // (Optional) Starting traits can be randomly assigned to NPCs during chargen.  This options prevents that (default: true).
+  "chargen_allow_npc": false,                 // (Optional) Starting traits can be randomly assigned to NPCs during chargen.  This options prevents that when false (default: true).
   "valid": false,                             // Can be mutated ingame (default: true).  Note that prerequisites can even mutate invalid mutations.
   "purifiable": false,                        // Sets if the mutation be purified (default: true).
   "profession": true,                         // Trait is a starting profession special trait (default: false).

--- a/src/character.h
+++ b/src/character.h
@@ -1334,9 +1334,9 @@ class Character : public Creature, public visitable
         int mabuff_armor_bonus( const damage_type_id &type ) const;
         // --------------- Mutation Stuff ---------------
         // In newcharacter.cpp
-        /** Returns the id of a random starting trait that costs >= 0 points */
+        /** Returns the id of a random starting chargen trait that costs >= 0 points */
         trait_id random_good_trait();
-        /** Returns the id of a random starting trait that costs < 0 points */
+        /** Returns the id of a random starting chargen trait that costs < 0 points */
         trait_id random_bad_trait();
         /** Returns the id of a random trait matching the given predicate */
         trait_id get_random_trait( const std::function<bool( const mutation_branch & )> &func );

--- a/src/mutation.h
+++ b/src/mutation.h
@@ -197,8 +197,8 @@ struct mutation_branch {
         // Whether it has positive as well as negative effects.
         bool mixed_effect  = false;
         bool startingtrait = false;
-        // By default startingtrait = true traits can be randomly assigned, this allows that to be reversed.
-        bool random_at_chargen = true;
+        // If false, NPCs cannot receive this trait during chargen
+        bool chargen_allow_npc = true;
         bool activated     = false;
         translation activation_msg;
         // Should it activate as soon as it is gained?

--- a/src/mutation_data.cpp
+++ b/src/mutation_data.cpp
@@ -307,7 +307,7 @@ void mutation_branch::load( const JsonObject &jo, std::string_view src )
     optional( jo, was_loaded, "visibility", visibility, 0 );
     optional( jo, was_loaded, "ugliness", ugliness, 0 );
     optional( jo, was_loaded, "starting_trait", startingtrait, false );
-    optional( jo, was_loaded, "random_at_chargen", random_at_chargen, true );
+    optional( jo, was_loaded, "chargen_allow_npc", chargen_allow_npc, true );
     optional( jo, was_loaded, "mixed_effect", mixed_effect, false );
     optional( jo, was_loaded, "active", activated, false );
     optional( jo, was_loaded, "starts_active", starts_active, false );

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -697,7 +697,7 @@ void Character::add_profession_items()
 void Character::randomize_hobbies()
 {
     hobbies.clear();
-    std::vector<profession_id> choices = get_scenario()->permitted_hobbies();
+    std::vector<profession_id> choices = get_scenario()->permitted_hobbies( is_npc() );
     choices.erase( std::remove_if( choices.begin(), choices.end(),
     [this]( const string_id<profession> &hobby ) {
         return !prof->allows_hobby( hobby );

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -460,7 +460,7 @@ void Character::randomize( const bool random_scenario, bool play_now )
     }
 
     const scenario *scenario_from = is_avatar() ? get_scenario() : scenario::generic();
-    prof = scenario_from->weighted_random_profession();
+    prof = scenario_from->weighted_random_profession( is_npc() );
     play_name_suffix = prof->gender_appropriate_name( male );
     zero_all_skills();
 
@@ -476,9 +476,11 @@ void Character::randomize( const bool random_scenario, bool play_now )
 
     set_body();
     randomize_hobbies();
-    const trait_id background = prof->pick_background();
-    if( !background.is_empty() ) {
-        set_mutation( background );
+    if( is_npc() ) {
+        const trait_id background = prof->pick_background();
+        if( !background.is_empty() ) {
+            set_mutation( background );
+        }
     }
 
     int num_gtraits = 0;
@@ -4953,15 +4955,15 @@ void Character::add_traits()
 
 trait_id Character::random_good_trait()
 {
-    return get_random_trait( []( const mutation_branch & mb ) {
-        return mb.points > 0 && mb.random_at_chargen;
+    return get_random_trait( [this]( const mutation_branch & mb ) {
+        return mb.points > 0 && ( mb.chargen_allow_npc || is_avatar() );
     } );
 }
 
 trait_id Character::random_bad_trait()
 {
-    return get_random_trait( []( const mutation_branch & mb ) {
-        return mb.points < 0 && mb.random_at_chargen;
+    return get_random_trait( [this]( const mutation_branch & mb ) {
+        return mb.points < 0 && ( mb.chargen_allow_npc || is_avatar() );
     } );
 }
 

--- a/src/profession.cpp
+++ b/src/profession.cpp
@@ -259,6 +259,7 @@ void profession::load( const JsonObject &jo, std::string_view )
     std::string background_group_id;
     optional( jo, was_loaded, "npc_background", _starting_npc_background,
               Trait_group_BG_survival_story_UNIVERSAL );
+    optional( jo, was_loaded, "chargen_allow_npc", _chargen_allow_npc, true );
     optional( jo, was_loaded, "age_lower", age_lower, 16 );
     optional( jo, was_loaded, "age_upper", age_upper, 55 );
     optional( jo, was_loaded, "starting_cash", _starting_cash );
@@ -750,6 +751,11 @@ bool profession::is_locked_trait( const trait_id &trait ) const
 bool profession::is_forbidden_trait( const trait_id &trait ) const
 {
     return _forbidden_traits.count( trait ) != 0;
+}
+
+bool profession::chargen_allow_npc() const
+{
+    return _chargen_allow_npc;
 }
 
 std::map<spell_id, int> profession::spells() const

--- a/src/profession.h
+++ b/src/profession.h
@@ -69,6 +69,7 @@ class profession
         std::optional<achievement_id> _requirement;
         // does this profession require the requirement even when metaprogression is disabled?
         bool hard_requirement = false;
+        bool _chargen_allow_npc = true;
 
         std::vector<addiction> _starting_addictions;
         std::vector<bionic_id> _starting_CBMs;
@@ -169,6 +170,7 @@ class profession
         ret_val<void> can_pick() const;
         bool is_locked_trait( const trait_id &trait ) const;
         bool is_forbidden_trait( const trait_id &trait ) const;
+        bool chargen_allow_npc() const;
         std::vector<trait_and_var> get_locked_traits() const;
         std::set<trait_id> get_forbidden_traits() const;
         trait_id pick_background() const;

--- a/src/scenario.cpp
+++ b/src/scenario.cpp
@@ -455,7 +455,7 @@ std::vector<string_id<profession>> scenario::permitted_professions( bool is_npc 
     return res;
 }
 
-std::vector<string_id<profession>> scenario::permitted_hobbies() const
+std::vector<string_id<profession>> scenario::permitted_hobbies( bool is_npc ) const
 {
     if( !cached_permitted_hobbies.empty() ) {
         return cached_permitted_hobbies;
@@ -474,6 +474,9 @@ std::vector<string_id<profession>> scenario::permitted_hobbies() const
             continue;
         }
         if( hobbies_whitelist && !hobby_exclusion.empty() && hobby_exclusion.count( hobby ) == 0 ) {
+            continue;
+        }
+        if( is_npc && !hobby->chargen_allow_npc() ) {
             continue;
         }
 

--- a/src/scenario.cpp
+++ b/src/scenario.cpp
@@ -413,7 +413,7 @@ void reset_scenarios_blacklist()
     sc_blacklist.whitelist = false;
 }
 
-std::vector<string_id<profession>> scenario::permitted_professions() const
+std::vector<string_id<profession>> scenario::permitted_professions( bool is_npc ) const
 {
     if( !cached_permitted_professions.empty() ) {
         return cached_permitted_professions;
@@ -422,7 +422,7 @@ std::vector<string_id<profession>> scenario::permitted_professions() const
     const std::vector<profession> &all = profession::get_all();
     std::vector<string_id<profession>> &res = cached_permitted_professions;
     for( const profession &p : all ) {
-        if( p.is_hobby() || p.is_blacklisted() ) {
+        if( p.is_hobby() || p.is_blacklisted() || ( is_npc && !p.chargen_allow_npc() ) ) {
             continue;
         }
         const bool present = std::find( professions.begin(), professions.end(),
@@ -520,11 +520,11 @@ bool scenario::has_hard_requirement() const
     return hard_requirement;
 }
 
-const profession *scenario::weighted_random_profession() const
+const profession *scenario::weighted_random_profession( bool is_npc ) const
 {
     // Strategy: 1/3 of the time, return the generic profession (if it's permitted).
     // Otherwise, the weight of each permitted profession is 2 / ( |point cost| + 2 )
-    const auto choices = permitted_professions();
+    const auto choices = permitted_professions( is_npc );
     if( one_in( 3 ) && choices.front() == profession::generic()->ident() ) {
         return profession::generic();
     }

--- a/src/scenario.h
+++ b/src/scenario.h
@@ -124,7 +124,7 @@ class scenario
 
         const profession *weighted_random_profession( bool is_npc = false ) const;
         std::vector<string_id<profession>> permitted_professions( bool is_npc = false ) const;
-        std::vector<string_id<profession>> permitted_hobbies() const;
+        std::vector<string_id<profession>> permitted_hobbies( bool is_npc = false ) const;
 
         bool traitquery( const trait_id &trait ) const;
         std::set<trait_id> get_locked_traits() const;

--- a/src/scenario.h
+++ b/src/scenario.h
@@ -122,8 +122,8 @@ class scenario
 
         vproto_id vehicle() const;
 
-        const profession *weighted_random_profession() const;
-        std::vector<string_id<profession>> permitted_professions() const;
+        const profession *weighted_random_profession( bool is_npc = false ) const;
+        std::vector<string_id<profession>> permitted_professions( bool is_npc = false ) const;
         std::vector<string_id<profession>> permitted_hobbies() const;
 
         bool traitquery( const trait_id &trait ) const;

--- a/tests/new_character_test.cpp
+++ b/tests/new_character_test.cpp
@@ -233,7 +233,7 @@ TEST_CASE( "Generated_character_with_category_mutations", "[mutation]" )
 TEST_CASE( "cannibal_not_randomly_selected", " [character] [traits] [random]" )
 {
     for( int i = 0; i < 1000; ++i ) {
-        trait_id random_trait = get_avatar().random_good_trait();
+        trait_id random_trait = get_avatar().random_bad_trait();
         REQUIRE( random_trait != trait_CANNIBAL );
     }
 }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "avatar-only traits/professions for chargen"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

- Closes #81674
- Closes #81096

Also, an unreported bug (AFAIK) was that the traits intended to be NPC-blacklisted were also PC-blacklisted.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Three issues:
1) avatar received NPC background trait; I set chargen to only do this for NPCs.
2) for mutation variable `random_at_chargen`, trait selection now takes into account whether the generated character is an NPC. Also renamed the variable to `chargen_allow_npc`, which correctly conveys its purpose: don't include the trait as an option if the generated character is an NPC.
3) added profession variable `chargen_allow_npc`, which has an identical purpose to the above mutation variable, but for professions.

Updated docs to reflect changes.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

PC with NPC-blacklisted trait "Pyromaniac"
<img width="1213" height="403" alt="image" src="https://github.com/user-attachments/assets/705bf8ce-1aaa-4fed-8597-08ad0dda641a" />

To test the profession blacklist, I removed all but two professions: Survivor and Vagabond.

This is with `chargen_allow_npc` = false
<img width="503" height="671" alt="image" src="https://github.com/user-attachments/assets/84fdbd7d-5e3b-4ec9-8b3f-8e05b2999f11" />

and then with `chargen_allow_npc` = true (default)
<img width="519" height="657" alt="image" src="https://github.com/user-attachments/assets/ce9273c8-f5cc-48fc-8747-593f6ce0316b" />

Finally, I generated over a dozen NPCs and didn't see any blacklisted traits. I can't screenshot this, but report misplaced traits if you see them.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

@Standing-Storm you'll need to manually blacklist whichever professions you want disabled for NPCs. Sorry this took so long, I somehow missed it in spite of the ping.

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
