### PR TITLE
Dedupe queuing multiple EOCs

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -527,6 +527,17 @@ std::string enum_to_string<blood_type>( blood_type data )
 
 } // namespace io
 
+void Character::queue_effects( const std::vector<effect_on_condition_id> &effects )
+{
+    for( const effect_on_condition_id &eoc_id : effects ) {
+        effect_on_condition eoc = eoc_id.obj();
+        if( is_avatar() || eoc.run_for_npcs ) {
+            queued_eoc new_eoc = queued_eoc{ eoc.id, calendar::turn_zero, {} };
+            queued_effect_on_conditions.push( new_eoc );
+        }
+    }
+}
+
 void Character::queue_effect( const std::string &name, const time_duration &delay,
                               const time_duration &effect_duration )
 {

--- a/src/character.h
+++ b/src/character.h
@@ -2850,6 +2850,8 @@ class Character : public Creature, public visitable
         std::vector<effect_on_condition_id> inactive_effect_on_condition_vector;
         queued_eocs queued_effect_on_conditions;
 
+        /** Queue mutliple EOCs without delay */
+        void queue_effects( const std::vector<effect_on_condition_id> &effects );
         /** Queue an EOC to add effect after a delay */
         void queue_effect( const std::string &name, const time_duration &delay,
                            const time_duration &duration );

--- a/src/effect_on_condition.cpp
+++ b/src/effect_on_condition.cpp
@@ -140,40 +140,26 @@ static time_duration next_recurrence( const effect_on_condition_id &eoc, dialogu
 void effect_on_conditions::load_new_character( Character &you )
 {
     bool is_avatar = you.is_avatar();
+
     // npcs do not have scenario, so check for that
-    if( get_scenario() ) {
-        for( const effect_on_condition_id &eoc_id : get_scenario()->eoc() ) {
-            effect_on_condition eoc = eoc_id.obj();
-            if( is_avatar || eoc.run_for_npcs ) {
-                queued_eoc new_eoc = queued_eoc{ eoc.id, calendar::turn_zero, {} };
-                you.queued_effect_on_conditions.push( new_eoc );
-            }
-        }
+    const scenario *scen = get_scenario();
+    if( scen ) {
+        you.queue_effects( scen->eoc() );
     }
 
-    if( you.get_profession() ) {
-        for( const effect_on_condition_id &eoc_id : you.get_profession()->get_eocs() ) {
-            effect_on_condition eoc = eoc_id.obj();
-            if( is_avatar || eoc.run_for_npcs ) {
-                queued_eoc new_eoc = queued_eoc{ eoc.id, calendar::turn_zero, {} };
-                you.queued_effect_on_conditions.push( new_eoc );
-            }
-        }
+    const profession *prof = you.get_profession();
+    if( prof ) {
+        you.queue_effects( prof->get_eocs() );
     }
 
-    for( const effect_on_condition &eoc : effect_on_conditions::get_all() ) {
+    for( const effect_on_condition &eoc : get_all() ) {
         if( eoc.type == eoc_type::RECURRING && ( ( is_avatar && eoc.global ) || !eoc.global ) ) {
             dialogue d( get_talker_for( you ), nullptr );
-            queued_eoc new_eoc = queued_eoc{ eoc.id, calendar::turn + next_recurrence( eoc.id, d ), {} };
-            if( eoc.global ) {
-                g->queued_global_effect_on_conditions.push( new_eoc );
-            } else {
-                you.queued_effect_on_conditions.push( new_eoc );
-            }
+            queue_effect_on_condition( next_recurrence( eoc.id, d ), eoc.id, you, {} );
         }
     }
 
-    effect_on_conditions::process_effect_on_conditions( you );
+    process_effect_on_conditions( you );
 }
 
 static void process_new_eocs( queued_eocs &eoc_queue,
@@ -208,7 +194,7 @@ void effect_on_conditions::load_existing_character( Character &you )
 {
     bool is_avatar = you.is_avatar();
     std::map<effect_on_condition_id, bool> new_eocs;
-    for( const effect_on_condition &eoc : effect_on_conditions::get_all() ) {
+    for( const effect_on_condition &eoc : get_all() ) {
         if( eoc.type == eoc_type::RECURRING && ( is_avatar || !eoc.global ) ) {
             new_eocs[eoc.id] = true;
         }
@@ -472,7 +458,7 @@ void effect_on_conditions::prevent_death()
 {
     avatar &player_character = get_avatar();
     dialogue d( get_talker_for( player_character ), nullptr );
-    for( const effect_on_condition &eoc : effect_on_conditions::get_all() ) {
+    for( const effect_on_condition &eoc : get_all() ) {
         if( eoc.type == eoc_type::PREVENT_DEATH ) {
             eoc.activate( d );
         }
@@ -492,7 +478,7 @@ void effect_on_conditions::avatar_death()
         return klr == &c;
     } );
     dialogue d( get_talker_for( get_avatar() ), klr == nullptr ? nullptr : get_talker_for( klr ) );
-    for( const effect_on_condition &eoc : effect_on_conditions::get_all() ) {
+    for( const effect_on_condition &eoc : get_all() ) {
         if( eoc.type == eoc_type::AVATAR_DEATH ) {
             eoc.activate( d );
         }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
During character creation, scenario and profession EOCs are queued with virtually identical code.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
Move that code to a method. Call it twice.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->
Created new characters with scenarios and/or professions with EOCs, confirmed they took effect.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
I also removed some superfluous namespace references.

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
