### PR TITLE
Create ui_helpers.cpp with first function full_screen_window

### DIFF
--- a/src/auto_note.cpp
+++ b/src/auto_note.cpp
@@ -23,8 +23,9 @@
 #include "string_formatter.h"
 #include "translation.h"
 #include "translations.h"
-#include "uilist.h"
+#include "ui_helpers.h"
 #include "ui_manager.h"
+#include "uilist.h"
 
 namespace auto_notes
 {
@@ -305,21 +306,8 @@ void auto_note_manager_gui::show()
 
     ui_adaptor ui;
     ui.on_screen_resize( [&]( ui_adaptor & ui ) {
-        iContentHeight = FULL_SCREEN_HEIGHT - 2 - iHeaderHeight;
-
-        const point iOffset( TERMX > FULL_SCREEN_WIDTH ? ( TERMX - FULL_SCREEN_WIDTH ) / 2 : 0,
-                             TERMY > FULL_SCREEN_HEIGHT ? ( TERMY - FULL_SCREEN_HEIGHT ) / 2 : 0 );
-
-        w_border = catacurses::newwin( FULL_SCREEN_HEIGHT, FULL_SCREEN_WIDTH,
-                                       iOffset );
-
-        w_header = catacurses::newwin( iHeaderHeight, FULL_SCREEN_WIDTH - 2,
-                                       iOffset + point::south_east );
-
-        w = catacurses::newwin( iContentHeight, FULL_SCREEN_WIDTH - 2,
-                                iOffset + point( 1, iHeaderHeight + 1 ) );
-
-        ui.position_from_window( w_border );
+        ui_helpers::full_screen_window( ui, &w, &w_border, &w_header, nullptr,
+                                        &iContentHeight, 1, iHeaderHeight, 0 );
     } );
     ui.mark_resize();
 

--- a/src/auto_pickup.cpp
+++ b/src/auto_pickup.cpp
@@ -39,8 +39,9 @@
 #include "string_formatter.h"
 #include "translations.h"
 #include "type_id.h"
-#include "uilist.h"
+#include "ui_helpers.h"
 #include "ui_manager.h"
+#include "uilist.h"
 #include "units.h"
 
 using namespace auto_pickup;
@@ -308,18 +309,8 @@ void user_interface::show()
     ui_adaptor ui;
 
     const auto init_windows = [&]( ui_adaptor & ui ) {
-        iContentHeight = FULL_SCREEN_HEIGHT - 2 - iHeaderHeight;
-        const point iOffset( TERMX > FULL_SCREEN_WIDTH ? ( TERMX - FULL_SCREEN_WIDTH ) / 2 : 0,
-                             TERMY > FULL_SCREEN_HEIGHT ? ( TERMY - FULL_SCREEN_HEIGHT ) / 2 : 0 );
-
-        w_border = catacurses::newwin( FULL_SCREEN_HEIGHT, FULL_SCREEN_WIDTH,
-                                       iOffset );
-        w_header = catacurses::newwin( iHeaderHeight, FULL_SCREEN_WIDTH - 2,
-                                       iOffset + point::south_east );
-        w = catacurses::newwin( iContentHeight, FULL_SCREEN_WIDTH - 2,
-                                iOffset + point( 1, iHeaderHeight + 1 ) );
-
-        ui.position_from_window( w_border );
+        ui_helpers::full_screen_window( ui, &w, &w_border, &w_header, nullptr,
+                                        &iContentHeight, 1, iHeaderHeight, 0 );
     };
     init_windows( ui );
     ui.on_screen_resize( init_windows );

--- a/src/color.cpp
+++ b/src/color.cpp
@@ -25,8 +25,9 @@
 #include "rng.h"
 #include "string_formatter.h"
 #include "translations.h"
-#include "uilist.h"
+#include "ui_helpers.h"
 #include "ui_manager.h"
+#include "uilist.h"
 #include "cata_imgui.h"
 
 nc_color::operator ImVec4()
@@ -838,8 +839,6 @@ void color_manager::show_gui()
     const int iHeaderHeight = 4;
     int iContentHeight = 0;
 
-    point iOffset;
-
     std::vector<int> vLines;
     vLines.reserve( 2 );
     vLines.push_back( -1 );
@@ -851,25 +850,10 @@ void color_manager::show_gui()
     catacurses::window w_colors_header;
     catacurses::window w_colors;
 
-    const auto calc_offset_y = []() -> int {
-        return TERMY > FULL_SCREEN_HEIGHT ? ( TERMY - FULL_SCREEN_HEIGHT ) / 2 : 0;
-    };
-
     ui_adaptor ui;
     const auto init_windows = [&]( ui_adaptor & ui ) {
-        iContentHeight = FULL_SCREEN_HEIGHT - 2 - iHeaderHeight;
-
-        iOffset.x = TERMX > FULL_SCREEN_WIDTH ? ( TERMX - FULL_SCREEN_WIDTH ) / 2 : 0;
-        iOffset.y = calc_offset_y();
-
-        w_colors_border = catacurses::newwin( FULL_SCREEN_HEIGHT, FULL_SCREEN_WIDTH,
-                                              iOffset );
-        w_colors_header = catacurses::newwin( iHeaderHeight, FULL_SCREEN_WIDTH - 2,
-                                              iOffset + point::south_east );
-        w_colors = catacurses::newwin( iContentHeight, FULL_SCREEN_WIDTH - 2,
-                                       iOffset + point( 1, iHeaderHeight + 1 ) );
-
-        ui.position_from_window( w_colors_border );
+        ui_helpers::full_screen_window( ui, &w_colors, &w_colors_border, &w_colors_header, nullptr,
+                                        &iContentHeight, 1, iHeaderHeight, 0 );
     };
     init_windows( ui );
     ui.on_screen_resize( init_windows );

--- a/src/distraction_manager.cpp
+++ b/src/distraction_manager.cpp
@@ -9,8 +9,9 @@
 #include "output.h"
 #include "point.h"
 #include "translations.h"
-#include "uilist.h"
+#include "ui_helpers.h"
 #include "ui_manager.h"
+#include "uilist.h"
 #include "uistate.h"
 
 namespace distraction_manager
@@ -57,21 +58,8 @@ void distraction_manager_gui::show()
 
     ui_adaptor ui;
     ui.on_screen_resize( [&]( ui_adaptor & ui ) {
-        iContentHeight = FULL_SCREEN_HEIGHT - 2 - iHeaderHeight;
-
-        const point iOffset( TERMX > FULL_SCREEN_WIDTH ? ( TERMX - FULL_SCREEN_WIDTH ) / 2 : 0,
-                             TERMY > FULL_SCREEN_HEIGHT ? ( TERMY - FULL_SCREEN_HEIGHT ) / 2 : 0 );
-
-        w_border = catacurses::newwin( FULL_SCREEN_HEIGHT, FULL_SCREEN_WIDTH,
-                                       iOffset );
-
-        w_header = catacurses::newwin( iHeaderHeight, FULL_SCREEN_WIDTH - 2,
-                                       iOffset + point::south_east );
-
-        w = catacurses::newwin( iContentHeight, FULL_SCREEN_WIDTH - 2,
-                                iOffset + point( 1, iHeaderHeight + 1 ) );
-
-        ui.position_from_window( w_border );
+        ui_helpers::full_screen_window( ui, &w, &w_border, &w_header, nullptr,
+                                        &iContentHeight, 1, iHeaderHeight, 0 );
     } );
     ui.mark_resize();
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -196,9 +196,10 @@
 #include "translation_cache.h"
 #include "translations.h"
 #include "trap.h"
-#include "uilist.h"
+#include "ui_helpers.h"
 #include "ui_extended_description.h"
 #include "ui_manager.h"
+#include "uilist.h"
 #include "uistate.h"
 #include "units.h"
 #include "value_ptr.h"
@@ -3837,10 +3838,7 @@ void game::disp_NPCs()
     catacurses::window w;
     ui_adaptor ui;
     ui.on_screen_resize( [&]( ui_adaptor & ui ) {
-        w = catacurses::newwin( FULL_SCREEN_HEIGHT, FULL_SCREEN_WIDTH,
-                                point( TERMX > FULL_SCREEN_WIDTH ? ( TERMX - FULL_SCREEN_WIDTH ) / 2 : 0,
-                                       TERMY > FULL_SCREEN_HEIGHT ? ( TERMY - FULL_SCREEN_HEIGHT ) / 2 : 0 ) );
-        ui.position_from_window( w );
+        ui_helpers::full_screen_window( ui, &w );
     } );
     ui.mark_resize();
     ui.on_redraw( [&]( const ui_adaptor & ) {

--- a/src/help.cpp
+++ b/src/help.cpp
@@ -27,6 +27,7 @@
 #include "string_formatter.h"
 #include "text_snippets.h"
 #include "translations.h"
+#include "ui_helpers.h"
 #include "ui_manager.h"
 
 help &get_help()
@@ -167,13 +168,7 @@ void help::display_help() const
 
     ui_adaptor ui;
     const auto init_windows = [&]( ui_adaptor & ui ) {
-        w_help_border = catacurses::newwin( FULL_SCREEN_HEIGHT, FULL_SCREEN_WIDTH,
-                                            point( TERMX > FULL_SCREEN_WIDTH ? ( TERMX - FULL_SCREEN_WIDTH ) / 2 : 0,
-                                                    TERMY > FULL_SCREEN_HEIGHT ? ( TERMY - FULL_SCREEN_HEIGHT ) / 2 : 0 ) );
-        w_help = catacurses::newwin( FULL_SCREEN_HEIGHT - 2, FULL_SCREEN_WIDTH - 2,
-                                     point( 1 + static_cast<int>( TERMX > FULL_SCREEN_WIDTH ? ( TERMX - FULL_SCREEN_WIDTH ) / 2 : 0 ),
-                                            1 + static_cast<int>( TERMY > FULL_SCREEN_HEIGHT ? ( TERMY - FULL_SCREEN_HEIGHT ) / 2 : 0 ) ) );
-        ui.position_from_window( w_help_border );
+        ui_helpers::full_screen_window( ui, &w_help, &w_help_border, nullptr, nullptr, nullptr, 1 );
     };
     init_windows( ui );
     ui.on_screen_resize( init_windows );

--- a/src/iuse_software_lightson.cpp
+++ b/src/iuse_software_lightson.cpp
@@ -16,6 +16,7 @@
 #include "point.h"
 #include "rng.h"
 #include "translations.h"
+#include "ui_helpers.h"
 #include "ui_manager.h"
 
 void lightson_game::new_level()
@@ -131,15 +132,9 @@ void lightson_game::toggle_lights_at( const point &pt )
 
 int lightson_game::start_game()
 {
-    const int w_height = 15;
-
     ui_adaptor ui;
     ui.on_screen_resize( [&]( ui_adaptor & ui ) {
-        const point iOffset( TERMX > FULL_SCREEN_WIDTH ? ( TERMX - FULL_SCREEN_WIDTH ) / 2 : 0,
-                             TERMY > FULL_SCREEN_HEIGHT ? ( TERMY - FULL_SCREEN_HEIGHT ) / 2 : 0 );
-        w_border = catacurses::newwin( w_height, FULL_SCREEN_WIDTH, iOffset );
-        w = catacurses::newwin( w_height - 6, FULL_SCREEN_WIDTH - 2, iOffset + point::south_east );
-        ui.position_from_window( w_border );
+        ui_helpers::full_screen_window( ui, &w, &w_border, nullptr, nullptr, nullptr, 1, 0, 4 );
     } );
     ui.mark_resize();
 
@@ -174,7 +169,7 @@ int lightson_game::start_game()
         }
 
         mvwputch( w_border, point( 2, 0 ), hilite( c_white ), _( "Lights on!" ) );
-        fold_and_print( w_border, point( 2, w_height - 5 ), FULL_SCREEN_WIDTH - 4, c_light_gray,
+        fold_and_print( w_border, point( 2, getmaxy( w_border ) - 5 ), FULL_SCREEN_WIDTH - 4, c_light_gray,
                         "%s\n%s\n%s", _( "<color_white>Game goal:</color> Switch all the lights on." ),
                         _( "<color_white>Legend: #</color> on, <color_dark_gray>-</color> off." ),
                         _( "Toggle lights switches selected light and 4 its neighbors." ) );

--- a/src/iuse_software_minesweeper.cpp
+++ b/src/iuse_software_minesweeper.cpp
@@ -17,8 +17,9 @@
 #include "string_formatter.h"
 #include "string_input_popup.h"
 #include "translations.h"
-#include "uilist.h"
+#include "ui_helpers.h"
 #include "ui_manager.h"
+#include "uilist.h"
 
 minesweeper_game::minesweeper_game()
 {
@@ -136,15 +137,8 @@ int minesweeper_game::start_game()
 
     ui_adaptor ui;
     ui.on_screen_resize( [&]( ui_adaptor & ui ) {
-        const point iCenter( TERMX > FULL_SCREEN_WIDTH ? ( TERMX - FULL_SCREEN_WIDTH ) / 2 : 0,
-                             TERMY > FULL_SCREEN_HEIGHT ? ( TERMY - FULL_SCREEN_HEIGHT ) / 2 : 0 );
-
-        w_minesweeper_border = catacurses::newwin( FULL_SCREEN_HEIGHT, FULL_SCREEN_WIDTH,
-                               iCenter );
-        w_minesweeper = catacurses::newwin( FULL_SCREEN_HEIGHT - 2, FULL_SCREEN_WIDTH - 2,
-                                            iCenter + point::south_east );
+        ui_helpers::full_screen_window( ui, &w_minesweeper, &w_minesweeper_border );
         max = point( FULL_SCREEN_WIDTH - 4, FULL_SCREEN_HEIGHT - 4 );
-        ui.position_from_window( w_minesweeper_border );
     } );
     ui.mark_resize();
 

--- a/src/iuse_software_snake.cpp
+++ b/src/iuse_software_snake.cpp
@@ -15,6 +15,7 @@
 #include "rng.h"
 #include "string_formatter.h"
 #include "translations.h"
+#include "ui_helpers.h"
 #include "ui_manager.h"
 
 snake_game::snake_game() = default;
@@ -94,13 +95,7 @@ int snake_game::start_game()
     catacurses::window w_snake;
     ui_adaptor ui;
     ui.on_screen_resize( [&]( ui_adaptor & ui ) {
-        const point iOffset( TERMX > FULL_SCREEN_WIDTH ? ( TERMX - FULL_SCREEN_WIDTH ) / 2 : 0,
-                             TERMY > FULL_SCREEN_HEIGHT ? ( TERMY - FULL_SCREEN_HEIGHT ) / 2 : 0 );
-
-        w_snake = catacurses::newwin( FULL_SCREEN_HEIGHT, FULL_SCREEN_WIDTH,
-                                      iOffset );
-
-        ui.position_from_window( w_snake );
+        ui_helpers::full_screen_window( ui, &w_snake );
     } );
     ui.mark_resize();
 

--- a/src/iuse_software_sokoban.cpp
+++ b/src/iuse_software_sokoban.cpp
@@ -17,6 +17,7 @@
 #include "path_info.h"
 #include "point.h"
 #include "translations.h"
+#include "ui_helpers.h"
 #include "ui_manager.h"
 
 sokoban_game::sokoban_game() = default;
@@ -227,11 +228,7 @@ int sokoban_game::start_game()
     catacurses::window w_sokoban;
     ui_adaptor ui;
     ui.on_screen_resize( [&]( ui_adaptor & ) {
-        const point iOffset( TERMX > FULL_SCREEN_WIDTH ? ( TERMX - FULL_SCREEN_WIDTH ) / 2 : 0,
-                             TERMY > FULL_SCREEN_HEIGHT ? ( TERMY - FULL_SCREEN_HEIGHT ) / 2 : 0 );
-        w_sokoban = catacurses::newwin( FULL_SCREEN_HEIGHT, FULL_SCREEN_WIDTH,
-                                        iOffset );
-        ui.position_from_window( w_sokoban );
+        ui_helpers::full_screen_window( ui, &w_sokoban );
     } );
     ui.mark_resize();
 

--- a/src/ui_helpers.cpp
+++ b/src/ui_helpers.cpp
@@ -1,0 +1,40 @@
+#include "ui_helpers.h"
+
+#include "cursesdef.h"
+#include "output.h"
+#include "point.h"
+#include "ui_manager.h"
+
+void ui_helpers::full_screen_window( ui_adaptor &ui,
+                                     catacurses::window *w, catacurses::window *const w_border,
+                                     catacurses::window *const w_header, catacurses::window *const w_footer,
+                                     int *const content_height, const int border_width,
+                                     const int header_height, const int footer_height )
+{
+    const int content_width = FULL_SCREEN_WIDTH - ( w_border ? border_width * 2 : 0 );
+    const int new_content_height =
+        FULL_SCREEN_HEIGHT
+        - ( w_border ? border_width * 2 : 0 )
+        - header_height
+        - footer_height;
+    if( content_height ) {
+        *content_height = new_content_height;
+    }
+    point offset( TERMX > FULL_SCREEN_WIDTH ? ( TERMX - FULL_SCREEN_WIDTH ) / 2 : 0,
+                  TERMY > FULL_SCREEN_HEIGHT ? ( TERMY - FULL_SCREEN_HEIGHT ) / 2 : 0 );
+    if( w_border ) {
+        *w_border = catacurses::newwin( FULL_SCREEN_HEIGHT, FULL_SCREEN_WIDTH, offset );
+        offset += point::south_east * border_width;
+    }
+    if( w_header ) {
+        *w_header = catacurses::newwin( header_height, content_width, offset );
+    }
+    offset += point::south * header_height;
+    *w = catacurses::newwin( new_content_height, content_width, offset );
+    offset += point::south * new_content_height;
+    if( w_footer ) {
+        *w_footer = catacurses::newwin( footer_height, content_width, offset );
+    }
+
+    ui.position_from_window( w_border ? *w_border : *w );
+}

--- a/src/ui_helpers.h
+++ b/src/ui_helpers.h
@@ -1,0 +1,23 @@
+#pragma once
+#ifndef CATA_SRC_UI_HELPERS_H
+#define CATA_SRC_UI_HELPERS_H
+
+class ui_adaptor;
+
+namespace catacurses
+{
+class window;
+} // namespace catacurses
+
+namespace ui_helpers
+{
+
+void full_screen_window( ui_adaptor &ui,
+                         catacurses::window *w, catacurses::window *w_border = nullptr,
+                         catacurses::window *w_header = nullptr, catacurses::window *w_footer = nullptr,
+                         int *content_height = nullptr, int border_width = 1,
+                         int header_height = 0, int footer_height = 0 );
+
+} // namespace ui_helpers
+
+#endif // CATA_SRC_UI_HELPERS_H


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Infrastructure "Begin moving duplicated UI code to new helpers library"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
A lot of small pieces of UI code are duplicated in many places, for creating windows and dialogs and such.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
I have created a new `ui_helpers.(h|cpp)` which define the `ui_helpers` namespace. The inaugural function is named `full_screen_window` and it replaces 8 separate places that subsets of the same code were used.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
I considered overloads or functions with more elaborate names, but the various permutations of options (border? header? footer? footer space but no footer window? etc) seem too numerous for either of those to make sense. I instead chose to pass in pointers and accept null pointers to disable certain features of the function.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->
I opened and manipulated each of the manager and video game UIs before and after the change and did not detect obvious differences. I did not exactly compare every character of every affected window.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
My previous efforts in #64463 involved lower level arithmetic functions and using those within existing code. The approach here is different, deduplicating whole blocks of code that actually create UI elements. The two efforts share a long term goal of making it easier to migrate the UI to newer implementations by reducing the amount of work required then.

I expect this new header file will eventually contain some common query functions, other common shapes of windows and nested windows, etc. I anticipate PRing a handful once this is accepted.

I also moved `uilist.h` below `ui_*.h` in the includes lists of various files, to match my and vscode's understanding of alphabetizing special characters. Other similar includes are inconsistent in ordering.

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
