### PR TITLE
Dedupe filesystem use of cata_path and string

### DIFF
--- a/src/filesystem.h
+++ b/src/filesystem.h
@@ -68,12 +68,11 @@ const char *eol();
  * @param match_extension If true, match pattern at the end of file names. Otherwise, match anywhere
  *                        in the file name.
  */
-std::vector<std::string> get_files_from_path( const std::string &pattern,
-        const std::string &root_path = "", bool recursive_search = false,
-        bool match_extension = false );
-std::vector<cata_path> get_files_from_path( const std::string &pattern,
-        const cata_path &root_path, bool recursive_search = false,
-        bool match_extension = false );
+template<typename P>
+std::vector<P> get_files_from_path( const std::string &pattern,
+                                    const P &root_path = P(), bool recursive_search = false,
+                                    bool match_extension = false );
+
 /**
  * Returns a vector of files or directories matching pattern at @p root_path excluding those who's path matches @p pattern_clash.
  *
@@ -87,13 +86,10 @@ std::vector<cata_path> get_files_from_path( const std::string &pattern,
  * @param match_extension If true, match pattern at the end of file names. Otherwise, match anywhere
  *                        in the file name.
  */
-std::vector<std::string> get_files_from_path_with_path_exclusion( const std::string &pattern,
+template<typename P>
+std::vector<P> get_files_from_path_with_path_exclusion( const std::string &pattern,
         const std::string &pattern_clash,
-        const std::string &root_path = "", bool recursive_search = false,
-        bool match_extension = false );
-std::vector<cata_path> get_files_from_path_with_path_exclusion( const std::string &pattern,
-        const std::string &pattern_clash,
-        const cata_path &root_path, bool recursive_search = false,
+        const P &root_path = P(), bool recursive_search = false,
         bool match_extension = false );
 
 //--------------------------------------------------------------------------------------------------
@@ -103,23 +99,17 @@ std::vector<cata_path> get_files_from_path_with_path_exclusion( const std::strin
  * @param patterns A vector or patterns to match.
  * @see get_files_from_path
  */
-std::vector<std::string> get_directories_with( const std::vector<std::string> &patterns,
-        const std::string &root_path = "", bool recursive_search = false );
+template<typename P>
+std::vector<P> get_directories_with( const std::vector<std::string> &patterns,
+                                     const P &root_path = P(), bool recursive_search = false );
 
-std::vector<std::string> get_directories_with( const std::string &pattern,
-        const std::string &root_path = "", bool recursive_search = false );
+template<typename P>
+std::vector<P> get_directories_with( const std::string &pattern,
+                                     const P &root_path = P(), bool recursive_search = false );
 
-std::vector<cata_path> get_directories_with( const std::vector<std::string> &patterns,
-        const cata_path &root_path = {}, bool recursive_search = false );
-
-std::vector<cata_path> get_directories_with( const std::string &pattern,
-        const cata_path &root_path = {}, bool recursive_search = false );
-
-std::vector<std::string> get_directories( const std::string &root_path = "",
-        bool recursive_search = false );
-
-std::vector<cata_path> get_directories( const cata_path &root_path = {}, bool recursive_search =
-        false );
+template<typename P>
+std::vector<P> get_directories( const P &root_path = P(),
+                                bool recursive_search = false );
 
 bool copy_file( const std::string &source_path, const std::string &dest_path );
 bool copy_file( const cata_path &source_path, const cata_path &dest_path );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
The filesystem code contains a lot of repeated code for dealing with paths stored as `std::string` vs `cata_path`, and some other significantly repeated code.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
Template most of the functions with identical or nearly-identical contents. Explicitly instanciate both versions.
Replace overloads with default parameter for `is_directory`.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
I tried to use a macro for the explicit instanciation, but MSVC balked at the forms that used decltype to avoid repeating the function signatures.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->
Ran the game. Pending automated tests.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
