### PR TITLE
[Xedra Evolved] Switch vampires powers over to using `human_blood_vitamin`

### DIFF
--- a/data/mods/Xedra_Evolved/mutations/vampire_trait_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/vampire_trait_eocs.json
@@ -928,7 +928,7 @@
     "id": "EOC_VAMPIRE_SCENT_BLOOD_activated",
     "condition": {
       "math": [
-        "(u_characters_nearby('radius': 30, 'attitude': 'any') + u_monsters_nearby('mon_feral_cop', 'mon_feral_human_pipe', 'mon_feral_human_crowbar', 'mon_feral_jackboot', 'mon_feral_marine_bayonet', 'mon_feral_soldier', 'mon_feral_prepper_knife', 'mon_feral_sailor_axe', 'mon_feral_maid_knife', 'mon_feral_maid_candlestick', 'mon_feral_officer', 'mon_feral_sailor_lug_wrench', 'mon_feral_sailor_mop', 'mon_feral_maid_broom', 'mon_feral_sailor_wrench', 'mon_feral_swimmer_kickboard', 'mon_feral_armored_battleaxe', 'mon_feral_sapien_spear', 'mon_feral_armored_mace', 'mon_feral_human_tool', 'mon_feral_militia', 'mon_feral_fancy_rapier_fake', 'mon_feral_fancy_rapier', 'mon_feral_human_axe', 'mon_feral_labsecurity_flashlight', 'mon_feral_labsecurity_9mm',  'mon_feral_survivalist', 'mon_feral_scientist_scalpel', 'mon_feral_zebra_agent', 'mon_renfield', 'mon_renfield_9mm', 'mon_renfield_shotgun', 'mon_renfield_flamethrower', 'radius': 30, 'attitude': 'both'))",
+        "(u_characters_nearby('radius': 30, 'attitude': 'any') + u_mon_species_nearby('FERAL', 'RENFIELD', 'radius': 30, 'attitude': 'both'))",
         ">=",
         "1"
       ]
@@ -938,41 +938,17 @@
   },
   {
     "type": "effect_on_condition",
-    "id": "EOC_STAMINAFORBLOOD_activated",
-    "condition": { "math": [ "u_vitamin('human_blood_vitamin') >= -500" ] },
-    "effect": [
-      { "u_assign_activity": "ACT_GENERIC_EOC", "duration": "1 seconds" },
-      { "math": [ "u_vitamin('human_blood_vitamin')", "-=", "100" ] },
-      {
-        "u_message": "Your veins pulse as your body pushes some of your blood reserves to exhaustion and early dissolution.",
-        "type": "good"
-      },
-      {
-        "math": [
-          "u_val('stamina')",
-          "+=",
-          "min((1500 + (vampire_total_tier_one_traits_plus_potency() * 200) + (vampire_total_tier_two_traits() * 450) + (vampire_total_tier_three_traits() * 900) + (vampire_total_tier_four_traits_plus_potence() * 1500) + (vampire_total_tier_five_traits_plus_cauldron() * 2000)), 15000)"
-        ]
-      }
-    ],
-    "false_effect": [ { "u_message": "You don't have enough blood to recover any stamina.", "type": "bad" } ]
-  },
-  {
-    "type": "effect_on_condition",
     "id": "EOC_COMMUNE_NIGHT_MAP",
-    "condition": { "math": [ "u_vitamin('human_blood_vitamin') >= -500" ] },
     "effect": [
       {
         "if": { "and": [ { "math": [ "u_val('pos_z') >= 0" ] }, { "not": "is_day" }, "u_is_outside" ] },
         "then": [
           { "u_cast_spell": { "id": "vampire_map_real" } },
-          { "math": [ "u_vitamin('human_blood_vitamin')", "-=", "100" ] },
           { "u_message": "The children of the night tell you what features of the map are nearby." }
         ],
         "else": [ { "u_message": "Without the ability to howl into the wilds of the night, there is no response." } ]
       }
-    ],
-    "false_effect": [ { "u_message": "You don't have enough blood to summon the creatures of the night.", "type": "bad" } ]
+    ]
   },
   {
     "type": "effect_on_condition",
@@ -1065,10 +1041,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_BLOODHEAL_activated",
-    "condition": { "math": [ "u_vitamin('human_blood_vitamin') >= -500" ] },
     "effect": [
-      { "math": [ "u_vitamin('human_blood_vitamin')", "-=", "750" ] },
-      { "u_message": "Blood suffuses your flesh, repairing any damage it comes across.", "type": "good" },
       {
         "if": { "and": [ { "u_has_trait": "DHAMPIR_TRAIT" }, { "u_has_effect": "disabled", "bodypart": "arm_l" } ] },
         "then": { "u_message": "But your left arm is too damaged.  Only time can heal it.", "type": "bad" },
@@ -1304,7 +1277,6 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_VAMPIRE_FEAR_GAZE_activated",
-    "condition": { "math": [ "n_vitamin('human_blood_vitamin') >= -500" ] },
     "effect": [
       {
         "math": [
@@ -1313,7 +1285,6 @@
           "(n_vampire_total_tier_one_traits_plus_potency * 0.5) + (n_vampire_total_tier_two_traits * 0.75) + (n_vampire_total_tier_three_traits * 1) + (n_vampire_total_tier_four_traits * 2) + (n_vampire_total_tier_five_traits_plus_cauldron * 3)"
         ]
       },
-      { "math": [ "n_vitamin('human_blood_vitamin')", "-=", "150" ] },
       {
         "run_eocs": [
           {
@@ -1342,8 +1313,7 @@
           }
         ]
       }
-    ],
-    "false_effect": [ { "npc_message": "You don't have enough blood to activate your predator's mien.", "type": "bad" } ]
+    ]
   },
   {
     "type": "effect_on_condition",
@@ -1451,29 +1421,7 @@
   },
   {
     "type": "effect_on_condition",
-    "id": "EOC_MAGICFORBLOOD_activated",
-    "condition": { "math": [ "u_vitamin('human_blood_vitamin') >= -500" ] },
-    "effect": [
-      { "u_assign_activity": "ACT_GENERIC_EOC", "duration": "1 seconds" },
-      { "math": [ "u_vitamin('human_blood_vitamin')", "-=", "200" ] },
-      {
-        "u_message": "Your veins pulse as your body pushes some of your blood reserves to exhaustion and early dissolution.",
-        "type": "good"
-      },
-      {
-        "math": [
-          "u_val('mana')",
-          "+=",
-          "min((150 + (vampire_total_tier_one_traits_plus_potency() * 20) + (vampire_total_tier_two_traits() * 45) + (vampire_total_tier_three_traits() * 90) + (vampire_total_tier_four_traits_plus_potence() * 150) + (vampire_total_tier_five_traits_plus_cauldron() * 200)), 1500)"
-        ]
-      }
-    ],
-    "false_effect": [ { "u_message": "You don't have enough blood to recover any mana.", "type": "bad" } ]
-  },
-  {
-    "type": "effect_on_condition",
     "id": "EOC_HYPNOTIC_GAZE_activated",
-    "condition": { "math": [ "n_vitamin('human_blood_vitamin') >= -500" ] },
     "effect": [
       {
         "math": [
@@ -1482,7 +1430,6 @@
           "2 + (n_vampire_total_tier_one_traits_plus_potency * 0.5) + (n_vampire_total_tier_two_traits * 0.75) + (n_vampire_total_tier_three_traits * 1.2) + (n_vampire_total_tier_four_traits * 2.5) + (n_vampire_total_tier_five_traits_plus_cauldron * 3.5)"
         ]
       },
-      { "math": [ "n_vitamin('human_blood_vitamin')", "-=", "150" ] },
       {
         "run_eocs": [
           {
@@ -1500,8 +1447,7 @@
           }
         ]
       }
-    ],
-    "false_effect": [ { "npc_message": "You don't have enough blood to activate your hypnotic gaze.", "type": "bad" } ]
+    ]
   },
   {
     "type": "effect_on_condition",
@@ -1584,27 +1530,6 @@
         ]
       }
     ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "EOC_VAMPIRE_COMMAND_BEAST_activated",
