### PR TITLE
Deduplicate weight penalty calculations

### DIFF
--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -1015,14 +1015,12 @@ void avatar::reset_stats()
     // Starvation
     const float bmi = get_bmi_fat();
     if( bmi < character_weight_category::normal ) {
-        const int str_penalty = std::floor( ( 1.0f - ( get_bmi_fat() /
-                                              character_weight_category::normal ) ) * str_max );
-        const int dexint_penalty = std::floor( ( character_weight_category::normal - bmi ) * 3.0f );
+        const stat_mod wpen = get_weight_penalty();
         add_miss_reason( _( "You're weak from hunger." ),
                          static_cast<unsigned>( ( get_starvation() + 300 ) / 1000 ) );
-        mod_str_bonus( -1 * str_penalty );
-        mod_dex_bonus( -1 * dexint_penalty );
-        mod_int_bonus( -1 * dexint_penalty );
+        mod_str_bonus( -wpen.strength );
+        mod_dex_bonus( -wpen.dexterity );
+        mod_int_bonus( -wpen.intelligence );
     }
     // Thirst
     if( get_thirst() >= 200 ) {

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -6343,9 +6343,8 @@ float Character::get_bmi_lean() const
 {
     //strength BMIs decrease to zero as you starve (muscle atrophy)
     if( get_bmi_fat() < character_weight_category::normal ) {
-        const int str_penalty = std::floor( ( 1.0f - ( get_bmi_fat() /
-                                              character_weight_category::normal ) ) * str_max );
-        return 12.0f + get_str_base() - str_penalty;
+        const stat_mod wpen = get_weight_penalty();
+        return 12.0f + get_str_base() - wpen.strength;
     }
     return 12.0f + get_str_base();
 }
@@ -12587,6 +12586,17 @@ void Character::set_underwater( bool u )
         recalc_sight_limits();
     }
 }
+
+stat_mod Character::get_weight_penalty() const
+{
+    stat_mod ret;
+    const float bmi = get_bmi_fat();
+    ret.strength = std::floor( ( 1.0f - ( bmi / character_weight_category::normal ) ) * str_max );
+    ret.dexterity = std::floor( ( character_weight_category::normal - bmi ) * 3.0f );
+    ret.intelligence = ret.dexterity;
+    return ret;
+}
+
 
 stat_mod Character::get_pain_penalty() const
 {

--- a/src/character.h
+++ b/src/character.h
@@ -413,6 +413,7 @@ struct consumption_event {
     void deserialize( const JsonObject &jo );
 };
 
+//* Modifiers to stats and speed. Positive/negative values are contextual; expected penalties are stored as positive values */
 struct stat_mod {
     int strength = 0;
     int dexterity = 0;
@@ -921,7 +922,9 @@ class Character : public Creature, public visitable
         bool has_mind() const override;
         /** Returns the penalty to speed from thirst */
         static int thirst_speed_penalty( int thirst );
-        /** Returns the effect of pain on stats */
+        /** Returns the effect of weight on stats, with positive penalties representing negative bonuses */
+        stat_mod get_weight_penalty() const;
+        /** Returns the effect of pain on stats, with positive penalties representing negative bonuses */
         stat_mod get_pain_penalty() const;
         stat_mod read_pain_penalty() const;
         /** returns players strength adjusted by any traits that affect strength during lifting jobs */

--- a/src/player_display.cpp
+++ b/src/player_display.cpp
@@ -1566,15 +1566,13 @@ void Character::disp_info( bool customize_character )
         }
 
         if( bmi < character_weight_category::normal ) {
-            const int str_penalty = std::floor( ( 1.0f - ( get_bmi_fat() /
-                                                  character_weight_category::normal ) ) * str_max );
-            const int dexint_penalty = std::floor( ( character_weight_category::normal - bmi ) * 3.0f );
+            const stat_mod wpen = get_weight_penalty();
             starvation_text += std::string( _( "Strength" ) ) + " -" + string_format( "%d\n",
-                               str_penalty );
+                               wpen.strength );
             starvation_text += std::string( _( "Dexterity" ) ) + " -" + string_format( "%d\n",
-                               dexint_penalty );
+                               wpen.dexterity );
             starvation_text += std::string( _( "Intelligence" ) ) + " -" + string_format( "%d",
-                               dexint_penalty );
+                               wpen.intelligence );
         }
 
         effect_name_and_text.emplace_back( starvation_name, starvation_text );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
Stat penalties due to character weight/obesity are currently duplicated in ~3 places.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
Move them out to a Character method partially patterned on the pain penalty calculations.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
Fully replicating the pain penalty implementation would involve [almost] only recalculating the values in `avatar::reset_stats` and then using a different method to fetch them. I didn't do this because the weight penalty calculation is much less complex/expensive than the pain penalty calculation.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->
An obese character appears to still be penalized, but I didn't check every level of obesity.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
I also added comments around the pain penalty method and the definition of `stat_mod` to describe the usage pattern where positive penalty values mean negative bonuses.

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
