### PR TITLE
Document debug character/world naming

### DIFF
--- a/doc/CONTRIBUTING.md
+++ b/doc/CONTRIBUTING.md
@@ -401,13 +401,29 @@ Bring up the keybindings menu (press `Escape` then `1`), scroll down almost to t
 │ g Game…                                                                   │
 │ s Spawning…                                                               │
 │ p Player…                                                                 │
+│ c Monster…                                                                │
+│ f Faction…                                                                │
 │ v Vehicle…                                                                │
 │ t Teleport…                                                               │
 │ m Map…                                                                    │
+│ d Dialogue…                                                               │
+│ q Quick setup…                                                            │
 └───────────────────────────────────────────────────────────────────────────┘
 ```
 
-With these commands, you should be able to recreate the proper conditions to test your changes.
+With the commands in this menu, you should be able to recreate the proper conditions to test your changes.  Most commands change one thing at a time.
+
+The last command, "Quick setup", does many things at once:
+* Gives you debug traits such as clairvoyance, invincibility, near infinite stamina and mana, etc
+* Gives you a nearly infinite backpack
+* Maxes your skills (but not your stats!)
+* Reveals the map
+
+### Debug names
+
+If you name a character starting with one of "Debug", "Test", "Sandbox", "Staging", "QA", or "UAT", they will spawn with the debug quick setup performed automatically.
+
+If you name a world one of those names, every character will spawn that way.
 
 ## Frequently Asked Questions
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Infrastructure "Document debug character/world naming for testing"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
I accidentally discovered what happens when you name a world "Test", and couldn't find it explained in the docs. I also wish I'd known much sooner.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
Document this feature.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
A bunch of CONTRIBUTING.md should probably get moved to TESTING_YOUR_CHANGES.md and then linked, but that's a bigger step than I wanted to tackle here.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
I also updated and fleshed out the description of the debug menu in general and the quick setup option in particular.

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
