### PR TITLE
Fix slime terrain being flammable(????)

### DIFF
--- a/data/json/furniture_and_terrain/terrain-traps.json
+++ b/data/json/furniture_and_terrain/terrain-traps.json
@@ -171,6 +171,6 @@
     "symbol": "~",
     "color": "green",
     "move_cost": 6,
-    "flags": [ "TRANSPARENT", "CONTAINER", "FLAMMABLE_ASH", "PLACE_ITEM" ]
+    "flags": [ "TRANSPARENT", "CONTAINER", "PLACE_ITEM" ]
   }
 ]


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
No magic fire

#### Describe the solution
Remove magic fire

Slime terrain does not normally catch or spread fires.

#### Describe alternatives you've considered


#### Testing
Simple flag change.

<img width="1167" height="375" alt="image" src="https://github.com/user-attachments/assets/acd1f46e-4bf5-4485-9705-e7701f654f98" />


#### Additional context
