### PR TITLE
[MoM] Add Psychometry clairsentient power

### DIFF
--- a/data/mods/MindOverMatter/PowerDescriptionSpoilers.md
+++ b/data/mods/MindOverMatter/PowerDescriptionSpoilers.md
@@ -309,6 +309,17 @@ This is natural painkiller and so has natural effects (reduces speed slightly)<b
 *Prerequisites*: Discern Weakness 7<br />
 </details>
 <details>
+<summary><h3>Psychometry</h3></summary>
+
+*Difficulty*: 4<br />
+*Target*: One item<br />
+*Duration*: Instant<br />
+*Stamina Cost*: 5000<br />
+*Channeling Time*: 5 minutes<br />
+*Effects*: Examine a single object, determining hidden information about it. Current supports determining: artifact resonance.<br />
+*Prerequisites*: Aura Sight 6, Speed Reading 8 *or* Premonition 8<br />
+</details>
+<details>
 <summary><h3>Sense Hostility (C)</h3></summary>
 
 *Difficulty*: 5<br />

--- a/data/mods/MindOverMatter/effectoncondition/eoc_learn_recipes.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_learn_recipes.json
@@ -150,6 +150,7 @@
           "EOC_CHECK_GAMEBEGIN_CLAIR_RECIPE_SPOT_WEAKNESS",
           "EOC_CHECK_GAMEBEGIN_CLAIR_RECIPE_AURA_SIGHT",
           "EOC_CHECK_GAMEBEGIN_CLAIR_RECIPE_RANGED_ENHANCE",
+          "EOC_CHECK_GAMEBEGIN_CLAIR_RECIPE_EXAMINE_ITEMS",
           "EOC_CHECK_GAMEBEGIN_CLAIR_RECIPE_SENSE_HOSTILE_CREATURES",
           "EOC_CHECK_GAMEBEGIN_CLAIR_RECIPE_VOYANCE",
           "EOC_CHECK_GAMEBEGIN_CLAIR_RECIPE_DODGE_POWER",
