### PR TITLE
Revert highway interchange frequency increase

### DIFF
--- a/data/json/overmap/overmap_special/highway_specials.json
+++ b/data/json/overmap/overmap_special/highway_specials.json
@@ -513,7 +513,7 @@
     ],
     "priority": 2,
     "locations": [ "land", "highway" ],
-    "occurrences": [ 4, 4 ],
+    "occurrences": [ 0, 4 ],
     "flags": [ "CLASSIC" ]
   },
   {

--- a/doc/JSON/OVERMAP.md
+++ b/doc/JSON/OVERMAP.md
@@ -490,6 +490,9 @@ until all sectors are occupied). For specials that are not common enough to warr
 than once per overmap please use the "OVERMAP_UNIQUE" flag. For specials that should only have one instance
 per world use "GLOBALLY_UNIQUE".
 
+NOTE: currently, minimum occurences are NOT enforced in-game but ARE enforced by 
+test case `default_overmap_generation_always_succeeds`.
+
 ### Occurrences ( OVERMAP_UNIQUE, GLOBALLY_UNIQUE )
 
 When the special has the "OVERMAP_UNIQUE" or "GLOBALLY_UNIQUE" flag, instead of defining the minimum and maximum


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

#82100 got lucky with its test CI and now `default_overmap_generation_always_succeeds` is failing. If an overmap special is generated at a count below its minimum occurrences, there aren't errors in-game (which I tested), but there _are_ errors reported in `default_overmap_generation_always_succeeds`.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Set the highway interchange occurrences back to [0,4], add a note in the docs about this behavior.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

There could be a JSON option to have this behavior not throw a test error, but the original highway change was intended as a patch, not a permanent solution.

Also, I'll just actually start working on highway-city interaction.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

To my knowledge, the original occurrences weren't causing `default_overmap_generation_always_succeeds` failures.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
