### PR TITLE
Dedupe activity_actor implementations

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -16,6 +16,7 @@
 #include <string>
 #include <unordered_set>
 #include <utility>
+#include <variant>
 #include <vector>
 
 #include "action.h"
@@ -342,7 +343,7 @@ void aim_activity_actor::start( player_activity &act, Character &who )
 
     // Time spent on aiming is determined on the go by the player
     act.moves_total = 1;
-    act.moves_left = 1;
+    act.set_moves_total_left();
 }
 
 bool aim_activity_actor::check_gun_ability_to_shoot( Character &who, item &it )
@@ -740,7 +741,7 @@ std::unique_ptr<activity_actor> bash_activity_actor::deserialize( JsonValue &jsi
 void gunmod_remove_activity_actor::start( player_activity &act, Character & )
 {
     act.moves_total = moves_total;
-    act.moves_left = moves_total;
+    act.set_moves_total_left();
 }
 
 void gunmod_remove_activity_actor::finish( player_activity &act, Character &who )
@@ -825,7 +826,7 @@ std::unique_ptr<activity_actor> gunmod_remove_activity_actor::deserialize( JsonV
 void hacking_activity_actor::start( player_activity &act, Character & )
 {
     act.moves_total = to_moves<int>( 5_minutes );
-    act.moves_left = to_moves<int>( 5_minutes );
+    act.set_moves_total_left();
 }
 
 enum class hack_result : int {
@@ -976,7 +977,7 @@ void bookbinder_copy_activity_actor::start( player_activity &act, Character & )
 {
     pages = bookbinder_copy_activity_actor::pages_for_recipe( *rec_id );
     act.moves_total = to_moves<int>( pages * 10_minutes );
-    act.moves_left = to_moves<int>( pages * 10_minutes );
+    act.set_moves_total_left();
 }
 
 void bookbinder_copy_activity_actor::do_turn( player_activity &, Character &p )
@@ -1050,7 +1051,7 @@ std::unique_ptr<activity_actor> bookbinder_copy_activity_actor::deserialize( Jso
 void hotwire_car_activity_actor::start( player_activity &act, Character & )
 {
     act.moves_total = moves_total;
-    act.moves_left = moves_total;
+    act.set_moves_total_left();
 }
 
 void hotwire_car_activity_actor::do_turn( player_activity &act, Character &who )
@@ -1124,36 +1125,97 @@ std::unique_ptr<activity_actor> hotwire_car_activity_actor::deserialize( JsonVal
     return actor.clone();
 }
 
-void hacksaw_activity_actor::start( player_activity &act, Character &/*who*/ )
+bool tool_activity_actor::start_finish( map &here, player_activity &act, Character &who,
+                                        int &moves, const std::string &tool_name,
+                                        const cata::value_ptr<activity_data_common> map_data_common_t::* const tool_member,
+                                        bool finish, activity_data_common *&data )
 {
-    const map &here = get_map();
-    int moves_before_quality;
-
     if( here.has_furn( target ) ) {
         const furn_id &furn_type = here.furn( target );
-        if( !furn_type->hacksaw->valid() ) {
+        data = &*( *furn_type.*tool_member );
+        if( !data->valid() ) {
             if( !testing ) {
-                debugmsg( "%s hacksaw is invalid", furn_type.id().str() );
+                debugmsg( "%s %s is invalid", furn_type.id().str(), tool_name );
             }
             act.set_to_null();
-            return;
+            return false;
         }
 
-        moves_before_quality = to_moves<int>( furn_type->hacksaw->duration() );
+        if( finish ) {
+            const furn_str_id new_furn = std::get<furn_str_id>( data->result() );
+            if( !new_furn.is_valid() ) {
+                if( !testing ) {
+                    debugmsg( "%s furniture: %s invalid furniture", tool_name, new_furn.str() );
+                }
+                act.set_to_null();
+                return false;
+            }
+
+            here.furn_set( target, new_furn );
+        }
     } else if( const ter_id &ter_type = here.ter( target ); !ter_type->is_null() ) {
-        if( !ter_type->hacksaw->valid() ) {
+        data = &*( *ter_type.*tool_member );
+        if( !data->valid() ) {
             if( !testing ) {
-                debugmsg( "%s hacksaw is invalid", ter_type.id().str() );
+                debugmsg( "%s %s is invalid", ter_type.id().str(), tool_name );
             }
             act.set_to_null();
-            return;
+            return false;
         }
-        moves_before_quality = to_moves<int>( ter_type->hacksaw->duration() );
+        if( finish ) {
+            const ter_str_id new_ter = std::get<ter_str_id>( data->result() );
+            if( !new_ter.is_valid() ) {
+                if( !testing ) {
+                    debugmsg( "%s terrain: %s invalid terrain", tool_name, new_ter.str() );
+                }
+                act.set_to_null();
+                return false;
+            }
+
+            here.ter_set( target, new_ter );
+        }
     } else {
         if( !testing ) {
-            debugmsg( "hacksaw activity called on invalid terrain" );
+            debugmsg( "%s activity called on invalid terrain", tool_name );
         }
         act.set_to_null();
+        return false;
+    }
+
+    if( finish ) {
+        for( const activity_byproduct &byproduct : data->byproducts() ) {
+            const int amount = byproduct.roll();
+            if( byproduct.item->count_by_charges() ) {
+                item byproduct_item( byproduct.item, calendar::turn, amount );
+                here.add_item_or_charges( target, byproduct_item );
+            } else {
+                item byproduct_item( byproduct.item, calendar::turn );
+                for( int i = 0; i < amount; ++i ) {
+                    here.add_item_or_charges( target, byproduct_item );
+                }
+            }
+        }
+
+        if( !data->message().empty() ) {
+            who.add_msg_if_player( m_info, data->message().translated() );
+        }
+
+        act.set_to_null();
+    } else {
+        moves = to_moves<int>( data->duration() );
+    }
+
+    return true;
+}
+
+void hacksaw_activity_actor::start( player_activity &act, Character &who )
+{
+    map &here = get_map();
+    int moves_before_quality;
+    activity_data_common *ad_discard;
+
+    if( !start_finish( here, act, who, moves_before_quality, "hacksaw",
+                       &map_data_common_t::hacksaw, false, ad_discard ) ) {
         return;
     }
 
@@ -1186,8 +1248,7 @@ void hacksaw_activity_actor::start( player_activity &act, Character &/*who*/ )
     //3 makes the speed one-and-a-half times, and the total moves 66% of hacksaw. 4 is twice the speed, 50% the moves, etc, 5 is 2.5 times the speed, 40% the original time
     //done because it's easy to code, and diminising returns on cutting speed make sense as the limiting factor becomes aligning the tool and controlling it instead of the actual cutting
     act.moves_total = moves_before_quality / ( qual / 2 );
-    add_msg_debug( debugmode::DF_ACTIVITY, "%s moves_total: %d", act.id().str(), act.moves_total );
-    act.moves_left = act.moves_total;
+    act.set_moves_total_left();
 }
 
 static void tool_out_of_charges( Character &who, const std::string &tool_name )
@@ -1216,11 +1277,9 @@ void hacksaw_activity_actor::do_turn( player_activity &/*act*/, Character &who )
             }
 
             tool->ammo_consume( ammo_consumed, here, tool.pos_bub( here ), &who );
-            sfx::play_activity_sound( "tool", "hacksaw", sfx::get_heard_volume( target ) );
-            if( calendar::once_every( 1_minutes ) ) {
-                //~ Sound of a metal sawing tool at work!
-                sounds::sound( target, 15, sounds::sound_t::destructive_activity, _( "grnd grnd grnd" ) );
-            }
+            sfx::play_activity_sound_repeat( "tool", "hacksaw", target, 1_minutes, 15,
+                                             //~ Sound of a metal sawing tool at work!
+                                             sounds::sound_t::destructive_activity, _( "grnd grnd grnd" ) );
         } else {
             tool_out_of_charges( who, tool->tname() );
         }
@@ -1233,11 +1292,9 @@ void hacksaw_activity_actor::do_turn( player_activity &/*act*/, Character &who )
         }
         vehicle &veh = vp->vehicle();
         if( vehicle::use_vehicle_tool( veh, &here, veh_pos.value(), type.value(), true ) ) {
-            sfx::play_activity_sound( "tool", "hacksaw", sfx::get_heard_volume( target ) );
-            if( calendar::once_every( 1_minutes ) ) {
-                //~ Sound of a metal sawing tool at work!
-                sounds::sound( target, 15, sounds::sound_t::destructive_activity, _( "grnd grnd grnd" ) );
-            }
+            sfx::play_activity_sound_repeat( "tool", "hacksaw", target, 1_minutes, 15,
+                                             //~ Sound of a metal sawing tool at work!
+                                             sounds::sound_t::destructive_activity, _( "grnd grnd grnd" ) );
         } else {
             tool_out_of_charges( who, type.value()->nname( 1 ) );
         }
@@ -1247,75 +1304,11 @@ void hacksaw_activity_actor::do_turn( player_activity &/*act*/, Character &who )
 void hacksaw_activity_actor::finish( player_activity &act, Character &who )
 {
     map &here = get_map();
-    const activity_data_common *data;
+    activity_data_common *data;
+    int moves_discard;
 
-    if( here.has_furn( target ) ) {
-        const furn_id &furn_type = here.furn( target );
-        if( !furn_type->hacksaw->valid() ) {
-            if( !testing ) {
-                debugmsg( "%s hacksaw is invalid", furn_type.id().str() );
-            }
-            act.set_to_null();
-            return;
-        }
-
-        const furn_str_id new_furn = furn_type->hacksaw->result();
-        if( !new_furn.is_valid() ) {
-            if( !testing ) {
-                debugmsg( "hacksaw furniture: %s invalid furniture", new_furn.str() );
-            }
-            act.set_to_null();
-            return;
-        }
-
-        data = static_cast<const activity_data_common *>( &*furn_type->hacksaw );
-        here.furn_set( target, new_furn );
-    } else if( const ter_id &ter_type = here.ter( target ); !ter_type->is_null() ) {
-        if( !ter_type->hacksaw->valid() ) {
-            if( !testing ) {
-                debugmsg( "%s hacksaw is invalid", ter_type.id().str() );
-            }
-            act.set_to_null();
-            return;
-        }
-
-        const ter_str_id new_ter = ter_type->hacksaw->result();
-        if( !new_ter.is_valid() ) {
-            if( !testing ) {
-                debugmsg( "hacksaw terrain: %s invalid terrain", new_ter.str() );
-            }
-            act.set_to_null();
-            return;
-        }
-
-        data = static_cast<const activity_data_common *>( &*ter_type->hacksaw );
-        here.ter_set( target, new_ter );
-    } else {
-        if( !testing ) {
-            debugmsg( "hacksaw activity finished on invalid terrain" );
-        }
-        act.set_to_null();
-        return;
-    }
-
-    for( const activity_byproduct &byproduct : data->byproducts() ) {
-        const int amount = byproduct.roll();
-        if( byproduct.item->count_by_charges() ) {
-            item byproduct_item( byproduct.item, calendar::turn, amount );
-            here.add_item_or_charges( target, byproduct_item );
-        } else {
-            item byproduct_item( byproduct.item, calendar::turn );
-            for( int i = 0; i < amount; ++i ) {
-                here.add_item_or_charges( target, byproduct_item );
-            }
-        }
-    }
-
-    if( !data->message().empty() ) {
-        who.add_msg_if_player( m_info, data->message().translated() );
-    }
-
-    act.set_to_null();
+    start_finish( here, act, who, moves_discard, "hacksaw", &map_data_common_t::hacksaw,
+                  true, data );
 }
 
 //TODO: Make hacksawing resumable with different tools with the same SAW_M quality.
@@ -1372,7 +1365,7 @@ bikerack_racking_activity_actor::bikerack_racking_activity_actor( const vehicle 
 void bikerack_racking_activity_actor::start( player_activity &act, Character & )
 {
     act.moves_total = moves_total;
-    act.moves_left = moves_total;
+    act.set_moves_total_left();
 }
 
 void bikerack_racking_activity_actor::finish( player_activity &act, Character & )
@@ -1572,7 +1565,7 @@ std::unique_ptr<activity_actor> glide_activity_actor::deserialize( JsonValue &js
 void glide_activity_actor::start( player_activity &act, Character & )
 {
     act.moves_total = moves_total;
-    act.moves_left = moves_total;
+    act.set_moves_total_left();
 }
 
 void glide_activity_actor::finish( player_activity &act, Character &you )
@@ -1595,7 +1588,7 @@ bikerack_unracking_activity_actor::bikerack_unracking_activity_actor( const vehi
 void bikerack_unracking_activity_actor::start( player_activity &act, Character & )
 {
     act.moves_total = moves_total;
-    act.moves_left = moves_total;
+    act.set_moves_total_left();
 }
 
 void bikerack_unracking_activity_actor::finish( player_activity &act, Character & )
@@ -1686,7 +1679,7 @@ void read_activity_actor::start( player_activity &act, Character &who )
     }
 
     act.moves_total = moves_total;
-    act.moves_left = moves_total;
+    act.set_moves_total_left();
 }
 
 void read_activity_actor::do_turn( player_activity &act, Character &who )
@@ -2110,7 +2103,7 @@ void read_activity_actor::finish( player_activity &act, Character &who )
         // restart the activity
         moves_total = to_moves<int>( time_taken );
         act.moves_total = to_moves<int>( time_taken );
-        act.moves_left = to_moves<int>( time_taken );
+        act.set_moves_total_left();
         return;
     } else  {
         who.add_msg_if_player( m_info, _( "You finish reading." ) );
@@ -2386,40 +2379,17 @@ std::unique_ptr<activity_actor> pickup_activity_actor::deserialize( JsonValue &j
     return actor.clone();
 }
 
-void boltcutting_activity_actor::start( player_activity &act, Character &/*who*/ )
+void boltcutting_activity_actor::start( player_activity &act, Character &who )
 {
-    const map &here = get_map();
+    map &here = get_map();
+    activity_data_common *ad_discard;
 
-    if( here.has_furn( target ) ) {
-        const furn_id &furn_type = here.furn( target );
-        if( !furn_type->boltcut->valid() ) {
-            if( !testing ) {
-                debugmsg( "%s boltcut is invalid", furn_type.id().str() );
-            }
-            act.set_to_null();
-            return;
-        }
-
-        act.moves_total = to_moves<int>( furn_type->boltcut->duration() );
-    } else if( const ter_id &ter_type = here.ter( target ); !ter_type->is_null() ) {
-        if( !ter_type->boltcut->valid() ) {
-            if( !testing ) {
-                debugmsg( "%s boltcut is invalid", ter_type.id().str() );
-            }
-            act.set_to_null();
-            return;
-        }
-        act.moves_total = to_moves<int>( ter_type->boltcut->duration() );
-    } else {
-        if( !testing ) {
-            debugmsg( "boltcut activity called on invalid terrain" );
-        }
-        act.set_to_null();
+    if( !start_finish( here, act, who, act.moves_total, "boltcut", &map_data_common_t::boltcut,
+                       false, ad_discard ) ) {
         return;
     }
 
-    add_msg_debug( debugmode::DF_ACTIVITY, "%s moves_total: %d", act.id().str(), act.moves_total );
-    act.moves_left = act.moves_total;
+    act.set_moves_total_left();
 }
 
 void boltcutting_activity_actor::do_turn( player_activity &/*act*/, Character &who )
@@ -2436,54 +2406,11 @@ void boltcutting_activity_actor::do_turn( player_activity &/*act*/, Character &w
 void boltcutting_activity_actor::finish( player_activity &act, Character &who )
 {
     map &here = get_map();
-    const activity_data_common *data;
+    activity_data_common *data;
+    int moves_discard;
 
-    if( here.has_furn( target ) ) {
-        const furn_id &furn_type = here.furn( target );
-        if( !furn_type->boltcut->valid() ) {
-            if( !testing ) {
-                debugmsg( "%s boltcut is invalid", furn_type.id().str() );
-            }
-            act.set_to_null();
-            return;
-        }
-
-        const furn_str_id new_furn = furn_type->boltcut->result();
-        if( !new_furn.is_valid() ) {
-            if( !testing ) {
-                debugmsg( "boltcut furniture: %s invalid furniture", new_furn.str() );
-            }
-            act.set_to_null();
-            return;
-        }
-
-        data = static_cast<const activity_data_common *>( &*furn_type->boltcut );
-        here.furn_set( target, new_furn );
-    } else if( const ter_id &ter_type = here.ter( target ); !ter_type->is_null() ) {
-        if( !ter_type->boltcut->valid() ) {
-            if( !testing ) {
-                debugmsg( "%s boltcut is invalid", ter_type.id().str() );
-            }
-            act.set_to_null();
-            return;
-        }
-
-        const ter_str_id new_ter = ter_type->boltcut->result();
-        if( !new_ter.is_valid() ) {
-            if( !testing ) {
-                debugmsg( "boltcut terrain: %s invalid terrain", new_ter.str() );
-            }
-            act.set_to_null();
-            return;
-        }
-
-        data = static_cast<const activity_data_common *>( &*ter_type->boltcut );
-        here.ter_set( target, new_ter );
-    } else {
-        if( !testing ) {
-            debugmsg( "boltcut activity finished on invalid terrain" );
-        }
-        act.set_to_null();
+    if( !start_finish( here, act, who, moves_discard, "boltcut", &map_data_common_t::boltcut,
+                       true, data ) ) {
         return;
     }
 
@@ -2494,25 +2421,6 @@ void boltcutting_activity_actor::finish( player_activity &act, Character &who )
         sounds::sound( target, 5, sounds::sound_t::combat, data->sound().translated(),
                        true, "tool", "boltcutters" );
     }
-
-    for( const activity_byproduct &byproduct : data->byproducts() ) {
-        const int amount = byproduct.roll();
-        if( byproduct.item->count_by_charges() ) {
-            item byproduct_item( byproduct.item, calendar::turn, amount );
-            here.add_item_or_charges( target, byproduct_item );
-        } else {
-            item byproduct_item( byproduct.item, calendar::turn );
-            for( int i = 0; i < amount; ++i ) {
-                here.add_item_or_charges( target, byproduct_item );
-            }
-        }
-    }
-
-    if( !data->message().empty() ) {
-        who.add_msg_if_player( m_info, data->message().translated() );
-    }
-
-    act.set_to_null();
 }
 
 void boltcutting_activity_actor::serialize( JsonOut &jsout ) const
@@ -2560,8 +2468,8 @@ lockpick_activity_actor lockpick_activity_actor::use_bionic(
 
 void lockpick_activity_actor::start( player_activity &act, Character & )
 {
-    act.moves_left = moves_total;
     act.moves_total = moves_total;
+    act.set_moves_total_left();
 
     const time_duration lockpicking_time = time_duration::from_moves( moves_total );
     add_msg_debug( debugmode::DF_ACT_LOCKPICK, "lockpicking time = %s",
@@ -3035,7 +2943,7 @@ void efile_activity_actor::start( player_activity &act, Character &who )
         done_processing = true;
         add_msg_debug( debugmode::DF_ACT_EBOOK, "no e-devices found to process!" );
     }
-    act.moves_left = act.moves_total;
+    act.set_moves_total_left();
 }
 
 void efile_activity_actor::do_turn( player_activity &act, Character &who )
@@ -3618,7 +3526,7 @@ std::unique_ptr<activity_actor> migration_cancel_activity_actor::deserialize( Js
 void open_gate_activity_actor::start( player_activity &act, Character & )
 {
     act.moves_total = moves_total;
-    act.moves_left = moves_total;
+    act.set_moves_total_left();
 }
 
 void open_gate_activity_actor::finish( player_activity &act, Character & )
@@ -3679,7 +3587,7 @@ void consume_activity_actor::start( player_activity &act, Character &guy )
     }
 
     act.moves_total = moves;
-    act.moves_left = moves;
+    act.set_moves_total_left();
 }
 
 void consume_activity_actor::finish( player_activity &act, Character & )
@@ -3775,7 +3683,7 @@ std::unique_ptr<activity_actor> consume_activity_actor::deserialize( JsonValue &
 void try_sleep_activity_actor::start( player_activity &act, Character &who )
 {
     act.moves_total = to_moves<int>( duration );
-    act.moves_left = act.moves_total;
+    act.set_moves_total_left();
     get_event_bus().send<event_type::character_attempt_to_fall_asleep>( who.getID() );
     who.set_movement_mode( move_mode_prone );
     who.add_msg_if_player( _( "You lie down preparing to fall asleep." ) );
@@ -3900,7 +3808,7 @@ void safecracking_activity_actor::start( player_activity &act, Character &who )
                    to_string_writable( cracking_time ) );
 
     act.moves_total = to_moves<int>( cracking_time );
-    act.moves_left = act.moves_total;
+    act.set_moves_total_left();
 }
 
 void safecracking_activity_actor::do_turn( player_activity &act, Character &who )
@@ -3973,8 +3881,8 @@ std::unique_ptr<activity_actor> safecracking_activity_actor::deserialize( JsonVa
 
 void unload_activity_actor::start( player_activity &act, Character & )
 {
-    act.moves_left = moves_total;
     act.moves_total = moves_total;
+    act.set_moves_total_left();
 }
 
 void unload_activity_actor::finish( player_activity &act, Character &who )
@@ -4446,7 +4354,7 @@ void workout_activity_actor::start( player_activity &act, Character &who )
         return;
     }
     act.moves_total = to_moves<int>( duration );
-    act.moves_left = act.moves_total;
+    act.set_moves_total_left();
     if( who.male ) {
         sfx::play_activity_sound( "plmove", "sleepiness_m_med", sfx::get_heard_volume( location ) );
     } else {
@@ -4515,7 +4423,7 @@ bool workout_activity_actor::query_keep_training( player_activity &act, Characte
     if( disable_query || !who.is_avatar() ) {
         elapsed += act.moves_total - act.moves_left;
         act.moves_total = to_moves<int>( 60_minutes );
-        act.moves_left = act.moves_total;
+        act.set_moves_total_left();
         return true;
     }
     int length;
@@ -4535,7 +4443,7 @@ bool workout_activity_actor::query_keep_training( player_activity &act, Characte
             disable_query = true;
             elapsed += act.moves_total - act.moves_left;
             act.moves_total = to_moves<int>( 60_minutes );
-            act.moves_left = act.moves_total;
+            act.set_moves_total_left();
             return true;
         case 2:
         default:
@@ -4546,7 +4454,7 @@ bool workout_activity_actor::query_keep_training( player_activity &act, Characte
                 duration = length * 1_minutes;
             }
             act.moves_total = to_moves<int>( duration );
-            act.moves_left = act.moves_total;
+            act.set_moves_total_left();
             return true;
     }
 }
@@ -4786,7 +4694,7 @@ void harvest_activity_actor::start( player_activity &act, Character &who )
     const time_duration forage_time = rng( 5_seconds, 15_seconds );
     add_msg_debug( debugmode::DF_ACT_HARVEST, "harvest time: %s", to_string_writable( forage_time ) );
     act.moves_total = to_moves<int>( forage_time );
-    act.moves_left = act.moves_total;
+    act.set_moves_total_left();
 }
 
 void harvest_activity_actor::finish( player_activity &act, Character &who )
@@ -4921,7 +4829,7 @@ std::unique_ptr<activity_actor> stash_activity_actor::deserialize( JsonValue &js
 void disable_activity_actor::start( player_activity &act, Character &/*who*/ )
 {
     act.moves_total = moves_total;
-    act.moves_left = moves_total;
+    act.set_moves_total_left();
     monster &critter = *get_creature_tracker().creature_at<monster>( target );
     critter.add_effect( effect_worked_on, 1_turns );
 }
@@ -5042,8 +4950,8 @@ void move_furniture_on_vehicle_activity_actor::start( player_activity &act, Char
     if( furn->move_str_req > who.get_arm_str() ) {
         moves = std::max<int>( 3000, furn->move_str_req * 10 + std::pow( furn->move_str_req, 2.0 ) * 10 );
     }
-    act.moves_left = moves;
     act.moves_total = moves;
+    act.set_moves_total_left();
 }
 
 bool move_furniture_on_vehicle_activity_actor::can_move_furn_on_veh_to( map &here,
@@ -5171,8 +5079,8 @@ std::unique_ptr<activity_actor> move_furniture_on_vehicle_activity_actor::deseri
 void move_furniture_activity_actor::start( player_activity &act, Character & )
 {
     int moves = g->grabbed_furn_move_time( dp );
-    act.moves_left = moves;
     act.moves_total = moves;
+    act.set_moves_total_left();
 }
 
 void move_furniture_activity_actor::finish( player_activity &act, Character &who )
@@ -5251,8 +5159,8 @@ void insert_item_activity_actor::start( player_activity &act, Character &who )
     all_pockets_rigid = holster->all_pockets_rigid();
 
     const int total_moves = item_move_cost( who, items.front().first, false );
-    act.moves_left = total_moves;
     act.moves_total = total_moves;
+    act.set_moves_total_left();
 }
 
 static ret_val<void> try_insert( item_location &holster, drop_location &holstered_item,
@@ -5410,8 +5318,8 @@ void insert_item_activity_actor::finish( player_activity &act, Character &who )
 
     // Restart the activity
     const int total_moves = item_move_cost( who, items.front().first, bulk_load );
-    act.moves_left = total_moves;
     act.moves_total = total_moves;
+    act.set_moves_total_left();
 }
 
 void insert_item_activity_actor::canceled( player_activity &/*act*/, Character &who )
@@ -5480,7 +5388,7 @@ bool reload_activity_actor::can_reload() const
 void reload_activity_actor::start( player_activity &act, Character &/*who*/ )
 {
     act.moves_total = moves_total;
-    act.moves_left = moves_total;
+    act.set_moves_total_left();
 }
 
 void reload_activity_actor::make_reload_sound( Character &who, item &reloadable )
@@ -5625,7 +5533,7 @@ std::unique_ptr<activity_actor> reload_activity_actor::deserialize( JsonValue &j
 void milk_activity_actor::start( player_activity &act, Character &/*who*/ )
 {
     act.moves_total = total_moves;
-    act.moves_left = total_moves;
+    act.set_moves_total_left();
     next_unit_move = calendar::turn + time_duration::from_moves( moves_per_unit );
 }
 
@@ -5826,7 +5734,7 @@ void shearing_activity_actor::start( player_activity &act, Character &who )
     }
 
     act.moves_total = to_moves<int>( shearing_time );
-    act.moves_left = act.moves_total;
+    act.set_moves_total_left();
 }
 
 void shearing_activity_actor::do_turn( player_activity &, Character &who )
@@ -6066,43 +5974,21 @@ std::unique_ptr<activity_actor> disassemble_activity_actor::deserialize( JsonVal
 
 void oxytorch_activity_actor::start( player_activity &act, Character &who )
 {
-    const map &here = get_map();
+    map &here = get_map();
+    activity_data_common *ad_discard;
 
-    if( here.has_furn( target ) ) {
-        const furn_id &furn_type = here.furn( target );
-        if( !furn_type->oxytorch->valid() ) {
-            if( !testing ) {
-                debugmsg( "%s oxytorch is invalid", furn_type.id().str() );
-            }
-            act.set_to_null();
-            return;
-        }
-
-        act.moves_total = to_moves<int>( furn_type->oxytorch->duration() );
-    } else if( const ter_id &ter_type = here.ter( target ); !ter_type->is_null() ) {
-        if( !ter_type->oxytorch->valid() ) {
-            if( !testing ) {
-                debugmsg( "%s oxytorch is invalid", ter_type.id().str() );
-            }
-            act.set_to_null();
-            return;
-        }
-        act.moves_total = to_moves<int>( ter_type->oxytorch->duration() );
-    } else {
-        if( !testing ) {
-            debugmsg( "oxytorch activity called on invalid terrain" );
-        }
-        act.set_to_null();
+    if( !start_finish( here, act, who, act.moves_total, "oxytorch", &map_data_common_t::oxytorch,
+                       false, ad_discard ) ) {
         return;
     }
+
     if( tool->ammo_sufficient( &who, act.moves_total / 100 ) ||
         query_yn(
             _( "Your %1$s doesn't have enough charges to complete the job.  Continue anyway?" ), tool->tname()
         ) ||
         test_mode // In the tests, we want to check that the activity can be resumed.
       ) {
-        add_msg_debug( debugmode::DF_ACTIVITY, "%s moves_total: %d", act.id().str(), act.moves_total );
-        act.moves_left = act.moves_total;
+        act.set_moves_total_left();
     } else {
         act.set_to_null();
         return;
@@ -6115,10 +6001,9 @@ void oxytorch_activity_actor::do_turn( player_activity &/*act*/, Character &who 
 
     if( tool->ammo_sufficient( &who ) ) {
         tool->ammo_consume( tool->ammo_required(), here, tool.pos_bub( here ), &who );
-        sfx::play_activity_sound( "tool", "oxytorch", sfx::get_heard_volume( target ) );
-        if( calendar::once_every( 2_turns ) ) {
-            sounds::sound( target, 10, sounds::sound_t::destructive_activity, _( "hissssssssss!" ) );
-        }
+        sfx::play_activity_sound_repeat( "tool", "oxytorch", target, 2_turns, 10,
+                                         //~ Sound of a gas torch tool at work!
+                                         sounds::sound_t::destructive_activity, _( "hissssssssss!" ) );
     } else {
         tool_out_of_charges( who, tool->tname() );
     }
@@ -6127,80 +6012,18 @@ void oxytorch_activity_actor::do_turn( player_activity &/*act*/, Character &who 
 void oxytorch_activity_actor::finish( player_activity &act, Character &who )
 {
     map &here = get_map();
-    const activity_data_common *data;
+    activity_data_common *data;
+    int moves_discard;
 
-    if( here.has_furn( target ) ) {
-        const furn_id &furn_type = here.furn( target );
-        if( !furn_type->oxytorch->valid() ) {
-            if( !testing ) {
-                debugmsg( "%s oxytorch is invalid", furn_type.id().str() );
-            }
-            act.set_to_null();
-            return;
-        }
-
-        const furn_str_id new_furn = furn_type->oxytorch->result();
-        if( !new_furn.is_valid() ) {
-            if( !testing ) {
-                debugmsg( "oxytorch furniture: %s invalid furniture", new_furn.str() );
-            }
-            act.set_to_null();
-            return;
-        }
-
-        data = static_cast<const activity_data_common *>( &*furn_type->oxytorch );
-        here.furn_set( target, new_furn );
-    } else if( const ter_id &ter_type = here.ter( target ); !ter_type->is_null() ) {
-        if( !ter_type->oxytorch->valid() ) {
-            if( !testing ) {
-                debugmsg( "%s oxytorch is invalid", ter_type.id().str() );
-            }
-            act.set_to_null();
-            return;
-        }
-
-        const ter_str_id new_ter = ter_type->oxytorch->result();
-        if( !new_ter.is_valid() ) {
-            if( !testing ) {
-                debugmsg( "oxytorch terrain: %s invalid terrain", new_ter.str() );
-            }
-            act.set_to_null();
-            return;
-        }
-
-        data = static_cast<const activity_data_common *>( &*ter_type->oxytorch );
-        here.ter_set( target, new_ter );
-    } else {
-        if( !testing ) {
-            debugmsg( "oxytorch activity finished on invalid terrain" );
-        }
-        act.set_to_null();
+    if( !start_finish( here, act, who, moves_discard, "oxytorch", &map_data_common_t::oxytorch,
+                       true, data ) ) {
         return;
-    }
-
-    for( const activity_byproduct &byproduct : data->byproducts() ) {
-        const int amount = byproduct.roll();
-        if( byproduct.item->count_by_charges() ) {
-            item byproduct_item( byproduct.item, calendar::turn, amount );
-            here.add_item_or_charges( target, byproduct_item );
-        } else {
-            item byproduct_item( byproduct.item, calendar::turn );
-            for( int i = 0; i < amount; ++i ) {
-                here.add_item_or_charges( target, byproduct_item );
-            }
-        }
     }
 
     // 50% chance of starting a fire.
     if( one_in( 2 ) && here.flammable_items_at( target ) ) {
         here.add_field( target, fd_fire, 1, 10_minutes );
     }
-
-    if( !data->message().empty() ) {
-        who.add_msg_if_player( m_info, data->message().translated() );
-    }
-
-    act.set_to_null();
 }
 
 void oxytorch_activity_actor::serialize( JsonOut &jsout ) const
@@ -6223,7 +6046,7 @@ std::unique_ptr<activity_actor> oxytorch_activity_actor::deserialize( JsonValue 
 void tent_placement_activity_actor::start( player_activity &act, Character & )
 {
     act.moves_total = moves_total;
-    act.moves_left = moves_total;
+    act.set_moves_total_left();
 }
 
 void tent_placement_activity_actor::finish( player_activity &act, Character &p )
@@ -6289,7 +6112,7 @@ std::unique_ptr<activity_actor> tent_placement_activity_actor::deserialize( Json
 void tent_deconstruct_activity_actor::start( player_activity &act, Character & )
 {
     act.moves_total = moves_total;
-    act.moves_left = moves_total;
+    act.set_moves_total_left();
 }
 
 void tent_deconstruct_activity_actor::finish( player_activity &act, Character & )
@@ -6327,7 +6150,7 @@ std::unique_ptr<activity_actor> tent_deconstruct_activity_actor::deserialize( Js
 void reel_cable_activity_actor::start( player_activity &act, Character & )
 {
     act.moves_total = moves_total;
-    act.moves_left = moves_total;
+    act.set_moves_total_left();
 }
 
 void reel_cable_activity_actor::finish( player_activity &act, Character &who )
@@ -6385,7 +6208,7 @@ void outfit_swap_actor::start( player_activity &act, Character &who )
             // Dropping takes no time? So I guess that's all we need
         }
     }
-    act.moves_left = act.moves_total;
+    act.set_moves_total_left();
 }
 
 void outfit_swap_actor::finish( player_activity &act, Character &who )
@@ -6456,7 +6279,7 @@ std::unique_ptr<activity_actor> outfit_swap_actor::deserialize( JsonValue &jsin 
 void meditate_activity_actor::start( player_activity &act, Character & )
 {
     act.moves_total = to_moves<int>( 20_minutes );
-    act.moves_left = act.moves_total;
+    act.set_moves_total_left();
 }
 
 void meditate_activity_actor::finish( player_activity &act, Character &who )
@@ -6479,7 +6302,7 @@ std::unique_ptr<activity_actor> meditate_activity_actor::deserialize( JsonValue 
 void play_with_pet_activity_actor::start( player_activity &act, Character & )
 {
     act.moves_total = rng( 50, 125 ) * 100;
-    act.moves_left = act.moves_total;
+    act.set_moves_total_left();
 }
 
 void play_with_pet_activity_actor::finish( player_activity &act, Character &who )
@@ -6533,39 +6356,24 @@ time_duration prying_activity_actor::prying_time( const activity_data_common &da
 
 void prying_activity_actor::start( player_activity &act, Character &who )
 {
-    const map &here = get_map();
+    map &here = get_map();
+    int moves_discard;
+    activity_data_common *ad_discard;
+
+    if( !start_finish( here, act, who, moves_discard, "prying", &map_data_common_t::prying,
+                       false, ad_discard ) ) {
+        return;
+    }
 
     if( here.has_furn( target ) ) {
         const furn_id &furn_type = here.furn( target );
-        if( !furn_type->prying->valid() ) {
-            if( !testing ) {
-                debugmsg( "%s prying is invalid", furn_type.id().str() );
-            }
-            act.set_to_null();
-            return;
-        }
-
         prying_nails = furn_type->prying->prying_data().prying_nails;
         act.moves_total = to_moves<int>(
                               prying_time( *furn_type->prying, tool, who ) );
     } else if( const ter_id &ter_type = here.ter( target ); !ter_type->is_null() ) {
-        if( !ter_type->prying->valid() ) {
-            if( !testing ) {
-                debugmsg( "%s prying is invalid", ter_type.id().str() );
-            }
-            act.set_to_null();
-            return;
-        }
-
         prying_nails = ter_type->prying->prying_data().prying_nails;
         act.moves_total = to_moves<int>(
                               prying_time( *ter_type->prying, tool, who ) );
-    } else {
-        if( !testing ) {
-            debugmsg( "prying activity called on invalid terrain" );
-        }
-        act.set_to_null();
-        return;
     }
 
     if( prying_nails && !tool->has_quality( qual_PRYING_NAIL ) ) {
@@ -6574,8 +6382,7 @@ void prying_activity_actor::start( player_activity &act, Character &who )
         return;
     }
 
-    add_msg_debug( debugmode::DF_ACTIVITY, "%s moves_total: %d", act.id().str(), act.moves_total );
-    act.moves_left = act.moves_total;
+    act.set_moves_total_left();
 }
 
 void prying_activity_actor::do_turn( player_activity &/*act*/, Character &who )
@@ -6656,7 +6463,7 @@ void prying_activity_actor::handle_prying( Character &who )
             return;
         }
 
-        const furn_str_id new_furn = furn_type->prying->result();
+        const furn_str_id new_furn = std::get<furn_str_id>( furn_type->prying->result() );
         if( !new_furn.is_valid() ) {
             if( !testing ) {
                 debugmsg( "prying furniture: %s invalid furniture", new_furn.str() );
@@ -6679,7 +6486,7 @@ void prying_activity_actor::handle_prying( Character &who )
             return;
         }
 
-        const ter_str_id new_ter = ter_type->prying->result();
+        const ter_str_id new_ter = std::get<ter_str_id>( ter_type->prying->result() );
         if( !new_ter.is_valid() ) {
             if( !testing ) {
                 debugmsg( "prying terrain: %s invalid terrain", new_ter.str() );
@@ -6725,70 +6532,15 @@ void prying_activity_actor::handle_prying( Character &who )
     }
 }
 
-void prying_activity_actor::handle_prying_nails( Character &who )
+void prying_activity_actor::handle_prying_nails( player_activity &act, Character &who )
 {
     map &here = get_map();
-    const activity_data_common *data;
+    activity_data_common *data;
+    int moves_discard;
 
-    if( here.has_furn( target ) ) {
-        const furn_id &furn_type = here.furn( target );
-        if( !furn_type->prying->valid() ) {
-            if( !testing ) {
-                debugmsg( "%s prying is invalid", furn_type.id().str() );
-            }
-            return;
-        }
-
-        const furn_str_id new_furn = furn_type->prying->result();
-        if( !new_furn.is_valid() ) {
-            if( !testing ) {
-                debugmsg( "prying furniture: %s invalid furniture", new_furn.str() );
-            }
-            return;
-        }
-
-        data = static_cast<const activity_data_common *>( &*furn_type->prying );
-        here.furn_set( target, new_furn );
-    } else if( const ter_id &ter_type = here.ter( target ); !ter_type->is_null() ) {
-        if( !ter_type->prying->valid() ) {
-            if( !testing ) {
-                debugmsg( "%s prying is invalid", ter_type.id().str() );
-            }
-            return;
-        }
-
-        const ter_str_id new_ter = ter_type->prying->result();
-        if( !new_ter.is_valid() ) {
-            if( !testing ) {
-                debugmsg( "prying terrain: %s invalid terrain", new_ter.str() );
-            }
-            return;
-        }
-
-        data = static_cast<const activity_data_common *>( &*ter_type->prying );
-        here.ter_set( target, new_ter );
-    } else {
-        if( !testing ) {
-            debugmsg( "prying nails activity finished on invalid terrain" );
-        }
+    if( !start_finish( here, act, who, moves_discard, "prying", &map_data_common_t::prying,
+                       true, data ) ) {
         return;
-    }
-
-    for( const activity_byproduct &byproduct : data->byproducts() ) {
-        const int amount = byproduct.roll();
-        if( byproduct.item->count_by_charges() ) {
-            item byproduct_item( byproduct.item, calendar::turn, amount );
-            here.add_item_or_charges( target, byproduct_item );
-        } else {
-            item byproduct_item( byproduct.item, calendar::turn );
-            for( int i = 0; i < amount; ++i ) {
-                here.add_item_or_charges( target, byproduct_item );
-            }
-        }
-    }
-
-    if( !data->message().empty() ) {
-        who.add_msg_if_player( m_info, data->message().translated() );
     }
 
     who.practice( skill_fabrication, 1, 1 );
@@ -6799,7 +6551,7 @@ void prying_activity_actor::finish( player_activity &act, Character &who )
     act.set_to_null();
 
     if( prying_nails ) {
-        handle_prying_nails( who );
+        handle_prying_nails( act, who );
     } else {
         handle_prying( who );
     }
@@ -6827,7 +6579,7 @@ std::unique_ptr<activity_actor> prying_activity_actor::deserialize( JsonValue &j
 void shave_activity_actor::start( player_activity &act, Character & )
 {
     act.moves_total = to_moves<int>( 5_minutes );
-    act.moves_left = act.moves_total;
+    act.set_moves_total_left();
 }
 
 void shave_activity_actor::finish( player_activity &act, Character &who )
@@ -6850,7 +6602,7 @@ std::unique_ptr<activity_actor> shave_activity_actor::deserialize( JsonValue & )
 void haircut_activity_actor::start( player_activity &act, Character & )
 {
     act.moves_total = to_moves<int>( 30_minutes );
-    act.moves_left = act.moves_total;
+    act.set_moves_total_left();
 }
 
 void haircut_activity_actor::finish( player_activity &act, Character &who )
@@ -7078,18 +6830,15 @@ std::unique_ptr<activity_actor> invoke_item_activity_actor::deserialize( JsonVal
 static void chop_single_do_turn( player_activity &act )
 {
     const map &here = get_map();
-    sfx::play_activity_sound( "tool", "axe",
-                              sfx::get_heard_volume( here.get_bub( act.placement ) ) );
-    if( calendar::once_every( 1_minutes ) ) {
-        //~ Sound of a wood chopping tool at work!
-        sounds::sound( here.get_bub( act.placement ), 15, sounds::sound_t::activity, _( "CHK!" ) );
-    }
+    sfx::play_activity_sound_repeat( "tool", "axe", here.get_bub( act.placement ), 1_minutes, 15,
+                                     //~ Sound of a wood chopping tool at work!
+                                     sounds::sound_t::activity, _( "CHK!" ) );
 }
 
 void chop_logs_activity_actor::start( player_activity &act, Character & )
 {
     act.moves_total = moves;
-    act.moves_left = moves;
+    act.set_moves_total_left();
 }
 
 void chop_logs_activity_actor::do_turn( player_activity &act, Character & )
@@ -7118,32 +6867,17 @@ void chop_logs_activity_actor::finish( player_activity &act, Character &who )
         stick_quan = 0;
         splint_quan = 0;
     }
-    for( int i = 0; i != log_quan; ++i ) {
-        item obj( itype_log, calendar::turn );
-        obj.set_var( "activity_var", who.name );
-        //The item may exceed the capacity of the pos and move to another coordinate.So get loc.
-        item_location loc = here.add_item_or_charges_ret_loc( pos, obj );
-        if( loc ) {
-            who.may_activity_occupancy_after_end_items_loc.push_back( loc );
-        }
 
-    }
-    for( int i = 0; i != stick_quan; ++i ) {
-        item obj( itype_stick_long, calendar::turn );
-        obj.set_var( "activity_var", who.name );
-        //The item may exceed the capacity of the pos and move to another coordinate.So get loc.
-        item_location loc = here.add_item_or_charges_ret_loc( pos, obj );
-        if( loc ) {
-            who.may_activity_occupancy_after_end_items_loc.push_back( loc );
-        }
-    }
-    for( int i = 0; i != splint_quan; ++i ) {
-        item obj( itype_splinter, calendar::turn );
-        obj.set_var( "activity_var", who.name );
-        //The item may exceed the capacity of the pos and move to another coordinate.So get loc.
-        item_location loc = here.add_item_or_charges_ret_loc( pos, obj );
-        if( loc ) {
-            who.may_activity_occupancy_after_end_items_loc.push_back( loc );
+    const std::array<std::pair<const itype_id, const int>, 3> pairs = {{{itype_log, log_quan}, {itype_stick_long, stick_quan}, {itype_splinter, splint_quan}}};
+    for( const auto pair : pairs ) {
+        for( int i = 0; i != pair.second; ++i ) {
+            item obj( pair.first, calendar::turn );
+            obj.set_var( "activity_var", who.name );
+            //The item may exceed the capacity of the pos and move to another coordinate.So get loc.
+            item_location loc = here.add_item_or_charges_ret_loc( pos, obj );
+            if( loc ) {
+                who.may_activity_occupancy_after_end_items_loc.push_back( loc );
+            }
         }
     }
     here.ter_set( pos, ter_t_dirt );
@@ -7178,7 +6912,7 @@ std::unique_ptr<activity_actor> chop_logs_activity_actor::deserialize( JsonValue
 void chop_planks_activity_actor::start( player_activity &act, Character & )
 {
     act.moves_total = moves;
-    act.moves_left = moves;
+    act.set_moves_total_left();
 }
 
 void chop_planks_activity_actor::do_turn( player_activity &act, Character & )
@@ -7236,7 +6970,7 @@ std::unique_ptr<activity_actor> chop_planks_activity_actor::deserialize( JsonVal
 void chop_tree_activity_actor::start( player_activity &act, Character & )
 {
     act.moves_total = moves;
-    act.moves_left = moves;
+    act.set_moves_total_left();
 }
 
 void chop_tree_activity_actor::do_turn( player_activity &act, Character & )
@@ -7338,7 +7072,7 @@ std::unique_ptr<activity_actor> chop_tree_activity_actor::deserialize( JsonValue
 void churn_activity_actor::start( player_activity &act, Character & )
 {
     act.moves_total = moves;
-    act.moves_left = moves;
+    act.set_moves_total_left();
 }
 
 void churn_activity_actor::finish( player_activity &act, Character &who )
@@ -7377,7 +7111,7 @@ std::unique_ptr<activity_actor> churn_activity_actor::deserialize( JsonValue &js
 void clear_rubble_activity_actor::start( player_activity &act, Character & )
 {
     act.moves_total = moves;
-    act.moves_left = moves;
+    act.set_moves_total_left();
 }
 
 void clear_rubble_activity_actor::finish( player_activity &act, Character &who )
@@ -7415,7 +7149,7 @@ std::unique_ptr<activity_actor> clear_rubble_activity_actor::deserialize( JsonVa
 void firstaid_activity_actor::start( player_activity &act, Character & )
 {
     act.moves_total = moves;
-    act.moves_left = moves;
+    act.set_moves_total_left();
     act.name = name;
 }
 
@@ -7520,7 +7254,7 @@ std::unique_ptr<activity_actor> firstaid_activity_actor::deserialize( JsonValue 
 void forage_activity_actor::start( player_activity &act, Character & )
 {
     act.moves_total = moves;
-    act.moves_left = moves;
+    act.set_moves_total_left();
 }
 
 void forage_activity_actor::finish( player_activity &act, Character &who )
@@ -7644,7 +7378,7 @@ std::unique_ptr<activity_actor> forage_activity_actor::deserialize( JsonValue &j
 void gunmod_add_activity_actor::start( player_activity &act, Character & )
 {
     act.moves_total = moves;
-    act.moves_left = moves;
+    act.set_moves_total_left();
     act.name = name;
 }
 
@@ -7794,7 +7528,7 @@ std::unique_ptr<activity_actor> longsalvage_activity_actor::deserialize( JsonVal
 void mop_activity_actor::start( player_activity &act, Character & )
 {
     act.moves_total = moves;
-    act.moves_left = moves;
+    act.set_moves_total_left();
 }
 
 void mop_activity_actor::finish( player_activity &act, Character &who )
@@ -7859,7 +7593,7 @@ std::unique_ptr<activity_actor> unload_loot_activity_actor::deserialize( JsonVal
 void unload_loot_activity_actor::start( player_activity &act, Character & )
 {
     act.moves_total = moves;
-    act.moves_left = moves;
+    act.set_moves_total_left();
 }
 
 static void move_item( Character &you, item &it, const int quantity, const tripoint_bub_ms &src,
@@ -8293,7 +8027,7 @@ void vehicle_folding_activity_actor::start( player_activity &act, Character &p )
     }
 
     act.moves_total = to_moves<int>( folding_time );
-    act.moves_left = to_moves<int>( folding_time );
+    act.set_moves_total_left();
 
     if( !fold_vehicle( p, /* check_only = */ true ) ) {
         act.set_to_null();
@@ -8410,7 +8144,7 @@ vehicle_unfolding_activity_actor::vehicle_unfolding_activity_actor( const item &
 void vehicle_unfolding_activity_actor::start( player_activity &act, Character &p )
 {
     act.moves_total = to_moves<int>( unfolding_time );
-    act.moves_left = to_moves<int>( unfolding_time );
+    act.set_moves_total_left();
     if( !unfold_vehicle( p, /* check_only = */ true ) ) {
         act.canceled( p );
     }
@@ -8475,7 +8209,7 @@ int heat_activity_actor::get_available_heater( Character &p, item_location &loc 
 void heat_activity_actor::start( player_activity &act, Character & )
 {
     act.moves_total = requirements.time;
-    act.moves_left = requirements.time;
+    act.set_moves_total_left();
 }
 
 void heat_activity_actor::do_turn( player_activity &act, Character &p )
@@ -8598,7 +8332,7 @@ std::unique_ptr<activity_actor> heat_activity_actor::deserialize( JsonValue &jsi
 void wash_activity_actor::start( player_activity &act, Character & )
 {
     act.moves_total = requirements.time;
-    act.moves_left = requirements.time;
+    act.set_moves_total_left();
 }
 
 void wash_activity_actor::finish( player_activity &act, Character &p )
@@ -8687,7 +8421,7 @@ void pulp_activity_actor::start( player_activity &act, Character &you )
     // indefinitely long so activity won't end until we pulp all the corpses
     // we then end the activity manually
     act.moves_total = calendar::INDEFINITELY_LONG;
-    act.moves_left = calendar::INDEFINITELY_LONG;
+    act.set_moves_total_left();
     you.recoil = MAX_RECOIL;
 
     map &here = get_map();
@@ -9196,7 +8930,7 @@ std::unique_ptr<activity_actor> butchery_activity_actor::deserialize( JsonValue 
 void wait_stamina_activity_actor::start( player_activity &act, Character & )
 {
     act.moves_total = calendar::INDEFINITELY_LONG;
-    act.moves_left = calendar::INDEFINITELY_LONG;
+    act.set_moves_total_left();
 }
 
 void wait_stamina_activity_actor::do_turn( player_activity &act, Character &you )

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -208,13 +208,39 @@ class gunmod_remove_activity_actor : public activity_actor
         static std::unique_ptr<activity_actor> deserialize( JsonValue &jsin );
 };
 
-class hacksaw_activity_actor : public activity_actor
+class tool_activity_actor : public activity_actor
+{
+    public:
+        explicit tool_activity_actor( const tripoint_bub_ms &target,
+                                      const item_location &tool ) : target( target ), tool( tool ) {};
+        explicit tool_activity_actor( const tripoint_bub_ms &target ) : target( target ) {};
+        // debugmsg causes a backtrace when fired during cata_test
+        bool testing = false;  // NOLINT(cata-serialize)
+    protected:
+        tripoint_bub_ms target;
+        item_location tool;
+        /// Helper for common functionality of ::start and ::finish.
+        /// start: calculate moves.
+        /// finish: set new ter/furn, produce byproducts, display result messages.
+        /// both: check validity of references, debugmsg and bail out on errors.
+        /// @param tool_member one of the map_data_common_t activity_data_common members
+        /// @param moves updated with activity duration when finish == false
+        /// @param data populated with the activity_data_common if one is found.
+        /// @return success of the start/finish operation
+        bool start_finish( map &here, player_activity &act, Character &who,
+                           int &moves, const std::string &tool_name,
+                           const cata::value_ptr<activity_data_common> map_data_common_t::* tool_member, bool finish,
+                           activity_data_common *&data );
+};
+
+class hacksaw_activity_actor : public tool_activity_actor
 {
     public:
         explicit hacksaw_activity_actor( const tripoint_bub_ms &target,
-                                         const item_location &tool ) : target( target ), tool( tool ) {};
+                                         const item_location &tool ) : tool_activity_actor( target, tool ) {};
         explicit hacksaw_activity_actor( const tripoint_bub_ms &target, const itype_id &type,
-                                         const tripoint_bub_ms &veh_pos ) : target( target ), type( type ), veh_pos( veh_pos ) {};
+                                         const tripoint_bub_ms &veh_pos ) : tool_activity_actor( target ), type( type ),
+            veh_pos( veh_pos ) {};
         const activity_id &get_type() const override {
             static const activity_id ACT_HACKSAW( "ACT_HACKSAW" );
             return ACT_HACKSAW;
@@ -231,11 +257,7 @@ class hacksaw_activity_actor : public activity_actor
         void serialize( JsonOut &jsout ) const override;
         static std::unique_ptr<activity_actor> deserialize( JsonValue &jsin );
 
-        // debugmsg causes a backtrace when fired during cata_test
-        bool testing = false;  // NOLINT(cata-serialize)
     private:
-        tripoint_bub_ms target;
-        item_location tool;
         std::optional<itype_id> type;
         std::optional<tripoint_bub_ms> veh_pos;
         bool can_resume_with_internal( const activity_actor &other,
@@ -589,11 +611,11 @@ class pickup_activity_actor : public activity_actor
         static std::unique_ptr<activity_actor> deserialize( JsonValue &jsin );
 };
 
-class boltcutting_activity_actor : public activity_actor
+class boltcutting_activity_actor : public tool_activity_actor
 {
     public:
         explicit boltcutting_activity_actor( const tripoint_bub_ms &target,
-                                             const item_location &tool ) : target( target ), tool( tool ) {};
+                                             const item_location &tool ) : tool_activity_actor( target, tool ) {};
 
         const activity_id &get_type() const override {
             static const activity_id ACT_BOLTCUTTING( "ACT_BOLTCUTTING" );
@@ -611,13 +633,7 @@ class boltcutting_activity_actor : public activity_actor
         void serialize( JsonOut &jsout ) const override;
         static std::unique_ptr<activity_actor> deserialize( JsonValue &jsin );
 
-        // debugmsg causes a backtrace when fired during cata_test
-        bool testing = false; // NOLINT(cata-serialize)
-
     private:
-        tripoint_bub_ms target;
-        item_location tool;
-
         bool can_resume_with_internal( const activity_actor &other,
                                        const Character &/*who*/ ) const override {
             const boltcutting_activity_actor &actor = static_cast<const boltcutting_activity_actor &>
@@ -1642,11 +1658,11 @@ class tent_placement_activity_actor : public activity_actor
         static std::unique_ptr<activity_actor> deserialize( JsonValue &jsin );
 };
 
-class oxytorch_activity_actor : public activity_actor
+class oxytorch_activity_actor : public tool_activity_actor
 {
     public:
         explicit oxytorch_activity_actor( const tripoint_bub_ms &target,
-                                          const item_location &tool ) : target( target ), tool( tool ) {};
+                                          const item_location &tool ) : tool_activity_actor( target, tool ) {};
 
         const activity_id &get_type() const override {
             static const activity_id ACT_OXYTORCH( "ACT_OXYTORCH" );
@@ -1663,13 +1679,7 @@ class oxytorch_activity_actor : public activity_actor
 
         void serialize( JsonOut &jsout ) const override;
         static std::unique_ptr<activity_actor> deserialize( JsonValue &jsin );
-
-        // debugmsg causes a backtrace when fired during cata_test
-        bool testing = false;  // NOLINT(cata-serialize)
     private:
-        tripoint_bub_ms target;
-        item_location tool;
-
         bool can_resume_with_internal( const activity_actor &other,
                                        const Character &/*who*/ ) const override {
             const oxytorch_activity_actor &actor = static_cast<const oxytorch_activity_actor &>
@@ -1754,11 +1764,11 @@ class play_with_pet_activity_actor : public activity_actor
         static std::unique_ptr<activity_actor> deserialize( JsonValue &jsin );
 };
 
-class prying_activity_actor : public activity_actor
+class prying_activity_actor : public tool_activity_actor
 {
     public:
         explicit prying_activity_actor( const tripoint_bub_ms &target,
-                                        const item_location &tool ) : target( target ), tool( tool ) {};
+                                        const item_location &tool ) : tool_activity_actor( target, tool ) {};
 
         const activity_id &get_type() const override {
             static const activity_id ACT_PRYING( "ACT_PRYING" );
@@ -1779,11 +1789,7 @@ class prying_activity_actor : public activity_actor
         void serialize( JsonOut &jsout ) const override;
         static std::unique_ptr<activity_actor> deserialize( JsonValue &jsin );
 
-        // debugmsg causes a backtrace when fired during cata_test
-        bool testing = false;  // NOLINT(cata-serialize)
     private:
-        tripoint_bub_ms target;
-        item_location tool;
         bool prying_nails = false;
 
         bool can_resume_with_internal( const activity_actor &other,
@@ -1796,7 +1802,7 @@ class prying_activity_actor : public activity_actor
         // regular prying has lots of conditionals...
         void handle_prying( Character &who );
         // prying nails is much simpler
-        void handle_prying_nails( Character &who );
+        void handle_prying_nails( player_activity &act, Character &who );
 };
 
 class tent_deconstruct_activity_actor : public activity_actor

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -583,12 +583,9 @@ void activity_handlers::game_do_turn( player_activity *act, Character *you )
 void activity_handlers::pickaxe_do_turn( player_activity *act, Character * )
 {
     const tripoint_bub_ms &pos = get_map().get_bub( act->placement );
-    sfx::play_activity_sound( "tool", "pickaxe", sfx::get_heard_volume( pos ) );
-    // each turn is too much
-    if( calendar::once_every( 1_minutes ) ) {
-        //~ Sound of a Pickaxe at work!
-        sounds::sound( pos, 30, sounds::sound_t::destructive_activity, _( "CHNK!  CHNK!  CHNK!" ) );
-    }
+    sfx::play_activity_sound_repeat( "tool", "pickaxe", pos, 1_minutes, 30,
+                                     //~ Sound of a pickaxe at work!
+                                     sounds::sound_t::destructive_activity, _( "CHNK!  CHNK!  CHNK!" ) );
 }
 
 void activity_handlers::pickaxe_finish( player_activity *act, Character *you )
@@ -2232,13 +2229,9 @@ void activity_handlers::eat_menu_finish( player_activity *, Character * )
 void activity_handlers::jackhammer_do_turn( player_activity *act, Character * )
 {
     map &here = get_map();
-    sfx::play_activity_sound( "tool", "jackhammer",
-                              sfx::get_heard_volume( here.get_bub( act->placement ) ) );
-    if( calendar::once_every( 1_minutes ) ) {
-        sounds::sound( here.get_bub( act->placement ), 15, sounds::sound_t::destructive_activity,
-                       //~ Sound of a jackhammer at work!
-                       _( "TATATATATATATAT!" ) );
-    }
+    sfx::play_activity_sound_repeat( "tool", "jackhammer", here.get_bub( act->placement ), 1_minutes,
+                                     //~ Sound of a jackhammer at work!
+                                     15, sounds::sound_t::destructive_activity, _( "TATATATATATATAT!" ) );
 }
 
 void activity_handlers::jackhammer_finish( player_activity *act, Character *you )

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -2217,11 +2217,9 @@ void construct::do_turn_deconstruct( const tripoint_bub_ms &p, Character &who )
 
 void construct::do_turn_shovel( const tripoint_bub_ms &p, Character &who )
 {
-    sfx::play_activity_sound( "tool", "shovel", sfx::get_heard_volume( p ) );
-    if( calendar::once_every( 1_minutes ) ) {
-        //~ Sound of a shovel digging a pit at work!
-        sounds::sound( p, 10, sounds::sound_t::activity, _( "hsh!" ) );
-    }
+    sfx::play_activity_sound_repeat( "tool", "shovel", p, 1_minutes, 10, sounds::sound_t::activity,
+                                     //~ Sound of a shovel digging a pit at work!
+                                     _( "hsh!" ) );
     if( !who.knows_trap( p ) ) {
         get_map().maybe_trigger_trap( p, who, true );
     }

--- a/src/flexbuffer_json-inl.h
+++ b/src/flexbuffer_json-inl.h
@@ -616,6 +616,14 @@ auto JsonArray::read( T &v, bool throw_on_error ) const -> decltype( v.front(), 
     return true;
 }
 
+template< typename... Ts >
+bool JsonValue::read( std::variant<Ts...> &v, bool throw_on_error ) const
+{
+    return std::visit( [&]( auto & value ) {
+        return read( value, throw_on_error );
+    }, v );
+}
+
 inline JsonValue JsonArray::operator[]( size_t idx ) const
 {
     // Manually bsearch for the key idx to store in visited_fields_bitset_.

--- a/src/flexbuffer_json.h
+++ b/src/flexbuffer_json.h
@@ -5,6 +5,7 @@
 #include <optional>
 #include <string>
 #include <type_traits>
+#include <variant>
 
 #include <flatbuffers/flexbuffers.h>
 
@@ -304,6 +305,10 @@ class JsonValue : Json
                        !std::is_same_v<typename T::key_type, typename T::value_type> > * = nullptr
                    >
         bool read( T &m, bool throw_on_error = true ) const;
+
+        // reads into a variant that already contains a readable type
+        template< typename... Ts >
+        bool read( std::variant<Ts...> &v, bool throw_on_error = true ) const;
 
         [[noreturn]] void string_error( const std::string &message ) const noexcept( false ) {
             string_error( 0, message );

--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -1204,22 +1204,22 @@ void ter_t::load( const JsonObject &jo, const std::string &src )
 
     optional( jo, was_loaded, "lockpick_result", lockpick_result, ter_str_id::NULL_ID() );
 
-    oxytorch = cata::make_value<activity_data_ter>();
+    oxytorch = cata::make_value<activity_data_common>( ter_str_id::NULL_ID() );
     if( jo.has_object( "oxytorch" ) ) { //TODO: Make overwriting these with eg "oxytorch": { } work while still allowing overwriting single values
         oxytorch->load( jo.get_object( "oxytorch" ) );
     }
 
-    boltcut = cata::make_value<activity_data_ter>();
+    boltcut = cata::make_value<activity_data_common>( ter_str_id::NULL_ID() );
     if( jo.has_object( "boltcut" ) ) {
         boltcut->load( jo.get_object( "boltcut" ) );
     }
 
-    hacksaw = cata::make_value<activity_data_ter>();
+    hacksaw = cata::make_value<activity_data_common>( ter_str_id::NULL_ID() );
     if( jo.has_object( "hacksaw" ) ) {
         hacksaw->load( jo.get_object( "hacksaw" ) );
     }
 
-    prying = cata::make_value<activity_data_ter>();
+    prying = cata::make_value<activity_data_common>( ter_str_id::NULL_ID() );
     if( jo.has_object( "prying" ) ) {
         prying->load( jo.get_object( "prying" ) );
     }
@@ -1414,22 +1414,22 @@ void furn_t::load( const JsonObject &jo, const std::string &src )
     optional( jo, was_loaded, "lockpick_result", lockpick_result, string_id_reader<furn_t> {},
               furn_str_id::NULL_ID() );
 
-    oxytorch = cata::make_value<activity_data_furn>();
+    oxytorch = cata::make_value<activity_data_common>( furn_str_id::NULL_ID() );
     if( jo.has_object( "oxytorch" ) ) {
         oxytorch->load( jo.get_object( "oxytorch" ) );
     }
 
-    boltcut = cata::make_value<activity_data_furn>();
+    boltcut = cata::make_value<activity_data_common>( furn_str_id::NULL_ID() );
     if( jo.has_object( "boltcut" ) ) {
         boltcut->load( jo.get_object( "boltcut" ) );
     }
 
-    hacksaw = cata::make_value<activity_data_furn>();
+    hacksaw = cata::make_value<activity_data_common>( furn_str_id::NULL_ID() );
     if( jo.has_object( "hacksaw" ) ) {
         hacksaw->load( jo.get_object( "hacksaw" ) );
     }
 
-    prying = cata::make_value<activity_data_furn>();
+    prying = cata::make_value<activity_data_common>( furn_str_id::NULL_ID() );
     if( jo.has_object( "prying" ) ) {
         prying->load( jo.get_object( "prying" ) );
     }
@@ -1564,19 +1564,9 @@ void activity_data_common::load( const JsonObject &jo )
     optional( jo, was_loaded, "byproducts", byproducts_ );
 
     optional( jo, was_loaded, "prying_data", prying_data_ );
-}
 
-void activity_data_ter::load( const JsonObject &jo )
-{
-    mandatory( jo, was_loaded, "result", result_ );
-    activity_data_common::load( jo );
-    valid_ = true;
-}
-
-void activity_data_furn::load( const JsonObject &jo )
-{
-    optional( jo, was_loaded, "result", result_, furn_str_id::NULL_ID() );
-    activity_data_common::load( jo );
+    // default here is needed to preserve the type-priming of the variant in ter_t::load and furn_t::load
+    optional( jo, was_loaded, "result", result_, result_ );
     valid_ = true;
 }
 

--- a/src/mapdata.h
+++ b/src/mapdata.h
@@ -10,6 +10,7 @@
 #include <string>
 #include <string_view>
 #include <utility>
+#include <variant>
 #include <vector>
 
 #include "calendar.h"
@@ -419,6 +420,10 @@ class activity_data_common
 {
     public:
         activity_data_common() = default;
+        template<typename T>
+        explicit activity_data_common( T result ) {
+            result_ = result;
+        }
 
         bool valid() const {
             return valid_;
@@ -447,6 +452,10 @@ class activity_data_common
         bool was_loaded = false;
         void load( const JsonObject &jo );
 
+        std::variant<ter_str_id, furn_str_id> result() const {
+            return result_;
+        }
+
     protected:
         bool valid_ = false;
         time_duration duration_;
@@ -454,36 +463,10 @@ class activity_data_common
         translation sound_;
         struct pry_data prying_data_;
         std::vector<activity_byproduct> byproducts_;
-};
-
-class activity_data_ter : public activity_data_common
-{
-    public:
-        activity_data_ter() = default;
-
-        const ter_str_id &result() const {
-            return result_;
-        }
-
-        void load( const JsonObject &jo );
 
     private:
-        ter_str_id result_;
-};
+        std::variant<ter_str_id, furn_str_id> result_;
 
-class activity_data_furn : public activity_data_common
-{
-    public:
-        activity_data_furn() = default;
-
-        const furn_str_id &result() const {
-            return result_;
-        }
-
-        void load( const JsonObject &jo );
-
-    private:
-        furn_str_id result_;
 };
 
 void init_mapdata();
@@ -552,6 +535,11 @@ struct map_data_common_t {
         int fall_damage_reduction = 0;
         // Maximal volume of items that can be stored in/on this furniture/terrain
         units::volume max_volume = DEFAULT_TILE_VOLUME;
+
+        cata::value_ptr<activity_data_common> boltcut; // Bolt cutting action data
+        cata::value_ptr<activity_data_common> hacksaw; // Hacksaw action data
+        cata::value_ptr<activity_data_common> oxytorch; // Oxytorch action data
+        cata::value_ptr<activity_data_common> prying;  // Prying action data
 
         itype_id liquid_source_item_id = itype_id::NULL_ID(); // id of a liquid this tile provides
         double liquid_source_min_temp = 4; // in centigrades, cold water as default value
@@ -673,11 +661,6 @@ struct ter_t : map_data_common_t {
 
     ter_str_id lockpick_result; // Lockpick action: transform when successfully lockpicked
 
-    cata::value_ptr<activity_data_ter> boltcut; // Bolt cutting action data
-    cata::value_ptr<activity_data_ter> hacksaw; // Hacksaw action data
-    cata::value_ptr<activity_data_ter> oxytorch; // Oxytorch action data
-    cata::value_ptr<activity_data_ter> prying;  // Prying action data
-
     std::string trap_id_str;     // String storing the id string of the trap.
     ter_str_id transforms_into; // Transform into what terrain?
     ter_str_id roof;            // What will be the floor above this terrain
@@ -732,11 +715,6 @@ struct furn_t : map_data_common_t {
 
     int move_str_req = 0; //The amount of strength required to move through this furniture easily.
     units::mass mass = 0_gram;
-
-    cata::value_ptr<activity_data_furn> boltcut; // Bolt cutting action data
-    cata::value_ptr<activity_data_furn> hacksaw; // Hacksaw action data
-    cata::value_ptr<activity_data_furn> oxytorch; // Oxytorch action data
-    cata::value_ptr<activity_data_furn> prying;  // Prying action data
 
     cata::value_ptr<furn_workbench_info> workbench;
 

--- a/src/player_activity.cpp
+++ b/src/player_activity.cpp
@@ -12,6 +12,7 @@
 #include "character.h"
 #include "construction.h"
 #include "creature.h"
+#include "debug.h"
 #include "dialogue.h"
 #include "effect_on_condition.h"
 #include "event.h"
@@ -22,6 +23,7 @@
 #include "itype.h"
 #include "magic.h"
 #include "map.h"
+#include "messages.h"
 #include "rng.h"
 #include "skill.h"
 #include "sounds.h"
@@ -90,6 +92,12 @@ player_activity::player_activity( const activity_actor &actor ) : type( actor.ge
             ignored_distractions.emplace( dt );
         }
     }
+}
+
+void player_activity::set_moves_total_left()
+{
+    add_msg_debug( debugmode::DF_ACTIVITY, "%s moves_total: %d", id().str(), moves_total );
+    moves_left = moves_total;
 }
 
 void player_activity::set_to_null()

--- a/src/player_activity.h
+++ b/src/player_activity.h
@@ -45,6 +45,8 @@ class player_activity
         int moves_total = 0;
         /** The number of moves remaining in this activity before it is complete. */
         int moves_left = calendar::INDEFINITELY_LONG;
+        /** Sets moves_left to moves_total and emits a debug message */
+        void set_moves_total_left();
         /** Controls whether this activity can be cancelled at all */
         bool interruptable = true;
         /** Controls whether this activity can be cancelled with 'pause' action */

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -1935,6 +1935,17 @@ void sfx::play_activity_sound( const std::string &id, const std::string &variant
     }
 }
 
+void sfx::play_activity_sound_repeat( const std::string &id, const std::string &variant,
+                                      const tripoint_bub_ms &p, const time_duration &once_every, int repeat_vol, sounds::sound_t category,
+                                      const std::string &description )
+{
+    sfx::play_activity_sound( id, variant, sfx::get_heard_volume( p ) );
+    if( calendar::once_every( once_every ) ) {
+        sounds::sound( p, repeat_vol, category, description );
+    }
+
+}
+
 void sfx::end_activity_sounds()
 {
     if( test_mode ) {
@@ -1997,6 +2008,9 @@ void sfx::play_variant_sound( const std::string &, const std::string &, int ) { 
 void sfx::play_ambient_variant_sound( const std::string &, const std::string &, int, channel, int,
                                       double, int ) { }
 void sfx::play_activity_sound( const std::string &, const std::string &, int ) { }
+void sfx::play_activity_sound_repeat( const std::string &, const std::string &,
+                                      const tripoint_bub_ms &, const time_duration &, int, sounds::sound_t,
+                                      const std::string & ) { }
 void sfx::end_activity_sounds() { }
 void sfx::generate_gun_sound( const Character &, const item & ) { }
 void sfx::generate_melee_sound( const tripoint_bub_ms &, const tripoint_bub_ms &, bool, bool,

--- a/src/sounds.h
+++ b/src/sounds.h
@@ -7,6 +7,7 @@
 #include <utility>
 #include <vector>
 
+#include "calendar.h"
 #include "coords_fwd.h"
 #include "units_fwd.h"
 
@@ -159,6 +160,9 @@ void play_ambient_variant_sound( const std::string &id, const std::string &varia
 void play_activity_sound( const std::string &id, const std::string &variant, int volume );
 void play_activity_sound( const std::string &id, const std::string &variant,
                           const std::string &season, int volume );
+void play_activity_sound_repeat( const std::string &id, const std::string &variant,
+                                 const tripoint_bub_ms &p, const time_duration &once_every, int repeat_vol, sounds::sound_t category,
+                                 const std::string &description );
 void end_activity_sounds();
 void generate_gun_sound( const Character &source_arg, const item &firing );
 void generate_melee_sound( const tripoint_bub_ms &source, const tripoint_bub_ms &target, bool hit,

--- a/tests/player_activities_test.cpp
+++ b/tests/player_activities_test.cpp
@@ -711,7 +711,7 @@ TEST_CASE( "boltcut", "[activity][boltcut]" )
             setup_activity( boltcutter );
             REQUIRE( dummy.activity.id() == ACT_BOLTCUTTING );
 
-            WHEN( "furniture has a duration of 5 seconds" ) {
+            WHEN( "furniture activity has a duration of 5 seconds" ) {
                 REQUIRE( furn_test_f_boltcut1->boltcut->duration() == 5_seconds );
                 THEN( "moves_left is equal to 5 seconds" ) {
                     CHECK( dummy.activity.moves_left == to_moves<int>( 5_seconds ) );
@@ -781,7 +781,7 @@ TEST_CASE( "boltcut", "[activity][boltcut]" )
             }
         }
 
-        GIVEN( "a tripoint with valid furniture" ) {
+        GIVEN( "a tripoint with valid furniture with no activity result" ) {
             clear_map();
             clear_avatar();
 
@@ -795,7 +795,7 @@ TEST_CASE( "boltcut", "[activity][boltcut]" )
             process_activity( dummy );
             REQUIRE( dummy.activity.id() == ACT_NULL );
 
-            THEN( "furniture gets converted to new furniture type" ) {
+            THEN( "furniture gets removed" ) {
                 CHECK( mp.furn( tripoint_bub_ms::zero ) == furn_str_id::NULL_ID() );
             }
         }
@@ -819,7 +819,7 @@ TEST_CASE( "boltcut", "[activity][boltcut]" )
             }
         }
 
-        GIVEN( "a tripoint with a valid furniture with byproducts" ) {
+        GIVEN( "a tripoint with a valid terrain with byproducts" ) {
             clear_map();
             clear_avatar();
 
@@ -975,7 +975,7 @@ TEST_CASE( "hacksaw", "[activity][hacksaw]" )
             setup_activity( hacksaw );
             REQUIRE( dummy.activity.id() == ACT_HACKSAW );
 
-            WHEN( "furniture has a duration of 5 minutes" ) {
+            WHEN( "furniture activity has a duration of 5 minutes" ) {
                 REQUIRE( furn_test_f_hacksaw1->hacksaw->duration() == 5_minutes );
                 THEN( "moves_left is equal to 5 minutes" ) {
                     CHECK( dummy.activity.moves_left == to_moves<int>( 5_minutes ) );
@@ -1046,7 +1046,7 @@ TEST_CASE( "hacksaw", "[activity][hacksaw]" )
             }
         }
 
-        GIVEN( "a tripoint with valid furniture" ) {
+        GIVEN( "a tripoint with valid furniture with no activity result" ) {
             clear_map();
             clear_avatar();
 
@@ -1060,7 +1060,7 @@ TEST_CASE( "hacksaw", "[activity][hacksaw]" )
             process_activity( dummy );
             REQUIRE( dummy.activity.id() == ACT_NULL );
 
-            THEN( "furniture gets converted to new furniture type" ) {
+            THEN( "furniture gets removed" ) {
                 CHECK( mp.furn( tripoint_bub_ms::zero ) == furn_str_id::NULL_ID() );
             }
         }
@@ -1084,7 +1084,7 @@ TEST_CASE( "hacksaw", "[activity][hacksaw]" )
             }
         }
 
-        GIVEN( "a tripoint with a valid furniture with byproducts" ) {
+        GIVEN( "a tripoint with a valid terrain with byproducts" ) {
             clear_map();
             clear_avatar();
 
@@ -1241,7 +1241,7 @@ TEST_CASE( "oxytorch", "[activity][oxytorch]" )
             setup_activity( welding_torch );
             REQUIRE( dummy.activity.id() == ACT_OXYTORCH );
 
-            WHEN( "furniture has a duration of 5 seconds" ) {
+            WHEN( "furniture activity has a duration of 5 seconds" ) {
                 REQUIRE( furn_test_f_oxytorch1->oxytorch->duration() == 5_seconds );
                 THEN( "moves_left is equal to 5 seconds" ) {
                     CHECK( dummy.activity.moves_left == to_moves<int>( 5_seconds ) );
@@ -1301,7 +1301,7 @@ TEST_CASE( "oxytorch", "[activity][oxytorch]" )
             }
         }
 
-        GIVEN( "a tripoint with valid furniture" ) {
+        GIVEN( "a tripoint with valid furniture with no activity result" ) {
             clear_map();
             clear_avatar();
 
@@ -1315,7 +1315,7 @@ TEST_CASE( "oxytorch", "[activity][oxytorch]" )
             process_activity( dummy );
             REQUIRE( dummy.activity.id() == ACT_NULL );
 
-            THEN( "furniture gets converted to new furniture type" ) {
+            THEN( "furniture gets removed" ) {
                 CHECK( mp.furn( tripoint_bub_ms::zero ) == furn_str_id::NULL_ID() );
             }
         }
@@ -1339,7 +1339,7 @@ TEST_CASE( "oxytorch", "[activity][oxytorch]" )
             }
         }
 
-        GIVEN( "a tripoint with a valid furniture with byproducts" ) {
+        GIVEN( "a tripoint with a valid terrain with byproducts" ) {
             clear_map();
             clear_avatar();
 
@@ -1538,7 +1538,7 @@ TEST_CASE( "prying", "[activity][prying]" )
             setup_activity( prying_tool );
             REQUIRE( dummy.activity.id() == ACT_PRYING );
 
-            WHEN( "furniture has a duration of 17 seconds" ) {
+            WHEN( "furniture activity has a duration of 17 seconds" ) {
                 REQUIRE( furn_test_f_prying1->prying->duration() == 17_seconds );
                 THEN( "moves_left is equal to 17 seconds" ) {
                     CHECK( dummy.activity.moves_left == to_moves<int>( 17_seconds ) );
@@ -1567,7 +1567,7 @@ TEST_CASE( "prying", "[activity][prying]" )
             }
         }
 
-        GIVEN( "a tripoint with valid furniture" ) {
+        GIVEN( "a tripoint with valid furniture with no activity result" ) {
             clear_map();
             clear_avatar();
 
@@ -1581,7 +1581,7 @@ TEST_CASE( "prying", "[activity][prying]" )
             process_activity( dummy );
             REQUIRE( dummy.activity.id() == ACT_NULL );
 
-            THEN( "furniture gets converted to new furniture type" ) {
+            THEN( "furniture gets removed" ) {
                 CHECK( mp.furn( tripoint_bub_ms::zero ) == furn_str_id::NULL_ID() );
             }
         }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
activity_actor method implementation is extremely repetitive and occasionally inconsistent. This makes it hard to tell which parts of which methods are doing the same boilerplate things vs doing something unique to that method. It also makes the code less navigable, with dozens of lines of boilerplate between the important parts. It also increases the chances of mistakes in future copy/paste/modify operations.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
* Create `tool_activity_actor` class between `activity_actor` and some of its children with common features.
* Move common method functionality to functions:
  * start and finish for tool activities
  * repeated sound effects
  * setting activity time left at the start of the activity, with a debugmsg
* Implement `JsonValue::read(std::variant...` which will read into a variant that already contains a type.
* Replace `activity_data_(ter|furn)` and their `result_` field with a `variant` in `activity_data_common`, primed with a null result so `read(` knows what type to read into it.
* Use a loop when spawning tree cutting results.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
See comments on changes.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->
TODO, so far just verified a couple of tool actions still work in typical scenarios

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
