### PR TITLE
Fix min save archive generation for compressed saves.

### DIFF
--- a/src/zzip.cpp
+++ b/src/zzip.cpp
@@ -469,6 +469,10 @@ bool zzip::add_file( std::filesystem::path const &zzip_relative_path, std::strin
 bool zzip::copy_files( std::vector<std::filesystem::path> const &zzip_relative_paths,
                        std::shared_ptr<zzip> const &from )
 {
+    if( zzip_relative_paths.empty() ) {
+        return true;
+    }
+
     zzip_footer other_footer{ from->footer_ };
     JsonObject original_footer = copy_footer();
     original_footer.allow_omitted_members();

--- a/src/zzip_stack.h
+++ b/src/zzip_stack.h
@@ -49,6 +49,12 @@ class zzip_stack
         bool add_file( std::filesystem::path const &zzip_relative_path, std::string_view content );
 
         /**
+         * Directly copies the most recent version of the given files into the destination zzip.
+         */
+        bool copy_files_to( std::vector<std::filesystem::path> const &zzip_relative_paths,
+                            std::shared_ptr<zzip> const &to );
+
+        /**
          * Returns true if the zzip contains the given path. Paths are checked through exact string
          * matches. Normalizing paths, and using generic u8 paths, is recommended.
          */
@@ -59,6 +65,11 @@ class zzip_stack
          * Returns 0 otherwise.
          */
         size_t get_file_size( std::filesystem::path const &zzip_relative_path ) const;
+
+        /**
+         * Returns a vector of filesystem paths of the contained entries.
+         */
+        std::vector<std::filesystem::path> get_entries() const;
 
         /**
          * Extracts the given file and returns it in a fresh std::vector<std::byte>.


### PR DESCRIPTION
Overmap logic needed to handle .zzip extension but otherwise unchanged. Map memory needs to generate a minimized zzip stack which requires iterating the current stack and copying the in-range entries to a new zzip.

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Compressed saves haven't supported minimal archive generation since they were introduced. They did at some point during the implementation, but the scope grew and min archive generation was not tested on the full feature.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Fix min archive support to handle overmaps and map memory. Save files did not need fixing. Overmaps needed to just trim the .zzip extension and otherwise 'just worked'.

Map memory was tricker because the storage format was structurally changed. Instead of individual files per region they are aggregated into a 'zzip stack'. The fix then is to iterate the stacks entries and copy the in-range ones into a new temp zzip which we copy into the minimal archive as the base/'cold' zzip of the stack.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Generate a min archive from an enormous save. The original save has nearly 80mb zzip of map memory. The minimal one has 60kb. Breakpoint debugging validates it is only saving 10 memory files. Load the minimal save and confirm map memory in the immediate area is preserved. 
[Willowick-trimmed.tar.gz](https://github.com/user-attachments/files/21554674/Willowick-trimmed.tar.gz)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
