### PR TITLE
Use optional/mandatory for ascii_art, bionic_data, bodypart

### DIFF
--- a/data/json/bionics.json
+++ b/data/json/bionics.json
@@ -1452,7 +1452,7 @@
     "description": "A small module connected to your brain allows you to interface with nearby devices with wireless capabilities.",
     "occupied_bodyparts": [ [ "head", 2 ] ],
     "flags": [ "BIONIC_TOGGLED" ],
-    "react_cost": 1,
+    "react_cost": "1 kJ",
     "time": "24 s"
   },
   {
@@ -1461,7 +1461,7 @@
     "name": { "str": "Sonic Resonator" },
     "description": "Your entire body may resonate at very high power, creating a short-range shockwave.  While it will not do much damage to creatures, solid objects such as walls and doors will be damaged.",
     "occupied_bodyparts": [ [ "torso", 15 ], [ "head", 1 ], [ "arm_l", 2 ], [ "arm_r", 2 ], [ "leg_l", 4 ], [ "leg_r", 4 ] ],
-    "act_cost": 100
+    "act_cost": "100 kJ"
   },
   {
     "id": "bio_scent_mask",
@@ -1471,8 +1471,8 @@
     "occupied_bodyparts": [ [ "torso", 3 ], [ "head", 1 ], [ "arm_l", 1 ], [ "arm_r", 1 ], [ "leg_l", 1 ], [ "leg_r", 1 ] ],
     "flags": [ "BIONIC_TOGGLED" ],
     "active_flags": [ "NO_SCENT" ],
-    "act_cost": 1,
-    "react_cost": 1,
+    "act_cost": "1 kJ",
+    "react_cost": "1 kJ",
     "time": "1 m"
   },
   {
@@ -1492,7 +1492,6 @@
     "flags": [ "BIONIC_TOGGLED" ],
     "active_flags": [ "STOP_SLEEP_DEPRIVATION" ],
     "occupied_bodyparts": [ [ "head", 1 ], [ "torso", 1 ] ],
-    "act_cost": 0,
     "react_cost": "1 kJ",
     "time": "100 s"
   },
@@ -1511,7 +1510,7 @@
     "name": { "str": "Shockwave Generator" },
     "description": "You generate a powerful shockwave, knocking back all nearby creatures.  Targets are stunned briefly, take damage and additional stun upon impact with impassable terrain, and knockback any creatures they collide with.",
     "occupied_bodyparts": [ [ "torso", 20 ] ],
-    "act_cost": 250
+    "act_cost": "250 kJ"
   },
   {
     "id": "bio_sleepy",
@@ -1648,7 +1647,7 @@
     "name": { "str": "Teleportation Unit" },
     "description": "This highly experimental unit folds space over short distances, instantly transporting your body up to 25 feet at the cost of much power.  Note that prolonged or frequent use may have dangerous side effects.",
     "occupied_bodyparts": [ [ "torso", 16 ], [ "arm_l", 3 ], [ "arm_r", 3 ], [ "leg_l", 4 ], [ "leg_r", 4 ] ],
-    "act_cost": 250
+    "act_cost": "250 kJ"
   },
   {
     "id": "bio_thumbs",
@@ -1677,7 +1676,7 @@
       [ "foot_l", 1 ],
       [ "foot_r", 1 ]
     ],
-    "act_cost": 50
+    "act_cost": "50 kJ"
   },
   {
     "id": "bio_tools",

--- a/src/ascii_art.cpp
+++ b/src/ascii_art.cpp
@@ -2,7 +2,6 @@
 
 #include <string>
 
-#include "assign.h"
 #include "catacharset.h"
 #include "debug.h"
 #include "generic_factory.h"
@@ -34,9 +33,7 @@ void ascii_art::load_ascii_art( const JsonObject &jo, const std::string &src )
 
 void ascii_art::load( const JsonObject &jo, std::string_view )
 {
-    assign( jo, "id", id );
-
-    assign( jo, "picture", picture );
+    mandatory( jo, was_loaded, "picture", picture );
     for( std::string &line : picture ) {
         if( utf8_width( remove_color_tags( line ) ) > ascii_art_width ) {
             line = trim_by_length( line, ascii_art_width );

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -18,7 +18,6 @@
 
 #include "action.h"
 #include "activity_actor_definitions.h"
-#include "assign.h"
 #include "avatar.h"
 #include "avatar_action.h"
 #include "ballistics.h"
@@ -313,12 +312,15 @@ void bionic_data::load( const JsonObject &jsobj, std::string_view src )
     mandatory( jsobj, was_loaded, "description", description );
 
     optional( jsobj, was_loaded, "cant_remove_reason", cant_remove_reason );
-    // uses assign because optional doesn't handle loading units as strings
-    assign( jsobj, "react_cost", power_over_time, false, 0_kJ );
-    assign( jsobj, "capacity", capacity, false );
-    assign( jsobj, "act_cost", power_activate, false, 0_kJ );
-    assign( jsobj, "deact_cost", power_deactivate, false, 0_kJ );
-    assign( jsobj, "trigger_cost", power_trigger, false, 0_kJ );
+    optional( jsobj, was_loaded, "react_cost", power_over_time,
+              units_bound_reader<units::energy>( 0_kJ ), 0_kJ );
+    optional( jsobj, was_loaded, "capacity", capacity, 0_kJ );
+    optional( jsobj, was_loaded, "act_cost", power_activate,
+              units_bound_reader<units::energy>( 0_kJ ), 0_kJ );
+    optional( jsobj, was_loaded, "deact_cost", power_deactivate,
+              units_bound_reader<units::energy>( 0_kJ ), 0_kJ );
+    optional( jsobj, was_loaded, "trigger_cost", power_trigger,
+              units_bound_reader<units::energy>( 0_kJ ), 0_kJ );
 
     optional( jsobj, was_loaded, "time", charge_time, 0_turns );
 


### PR DESCRIPTION
#### Summary
Infrastructure "Use optional/mandatory for ascii art, bionic data, bodypart"

#### Purpose of change
See https://github.com/CleverRaven/Cataclysm-DDA/pull/82165

#### Testing
Compiles, no errors in JSON loading.