### PR TITLE
Abort 'fired' reach attack if there are no valid targets

### DIFF
--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -2748,6 +2748,12 @@ target_handler::trajectory target_ui::run()
     src = you->pos_bub();
     update_target_list();
 
+    if( mode == TargetMode::Reach && targets.empty() ) {
+        add_msg( m_info, _( "No hostile creature in reach." ) );
+        traj.clear();
+        return traj; // nothing to attack.
+    }
+
     if( activity && activity->abort_if_no_targets && targets.empty() ) {
         // this branch is taken when already shot once and re-entered
         // aiming, if no targets are available we want to abort so


### PR DESCRIPTION
#### Summary
Bugfixes "Abort 'fired' reach attack if there are no valid targets"

#### Purpose of change
* Fixes #80258

#### Describe the solution
Actually check if we have valid targets.

#### Describe alternatives you've considered
Putting the failure message into target_ui::run() is kind of nasty, but I looked through the call stack and couldn't find a better place for it.

#### Testing
<img width="2560" height="1400" alt="image" src="https://github.com/user-attachments/assets/f62615bb-25c9-47e3-8a18-d2b7ad09069a" />


#### Additional context