@@ -204,6 +205,12 @@
     "id": "EOC_CHECK_GAMEBEGIN_CLAIR_RECIPE_RANGED_ENHANCE",
     "condition": { "and": [ { "u_has_trait": "CLAIRSENTIENT" }, { "math": [ "u_spell_level('clair_ranged_enhance') >= 0" ] } ] },
     "effect": [ { "u_learn_recipe": "practice_clair_ranged_enhance" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_CHECK_GAMEBEGIN_CLAIR_RECIPE_EXAMINE_ITEMS",
+    "condition": { "and": [ { "u_has_trait": "CLAIRSENTIENT" }, { "math": [ "u_spell_level('clair_examine_item') >= 0" ] } ] },
+    "effect": [ { "u_learn_recipe": "practice_clair_examine_item" } ]
   },
   {
     "type": "effect_on_condition",

--- a/data/mods/MindOverMatter/hobbies.json
+++ b/data/mods/MindOverMatter/hobbies.json
@@ -592,6 +592,16 @@
   {
     "type": "profession",
     "subtype": "hobby",
+    "id": "knack_clair_examine_item",
+    "name": "Psychic Knack (Psychometry)",
+    "description": "Before the Cataclysm you would sometimes get strong impressions from items you touched, or have dreams about things you had bought.  Bits of their history that seemed so real, they had to have happened.  Hopefully it helps you survive.",
+    "points": 3,
+    "traits": [ "PSYCHIC_KNACK" ],
+    "spells": [ { "id": "clair_examine_item_knack", "level": 6 } ]
+  },
+  {
+    "type": "profession",
+    "subtype": "hobby",
     "id": "knack_clair_astral_projection",
     "name": "Psychic Knack (Astral Projection)",
     "description": "Before the Cataclysm you sometimes felt like already new unfamiliar places, like you had been there before in a dream, and that ability has been greatly heightened after the world ended.  While you are not a fully awakened psion, you have a single trick you can use.  Hopefully it helps you survive.",

--- a/data/mods/MindOverMatter/items/teleporter_start_items.json
+++ b/data/mods/MindOverMatter/items/teleporter_start_items.json
@@ -24,7 +24,7 @@
     "ammo_effects": [ "PLASMA", "PLASMA_BUBBLE", "IGNITE" ],
     "ammo": [ "mom_fusion_ammo" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE_WELL", "magazine_well": "25 ml", "item_restriction": [ "mom_fusion_mag" ] } ],
-    "flags": [ "NEVER_JAMS", "NON_FOULING", "NEEDS_NO_LUBE", "NO_REPAIR" ]
+    "flags": [ "NEVER_JAMS", "NON_FOULING", "NEEDS_NO_LUBE", "NO_REPAIR", "FIFTH_SUN_TECHNOLOGY" ]
   },
   {
     "id": "mom_fusion_mag",
@@ -91,7 +91,7 @@
     "ammo_effects": [ "NEURAL_STUNGUN" ],
     "ammo": [ "mom_fifth_sun_stungun_ammo" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE_WELL", "magazine_well": "25 ml", "item_restriction": [ "mom_fifth_sun_stungun_mag" ] } ],
-    "flags": [ "NEVER_JAMS", "NON_FOULING", "NEEDS_NO_LUBE", "NO_REPAIR" ]
+    "flags": [ "NEVER_JAMS", "NON_FOULING", "NEEDS_NO_LUBE", "NO_REPAIR", "FIFTH_SUN_TECHNOLOGY" ]
   },
   {
     "id": "mom_fifth_sun_stungun_mag",
@@ -164,7 +164,7 @@
     "melee_damage": { "bash": 12 },
     "ammo": [ "mom_lightning_rifle_ammo" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE_WELL", "magazine_well": "50 ml", "item_restriction": [ "mom_lightning_rifle_mag" ] } ],
-    "flags": [ "NEVER_JAMS", "NO_REPAIR", "NON_FOULING", "NEEDS_NO_LUBE", "NO_REPAIR" ],
+    "flags": [ "NEVER_JAMS", "NO_REPAIR", "NON_FOULING", "NEEDS_NO_LUBE", "NO_REPAIR", "FIFTH_SUN_TECHNOLOGY" ],
     "variant_type": "generic",
     "variants": [
       {
@@ -267,7 +267,7 @@
       { "covers": [ "eyes" ], "rigid_layer_only": true, "coverage": 100, "encumbrance": 10 }
     ],
     "melee_damage": { "bash": 1 },
-    "flags": [ "VARSIZE", "WATERPROOF", "MUNDANE", "STURDY", "PADDED" ]
+    "flags": [ "VARSIZE", "WATERPROOF", "MUNDANE", "STURDY", "PADDED", "FIFTH_SUN_TECHNOLOGY" ]
   },
   {
     "id": "mom_fifth_sun_eagle_tac_helmet_on",
@@ -370,7 +370,7 @@
         ]
       }
     ],
-    "flags": [ "VARSIZE", "STURDY", "MUNDANE", "OUTER", "NO_REPAIR" ]
+    "flags": [ "VARSIZE", "STURDY", "MUNDANE", "OUTER", "NO_REPAIR", "FIFTH_SUN_TECHNOLOGY" ]
   },
   {
     "id": "mom_fifth_sun_standard_body_armor_on",
@@ -457,7 +457,8 @@
     "subtypes": [ "ARMOR" ],
     "name": { "str_sp": "Itzcuāuhtli Corps tilmàtli" },
     "description": "A formal dress cape for the Itzcuāuhtli Corps in crimson and gold, with the eagle's head over a field of stars insignia on the left shoulder, worn by generations of those who sought out new worlds in service to the Huey Tlatoani and the Ēxcān Tlahtōlōyān.  You're pretty sure this is the furthest anyone wearing one has ever been from Anáhuac.",
-    "delete": { "flags": [ "HOOD" ] }
+    "delete": { "flags": [ "HOOD" ] },
+    "extend": { "flags": [ "FIFTH_SUN_TECHNOLOGY" ] }
   },
   {
     "id": "itzcuauhtli_hat",
@@ -465,7 +466,8 @@
     "type": "ITEM",
     "subtypes": [ "ARMOR" ],
     "name": { "str": "Imperial navy cap" },
-    "description": "A flat crimson hat worn by members of the Imperial navy at formal events.  This one has the black circle of the Yohualli Ehēcatl on it."
+    "description": "A flat crimson hat worn by members of the Imperial navy at formal events.  This one has the black circle of the Yohualli Ehēcatl on it.",
+    "extend": { "flags": [ "FIFTH_SUN_TECHNOLOGY" ] }
   },
   {
     "id": "itzcuauhtli_holster",
@@ -485,7 +487,8 @@
         "max_item_length": "30 cm",
         "moves": 50
       }
-    ]
+    ],
+    "extend": { "flags": [ "FIFTH_SUN_TECHNOLOGY" ] }
   },
   {
     "id": "itzcuauhtli_holster_m12",
@@ -505,7 +508,8 @@
         "max_item_length": "30 cm",
         "moves": 50
       }
