### PR TITLE
[Mods] Add `SUFFOCATION_IMMUNE` and `INHALED_TOXIN_IMMUNE` flags, apply to appropriate places in mods.

### DIFF
--- a/data/json/field_type.json
+++ b/data/json/field_type.json
@@ -454,7 +454,7 @@
     "has_fume": true,
     "percent_spread": 90,
     "dirty_transparency_cache": true,
-    "immunity_data": { "body_part_env_resistance": [ [ "mouth", 15 ] ] }
+    "immunity_data": { "body_part_env_resistance": [ [ "mouth", 15 ] ], "flags": [ "INHALED_TOXIN_IMMUNE" ] }
   },
   {
     "id": "fd_rubble",
@@ -512,7 +512,7 @@
             "intensity": 1,
             "min_duration": "2 seconds",
             "max_duration": "2 seconds",
-            "immunity_data": { "body_part_env_resistance": [ [ "mouth", 3 ] ] },
+            "immunity_data": { "body_part_env_resistance": [ [ "mouth", 3 ] ], "flags": [ "INHALED_TOXIN_IMMUNE" ] },
             "immune_inside_vehicle": true
           }
         ]
@@ -539,7 +539,7 @@
             "intensity": 2,
             "min_duration": "7 seconds",
             "max_duration": "7 seconds",
-            "immunity_data": { "body_part_env_resistance": [ [ "mouth", 5 ] ] },
+            "immunity_data": { "body_part_env_resistance": [ [ "mouth", 5 ] ], "flags": [ "INHALED_TOXIN_IMMUNE" ] },
             "immune_inside_vehicle": true
           }
         ],
@@ -566,7 +566,7 @@
             "intensity": 4,
             "min_duration": "15 seconds",
             "max_duration": "15 seconds",
-            "immunity_data": { "body_part_env_resistance": [ [ "mouth", 7 ] ] },
+            "immunity_data": { "body_part_env_resistance": [ [ "mouth", 7 ] ], "flags": [ "INHALED_TOXIN_IMMUNE" ] },
             "immune_inside_vehicle": true
           }
         ],
@@ -617,7 +617,7 @@
             "min_duration": "2 minutes",
             "max_duration": "2 minutes",
             "immune_inside_vehicle": true,
-            "immunity_data": { "body_part_env_resistance": [ [ "mouth", 15 ] ] },
+            "immunity_data": { "body_part_env_resistance": [ [ "mouth", 15 ] ], "flags": [ "INHALED_TOXIN_IMMUNE" ] },
             "message": "You feel sick from inhaling the hazy cloud.",
             "message_type": "bad"
           }
@@ -648,7 +648,7 @@
             "min_duration": "3 minutes",
             "max_duration": "3 minutes",
             "immune_inside_vehicle": true,
-            "immunity_data": { "body_part_env_resistance": [ [ "mouth", 15 ] ] },
+            "immunity_data": { "body_part_env_resistance": [ [ "mouth", 15 ] ], "flags": [ "INHALED_TOXIN_IMMUNE" ] },
             "message": "You feel sick from inhaling the toxic gas.",
             "message_type": "bad"
           }
@@ -692,7 +692,7 @@
             "max_duration": "3 minutes",
             "//": "won't be applied outside of vehicles, so it could apply harsher effect",
             "immune_outside_vehicle": true,
-            "immunity_data": { "body_part_env_resistance": [ [ "mouth", 15 ] ] },
+            "immunity_data": { "body_part_env_resistance": [ [ "mouth", 15 ] ], "flags": [ "INHALED_TOXIN_IMMUNE" ] },
             "message": "You feel sick from inhaling the thick toxic gas.",
             "message_type": "bad"
           },
@@ -704,7 +704,7 @@
             "max_duration": "3 minutes",
             "//": "won't be applied inside of vehicles, so it could apply lesser effect",
             "immune_inside_vehicle": true,
-            "immunity_data": { "body_part_env_resistance": [ [ "mouth", 15 ] ] },
+            "immunity_data": { "body_part_env_resistance": [ [ "mouth", 15 ] ], "flags": [ "INHALED_TOXIN_IMMUNE" ] },
             "message": "You feel sick from inhaling the thick toxic gas.",
             "message_type": "bad"
           }
@@ -774,7 +774,7 @@
     "outdoor_age_speedup": "3 minutes",
     "dirty_transparency_cache": true,
     "has_fume": true,
