### PR TITLE
[0.I] Update char creation offense calculations for 0.I

### DIFF
--- a/src/player_difficulty.cpp
+++ b/src/player_difficulty.cpp
@@ -205,14 +205,14 @@ double player_difficulty::calc_dps_value( const Character &u )
     item early_cutting = item( itype_machete );
     item early_bashing = item( itype_bat );
 
-    double baseline = std::max( u.weapon_value( early_piercing ),
-                                u.weapon_value( early_cutting ) );
-    baseline = std::max( baseline, u.weapon_value( early_bashing ) );
+    double baseline = std::max( u.weapon_value( early_piercing, true ),
+                                u.weapon_value( early_cutting, true ) );
+    baseline = std::max( baseline, u.weapon_value( early_bashing, true ) );
 
     // check any other items the character has on them
     if( u.prof ) {
         for( const item &i : u.prof->items( true, std::vector<trait_id>() ) ) {
-            baseline = std::max( baseline, u.weapon_value( i ) );
+            baseline = std::max( baseline, u.weapon_value( i, true ) );
         }
     }
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
* Fix #81383

#### Describe the solution
Add some guns to the calculation.

-Add an optional bool argument to Character::weapon_value()
-If that bool is true, instead of dividing gun value by 5 and **squaring** melee value, just divide gun value by like... 2, instead.
-Otherwise it works exactly the same as before.
-Only use this bool inside of character creation to avoid ANY possibility of changes outside character creation

#### Describe alternatives you've considered


#### Testing
Opened as draft so I can more easily pull this as a branch

#### Additional context

