### PR TITLE
Evac flyer

### DIFF
--- a/data/json/furniture_and_terrain/furniture-signs.json
+++ b/data/json/furniture_and_terrain/furniture-signs.json
@@ -97,7 +97,7 @@
         { "item": "2x4", "count": [ 0, 3 ] },
         { "item": "nail", "charges": [ 4, 6 ] },
         { "item": "splinter", "count": [ 1, 4 ] },
-        { "item": "paper", "count": [ 1, 4 ] }
+        { "item": "flyer_evac", "count": [ 1, 4 ] }
       ],
       "hit_field": [ "fd_dust", 2 ],
       "destroyed_field": [ "fd_splinters", 1 ]

--- a/data/json/itemgroups/SUS/trash.json
+++ b/data/json/itemgroups/SUS/trash.json
@@ -64,6 +64,7 @@
       { "//": "Lore items" },
       { "group": "SUS_book_nonf_zine_news", "prob": 5 },
       { "item": "flyer", "prob": 5 },
+      { "item": "flyer_evac", "prob": 10 },
       { "item": "survnote", "prob": 1 }
     ]
   },
@@ -126,7 +127,8 @@
       { "item": "cig_butt", "prob": 20, "count": [ 3, 6 ] },
       { "//": "Lore items" },
       { "group": "SUS_book_nonf_zine_news", "prob": 20 },
-      { "item": "flyer", "prob": 20, "count": [ 1, 3 ] }
+      { "item": "flyer", "prob": 20, "count": [ 1, 3 ] },
+      { "item": "flyer_evac", "prob": 20, "count": [ 1, 3 ] }
     ]
   },
   {

--- a/data/json/itemgroups/books.json
+++ b/data/json/itemgroups/books.json
@@ -1132,6 +1132,7 @@
     "entries": [
       { "group": "missing_poster_all", "prob": 30 },
       { "item": "flyer", "prob": 70, "count": [ 1, 2 ] },
+      { "item": "flyer_evac", "prob": 70, "count": [ 1, 2 ] },
       { "item": "buylocalpamphlet", "prob": 15 }
     ]
   },

--- a/data/json/itemgroups/mail.json
+++ b/data/json/itemgroups/mail.json
@@ -12,6 +12,7 @@
       { "group": "brochures", "prob": 15 },
       { "group": "pamphlets", "prob": 5 },
       { "item": "flyer", "prob": 30, "count": [ 0, 2 ] },
+      { "item": "flyer_evac", "prob": 40 },
       { "item": "survnote", "prob": 3 }
     ]
   },

--- a/data/json/itemgroups/stashes.json
+++ b/data/json/itemgroups/stashes.json
@@ -401,7 +401,8 @@
       { "group": "jewelry_front", "count": [ 1, 4 ], "prob": 40 },
       { "group": "jewelry_safe", "count": [ 4, 12 ], "prob": 10 },
       { "group": "tampon_box_full", "prob": 20 },
-      { "group": "menstrual_pad_box_full", "prob": 20 }
+      { "group": "menstrual_pad_box_full", "prob": 20 },
+      { "item": "flyer_evac", "prob": 40 }
     ]
   },
   {

--- a/data/json/items/book/maps.json
+++ b/data/json/items/book/maps.json
@@ -518,5 +518,53 @@
       ],
       "message": "You add roads and local electronic and hardware stores as well as arcades and internet cafes to your map."
     }
+  },
+  {
+    "type": "ITEM",
+    "id": "flyer_evac",
+    "name": "FEMA evacuation flyer",
+    "category": "maps",
+    "symbol": ",",
+    "color": "white",
+    "description": "A FEMA-issued flyer as to potential evacuations that'll occur and what to do when it starts.  Activate to look for the address of the nearest Refugee Center.",
+    "price": "0 cent",
+    "price_postapoc": "0 cent",
+    "material": [ "paper" ],
+    "flags": [ "PAPER_SHAPED" ],
+    "weight": "3 g",
+    "volume": "5 ml",
+    "use_action": {
+      "type": "effect_on_conditions",
+      "menu_text": "Study the flyer",
+      "description": "Activate to look for the address of the nearest Refugee Center",
+      "effect_on_conditions": [
+        {
+          "id": "EOC_EVAC_FLYER",
+          "condition": {
+            "and": [
+              "u_can_see",
+              {
+                "or": [ { "u_has_flag": "READ_IN_DARKNESS" }, { "math": [ "u_val('fine_detail_vision_mod') <= 4" ] } ]
+              }
+            ]
+          },
+          "effect": {
+            "if": { "u_has_mission": "MISSION_REACH_REFUGEE_CENTER" },
+            "then": {
+              "u_message": "You study the flyer.  It shows a similar set of directions to the ones you already have.  You cross-reference them and don't learn anything new.",
+              "popup": true
+            },
+            "else": [
+              {
+                "u_message": "You study the flyer.  One part of the flyer has a map and address for a nearby refugee center alongside minutia you no longer need trouble yourself with now that society has collapsed, like 'operating hours' and 'acceptable forms of ID'.  You take careful note of the map and address on the flyer and mark down the coordinates.",
+                "popup": true
+              },
+              { "assign_mission": "MISSION_REACH_REFUGEE_CENTER" }
+            ]
+          },
+          "false_effect": { "u_message": "It's too dark to read." }
+        }
+      ]
+    }
   }
 ]


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Gives FEMA evacuation flyer as some alternative to finding refugee center through the evac shelter info board. Works basically like the aforementioned furniture.

#### Describe the solution

Adds the item and put it in some itemgroups that could have it.

#### Describe alternatives you've considered

Not doing so?

#### Testing
![Screenshot_20250815_041639](https://github.com/user-attachments/assets/97ec25f4-403c-40b8-8f36-8c483fa8a2c3)
![Screenshot_20250815_041540](https://github.com/user-attachments/assets/056365a9-8ca1-4855-a98f-b5323d586a3f)
![Screenshot_20250815_041503](https://github.com/user-attachments/assets/4d43ce95-bc82-48f4-a903-bfc7029262de)


#### Additional context
Feels like theres more itemgroup it could be inside it.

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
