### PR TITLE
Fix crash on NPC spawn

### DIFF
--- a/src/effect_on_condition.cpp
+++ b/src/effect_on_condition.cpp
@@ -140,11 +140,14 @@ static time_duration next_recurrence( const effect_on_condition_id &eoc, dialogu
 void effect_on_conditions::load_new_character( Character &you )
 {
     bool is_avatar = you.is_avatar();
-    for( const effect_on_condition_id &eoc_id : get_scenario()->eoc() ) {
-        effect_on_condition eoc = eoc_id.obj();
-        if( is_avatar || eoc.run_for_npcs ) {
-            queued_eoc new_eoc = queued_eoc{ eoc.id, calendar::turn_zero, {} };
-            you.queued_effect_on_conditions.push( new_eoc );
+    // npcs do not have scenario, so check for that
+    if( get_scenario() ) {
+        for( const effect_on_condition_id &eoc_id : get_scenario()->eoc() ) {
+            effect_on_condition eoc = eoc_id.obj();
+            if( is_avatar || eoc.run_for_npcs ) {
+                queued_eoc new_eoc = queued_eoc{ eoc.id, calendar::turn_zero, {} };
+                you.queued_effect_on_conditions.push( new_eoc );
+            }
         }
     }
 


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
While testing another stuff, found a crash when walking to refugee center. Traced it to game trying to spawn NPC, running a scenario EoCs, but since NPCs do not have scenario, the game fails
#### Describe the solution
Protect the scenario eoc check from nullptr
#### Testing
I do not have the bug anymore
#### Additional context
I am very surprised no one reported it yet, either the combination of factor to trigger it made it very hard to actually spot, or people just do not bother walking to refugee center