### PR TITLE
Energy source works if defined at magic_type level

### DIFF
--- a/doc/JSON/MAGIC.md
+++ b/doc/JSON/MAGIC.md
@@ -110,7 +110,17 @@ In `data/mods/Magiclysm` there is a template spell, copied here for your perusal
     "sound_ambient": true,                                    // whether or not this is treated as an ambient sound or not
     "sound_id": "misc",                                       // the sound id
     "sound_variant": "shockwave",                             // the sound variant
-    "learn_spells": { "create_atomic_light": 5, "megablast": 10 }   // the caster will learn these spells when the current spell reaches the specified level. should be a map of spell_type_id and the level at which the new spell is learned.
+    "learn_spells": { "create_atomic_light": 5, "megablast": 10 },   // the caster will learn these spells when the current spell reaches the specified level. should be a map of spell_type_id and the level at which the new spell is learned.
+    "condition": {                                            // if valid_targets, targeted_monster_ids, targeted_monster_species and ignored_monster_species is not enough,
+      "and": [                                                // you can place more conditions to check both the caster (alpha/u_) and target (beta/npc/n_).
+        { "not": { "npc_has_worn_with_flag": "DIMENSIONAL_ANCHOR" } }, // If it return false, you cannot cast this spell against creature you are aiming at
+        { "not": { "npc_has_worn_with_flag": "STABILIZED_TIMELINE" } }
+      ]
+    },
+    "condition_fail_message": "Cannot be used against time or space anchored." // if `condition` fails, this message would be printed.
+                                                                               // because `condition` is designed to evaluate both alpha and beta,
+                                                                               // the only place where this message can be rendered is at aiming menu
+                                                                               // which i consider a bug that needs to be resovled
   }
 ```
 The template spell above shows every JSON field that spells can have.  Most of these values can be set at 0 or "NONE", so you may leave out most of these fields if they do not pertain to your spell.

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -511,7 +511,7 @@ void spell_type::load( const JsonObject &jo, std::string_view src )
 
     optional( jo, was_loaded, "spell_class", spell_class, spell_class_default );
     if( jo.has_string( "energy_source" ) ) {
-        optional( jo, was_loaded, "energy_source", energy_source );
+        mandatory( jo, was_loaded, "energy_source", energy_source );
     } else if( jo.has_object( "energy_source" ) ) {
         const JsonObject jo_energy = jo.get_object( "energy_source" );
         mandatory( jo_energy, was_loaded, "type", energy_source );
@@ -723,13 +723,13 @@ void spell_type::check_consistency()
             debugmsg( "ERROR: %s has WONDER flag but no spells to choose from!", sp_t.id.c_str() );
         }
         if( sp_t.get_energy_source() == magic_energy_type::vitamin &&
-            !sp_t.vitamin_energy_source().has_value() ) {
-            debugmsg( R"(spell %s uses energy_source "vitamin", but doesn't specify the "vitamin")",
+            sp_t.vitamin_energy_source() == vitamin_id::NULL_ID() ) {
+            debugmsg( R"(spell %s uses energy_source "VITAMIN", but doesn't specify the "vitamin" id)",
                       sp_t.id.c_str() );
         }
         if( sp_t.get_energy_source() != magic_energy_type::vitamin &&
-            sp_t.vitamin_energy_source().has_value() ) {
-            debugmsg( R"(spell %s specifies "vitamin", but doesn't use the vitamin energy source)",
+            sp_t.vitamin_energy_source() == vitamin_id::NULL_ID() ) {
+            debugmsg( R"(spell %s specifies "vitamin" field, but doesn't use the vitamin energy source)",
                       sp_t.id.c_str() );
         }
 
@@ -1849,14 +1849,27 @@ magic_energy_type spell_type::get_energy_source() const
     }
 }
 
-std::optional<vitamin_id> spell_type::vitamin_energy_source() const
+vitamin_id spell_type::vitamin_energy_source() const
 {
-    return vitamin_energy_source_;
+    if( vitamin_energy_source_.has_value() ) {
+        return vitamin_energy_source_.value();
+    } else if( magic_type.has_value() && magic_type.value()->vitamin_energy_source_.has_value() ) {
+        return magic_type.value()->vitamin_energy_source_.value();
+    } else {
+        // should happen only at check_consistency()
+        return vitamin_id::NULL_ID();
+    }
 }
 
 nc_color spell_type::energy_color() const
 {
-    return energy_color_;
+    if( energy_color_.has_value() ) {
+        return energy_color_.value();
+    } else if( magic_type.has_value() && magic_type.value()->energy_color_.has_value() ) {
+        return magic_type.value()->energy_color_.value();
+    } else {
+        return c_cyan;
+    }
 }
 
 std::optional<jmath_func_id> spell_type::overall_get_level_formula_id() const

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -358,6 +358,7 @@ void spell_type::load( const JsonObject &jo, std::string_view src )
         read_condition( jo, "condition", condition, false );
         has_condition = true;
     }
+    optional( jo, was_loaded, "condition_fail_message", condition_fail_message_ );
 
     optional( jo, was_loaded, "extra_effects", additional_spells );
 
@@ -728,7 +729,7 @@ void spell_type::check_consistency()
                       sp_t.id.c_str() );
         }
         if( sp_t.get_energy_source() != magic_energy_type::vitamin &&
-            sp_t.vitamin_energy_source() == vitamin_id::NULL_ID() ) {
+            sp_t.vitamin_energy_source() != vitamin_id::NULL_ID() ) {
             debugmsg( R"(spell %s specifies "vitamin" field, but doesn't use the vitamin energy source)",
                       sp_t.id.c_str() );
         }
@@ -1723,6 +1724,10 @@ bool spell::valid_by_condition( const Creature &caster ) const
     }
 }
 
+std::string spell::failed_condition_message() const
+{
+    return type->condition_fail_message_.translated();
+}
 
 bool spell::is_valid_target( const Creature &caster, const tripoint_bub_ms &p ) const
 {

--- a/src/magic.h
+++ b/src/magic.h
@@ -343,7 +343,7 @@ class spell_type
         magic_energy_type get_energy_source() const;
 
         // what energy do you use to cast this spell
-        std::optional<vitamin_id> vitamin_energy_source() const;
+        vitamin_id vitamin_energy_source() const;
 
         // if vitamin is used, specifies the color of an energy
         nc_color energy_color() const;
@@ -448,7 +448,7 @@ class spell_type
 
         std::optional<magic_energy_type> energy_source;
         std::optional<vitamin_id> vitamin_energy_source_; // NOLINT(cata-serialize)
-        nc_color energy_color_ = c_cyan; // NOLINT(cata-serialize)
+        std::optional<nc_color> energy_color_; // NOLINT(cata-serialize)
         std::optional<jmath_func_id> get_level_formula_id;
         std::optional<jmath_func_id> exp_for_level_formula_id;
         std::optional<int> max_book_level;

--- a/src/magic.h
+++ b/src/magic.h
@@ -356,6 +356,8 @@ class spell_type
         std::function<bool( const_dialogue const & )> condition; // NOLINT(cata-serialize)
         bool has_condition = false; // NOLINT(cata-serialize)
 
+        translation condition_fail_message_;
+
         std::set<mtype_id> targeted_monster_ids;
 
         std::set<species_id> targeted_species_ids;
@@ -696,6 +698,8 @@ class spell
         bool ignore_by_species_id( const tripoint_bub_ms &p ) const;
         bool valid_by_condition( const Creature &caster, const Creature &target ) const;
         bool valid_by_condition( const Creature &caster ) const;
+
+        std::string failed_condition_message() const;
 
         // picks a random valid tripoint from @area
         std::optional<tripoint_bub_ms> random_valid_target( const Creature &caster,

--- a/src/magic.h
+++ b/src/magic.h
@@ -188,6 +188,7 @@ class spell_events : public event_subscriber
         void notify( const cata::event & ) override;
 };
 
+// NOLINTNEXTLINE(clang-analyzer-optin.performance.Padding)
 class spell_type
 {
     public:

--- a/src/magic.h
+++ b/src/magic.h
@@ -357,7 +357,7 @@ class spell_type
         std::function<bool( const_dialogue const & )> condition; // NOLINT(cata-serialize)
         bool has_condition = false; // NOLINT(cata-serialize)
 
-        translation condition_fail_message_;
+        translation condition_fail_message_; // NOLINT(cata-serialize)
 
         std::set<mtype_id> targeted_monster_ids;
 

--- a/src/magic_type.cpp
+++ b/src/magic_type.cpp
@@ -47,7 +47,14 @@ void magic_type::load( const JsonObject &jo, std::string_view src )
     }
     optional( jo, was_loaded, "casting_xp_formula_id", casting_xp_formula_id );
     optional( jo, was_loaded, "failure_chance_formula_id", failure_chance_formula_id );
-    optional( jo, was_loaded, "energy_source", energy_source );
+    if( jo.has_string( "energy_source" ) ) {
+        mandatory( jo, was_loaded, "energy_source", energy_source );
+    } else if( jo.has_object( "energy_source" ) ) {
+        const JsonObject jo_energy = jo.get_object( "energy_source" );
+        mandatory( jo_energy, was_loaded, "type", energy_source );
+        optional( jo_energy, was_loaded, "vitamin", vitamin_energy_source_ );
+        optional( jo_energy, was_loaded, "color", energy_color_, nc_color_reader{}, c_cyan );
+    }
     if( jo.has_array( "cannot_cast_flags" ) ) {
         for( auto &cannot_cast_flag : jo.get_string_array( "cannot_cast_flags" ) ) {
             cannot_cast_flags.insert( cannot_cast_flag );

--- a/src/magic_type.h
+++ b/src/magic_type.h
@@ -55,8 +55,8 @@ class magic_type
         std::optional<jmath_func_id> casting_xp_formula_id;
         std::optional<jmath_func_id> failure_chance_formula_id;
         std::optional<magic_energy_type> energy_source;
-        std::optional<vitamin_id> vitamin_energy_source_;
-        std::optional<nc_color> energy_color_;
+        std::optional<vitamin_id> vitamin_energy_source_; // NOLINT(cata-serialize)
+        std::optional<nc_color> energy_color_; // NOLINT(cata-serialize)
         std::set<std::string> cannot_cast_flags; // string flags
         std::optional<std::string> cannot_cast_message;
         std::optional<int> max_book_level;

--- a/src/magic_type.h
+++ b/src/magic_type.h
@@ -9,6 +9,7 @@
 #include <string_view>
 #include <vector>
 
+#include "color.h"
 #include "dialogue_helpers.h"
 #include "type_id.h"
 
@@ -54,6 +55,8 @@ class magic_type
         std::optional<jmath_func_id> casting_xp_formula_id;
         std::optional<jmath_func_id> failure_chance_formula_id;
         std::optional<magic_energy_type> energy_source;
+        std::optional<vitamin_id> vitamin_energy_source_;
+        std::optional<nc_color> energy_color_;
         std::set<std::string> cannot_cast_flags; // string flags
         std::optional<std::string> cannot_cast_message;
         std::optional<int> max_book_level;

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -4242,6 +4242,12 @@ void target_ui::panel_spell_info( int &text_y )
     }
     print_colored_text( w_target, point( 1, text_y++ ), clr, clr, fail_str );
 
+    if( dst_critter != nullptr && !casting->valid_by_condition( *you, *dst_critter ) ) {
+        nc_color red_color = c_red;
+        print_colored_text( w_target, point( 1, text_y++ ), red_color, red_color,
+                            casting->failed_condition_message() );
+    }
+
     if( casting->aoe( get_player_character() ) > 0 ) {
         nc_color color = c_light_gray;
         const std::string fx = casting->effect();


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Storm reported that energy source changes i made do not work when used in magic_type. Obviously, i didn't implement it, duh
#### Describe the solution
Implement it
Also add a field that notify user if spell condition fails
#### Testing
Seems to work
condition message:
<img width="442" height="534" alt="image" src="https://github.com/user-attachments/assets/580e74b8-18f3-4e9d-84ef-7e689e0bc353" />