-    "condition": { "math": [ "n_vitamin('human_blood_vitamin') >= -500" ] },
-    "effect": [
-      { "math": [ "n_vitamin('human_blood_vitamin')", "-=", "500" ] },
-      { "u_location_variable": { "context_val": "loc" } },
-      {
-        "run_eocs": [
-          {
-            "id": "EOC_VAMPIRE_COMMAND_BEAST_activated_2",
-            "effect": [
-              { "npc_cast_spell": { "id": "vampire_command_beast_spell_real", "min_level": 1 }, "loc": { "context_val": "loc" } },
-              { "npc_message": "You exert your predatory will on your target.", "type": "good" }
-            ]
-          }
-        ]
-      }
-    ],
-    "false_effect": [ { "npc_message": "You don't have enough blood to attempt to cow the beast.", "type": "bad" } ]
   },
   {
     "type": "effect_on_condition",
@@ -1705,30 +1630,6 @@
         ]
       }
     ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "EOC_VAMPIRE_DOMINATE_activated",
-    "condition": { "math": [ "n_vitamin('human_blood_vitamin') >= -500" ] },
-    "effect": [
-      { "math": [ "n_vitamin('human_blood_vitamin')", "-=", "700" ] },
-      { "u_location_variable": { "context_val": "loc" } },
-      {
-        "run_eocs": [
-          {
-            "id": "EOC_VAMPIRE_DOMINATE_activated2",
-            "effect": [
-              { "npc_cast_spell": { "id": "vampire_dominate_real", "min_level": 1 }, "loc": { "context_val": "loc" } },
-              {
-                "npc_message": "You focus your gaze on your target's mind, attempting to take control of it.",
-                "type": "good"
-              }
-            ]
-          }
-        ]
-      }
-    ],
-    "false_effect": [ { "npc_message": "You don't have enough blood to activate your dominating gaze.", "type": "bad" } ]
   },
   {
     "type": "effect_on_condition",
@@ -2578,31 +2479,20 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_VAMPIRE_INVISIBLE_IN_DARK",
-    "condition": { "math": [ "u_vitamin('human_blood_vitamin') >= -500" ] },
+    "condition": { "not": { "and": [ "is_day", "u_is_outside", { "not": { "is_weather": "blotted_sun" } } ] } },
     "effect": [
+      { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 0.25 },
+      { "math": [ "u_vitamin('human_blood_vitamin')", "-=", "300" ] },
       {
-        "run_eocs": [
-          {
-            "id": "EOC_VAMPIRE_INVISIBLE_IN_DARK_2",
-            "condition": { "not": { "and": [ "is_day", "u_is_outside", { "not": { "is_weather": "blotted_sun" } } ] } },
-            "effect": [
-              { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 0.25 },
-              { "math": [ "u_vitamin('human_blood_vitamin')", "-=", "300" ] },
-              {
-                "u_add_effect": "effect_vampire_invisible_in_dark",
-                "duration": {
-                  "math": [
-                    "rng(0.75,1.25) * (200 + (vampire_total_tier_one_traits_plus_potency() * 20) + (vampire_total_tier_two_traits() * 45) + (vampire_total_tier_three_traits() * 70) + (vampire_total_tier_four_traits_plus_potence() * 100) + (vampire_total_tier_five_traits_plus_cauldron() * 150))"
-                  ]
-                }
-              }
-            ],
-            "false_effect": [ { "u_message": "You cannot use this power under the sun's rays.", "type": "bad" } ]
-          }
-        ]
+        "u_add_effect": "effect_vampire_invisible_in_dark",
+        "duration": {
+          "math": [
+            "rng(0.75,1.25) * (200 + (vampire_total_tier_one_traits_plus_potency() * 20) + (vampire_total_tier_two_traits() * 45) + (vampire_total_tier_three_traits() * 70) + (vampire_total_tier_four_traits_plus_potence() * 100) + (vampire_total_tier_five_traits_plus_cauldron() * 150))"
+          ]
+        }
       }
     ],
-    "false_effect": [ { "u_message": "You don't have enough blood to shroud yourself in shadows.", "type": "bad" } ]
+    "false_effect": [ { "u_message": "You cannot use this power under the sun's rays.", "type": "bad" } ]
   },
   {
     "type": "effect_on_condition",

--- a/data/mods/Xedra_Evolved/obsoletion_and_migration/spells.json
+++ b/data/mods/Xedra_Evolved/obsoletion_and_migration/spells.json
@@ -682,5 +682,83 @@
     "final_energy_cost": 400,
     "energy_increment": -12,
     "base_casting_time": 150
+  },
+  {
+    "id": "vampire_command_beast_spell_real",
+    "type": "SPELL",
+    "name": { "str": "Cowing the Beast Real", "//~": "NO_I18N" },
+    "description": { "str": "The actual power that lets you command a beast.  If you see this, it's a bug.", "//~": "NO_I18N" },
+    "message": "",
+    "teachable": false,
+    "magic_type": "xe_vampire_blood_powers",
+    "valid_targets": [ "hostile" ],
+    "effect": "charm_monster",
+    "shape": "blast",
+    "flags": [ "NO_HANDS", "SILENT", "NO_FAIL" ],
+    "spell_class": "VAMPIRE_BLOOD_ARTS",
+    "difficulty": 7,
+    "max_level": 1,
+    "min_range": 60,
+    "max_range": 60,
+    "min_damage": {
+      "math": [
+        "rng (0.75,1.25) * (50 + (vampire_total_tier_one_traits()  * 5) + (vampire_total_tier_two_traits() * 12) + (vampire_total_tier_three_traits() * 20) + (vampire_total_tier_three_traits() * 35))"
+      ]
+    },
+    "max_damage": {
+      "math": [
+        "rng (0.75,1.25) * (50 + (vampire_total_tier_one_traits()  * 5) + (vampire_total_tier_two_traits() * 12) + (vampire_total_tier_three_traits() * 20) + (vampire_total_tier_three_traits() * 35))"
+      ]
+    },
+    "min_duration": {
+      "math": [
+        "rng (0.75,1.25) * (6000 + (vampire_total_tier_one_traits()  * 1000) + (vampire_total_tier_two_traits() * 1800) + (vampire_total_tier_three_traits() * 2700) + (vampire_total_tier_three_traits() * 4500))"
+      ]
+    },
+    "max_duration": {
+      "math": [
+        "rng (0.75,1.25) * (6000 + (vampire_total_tier_one_traits()  * 1000) + (vampire_total_tier_two_traits() * 1800) + (vampire_total_tier_three_traits() * 2700) + (vampire_total_tier_three_traits() * 4500))"
+      ]
+    }
+  },
+  {
+    "id": "vampire_dominate_real",
+    "type": "SPELL",
+    "name": { "str": "Dominating Gaze real", "//~": "NO_I18N" },
+    "description": { "str": "The actual power that lets you take over a mind.  If you see this, it's a bug.", "//~": "NO_I18N" },
+    "message": "",
+    "teachable": false,
+    "magic_type": "xe_vampire_blood_powers",
+    "valid_targets": [ "hostile" ],
+    "effect": "charm_monster",
+    "shape": "blast",
+    "flags": [ "NO_HANDS", "SILENT", "NO_FAIL" ],
+    "spell_class": "VAMPIRE_BLOOD_ARTS",
+    "skill": "deduction",
+    "difficulty": 8,
+    "max_level": 1,
+    "min_range": 60,
+    "max_range": 60,
+    "min_damage": {
+      "math": [
+        "rng (0.75,1.25) * (20 + (vampire_total_tier_one_traits()  * 4) + (vampire_total_tier_two_traits() * 10) + (vampire_total_tier_three_traits() * 16) + (vampire_total_tier_four_traits() * 30))"
+      ]
+    },
+    "max_damage": {
+      "math": [
+        "rng (0.75,1.25) * (20 + (vampire_total_tier_one_traits()  * 4) + (vampire_total_tier_two_traits() * 10) + (vampire_total_tier_three_traits() * 16) + (vampire_total_tier_four_traits() * 30))"
+      ]
+    },
+    "min_duration": {
+      "math": [
+        "rng (0.75,1.25) * (2500 + (vampire_total_tier_one_traits()  * 400) + (vampire_total_tier_two_traits() * 800) + (vampire_total_tier_three_traits() * 1150) + (vampire_total_tier_four_traits() * 2050))"
+      ]
+    },
+    "max_duration": {
+      "math": [
+        "rng (0.75,1.25) * (2500 + (vampire_total_tier_one_traits()  * 400) + (vampire_total_tier_two_traits() * 800) + (vampire_total_tier_three_traits() * 1150) + (vampire_total_tier_four_traits() * 2050))"
+      ]
+    },
+    "targeted_monster_species": [ "HUMAN", "FERAL", "CYBORG" ]
   }
 ]

