### PR TITLE
Magiclysm: Silver Infuser uses gem bracelets

### DIFF
--- a/data/mods/Magiclysm/recipes/magic_tools.json
+++ b/data/mods/Magiclysm/recipes/magic_tools.json
@@ -109,7 +109,26 @@
       { "proficiency": "prof_fine_metalsmithing", "required": false, "time_multiplier": 3 }
     ],
     "qualities": [ { "id": "CHISEL", "level": 1 } ],
-    "components": [ [ [ "silver_bracelet", 1 ] ] ]
+    "components": [
+      [
+        [ "silver_bracelet", 1 ],
+        [ "diamond_silver_bracelet", 1 ],
+        [ "garnet_silver_bracelet", 1 ],
+        [ "amethyst_silver_bracelet", 1 ],
+        [ "aquamarine_silver_bracelet", 1 ],
+        [ "emerald_silver_bracelet", 1 ],
+        [ "alexandrite_silver_bracelet", 1 ],
+        [ "ruby_silver_bracelet", 1 ],
+        [ "peridot_silver_bracelet", 1 ],
+        [ "sapphire_silver_bracelet", 1 ],
+        [ "tourmaline_silver_bracelet", 1 ],
+        [ "citrine_silver_bracelet", 1 ],
+        [ "blue_topaz_silver_bracelet", 1 ],
+        [ "opal_silver_bracelet", 1 ],
+        [ "pearl_silver_bracelet", 1 ],
+        [ "onyx_silver_bracelet", 1 ]
+      ]
+    ]
   },
   {
     "type": "recipe",


### PR DESCRIPTION
#### Summary
Mods "Expanded the Magiclysm silver infuser recipe to use any silver bracelet."

#### Purpose of change

The purpose of this change is to make it simpler to craft silver infusers by letting you use any silver bracelet as an ingredient, not just a silver bracelet without a gemstone.

#### Describe the solution

Expanded the recipe for the silver infuser to include items such as the "diamond_silver_bracelet" as alternate ingredients instead of just the "silver_bracelet" .

#### Describe alternatives you've considered

I considered also adding some sort of recipe to remove gemstones from silver bracelets, but this was simpler. And really why would a gemstone interfere with a magic bracelet anyway?

#### Testing

I linted the changes I made to the JSON file, and then copied the whole thing over into my game.

The recipe shows up as expected and I was able to craft a silver infusion bracelet using a citrine silver bracelet.

#### Additional context
