### PR TITLE
Add type alias for event field

### DIFF
--- a/doc/JSON/JSON_INFO.md
+++ b/doc/JSON/JSON_INFO.md
@@ -2160,9 +2160,11 @@ specification for it in `event.h`:
 
 <!-- {% raw %} -->
 ```cpp
+using event_field = std::pair<const char *, cata_variant_type>;
+//...
 template<>
 struct event_spec<event_type::gains_skill_level> {
-    static constexpr std::array<std::pair<const char *, cata_variant_type>, 3> fields = {{
+    static constexpr std::array<event_field, 3> fields = {{
             { "character", cata_variant_type::character_id },
             { "skill", cata_variant_type::skill_id },
             { "new_level", cata_variant_type::int_ },

--- a/src/event.cpp
+++ b/src/event.cpp
@@ -139,8 +139,7 @@ namespace event_detail
 {
 
 #define DEFINE_EVENT_HELPER_FIELDS(type) \
-    constexpr std::array<std::pair<const char *, cata_variant_type>, \
-    type::fields.size()> type::fields;
+    constexpr std::array<event_field, type::fields.size()> type::fields;
 
 DEFINE_EVENT_HELPER_FIELDS( event_spec_empty )
 DEFINE_EVENT_HELPER_FIELDS( event_spec_character )
@@ -152,7 +151,7 @@ static_assert( static_cast<int>( event_type::num_event_types ) == 107,
                "its fields definition then you probably don't need a definition here." );
 
 #define DEFINE_EVENT_FIELDS(type) \
-    constexpr std::array<std::pair<const char *, cata_variant_type>, \
+    constexpr std::array<event_field, \
     event_spec<event_type::type>::fields.size()> \
     event_spec<event_type::type>::fields;
 

--- a/src/event.h
+++ b/src/event.h
@@ -169,22 +169,24 @@ namespace event_detail
 // keys and corresponding data types are specified in a specialization of
 // event_spec.
 
+using event_field = std::pair<const char *, cata_variant_type>;
+
 template<event_type Type>
 struct event_spec;
 
 struct event_spec_empty {
-    static constexpr std::array<std::pair<const char *, cata_variant_type>, 0> fields = {};
+    static constexpr std::array<event_field, 0> fields = {};
 };
 
 struct event_spec_character {
-    static constexpr std::array<std::pair<const char *, cata_variant_type>, 1> fields = {{
+    static constexpr std::array<event_field, 1> fields = {{
             { "character", cata_variant_type::character_id },
         }
     };
 };
 
 struct event_spec_character_item {
-    static constexpr std::array<std::pair<const char *, cata_variant_type>, 2> fields = {{
+    static constexpr std::array<event_field, 2> fields = {{
             { "character", cata_variant_type::character_id },
             { "itype", cata_variant_type::itype_id },
         }
@@ -197,7 +199,7 @@ static_assert( static_cast<int>( event_type::num_event_types ) == 107,
 
 template<>
 struct event_spec<event_type::activates_artifact> {
-    static constexpr std::array<std::pair<const char *, cata_variant_type>, 2> fields = {{
+    static constexpr std::array<event_field, 2> fields = {{
             { "character", cata_variant_type::character_id },
             { "item_name", cata_variant_type::string },
         }
@@ -209,7 +211,7 @@ struct event_spec<event_type::activates_mininuke> : event_spec_character {};
 
 template<>
 struct event_spec<event_type::administers_mutagen> {
-    static constexpr std::array<std::pair<const char *, cata_variant_type>, 2> fields = {{
+    static constexpr std::array<event_field, 2> fields = {{
             { "character", cata_variant_type::character_id },
             { "technique", cata_variant_type::mutagen_technique },
         }
@@ -221,7 +223,7 @@ struct event_spec<event_type::angers_amigara_horrors> : event_spec_empty {};
 
 template<>
 struct event_spec<event_type::avatar_enters_omt> {
-    static constexpr std::array<std::pair<const char *, cata_variant_type>, 2> fields = {{
+    static constexpr std::array<event_field, 2> fields = {{
             { "pos", cata_variant_type::tripoint },
             { "oter_id", cata_variant_type::oter_id },
         }
@@ -230,7 +232,7 @@ struct event_spec<event_type::avatar_enters_omt> {
 
 template<>
 struct event_spec<event_type::avatar_moves> {
-    static constexpr std::array<std::pair<const char *, cata_variant_type>, 5> fields = {{
+    static constexpr std::array<event_field, 5> fields = {{
             { "mount", cata_variant_type::mtype_id },
             { "terrain", cata_variant_type::ter_id },
             { "movement_mode", cata_variant_type::move_mode_id },
@@ -251,7 +253,7 @@ struct event_spec<event_type::becomes_wanted> : event_spec_character {};
 
 template<>
 struct event_spec<event_type::broken_bone> {
-    static constexpr std::array<std::pair<const char *, cata_variant_type>, 2> fields = {{
+    static constexpr std::array<event_field, 2> fields = {{
             { "character", cata_variant_type::character_id },
             { "part", cata_variant_type::body_part },
         }
@@ -260,7 +262,7 @@ struct event_spec<event_type::broken_bone> {
 
 template<>
 struct event_spec<event_type::broken_bone_mends> {
-    static constexpr std::array<std::pair<const char *, cata_variant_type>, 2> fields = {{
+    static constexpr std::array<event_field, 2> fields = {{
             { "character", cata_variant_type::character_id },
             { "part", cata_variant_type::body_part },
         }
@@ -269,7 +271,7 @@ struct event_spec<event_type::broken_bone_mends> {
 
 template<>
 struct event_spec<event_type::buries_corpse> {
-    static constexpr std::array<std::pair<const char *, cata_variant_type>, 3> fields = {{
+    static constexpr std::array<event_field, 3> fields = {{
             { "character", cata_variant_type::character_id },
             { "corpse_type", cata_variant_type::mtype_id },
             { "corpse_name", cata_variant_type::string },
@@ -279,7 +281,7 @@ struct event_spec<event_type::buries_corpse> {
 
 template<>
 struct event_spec<event_type::camp_taken_over> {
-    static constexpr std::array<std::pair<const char *, cata_variant_type>, 4> fields = {{
+    static constexpr std::array<event_field, 4> fields = {{
             { "old_owner", cata_variant_type::faction_id },
             { "new_owner", cata_variant_type::faction_id },
             { "camp_name", cata_variant_type::string },
@@ -299,7 +301,7 @@ struct event_spec<event_type::character_eats_item> : event_spec_character_item {
 
 template<>
 struct event_spec<event_type::character_casts_spell> {
-    static constexpr std::array<std::pair<const char *, cata_variant_type>, 7> fields = { {
+    static constexpr std::array<event_field, 7> fields = { {
             { "character", cata_variant_type::character_id },
             { "spell", cata_variant_type::spell_id },
             { "school", cata_variant_type::trait_id },
@@ -313,7 +315,7 @@ struct event_spec<event_type::character_casts_spell> {
 
 template<>
 struct event_spec<event_type::character_dies> {
-    static constexpr std::array<std::pair<const char *, cata_variant_type>, 1> fields = {{
+    static constexpr std::array<event_field, 1> fields = {{
             { "character", cata_variant_type::character_id }
         }
     };
@@ -321,7 +323,7 @@ struct event_spec<event_type::character_dies> {
 
 template<>
 struct event_spec<event_type::character_finished_activity> {
-    static constexpr std::array<std::pair<const char *, cata_variant_type>, 3> fields = { {
+    static constexpr std::array<event_field, 3> fields = { {
             { "character", cata_variant_type::character_id },
             { "activity", cata_variant_type::activity_id },
             { "canceled", cata_variant_type::bool_ }
@@ -331,7 +333,7 @@ struct event_spec<event_type::character_finished_activity> {
 
 template<>
 struct event_spec<event_type::character_forgets_spell> {
-    static constexpr std::array<std::pair<const char *, cata_variant_type>, 2> fields = { {
+    static constexpr std::array<event_field, 2> fields = { {
             { "character", cata_variant_type::character_id },
             { "spell", cata_variant_type::spell_id }
         }
@@ -340,7 +342,7 @@ struct event_spec<event_type::character_forgets_spell> {
 
 template<>
 struct event_spec<event_type::character_gains_effect> {
-    static constexpr std::array<std::pair<const char *, cata_variant_type>, 4> fields = {{
+    static constexpr std::array<event_field, 4> fields = {{
             { "character", cata_variant_type::character_id },
             { "bodypart", cata_variant_type::body_part},
             { "effect", cata_variant_type::efftype_id },
@@ -354,7 +356,7 @@ struct event_spec<event_type::character_gets_headshot> : event_spec_character {}
 
 template<>
 struct event_spec<event_type::character_heals_damage> {
-    static constexpr std::array<std::pair<const char *, cata_variant_type>, 2> fields = {{
+    static constexpr std::array<event_field, 2> fields = {{
             { "character", cata_variant_type::character_id },
             { "damage", cata_variant_type::int_ },
         }
@@ -363,7 +365,7 @@ struct event_spec<event_type::character_heals_damage> {
 
 template<>
 struct event_spec<event_type::character_kills_monster> {
-    static constexpr std::array<std::pair<const char *, cata_variant_type>, 3> fields = {{
+    static constexpr std::array<event_field, 3> fields = {{
             { "killer", cata_variant_type::character_id },
             { "victim_type", cata_variant_type::mtype_id },
             { "exp", cata_variant_type::int_},
@@ -373,7 +375,7 @@ struct event_spec<event_type::character_kills_monster> {
 
 template<>
 struct event_spec<event_type::character_kills_character> {
-    static constexpr std::array<std::pair<const char *, cata_variant_type>, 3> fields = {{
+    static constexpr std::array<event_field, 3> fields = {{
             { "killer", cata_variant_type::character_id },
             { "victim", cata_variant_type::character_id },
             { "victim_name", cata_variant_type::string },
@@ -383,7 +385,7 @@ struct event_spec<event_type::character_kills_character> {
 
 template<>
 struct event_spec<event_type::character_learns_spell> {
-    static constexpr std::array<std::pair<const char *, cata_variant_type>, 2> fields = { {
+    static constexpr std::array<event_field, 2> fields = { {
             { "character", cata_variant_type::character_id },
             { "spell", cata_variant_type::spell_id }
         }
@@ -392,7 +394,7 @@ struct event_spec<event_type::character_learns_spell> {
 
 template<>
 struct event_spec<event_type::character_loses_effect> {
-    static constexpr std::array<std::pair<const char *, cata_variant_type>, 3> fields = {{
+    static constexpr std::array<event_field, 3> fields = {{
             { "character", cata_variant_type::character_id },
             { "bodypart", cata_variant_type::body_part},
             { "effect", cata_variant_type::efftype_id },
@@ -402,7 +404,7 @@ struct event_spec<event_type::character_loses_effect> {
 
 template<>
 struct event_spec<event_type::character_melee_attacks_character> {
-    static constexpr std::array<std::pair<const char *, cata_variant_type>, 5> fields = {{
+    static constexpr std::array<event_field, 5> fields = {{
             { "attacker", cata_variant_type::character_id },
             { "weapon", cata_variant_type::itype_id },
             { "hits", cata_variant_type::bool_ },
@@ -414,7 +416,7 @@ struct event_spec<event_type::character_melee_attacks_character> {
 
 template<>
 struct event_spec<event_type::character_melee_attacks_monster> {
-    static constexpr std::array<std::pair<const char *, cata_variant_type>, 4> fields = {{
+    static constexpr std::array<event_field, 4> fields = {{
             { "attacker", cata_variant_type::character_id },
             { "weapon", cata_variant_type::itype_id },
             { "hits", cata_variant_type::bool_ },
@@ -428,7 +430,7 @@ struct event_spec<event_type::character_radioactively_mutates> : event_spec_char
 
 template<>
 struct event_spec<event_type::character_ranged_attacks_character> {
-    static constexpr std::array<std::pair<const char *, cata_variant_type>, 6> fields = {{
+    static constexpr std::array<event_field, 6> fields = {{
             { "attacker", cata_variant_type::character_id },
             { "weapon", cata_variant_type::itype_id },
             { "ammo", cata_variant_type::itype_id },
@@ -441,7 +443,7 @@ struct event_spec<event_type::character_ranged_attacks_character> {
 
 template<>
 struct event_spec<event_type::character_ranged_attacks_monster> {
-    static constexpr std::array<std::pair<const char *, cata_variant_type>, 5> fields = {{
+    static constexpr std::array<event_field, 5> fields = {{
             { "attacker", cata_variant_type::character_id },
             { "weapon", cata_variant_type::itype_id },
             { "ammo", cata_variant_type::itype_id },
@@ -453,7 +455,7 @@ struct event_spec<event_type::character_ranged_attacks_monster> {
 
 template<>
 struct event_spec<event_type::character_smashes_tile> {
-    static constexpr std::array<std::pair<const char *, cata_variant_type>, 3> fields = {{
+    static constexpr std::array<event_field, 3> fields = {{
             { "character", cata_variant_type::character_id },
             { "terrain", cata_variant_type::ter_str_id },
             { "furniture", cata_variant_type::furn_str_id },
@@ -463,7 +465,7 @@ struct event_spec<event_type::character_smashes_tile> {
 
 template<>
 struct event_spec<event_type::character_starts_activity> {
-    static constexpr std::array<std::pair<const char *, cata_variant_type>, 3> fields = { {
+    static constexpr std::array<event_field, 3> fields = { {
             { "character", cata_variant_type::character_id },
             { "activity", cata_variant_type::activity_id },
             { "resume", cata_variant_type::bool_ }
@@ -473,7 +475,7 @@ struct event_spec<event_type::character_starts_activity> {
 
 template<>
 struct event_spec<event_type::character_takes_damage> {
-    static constexpr std::array<std::pair<const char *, cata_variant_type>, 4> fields = {{
+    static constexpr std::array<event_field, 4> fields = {{
             { "character", cata_variant_type::character_id },
             { "damage", cata_variant_type::int_ },
             { "bodypart", cata_variant_type::body_part },
@@ -484,7 +486,7 @@ struct event_spec<event_type::character_takes_damage> {
 
 template<>
 struct event_spec<event_type::monster_takes_damage> {
-    static constexpr std::array<std::pair<const char *, cata_variant_type>, 2> fields = { {
+    static constexpr std::array<event_field, 2> fields = { {
             { "damage", cata_variant_type::int_ },
             { "dies", cata_variant_type::bool_ },
         }
@@ -493,7 +495,7 @@ struct event_spec<event_type::monster_takes_damage> {
 
 template<>
 struct event_spec<event_type::character_triggers_trap> {
-    static constexpr std::array<std::pair<const char *, cata_variant_type>, 2> fields = {{
+    static constexpr std::array<event_field, 2> fields = {{
             { "character", cata_variant_type::character_id },
             { "trap", cata_variant_type::trap_str_id },
         }
@@ -502,7 +504,7 @@ struct event_spec<event_type::character_triggers_trap> {
 
 template<>
 struct event_spec<event_type::character_wakes_up> {
-    static constexpr std::array<std::pair<const char *, cata_variant_type>, 1> fields = {{
+    static constexpr std::array<event_field, 1> fields = {{
             { "character", cata_variant_type::character_id },
         }
     };
@@ -510,7 +512,7 @@ struct event_spec<event_type::character_wakes_up> {
 
 template<>
 struct event_spec<event_type::character_falls_asleep> {
-    static constexpr std::array<std::pair<const char *, cata_variant_type>, 2> fields = {{
+    static constexpr std::array<event_field, 2> fields = {{
             { "character", cata_variant_type::character_id },
             { "duration", cata_variant_type::int_ },
         }
@@ -519,7 +521,7 @@ struct event_spec<event_type::character_falls_asleep> {
 
 template<>
 struct event_spec<event_type::character_attempt_to_fall_asleep> {
-    static constexpr std::array<std::pair<const char *, cata_variant_type>, 1> fields = {{
+    static constexpr std::array<event_field, 1> fields = {{
             { "character", cata_variant_type::character_id },
         }
     };
@@ -527,7 +529,7 @@ struct event_spec<event_type::character_attempt_to_fall_asleep> {
 
 template<>
 struct event_spec<event_type::character_butchered_corpse> {
-    static constexpr std::array<std::pair<const char *, cata_variant_type>, 3> fields = { {
+    static constexpr std::array<event_field, 3> fields = { {
             { "character", cata_variant_type::character_id },
             { "monster_id", cata_variant_type::mtype_id },
             { "butcher_type", cata_variant_type::string },
@@ -554,7 +556,7 @@ struct event_spec<event_type::crosses_marloss_threshold> : event_spec_character 
 
 template<>
 struct event_spec<event_type::crosses_mutation_threshold> {
-    static constexpr std::array<std::pair<const char *, cata_variant_type>, 2> fields = {{
+    static constexpr std::array<event_field, 2> fields = {{
             { "character", cata_variant_type::character_id },
             { "category", cata_variant_type::mutation_category_id },
         }
@@ -581,7 +583,7 @@ struct event_spec<event_type::dies_from_asthma_attack> : event_spec_character {}
 
 template<>
 struct event_spec<event_type::dies_from_drug_overdose> {
-    static constexpr std::array<std::pair<const char *, cata_variant_type>, 2> fields = {{
+    static constexpr std::array<event_field, 2> fields = {{
             { "character", cata_variant_type::character_id },
             { "effect", cata_variant_type::efftype_id },
         }
@@ -617,7 +619,7 @@ struct event_spec<event_type::eats_sewage> : event_spec_empty {};
 
 template<>
 struct event_spec<event_type::evolves_mutation> {
-    static constexpr std::array<std::pair<const char *, cata_variant_type>, 3> fields = {{
+    static constexpr std::array<event_field, 3> fields = {{
             { "character", cata_variant_type::character_id },
             { "from_trait", cata_variant_type::trait_id },
             { "to_trait", cata_variant_type::trait_id },
@@ -630,7 +632,7 @@ struct event_spec<event_type::exhumes_grave> : event_spec_character {};
 
 template<>
 struct event_spec<event_type::fails_to_install_cbm> {
-    static constexpr std::array<std::pair<const char *, cata_variant_type>, 2> fields = {{
+    static constexpr std::array<event_field, 2> fields = {{
             { "character", cata_variant_type::character_id },
             { "bionic", cata_variant_type::bionic_id },
         }
@@ -639,7 +641,7 @@ struct event_spec<event_type::fails_to_install_cbm> {
 
 template<>
 struct event_spec<event_type::fails_to_remove_cbm> {
-    static constexpr std::array<std::pair<const char *, cata_variant_type>, 2> fields = {{
+    static constexpr std::array<event_field, 2> fields = {{
             { "character", cata_variant_type::character_id },
             { "bionic", cata_variant_type::bionic_id },
         }
@@ -651,7 +653,7 @@ struct event_spec<event_type::falls_asleep_from_exhaustion> : event_spec_charact
 
 template<>
 struct event_spec<event_type::fuel_tank_explodes> {
-    static constexpr std::array<std::pair<const char *, cata_variant_type>, 1> fields = {{
+    static constexpr std::array<event_field, 1> fields = {{
             { "vehicle_name", cata_variant_type::string },
         }
     };
@@ -659,7 +661,7 @@ struct event_spec<event_type::fuel_tank_explodes> {
 
 template<>
 struct event_spec<event_type::gains_addiction> {
-    static constexpr std::array<std::pair<const char *, cata_variant_type>, 2> fields = {{
+    static constexpr std::array<event_field, 2> fields = {{
             { "character", cata_variant_type::character_id },
             { "add_type", cata_variant_type::addiction_id },
         }
@@ -668,7 +670,7 @@ struct event_spec<event_type::gains_addiction> {
 
 template<>
 struct event_spec<event_type::gains_mutation> {
-    static constexpr std::array<std::pair<const char *, cata_variant_type>, 2> fields = {{
+    static constexpr std::array<event_field, 2> fields = {{
             { "character", cata_variant_type::character_id },
             { "trait", cata_variant_type::trait_id },
         }
@@ -677,7 +679,7 @@ struct event_spec<event_type::gains_mutation> {
 
 template<>
 struct event_spec<event_type::gains_proficiency> {
-    static constexpr std::array<std::pair<const char *, cata_variant_type>, 2> fields = {{
+    static constexpr std::array<event_field, 2> fields = {{
             { "character", cata_variant_type::character_id },
             { "proficiency", cata_variant_type::proficiency_id },
         }
@@ -686,7 +688,7 @@ struct event_spec<event_type::gains_proficiency> {
 
 template<>
 struct event_spec<event_type::gains_skill_level> {
-    static constexpr std::array<std::pair<const char *, cata_variant_type>, 3> fields = {{
+    static constexpr std::array<event_field, 3> fields = {{
             { "character", cata_variant_type::character_id },
             { "skill", cata_variant_type::skill_id },
             { "new_level", cata_variant_type::int_ },
@@ -696,7 +698,7 @@ struct event_spec<event_type::gains_skill_level> {
 
 template<>
 struct event_spec<event_type::game_avatar_death> {
-    static constexpr std::array<std::pair<const char *, cata_variant_type>, 4> fields = {{
+    static constexpr std::array<event_field, 4> fields = {{
             { "avatar_id", cata_variant_type::character_id },
             { "avatar_name", cata_variant_type::string },
             { "is_suicide", cata_variant_type::bool_ },
@@ -707,7 +709,7 @@ struct event_spec<event_type::game_avatar_death> {
 
 template<>
 struct event_spec<event_type::game_avatar_new> {
-    static constexpr std::array<std::pair<const char *, cata_variant_type>, 5> fields = {{
+    static constexpr std::array<event_field, 5> fields = {{
             { "is_new_game", cata_variant_type::bool_ },
             { "is_debug", cata_variant_type::bool_ },
             { "avatar_id", cata_variant_type::character_id },
@@ -719,7 +721,7 @@ struct event_spec<event_type::game_avatar_new> {
 
 template<>
 struct event_spec<event_type::game_load> {
-    static constexpr std::array<std::pair<const char *, cata_variant_type>, 1> fields = {{
+    static constexpr std::array<event_field, 1> fields = {{
             { "cdda_version", cata_variant_type::string },
         }
     };
@@ -727,7 +729,7 @@ struct event_spec<event_type::game_load> {
 
 template<>
 struct event_spec<event_type::game_begin> {
-    static constexpr std::array<std::pair<const char *, cata_variant_type>, 1> fields = { {
+    static constexpr std::array<event_field, 1> fields = { {
             { "cdda_version", cata_variant_type::string },
         }
     };
@@ -735,7 +737,7 @@ struct event_spec<event_type::game_begin> {
 
 template<>
 struct event_spec<event_type::game_over> {
-    static constexpr std::array<std::pair<const char *, cata_variant_type>, 1> fields = {{
+    static constexpr std::array<event_field, 1> fields = {{
             { "total_time_played", cata_variant_type::chrono_seconds },
         }
     };
@@ -743,7 +745,7 @@ struct event_spec<event_type::game_over> {
 
 template<>
 struct event_spec<event_type::game_save> {
-    static constexpr std::array<std::pair<const char *, cata_variant_type>, 2> fields = {{
+    static constexpr std::array<event_field, 2> fields = {{
             { "time_since_load", cata_variant_type::chrono_seconds },
             { "total_time_played", cata_variant_type::chrono_seconds },
         }
@@ -752,7 +754,7 @@ struct event_spec<event_type::game_save> {
 
 template<>
 struct event_spec<event_type::game_start> {
-    static constexpr std::array<std::pair<const char *, cata_variant_type>, 1> fields = {{
+    static constexpr std::array<event_field, 1> fields = {{
             { "game_version", cata_variant_type::string },
         }
     };
@@ -760,7 +762,7 @@ struct event_spec<event_type::game_start> {
 
 template<>
 struct event_spec<event_type::installs_cbm> {
-    static constexpr std::array<std::pair<const char *, cata_variant_type>, 2> fields = {{
+    static constexpr std::array<event_field, 2> fields = {{
             { "character", cata_variant_type::character_id },
             { "bionic", cata_variant_type::bionic_id },
         }
@@ -769,7 +771,7 @@ struct event_spec<event_type::installs_cbm> {
 
 template<>
 struct event_spec<event_type::installs_faulty_cbm> {
-    static constexpr std::array<std::pair<const char *, cata_variant_type>, 2> fields = {{
+    static constexpr std::array<event_field, 2> fields = {{
             { "character", cata_variant_type::character_id },
             { "bionic", cata_variant_type::bionic_id },
         }
@@ -778,7 +780,7 @@ struct event_spec<event_type::installs_faulty_cbm> {
 
 template<>
 struct event_spec<event_type::learns_martial_art> {
-    static constexpr std::array<std::pair<const char *, cata_variant_type>, 2> fields = {{
+    static constexpr std::array<event_field, 2> fields = {{
             { "character", cata_variant_type::character_id },
             { "martial_art", cata_variant_type::matype_id },
         }
@@ -787,7 +789,7 @@ struct event_spec<event_type::learns_martial_art> {
 
 template<>
 struct event_spec<event_type::loses_addiction> {
-    static constexpr std::array<std::pair<const char *, cata_variant_type>, 2> fields = {{
+    static constexpr std::array<event_field, 2> fields = {{
             { "character", cata_variant_type::character_id },
             { "add_type", cata_variant_type::addiction_id },
         }
@@ -795,7 +797,7 @@ struct event_spec<event_type::loses_addiction> {
 };
 template<>
 struct event_spec<event_type::loses_mutation> {
-    static constexpr std::array<std::pair<const char *, cata_variant_type>, 2> fields = { {
+    static constexpr std::array<event_field, 2> fields = { {
             { "character", cata_variant_type::character_id },
             { "trait", cata_variant_type::trait_id },
         }
@@ -804,7 +806,7 @@ struct event_spec<event_type::loses_mutation> {
 
 template<>
 struct event_spec<event_type::npc_becomes_hostile> {
-    static constexpr std::array<std::pair<const char *, cata_variant_type>, 2> fields = {{
+    static constexpr std::array<event_field, 2> fields = {{
             { "npc", cata_variant_type::character_id },
             { "npc_name", cata_variant_type::string },
         }
@@ -813,7 +815,7 @@ struct event_spec<event_type::npc_becomes_hostile> {
 
 template<>
 struct event_spec<event_type::opens_spellbook> {
-    static constexpr std::array<std::pair<const char *, cata_variant_type>, 1> fields = { {
+    static constexpr std::array<event_field, 1> fields = { {
             { "character", cata_variant_type::character_id }
         }
     };
@@ -830,7 +832,7 @@ struct event_spec<event_type::releases_subspace_specimens> : event_spec_empty {}
 
 template<>
 struct event_spec<event_type::player_fails_conduct> {
-    static constexpr std::array<std::pair<const char *, cata_variant_type>, 2> fields = {{
+    static constexpr std::array<event_field, 2> fields = {{
             { "conduct", cata_variant_type::achievement_id },
             { "achievements_enabled", cata_variant_type::bool_ },
         }
@@ -839,7 +841,7 @@ struct event_spec<event_type::player_fails_conduct> {
 
 template<>
 struct event_spec<event_type::player_gets_achievement> {
-    static constexpr std::array<std::pair<const char *, cata_variant_type>, 2> fields = {{
+    static constexpr std::array<event_field, 2> fields = {{
             { "achievement", cata_variant_type::achievement_id },
             { "achievements_enabled", cata_variant_type::bool_ },
         }
@@ -848,7 +850,7 @@ struct event_spec<event_type::player_gets_achievement> {
 
 template<>
 struct event_spec<event_type::player_levels_spell> {
-    static constexpr std::array<std::pair<const char *, cata_variant_type>, 4> fields = {{
+    static constexpr std::array<event_field, 4> fields = {{
             { "character", cata_variant_type::character_id },
             { "spell", cata_variant_type::spell_id },
             { "new_level", cata_variant_type::int_ },
@@ -862,7 +864,7 @@ struct event_spec<event_type::reads_book> : event_spec_character_item {};
 
 template<>
 struct event_spec<event_type::removes_cbm> {
-    static constexpr std::array<std::pair<const char *, cata_variant_type>, 2> fields = {{
+    static constexpr std::array<event_field, 2> fields = {{
             { "character", cata_variant_type::character_id },
             { "bionic", cata_variant_type::bionic_id },
         }
@@ -874,7 +876,7 @@ struct event_spec<event_type::seals_hazardous_material_sarcophagus> : event_spec
 
 template<>
 struct event_spec<event_type::spellcasting_finish> {
-    static constexpr std::array<std::pair<const char *, cata_variant_type>, 8> fields = { {
+    static constexpr std::array<event_field, 8> fields = { {
             { "character", cata_variant_type::character_id },
             { "success", cata_variant_type::bool_ },
             { "spell", cata_variant_type::spell_id },
@@ -889,7 +891,7 @@ struct event_spec<event_type::spellcasting_finish> {
 
 template<>
 struct event_spec<event_type::telefrags_creature> {
-    static constexpr std::array<std::pair<const char *, cata_variant_type>, 2> fields = {{
+    static constexpr std::array<event_field, 2> fields = {{
             { "character", cata_variant_type::character_id },
             { "victim_name", cata_variant_type::string },
         }
@@ -901,7 +903,7 @@ struct event_spec<event_type::teleglow_teleports> : event_spec_character {};
 
 template<>
 struct event_spec<event_type::teleports_into_wall> {
-    static constexpr std::array<std::pair<const char *, cata_variant_type>, 2> fields = {{
+    static constexpr std::array<event_field, 2> fields = {{
             { "character", cata_variant_type::character_id },
             { "obstacle_name", cata_variant_type::string },
         }
@@ -919,7 +921,7 @@ struct event_spec<event_type::triggers_alarm> : event_spec_character {};
 
 template<>
 struct event_spec<event_type::uses_debug_menu> {
-    static constexpr std::array<std::pair<const char *, cata_variant_type>, 1> fields = {{
+    static constexpr std::array<event_field, 1> fields = {{
             { "debug_menu_option", cata_variant_type::debug_menu_index },
         }
     };
@@ -927,7 +929,7 @@ struct event_spec<event_type::uses_debug_menu> {
 
 template<>
 struct event_spec<event_type::u_var_changed> {
-    static constexpr std::array<std::pair<const char *, cata_variant_type>, 2> fields = { {
+    static constexpr std::array<event_field, 2> fields = { {
             { "var", cata_variant_type::string },
             { "value", cata_variant_type::string },
         }
@@ -936,7 +938,7 @@ struct event_spec<event_type::u_var_changed> {
 
 template<>
 struct event_spec<event_type::vehicle_moves> {
-    static constexpr std::array<std::pair<const char *, cata_variant_type>, 11> fields = {{
+    static constexpr std::array<event_field, 11> fields = {{
             { "avatar_on_board", cata_variant_type::bool_ },
             { "avatar_is_driving", cata_variant_type::bool_ }, // non-remote-control
             { "avatar_remote_control", cata_variant_type::bool_ },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
The event field type is used dozens of times, fully repeated each time.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
Add a type alias and use it in all of those other places. Also update the JSON docs to reflect this change.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
A templated type for an event field array would shrink the definitions even more, but I didn't think that improved clarity much.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->
I do not believe this PR requires non-automated testing, or even much testing beyond compilation.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