-    "immunity_data": { "body_part_env_resistance": [ [ "mouth", 15 ] ] },
+    "immunity_data": { "body_part_env_resistance": [ [ "mouth", 15 ] ], "flags": [ "INHALED_TOXIN_IMMUNE" ] },
     "priority": 8,
     "half_life": "10 minutes",
     "phase": "gas",
@@ -808,7 +808,7 @@
           {
             "effect_id": "teargas",
             "body_part": "mouth",
-            "immunity_data": { "body_part_env_resistance": [ [ "mouth", 15 ] ] },
+            "immunity_data": { "body_part_env_resistance": [ [ "mouth", 15 ] ], "flags": [ "INHALED_TOXIN_IMMUNE" ] },
             "intensity": 1,
             "min_duration": "2 minutes",
             "max_duration": "5 minutes",
@@ -840,7 +840,7 @@
           {
             "effect_id": "teargas",
             "body_part": "mouth",
-            "immunity_data": { "body_part_env_resistance": [ [ "mouth", 15 ] ] },
+            "immunity_data": { "body_part_env_resistance": [ [ "mouth", 15 ] ], "flags": [ "INHALED_TOXIN_IMMUNE" ] },
             "intensity": 1,
             "min_duration": "5 minutes",
             "max_duration": "15 minutes",
@@ -871,7 +871,7 @@
           {
             "effect_id": "teargas",
             "body_part": "mouth",
-            "immunity_data": { "body_part_env_resistance": [ [ "mouth", 15 ] ] },
+            "immunity_data": { "body_part_env_resistance": [ [ "mouth", 15 ] ], "flags": [ "INHALED_TOXIN_IMMUNE" ] },
             "intensity": 1,
             "min_duration": "15 minutes",
             "max_duration": "20 minutes",
@@ -941,7 +941,7 @@
     "wandering_field": "fd_toxic_gas",
     "gas_absorption_factor": "80m",
     "dirty_transparency_cache": true,
-    "immunity_data": { "body_part_env_resistance": [ [ "mouth", 15 ] ] },
+    "immunity_data": { "body_part_env_resistance": [ [ "mouth", 15 ] ], "flags": [ "INHALED_TOXIN_IMMUNE" ] },
     "phase": "gas",
     "display_items": false,
     "display_field": true,
@@ -1484,7 +1484,7 @@
     "outdoor_age_speedup": "5 minutes",
     "dirty_transparency_cache": true,
     "has_fume": true,
-    "immunity_data": { "body_part_env_resistance": [ [ "mouth", 15 ] ] },
+    "immunity_data": { "body_part_env_resistance": [ [ "mouth", 15 ] ], "flags": [ "INHALED_TOXIN_IMMUNE" ] },
     "priority": 8,
     "half_life": "50 minutes",
     "phase": "gas",
@@ -1506,7 +1506,7 @@
     "outdoor_age_speedup": "1 minutes",
     "dirty_transparency_cache": true,
     "has_fume": true,
-    "immunity_data": { "body_part_env_resistance": [ [ "mouth", 15 ] ] },
+    "immunity_data": { "body_part_env_resistance": [ [ "mouth", 15 ] ], "flags": [ "INHALED_TOXIN_IMMUNE" ] },
     "priority": 8,
     "half_life": "15 minutes",
     "phase": "gas",
@@ -1550,7 +1550,10 @@
     "outdoor_age_speedup": "5 turns",
     "dirty_transparency_cache": true,
     "has_fume": true,
-    "immunity_data": { "flags": [ "MYCUS_IMMUNE" ], "body_part_env_resistance": [ [ "mouth", 15 ], [ "sensor", 15 ] ] },
+    "immunity_data": {
+      "flags": [ "MYCUS_IMMUNE", "INHALED_TOXIN_IMMUNE" ],
+      "body_part_env_resistance": [ [ "mouth", 15 ], [ "sensor", 15 ] ]
+    },
     "priority": 8,
     "half_life": "4 minutes",
     "phase": "gas",
@@ -1625,7 +1628,10 @@
     "outdoor_age_speedup": "4 minutes",
     "dirty_transparency_cache": true,
     "has_fume": true,
-    "immunity_data": { "flags": [ "MYCUS_IMMUNE" ], "body_part_env_resistance": [ [ "mouth", 15 ], [ "sensor", 15 ] ] },
+    "immunity_data": {
+      "flags": [ "MYCUS_IMMUNE", "INHALED_TOXIN_IMMUNE" ],
+      "body_part_env_resistance": [ [ "mouth", 15 ], [ "sensor", 15 ] ]
+    },
     "priority": 8,
     "half_life": "15 minutes",
     "phase": "gas",
@@ -1831,7 +1837,7 @@
     "outdoor_age_speedup": "3 minutes",
     "dirty_transparency_cache": true,
     "has_fume": true,
-    "immunity_data": { "body_part_env_resistance": [ [ "mouth", 15 ] ] },
+    "immunity_data": { "body_part_env_resistance": [ [ "mouth", 15 ] ], "flags": [ "INHALED_TOXIN_IMMUNE" ] },
     "priority": 8,
     "half_life": "10 minutes",
     "phase": "gas"
@@ -1851,7 +1857,7 @@
     "outdoor_age_speedup": "1 minutes",
     "dirty_transparency_cache": true,
     "has_fume": true,
-    "immunity_data": { "body_part_env_resistance": [ [ "mouth", 15 ] ] },
+    "immunity_data": { "body_part_env_resistance": [ [ "mouth", 15 ] ], "flags": [ "INHALED_TOXIN_IMMUNE" ] },
     "priority": 8,
     "half_life": "30 minutes",
     "phase": "gas",
@@ -1873,7 +1879,7 @@
     "outdoor_age_speedup": "1 minutes",
     "dirty_transparency_cache": true,
     "has_fume": true,
-    "immunity_data": { "body_part_env_resistance": [ [ "mouth", 15 ] ] },
+    "immunity_data": { "body_part_env_resistance": [ [ "mouth", 15 ] ], "flags": [ "INHALED_TOXIN_IMMUNE" ] },
     "priority": 8,
     "half_life": "30 minutes",
     "phase": "gas",
@@ -2054,7 +2060,7 @@
     "percent_spread": 25,
     "outdoor_age_speedup": "1 minutes",
     "dirty_transparency_cache": true,
-    "immunity_data": { "body_part_env_resistance": [ [ "mouth", 15 ] ] },
+    "immunity_data": { "body_part_env_resistance": [ [ "mouth", 15 ] ], "flags": [ "INHALED_TOXIN_IMMUNE" ] },
     "has_fume": true,
     "priority": 8,
     "half_life": "15 minutes",

--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -2535,6 +2535,16 @@
     "info": "You have nonhuman ancestry or are not human"
   },
   {
+    "id": "SUFFOCATION_IMMUNE",
+    "type": "json_flag",
+    "info": "You are immune to being crowd-crushed"
+  },
+  {
+    "id": "SUFFOCATION_IMMUNE",
+    "type": "json_flag",
+    "info": "You are immune to being crowd-crushed"
+  },
+  {
     "id": "TREE_COMMUNION_PLUS",
     "type": "json_flag",
     "info": "You gain greatly enhanced effects from the Mycorrhizal Communion mutation"

--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -2540,9 +2540,9 @@
     "info": "You are immune to being crowd-crushed"
   },
   {
-    "id": "SUFFOCATION_IMMUNE",
+    "id": "INHALED_TOXIN_IMMUNE",
     "type": "json_flag",
-    "info": "You are immune to being crowd-crushed"
+    "info": "You are immune to gaseous toxins"
   },
   {
     "id": "TREE_COMMUNION_PLUS",

--- a/data/mods/MindOverMatter/effects/effects_psionic.json
+++ b/data/mods/MindOverMatter/effects/effects_psionic.json
@@ -155,11 +155,11 @@
   {
     "type": "effect_type",
     "id": "effect_biokin_breathe_skin",
-    "//": "effect used as tracker",
     "name": [ "Oxygen Absorption" ],
     "desc": [ "You can absorb oxygen through your skin." ],
     "rating": "good",
-    "max_duration": "7 days"
+    "max_duration": "7 days",
+    "flags": [ "GILLS", "SUFFOCATION_IMMUNE" ]
   },
   {
     "type": "effect_type",
@@ -428,23 +428,10 @@
     "max_intensity": 50,
     "dur_add_perc": 10,
     "int_dur_factor": "9 s",
-    "blocks_effects": [
-      "smoke_eyes",
-      "smoke_lungs",
-      "teargas",
-      "boomered",
-      "migo_atmosphere",
-      "fetid_goop",
-      "relax_gas",
-      "spores",
-      "dermatik",
-      "tpollen",
-      "poison",
-      "badpoison"
-    ],
+    "blocks_effects": [ "smoke_eyes", "teargas", "boomered", "fetid_goop", "spores", "dermatik" ],
     "removes_effects": [ "bleed" ],
     "//": "Gills here because they're holding their breath",
-    "flags": [ "NO_SCENT", "ELECTRIC_IMMUNE", "RAD_RESIST", "GILLS", "WALK_UNDERWATER" ]
+    "flags": [ "NO_SCENT", "ELECTRIC_IMMUNE", "RAD_RESIST", "GILLS", "WALK_UNDERWATER", "INHALED_TOXIN_IMMUNE" ]
   },
   {
     "type": "effect_type",

--- a/data/mods/MindOverMatter/items/psions_summon_items.json
+++ b/data/mods/MindOverMatter/items/psions_summon_items.json
@@ -1,33 +1,5 @@
 [
   {
-    "id": "biokin_breathe_skin_item",
-    "type": "ITEM",
-    "subtypes": [ "TOOL", "ARMOR" ],
-    "name": { "str_sp": "[Ψ]oxygen absorption" },
-    "description": "You are breathing through your skin.",
-    "weight": "0 g",
-    "volume": "0 L",
-    "price": "1 cent",
-    "price_postapoc": "1 cent",
-    "symbol": "[",
-    "color": "pink",
-    "flags": [
-      "PERSONAL",
-      "UNBREAKABLE",
-      "ZERO_WEIGHT",
-      "ALLOWS_NATURAL_ATTACKS",
-      "INTEGRATED",
-      "PADDED",
-      "SEMITANGIBLE",
-      "REBREATHER",
-      "WATER_FRIENDLY",
-      "NO_DROP"
-    ],
-    "max_worn": 1,
-    "environmental_protection": -5,
-    "armor": [ { "encumbrance": 0, "coverage": 0, "covers": [ "mouth", "head", "torso", "arm_l", "arm_r", "leg_l", "leg_r" ] } ]
-  },
-  {
     "id": "biokin_hammerhand_item",
     "type": "ITEM",
     "subtypes": [ "TOOL", "ARMOR" ],

--- a/data/mods/MindOverMatter/obsolete/items.json
+++ b/data/mods/MindOverMatter/obsolete/items.json
@@ -18,5 +18,11 @@
       "electrokinetic_ups_6"
     ],
     "replace": "manual_swimming"
+  },
+  {
+    "type": "MIGRATION",
+    "//": "remove after 0.J",
+    "id": [ "biokin_breathe_skin_item" ],
+    "replace": "manual_swimming"
   }
 ]

--- a/data/mods/MindOverMatter/powers/biokinesis_concentration_eocs.json
+++ b/data/mods/MindOverMatter/powers/biokinesis_concentration_eocs.json
@@ -153,7 +153,6 @@
       { "u_message": "As you seal your lips, your chest still rises and falls.", "type": "good" },
       { "run_eocs": "EOC_POWER_MAINTENANCE_PLUS_ONE" },
       { "u_add_effect": "effect_biokin_breathe_skin", "duration": "PERMANENT" },
-      { "u_spawn_item": "biokin_breathe_skin_item", "suppress_message": true, "force_equip": true },
       { "u_lose_effect": "biokin_sealed_system" },
       {
         "run_eocs": "EOC_BIOKIN_BREATH_SKIN_DRAIN",
@@ -177,11 +176,7 @@
     "type": "effect_on_condition",
     "id": "EOC_BIOKIN_REMOVE_BREATHE_SKIN",
     "condition": { "u_has_effect": "effect_biokin_breathe_skin" },
-    "effect": [
-      { "run_eocs": "EOC_POWER_MAINTENANCE_MINUS_ONE" },
-      { "u_lose_effect": "effect_biokin_breathe_skin" },
-      { "u_remove_item_with": "biokin_breathe_skin_item" }
-    ]
+    "effect": [ { "run_eocs": "EOC_POWER_MAINTENANCE_MINUS_ONE" }, { "u_lose_effect": "effect_biokin_breathe_skin" } ]
   },
   {
     "type": "effect_on_condition",

--- a/data/mods/Xedra_Evolved/effects/effects.json
+++ b/data/mods/Xedra_Evolved/effects/effects.json
@@ -2023,7 +2023,7 @@
     "remove_message": "Your body regains its solidity.",
     "rating": "good",
     "enchantments": [ { "values": [ { "value": "MOVE_COST", "multiply": -0.8 }, { "value": "EVASION", "add": 1 } ] } ],
-    "flags": [ "ETHEREAL", "INVISIBLE", "LEVITATION", "CLIMB_FLYING" ]
+    "flags": [ "ETHEREAL", "INVISIBLE", "LEVITATION", "CLIMB_FLYING", "INHALED_TOXIN_IMMUNE" ]
   },
   {
     "type": "effect_type",

--- a/data/mods/Xedra_Evolved/items/armor/integrated.json
+++ b/data/mods/Xedra_Evolved/items/armor/integrated.json
@@ -828,23 +828,6 @@
     "armor": [ { "covers": [ "torso" ], "coverage": 0, "encumbrance": 0 } ]
   },
   {
-    "id": "integrated_nobreathe",
-    "type": "ITEM",
-    "subtypes": [ "ARMOR" ],
-    "category": "armor",
-    "name": { "str_sp": "vestigial lungs" },
-    "description": "Breathing is now something you decide to do, rather than a biological necessity.",
-    "volume": "1 ml",
-    "price": "0 cent",
-    "price_postapoc": "0 cent",
-    "material": [ "flesh" ],
-    "symbol": "o",
-    "color": "magenta",
-    "flags": [ "INTEGRATED", "REBREATHER", "UNBREAKABLE", "PERSONAL", "NO_SALVAGE", "TRADER_AVOID" ],
-    "environmental_protection": 15,
-    "armor": [ { "encumbrance": 0, "coverage": 100, "covers": [ "mouth" ] } ]
-  },
-  {
     "id": "integrated_claws_werewolf",
     "type": "ITEM",
     "subtypes": [ "ARMOR" ],

--- a/data/mods/Xedra_Evolved/mutations/mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/mutations.json
@@ -1260,9 +1260,8 @@
     "valid": false,
     "name": { "str": "Facultative Breathing" },
     "description": "You do not need to breathe air to live anymore.  It prevents you from being drowned or suffocated and allows you to ignore inhaled gases.",
-    "flags": [ "GILLS" ],
-    "cancels": [ "ASTHMA" ],
-    "integrated_armor": [ "integrated_nobreathe" ]
+    "flags": [ "GILLS", "SUFFOCATION_IMMUNE", "INHALED_TOXIN_IMMUNE" ],
+    "cancels": [ "ASTHMA" ]
   },
   {
     "type": "mutation",

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/ierde_mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/ierde_mutations.json
@@ -738,7 +738,16 @@
     "valid": false,
     "enchantments": [ "ench_ierde_stone_form" ],
     "override_look": { "id": "mon_stonegolem", "tile_category": "monster" },
-    "flags": [ "ACID_IMMUNE", "BIO_IMMUNE", "COLD_IMMUNE", "STAB_IMMUNE", "BULLET_IMMUNE" ]
+    "flags": [
+      "ACID_IMMUNE",
+      "BIO_IMMUNE",
+      "COLD_IMMUNE",
+      "STAB_IMMUNE",
+      "BULLET_IMMUNE",
+      "SUFFOCATION_IMMUNE",
+      "INHALED_TOXIN_IMMUNE",
+      "GILLS"
+    ]
   },
   {
     "type": "mutation",

--- a/data/mods/Xedra_Evolved/obsoletion_and_migration/items.json
+++ b/data/mods/Xedra_Evolved/obsoletion_and_migration/items.json
@@ -1,0 +1,7 @@
+[
+  {
+    "id": [ "integrated_nobreathe" ],
+    "type": "MIGRATION",
+    "replace": "manual_swimming"
+  }
+]

--- a/doc/JSON/JSON_FLAGS.md
+++ b/doc/JSON/JSON_FLAGS.md
@@ -389,6 +389,7 @@ Character flags can be `trait_id`, `json_flag_id` or `flag_id`.  Some of these a
 - ```HERITAGE``` Turns a mutation with this flag light cyan on the list.  Currently used in mods for mutations that indicate non-human ancestry.
 - ```HUGE``` Changes your size to `creature_size::huge`.  Checked last of the size category flags, if no size flags are found your size defaults to `creature_size::medium`.
 - ```HYPEROPIC``` You are far-sighted: close combat is hampered and reading is impossible without glasses.
+- ```INHALED_TOXIN_IMMUNE``` You are immune to any inhaled toxin that mouth environmental resistance would also protect against.
 - ```IMMUNE_HEARING_DAMAGE``` Immune to hearing damage from loud sounds.
 - ```IMMUNE_SPOIL``` You are immune to negative outcomes from spoiled food.
 - ```INFECTION_IMMUNE``` This mutation grants immunity to infections, including infection from bites and tetanus.
@@ -440,6 +441,7 @@ Character flags can be `trait_id`, `json_flag_id` or `flag_id`.  Some of these a
 - ```STEADY``` Your speed can never go below base speed, bonuses from effects etc can still apply.
 - ```STOP_SLEEP_DEPRIVATION``` Stops Sleep Deprivation while awake and boosts it while sleeping.
 - ```STRICT_HUMANITARIAN``` You can eat foodstuffs tagged with `STRICT_HUMANITARIANISM` without morale penalties.
+- ```SUFFOCATION_IMMUNE``` You cannot suffocate by being crushed from multiple enemies.
 - ```SUNBURN``` TBD, probably related to `ALBINO`.
 - ```SUPER_CLAIRVOYANCE``` Gives a super clairvoyance effect (works with multiple z-levels), used for debug purposes.
 - ```SAFECRACK_NO_TOOL``` Allows to open safes without stethoscope.

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -369,7 +369,7 @@ void suffer::while_grabbed( Character &you )
     }
 
     // if you don't need to breathe, you can't suffocate from being crushed
-    if( you.has_flag( json_flag_SUFFOCATION_IMMUNE) ) { 
+    if( you.has_flag( json_flag_SUFFOCATION_IMMUNE ) ) {
         return;
     }
 

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -130,6 +130,7 @@ static const json_character_flag json_flag_MEND_LIMB( "MEND_LIMB" );
 static const json_character_flag json_flag_NYCTOPHOBIA( "NYCTOPHOBIA" );
 static const json_character_flag json_flag_PAIN_IMMUNE( "PAIN_IMMUNE" );
 static const json_character_flag json_flag_RAD_DETECT( "RAD_DETECT" );
+static const json_character_flag json_flag_SUFFOCATION_IMMUNE( "SUFFOCATION_IMMUNE" );
 static const json_character_flag json_flag_SUNBURN( "SUNBURN" );
 
 static const morale_type morale_feeling_bad( "morale_feeling_bad" );
@@ -366,6 +367,12 @@ void suffer::while_grabbed( Character &you )
     if( crowd < crush_grabs_req ) {
         return;
     }
+
+    // if you don't need to breathe, you can't suffocate from being crushed
+    if( you.has_flag( json_flag_SUFFOCATION_IMMUNE) ) { 
+        return;
+    }
+
     // Getting crushed against the wall counts as a monster
     if( impassable_ter ) {
         you.add_msg_if_player( m_bad, _( "You're crushed against the walls!" ) );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[Mods] Add `SUFFOCATION_IMMUNE` and `INHALED_TOXIN_IMMUNE` flags, apply to appropriate places in mods."

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

I'm tired of fake integrated_armor respirators, we can do better than that.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add `SUFFOCATION_IMMUNE` and `INHALED_TOXIN_IMMUNE` flags for use by various creatures or supernatural powers that remove the need to breathe and implement them across Mind Over Matter and Xedra Evolved.

If you have the `SUFFOCATION_IMMUNE` flag, then you are immune to crowd-crushing. The MoM power Oxygen Absorption grants this flag, as does the Ierde `Form of the Solid Earth` and the vampire power `Facultative Breathing`

If you have the `INHALED_TOXIN_IMMUNE` flag, you are immune to anything that 15 mouth environmental resistance would protect you from, like teargas, smoke, poison gas, etc. Note that this does _not_ protect your eyes. The MoM power Sealed System grants this flag, as does the Ierde `Form of the Solid Earth`, the Sylph `Body of Clouds`, and the vampire power `Facultative Breathing`
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Gave self the Facultative Breathing trait, swam across a river and did not drown, threw a smoke grenade and only got eye irritation, ran through triffid pollen with no problems. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Teargas could probably do with separating into eye and mouth effects like smoke. Right now both say "you inhale a lungful of tear gas" even when it only affects your eyes. 
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
