### PR TITLE
Small JSON loading cleanup to optional/mandatory 

### DIFF
--- a/src/assign.h
+++ b/src/assign.h
@@ -319,6 +319,4 @@ inline bool assign( const JsonObject &jo, const std::string_view name, std::opti
     return assign( jo, name, *val, strict );
 }
 
-constexpr float float_max = std::numeric_limits<float>::max();
-
 #endif // CATA_SRC_ASSIGN_H

--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -16,7 +16,6 @@
 #include <vector>
 
 #include "addiction.h"
-#include "assign.h"
 #include "avatar.h"
 #include "bodypart.h"
 #include "calendar.h"
@@ -766,7 +765,7 @@ float Character::metabolic_rate_base() const
     float hunger_rate = get_option< float >( hunger_rate_string );
     const float final_hunger_rate = enchantment_cache->modify_value( enchant_vals::mod::METABOLISM,
                                     hunger_rate );
-    return std::clamp( final_hunger_rate, 0.0f, float_max );
+    return std::clamp( final_hunger_rate, 0.0f, std::numeric_limits<float>::max() );
 }
 
 // TODO: Make this less chaotic to let NPC retroactive catch up work here

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -894,6 +894,38 @@ void map::generate( const tripoint_abs_omt &p, const time_point &when, bool save
     set_abs_sub( p_sm_base );
 }
 
+class spawn_data_ammo_reader : public generic_typed_reader<spawn_data_ammo_reader>
+{
+    public:
+        std::pair<itype_id, jmapgen_int> get_next( const JsonValue &jv ) const {
+            if( !jv.test_object() ) {
+                jv.throw_error( "Invalid format" );
+            }
+            JsonObject jo = jv.get_object();
+            return std::pair<itype_id, jmapgen_int> { jo.get_string( "ammo_id" ), jmapgen_int( jo, "qty" ) };
+        }
+};
+
+class spawn_data_patrol_reader : public generic_typed_reader<spawn_data_patrol_reader>
+{
+    public:
+        point_rel_ms get_next( const JsonValue &jv ) const {
+            if( !jv.test_object() ) {
+                jv.throw_error( "Invalid format" );
+            }
+            JsonObject jo = jv.get_object();
+            jmapgen_int ptx( jo, "x" );
+            jmapgen_int pty( jo, "y" );
+            return point_rel_ms( ptx.get(), pty.get() );
+        }
+};
+
+void spawn_data::deserialize( const JsonObject &jo )
+{
+    optional( jo, false, "ammo", ammo, spawn_data_ammo_reader{} );
+    optional( jo, false, "patrol", patrol_points_rel_ms, spawn_data_patrol_reader{} );
+}
+
 void map::delete_unmerged_submaps()
 {
     tripoint_abs_sm sm_base = get_abs_sub();
@@ -3054,26 +3086,7 @@ class jmapgen_monster : public jmapgen_piece
                 debugmsg( "Invalid random name '%s'", random_name_str );
             }
 
