### PR TITLE
[Aftershock] Power grid moves with the ship without deletion

### DIFF
--- a/src/teleport.cpp
+++ b/src/teleport.cpp
@@ -51,6 +51,8 @@ static const flag_id json_flag_TELEPORT_LOCK( "TELEPORT_LOCK" );
 static const itype_id itype_wall_wiring( "wall_wiring" );
 static const itype_id itype_power_cord( "power_cord" );
 
+const std::string flag_WIRING( "WIRING" );
+
 static bool TestForVehicleTeleportCollision( vehicle &veh, map &here, map *dest,
         const tripoint_abs_ms &dp )
 {
@@ -60,7 +62,7 @@ static bool TestForVehicleTeleportCollision( vehicle &veh, map &here, map *dest,
             dest->load( project_to<coords::sm>( dp + rel_pos ), false );
         }
 
-        if( part.info().base_item == itype_wall_wiring ||
+        if( part.info().has_flag( flag_WIRING ) ||
             part.info().base_item == itype_power_cord
           ) {
             continue;

--- a/src/teleport.cpp
+++ b/src/teleport.cpp
@@ -35,6 +35,7 @@
 #include "translations.h"
 #include "type_id.h"
 #include "units.h"
+#include "veh_type.h"
 #include "vehicle.h"
 #include "viewer.h"
 #include "ui_manager.h"
@@ -47,6 +48,8 @@ static const flag_id json_flag_DIMENSIONAL_ANCHOR( "DIMENSIONAL_ANCHOR" );
 static const flag_id json_flag_GRAB( "GRAB" );
 static const flag_id json_flag_TELEPORT_LOCK( "TELEPORT_LOCK" );
 
+static const itype_id itype_wall_wiring( "wall_wiring" );
+static const itype_id itype_power_cord( "power_cord" );
 
 static bool TestForVehicleTeleportCollision( vehicle &veh, map &here, map *dest,
         const tripoint_abs_ms &dp )
@@ -57,6 +60,11 @@ static bool TestForVehicleTeleportCollision( vehicle &veh, map &here, map *dest,
             dest->load( project_to<coords::sm>( dp + rel_pos ), false );
         }
 
+        if( part.info().base_item == itype_wall_wiring ||
+            part.info().base_item == itype_power_cord
+          ) {
+            continue;
+        }
         veh_collision coll = veh.part_collision( *dest, part.part_index(), dp + rel_pos, true, false );
         if( coll.type != veh_coll_nothing ) {
             tripoint_abs_ms point = dp + rel_pos;


### PR DESCRIPTION
#### Summary
Bugfixes "Power grid deleted on ship movement"

#### Purpose of change
Fixes #82282

As far as I know, the bug currently only occurs from ship movement running Aftershock using the Smuggler's Hideout scenario. Power grid gets deleted if using any wall wiring.

#### Describe the solution

Wall wiring and power cords would collide with walls and cancel the copy of the power grid to the new location.

This fix ignores any collisions caused by wall wiring or power cords.

#### Describe alternatives you've considered

None.

#### Testing

Full test program ran. Only errors found were unrelated translation errors.

Piloted ship to space, starting spaceport, and manual travel. Power grid stayed intact.

#### Additional context


