### PR TITLE
Save bionic power as string value consistently

### DIFF
--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -1465,9 +1465,10 @@ void Character::store( JsonOut &json ) const
     } else if( power_level < 1_kJ ) {
         json.member( "power_level", std::to_string( units::to_joule( power_level ) ) + " J" );
     } else {
-        json.member( "power_level", units::to_kilojoule( power_level ) );
+        json.member( "power_level", std::to_string( units::to_kilojoule( power_level ) ) + " kJ" );
     }
-    json.member( "max_power_level_modifier", units::to_kilojoule( max_power_level_modifier ) );
+    json.member( "max_power_level_modifier",
+                 std::to_string( units::to_kilojoule( max_power_level_modifier ) ) + " kJ" );
 
     if( !overmap_time.empty() ) {
         json.member( "overmap_time" );


### PR DESCRIPTION

#### Summary
Category "Save of bionic power as integer can lead to a  broken save"

#### Purpose of change

Bionic power saved as an integer can break the save. 

Saving as an integer loses the scale values of mJ, J, or kJ. Changing it to a string fixes that oversight.

#### Describe the solution

Make the save of bionic power consistent. 2 writes were as string and 2 writes as integers.

This change makes so that all json writes of bionic power are consistent as a string.

#### Describe alternatives you've considered

None

#### Testing

Compared problematic save file before and after the fix. Old file has some bionic integer values, and new save file correctly has all bionic power values as a string.

Saved and loaded multiple starts with bionic characters. No problems found.

#### Additional context

