### PR TITLE
Resolve errors from loading 0.H options on 0.I

### DIFF
--- a/src/font_loader.cpp
+++ b/src/font_loader.cpp
@@ -122,6 +122,11 @@ static void load_font_from_config( const JsonObject &config, const std::string &
                           key );
             }
         }
+    } else if( key == "gui_typeface" &&
+               !config.has_member( key ) ) { // More legacy migration, remove after 0.I
+        typefaces.emplace_back( "data/font/Roboto-Medium.ttf", ImGuiFreeTypeBuilderFlags_LightHinting );
+        typefaces.emplace_back( "data/font/Terminus.ttf", ImGuiFreeTypeBuilderFlags_Bitmap );
+        typefaces.emplace_back( "data/font/unifont.ttf" ); // default hinting
     } else {
         debugmsg( "Font specifiers must be an array, object, or string." );
     }

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -3975,7 +3975,17 @@ void options_manager::deserialize( const JsonArray &ja )
     for( JsonObject joOptions : ja ) {
         joOptions.allow_omitted_members();
 
+        // yay hardcoded list! remove after 0.J
+        std::vector<std::string> removed_options = { "DISTANCE_INITIAL_VISIBILITY", "FOV_3D_Z_RANGE",
+                                                     "INITIAL_STAT_POINTS", "INITIAL_TRAIT_POINTS", "INITIAL_SKILL_POINTS", "MAX_TRAIT_POINTS",
+                                                     "SKILL_TRAINING_SPEED", "PROFICIENCY_TRAINING_SPEED"
+                                                   };
+
         const std::string name = migrateOptionName( joOptions.get_string( "name" ) );
+
+        if( std::find( removed_options.begin(), removed_options.end(), name ) != removed_options.end() ) {
+            continue; // option was removed so we just don't do anything here.
+        }
         const std::string value = migrateOptionValue( joOptions.get_string( "name" ),
                                   joOptions.get_string( "value" ) );
 


### PR DESCRIPTION
#### Summary
Bugfixes "Resolve errors from loading 0.H options on 0.I"

#### Purpose of change
* Fixes #80679

#### Describe the solution
Skip deserializing options that are no longer in the options menu.

#### Describe alternatives you've considered


#### Testing
[config.zip](https://github.com/user-attachments/files/21566534/config.zip)

Load game with these options. No errors

#### Additional context
There is another error regarding the font loading which appears to be due to an imgui migration. I will look at resolving that before undrafting


Note: "DISTANCE_INITIAL_VISIBILITY" and "FOV_3D_Z_RANGE" were not throwing errors but we did completely remove those so we likely want to skip loading them anyway. Just in case.