--- a/data/mods/Xedra_Evolved/spells/vampire_spells.json
+++ b/data/mods/Xedra_Evolved/spells/vampire_spells.json
@@ -38,7 +38,7 @@
     "id": "vampire_smell_nearby_blood_spell",
     "type": "SPELL",
     "name": "Scent of Blood",
-    "description": "You can smell even the faintest traces of living human, or nearly-human, blood.\n\n<color_light_red>Blood Cost:</color> 0 ml.",
+    "description": "You can smell even the faintest traces of living human, or nearly-human, blood.",
     "message": "",
     "teachable": false,
     "magic_type": "xe_vampire_blood_powers",
@@ -49,6 +49,8 @@
     "flags": [ "NO_HANDS", "SILENT", "NO_FAIL" ],
     "skill": "deduction",
     "spell_class": "VAMPIRE_BLOOD_ARTS",
+    "energy_source": { "type": "VITAMIN", "vitamin": "human_blood_vitamin", "color": "c_red" },
+    "base_energy_cost": 0,
     "base_casting_time": 25,
     "difficulty": 1
   },
@@ -67,6 +69,7 @@
     "flags": [ "NO_HANDS", "SILENT", "NO_FAIL" ],
     "skill": "deduction",
     "spell_class": "VAMPIRE_BLOOD_ARTS",
