### PR TITLE
[0.I] Update char creation offense calculations for 0.I

### DIFF
--- a/src/character.h
+++ b/src/character.h
@@ -1197,7 +1197,8 @@ class Character : public Creature, public visitable
         bool can_attack_high() const override;
 
         /** NPC-related item rating functions */
-        double weapon_value( const item &weap, int ammo = 10 ) const; // Evaluates item as a weapon
+        double weapon_value( const item &weap, int ammo = 10,
+                             bool char_creation = false ) const; // Evaluates item as a weapon
         double gun_value( const item &weap, int ammo = 10 ) const; // Evaluates item as a gun
         double melee_value( const item &weap ) const; // As above, but only as melee
         double unarmed_value() const; // Evaluate yourself!

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -2711,7 +2711,7 @@ int Character::attack_speed( const item &weap ) const
     return std::round( move_cost );
 }
 
-double Character::weapon_value( const item &weap, int ammo ) const
+double Character::weapon_value( const item &weap, int ammo, bool char_creation ) const
 {
     if( is_wielding( weap ) || ( !get_wielded_item() && weap.is_null() ) ) {
         auto cached_value = cached_info.find( "weapon_value" );
@@ -2720,8 +2720,9 @@ double Character::weapon_value( const item &weap, int ammo ) const
         }
     }
     double val_gun = gun_value( weap, ammo );
+    const double gun_divisor = char_creation ? 2.0 : 5.0;
     val_gun = val_gun /
-              5.0f; // This is an emergency patch to get melee and ranged in approximate parity, if you're looking at it in 2025 or later and it's still here... I'm sorry.  Kill it with fire.  Tear it all down, and rebuild a glorious castle from the ashes.
+              gun_divisor; // This is an emergency patch to get melee and ranged in approximate parity, if you're looking at it in 2025 or later and it's still here... I'm sorry.  Kill it with fire.  Tear it all down, and rebuild a glorious castle from the ashes.
     add_msg_debug( debugmode::DF_NPC_ITEMAI,
                    "<color_magenta>weapon_value</color>%s %s valued at <color_light_cyan>%1.2f as a ranged weapon</color>.",
                    disp_name( true ), weap.type->get_id().str(), val_gun );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
* Fix #81383

#### Describe the solution
Add some guns to the calculation.

-Add an optional bool argument to Character::weapon_value()
-If that bool is true, instead of dividing gun value by 5 and **squaring** melee value, just divide gun value by like... 2, instead.
-Otherwise it works exactly the same as before.
-Only use this bool inside of character creation to avoid ANY possibility of changes outside character creation

Also changed the threshold for "strong/overpowered" to 20% better rather than 50% better. This still requires something like marksmanship 5/shotguns 3, but it does *something*. And it should properly count guns that the profession starts with.

#### Describe alternatives you've considered


#### Testing
See #82159

#### Additional context