-    ]
+    ],
+    "extend": { "flags": [ "FIFTH_SUN_TECHNOLOGY" ] }
   },
   {
     "id": "itzcuauhtli_tunic",
@@ -513,7 +517,8 @@
     "type": "ITEM",
     "subtypes": [ "ARMOR" ],
     "name": { "str": "Yohualli Ehēcatl division tunic" },
-    "description": "A dress tunic, in gold and crimson, slashed with black bars.  This would immediately mark your exact rank and position to anyone else in the Imperial Navy, if you ever see another one again."
+    "description": "A dress tunic, in gold and crimson, slashed with black bars.  This would immediately mark your exact rank and position to anyone else in the Imperial Navy, if you ever see another one again.",
+    "extend": { "flags": [ "FIFTH_SUN_TECHNOLOGY" ] }
   },
   {
     "id": "itzcuauhtli_tunic_jaguar",
@@ -536,7 +541,8 @@
         "description": "Some sort of uniform dress shirt in a blood-red crimson color with gold accents and a series of yellow bars on the left side.  You can't recall any military that dresses quite like this.",
         "weight": 1
       }
-    ]
+    ],
+    "extend": { "flags": [ "FIFTH_SUN_TECHNOLOGY" ] }
   },
   {
     "id": "itzcuauhtli_pants",
@@ -559,7 +565,8 @@
         "description": "Some sort of uniform pants in a blood-red crimson color with gold accents.  You can't recall any military that dresses quite like this.",
         "weight": 1
       }
-    ]
+    ],
+    "extend": { "flags": [ "FIFTH_SUN_TECHNOLOGY" ] }
   },
   {
     "id": "itzcuauhtli_boots",
@@ -582,7 +589,8 @@
         "description": "Simple black leather boots.",
         "weight": 1
       }
-    ]
+    ],
+    "extend": { "flags": [ "FIFTH_SUN_TECHNOLOGY" ] }
   },
   {
     "id": "itzcuauhtli_wrist_computer",
@@ -608,7 +616,8 @@
       "NO_RELOAD",
       "ALLOWS_NATURAL_ATTACKS",
       "OVERSIZE",
-      "NO_REPAIR"
+      "NO_REPAIR",
+      "FIFTH_SUN_TECHNOLOGY"
     ],
     "symbol": "[",
     "use_action": [ "E_FILE_DEVICE", "EBOOKSAVE", "MP3", "CAMERA", "CALORIES_INTAKE_TRACKER", "PORTABLE_GAME", "FITNESS_CHECK" ],
@@ -646,7 +655,8 @@
     "type": "ITEM",
     "subtypes": [ "ARMOR" ],
     "name": { "str_sp": "Itzcuāuhtli Corps combat uniform pants" },
