### PR TITLE
Update cranberry juice fun value from -1 to 2.

### DIFF
--- a/data/json/items/comestibles/drink.json
+++ b/data/json/items/comestibles/drink.json
@@ -526,7 +526,7 @@
     "phase": "liquid",
     "flags": [ "EATEN_COLD" ],
     "vitamins": [ [ "vitC", 131 ], [ "calcium", 3 ], [ "iron", 1 ], [ "fruit_allergen", 1 ] ],
-    "fun": -1
+    "fun": 2
   },
   {
     "type": "ITEM",


### PR DESCRIPTION
#### Summary
Content "Update cranberry juice fun value and description."

#### Purpose of change

I believe 2 fun better reflects the value of cranberry juice, which is pretty sugary. Given that water is 0, and cranberry soda is 6 fun, this seems like a more realistic fun value, rather than -1, Which is the fun value for something a bit unappetizing. Of course, this is subjective, but again, given that crispy cran is 6 fun, which seems to have a similar favor profile (Cranberry juice and lemon-lime soda), I think it's justified.

#### Describe the solution

Just a small update, which fits better than cranberry's current fun of -1. 

#### Describe alternatives you've considered

I considered +0 as a new value, but given that plain, boring water is +0, something with a substantial amount of sugar like cranberry juice should have a positive value (like my proposed 2)

#### Testing

No testing done, just a simple .json update.
