### PR TITLE
Silence (but do not fix) 'tried to set non-permanent morale' test failure

### DIFF
--- a/tests/projectile_test.cpp
+++ b/tests/projectile_test.cpp
@@ -106,6 +106,7 @@ TEST_CASE( "liquid_projectiles_applies_effect", "[projectile_effect]" )
 
     npc &dummy = spawn_npc( next_to.xy(), "mi-go_prisoner" );
     dummy.clear_worn();
+    dummy.clear_mutations();
 
     REQUIRE( dummy.top_items_loc().empty() );
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
https://github.com/CleverRaven/Cataclysm-DDA/issues/81990 is causing CI failures.

#### Describe the solution
Clear the traits to ensure no magiclysm background are applied to the test NPC which result in this failure

#### Describe alternatives you've considered
Fix the bug. I think it may be worth fixing the CI impact separately from the bug, thus this PR. I understand if actually fixing the bug is preferred.

#### Testing
The bug is due in some way to trait interaction, and can be trivially reproduced by creating a world with magiclysm, selecting the golbin background, stripping naked, and letting boomers take shots at you.

`while tests/cata_test --mods=magiclysm 'liquid_projectiles_applies_effect' --rng-seed=time; do touch /dev/null; done` does not fail.

#### Additional context
The debug message occurs when it tries to set the morale with a duration of zero, but I don't see how that is being affected by traits - it goes straight from the EOC to applying the morale with the duration set in the EOC, and I don't see how the duration can be zero.