### PR TITLE
Allow professions with multiple achievement requirements

### DIFF
--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -1346,7 +1346,7 @@
     "type": "profession",
     "id": "major-general",
     "name": "Major General",
-    "requirement": "achievement_reach_military_bunker",
+    "requirement": [ "achievement_reach_military_bunker", "achievement_reach_military_base" ],
     "description": "You worked your way up through the ranks from a no-name private to a big shot Major General, respected and decorated.  On the downside, years of desk duty have left your shooting skills rusty, and all the medals in the world won't protect you now.",
     "npc_background": "BG_survival_story_SOLDIER",
     "points": 4,

--- a/doc/JSON/JSON_INFO.md
+++ b/doc/JSON/JSON_INFO.md
@@ -1965,7 +1965,7 @@ The following properties (mandatory, except if noted otherwise) are supported:
     "flags": [ "SCEN_ONLY", "NO_BONUS_ITEMS" ],                // (optional) Array of flags applied to the character, for character creation purposes
     "CBMs": [ "bio_fuel_cell_blood" ],                         // (optional) Array of starting implanted CMBs
     "traits": [ "PROF_CHURL", "ILLITERATE" ],                  // (optional) Array of starting traits/mutations. For further information, see mutations.json and MUTATIONS.md. Note: "trait" is also supported, used for a single trait/mutation ID (legacy!)
-    "requirement": "achievement_survive_28_days",              // (optional) String of an achievement ID required to unlock this profession
+    "requirement": "achievement_survive_28_days",              // (optional) String or Array of String of achievement ID(s) required to unlock this profession
     "hard_requirement": true,                                  // (optional) Defaults false. Whether or not the requirement ignores the metaprogression setting and is always required. Intended for use by mods.
     "effect_on_conditions": [ "scenario_assassin_conv" ],      // (optional) eoc id, inline eoc, or multiple of them, that would run when scenario starts
     "spells": [                                                // (optional) Array of starting spell IDs the character knows upon creation. For further information, see MAGIC.md

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -2276,12 +2276,17 @@ static std::string assemble_profession_details( const avatar &u, const input_con
                                 profession_name ) + "\n";
     assembled += string_format( dress_switch_msg(), ctxt.get_desc( "CHANGE_OUTFIT" ) ) + "\n";
 
-    if( sorted_profs[cur_id]->get_requirement().has_value() ) {
+    if( !sorted_profs[cur_id]->get_requirements().empty() ) {
         assembled += "\n" + colorize( _( "Profession requirements:" ), COL_HEADER ) + "\n";
         ret_val<void> can_pick_prof = sorted_profs[cur_id]->can_pick();
         if( can_pick_prof.success() ) {
-            assembled += colorize( string_format( _( "Completed \"%s\"\n" ),
-                                                  sorted_profs[cur_id]->get_requirement().value()->name() ),
+            std::vector<std::string> req_names;
+            for( const auto &req : sorted_profs[cur_id]->get_requirements() ) {
+                req_names.emplace_back( req->name().translated() );
+            }
+            assembled += colorize( string_format( n_gettext( _( "Completed \"%s\"\n" ), _( "Completed: %s\n" ),
+                                                  req_names.size() ),
+                                                  enumerate_as_string( req_names ) ),
                                    c_green ) + "\n";
         } else { // fail, can't pick so display ret_val's reason
             assembled += colorize( can_pick_prof.str(), c_red ) + "\n";

--- a/src/profession.h
+++ b/src/profession.h
@@ -66,7 +66,7 @@ class profession
         itype_id no_bonus; // See profession::items and class json_item_substitution in profession.cpp
 
         // does this profession require a specific achiement to unlock
-        std::optional<achievement_id> _requirement;
+        std::vector<achievement_id> _requirements;
         // does this profession require the requirement even when metaprogression is disabled?
         bool hard_requirement = false;
         bool _chargen_allow_npc = true;
@@ -140,7 +140,7 @@ class profession
 
         std::vector<std::pair<string_id<profession>, mod_id>> src;
 
-        std::optional<achievement_id> get_requirement() const;
+        std::vector<achievement_id> get_requirements() const;
 
         std::map<spell_id, int> spells() const;
         void learn_spells( avatar &you ) const;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Content "Professions can have multiple achievement requirements"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
#82441 needs to be able to specify multiple requirements for a profession to make meta progression more interesting.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
Store requirements as a `vector` instead of an `optional`.
Change one existing profession to have two requirements.
Update the display of requirements with a variation for a list.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
I decided not to rename the json field to `requirements` to reduce churn.
I decided to only implement "and" semantics for now. If someone needs "or" semantics later then the structure will get more complex.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->
I temporarily modified some existing profession definitions:
<img width="984" height="97" alt="image" src="https://github.com/user-attachments/assets/d5913dac-a543-4da9-acee-b049b81b874f" />
<img width="982" height="98" alt="image" src="https://github.com/user-attachments/assets/3d39fb43-555c-4790-b29b-17e3e66f7d52" />

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
