### PR TITLE
Generic factory: more reader correctness

### DIFF
--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -245,6 +245,10 @@ dbl_or_var dbl_or_var_reader::get_next( const JsonValue &jv ) const
 bool dbl_or_var_reader::operator()( const JsonObject &jo, const std::string_view member_name,
                                     dbl_or_var &member, bool /*was_loaded*/ ) const
 {
+    warn_disabled_feature( jo, "extend", member_name, "disabled for dbl_or_var_reader" );
+    warn_disabled_feature( jo, "delete", member_name, "disabled for dbl_or_var_reader" );
+    warn_disabled_feature( jo, "relative", member_name, "disabled for dbl_or_var_reader" );
+    warn_disabled_feature( jo, "proportional", member_name, "disabled for dbl_or_var_reader" );
     if( !jo.has_member( member_name ) ) {
         return false;
     }

--- a/src/generic_factory.cpp
+++ b/src/generic_factory.cpp
@@ -23,6 +23,10 @@ void warn_disabled_feature( const JsonObject &jo, const std::string_view feature
 bool one_char_symbol_reader( const JsonObject &jo, std::string_view member_name, int &sym,
                              bool )
 {
+    warn_disabled_feature( jo, "extend", member_name, "disabled for one_char_symbol_reader" );
+    warn_disabled_feature( jo, "delete", member_name, "disabled for one_char_symbol_reader" );
+    warn_disabled_feature( jo, "relative", member_name, "disabled for one_char_symbol_reader" );
+    warn_disabled_feature( jo, "proportional", member_name, "disabled for one_char_symbol_reader" );
     std::string sym_as_string;
     if( !jo.read( member_name, sym_as_string ) ) {
         return false;
@@ -47,6 +51,14 @@ bool one_char_symbol_reader( const JsonObject &jo, std::string_view member_name,
 bool unicode_codepoint_from_symbol_reader( const JsonObject &jo,
         std::string_view member_name, uint32_t &member, bool )
 {
+    warn_disabled_feature( jo, "extend", member_name,
+                           "disabled for unicode_codepoint_from_symbol_reader" );
+    warn_disabled_feature( jo, "delete", member_name,
+                           "disabled for unicode_codepoint_from_symbol_reader" );
+    warn_disabled_feature( jo, "relative", member_name,
+                           "disabled for unicode_codepoint_from_symbol_reader" );
+    warn_disabled_feature( jo, "proportional", member_name,
+                           "disabled for unicode_codepoint_from_symbol_reader" );
     int sym_as_int;
     std::string sym_as_string;
     if( !jo.read( member_name, sym_as_string, false ) ) {

--- a/src/generic_factory.h
+++ b/src/generic_factory.h
@@ -1525,50 +1525,26 @@ public:
 
 using string_reader = auto_flags_reader<>;
 
-class volume_reader : public generic_typed_reader<units::volume>
+class volume_reader : public generic_typed_reader<volume_reader>
 {
     public:
-        bool operator()( const JsonObject &jo, const std::string_view member_name,
-                         units::volume &member, bool /* was_loaded */ ) const {
-            if( !jo.has_member( member_name ) ) {
-                return false;
-            }
-            member = read_from_json_string<units::volume>( jo.get_member( member_name ), units::volume_units );
-            return true;
-        }
-        units::volume get_next( JsonValue &jv ) const {
+        units::volume get_next( const JsonValue &jv ) const {
             return read_from_json_string<units::volume>( jv, units::volume_units );
         }
 };
 
-class mass_reader : public generic_typed_reader<units::mass>
+class mass_reader : public generic_typed_reader<mass_reader>
 {
     public:
-        bool operator()( const JsonObject &jo, const std::string_view member_name,
-                         units::mass &member, bool /* was_loaded */ ) const {
-            if( !jo.has_member( member_name ) ) {
-                return false;
-            }
-            member = read_from_json_string<units::mass>( jo.get_member( member_name ), units::mass_units );
-            return true;
-        }
-        units::mass get_next( JsonValue &jv ) const {
+        units::mass get_next( const JsonValue &jv ) const {
             return read_from_json_string<units::mass>( jv, units::mass_units );
         }
 };
 
-class money_reader : public generic_typed_reader<units::money>
+class money_reader : public generic_typed_reader<money_reader>
 {
     public:
-        bool operator()( const JsonObject &jo, const std::string_view member_name,
-                         units::money &member, bool /* was_loaded */ ) const {
-            if( !jo.has_member( member_name ) ) {
-                return false;
-            }
-            member = read_from_json_string<units::money>( jo.get_member( member_name ), units::money_units );
-            return true;
-        }
-        static units::money get_next( JsonValue &jv ) {
+        units::money get_next( const JsonValue &jv ) const {
             return read_from_json_string<units::money>( jv, units::money_units );
         }
 };

--- a/src/generic_factory.h
+++ b/src/generic_factory.h
@@ -918,6 +918,7 @@ template < typename MemberType, typename ReaderType, typename DefaultType = Memb
 inline void optional( const JsonObject &jo, const bool was_loaded, const std::string_view name,
                       MemberType &member, const ReaderType &reader )
 {
+    // reader handles disabled features
     if( !reader( jo, name, member, was_loaded ) ) {
         if( !was_loaded ) {
             member = MemberType();
@@ -928,6 +929,7 @@ template<typename MemberType, typename ReaderType, typename DefaultType = Member
 inline void optional( const JsonObject &jo, const bool was_loaded, const std::string_view name,
                       MemberType &member, const ReaderType &reader, const DefaultType &default_value )
 {
+    // reader handles disabled features
     if( !reader( jo, name, member, was_loaded ) ) {
         if( !was_loaded ) {
             member = default_value;

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -2161,19 +2161,6 @@ void Item_factory::init()
         std::make_unique<Item_group>( Item_group::G_COLLECTION, 100, 0, 0, "EMPTY_GROUP" );
 }
 
-//reads nc_color from string
-class color_reader : public generic_typed_reader<color_reader>
-{
-    public:
-        nc_color get_next( const JsonValue &val ) const {
-            if( val.test_string() ) {
-                return nc_color( color_from_string( val.get_string() ) );
-            }
-            val.throw_error( "color must be string" );
-            return nc_color();
-        }
-};
-
 //reads snippet as array or string
 class snippet_reader : public generic_typed_reader<snippet_reader>
 {
@@ -4098,7 +4085,7 @@ void itype::load( const JsonObject &jo, std::string_view src )
     optional( jo, was_loaded, "repairs_with", repairs_with, auto_flags_reader<material_id> {} );
     optional( jo, was_loaded, "ememory_size", ememory_size );
 
-    optional( jo, was_loaded, "color", color, color_reader{} );
+    optional( jo, was_loaded, "color", color, nc_color_reader{} );
 
     optional( jo, was_loaded, "repairs_like", repairs_like );
 


### PR DESCRIPTION
#### Summary
Infrastructure "Report failure to read extended features for all generic factory readers"

#### Describe the solution
Also delete duplicate color reader, and fix the units readers to not require overwriting operator().

#### Testing
`tools/force_load_game.sh`