+    "energy_source": { "type": "VITAMIN", "vitamin": "human_blood_vitamin", "color": "c_red" },
     "base_casting_time": 0,
     "difficulty": 1,
     "min_range": 1
@@ -75,17 +78,30 @@
     "id": "vampire_stamina_for_blood_spell",
     "type": "SPELL",
     "name": "Unholy Endurance",
-    "description": "You focus on sending the blood in your veins to where it can do the most good for your immediate stamina.\n\n<color_light_red>Blood Cost:</color> 100 ml (<u_val:blood_amount_for_graph> ml current).",
-    "message": "",
+    "description": "You focus on sending the blood in your veins to where it can do the most good for your immediate stamina.\n\nYou must have <color_yellow>greater</color> than <color_red>-500</color> Stolen Blood to use this blood art.",
+    "message": "Your veins pulse as your body pushes some of your blood reserves to exhaustion and early dissolution.",
     "teachable": false,
     "magic_type": "xe_vampire_blood_powers",
-    "effect": "effect_on_condition",
-    "effect_str": "EOC_STAMINAFORBLOOD_activated",
+    "effect": "recover_energy",
+    "effect_str": "STAMINA",
+    "condition": { "math": [ "u_vitamin('human_blood_vitamin') > -500" ] },
     "shape": "blast",
     "valid_targets": [ "self" ],
-    "flags": [ "NO_HANDS", "SILENT", "NO_FAIL" ],
+    "min_damage": {
+      "math": [
+        "min((1500 + (vampire_total_tier_one_traits_plus_potency() * 200) + (vampire_total_tier_two_traits() * 450) + (vampire_total_tier_three_traits() * 900) + (vampire_total_tier_four_traits_plus_potence() * 1500) + (vampire_total_tier_five_traits_plus_cauldron() * 2000)), 15000) * 0.75"
+      ]
+    },
+    "max_damage": {
+      "math": [
+        "min((1500 + (vampire_total_tier_one_traits_plus_potency() * 200) + (vampire_total_tier_two_traits() * 450) + (vampire_total_tier_three_traits() * 900) + (vampire_total_tier_four_traits_plus_potence() * 1500) + (vampire_total_tier_five_traits_plus_cauldron() * 2000)), 15000) * 1.25"
+      ]
+    },
+    "flags": [ "NO_HANDS", "SILENT", "NO_FAIL", "RANDOM_DAMAGE" ],
     "skill": "deduction",
     "spell_class": "VAMPIRE_BLOOD_ARTS",
+    "energy_source": { "type": "VITAMIN", "vitamin": "human_blood_vitamin", "color": "c_red" },
+    "base_energy_cost": 100,
     "base_casting_time": 100,
     "difficulty": 5
   },
@@ -93,17 +109,20 @@
     "id": "vampire_commune_with_night_spell",
     "type": "SPELL",
     "name": "Learn from the Children of the Night",
-    "description": "Speak to nearby night-creatures; rats, bats, wolves, and so on.  They will tell you the layout of your surrounding area.\n\n<color_light_red>Blood Cost:</color> 100 ml (<u_val:blood_amount_for_graph> ml current).",
+    "description": "Speak to nearby night-creatures; rats, bats, wolves, and so on.  They will tell you the layout of your surrounding area.\n\nYou must have <color_yellow>greater</color> than <color_red>-500</color> Stolen Blood to use this blood art.  It only works <color_yellow>outside at night</color>.",
     "message": "",
     "teachable": false,
     "magic_type": "xe_vampire_blood_powers",
     "effect": "effect_on_condition",
     "effect_str": "EOC_COMMUNE_NIGHT_MAP",
+    "condition": { "math": [ "u_vitamin('human_blood_vitamin') > -500" ] },
     "shape": "blast",
     "valid_targets": [ "self" ],
     "flags": [ "NO_HANDS", "SILENT", "NO_FAIL" ],
     "skill": "deduction",
     "spell_class": "VAMPIRE_BLOOD_ARTS",
+    "energy_source": { "type": "VITAMIN", "vitamin": "human_blood_vitamin", "color": "c_red" },
+    "base_energy_cost": 100,
     "base_casting_time": 12000,
     "difficulty": 5
   },
@@ -111,17 +130,30 @@
     "id": "vampire_magic_for_blood_spell",
     "type": "SPELL",
     "name": "Blood-Fueled Magic",
-    "description": "You consume some of the blood in your veins, turning it into magical power.\n\n<color_light_red>Blood Cost:</color> 200 ml (<u_val:blood_amount_for_graph> ml current).",
-    "message": "",
+    "description": "You consume some of the blood in your veins, turning it into magical power.\n\nYou must have <color_yellow>greater</color> than <color_red>-500</color> Stolen Blood to use this blood art.",
+    "message": "Your veins pulse as your body pushes some of your blood reserves to exhaustion and early dissolution.",
     "teachable": false,
     "magic_type": "xe_vampire_blood_powers",
