### PR TITLE
Improve keybind UI on debug wish menus

### DIFF
--- a/src/cata_imgui.cpp
+++ b/src/cata_imgui.cpp
@@ -72,7 +72,7 @@ static ImVec4 compute_color( uint8_t index )
     }
 }
 
-ImVec4 cataimgui::imvec4_from_color( nc_color &color )
+ImVec4 cataimgui::imvec4_from_color( const nc_color &color )
 {
     int pair_id = color.get_index();
     pairs &pair = colorpairs[pair_id];
@@ -239,7 +239,7 @@ RGBTuple color_loader<RGBTuple>::from_rgb( const int r, const int g, const int b
 #include <imgui/imgui_impl_sdl2.h>
 #include <imgui/imgui_impl_sdlrenderer2.h>
 
-ImVec4 cataimgui::imvec4_from_color( nc_color &color )
+ImVec4 cataimgui::imvec4_from_color( const nc_color &color )
 {
     SDL_Color c = curses_color_to_SDL( color );
     return { static_cast<float>( c.r / 255. ),
@@ -1251,4 +1251,29 @@ void cataimgui::init_colors()
         debugmsg( "Failed to load imgui color data from \"%s\": %s",
                   style_path.generic_u8string(), err.what() );
     }
+}
+
+void cataimgui::TextKeybinding( const input_context &ctxt,
+                                const char *action, const char *description, bool active,
+                                int max_limit, const nc_color &default_color )
+{
+    const nc_color color = active ? ACTIVE_HOTKEY_COLOR : default_color;
+    ImGui::TextColored( default_color, "[" );
+    ImGui::SameLine( 0, 0 );
+    ImGui::TextColored( color, "%s",
+                        // strlen(action) <= 1 // for non-action explicit keys
+                        ( *action == 0 || *( action + 1 ) == 0 ) ?
+                        action :
+                        ctxt.get_desc( action, max_limit ).c_str() );
+    ImGui::SameLine( 0, 0 );
+    ImGui::TextColored( default_color, "] " );
+    ImGui::SameLine( 0, 0 );
+    ImGui::TextColored( color, "%s", description );
+}
+
+void cataimgui::TextListSeparator( const nc_color &color )
+{
+    ImGui::SameLine( 0, 0 );
+    ImGui::TextColored( color, ", " );
+    ImGui::SameLine( 0, 0 );
 }

--- a/src/cata_imgui.h
+++ b/src/cata_imgui.h
@@ -5,6 +5,7 @@
 #include <vector>
 #include <unordered_map>
 
+#include "color.h"
 #include "font_loader.h"
 
 class nc_color;
@@ -99,7 +100,7 @@ class client
 void point_to_imvec2( point *src, ImVec2 *dest );
 void imvec2_to_point( ImVec2 *src, point *dest );
 
-ImVec4 imvec4_from_color( nc_color &color );
+ImVec4 imvec4_from_color( const nc_color &color );
 
 void set_scroll( scroll &s );
 
@@ -169,4 +170,25 @@ void EndRightAlign();
 // This loads the settings from `config/imgui_style.json` and - optionally - falls back to base colors
 // for elements not explicitly specified.
 void init_colors();
+
+/**
+ * Print out key(s) and description for a keybinding
+ * e.g. "[/] Filter"
+ * @param ctxt input context
+ * @param action action name, e.g. "FILTER", "QUIT"
+ * @param description action description, e.g. "Do thing", "Whatever else"
+ * @param active whether the action should be highlighted
+ * @param max_limit no more than this many keys will be printed
+ * @param default_color the color to use for non-highlighted actions
+ */
+void TextKeybinding( const input_context &ctxt,
+                     const char *action, const char *description, bool active,
+                     int max_limit = 0, const nc_color &default_color = c_light_gray );
+
+/**
+ * Print out a list separator, ", " in English
+ * The previous and next outputs will appear on the same line.
+ */
+void TextListSeparator( const nc_color &color = c_light_gray );
+
 } // namespace cataimgui

--- a/src/color.cpp
+++ b/src/color.cpp
@@ -30,7 +30,7 @@
 #include "uilist.h"
 #include "cata_imgui.h"
 
-nc_color::operator ImVec4()
+nc_color::operator ImVec4() const
 {
     return cataimgui::imvec4_from_color( *this );
 }

--- a/src/color.h
+++ b/src/color.h
@@ -368,7 +368,7 @@ class nc_color
     public:
         nc_color() : attribute_value( 0 ), index( 0 ) { }
 
-        operator ImVec4(); // NOLINT(google-explicit-constructor): the conversion is not expensive
+        operator ImVec4() const; // NOLINT(google-explicit-constructor): the conversion is not expensive
 
         // Most of the functions here are implemented in ncurses_def.cpp
         // (for ncurses builds) *and* in cursesport.cpp (for other builds).

--- a/src/uilist.h
+++ b/src/uilist.h
@@ -433,6 +433,7 @@ class uilist // NOLINT(cata-xy)
         std::optional<cataimgui::bounds> desired_bounds;
         bool desc_enabled = false;
 
+        std::string filter;
         bool filtering = false;
         bool filtering_nocase = false;
 
@@ -477,7 +478,6 @@ class uilist // NOLINT(cata-xy)
         weak_ptr_fast<uilist_impl> ui;
 
         std::unique_ptr<string_input_popup_imgui> filter_popup;
-        std::string filter;
 
         int max_entry_len = 0;
         int max_column_len = 0;

--- a/src/wish.cpp
+++ b/src/wish.cpp
@@ -243,14 +243,15 @@ class wish_mutate_callback: public uilist_callback
             ImGui::TextColored( c_green, "%s", msg.c_str() );
             msg.clear();
             input_context ctxt( menu->input_category, keyboard_mode::keycode );
-            ImGui::Text( _( "[%s] find, [%s] quit, [t] toggle base trait" ),
-                         ctxt.get_desc( "FILTER" ).c_str(), ctxt.get_desc( "QUIT" ).c_str() );
 
-            if( only_active ) {
-                ImGui::TextColored( c_green, "%s", _( "[a] show active traits (active)" ) );
-            } else {
-                ImGui::TextColored( c_white, "%s", _( "[a] show active traits" ) );
-            }
+            cataimgui::TextKeybinding( ctxt, "FILTER", _( "Find" ),
+                                       menu->filtering && ( !menu->filter.empty() ) );
+            cataimgui::TextListSeparator();
+            cataimgui::TextKeybinding( ctxt, "t",      _( "Toggle base trait" ),  false );
+            cataimgui::TextListSeparator();
+            cataimgui::TextKeybinding( ctxt, "a",      _( "Show active traits" ), only_active );
+            cataimgui::TextListSeparator();
+            cataimgui::TextKeybinding( ctxt, "QUIT",   _( "Quit" ),               false );
         }
 
         ~wish_mutate_callback() override = default;
