### PR TITLE
Fix CTRL+U not clearing text

### DIFF
--- a/src/input_popup.cpp
+++ b/src/input_popup.cpp
@@ -175,7 +175,26 @@ static int input_callback( ImGuiInputTextCallbackData *data )
         }
     }
 
+    if( data->EventFlag = ImGuiInputTextFlags_CallbackAlways && popup->want_clear_text() ) {
+        // Only called when popup->text is empty
+        data->BufTextLen = 0;
+        data->SelectionStart = 0;
+        data->SelectionEnd = 0;
+        data->CursorPos = 0;
+        data->Buf[0] = '\000';
+        data->BufDirty = true;
+    }
+
     return 0;
+}
+
+bool string_input_popup_imgui::want_clear_text()
+{
+    if( do_clear_text ) {
+        do_clear_text = false;
+        return true;
+    }
+    return false;
 }
 
 void string_input_popup_imgui::draw_input_control()
@@ -184,6 +203,10 @@ void string_input_popup_imgui::draw_input_control()
 
     if( !is_uilist_history ) {
         flags |= ImGuiInputTextFlags_CallbackHistory;
+    }
+
+    if( do_clear_text ) {
+        flags |= ImGuiInputTextFlags_CallbackAlways;
     }
 
     // shrink width of input field if we only allow short inputs
@@ -328,7 +351,7 @@ std::string string_input_popup_imgui::query()
             // non-uilist history is handled inside input callback
             show_history();
         } else if( action == "TEXT.CLEAR" ) {
-            text.clear();
+            do_clear_text = true;
         }
 
         // mouse click on x to close leads here

--- a/src/input_popup.cpp
+++ b/src/input_popup.cpp
@@ -175,7 +175,7 @@ static int input_callback( ImGuiInputTextCallbackData *data )
         }
     }
 
-    if( data->EventFlag = ImGuiInputTextFlags_CallbackAlways && popup->want_clear_text() ) {
+    if( data->EventFlag == ImGuiInputTextFlags_CallbackAlways && popup->want_clear_text() ) {
         // Only called when popup->text is empty
         data->BufTextLen = 0;
         data->SelectionStart = 0;

--- a/src/input_popup.h
+++ b/src/input_popup.h
@@ -90,6 +90,7 @@ class string_input_popup_imgui : public input_popup
         void set_text( const std::string &txt );
         void use_uilist_history( bool use_uilist );
         void update_input_history( ImGuiInputTextCallbackData *data );
+        bool want_clear_text();
     protected:
         void draw_input_control() override;
     private:
@@ -103,6 +104,7 @@ class string_input_popup_imgui : public input_popup
         bool is_uilist_history = true;
         uint64_t max_history_size = 100;
         int history_index = 0;
+        bool do_clear_text = false;
 };
 
 // todo: make generic for any numeric type?


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Fix CTRL+U not clearing text"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Clear the text in the input text ImGui by pressing CTRL+U.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Contrivert use of CallbackAlways to allow a callback to access once and clear the ImGui internal text buffer.
The problem in the old code is ImGui was setting `text` back even when cleared because the internal state of the input text box was kept during redraw.
This fix now "flips" the issue by not clearing `text` but instead change the internal state through a forced callback.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
As described in the last comments of #77863.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Windows MSVC SDL, Windows MSVC curses.
V menu F, overmap search.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
