### PR TITLE
Fixes Alpha Member of the Group to work as intended

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -10584,8 +10584,18 @@
     "category": [ "ALPHA" ],
     "social_modifiers": { "intimidate": 5, "persuade": 15, "lie": 10 },
     "triggers": [
-      [ { "condition": { "or": [ { "math": [ "u_val('morale') < -75" ] }, { "math": [ "u_val('morale') < 75" ] } ] } } ],
-      [ { "condition": { "or": [ { "math": [ "u_val('stim') < -50" ] }, { "math": [ "u_val('stim') < 50" ] } ] } } ]
+      [
+        {
+          "condition": {
+            "or": [
+              { "math": [ "u_val('morale') < -75" ] },
+              { "math": [ "u_val('morale') > 75" ] },
+              { "math": [ "u_val('stim') < -50" ] },
+              { "math": [ "u_val('stim') > 50" ] }
+            ]
+          }
+        }
+      ]
     ],
     "transform": { "target": "DARK_TRIAD", "msg_transform": "You give in to your worst instincts.", "active": false, "moves": 10 }
   },


### PR DESCRIPTION
#### Summary
Bugfixes "Fixes Alpha Member of the Group to work as intended"

#### Purpose of change
Solves two issues with Alpha Member of the Group. 1) Flips the inequality sign for the upper values so the conditions aren't almost always true, causing the mutation to instantly transform into Dark Triad. 2) Moves the morale and stim requirements into one `or` block, as the original intention was to have AMOG transform under "strong emotions or overindulging in drugs." Previously, it was strong emotions *and* overindulging in drugs.
These bugs can be reproduced by creating a new character and debugging in the AMOG mutation. It will transform into Dark Triad immediately since the new character will have <75 morale and <50 stim. Setting morale to >75 or getting >50 stim will prevent AMOG from transforming into Dark Triad, which is obviously not intended.

#### Describe the solution
Flip the inequality for the upper values and roll the two conditions into one `or` block.

#### Describe alternatives you've considered
None

#### Testing
Successfully loaded the game with the changes made. Saw that AMOG would transform into Dark Triad with morale <-75, morale >75, stim <-50, and stim >50.

#### Additional context
Alpha Member of the Group added in #74304

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
