### PR TITLE
Deduplicate armor power usage code. Also tell player when UPS items run out of charge.

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -13099,6 +13099,7 @@ void Character::process_items( map *here )
                 continue;
             } else if( it->active && !it->ammo_sufficient( this ) ) {
                 it->deactivate();
+                add_msg_if_player( _( "Your %s shut down due to lack of power." ), it->tname() );
             } else if( available_charges - ups_used >= 1_kJ &&
                        it->ammo_remaining_linked( *here, nullptr ) < it->ammo_capacity( ammo_battery ) ) {
                 // Charge the battery in the UPS modded tool

--- a/src/character.h
+++ b/src/character.h
@@ -1306,6 +1306,8 @@ class Character : public Creature, public visitable
         float melee_weakpoint_skill( const item &weapon ) const;
         float ranged_weakpoint_skill( const item &weapon ) const;
         float throw_weakpoint_skill() const;
+        /** Consumes power from power armor or deactivates without enough power */
+        void armor_use_power_when_hit( damage_unit &du, item &armor ) const;
         /**
          * Reduces and mutates du, prints messages about armor taking damage.
          * Requires a roll out of 100

--- a/src/character_armor.cpp
+++ b/src/character_armor.cpp
@@ -210,6 +210,18 @@ const weakpoint *Character::absorb_hit( const weakpoint_attack &, const bodypart
     return nullptr;
 }
 
+void Character::armor_use_power_when_hit( damage_unit &du, item &armor ) const
+{
+    const auto amount = units::from_kilojoule( du.amount );
+    if( amount > armor.energy_remaining( nullptr, true ) ) {
+        armor.deactivate( nullptr, false );
+        add_msg_if_player( _( "Your %s doesn't have enough power to absorb the blow and shuts down!" ),
+                           armor.tname() );
+    } else {
+        armor.energy_consume( amount, pos_bub(), nullptr );
+    }
+}
+
 bool Character::armor_absorb( damage_unit &du, item &armor, const bodypart_id &bp,
                               const sub_bodypart_id &sbp, int roll ) const
 {
@@ -219,17 +231,11 @@ bool Character::armor_absorb( damage_unit &du, item &armor, const bodypart_id &b
     if( roll > armor.get_coverage( sbp, ctype ) ) {
         return false;
     }
-    // if this armor has the flag, try to deduct that much energy from it. If that takes it to 0 energy, turn it off before it absorbs damage.
-    if( armor.has_flag( flag_USE_POWER_WHEN_HIT ) &&
-        units::from_kilojoule( du.amount ) > armor.energy_remaining( nullptr, true ) ) {
-        armor.deactivate( nullptr, false );
-        add_msg_if_player( _( "Your %s doesn't have enough power to absorb the blow and shuts down!" ),
-                           armor.tname() );
-    } else if( armor.has_flag( flag_USE_POWER_WHEN_HIT ) &&
-               units::from_kilojoule( du.amount ) < armor.energy_remaining( nullptr, true ) ) {
-        armor.energy_consume( units::from_kilojoule( du.amount ),
-                              pos_bub(), nullptr );
+
+    if( armor.has_flag( flag_USE_POWER_WHEN_HIT ) ) {
+        armor_use_power_when_hit( du, armor );
     }
+
     // We copy the damage unit here since it will be mutated by mitigate_damage()
     damage_unit pre_mitigation = du;
 
@@ -257,17 +263,11 @@ bool Character::armor_absorb( damage_unit &du, item &armor, const bodypart_id &b
     if( roll > armor.get_coverage( bp, ctype ) ) {
         return false;
     }
-    // if this armor has the flag, try to deduct that much energy from it. If that takes it to 0 energy, turn it off before it absorbs damage.
-    if( armor.has_flag( flag_USE_POWER_WHEN_HIT ) &&
-        units::from_kilojoule( du.amount ) > armor.energy_remaining( nullptr, true ) ) {
-        armor.deactivate( nullptr, false );
-        add_msg_if_player( _( "Your %s doesn't have enough power to absorb the blow and shuts down!" ),
-                           armor.tname() );
-    } else if( armor.has_flag( flag_USE_POWER_WHEN_HIT ) &&
-               units::from_kilojoule( du.amount ) < armor.energy_remaining( nullptr, true ) ) {
-        armor.energy_consume( units::from_kilojoule( du.amount ),
-                              pos_bub(), nullptr );
+
+    if( armor.has_flag( flag_USE_POWER_WHEN_HIT ) ) {
+        armor_use_power_when_hit( du, armor );
     }
+
     // We copy the damage unit here since it will be mutated by mitigate_damage()
     damage_unit pre_mitigation = du;
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Interface "Message to player when UPS equipment runs out of power."

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
The code to deduct power from power armor when hit, or shut it down if there's not enough power, was duplicated in two places. Also there was no notification when power armor (or other UPS items) otherwise shut off due to lack of power.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
Move the power consumption and conditional shutdown to a function. Add a message for the other shutdown case.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
`if( armor.has_flag( flag_USE_POWER_WHEN_HIT ) )` could go in the function and it get called unconditionally, but that seemed less legible.

The new function could be a method on `item`, likely with `Character` as a parameter for message purposes. This didn't occur to me until after I had finished the current implementation.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->
Spawned power armor (and de/re-activated it to fix broken `active` flag) then engaged with an enemy to observe the different outcomes. Also let some other UPS items run out of power on their own to see the new message.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
