### PR TITLE
Relic Recharge subtle message

### DIFF
--- a/src/relic.cpp
+++ b/src/relic.cpp
@@ -334,9 +334,9 @@ void relic_charge_info::accumulate_charge( item &parent )
             } else {
                 current_magazine->ammo_set( current_ammo, current_magazine->ammo_remaining( ) + 1 );
                 if( carrier != nullptr && carrier->is_avatar() ) {
-    carrier->add_msg_if_player( m_good,
-        _( "The artifact suddenly emits a slight warmth and a glow beyond the edge of sight." ) );
-}
+                    carrier->add_msg_if_player( m_good,
+                                                _( "The artifact suddenly emits a slight warmth and a glow beyond the edge of sight." ) );
+                }
             }
         } else {
             charges++;

--- a/src/relic.cpp
+++ b/src/relic.cpp
@@ -333,6 +333,7 @@ void relic_charge_info::accumulate_charge( item &parent )
                 current_magazine->ammo_set( current_magazine->ammo_default(), 1 );
             } else {
                 current_magazine->ammo_set( current_ammo, current_magazine->ammo_remaining( ) + 1 );
+                caster.add_msg_if_player( m_good, _( "The artifact suddenly emits a slight warmth and a glow beyond the edge of sight." ) );
             }
         } else {
             charges++;

--- a/src/relic.cpp
+++ b/src/relic.cpp
@@ -333,7 +333,8 @@ void relic_charge_info::accumulate_charge( item &parent )
                 current_magazine->ammo_set( current_magazine->ammo_default(), 1 );
             } else {
                 current_magazine->ammo_set( current_ammo, current_magazine->ammo_remaining( ) + 1 );
-                caster.add_msg_if_player( m_good, _( "The artifact suddenly emits a slight warmth and a glow beyond the edge of sight." ) );
+                caster.add_msg_if_player( m_good,
+                                          _( "The artifact suddenly emits a slight warmth and a glow beyond the edge of sight." ) );
             }
         } else {
             charges++;

--- a/src/relic.cpp
+++ b/src/relic.cpp
@@ -333,8 +333,10 @@ void relic_charge_info::accumulate_charge( item &parent )
                 current_magazine->ammo_set( current_magazine->ammo_default(), 1 );
             } else {
                 current_magazine->ammo_set( current_ammo, current_magazine->ammo_remaining( ) + 1 );
-                caster.add_msg_if_player( m_good,
-                                          _( "The artifact suddenly emits a slight warmth and a glow beyond the edge of sight." ) );
+                if( carrier != nullptr && carrier->is_avatar() ) {
+    carrier->add_msg_if_player( m_good,
+        _( "The artifact suddenly emits a slight warmth and a glow beyond the edge of sight." ) );
+}
             }
         } else {
             charges++;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Relics have multiple ways they can recharge, however they all happen passively to the pc, and without any notice.  By adding a small message it will give the player a way to investigate what causes a recharge method on an artifact through trial and error instead of relying exclusively on save file investigations.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Adds a message when an artifact recharges.  By recreating the conditions under which the message displayed the PC can eventually possibly understand when a relic will recharge.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
I've been thinking about this for a while and I think it's the best alternative.  If this isn't accepted I'll adjust it to be something that mods can use.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
