### PR TITLE
[0.I] replace repairing item for `steel` material

### DIFF
--- a/data/json/materials.json
+++ b/data/json/materials.json
@@ -2142,7 +2142,7 @@
     "latent_heat": 273,
     "conductive": true,
     "chip_resist": 20,
-    "repaired_with": "lc_steel_chunk",
+    "repaired_with": "welding_rod_steel",
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",

--- a/data/json/materials.json
+++ b/data/json/materials.json
@@ -2142,7 +2142,7 @@
     "latent_heat": 273,
     "conductive": true,
     "chip_resist": 20,
-    "repaired_with": "steel_chunk",
+    "repaired_with": "lc_steel_chunk",
     "dmg_adj": [ "marked", "dented", "smashed", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "scratched",


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
The game shows that you can repair items with generic chunks of steel, but said generic chunks of steel are unobtainable
#### Describe the solution
switch to low carbon steel chunk
#### Describe alternatives you've considered
Not