### PR TITLE
Restore butchery with negative quality

### DIFF
--- a/src/butchery.cpp
+++ b/src/butchery.cpp
@@ -236,7 +236,7 @@ bool set_up_butchery( player_activity &act, Character &you, butchery_data bd )
     const mtype &corpse = *corpse_item.get_mtype();
 
     if( bd.b_type != butcher_type::DISSECT ) {
-        if( factor == 0 ) {
+        if( factor == INT_MIN ) {
             you.add_msg_if_player( m_info,
                                    _( "None of your cutting tools are suitable for butchering." ) );
             act.set_to_null();


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Fix #81423
#### Describe the solution
Switch the check back to `factor == INT_MIN`
#### Additional context
I'm yet to find examples where it works, but i trust Light-Wave has some
also see https://github.com/CleverRaven/Cataclysm-DDA/issues/81423#issuecomment-3153294096