### PR TITLE
Spells can use vitamin as spell energy source now

### DIFF
--- a/doc/JSON/MAGIC.md
+++ b/doc/JSON/MAGIC.md
@@ -71,7 +71,7 @@ In `data/mods/Magiclysm` there is a template spell, copied here for your perusal
     "base_energy_cost": 30,                                   // the amount of energy (of the requisite type) to cast the spell
     "final_energy_cost": 100,
     "energy_increment": -6,
-    "energy_source": "MANA",                                  // the type of energy used to cast the spell. types are: MANA, BIONIC, HP, STAMINA, NONE (none will not use mana)
+    "energy_source": "MANA",                                  // the type of energy used to cast the spell. types are: MANA, BIONIC, HP, STAMINA, NONE. Alternative notation can be used for spell consuming vitamins, see example below
     "components": [ /* requirement_id */],                    // an id from a requirement, like the ones you use for crafting. spell components require to cast.
     "difficulty": 12,                                         // the difficulty to learn/cast the spell
     "max_level": 10,                                          // maximum level you can achieve in the spell
@@ -197,7 +197,7 @@ Effect                 | Description
 `pain_split`           | Evens out all of your limbs' damage.
 `pull_target`          | Attempts to pull the target towards the caster in a straight line.  If the path is blocked by impassable furniture or terrain, the effect fails.
 `recharge_vehicle`     | Increases or decreases the battery charge of a vehicle or battery-connected power grid. Damage is equal to the charge (negative decreases).
-`recover_energy`       | Recovers an energy source equal to damage of the spell.  The energy source is defined in `effect_str` and may be one of `BIONIC`, `SLEEPINESS`, `PAIN`, `MANA` or `STAMINA`.
+`recover_energy`       | Recovers an energy source equal to damage of the spell and may be one of `BIONIC`, `SLEEPINESS`, `PAIN`, `MANA` or `STAMINA`. Alternative notation can be used for spell consuming vitamins, see example below
 `remove_effect`        | Removes `effect_str` effects from all creatures in the aoe.
 `remove_field`         | Removes a `effect_str` field in the aoe.  Causes teleglow of varying intensity and potentially teleportation depending on field density, if the field removed is `fd_reality_tear`.  (see `ter_transform` for more versatility)
 `revive`               | Revives a monster like a zombie necromancer.  The monster must have the `REVIVES` flag.
@@ -322,20 +322,22 @@ Flag                       | Description
 
 ### Damage Types
 
-The following are the available damage types, for those spells that have a damaging component:
+Any damage type can be used, see [JSON_INFO.md#damage-types](JSON_INFO.md#damage-types) for how they are defined and their specific property
 
-Damage type  | Description
----          |---
-`acid`       | 
-`bash`       | 
-`biological` | Internal damage such as poison.
-`cold`       | 
-`cut`        | 
-`electric`   | 
-`heat`       | 
-`pure`       | This damage type goes through armor altogether.  Set by default.
-`stab`       | 
+### Energy Type
 
+`energy_source` responds for the type of energy consumed, and as of now, can look like:
+
+`BIONIC`, `SLEEPINESS`, `PAIN`, `MANA` or `STAMINA`
+
+```jsonc
+"energy_source": "MANA",
+"energy_source": "STAMINA",
+"energy_source": "BIONIC", // consumes MJ from your CBM batteries
+"energy_source": "NONE",
+"energy_source": "HP", // Require a tool with CUT 1, and allow to pick the limb to be damaged
+"energy_source": { "type": "VITAMIN", "vitamin": "vitamin_id" },
+```
 
 ### Spell level
 

--- a/src/magic.h
+++ b/src/magic.h
@@ -342,6 +342,9 @@ class spell_type
         // what energy do you use to cast this spell
         magic_energy_type get_energy_source() const;
 
+        // what energy do you use to cast this spell
+        std::optional<vitamin_id> vitamin_energy_source() const;
+
         damage_type_id dmg_type = damage_type_id::NULL_ID();
 
         // list of valid targets enum
@@ -441,6 +444,7 @@ class spell_type
         static const float casting_time_increment_default;
 
         std::optional<magic_energy_type> energy_source;
+        std::optional<vitamin_id> vitamin_energy_source_; // NOLINT(cata-serialize)
         std::optional<jmath_func_id> get_level_formula_id;
         std::optional<jmath_func_id> exp_for_level_formula_id;
         std::optional<int> max_book_level;
@@ -632,6 +636,7 @@ class spell
 
         // magic energy source enum
         magic_energy_type energy_source() const;
+        std::optional<vitamin_id> vitamin_energy_source() const;
         // the color that's representative of the damage type
         nc_color damage_type_color() const;
         std::string damage_type_string() const;

--- a/src/magic_type.h
+++ b/src/magic_type.h
@@ -21,6 +21,7 @@ enum class magic_energy_type : int {
     mana,
     stamina,
     bionic,
+    vitamin,
     none,
     last
 };


### PR DESCRIPTION
#### Summary
None
#### Purpose of change

<img width="325" height="80" alt="image" src="https://github.com/user-attachments/assets/d3da93a4-da93-445d-8538-d718f6249efe" />

#### Describe the solution
Make so that spells can use vitamins as energy source
#### Testing
<img width="991" height="613" alt="image" src="https://github.com/user-attachments/assets/820f9977-e261-47ac-acdf-c6cf36b0df04" />

#### Additional context
Maybe some additional features will be nice? specifying the color of the text for energy source, showing or hiding the current amount of vitamin you have etc? i summon ye @Standing-Storm to answer this