-    "effect": "effect_on_condition",
-    "effect_str": "EOC_MAGICFORBLOOD_activated",
+    "effect": "recover_energy",
+    "effect_str": "MANA",
+    "condition": { "math": [ "u_vitamin('human_blood_vitamin') > -500" ] },
     "shape": "blast",
     "valid_targets": [ "self" ],
-    "flags": [ "NO_HANDS", "SILENT", "NO_FAIL" ],
+    "min_damage": {
+      "math": [
+        "min((150 + (vampire_total_tier_one_traits_plus_potency() * 20) + (vampire_total_tier_two_traits() * 45) + (vampire_total_tier_three_traits() * 90) + (vampire_total_tier_four_traits_plus_potence() * 150) + (vampire_total_tier_five_traits_plus_cauldron() * 200)), 1500) * 0.75"
+      ]
+    },
+    "max_damage": {
+      "math": [
+        "min((150 + (vampire_total_tier_one_traits_plus_potency() * 20) + (vampire_total_tier_two_traits() * 45) + (vampire_total_tier_three_traits() * 90) + (vampire_total_tier_four_traits_plus_potence() * 150) + (vampire_total_tier_five_traits_plus_cauldron() * 200)), 1500) * 1.25"
+      ]
+    },
+    "flags": [ "NO_HANDS", "SILENT", "NO_FAIL", "RANDOM_DAMAGE" ],
     "skill": "deduction",
     "spell_class": "VAMPIRE_BLOOD_ARTS",
+    "energy_source": { "type": "VITAMIN", "vitamin": "human_blood_vitamin", "color": "c_red" },
+    "base_energy_cost": 200,
     "base_casting_time": 100,
     "difficulty": 5
   },
@@ -129,30 +161,34 @@
     "id": "spell_blood_heal",
     "type": "SPELL",
     "name": "Sanguine Restoration",
-    "description": "Heal your wounds with the power of stolen blood.\n\n<color_light_red>Blood Cost:</color> 750 ml (<u_val:blood_amount_for_graph> ml current).",
-    "message": "",
+    "description": "Heal your wounds with the power of stolen blood.\n\nYou must have <color_yellow>greater</color> than <color_red>-500</color> Stolen Blood to use this blood art.",
+    "message": "Blood suffuses your flesh, repairing any damage it comes across.",
     "teachable": false,
     "magic_type": "xe_vampire_blood_powers",
     "valid_targets": [ "self" ],
     "effect": "effect_on_condition",
     "effect_str": "EOC_BLOODHEAL_activated",
+    "condition": { "math": [ "u_vitamin('human_blood_vitamin') > -500" ] },
     "shape": "blast",
-    "base_casting_time": 20,
     "flags": [ "NO_HANDS", "SILENT", "NO_FAIL" ],
     "skill": "deduction",
     "spell_class": "VAMPIRE_BLOOD_ARTS",
+    "energy_source": { "type": "VITAMIN", "vitamin": "human_blood_vitamin", "color": "c_red" },
+    "base_energy_cost": 750,
+    "base_casting_time": 20,
     "difficulty": 2
   },
   {
     "id": "vampire_fear_gaze_spell",
     "type": "SPELL",
     "name": { "str": "Predator's Mien" },
-    "description": "With a bit of stolen blood and a savage expression, you can send your enemies fleeing.  This power only works on enemies capable of feeling fear.\n\n<color_light_red>Blood Cost:</color> 150 ml (<u_val:blood_amount_for_graph> ml current).",
+    "description": "With a bit of stolen blood and a savage expression, you can send your enemies fleeing.  This power only works on enemies capable of feeling fear.\n\nYou must have <color_yellow>greater</color> than <color_red>-500</color> Stolen Blood to use this blood art.",
     "message": "",
     "teachable": false,
     "magic_type": "xe_vampire_blood_powers",
     "effect": "effect_on_condition",
     "effect_str": "EOC_VAMPIRE_FEAR_GAZE_activated",
+    "condition": { "math": [ "u_vitamin('human_blood_vitamin') > -500" ] },
     "shape": "blast",
     "valid_targets": [ "ally", "hostile" ],
     "flags": [ "NO_HANDS", "SILENT", "NO_FAIL", "NO_PROJECTILE" ],
@@ -168,13 +204,16 @@
         "min((3 + (vampire_total_tier_one_traits() * 0.2) + (vampire_total_tier_two_traits() * 0.33) + (vampire_total_tier_three_traits() * 0.5) + (vampire_total_tier_four_traits() * 0.75)), 12)"
       ]
     },
