### PR TITLE
Remove bonus damage for 9 mm

### DIFF
--- a/data/json/items/gun/9mm.json
+++ b/data/json/items/gun/9mm.json
@@ -25,7 +25,6 @@
     "material": [ "steel" ],
     "skill": "smg",
     "range": 6,
-    "ranged_damage": { "damage_type": "bullet", "amount": 2 },
     "dispersion": 280,
     "durability": 6,
     "modes": [ [ "DEFAULT", "semi-auto", 1 ], [ "AUTO", "auto", 4 ] ],
@@ -77,7 +76,6 @@
     "barrel_length": "102 mm",
     "price": "690 USD",
     "material": [ "plastic", "steel" ],
-    "ranged_damage": { "damage_type": "bullet", "amount": -1 },
     "dispersion": 480,
     "valid_mod_locations": [ [ "barrel", 1 ], [ "mechanism", 2 ], [ "rail", 1 ], [ "sights mount", 1 ], [ "stock mount", 1 ] ],
     "pocket_data": [
@@ -112,7 +110,6 @@
     "valid_mod_locations": [ [ "barrel", 1 ], [ "mechanism", 2 ], [ "sights mount", 1 ], [ "stock mount", 1 ] ],
     "price": "690 USD",
     "material": [ "plastic", "steel" ],
-    "ranged_damage": { "damage_type": "bullet", "amount": -1 },
     "dispersion": 480,
     "pocket_data": [
       {
@@ -144,7 +141,6 @@
     "barrel_length": "135 mm",
     "price": "630 USD",
     "material": [ "plastic", "steel" ],
-    "ranged_damage": { "damage_type": "bullet", "amount": -1 },
     "dispersion": 380,
     "valid_mod_locations": [ [ "barrel", 1 ], [ "mechanism", 2 ], [ "rail", 1 ], [ "sights mount", 1 ], [ "stock mount", 1 ] ],
     "pocket_data": [
@@ -169,7 +165,6 @@
     "barrel_length": "87 mm",
     "price": "570 USD",
     "material": [ "plastic", "steel" ],
-    "ranged_damage": { "damage_type": "bullet", "amount": -1 },
     "dispersion": 480,
     "pocket_data": [ { "magazine_well": "250 ml", "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "glock43_mag" ] } ]
   },
@@ -188,7 +183,6 @@
     "barrel_length": "87 mm",
     "price": "570 USD",
     "material": [ "plastic", "steel" ],
-    "ranged_damage": { "damage_type": "bullet", "amount": -1 },
     "valid_mod_locations": [ [ "barrel", 1 ], [ "mechanism", 2 ], [ "sights mount", 1 ], [ "stock mount", 1 ] ],
     "dispersion": 480,
     "pocket_data": [ { "magazine_well": "250 ml", "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "glock43x/48_mag" ] } ]
@@ -207,7 +201,6 @@
     "barrel_length": "106 mm",
     "price": "570 USD",
     "material": [ "plastic", "steel" ],
-    "ranged_damage": { "damage_type": "bullet", "amount": -1 },
     "valid_mod_locations": [ [ "barrel", 1 ], [ "mechanism", 2 ], [ "sights mount", 1 ], [ "stock mount", 1 ] ],
     "dispersion": 480,
     "pocket_data": [ { "magazine_well": "250 ml", "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "glock43x/48_mag" ] } ]
@@ -230,7 +223,6 @@
     "price_postapoc": "35 USD",
     "material": [ "steel", "plastic" ],
     "skill": "smg",
-    "ranged_damage": { "damage_type": "bullet", "amount": 1 },
     "range": 4,
     "dispersion": 240,
     "modes": [ [ "DEFAULT", "semi-auto", 1 ], [ "BURST", "3 rd.", 3 ], [ "AUTO", "auto", 4 ] ],
@@ -286,7 +278,6 @@
     "price_postapoc": "35 USD",
     "dispersion": 270,
     "range": 1,
-    "ranged_damage": { "damage_type": "bullet", "amount": 0 },
     "built_in_mods": [ "folding_stock", "grip" ],
     "valid_mod_locations": [
       [ "barrel", 1 ],
@@ -337,7 +328,6 @@
       [ "stock mount", 1 ],
       [ "underbarrel mount", 1 ]
     ],
-    "ranged_damage": { "damage_type": "bullet", "amount": 0 },
     "melee_damage": { "bash": 7 }
   },
   {
@@ -400,7 +390,6 @@
     "barrel_length": "100 mm",
     "price": "1 kUSD",
     "material": "steel",
-    "ranged_damage": { "damage_type": "bullet", "amount": -1 },
     "dispersion": 420,
     "valid_mod_locations": [ [ "barrel", 1 ], [ "mechanism", 2 ], [ "rail mount", 1 ], [ "stock mount", 1 ] ],
     "pocket_data": [ { "magazine_well": "55 ml", "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "p08mag_8rd", "p08mag_32rd" ] } ]
@@ -463,7 +452,6 @@
     "price": "15 kUSD",
     "material": [ "steel" ],
     "skill": "smg",
-    "ranged_damage": { "damage_type": "bullet", "amount": 1 },
     "range": 4,
     "dispersion": 360,
     "durability": 6,
@@ -495,7 +483,6 @@
     "barrel_length": "274 mm",
     "price": "900 USD",
     "material": [ "steel" ],
-    "ranged_damage": { "damage_type": "bullet", "amount": 1 },
     "range": 4,
     "dispersion": 360,
     "valid_mod_locations": [ [ "brass catcher", 1 ], [ "stock mount", 1 ], [ "rail mount", 1 ], [ "sights mount", 1 ] ],
@@ -526,7 +513,6 @@
     "price": "750 USD",
     "material": [ "steel", "plastic" ],
     "range": 6,
-    "ranged_damage": { "damage_type": "bullet", "amount": 3 },
     "dispersion": 180,
     "durability": 7,
     "built_in_mods": [ "sub2000_folding_mechanism" ],
@@ -628,7 +614,6 @@
     "price": "200 USD",
     "material": [ "steel" ],
     "skill": "smg",
-    "ranged_damage": { "damage_type": "bullet", "amount": -3 },
     "dispersion": 590,
     "durability": 4,
     "modes": [ [ "DEFAULT", "burst", 5 ] ],
@@ -660,7 +645,6 @@
     "price": "400 USD",
     "material": [ "steel" ],
     "skill": "smg",
-    "ranged_damage": { "damage_type": "bullet", "amount": 1 },
     "range": 2,
     "dispersion": 360,
     "durability": 5,
@@ -722,7 +706,6 @@
     "barrel_length": "108 mm",
     "price": "680 USD",
     "material": [ "steel", "plastic" ],
-    "ranged_damage": { "damage_type": "bullet", "amount": -1 },
     "dispersion": 400,
     "valid_mod_locations": [ [ "barrel", 1 ], [ "mechanism", 2 ], [ "rail", 1 ], [ "sights mount", 1 ], [ "stock mount", 1 ] ],
     "durability": 9,
@@ -750,7 +733,6 @@
     "price": "2 kUSD 80 USD",
     "material": [ "steel" ],
     "skill": "smg",
-    "ranged_damage": { "damage_type": "bullet", "amount": 1 },
     "range": 7,
     "dispersion": 360,
     "modes": [ [ "DEFAULT", "semi-auto", 1 ], [ "AUTO", "auto", 4 ] ],
@@ -796,7 +778,6 @@
     "barrel_length": "114 mm",
     "price": "690 USD",
     "material": [ "plastic", "steel" ],
-    "ranged_damage": { "damage_type": "bullet", "amount": -1 },
     "dispersion": 480,
     "valid_mod_locations": [ [ "barrel", 1 ], [ "mechanism", 2 ], [ "rail", 1 ], [ "sights mount", 1 ], [ "stock mount", 1 ] ],
     "//2": "Glock 17s cannot load magazines shorter than the standard 17rd magazine.",
@@ -1098,7 +1079,6 @@
     "color": "dark_gray",
     "ammo": [ "9mm" ],
     "skill": "smg",
-    "ranged_damage": { "damage_type": "bullet", "amount": 1 },
     "range": 5,
     "dispersion": 240,
     "modes": [ [ "DEFAULT", "semi-auto", 1 ], [ "AUTO", "auto", 4 ] ],
@@ -1189,7 +1169,6 @@
     "price": "779 USD",
     "material": [ "steel", "plastic", "aluminum" ],
     "range": 6,
-    "ranged_damage": { "damage_type": "bullet", "amount": 4 },
     "dispersion": 180,
     "valid_mod_locations": [
       [ "barrel", 1 ],
@@ -1242,7 +1221,6 @@
     "barrel_length": "94 mm",
     "price": "679 USD 99 cent",
     "material": [ "steel", "plastic" ],
-    "ranged_damage": { "damage_type": "bullet", "amount": -2 },
     "dispersion": 300,
     "valid_mod_locations": [ [ "barrel", 1 ], [ "mechanism", 2 ], [ "rail", 1 ], [ "sights", 1 ], [ "stock mount", 1 ] ],
     "pocket_data": [ { "magazine_well": "66 ml", "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "p365_mag" ] } ]


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
#82266 made me realize the same need to be done for 9mm
#### Describe the solution
Remove damage bonus from 9 mm guns, for now it is handled via barrel length and ammo definition added in #82262