### PR TITLE
Allow climbing freestanding ladder

### DIFF
--- a/data/json/furniture_and_terrain/furniture-tools.json
+++ b/data/json/furniture_and_terrain/furniture-tools.json
@@ -765,17 +765,11 @@
     "deployed_item": "stepladder",
     "rotates_to": "WALL",
     "bash": {
-      "str_min": 6,
-      "str_max": 40,
-      "sound": "smash!",
-      "sound_fail": "whump.",
-      "items": [
-        { "item": "2x4", "count": [ 4, 10 ] },
-        { "item": "nail", "charges": [ 10, 30 ] },
-        { "item": "splinter", "count": [ 5, 10 ] }
-      ],
-      "hit_field": [ "fd_dust", 2 ],
-      "destroyed_field": [ "fd_splinters", 1 ]
+      "str_min": 0,
+      "str_max": 2,
+      "sound": "thunk!",
+      "sound_fail": "tap.",
+      "items": [ { "item": "stepladder", "count": 1 } ]
     }
   },
   {
@@ -792,11 +786,11 @@
     "looks_like": "f_ladder",
     "deployed_item": "aluminum_stepladder",
     "bash": {
-      "str_min": 6,
-      "str_max": 40,
-      "sound": "smash!",
-      "sound_fail": "whump.",
-      "items": [ { "item": "scrap_aluminum", "count": [ 15, 285 ] } ]
+      "str_min": 0,
+      "str_max": 2,
+      "sound": "clang!",
+      "sound_fail": "tink.",
+      "items": [ { "item": "aluminum_stepladder", "count": 1 } ]
     }
   },
   {

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -2466,7 +2466,8 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
             if( !player_character.in_vehicle ) {
                 // We're NOT standing on tiles with stairs, ropes, ladders etc
                 if( !here.has_flag( ter_furn_flag::TFLAG_GOES_DOWN, player_character.pos_bub() ) &&
-                    !u.has_flag( json_flag_PHASE_MOVEMENT ) ) {
+                    !u.has_flag( json_flag_PHASE_MOVEMENT ) &&
+                    !here.has_flag( ter_furn_flag::TFLAG_LADDER, player_character.pos_bub() + tripoint::below ) ) {
                     std::vector<tripoint_bub_ms> pts;
 
                     // If levitating, just move straight down if possible.

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -10050,6 +10050,12 @@ bool map::try_fall( const tripoint_bub_ms &p, Creature *c )
     int height = 0;
     tripoint_bub_ms where( p );
     tripoint_bub_ms below( where + tripoint_rel_ms::below );
+
+    if( has_flag( ter_furn_flag::TFLAG_LADDER, below ) ) {
+        // you can stand at the top of a ladder
+        return false;
+    }
+
     creature_tracker &creatures = get_creature_tracker();
     while( valid_move( where, below, false, true ) ) {
         where.z()--;

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -2190,6 +2190,12 @@ bool monster::melee_attack( Creature &target, float accuracy )
         return false;
     }
 
+    if( target.pos_abs() == pos_abs() + tripoint::above &&
+        here.has_flag_furn( ter_furn_flag::TFLAG_LADDER, pos_bub() ) ) {
+        // any melee attack from the bottom to the top of a deployed ladder can topple the ladder
+        bash_at( pos_bub(), true );
+    }
+
     const int monster_hit_roll = melee::melee_hit_range( accuracy );
     int hitspread = target.deal_melee_attack( this, monster_hit_roll );
     if( type->melee_dice == 0 ) {

--- a/src/monster.h
+++ b/src/monster.h
@@ -323,7 +323,7 @@ class monster : public Creature
          *
          * @return true if we destroyed something, false otherwise.
          */
-        bool bash_at( const tripoint_bub_ms &p );
+        bool bash_at( const tripoint_bub_ms &p, bool bash_here = false );
 
         /**
          * Try to push away whatever occupies p, then step in.


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Content "Freestanding ladders can now be climbed and stood atop"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
Currently a deployed ladder cannot be climbed directly, it only gives a benefit to climbing to nearby roofs/etc. This seems unrealistic.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
Allow the player to climb up while standing at a deployed ladder, and to stand in the open air tile above the ladder.
Change the bash results for ladders to "tip them over" and produce an intact ladder, so monsters can tip them.
Allow monsters to bash their own square if it's a ladder and they are attacking the player above them.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->
Climbed ladders and things near ladders, climbed down ladders and down from things near ladders. More exhaustive testing and potential automated tests TBD.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
Remaining bug: The tile with the ladder, below the player after they climb, is Unseen. I need to find what part of the vision code is obscuring it.

Stretch goal: Get monsters to knock over ladders they are standing at even with no player on top, so they will eventually tip over any ladder left beside a building they are surrounding, even if they don't move off/on the ladder tile.

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
