### PR TITLE
Dedupe flood fill 4 way

### DIFF
--- a/src/flood_fill.h
+++ b/src/flood_fill.h
@@ -29,11 +29,11 @@ namespace ff
 * @param predicate UnaryPredicate that will be provided with a point for evaluation as to whether or
 * not the point should be filled.
 */
-template<typename Point, typename UnaryPredicate>
-std::vector<Point> point_flood_fill_4_connected( const Point &starting_point,
+template<template <typename...> typename Container, typename Point, typename UnaryPredicate>
+Container<Point> point_flood_fill_4_connected( const Point &starting_point,
         std::unordered_set<Point> &visited, UnaryPredicate predicate )
 {
-    std::vector<Point> filled_points;
+    Container<Point> filled_points;
     std::queue<Point> to_check;
     to_check.push( starting_point );
     while( !to_check.empty() ) {
@@ -47,7 +47,11 @@ std::vector<Point> point_flood_fill_4_connected( const Point &starting_point,
         visited.emplace( current_point );
 
         if( predicate( current_point ) ) {
-            filled_points.emplace_back( current_point );
+            if constexpr( std::is_same_v<Container<Point>, std::vector<Point>> ) {
+                filled_points.emplace_back( current_point );
+            } else {
+                filled_points.emplace( current_point );
+            }
             to_check.push( current_point + point::south );
             to_check.push( current_point + point::north );
             to_check.push( current_point + point::east );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -103,6 +103,7 @@
 #include "flag.h"
 #include "flexbuffer_json-inl.h"
 #include "flexbuffer_json.h"
+#include "flood_fill.h"
 #include "game_constants.h"
 #include "game_inventory.h"
 #include "game_ui.h"
@@ -4556,44 +4557,13 @@ std::unordered_set<tripoint_bub_ms> game::get_fishable_locations_bub( int distan
     const inclusive_cuboid<tripoint_bub_ms> fishing_boundaries(
         fishing_boundary_min, fishing_boundary_max );
 
-    const auto get_fishable_terrain = [&]( tripoint_bub_ms starting_point,
-    std::unordered_set<tripoint_bub_ms> &fishable_terrain ) {
-        std::queue<tripoint_bub_ms> to_check;
-        to_check.push( starting_point );
-        while( !to_check.empty() ) {
-            const tripoint_bub_ms current_point = to_check.front();
-            to_check.pop();
-
-            // We've been here before, so bail.
-            if( visited.find( current_point ) != visited.end() ) {
-                continue;
-            }
-
-            // This point is out of bounds, so bail.
-            if( !fishing_boundaries.contains( current_point ) ) {
-                continue;
-            }
-
-            // Mark this point as visited.
-            visited.emplace( current_point );
-
-            if( here.has_flag( ter_furn_flag::TFLAG_FISHABLE, current_point ) ) {
-                fishable_terrain.emplace( current_point );
-                to_check.push( current_point + point::south );
-                to_check.push( current_point + point::north );
-                to_check.push( current_point + point::east );
-                to_check.push( current_point + point::west );
-            }
-        }
-    };
-
     // Starting at the provided location, get our fishable terrain
     // and populate a set with those locations which we'll then use
     // to determine if any fishable monsters are in those locations.
-    std::unordered_set<tripoint_bub_ms> fishable_points;
-    get_fishable_terrain( fish_pos, fishable_points );
-
-    return fishable_points;
+    return ff::point_flood_fill_4_connected<std::unordered_set>( fish_pos, visited, [&here,
+    &fishing_boundaries]( const tripoint_bub_ms & p ) {
+        return !fishing_boundaries.contains( p ) && here.has_flag( ter_furn_flag::TFLAG_FISHABLE, p );
+    } );
 }
 
 std::vector<monster *> game::get_fishable_monsters( std::unordered_set<tripoint_abs_ms>

--- a/src/mapgen_functions.cpp
+++ b/src/mapgen_functions.cpp
@@ -1562,9 +1562,9 @@ void mapgen_lake_shore( mapgendata &dat )
     };
 
     const auto fill_deep_water = [&]( const point_bub_ms & starting_point ) {
-        std::vector<point_bub_ms> water_points = ff::point_flood_fill_4_connected( starting_point, visited,
-                should_fill );
-        for( point_bub_ms &wp : water_points ) {
+        std::vector<point_bub_ms> water_points =
+            ff::point_flood_fill_4_connected<std::vector>( starting_point, visited, should_fill );
+        for( const point_bub_ms &wp : water_points ) {
             m->ter_set( wp, ter_t_water_dp );
             m->furn_set( wp, furn_str_id::NULL_ID() );
         }
@@ -2028,9 +2028,9 @@ void mapgen_ocean_shore( mapgendata &dat )
     };
 
     const auto fill_deep_water = [&]( const point_bub_ms & starting_point ) {
-        std::vector<point_bub_ms> water_points = ff::point_flood_fill_4_connected( starting_point, visited,
-                should_fill );
-        for( point_bub_ms &wp : water_points ) {
+        std::vector<point_bub_ms> water_points =
+            ff::point_flood_fill_4_connected<std::vector>( starting_point, visited, should_fill );
+        for( const point_bub_ms &wp : water_points ) {
             m->ter_set( wp, ter_t_swater_dp );
             m->furn_set( wp, furn_str_id::NULL_ID() );
         }

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -4342,7 +4342,8 @@ void overmap::flood_fill_city_tiles()
                 return true;
             };
             // All the points connected to this point that aren't part of a city
-            std::vector<point_om_omt> area = ff::point_flood_fill_4_connected( checked, visited, is_unchecked );
+            std::vector<point_om_omt> area =
+                ff::point_flood_fill_4_connected<std::vector>( checked, visited, is_unchecked );
             if( !enclosed ) {
                 continue;
             }
@@ -4893,7 +4894,7 @@ void overmap::place_forest_trails()
 
             // Get the contiguous forest from this point.
             std::vector<point_om_omt> forest_points =
-                ff::point_flood_fill_4_connected( seed_point.xy(), visited, is_forest );
+                ff::point_flood_fill_4_connected<std::vector>( seed_point.xy(), visited, is_forest );
 
             // If we don't have enough points to build a trail, move on.
             if( forest_points.empty() ||
@@ -4957,7 +4958,7 @@ void overmap::place_forest_trails()
             // ...and then add our random points.
             int random_point_count = 0;
             std::shuffle( forest_points.begin(), forest_points.end(), rng_get_engine() );
-            for( auto &random_point : forest_points ) {
+            for( const auto &random_point : forest_points ) {
                 if( random_point_count >= max_random_points ) {
                     break;
                 }

--- a/src/overmap_water.cpp
+++ b/src/overmap_water.cpp
@@ -285,7 +285,7 @@ void overmap::place_lakes( const std::vector<const overmap *> &neighbor_overmaps
             // We're going to flood-fill our lake so that we can consider the entire lake when evaluating it
             // for placement, even when the lake runs off the edge of the current overmap.
             std::vector<point_om_omt> lake_points =
-                ff::point_flood_fill_4_connected( seed_point, visited, is_lake );
+                ff::point_flood_fill_4_connected<std::vector>( seed_point, visited, is_lake );
 
             // If this lake doesn't exceed our minimum size threshold, then skip it. We can use this to
             // exclude the tiny lakes that don't provide interesting map features and exist mostly as a
@@ -299,10 +299,7 @@ void overmap::place_lakes( const std::vector<const overmap *> &neighbor_overmaps
             // we just found AND all of the rivers on the map, because we want our lakes to write
             // over any rivers that are placed already. Note that the assumption here is that river
             // overmap generation (e.g. place_rivers) runs BEFORE lake overmap generation.
-            std::unordered_set<point_om_omt> lake_set;
-            for( auto &p : lake_points ) {
-                lake_set.emplace( p );
-            }
+            std::unordered_set<point_om_omt> lake_set( lake_points.begin(), lake_points.end() );
 
             // Before we place the lake terrain and get river points, generate a river to somewhere
             // in the lake from an existing river.
@@ -442,7 +439,7 @@ void overmap::place_oceans( const std::vector<const overmap *> &neighbor_overmap
             }
 
             std::vector<point_om_omt> ocean_points =
-                ff::point_flood_fill_4_connected( seed_point, visited, is_ocean );
+                ff::point_flood_fill_4_connected<std::vector>( seed_point, visited, is_ocean );
 
             // Ocean size is checked like lake size, but minimum size is much bigger.
             // you could change this, if you want little tiny oceans all over the place.
@@ -452,10 +449,7 @@ void overmap::place_oceans( const std::vector<const overmap *> &neighbor_overmap
                 continue;
             }
 
-            std::unordered_set<point_om_omt> ocean_set;
-            for( auto &p : ocean_points ) {
-                ocean_set.emplace( p );
-            }
+            std::unordered_set<point_om_omt> ocean_set( ocean_points.begin(), ocean_points.end() );
 
             for( int x = 0; x < OMAPX; x++ ) {
                 for( int y = 0; y < OMAPY; y++ ) {

--- a/src/vehicle_autodrive.cpp
+++ b/src/vehicle_autodrive.cpp
@@ -860,8 +860,8 @@ void vehicle::autodrive_controller::compute_obstacles_from_enqueued_ramp_points(
     while( !ramp_points.to_check.empty() ) {
         const tripoint_bub_ms ramp_point = ramp_points.to_check.front();
         ramp_points.to_check.pop();
-        for( const tripoint_bub_ms &p : ff::point_flood_fill_4_connected( ramp_point, ramp_points.visited,
-                is_drivable ) ) {
+        for( const tripoint_bub_ms &p : ff::point_flood_fill_4_connected<std::vector>( ramp_point,
+                ramp_points.visited, is_drivable ) ) {
             const point pt_view = data.to_view( here, p );
             if( !data.view_bounds.contains( pt_view ) ) {
                 continue;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
The fishing code has its own almost identical copy of the 4 way flood fill function.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
Template the function in flood_fill.h, use it everywhere.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
There is one use case that shuffles the filled points for random order iteration, which ~needs a vector.
There is another use case that does a bunch of `.find()` on the filled points, which is faster with a set.
I decided to template and support both rather than always returning one of them and copying to the other when necessary.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->
Generated some overmaps. Lakes and forests and forest trails look normal.
Did some fishing. Seems to still work.
Hard to confirm things are exactly the same as before, though. I'm open to more testing ideas.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
