### PR TITLE
Revert diagonal OMT pathing for land/air vehicles

### DIFF
--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -953,7 +953,7 @@ overmap_path_params overmap_path_params::for_land_vehicle( float offroad_coeff, 
         ret.set_cost( oter_travel_cost_type::water, boat_params.get_cost( oter_travel_cost_type::water ) );
         ret.set_cost( oter_travel_cost_type::shore, boat_params.get_cost( oter_travel_cost_type::shore ) );
     }
-    ret.allow_diagonal = true;
+    ret.allow_diagonal = false;
     return ret;
 }
 
@@ -970,7 +970,7 @@ overmap_path_params overmap_path_params::for_aircraft()
 {
     overmap_path_params ret;
     ret.set_cost( oter_travel_cost_type::air, 8 ); // limited by vehicle autodrive speed
-    ret.allow_diagonal = true;
+    ret.allow_diagonal = false;
     return ret;
 }
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "revert diagonal OMT pathing for land/air vehicles"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

- Fix #82058

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

See title. First, I'll say that the original goal is good; there are many cases where it makes sense to path diagonally in a vehicle with autodrive.

The linked issue was caused (at least, in the short term) by #81945. I started a run, and after about ten minutes, came to the conclusion that diagonal autodrive is not ready to use for land vehicles. It cancels too often to make autodrive worth using.

There needs to first be work done for autodrive to handle diagonal OMTs. In 81945, sparr correctly noted this:

> If you want to diagonal pathfind with vehicles, you'd need to do tile level pathfinding in that situation instead of just omt level pathfinding. And then of course there's the zigzag and autodrive failures to address.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

An example of how autodrive does not handle diagonal OMT checks:
https://github.com/CleverRaven/Cataclysm-DDA/blob/405dbe4e4b569cf29458cfbc17b3e8426434e018/src/vehicle_autodrive.cpp#L650-L651

When you're feeding a diagonal `tripoint_rel_omt` into `to_quad_rotation()`, it gets truncated to x-only. It only works in-game because autodrive handles vehicle orientations, and a diagonal orientation is the most optimal route that also happens to move the vehicle to the correct OMT on the autodrive path.

I attempted to replace `to_quad_rotation()` with `orientation`, but autodrive uses a 1x2 OMT range to check for obstacles, vision, etc. And that leads to another issue that sparr brought up:

> Consider an overmap like so:
> 
> ```
> X.
> .X
> ```
> 
> where `.` is an empty field and `X` is generally impassable terrain. A player, npc, or monster can walk between the two fields. A one-tile-wide vehicle like a bicycle can also cross between them. But any wider vehicle cannot; it will collide with the obstructions in the X tiles.

There has to be more than 1x2 OMTs checked here; probably 2x2, but only in diagonal cases.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

I could not complete this simple route twice with diagonal pathing; both times I ended up going northeast (!?).
Route
<img width="178" height="277" alt="image" src="https://github.com/user-attachments/assets/2194da1e-fa04-4673-952d-47a31d4bb4cd" />
Start
<img width="731" height="489" alt="image" src="https://github.com/user-attachments/assets/4652401f-56dd-40e3-894b-ddeddd570568" />
"Finish"
<img width="627" height="425" alt="image" src="https://github.com/user-attachments/assets/14818efe-d20f-4621-8d7b-c93e1eb34fe5" />

Without diagonal pathing, the above route worked first try, to and from.

I verified that air diagonal autodrive also had weird turning that made it take 10 in-game seconds longer.

Water diagonal autodrive seemed fine, so I kept it.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Tagging @sparr and @ZhilkinSerg

The speed increases to autodrive are probably also causing some autodrive cancellations (and probably the loops it likes to do sometimes), but not nearly as badly as this is.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
