### PR TITLE
Vitamin spell support custom color, also support going lower than 0

### DIFF
--- a/doc/JSON/MAGIC.md
+++ b/doc/JSON/MAGIC.md
@@ -333,10 +333,14 @@ Any damage type can be used, see [JSON_INFO.md#damage-types](JSON_INFO.md#damage
 ```jsonc
 "energy_source": "MANA",
 "energy_source": "STAMINA",
-"energy_source": "BIONIC", // consumes MJ from your CBM batteries
+"energy_source": "BIONIC",  // consumes MJ from your CBM batteries
 "energy_source": "NONE",
-"energy_source": "HP", // Require a tool with CUT 1, and allow to pick the limb to be damaged
-"energy_source": { "type": "VITAMIN", "vitamin": "vitamin_id" },
+"energy_source": "HP",      // Require a tool with CUT 1, and allow to pick the limb to be damaged
+"energy_source": { 
+  "type": "VITAMIN",
+  "vitamin": "vitamin_id",
+  "color": "c_red"          // default color is c_cyan
+  } 
 ```
 
 ### Spell level

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -516,7 +516,7 @@ void spell_type::load( const JsonObject &jo, std::string_view src )
         const JsonObject jo_energy = jo.get_object( "energy_source" );
         mandatory( jo_energy, was_loaded, "type", energy_source );
         optional( jo_energy, was_loaded, "vitamin", vitamin_energy_source_ );
-    optional( jo_energy, was_loaded, "color", energy_color_, nc_color_reader{}, c_cyan );
+        optional( jo_energy, was_loaded, "color", energy_color_, nc_color_reader{}, c_cyan );
     }
     optional( jo, was_loaded, "damage_type", dmg_type, dmg_type_default );
     optional( jo, was_loaded, "get_level_formula_id", get_level_formula_id );

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -1556,7 +1556,7 @@ std::string spell::energy_string() const
         case magic_energy_type::bionic:
             return _( "kJ" );
         case magic_energy_type::vitamin:
-            return vitamin_energy_source().value().obj().name();
+            return to_lower_case( vitamin_energy_source().value().obj().name() );
         default:
             return "";
     }

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -516,9 +516,7 @@ void spell_type::load( const JsonObject &jo, std::string_view src )
         const JsonObject jo_energy = jo.get_object( "energy_source" );
         mandatory( jo_energy, was_loaded, "type", energy_source );
         optional( jo_energy, was_loaded, "vitamin", vitamin_energy_source_ );
-        if( jo_energy.has_string( "color" ) ) {
-            energy_color_ = color_from_string( jo_energy.get_string( "color" ) );
-        }
+    optional( jo_energy, was_loaded, "color", energy_color_, nc_color_reader{}, c_cyan );
     }
     optional( jo, was_loaded, "damage_type", dmg_type, dmg_type_default );
     optional( jo, was_loaded, "get_level_formula_id", get_level_formula_id );

--- a/src/magic.h
+++ b/src/magic.h
@@ -15,6 +15,7 @@
 
 #include "body_part_set.h"
 #include "bodypart.h"
+#include "color.h"
 #include "coordinates.h"
 #include "damage.h"
 #include "dialogue_helpers.h"
@@ -31,7 +32,6 @@ class Character;
 class Creature;
 class JsonObject;
 class JsonOut;
-class nc_color;
 class spell;
 class time_duration;
 struct const_dialogue;
@@ -345,6 +345,9 @@ class spell_type
         // what energy do you use to cast this spell
         std::optional<vitamin_id> vitamin_energy_source() const;
 
+        // if vitamin is used, specifies the color of an energy
+        nc_color energy_color() const;
+
         damage_type_id dmg_type = damage_type_id::NULL_ID();
 
         // list of valid targets enum
@@ -445,6 +448,7 @@ class spell_type
 
         std::optional<magic_energy_type> energy_source;
         std::optional<vitamin_id> vitamin_energy_source_; // NOLINT(cata-serialize)
+        nc_color energy_color_ = c_cyan; // NOLINT(cata-serialize)
         std::optional<jmath_func_id> get_level_formula_id;
         std::optional<jmath_func_id> exp_for_level_formula_id;
         std::optional<int> max_book_level;
@@ -637,6 +641,7 @@ class spell
         // magic energy source enum
         magic_energy_type energy_source() const;
         std::optional<vitamin_id> vitamin_energy_source() const;
+        nc_color energy_color() const;
         // the color that's representative of the damage type
         nc_color damage_type_color() const;
         std::string damage_type_string() const;

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -1538,6 +1538,14 @@ std::string to_upper_case( const std::string &s )
     return wstr_to_utf8( wstr );
 }
 
+std::string to_lower_case( const std::string &s )
+{
+    const auto &f = std::use_facet<std::ctype<wchar_t>>( std::locale() );
+    std::wstring wstr = utf8_to_wstr( s );
+    f.tolower( wstr.data(), wstr.data() + wstr.size() );
+    return wstr_to_utf8( wstr );
+}
+
 // find the position of each non-printing tag in a string
 std::vector<size_t> get_tag_positions( std::string_view s )
 {

--- a/src/output.h
+++ b/src/output.h
@@ -632,6 +632,8 @@ std::string trim_trailing_punctuations( std::string_view s );
 std::string remove_punctuations( const std::string &s );
 // Converts the string to upper case.
 std::string to_upper_case( const std::string &s );
+// Converts the string to lower case.
+std::string to_lower_case( const std::string &s );
 
 std::string rewrite_vsnprintf( const char *msg );
 


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Continuation of #82318
#### Describe the solution
Make vitamin spell support custom colors
Add support consuming vitamin lower than 0, if `min` of vitamin is lower than 0.
Print the name of vitamin in lowercase
#### Testing
<img width="991" height="612" alt="image" src="https://github.com/user-attachments/assets/d6fa61f0-9d28-47ab-9e1b-1e17bf64acea" />

#### Additional context
I have concerns about visibility, it seems to me that it's not very clear now if you can use the spell or not on this screenshot

~~Also, `color` loads manually using color_from_string instead of using generic factory, because `color_reader{}` is part of item factory, not generic factory, someome might want to fix it~~ relies on #82363, should be merged after this one