### PR TITLE
[XE/DDotD] Dhampirs and pre-undead vampires are resistant to the zombie infection

### DIFF
--- a/data/mods/Xedra_Evolved/mod_interactions/classic_zombies/effects.json
+++ b/data/mods/Xedra_Evolved/mod_interactions/classic_zombies/effects.json
@@ -1,0 +1,9 @@
+[
+  {
+    "type": "effect_type",
+    "id": "effect_xe_ddotd_zombie_virus_resistance",
+    "//": "Hidden effect, exists to keep track of zombie virus resistance",
+    "name": [ "" ],
+    "desc": [ "" ]
+  }
+]

--- a/data/mods/Xedra_Evolved/mod_interactions/classic_zombies/eocs.json
+++ b/data/mods/Xedra_Evolved/mod_interactions/classic_zombies/eocs.json
@@ -18,7 +18,10 @@
         "then": [
           { "u_lose_effect": "zombie_virus" },
           { "u_lose_effect": "effect_xe_ddotd_zombie_virus_resistance" },
-          { "u_message": "You've started feeling a bit better.  Maybe your unique condition has saved you from the zombie bite's inexorable…death this time.", "type": "good" }
+          {
+            "u_message": "You've started feeling a bit better.  Maybe your unique condition has saved you from the zombie bite's inexorable…death this time.",
+            "type": "good"
+          }
         ],
         "else": { "run_eocs": "EOC_XE_DDOTD_DHAMPIRS_VAMPIRES_RESIST_INFECTION_FOLLOWUP", "time_in_future": "24 hours" }
       }

--- a/data/mods/Xedra_Evolved/mod_interactions/classic_zombies/eocs.json
+++ b/data/mods/Xedra_Evolved/mod_interactions/classic_zombies/eocs.json
@@ -23,7 +23,7 @@
             "type": "good"
           }
         ],
-        "else": { "run_eocs": "EOC_XE_DDOTD_DHAMPIRS_VAMPIRES_RESIST_INFECTION_FOLLOWUP", "time_in_future": "1 hours" }
+        "else": { "run_eocs": "EOC_XE_DDOTD_DHAMPIRS_VAMPIRES_RESIST_INFECTION_FOLLOWUP", "time_in_future": "1 days" }
       }
     ]
   },
@@ -42,7 +42,7 @@
             "type": "good"
           }
         ],
-        "else": { "run_eocs": "EOC_XE_DDOTD_DHAMPIRS_VAMPIRES_RESIST_INFECTION_FOLLOWUP", "time_in_future": "1 hours" }
+        "else": { "run_eocs": "EOC_XE_DDOTD_DHAMPIRS_VAMPIRES_RESIST_INFECTION_FOLLOWUP", "time_in_future": "1 days" }
       }
     ]
   }

--- a/data/mods/Xedra_Evolved/mod_interactions/classic_zombies/eocs.json
+++ b/data/mods/Xedra_Evolved/mod_interactions/classic_zombies/eocs.json
@@ -37,7 +37,10 @@
         "then": [
           { "u_lose_effect": "zombie_virus" },
           { "u_lose_effect": "effect_xe_ddotd_zombie_virus_resistance" },
-          { "u_message": "You've started feeling a bit better.  Maybe your unique condition has saved you from the zombie bite's inexorable…death this time.", "type": "good" }
+          {
+            "u_message": "You've started feeling a bit better.  Maybe your unique condition has saved you from the zombie bite's inexorable…death this time.",
+            "type": "good"
+          }
         ],
         "else": { "run_eocs": "EOC_XE_DDOTD_DHAMPIRS_VAMPIRES_RESIST_INFECTION_FOLLOWUP", "time_in_future": "24 hours" }
       }

--- a/data/mods/Xedra_Evolved/mod_interactions/classic_zombies/eocs.json
+++ b/data/mods/Xedra_Evolved/mod_interactions/classic_zombies/eocs.json
@@ -23,7 +23,7 @@
             "type": "good"
           }
         ],
