### PR TITLE
Make Aftershock load for stable

### DIFF
--- a/data/mods/Aftershock/itemgroups/item_groups.json
+++ b/data/mods/Aftershock/itemgroups/item_groups.json
@@ -46,12 +46,6 @@
     }
   },
   {
-    "id": "spider",
-    "type": "item_group",
-    "copy-from": "spider",
-    "extend": { "items": [ [ "afs_energy_saber_off", 1 ], [ "afs_hydraulic_gauntlet", 1 ], [ "alien_battery", 1 ] ] }
-  },
-  {
     "id": "camping",
     "type": "item_group",
     "copy-from": "camping",

--- a/data/mods/Aftershock/mobs/robots.json
+++ b/data/mods/Aftershock/mobs/robots.json
@@ -404,7 +404,8 @@
         "gun_type": "nailgun",
         "fake_skills": [ [ "gun", 0 ], [ "pistol", 2 ] ],
         "fake_dex": 8,
-        "ranges": [ [ 0, 3, "BURST" ] ]
+        "ranges": [ [ 0, 3, "BURST" ] ],
+        "cooldown": 0
       }
     ],
     "extend": { "flags": [ "DROPS_AMMO" ] }
@@ -423,7 +424,7 @@
     "melee_dice": 4,
     "melee_dice_sides": 5,
     "melee_dice_ap": 4,
-    "special_attacks": [ { "id": "smash", "throw_strength": 96 } ],
+    "special_attacks": [ { "id": "smash", "throw_strength": 96, "cooldown": 0 } ],
     "extend": { "flags": [ "BASHES", "DESTROYS", "ATTACKMON" ] }
   },
   {
@@ -487,7 +488,8 @@
         "gun_type": "watercannon",
         "fake_skills": [ [ "gun", 2 ], [ "launcher", 2 ] ],
         "fake_dex": 8,
-        "ranges": [ [ 0, 5, "BURST" ] ]
+        "ranges": [ [ 0, 5, "BURST" ] ],
+        "cooldown": 0
       }
     ],
     "extend": { "flags": [ "FIREPROOF", "BASHES" ] }
@@ -547,7 +549,7 @@
     "melee_damage": [ { "damage_type": "cut", "amount": 5 } ],
     "attack_effs": [ { "id": "bleed", "chance": 20, "duration": 3 } ],
     "vision_day": 50,
-    "special_attacks": [ { "id": "hypo_pkill" } ],
+    "special_attacks": [ { "id": "hypo_pkill", "cooldown": 0 } ],
     "anger_triggers": [ "FRIEND_ATTACKED", "PLAYER_WEAK", "HURT", "PLAYER_CLOSE" ],
     "death_function": { "corpse_type": "BROKEN" },
     "death_drops": { "groups": [ [ "broken_robots", 3 ] ] },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
While we're no longer updating standalone Aftershock bc it got merged with exoplanet it's easy enough to make it at least load for 0.I so lets do that
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Removes the spider group as per https://github.com/CleverRaven/Cataclysm-DDA/pull/81341/files#diff-5ba25724321152965c714424141b2b7893447d77b6b9af9242d021fb8efb630eL48-L53 (I tried extending the appropriate group but you can't extend entries and it didn't seem worth)
Adds mandatory special attack cooldowns
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Started a fresh save without errors, managed to load the 0.H save from #82331 (with alot of errors that weren't Aftershock specific)
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
