### PR TITLE
Redefine glue itemgroups

### DIFF
--- a/data/json/itemgroups/tools.json
+++ b/data/json/itemgroups/tools.json
@@ -1105,9 +1105,9 @@
     "subtype": "distribution",
     "id": "glue_strong_domestic",
     "items": [
-      { "item": "glue_strong", "contents-item": "small_squeeze_tube", "charges": [ 0, 4 ] },
-      { "item": "glue_strong", "contents-item": "bottle_plastic_tiny_glue", "charges": [ 0, 30 ] },
-      { "item": "glue_strong", "contents-item": "bottle_plastic_small_glue", "charges": [ 0, 250 ] }
+      { "item": "glue_strong", "container-item": "small_squeeze_tube", "charges": [ 0, 4 ] },
+      { "item": "glue_strong", "container-item": "bottle_plastic_tiny_glue", "charges": [ 0, 30 ] },
+      { "item": "glue_strong", "container-item": "bottle_plastic_small_glue", "charges": [ 0, 250 ] }
     ]
   },
   {
@@ -1115,9 +1115,9 @@
     "subtype": "distribution",
     "id": "glue_strong_domestic_full",
     "items": [
-      { "item": "glue_strong", "contents-item": "small_squeeze_tube", "charges": 4 },
-      { "item": "glue_strong", "contents-item": "bottle_plastic_tiny_glue", "charges": 30 },
-      { "item": "glue_strong", "contents-item": "bottle_plastic_small_glue", "charges": 250 }
+      { "item": "glue_strong", "container-item": "small_squeeze_tube", "charges": 4 },
+      { "item": "glue_strong", "container-item": "bottle_plastic_tiny_glue", "charges": 30 },
+      { "item": "glue_strong", "container-item": "bottle_plastic_small_glue", "charges": 250 }
     ]
   },
   {
@@ -1125,10 +1125,10 @@
     "subtype": "distribution",
     "id": "glue_strong_professional",
     "items": [
-      { "item": "glue_strong", "contents-item": "bottle_plastic_small_glue", "charges": [ 0, 500 ] },
-      { "item": "glue_strong", "contents-item": "bottle_plastic_glue", "charges": [ 0, 1000 ] },
-      { "item": "glue_strong", "contents-item": "bottle_twoliter_glue", "charges": [ 0, 2000 ] },
-      { "item": "glue_strong", "contents-item": "jug_plastic_glue", "charges": [ 0, 3750 ] }
+      { "item": "glue_strong", "container-item": "bottle_plastic_small_glue", "charges": [ 0, 500 ] },
+      { "item": "glue_strong", "container-item": "bottle_plastic_glue", "charges": [ 0, 1000 ] },
+      { "item": "glue_strong", "container-item": "bottle_twoliter_glue", "charges": [ 0, 2000 ] },
+      { "item": "glue_strong", "container-item": "jug_plastic_glue", "charges": [ 0, 3750 ] }
     ]
   },
   {
@@ -1136,10 +1136,10 @@
     "subtype": "distribution",
     "id": "glue_strong_professional_full",
     "items": [
-      { "item": "glue_strong", "contents-item": "bottle_plastic_small_glue", "charges": 500 },
-      { "item": "glue_strong", "contents-item": "bottle_plastic_glue", "charges": 1000 },
-      { "item": "glue_strong", "contents-item": "bottle_twoliter_glue", "charges": 2000 },
-      { "item": "glue_strong", "contents-item": "jug_plastic_glue", "charges": 3750 }
+      { "item": "glue_strong", "container-item": "bottle_plastic_small_glue", "charges": 500 },
+      { "item": "glue_strong", "container-item": "bottle_plastic_glue", "charges": 1000 },
+      { "item": "glue_strong", "container-item": "bottle_twoliter_glue", "charges": 2000 },
+      { "item": "glue_strong", "container-item": "jug_plastic_glue", "charges": 3750 }
     ]
   }
 ]

