### PR TITLE
Revert "Stop using pre-apoc price as a fallback for postapoc price"

### DIFF
--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -386,6 +386,10 @@ void Item_factory::finalize_pre( itype &obj )
         obj.category_force = calc_category( obj );
     }
 
+    // use pre-Cataclysm price as default if post-cataclysm price unspecified
+    if( obj.price_post < 0_cent ) {
+        obj.price_post = obj.price;
+    }
     // use base volume if integral volume unspecified
     if( obj.integral_volume < 0_ml ) {
         obj.integral_volume = obj.volume;
@@ -4069,7 +4073,7 @@ void itype::load( const JsonObject &jo, std::string_view src )
     optional( jo, was_loaded, "volume", volume );
     optional( jo, was_loaded, "longest_side", longest_side, -1_mm );
     optional( jo, was_loaded, "price", price, not_negative_money, 0_cent );
-    optional( jo, was_loaded, "price_postapoc", price_post, not_negative_money, 0_cent );
+    optional( jo, was_loaded, "price_postapoc", price_post, not_negative_money, -1_cent );
     optional( jo, was_loaded, "stackable", stackable_ );
     optional( jo, was_loaded, "integral_volume", integral_volume, not_negative_volume, -1_ml );
     optional( jo, was_loaded, "integral_longest_side", integral_longest_side, not_negative_length,

--- a/src/itype.h
+++ b/src/itype.h
@@ -1515,7 +1515,7 @@ struct itype {
         units::money price = 0_cent;
 
         /** Value after the Cataclysm, dependent upon practical usages. Price given is for a default-sized stack. */
-        units::money price_post = 0_cent;
+        units::money price_post = -1_cent;
 
         // TODO: Add some very basic unweildiness calc for non specified to_hit?
         int m_to_hit = -2;  // To-hit bonus for melee combat, see GAME_BALANCE.md#to-hit-value


### PR DESCRIPTION
#### Summary

None

#### Purpose of change 
Was midway into trying to figure out how updating json with python worked when I realized that I'm not sure this was a meaningful change.

Before #82075 a set of items without `price_postapoc` defined where too expensive in ways that didnt make sense, now a different set of items without `price_postapoc` are free in ways that dont make sense.  But this doesnt bring us any closer to the ideal economic system the game actually wants (factions need some items based on personality and we simulate supply/demand).

It has more or less just changed what items need fixing in a way that encourages contributors to fix the issue in a way that isn't the desired solution (setting `price_postapoc` instead of actually reworking the system)

#### Describe the solution

Simple proposal to revert this,  see above.

#### Describe alternatives you've considered
I do learn to use python but I dont want to. I want to finish bugfixing aftershock.
Also having to constantly define both fields to be the same thing forever seems like pointless extra work.