### PR TITLE
[ Xedra Evolved ] No Mana regen for the dead

### DIFF
--- a/data/mods/Xedra_Evolved/mutations/mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/mutations.json
@@ -1045,7 +1045,7 @@
     "flags": [ "CANNIBAL", "ALBINO", "DAYFEAR", "HEMOVORE" ],
     "enchantments": [
       { "condition": { "not": "is_day" }, "values": [ { "value": "OVERMAP_SIGHT", "add": 1 } ] },
-      { "values": [ { "value": "STAMINA_REGEN_MOD", "add": 0.2 }, { "value": "METABOLISM", "multiply": -0.2 }] }
+      { "values": [ { "value": "STAMINA_REGEN_MOD", "add": 0.2 }, { "value": "METABOLISM", "multiply": -0.2 } ] }
     ]
   },
   {
@@ -1179,7 +1179,7 @@
           { "value": "METABOLISM", "multiply": -0.5 },
           { "value": "DISINFECTANT_BONUS", "multiply": -1 },
           { "value": "BANDAGE_BONUS", "multiply": -1 },
-          { "value": "MANA", "multiply": 0 } 
+          { "value": "MANA", "multiply": 0 }
         ]
       },
       {

--- a/data/mods/Xedra_Evolved/mutations/mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/mutations.json
@@ -1179,7 +1179,7 @@
           { "value": "METABOLISM", "multiply": -0.5 },
           { "value": "DISINFECTANT_BONUS", "multiply": -1 },
           { "value": "BANDAGE_BONUS", "multiply": -1 },
-          { "value": "MANA", "multiply": 0 }
+          { "value": "MAX_MANA", "multiply": 0 }
         ]
       },
       {

--- a/data/mods/Xedra_Evolved/mutations/mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/mutations.json
@@ -1179,7 +1179,7 @@
           { "value": "METABOLISM", "multiply": -0.5 },
           { "value": "DISINFECTANT_BONUS", "multiply": -1 },
           { "value": "BANDAGE_BONUS", "multiply": -1 },
-          { "value": "REGEN_MANA", "multiply": 0 }
+          { "value": "REGEN_MANA", "multiply": -50 }
         ]
       },
       {

--- a/data/mods/Xedra_Evolved/mutations/mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/mutations.json
@@ -1179,7 +1179,7 @@
           { "value": "METABOLISM", "multiply": -0.5 },
           { "value": "DISINFECTANT_BONUS", "multiply": -1 },
           { "value": "BANDAGE_BONUS", "multiply": -1 },
-          { "value": "MAX_MANA", "multiply": 0 }
+          { "value": "REGEN_MANA", "multiply": 0 }
         ]
       },
       {

--- a/data/mods/Xedra_Evolved/mutations/mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/mutations.json
@@ -1045,7 +1045,7 @@
     "flags": [ "CANNIBAL", "ALBINO", "DAYFEAR", "HEMOVORE" ],
     "enchantments": [
       { "condition": { "not": "is_day" }, "values": [ { "value": "OVERMAP_SIGHT", "add": 1 } ] },
-      { "values": [ { "value": "STAMINA_REGEN_MOD", "add": 0.2 }, { "value": "METABOLISM", "multiply": -0.2 } ] }
+      { "values": [ { "value": "STAMINA_REGEN_MOD", "add": 0.2 }, { "value": "METABOLISM", "multiply": -0.2 }] }
     ]
   },
   {
@@ -1178,7 +1178,8 @@
           { "value": "STAMINA_REGEN_MOD", "add": 0.5 },
           { "value": "METABOLISM", "multiply": -0.5 },
           { "value": "DISINFECTANT_BONUS", "multiply": -1 },
-          { "value": "BANDAGE_BONUS", "multiply": -1 }
+          { "value": "BANDAGE_BONUS", "multiply": -1 },
+          { "value": "MANA", "multiply": 0 } 
         ]
       },
       {

--- a/data/mods/Xedra_Evolved/spells/vampire_spells.json
+++ b/data/mods/Xedra_Evolved/spells/vampire_spells.json
@@ -407,7 +407,7 @@
     "difficulty": 0,
     "min_duration": 16640000,
     "base_energy_cost": 350,
-        "energy_source": "MANA"
+    "energy_source": "MANA"
   },
   {
     "id": "vampire_invisible_in_dark",

--- a/data/mods/Xedra_Evolved/spells/vampire_spells.json
+++ b/data/mods/Xedra_Evolved/spells/vampire_spells.json
@@ -407,7 +407,7 @@
     "difficulty": 0,
     "min_duration": 16640000,
     "base_energy_cost": 350,
-    "energy_source": { "type": "VITAMIN", "vitamin": "human_blood_vitamin" }
+        "energy_source": "MANA"
   },
   {
     "id": "vampire_invisible_in_dark",

--- a/data/mods/Xedra_Evolved/spells/vampire_spells.json
+++ b/data/mods/Xedra_Evolved/spells/vampire_spells.json
@@ -407,7 +407,7 @@
     "difficulty": 0,
     "min_duration": 16640000,
     "base_energy_cost": 350,
-    "energy_source": "MANA"
+    "energy_source": { "type": "VITAMIN", "vitamin": "human_blood_vitamin" }
   },
   {
     "id": "vampire_invisible_in_dark",

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -2652,7 +2652,7 @@ void known_magic::update_mana( const Character &guy, float turns )
     // mana should replenish in 8 hours.
     const double full_replenish = to_turns<double>( 8_hours );
     const double ratio = turns / full_replenish;
-    mod_mana( guy, std::floor( ratio * std::max( 0,
+    mod_mana( guy, std::floor( ratio * std::max( 0.0,
                                guy.calculate_by_enchantment( static_cast<double>( max_mana(
                                            guy ) ), enchant_vals::mod::REGEN_MANA ) ) ) );
 }

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -2652,8 +2652,8 @@ void known_magic::update_mana( const Character &guy, float turns )
     // mana should replenish in 8 hours.
     const double full_replenish = to_turns<double>( 8_hours );
     const double ratio = turns / full_replenish;
-    mod_mana( guy, std::floor( ratio * guy.calculate_by_enchantment( static_cast<double>( max_mana(
-                                   guy ) ), enchant_vals::mod::REGEN_MANA ) ) );
+        mod_mana( guy, std::floor( ratio * std::max( 0, guy.calculate_by_enchantment( static_cast<double>( max_mana(
+                                   guy ) ), enchant_vals::mod::REGEN_MANA ) ) ) );
 }
 
 std::vector<spell_id> known_magic::spells() const

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -2652,8 +2652,9 @@ void known_magic::update_mana( const Character &guy, float turns )
     // mana should replenish in 8 hours.
     const double full_replenish = to_turns<double>( 8_hours );
     const double ratio = turns / full_replenish;
-        mod_mana( guy, std::floor( ratio * std::max( 0, guy.calculate_by_enchantment( static_cast<double>( max_mana(
-                                   guy ) ), enchant_vals::mod::REGEN_MANA ) ) ) );
+    mod_mana( guy, std::floor( ratio * std::max( 0,
+                               guy.calculate_by_enchantment( static_cast<double>( max_mana(
+                                           guy ) ), enchant_vals::mod::REGEN_MANA ) ) ) );
 }
 
 std::vector<spell_id> known_magic::spells() const


### PR DESCRIPTION
Update mutations.json

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
If vampires somehow have spells to cast they can only regen mana by spending blood on it to imitate human life.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Changes mana regen for vampires to zero.  
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