@@ -725,9 +726,20 @@ class wish_monster_callback: public uilist_callback
                 ImGui::TextColored( c_green, "%s", msg.c_str() );
                 msg.clear();
                 input_context ctxt( menu->input_category, keyboard_mode::keycode );
-                ImGui::Text(
-                    _( "[%s] find, [f]riendly, [h]allucination, [i]ncrease group, [d]ecrease group, [%s] quit" ),
-                    ctxt.get_desc( "FILTER" ).c_str(), ctxt.get_desc( "QUIT" ).c_str() );
+
+                cataimgui::TextKeybinding( ctxt, "FILTER", _( "Find" ),
+                                           menu->filtering && ( !menu->filter.empty() ) );
+                cataimgui::TextListSeparator();
+                cataimgui::TextKeybinding( ctxt, "f",      _( "Friendly" ),       friendly );
+                cataimgui::TextListSeparator();
+                cataimgui::TextKeybinding( ctxt, "h",      _( "Hallucination" ),  hallucination );
+                cataimgui::TextListSeparator();
+                cataimgui::TextKeybinding( ctxt, "i",      _( "Increase Group" ), false );
+                cataimgui::TextListSeparator();
+                cataimgui::TextKeybinding( ctxt, "d",      _( "Decrease Group" ), false );
+                cataimgui::TextListSeparator();
+                cataimgui::TextKeybinding( ctxt, "QUIT",   _( "Quit" ),           false );
+
             }
             ImGui::EndChild();
         }
@@ -1062,13 +1074,19 @@ class wish_item_callback: public uilist_callback
 
             ImGui::TextColored( c_green, "%s", msg.c_str() );
             input_context ctxt( menu->input_category, keyboard_mode::keycode );
-            ImGui::Text( _( "[%s] find, [%s] container, [%s] flag, [%s] everything, [%s] snippet, [%s] quit" ),
-                         ctxt.get_desc( "FILTER" ).c_str(),
-                         ctxt.get_desc( "CONTAINER" ).c_str(),
-                         ctxt.get_desc( "FLAG" ).c_str(),
-                         ctxt.get_desc( "EVERYTHING" ).c_str(),
-                         ctxt.get_desc( "SNIPPET" ).c_str(),
-                         ctxt.get_desc( "QUIT" ).c_str() );
+
+            cataimgui::TextKeybinding( ctxt, "FILTER",     _( "Find" ),
+                                       menu->filtering && ( !menu->filter.empty() ) );
+            cataimgui::TextListSeparator();
+            cataimgui::TextKeybinding( ctxt, "CONTAINER",  _( "Container" ),  incontainer );
+            cataimgui::TextListSeparator();
+            cataimgui::TextKeybinding( ctxt, "FLAG",       _( "Flag" ),       !flags.empty() );
+            cataimgui::TextListSeparator();
+            cataimgui::TextKeybinding( ctxt, "EVERYTHING", _( "Everything" ), spawn_everything );
+            cataimgui::TextListSeparator();
+            cataimgui::TextKeybinding( ctxt, "SNIPPET",    _( "Snippet" ),    chosen_snippet_id.first != -1 );
+            cataimgui::TextListSeparator();
+            cataimgui::TextKeybinding( ctxt, "QUIT",       _( "Quit" ),       false );
         }
 };
 
@@ -1169,7 +1187,7 @@ void debug_menu::wishitem( Character *you, const tripoint_bub_ms &pos )
                 popup
                 .title( _( "How many?" ) )
                 .width( 20 )
-                .description( granted.tname() )
+                .description( cb.spawn_everything ? _( "Everything" ) : granted.tname() )
                 .edit( amount );
                 canceled = popup.canceled();
             }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Interface "UI keybind feedback when toggling options in debug menus"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
Originally: The debug item spawn (aka "wish") interface gives no visual indication the player has opted to spawn "everything".

Now: Same concern, but for all the toggle-able keybinds in all the wish menus.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
New `cataimgui::TextKeybindings` that will print out a list of keybinds with keys, descriptions, and optional highlight per entry. Used for the three wish menus with keybind printouts.

Also change the label in the "How many?" prompt for spawning item "Everything".

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
I started to put the actions, descriptions, and actives into a single `vector<tuple<string,string,bool>>` but that would require rebuilding everything when only the bools have changed.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->
I tested this thoroughly enough to trigger multiple existing adjacent bugs in the wish interface. I'm working on issues and/or PRs for those now and soon. Aside from those, this works as expected.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
Thanks to @db48x for feedback and guidance on the implementation.

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
