### PR TITLE
Stop smashing stuff with your face

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -3776,6 +3776,10 @@ std::pair<bodypart_id, int> Character::best_part_to_smash() const
         }
     }
 
+    if( !best_part_to_smash.first.obj().main_part.is_empty() ) {
+        best_part_to_smash = {best_part_to_smash.first.obj().main_part, best_part_to_smash.second};
+    }
+
     return best_part_to_smash;
 }
 


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Opened the game, started randomly as hobo, found smashing stuff uses `You use your flippin' face to smash the %s.  EXTREME.`. wtf?
#### Describe the solution
~~make best_part_to_smash() check only main parts, avoiding checking eyes, mouth, toes etc etc~~ the old approach seems to calculate the bashability incorrectly, now we check armor for all bodyparts, and just grab the parent part of picked bp, if such presented 
#### Testing
Now it says i smash with my elbow
#### Additional context
I have suspicion that something else should go into this calculation, i think leg supposed to be the best bodypart to kick stuff, no?