### PR TITLE
Scavenger anvil desc fix

### DIFF
--- a/data/json/construction_group.json
+++ b/data/json/construction_group.json
@@ -1568,7 +1568,7 @@
   {
     "type": "construction_group",
     "id": "place_anvil_scavenged",
-    "name": "Mount Scavenged Anvil"
+    "name": "Mount Scavenger's Anvil"
   },
   {
     "type": "construction_group",

--- a/data/json/furniture_and_terrain/furniture-tools.json
+++ b/data/json/furniture_and_terrain/furniture-tools.json
@@ -289,7 +289,7 @@
   {
     "type": "furniture",
     "id": "f_anvil_scavenged",
-    "name": "scavenged anvil",
+    "name": "scavenger's anvil",
     "looks_like": "f_anvil",
     "description": "An old machinery part, cut and smoothed to make a serviceable anvil, and mounted to a heavy log stand.",
     "symbol": "^",

--- a/data/json/items/tool/metalworking.json
+++ b/data/json/items/tool/metalworking.json
@@ -90,7 +90,7 @@
     "type": "ITEM",
     "subtypes": [ "TOOL" ],
     "name": { "str": "scavenger's anvil" },
-    "description": "A portion of heavy steel machinery that has been smoothed and shaped to form a very adequate anvil.",
+    "description": "A portion of heavy steel machinery that has been smoothed and shaped to form a very adequate anvil.  If it were mounted onto a good solid log, it would be adequate for any task.",
     "//": "Represents any number of heavy machinery parts that serve this purpose.",
     "weight": "50 kg",
     "volume": "30 L",


### PR DESCRIPTION


#### Summary
None

#### Purpose of change
The scavenger's anvil's description could do some hinting on the fact that ya can mount it on a log to improve the anvil's tool quality. Also changed the construction's name and the furniture's name for consistency reasons

#### Describe the solution
Gives a bit more description hinting to mount it on a log (by @Sutremaine), and change construction and furniture name into `scavenger's anvil` for consistency.

#### Describe alternatives you've considered
Not doing so.

#### Testing

![Screenshot_20250817_042653](https://github.com/user-attachments/assets/9f2396d1-205c-4772-8ce6-4f9c82c87ea0)
![Screenshot_20250817_042633](https://github.com/user-attachments/assets/783a00c4-400e-4634-a0e9-57b6be223568)
![Screenshot_20250817_040548](https://github.com/user-attachments/assets/9ec3cf53-a928-450a-ab99-a5746182103b)


#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
