### PR TITLE
[WIP] General improvements to item stealing

### DIFF
--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -2489,6 +2489,17 @@
   },
   {
     "type": "keybinding",
+    "id": "TOGGLE_THIEF_MODE_ZONE",
+    "category": "ZONES_MANAGER",
+    "name": "Toggle thief mode",
+    "bindings": [
+      { "input_method": "keyboard_any", "key": "l" },
+      { "input_method": "keyboard_char", "key": "L" },
+      { "input_method": "keyboard_code", "key": "l", "mod": [ "shift" ] }
+    ]
+  },
+  {
+    "type": "keybinding",
     "name": "Peek around corners",
     "category": "DEFAULTMODE",
     "id": "peek",

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -6888,7 +6888,7 @@ static bool check_stealing( Character &who, item &it )
     if( !it.is_owned_by( who, true ) ) {
         // Has the player given input on if stealing is ok?
         if( who.get_value( "THIEF_MODE" ).str() == "THIEF_ASK" ) {
-            Pickup::query_thief();
+            Pickup::query_thief( it );
         }
         if( who.get_value( "THIEF_MODE" ).str() == "THIEF_HONEST" ) {
             if( who.get_value( "THIEF_MODE_KEEP" ).str() != "YES" ) {

--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -1843,7 +1843,7 @@ static bool query_consume_ownership( item &target, Character &p )
     if( !target.is_owned_by( p, true ) ) {
         bool choice = true;
         if( p.get_value( "THIEF_MODE" ).str() == "THIEF_ASK" ) {
-            choice = Pickup::query_thief();
+            choice = Pickup::query_thief( target );
         }
         if( p.get_value( "THIEF_MODE" ).str() == "THIEF_HONEST" || !choice ) {
             return false;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -7090,6 +7090,18 @@ static void zones_manager_shortcuts( const catacurses::window &w_info, faction_i
     std::vector<std::string> act_descs;
     std::string show_zones_text = show_all_zones ? "Showing all zones" : "Hiding distant zones";
     std::string zone_faction = string_format( _( "Shown faction: %s" ), faction.str() );
+
+    std::array< std::string, 3 > thief_text_options = { _( "ASK" ), _( "ON" ), _( "OFF" ) };
+    std::string thief_text = "Steal:";
+    std::string thief_value = get_player_character().get_value( "THIEF_MODE" ).to_string();
+    if( thief_value == "THIEF_ASK" ) {
+        thief_text += thief_text_options[0];
+    } else if( thief_value == "THIEF_STEAL" ) {
+        thief_text += thief_text_options[1];
+    } else if( thief_value == "THIEF_HONEST" ) {
+        thief_text += thief_text_options[2];
+    }
+
     const auto add_action_desc = [&]( const std::string & act, const std::string & txt ) {
         act_descs.emplace_back( ctxt.get_desc( act, txt, input_context::allow_all_keys ) );
     };
@@ -7107,6 +7119,7 @@ static void zones_manager_shortcuts( const catacurses::window &w_info, faction_i
     add_action_desc( "CONFIRM", pgettext( "zones manager", "Edit" ) );
     add_action_desc( "SHOW_ALL_ZONES", pgettext( "zones manager", show_zones_text.c_str() ) );
     add_action_desc( "SHOW_ZONE_ON_MAP", pgettext( "zones manager", "Map" ) );
+    add_action_desc( "TOGGLE_THIEF_MODE_ZONE", pgettext( "zones manager", thief_text.c_str() ) );
     if( debug_mode ) {
         add_action_desc( "CHANGE_FACTION", pgettext( "zones manager", zone_faction.c_str() ) );
     }
@@ -7229,6 +7242,7 @@ void game::zones_manager()
     ctxt.register_action( "DISABLE_PERSONAL_ZONES" );
     ctxt.register_action( "SHOW_ALL_ZONES" );
     ctxt.register_action( "HELP_KEYBINDINGS" );
+    ctxt.register_action( "TOGGLE_THIEF_MODE_ZONE" );
     if( debug_mode ) {
         ctxt.register_action( "CHANGE_FACTION" );
     }
@@ -7614,6 +7628,8 @@ void game::zones_manager()
             show_all_zones = !show_all_zones;
             zones = get_zones();
             active_index = 0;
+        } else if( action == "TOGGLE_THIEF_MODE_ZONE" ) {
+            Pickup::toggle_thief_mode( u );
         } else if( action == "CHANGE_FACTION" ) {
             ui.invalidate_ui();
             std::string facname = zones_faction.str();

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -76,6 +76,7 @@
 #include "overmap_ui.h"
 #include "panels.h"
 #include "pathfinding.h"
+#include "pickup.h"
 #include "player_activity.h"
 #include "point.h"
 #include "popup.h"
@@ -3045,26 +3046,7 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
             break;
 
         case ACTION_TOGGLE_THIEF_MODE:
-            if( player_character.get_value( "THIEF_MODE" ).str() == "THIEF_ASK" ) {
-                player_character.set_value( "THIEF_MODE", "THIEF_HONEST" );
-                player_character.set_value( "THIEF_MODE_KEEP", "YES" );
-                //~ Thief mode cycled between THIEF_ASK/THIEF_HONEST/THIEF_STEAL
-                add_msg( _( "You will not pick up other peoples belongings." ) );
-            } else if( player_character.get_value( "THIEF_MODE" ).str() == "THIEF_HONEST" ) {
-                player_character.set_value( "THIEF_MODE", "THIEF_STEAL" );
-                player_character.set_value( "THIEF_MODE_KEEP", "YES" );
-                //~ Thief mode cycled between THIEF_ASK/THIEF_HONEST/THIEF_STEAL
-                add_msg( _( "You will pick up also those things that belong to others!" ) );
-            } else if( player_character.get_value( "THIEF_MODE" ).str() == "THIEF_STEAL" ) {
-                player_character.set_value( "THIEF_MODE", "THIEF_ASK" );
-                player_character.set_value( "THIEF_MODE_KEEP", "NO" );
-                //~ Thief mode cycled between THIEF_ASK/THIEF_HONEST/THIEF_STEAL
-                add_msg( _( "You will be reminded not to steal." ) );
-            } else {
-                // ERROR
-                add_msg( _( "THIEF_MODE CONTAINED BAD VALUE [ %s ]!" ),
-                         player_character.get_value( "THIEF_MODE" ).to_string() );
-            }
+            Pickup::toggle_thief_mode( player_character );
             break;
 
         case ACTION_TOGGLE_AUTO_FORAGING:

--- a/src/pickup.h
+++ b/src/pickup.h
@@ -37,7 +37,12 @@ struct pick_info {
  */
 bool do_pickup( std::vector<item_location> &targets, std::vector<int> &quantities,
                 bool autopickup, bool &stash_successful, Pickup::pick_info &info );
-bool query_thief();
+/**
+* Returns true if the player has thief mode = OFF, prompts if thief mode = ASK
+*/
+bool check_no_stealing( const item &it );
+bool query_thief( const item &it );
+void toggle_thief_mode( Character &player_character );
 
 enum from_where : int {
     from_cargo = 0,


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Features "general improvements to item stealing"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Thief mode is very underdeveloped. You may not even know it exists: it has no default keybind and is only encountered when stealing an item.

A brief reminder: if you try to pick up an item owned by another faction, you're prompted that you're stealing it, which can have consequences.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

1. Add support for stealing for the zone manager. Presently, sorting loot ignores any items owned by different factions, which makes looting e.g. `bandit_camp` painstakingly slow. The zone manager now displays thief mode's status, and you can toggle thief mode from the zone manager.
2. The prompt for stealing an item now displays the item name and its faction owner's name.

Also deduplicates some zone sorting item checks and cleans up some comments.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

A message for not picking up items due to thief mode being OFF would be a good idea later. Right now, there's no feedback.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

- Sorted items in `bandit_camp` with a personal zone, using ASK, OFF, ON thief mode settings. 
- Picked items up in `bandit_camp` normally.
- Tested both of the above cases and made sure thief mode was set to the correct value after using ALWAYS/NEVER prompt selections.
- Verified that items owned by player can still be picked up and sorted if NO/OFF are selected, even from a pile of mixed-ownership items.

<img width="615" height="120" alt="image" src="https://github.com/user-attachments/assets/14f7f404-699d-4ce7-9838-a55af740272c" />
<img width="359" height="151" alt="image" src="https://github.com/user-attachments/assets/9fa3c87b-a3f1-4d0b-b83e-6027898034a7" />


<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

I would like to ImGui-fy the zone manager but feel I should do something more approachable first

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
