### PR TITLE
Fix Ship Vehicle Teleport

### DIFF
--- a/src/teleport.cpp
+++ b/src/teleport.cpp
@@ -389,7 +389,7 @@ bool teleport::teleport_vehicle( vehicle &veh, const tripoint_abs_ms &dp )
     tileray facing;
     facing.init( veh.turn_dir );
 
-    veh.precalc_mounts( 1, veh.skidding ? veh.turn_dir : facing.dir(), point_rel_ms( 0, 0 ) );
+    veh.precalc_mounts( 1, veh.skidding ? veh.turn_dir : facing.dir(), veh.pivot_anchor[0] );
 
     Character &player_character = get_player_character();
     tripoint_bub_ms src = veh.pos_bub( here );


### PR DESCRIPTION
#### Summary
Bugfixes "Vehicles no longer move around when you use the Aftershock Spaceship"

#### Purpose of change
Fix #82134

#### Describe the solution
Teleports vehicles around `anchor_point[0]` which if I understand corrrectly is always the last pivot point used by the vehicle to move, instead of submap point 0,0


#### Testing
Used the save and it seemed to fix the issue.

Spawned more new vehicles inside the ship and they also teleported without issue.

Fixed??
