### PR TITLE
fix clang tidy failure in teleport.cpp

### DIFF
--- a/src/teleport.cpp
+++ b/src/teleport.cpp
@@ -48,10 +48,9 @@ static const flag_id json_flag_DIMENSIONAL_ANCHOR( "DIMENSIONAL_ANCHOR" );
 static const flag_id json_flag_GRAB( "GRAB" );
 static const flag_id json_flag_TELEPORT_LOCK( "TELEPORT_LOCK" );
 
-static const itype_id itype_wall_wiring( "wall_wiring" );
 static const itype_id itype_power_cord( "power_cord" );
 
-const std::string flag_WIRING( "WIRING" );
+static const std::string flag_WIRING( "WIRING" );
 
 static bool TestForVehicleTeleportCollision( vehicle &veh, map &here, map *dest,
         const tripoint_abs_ms &dp )


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/16897567290/job/47870347818?pr=82398
```
/home/runner/work/Cataclysm-DDA/Cataclysm-DDA/src/teleport.cpp:52:1: note: 'itype_power_cord' should be before 'itype_wall_wiring'.
   52 | static const itype_id itype_power_cord( "power_cord" );
      | ^
Error: /home/runner/work/Cataclysm-DDA/Cataclysm-DDA/src/teleport.cpp:51:1: error: Variable 'itype_wall_wiring' declared but not used. [cata-unused-statics,-warnings-as-errors]
   51 | static const itype_id itype_wall_wiring( "wall_wiring" );
      | ^
Error: /home/runner/work/Cataclysm-DDA/Cataclysm-DDA/src/teleport.cpp:54:1: error: Global declaration of 'flag_WIRING' in a cpp file should be static or have a previous declaration in a header. [cata-static-declarations,-warnings-as-errors]
   54 | const std::string flag_WIRING( "WIRING" );
      | ^
```
Caused by #82285

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
Apply the fixes requested/required by clang-tidy.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
