### PR TITLE
Dedupe editmap functionality

### DIFF
--- a/src/editmap.h
+++ b/src/editmap.h
@@ -11,6 +11,7 @@
 
 #include "color.h"
 #include "coordinates.h"
+#include "creature_tracker.h"
 #include "cursesdef.h"
 #include "memory_fast.h"
 #include "point.h"
@@ -33,7 +34,7 @@ enum shapetype {
 class editmap;
 
 struct editmap_hilight {
-    std::vector<bool> blink_interval;
+    int blink_interval;
     int cur_blink = 0;
     nc_color color;
     std::map<tripoint_bub_ms, char> points;
@@ -99,6 +100,7 @@ class editmap
         ~editmap();
 
     private:
+        void setup();
         shared_ptr_fast<ui_adaptor> create_or_get_ui_adaptor();
 
         weak_ptr_fast<ui_adaptor> ui;
@@ -116,6 +118,8 @@ class editmap
 
         bool run_post_process = true;
 
+        void draw_pos( map &here, const tripoint_bub_ms &p, creature_tracker &creatures,
+                       const std::function<nc_color( nc_color & )> &color_func );
         void draw_main_ui_overlay();
         void do_ui_invalidation();
 
@@ -124,6 +128,8 @@ class editmap
 
         std::unique_ptr<game_draw_callback_t_container> draw_cb_container_;
         game_draw_callback_t_container &draw_cb_container();
+
+        friend struct editmap_hilight;
 };
 
 #endif // CATA_SRC_EDITMAP_H


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
The debug map editor has a lot of duplicated code, specifically:
* drawing a position with terrain and possibly furniture and fields on top of the world view
* setting up the ui callbacks and restoration
* describing the move cost and flags of terrain/furniture
* making a list of a square perimeter of points around a central position

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
New methods and helper functions.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->
TODO

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
I also simplified the map editor graphics blinking implementation.

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
