### PR TITLE
Update NECC/Cody & Jay to use faction relationship setting.

### DIFF
--- a/data/json/npcs/godco/members/NPC_Julian_Ray.json
+++ b/data/json/npcs/godco/members/NPC_Julian_Ray.json
@@ -169,7 +169,7 @@
     "id": "TALK_GODCO_Julian_Join",
     "dynamic_line": "Aight, here are the rules: don't commit sins, don't litter, and try not to die.  Have some mutual respect, capiche?",
     "responses": [
-      { "text": "Got it.", "topic": "TALK_GODCO_Julian_Joinee" },
+      { "text": "Got it.", "topic": "TALK_GODCO_Julian_Joinee", "effect": { "u_set_fac_relation": "share public goods" } },
       { "text": "Actually, <end_talking_leave>", "topic": "TALK_DONE" }
     ]
   },

--- a/data/json/npcs/isolated_road/isolated_road_cody_dialogue.json
+++ b/data/json/npcs/isolated_road/isolated_road_cody_dialogue.json
@@ -81,6 +81,7 @@
         "effect": [
           { "u_sell_item": "FMCNote", "count": 100 },
           { "u_spawn_item": "id_artisan_member" },
+          { "u_set_fac_relation": "share public goods" },
           { "u_add_var": "dialogue_artisans_blacksmith_can_buy_coop", "value": "no" }
         ],
         "topic": "TALK_BLACKSMITH_BOUGHT_COOP"


### PR DESCRIPTION
#### Summary
Bugfixes "Update NECC/Cody & Jay after asking permission to use their stuff"

#### Purpose of change
Cody & Jay don't actually let you use their forge
NECC doesn't actually let you sleep there

#### Describe the solution
They properly set relationship now

#### Describe alternatives you've considered
I thought about making Cody & Jay's permission much narrower (via updating the furniture in question with FREE_TO_EXAMINE), to prevent the player from taking advantage of it. However the extra equipment in the workshop (lathe, etc) cannot be used as furniture and must be set up as appliances. Giving *general* examine permissions allows the player to do that.

The player still *could* set it up and then take the resulting appliance down, but cmon, really? None of those are rare or particularly useful.

The most important thing is the anvil, which requires a deconstruct to steal. (De)construction is still forbidden under the player's expanded permissions.

<img width="2210" height="760" alt="image" src="https://github.com/user-attachments/assets/5bec0288-d854-4081-83ae-64613a968bd1" />


#### Testing


#### Additional context
It turns out there's a funny bug where you can repeatedly ask about becoming a coop member, so for saves that previously bought coop membership you may have to buy it again. But it will work and doesn't require any save migration on our part.