### PR TITLE
Fix weather

### DIFF
--- a/src/weather_gen.cpp
+++ b/src/weather_gen.cpp
@@ -67,12 +67,15 @@ static weather_gen_common get_common_data( const tripoint_abs_ms &location,
     result.modSEED = seed % SIMPLEX_NOISE_RANDOM_SEED_LIMIT;
     const double year_fraction( time_past_new_year( t.t ) /
                                 calendar::year_length() ); // [0,1)
-
-    result.cyf = std::cos( tau * ( year_fraction + .125 ) ); // [-1, 1]
-    // We add one-eighth to line up `cyf` so that 1 is at
+    // We add an offset to line up `cyf` so that 1 is at
     // midwinter and -1 at midsummer. (Cataclsym DDA years
-    // start when spring starts. Gregorian years start when
-    // winter starts.)
+    // start season_length - turn_zero_offset days into winter.
+    // Gregorian years start when winter starts.)
+    // LATER: Do gregorian years start on winter? They start ~10 days into winter...
+    const double days_year_start_to_midwinter = to_days<double>( ( calendar::season_length() / 2 ) -
+            ( calendar::season_length() - calendar::turn_zero_offset() ) );
+    const double offset = days_year_start_to_midwinter / to_days<double>( calendar::year_length() );
+    result.cyf = std::cos( tau * ( year_fraction - offset ) ); // [-1, 1]
     result.season = season_of_year( t.t );
 
     return result;

--- a/tests/weather_test.cpp
+++ b/tests/weather_test.cpp
@@ -77,10 +77,10 @@ static year_of_weather_data collect_weather_data( unsigned seed )
     // Collect generated weather data for a single year.
     for( time_point i = begin ; i < end ; i += 1_minutes ) {
         w_point w = wgen.get_weather( tripoint_abs_ms::zero, i, seed );
-        int day = to_days<int>( time_past_new_year( i ) );
+        int day = to_days<int>( i - begin );
         int minute = to_minutes<int>( time_past_midnight( i ) );
         result.temperature[day][minute] = units::to_fahrenheit( w.temperature );
-        int hour = to_hours<int>( time_past_new_year( i ) );
+        int hour = to_hours<int>( i - begin );
         *get_weather().weather_precise = w;
         result.hourly_precip[hour] +=
             precip_mm_per_hour(
@@ -131,8 +131,9 @@ TEST_CASE( "weather_realism", "[weather]" )
         CHECK( mean_of_ranges <= 25 );
 
         // Check that summer and winter temperatures are very different.
-        size_t summer_idx = data.lows.size() / 4;
-        size_t winter_idx = 5 * data.highs.size() / 6;
+        // 0 is the start of spring, 1/4 is the start of summer, 1/8 is halfway through
+        size_t summer_idx = 3 * data.lows.size() / 8;
+        size_t winter_idx = 7 * data.highs.size() / 8;
         double summer_low = data.lows[summer_idx];
         double winter_high = data.highs[winter_idx];
         {


### PR DESCRIPTION
#### Summary
Bugfixes "Fix seasonal weather"

#### Purpose of change
Fixes https://github.com/CleverRaven/Cataclysm-DDA/issues/82347

#### Describe the solution
Fix the offset in the weather generator to properly place midwinter after the change to time_past_new_year.

See commits for more details.

#### Testing
`'tests/cata_test 'weather_realism'`
Create new character, spawn in a thermometer, spring temperature is more reasonable.