### PR TITLE
replace `ammo_restriction` with `max_item_length` in `22lr_ammo_tray` to prevent negative volume in drop menu.

### DIFF
--- a/data/json/items/containers/ammo_boxes.json
+++ b/data/json/items/containers/ammo_boxes.json
@@ -84,7 +84,16 @@
     "weight": "5 g",
     "volume": "46 ml",
     "material": [ "plastic" ],
-    "pocket_data": [ { "ammo_restriction": { "22": 50 }, "rigid": true } ]
+    "pocket_data": [
+      {
+        "pocket_type": "CONTAINER",
+        "max_item_length": "26 mm",
+        "max_contains_volume": "33 ml",
+        "max_item_volume": "1 ml",
+        "max_contains_weight": "200 g",
+        "rigid": true
+      }
+    ]
   },
   {
     "id": "22lr_ammo_box_100",


### PR DESCRIPTION
#### Summary
Bugfixes "Negative volume in drop menu for ammo trays."

#### Purpose of change
Fixes #80946

#### Describe the solution

AFAIK, this is the only ammo tray in existence.

Replace `ammo_restricted` with `max_item_length = 26 mm`, which is the length of `.22 LR` bullet. Volume set to `33 ml`, which contains exactly 50 bullets. And `max_item_volume: 1 ml`.

You can now put other things in there, which I think is correct. Like dimes and other currency. But not `charcoal`, as it is `5 ml`.

See linked issue.

#### Describe alternatives you've considered

Mark ammo tray as MAGAZINE. - The original approach. You could not reload a gun from a MAGAZINE, as @mqrause pointed out.

#### Testing

1. Loaded the save from the issue.
2. ~The ammo dropped on the ground while loading. (is this ok?)~ No longer happens with the `max_item_length` approach.
3. ~Loaded the ammo into the ammo tray.~
4. `d`rop menu.
5. I can see no negative volumes.
   - <img width="885" height="895" alt="image" src="https://github.com/user-attachments/assets/2157fcad-88d9-47a2-8762-3c197e2f4f12" />

Also tested:
1. Reload a gun.
2. I can see the tray in the reload menu.

 - [x] spawn the item group (`22lr_tray_full`) through the debug menu - it stays full
 - [x] Do spawned ammo trays work? If not, we should probably make a migration.
   - When I lowered the pocket volume, it said it could not spawn the items. Presumably, when I increased the volume and it stopped reporting that it cannot spawn, it is ok.

#### Additional context

~Is this valid? Or do we now like accept the item in a gun? I never worked with magazines.~

I don't get why it needs volume `33 ml`, I would expect `40 ml`, as the item with id `"22"` has 80 charges and 65 ml, so `50/80*65ml = 40.625 ml`.