### PR TITLE
Hardcode placement of highway interchanges

### DIFF
--- a/data/json/overmap/overmap_connections.json
+++ b/data/json/overmap/overmap_connections.json
@@ -8,7 +8,7 @@
       { "terrain": "road", "locations": [ "field" ], "basic_cost": 5 },
       { "terrain": "road", "locations": [ "forest" ], "basic_cost": 20 },
       { "terrain": "road", "locations": [ "swamp" ], "basic_cost": 40 },
-      { "terrain": "road", "locations": [ "highway" ], "basic_cost": 120, "flags": [ "PERPENDICULAR_CROSSING" ] },
+      { "terrain": "road", "locations": [ "highway" ], "basic_cost": 80, "flags": [ "PERPENDICULAR_CROSSING" ] },
       { "terrain": "road_nesw_manhole", "locations": [  ] },
       { "terrain": "bridge", "locations": [ "water" ], "basic_cost": 120, "flags": [ "ORTHOGONAL" ] },
       { "terrain": "bridgehead_ground", "locations": [ "water" ], "basic_cost": 120, "flags": [ "ORTHOGONAL" ] }

--- a/data/json/overmap/overmap_special/highway_specials.json
+++ b/data/json/overmap/overmap_special/highway_specials.json
@@ -508,12 +508,12 @@
       { "point": [ 1, 4, 0 ], "overmap": "hw_three_lane_merge_w_south", "locations": [ "highway" ] }
     ],
     "connections": [
-      { "point": [ -3, 0, 0 ], "terrain": "road", "connection": "highway_road_connection", "from": [ -2, 0, 0 ] },
-      { "point": [ 4, 0, 0 ], "terrain": "road", "connection": "highway_road_connection", "from": [ 3, 0, 0 ] }
+      { "point": [ -3, 0, 0 ], "terrain": "road", "connection": "local_road", "from": [ -2, 0, 0 ] },
+      { "point": [ 4, 0, 0 ], "terrain": "road", "connection": "local_road", "from": [ 3, 0, 0 ] }
     ],
     "priority": 2,
     "locations": [ "land", "highway" ],
