### PR TITLE
Dedupe various crafting code

### DIFF
--- a/src/butchery.cpp
+++ b/src/butchery.cpp
@@ -875,10 +875,8 @@ bool butchery_drops_harvest( butchery_data bt, Character &you )
                 // If we're not bleeding the animal we don't care about the blood being wasted
                 if( action != butcher_type::BLEED ) {
                     drop_on_map( you, item_drop_reason::deliberate, { obj }, &here, corpse_loc );
-                } else if( you.is_avatar() ) {
-                    liquid_handler::handle_all_liquid( obj, 1 );
                 } else {
-                    liquid_handler::handle_npc_liquid( obj, you );
+                    liquid_handler::handle_all_or_npc_liquid( you, obj, 1 );
                 }
             } else if( drop->count_by_charges() ) {
                 std::vector<item> objs = create_charge_items( drop, roll, entry, &corpse_item, you );

--- a/src/character.h
+++ b/src/character.h
@@ -3607,6 +3607,9 @@ class Character : public Creature, public visitable
         float crafting_speed_multiplier( const recipe &rec ) const;
         float workbench_crafting_speed_multiplier( const item &craft,
                 const std::optional<tripoint_bub_ms> &loc )const;
+        float limb_score_crafting_speed_multiplier( const recipe &rec ) const;
+        float pain_crafting_speed_multiplier( const recipe &rec ) const;
+        float mut_crafting_speed_multiplier( const recipe &rec ) const;
         /** For use with in progress crafts.
          *  Workbench multiplier calculation (especially finding lifters nearby)
          *  is expensive when numorous items are around.

--- a/src/character_modifier.cpp
+++ b/src/character_modifier.cpp
@@ -13,6 +13,7 @@
 #include "flexbuffer_json.h"
 #include "game_constants.h"
 #include "generic_factory.h"
+#include "magic_enchantment.h"
 #include "messages.h"
 #include "move_mode.h"
 #include "output.h"

--- a/src/character_modifier.cpp
+++ b/src/character_modifier.cpp
@@ -13,7 +13,6 @@
 #include "flexbuffer_json.h"
 #include "game_constants.h"
 #include "generic_factory.h"
-#include "magic_enchantment.h"
 #include "messages.h"
 #include "move_mode.h"
 #include "output.h"

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -750,11 +750,7 @@ static item_location set_item_inventory( Character &p, item &newit )
 {
     item_location ret_val = item_location::nowhere;
     if( newit.made_of( phase_id::LIQUID ) ) {
-        if( p.is_avatar() ) {
-            liquid_handler::handle_all_liquid( newit, PICKUP_RANGE );
-        } else {
-            liquid_handler::handle_npc_liquid( newit, p );
-        }
+        liquid_handler::handle_all_or_npc_liquid( p, newit, PICKUP_RANGE );
     } else {
         p.inv->assign_empty_invlet( newit, p );
         // We might not have space for the item
@@ -1494,11 +1490,7 @@ static void spawn_items( Character &guy, std::vector<item> &results,
 
         newit.set_owner( guy.get_faction()->id );
         if( newit.made_of( phase_id::LIQUID ) ) {
-            if( guy.is_avatar() ) {
-                liquid_handler::handle_all_liquid( newit, PICKUP_RANGE );
-            } else {
-                liquid_handler::handle_npc_liquid( newit, guy );
-            }
+            liquid_handler::handle_all_or_npc_liquid( guy, newit, PICKUP_RANGE );
         } else if( !loc && allow_wield && !guy.has_wield_conflicts( newit ) &&
                    guy.can_wield( newit ).success() ) {
             wield_craft( guy, newit );
@@ -2980,11 +2972,7 @@ void Character::complete_disassemble( item_location &target, const recipe &dis )
             }
 
             if( act_item.made_of( phase_id::LIQUID ) ) {
-                if( is_avatar() ) {
-                    liquid_handler::handle_all_liquid( act_item, PICKUP_RANGE );
-                } else {
-                    liquid_handler::handle_npc_liquid( act_item, *this );
-                }
+                liquid_handler::handle_all_or_npc_liquid( *this, act_item, PICKUP_RANGE );
             } else {
                 drop_items.push_back( act_item );
             }
@@ -3051,14 +3039,10 @@ void remove_ammo( std::list<item> &dis_items, Character &p )
 
 void drop_or_handle( const item &newit, Character &p )
 {
+    item tmp( newit );
     if( newit.made_of( phase_id::LIQUID ) ) {
-        if( p.is_avatar() ) {
-            liquid_handler::handle_all_liquid( newit, PICKUP_RANGE );
-        } else {
-            liquid_handler::handle_npc_liquid( newit, p );
-        }
+        liquid_handler::handle_all_or_npc_liquid( p, tmp, PICKUP_RANGE );
     } else {
-        item tmp( newit );
         p.i_add_or_drop( tmp );
     }
 }

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -2874,18 +2874,7 @@ void Character::complete_disassemble( item_location &target, const recipe &dis )
             if( dis_item.count_by_charges() ) {
                 compcount *= activity.position;
             }
-            const bool is_liquid = newit.made_of( phase_id::LIQUID );
-            // Compress liquids and counted-by-charges items into one item,
-            // they are added together on the map anyway and handle_liquid
-            // should only be called once to put it all into a container at once.
-            if( newit.count_by_charges() || is_liquid ) {
-                newit.charges = compcount;
-                compcount = 1;
-            } else if( !newit.craft_has_charges() && newit.charges > 0 ) {
-                // tools that can be unloaded should be created unloaded,
-                // tools that can't be unloaded will keep their default charges.
-                newit.charges = 0;
-            }
+            newit.compress_charges_or_liquid( compcount );
 
             // If the recipe has a `FULL_MAGAZINE` flag, spawn any magazines full of ammo
             if( newit.is_magazine() && dis.has_flag( flag_FULL_MAGAZINE ) ) {

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -46,7 +46,6 @@
 #include "localized_comparator.h"
 #include "options.h"
 #include "output.h"
-#include "pimpl.h"
 #include "point.h"
 #include "popup.h"
 #include "recipe.h"

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -44,7 +44,6 @@
 #include "item_location.h"
 #include "itype.h"
 #include "localized_comparator.h"
-#include "magic_enchantment.h"
 #include "options.h"
 #include "output.h"
 #include "pimpl.h"
@@ -65,13 +64,8 @@
 #include "ui_manager.h"
 #include "uistate.h"
 
-static const limb_score_id limb_score_manip( "manip" );
-
-static const std::string flag_AFFECTED_BY_PAIN( "AFFECTED_BY_PAIN" );
 static const std::string flag_BLIND_EASY( "BLIND_EASY" );
 static const std::string flag_BLIND_HARD( "BLIND_HARD" );
-static const std::string flag_NO_ENCHANTMENT( "NO_ENCHANTMENT" );
-static const std::string flag_NO_MANIP( "NO_MANIP" );
 
 enum TAB_MODE {
     NORMAL,
@@ -2370,11 +2364,8 @@ static void draw_hidden_amount( const catacurses::window &w, int amount, int num
 static void draw_can_craft_indicator( const catacurses::window &w, const recipe &rec,
                                       Character &crafter )
 {
-    int limb_modifier = rec.has_flag( flag_NO_MANIP ) ? 100 : crafter.get_limb_score(
-                            limb_score_manip ) * 100;
-    int mut_multi = rec.has_flag( flag_NO_ENCHANTMENT ) ? 100 : ( 1.0 +
-                    crafter.enchantment_cache->get_value_multiply( enchant_vals::mod::CRAFTING_SPEED_MULTIPLIER ) ) *
-                    100;
+    int limb_modifier = crafter.limb_score_crafting_speed_multiplier( rec ) * 100;
+    int mut_multi = crafter.mut_crafting_speed_multiplier( rec ) * 100;
 
     std::stringstream modifiers_list;
     if( limb_modifier != 100 ) {
@@ -2398,8 +2389,7 @@ static void draw_can_craft_indicator( const catacurses::window &w, const recipe 
     } else if( crafter.crafting_speed_multiplier( rec ) < 1.0f ) {
         int morale_modifier = crafter.morale_crafting_speed_multiplier( rec ) * 100;
         int lighting_modifier = crafter.lighting_craft_speed_multiplier( rec ) * 100;
-        int pain_multi = rec.has_flag( flag_AFFECTED_BY_PAIN ) ? 100 * std::max( 0.0f,
-                         1.0f - ( crafter.get_perceived_pain() / 100.0f ) ) : 100;
+        const int pain_multi = crafter.pain_crafting_speed_multiplier( rec ) * 100;
 
         if( morale_modifier < 100 ) {
             if( !modifiers_list.str().empty() ) {

--- a/src/handle_liquid.cpp
+++ b/src/handle_liquid.cpp
@@ -224,6 +224,15 @@ void handle_npc_liquid( item liquid, Character &who )
     who.invalidate_weight_carried_cache();
 }
 
+void handle_all_or_npc_liquid( Character &p, item &newit, int radius, const item *avoid )
+{
+    if( p.is_avatar() ) {
+        liquid_handler::handle_all_liquid( newit, radius, avoid );
+    } else {
+        liquid_handler::handle_npc_liquid( newit, p );
+    }
+}
+
 bool consume_liquid( item &liquid, const int radius, const item *const avoid )
 {
     const int original_charges = liquid.charges;

--- a/src/handle_liquid.h
+++ b/src/handle_liquid.h
@@ -52,6 +52,10 @@ void handle_all_liquid( item liquid, int radius, const item *avoid = nullptr );
  */
 void handle_npc_liquid( item liquid, Character &who );
 
+/** Call handle_all_liquid for player or handle_npc_liquid for npc */
+void handle_all_or_npc_liquid( Character &p, item &newit, int radius = 0,
+                               const item *avoid = nullptr );
+
 /**
  * Consume / handle as much of the liquid as possible in varying ways. This function can
  * be used when the action can be canceled, which implies the liquid can be put back

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -9127,6 +9127,18 @@ bool item::count_by_charges() const
     return type->count_by_charges();
 }
 
+void item::compress_charges_or_liquid( int &compcount )
+{
+    if( count_by_charges() || made_of( phase_id::LIQUID ) ) {
+        charges = compcount;
+        compcount = 1;
+    } else if( !craft_has_charges() && charges > 0 ) {
+        // tools that can be unloaded should be created unloaded,
+        // tools that can't be unloaded will keep their default charges.
+        charges = 0;
+    }
+}
+
 int item::count() const
 {
     return count_by_charges() ? charges : 1;

--- a/src/item.h
+++ b/src/item.h
@@ -1060,6 +1060,13 @@ class item : public visitable
         bool count_by_charges() const;
 
         /**
+         * Compress liquids and counted-by-charges items into one item.
+         * They are added together on the map anyway and handle_liquid
+         * should only be called once to put it all into a container at once.
+         */
+        void compress_charges_or_liquid( int &compcount );
+
+        /**
          * If count_by_charges(), returns charges, otherwise 1
          */
         int count() const;

--- a/src/vehicle_part.cpp
+++ b/src/vehicle_part.cpp
@@ -80,13 +80,7 @@ std::vector<item> vehicle_part::get_salvageable() const
         item newit( comp.type, calendar::turn );
         if( base.typeId() != comp.type && !newit.has_flag( flag_UNRECOVERABLE ) ) {
             int compcount = comp.count;
-            const bool is_liquid = newit.made_of( phase_id::LIQUID );
-            if( newit.count_by_charges() || is_liquid ) {
-                newit.charges = compcount;
-                compcount = 1;
-            } else if( !newit.craft_has_charges() && newit.charges > 0 ) {
-                newit.charges = 0;
-            }
+            newit.compress_charges_or_liquid( compcount );
             for( ; compcount > 0; compcount-- ) {
                 tmp.push_back( newit );
             }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
`crafting.cpp` has a few blocks of duplicated code, including:
* compressing liquids and charges to a single item
* collecting liquids as npc or around a player
* wielding an item to craft without a workbench
* calculating multipliers/penalties for crafting speed

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
Moved each block of duped code to a new method, function, or lambda.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
This spilled into a few other files, but I focused on things that existed more often in `crafting.cpp` than elsewhere.

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
