### PR TITLE
Unify NPC weapon evaluation

### DIFF
--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -694,7 +694,7 @@ static float rate_critter( const Creature &c )
     if( np != nullptr ) {
         item_location wielded = np->get_wielded_item();
         if( wielded ) {
-            return np->weapon_value( *wielded );
+            return np->evaluate_weapon( *wielded );
         } else {
             return np->unarmed_value();
         }

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -684,9 +684,7 @@ void npc::check_or_use_weapon_cbm( const bionic_id &cbm_id )
             return;
         }
 
-        const int cbm_ammo = free_power / cbm_weapon.get_gun_energy_drain();
-
-        if( weapon_value( weap, ammo_count ) < weapon_value( cbm_weapon, cbm_ammo ) ) {
+        if( evaluate_weapon( weap ) < evaluate_weapon( cbm_weapon ) ) {
             if( real_weapon.is_null() ) {
                 // Prevent replacing real weapon when migrating saves
                 real_weapon = weap;
@@ -706,7 +704,7 @@ void npc::check_or_use_weapon_cbm( const bionic_id &cbm_id )
 
         const item cbm_weapon = bio.get_weapon();
 
-        if( weapon_value( weap, ammo_count ) < weapon_value( cbm_weapon, 0 ) ) {
+        if( evaluate_weapon( weap ) < evaluate_weapon( cbm_weapon ) ) {
             if( is_armed() ) {
                 stow_item( *weapon );
             }

--- a/src/character.h
+++ b/src/character.h
@@ -1197,6 +1197,7 @@ class Character : public Creature, public visitable
         bool can_attack_high() const override;
 
         /** NPC-related item rating functions */
+        double evaluate_weapon( const item &maybe_weapon ) const;
         double weapon_value( const item &weap, int ammo = 10 ) const; // Evaluates item as a weapon
         double gun_value( const item &weap, int ammo = 10 ) const; // Evaluates item as a gun
         double melee_value( const item &weap ) const; // As above, but only as melee
@@ -1220,6 +1221,8 @@ class Character : public Creature, public visitable
         bool is_dead_state() const override;
 
     private:
+        double evaluate_weapon_internal( const item &maybe_weapon, bool can_use_gun,
+                                         bool use_silent ) const;
         mutable std::optional<bool> cached_dead_state;
     public:
         void set_part_hp_cur( const bodypart_id &id, int set ) override;

--- a/src/character.h
+++ b/src/character.h
@@ -1221,7 +1221,7 @@ class Character : public Creature, public visitable
 
     private:
         double evaluate_weapon_internal( const item &maybe_weapon, bool can_use_gun,
-                                         bool use_silent, const int pretend_ammo = 0 ) const;
+                                         bool use_silent, int pretend_ammo = 0 ) const;
         mutable std::optional<bool> cached_dead_state;
     public:
         void set_part_hp_cur( const bodypart_id &id, int set ) override;

--- a/src/character.h
+++ b/src/character.h
@@ -1197,8 +1197,7 @@ class Character : public Creature, public visitable
         bool can_attack_high() const override;
 
         /** NPC-related item rating functions */
-        double evaluate_weapon( const item &maybe_weapon ) const;
-        double weapon_value( const item &weap, int ammo = 10 ) const; // Evaluates item as a weapon
+        double evaluate_weapon( const item &maybe_weapon, bool pretend_have_ammo = false ) const;
         double gun_value( const item &weap, int ammo = 10 ) const; // Evaluates item as a gun
         double melee_value( const item &weap ) const; // As above, but only as melee
         double unarmed_value() const; // Evaluate yourself!
@@ -1222,7 +1221,7 @@ class Character : public Creature, public visitable
 
     private:
         double evaluate_weapon_internal( const item &maybe_weapon, bool can_use_gun,
-                                         bool use_silent ) const;
+                                         bool use_silent, const int pretend_ammo = 0 ) const;
         mutable std::optional<bool> cached_dead_state;
     public:
         void set_part_hp_cur( const bodypart_id &id, int set ) override;

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -2742,6 +2742,12 @@ double Character::evaluate_weapon( const item &maybe_weapon ) const
 double Character::evaluate_weapon_internal( const item &maybe_weapon, bool can_use_gun,
         bool use_silent ) const
 {
+    if( is_wielding( maybe_weapon ) || ( !get_wielded_item() && maybe_weapon.is_null() ) ) {
+        auto cached_value = cached_info.find( "weapon_value" );
+        if( cached_value != cached_info.end() ) {
+            return cached_value->second;
+        }
+    }
     // Needed because evaluation includes electricity via linked cables.
     const map &here = get_map();
 
@@ -2760,6 +2766,11 @@ double Character::evaluate_weapon_internal( const item &maybe_weapon, bool can_u
                    "%s %s valued at <color_light_cyan>%1.2f as a melee weapon to wield</color>.", disp_name( true ),
                    maybe_weapon.type->get_id().str(), val_melee );
     double val = std::max( val_gun, val_melee );
+
+
+    if( is_wielding( maybe_weapon ) || ( !get_wielded_item() && maybe_weapon.is_null() ) ) {
+        cached_info.emplace( "weapon_value", val );
+    }
     return val;
 }
 

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1621,7 +1621,7 @@ npc_opinion npc::get_opinion_values( const Character &you ) const
         } else {
             npc_values.fear += 6;
         }
-    } else if( you.weapon_value( *weapon ) > 20 ) {
+    } else if( you.evaluate_weapon( *weapon ) > 20 ) {
         npc_values.fear += 2;
     }
 

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1851,7 +1851,7 @@ void npc::decide_needs()
     }
 
     const item &weap = weapon ? *weapon : null_item_reference();