-    "description": "The standard combat uniform of the Itzcuāuhtli Corps, in shades of dark green and grey.  These are pants, with several pockets."
+    "description": "The standard combat uniform of the Itzcuāuhtli Corps, in shades of dark green and grey.  These are pants, with several pockets.",
+    "extend": { "flags": [ "FIFTH_SUN_TECHNOLOGY" ] }
   },
   {
     "id": "itzcuauhtli_combat_shirt",
@@ -654,7 +664,8 @@
     "type": "ITEM",
     "subtypes": [ "ARMOR" ],
     "name": { "str_sp": "Itzcuāuhtli Corps combat uniform shirt" },
-    "description": "The standard combat uniform of the Itzcuāuhtli Corps, in shades of dark green and grey.  This is a shirt."
+    "description": "The standard combat uniform of the Itzcuāuhtli Corps, in shades of dark green and grey.  This is a shirt.",
+    "extend": { "flags": [ "FIFTH_SUN_TECHNOLOGY" ] }
   },
   {
     "id": "itzcuauhtli_jacket_army_modern",
@@ -662,7 +673,8 @@
     "type": "ITEM",
     "subtypes": [ "ARMOR" ],
     "name": { "str_sp": "Itzcuāuhtli Corps combat uniform jacket" },
-    "description": "The standard combat uniform of the Itzcuāuhtli Corps, in shades of dark green and grey.  This is a jacket.  It has the eagle over a field of stars symbol of the Itzcuāuhtli Corps on both shoulders."
+    "description": "The standard combat uniform of the Itzcuāuhtli Corps, in shades of dark green and grey.  This is a jacket.  It has the eagle over a field of stars symbol of the Itzcuāuhtli Corps on both shoulders.",
+    "extend": { "flags": [ "FIFTH_SUN_TECHNOLOGY" ] }
   },
   {
     "id": "holy_symbol_fifth_sun",
@@ -670,6 +682,7 @@
     "type": "ITEM",
     "subtypes": [ "ARMOR" ],
     "name": { "str": "Imperial Church holy symbol" },
-    "description": "A necklace made of fine gold chain, bearing an image of Jesucristo as the Ultimate Sacrifice as a pendant, his heart clearly visible through his chest.  Under his left hand is a raindrop, representing the Aeon Tláloc, and under his right hand is a sun disc, representing the Aeon Huītzilōpōchtli."
+    "description": "A necklace made of fine gold chain, bearing an image of Jesucristo as the Ultimate Sacrifice as a pendant, his heart clearly visible through his chest.  Under his left hand is a raindrop, representing the Aeon Tláloc, and under his right hand is a sun disc, representing the Aeon Huītzilōpōchtli.",
+    "extend": { "flags": [ "FIFTH_SUN_TECHNOLOGY" ] }
   }
 ]

--- a/data/mods/MindOverMatter/json_flags.json
+++ b/data/mods/MindOverMatter/json_flags.json
@@ -112,5 +112,9 @@
     "id": "PHOTOKIN_IRRADIATION_READY",
     "type": "json_flag",
     "//": "Used to tag foods to be radiation sterilized"
+  },
+  {
+    "id": "FIFTH_SUN_TECHNOLOGY",
+    "type": "json_flag"
   }
 ]

