### PR TITLE
Refactor effect parameter updating

### DIFF
--- a/src/effect.h
+++ b/src/effect.h
@@ -277,6 +277,9 @@ class effect
             eff_type( peff_type ), duration( dur ), bp( part ),
             permanent( perm ), intensity( nintensity ), start_time( nstart_time ),
             source( source ) {
+            clamp_duration();
+            apply_int_dur_factor();
+            clamp_intensity();
         }
         effect( const effect & ) = default;
         effect &operator=( const effect & ) = default;
@@ -318,6 +321,8 @@ class effect
         void mod_duration( const time_duration &dur, bool alert = false );
         /** Multiplies the duration, capping at max_duration. */
         void mult_duration( double dur, bool alert = false );
+        /** Caps duration at max_duration. */
+        void clamp_duration();
 
         std::vector<vitamin_applied_effect> vit_effects( bool reduced ) const;
 
@@ -354,12 +359,24 @@ class effect
         int set_intensity( int val, bool alert = false );
 
         /**
+         * Clamps intensity of effect to range [1..max_intensity]
+         * @return new clamped intensity of the effect
+         */
+        int clamp_intensity();
+
+        /**
          * Modify intensity of effect capped by range [1..max_intensity]
          * @param mod Amount to increase current intensity by
          * @param alert whether decay messages should be displayed
          * @return new intensity of the effect after modification and capping
          */
         int mod_intensity( int mod, bool alert = false );
+
+        /**
+         * Set intensity of effect if it is duration based
+         * @return potentially updated intensity of the effect
+         */
+        int apply_int_dur_factor( bool alert = false );
 
         /** Returns the string id of the resist trait to be used in has_trait("id"). */
         const std::vector<trait_id> &get_resist_traits() const;

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -1579,14 +1579,6 @@ void vehicle::add_effect( const effect_source &source, const efftype_id &eff_id,
         effect &e = found_effect->second;
         // If we do, mod the duration, factoring in the mod value
         e.mod_duration( dur * e.get_dur_add_perc() / 100 );
-        // Limit to max duration
-        if( e.get_duration() > e.get_max_duration() ) {
-            e.set_duration( e.get_max_duration() );
-        }
-        // Adding a permanent effect makes it permanent
-        if( e.is_permanent() ) {
-            e.pause_effect();
-        }
     }
 
     if( !found ) {
@@ -1595,23 +1587,7 @@ void vehicle::add_effect( const effect_source &source, const efftype_id &eff_id,
         // Now we can make the new effect for application
         effect e( effect_source( source ), &type, dur, bodypart_str_id::NULL_ID(), permanent, intensity,
                   calendar::turn );
-        // Bound to max duration
-        if( e.get_duration() > e.get_max_duration() ) {
-            e.set_duration( e.get_max_duration() );
-        }
 
-        // Force intensity if it is duration based
-        if( e.get_int_dur_factor() != 0_turns ) {
-            const int intensity = std::ceil( e.get_duration() / e.get_int_dur_factor() );
-            e.set_intensity( std::max( 1, intensity ) );
-        }
-        // Bound new effect intensity by [1, max intensity]
-        if( e.get_intensity() < 1 ) {
-            add_msg_debug( debugmode::DF_CREATURE, "Bad intensity, ID: %s", e.get_id().c_str() );
-            e.set_intensity( 1 );
-        } else if( e.get_intensity() > e.get_max_intensity() ) {
-            e.set_intensity( e.get_max_intensity() );
-        }
         effects[eff_id] = e;
     }
 }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
The code to clamp effect intensity from 1 to max_intensity, inclusive, is repeated in multiple places. Ditto for capping effect duration at max_duration. Ditto for setting intensity based on duration.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
Move both behaviors to new methods and call them where necessary, including moving calls into the constructor.
Update `effect_test.cpp` `effect_initialization_test` to reflect that the constructor now enforces the rules about `max_duration` and `int_dur_factor`.

Eliminate most duration cap operations as redundant.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->
Traced through a bunch of effect intensity and duration changes and observed apparently correct behavior. Also updated and added some automated tests related to this change.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
I also replaced a min(max)) with clamp. It seems like some of these have snuck in since #64380 

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
