### PR TITLE
Place broken vehicles and trash on highways, correct highway vision level

### DIFF
--- a/data/json/itemgroups/Locations_MapExtras/locations.json
+++ b/data/json/itemgroups/Locations_MapExtras/locations.json
@@ -1388,7 +1388,8 @@
     "items": [
       { "group": "ammo_casings", "prob": 20 },
       { "group": "everyday_corpse", "prob": 1 },
-      { "group": "SUS_trash_floor", "prob": 60 },
+      { "group": "SUS_trash_floor", "prob": 30 },
+      { "group": "SUS_trash_trashcan", "prob": 30 },
       [ "jumper_cable", 5 ],
       [ "pipe", 10 ],
       [ "stereo", 6 ],
@@ -1428,7 +1429,9 @@
       [ "battery_car", 6 ],
       [ "one_year_old_newspaper", 2 ],
       { "item": "foodperson_mask", "prob": 1, "charges": [ 0, 500 ] },
-      [ "survnote", 1 ]
+      [ "survnote", 1 ],
+      [ "2x4", 5 ],
+      [ "splinter", 10 ]
     ]
   },
   {

--- a/data/json/itemgroups/SUS/trash.json
+++ b/data/json/itemgroups/SUS/trash.json
@@ -519,5 +519,36 @@
       { "item": "jar_glass_sealed", "prob": 2 },
       { "item": "jar_3l_glass_sealed", "prob": 1 }
     ]
+  },
+  {
+    "type": "item_group",
+    "id": "SUS_trash_highway_shoulder",
+    "//": "Trash that's often found on the side of the highway.",
+    "subtype": "distribution",
+    "items": [
+      [ "rubber_tire_chunk", 300 ],
+      [ "wrapper", 100 ],
+      [ "plastic_shopping_bag", 100 ],
+      { "group": "SUS_trash_trashcan", "prob": 50 },
+      [ "plastic_chunk", 50 ],
+      { "item": "cup_plastic", "prob": 50, "count": [ 1, 3 ] },
+      [ "jug_plastic", 5 ],
+      { "item": "bottle_plastic", "prob": 50, "count": [ 1, 3 ] },
+      { "item": "bottle_plastic_small", "prob": 10, "count": [ 1, 5 ] },
+      [ "can_drink", 50 ],
+      [ "can_food", 50 ],
+      [ "box_cigarette", 50 ],
+      [ "bubblewrap", 5 ],
+      [ "flyer", 5 ],
+      [ "lc_steel_lump", 50 ],
+      [ "lc_steel_chunk", 50 ],
+      [ "cardboard", 25 ],
+      [ "bag_zipper", 25 ],
+      [ "box_snack", 25 ],
+      [ "box_small", 10 ],
+      [ "box_small_folded", 10 ],
+      [ "box_medium_folded", 5 ],
+      [ "box_large_folded", 5 ]
+    ]
   }
 ]

--- a/data/json/mapgen/highway/highway.json
+++ b/data/json/mapgen/highway/highway.json
@@ -48,7 +48,12 @@
       ],
       "palettes": [ "highway_palette" ],
       "place_nested": [ { "chunks": [ "24x24_highway_road_bridge_ramp" ], "x": 0, "y": 0, "neighbors": { "above": "hw_road_bridge" } } ],
-      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ]
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
+      "place_items": [
+        { "item": "SUS_trash_highway_shoulder", "x": [ 0, 9 ], "y": [ 0, 23 ], "chance": 10, "repeat": [ 0, 32 ] },
+        { "item": "road", "x": [ 8, 23 ], "y": [ 0, 23 ], "chance": 20 }
+      ],
+      "place_vehicles": [ { "vehicle": "highway", "x": 10, "y": 10, "fuel": -1, "status": 1, "chance": 10, "rotation": 270 } ]
     }
   },
   {

--- a/data/json/overmap/overmap_terrain/overmap_terrain_transportation.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_transportation.json
@@ -561,7 +561,8 @@
     "sym": "│",
     "color": "light_gray",
     "//": "SHOULD_NOT_SPAWN is to temporarily avoid overmap_test failures",
-    "flags": [ "HIGHWAY" ]
+    "flags": [ "HIGHWAY" ],
+    "vision_levels": "blends_till_outlines"
   },
   {
     "type": "overmap_terrain",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Content "Place trash on highways, correct highway vision level"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Highways are completely barren as-is, there realistically should be trash along them.
Also, highways currently inherit the wrong vision level and therefore display as fields.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Place existing road trash group in the highway road, and a new trash group for the "shoulder" of the highway consisting mostly of tire rubber and plastic containers.

Add correct vision levels for highway OMTs.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Trash frequency can be adjusted in the future; it is currently significantly less than trash around streams.

As for vehicles, I used the existing `highway` vehicle group, which could also be adjusted. It's tough to find a realistic line between "highways are fully backed up from people fleeing cities" and "autodrive can effectively use the highway".

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

These are more or less a representative sample:

<img width="1360" height="728" alt="Screenshot 2025-08-13 201538" src="https://github.com/user-attachments/assets/9c58f3be-f69b-48c6-873c-676c3f3b8ac9" />
<img width="1360" height="728" alt="Screenshot 2025-08-13 201604" src="https://github.com/user-attachments/assets/729da147-8662-4d10-be79-a932c0ac479d" />


<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
