### PR TITLE
Scavenger's anvil recipe tweak

### DIFF
--- a/data/json/recipes/recipe_others.json
+++ b/data/json/recipes/recipe_others.json
@@ -2984,8 +2984,8 @@
     "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "GRIND", "level": 2 }, { "id": "WRENCH", "level": 2 } ],
     "tools": [ [ [ "angle_grinder", 220 ] ] ],
     "proficiencies": [ { "proficiency": "prof_metalworking", "required": true }, { "proficiency": "prof_blacksmithing" } ],
-    "components": [ [ [ "hdframe", 1 ], [ "engine_block_large", 1 ] ] ],
-    "byproducts": [ [ "mc_steel_lump", 15 ] ]
+    "components": [ [ [ "hdframe", 1 ], [ "frame", 1 ], [ "engine_block_large", 1 ] ] ],
+    "byproducts": [ [ "lc_steel_lump", 15 ] ]
   },
   {
     "result": "anvil_bronze",


### PR DESCRIPTION


#### Summary
None

#### Purpose of change
I was looking at this recipe the other day and i noticed it gets medium steel lumps as byproducts of said craft, which i think makes no sense cuz the heavy-duty frame is low carbon steel and large engine block is cast iron. So i changed that and add steel frame into there as well to make it a bit more accessible.

#### Describe the solution

change the byproducts to mild steel lumps and add steel frame as one od the options.

#### Describe alternatives you've considered

Not doing so?
Yote the large engine block off the list?

#### Testing

![Screenshot_20250813_022604](https://github.com/user-attachments/assets/dbecb0c7-bb30-40ca-b60d-0f0eb01bc3b5)


#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
