### PR TITLE
Fix deserialize/serialize of power level

### DIFF
--- a/src/flexbuffer_json-inl.h
+++ b/src/flexbuffer_json-inl.h
@@ -849,6 +849,11 @@ inline int JsonObject::get_int( const std::string_view key ) const
     return get_member( key );
 }
 
+inline int64_t JsonObject::get_int64( const std::string_view key ) const
+{
+    return get_member( key );
+}
+
 inline double JsonObject::get_float( const std::string_view key ) const
 {
     return get_member( key );

--- a/src/flexbuffer_json.h
+++ b/src/flexbuffer_json.h
@@ -617,6 +617,7 @@ class JsonObject : JsonWithPath
         // Vanilla accessors. Just return the named member and use it's conversion function.
         bool get_bool( std::string_view key ) const;
         int get_int( std::string_view key ) const;
+        int64_t get_int64( std::string_view key ) const;
         double get_float( std::string_view key ) const;
         JsonArray get_array( std::string_view key ) const;
         JsonObject get_object( std::string_view key ) const;

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -1094,8 +1094,18 @@ void Character::load( const JsonObject &data )
     recalc_sight_limits();
     calc_encumbrance();
 
-    optional( data, false, "power_level", power_level, 0_kJ );
-    optional( data, false, "max_power_level_modifier", max_power_level_modifier, units::energy::min() );
+    // migration code, added in early 0.J
+    if( data.has_int( "power_level" ) ) {
+        power_level = units::from_kilojoule( data.get_int64( "power_level" ) );
+    } else {
+        data.read( "power_level", power_level );
+    }
+    // migration code, added in early 0.J
+    if( data.has_int( "max_power_level_modifier" ) ) {
+        max_power_level_modifier = units::from_kilojoule( data.get_int64( "max_power_level_modifier" ) );
+    } else {
+        data.read( "max_power_level_modifier", max_power_level_modifier );
+    }
 
     // Bionic power should not be negative!
     if( power_level < 0_mJ ) {
@@ -1460,14 +1470,8 @@ void Character::store( JsonOut &json ) const
     json.member( "proficiencies", _proficiencies );
 
     // npc; unimplemented
-    if( power_level < 1_J ) {
-        json.member( "power_level", std::to_string( units::to_millijoule( power_level ) ) + " mJ" );
-    } else if( power_level < 1_kJ ) {
-        json.member( "power_level", std::to_string( units::to_joule( power_level ) ) + " J" );
-    } else {
-        json.member( "power_level", units::to_kilojoule( power_level ) );
-    }
-    json.member( "max_power_level_modifier", units::to_kilojoule( max_power_level_modifier ) );
+    json.member( "power_level", power_level );
+    json.member( "max_power_level_modifier", max_power_level_modifier );
 
     if( !overmap_time.empty() ) {
         json.member( "overmap_time" );


### PR DESCRIPTION
#### Summary
Bugfixes "Fix deserialization error with power level"

#### Purpose of change
Bug introduced in https://github.com/CleverRaven/Cataclysm-DDA/pull/82226

These were not being serialized as units strings, but as integers, and changing it to optional resulted in a loading error.


#### Describe the solution
Save them as units strings always and handle loading ints.

#### Testing
I have not had a chance to test this.
