### PR TITLE
[Fix 0.I blocker] Riot damage "pre-burnt" doesn't destroy stairs

### DIFF
--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -603,7 +603,10 @@ static void GENERATOR_pre_burn( map &md,
             continue; // failed roll
         }
         for( tripoint_bub_ms current_tile : all_points_in_map ) {
-            if( md.has_flag_ter( ter_furn_flag::TFLAG_NATURAL_UNDERGROUND, current_tile ) ) {
+            if( md.has_flag_ter( ter_furn_flag::TFLAG_NATURAL_UNDERGROUND, current_tile ) ||
+                md.has_flag_ter( ter_furn_flag::TFLAG_GOES_DOWN, current_tile ) ||
+                md.has_flag_ter( ter_furn_flag::TFLAG_GOES_UP, current_tile ) ) {
+                // skip natural underground walls, or any stairs. (Even man-made or wooden stairs)
                 continue;
             }
             if( md.has_flag_ter( ter_furn_flag::TFLAG_WALL, current_tile ) ) {


### PR DESCRIPTION
#### Summary
Bugfixes "Riot damage 'pre-burnt' doesn't destroy stairs"

#### Purpose of change
Fix 0.I blocker

#### Describe the solution
When burning the terrain by transforming it into new terrain, simply skip any stairs.

#### Describe alternatives you've considered
My first inclination was to simply replace any `STAIRS` flagged tile with open air, but that would create weird situations if the first floor was burnt where there could be an inaccessible second floor.

I don't want to make a `burnt stairs` terrain. (It would also need to be duplicated for both going up and going down)

#### Testing
I did not test this but it's a pretty simple change. If it builds it should be good to go.

#### Additional context
