### PR TITLE
[Xedra Evolved] Werewolves get mana back on Nether kills

### DIFF
--- a/data/mods/Xedra_Evolved/eocs/shapeshifter_eocs.json
+++ b/data/mods/Xedra_Evolved/eocs/shapeshifter_eocs.json
@@ -122,10 +122,10 @@
                 "run_eocs": [
                   {
                     "id": "EOC_WEREWOLF_WOLF_FORM_activated_3",
-                    "condition": { "math": [ "u_val('mana') >= 50" ] },
+                    "condition": { "math": [ "u_val('mana') >= 20" ] },
                     "effect": [
                       { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 1.5 },
-                      { "math": [ "u_val('mana') -= 50" ] },
+                      { "math": [ "u_val('mana') -= 20" ] },
                       { "run_eocs": "EOC_SHAPESHIFTING_ARMOR_CHECK_SUBSUME_INTO_FORM" },
                       { "u_add_trait": "VAMPIRE_WOLF_FORM_TRAITS" },
                       { "u_add_trait": "CARNIVORE" },
@@ -196,10 +196,10 @@
                 "run_eocs": [
                   {
                     "id": "EOC_WEREWOLF_HYBRID_FORM_activated_3",
-                    "condition": { "math": [ "u_val('mana') >= 50" ] },
+                    "condition": { "math": [ "u_val('mana') >= 20" ] },
                     "effect": [
                       { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 1.5 },
-                      { "math": [ "u_val('mana') -= 50" ] },
+                      { "math": [ "u_val('mana') -= 20" ] },
                       { "math": [ "u_calories('dont_affect_weariness': true)", "*=", "3" ] },
                       { "math": [ "u_werewolf_healing_tick_counter = 0" ] },
                       { "run_eocs": "EOC_SHAPESHIFTING_ARMOR_CHECK_SUBSUME_INTO_FORM" },

--- a/data/mods/Xedra_Evolved/mutations/shapeshifters.json
+++ b/data/mods/Xedra_Evolved/mutations/shapeshifters.json
@@ -114,7 +114,12 @@
       },
       {
         "condition": { "and": [ { "not": "is_day" }, { "math": [ "moon_phase() == 4" ] } ] },
-        "values": [ { "value": "DEXTERITY", "add": 2 }, { "value": "STRENGTH", "add": 2 }, { "value": "SPEED", "multiply": 0.05 } ]
+        "values": [
+          { "value": "DEXTERITY", "add": 2 },
+          { "value": "STRENGTH", "add": 2 },
+          { "value": "SPEED", "multiply": 0.05 },
+          { "value": "REGEN_MANA", "multiply": 1 }
+        ]
       }
     ],
     "integrated_armor": [ "integrated_claws_werewolf" ],

--- a/data/mods/Xedra_Evolved/mutations/werewolf_trait_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/werewolf_trait_eocs.json
@@ -1,6 +1,14 @@
 [
   {
     "type": "effect_on_condition",
+    "id": "EOC_WEREWOLF_GET_MANA_ON_NETHER_KILLS",
+    "eoc_type": "EVENT",
+    "required_event": "character_kills_monster",
+    "condition": { "and": [ { "not": "u_has_weapon" }, { "test_eoc": "EOC_CONDITIONS_WEREWOLF_HUNT_TARGETS" } ] },
+    "effect": [ { "math": [ "u_val('mana')", "+=", "25" ] } ]
+  },
+  {
+    "type": "effect_on_condition",
     "id": "EOC_WEREWOLF_SENSE_SPIRITS_AND_ALIENS_ON",
     "effect": [ { "u_add_trait": "WEREWOLF_SENSE_SPIRITS_AND_ALIENS_ACTIVE" } ]
   },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[Xedra Evolved] Werewolves get mana back on Nether kills"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Talking about it with Maleclypse and came to this solution
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Reduce the cost of form shifting to 20 mana (from 50)
Werewolves get 25 mana back on Nether monster kills (+50 if they have Thrill of the Hunt). 
Werewolves regenerate mana at double speed during the full moon at night
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Someone make custom mana pools please
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
