### PR TITLE
Use optional/mandatory for mutation, material, mission def, move mode

### DIFF
--- a/src/fire.h
+++ b/src/fire.h
@@ -53,6 +53,8 @@ struct mat_burn_data {
     float smoke = 0.0f;
     /** Volume of material destroyed per tick when this material burns. */
     float burn = 0.0f;
+
+    void deserialize( const JsonObject &jo );
 };
 
 #endif // CATA_SRC_FIRE_H

--- a/src/generic_factory.cpp
+++ b/src/generic_factory.cpp
@@ -1,6 +1,7 @@
 #include "generic_factory.h"
 
 #include "catacharset.h"
+#include "color.h"
 #include "game_constants.h"
 #include "output.h"
 #include "wcwidth.h"
@@ -75,6 +76,14 @@ float read_proportional_entry( const JsonObject &jo, std::string_view key )
         return scalar;
     }
     return 1.0f;
+}
+
+nc_color nc_color_reader::get_next( const JsonValue &jv ) const
+{
+    if( !jv.test_string() ) {
+        jv.throw_error( "invalid format for nc_color" );
+    }
+    return color_from_string( jv.get_string() );
 }
 
 float activity_level_reader::get_next( const JsonValue &jv ) const

--- a/src/generic_factory.h
+++ b/src/generic_factory.h
@@ -1757,6 +1757,13 @@ public:
     }
 };
 
+class nc_color;
+class nc_color_reader : public generic_typed_reader<nc_color_reader>
+{
+    public:
+        nc_color get_next( const JsonValue &jv ) const;
+};
+
 template<typename T>
 static T bound_check( T low, T high, const JsonValue &jv, T read_value )
 {

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -6,7 +6,6 @@
 #include <set>
 #include <unordered_map>
 
-#include "assign.h"
 #include "debug.h"
 #include "flexbuffer_json.h"
 #include "generic_factory.h"
@@ -68,21 +67,20 @@ material_type::material_type() :
     _dmg_adj = { to_translation( "lightly damaged" ), to_translation( "damaged" ), to_translation( "very damaged" ), to_translation( "thoroughly damaged" ) };
 }
 