-            if( jsi.has_object( "spawn_data" ) ) {
-                const JsonObject &sd = jsi.get_object( "spawn_data" );
-                if( sd.has_array( "ammo" ) ) {
-                    const JsonArray &ammos = sd.get_array( "ammo" );
-                    for( const JsonObject adata : ammos ) {
-                        data.ammo.emplace( itype_id( adata.get_string( "ammo_id" ) ),
-                                           jmapgen_int( adata, "qty" ) );
-                    }
-                }
-                if( sd.has_array( "patrol" ) ) {
-                    const JsonArray &patrol_pts = sd.get_array( "patrol" );
-                    for( const JsonObject p_pt : patrol_pts ) {
-                        jmapgen_int ptx = jmapgen_int( p_pt, "x" );
-                        jmapgen_int pty = jmapgen_int( p_pt, "y" );
-                        //"unnecessary" temporary object created while calling emplace_back [modernize-use-emplace,-warnings-as-errors]
-                        const point_rel_ms work_around = point_rel_ms( ptx.get(), pty.get() );
-                        data.patrol_points_rel_ms.emplace_back( work_around );
-                    }
-                }
-            }
+            optional( jsi, false, "spawn_data", data );
         }
 
         void check( const std::string &oter_name, const mapgen_parameters &parameters,

--- a/src/mapgen_primitives.h
+++ b/src/mapgen_primitives.h
@@ -42,6 +42,8 @@ struct jmapgen_int {
 struct spawn_data {
     std::map<itype_id, jmapgen_int> ammo;
     std::vector<point_rel_ms> patrol_points_rel_ms;
+
+    void deserialize( const JsonObject &jo );
 };
 
 #endif // CATA_SRC_MAPGEN_PRIMITIVES_H

--- a/src/profession_group.cpp
+++ b/src/profession_group.cpp
@@ -1,6 +1,5 @@
 #include "profession_group.h"
 
-#include "assign.h"
 #include "debug.h"
 #include "generic_factory.h"
 
@@ -30,8 +29,7 @@ void profession_group::load_profession_group( const JsonObject &jo, const std::s
 
 void profession_group::load( const JsonObject &jo, std::string_view )
 {
-    assign( jo, "id", id );
-    assign( jo, "professions", profession_list );
+    mandatory( jo, was_loaded, "professions", profession_list );
 
 }
 

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -36,7 +36,6 @@
 #include "activity_actor_definitions.h"
 #include "activity_type.h"
 #include "addiction.h"
-#include "assign.h"
 #include "auto_pickup.h"
 #include "avatar.h"
 #include "basecamp.h"
@@ -1095,8 +1094,8 @@ void Character::load( const JsonObject &data )
     recalc_sight_limits();
     calc_encumbrance();
 
-    assign( data, "power_level", power_level, false, 0_kJ );
-    assign( data, "max_power_level_modifier", max_power_level_modifier, false, units::energy::min() );
+    optional( data, false, "power_level", power_level, 0_kJ );
+    optional( data, false, "max_power_level_modifier", max_power_level_modifier, units::energy::min() );
 
     // Bionic power should not be negative!
     if( power_level < 0_mJ ) {

--- a/src/scent_map.cpp
+++ b/src/scent_map.cpp
@@ -3,7 +3,6 @@
 #include <algorithm>
 #include <cstdlib>
 
-#include "assign.h"
 #include "calendar.h"
 #include "cata_assert.h"
 #include "color.h"
@@ -291,8 +290,7 @@ void scent_type::load_scent_type( const JsonObject &jo, const std::string &src )
 
 void scent_type::load( const JsonObject &jo, std::string_view )
 {
-    assign( jo, "id", id );
-    assign( jo, "receptive_species", receptive_species );
+    mandatory( jo, was_loaded, "receptive_species", receptive_species );
 }
 
 const std::vector<scent_type> &scent_type::get_all()

--- a/src/start_location.cpp
+++ b/src/start_location.cpp
@@ -5,7 +5,6 @@
 #include <functional>
 #include <optional>
 
-#include "assign.h"
 #include "avatar.h"
 #include "bodypart.h"
 #include "calendar.h"
@@ -17,7 +16,6 @@
 #include "creature.h"
 #include "current_map.h"
 #include "debug.h"
-#include "enum_conversions.h"
 #include "enums.h"
 #include "field_type.h"
 #include "flexbuffer_json.h"
@@ -25,6 +23,7 @@
 #include "map.h"
 #include "map_extras.h"
 #include "map_iterator.h"
+#include "map_scale_constants.h"
 #include "mapdata.h"
 #include "mapgen_parameter.h"
 #include "mapgendata.h"
@@ -118,38 +117,27 @@ const std::set<std::string> &start_location::flags() const
     return _flags;
 }
 
-void start_location::load( const JsonObject &jo, const std::string &src )
+void omt_types_parameters::deserialize( const JsonValue &jv )
 {
-    const bool strict = src == "dda";
+    if( jv.test_string() ) {
+        jv.read( omt, true );
+        omt_type = ot_match_type::type;
+        return;
+    }
+    JsonObject jo = jv.get_object();
+    mandatory( jo, false, "om_terrain", omt );
+    optional( jo, false, "om_terrain_match_type", omt_type );
+    optional( jo, false, "parameters", parameters );
+}
 
+void start_location::load( const JsonObject &jo, const std::string_view )
+{
     mandatory( jo, was_loaded, "name", _name );
-    std::string ter;
-    for( const JsonValue entry : jo.get_array( "terrain" ) ) {
-        ot_match_type ter_match_type = ot_match_type::type;
-        std::unordered_map<std::string, std::string> parameter_map;
-        if( entry.test_string() ) {
-            ter = entry.get_string();
-        } else {
-            JsonObject jot = entry.get_object();
-            ter = jot.get_string( "om_terrain" );
-            if( jot.has_string( "om_terrain_match_type" ) ) {
-                ter_match_type = jot.get_enum_value<ot_match_type>( "om_terrain_match_type", ter_match_type );
-            }
-            if( jot.has_object( "parameters" ) ) {
-                jot.read( "parameters", parameter_map );
-            }
-        }
-        _locations.emplace_back( omt_types_parameters{ ter, ter_match_type, parameter_map } );
-    }
-    if( jo.has_array( "city_sizes" ) ) {
-        assign( jo, "city_sizes", constraints_.city_size, strict );
-    }
-    if( jo.has_array( "city_distance" ) ) {
-        assign( jo, "city_distance", constraints_.city_distance, strict );
-    }
-    if( jo.has_array( "allowed_z_levels" ) ) {
-        assign( jo, "allowed_z_levels", constraints_.allowed_z_levels, strict );
-    }
+    optional( jo, was_loaded, "terrain", _locations );
+    optional( jo, was_loaded, "city_sizes", constraints_.city_size, { 0, INT_MAX } );
+    optional( jo, was_loaded, "city_distance", constraints_.city_distance, { 0, INT_MAX } );
+    optional( jo, was_loaded, "allowed_z_levels", constraints_.allowed_z_levels,
+    { -OVERMAP_DEPTH, OVERMAP_HEIGHT} );
     optional( jo, was_loaded, "flags", _flags, auto_flags_reader<> {} );
 }
 

--- a/src/start_location.h
+++ b/src/start_location.h
@@ -2,36 +2,38 @@
 #ifndef CATA_SRC_START_LOCATION_H
 #define CATA_SRC_START_LOCATION_H
 
-#include <climits>
 #include <cstddef>
 #include <set>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <utility>
 #include <vector>
 
 #include "common_types.h"
 #include "coords_fwd.h"
-#include "map_scale_constants.h"
 #include "translation.h"
 #include "type_id.h"
 
 class JsonObject;
+class JsonValue;
 class avatar;
 class tinymap;
 enum class ot_match_type : int;
 struct city;
 
 struct start_location_placement_constraints {
-    numeric_interval<int> city_size{ 0, INT_MAX };
-    numeric_interval<int> city_distance{ 0, INT_MAX };
-    numeric_interval<int> allowed_z_levels{ -OVERMAP_DEPTH, OVERMAP_HEIGHT };
+    numeric_interval<int> city_size;
+    numeric_interval<int> city_distance;
+    numeric_interval<int> allowed_z_levels;
 };
 
 struct omt_types_parameters {
     std::string omt;
     ot_match_type omt_type;
     std::unordered_map<std::string, std::string> parameters;
+
+    void deserialize( const JsonValue &jv );
 };
 
 class start_location
@@ -40,7 +42,7 @@ class start_location
         start_location_id id;
         std::vector<std::pair<start_location_id, mod_id>> src;
         bool was_loaded = false;
-        void load( const JsonObject &jo, const std::string &src );
+        void load( const JsonObject &jo, std::string_view src );
         void finalize();
         void check() const;
 

--- a/src/trap.cpp
+++ b/src/trap.cpp
@@ -4,7 +4,6 @@
 #include <typeinfo>
 #include <vector>
 
-#include "assign.h"
 #include "bodypart.h"
 #include "character.h"
 #include "coordinates.h"
@@ -118,10 +117,7 @@ void trap::load( const JsonObject &jo, std::string_view )
 {
     mandatory( jo, was_loaded, "id", id );
     mandatory( jo, was_loaded, "name", name_ );
-    // TODO: Is there a generic_factory version of this?
-    if( !assign( jo, "color", color ) && !was_loaded ) {
-        jo.throw_error( "Missing mandatory member \"color\"" );
-    }
+    mandatory( jo, was_loaded, "color", color, nc_color_reader{} );
     mandatory( jo, was_loaded, "symbol", sym, one_char_symbol_reader );
     mandatory( jo, was_loaded, "visibility", visibility );
     mandatory( jo, was_loaded, "avoidance", avoidance );
@@ -165,6 +161,7 @@ void trap::load( const JsonObject &jo, std::string_view )
         }
         optional( jo, was_loaded, "spell_data", spell_data );
     }
+    // FIXME: load eoc with generic factory
     if( jo.has_member( "eocs" ) ) {
         if( act.target_type() != trap_function_from_string( "eocs" ).target_type() ) {
             jo.throw_error_at( "eocs", R"(Can't use "eocs" without specifying "action": "eocs")" );
@@ -173,54 +170,43 @@ void trap::load( const JsonObject &jo, std::string_view )
             eocs.push_back( effect_on_conditions::load_inline_eoc( jv, "" ) );
         }
     }
-    assign( jo, "trigger_weight", trigger_weight );
+    optional( jo, was_loaded, "trigger_weight", trigger_weight );
     optional( jo, was_loaded, "sound_threshold", sound_threshold );
-    for( const JsonValue entry : jo.get_array( "drops" ) ) {
-        itype_id item_type;
-        int quantity = 0;
-        int charges = 0;
-        if( entry.test_object() ) {
-            JsonObject jc = entry.get_object();
-            jc.read( "item", item_type, true );
-            quantity = jc.get_int( "quantity", 1 );
-            charges = jc.get_int( "charges", 1 );
-        } else {
-            entry.read( item_type, true );
-            quantity = 1;
-            charges = 1;
-        }
-        if( !item_type.is_empty() && quantity > 0 && charges > 0 ) {
-            components.emplace_back( item_type, quantity, charges );
-        }
+    optional( jo, was_loaded, "drops", components );
+    optional( jo, was_loaded, "vehicle_data", vehicle_data );
+}
+
+void vehicle_handle_trap_data::deserialize( const JsonObject &jo )
+{
+    optional( jo, false, "do_explosion", do_explosion, false );
+    optional( jo, false, "is_falling", is_falling, false );
+    optional( jo, false, "chance", chance, 100 );
+    optional( jo, false, "damage", damage, 0 );
+    optional( jo, false, "shrapnel", shrapnel, 0 );
+    optional( jo, false, "sound_volume", sound_volume, 0 );
+    optional( jo, false, "sound", sound );
+    optional( jo, false, "sound_type", sound_type, "" );
+    optional( jo, false, "sound_variant", sound_variant, "" );
+    optional( jo, false, "spawn_items", spawn_items, named_pair_reader<itype_id, double> { "id", "chance", 1.0 } );
+    optional( jo, false, "set_trap", set_trap, trap_str_id::NULL_ID() );
+    if( set_trap != trap_str_id::NULL_ID() ) {
+        remove_trap = false;
+    } else {
+        optional( jo, false, "remove_trap", remove_trap, false );
     }
-    if( jo.has_object( "vehicle_data" ) ) {
-        JsonObject jv = jo.get_object( "vehicle_data" );
-        vehicle_data.remove_trap = jv.get_bool( "remove_trap", false );
-        vehicle_data.do_explosion = jv.get_bool( "do_explosion", false );
-        vehicle_data.is_falling = jv.get_bool( "is_falling", false );
-        vehicle_data.chance = jv.get_int( "chance", 100 );
-        vehicle_data.damage = jv.get_int( "damage", 0 );
-        vehicle_data.shrapnel = jv.get_int( "shrapnel", 0 );
-        vehicle_data.sound_volume = jv.get_int( "sound_volume", 0 );
-        jv.read( "sound", vehicle_data.sound );
-        vehicle_data.sound_type = jv.get_string( "sound_type", "" );
-        vehicle_data.sound_variant = jv.get_string( "sound_variant", "" );
-        vehicle_data.spawn_items.clear();
-        if( jv.has_array( "spawn_items" ) ) {
-            for( const JsonValue entry : jv.get_array( "spawn_items" ) ) {
-                if( entry.test_object() ) {
-                    JsonObject joitm = entry.get_object();
-                    vehicle_data.spawn_items.emplace_back(
-                        itype_id( joitm.get_string( "id" ) ), joitm.get_float( "chance" ) );
-                } else {
-                    vehicle_data.spawn_items.emplace_back( itype_id( entry.get_string() ), 1.0 );
-                }
-            }
-        }
-        vehicle_data.set_trap = trap_str_id::NULL_ID();
-        if( jv.read( "set_trap", vehicle_data.set_trap ) ) {
-            vehicle_data.remove_trap = false;
-        }
+}
+
+void trap::comp::deserialize( const JsonValue &jv )
+{
+    if( jv.test_object() ) {
+        JsonObject jo = jv.get_object();
+        mandatory( jo, false, "item", item_type );
+        optional( jo, false, "quantity", quantity, 1 );
+        optional( jo, false, "charges", charges, 1 );
+    } else {
+        jv.read( item_type, true );
+        quantity = 1;
+        charges = 1;
     }
 }
 
@@ -404,11 +390,8 @@ bool trap::triggered_by_sound( int vol, int dist ) const
 
 void trap::on_disarmed( map &m, const tripoint_bub_ms &p ) const
 {
-    for( const auto &i : components ) {
-        const itype_id &item_type = std::get<0>( i );
-        const int quantity = std::get<1>( i );
-        const int charges = std::get<2>( i );
-        m.spawn_item( p.xy(), item_type, quantity, charges );
+    for( const trap::comp &i : components ) {
+        m.spawn_item( p.xy(), i.item_type, i.quantity, i.charges );
     }
     for( const tripoint_bub_ms &dest : m.points_in_radius( p, trap_radius ) ) {
         m.remove_trap( dest );
@@ -422,10 +405,9 @@ trap_id tr_null;
 void trap::check_consistency()
 {
     for( const trap &t : trap_factory.get_all() ) {
-        for( const auto &i : t.components ) {
-            const itype_id &item_type = std::get<0>( i );
-            if( !item::type_is_defined( item_type ) ) {
-                debugmsg( "trap %s has unknown item as component %s", t.id.str(), item_type.str() );
+        for( const trap::comp &i : t.components ) {
+            if( !item::type_is_defined( i.item_type ) ) {
+                debugmsg( "trap %s has unknown item as component %s", t.id.str(), i.item_type.str() );
             }
         }
         if( t.sound_threshold.first > t.sound_threshold.second ) {

--- a/src/trap.h
+++ b/src/trap.h
@@ -7,7 +7,6 @@
 #include <optional>
 #include <string>
 #include <string_view>
-#include <tuple>
 #include <utility>
 #include <vector>
 
@@ -22,6 +21,7 @@
 class Character;
 class Creature;
 class JsonObject;
+class JsonValue;
 class item;
 class map;
 
@@ -82,6 +82,8 @@ struct vehicle_handle_trap_data {
     // the double represents the count or chance to spawn.
     std::vector<std::pair<itype_id, double>> spawn_items;
     trap_str_id set_trap = trap_str_id::NULL_ID();
+
+    void deserialize( const JsonObject &jo );
 };
 
 using trap_function = std::function<bool( const tripoint_bub_ms &, Creature *, item * )>;
@@ -157,8 +159,15 @@ struct trap {
          */
         std::pair<int, int> sound_threshold = {0, 0};
         int funnel_radius_mm = 0;
+
+        struct comp {
+            itype_id item_type;
+            int quantity;
+            int charges;
+            void deserialize( const JsonValue &jv );
+        };
         // For disassembly?
-        std::vector<std::tuple<itype_id, int, int>> components;
+        std::vector<comp> components;
     public:
         std::optional<itype_id> trap_item_type;
         // data required for trapfunc::spell()

--- a/src/weather_type.cpp
+++ b/src/weather_type.cpp
@@ -1,6 +1,5 @@
 #include "weather_type.h"
 
-#include "assign.h"
 #include "condition.h"
 #include "debug.h"
 #include "flexbuffer_json.h"
@@ -99,8 +98,8 @@ void weather_type::load( const JsonObject &jo, std::string_view )
     mandatory( jo, was_loaded, "name", name );
     mandatory( jo, was_loaded, "id",  id );
 
-    assign( jo, "color", color );
-    assign( jo, "map_color", map_color );
+    optional( jo, was_loaded, "color", color, nc_color_reader{} );
+    optional( jo, was_loaded, "map_color", map_color, nc_color_reader{} );
 
     mandatory( jo, was_loaded, "sym", symbol, unicode_codepoint_from_symbol_reader );
 
@@ -125,17 +124,17 @@ void weather_type::load( const JsonObject &jo, std::string_view )
     optional( jo, was_loaded, "debug_cause_eoc", debug_cause_eoc );
     optional( jo, was_loaded, "debug_leave_eoc", debug_leave_eoc );
 
-    if( jo.has_member( "weather_animation" ) ) {
-        JsonObject weather_animation_jo = jo.get_object( "weather_animation" );
-        mandatory( weather_animation_jo, was_loaded, "factor", weather_animation.factor );
-        if( !assign( weather_animation_jo, "color", weather_animation.color ) ) {
-            weather_animation_jo.throw_error( "missing mandatory member \"color\"" );
-        }
-        mandatory( weather_animation_jo, was_loaded, "sym", weather_animation.symbol,
-                   unicode_codepoint_from_symbol_reader );
-    }
+    optional( jo, was_loaded, "weather_animation", weather_animation );
     optional( jo, was_loaded, "required_weathers", required_weathers );
+    // FIXME: generic factory reader for condition
     read_condition( jo, "condition", condition, true );
+}
+
+void weather_animation_t::deserialize( const JsonObject &jo )
+{
+    mandatory( jo, false, "factor", factor );
+    mandatory( jo, false, "color", color, nc_color_reader{} );
+    mandatory( jo, false, "sym", symbol, unicode_codepoint_from_symbol_reader );
 }
 
 void weather_types::reset()

--- a/src/weather_type.h
+++ b/src/weather_type.h
@@ -68,6 +68,8 @@ struct weather_animation_t {
     std::string get_symbol() const {
         return utf32_to_utf8( symbol );
     }
+
+    void deserialize( const JsonObject &jo );
 };
 
 struct weather_type {


### PR DESCRIPTION
#### Summary
Infrastructure "Use optional/mandatory for weather type, trap, start location, scent map, profession group, and various json loading cleanup"

#### Purpose of change
See https://github.com/CleverRaven/Cataclysm-DDA/pull/82165

Small changes across many locations.

#### Describe the solution
Use `optional`/`mandatory` for loading, clean up loading code by using `deserialize` functions, inline pointless float_max definition.

#### Testing
Game data successfully loads with all mod combinations.