-    needrank[need_weapon] = weapon_value( weap );
+    needrank[need_weapon] = evaluate_weapon( weap );
     needrank[need_food] = 15 - get_hunger();
     needrank[need_drink] = 15 - get_thirst();
     cache_visit_items_with( "is_food", &item::is_food, [&]( const item & it ) {
@@ -2230,8 +2230,8 @@ double npc::value( const item &it, double market_price ) const
     float ret = 1;
     if( it.is_maybe_melee_weapon() || it.is_gun() ) {
         // todo: remove when weapon_value takes an item_location
-        double wield_val = weapon ? weapon_value( *weapon ) : weapon_value( null_item_reference() );
-        double weapon_val = weapon_value( it ) - wield_val;
+        double wield_val = weapon ? evaluate_weapon( *weapon ) : evaluate_weapon( null_item_reference() );
+        double weapon_val = evaluate_weapon( it ) - wield_val;
 
         if( weapon_val > 0 ) {
             ret += weapon_val * 0.0002;

--- a/src/npc.h
+++ b/src/npc.h
@@ -1131,12 +1131,6 @@ class npc : public Character
         int evaluate_sleep_spot( tripoint_bub_ms p );
         // Returns true if did something and we should end turn
         bool scan_new_items();
-        // Returns score for how well this weapon might kill things
-        double evaluate_weapon( const item &maybe_weapon ) const;
-    private:
-        // Returns score for how well this weapon might kill things
-        double evaluate_weapon_internal( const item &maybe_weapon, bool can_use_gun,
-                                         bool use_silent ) const;
     public:
         // Returns best weapon. Can return null (fists)
         item *evaluate_best_weapon() const;

--- a/src/npc.h
+++ b/src/npc.h
@@ -1132,7 +1132,12 @@ class npc : public Character
         // Returns true if did something and we should end turn
         bool scan_new_items();
         // Returns score for how well this weapon might kill things
-        double evaluate_weapon( item &maybe_weapon, bool can_use_gun, bool use_silent ) const;
+        double evaluate_weapon( const item &maybe_weapon ) const;
+    private:
+        // Returns score for how well this weapon might kill things
+        double evaluate_weapon_internal( const item &maybe_weapon, bool can_use_gun,
+                                         bool use_silent ) const;
+    public:
         // Returns best weapon. Can return null (fists)
         item *evaluate_best_weapon() const;
         // Returns true if did wield it

--- a/src/npc.h
+++ b/src/npc.h
@@ -1131,7 +1131,6 @@ class npc : public Character
         int evaluate_sleep_spot( tripoint_bub_ms p );
         // Returns true if did something and we should end turn
         bool scan_new_items();
-    public:
         // Returns best weapon. Can return null (fists)
         item *evaluate_best_weapon() const;
         // Returns true if did wield it

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -4135,9 +4135,6 @@ bool npc::do_player_activity()
 
 item *npc::evaluate_best_weapon() const
 {
-    bool can_use_gun = !is_player_ally() || rules.has_flag( ally_rule::use_guns );
-    bool use_silent = is_player_ally() && rules.has_flag( ally_rule::use_silent );
-
     item_location weapon = get_wielded_item();
     item &weap = weapon ? *weapon : null_item_reference();
 
@@ -4157,7 +4154,7 @@ item *npc::evaluate_best_weapon() const
     }
 
     //Now check through the NPC's inventory for melee weapons, guns, or holstered items
-    visit_items( [this, can_use_gun, use_silent, &weap, &best_value, &best]( item * node, item * ) {
+    visit_items( [this, &weap, &best_value, &best]( item * node, item * ) {
         if( can_wield( *node ).success() ) {
             double weapon_value = 0.0;
             bool using_same_type_bionic_weapon = is_using_bionic_weapon()

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -4133,37 +4133,6 @@ bool npc::do_player_activity()
     return moves != old_moves;
 }
 
-double npc::evaluate_weapon( const item &maybe_weapon ) const
-{
-    const bool can_use_gun = !is_player_ally() || rules.has_flag( ally_rule::use_guns );
-    const bool use_silent = is_player_ally() && rules.has_flag( ally_rule::use_silent );
-    return evaluate_weapon_internal( maybe_weapon, can_use_gun, use_silent );
-}
-
-double npc::evaluate_weapon_internal( const item &maybe_weapon, bool can_use_gun,
-                                      bool use_silent ) const
-{
-    // Needed because evaluation includes electricity via linked cables.
-    const map &here = get_map();
-
-    bool allowed = can_use_gun && maybe_weapon.is_gun() && ( !use_silent || maybe_weapon.is_silent() );
-    // According to unmodified evaluation score, NPCs almost always prioritize wielding guns if they have one.
-    // This is relatively reasonable, as players can issue commands to NPCs when we do not want them to use ranged weapons.
-    // Conversely, we cannot directly issue commands when we want NPCs to prioritize ranged weapons.
-    // Note that the scoring method here is different from the 'weapon_value' used elsewhere.
-    double val_gun = allowed ? gun_value( maybe_weapon, maybe_weapon.shots_remaining( here,
-                                          this ) ) : 0;
-    add_msg_debug( debugmode::DF_NPC_ITEMAI,
-                   "%s %s valued at <color_light_cyan>%1.2f as a ranged weapon to wield</color>.",
-                   disp_name( true ), maybe_weapon.type->get_id().str(), val_gun );
-    double val_melee = melee_value( maybe_weapon );
-    add_msg_debug( debugmode::DF_NPC_ITEMAI,
-                   "%s %s valued at <color_light_cyan>%1.2f as a melee weapon to wield</color>.", disp_name( true ),
-                   maybe_weapon.type->get_id().str(), val_melee );
-    double val = std::max( val_gun, val_melee );
-    return val;
-}
-
 item *npc::evaluate_best_weapon() const
 {
     bool can_use_gun = !is_player_ally() || rules.has_flag( ally_rule::use_guns );

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -512,7 +512,7 @@ float npc::evaluate_character( const Character &candidate, bool my_gun, bool ene
     bool candidate_gun = candidate.get_wielded_item() && candidate.get_wielded_item()->is_gun();
     const item &candidate_weap = candidate.get_wielded_item() ? *candidate.get_wielded_item() :
                                  null_item_reference();
-    double candidate_weap_val = candidate.weapon_value( candidate_weap );
+    double candidate_weap_val = candidate.evaluate_weapon( candidate_weap );
     float candidate_health =  candidate.hp_percentage() / 100.0f;
     float armour = estimate_armour( candidate );
     float speed = std::max( 0.25f, candidate.get_speed() / 100.0f );

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -1317,7 +1317,7 @@ void npc::regen_ai_cache()
     ai_cache.danger = 0.0f;
     ai_cache.total_danger = 0.0f;
     item &weapon = get_wielded_item() ? *get_wielded_item() : null_item_reference();
-    ai_cache.my_weapon_value = weapon_value( weapon );
+    ai_cache.my_weapon_value = evaluate_weapon( weapon );
     ai_cache.dangerous_explosives = find_dangerous_explosives();
     mem_combat.formation_distance = -1;
 
@@ -3897,7 +3897,7 @@ bool npc::wants_take_that( const item &it )
 
     item &weap = get_wielded_item() ? *get_wielded_item() : null_item_reference();
     if( ( ( !whitelisting && value( it ) > min_value ) || item_whitelisted( it ) ) ||
-        weapon_value( it ) > weapon_value( weap ) ) {
+        evaluate_weapon( it ) > evaluate_weapon( weap ) ) {
         good = true;
     }
 

--- a/src/player_difficulty.cpp
+++ b/src/player_difficulty.cpp
@@ -11,7 +11,6 @@
 #include "character_martial_arts.h"
 #include "inventory.h"
 #include "item.h"
-#include "itype.h"
 #include "mutation.h"
 #include "npc_opinion.h"
 #include "options.h"

--- a/src/player_difficulty.cpp
+++ b/src/player_difficulty.cpp
@@ -11,6 +11,7 @@
 #include "character_martial_arts.h"
 #include "inventory.h"
 #include "item.h"
+#include "itype.h"
 #include "mutation.h"
 #include "npc_opinion.h"
 #include "options.h"
@@ -30,6 +31,9 @@ static const damage_type_id damage_bash( "bash" );
 static const itype_id itype_bat( "bat" );
 static const itype_id itype_knife_combat( "knife_combat" );
 static const itype_id itype_machete( "machete" );
+static const itype_id itype_mossberg_500( "mossberg_500" );
+static const itype_id itype_ruger_1022( "ruger_1022" );
+static const itype_id itype_swbodyguard( "swbodyguard" );
 
 static const profession_id profession_unemployed( "unemployed" );
 
@@ -205,14 +209,23 @@ double player_difficulty::calc_dps_value( const Character &u )
     item early_cutting = item( itype_machete );
     item early_bashing = item( itype_bat );
 
-    double baseline = std::max( u.weapon_value( early_piercing ),
-                                u.weapon_value( early_cutting ) );
-    baseline = std::max( baseline, u.weapon_value( early_bashing ) );
+    // and some firearms, based on availability.
+    item most_common_pistol = item( itype_swbodyguard );
+    item most_common_rifle = item( itype_ruger_1022 );
+    item most_common_shotgun = item( itype_mossberg_500 );
+
+    std::vector<item> weapons_to_test = {early_piercing, early_cutting, early_bashing, most_common_pistol, most_common_rifle, most_common_shotgun};
+    double baseline = 0.0;
+
+    for( item &weapon : weapons_to_test ) {
+        const double new_weapon_value = u.evaluate_weapon( weapon, true );
+        baseline = std::max( baseline, new_weapon_value );
+    }
 
     // check any other items the character has on them
     if( u.prof ) {
         for( const item &i : u.prof->items( true, std::vector<trait_id>() ) ) {
-            baseline = std::max( baseline, u.weapon_value( i ) );
+            baseline = std::max( baseline, u.evaluate_weapon( i, true ) );
         }
     }
 

--- a/src/talker_npc.cpp
+++ b/src/talker_npc.cpp
@@ -433,15 +433,13 @@ std::string talker_npc::give_item_to( const bool to_use )
     bool taken = false;
     std::string reason = me_npc->chat_snippets().snip_give_nope.translated();
     const item_location weapon = me_npc->get_wielded_item();
-    int our_ammo = me_npc->ammo_count_for( weapon );
-    int new_ammo = me_npc->ammo_count_for( loc );
-    const double new_weapon_value = me_npc->weapon_value( given, new_ammo );
+    const double new_weapon_value = me_npc->evaluate_weapon( given );
     const item &weap = weapon ? *weapon : null_item_reference();
-    const double cur_weapon_value = me_npc->weapon_value( weap, our_ammo );
-    add_msg_debug( debugmode::DF_TALKER, "NPC evaluates own %s (%d ammo): %0.1f",
-                   weap.typeId().str(), our_ammo, cur_weapon_value );
-    add_msg_debug( debugmode::DF_TALKER, "NPC evaluates your %s (%d ammo): %0.1f",
-                   given.typeId().str(), new_ammo, new_weapon_value );
+    const double cur_weapon_value = me_npc->evaluate_weapon( weap );
+    add_msg_debug( debugmode::DF_TALKER, "NPC evaluates own %s: %0.1f",
+                   weap.typeId().str(), cur_weapon_value );
+    add_msg_debug( debugmode::DF_TALKER, "NPC evaluates your %s: %0.1f",
+                   given.typeId().str(), new_weapon_value );
     if( to_use ) {
         // Eating first, to avoid evaluating bread as a weapon
         const consumption_result consume_res = try_consume( *me_npc, given, reason );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Character::weapon_value() is used in some places but the actually critical place (NPCs evaluating their weapons) it uses npc::evaluate_weapon() instead
<img width="534" height="378" alt="image" src="https://github.com/user-attachments/assets/c5d50fa5-f718-4f9b-83a8-7e3790a518ef" />

Workings towards fixing #81383 but might need another PR. Not sure what can be backported to 0.I at this time.

The only functional places Character::weapon_value() were being used was in opinion-forming and when specifically handing a weapon directly to a NPC to ask them to use it.


#### Describe the solution
Move it all to evaluate_weapon(), which was already load-bearing and what we check in the tests/etc

And then move evaluate_weapon() to the character namespace, so we can use it elsewhere (e.g. when NPCs evaluate **the player**, who is not a NPC)

This also involves updating the offense calculation for new character creation. In addition, I added using the 3 most common firearms available in MA based on the data we have, instead of just melee weapons.

#### Describe alternatives you've considered


#### Testing


#### Additional context

