### PR TITLE
Oops - remove remaining mentions of speedydex

### DIFF
--- a/.github/reviewers.yml
+++ b/.github/reviewers.yml
@@ -2,6 +2,9 @@ files:
   'data/mods/Aftershock/**':
     - Maleclypse
     - John-Candlebury
+  'data/mods/aftershock_exoplanet/**':
+    - Maleclypse
+    - John-Candlebury
   'data/mods/Backrooms/**':
     - onura46
   'data/mods/DinoMod/**':
@@ -20,8 +23,6 @@ files:
     - Fris0uman
   'data/mods/ruralbiome/**':
     - I-am-Erk
-  'data/mods/speedydex/**':
-    - KorGgenT
   'data/mods/stats_through_kills/**':
     - KorGgenT
   'data/mods/Xedra_Evolved/**':

--- a/data/core/external_options.json
+++ b/data/core/external_options.json
@@ -176,20 +176,6 @@
   },
   {
     "type": "EXTERNAL_OPTION",
-    "name": "SPEEDYDEX_MIN_DEX",
-    "//": "The minimum dex required for speedydex mod to add speed",
-    "stype": "int",
-    "value": 0
-  },
-  {
-    "type": "EXTERNAL_OPTION",
-    "name": "SPEEDYDEX_DEX_SPEED",
-    "//": "The amount of moves gained per dex above SPEEDYDEX_MIN_DEX",
-    "stype": "int",
-    "value": 0
-  },
-  {
-    "type": "EXTERNAL_OPTION",
     "name": "DISABLE_ROBOT_RESPONSE",
     "//": "Disables robot spawning from alerts and from being wanted.",
     "stype": "bool",


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Missed some stuff in #82143

#### Describe the solution
Clean up the rest.

#### Describe alternatives you've considered
Maybe we could have some sort of custom linting rule that would find any external options without matching calls in the code.

#### Testing
If it builds in CI it should be good to go

#### Additional context
@Maleclypse @John-Candlebury 
I also updated the reviewers rules to point to aftershock_exoplanet.

I left the normal aftershock rule in there since it's still been getting some updates?