+    "energy_source": { "type": "VITAMIN", "vitamin": "human_blood_vitamin", "color": "c_red" },
+    "base_energy_cost": 150,
+    "base_casting_time": 25,
     "ignored_monster_species": [ "ZOMBIE", "ROBOT", "ROBOT_FLYING", "NETHER", "NETHER_EMANATION", "LEECH_PLANT", "WORM", "FUNGUS", "SLIME" ]
   },
   {
     "id": "spell_hypnotic_gaze",
     "type": "SPELL",
     "name": "Hypnotic Gaze",
-    "description": "Stare into the eyes of your victim and wills them to pause.  This power does not work on unliving targets.\n\n<color_light_red>Blood Cost:</color> 150 ml (<u_val:blood_amount_for_graph> ml current).",
+    "description": "Stare into the eyes of your victim and wills them to pause.  This power does not work on unliving targets.\n\nYou must have <color_yellow>greater</color> than <color_red>-500</color> Stolen Blood to use this blood art.",
     "message": "",
     "teachable": false,
     "magic_type": "xe_vampire_blood_powers",
@@ -183,10 +222,10 @@
     "valid_targets": [ "ally", "hostile" ],
     "effect": "effect_on_condition",
     "effect_str": "EOC_HYPNOTIC_GAZE_activated",
+    "condition": { "math": [ "u_vitamin('human_blood_vitamin') > -500" ] },
     "shape": "blast",
     "flags": [ "NO_HANDS", "SILENT", "NO_FAIL", "NO_PROJECTILE" ],
     "difficulty": 3,
-    "base_casting_time": 100,
     "min_range": {
       "math": [
         "min((3 + (vampire_total_tier_one_traits() * 0.2) + (vampire_total_tier_two_traits() * 0.33) + (vampire_total_tier_three_traits() * 0.5) + (vampire_total_tier_four_traits() * 0.75)), 12)"
@@ -197,25 +236,47 @@
         "min((3 + (vampire_total_tier_one_traits() * 0.2) + (vampire_total_tier_two_traits() * 0.33) + (vampire_total_tier_three_traits() * 0.5) + (vampire_total_tier_four_traits() * 0.75)), 12)"
       ]
     },
+    "energy_source": { "type": "VITAMIN", "vitamin": "human_blood_vitamin", "color": "c_red" },
+    "base_energy_cost": 150,
+    "base_casting_time": 100,
     "ignored_monster_species": [ "ZOMBIE", "ROBOT", "ROBOT_FLYING", "NETHER", "NETHER_EMANATION", "LEECH_PLANT", "WORM", "FUNGUS", "SLIME" ]
   },
   {
     "id": "vampire_command_beast_spell",
     "type": "SPELL",
     "name": "Cowing the Beast",
-    "description": "Exert command over a predatory wild animal like a wolf or a rat, making it your ally for a time.\n\n<color_light_red>Blood Cost:</color> 500 ml (<u_val:blood_amount_for_graph> ml current).",
+    "description": "Exert command over a predatory wild animal like a wolf or a rat, making it your ally for a time.\n\nYou must have <color_yellow>greater</color> than <color_red>-500</color> Stolen Blood to use this blood art.",
     "message": "",
     "teachable": false,
     "magic_type": "xe_vampire_blood_powers",
     "valid_targets": [ "hostile" ],
-    "effect": "effect_on_condition",
-    "effect_str": "EOC_VAMPIRE_COMMAND_BEAST_activated",
+    "effect": "charm_monster",
+    "condition": { "math": [ "u_vitamin('human_blood_vitamin') > -500" ] },
     "shape": "blast",
-    "base_casting_time": 75,
-    "flags": [ "NO_HANDS", "SILENT", "NO_FAIL" ],
+    "flags": [ "NO_HANDS", "SILENT", "NO_FAIL", "RECHARM", "RANDOM_DAMAGE", "RANDOM_DURATION" ],
     "skill": "deduction",
     "spell_class": "VAMPIRE_BLOOD_ARTS",
     "difficulty": 7,
+    "min_damage": {
+      "math": [
+        "(50 + (vampire_total_tier_one_traits()  * 5) + (vampire_total_tier_two_traits() * 12) + (vampire_total_tier_three_traits() * 20) + (vampire_total_tier_three_traits() * 35))* 0.75"
+      ]
+    },
+    "max_damage": {
+      "math": [
+        "(50 + (vampire_total_tier_one_traits()  * 5) + (vampire_total_tier_two_traits() * 12) + (vampire_total_tier_three_traits() * 20) + (vampire_total_tier_three_traits() * 35)) * 1.25"
+      ]
+    },
+    "min_duration": {
+      "math": [
+        "(6000 + (vampire_total_tier_one_traits()  * 1000) + (vampire_total_tier_two_traits() * 1800) + (vampire_total_tier_three_traits() * 2700) + (vampire_total_tier_three_traits() * 4500)) * 0.75"
+      ]
+    },
+    "max_duration": {
+      "math": [
+        "(6000 + (vampire_total_tier_one_traits()  * 1000) + (vampire_total_tier_two_traits() * 1800) + (vampire_total_tier_three_traits() * 2700) + (vampire_total_tier_three_traits() * 4500)) * 1.25"
+      ]
+    },
     "min_range": {
       "math": [
         "min((3 + (vampire_total_tier_one_traits() * 0.2) + (vampire_total_tier_two_traits() * 0.33) + (vampire_total_tier_three_traits() * 0.5) + (vampire_total_tier_four_traits() * 0.75)), 12)"
@@ -226,51 +287,16 @@
         "min((3 + (vampire_total_tier_one_traits() * 0.2) + (vampire_total_tier_two_traits() * 0.33) + (vampire_total_tier_three_traits() * 0.5) + (vampire_total_tier_four_traits() * 0.75)), 12)"
       ]
     },
+    "energy_source": { "type": "VITAMIN", "vitamin": "human_blood_vitamin", "color": "c_red" },
+    "base_energy_cost": 500,
+    "base_casting_time": 75,
     "targeted_monster_species": [ "NIGHT_CREATURE" ]
-  },
-  {
-    "id": "vampire_command_beast_spell_real",
-    "type": "SPELL",
-    "name": { "str": "Cowing the Beast Real", "//~": "NO_I18N" },
-    "description": { "str": "The actual power that lets you command a beast.  If you see this, it's a bug.", "//~": "NO_I18N" },
-    "message": "",
-    "teachable": false,
-    "magic_type": "xe_vampire_blood_powers",
-    "valid_targets": [ "hostile" ],
-    "effect": "charm_monster",
-    "shape": "blast",
-    "flags": [ "NO_HANDS", "SILENT", "NO_FAIL" ],
-    "spell_class": "VAMPIRE_BLOOD_ARTS",
-    "difficulty": 7,
-    "max_level": 1,
-    "min_range": 60,
-    "max_range": 60,
-    "min_damage": {
-      "math": [
-        "rng (0.75,1.25) * (50 + (vampire_total_tier_one_traits()  * 5) + (vampire_total_tier_two_traits() * 12) + (vampire_total_tier_three_traits() * 20) + (vampire_total_tier_three_traits() * 35))"
-      ]
-    },
-    "max_damage": {
-      "math": [
-        "rng (0.75,1.25) * (50 + (vampire_total_tier_one_traits()  * 5) + (vampire_total_tier_two_traits() * 12) + (vampire_total_tier_three_traits() * 20) + (vampire_total_tier_three_traits() * 35))"
-      ]
-    },
-    "min_duration": {
-      "math": [
-        "rng (0.75,1.25) * (6000 + (vampire_total_tier_one_traits()  * 1000) + (vampire_total_tier_two_traits() * 1800) + (vampire_total_tier_three_traits() * 2700) + (vampire_total_tier_three_traits() * 4500))"
-      ]
-    },
-    "max_duration": {
-      "math": [
-        "rng (0.75,1.25) * (6000 + (vampire_total_tier_one_traits()  * 1000) + (vampire_total_tier_two_traits() * 1800) + (vampire_total_tier_three_traits() * 2700) + (vampire_total_tier_three_traits() * 4500))"
-      ]
-    }
   },
   {
     "id": "vampire_earth_slumber_spell",
     "type": "SPELL",
     "name": "Earthen Slumber",
-    "description": "You can sleep within the earth itself, avoiding the hateful light of the sun.  This power must be used on diggable soil.\n\n<color_light_red>Blood Cost:</color> 0 ml.",
+    "description": "You can sleep within the earth itself, avoiding the hateful light of the sun.  This power must be used on diggable soil.",
     "message": "",
     "teachable": false,
     "magic_type": "xe_vampire_blood_powers",
@@ -278,10 +304,12 @@
     "effect": "effect_on_condition",
     "effect_str": "EOC_VAMPIRE_EARTH_SLUMBER_activated",
     "shape": "blast",
-    "base_casting_time": 150,
     "flags": [ "NO_HANDS", "SILENT", "NO_FAIL" ],
     "skill": "deduction",
     "spell_class": "VAMPIRE_BLOOD_ARTS",
+    "energy_source": { "type": "VITAMIN", "vitamin": "human_blood_vitamin", "color": "c_red" },
+    "base_energy_cost": 0,
+    "base_casting_time": 150,
     "difficulty": 2
   },
   {
@@ -299,6 +327,8 @@
     "effect": "effect_on_condition",
     "effect_str": "EOC_VAMPIRE_TORPOR_activated",
     "shape": "blast",
+    "energy_source": { "type": "VITAMIN", "vitamin": "human_blood_vitamin", "color": "c_red" },
+    "base_energy_cost": 0,
     "base_casting_time": 100,
     "difficulty": 2
   },
