### PR TITLE
XL/XS pipebomb bandolier

### DIFF
--- a/data/json/items/armor/bandolier.json
+++ b/data/json/items/armor/bandolier.json
@@ -568,7 +568,13 @@
     ],
     "flags": [ "WATER_FRIENDLY", "BELTED", "UNDERSIZE", "PREFIX_XS" ],
     "armor": [
-      { "encumbrance": 6, "coverage": 35, "covers": [ "torso" ], "specifically_covers": [ "torso_upper" ] },
+      {
+        "encumbrance": 6,
+        "volume_encumber_modifier": 1.4,
+        "coverage": 35,
+        "covers": [ "torso" ],
+        "specifically_covers": [ "torso_upper" ]
+      },
       {
         "encumbrance": 3,
         "volume_encumber_modifier": 0,
@@ -653,7 +659,13 @@
     ],
     "flags": [ "WATER_FRIENDLY", "BELTED", "OVERSIZE", "PREFIX_XL" ],
     "armor": [
-      { "encumbrance": 6, "coverage": 35, "covers": [ "torso" ], "specifically_covers": [ "torso_upper" ] },
+      {
+        "encumbrance": 6,
+        "volume_encumber_modifier": 0.8,
+        "coverage": 35,
+        "covers": [ "torso" ],
+        "specifically_covers": [ "torso_upper" ]
+      },
       {
         "encumbrance": 3,
         "volume_encumber_modifier": 0,

--- a/data/json/items/armor/bandolier.json
+++ b/data/json/items/armor/bandolier.json
@@ -513,7 +513,145 @@
         "max_item_length": "30 cm"
       }
     ],
-    "flags": [ "WATER_FRIENDLY", "BELTED", "OVERSIZE" ],
+    "flags": [ "WATER_FRIENDLY", "BELTED" ],
+    "armor": [
+      { "encumbrance": 6, "coverage": 35, "covers": [ "torso" ], "specifically_covers": [ "torso_upper" ] },
+      {
+        "encumbrance": 3,
+        "volume_encumber_modifier": 0,
+        "coverage": 60,
+        "covers": [ "arm_l", "arm_r" ],
+        "specifically_covers": [ "arm_shoulder_l", "arm_shoulder_r" ]
+      }
+    ]
+  },
+  {
+    "id": "bandolier_pipebomb_xs",
+    "type": "ITEM",
+    "subtypes": [ "ARMOR" ],
+    "name": { "str": "large grenade bandolier" },
+    "description": "A homemade nylon bandolier covering the upper chest while supported by straps on both shoulders.  While fairly hefty and cumbersome when full, it does allow the wearer to carry larger grenades such as pipebombs or Molotovs.",
+    "weight": "623 g",
+    "volume": "548 ml",
+    "price": "19 USD",
+    "price_postapoc": "4 USD",
+    "material": [ "nylon" ],
+    "symbol": "[",
+    "looks_like": "leather_belt",
+    "color": "dark_gray",
+    "material_thickness": 1,
+    "pocket_data": [
+      {
+        "moves": 140,
+        "flag_restriction": [ "CYLINDER_GRENADE" ],
+        "holster": true,
+        "max_contains_volume": "1 L",
+        "max_contains_weight": "1200 g",
+        "max_item_length": "30 cm"
+      },
+      {
+        "moves": 140,
+        "flag_restriction": [ "CYLINDER_GRENADE" ],
+        "holster": true,
+        "max_contains_volume": "1 L",
+        "max_contains_weight": "1200 g",
+        "max_item_length": "30 cm"
+      },
+      {
+        "moves": 140,
+        "flag_restriction": [ "CYLINDER_GRENADE" ],
+        "holster": true,
+        "max_contains_volume": "1 L",
+        "max_contains_weight": "1200 g",
+        "max_item_length": "30 cm"
+      }
+    ],
+    "flags": [ "WATER_FRIENDLY", "BELTED", "UNDERSIZE", "PREFIX_XS" ],
+    "armor": [
+      { "encumbrance": 6, "coverage": 35, "covers": [ "torso" ], "specifically_covers": [ "torso_upper" ] },
+      {
+        "encumbrance": 3,
+        "volume_encumber_modifier": 0,
+        "coverage": 60,
+        "covers": [ "arm_l", "arm_r" ],
+        "specifically_covers": [ "arm_shoulder_l", "arm_shoulder_r" ]
+      }
+    ]
+  },
+  {
+    "id": "bandolier_pipebomb_xl",
+    "type": "ITEM",
+    "subtypes": [ "ARMOR" ],
+    "name": { "str": "large grenade bandolier" },
+    "description": "A homemade nylon bandolier covering the upper chest while supported by straps on both shoulders.  While fairly hefty and cumbersome when full, it does allow the wearer to carry larger grenades such as pipebombs or Molotovs.",
+    "weight": "934 g",
+    "volume": "825 ml",
+    "price": "19 USD",
+    "price_postapoc": "4 USD",
+    "material": [ "nylon" ],
+    "symbol": "[",
+    "looks_like": "leather_belt",
+    "color": "dark_gray",
+    "material_thickness": 1,
+    "pocket_data": [
+      {
+        "moves": 140,
+        "flag_restriction": [ "CYLINDER_GRENADE" ],
+        "holster": true,
+        "max_contains_volume": "1 L",
+        "max_contains_weight": "1200 g",
+        "max_item_length": "30 cm"
+      },
+      {
+        "moves": 140,
+        "flag_restriction": [ "CYLINDER_GRENADE" ],
+        "holster": true,
+        "max_contains_volume": "1 L",
+        "max_contains_weight": "1200 g",
+        "max_item_length": "30 cm"
+      },
+      {
+        "moves": 140,
+        "flag_restriction": [ "CYLINDER_GRENADE" ],
+        "holster": true,
+        "max_contains_volume": "1 L",
+        "max_contains_weight": "1200 g",
+        "max_item_length": "30 cm"
+      },
+      {
+        "moves": 140,
+        "flag_restriction": [ "CYLINDER_GRENADE" ],
+        "holster": true,
+        "max_contains_volume": "1 L",
+        "max_contains_weight": "1200 g",
+        "max_item_length": "30 cm"
+      },
+      {
+        "moves": 140,
+        "flag_restriction": [ "CYLINDER_GRENADE" ],
+        "holster": true,
+        "max_contains_volume": "1 L",
+        "max_contains_weight": "1200 g",
+        "max_item_length": "30 cm"
+      },
+      {
+        "moves": 140,
+        "flag_restriction": [ "CYLINDER_GRENADE" ],
+        "holster": true,
+        "max_contains_volume": "1 L",
+        "max_contains_weight": "1200 g",
+        "max_item_length": "30 cm"
+      },
+      {
+        "moves": 140,
+        "flag_restriction": [ "CYLINDER_GRENADE" ],
+        "holster": true,
+        "max_contains_volume": "1 L",
+        "max_contains_weight": "1200 g",
+        "max_item_length": "30 cm"
+      }
+    ],
+    "flags": [ "WATER_FRIENDLY", "BELTED", "OVERSIZE", "PREFIX_XL" ],
     "armor": [
       { "encumbrance": 6, "coverage": 35, "covers": [ "torso" ], "specifically_covers": [ "torso_upper" ] },
       {

--- a/data/json/recipes/armor/storage.json
+++ b/data/json/recipes/armor/storage.json
@@ -2614,5 +2614,33 @@
     "using": [ [ "tailoring_nylon", 21 ] ],
     "proficiencies": [ { "proficiency": "prof_closures" } ],
     "components": [ [ [ "clasps", 7, "LIST" ] ] ]
+  },
+  {
+    "result": "bandolier_pipebomb_xs",
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "category": "CC_*",
+    "subcategory": "CSC_*_NESTED",
+    "skill_used": "tailor",
+    "difficulty": 3,
+    "time": "6 h",
+    "autolearn": true,
+    "using": [ [ "tailoring_nylon", 16 ] ],
+    "proficiencies": [ { "proficiency": "prof_closures" } ],
+    "components": [ [ [ "clasps", 5, "LIST" ] ] ]
+  },
+  {
+    "result": "bandolier_pipebomb_xl",
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "category": "CC_*",
+    "subcategory": "CSC_*_NESTED",
+    "skill_used": "tailor",
+    "difficulty": 3,
+    "time": "12 h",
+    "autolearn": true,
+    "using": [ [ "tailoring_nylon", 28 ] ],
+    "proficiencies": [ { "proficiency": "prof_closures" } ],
+    "components": [ [ [ "clasps", 9, "LIST" ] ] ]
   }
 ]

--- a/data/json/recipes/nested.json
+++ b/data/json/recipes/nested.json
@@ -158,7 +158,9 @@
       "torso_bandolier_shotgun",
       "torso_bandolier_grenade",
       "bandolier_wrist",
-      "bandolier_pipebomb"
+      "bandolier_pipebomb",
+      "bandolier_pipebomb_xs",
+      "bandolier_pipebomb_xl"
     ],
     "difficulty": 1
   },

