### PR TITLE
[Bombastic Perks] Add Dexterous Speed playstyle perk

### DIFF
--- a/data/mods/BombasticPerks/perkmenu.json
+++ b/data/mods/BombasticPerks/perkmenu.json
@@ -1657,6 +1657,25 @@
         ],
         "topic": "TALK_PERK_MENU_SELECT_PLAYSTYLE"
       },
+      {
+        "condition": { "not": { "u_has_trait": "perk_dexterous_speed" } },
+        "text": "Gain [<trait_name:perk_dexterous_speed>]",
+        "effect": [
+          { "set_string_var": "<trait_name:perk_dexterous_speed>", "target_var": { "context_val": "trait_name" } },
+          {
+            "set_string_var": "<trait_description:perk_dexterous_speed>",
+            "target_var": { "context_val": "trait_description" }
+          },
+          { "set_string_var": "perk_dexterous_speed", "target_var": { "context_val": "trait_id" } },
+          {
+            "set_string_var": "No Requirements",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
+          { "set_condition": "perk_condition", "condition": { "math": [ "0 == 0" ] } }
+        ],
+        "topic": "TALK_PERK_MENU_SELECT_PLAYSTYLE"
+      },
       { "text": "Playstyle Perks: Stormwrought", "topic": "TALK_PERK_MENU_PLAYSTYLE_STORMWROUGHT" },
       { "text": "Lifestyle Perks", "topic": "TALK_PERK_MENU_MAIN" },
       { "text": "Settings", "topic": "TALK_PERK_MENU_CONFIG" },

--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -1188,7 +1188,9 @@
     "valid": false,
     "description": "You've found that you can move just a little bit quicker the more dexterous you are.  Unfortunately, this applies in the reverse as well.  Gain or lose 2 speed for every point of DEX away from 8.",
     "category": [ "perk" ],
-    "enchantments": [ { "condition": "ALWAYS", "values": [ { "value": "SPEED", "add": { "math": [ "( u_val('dexterity') - 8 ) * 2" ] } } ] } ]
+    "enchantments": [
+      { "condition": "ALWAYS", "values": [ { "value": "SPEED", "add": { "math": [ "( u_val('dexterity') - 8 ) * 2" ] } } ] }
+    ]
   },
   {
     "type": "mutation",

--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -1181,6 +1181,17 @@
   },
   {
     "type": "mutation",
+    "id": "perk_dexterous_speed",
+    "name": { "str": "Dexterous Speed" },
+    "points": 0,
+    "purifiable": false,
+    "valid": false,
+    "description": "You've found that you can move just a little bit quicker the more dexterous you are.  Unfortunately, this applies in the reverse as well.  Gain or lose 2 speed for every point of DEX away from 8.",
+    "category": [ "perk" ],
+    "enchantments": [ { "condition": "ALWAYS", "values": [ { "value": "SPEED", "add": { "math": [ "( u_val('dexterity') - 8 ) * 2" ] } } ] } ]
+  },
+  {
+    "type": "mutation",
     "id": "perk_portal_storm_mutator_bird",
     "name": { "str": "Stormwrought: Bird" },
     "points": 0,


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[Bombastic Perks] Add Dexterous Speed playstyle perk"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Add the dexterous speed perk that modifies the character's speed based on their dexterity
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Dexterous Speed Perk:
- Playstyle perk, so 4 points worth
- For every 1 dexterity above or below 8, the character gains or loses 2 speed.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
N/A
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
<img width="1914" height="1026" alt="dex speed" src="https://github.com/user-attachments/assets/e7290dd6-ac78-44e7-8666-c569529622f4" />

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Yes, this is inspired by speedydex
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
