### PR TITLE
Improve vector reservations

### DIFF
--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -5108,11 +5108,12 @@ void om_range_mark( const tripoint_abs_omt &origin, int range, bool add_notes,
     std::vector<tripoint_abs_omt> note_pts;
 
     if( trigdist ) {
+        note_pts.reserve( range * 7 ); // actual multiplier varies from 5.33 to 8, mostly 6 to 7
         for( const tripoint_abs_omt &pos : points_on_radius_circ( origin, range ) ) {
             note_pts.emplace_back( pos );
         }
     } else {
-        note_pts.reserve( range * 4 - 4 );
+        note_pts.reserve( range * 8 );
         //North Limit
         for( int x = origin.x() - range; x < origin.x() + range + 1; x++ ) {
             note_pts.emplace_back( x, origin.y() - range, origin.z() );

--- a/src/line.cpp
+++ b/src/line.cpp
@@ -223,13 +223,13 @@ void bresenham( const tripoint_bub_ms &loc1, const tripoint_bub_ms &loc2, int t,
 //probably slow, so leaving two full functions for now
 std::vector<point> line_to( const point &p1, const point &p2, int t )
 {
-    std::vector<point> line;
     // Preallocate the number of cells we need instead of allocating them piecewise.
-    const int numCells = square_dist( p1, p2 );
-    if( numCells == 0 ) {
+    const int numCells = square_dist( p1, p2 ) + 1;
+    std::vector<point> line;
+    line.reserve( numCells );
+    if( numCells == 1 ) {
         line.push_back( p1 );
     } else {
-        line.reserve( numCells );
         bresenham( point_bub_ms( p1 ), point_bub_ms( p2 ), t, [&line]( const point_bub_ms & new_point ) {
             line.push_back( new_point.raw() );
             return true;
@@ -240,13 +240,13 @@ std::vector<point> line_to( const point &p1, const point &p2, int t )
 
 std::vector <tripoint> line_to( const tripoint &loc1, const tripoint &loc2, int t, int t2 )
 {
-    std::vector<tripoint> line;
     // Preallocate the number of cells we need instead of allocating them piecewise.
-    const int numCells = square_dist( loc1, loc2 );
-    if( numCells == 0 ) {
+    const int numCells = square_dist( loc1, loc2 ) + 1;
+    std::vector<tripoint> line;
+    line.reserve( numCells );
+    if( numCells == 1 ) {
         line.push_back( loc1 );
     } else {
-        line.reserve( numCells );
         bresenham( tripoint_bub_ms( loc1 ), tripoint_bub_ms( loc2 ), t,
         t2, [&line]( const tripoint_bub_ms & new_point ) {
             line.push_back( new_point.raw() );
@@ -258,12 +258,16 @@ std::vector <tripoint> line_to( const tripoint &loc1, const tripoint &loc2, int 
 
 std::vector<point_abs_om> orthogonal_line_to( const point_abs_om &p1, const point_abs_om &p2 )
 {
+    // Preallocate the number of cells we need instead of allocating them piecewise.
+    const int numCells = manhattan_dist( p1, p2 ) + 1;
+    std::vector<point_abs_om> points;
+    points.reserve( numCells );
     point diff( p2.x() - p1.x(), p2.y() - p1.y() );
     point diff_abs = diff.abs();
     point diff_sign( diff.x > 0 ? 1 : -1, diff.y > 0 ? 1 : -1 );
 
     point_abs_om iter = p1;
-    std::vector<point_abs_om> points = { iter };
+    points.emplace_back( iter );
     point i;
     for( i.x = 0, i.y = 0; i.x < diff_abs.x || i.y < diff_abs.y; ) {
         if( ( 0.5 + i.x ) / diff_abs.x < ( 0.5 + i.y ) / diff_abs.y ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
Some vectors in `faction_camp` and `line` have no or poor reserved sizes.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
Reserve appropriate sizes before emplace loops populate the vector to avoid resizing.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->
Played with this PR. Followed some reservations in debugger and confirmed they are accurate or approximately accurate.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