--- a/data/json/uncraft/armor/storage.json
+++ b/data/json/uncraft/armor/storage.json
@@ -74,5 +74,21 @@
     "time": "20 m",
     "qualities": [ { "id": "FABRIC_CUT", "level": 1 }, { "id": "CUT", "level": 2 } ],
     "components": [ [ [ "strap_cotton", 2 ] ], [ [ "snapfastener_steel", 5 ] ], [ [ "sheet_nylon_patchwork", 20 ] ], [ [ "nylon", 8 ] ] ]
+  },
+  {
+    "result": "bandolier_pipebomb_xs",
+    "type": "uncraft",
+    "activity_level": "LIGHT_EXERCISE",
+    "time": "20 m",
+    "qualities": [ { "id": "FABRIC_CUT", "level": 1 }, { "id": "CUT", "level": 2 } ],
+    "components": [ [ [ "strap_cotton", 2 ] ], [ [ "snapfastener_steel", 3 ] ], [ [ "sheet_nylon_patchwork", 15 ] ], [ [ "nylon", 8 ] ] ]
+  },
+  {
+    "result": "bandolier_pipebomb_xl",
+    "type": "uncraft",
+    "activity_level": "LIGHT_EXERCISE",
+    "time": "20 m",
+    "qualities": [ { "id": "FABRIC_CUT", "level": 1 }, { "id": "CUT", "level": 2 } ],
+    "components": [ [ [ "strap_cotton", 2 ] ], [ [ "snapfastener_steel", 7 ] ], [ [ "sheet_nylon_patchwork", 26 ] ], [ [ "nylon", 8 ] ] ]
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Content "XS/XL pipebomb bandolier"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

These badboys should be used by mutants too.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

XL one gets 7 slots, XS gets 3, with the same encumbrance. Magic, eh?
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Loads fine, encumbrance while full is roughly the same. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
