### PR TITLE
Allow using "extend/delete" on variants

### DIFF
--- a/src/generic_factory.h
+++ b/src/generic_factory.h
@@ -1505,6 +1505,27 @@ public:
 };
 
 /**
+ * This reader is for any object that can be read from a JsonValue,
+ * but does not otherwise need special handling in a reader.
+ * This enables using extend/delete for arbitrary types without a specialized reader,
+ * by implementing a deserialize function for the type and using this reader.
+ * The type must be constructible with no arguments, and may need to implement some operators,
+ * depending on the underlying container. (e.g. vector requires operator==() for the handler above)
+ */
+template<typename T>
+class json_read_reader : public generic_typed_reader<json_read_reader<T>>
+{
+public:
+    T get_next( const JsonValue &jv ) const {
+        T ret;
+        if( !jv.read( ret ) ) {
+            jv.throw_error( string_format( "Couldn't read %s", demangle( typeid( T ).name() ) ) );
+        }
+        return ret;
+    }
+};
+
+/**
  * Converts the JSON string to some type that must be construable from a `std::string`,
  * e.g. @ref string_id.
  * Example:

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -4066,7 +4066,7 @@ void itype::load( const JsonObject &jo, std::string_view src )
     optional( jo, was_loaded, "integral_longest_side", integral_longest_side, not_negative_length,
               -1_mm );
     optional( jo, was_loaded, "variant_type", variant_kind, itype_variant_kind::generic );
-    optional( jo, was_loaded, "variants", variants );
+    optional( jo, was_loaded, "variants", variants, json_read_reader<itype_variant_data> {} );
     optional( jo, was_loaded, "container", default_container );
     optional( jo, was_loaded, "container_variant", default_container_variant );
     optional( jo, was_loaded, "sealed", default_container_sealed, true );

--- a/src/itype.h
+++ b/src/itype.h
@@ -724,6 +724,11 @@ struct itype_variant_data {
 
     int weight = 1;
 
+    // this is only needed for delete in generic_factory, so only compares id!
+    // Not safe for general use!
+    bool operator==( const itype_variant_data &rhs ) const {
+        return id == rhs.id;
+    }
     void deserialize( const JsonObject &jo );
     void load( const JsonObject &jo );
 };


### PR DESCRIPTION
#### Summary
Infrastructure "Add json_read_reader typed reader for mandatory/optional, enabling more use of extend/delete for containers loaded from JSON"

#### Purpose of change
GetUsedTo asked how to extend variants, and it is not currently possible because it does not use a reader.

#### Describe the solution
Implement a generic reader that can read any type that JsonValue can read and has appropriate operators for the container handlers to use.

This reader allows many more containers to take advantage of the "extend"/"delete" features.

#### Testing
<img width="671" height="195" alt="a variant 'sweet hoodie', with the variant added in my sweet cataclysm by use of the extend feature" src="https://github.com/user-attachments/assets/84663f05-0a86-4ce9-965a-b908e00e6890" />

```json
  {
    "id": "hoodie",
    "type": "ITEM",
    "copy-from": "hoodie",
    "extend": {
      "variants": [
        {
          "id": "hoodie_delicious",
          "name": { "str": "sweet hoodie" },
          "description": "This one is extra tasty.",
          "color": "red",
          "append": true,
          "weight": 100
        }
      ]
    }
  }
```
#### Additional context
Some template work could be done to make the operator==() for vector optional (and disable delete if it doesn't exist), but it is not an obstacle now.