@@ -306,19 +336,38 @@
     "id": "vampire_dominate",
     "type": "SPELL",
     "name": "Dominating Gaze",
-    "description": "Take control of a mind.  Only works on targets that have weak minds.\n\n<color_light_red>Blood Cost:</color> 700 ml (<u_val:blood_amount_for_graph> ml current).",
-    "message": "You look for a mind to control.",
+    "description": "Take control of a mind.  Only works on targets that have weak minds.\n\nYou must have <color_yellow>greater</color> than <color_red>-500</color> Stolen Blood to use this blood art.",
+    "message": "You focus your gaze on your target's mind, attempting to take control of it.",
     "teachable": false,
     "magic_type": "xe_vampire_blood_powers",
     "valid_targets": [ "hostile" ],
     "skill": "deduction",
     "spell_class": "VAMPIRE_BLOOD_ARTS",
-    "flags": [ "SILENT", "NO_HANDS", "NO_LEGS", "NO_FAIL" ],
-    "effect": "effect_on_condition",
-    "effect_str": "EOC_VAMPIRE_DOMINATE_activated",
+    "flags": [ "SILENT", "NO_HANDS", "NO_LEGS", "NO_FAIL", "RANDOM_DURATION" ],
+    "effect": "charm_monster",
+    "condition": { "math": [ "u_vitamin('human_blood_vitamin') > -500" ] },
     "shape": "blast",
-    "base_casting_time": 100,
     "difficulty": 8,
+    "min_damage": {
+      "math": [
+        "(20 + (vampire_total_tier_one_traits()  * 4) + (vampire_total_tier_two_traits() * 10) + (vampire_total_tier_three_traits() * 16) + (vampire_total_tier_four_traits() * 30)) * 0.75"
+      ]
+    },
+    "max_damage": {
+      "math": [
+        "(20 + (vampire_total_tier_one_traits()  * 4) + (vampire_total_tier_two_traits() * 10) + (vampire_total_tier_three_traits() * 16) + (vampire_total_tier_four_traits() * 30)) * 1.25"
+      ]
+    },
+    "min_duration": {
+      "math": [
+        "(2500 + (vampire_total_tier_one_traits()  * 400) + (vampire_total_tier_two_traits() * 800) + (vampire_total_tier_three_traits() * 1150) + (vampire_total_tier_four_traits() * 2050)) * 0.75"
+      ]
+    },
+    "max_duration": {
+      "math": [
+        "(2500 + (vampire_total_tier_one_traits()  * 400) + (vampire_total_tier_two_traits() * 800) + (vampire_total_tier_three_traits() * 1150) + (vampire_total_tier_four_traits() * 2050)) * 1.25"
+      ]
+    },
     "min_range": {
       "math": [
         "min((3 + (vampire_total_tier_one_traits() * 0.2) + (vampire_total_tier_two_traits() * 0.33) + (vampire_total_tier_three_traits() * 0.5) + (vampire_total_tier_four_traits() * 0.75)), 12)"
@@ -329,46 +378,9 @@
         "min((3 + (vampire_total_tier_one_traits() * 0.2) + (vampire_total_tier_two_traits() * 0.33) + (vampire_total_tier_three_traits() * 0.5) + (vampire_total_tier_four_traits() * 0.75)), 12)"
       ]
     },