-        "else": { "run_eocs": "EOC_XE_DDOTD_DHAMPIRS_VAMPIRES_RESIST_INFECTION_FOLLOWUP", "time_in_future": "24 hours" }
+        "else": { "run_eocs": "EOC_XE_DDOTD_DHAMPIRS_VAMPIRES_RESIST_INFECTION_FOLLOWUP", "time_in_future": "1 hours" }
       }
     ]
   },
@@ -42,7 +42,7 @@
             "type": "good"
           }
         ],
-        "else": { "run_eocs": "EOC_XE_DDOTD_DHAMPIRS_VAMPIRES_RESIST_INFECTION_FOLLOWUP", "time_in_future": "24 hours" }
+        "else": { "run_eocs": "EOC_XE_DDOTD_DHAMPIRS_VAMPIRES_RESIST_INFECTION_FOLLOWUP", "time_in_future": "1 hours" }
       }
     ]
   }

--- a/data/mods/Xedra_Evolved/mod_interactions/classic_zombies/eocs.json
+++ b/data/mods/Xedra_Evolved/mod_interactions/classic_zombies/eocs.json
@@ -8,7 +8,7 @@
       "and": [
         { "u_has_any_trait": [ "VAMPIRE", "DHAMPIR_TRAIT" ] },
         { "not": { "u_has_trait": "VAMPIRE4" } },
-        { "compare_string": [ "taint", { "zombie_virus": "effect" } ] }
+        { "compare_string": [ "zombie_virus", { "context_val": "effect" } ] }
       ]
     },
     "effect": [

--- a/data/mods/Xedra_Evolved/mod_interactions/classic_zombies/eocs.json
+++ b/data/mods/Xedra_Evolved/mod_interactions/classic_zombies/eocs.json
@@ -19,7 +19,7 @@
           { "u_lose_effect": "zombie_virus" },
           { "u_lose_effect": "effect_xe_ddotd_zombie_virus_resistance" },
           {
-            "u_message": "You've started feeling a bit better.  Maybe your unique condition has saved you from the zombie bite's inexorable…death this time.",
+            "u_message": "You've started feeling a bit better.  Maybe your unique condition has saved you from the zombie bite's inexorable death…this time.",
             "type": "good"
           }
         ],
@@ -38,7 +38,7 @@
           { "u_lose_effect": "zombie_virus" },
           { "u_lose_effect": "effect_xe_ddotd_zombie_virus_resistance" },
           {
-            "u_message": "You've started feeling a bit better.  Maybe your unique condition has saved you from the zombie bite's inexorable…death this time.",
+            "u_message": "You've started feeling a bit better.  Maybe your unique condition has saved you from the zombie bite's inexorable death…this time.",
             "type": "good"
           }
         ],

