### PR TITLE
Fix AIM uilist submenu shaking violently. (and debug m>M menus)

### DIFF
--- a/src/editmap.cpp
+++ b/src/editmap.cpp
@@ -1154,7 +1154,7 @@ void editmap::edit_feature()
         info_title_curr = info_title<T_t>();
         do_ui_invalidation();
 
-        emenu.query( false, get_option<int>( "BLINK_SPEED" ) );
+        emenu.query( true, get_option<int>( "BLINK_SPEED" ) );
         if( emenu.ret == UILIST_CANCEL ) {
             quit = true;
         } else if( ( emenu.ret >= 0 && static_cast<size_t>( emenu.ret ) < T_t::count() ) ||
@@ -1280,7 +1280,7 @@ void editmap::edit_fld()
         info_title_curr = pgettext( "Map editor: Editing field effects", "Field effects" );
         do_ui_invalidation();
 
-        fmenu.query( false, get_option<int>( "BLINK_SPEED" ) );
+        fmenu.query( true, get_option<int>( "BLINK_SPEED" ) );
         if( ( fmenu.ret > 0 && static_cast<size_t>( fmenu.ret ) < field_type::count() ) ||
             ( fmenu.ret == UILIST_ADDITIONAL && ( fmenu.ret_act == "LEFT" || fmenu.ret_act == "RIGHT" ) ) ) {
 
@@ -1893,7 +1893,7 @@ void editmap::mapgen_preview( const real_coords &tc, uilist &gmenu )
                                          oter_id( gmenu.selected ).id().str() );
         do_ui_invalidation();
 
-        gpmenu.query( false, get_option<int>( "BLINK_SPEED" ) * 3 );
+        gpmenu.query( true, get_option<int>( "BLINK_SPEED" ) * 3 );
 
         if( gpmenu.ret == 0 ) {
             cleartmpmap( tmpmap );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2371,7 +2371,7 @@ int game::inventory_item_menu( item_location locThisItem,
             }
 
             const int prev_selected = action_menu.selected;
-            action_menu.query( false );
+            action_menu.query( true );
             if( action_menu.ret >= 0 ) {
                 cMenu = action_menu.ret; /* Remember: hotkey == retval, see addentry above. */
             } else if( action_menu.ret == UILIST_UNBOUND && action_menu.ret_act == "RIGHT" ) {


### PR DESCRIPTION
#### Summary
Bugfixes "AIM uilist submenu shaking violently."

#### Purpose of change

Fix #78783

#### Describe the solution

Wait for the uilist to return the value. This might break the list BLINKing for the affected debug menus, but it's a huge improvement.

#### Describe alternatives you've considered


#### Testing

Tested all affected menus. They don't shake anymore.

There is latency in the debug menus: you move in the menu, the selection moves, and after 500ms or so, the list recenters. In AIM the latency is much shorter.

#### Additional context

