### PR TITLE
Enable 3D overmap vision

### DIFF
--- a/data/json/overmap/overmap_terrain/overmap_terrain_hardcoded.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_hardcoded.json
@@ -2,11 +2,7 @@
   {
     "type": "overmap_terrain",
     "id": "open_air",
-    "name": "open air",
-    "sym": ".",
-    "color": "blue",
-    "see_cost": "all_clear",
-    "vision_levels": "roof_or_air",
+    "copy-from": "generic_air",
     "travel_cost_type": "air",
     "uniform_terrain": "t_open_air",
     "flags": [ "NO_ROTATE" ]

--- a/data/json/overmap/overmap_terrain/overmap_terrain_special.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_special.json
@@ -94,8 +94,8 @@
     "vision_levels": "roof_or_air",
     "see_cost": "all_clear",
     "name": "open air",
-    "sym": ".",
-    "color": "blue",
+    "sym": " ",
+    "color": "cyan",
     "looks_like": "open_air"
   },
   {

--- a/doc/TILESET.md
+++ b/doc/TILESET.md
@@ -684,6 +684,7 @@ Each legacy tileset has a `tile_config.json` describing how to map the contents 
         "height": 32,
         "width": 32,
         "iso" : true,                             //  Optional. Indicates an isometric tileset. Defaults to false.
+        "supports_overmap_transparency" : true,   //  Optional. Indicates a tileset supports overmap transparency. Defaults to false.
         "pixelscale" : 2                          //  Optional. Sets a multiplier for resizing a tileset. Defaults to 1.
       }
     ],

--- a/src/cached_options.cpp
+++ b/src/cached_options.cpp
@@ -10,6 +10,7 @@ bool prevent_occlusion_retract;
 bool prevent_occlusion_transp;
 float prevent_occlusion_min_dist;
 float prevent_occlusion_max_dist;
+bool override_overmap_tileset_transparency;
 bool show_creature_overlay_icons;
 bool use_tiles;
 bool use_far_tiles;

--- a/src/cached_options.cpp
+++ b/src/cached_options.cpp
@@ -10,7 +10,6 @@ bool prevent_occlusion_retract;
 bool prevent_occlusion_transp;
 float prevent_occlusion_min_dist;
 float prevent_occlusion_max_dist;
-bool override_overmap_tileset_transparency;
 bool show_creature_overlay_icons;
 bool use_tiles;
 bool use_far_tiles;

--- a/src/cached_options.h
+++ b/src/cached_options.h
@@ -19,6 +19,7 @@ extern bool prevent_occlusion_retract;
 extern bool prevent_occlusion_transp;
 extern float prevent_occlusion_min_dist;
 extern float prevent_occlusion_max_dist;
+extern bool override_overmap_tileset_transparency;
 extern bool show_creature_overlay_icons;
 extern bool use_tiles;
 extern bool use_far_tiles;

--- a/src/cached_options.h
+++ b/src/cached_options.h
@@ -19,7 +19,6 @@ extern bool prevent_occlusion_retract;
 extern bool prevent_occlusion_transp;
 extern float prevent_occlusion_min_dist;
 extern float prevent_occlusion_max_dist;
