### PR TITLE
Remove bonus damage of 22 LR

### DIFF
--- a/data/json/items/gun/22.json
+++ b/data/json/items/gun/22.json
@@ -25,7 +25,6 @@
     "material": [ "iron", "wood" ],
     "range": 7,
     "ammo": [ "22" ],
-    "ranged_damage": { "damage_type": "bullet", "amount": 5 },
     "dispersion": 90,
     "clip_size": 19,
     "valid_mod_locations": [
@@ -65,7 +64,6 @@
     "price_postapoc": "5 USD",
     "material": [ "steel", "wood" ],
     "ammo": [ "22" ],
-    "ranged_damage": { "damage_type": "bullet", "amount": 1 },
     "dispersion": 550,
     "durability": 6,
     "blackpowder_tolerance": 60,
@@ -97,12 +95,11 @@
     "weight": "2270 g",
     "volume": "2120 ml",
     "longest_side": "942 mm",
-    "barrel_length": "406 mm",
+    "barrel_length": "470 mm",
     "price": "270 USD",
     "material": [ "steel", "wood" ],
     "range": 6,
     "//range": "It is a blowback action, like most non-target, sporting rifles of this caliber.",
-    "ranged_damage": { "damage_type": "bullet", "amount": 4 },
     "dispersion": 110,
     "barrel_volume": "500 ml",
     "valid_mod_locations": [
@@ -211,7 +208,6 @@
     "barrel_length": "99 mm",
     "price": "360 USD",
     "material": [ "aluminum", "steel", "plastic" ],
-    "ranged_damage": { "damage_type": "bullet", "amount": -1 },
     "dispersion": 480,
     "valid_mod_locations": [ [ "barrel", 1 ], [ "mechanism", 2 ], [ "rail", 1 ], [ "sights mount", 1 ], [ "stock mount", 1 ] ],
     "pocket_data": [ { "magazine_well": "250 ml", "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "mosquitomag" ] } ]
@@ -358,7 +354,6 @@
     "material": [ "steel", "wood", "aluminum" ],
     "range": 7,
     "ammo": [ "22" ],
-    "ranged_damage": { "damage_type": "bullet", "amount": 3 },
     "dispersion": 140,
     "clip_size": 15,
     "valid_mod_locations": [
@@ -416,7 +411,6 @@
     "barrel_length": "254 mm",
     "price": "288 USD 99 cent",
     "range": 2,
-    "ranged_damage": { "damage_type": "bullet", "amount": 1 },
     "dispersion": 340,
     "variant_type": "gun",
     "variants": [
@@ -444,7 +438,6 @@
     "price": "749 USD 99 cent",
     "price_postapoc": "10 USD",
     "material": [ "steel" ],
-    "ranged_damage": { "damage_type": "bullet", "amount": -1 },
     "dispersion": 320,
     "valid_mod_locations": [ [ "barrel", 1 ], [ "mechanism", 2 ], [ "rail mount", 1 ], [ "sights mount", 1 ], [ "stock mount", 1 ] ],
     "pocket_data": [ { "magazine_well": "40 ml", "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "1911_22_mag" ] } ],
@@ -484,7 +477,6 @@
     "material": [ "steel", "wood", "aluminum" ],
     "range": 5,
     "ammo": [ "22" ],
-    "ranged_damage": { "damage_type": "bullet", "amount": 3 },
     "dispersion": 110,
     "clip_size": 15,
     "valid_mod_locations": [
@@ -527,7 +519,6 @@
     "material": [ "steel", "wood", "aluminum", "brass" ],
     "range": 6,
     "ammo": [ "22" ],
-    "ranged_damage": { "damage_type": "bullet", "amount": 3 },
     "dispersion": 100,
     "clip_size": 16,
     "valid_mod_locations": [
@@ -567,7 +558,6 @@
     "price": "250 USD",
     "material": [ "steel", "wood" ],
     "range": 6,
-    "ranged_damage": { "damage_type": "bullet", "amount": 3 },
     "dispersion": 110,
     "flags": [ "RELOAD_ONE" ],
     "clip_size": 14,
@@ -628,7 +618,6 @@
     "barrel_length": "89 mm",
     "price": "559 USD",
     "material": [ "steel" ],
-    "ranged_damage": { "damage_type": "bullet", "amount": -1 },
     "dispersion": 320,
     "valid_mod_locations": [ [ "barrel", 1 ], [ "mechanism", 2 ], [ "rail", 1 ], [ "sights mount", 1 ], [ "stock mount", 1 ] ],
     "pocket_data": [ { "magazine_well": "40 ml", "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "sr22_mag" ] } ],
@@ -656,7 +645,6 @@
     "price": "380 USD",
     "price_postapoc": "10 USD",
     "material": [ "steel", "plastic" ],
-    "ranged_damage": { "damage_type": "bullet", "amount": -1 },
     "dispersion": 580,
     "valid_mod_locations": [ [ "barrel", 1 ], [ "mechanism", 2 ], [ "rail", 1 ], [ "sights mount", 1 ], [ "stock mount", 1 ] ],
     "pocket_data": [ { "magazine_well": "40 ml", "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "glock44_mag" ] } ]
@@ -688,7 +676,6 @@
     "melee_damage": { "bash": 7 },
     "range": 4,
     "ammo": [ "22" ],
-    "ranged_damage": { "damage_type": "bullet", "amount": 3 },
     "dispersion": 100,
     "clip_size": 1,
     "valid_mod_locations": [


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

#82263 Adds in BBTI for .22 LR, no need to keep the old system about. 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Removes the extra damage and changes the barrel length of the 10/22 cause it was wrong 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Wait until #82263 is merged please
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