-    "targeted_monster_species": [ "HUMAN", "FERAL", "CYBORG" ]
-  },
-  {
-    "id": "vampire_dominate_real",
-    "type": "SPELL",
-    "name": { "str": "Dominating Gaze real", "//~": "NO_I18N" },
-    "description": { "str": "The actual power that lets you take over a mind.  If you see this, it's a bug.", "//~": "NO_I18N" },
-    "message": "",
-    "teachable": false,
-    "magic_type": "xe_vampire_blood_powers",
-    "valid_targets": [ "hostile" ],
-    "effect": "charm_monster",
-    "shape": "blast",
-    "flags": [ "NO_HANDS", "SILENT", "NO_FAIL" ],
-    "spell_class": "VAMPIRE_BLOOD_ARTS",
-    "skill": "deduction",
-    "difficulty": 8,
-    "max_level": 1,
-    "min_range": 60,
-    "max_range": 60,
-    "min_damage": {
-      "math": [
-        "rng (0.75,1.25) * (20 + (vampire_total_tier_one_traits()  * 4) + (vampire_total_tier_two_traits() * 10) + (vampire_total_tier_three_traits() * 16) + (vampire_total_tier_four_traits() * 30))"
-      ]
-    },
-    "max_damage": {
-      "math": [
-        "rng (0.75,1.25) * (20 + (vampire_total_tier_one_traits()  * 4) + (vampire_total_tier_two_traits() * 10) + (vampire_total_tier_three_traits() * 16) + (vampire_total_tier_four_traits() * 30))"
-      ]
-    },
-    "min_duration": {
-      "math": [
-        "rng (0.75,1.25) * (2500 + (vampire_total_tier_one_traits()  * 400) + (vampire_total_tier_two_traits() * 800) + (vampire_total_tier_three_traits() * 1150) + (vampire_total_tier_four_traits() * 2050))"
-      ]
-    },
-    "max_duration": {
-      "math": [
-        "rng (0.75,1.25) * (2500 + (vampire_total_tier_one_traits()  * 400) + (vampire_total_tier_two_traits() * 800) + (vampire_total_tier_three_traits() * 1150) + (vampire_total_tier_four_traits() * 2050))"
-      ]
-    },
+    "energy_source": { "type": "VITAMIN", "vitamin": "human_blood_vitamin", "color": "c_red" },
+    "base_energy_cost": 700,
+    "base_casting_time": 100,
     "targeted_monster_species": [ "HUMAN", "FERAL", "CYBORG" ]
   },
   {
@@ -392,13 +404,14 @@
     "id": "vampire_summon_blood_container",
     "type": "SPELL",
     "name": "Create blood-storing sphere.",
-    "description": "Create a magical sphere that will contain any blood you will put in it until the spell ends.",
+    "description": "Create a magical sphere that will contain any blood you will put in it until the spell ends.\n\nYou must have <color_yellow>greater</color> than <color_red>-500</color> Stolen Blood to use this blood art.",
     "message": "You conjure a magical sphere to store blood.",
     "teachable": false,
     "magic_type": "xe_vampire_blood_powers",
     "valid_targets": [ "self" ],
     "effect": "spawn_item",
     "effect_str": "vampire_blood_ball",
+    "condition": { "math": [ "u_vitamin('human_blood_vitamin') > -500" ] },
     "shape": "blast",
     "base_casting_time": 75,
     "flags": [ "NO_HANDS", "SILENT", "NO_FAIL" ],
@@ -413,7 +426,7 @@
     "id": "vampire_invisible_in_dark",
     "type": "SPELL",
     "name": "Shrouded by the Shadowed Path.",
-    "description": "Surround yourself in shadows, becoming invisible for a while.  This power will fail if you stand outside under the sun.\n\n<color_light_red>Blood Cost:</color> 300 ml (<u_val:blood_amount_for_graph> ml current).",
+    "description": "Surround yourself in shadows, becoming invisible for a while.  This power <color_yellow>will fail</color> if you stand outside under the sun.\n\nYou must have <color_yellow>greater</color> than <color_red>-500</color> Stolen Blood to use this blood art.",
     "message": "You gather as many shadows as you can.",
     "teachable": false,
     "magic_type": "xe_vampire_blood_powers",
@@ -423,7 +436,11 @@
     "flags": [ "SILENT", "NO_HANDS", "NO_LEGS", "NO_FAIL" ],
     "effect": "effect_on_condition",
     "effect_str": "EOC_VAMPIRE_INVISIBLE_IN_DARK",
+    "condition": { "math": [ "u_vitamin('human_blood_vitamin') > -500" ] },
     "shape": "blast",
+    "energy_source": { "type": "VITAMIN", "vitamin": "human_blood_vitamin", "color": "c_red" },
+    "base_energy_cost": 300,
+    "base_casting_time": 50,
     "difficulty": 5
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[Xedra Evolved] Switch vampires powers over to using `human_blood_vitamin`"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

I have to maintain my reputation for nearly-immediately implementing people's changes they make for me, that's what encourages people to do it (thank you all)
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Switch vampire powers over the `human_blood_vitamin`. Delete all EoCs and subspells that existed only to account for blood expenditure. Put ` "condition": { "math": [ "u_vitamin('human_blood_vitamin') > -500" ] }` on almost all powers (sleeping in earth and torpor excepted) and a note in the power description that you need more then -500 blood vitamin to use the power. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
<img width="541" height="354" alt="Untitled2" src="https://github.com/user-attachments/assets/444cf987-3f10-4958-a16f-4ccaeff9eb9f" />

Powers are usable even if it takes you negative, as expected. 

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