-extern bool override_overmap_tileset_transparency;
 extern bool show_creature_overlay_icons;
 extern bool use_tiles;
 extern bool use_far_tiles;

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -2759,7 +2759,7 @@ bool cata_tiles::draw_from_id_string_internal( const std::string &id, TILE_CATEG
             // What about isBlink?
             const bool isBold = col.is_bold();
             const int FG = colorpair.FG + ( isBold ? 8 : 0 );
-            const int BG = ( override_overmap_tileset_transparency || get_supports_overmap_transparency() ) &&
+            const int BG = get_supports_overmap_transparency() &&
                            category == TILE_CATEGORY::OVERMAP_TERRAIN ? catacurses::black + 8 : -1;
             std::string generic_id = get_ascii_tile_id( sym, FG, BG );
 

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -707,6 +707,7 @@ void tileset_cache::loader::load( const std::string &tileset_id, const bool prec
         ts.max_tile_extent = half_open_rectangle<point>( point::zero, { ts.tile_width, ts.tile_height } );
         ts.zlevel_height = curr_info.get_int( "zlevel_height", 0 );
         ts.tile_isometric = curr_info.get_bool( "iso", false );
+        ts.supports_overmap_transparency = curr_info.get_bool( "supports_overmap_transparency", false );
         ts.tile_pixelscale = curr_info.get_float( "pixelscale", 1.0f );
         ts.prevent_occlusion_min_dist = curr_info.get_float( "retract_dist_min", -1.0f );
         ts.prevent_occlusion_max_dist = curr_info.get_float( "retract_dist_max", 0.0f );
@@ -1736,7 +1737,7 @@ void cata_tiles::draw( const point &dest, const tripoint_bub_ms &center, int wid
     color_blocks = here.color_blocks_cache;
 
     // List all layers for a single z-level
-    const std::array<decltype( &cata_tiles::draw_furniture ), 11> drawing_layers = {{
+    static const std::array<decltype( &cata_tiles::draw_furniture ), 11> drawing_layers = {{
             &cata_tiles::draw_terrain, &cata_tiles::draw_furniture, &cata_tiles::draw_graffiti, &cata_tiles::draw_trap, &cata_tiles::draw_part_con,
             &cata_tiles::draw_field_or_item,
             &cata_tiles::draw_vpart_no_roof, &cata_tiles::draw_vpart_roof,

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -339,8 +339,6 @@ class tileset_cache::loader
 
         void process_variations_after_loading( weighted_int_list<std::vector<int>> &v ) const;
 
-        void add_ascii_subtile( tile_type &curr_tile, const std::string &t_id, int sprite_id,
-                                const std::string &s_id );
         void load_ascii_set( const JsonObject &entry );
         /**
          * Create a new tile_type, add it to tile_ids (using <B>id</B>).

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -180,6 +180,7 @@ class tileset
         std::string tileset_id;
 
         bool tile_isometric = false;
+        bool supports_overmap_transparency = false;
         // Unscaled default size of sprites. See cata_tiles::tile_(width|height)
         // for more detail.
         int tile_width = 0;
@@ -224,6 +225,9 @@ class tileset
 
         bool is_isometric() const {
             return tile_isometric;
+        }
+        bool get_supports_overmap_transparency() const {
+            return supports_overmap_transparency;
         }
         int get_tile_width() const {
             return tile_width;
@@ -742,6 +746,9 @@ class cata_tiles
 
         bool is_isometric() const {
             return tileset_ptr->is_isometric();
+        }
+        bool get_supports_overmap_transparency() const {
+            return tileset_ptr->get_supports_overmap_transparency();
         }
         int get_tile_height() const {
             return tile_height;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2893,14 +2893,6 @@ void options_manager::add_options_debug()
 
     add_empty_line();
 
-    add( "OVERRIDE_OVERMAP_TILESET_TRANSPARENCY", "debug",
-         to_translation( "Override overmap tileset's transparency support" ),
-         to_translation( "If true all overmap z-levels below the current will render regardless of explicit support for testing." ),
-         false
-       );
-
-    add_empty_line();
-
     add( "SKIP_VERIFICATION", "debug", to_translation( "Skip verification step during loading" ),
          to_translation( "If enabled, this skips the JSON verification step during loading.  This may give a faster loading time, but risks JSON errors not being caught until runtime." ),
 #if defined(EMSCRIPTEN)
@@ -4045,8 +4037,6 @@ void options_manager::update_options_cache()
     prevent_occlusion_transp = ::get_option<bool>( "PREVENT_OCCLUSION_TRANSP" );
     prevent_occlusion_min_dist = ::get_option<float>( "PREVENT_OCCLUSION_MIN_DIST" );
     prevent_occlusion_max_dist = ::get_option<float>( "PREVENT_OCCLUSION_MAX_DIST" );
-    override_overmap_tileset_transparency
-        = ::get_option<bool>( "OVERRIDE_OVERMAP_TILESET_TRANSPARENCY" );
     show_creature_overlay_icons = ::get_option<bool>( "CREATURE_OVERLAY_ICONS" );
 
     // if the tilesets are identical don't duplicate

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2893,6 +2893,14 @@ void options_manager::add_options_debug()
 
     add_empty_line();
 
+    add( "OVERRIDE_OVERMAP_TILESET_TRANSPARENCY", "debug",
+         to_translation( "Override overmap tileset's transparency support" ),
+         to_translation( "If true all overmap z-levels below the current will render regardless of explicit support for testing." ),
+         false
+       );
+
+    add_empty_line();
+
     add( "SKIP_VERIFICATION", "debug", to_translation( "Skip verification step during loading" ),
          to_translation( "If enabled, this skips the JSON verification step during loading.  This may give a faster loading time, but risks JSON errors not being caught until runtime." ),
 #if defined(EMSCRIPTEN)
@@ -4037,6 +4045,8 @@ void options_manager::update_options_cache()
     prevent_occlusion_transp = ::get_option<bool>( "PREVENT_OCCLUSION_TRANSP" );
     prevent_occlusion_min_dist = ::get_option<float>( "PREVENT_OCCLUSION_MIN_DIST" );
     prevent_occlusion_max_dist = ::get_option<float>( "PREVENT_OCCLUSION_MAX_DIST" );
+    override_overmap_tileset_transparency
+        = ::get_option<bool>( "OVERRIDE_OVERMAP_TILESET_TRANSPARENCY" );
     show_creature_overlay_icons = ::get_option<bool>( "CREATURE_OVERLAY_ICONS" );
 
     // if the tilesets are identical don't duplicate

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -2545,16 +2545,17 @@ std::pair<std::string, nc_color> oter_symbol_and_color( const tripoint_abs_omt &
             ret.second = c_dark_gray;
         }
     } else if( overmap_buffer.draw_below_curses( omp ) ) {
-        // 1 zlevel 3D vision roughly equivilant to map::draw_from_above's implementation
-        cur_ter = overmap_buffer.ter( omp + tripoint_rel_omt::below );
+        // 1 z-level 3D vision roughly equivilant to map::draw_from_above's implementation
+        const tripoint_abs_omt below = omp + tripoint_rel_omt::below;
+        cur_ter = overmap_buffer.ter( below );
+        // Most of the time just "." is fine as for air the fg colour == bg colour but if the colour is changed after this eg cursor highlighting using " " is better
+        ret.first = overmap_buffer.draw_below_curses( below ) ? " " : ".";
         ret.second = lru ? lru->get_symbol_and_color( cur_ter, args.vision ).second :
                      cur_ter->get_color( args.vision, uistate.overmap_show_land_use_codes );
-        ret.second = cyan_background( ret.second );
-        //BEFOREMERGE: For some reason the highlighted cursor tile diplays this rather than "open_air"'s symbol when looking at open_air with nothing displayable below? (but is correct otherwise)
-        ret.first = ".";
-        if( opts.show_explored && overmap_buffer.is_explored( omp + tripoint_rel_omt::below ) ) {
+        if( opts.show_explored && overmap_buffer.is_explored( below ) ) {
             ret.second = c_dark_gray;
         }
+        ret.second = cyan_background( ret.second );
     } else {
         // Nothing special, but is visible to the player.
         ret = lru ? lru->get_symbol_and_color( cur_ter, args.vision ) : std::pair<std::string, nc_color> {

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -892,6 +892,15 @@ bool overmapbuffer::reveal( const tripoint_abs_omt &center, int radius,
     return result;
 }
 
+bool overmapbuffer::draw_below_curses( const tripoint_abs_omt &p )
+{
+    if( p.z() <= -OVERMAP_DEPTH ) {
+        return false;
+    } else {
+        return ter_existing( p )->can_see_down_through();
+    }
+}
+
 overmap_path_params overmap_path_params::for_player()
 {
     overmap_path_params ret;

--- a/src/overmapbuffer.h
+++ b/src/overmapbuffer.h
@@ -379,7 +379,7 @@ class overmapbuffer
         bool reveal( const tripoint_abs_omt &center, int radius );
         bool reveal( const tripoint_abs_omt &center, int radius,
                      const std::function<bool( const oter_id & )> &filter );
-        bool draw_below_curses( const tripoint_abs_omt &p ); //BEFOREMERGE: ter_existing isn't const?
+        bool draw_below_curses( const tripoint_abs_omt &p );
         pf::simple_path<tripoint_abs_omt> get_travel_path(
             const tripoint_abs_omt &src, const tripoint_abs_omt &dest, const overmap_path_params &params );
         bool reveal_route( const tripoint_abs_omt &source, const tripoint_abs_omt &dest,

--- a/src/overmapbuffer.h
+++ b/src/overmapbuffer.h
@@ -379,6 +379,7 @@ class overmapbuffer
         bool reveal( const tripoint_abs_omt &center, int radius );
         bool reveal( const tripoint_abs_omt &center, int radius,
                      const std::function<bool( const oter_id & )> &filter );
+        bool draw_below_curses( const tripoint_abs_omt &p ); //BEFOREMERGE: ter_existing isn't const?
         pf::simple_path<tripoint_abs_omt> get_travel_path(
             const tripoint_abs_omt &src, const tripoint_abs_omt &dest, const overmap_path_params &params );
         bool reveal_route( const tripoint_abs_omt &source, const tripoint_abs_omt &dest,

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -833,11 +833,10 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
         return tripoint_abs_omt( omp.xy(), 0 );
     };
 
-    for( int cur_z = draw_3D ? -OVERMAP_DEPTH : origin_z; cur_z <= origin_z; cur_z++ ) {
-        const tripoint_rel_omt dz( 0, 0, cur_z - origin_z );
-        for( int row = min_row; row < max_row; row++ ) {
-            for( int col = min_col; col < max_col; col++ ) {
-                const tripoint_abs_omt omp = origin + point_rel_omt( col, row ) + dz;
+    for( int row = min_row; row < max_row; row++ ) {
+        for( int col = min_col; col < max_col; col++ ) {
+            for( int cur_z = draw_3D ? -OVERMAP_DEPTH : origin_z; cur_z <= origin_z; cur_z++ ) {
+                const tripoint_abs_omt omp = origin + tripoint_rel_omt( col, row, cur_z - origin_z );
                 //TODO: Could add some kind of check as to whether to draw below and continue if not rather than brute force drawing everything (eg a tileset json sprite bool)
 
                 const om_vision_level vision = overmap_buffer.seen( omp );

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -830,8 +830,7 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
 
     // If the tileset supports it draw lower zlevels
     //BEFOREMERGE: Deduplicate?
-    if( !viewing_weather && ( override_overmap_tileset_transparency ||
-                              get_supports_overmap_transparency() ) ) {
+    if( !viewing_weather && get_supports_overmap_transparency() ) {
         for( int cur_zlevel = -OVERMAP_DEPTH; cur_zlevel < center_abs_omt.z(); cur_zlevel++ ) {
             const tripoint_rel_omt dz( 0, 0, cur_zlevel - center_abs_omt.z() );
             for( int row = min_row; row < max_row; row++ ) {

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -801,14 +801,15 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
     if( fast_traveling ) {
         center_pos = you.pos_abs_omt();
     }
-    const tripoint_abs_omt origin = center_pos - point( s.x / 2, s.y / 2 );
+    const tripoint_abs_omt origin = center_pos - point_rel_omt( s.x / 2, s.y / 2 );
+    const int origin_z = center_abs_omt.z();
     int height_3d = 0; // Offsetting the height_3d doesn't work well in the context of the overmap
     const tripoint_abs_omt corner_NW = origin + any_tile_range.p_min;
-    const tripoint_abs_omt corner_SE = origin + any_tile_range.p_max + point::north_west;
+    const tripoint_abs_omt corner_SE = origin + any_tile_range.p_max + point_rel_omt::north_west;
     const inclusive_cuboid<tripoint_abs_omt> overmap_area( corner_NW, corner_SE );
     // Area of fully shown tiles
     const tripoint_abs_omt full_corner_NW = origin + full_base_range.p_min;
-    const tripoint_abs_omt full_corner_SE = origin + full_base_range.p_max + point::north_west;
+    const tripoint_abs_omt full_corner_SE = origin + full_base_range.p_max + point_rel_omt::north_west;
     const inclusive_cuboid<tripoint_abs_omt> full_om_tile_area( full_corner_NW, full_corner_SE );
     // Debug vision allows seeing everything
     const bool has_debug_vision = you.has_trait( trait_DEBUG_NIGHTVISION );
@@ -822,185 +823,159 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
     const bool viewing_weather = uistate.overmap_debug_weather || uistate.overmap_visible_weather;
     const bool draw_overlays = blink || fast_traveling;
     o = origin.xy().raw();
+    const bool draw_3D = !viewing_weather && get_supports_overmap_transparency();
 
     const auto global_omt_to_draw_position = []( const tripoint_abs_omt & omp ) {
         // z position is hardcoded to 0 because the things this will be used to draw should not be skipped
         return tripoint_abs_omt( omp.xy(), 0 );
     };
 
-    // If the tileset supports it draw lower zlevels
-    //BEFOREMERGE: Deduplicate?
-    if( !viewing_weather && get_supports_overmap_transparency() ) {
-        for( int cur_zlevel = -OVERMAP_DEPTH; cur_zlevel < center_abs_omt.z(); cur_zlevel++ ) {
-            const tripoint_rel_omt dz( 0, 0, cur_zlevel - center_abs_omt.z() );
-            for( int row = min_row; row < max_row; row++ ) {
-                for( int col = min_col; col < max_col; col++ ) {
-                    tripoint_abs_omt omp = origin + point( col, row ) + dz + tripoint_rel_omt::above;
-                    //TODO: Could add some kind of check here as to whether to draw below and continue if not rather than brute force drawing everything (eg a tileset json sprite bool)
-                    omp += tripoint_rel_omt::below;
+    for( int cur_z = draw_3D ? -OVERMAP_DEPTH : origin_z; cur_z <= origin_z; cur_z++ ) {
+        const tripoint_rel_omt dz( 0, 0, cur_z - origin_z );
+        for( int row = min_row; row < max_row; row++ ) {
+            for( int col = min_col; col < max_col; col++ ) {
+                const tripoint_abs_omt omp = origin + point_rel_omt( col, row ) + dz;
+                //TODO: Could add some kind of check as to whether to draw below and continue if not rather than brute force drawing everything (eg a tileset json sprite bool)
 
-                    const om_vision_level vision = overmap_buffer.seen( omp );
-                    std::string id;
-                    TILE_CATEGORY category = TILE_CATEGORY::OVERMAP_TERRAIN;
-                    int rotation = 0;
-                    int subtile = -1;
+                const om_vision_level vision = overmap_buffer.seen( omp );
+                // the full string from the ter_id including _north etc.
+                std::string id;
+                TILE_CATEGORY category = TILE_CATEGORY::OVERMAP_TERRAIN;
+                int rotation = 0;
+                int subtile = -1;
+                map_extra_id mx;
 
-                    if( vision == om_vision_level::unseen ) {
-                        id = "unknown_terrain";
+                if( viewing_weather ) {
+                    const tripoint_abs_omt omp_sky( omp.xy(), OVERMAP_HEIGHT );
+                    if( uistate.overmap_debug_weather ||
+                        you.overmap_los( omp_sky, sight_points * 2 ) ) {
+                        id = overmap_ui::get_weather_at_point( omp_sky ).c_str();
+                        category = TILE_CATEGORY::OVERMAP_WEATHER;
                     } else {
-                        bool is_omt = false;
-                        std::tie( id, is_omt ) = get_omt_id_rotation_and_subtile( omp, rotation, subtile );
-                        if( !is_omt ) {
-                            category = TILE_CATEGORY::OVERMAP_VISION_LEVEL;
+                        id = "unexplored_terrain";
+                    }
+                } else if( vision == om_vision_level::unseen ) {
+                    id = "unknown_terrain";
+                } else {
+                    bool is_omt = false;
+                    std::tie( id, is_omt ) = get_omt_id_rotation_and_subtile( omp, rotation, subtile );
+                    if( cur_z == origin_z ) {
+                        mx = overmap_buffer.extra( omp );
+                    }
+                    if( !is_omt ) {
+                        category = TILE_CATEGORY::OVERMAP_VISION_LEVEL;
+                    }
+                }
+
+                const lit_level ll = overmap_buffer.is_explored( omp ) ? lit_level::LOW : lit_level::LIT;
+                // light level is now used for choosing between grayscale filter and normal lit tiles.
+                draw_from_id_string( id, category,
+                                     category == TILE_CATEGORY::OVERMAP_TERRAIN ? "overmap_terrain" : "",
+                                     omp, subtile, rotation, ll, false, height_3d );
+
+                if( cur_z != origin_z ) {
+                    continue;
+                }
+                if( !mx.is_empty() && mx->autonote ) {
+                    draw_from_id_string( mx.str(), TILE_CATEGORY::MAP_EXTRA, "map_extra", omp,
+                                         0, 0, ll, false );
+                }
+
+                if( draw_overlays && show_map_revealed ) {
+                    auto it = revealed_highlights.find( omp );
+                    if( it != revealed_highlights.end() ) {
+                        draw_from_id_string( "highlight", omp, 0, 0, lit_level::LIT, false );
+                    }
+                }
+
+                if( vision != om_vision_level::unseen ) {
+                    if( draw_overlays && uistate.overmap_debug_mongroup ) {
+                        const std::vector<mongroup *> mgroups = overmap_buffer.monsters_at( omp );
+                        if( !mgroups.empty() ) {
+                            auto mgroup_iter = mgroups.begin();
+                            std::advance( mgroup_iter, rng( 0, mgroups.size() - 1 ) );
+                            draw_from_id_string( ( *mgroup_iter )->type->defaultMonster.str(),
+                                                 omp, 0, 0, lit_level::LIT, false );
                         }
                     }
-
-                    const lit_level ll = overmap_buffer.is_explored( omp ) ? lit_level::LOW : lit_level::LIT;
-                    // light level is now used for choosing between grayscale filter and normal lit tiles.
-                    draw_from_id_string( id, category,
-                                         category == TILE_CATEGORY::OVERMAP_TERRAIN ? "overmap_terrain" : "",
-                                         omp, subtile, rotation, ll, false, height_3d );
-                }
-            }
-        }
-    }
-
-    for( int row = min_row; row < max_row; row++ ) {
-        for( int col = min_col; col < max_col; col++ ) {
-            const tripoint_abs_omt omp = origin + point( col, row );
-
-            const om_vision_level vision = overmap_buffer.seen( omp );
-            const bool los = overmap_buffer.seen_more_than( omp, om_vision_level::details ) &&
-                             ( you.overmap_los( omp, sight_points ) || uistate.overmap_debug_mongroup ||
-                               you.has_trait( trait_DEBUG_CLAIRVOYANCE ) );
-            // the full string from the ter_id including _north etc.
-            std::string id;
-            TILE_CATEGORY category = TILE_CATEGORY::OVERMAP_TERRAIN;
-            int rotation = 0;
-            int subtile = -1;
-            map_extra_id mx;
-
-            if( viewing_weather ) {
-                const tripoint_abs_omt omp_sky( omp.xy(), OVERMAP_HEIGHT );
-                if( uistate.overmap_debug_weather ||
-                    you.overmap_los( omp_sky, sight_points * 2 ) ) {
-                    id = overmap_ui::get_weather_at_point( omp_sky ).c_str();
-                    category = TILE_CATEGORY::OVERMAP_WEATHER;
-                } else {
-                    id = "unexplored_terrain";
-                }
-            } else if( vision == om_vision_level::unseen ) {
-                id = "unknown_terrain";
-            } else {
-                bool is_omt = false;
-                std::tie( id, is_omt ) = get_omt_id_rotation_and_subtile( omp, rotation, subtile );
-                mx = overmap_buffer.extra( omp );
-                if( !is_omt ) {
-                    category = TILE_CATEGORY::OVERMAP_VISION_LEVEL;
-                }
-            }
-
-            const lit_level ll = overmap_buffer.is_explored( omp ) ? lit_level::LOW : lit_level::LIT;
-            // light level is now used for choosing between grayscale filter and normal lit tiles.
-            draw_from_id_string( id, category,
-                                 category == TILE_CATEGORY::OVERMAP_TERRAIN ? "overmap_terrain" : "",
-                                 omp, subtile, rotation, ll, false, height_3d );
-            if( !mx.is_empty() && mx->autonote ) {
-                draw_from_id_string( mx.str(), TILE_CATEGORY::MAP_EXTRA, "map_extra", omp,
-                                     0, 0, ll, false );
-            }
-
-            if( draw_overlays && show_map_revealed ) {
-                auto it = revealed_highlights.find( omp );
-                if( it != revealed_highlights.end() ) {
-                    draw_from_id_string( "highlight", omp, 0, 0, lit_level::LIT, false );
-                }
-            }
-
-            if( vision != om_vision_level::unseen ) {
-                if( draw_overlays && uistate.overmap_debug_mongroup ) {
-                    const std::vector<mongroup *> mgroups = overmap_buffer.monsters_at( omp );
-                    if( !mgroups.empty() ) {
-                        auto mgroup_iter = mgroups.begin();
-                        std::advance( mgroup_iter, rng( 0, mgroups.size() - 1 ) );
-                        draw_from_id_string( ( *mgroup_iter )->type->defaultMonster.str(),
-                                             omp, 0, 0, lit_level::LIT, false );
-                    }
-                }
-                if( showhordes && los ) {
-                    const int horde_size = overmap_buffer.get_horde_size( omp );
-                    if( horde_size >= HORDE_VISIBILITY_SIZE ) {
-                        // a little bit of hardcoded fallbacks for hordes
-                        if( find_tile_with_season( id ) ) {
-                            // NOLINTNEXTLINE(cata-translate-string-literal)
-                            draw_from_id_string( string_format( "overmap_horde_%d", horde_size < 10 ? horde_size : 10 ),
-                                                 omp, 0, 0, lit_level::LIT, false );
-                        } else {
-                            switch( horde_size ) {
-                                case HORDE_VISIBILITY_SIZE:
-                                    draw_from_id_string( "mon_zombie", omp, 0, 0, lit_level::LIT,
-                                                         false );
-                                    break;
-                                case HORDE_VISIBILITY_SIZE + 1:
-                                    draw_from_id_string( "mon_zombie_tough", omp, 0, 0,
-                                                         lit_level::LIT, false );
-                                    break;
-                                case HORDE_VISIBILITY_SIZE + 2:
-                                    draw_from_id_string( "mon_zombie_brute", omp, 0, 0,
-                                                         lit_level::LIT, false );
-                                    break;
-                                case HORDE_VISIBILITY_SIZE + 3:
-                                    draw_from_id_string( "mon_zombie_hulk", omp, 0, 0,
-                                                         lit_level::LIT, false );
-                                    break;
-                                case HORDE_VISIBILITY_SIZE + 4:
-                                    draw_from_id_string( "mon_zombie_necro", omp, 0, 0,
-                                                         lit_level::LIT, false );
-                                    break;
-                                default:
-                                    draw_from_id_string( "mon_zombie_master", omp, 0, 0,
-                                                         lit_level::LIT, false );
-                                    break;
+                    const bool los = overmap_buffer.seen_more_than( omp, om_vision_level::details ) &&
+                                     ( you.overmap_los( omp, sight_points ) || uistate.overmap_debug_mongroup ||
+                                       you.has_trait( trait_DEBUG_CLAIRVOYANCE ) );
+                    if( showhordes && los ) {
+                        const int horde_size = overmap_buffer.get_horde_size( omp );
+                        if( horde_size >= HORDE_VISIBILITY_SIZE ) {
+                            // a little bit of hardcoded fallbacks for hordes
+                            if( find_tile_with_season( id ) ) {
+                                // NOLINTNEXTLINE(cata-translate-string-literal)
+                                draw_from_id_string( string_format( "overmap_horde_%d", horde_size < 10 ? horde_size : 10 ),
+                                                     omp, 0, 0, lit_level::LIT, false );
+                            } else {
+                                switch( horde_size ) {
+                                    case HORDE_VISIBILITY_SIZE:
+                                        draw_from_id_string( "mon_zombie", omp, 0, 0, lit_level::LIT,
+                                                             false );
+                                        break;
+                                    case HORDE_VISIBILITY_SIZE + 1:
+                                        draw_from_id_string( "mon_zombie_tough", omp, 0, 0,
+                                                             lit_level::LIT, false );
+                                        break;
+                                    case HORDE_VISIBILITY_SIZE + 2:
+                                        draw_from_id_string( "mon_zombie_brute", omp, 0, 0,
+                                                             lit_level::LIT, false );
+                                        break;
+                                    case HORDE_VISIBILITY_SIZE + 3:
+                                        draw_from_id_string( "mon_zombie_hulk", omp, 0, 0,
+                                                             lit_level::LIT, false );
+                                        break;
+                                    case HORDE_VISIBILITY_SIZE + 4:
+                                        draw_from_id_string( "mon_zombie_necro", omp, 0, 0,
+                                                             lit_level::LIT, false );
+                                        break;
+                                    default:
+                                        draw_from_id_string( "mon_zombie_master", omp, 0, 0,
+                                                             lit_level::LIT, false );
+                                        break;
+                                }
                             }
                         }
                     }
                 }
-            }
 
-            if( ( uistate.place_terrain || uistate.place_special ) &&
-                overmap_ui::is_generated_omt( omp.xy() ) ) {
-                // Highlight areas that already have been generated
-                draw_from_id_string( "highlight", omp, 0, 0, lit_level::LIT, false );
-            }
-
-            if( draw_overlays && overmap_buffer.has_vehicle( omp ) ) {
-                const std::string tile_id = overmap_buffer.get_vehicle_tile_id( omp );
-                if( find_tile_looks_like( tile_id, TILE_CATEGORY::OVERMAP_NOTE, "" ) ) {
-                    draw_from_id_string( tile_id, TILE_CATEGORY::OVERMAP_NOTE,
-                                         "overmap_note", omp, 0, 0, lit_level::LIT, false );
-                } else {
-                    const std::string ter_sym = overmap_buffer.get_vehicle_ter_sym( omp );
-                    std::string note_name = "note_" + ter_sym + "_cyan";
-                    draw_from_id_string( note_name, TILE_CATEGORY::OVERMAP_NOTE,
-                                         "overmap_note", omp, 0, 0, lit_level::LIT, false );
+                if( ( uistate.place_terrain || uistate.place_special ) &&
+                    overmap_ui::is_generated_omt( omp.xy() ) ) {
+                    // Highlight areas that already have been generated
+                    draw_from_id_string( "highlight", omp, 0, 0, lit_level::LIT, false );
                 }
-            }
 
-            if( draw_overlays && uistate.overmap_show_map_notes ) {
-                if( overmap_buffer.has_note( omp ) ) {
-                    nc_color ter_color = c_black;
-                    std::string ter_sym = " ";
-                    // Display notes in all situations, even when not seen
-                    std::tie( ter_sym, ter_color, std::ignore ) =
-                        overmap_ui::get_note_display_info( overmap_buffer.note( omp ) );
+                if( draw_overlays && overmap_buffer.has_vehicle( omp ) ) {
+                    const std::string tile_id = overmap_buffer.get_vehicle_tile_id( omp );
+                    if( find_tile_looks_like( tile_id, TILE_CATEGORY::OVERMAP_NOTE, "" ) ) {
+                        draw_from_id_string( tile_id, TILE_CATEGORY::OVERMAP_NOTE,
+                                             "overmap_note", omp, 0, 0, lit_level::LIT, false );
+                    } else {
+                        const std::string ter_sym = overmap_buffer.get_vehicle_ter_sym( omp );
+                        std::string note_name = "note_" + ter_sym + "_cyan";
+                        draw_from_id_string( note_name, TILE_CATEGORY::OVERMAP_NOTE,
+                                             "overmap_note", omp, 0, 0, lit_level::LIT, false );
+                    }
+                }
 
-                    std::string note_name = "note_" + ter_sym + "_" + string_from_color( ter_color );
-                    draw_from_id_string( note_name, TILE_CATEGORY::OVERMAP_NOTE, "overmap_note",
-                                         omp, 0, 0, lit_level::LIT, false );
-                } else if( overmap_buffer.is_marked_dangerous( omp ) ) {
-                    draw_from_id_string( "note_X_red", TILE_CATEGORY::OVERMAP_NOTE, "overmap_note",
-                                         omp, 0, 0, lit_level::LIT, false );
+                if( draw_overlays && uistate.overmap_show_map_notes ) {
+                    if( overmap_buffer.has_note( omp ) ) {
+                        nc_color ter_color = c_black;
+                        std::string ter_sym = " ";
+                        // Display notes in all situations, even when not seen
+                        std::tie( ter_sym, ter_color, std::ignore ) =
+                            overmap_ui::get_note_display_info( overmap_buffer.note( omp ) );
 
+                        std::string note_name = "note_" + ter_sym + "_" + string_from_color( ter_color );
+                        draw_from_id_string( note_name, TILE_CATEGORY::OVERMAP_NOTE, "overmap_note",
+                                             omp, 0, 0, lit_level::LIT, false );
+                    } else if( overmap_buffer.is_marked_dangerous( omp ) ) {
+                        draw_from_id_string( "note_X_red", TILE_CATEGORY::OVERMAP_NOTE, "overmap_note",
+                                             omp, 0, 0, lit_level::LIT, false );
+
+                    }
                 }
             }
         }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Features "ASCII overmap shows terrain below air as a '.' similarly to how it does so with regular vision"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
3D vision is cool, no 3D vision on overmap sad
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
~~UNTIL TILESETS GET BACKPORTED FOR 0.I STABLE NO TILESETS IN THE MAIN REPO SHOULD USE THIS TO MAKE BACKPORTING SMOOTHER.~~

- Enable 3D overmap vision on the overmap for ASCII aiming for similar results to map::draw_from_above
- Adds support for overmap sprites with alpha usage, currently the logic is disabled unless using `"supports_overmap_transparency" : true` in the tileset (which you can add in /gfx/<tileset_you're_testing>/tile_config.json in tile_info for testing with a mod_tileset rather than composing)
- Tilesets ascii fallback sprites use the "bold" "black" █ tile as a background on the overmap when rendering 3D vision. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
- I did get fairly far into rewriting the tiles draw_om loop with overmap instead of overmap buffer functions bc the majority of expense comes from repeated coordinate manipulation (project_remain) from forwarding the functions to (or just straight doing functions on) the right overmap which is very much unnecessary but decided this makes reviewing more awkward so I've put it off for a followup PR.
- I planned on adding a basic if we've hit solid_earth/empty_rock/deep_rock skip the rest of the point_abs_omt... except that needs us to iterate down so you don't see through those omts to lower ones... except the drawing needs to occur in the current order. Thankfully I've figured out how to store the calls as std::functions... expect that means reversing the whole draw_om function or temporarily storing each z levels draw functions in a seperate vector and feeding that in backwards to the point_abs_omt one which feels very suboptimal for an optimisation so I'll again wait for a followup PR. (I also have no clue how expensive constructing and storing a point_abs_omt's worth of std::function wrapped draw calls is as to whether this would even be more optimal)
- If overmap LOS wasn't so dumb I'd probably make weather force the origin to z10 and display the other z-levels normally
- It'd be nicer if fallback tiles used region settings rendered over the region settings default_oter for their z-level instead but whether an ascii tile is being drawn is fairly far down the callstack to try to do that.
- Ideally compose would automatically apply an open_air bg to sprites with transparency and no bg and determine the tileset wide bool |= them but we have various overmap overlay sprites with transparency that wouldn't want this applying (hordes, extras, weather) and no automatic way to tell that and maintaining a list of them or enforcing they live in there own spritesheet both seem like bad options (and that's without recognising that overmap sprites aren't seperated in any enforced way rn). I think this would also mean adding a pillow dependency to compose bc I can't find any well to test for transparency in libvips. - 
Lacking the ability to do that I don't see any point complicating things with some kind of per sprite transparent bool rather than just specifying the bg as being open_air.
- It'd be nice if ascii tiles could share the curses implementation for this and regular 3D map vision, might look how doable that would be at some point.
- I did add a temporary debug option to override the tileset bool until stable gets its backports but that seemed fairly pointless compared to just adding the bool pre or post compose
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Messed up some stuff when rebasing in sdltiles.cpp, need to reapply some changes

Will add screenshots of the ASCII implementation and the sprite implementation with some modified MSX sprites

Doesn't work well where there's a larger than gridsize sprite on a lower level currently, if you have a tall sprite the sticky out bit is rendered after the higher z levels of the tile north of it so it appears to be on the current z level
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Surprised noone had done this when 3D vision was originally added bc it really wasn't very hard '^^

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
