### PR TITLE
Add doc re c++ code comments for translator context

### DIFF
--- a/doc/TRANSLATING.md
+++ b/doc/TRANSLATING.md
@@ -308,7 +308,11 @@ the singular form + "s". However, `"str_pl"` may still be needed if the unit
 test cannot determine whether the correct plural form can be formed by simply
 appending "s".
 
-You can also add comments for translators by writing it like below (the order
+### Translation Context Comments
+
+#### JSON
+
+JSON objects can add comments for translators by writing it like below (the order
 of the entries does not matter):
 
 ```jsonc
@@ -333,6 +337,16 @@ If a string doesn't need to be translated, you can write `"NO_I18N"` in the
     "//~": "NO_I18N",
     "str": "Fake Monster-Only Spell"
 }
+```
+
+#### C++
+
+C++ code can add comments for translators by including a ~ in a comment on the
+previous line of the file containing the string to be translated.
+
+```C++
+//~ foo
+some.function( _( "translators get 'foo' for context translating this string" ) );
 ```
 
 ### Static string variables


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
I18N "Add documentation for C++ translation context comments"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
The docs don't explain how `//~` comments in C++ code work.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
Add a small section and rearrange the existing json comment section along with it.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
I could mention `xgettext` or the legal variations (e.g. `// comment for coder ~ comment for translator`) or illegal alternatives (e.g. `_() //~ comment` doesn't work), but I wanted to start small and just get this in the docs at all first.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
