### PR TITLE
Make iuse param check consistent

### DIFF
--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -499,6 +499,42 @@ void remove_radio_mod( item &it, Character &p )
     it.unset_flag( flag_RADIOCARITEM );
 }
 
+bool iuse::check_params( const Character *const p, const item *const it, const std::string &action )
+{
+    if( !p ) {
+        if( it ) {
+            debugmsg( "%s called action %s without required character.",
+                      it->typeId().str(), action );
+        } else {
+            debugmsg( "Action %s called without required character and item.",
+                      action );
+        }
+        return false;
+    }
+    if( !it ) {
+        debugmsg( "Action %s called without required item.", action );
+    }
+    return true;
+}
+
+bool iuse::check_params( const Character *const p, const std::string &action )
+{
+    if( !p ) {
+        debugmsg( "Action %s called without required character.", action );
+        return false;
+    }
+    return true;
+}
+
+bool iuse::check_params( const item *const it, const std::string &action )
+{
+    if( !it ) {
+        debugmsg( "Action %s called without required item.", action );
+    }
+    return true;
+}
+
+
 // Checks that the player can smoke
 std::optional<std::string> iuse::can_smoke( const Character &you )
 {
@@ -518,6 +554,10 @@ std::optional<std::string> iuse::can_smoke( const Character &you )
 
 std::optional<int> iuse::sewage( Character *p, item *, const tripoint_bub_ms & )
 {
+    if( !check_params( p, __func__ ) ) {
+        return std::nullopt;
+    }
+
     if( !p->query_yn( _( "Are you sure you want to drink… this?" ) ) ) {
         return std::nullopt;
     }
@@ -529,12 +569,18 @@ std::optional<int> iuse::sewage( Character *p, item *, const tripoint_bub_ms & )
 
 std::optional<int> iuse::honeycomb( Character *p, item *, const tripoint_bub_ms & )
 {
+    if( !check_params( p, __func__ ) ) {
+        return std::nullopt;
+    }
     get_map().spawn_item( p->pos_bub(), itype_wax, 2 );
     return 1;
 }
 
 std::optional<int> iuse::xanax( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     p->add_msg_if_player( _( "You take some %s." ), it->tname() );
     p->add_effect( effect_took_xanax, 90_minutes );
     p->add_effect( effect_took_xanax_visible, rng( 70_minutes, 110_minutes ) );
@@ -572,16 +618,25 @@ static int alcohol( Character &p, const item &it, const int strength )
 
 std::optional<int> iuse::alcohol_weak( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     return alcohol( *p, *it, 0 );
 }
 
 std::optional<int> iuse::alcohol_medium( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     return alcohol( *p, *it, 1 );
 }
 
 std::optional<int> iuse::alcohol_strong( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     return alcohol( *p, *it, 2 );
 }
 
@@ -595,6 +650,9 @@ std::optional<int> iuse::alcohol_strong( Character *p, item *it, const tripoint_
  */
 std::optional<int> iuse::smoking( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     std::optional<std::string> litcig = can_smoke( *p );
     if( litcig.has_value() ) {
         p->add_msg_if_player( m_info, _( litcig.value_or( "" ) ) );
@@ -649,6 +707,9 @@ std::optional<int> iuse::smoking( Character *p, item *it, const tripoint_bub_ms 
 
 std::optional<int> iuse::ecig( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     if( it->typeId() == itype_ecig ) {
         p->add_msg_if_player( m_neutral, _( "You take a puff from your electronic cigarette." ) );
     } else if( it->typeId() == itype_advanced_ecig ) {
@@ -676,6 +737,9 @@ std::optional<int> iuse::ecig( Character *p, item *it, const tripoint_bub_ms & )
 
 std::optional<int> iuse::antibiotic( Character *p, item *, const tripoint_bub_ms & )
 {
+    if( !check_params( p, __func__ ) ) {
+        return std::nullopt;
+    }
     p->add_msg_player_or_npc( m_neutral,
                               _( "You take some antibiotics." ),
                               _( "<npcname> takes some antibiotics." ) );
@@ -698,6 +762,9 @@ std::optional<int> iuse::antibiotic( Character *p, item *, const tripoint_bub_ms
 
 std::optional<int> iuse::eyedrops( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     if( p->cant_do_underwater() ) {
         return std::nullopt;
     }
@@ -723,6 +790,9 @@ std::optional<int> iuse::eyedrops( Character *p, item *it, const tripoint_bub_ms
 
 std::optional<int> iuse::fungicide( Character *p, item *, const tripoint_bub_ms & )
 {
+    if( !check_params( p, __func__ ) ) {
+        return std::nullopt;
+    }
     if( p->cant_do_underwater() ) {
         return std::nullopt;
     }
@@ -780,6 +850,9 @@ std::optional<int> iuse::fungicide( Character *p, item *, const tripoint_bub_ms 
 
 std::optional<int> iuse::antifungal( Character *p, item *, const tripoint_bub_ms & )
 {
+    if( !check_params( p, __func__ ) ) {
+        return std::nullopt;
+    }
     if( p->cant_do_underwater() ) {
         return std::nullopt;
     }
@@ -798,6 +871,9 @@ std::optional<int> iuse::antifungal( Character *p, item *, const tripoint_bub_ms
 
 std::optional<int> iuse::antiparasitic( Character *p, item *, const tripoint_bub_ms & )
 {
+    if( !check_params( p, __func__ ) ) {
+        return std::nullopt;
+    }
     if( p->cant_do_underwater() ) {
         return std::nullopt;
     }
@@ -847,6 +923,9 @@ std::optional<int> iuse::antiparasitic( Character *p, item *, const tripoint_bub
 
 std::optional<int> iuse::anticonvulsant( Character *p, item *, const tripoint_bub_ms & )
 {
+    if( !check_params( p, __func__ ) ) {
+        return std::nullopt;
+    }
     p->add_msg_if_player( _( "You take some anticonvulsant medication." ) );
     /** @EFFECT_STR reduces duration of anticonvulsant medication */
     time_duration duration = 8_hours - p->str_cur * rng( 0_turns, 10_minutes );
@@ -868,6 +947,9 @@ std::optional<int> iuse::anticonvulsant( Character *p, item *, const tripoint_bu
 
 std::optional<int> iuse::weed_cake( Character *p, item *, const tripoint_bub_ms & )
 {
+    if( !check_params( p, __func__ ) ) {
+        return std::nullopt;
+    }
     p->add_msg_if_player(
         _( "You start scarfing down the delicious cake.  It tastes a little funny, though…" ) );
     time_duration duration = 12_minutes;
@@ -892,6 +974,9 @@ std::optional<int> iuse::weed_cake( Character *p, item *, const tripoint_bub_ms 
 
 std::optional<int> iuse::coke( Character *p, item *, const tripoint_bub_ms & )
 {
+    if( !check_params( p, __func__ ) ) {
+        return std::nullopt;
+    }
     p->add_msg_if_player( _( "You snort a bump of coke." ) );
     /** @EFFECT_STR reduces duration of coke */
     time_duration duration = 20_minutes - 1_seconds * p->str_cur + rng( 0_minutes, 1_minutes );
@@ -908,6 +993,9 @@ std::optional<int> iuse::coke( Character *p, item *, const tripoint_bub_ms & )
 
 std::optional<int> iuse::meth( Character *p, item *, const tripoint_bub_ms & )
 {
+    if( !check_params( p, __func__ ) ) {
+        return std::nullopt;
+    }
     /** @EFFECT_STR reduces duration of meth */
     time_duration duration = 1_minutes * ( 60 - p->str_cur );
     if( p->has_amount( itype_apparatus, 1 ) && p->use_charges_if_avail( itype_fire, 1 ) ) {
@@ -946,6 +1034,9 @@ std::optional<int> iuse::meth( Character *p, item *, const tripoint_bub_ms & )
 
 std::optional<int> iuse::flu_vaccine( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     p->add_msg_if_player( _( "You inject the vaccine." ) );
     time_point expiration_date = it->birthday() + 24_weeks;
     time_duration remaining_time = expiration_date - calendar::turn;
@@ -965,6 +1056,9 @@ std::optional<int> iuse::flu_vaccine( Character *p, item *it, const tripoint_bub
 
 std::optional<int> iuse::poison( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     if( p->has_trait( trait_EATDEAD ) ) {
         return 1;
     }
@@ -987,9 +1081,7 @@ std::optional<int> iuse::poison( Character *p, item *it, const tripoint_bub_ms &
 
 std::optional<int> iuse::meditate( Character *p, item *it, const tripoint_bub_ms & )
 {
-    if( !p ) {
-        debugmsg( "%s called action meditate that requires character but no character is present",
-                  it->typeId().str() );
+    if( !check_params( p, it, __func__ ) ) {
         return std::nullopt;
     }
     if( p->cant_do_mounted() ) {
@@ -1006,6 +1098,9 @@ std::optional<int> iuse::meditate( Character *p, item *it, const tripoint_bub_ms
 
 std::optional<int> iuse::thorazine( Character *p, item *, const tripoint_bub_ms & )
 {
+    if( !check_params( p, __func__ ) ) {
+        return std::nullopt;
+    }
     if( p->has_effect( effect_took_thorazine ) ) {
         p->remove_effect( effect_took_thorazine );
         p->mod_sleepiness( 15 );
@@ -1031,6 +1126,9 @@ std::optional<int> iuse::thorazine( Character *p, item *, const tripoint_bub_ms 
 
 std::optional<int> iuse::prozac( Character *p, item *, const tripoint_bub_ms & )
 {
+    if( !check_params( p, __func__ ) ) {
+        return std::nullopt;
+    }
     if( !p->has_effect( effect_took_prozac ) ) {
         p->add_effect( effect_took_prozac, 12_hours );
     } else {
@@ -1046,6 +1144,9 @@ std::optional<int> iuse::prozac( Character *p, item *, const tripoint_bub_ms & )
 
 std::optional<int> iuse::datura( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     if( p->is_npc() ) {
         return std::nullopt;
     }
@@ -1060,6 +1161,9 @@ std::optional<int> iuse::datura( Character *p, item *it, const tripoint_bub_ms &
 
 std::optional<int> iuse::flumed( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     p->add_effect( effect_took_flumed, 10_hours );
     p->add_msg_if_player( _( "You take some %s." ), it->tname() );
     return 1;
@@ -1067,6 +1171,9 @@ std::optional<int> iuse::flumed( Character *p, item *it, const tripoint_bub_ms &
 
 std::optional<int> iuse::flusleep( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     p->add_effect( effect_took_flumed, 12_hours );
     p->mod_sleepiness( 30 );
     p->add_msg_if_player( _( "You take some %s." ), it->tname() );
@@ -1076,6 +1183,9 @@ std::optional<int> iuse::flusleep( Character *p, item *it, const tripoint_bub_ms
 
 std::optional<int> iuse::inhaler( Character *p, item *, const tripoint_bub_ms & )
 {
+    if( !check_params( p, __func__ ) ) {
+        return std::nullopt;
+    }
     p->add_msg_player_or_npc( m_neutral, _( "You take a puff from your inhaler." ),
                               _( "<npcname> takes a puff from their inhaler." ) );
     if( !p->remove_effect( effect_asthma ) ) {
@@ -1091,6 +1201,9 @@ std::optional<int> iuse::inhaler( Character *p, item *, const tripoint_bub_ms & 
 
 std::optional<int> iuse::oxygen_bottle( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     p->mod_moves( -to_moves<int>( 10_seconds ) );
     p->add_msg_player_or_npc( m_neutral, string_format( _( "You breathe deeply from the %s." ),
                               it->tname() ),
@@ -1112,6 +1225,9 @@ std::optional<int> iuse::oxygen_bottle( Character *p, item *it, const tripoint_b
 
 std::optional<int> iuse::blech( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     // TODO: Add more effects?
     if( it->made_of( phase_id::LIQUID ) ) {
         if( !p->query_yn( _( "This looks unhealthy, sure you want to drink it?" ) ) ) {
@@ -1150,6 +1266,9 @@ std::optional<int> iuse::blech( Character *p, item *it, const tripoint_bub_ms & 
 
 std::optional<int> iuse::blech_because_unclean( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     if( !p->is_npc() ) {
         if( test_mode ) {
             p->add_msg_if_player( m_info,
@@ -1171,6 +1290,9 @@ std::optional<int> iuse::blech_because_unclean( Character *p, item *it, const tr
 
 std::optional<int> iuse::plantblech( Character *p, item *it, const tripoint_bub_ms &pos )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     if( p->has_trait( trait_THRESH_PLANT ) ) {
         double multiplier = -1;
         if( p->has_trait( trait_CHLOROMORPH ) ) {
@@ -1194,6 +1316,9 @@ std::optional<int> iuse::plantblech( Character *p, item *it, const tripoint_bub_
 
 std::optional<int> iuse::chew( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     // TODO: Add more effects?
     p->add_msg_if_player( _( "You chew your %s." ), it->tname() );
     return 1;
@@ -1227,6 +1352,9 @@ static void do_purify( Character &p )
 
 std::optional<int> iuse::purify_smart( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     std::vector<trait_id> valid; // Which flags the player has
     std::vector<std::string> valid_names; // Which flags the player has
     for( const mutation_branch &traits_iter : mutation_branch::get_all() ) {
@@ -1446,6 +1574,9 @@ static bool marloss_prevented( const Character &p )
 
 std::optional<int> iuse::marloss( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     if( marloss_prevented( *p ) ) {
         return std::nullopt;
     }
@@ -1458,6 +1589,9 @@ std::optional<int> iuse::marloss( Character *p, item *it, const tripoint_bub_ms 
 
 std::optional<int> iuse::marloss_seed( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     if( !query_yn( _( "Are you sure you want to eat the %s?  You could plant it in a mound of dirt." ),
                    colorize( it->tname(), it->color_in_inventory() ) ) ) {
         return std::nullopt; // Save the seed for later!
@@ -1475,6 +1609,9 @@ std::optional<int> iuse::marloss_seed( Character *p, item *it, const tripoint_bu
 
 std::optional<int> iuse::marloss_gel( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     if( marloss_prevented( *p ) ) {
         return std::nullopt;
     }
@@ -1487,6 +1624,9 @@ std::optional<int> iuse::marloss_gel( Character *p, item *it, const tripoint_bub
 
 std::optional<int> iuse::mycus( Character *p, item *, const tripoint_bub_ms & )
 {
+    if( !check_params( p, __func__ ) ) {
+        return std::nullopt;
+    }
     if( p->is_npc() ) {
         return 1;
     }
@@ -1588,6 +1728,9 @@ std::optional<int> iuse::mycus( Character *p, item *, const tripoint_bub_ms & )
 
 std::optional<int> iuse::petfood( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     map &here = get_map();
 
     if( !it->is_comestible() ) {
@@ -1679,6 +1822,9 @@ std::optional<int> iuse::petfood( Character *p, item *it, const tripoint_bub_ms 
 
 std::optional<int> iuse::radio_mod( Character *p, item *, const tripoint_bub_ms & )
 {
+    if( !check_params( p, __func__ ) ) {
+        return std::nullopt;
+    }
     if( p->is_npc() ) {
         // Now THAT would be kinda cruel
         return std::nullopt;
@@ -1740,7 +1886,7 @@ std::optional<int> iuse::radio_mod( Character *p, item *, const tripoint_bub_ms 
 
 std::optional<int> iuse::remove_all_mods( Character *p, item *, const tripoint_bub_ms & )
 {
-    if( !p ) {
+    if( !check_params( p, __func__ ) ) {
         return std::nullopt;
     }
 
@@ -1797,6 +1943,9 @@ static bool good_fishing_spot( const tripoint_bub_ms &pos, Character *p )
 
 std::optional<int> iuse::fishing_rod( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     if( p->is_npc() ) {
         // Long actions - NPCs don't like those yet.
         return std::nullopt;
@@ -1825,6 +1974,9 @@ std::optional<int> iuse::fishing_rod( Character *p, item *it, const tripoint_bub
 
 std::optional<int> iuse::fish_trap( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     map &here = get_map();
     // Handle deploying fish trap.
     if( it->active ) {
@@ -1870,6 +2022,9 @@ std::optional<int> iuse::fish_trap( Character *p, item *it, const tripoint_bub_m
 
 std::optional<int> iuse::fish_trap_tick( Character *p, item *it, const tripoint_bub_ms &pos )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     map &here = get_map();
     // Handle processing fish trap over time.
     if( it->ammo_remaining( ) == 0 ) {
@@ -1960,6 +2115,9 @@ std::optional<int> iuse::fish_trap_tick( Character *p, item *it, const tripoint_
 
 std::optional<int> iuse::extinguisher( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     if( !it->ammo_sufficient( p ) ) {
         return std::nullopt;
     }
@@ -2338,6 +2496,9 @@ class exosuit_interact
 
 std::optional<int> iuse::mace( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     if( !it->ammo_sufficient( p ) ) {
         return std::nullopt;
     }
@@ -2382,6 +2543,9 @@ std::optional<int> iuse::mace( Character *p, item *it, const tripoint_bub_ms & )
 
 std::optional<int> iuse::manage_exosuit( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     if( !p->is_avatar() ) {
         return std::nullopt;
     }
@@ -2395,6 +2559,9 @@ std::optional<int> iuse::manage_exosuit( Character *p, item *it, const tripoint_
 
 std::optional<int> iuse::unpack_item( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     if( p->cant_do_underwater() ) {
         return std::nullopt;
     }
@@ -2409,6 +2576,9 @@ std::optional<int> iuse::unpack_item( Character *p, item *it, const tripoint_bub
 
 std::optional<int> iuse::pack_cbm( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     item_location bionic = g->inv_map_splice( []( const item & e ) {
         return e.is_bionic() && e.has_flag( flag_NO_PACKED );
     }, _( "Choose CBM to pack" ), PICKUP_RANGE, _( "You don't have any CBMs." ) );
@@ -2440,9 +2610,7 @@ std::optional<int> iuse::pack_cbm( Character *p, item *it, const tripoint_bub_ms
 
 std::optional<int> iuse::pack_item( Character *p, item *it, const tripoint_bub_ms & )
 {
-    if( !p ) {
-        debugmsg( "%s called action pack_item that requires character but no character is present",
-                  it->typeId().str() );
+    if( !check_params( p, it, __func__ ) ) {
         return std::nullopt;
     }
     if( p->cant_do_underwater() ) {
@@ -2470,6 +2638,9 @@ std::optional<int> iuse::pack_item( Character *p, item *it, const tripoint_bub_m
 
 std::optional<int> iuse::water_purifier( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     if( p->cant_do_mounted() ) {
         return std::nullopt;
     }
@@ -2508,6 +2679,9 @@ std::optional<int> iuse::water_purifier( Character *p, item *it, const tripoint_
 // Part of iuse::water_tablets, but with the user interaction split out so it can be unit tested
 std::optional<int> iuse::purify_water( Character *p, item *purifier, item_location &water )
 {
+    if( !check_params( p, purifier, __func__ ) ) {
+        return std::nullopt;
+    }
     const double default_ratio = 4; // Existing pur_tablets will not have the var
     const int max_water_per_tablet = static_cast<int>( purifier->get_var( "water_per_tablet",
                                      default_ratio ) );
@@ -2560,6 +2734,9 @@ std::optional<int> iuse::purify_water( Character *p, item *purifier, item_locati
 
 std::optional<int> iuse::water_tablets( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     map &here = get_map();
 
     if( p->cant_do_mounted() ) {
@@ -2583,6 +2760,9 @@ std::optional<int> iuse::water_tablets( Character *p, item *it, const tripoint_b
 
 std::optional<int> iuse::radio_off( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     if( !it->ammo_sufficient( p ) ) {
         p->add_msg_if_player( _( "It's dead." ) );
     } else {
@@ -2594,6 +2774,9 @@ std::optional<int> iuse::radio_off( Character *p, item *it, const tripoint_bub_m
 
 std::optional<int> iuse::directional_antenna( Character *p, item *, const tripoint_bub_ms & )
 {
+    if( !check_params( p, __func__ ) ) {
+        return std::nullopt;
+    }
     // Find out if we have an active radio
     auto radios = p->cache_get_items_with( itype_radio_on );
     // If we don't wield the radio, also check on the ground
@@ -2649,6 +2832,9 @@ static int radio_static_chance( const radio_tower_reference &tref )
 
 std::optional<int> iuse::radio_tick( Character *, item *it, const tripoint_bub_ms &pos )
 {
+    if( !check_params( it, __func__ ) ) {
+        return std::nullopt;
+    }
     std::string message = _( "Radio: Kssssssssssssh." );
     const radio_tower_reference tref = overmap_buffer.find_radio_station( it->frequency );
     add_msg_debug( debugmode::DF_RADIO, "Set freq: %d", it->frequency );
@@ -2703,6 +2889,9 @@ std::optional<int> iuse::radio_tick( Character *, item *it, const tripoint_bub_m
 
 std::optional<int> iuse::radio_on( Character *, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( it, __func__ ) ) {
+        return std::nullopt;
+    }
 
     const auto tower_desc = []( const int noise ) {
         if( noise == 0 ) {
@@ -2813,6 +3002,9 @@ std::optional<int> iuse::emf_passive_on( Character *, item *, const tripoint_bub
 
 std::optional<int> iuse::ma_manual( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     // [CR] - should NPCs just be allowed to learn this stuff? Just like that?
 
     const matype_id style_to_learn = martial_art_learned_from( *it->type );
@@ -2827,14 +3019,19 @@ std::optional<int> iuse::ma_manual( Character *p, item *it, const tripoint_bub_m
     return 1;
 }
 
-// TODO: Why does this exist?
 std::optional<int> iuse::crowbar_weak( Character *p, item *it, const tripoint_bub_ms &pos )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     return iuse::crowbar( p, it, pos );
 }
 
 std::optional<int> iuse::crowbar( Character *p, item *it, const tripoint_bub_ms &pos )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     if( p->cant_do_mounted() ) {
         return std::nullopt;
     }
@@ -2911,9 +3108,7 @@ std::optional<int> iuse::crowbar( Character *p, item *it, const tripoint_bub_ms 
 
 std::optional<int> iuse::makemound( Character *p, item *it, const tripoint_bub_ms & )
 {
-    if( !p ) {
-        debugmsg( "%s called action makemound that requires character but no character is present",
-                  it->typeId().str() );
+    if( !check_params( p, it, __func__ ) ) {
         return std::nullopt;
     }
     if( p->cant_do_mounted() ) {
@@ -2946,9 +3141,7 @@ std::optional<int> iuse::makemound( Character *p, item *it, const tripoint_bub_m
 
 std::optional<int> iuse::dig( Character *p, item *it, const tripoint_bub_ms & )
 {
-    if( !p ) {
-        debugmsg( "%s called action dig that requires character but no character is present",
-                  it->typeId().str() );
+    if( !check_params( p, it, __func__ ) ) {
         return std::nullopt;
     }
     if( p->cant_do_mounted() ) {
@@ -2970,9 +3163,7 @@ std::optional<int> iuse::dig( Character *p, item *it, const tripoint_bub_ms & )
 
 std::optional<int> iuse::dig_channel( Character *p, item *it, const tripoint_bub_ms & )
 {
-    if( !p ) {
-        debugmsg( "%s called action dig_channel that requires character but no character is present",
-                  it->typeId().str() );
+    if( !check_params( p, it, __func__ ) ) {
         return std::nullopt;
     }
     if( p->cant_do_mounted() ) {
@@ -2990,9 +3181,7 @@ std::optional<int> iuse::dig_channel( Character *p, item *it, const tripoint_bub
 
 std::optional<int> iuse::fill_pit( Character *p, item *it, const tripoint_bub_ms & )
 {
-    if( !p ) {
-        debugmsg( "%s called action fill_pit that requires character but no character is present",
-                  it->typeId().str() );
+    if( !check_params( p, it, __func__ ) ) {
         return std::nullopt;
     }
     if( p->cant_do_mounted() ) {
@@ -3008,11 +3197,9 @@ std::optional<int> iuse::fill_pit( Character *p, item *it, const tripoint_bub_ms
     return 0;
 }
 
-std::optional<int> iuse::clear_rubble( Character *p, item *it, const tripoint_bub_ms & )
+std::optional<int> iuse::clear_rubble( Character *p, item *, const tripoint_bub_ms & )
 {
-    if( !p ) {
-        debugmsg( "%s called action clear_rubble that requires character but no character is present",
-                  it->typeId().str() );
+    if( !check_params( p, __func__ ) ) {
         return std::nullopt;
     }
     if( p->cant_do_mounted() ) {
@@ -3024,12 +3211,20 @@ std::optional<int> iuse::clear_rubble( Character *p, item *it, const tripoint_bu
         return it.str_id == construction_constr_clear_rubble;
     } );
 
+    if( build == cnstr.end() ) {
+        debugmsg( "Clear rubble construction unexpectly does not exist" );
+        return std::nullopt;
+    }
+
     place_construction( { build->group } );
     return 0;
 }
 
 std::optional<int> iuse::siphon( Character *p, item *, const tripoint_bub_ms & )
 {
+    if( !check_params( p, __func__ ) ) {
+        return std::nullopt;
+    }
     if( p->cant_do_mounted() ) {
         return std::nullopt;
     }
@@ -3080,6 +3275,9 @@ std::optional<int> iuse::siphon( Character *p, item *, const tripoint_bub_ms & )
 
 std::optional<int> iuse::change_eyes( Character *p, item *, const tripoint_bub_ms & )
 {
+    if( !check_params( p, __func__ ) ) {
+        return std::nullopt;
+    }
     if( p->is_avatar() ) {
         p->customize_appearance( customize_appearance_choice::EYES );
     }
@@ -3088,6 +3286,9 @@ std::optional<int> iuse::change_eyes( Character *p, item *, const tripoint_bub_m
 
 std::optional<int> iuse::change_skin( Character *p, item *, const tripoint_bub_ms & )
 {
+    if( !check_params( p, __func__ ) ) {
+        return std::nullopt;
+    }
     if( p->is_avatar() ) {
         p->customize_appearance( customize_appearance_choice::SKIN );
     }
@@ -3168,6 +3369,9 @@ static std::optional<int> dig_tool( Character *p, item *it, const tripoint_bub_m
 
 std::optional<int> iuse::jackhammer( Character *p, item *it, const tripoint_bub_ms &pos )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     // use has_enough_charges to check for UPS availability
     // p is assumed to exist for iuse cases
     if( !it->ammo_sufficient( p ) ) {
@@ -3182,6 +3386,9 @@ std::optional<int> iuse::jackhammer( Character *p, item *it, const tripoint_bub_
 
 std::optional<int> iuse::pick_lock( Character *p, item *it, const tripoint_bub_ms &pos )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     if( p->is_npc() ) {
         return std::nullopt;
     }
@@ -3229,6 +3436,9 @@ std::optional<int> iuse::pick_lock( Character *p, item *it, const tripoint_bub_m
 
 std::optional<int> iuse::pickaxe( Character *p, item *it, const tripoint_bub_ms &pos )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     if( p->is_npc() ) {
         // Long action
         return std::nullopt;
@@ -3244,6 +3454,9 @@ std::optional<int> iuse::pickaxe( Character *p, item *it, const tripoint_bub_ms 
 
 std::optional<int> iuse::geiger( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     map &here = get_map();
 
     int ch = uilist( _( "Geiger counter:" ), {
@@ -3327,6 +3540,9 @@ std::optional<int> iuse::geiger_active( Character *, item *, const tripoint_bub_
 
 std::optional<int> iuse::teleport( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     if( p->is_npc() ) {
         // That would be evil
         return std::nullopt;
@@ -3344,6 +3560,9 @@ std::optional<int> iuse::teleport( Character *p, item *it, const tripoint_bub_ms
 
 std::optional<int> iuse::can_goo( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     map &here = get_map();
 
     it->convert( itype_canister_empty );
@@ -3397,6 +3616,9 @@ std::optional<int> iuse::can_goo( Character *p, item *it, const tripoint_bub_ms 
 
 std::optional<int> iuse::granade_act( Character *, item *it, const tripoint_bub_ms &pos )
 {
+    if( !check_params( it, __func__ ) ) {
+        return std::nullopt;
+    }
     if( pos.x() == -999 || pos.y() == -999 ) {
         return std::nullopt;
     }
@@ -3529,6 +3751,9 @@ std::optional<int> iuse::granade_act( Character *, item *it, const tripoint_bub_
 
 std::optional<int> iuse::c4( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     int time = 0;
     bool got_value = false;
     if( p->is_avatar() ) {
@@ -3554,6 +3779,9 @@ std::optional<int> iuse::c4( Character *p, item *it, const tripoint_bub_ms & )
 std::optional<int> iuse::acidbomb_act( Character *p, item *it, const tripoint_bub_ms &pos )
 {
     if( !p ) {
+        if( !check_params( it, __func__ ) ) {
+            return std::nullopt;
+        }
         it->charges = -1;
         map &here = get_map();
         for( const tripoint_bub_ms &tmp : here.points_in_radius( pos, 1 ) ) {
@@ -3566,6 +3794,9 @@ std::optional<int> iuse::acidbomb_act( Character *p, item *it, const tripoint_bu
 
 std::optional<int> iuse::grenade_inc_act( Character *p, item *, const tripoint_bub_ms &pos )
 {
+    if( !check_params( p, __func__ ) ) {
+        return std::nullopt;
+    }
     if( pos.x() == -999 || pos.y() == -999 ) {
         return std::nullopt;
     }
@@ -3595,6 +3826,9 @@ std::optional<int> iuse::grenade_inc_act( Character *p, item *, const tripoint_b
 
 std::optional<int> iuse::molotov_lit( Character *p, item *it, const tripoint_bub_ms &pos )
 {
+    if( !check_params( it, __func__ ) ) {
+        return std::nullopt;
+    }
 
     if( !p ) {
         // It was thrown or dropped, so burst into flames
@@ -3626,6 +3860,9 @@ std::optional<int> iuse::molotov_lit( Character *p, item *it, const tripoint_bub
 
 std::optional<int> iuse::firecracker_pack( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     if( p->cant_do_underwater() ) {
         return std::nullopt;
     }
@@ -3643,6 +3880,9 @@ std::optional<int> iuse::firecracker_pack( Character *p, item *it, const tripoin
 
 std::optional<int> iuse::firecracker_pack_act( Character *, item *it, const tripoint_bub_ms &pos )
 {
+    if( !check_params( it, __func__ ) ) {
+        return std::nullopt;
+    }
     // Two seconds of lit fuse burning
     // Followed by random number of explosions (4-6) per turn until 25 epxlosions have happened
     // Finally item despawns since countdown has ended
@@ -3663,6 +3903,9 @@ std::optional<int> iuse::firecracker_pack_act( Character *, item *it, const trip
 
 std::optional<int> iuse::firecracker( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     if( p->cant_do_underwater() ) {
         return std::nullopt;
     }
@@ -3679,6 +3922,9 @@ std::optional<int> iuse::firecracker( Character *p, item *it, const tripoint_bub
 
 std::optional<int> iuse::mininuke( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     int time;
     bool got_value = query_int( time, false, _( "Set the timer to ___ turns (0 to cancel)?" ) );
     if( !got_value || time <= 0 ) {
@@ -3696,6 +3942,9 @@ std::optional<int> iuse::mininuke( Character *p, item *it, const tripoint_bub_ms
 
 std::optional<int> iuse::portal( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     map &here = get_map();
     const tripoint_bub_ms pos = p->pos_bub( here );
 
@@ -3712,6 +3961,9 @@ std::optional<int> iuse::portal( Character *p, item *it, const tripoint_bub_ms &
 
 std::optional<int> iuse::tazer( Character *p, item *it, const tripoint_bub_ms &pos )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     if( !it->ammo_sufficient( p ) ) {
         return std::nullopt;
     }
@@ -3785,6 +4037,9 @@ std::optional<int> iuse::tazer( Character *p, item *it, const tripoint_bub_ms &p
 
 std::optional<int> iuse::tazer2( Character *p, item *it, const tripoint_bub_ms &pos )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     map &here = get_map();
 
     if( it->ammo_remaining_linked( here, p ) >= 2 ) {
@@ -3802,9 +4057,8 @@ std::optional<int> iuse::tazer2( Character *p, item *it, const tripoint_bub_ms &
 
 std::optional<int> iuse::shocktonfa_off( Character *p, item *it, const tripoint_bub_ms &pos )
 {
-    if( !p ) {
-        debugmsg( "%s called action shocktonfa_off that requires character but no character is present",
-                  it->typeId().str() );
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
     }
     int choice = uilist( _( "tactical tonfa" ), {
         _( "Zap something" ), _( "Turn on light" )
@@ -3830,26 +4084,25 @@ std::optional<int> iuse::shocktonfa_off( Character *p, item *it, const tripoint_
 
 std::optional<int> iuse::shocktonfa_on( Character *p, item *it, const tripoint_bub_ms &pos )
 {
-    if( !p ) { // Effects while simply on
-        debugmsg( "%s called action shocktonfa_on that requires character but no character is present",
-                  it->typeId().str() );
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
+    // Effects while simply on
+    if( !it->ammo_sufficient( p ) ) {
+        p->add_msg_if_player( m_info, _( "Your tactical tonfa is out of power." ) );
+        it->convert( itype_shocktonfa_off, p ).active = false;
     } else {
-        if( !it->ammo_sufficient( p ) ) {
-            p->add_msg_if_player( m_info, _( "Your tactical tonfa is out of power." ) );
-            it->convert( itype_shocktonfa_off, p ).active = false;
-        } else {
-            int choice = uilist( _( "tactical tonfa" ), {
-                _( "Zap something" ), _( "Turn off light" )
-            } );
+        int choice = uilist( _( "tactical tonfa" ), {
+            _( "Zap something" ), _( "Turn off light" )
+        } );
 
-            switch( choice ) {
-                case 0: {
-                    return iuse::tazer2( p, it, pos );
-                }
-                case 1: {
-                    p->add_msg_if_player( _( "You turn off the light." ) );
-                    it->convert( itype_shocktonfa_off, p ).active = false;
-                }
+        switch( choice ) {
+            case 0: {
+                return iuse::tazer2( p, it, pos );
+            }
+            case 1: {
+                p->add_msg_if_player( _( "You turn off the light." ) );
+                it->convert( itype_shocktonfa_off, p ).active = false;
             }
         }
     }
@@ -3858,6 +4111,9 @@ std::optional<int> iuse::shocktonfa_on( Character *p, item *it, const tripoint_b
 
 std::optional<int> iuse::mp3( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     // TODO: avoid item id hardcoding to make this function usable for pure json-defined devices.
     if( !it->ammo_sufficient( p ) ) {
         p->add_msg_if_player( m_info, _( "The device's batteries are dead." ) );
@@ -3914,6 +4170,9 @@ static std::string get_music_description()
 void iuse::play_music( Character *p, const tripoint_bub_ms &source, const int volume,
                        const int max_morale, bool play_sounds )
 {
+    if( !check_params( p, __func__ ) ) {
+        return;
+    }
     std::string sound = "music";
 
     auto lambda_should_do_effects = [&source, &volume]( Character * p ) {
@@ -3962,6 +4221,9 @@ void iuse::play_music( Character *p, const tripoint_bub_ms &source, const int vo
 
 std::optional<int> iuse::mp3_on( Character *p, item *, const tripoint_bub_ms &pos )
 {
+    if( !check_params( p,  __func__ ) ) {
+        return std::nullopt;
+    }
     // mp3 player in inventory, we can listen
     play_music( p, pos, 0, 20 );
     music::activate_music_id( music::music_id::mp3 );
@@ -3970,7 +4232,9 @@ std::optional<int> iuse::mp3_on( Character *p, item *, const tripoint_bub_ms &po
 
 std::optional<int> iuse::mp3_deactivate( Character *p, item *it, const tripoint_bub_ms & )
 {
-
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     if( it->typeId() == itype_mp3_on ) {
         p->add_msg_if_player( _( "The mp3 player turns off." ) );
         it->convert( itype_mp3, p ).active = false;
@@ -3988,11 +4252,13 @@ std::optional<int> iuse::mp3_deactivate( Character *p, item *it, const tripoint_
     music::deactivate_music_id( music::music_id::mp3 );
 
     return 0;
-
 }
 
 std::optional<int> iuse::rpgdie( Character *you, item *die, const tripoint_bub_ms & )
 {
+    if( !check_params( you, die, __func__ ) ) {
+        return std::nullopt;
+    }
     if( you->cant_do_mounted() ) {
         return std::nullopt;
     }
@@ -4015,6 +4281,9 @@ std::optional<int> iuse::rpgdie( Character *you, item *die, const tripoint_bub_m
 
 std::optional<int> iuse::dive_tank( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     if( p && p->is_worn( *it ) ) {
         if( p->is_underwater() && p->oxygen < 10 ) {
             p->oxygen += 20;
@@ -4037,6 +4306,9 @@ std::optional<int> iuse::dive_tank( Character *p, item *it, const tripoint_bub_m
 
 std::optional<int> iuse::dive_tank_activate( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     if( it->ammo_remaining( ) == 0 ) {
         p->add_msg_if_player( _( "Your %s is empty." ), it->tname() );
     } else if( it->active ) { //off
@@ -4057,9 +4329,7 @@ std::optional<int> iuse::dive_tank_activate( Character *p, item *it, const tripo
 
 std::optional<int> iuse::solarpack( Character *p, item *it, const tripoint_bub_ms & )
 {
-    if( !p ) {
-        debugmsg( "%s called action solarpack that requires character but no character is present",
-                  it->typeId().str() );
+    if( !check_params( p, it, __func__ ) ) {
         return std::nullopt;
     }
     const bionic_id rem_bid = p->get_remote_fueled_bionic();
@@ -4091,13 +4361,11 @@ std::optional<int> iuse::solarpack( Character *p, item *it, const tripoint_bub_m
 
 std::optional<int> iuse::solarpack_off( Character *p, item *it, const tripoint_bub_ms & )
 {
-    map &here = get_map();
-
-    if( !p ) {
-        debugmsg( "%s called action solarpack_off that requires character but no character is present",
-                  it->typeId().str() );
+    if( !check_params( p, it, __func__ ) ) {
         return std::nullopt;
     }
+    map &here = get_map();
+
     if( !p->is_worn( *it ) ) {  // folding when not worn
         p->add_msg_if_player( _( "You fold your portable solar array into the pack." ) );
     } else {
@@ -4115,6 +4383,9 @@ std::optional<int> iuse::solarpack_off( Character *p, item *it, const tripoint_b
 
 std::optional<int> iuse::gasmask_activate( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     if( it->ammo_remaining( ) == 0 ) {
         p->add_msg_if_player( _( "Your %s doesn't have a filter." ), it->tname() );
     } else {
@@ -4128,6 +4399,9 @@ std::optional<int> iuse::gasmask_activate( Character *p, item *it, const tripoin
 
 std::optional<int> iuse::gasmask( Character *p, item *it, const tripoint_bub_ms &pos )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     map &here = get_map();
 
     if( p && p->is_worn( *it ) ) {
@@ -4181,6 +4455,9 @@ std::optional<int> iuse::gasmask( Character *p, item *it, const tripoint_bub_ms 
 
 std::optional<int> iuse::portable_game( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     const map &here = get_map();
 
     if( p->is_npc() ) {
@@ -4324,6 +4601,9 @@ std::optional<int> iuse::portable_game( Character *p, item *it, const tripoint_b
 
 std::optional<int> iuse::fitness_check( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     if( p->has_trait( trait_ILLITERATE ) ) {
         p->add_msg_if_player( m_info, _( "You don't know what you're looking at." ) );
         return std::nullopt;
@@ -4375,6 +4655,9 @@ std::optional<int> iuse::fitness_check( Character *p, item *it, const tripoint_b
 
 std::optional<int> iuse::hand_crank( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     if( p->is_npc() ) {
         // Long action
         return std::nullopt;
@@ -4409,6 +4692,9 @@ std::optional<int> iuse::hand_crank( Character *p, item *it, const tripoint_bub_
 
 std::optional<int> iuse::vibe( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     if( p->is_npc() ) {
         // Long action
         // Also, that would be creepy as fuck, seriously
@@ -4449,13 +4735,19 @@ std::optional<int> iuse::vibe( Character *p, item *it, const tripoint_bub_ms & )
 
 std::optional<int> iuse::vortex( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     std::vector<point_rel_ms> spawn;
-    spawn.reserve( 28 );
+    spawn.reserve( 24 );
     for( int i = -3; i <= 3; i++ ) {
         spawn.emplace_back( -3, i );
         spawn.emplace_back( +3, i );
-        spawn.emplace_back( i, -3 );
-        spawn.emplace_back( i, +3 );
+        if( i > -3 && i < 3 ) {
+            // avoid emplacing the corner positions twice
+            spawn.emplace_back( i, -3 );
+            spawn.emplace_back( i, +3 );
+        }
     }
 
     while( !spawn.empty() ) {
@@ -4478,6 +4770,9 @@ std::optional<int> iuse::vortex( Character *p, item *it, const tripoint_bub_ms &
 
 std::optional<int> iuse::dog_whistle( Character *p, item *, const tripoint_bub_ms & )
 {
+    if( !check_params( p, __func__ ) ) {
+        return std::nullopt;
+    }
     const map &here = get_map();
 
     if( !p->is_avatar() ) {
@@ -4540,6 +4835,9 @@ std::optional<int> iuse::dog_whistle( Character *p, item *, const tripoint_bub_m
 
 std::optional<int> iuse::call_of_tindalos( Character *p, item *, const tripoint_bub_ms & )
 {
+    if( !check_params( p, __func__ ) ) {
+        return std::nullopt;
+    }
     map &here = get_map();
     for( const tripoint_bub_ms &dest : here.points_in_radius( p->pos_bub(), 12 ) ) {
         if( here.is_cornerfloor( dest ) ) {
@@ -4552,6 +4850,9 @@ std::optional<int> iuse::call_of_tindalos( Character *p, item *, const tripoint_
 
 std::optional<int> iuse::blood_draw( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     map &here = get_map();
     const tripoint_bub_ms pos = p->pos_bub( here );
 
@@ -4658,9 +4959,7 @@ void iuse::cut_log_into_planks( Character &p )
 
 std::optional<int> iuse::lumber( Character *p, item *it, const tripoint_bub_ms & )
 {
-    if( !p ) {
-        debugmsg( "%s called action lumber that requires character but no character is present",
-                  it->typeId().str() );
+    if( !check_params( p, it, __func__ ) ) {
         return std::nullopt;
     }
     if( p->cant_do_mounted() ) {
@@ -4711,9 +5010,7 @@ static int chop_moves( Character *p, item *it )
 
 std::optional<int> iuse::chop_tree( Character *p, item *it, const tripoint_bub_ms & )
 {
-    if( !p ) {
-        debugmsg( "%s called action chop_tree that requires character but no character is present",
-                  it->typeId().str() );
+    if( !check_params( p, it, __func__ ) ) {
         return std::nullopt;
     }
     if( p->cant_do_mounted() ) {
@@ -4757,9 +5054,7 @@ std::optional<int> iuse::chop_tree( Character *p, item *it, const tripoint_bub_m
 
 std::optional<int> iuse::chop_logs( Character *p, item *it, const tripoint_bub_ms & )
 {
-    if( !p ) {
-        debugmsg( "%s called action chop_logs that requires character but no character is present",
-                  it->typeId().str() );
+    if( !check_params( p, it, __func__ ) ) {
         return std::nullopt;
     }
     if( p->cant_do_mounted() ) {
@@ -4802,6 +5097,9 @@ std::optional<int> iuse::chop_logs( Character *p, item *it, const tripoint_bub_m
 
 std::optional<int> iuse::oxytorch( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     if( p->is_npc() ) {
         // Long action
         return std::nullopt;
@@ -4849,9 +5147,7 @@ std::optional<int> iuse::oxytorch( Character *p, item *it, const tripoint_bub_ms
 
 std::optional<int> iuse::hacksaw( Character *p, item *it, const tripoint_bub_ms &it_pnt )
 {
-    if( !p ) {
-        debugmsg( "%s called action hacksaw that requires character but no character is present",
-                  it->typeId().str() );
+    if( !check_params( p, it, __func__ ) ) {
         return std::nullopt;
     }
     if( p->cant_do_mounted() ) {
@@ -4897,6 +5193,9 @@ std::optional<int> iuse::hacksaw( Character *p, item *it, const tripoint_bub_ms 
 
 std::optional<int> iuse::boltcutters( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     if( p->cant_do_mounted() ) {
         return std::nullopt;
     }
@@ -4936,6 +5235,9 @@ std::optional<int> iuse::boltcutters( Character *p, item *it, const tripoint_bub
 
 std::optional<int> iuse::mop( Character *p, item *, const tripoint_bub_ms & )
 {
+    if( !check_params( p, __func__ ) ) {
+        return std::nullopt;
+    }
     if( p->cant_do_mounted() ) {
         return std::nullopt;
     }
@@ -4976,6 +5278,9 @@ std::optional<int> iuse::mop( Character *p, item *, const tripoint_bub_ms & )
 
 std::optional<int> iuse::spray_can( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, __func__ ) ) {
+        return std::nullopt;
+    }
     map &here = get_map();
 
     const std::optional<tripoint_bub_ms> dest_ = choose_adjacent( _( "Spray where?" ) );
@@ -5064,6 +5369,9 @@ static bool heat_item( Character &p )
 
 std::optional<int> iuse::heatpack( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     if( heat_item( *p ) ) {
         it->convert( itype_heatpack_used, p );
     }
@@ -5072,6 +5380,9 @@ std::optional<int> iuse::heatpack( Character *p, item *it, const tripoint_bub_ms
 
 std::optional<int> iuse::heat_food( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     if( get_map().has_nearby_fire( p->pos_bub() ) ) {
         heat_item( *p );
         return 0;
@@ -5091,6 +5402,9 @@ std::optional<int> iuse::heat_food( Character *p, item *it, const tripoint_bub_m
 
 std::optional<int> iuse::hotplate( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     if( p->cant_do_mounted() ) {
         return std::nullopt;
     }
@@ -5107,6 +5421,9 @@ std::optional<int> iuse::hotplate( Character *p, item *it, const tripoint_bub_ms
 
 std::optional<int> iuse::hotplate_atomic( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     if( p->cant_do_mounted() ) {
         return std::nullopt;
     }
@@ -5119,16 +5436,14 @@ std::optional<int> iuse::hotplate_atomic( Character *p, item *it, const tripoint
 
 std::optional<int> iuse::towel( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, __func__ ) ) {
+        return std::nullopt;
+    }
     return towel_common( p, it, false );
 }
 
 int iuse::towel_common( Character *p, item *it, bool )
 {
-    if( !p ) {
-        debugmsg( "%s called action towel that requires character but no character is present",
-                  it->typeId().str() );
-        return 0;
-    }
     bool slime = p->has_effect( effect_slimed );
     bool boom = p->has_effect( effect_boomered );
     bool glow = p->has_effect( effect_glowing );
@@ -5194,6 +5509,9 @@ int iuse::towel_common( Character *p, item *it, bool )
 
 std::optional<int> iuse::unfold_generic( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     p->assign_activity( vehicle_unfolding_activity_actor( *it ) );
     p->i_rem( it );
     return 0;
@@ -5201,6 +5519,9 @@ std::optional<int> iuse::unfold_generic( Character *p, item *it, const tripoint_
 
 std::optional<int> iuse::adrenaline_injector( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     if( p->is_npc() && p->get_effect_dur( effect_adrenaline ) >= 30_minutes ) {
         return std::nullopt;
     }
@@ -5224,6 +5545,9 @@ std::optional<int> iuse::adrenaline_injector( Character *p, item *it, const trip
 
 std::optional<int> iuse::jet_injector( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     if( !it->ammo_sufficient( p ) ) {
         p->add_msg_if_player( m_info, _( "The jet injector is empty." ) );
         return std::nullopt;
@@ -5246,6 +5570,9 @@ std::optional<int> iuse::jet_injector( Character *p, item *it, const tripoint_bu
 
 std::optional<int> iuse::stimpack( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     if( p->get_item_position( it ) >= -1 ) {
         p->add_msg_if_player( m_info,
                               _( "You must wear the stimulant delivery system before you can activate it." ) );
@@ -5269,6 +5596,9 @@ std::optional<int> iuse::stimpack( Character *p, item *it, const tripoint_bub_ms
 
 std::optional<int> iuse::radglove( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     if( p->get_item_position( it ) >= -1 ) {
         p->add_msg_if_player( m_info,
                               _( "You must wear the radiation biomonitor before you can activate it." ) );
@@ -5297,6 +5627,9 @@ std::optional<int> iuse::radglove( Character *p, item *it, const tripoint_bub_ms
 
 std::optional<int> iuse::talking_doll( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     if( !it->ammo_sufficient( p ) ) {
         p->add_msg_if_player( m_info, _( "The %s's batteries are dead." ), it->tname() );
         return std::nullopt;
@@ -5312,6 +5645,9 @@ std::optional<int> iuse::talking_doll( Character *p, item *it, const tripoint_bu
 
 std::optional<int> iuse::gun_repair( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     if( !it->ammo_sufficient( p ) ) {
         return std::nullopt;
     }
@@ -5338,6 +5674,9 @@ std::optional<int> iuse::gun_repair( Character *p, item *it, const tripoint_bub_
 
 std::optional<int> gun_repair( Character *p, item *, item_location &loc )
 {
+    if( !iuse::check_params( p, __func__ ) ) {
+        return std::nullopt;
+    }
     item &fix = *loc;
     if( p->fine_detail_vision_mod() > 4 ) {
         p->add_msg_if_player( m_info, _( "You can't see to do that!" ) );
@@ -5367,12 +5706,11 @@ std::optional<int> gun_repair( Character *p, item *, item_location &loc )
 
 std::optional<int> iuse::gunmod_attach( Character *p, item *it, const tripoint_bub_ms & )
 {
-    if( !it || !it->is_gunmod() ) {
-        debugmsg( "tried to attach non-gunmod" );
+    if( !check_params( p, it, __func__ ) ) {
         return std::nullopt;
     }
-
-    if( !p ) {
+    if( !it->is_gunmod() ) {
+        debugmsg( "tried to attach non-gunmod" );
         return std::nullopt;
     }
 
@@ -5404,12 +5742,11 @@ std::optional<int> iuse::gunmod_attach( Character *p, item *it, const tripoint_b
 
 std::optional<int> iuse::toolmod_attach( Character *p, item *it, const tripoint_bub_ms & )
 {
-    if( !it || !it->is_toolmod() ) {
-        debugmsg( "tried to attach non-toolmod" );
+    if( !check_params( p, it, __func__ ) ) {
         return std::nullopt;
     }
-
-    if( !p ) {
+    if( !it->is_toolmod() ) {
+        debugmsg( "tried to attach non-toolmod" );
         return std::nullopt;
     }
 
@@ -5459,6 +5796,9 @@ std::optional<int> iuse::toolmod_attach( Character *p, item *it, const tripoint_
 
 std::optional<int> iuse::bell( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     if( it->typeId() == itype_cow_bell ) {
         sounds::sound( p->pos_bub(), 12, sounds::sound_t::music, _( "Clank!  Clank!" ), true, "misc",
                        "cow_bell" );
@@ -5479,6 +5819,9 @@ std::optional<int> iuse::bell( Character *p, item *it, const tripoint_bub_ms & )
 
 std::optional<int> iuse::seed( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     if( p->is_npc() ||
         query_yn( _( "Are you sure you want to eat the %s?  You could plant it in a mound of dirt." ),
                   colorize( it->tname(), it->color_in_inventory() ) ) ) {
@@ -5497,6 +5840,9 @@ bool iuse::robotcontrol_can_target( Character *p, const monster &m )
 
 std::optional<int> iuse::robotcontrol( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     const map &here = get_map();
 
     bool isComputer = !it->has_flag( flag_MAGICAL );
@@ -5664,6 +6010,9 @@ void item::extended_photo_def::serialize( JsonOut &jsout ) const
 
 std::optional<int> iuse::efiledevice( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     //restrictions
     if( p->is_npc() ) {
         return std::nullopt;
@@ -6622,9 +6971,7 @@ std::optional<int> iuse::camera( Character *p, item *it, const tripoint_bub_ms &
     enum {c_shot, c_view};
 
     // From item processing
-    if( !p ) {
-        debugmsg( "%s called action camera that requires character but no character is present",
-                  it->typeId().str() );
+    if( !check_params( p, it, __func__ ) ) {
         return std::nullopt;
     }
 
@@ -6815,6 +7162,10 @@ std::optional<int> iuse::view_photos( Character *p, item *it, const tripoint_bub
 {
     enum { c_photos, c_monsters };
 
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
+
     uilist amenu;
     amenu.text = _( "View which photos?" );
     amenu.addentry( c_photos, true, 'g', _( "General" ) );
@@ -6881,6 +7232,9 @@ std::optional<int> iuse::view_photos( Character *p, item *it, const tripoint_bub
 
 std::optional<int> iuse::view_recipes( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     p->mod_moves( -to_moves<int>( 1_seconds ) * 0.5 );
 
     uilist rmenu;
@@ -6895,6 +7249,9 @@ std::optional<int> iuse::view_recipes( Character *p, item *it, const tripoint_bu
 
 std::optional<int> iuse::ehandcuffs_tick( Character *p, item *it, const tripoint_bub_ms &pos )
 {
+    if( !check_params( it, __func__ ) ) {
+        return std::nullopt;
+    }
     if( get_map().has_flag( ter_furn_flag::TFLAG_SWIMMABLE, pos.xy() ) ) {
         it->unset_flag( flag_NO_UNWIELD );
         it->ammo_unset();
@@ -6976,6 +7333,9 @@ std::optional<int> iuse::ehandcuffs_tick( Character *p, item *it, const tripoint
 
 std::optional<int> iuse::ehandcuffs( Character *, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( it, __func__ ) ) {
+        return std::nullopt;
+    }
     if( it->active ) {
         add_msg( _( "The %s are clamped tightly on your wrists.  You can't take them off." ),
                  it->tname() );
@@ -6988,6 +7348,9 @@ std::optional<int> iuse::ehandcuffs( Character *, item *it, const tripoint_bub_m
 
 std::optional<int> iuse::afs_translocator( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     if( !it->ammo_sufficient( p ) ) {
         return std::nullopt;
     }
@@ -7026,6 +7389,9 @@ std::optional<int> iuse::foodperson_voice( Character *, item *, const tripoint_b
 
 std::optional<int> iuse::foodperson( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     // Prevent crash if battery was somehow removed.
     if( !it->magazine_current() ) {
         return std::nullopt;
@@ -7041,6 +7407,9 @@ std::optional<int> iuse::foodperson( Character *p, item *it, const tripoint_bub_
 
 std::optional<int> iuse::radiocar( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     int choice = -1;
     item *bomb_it = it->get_item_with( []( const item & c ) {
         return c.has_flag( flag_RADIOCARITEM );
@@ -7118,6 +7487,9 @@ std::optional<int> iuse::radiocar( Character *p, item *it, const tripoint_bub_ms
 
 std::optional<int> iuse::radiocaron( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     if( !it->ammo_sufficient( p ) ) {
         // Deactivate since other mode has an iuse too.
         it->convert( itype_radio_car, p ).active = false;
@@ -7184,6 +7556,9 @@ static void sendRadioSignal( Character &p, const flag_id &signal )
 
 std::optional<int> iuse::radiocontrol_tick( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( it, __func__ ) ) {
+        return std::nullopt;
+    }
     if( !p ) {
         // Player has dropped the controller
         avatar &player = get_avatar();
@@ -7203,6 +7578,9 @@ std::optional<int> iuse::radiocontrol_tick( Character *p, item *it, const tripoi
 
 std::optional<int> iuse::radiocontrol( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     const char *car_action = nullptr;
 
     if( !it->active ) {
@@ -7387,6 +7765,9 @@ static vehicle *pickveh( const tripoint_bub_ms &center, bool advanced )
 
 std::optional<int> iuse::remoteveh_tick( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     map &here = get_map();
 
     vehicle *remote = g->remoteveh();
@@ -7411,6 +7792,9 @@ std::optional<int> iuse::remoteveh_tick( Character *p, item *it, const tripoint_
 
 std::optional<int> iuse::remoteveh( Character *p, item *it, const tripoint_bub_ms &pos )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     map &here = get_map();
 
     vehicle *remote = g->remoteveh();
@@ -7525,6 +7909,9 @@ static bool multicooker_hallu( Character &p )
 
 std::optional<int> iuse::multicooker( Character *p, item *it, const tripoint_bub_ms &pos )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     map &here = get_map();
 
     static const int charges_to_start = 50;
@@ -7815,6 +8202,10 @@ std::optional<int> iuse::multicooker( Character *p, item *it, const tripoint_bub
 
 std::optional<int> iuse::multicooker_tick( Character *p, item *it, const tripoint_bub_ms &pos )
 {
+    // p can be null when multicooker is not carried
+    if( !check_params( it, __func__ ) ) {
+        return std::nullopt;
+    }
     map &here = get_map();
 
     const int charge_buffer = 2;
@@ -7881,6 +8272,9 @@ std::optional<int> iuse::multicooker_tick( Character *p, item *it, const tripoin
 
 std::optional<int> iuse::weather_tool( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     map &here = get_map();
 
     weather_manager &weather = get_weather();
@@ -7953,6 +8347,9 @@ std::optional<int> iuse::weather_tool( Character *p, item *it, const tripoint_bu
 
 std::optional<int> iuse::sextant( Character *p, item *, const tripoint_bub_ms &pos )
 {
+    if( !check_params( p, __func__ ) ) {
+        return std::nullopt;
+    }
     const std::pair<units::angle, units::angle> sun_position = sun_azimuth_altitude( calendar::turn );
     const float altitude = to_degrees( sun_position.second );
     if( debug_mode ) {
@@ -7972,6 +8369,9 @@ std::optional<int> iuse::sextant( Character *p, item *, const tripoint_bub_ms &p
 
 std::optional<int> iuse::lux_meter( Character *p, item *it, const tripoint_bub_ms &pos )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     p->add_msg_if_player( m_neutral, _( "The illumination is %.1f." ),
                           g->natural_light_level( pos.z() ) );
 
@@ -7980,6 +8380,9 @@ std::optional<int> iuse::lux_meter( Character *p, item *it, const tripoint_bub_m
 
 std::optional<int> iuse::dbg_lux_meter( Character *p, item *, const tripoint_bub_ms &pos )
 {
+    if( !check_params( p, __func__ ) ) {
+        return std::nullopt;
+    }
     map &here = get_map();
     const float incident_light = incident_sunlight( current_weather( here.get_abs( pos ) ),
                                  calendar::turn );
@@ -7997,6 +8400,9 @@ std::optional<int> iuse::dbg_lux_meter( Character *p, item *, const tripoint_bub
 
 std::optional<int> iuse::calories_intake_tracker( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     if( p->has_trait( trait_ILLITERATE ) ) {
         p->add_msg_if_player( m_info, _( "You don't know what you're looking at." ) );
         return std::nullopt;
@@ -8018,6 +8424,9 @@ std::optional<int> iuse::calories_intake_tracker( Character *p, item *it, const 
 
 std::optional<int> iuse::directional_hologram( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     if( it->is_armor() &&  !p->is_worn( *it ) ) {
         p->add_msg_if_player( m_neutral, _( "You need to wear the %1$s before activating it." ),
                               it->tname() );
@@ -8047,6 +8456,9 @@ std::optional<int> iuse::directional_hologram( Character *p, item *it, const tri
 
 std::optional<int> iuse::capture_monster_veh( Character *p, item *it, const tripoint_bub_ms &pos )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     if( p->cant_do_mounted() ) {
         return std::nullopt;
     }
@@ -8100,6 +8512,9 @@ int item::contain_monster( const tripoint_bub_ms &target )
 
 std::optional<int> iuse::capture_monster_act( Character *p, item *it, const tripoint_bub_ms &pos )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     map &here = get_map();
 
     if( p->is_mounted() ) {
@@ -8458,6 +8873,9 @@ static bool heat_items( Character *p, item *it, bool liquid_items, bool solid_it
 
 std::optional<int> iuse::heat_solid_items( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     if( p->fine_detail_vision_mod() > 4 ) {
         p->add_msg_if_player( _( "You can't see to do that!" ) );
         return std::nullopt;
@@ -8478,6 +8896,9 @@ std::optional<int> iuse::heat_solid_items( Character *p, item *it, const tripoin
 
 std::optional<int> iuse::heat_liquid_items( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     if( p->fine_detail_vision_mod() > 4 ) {
         p->add_msg_if_player( _( "You can't see to do that!" ) );
         return std::nullopt;
@@ -8498,6 +8919,9 @@ std::optional<int> iuse::heat_liquid_items( Character *p, item *it, const tripoi
 
 std::optional<int> iuse::heat_all_items( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     if( p->fine_detail_vision_mod() > 4 ) {
         p->add_msg_if_player( _( "You can't see to do that!" ) );
         return std::nullopt;
@@ -8526,6 +8950,9 @@ washing_requirements washing_requirements_for_volume( const units::volume &vol )
 
 std::optional<int> iuse::wash_soft_items( Character *p, item *, const tripoint_bub_ms & )
 {
+    if( !check_params( p, __func__ ) ) {
+        return std::nullopt;
+    }
     if( p->fine_detail_vision_mod() > 4 ) {
         p->add_msg_if_player( _( "You can't see to do that!" ) );
         return std::nullopt;
@@ -8546,6 +8973,9 @@ std::optional<int> iuse::wash_soft_items( Character *p, item *, const tripoint_b
 
 std::optional<int> iuse::wash_hard_items( Character *p, item *, const tripoint_bub_ms & )
 {
+    if( !check_params( p, __func__ ) ) {
+        return std::nullopt;
+    }
     if( p->fine_detail_vision_mod() > 4 ) {
         p->add_msg_if_player( _( "You can't see to do that!" ) );
         return std::nullopt;
@@ -8566,6 +8996,9 @@ std::optional<int> iuse::wash_hard_items( Character *p, item *, const tripoint_b
 
 std::optional<int> iuse::wash_all_items( Character *p, item *, const tripoint_bub_ms & )
 {
+    if( !check_params( p, __func__ ) ) {
+        return std::nullopt;
+    }
     if( p->fine_detail_vision_mod() > 4 ) {
         p->add_msg_if_player( _( "You can't see to do that!" ) );
         return std::nullopt;
@@ -8584,6 +9017,9 @@ std::optional<int> iuse::wash_all_items( Character *p, item *, const tripoint_bu
 
 std::optional<int> iuse::wash_items( Character *p, bool soft_items, bool hard_items )
 {
+    if( !check_params( p, __func__ ) ) {
+        return std::nullopt;
+    }
     if( p->cant_do_mounted() ) {
         return std::nullopt;
     }
@@ -8685,6 +9121,9 @@ std::optional<int> iuse::wash_items( Character *p, bool soft_items, bool hard_it
 
 std::optional<int> iuse::break_stick( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     p->mod_moves( -to_moves<int>( 2_seconds ) );
     p->mod_stamina( static_cast<int>( 0.05f * p->get_stamina_max() ) );
 
@@ -8720,6 +9159,9 @@ std::optional<int> iuse::break_stick( Character *p, item *it, const tripoint_bub
 
 std::optional<int> iuse::weak_antibiotic( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     p->add_msg_if_player( _( "You take some %s." ), it->tname() );
     if( p->has_effect( effect_infected ) && !p->has_effect( effect_weak_antibiotic ) ) {
         p->add_msg_if_player( m_good, _( "The throbbing of the infection diminishes.  Slightly." ) );
@@ -8731,6 +9173,9 @@ std::optional<int> iuse::weak_antibiotic( Character *p, item *it, const tripoint
 
 std::optional<int> iuse::strong_antibiotic( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     p->add_msg_if_player( _( "You take some %s." ), it->tname() );
     if( p->has_effect( effect_infected ) && !p->has_effect( effect_strong_antibiotic ) ) {
         p->add_msg_if_player( m_good, _( "You feel much better - almost entirely." ) );
@@ -8761,6 +9206,9 @@ static item *wield_before_use( Character *const p, item *const it, const std::st
 
 std::optional<int> iuse::craft( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     if( p->cant_do_mounted() ) {
         return std::nullopt;
     }
@@ -8798,6 +9246,9 @@ std::optional<int> iuse::craft( Character *p, item *it, const tripoint_bub_ms & 
 
 std::optional<int> iuse::disassemble( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     if( p->cant_do_mounted() ) {
         return std::nullopt;
     }
@@ -8816,6 +9267,9 @@ std::optional<int> iuse::disassemble( Character *p, item *it, const tripoint_bub
 
 std::optional<int> iuse::post_up( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     map &here = get_map();
 
     //arbitrary limit of 10 postable items per wall
@@ -8841,6 +9295,9 @@ std::optional<int> iuse::post_up( Character *p, item *it, const tripoint_bub_ms 
 
 std::optional<int> iuse::melatonin_tablet( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     p->add_msg_if_player( _( "You pop a %s." ), it->tname() );
     if( p->has_effect( effect_melatonin ) ) {
         p->add_msg_if_player( m_warning,
@@ -8852,6 +9309,9 @@ std::optional<int> iuse::melatonin_tablet( Character *p, item *it, const tripoin
 
 std::optional<int> iuse::coin_flip( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     p->add_msg_if_player( m_info, _( "You flip a %s." ), it->tname() );
     p->add_msg_if_player( m_info, one_in( 2 ) ? _( "Heads!" ) : _( "Tails!" ) );
     return 0;
@@ -8859,6 +9319,9 @@ std::optional<int> iuse::coin_flip( Character *p, item *it, const tripoint_bub_m
 
 std::optional<int> iuse::play_game( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     const map &here = get_map();
 
     if( p->is_avatar() ) {
@@ -8909,6 +9372,9 @@ std::optional<int> iuse::play_game( Character *p, item *it, const tripoint_bub_m
 
 std::optional<int> iuse::magic_8_ball( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     p->add_msg_if_player( m_info, _( "You ask the %s, then flip it." ), it->tname() );
     int rn = rng( 0, 3 );
     std::string msg_category;
@@ -8930,6 +9396,9 @@ std::optional<int> iuse::magic_8_ball( Character *p, item *it, const tripoint_bu
 
 std::optional<int> iuse::measure_resonance( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     if( !it->ammo_sufficient( p ) ) {
         popup( _( "The device doesn't have enough power to function!" ) );
         return std::nullopt;
@@ -8996,6 +9465,9 @@ std::optional<int> iuse::measure_resonance( Character *p, item *it, const tripoi
 
 std::optional<int> iuse::change_outfit( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !check_params( p, it, __func__ ) ) {
+        return std::nullopt;
+    }
     if( !p->is_avatar() ) {
         debugmsg( "NPC %s tried to swap outfit", p->get_name() );
         return std::nullopt;
@@ -9009,11 +9481,10 @@ std::optional<int> iuse::change_outfit( Character *p, item *it, const tripoint_b
 
 std::optional<int> iuse::ebooksave( Character *p, item *it, const tripoint_bub_ms & )
 {
-    if( !p ) {
-        debugmsg( "%s called action ebooksave that requires character but no character is present",
-                  it->typeId().str() );
+    if( !check_params( p, it, __func__ ) ) {
         return std::nullopt;
     }
+
     if( !it->is_estorage() ) {
         debugmsg( "EBOOKSAVE iuse called on item without ESTORAGE pocket_type" );
         return std::nullopt;
@@ -9057,6 +9528,9 @@ std::optional<int> iuse::ebooksave( Character *p, item *it, const tripoint_bub_m
 
 std::optional<int> iuse::binder_add_recipe( Character *p, item *binder, const tripoint_bub_ms & )
 {
+    if( !check_params( p, binder, __func__ ) ) {
+        return std::nullopt;
+    }
     if( p->cant_do_mounted() ) {
         return std::nullopt;
     }
@@ -9134,6 +9608,9 @@ std::optional<int> iuse::binder_add_recipe( Character *p, item *binder, const tr
 std::optional<int> iuse::binder_manage_recipe( Character *p, item *binder,
         const tripoint_bub_ms &ipos )
 {
+    if( !check_params( p, binder, __func__ ) ) {
+        return std::nullopt;
+    }
     if( p->is_underwater() ) {
         p->add_msg_if_player( m_info, _( "Doing that would ruin the %1$s." ), binder->tname() );
         return std::nullopt;
@@ -9180,6 +9657,9 @@ std::optional<int> iuse::binder_manage_recipe( Character *p, item *binder,
 
 std::optional<int> iuse::voltmeter( Character *p, item *, const tripoint_bub_ms & )
 {
+    if( !check_params( p, __func__ ) ) {
+        return std::nullopt;
+    }
     map &here = get_map();
 
     const std::optional<tripoint_bub_ms> pnt_ = choose_adjacent( _( "Check voltage where?" ) );

--- a/src/iuse.h
+++ b/src/iuse.h
@@ -231,6 +231,10 @@ void play_music( Character *p, const tripoint_bub_ms &source, int volume, int ma
                  bool play_sounds = true );
 std::optional<int> purify_water( Character *p, item *purifier, item_location &water );
 int towel_common( Character *, item *, bool );
+bool check_params( const Character *p, const item *it,
+                   const std::string &action = "UNKNOWN" );
+bool check_params( const Character *p, const std::string &action = "UNKNOWN " );
+bool check_params( const item *it, const std::string &action = "UNKNOWN" );
 
 // Helper for validating a potential target of robot control
 bool robotcontrol_can_target( Character *, const monster & );

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -287,15 +287,13 @@ std::optional<int> iuse_transform::use( Character *p, item &it, const tripoint_b
 std::optional<int> iuse_transform::use( Character *p, item &it, map *,
                                         const tripoint_bub_ms & ) const
 {
+    if( !iuse::check_params( p, &it, "transform" ) ) {
+        return std::nullopt;
+    }
     int scale = 1;
     auto iter = it.type->ammo_scale.find( type );
     if( iter != it.type->ammo_scale.end() ) {
         scale = iter->second;
-    }
-    if( !p ) {
-        debugmsg( "%s called action transform that requires character but no character is present",
-                  it.typeId().str() );
-        return std::nullopt;
     }
 
     it.set_var( "last_act_by_char_id", p->getID().get_value() );
@@ -590,6 +588,9 @@ std::optional<int> unpack_actor::use( Character *p, item &it, const tripoint_bub
 std::optional<int> unpack_actor::use( Character *p, item &it, map *here,
                                       const tripoint_bub_ms & ) const
 {
+    if( !iuse::check_params( p, &it, "unpack" ) ) {
+        return std::nullopt;
+    }
     std::vector<item> items = item_group::items_from( unpack_group, calendar::turn );
     item last_armor;
 
@@ -648,7 +649,11 @@ std::optional<int> message_iuse::use( Character *p, item &it,
 std::optional<int> message_iuse::use( Character *p, item &it,
                                       map *here, const tripoint_bub_ms &pos ) const
 {
+    // p can be null when called as a countdown action, not an error
     if( !p ) {
+        return std::nullopt;
+    }
+    if( !iuse::check_params( &it, "message" ) ) {
         return std::nullopt;
     }
 
@@ -908,6 +913,9 @@ std::optional<int> consume_drug_iuse::use( Character *p, item &it,
 std::optional<int> consume_drug_iuse::use( Character *p, item &it, map *here,
         const tripoint_bub_ms & ) const
 {
+    if( !iuse::check_params( p, &it, "consume_drug" ) ) {
+        return std::nullopt;
+    }
     auto need_these = tools_needed;
 
     // Check prerequisites first.
@@ -1013,6 +1021,9 @@ std::optional<int> delayed_transform_iuse::use( Character *p, item &it,
 std::optional<int> delayed_transform_iuse::use( Character *p, item &it,
         map *here, const tripoint_bub_ms &pos ) const
 {
+    if( !iuse::check_params( p, &it, "delayed_transform" ) ) {
+        return std::nullopt;
+    }
     if( time_to_do( it ) > 0 ) {
         p->add_msg_if_player( m_info, "%s", not_ready_msg );
         return std::nullopt;
@@ -1054,6 +1065,9 @@ std::optional<int> place_monster_iuse::use( Character *p, item &it,
 std::optional<int> place_monster_iuse::use( Character *p, item &it, map *here,
         const tripoint_bub_ms & ) const
 {
+    if( !iuse::check_params( p, &it, "place_monster" ) ) {
+        return std::nullopt;
+    }
     if( here != &reality_bubble() ) { // Because of the g usage below
         debugmsg( "Not supported for maps other than the reality bubble" );
         return std::nullopt;
@@ -1159,6 +1173,9 @@ std::optional<int> place_npc_iuse::use( Character *p, item &it, const tripoint_b
 std::optional<int> place_npc_iuse::use( Character *p, item &, map *here,
                                         const tripoint_bub_ms & ) const
 {
+    if( !iuse::check_params( p, "place_npc" ) ) {
+        return std::nullopt;
+    }
     const tripoint_range<tripoint_bub_ms> target_range = place_randomly ?
             points_in_radius( p->pos_bub( *here ), radius ) :
             points_in_radius( choose_adjacent( _( "Place NPC where?" ) ).value_or( p->pos_bub( *here ) ), 0 );
@@ -1329,6 +1346,9 @@ std::optional<int> deploy_furn_actor::use( Character *p, item &it,
 std::optional<int> deploy_furn_actor::use( Character *p, item &it,
         map *here, const tripoint_bub_ms &pos ) const
 {
+    if( !iuse::check_params( p, &it, "deploy_furn" ) ) {
+        return std::nullopt;
+    }
     ret_val<tripoint_bub_ms> suitable = check_deploy_square( p, it, here, pos );
     if( !suitable.success() ) {
         p->add_msg_if_player( m_info, suitable.str() );
@@ -1368,6 +1388,9 @@ std::optional<int> deploy_appliance_actor::use( Character *p, item &it,
 std::optional<int> deploy_appliance_actor::use( Character *p, item &it,
         map *here, const tripoint_bub_ms &pos ) const
 {
+    if( !iuse::check_params( p, &it, "deploy_appliance" ) ) {
+        return std::nullopt;
+    }
     ret_val<tripoint_bub_ms> suitable = check_deploy_square( p, it, here, pos );
     if( !suitable.success() ) {
         p->add_msg_if_player( m_info, suitable.str() );
@@ -1433,6 +1456,9 @@ std::optional<int> reveal_map_actor::use( Character *p, item &it, const tripoint
 std::optional<int> reveal_map_actor::use( Character *p, item &it, map *,
         const tripoint_bub_ms & ) const
 {
+    if( !iuse::check_params( p, &it, "reveal_map" ) ) {
+        return std::nullopt;
+    }
     if( it.already_used_by_player( *p ) ) {
         p->add_msg_if_player( _( "There isn't anything new on the %s." ), it.tname() );
         return std::nullopt;
@@ -1663,9 +1689,7 @@ std::optional<int> firestarter_actor::use( Character *p, item &it,
 std::optional<int> firestarter_actor::use( Character *p, item &it,
         map *here,  const tripoint_bub_ms &spos ) const
 {
-    if( !p ) {
-        debugmsg( "%s called action firestarter that requires character but no character is present",
-                  it.typeId().str() );
+    if( !iuse::check_params( p, &it, "firestarter" ) ) {
         return std::nullopt;
     }
 
@@ -1725,9 +1749,7 @@ std::unique_ptr<iuse_actor> salvage_actor::clone() const
 
 std::optional<int> salvage_actor::use( Character *p, item &cutter, const tripoint_bub_ms & ) const
 {
-    if( !p ) {
-        debugmsg( "%s called action salvage that requires character but no character is present",
-                  cutter.typeId().str() );
+    if( !iuse::check_params( p, &cutter, "salvage" ) ) {
         return std::nullopt;
     }
 
@@ -1755,9 +1777,7 @@ std::optional<int> salvage_actor::use( Character *p, item &cutter, const tripoin
 std::optional<int> salvage_actor::use( Character *p, item &cutter, map *,
                                        const tripoint_bub_ms & ) const
 {
-    if( !p ) {
-        debugmsg( "%s called action salvage that requires character but no character is present",
-                  cutter.typeId().str() );
+    if( !iuse::check_params( p, &cutter, "salvage" ) ) {
         return std::nullopt;
     }
 
@@ -2193,9 +2213,7 @@ std::optional<int> inscribe_actor::use( Character *p, item &it, map *here,
         return std::nullopt;
     }
 
-    if( !p ) {
-        debugmsg( "%s called action inscribe that requires character but no character is present",
-                  it.typeId().str() );
+    if( !iuse::check_params( p, &it, "inscribe" ) ) {
         return std::nullopt;
     }
 
@@ -2269,9 +2287,7 @@ std::optional<int> fireweapon_off_actor::use( Character *p, item &it,
 std::optional<int> fireweapon_off_actor::use( Character *p, item &it,
         map *, const tripoint_bub_ms & ) const
 {
-    if( !p ) {
-        debugmsg( "%s called action fireweapon_off that requires character but no character is present",
-                  it.typeId().str() );
+    if( !iuse::check_params( p, &it, "fireweapon_off" ) ) {
         return std::nullopt;
     }
 
@@ -2395,6 +2411,9 @@ std::optional<int> manualnoise_actor::use( Character *p, item &it,
 std::optional<int> manualnoise_actor::use( Character *p, item &, map *,
         const tripoint_bub_ms & ) const
 {
+    if( !iuse::check_params( p, "manualnoise" ) ) {
+        return std::nullopt;
+    }
     map &bubble_map = reality_bubble();
 
     // Uses the moves specified by iuse_actor's definition
@@ -2441,6 +2460,9 @@ std::optional<int> play_instrument_iuse::use( Character *p, item &it,
 std::optional<int> play_instrument_iuse::use( Character *p, item &it,
         map *, const tripoint_bub_ms & ) const
 {
+    if( !iuse::check_params( p, &it, "play_instrument" ) ) {
+        return std::nullopt;
+    }
     if( it.active ) {
         it.active = false;
         p->remove_effect( effect_playing_instrument );
@@ -2715,6 +2737,9 @@ std::optional<int> learn_spell_actor::use( Character *p, item &it,
 std::optional<int> learn_spell_actor::use( Character *p, item &, map *,
         const tripoint_bub_ms & ) const
 {
+    if( !iuse::check_params( p, "learn_spell" ) ) {
+        return std::nullopt;
+    }
     //TODO: combine/replace the checks below with "checks for conditions" from Character::check_read_condition
 
     if( p->fine_detail_vision_mod() > 4 ) {
@@ -2857,6 +2882,9 @@ std::optional<int> cast_spell_actor::use( Character *p, item &it, const tripoint
 std::optional<int> cast_spell_actor::use( Character *p, item &it, map * /*here*/,
         const tripoint_bub_ms &pos ) const
 {
+    if( !iuse::check_params( p, &it, "cast_spell" ) ) {
+        return std::nullopt;
+    }
     if( need_worn && !p->is_worn( it ) ) {
         p->add_msg_if_player( m_info, _( "You need to wear the %1$s before activating it." ), it.tname() );
         return std::nullopt;
@@ -2948,6 +2976,9 @@ std::optional<int> holster_actor::use( Character *you, item &it, const tripoint_
 std::optional<int> holster_actor::use( Character *you, item &it, map *here,
                                        const tripoint_bub_ms &p ) const
 {
+    if( !iuse::check_params( you, &it, "holster" ) ) {
+        return std::nullopt;
+    }
     if( you->is_wielding( it ) ) {
         you->add_msg_if_player( _( "You need to unwield your %s before using it." ), it.tname() );
         return std::nullopt;
@@ -3048,6 +3079,9 @@ std::optional<int> ammobelt_actor::use( Character *p, item &it, const tripoint_b
 
 std::optional<int> ammobelt_actor::use( Character *p, item &, map *, const tripoint_bub_ms & ) const
 {
+    if( !iuse::check_params( p, "ammobelt" ) ) {
+        return std::nullopt;
+    }
     item mag( belt );
     mag.ammo_unset();
 
@@ -3138,6 +3172,9 @@ std::optional<int> repair_item_actor::use( Character *p, item &it,
 std::optional<int> repair_item_actor::use( Character *p, item &it,
         map *here, const tripoint_bub_ms &pos ) const
 {
+    if( !iuse::check_params( p, &it, "repair_item" ) ) {
+        return std::nullopt;
+    }
     if( !can_use_tool( *p, it, true ) ) {
         return std::nullopt;
     }
@@ -3728,6 +3765,9 @@ std::optional<int> heal_actor::use( Character *p, item &it, const tripoint_bub_m
 std::optional<int> heal_actor::use( Character *p, item &it, map *here,
                                     const tripoint_bub_ms &pos ) const
 {
+    if( !iuse::check_params( p, &it, "heal" ) ) {
+        return std::nullopt;
+    }
     if( p->cant_do_underwater() ) {
         return std::nullopt;
     }
@@ -4284,6 +4324,9 @@ std::optional<int> place_trap_actor::use( Character *p, item &it, const tripoint
 std::optional<int> place_trap_actor::use( Character *p, item &it, map *here,
         const tripoint_bub_ms & ) const
 {
+    if( !iuse::check_params( p, &it, "place_trap" ) ) {
+        return std::nullopt;
+    }
     map &bubble_map = reality_bubble();
 
     if( here != &bubble_map ) { // Or make 'choose_adjacent' and 'is_allowed' map aware.
@@ -4432,9 +4475,7 @@ std::optional<int> saw_barrel_actor::use( Character *p, item &it, const tripoint
 std::optional<int> saw_barrel_actor::use( Character *p, item &it, map *,
         const tripoint_bub_ms & ) const
 {
-    if( !p ) {
-        debugmsg( "%s called action saw_barrel that requires character but no character is present",
-                  it.typeId().str() );
+    if( !iuse::check_params( p, &it, "saw_barrel" ) ) {
         return std::nullopt;
     }
 
@@ -4499,9 +4540,7 @@ std::optional<int> saw_stock_actor::use( Character *p, item &it, const tripoint_
 std::optional<int> saw_stock_actor::use( Character *p, item &it, map *,
         const tripoint_bub_ms & ) const
 {
-    if( !p ) {
-        debugmsg( "%s called action saw_stock that requires character but no character is present",
-                  it.typeId().str() );
+    if( !iuse::check_params( p, &it, "saw_stock" ) ) {
         return std::nullopt;
     }
 
@@ -4581,9 +4620,7 @@ std::optional<int> molle_attach_actor::use( Character *p, item &it,
 std::optional<int> molle_attach_actor::use( Character *p, item &it,
         map *, const tripoint_bub_ms & ) const
 {
-    if( !p ) {
-        debugmsg( "%s called action molle_attach that requires character but no character is present",
-                  it.typeId().str() );
+    if( !iuse::check_params( p, &it, "molle_attach" ) ) {
         return std::nullopt;
     }
 
@@ -4619,6 +4656,9 @@ std::optional<int> molle_detach_actor::use( Character *p, item &it,
 std::optional<int> molle_detach_actor::use( Character *p, item &it,
         map *, const tripoint_bub_ms & ) const
 {
+    if( !iuse::check_params( p, &it, "molle_detach" ) ) {
+        return std::nullopt;
+    }
 
     std::vector<const item *> items_attached = it.get_contents().get_added_pockets();
     uilist prompt;
@@ -4659,6 +4699,9 @@ std::optional<int> install_bionic_actor::use( Character *p, item &it,
 std::optional<int> install_bionic_actor::use( Character *p, item &it,
         map *, const tripoint_bub_ms & ) const
 {
+    if( !iuse::check_params( p, &it, "install_bionic" ) ) {
+        return std::nullopt;
+    }
     if( p->can_install_bionics( *it.type, *p, false ) ) {
         if( !p->has_trait( trait_DEBUG_BIONICS ) && !p->has_flag( json_flag_MANUAL_CBM_INSTALLATION ) ) {
             p->consume_installation_requirement( it.type->bionic->id );
@@ -4743,6 +4786,9 @@ std::optional<int> detach_gunmods_actor::use( Character *p, item &it,
 std::optional<int> detach_gunmods_actor::use( Character *p, item &it,
         map *, const tripoint_bub_ms & ) const
 {
+    if( !iuse::check_params( p, &it, "detach_gunmods" ) ) {
+        return std::nullopt;
+    }
     auto filter_irremovable = []( std::vector<item *> &gunmods ) {
         gunmods.erase(
             std::remove_if(
@@ -4847,6 +4893,9 @@ std::optional<int> modify_gunmods_actor::use( Character *p, item &it,
 std::optional<int> modify_gunmods_actor::use( Character *p, item &it,
         map */*here*/, const tripoint_bub_ms &pos ) const
 {
+    if( !iuse::check_params( p, &it, "modify_gunmods" ) ) {
+        return std::nullopt;
+    }
 
     std::vector<item *> mods;
     for( item *mod : it.gunmods() ) {
@@ -5018,9 +5067,7 @@ std::optional<int> link_up_actor::use( Character *p, item &it, const tripoint_bu
 std::optional<int> link_up_actor::use( Character *p, item &it, map *here,
                                        const tripoint_bub_ms &pos ) const
 {
-    if( !p ) {
-        debugmsg( "%s called action link_up that requires character but no character is present",
-                  it.typeId().str() );
+    if( !iuse::check_params( p, &it, "link_up" ) ) {
         return std::nullopt;
     }
 
@@ -5677,6 +5724,9 @@ std::optional<int> deploy_tent_actor::use( Character *p, item &it,
 std::optional<int> deploy_tent_actor::use( Character *p, item &it, map *here,
         const tripoint_bub_ms & ) const
 {
+    if( !iuse::check_params( p, &it, "deploy_tent" ) ) {
+        return std::nullopt;
+    }
     map &bubble_map = reality_bubble();
 
     if( here != &bubble_map ) { // Or make 'choose_direction' map aware.
@@ -5767,6 +5817,9 @@ std::optional<int> weigh_self_actor::use( Character *p, item &it, const tripoint
 std::optional<int> weigh_self_actor::use( Character *p, item &, map *,
         const tripoint_bub_ms & ) const
 {
+    if( !iuse::check_params( p, "weigh_self" ) ) {
+        return std::nullopt;
+    }
     if( p->is_mounted() ) {
         p->add_msg_if_player( m_info, _( "You cannot weigh yourself while mounted." ) );
         return std::nullopt;
@@ -5818,6 +5871,9 @@ std::optional<int> sew_advanced_actor::use( Character *p, item &it,
 std::optional<int> sew_advanced_actor::use( Character *p, item &it, map *here,
         const tripoint_bub_ms & ) const
 {
+    if( !iuse::check_params( p, &it, "sew_advanced" ) ) {
+        return std::nullopt;
+    }
     if( p->is_npc() ) {
         return std::nullopt;
     }
@@ -6066,6 +6122,9 @@ std::optional<int> change_scent_iuse::use( Character *p, item &it,
 std::optional<int> change_scent_iuse::use( Character *p, item &it, map *,
         const tripoint_bub_ms & ) const
 {
+    if( !iuse::check_params( p, &it, "change_scent" ) ) {
+        return std::nullopt;
+    }
     p->set_value( "prev_scent", p->get_type_of_scent().c_str() );
     if( waterproof ) {
         p->set_value( "waterproof_scent", "true" );
@@ -6126,6 +6185,9 @@ std::optional<int> effect_on_conditions_actor::use( Character *p, item &it,
 std::optional<int> effect_on_conditions_actor::use( Character *p, item &it,
         map *here, const tripoint_bub_ms &pos ) const
 {
+    if( !iuse::check_params( p, &it, "effect_on_conditions" ) ) {
+        return std::nullopt;
+    }
     if( it.type->comestible ) {
         debugmsg( "Comestibles are not properly consumed via effect_on_conditions and effect_on_conditions should not be used on items of type comestible until/unless this is resolved.  Rather than a use_action, use the consumption_effect_on_conditions JSON parameter on the comestible" );
         return 0;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
iuse and iuse_actor perform the same check on many different action functions, emitting a debug message if given a null character pointer, but they never check the item pointer, and the check is only performed for a seemingly arbitrary subset of such functions.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
Move the check and message to functions, use those functions to validate param(s) on every relevant function.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->
I haven't found a way to produce these error conditions in normal play or even with debug mode. Along the way I made one mistake in a check, which an automated test triggered.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
This started as just an effort to deduplicate the message, but grew when someone pointed out the inconsistency.

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