-static mat_burn_data load_mat_burn_data( const JsonObject &jsobj )
+void mat_burn_data::deserialize( const JsonObject &jo )
 {
-    mat_burn_data bd;
-    assign( jsobj, "immune", bd.immune );
-    assign( jsobj, "volume_per_turn", bd.volume_per_turn );
-    jsobj.read( "fuel", bd.fuel );
-    jsobj.read( "smoke", bd.smoke );
-    jsobj.read( "burn", bd.burn );
-    return bd;
+    optional( jo, false, "immune", immune, false );
+    optional( jo, false, "volume_per_turn", volume_per_turn, 0_ml );
+    optional( jo, false, "fuel", fuel, 0.f );
+    optional( jo, false, "smoke", smoke, 0.f );
+    optional( jo, false, "burn", burn, 0.f );
 }
 
 void material_type::load( const JsonObject &jsobj, std::string_view )
 {
     mandatory( jsobj, was_loaded, "name", _name );
 
+    // FIXME: load resistances by deserialize or reader class
     if( jsobj.has_object( "resist" ) ) {
         _res_was_loaded.clear();
         JsonObject jo = jsobj.get_object( "resist" );
@@ -108,38 +106,26 @@ void material_type::load( const JsonObject &jsobj, std::string_view )
 
     optional( jsobj, was_loaded, "breathability", _breathability, breathability_rating::IMPERMEABLE );
 
-    assign( jsobj, "salvaged_into", _salvaged_into );
+    optional( jsobj, was_loaded, "salvaged_into", _salvaged_into );
     optional( jsobj, was_loaded, "repaired_with", _repaired_with, itype_id::NULL_ID() );
     optional( jsobj, was_loaded, "rotting", _rotting, false );
     optional( jsobj, was_loaded, "soft", _soft, false );
     optional( jsobj, was_loaded, "uncomfortable", _uncomfortable, false );
 
-    for( JsonArray pair : jsobj.get_array( "vitamins" ) ) {
-        _vitamins.emplace( vitamin_id( pair.get_string( 0 ) ), pair.get_float( 1 ) );
-    }
+    optional( jsobj, was_loaded, "vitamins", _vitamins, weighted_string_id_reader<vitamin_id, double> { 1 } );
 
     mandatory( jsobj, was_loaded, "bash_dmg_verb", _bash_dmg_verb );
     mandatory( jsobj, was_loaded, "cut_dmg_verb", _cut_dmg_verb );
 
     mandatory( jsobj, was_loaded, "dmg_adj", _dmg_adj );
 
-    if( jsobj.has_array( "burn_data" ) ) {
-        for( JsonObject brn : jsobj.get_array( "burn_data" ) ) {
-            _burn_data.emplace_back( load_mat_burn_data( brn ) );
-        }
-    }
-    if( _burn_data.empty() ) {
-        // If not specified, supply default
-        mat_burn_data mbd;
-        if( _resistances.type_resist( damage_heat ) <= 0.f ) {
-            mbd.burn = 1;
-        }
-        _burn_data.emplace_back( mbd );
-    }
+    mat_burn_data default_burn_data;
+    default_burn_data.burn = _resistances.type_resist( damage_heat ) <= 0.f;
+    optional( jsobj, was_loaded, "burn_data", _burn_data, { default_burn_data } );
 
     optional( jsobj, was_loaded, "fuel_data", fuel );
 
-    jsobj.read( "burn_products", _burn_products, true );
+    optional( jsobj, was_loaded, "burn_products", _burn_products );
 }
 
 void material_type::finalize_all()

--- a/src/mission.h
+++ b/src/mission.h
@@ -256,7 +256,7 @@ struct mission_type {
 
         bool parse_funcs( const JsonObject &jo, std::string_view src,
                           std::function<void( mission * )> &phase_func );
-        bool load( const JsonObject &jo, const std::string &src );
+        bool load( const JsonObject &jo, std::string_view src );
 
         /**
          * Returns the translated name

--- a/src/move_mode.cpp
+++ b/src/move_mode.cpp
@@ -5,7 +5,6 @@
 #include <string>
 #include <unordered_map>
 
-#include "assign.h"
 #include "debug.h"
 #include "flexbuffer_json.h"
 #include "generic_factory.h"
@@ -53,8 +52,8 @@ void move_mode::load( const JsonObject &jo, std::string_view/*src*/ )
     mandatory( jo, was_loaded, "name",  _name );
 
     mandatory( jo, was_loaded, "panel_char", _panel_letter, unicode_codepoint_from_symbol_reader );
-    assign( jo, "panel_color", _panel_color );
-    assign( jo, "symbol_color", _symbol_color );
+    optional( jo, was_loaded, "panel_color", _panel_color, nc_color_reader{} );
+    optional( jo, was_loaded, "symbol_color", _symbol_color, nc_color_reader{} );
 
     mandatory( jo, was_loaded, "exertion_level", _exertion_level, activity_level_reader{} );
 

--- a/src/mutation_data.cpp
+++ b/src/mutation_data.cpp
@@ -10,7 +10,6 @@
 #include <unordered_map>
 #include <vector>
 
-#include "assign.h"
 #include "color.h"
 #include "condition.h"
 #include "debug.h"
@@ -200,11 +199,11 @@ bool mut_transform::load( const JsonObject &jsobj, std::string_view member )
 {
     JsonObject j = jsobj.get_object( member );
 
-    assign( j, "target", target );
-    assign( j, "msg_transform", msg_transform );
-    assign( j, "active", active );
+    optional( j, false, "target", target );
+    optional( j, false, "msg_transform", msg_transform );
+    optional( j, false, "active", active, false );
     optional( j, false, "safe", safe, false );
-    assign( j, "moves", moves );
+    optional( j, false, "moves", moves, 0 );
 
     return true;
 }


### PR DESCRIPTION
#### Summary
Infrastructure "Use optional/mandatory for mutation, material, mission def, move mode"

#### Purpose of change
See https://github.com/CleverRaven/Cataclysm-DDA/pull/82165

#### Describe the solution
Use `optional`/`mandatory` for loading.

#### Testing
Game data loads successfully with all mod configurations.