-    "occurrences": [ 0, 4 ],
+    "occurrences": [ 0, 0 ],
     "flags": [ "CLASSIC" ]
   },
   {

--- a/data/json/regional_map_settings.json
+++ b/data/json/regional_map_settings.json
@@ -358,6 +358,7 @@
       "three_way_intersections": { "Highway Trumpet Interchange": 1 },
       "fallback_three_way_intersection_special": "Highway Fallback Tee",
       "bends": { "Highway Bend": 1 },
+      "interchanges": { "Highway Diamond Interchange": 1 },
       "fallback_bend_special": "Highway Bend",
       "fallback_supports": "hw_fb_supports",
       "clockwise_slant_special": "Highway Slant Minor Clockwise",

--- a/data/mods/aftershock_exoplanet/region_settings.json
+++ b/data/mods/aftershock_exoplanet/region_settings.json
@@ -154,6 +154,7 @@
       "three_way_intersections": { "Highway Trumpet Interchange": 1 },
       "fallback_three_way_intersection_special": "Highway Fallback Tee",
       "bends": { "Highway Bend": 1 },
+      "interchanges": { "Highway Diamond Interchange": 1 },
       "fallback_bend_special": "Highway Bend",
       "fallback_supports": "hw_fb_supports",
       "clockwise_slant_special": "Highway Slant Minor Clockwise",

--- a/data/mods/desert_region/desert_regional_map_settings.json
+++ b/data/mods/desert_region/desert_regional_map_settings.json
@@ -103,6 +103,7 @@
       "three_way_intersections": { "Highway Trumpet Interchange": 1 },
       "fallback_three_way_intersection_special": "Highway Fallback Tee",
       "bends": { "Highway Bend": 1 },
+      "interchanges": { "Highway Diamond Interchange": 1 },
       "fallback_bend_special": "Highway Bend",
       "fallback_supports": "hw_fb_supports",
       "clockwise_slant_special": "Highway Slant Minor Clockwise",

--- a/src/overmap.h
+++ b/src/overmap.h
@@ -246,6 +246,7 @@ struct intrahighway_node {
     overmap_special_id placed_special = overmap_special_id::NULL_ID();
     bool is_segment = true;
     bool is_ramp = false;
+    bool is_interchange = false;
     //whether to flip ramp direction
     bool ramp_down = false;
     explicit intrahighway_node( tripoint_om_omt pos, om_direction::type dir,
@@ -632,6 +633,10 @@ class overmap
         Highway_path place_highway_reserved_path( const tripoint_om_omt &p1,
                 const tripoint_om_omt &p2,
                 int dir1, int dir2, int base_z );
+        /**
+        * Places some guaranteed interchange specials on the given path if possible
+        */
+        void place_highway_interchanges( std::vector<Highway_path> &highway_path );
         /*
         * tries to find a point to place an intersection special where it isn't on water
         * @return point in radius of center without water; invalid if none found
@@ -707,7 +712,10 @@ class overmap
         void calculate_urbanity();
         void calculate_forestosity();
 
+        // place city centers
         void place_cities();
+        // build cities using placed centers
+        void build_cities();
         void place_building( const tripoint_om_omt &p, om_direction::type dir, const city &town,
                              std::unordered_set<overmap_special_id> &placed_unique_buildings );
 

--- a/src/overmap_highway.cpp
+++ b/src/overmap_highway.cpp
@@ -1112,3 +1112,29 @@ void overmap::place_highway_supported_special( const overmap_special_id &special
         }
     }
 }
+
+void overmap::place_highway_interchanges( std::vector<Highway_path> &highway_path )
+{
+    // slightly higher than it should realistically be for convenience's sake
+    const int HIGHWAY_INTERCHANGE_SPACING = OMAPX / 4;
+    const int HIGHWAY_INTERCHANGE_VARIANCE = HIGHWAY_INTERCHANGE_SPACING / 10;
+    for( Highway_path &path : highway_path ) {
+        int node_count = HIGHWAY_INTERCHANGE_SPACING + rng( -HIGHWAY_INTERCHANGE_VARIANCE,
+                         HIGHWAY_INTERCHANGE_VARIANCE );
+        for( intrahighway_node &node : path ) {
+            if( node.is_segment && node_count == 0 ) {
+                const overmap_special_id interchange = settings->overmap_highway.interchanges.pick();
+                const tripoint_om_omt &node_pos = node.path_node.pos;
+                const om_direction::type node_dir = node.get_effective_dir();
+                if( can_place_special( *interchange, node_pos, node_dir, false ) ) {
+                    place_special( *interchange, node_pos, node_dir, get_nearest_city( node_pos ), false, true );
+                    node.is_interchange = true;
+                    node_count = HIGHWAY_INTERCHANGE_SPACING;
+                }
+            }
+            if( node_count > 0 ) {
+                node_count--;
+            }
+        }
+    }
+}

--- a/src/regional_settings.cpp
+++ b/src/regional_settings.cpp
@@ -537,6 +537,8 @@ static void load_overmap_highway_settings( const JsonObject &jo,
                                     overmap_highway_settings.three_way_intersections );
         load_highway_special_types( "bends", overmap_highway_settings.bends );
         load_highway_special_types( "road_connections", overmap_highway_settings.road_connections );
+        load_highway_special_types( "interchanges",
+                                    overmap_highway_settings.interchanges );
 
         if( overmap_highway_settings.intersection_max_radius >=
             overmap_highway_settings.grid_column_seperation / 2 ||
@@ -1105,6 +1107,7 @@ void overmap_highway_settings::finalize()
         three_way_intersections.finalize();
         bends.finalize();
         road_connections.finalize();
+        interchanges.finalize();
 
         longest_bend_length = find_longest_special( bends );
         longest_slant_length = std::max( clockwise_slant->longest_side(),

--- a/src/regional_settings.h
+++ b/src/regional_settings.h
@@ -284,6 +284,7 @@ struct overmap_highway_settings {
     building_bin four_way_intersections;
     building_bin three_way_intersections;
     building_bin bends;
+    building_bin interchanges;
     building_bin road_connections;
 
     int longest_slant_length = 0;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Features "hardcode placement of highway interchanges, cities can build over highways"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

The alternative to the now-reverted interchange frequency increase in #82100 

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

1. `Highway Diamond Interchange`s are now placed at mostly-regular intervals on highways. As opposed to during `overmap::place_specials()`, so now there are roughly 3-4 interchanges per overmap for a straight segment of highway.
2. Cities can build over highways. Self-explanatory, it was just disabled for the initial highway implementation. All roads currently bridge over the highway.
3. A nice side effect of the above two changes is that small cities should no longer be "eaten" by the highway.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

When using `highway_road_connection`, the two local road ends of `Highway Diamond Interchange` sometimes wouldn't be able to connect to anything because they're a) using city locations (which weren't yet generated) to connect to, and/or b) get stuck in a loop because of greedy pathing being unable to handle the straight line of high-cost highway.

I split up `overmap::place_cities()` into two functions: `place_cities()`, which determines city center points, and `build_cities()`, which builds cities from those points. The generation order looks like this:

```C++
if( get_option<bool>( "OVERMAP_PLACE_HIGHWAYS" ) ) {
    highway_paths = place_highways( neighbor_overmaps );
}
if( get_option<bool>( "OVERMAP_PLACE_CITIES" ) ) {
    place_cities();
}
if( get_option<bool>( "OVERMAP_PLACE_HIGHWAYS" ) ) {
    place_highway_interchanges( highway_paths );
}
if( get_option<bool>( "OVERMAP_PLACE_CITIES" ) ) {
    build_cities();
}
```

This is all to say: most interchanges now have a second redundant road bridge; you can see it in the below screenshots. Connections of fixed overmap specials should be able to target a destination other than a city or fallback point to fix this in the future.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<details>
<summary>Screenshots</summary>

Two connected overmaps with interchanges:
<img width="1091" height="709" alt="image" src="https://github.com/user-attachments/assets/4119707d-b9c1-468d-b696-b269cee6e0dd" />
<img width="1091" height="705" alt="image" src="https://github.com/user-attachments/assets/bdaf5ef2-82a3-42e9-8d4a-9f30771861c0" />

Highways going through cities, with roads bridging over them
<img width="1093" height="705" alt="image" src="https://github.com/user-attachments/assets/fa7e15e3-dc95-410a-90d4-ebc02c05bae3" />
<img width="1093" height="709" alt="image" src="https://github.com/user-attachments/assets/3ff15d9d-8750-47c2-bd3b-6bbb484e50fc" />
<img width="1005" height="703" alt="image" src="https://github.com/user-attachments/assets/17665036-a981-45fe-9f8d-90fc2b42afe8" />
<img width="1089" height="707" alt="image" src="https://github.com/user-attachments/assets/43f0053a-8a0b-49bb-8ffc-1c6b1e78b58f" />

</details>

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

CI checks still needed

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
