### PR TITLE
Fix mentions of evac 'center' starts

### DIFF
--- a/data/json/start_locations.json
+++ b/data/json/start_locations.json
@@ -8,19 +8,19 @@
   {
     "type": "start_location",
     "id": "sloc_shelter_safe",
-    "name": "Evac Center",
+    "name": "Evacuation Shelter",
     "terrain": [ { "om_terrain": "shelter", "parameters": { "shelter_palette": "shelter_basic" } } ]
   },
   {
     "type": "start_location",
     "id": "sloc_shelter_vandal",
-    "name": "Vandalized Evac Center",
+    "name": "Vandalized Evacuation Shelter",
     "terrain": [ { "om_terrain": "shelter", "parameters": { "shelter_palette": "shelter_vandal" } } ]
   },
   {
     "type": "start_location",
     "id": "sloc_shelter_under_infested",
-    "name": "Infested Evac Center Basement",
+    "name": "Infested Evacuation Shelter Basement",
     "terrain": [ { "om_terrain": "shelter_under", "parameters": { "shelter_palette": "shelter_infested_scenario" } } ]
   },
   {

--- a/data/mods/No_Hope/start_locations.json
+++ b/data/mods/No_Hope/start_locations.json
@@ -2,7 +2,7 @@
   {
     "type": "start_location",
     "id": "sloc_shelter_safe",
-    "name": "Evac Center",
+    "name": "Evacuation Shelter",
     "terrain": [ { "om_terrain": "shelter", "parameters": { "shelter_palette": "shelter_used" } } ]
   }
 ]


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
#72561 changed these starting locations and renamed them, but called them "Evac Center". These are not an evacuation center in any way.

#### Describe the solution
These are shelters. Call them shelters.

<img width="337" height="80" alt="image" src="https://github.com/user-attachments/assets/ec015c15-ded2-423f-acdc-0b44326aefdc" />


Do not confuse them with the refugee **center**, which is already confusing enough terminology. 

Also use the properly formed "Evacuation" not "Evac". We don't need to shorten these.

#### Describe alternatives you've considered


#### Testing
String change, if it builds it can ship

#### Additional context