--- a/data/mods/MindOverMatter/powers/clairsentience.json
+++ b/data/mods/MindOverMatter/powers/clairsentience.json
@@ -339,6 +339,26 @@
     }
   },
   {
+    "id": "clair_examine_item",
+    "type": "SPELL",
+    "name": "[Ψ]Psychometry",
+    "description": "You can examine an item and use your enhanced senses to determine its properties that may not be obvious to the eye.",
+    "message": "",
+    "teachable": false,
+    "valid_targets": [ "self" ],
+    "spell_class": "CLAIRSENTIENT",
+    "magic_type": "mom_psionics",
+    "skill": "metaphysics",
+    "flags": [ "PSIONIC", "SILENT", "NO_HANDS", "NO_LEGS", "NO_EXPLOSION_SFX" ],
+    "difficulty": 4,
+    "max_level": { "math": [ "int_to_level(1)" ] },
+    "effect": "effect_on_condition",
+    "effect_str": "EOC_CLAIR_EXAMINE_ITEM_INITIATE",
+    "shape": "blast",
+    "base_energy_cost": 5000,
+    "base_casting_time": 30000
+  },
+  {
     "id": "clair_sense_hostile_creatures",
     "type": "SPELL",
     "name": "[Ψ]Sense Hostility (C)",

--- a/data/mods/MindOverMatter/powers/clairsentience_eoc.json
+++ b/data/mods/MindOverMatter/powers/clairsentience_eoc.json
@@ -164,7 +164,7 @@
               {
                 "if": { "npc_has_flag": "FIFTH_SUN_TECHNOLOGY" },
                 "then": {
-                  "u_message": "You have a sense of utter distance from this object, as though it came from a place you would never find on any map.  For a moment, you see an eagle stooping over a snake, wings flashing in the sun."
+                  "u_message": "You have a sense of vast distances from this object, as though it came from a place you would never find on any map.  For a moment, you see an eagle stooping over a snake, wings flashing in the sun."
                 }
               }
             ]

--- a/data/mods/MindOverMatter/powers/clairsentience_eoc.json
+++ b/data/mods/MindOverMatter/powers/clairsentience_eoc.json
@@ -166,7 +166,7 @@
               {
                 "if": { "npc_has_flag": "FIFTH_SUN_TECHNOLOGY" },
                 "then": {
-                  "u_message": "You have a sense of vast distances from this object, as though it came from a place you would never find on any map.  For a moment, you see an eagle stooping over a snake, wings flashing in the sun."
+                  "u_message": "You have a sense of vast distances from this object, as though it came from a place you would never find on any map.  For a moment, you see an eagle stooping over a snake, wings flashing in the sun, and a vast shape moving through the void between the stars."
                 }
               }
             ]