--- a/data/json/itemgroups/tools.json
+++ b/data/json/itemgroups/tools.json
@@ -1065,8 +1065,8 @@
     "subtype": "distribution",
     "id": "glue_weak_domestic",
     "items": [
-      { "item": "bottle_plastic_tiny_glue", "contents-item": "glue_weak", "count": [ 0, 30 ], "prob": 1 },
-      { "item": "bottle_plastic_small_glue", "contents-item": "glue_weak", "count": [ 0, 250 ], "prob": 1 }
+      { "item": "glue_weak", "container-item": "bottle_plastic_tiny_glue", "charges": [ 0, 30 ] },
+      { "item": "glue_weak", "container-item": "bottle_plastic_small_glue", "charges": [ 0, 250 ] }
     ]
   },
   {
@@ -1074,8 +1074,8 @@
     "subtype": "distribution",
     "id": "glue_weak_domestic_full",
     "items": [
-      { "item": "bottle_plastic_tiny_glue", "contents-item": "glue_weak", "count": 30, "prob": 1 },
-      { "item": "bottle_plastic_small_glue", "contents-item": "glue_weak", "count": 250, "prob": 1 }
+      { "item": "glue_weak", "container-item": "bottle_plastic_tiny_glue", "charges": 30 },
+      { "item": "glue_weak", "container-item": "bottle_plastic_small_glue", "charges": 250 }
     ]
   },
   {
@@ -1083,10 +1083,10 @@
     "subtype": "distribution",
     "id": "glue_weak_professional",
     "items": [
-      { "item": "bottle_plastic_small_glue", "contents-item": "glue_weak", "count": [ 0, 500 ], "prob": 1 },
-      { "item": "bottle_plastic_glue", "contents-item": "glue_weak", "count": [ 0, 1000 ], "prob": 1 },
-      { "item": "bottle_twoliter_glue", "contents-item": "glue_weak", "count": [ 0, 2000 ], "prob": 1 },
-      { "item": "jug_plastic_glue", "contents-item": "glue_weak", "count": [ 0, 3750 ], "prob": 1 }
+      { "item": "glue_weak", "container-item": "bottle_plastic_small_glue", "charges": [ 0, 500 ] },
+      { "item": "glue_weak", "container-item": "bottle_plastic_glue", "charges": [ 0, 1000 ] },
+      { "item": "glue_weak", "container-item": "bottle_twoliter_glue", "charges": [ 0, 2000 ] },
+      { "item": "glue_weak", "container-item": "jug_plastic_glue", "charges": [ 0, 3750 ] }
     ]
   },
   {
@@ -1094,10 +1094,10 @@
     "subtype": "distribution",
     "id": "glue_weak_professional_full",
     "items": [
-      { "item": "bottle_plastic_small_glue", "contents-item": "glue_weak", "count": 500, "prob": 1 },
-      { "item": "bottle_plastic_glue", "contents-item": "glue_weak", "count": 1000, "prob": 1 },
-      { "item": "bottle_twoliter_glue", "contents-item": "glue_weak", "count": 2000, "prob": 1 },
-      { "item": "jug_plastic_glue", "contents-item": "glue_weak", "count": 3750, "prob": 1 }
+      { "item": "glue_weak", "container-item": "bottle_plastic_small_glue", "charges": 500 },
+      { "item": "glue_weak", "container-item": "bottle_plastic_glue", "charges": 1000 },
+      { "item": "glue_weak", "container-item": "bottle_twoliter_glue", "charges": 2000 },
+      { "item": "glue_weak", "container-item": "jug_plastic_glue", "charges": 3750 }
     ]
   },
   {
@@ -1105,9 +1105,9 @@
     "subtype": "distribution",
     "id": "glue_strong_domestic",
     "items": [
-      { "item": "small_squeeze_tube", "contents-item": "glue_strong", "count": [ 0, 4 ], "prob": 1 },
-      { "item": "bottle_plastic_tiny_glue", "contents-item": "glue_strong", "count": [ 0, 30 ], "prob": 1 },
-      { "item": "bottle_plastic_small_glue", "contents-item": "glue_strong", "count": [ 0, 250 ], "prob": 1 }
+      { "item": "glue_strong", "contents-item": "small_squeeze_tube", "charges": [ 0, 4 ] },
+      { "item": "glue_strong", "contents-item": "bottle_plastic_tiny_glue", "charges": [ 0, 30 ] },
+      { "item": "glue_strong", "contents-item": "bottle_plastic_small_glue", "charges": [ 0, 250 ] }
     ]
   },
   {
@@ -1115,9 +1115,9 @@
     "subtype": "distribution",
     "id": "glue_strong_domestic_full",
     "items": [
-      { "item": "small_squeeze_tube", "contents-item": "glue_strong", "count": 4, "prob": 1 },
-      { "item": "bottle_plastic_tiny_glue", "contents-item": "glue_strong", "count": 30, "prob": 1 },
-      { "item": "bottle_plastic_small_glue", "contents-item": "glue_strong", "count": 250, "prob": 1 }
+      { "item": "glue_strong", "contents-item": "small_squeeze_tube", "charges": 4 },
+      { "item": "glue_strong", "contents-item": "bottle_plastic_tiny_glue", "charges": 30 },
+      { "item": "glue_strong", "contents-item": "bottle_plastic_small_glue", "charges": 250 }
     ]
   },
   {
@@ -1125,10 +1125,10 @@
     "subtype": "distribution",
     "id": "glue_strong_professional",
     "items": [
-      { "item": "bottle_plastic_small_glue", "contents-item": "glue_strong", "count": [ 0, 500 ], "prob": 1 },
-      { "item": "bottle_plastic_glue", "contents-item": "glue_strong", "count": [ 0, 1000 ], "prob": 1 },
-      { "item": "bottle_twoliter_glue", "contents-item": "glue_strong", "count": [ 0, 2000 ], "prob": 1 },
-      { "item": "jug_plastic_glue", "contents-item": "glue_strong", "count": [ 0, 3750 ], "prob": 1 }
+      { "item": "glue_strong", "contents-item": "bottle_plastic_small_glue", "charges": [ 0, 500 ] },
+      { "item": "glue_strong", "contents-item": "bottle_plastic_glue", "charges": [ 0, 1000 ] },
+      { "item": "glue_strong", "contents-item": "bottle_twoliter_glue", "charges": [ 0, 2000 ] },
+      { "item": "glue_strong", "contents-item": "jug_plastic_glue", "charges": [ 0, 3750 ] }
     ]
   },
   {
@@ -1136,10 +1136,10 @@
     "subtype": "distribution",
     "id": "glue_strong_professional_full",
     "items": [
-      { "item": "bottle_plastic_small_glue", "contents-item": "glue_strong", "count": 500, "prob": 1 },
-      { "item": "bottle_plastic_glue", "contents-item": "glue_strong", "count": 1000, "prob": 1 },
-      { "item": "bottle_twoliter_glue", "contents-item": "glue_strong", "count": 2000, "prob": 1 },
-      { "item": "jug_plastic_glue", "contents-item": "glue_strong", "count": 3750, "prob": 1 }
+      { "item": "glue_strong", "contents-item": "bottle_plastic_small_glue", "charges": 500 },
+      { "item": "glue_strong", "contents-item": "bottle_plastic_glue", "charges": 1000 },
+      { "item": "glue_strong", "contents-item": "bottle_twoliter_glue", "charges": 2000 },
+      { "item": "glue_strong", "contents-item": "jug_plastic_glue", "charges": 3750 }
     ]
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Our glue itemgroups spawn `count` amounts of bottles with single units of glue instead of the intended randomized amount of glue for individual bottles.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Redefine the itemgroups to make them behave as intended.

`item` is now the glue.
`contents-item` is changed to `container-item` and is now the container.
`count` is changed to `charges` to define the amount of glue per container.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Spawned the itemgroup, behaves as expected.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Fixes #82352.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
