### PR TITLE
Actually respect default world compression setting

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1770,6 +1770,13 @@ void options_manager::add_options_general()
 
         get_option( "AMBIENT_SOUND_VOLUME" ).setPrerequisite( "SOUND_ENABLED" );
     } );
+
+    add_empty_line();
+
+    add( "WORLD_COMPRESSION2", "general", to_translation( "World data compression" ),
+         to_translation( "If true, new worlds store data in a compressed format." ),
+         true
+       );
 }
 
 void options_manager::add_options_interface()
@@ -2751,11 +2758,6 @@ void options_manager::add_options_world_default()
         { "reset", to_translation( "Reset" ) }, { "delete", to_translation( "Delete" ) },
         { "query", to_translation( "Query" ) }, { "keep", to_translation( "Keep" ) }
     }, "reset"
-       );
-
-    add( "WORLD_COMPRESSION", "world_default", to_translation( "World data compression" ),
-         to_translation( "If true, new worlds store data in a compressed format." ),
-         false
        );
 
     add_empty_line();

--- a/src/worldfactory.cpp
+++ b/src/worldfactory.cpp
@@ -139,6 +139,18 @@ WORLD *worldfactory::add_world( std::unique_ptr<WORLD> retworld )
     if( !retworld->save() ) {
         return nullptr;
     }
+    if( get_option<bool>( "WORLD_COMPRESSION2" ) ) {
+        cata_path dictionary_folder = PATH_INFO::compression_folder_path();
+        cata_path maps_dict = dictionary_folder / "maps.dict";
+        cata_path mmr_dict = dictionary_folder / "mmr.dict";
+        cata_path overmaps_dict = dictionary_folder / "overmaps.dict";
+
+        if( !copy_file( maps_dict, retworld->folder_path() / "maps.dict" ) ||
+            !copy_file( mmr_dict, retworld->folder_path() / "mmr.dict" ) ||
+            !copy_file( overmaps_dict, retworld->folder_path() / "overmaps.dict" ) ) {
+            return nullptr;
+        }
+    }
     return ( all_worlds[ retworld->world_name ] = std::move( retworld ) ).get();
 }
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Features "Enable save compression by default for new worlds"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
I didn't finish implementing the functionality for actually default enabling save compression. Do that and make it enabled by default.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Rename the option so it defaults to true instead of the current option which is false and stays false until flipped. Move it to general because it doesn't actually belong in the proper world options. Copy the compression dictionaries into the world on creation in `add_world`.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Loaded the game, checked the bool was true, made a world, checked it had dictionaries in it, created a character in it and saved, the save was compressed.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