--- a/data/mods/MindOverMatter/powers/clairsentience_eoc.json
+++ b/data/mods/MindOverMatter/powers/clairsentience_eoc.json
@@ -149,16 +149,18 @@
           {
             "id": "EOC_CLAIR_EXAMINE_ITEM_DETECTION",
             "effect": [
-              { "math": [ "_artifact_resonance = artifact_resonance()" ] },
-              { "math": [ "_resonance_modifier = max( (u_spell_level('clair_examine_item') ),0) )" ] },
-              { "math": [ "_resonance_modifier = (10 - _resonance_modifier) / 10" ] },
+              { "math": [ "_artifact_resonance = n_artifact_resonance()" ] },
+              {
+                "math": [ "_resonance_modifier = min( (u_spell_level('clair_examine_item') + u_spell_level('clair_examine_item_knack')),10)" ]
+              },
+              { "math": [ "_resonance_modifier = (10 - _resonance_modifier) / 50" ] },
               {
                 "math": [ "_artifact_resonance = _artifact_resonance * rng( ( 1 - _resonance_modifier), (1 + _resonance_modifier) )" ]
               },
               {
                 "if": { "math": [ "_artifact_resonance > 0" ] },
                 "then": {
-                  "u_message": "The strange object has an otherworldly resonance about it (about <context_val:artifact_resonance> resonance )."
+                  "u_message": "The strange object has an otherworldly resonance about it (about <color_light_cyan><context_val:artifact_resonance></color> resonance )."
                 }
               },
               {

--- a/data/mods/MindOverMatter/powers/clairsentience_eoc.json
+++ b/data/mods/MindOverMatter/powers/clairsentience_eoc.json
@@ -141,6 +141,40 @@
   },
   {
     "type": "effect_on_condition",
+    "id": "EOC_CLAIR_EXAMINE_ITEM_INITIATE",
+    "effect": [
+      {
+        "u_run_inv_eocs": "manual",
+        "true_eocs": [
+          {
+            "id": "EOC_CLAIR_EXAMINE_ITEM_DETECTION",
+            "effect": [
+              { "math": [ "_artifact_resonance = artifact_resonance()" ] },
+              { "math": [ "_resonance_modifier = max( (u_spell_level('clair_examine_item') ),0) )" ] },
+              { "math": [ "_resonance_modifier = (10 - _resonance_modifier) / 10" ] },
+              {
+                "math": [ "_artifact_resonance = _artifact_resonance * rng( ( 1 - _resonance_modifier), (1 + _resonance_modifier) )" ]
+              },
+              {
+                "if": { "math": [ "_artifact_resonance > 0" ] },
+                "then": {
+                  "u_message": "The strange object has an otherworldly resonance about it (about <context_val:artifact_resonance> resonance )."
+                }
+              },
+              {
+                "if": { "npc_has_flag": "FIFTH_SUN_TECHNOLOGY" },
+                "then": {
+                  "u_message": "You have a sense of utter distance from this object, as though it came from a place you would never find on any map.  For a moment, you see an eagle stooping over a snake, wings flashing in the sun."
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
     "id": "EOC_CLAIR_CRAFTING_ADD_BLINDNESS_WHEN_CRAFTING",
     "eoc_type": "EVENT",
     "required_event": "character_starts_activity",

--- a/data/mods/MindOverMatter/powers/learning_eocs/clairsentience.json
+++ b/data/mods/MindOverMatter/powers/learning_eocs/clairsentience.json
@@ -173,6 +173,44 @@
   },
   {
     "type": "effect_on_condition",
+    "id": "EOC_CLAIR_LEARNING_EXAMINE_ITEM",
+    "recurrence": [
+      { "math": [ "jmath_clairsentience_learning_eocs_modifiers(global_tier_two_power_learning_time_low)" ] },
+      { "math": [ "jmath_clairsentience_learning_eocs_modifiers(global_tier_two_power_learning_time_high)" ] }
+    ],
+    "condition": {
+      "and": [
+        { "u_has_trait": "CLAIRSENTIENT" },
+        { "math": [ "u_vitamin('vitamin_psi_learning_counter') == 1" ] },
+        {
+          "or": [
+            { "test_eoc": "EOC_CONDITION_ODDS_OF_RANDOM_TIER_TWO_POWER_INSIGHT" },
+            { "math": [ "u_spell_level('clair_see_auras') >= 6" ] },
+            {
+              "or": [
+                { "math": [ "u_spell_level('clair_speed_reading') >= 8" ] },
+                { "math": [ "u_spell_level('clair_danger_sense') >= 8" ] }
+              ]
+            }
+          ]
+        },
+        { "test_eoc": "EOC_PSI_LEARNING_BANNED_EFFECTS" },
+        { "math": [ "u_spell_level('clair_examine_item') <= 0" ] },
+        { "not": { "u_know_recipe": "practice_clair_examine_item" } }
+      ]
+    },
+    "deactivate_condition": { "or": [ { "not": { "u_has_trait": "CLAIRSENTIENT" } }, { "math": [ "u_spell_level('clair_examine_item') >= 1" ] } ] },
+    "effect": [
+      { "math": [ "u_vitamin('vitamin_psi_learning_counter') = 0" ] },
+      { "u_learn_recipe": "practice_clair_examine_item" },
+      {
+        "u_message": "Use of your powers has led to an insight.  You could examine an item with preternatural senses, discovering information that would be impossible to figure out with any normal investigation, if you can figure out the technique.",
+        "popup": true
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
     "id": "EOC_CLAIR_LEARNING_SENSE_HOSTILE_CREATURES",
     "recurrence": [
       { "math": [ "jmath_clairsentience_learning_eocs_modifiers(global_tier_two_power_learning_time_low)" ] },

--- a/data/mods/MindOverMatter/powers/psychic_knacks.json
+++ b/data/mods/MindOverMatter/powers/psychic_knacks.json
@@ -28,6 +28,13 @@
     "difficulty": { "math": [ "ceil(max( (u_spell_difficulty('clair_danger_sense') / 2), 1) )" ] }
   },
   {
+    "id": "clair_examine_item_knack",
+    "copy-from": "clair_examine_item",
+    "type": "SPELL",
+    "spell_class": "PSYCHIC_KNACK",
+    "difficulty": { "math": [ "ceil(max( (u_spell_difficulty('clair_examine_item') / 2), 1) )" ] }
+  },
+  {
     "id": "clair_astral_projection_knack",
     "copy-from": "clair_astral_projection",
     "type": "SPELL",

--- a/data/mods/MindOverMatter/recipes/practice/clairsentient_practice.json
+++ b/data/mods/MindOverMatter/recipes/practice/clairsentient_practice.json
@@ -17,6 +17,7 @@
       "practice_clair_sense_rads",
       "practice_clair_spot_weakness",
       "practice_clair_ranged_enhance",
+      "practice_clair_examine_item",
       "practice_clair_sense_hostile_creatures",
       "practice_clair_voyance",
       "practice_clair_dodge_power",
@@ -362,6 +363,64 @@
     "activity_level": "LIGHT_EXERCISE",
     "name": "contemplation: marksman's eye",
     "id": "practice_clair_ranged_enhance",
+    "description": "Contemplate your powers and improve your ability to aim ranged weapons with precision.\n\nPower Difficulty: 4",
+    "category": "CC_*",
+    "subcategory": "CSC_*_NESTED",
+    "skill_used": "metaphysics",
+    "difficulty": 0,
+    "time": "0 s",
+    "autolearn": false,
+    "proficiencies": [ { "proficiency": "prof_contemplation_clairsentience", "required": false } ],
+    "tools": [
+      [
+        [ "matrix_crystal_drained", -1 ],
+        [ "black_nether_crystal_pseudo_tool", -1 ],
+        [ "matrix_crystal_clairsentience", -1 ]
+      ]
+    ],
+    "components": [ [ [ "matrix_crystal_clair_dust", 1 ] ] ],
+    "flags": [ "SECRET", "BLIND_EASY", "NO_MANIP", "AFFECTED_BY_PAIN", "NO_BENCH", "NO_ENCHANTMENT" ],
+    "result_eocs": [
+      {
+        "id": "EOC_PRACTICE_CLAIR_RANGED_ENHANCE",
+        "condition": { "u_has_trait": "CLAIRSENTIENT" },
+        "effect": [
+          { "set_string_var": "clair_ranged_enhance", "target_var": { "u_val": "latest_studied_power_name" } },
+          { "run_eocs": "EOC_PSI_STUDYING_CLAIR_POWER_SETUP" },
+          {
+            "if": { "math": [ "u_spell_level('clair_ranged_enhance') >= 1" ] },
+            "then": { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] },
+            "else": [
+              { "run_eocs": [ "EOC_PSI_STUDYING_POWER_INITIAL_SETUP", "EOC_PSI_PRACTICE_FOCUS_MOD" ] },
+              {
+                "run_eocs": "EOC_PRACTICE_CLAIR_RANGED_ENHANCE_LEARNING",
+                "time_in_future": [
+                  { "math": [ "learn_new_power_lower_time_bound(u_latest_studied_power_difficulty)" ] },
+                  { "math": [ "learn_new_power_upper_time_bound(u_latest_studied_power_difficulty)" ] }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PRACTICE_CLAIR_RANGED_ENHANCE_LEARNING",
+    "condition": {
+      "and": [
+        { "compare_string": [ "clair_ranged_enhance", { "u_val": "latest_studied_power_name" } ] },
+        { "test_eoc": "EOC_CONDITION_PSI_REQUIRED_FOR_LEARNING_NEW_POWER" }
+      ]
+    },
+    "effect": [ { "run_eocs": "EOC_PRACTICE_PSIONICS_FINAL_LEARNING_CHECK" } ]
+  },
+  {
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "name": "contemplation: psychometry",
+    "id": "practice_clair_examine_item",
     "description": "Contemplate your powers and improve your ability to aim ranged weapons with precision.\n\nPower Difficulty: 4",
     "category": "CC_*",
     "subcategory": "CSC_*_NESTED",

--- a/data/mods/MindOverMatter/recipes/practice/clairsentient_practice.json
+++ b/data/mods/MindOverMatter/recipes/practice/clairsentient_practice.json
@@ -421,7 +421,7 @@
     "activity_level": "LIGHT_EXERCISE",
     "name": "contemplation: psychometry",
     "id": "practice_clair_examine_item",
-    "description": "Contemplate your powers and improve your ability to aim ranged weapons with precision.\n\nPower Difficulty: 4",
+    "description": "Contemplate your powers and improve your ability to determine hidden aspects of items.\n\nPower Difficulty: 4",
     "category": "CC_*",
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",
@@ -440,18 +440,18 @@
     "flags": [ "SECRET", "BLIND_EASY", "NO_MANIP", "AFFECTED_BY_PAIN", "NO_BENCH", "NO_ENCHANTMENT" ],
     "result_eocs": [
       {
-        "id": "EOC_PRACTICE_CLAIR_RANGED_ENHANCE",
+        "id": "EOC_PRACTICE_CLAIR_EXAMINE_ITEM",
         "condition": { "u_has_trait": "CLAIRSENTIENT" },
         "effect": [
-          { "set_string_var": "clair_ranged_enhance", "target_var": { "u_val": "latest_studied_power_name" } },
+          { "set_string_var": "clair_examine_item", "target_var": { "u_val": "latest_studied_power_name" } },
           { "run_eocs": "EOC_PSI_STUDYING_CLAIR_POWER_SETUP" },
           {
-            "if": { "math": [ "u_spell_level('clair_ranged_enhance') >= 1" ] },
+            "if": { "math": [ "u_spell_level('clair_examine_item') >= 1" ] },
             "then": { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] },
             "else": [
               { "run_eocs": [ "EOC_PSI_STUDYING_POWER_INITIAL_SETUP", "EOC_PSI_PRACTICE_FOCUS_MOD" ] },
               {
-                "run_eocs": "EOC_PRACTICE_CLAIR_RANGED_ENHANCE_LEARNING",
+                "run_eocs": "EOC_PRACTICE_CLAIR_EXAMINE_ITEM_LEARNING",
                 "time_in_future": [
                   { "math": [ "learn_new_power_lower_time_bound(u_latest_studied_power_difficulty)" ] },
                   { "math": [ "learn_new_power_upper_time_bound(u_latest_studied_power_difficulty)" ] }
@@ -465,10 +465,10 @@
   },
   {
     "type": "effect_on_condition",
-    "id": "EOC_PRACTICE_CLAIR_RANGED_ENHANCE_LEARNING",
+    "id": "EOC_PRACTICE_CLAIR_EXAMINE_ITEM_LEARNING",
     "condition": {
       "and": [
-        { "compare_string": [ "clair_ranged_enhance", { "u_val": "latest_studied_power_name" } ] },
+        { "compare_string": [ "clair_examine_item", { "u_val": "latest_studied_power_name" } ] },
         { "test_eoc": "EOC_CONDITION_PSI_REQUIRED_FOR_LEARNING_NEW_POWER" }
       ]
     },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[MoM] Add Psychometry clairsentient power"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Been wanting to add this for a while and now it's possible.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add the Psychometry clairsentient power. When used, you get to pick an item and learn its artifact resonance (with some variance--variance reduced based on your power level). When there is more infrastructure to discover more things, I'll add it.

There is some variance, which goes down the higher your power level:
<img width="797" height="93" alt="Untitled2" src="https://github.com/user-attachments/assets/5ebd2ce7-0711-4eb4-a410-6ad57c7e33ca" />
Exact resonance here is 3075.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Checked an item, leveled power, checked again, contemplated power
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Resonance isn't the only thing you can learn...

<img width="484" height="69" alt="Untitled2" src="https://github.com/user-attachments/assets/4162256b-5f1f-444a-9880-eb67847d2b0f" />
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
