### PR TITLE
"Plain Mead" name change to just "Mead"

### DIFF
--- a/data/json/items/comestibles/alcohol.json
+++ b/data/json/items/comestibles/alcohol.json
@@ -1099,7 +1099,7 @@
     "type": "ITEM",
     "subtypes": [ "COMESTIBLE" ],
     "id": "plain_mead",
-    "name": { "str_sp": "plain mead" },
+    "name": { "str_sp": "mead" },
     "copy-from": "mead",
     "description": "Homebrewed honey wine, a smooth and silky golden beverage.",
     "fun": 10

--- a/data/json/items/comestibles/brewing.json
+++ b/data/json/items/comestibles/brewing.json
@@ -390,7 +390,7 @@
     "subtypes": [ "BREWABLE", "COMESTIBLE" ],
     "id": "brew_mead",
     "looks_like": "mead",
-    "name": { "str_sp": "plain mead must" },
+    "name": { "str_sp": "mead must" },
     "description": "Unfermented plain mead.  Diluted honey and yeast.  You need to put it in a fermenting vat to brew it.",
     "material": [ { "type": "water", "portion": 4 }, { "type": "honey", "portion": 1 } ],
     "weight": "34 g",
@@ -409,7 +409,7 @@
     "phase": "liquid",
     "comestible_type": "DRINK",
     "brew_time": "14 days",
-    "brew_results": [ "plain_mead", "yeast" ]
+    "brew_results": [ "mead", "yeast" ]
   },
   {
     "id": "brew_hopped_mead",

--- a/data/json/items/comestibles/brewing.json
+++ b/data/json/items/comestibles/brewing.json
@@ -409,7 +409,7 @@
     "phase": "liquid",
     "comestible_type": "DRINK",
     "brew_time": "14 days",
-    "brew_results": [ "mead", "yeast" ]
+    "brew_results": [ "plain_mead", "yeast" ]
   },
   {
     "id": "brew_hopped_mead",


### PR DESCRIPTION
#### Summary
Features "Plain Mead name change to just Mead"

#### Purpose of change

The term "Plain Mead" is redundant since "mead" by default refers to traditional fermented honey wine.

#### Describe the solution

I just changed the name.

#### Describe alternatives you've considered

none

#### Testing

I just changed the item's string 

#### Additional context

https://en.wikipedia.org/wiki/Mead#Varieties

Mead itself is referred to as the "default" so other variants that exist are variants, which include hopped and spiced meads, which we have different names for.

If I missed anything just let me know!

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