--- a/data/mods/Xedra_Evolved/mod_interactions/classic_zombies/eocs.json
+++ b/data/mods/Xedra_Evolved/mod_interactions/classic_zombies/eocs.json
@@ -30,12 +30,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_XE_DDOTD_DHAMPIRS_VAMPIRES_RESIST_INFECTION_FOLLOWUP",
-    "condition": {
-      "and": [
-        { "u_has_effect": "zombie_virus" },
-        { "u_has_effect": "effect_xe_ddotd_zombie_virus_resistance" }
-      ]
-    },
+    "condition": { "and": [ { "u_has_effect": "zombie_virus" }, { "u_has_effect": "effect_xe_ddotd_zombie_virus_resistance" } ] },
     "effect": [
        { "if": { "x_in_y_chance": { "x": 1, "y": 4 } },
         "then": [

--- a/data/mods/Xedra_Evolved/mod_interactions/classic_zombies/eocs.json
+++ b/data/mods/Xedra_Evolved/mod_interactions/classic_zombies/eocs.json
@@ -13,7 +13,8 @@
     },
     "effect": [
       { "u_add_effect": "effect_xe_ddotd_zombie_virus_resistance", "duration": "49 hours" },
-      { "if": { "x_in_y_chance": { "x": 1, "y": 4 } },
+      {
+        "if": { "x_in_y_chance": { "x": 1, "y": 4 } },
         "then": [
           { "u_lose_effect": "zombie_virus" },
           { "u_lose_effect": "effect_xe_ddotd_zombie_virus_resistance" },

--- a/data/mods/Xedra_Evolved/mod_interactions/classic_zombies/eocs.json
+++ b/data/mods/Xedra_Evolved/mod_interactions/classic_zombies/eocs.json
@@ -32,7 +32,8 @@
     "id": "EOC_XE_DDOTD_DHAMPIRS_VAMPIRES_RESIST_INFECTION_FOLLOWUP",
     "condition": { "and": [ { "u_has_effect": "zombie_virus" }, { "u_has_effect": "effect_xe_ddotd_zombie_virus_resistance" } ] },
     "effect": [
-       { "if": { "x_in_y_chance": { "x": 1, "y": 4 } },
+      {
+        "if": { "x_in_y_chance": { "x": 1, "y": 4 } },
         "then": [
           { "u_lose_effect": "zombie_virus" },
           { "u_lose_effect": "effect_xe_ddotd_zombie_virus_resistance" },

--- a/data/mods/Xedra_Evolved/mod_interactions/classic_zombies/eocs.json
+++ b/data/mods/Xedra_Evolved/mod_interactions/classic_zombies/eocs.json
@@ -1,0 +1,46 @@
+[
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_XE_DDOTD_DHAMPIRS_VAMPIRES_RESIST_INFECTION",
+    "eoc_type": "EVENT",
+    "required_event": "character_gains_effect",
+    "condition": {
+      "and": [
+        { "u_has_any_trait": [ "VAMPIRE", "DHAMPIR_TRAIT" ] },
+        { "not": { "u_has_trait": "VAMPIRE4" } },
+        { "compare_string": [ "taint", { "zombie_virus": "effect" } ] }
+      ]
+    },
+    "effect": [
+      { "u_add_effect": "effect_xe_ddotd_zombie_virus_resistance", "duration": "49 hours" },
+      { "if": { "x_in_y_chance": { "x": 1, "y": 4 } },
+        "then": [
+          { "u_lose_effect": "zombie_virus" },
+          { "u_lose_effect": "effect_xe_ddotd_zombie_virus_resistance" },
+          { "u_message": "You've started feeling a bit better.  Maybe your unique condition has saved you from the zombie bite's inexorable…death this time.", "type": "good" }
+        ],
+        "else": { "run_eocs": "EOC_XE_DDOTD_DHAMPIRS_VAMPIRES_RESIST_INFECTION_FOLLOWUP", "time_in_future": "24 hours" }
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_XE_DDOTD_DHAMPIRS_VAMPIRES_RESIST_INFECTION_FOLLOWUP",
+    "condition": {
+      "and": [
+        { "u_has_effect": "zombie_virus" },
+        { "u_has_effect": "effect_xe_ddotd_zombie_virus_resistance" }
+      ]
+    },
+    "effect": [
+       { "if": { "x_in_y_chance": { "x": 1, "y": 4 } },
+        "then": [
+          { "u_lose_effect": "zombie_virus" },
+          { "u_lose_effect": "effect_xe_ddotd_zombie_virus_resistance" },
+          { "u_message": "You've started feeling a bit better.  Maybe your unique condition has saved you from the zombie bite's inexorable…death this time.", "type": "good" }
+        ],
+        "else": { "run_eocs": "EOC_XE_DDOTD_DHAMPIRS_VAMPIRES_RESIST_INFECTION_FOLLOWUP", "time_in_future": "24 hours" }
+      }
+    ]
+  }
+]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[XE/DDotD] Dhampirs and pre-undead vampires are resistant to the zombie infection"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Follow-up to #82416
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

When dhampirs and pre-undead vampires gain the Zombie Bite effect, they have a 25% chance to shake it off. They get another 25% chance to shake it off after 1 day, and another after 2 days. After that, they're stuck with whatever their results are. This works out to about a 60% resistance--good enough that you can get lucky, not good enough that you should be okay with getting bit.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Set interval of checks to 1 hour, got bitten waited 6 hours, bite cleared up. But it took a few hours, so again--this is not immunity.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Since the Fair Folk revive into draugr in DDA on death I'm not sure they should have any special resistance. Maybe non-homullus Paraclesians should also be resistant but homullus are just as susceptible as humans. 
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
