### PR TITLE
Close revive loophole

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5763,6 +5763,10 @@ bool game::revive_corpse( const tripoint_bub_ms &p, item &it, int radius )
         }
     }
 
+    if( it.get_var( "times_combatted", 0.0 ) > 0.0 ) {
+        critter.times_combatted_player = it.get_var( "times_combatted", 0.0 );
+    }
+
     return place_critter_around( newmon_ptr, tripoint_bub_ms( p ), radius );
 }
 

--- a/src/mondeath.cpp
+++ b/src/mondeath.cpp
@@ -291,5 +291,8 @@ item_location make_mon_corpse( map *here, monster &z, int damageLvl )
     if( !z.has_eaten_enough() ) {
         corpse.set_flag( json_flag_UNDERFED );
     }
+    if( z.times_combatted_player ) {
+        corpse.set_var( "times_combatted", z.times_combatted_player );
+    }
     return here->add_item_or_charges_ret_loc( z.pos_bub( *here ), corpse );
 }


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
When #81921 prevented indefinitely training on a monster it left a loophole where the limit it sets is reset on monster revival.

#### Describe the solution
This closes that loophole by storing the count in the monster corpse item on death then restoring it when the corpses raises.

#### Testing
Spawned a monster, hit it 100x.
Reset melee skills.
Verified that attacking no longer trained melee or dodge.
Killed monster, waited for it to revive.
Verified that attacking no longer trained melee or dodge.

#### Additional context
Code examination indicates that monster evolution shouldn't reset the counter, but I didn't test as it seems like it will take a long time to set up.