### PR TITLE
[MoM] More Nether Attunement backlashes

### DIFF
--- a/data/mods/MindOverMatter/NetherAttunementSpoilers.md
+++ b/data/mods/MindOverMatter/NetherAttunementSpoilers.md
@@ -54,7 +54,7 @@ Once a consequence is selected, it has a chance to actually be applied. There is
 | [Power Surge](#power-surge)+ | 5 |
 | [Sleepiness](#sleepiness) | 5 |
 | [Nether Conduit](#nether-conduit) | 9 |
-| [Extra Weariness](#extra_weariness)+ | 7 |
+| [Extra Weariness](#extra-weariness)+ | 7 |
 | [Feedback](#feedback) | 9 |
 | [Observed](#observed)+ | 6 |
 | [Incorporeality](#incorporeality) | 4 |

--- a/data/mods/MindOverMatter/NetherAttunementSpoilers.md
+++ b/data/mods/MindOverMatter/NetherAttunementSpoilers.md
@@ -54,14 +54,15 @@ Once a consequence is selected, it has a chance to actually be applied. There is
 | [Sleepiness](#sleepiness) | 5 |
 | [Nether Conduit](#nether-conduit) | 9 |
 | [Extra Weariness](#extra_weariness)+ | 7 |
-| [Difficulty Breathing](#difficulty_breathing) | 6 |
 | [Feedback](#feedback) | 9 |
 | [Observed](#observed)+ | 6 |
 | [Incorporeality](#incorporeality) | 4 |
 | [Teleport Lock](#teleport-lock) | 5 |
 | [Metabolic Inversion](#metabolic-inversion) | 5 |
 | [Power Drain](#power-drain) | 5 |
+| [Pyrokinetic Fever](#pyrokinetic-fever) | 7 |
 | [Weakness](#weakness) | 5 |
+| [Pyrokinetic Fog](#pyrokinetic-fog) | 4 |
 | [KCal Consumption](#kcal-consumption) | 6 |
 | [Mindshock](#mindshock)+ | 6 |
 | [Attenuation](#attenuation)+ | 8 |
@@ -148,12 +149,6 @@ Chance: 1.5% to 38%
 Description: You immediately lose a large amount of stored calories with the attendant effect on your weariness  
 <sub>[Back to List](#attunement-consequences)</sub>
 
-### Difficulty Breathing
-Minimum Attunement: 4  
-Chance: 2.5% to 39%  
-Description: You suffer difficulty in breathing, reducing your stamina regeneration for a random period of time based on your attunement vitamin.  Subsequent effects stack
-<sub>[Back to List](#attunement-consequences)</sub>
-
 ### Feedback
 Minimum Attunement: 5  
 Chance: 3% to 39.5%  
@@ -168,32 +163,50 @@ Description: You gain an effect that unlocks nastier consequences, comes with ni
 
 ### Incorporeality
 Minimum Attunement: 4  
+Required School/Power: Teleportation (Ephemeral Walk)
 Chance: 4% to 37%  
-Description: When using the ephemeral walk power, you become incorporeal for a brief period based on your attunement vitamin  
+Description: You become incorporeal for a brief period based on your attunement vitamin  
 <sub>[Back to List](#attunement-consequences)</sub>
 
 ### Teleport Lock
 Minimum Attunement: 4  
+Required School/Power: Teleporter
 Chance: 2% to 33.5%  
 Description: You are unable to teleport yourself for a brief period based on your attunement vitamin  
 <sub>[Back to List](#attunement-consequences)</sub>
 
 ### Metabolic Inversion
 Minimum Attunement: 4  
+Required School/Power: Biokinesis
 Chance: 1% to 29%  
-Description: Only applicable if you have the Biokinetic power path. The effects of the Efficient System trait and Metabolic Hyperefficiency power are inverted for a random length of time based on your attunement vitamin  
+Description: The effects of the Efficient System trait and Metabolic Hyperefficiency power are inverted for a random length of time based on your attunement vitamin  
 <sub>[Back to List](#attunement-consequences)</sub>
 
 ### Power Drain
 Minimum Attunement: 4  
+Required School/Power: Electrokinesis
 Chance: 1% to 29%  
 Description: Your electronics slowly lose power and you cannot activate Electron Overflow for a random period of time based on your attunement vitamin  
+<sub>[Back to List](#attunement-consequences)</sub>
+
+### Pyrokinetic Fever
+Minimum Attunement: 4
+Required School/Power: Pyrokinesis
+Chance: 2.5% to 32.5%  
+Description: You sweat more, have reduced lifting and balance limb scores, and have a higer internal body temperature for a random period of time based on your attunement vitamin  
 <sub>[Back to List](#attunement-consequences)</sub>
 
 ### Weakness
 Minimum Attunement: 5  
 Chance: 2% to 31%  
 Description: You have lowered strength and dexterity along with increased stamina usage in melee for a short period based on your attunement vitamin  
+<sub>[Back to List](#attunement-consequences)</sub>
+
+### Pyrokinetic Fog
+Minimum Attunement: 5
+Required School/Power: Pyrokinesis
+Chance: 1% to 29%  
+Description: Fog condenses out of the air around you for a random period based on your attunement vitamin  
 <sub>[Back to List](#attunement-consequences)</sub>
 
 ### KCal Consumption
@@ -228,14 +241,16 @@ Description: When using a telekinetic power, a wave of force knocks you and ever
 
 ### Teleport Misjump
 Minimum Attunement: 7  
+Required School/Power: Teleporter (Blink, Phase, Transposition, Farstep, Loci Technique, Gateway, Dialated Gateway)
 Chance: 3% to 21%  
 Description: When using a power that teleports you, you get sent somewhere far away and gain an effect that will summon the hounds of tindalos if you use a teleportation power before it wears off  
 <sub>[Back to List](#attunement-consequences)</sub>
 
 ### EMP Blast
 Minimum Attunement: 8  
+Required School/Power: Photokinesis
 Chance: 2% to 18.75%  
-Description: Only applicable if you have the Photokinetic power path. You emit an EMP blast centered on yourself  
+Description: You emit an EMP blast centered on yourself  
 <sub>[Back to List](#attunement-consequences)</sub>
 
 ### Lightning Blast

--- a/data/mods/MindOverMatter/NetherAttunementSpoilers.md
+++ b/data/mods/MindOverMatter/NetherAttunementSpoilers.md
@@ -72,7 +72,6 @@ Once a consequence is selected, it has a chance to actually be applied. There is
 | [Teleport Misjump](#teleport-misjump) | 4 |
 | [EMP Blast](#emp-blast) | 3 |
 | [Lightning Blast](#lightning-blast)+ | 3 |
-| [Oubliette](#oubliette) | 4 |
 | [Crack in Reality](#crack-in-reality)+ | 2 |
 | [Nullified](#nullified) | 3 |
 | [Hounds of Tindalos](#hounds-of-tindalos)* | 2 |
@@ -266,13 +265,6 @@ Description: You emit an EMP blast centered on yourself
 Minimum Attunement: 9  
 Chance: 3% to 19.25%  
 Description: You emit a blast of lighting, electrocuting yourself and your surroundings  
-<sub>[Back to List](#attunement-consequences)</sub>
-
-### Oubliette
-Minimum Attunement: 9  
-Required School/Power: Clairsentience (Heightened Senses, Night Eyes, Clairvoyance, Clarity, Omniscience)
-Chance: 3% to 13%  
-Description: Your senses are all cut off from your mind, plunging you into complete silent blackness for a period of time based on your attunement vitamin
 <sub>[Back to List](#attunement-consequences)</sub>
 
 ### Crack in Reality

--- a/data/mods/MindOverMatter/NetherAttunementSpoilers.md
+++ b/data/mods/MindOverMatter/NetherAttunementSpoilers.md
@@ -54,6 +54,7 @@ Once a consequence is selected, it has a chance to actually be applied. There is
 | [Sleepiness](#sleepiness) | 5 |
 | [Nether Conduit](#nether-conduit) | 9 |
 | [Extra Weariness](#extra_weariness)+ | 7 |
+| [Difficulty Breathing](#difficulty_breathing) | 6 |
 | [Feedback](#feedback) | 9 |
 | [Observed](#observed)+ | 6 |
 | [Incorporeality](#incorporeality) | 4 |
@@ -144,6 +145,12 @@ Description: You gain an effect that unlocks nastier consequences and slowly inc
 Minimum Attunement: 3  
 Chance: 1.5% to 38%  
 Description: You immediately lose a large amount of stored calories with the attendant effect on your weariness  
+<sub>[Back to List](#attunement-consequences)</sub>
+
+### Difficulty Breathing
+Minimum Attunement: 4  
+Chance: 2.5% to 39%  
+Description: You suffer difficulty in breathing, reducing your stamina regeneration for a random period of time based on your attunement vitamin.  Subsequent effects stack
 <sub>[Back to List](#attunement-consequences)</sub>
 
 ### Feedback

--- a/data/mods/MindOverMatter/NetherAttunementSpoilers.md
+++ b/data/mods/MindOverMatter/NetherAttunementSpoilers.md
@@ -50,6 +50,7 @@ Once a consequence is selected, it has a chance to actually be applied. There is
 | [Vomit](#vomit) | 9 | 
 | [Nosebleed](#nosebleed) | 12 |
 | [Stamina Loss](#stamina-loss) | 8 |
+| [Blurred Sight](#blurred-sight) | 6 |
 | [Power Surge](#power-surge)+ | 5 |
 | [Sleepiness](#sleepiness) | 5 |
 | [Nether Conduit](#nether-conduit) | 9 |
@@ -71,6 +72,7 @@ Once a consequence is selected, it has a chance to actually be applied. There is
 | [Teleport Misjump](#teleport-misjump) | 4 |
 | [EMP Blast](#emp-blast) | 3 |
 | [Lightning Blast](#lightning-blast)+ | 3 |
+| [Oubliette](#oubliette) | 4 |
 | [Crack in Reality](#crack-in-reality)+ | 2 |
 | [Nullified](#nullified) | 3 |
 | [Hounds of Tindalos](#hounds-of-tindalos)* | 2 |
@@ -123,6 +125,13 @@ Description: You develop a nosebleed
 Minimum Attunement: 2  
 Chance: 2% to 31%  
 Description: You lose a random amount of stamina  
+<sub>[Back to List](#attunement-consequences)</sub>
+
+### Blurred Sight
+Minimum Attunement: 3
+Required School/Power: Clairsentience
+Chance: 3% to 35.75%  
+Description: You have blurred sight, suffering from both farsightedness and nearsightened, for a random period of time based on your attunement vitamin  
 <sub>[Back to List](#attunement-consequences)</sub>
 
 ### Power Surge
@@ -257,6 +266,13 @@ Description: You emit an EMP blast centered on yourself
 Minimum Attunement: 9  
 Chance: 3% to 19.25%  
 Description: You emit a blast of lighting, electrocuting yourself and your surroundings  
+<sub>[Back to List](#attunement-consequences)</sub>
+
+### Oubliette
+Minimum Attunement: 9  
+Required School/Power: Clairsentience (Heightened Senses, Night Eyes, Clairvoyance, Clarity, Omniscience)
+Chance: 3% to 13%  
+Description: Your senses are all cut off from your mind, plunging you into complete silent blackness for a period of time based on your attunement vitamin 
 <sub>[Back to List](#attunement-consequences)</sub>
 
 ### Crack in Reality

--- a/data/mods/MindOverMatter/NetherAttunementSpoilers.md
+++ b/data/mods/MindOverMatter/NetherAttunementSpoilers.md
@@ -272,7 +272,7 @@ Description: You emit a blast of lighting, electrocuting yourself and your surro
 Minimum Attunement: 9  
 Required School/Power: Clairsentience (Heightened Senses, Night Eyes, Clairvoyance, Clarity, Omniscience)
 Chance: 3% to 13%  
-Description: Your senses are all cut off from your mind, plunging you into complete silent blackness for a period of time based on your attunement vitamin 
+Description: Your senses are all cut off from your mind, plunging you into complete silent blackness for a period of time based on your attunement vitamin
 <sub>[Back to List](#attunement-consequences)</sub>
 
 ### Crack in Reality

--- a/data/mods/MindOverMatter/NetherAttunementSpoilers.md
+++ b/data/mods/MindOverMatter/NetherAttunementSpoilers.md
@@ -63,6 +63,7 @@ Once a consequence is selected, it has a chance to actually be applied. There is
 | [Power Drain](#power-drain) | 5 |
 | [Weakness](#weakness) | 5 |
 | [KCal Consumption](#kcal-consumption) | 6 |
+| [Mindshock](#mindshock)+ | 6 |
 | [Attenuation](#attenuation)+ | 8 |
 | [Short of Breath](#short-of-breath) | 5 |
 | [Force Wave](#force-wave) | 5 |
@@ -199,6 +200,12 @@ Description: You have lowered strength and dexterity along with increased stamin
 Minimum Attunement: 5  
 Chance: 4% to 38%  
 Description: The KCal consumption of your powers is tripled  
+<sub>[Back to List](#attunement-consequences)</sub>
+
+### Mindshock
+Minimum Attunement: 6  
+Chance: 3% to 33.5%  
+Description: You are stunned for a few seconds, cancelling all ongoing powers.
 <sub>[Back to List](#attunement-consequences)</sub>
 
 ### Attenuation

--- a/data/mods/MindOverMatter/NetherAttunementSpoilers.md
+++ b/data/mods/MindOverMatter/NetherAttunementSpoilers.md
@@ -53,6 +53,7 @@ Once a consequence is selected, it has a chance to actually be applied. There is
 | [Power Surge](#power-surge)+ | 5 |
 | [Sleepiness](#sleepiness) | 5 |
 | [Nether Conduit](#nether-conduit) | 9 |
+| [Extra Weariness](#extra_weariness)+ | 7 |
 | [Feedback](#feedback) | 9 |
 | [Observed](#observed)+ | 6 |
 | [Incorporeality](#incorporeality) | 4 |
@@ -137,6 +138,12 @@ Description: You gain a random amount of sleepiness, feeling more tired
 Minimum Attunement: 3  
 Chance: 3% to 38.25%  
 Description: You gain an effect that unlocks nastier consequences and slowly increases your attunement vitamin for a random period of time based on your attunement vitamin  
+<sub>[Back to List](#attunement-consequences)</sub>
+
+### Extra Weariness
+Minimum Attunement: 3  
+Chance: 1.5% to 38%  
+Description: You immediately lose a large amount of stored calories with the attendant effect on your weariness  
 <sub>[Back to List](#attunement-consequences)</sub>
 
 ### Feedback

--- a/data/mods/MindOverMatter/effectoncondition/eoc_nether_attunement_events.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_nether_attunement_events.json
@@ -346,14 +346,15 @@
         [ "EOC_DRAIN_EFFECT_CHECK_SLEEPINESS", 5 ],
         [ "EOC_NETHER_EFFECT_CHECK_ATTUNEMENT_RAISING_EFFECT", 9 ],
         [ "EOC_NETHER_EFFECT_CHECK_WEARINESS_EXTRA_CALORIE_EFFECT", 7 ],
-        [ "EOC_NETHER_EFFECT_CHECK_BIOKIN_DIFFICULTY_BREATHING", 6 ],
         [ "EOC_NETHER_EFFECT_CHECK_FEEDBACK", 9 ],
         [ "EOC_NETHER_EFFECT_CHECK_OBSERVED", 6 ],
+        [ "EOC_NETHER_EFFECT_CHECK_PYROKINETIC_FEVER", 7 ],
         [ "EOC_NETHER_EFFECT_CHECK_TELEPORTATION_INCORPOREALITY", 4 ],
         [ "EOC_DRAIN_EFFECT_CHECK_TELEPORT_LOCK", 5 ],
         [ "EOC_NETHER_EFFECT_CHECK_BIOKIN_METABOLIC_INVERSION", 5 ],
         [ "EOC_NETHER_EFFECT_CHECK_ELECTROKINETIC_POWER_DRAIN", 5 ],
         [ "EOC_DRAIN_EFFECT_CHECK_WEAKNESS", 5 ],
+        [ "EOC_NETHER_EFFECT_CHECK_PYROKINETIC_FOG", 4 ],
         [ "EOC_NETHER_EFFECT_CHECK_EXTRA_KCAL", 6 ],
         [ "EOC_NETHER_EFFECT_CHECK_MINDSHOCK_STUN", 6 ],
         [ "EOC_NETHER_EFFECT_CHECK_ATTENUATION", 8 ],
@@ -640,41 +641,6 @@
   },
   {
     "type": "effect_on_condition",
-    "id": "EOC_NETHER_EFFECT_CHECK_BIOKIN_DIFFICULTY_BREATHING",
-    "//": "Base is 2.5% chance from 80 attunement to 120 attunement, then scaling up 0.2% per attunement up to 14.5% chance at 180 attunement, then scaling up 0.35% chance per attunement up to 39% chance at max, plus 1/10th the Difficulty squared.",
-    "condition": {
-      "or": [
-        { "math": [ "u_vitamin('vitamin_psionic_drain') >= 85" ] },
-        { "compare_string": [ "BIOKINETIC", { "context_val": "school" } ] }
-      ]
-    },
-    "effect": [
-      {
-        "if": {
-          "x_in_y_chance": {
-            "x": {
-              "math": [
-                "( clamp( ( (u_vitamin('vitamin_psionic_drain') - 120) * 2), 0, 120) + clamp( ( (u_vitamin('vitamin_psionic_drain') - 180) * 3.5 ), 0, 250) + (nether_attune_difficulty_scaler(u_latest_channeled_power_difficulty)) + 25) + nether_attune_torrential_channeling_influence()"
-              ]
-            },
-            "y": 1000
-          }
-        },
-        "then": [
-          { "u_message": "Your lungs spasm and you have a hard time catching your breath!", "type": "bad" },
-          {
-            "u_add_effect": "effect_nether_attunement_difficulty_breathing",
-            "duration": {
-              "math": [ "time(' 3 m') * rng( ( u_vitamin('vitamin_psionic_drain') / 2 ), ( u_vitamin('vitamin_psionic_drain') * 2 ) )" ]
-            }
-          }
-        ]
-      }
-    ],
-    "false_effect": [ { "run_eocs": "EOC_PSIONICS_NETHER_ATTUNEMENT_CONSEQUENCES" } ]
-  },
-  {
-    "type": "effect_on_condition",
     "id": "EOC_NETHER_EFFECT_CHECK_FEEDBACK",
     "//": "Base is 3% chance from 100 attunement to 135 attunement, then scaling up 0.15% per attunement up to 9% chance at 175 attunement, then scaling up 0.25% chance per attunement up to 17.75% chance at 210 attunement, then scaling up 0.5% to 39.5% chance at max, plus 1/10th the Difficulty squared.",
     "condition": { "math": [ "u_vitamin('vitamin_psionic_drain') >= 100" ] },
@@ -763,6 +729,41 @@
           {
             "u_add_effect": "psi_nether_attention",
             "duration": { "math": [ "(u_vitamin('vitamin_psionic_drain') * rng(150,600)) + 86400" ] }
+          }
+        ]
+      }
+    ],
+    "false_effect": [ { "run_eocs": "EOC_PSIONICS_NETHER_ATTUNEMENT_CONSEQUENCES" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_NETHER_EFFECT_CHECK_PYROKINETIC_FEVER",
+    "//": "Base is 2.5% chance from 75 attunement to 120 attunement, then scaling up 0.15% per attunement up to 11.5% chance at 180 attunement, then scaling up 0.3% chance per attunement up to 32.5% chance at max, plus 1/10th the Difficulty squared.",
+    "condition": {
+      "and": [
+        { "compare_string": [ "PYROKINETIC", { "context_val": "school" } ] },
+        { "math": [ "u_vitamin('vitamin_psionic_drain') >= 75" ] }
+      ]
+    },
+    "effect": [
+      {
+        "if": {
+          "x_in_y_chance": {
+            "x": {
+              "math": [
+                "( clamp( ( (u_vitamin('vitamin_psionic_drain') - 120) * 1.5), 0, 105) + clamp( ( (u_vitamin('vitamin_psionic_drain') - 180) * 3 ), 0, 375) + (nether_attune_difficulty_scaler(u_latest_channeled_power_difficulty)) + 25) + nether_attune_torrential_channeling_influence()"
+              ]
+            },
+            "y": 1000
+          }
+        },
+        "then": [
+          { "u_message": "You feel feverish and weak.", "type": "bad" },
+          {
+            "u_add_effect": "effect_nether_attunement_pyrokinetic_fever",
+            "duration": {
+              "math": [ "time(' 10 m') * rng( ( u_vitamin('vitamin_psionic_drain') / 2 ), ( u_vitamin('vitamin_psionic_drain') * 2 ) )" ]
+            }
           }
         ]
       }
@@ -970,7 +971,7 @@
           {
             "u_add_effect": "effect_nether_attunement_pyrokinetic_fog",
             "duration": {
-              "math": [ "time(' 15 m') * rng( ( u_vitamin('vitamin_psionic_drain') / 2 ), ( u_vitamin('vitamin_psionic_drain') * 2 ) )" ]
+              "math": [ "time(' 4 m') * rng( ( u_vitamin('vitamin_psionic_drain') / 2 ), ( u_vitamin('vitamin_psionic_drain') * 2 ) )" ]
             }
           }
         ]

--- a/data/mods/MindOverMatter/effectoncondition/eoc_nether_attunement_events.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_nether_attunement_events.json
@@ -345,6 +345,7 @@
         [ "EOC_DRAIN_EFFECT_CHECK_POWER_SURGE", 5 ],
         [ "EOC_DRAIN_EFFECT_CHECK_SLEEPINESS", 5 ],
         [ "EOC_NETHER_EFFECT_CHECK_ATTUNEMENT_RAISING_EFFECT", 9 ],
+        [ "EOC_NETHER_EFFECT_CHECK_WEARINESS_EXTRA_CALORIE_EFFECT", 7 ],
         [ "EOC_NETHER_EFFECT_CHECK_FEEDBACK", 9 ],
         [ "EOC_NETHER_EFFECT_CHECK_OBSERVED", 6 ],
         [ "EOC_NETHER_EFFECT_CHECK_TELEPORTATION_INCORPOREALITY", 4 ],
@@ -600,6 +601,35 @@
             "duration": {
               "math": [ "time(' 10 m') * rng( ( u_vitamin('vitamin_psionic_drain') / 2 ), ( u_vitamin('vitamin_psionic_drain') * 2 ) )" ]
             }
+          }
+        ]
+      }
+    ],
+    "false_effect": [ { "run_eocs": "EOC_PSIONICS_NETHER_ATTUNEMENT_CONSEQUENCES" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_NETHER_EFFECT_CHECK_WEARINESS_EXTRA_CALORIE_EFFECT",
+    "//": "Base is 3% chance from 70 attunement to 90 attunement, then scaling up 0.15% per attunement up to 15.75% chance at 175 attunement, then scaling up 0.3% chance per attunement up to 38.25% chance at max, plus 1/10th the Difficulty squared.",
+    "condition": {
+      "or": [ { "math": [ "u_vitamin('vitamin_psionic_drain') >= 70" ] }, { "u_has_trait": "PSI_TORRENTIAL_CHANNELING_active" } ]
+    },
+    "effect": [
+      {
+        "if": {
+          "x_in_y_chance": {
+            "x": {
+              "math": [
+                "( clamp( ( (u_vitamin('vitamin_psionic_drain') - 90) * 1.5), 0, 127.5) + clamp( ( (u_vitamin('vitamin_psionic_drain') - 175) * 3 ), 0, 375) + (nether_attune_difficulty_scaler(u_latest_channeled_power_difficulty)) + 30) + nether_attune_torrential_channeling_influence()"
+              ]
+            },
+            "y": 1000
+          }
+        },
+        "then": [
+          { "u_message": "You feel a wave of bone-deep weariness.", "type": "mixed" },
+          {
+            "math": [ "u_calories() -= rng( ( u_vitamin('vitamin_psionic_drain') * 4), ( u_vitamin('vitamin_psionic_drain') * 10) )" ]
           }
         ]
       }

--- a/data/mods/MindOverMatter/effectoncondition/eoc_nether_attunement_events.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_nether_attunement_events.json
@@ -346,6 +346,7 @@
         [ "EOC_DRAIN_EFFECT_CHECK_SLEEPINESS", 5 ],
         [ "EOC_NETHER_EFFECT_CHECK_ATTUNEMENT_RAISING_EFFECT", 9 ],
         [ "EOC_NETHER_EFFECT_CHECK_WEARINESS_EXTRA_CALORIE_EFFECT", 7 ],
+        [ "EOC_NETHER_EFFECT_CHECK_BIOKIN_DIFFICULTY_BREATHING", 6 ],
         [ "EOC_NETHER_EFFECT_CHECK_FEEDBACK", 9 ],
         [ "EOC_NETHER_EFFECT_CHECK_OBSERVED", 6 ],
         [ "EOC_NETHER_EFFECT_CHECK_TELEPORTATION_INCORPOREALITY", 4 ],
@@ -627,9 +628,44 @@
           }
         },
         "then": [
-          { "u_message": "You feel a wave of bone-deep weariness.", "type": "mixed" },
+          { "u_message": "You feel a wave of bone-deep weariness.", "type": "bad" },
           {
             "math": [ "u_calories() -= rng( ( u_vitamin('vitamin_psionic_drain') * 4), ( u_vitamin('vitamin_psionic_drain') * 10) )" ]
+          }
+        ]
+      }
+    ],
+    "false_effect": [ { "run_eocs": "EOC_PSIONICS_NETHER_ATTUNEMENT_CONSEQUENCES" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_NETHER_EFFECT_CHECK_BIOKIN_DIFFICULTY_BREATHING",
+    "//": "Base is 2.5% chance from 80 attunement to 120 attunement, then scaling up 0.2% per attunement up to 14.5% chance at 180 attunement, then scaling up 0.35% chance per attunement up to 39% chance at max, plus 1/10th the Difficulty squared.",
+    "condition": {
+      "or": [
+        { "math": [ "u_vitamin('vitamin_psionic_drain') >= 85" ] },
+        { "compare_string": [ "BIOKINETIC", { "context_val": "school" } ] }
+      ]
+    },
+    "effect": [
+      {
+        "if": {
+          "x_in_y_chance": {
+            "x": {
+              "math": [
+                "( clamp( ( (u_vitamin('vitamin_psionic_drain') - 120) * 2), 0, 120) + clamp( ( (u_vitamin('vitamin_psionic_drain') - 180) * 3.5 ), 0, 250) + (nether_attune_difficulty_scaler(u_latest_channeled_power_difficulty)) + 25) + nether_attune_torrential_channeling_influence()"
+              ]
+            },
+            "y": 1000
+          }
+        },
+        "then": [
+          { "u_message": "Your lungs spasm and you have a hard time catching your breath!", "type": "bad" },
+          {
+            "u_add_effect": "effect_nether_attunement_difficulty_breathing",
+            "duration": {
+              "math": [ "time(' 3 m') * rng( ( u_vitamin('vitamin_psionic_drain') / 2 ), ( u_vitamin('vitamin_psionic_drain') * 2 ) )" ]
+            }
           }
         ]
       }

--- a/data/mods/MindOverMatter/effectoncondition/eoc_nether_attunement_events.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_nether_attunement_events.json
@@ -364,7 +364,6 @@
         [ "EOC_NETHER_EFFECT_CHECK_TELEPORT_MISJUMP", 4 ],
         [ "EOC_NETHER_EFFECT_CHECK_PHOTOKIN_EMP", 3 ],
         [ "EOC_NETHER_EFFECT_CHECK_NETHER_LIGHTNING", 3 ],
-        [ "EOC_NETHER_EFFECT_CHECK_CLAIR_SENSORY_DEPRIVATION", 4 ],
         [ "EOC_NETHER_EFFECT_CHECK_TEMPORARY_TEAR_IN_REALITY", 2 ],
         [ "EOC_NETHER_EFFECT_CHECK_NO_PSIONICS", 3 ],
         [ "EOC_NETHER_EFFECT_CHECK_SUMMON_HOUNDS", 2 ],
@@ -1396,49 +1395,6 @@
         "then": [
           { "u_message": "Crackling energy erupts all around you!", "type": "bad" },
           { "u_cast_spell": { "id": "nether_attunement_nether_lightning", "hit_self": false } }
-        ]
-      }
-    ],
-    "false_effect": [ { "run_eocs": "EOC_PSIONICS_NETHER_ATTUNEMENT_CONSEQUENCES" } ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "EOC_NETHER_EFFECT_CHECK_CLAIR_SENSORY_DEPRIVATION",
-    "//": "Base is 3% chance from 175 attunement to 200 attunement, then scaling up 0.15% per attunement up to 6.75% chance at 225 attunement, then scaling up 0.25% chance per attunement up to 13% chance at max, plus 1/10th the Difficulty squared.",
-    "condition": {
-      "and": [
-        {
-          "or": [
-            { "compare_string": [ "clair_better_senses", { "context_val": "spell" } ] },
-            { "compare_string": [ "clair_night_vision", { "context_val": "spell" } ] },
-            { "compare_string": [ "clair_voyance", { "context_val": "spell" } ] },
-            { "compare_string": [ "clair_clear_sight", { "context_val": "spell" } ] },
-            { "compare_string": [ "clair_omniscience", { "context_val": "spell" } ] }
-          ]
-        },
-        { "math": [ "u_vitamin('vitamin_psionic_drain') >= 175" ] }
-      ]
-    },
-    "effect": [
-      {
-        "if": {
-          "x_in_y_chance": {
-            "x": {
-              "math": [
-                "( clamp( ( (u_vitamin('vitamin_psionic_drain') - 200) * 1.5), 0, 25) + clamp( ( (u_vitamin('vitamin_psionic_drain') - 225) * 2.5 ), 0, 375) + (nether_attune_difficulty_scaler(u_latest_channeled_power_difficulty)) + 30) + nether_attune_torrential_channeling_influence()"
-              ]
-            },
-            "y": 1000
-          }
-        },
-        "then": [
-          { "u_message": "You are suddenly enveloped in darkness and silence!", "type": "bad" },
-          {
-            "u_add_effect": "effect_nether_attunement_sensory_deprivation",
-            "duration": {
-              "math": [ "time(' 1 s') * rng( ( u_vitamin('vitamin_psionic_drain') / 2 ), ( u_vitamin('vitamin_psionic_drain') * 2 ) )" ]
-            }
-          }
         ]
       }
     ],

--- a/data/mods/MindOverMatter/effectoncondition/eoc_nether_attunement_events.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_nether_attunement_events.json
@@ -355,6 +355,7 @@
         [ "EOC_NETHER_EFFECT_CHECK_ELECTROKINETIC_POWER_DRAIN", 5 ],
         [ "EOC_DRAIN_EFFECT_CHECK_WEAKNESS", 5 ],
         [ "EOC_NETHER_EFFECT_CHECK_EXTRA_KCAL", 6 ],
+        [ "EOC_NETHER_EFFECT_CHECK_MINDSHOCK_STUN", 6 ],
         [ "EOC_NETHER_EFFECT_CHECK_ATTENUATION", 8 ],
         [ "EOC_NETHER_EFFECT_CHECK_BREATHING", 5 ],
         [ "EOC_NETHER_EFFECT_CHECK_FORCE_WAVE", 5 ],
@@ -997,6 +998,36 @@
         "then": [
           { "u_message": "As you unleash your powers, your stomach rumbles!", "type": "bad" },
           { "u_add_effect": "effect_nether_attunement_extra_kcal", "duration": { "math": [ "7200 + rand(86400)" ] } }
+        ]
+      }
+    ],
+    "false_effect": [ { "run_eocs": "EOC_PSIONICS_NETHER_ATTUNEMENT_CONSEQUENCES" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_NETHER_EFFECT_CHECK_MINDSHOCK_STUN",
+    "//": "Base is 3% chance from 115 attunement to 150 attunement, then scaling up 0.2% per attunement up to 9% chance at 180 attunement, then scaling up 0.35% chance per attunement up to 33.5% chance at max, plus 1/10th the Difficulty squared.",
+    "condition": {
+      "or": [ { "math": [ "u_vitamin('vitamin_psionic_drain') >= 115" ] }, { "u_has_trait": "PSI_TORRENTIAL_CHANNELING_active" } ]
+    },
+    "effect": [
+      {
+        "if": {
+          "x_in_y_chance": {
+            "x": {
+              "math": [
+                "( clamp( (( u_vitamin('vitamin_psionic_drain') - 150 ) * 2), 0, 60) + clamp( ( (u_vitamin('vitamin_psionic_drain') - 180) * 3.5 ), 0, 300) + (nether_attune_difficulty_scaler(u_latest_channeled_power_difficulty)) + 30) + nether_attune_torrential_channeling_influence()"
+              ]
+            },
+            "y": 1000
+          }
+        },
+        "then": [
+          { "u_message": "Power floods into your mind, washing away all other thought!", "type": "bad" },
+          {
+            "u_add_effect": "stunned",
+            "duration": { "math": [ "1 + rand( (u_vitamin('vitamin_psionic_drain') / 50 ) )" ] }
+          }
         ]
       }
     ],

--- a/data/mods/MindOverMatter/effectoncondition/eoc_nether_attunement_events.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_nether_attunement_events.json
@@ -1064,7 +1064,11 @@
           { "u_message": "Power floods into your mind, washing away all other thought!", "type": "bad" },
           {
             "u_add_effect": "stunned",
-            "duration": { "math": [ "1 + rand( (u_vitamin('vitamin_psionic_drain') / 50 ) )" ] }
+            "duration": { "math": [ "2 + rand( (u_vitamin('vitamin_psionic_drain') / 50 ) )" ] }
+          },
+          {
+            "u_add_effect": "psi_stunned",
+            "duration": { "math": [ "2 + rand( (u_vitamin('vitamin_psionic_drain') / 50 ) )" ] }
           }
         ]
       }

--- a/data/mods/MindOverMatter/effectoncondition/eoc_nether_attunement_events.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_nether_attunement_events.json
@@ -342,6 +342,7 @@
         [ "EOC_NETHER_EFFECT_CHECK_VOMIT", 9 ],
         [ "EOC_DRAIN_EFFECT_CHECK_NOSEBLEED", 12 ],
         [ "EOC_DRAIN_EFFECT_CHECK_STAMINA_LOSS", 8 ],
+        [ "EOC_NETHER_EFFECT_CHECK_CLAIR_BLURRED_SIGHT", 6 ],
         [ "EOC_DRAIN_EFFECT_CHECK_POWER_SURGE", 5 ],
         [ "EOC_DRAIN_EFFECT_CHECK_SLEEPINESS", 5 ],
         [ "EOC_NETHER_EFFECT_CHECK_ATTUNEMENT_RAISING_EFFECT", 9 ],
@@ -363,6 +364,7 @@
         [ "EOC_NETHER_EFFECT_CHECK_TELEPORT_MISJUMP", 4 ],
         [ "EOC_NETHER_EFFECT_CHECK_PHOTOKIN_EMP", 3 ],
         [ "EOC_NETHER_EFFECT_CHECK_NETHER_LIGHTNING", 3 ],
+        [ "EOC_NETHER_EFFECT_CHECK_CLAIR_SENSORY_DEPRIVATION", 4 ],
         [ "EOC_NETHER_EFFECT_CHECK_TEMPORARY_TEAR_IN_REALITY", 2 ],
         [ "EOC_NETHER_EFFECT_CHECK_NO_PSIONICS", 3 ],
         [ "EOC_NETHER_EFFECT_CHECK_SUMMON_HOUNDS", 2 ],
@@ -550,6 +552,41 @@
         "then": [
           { "u_message": "You feel a sudden wave of fatigue.", "type": "bad" },
           { "math": [ "u_val('stamina') -= rng(3000,9000)" ] }
+        ]
+      }
+    ],
+    "false_effect": [ { "run_eocs": "EOC_PSIONICS_NETHER_ATTUNEMENT_CONSEQUENCES" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_NETHER_EFFECT_CHECK_CLAIR_BLURRED_SIGHT",
+    "//": "Base is 3% chance from 55 attunement to 95 attunement, then scaling up 0.15% per attunement up to 12% chance at 155 attunement, then scaling up 0.25% chance per attunement up to 35.75% chance at max, plus 1/10th the Difficulty squared.",
+    "condition": {
+      "and": [
+        { "compare_string": [ "CLAIRSENTIENT", { "context_val": "school" } ] },
+        { "math": [ "u_vitamin('vitamin_psionic_drain') >= 55" ] }
+      ]
+    },
+    "effect": [
+      {
+        "if": {
+          "x_in_y_chance": {
+            "x": {
+              "math": [
+                "( clamp( ( (u_vitamin('vitamin_psionic_drain') - 95) * 1.5 ), 0, 90) + clamp( ( (u_vitamin('vitamin_psionic_drain') - 155) * 2.5 ), 0, 300) + (nether_attune_difficulty_scaler(u_latest_channeled_power_difficulty)) + 30) + nether_attune_torrential_channeling_influence()"
+              ]
+            },
+            "y": 1000
+          }
+        },
+        "then": [
+          { "u_message": "As you unleash your powers, your vision blurs!", "type": "bad" },
+          {
+            "u_add_effect": "effect_nether_attunement_clair_blurred_sight",
+            "duration": {
+              "math": [ "time(' 20 m') * rng( ( u_vitamin('vitamin_psionic_drain') / 2 ), ( u_vitamin('vitamin_psionic_drain') * 2 ) )" ]
+            }
+          }
         ]
       }
     ],
@@ -1355,6 +1392,49 @@
         "then": [
           { "u_message": "Crackling energy erupts all around you!", "type": "bad" },
           { "u_cast_spell": { "id": "nether_attunement_nether_lightning", "hit_self": false } }
+        ]
+      }
+    ],
+    "false_effect": [ { "run_eocs": "EOC_PSIONICS_NETHER_ATTUNEMENT_CONSEQUENCES" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_NETHER_EFFECT_CHECK_CLAIR_SENSORY_DEPRIVATION",
+    "//": "Base is 3% chance from 175 attunement to 200 attunement, then scaling up 0.15% per attunement up to 6.75% chance at 225 attunement, then scaling up 0.25% chance per attunement up to 13% chance at max, plus 1/10th the Difficulty squared.",
+    "condition": {
+      "and": [
+        {
+          "or": [
+            { "compare_string": [ "clair_better_senses", { "context_val": "spell" } ] },
+            { "compare_string": [ "clair_night_vision", { "context_val": "spell" } ] },
+            { "compare_string": [ "clair_voyance", { "context_val": "spell" } ] },
+            { "compare_string": [ "clair_clear_sight", { "context_val": "spell" } ] },
+            { "compare_string": [ "clair_omniscience", { "context_val": "spell" } ] }
+          ]
+        },
+        { "math": [ "u_vitamin('vitamin_psionic_drain') >= 175" ] }
+      ]
+    },
+    "effect": [
+      {
+        "if": {
+          "x_in_y_chance": {
+            "x": {
+              "math": [
+                "( clamp( ( (u_vitamin('vitamin_psionic_drain') - 200) * 1.5), 0, 25) + clamp( ( (u_vitamin('vitamin_psionic_drain') - 225) * 2.5 ), 0, 375) + (nether_attune_difficulty_scaler(u_latest_channeled_power_difficulty)) + 30) + nether_attune_torrential_channeling_influence()"
+              ]
+            },
+            "y": 1000
+          }
+        },
+        "then": [
+          { "u_message": "You are suddenly enveloped in darkness and silence!", "type": "bad" },
+          {
+            "u_add_effect": "effect_nether_attunement_sensory_deprivation",
+            "duration": {
+              "math": [ "time(' 1 s') * rng( ( u_vitamin('vitamin_psionic_drain') / 2 ), ( u_vitamin('vitamin_psionic_drain') * 2 ) )" ]
+            }
+          }
         ]
       }
     ],

--- a/data/mods/MindOverMatter/effectoncondition/eoc_on_power_use_events.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_on_power_use_events.json
@@ -206,11 +206,11 @@
       },
       {
         "u_add_effect": "blind_clair_overload",
-        "duration": { "math": [ "time(' 15 s') * (1 + ( u_vitamin('vitamin_psionic_drain') / 2 ) ) * rng(1, _difficulty)" ] }
+        "duration": { "math": [ "time(' 2 s') * (1 + ( u_vitamin('vitamin_psionic_drain') / 2 ) ) * rng(1, _difficulty)" ] }
       },
       {
         "u_add_effect": "deaf_clair_overload",
-        "duration": { "math": [ "time(' 15 s') * (1 + ( u_vitamin('vitamin_psionic_drain') / 2 ) ) * rng(1, _difficulty)" ] }
+        "duration": { "math": [ "time(' 2 s') * (1 + ( u_vitamin('vitamin_psionic_drain') / 2 ) ) * rng(1, _difficulty)" ] }
       }
     ]
   },

--- a/data/mods/MindOverMatter/effects/effects_nether_attunement.json
+++ b/data/mods/MindOverMatter/effects/effects_nether_attunement.json
@@ -70,25 +70,26 @@
     "name": [ "Nether Attenuation" ],
     "desc": [ "You have to work extra hard to draw enough energy to use your powers." ],
     "remove_message": "Your difficulty in drawing on the Nether fades.",
+    "rating": "bad",
     "enchantments": [ { "values": [ { "value": "CASTING_TIME_MULTIPLIER", "multiply": 4 } ] } ]
+  },
+  {
+    "type": "effect_type",
+    "id": "effect_nether_attunement_clair_blurred_sight",
+    "name": [ "Blurred Sight" ],
+    "desc": [ "Your vision is blurry." ],
+    "remove_message": "Your vision finally clears.",
+    "rating": "bad",
+    "limb_score_mods": [ { "limb_score": "night_vis", "modifier": 0.1 }, { "limb_score": "vision", "modifier": 0.2 } ],
+    "flags": [ "EFFECT_LIMB_SCORE_MOD", "HYPEROPIA", "MYOPIA" ]
   },
   {
     "type": "effect_type",
     "id": "effect_nether_attunement_extra_kcal",
     "name": [ "Gnawing Hunger" ],
     "desc": [ "Whenever you use your powers, your stomach rumbles." ],
-    "remove_message": "Your stomach finally calms down."
-  },
-  {
-    "type": "effect_type",
-    "id": "effect_nether_attunement_difficulty_breathing",
-    "name": [ "Difficulty Breathing" ],
-    "desc": [ "You're having a hard time catching your breath." ],
-    "remove_message": "You draw a full breath into your lungs.",
-    "max_intensity": 5,
-    "int_add_val": 1,
-    "limb_score_mods": [ { "limb_score": "breathing", "modifier": 0.75, "scaling": -0.1 } ],
-    "flags": [ "EFFECT_LIMB_SCORE_MOD" ]
+    "remove_message": "Your stomach finally calms down.",
+    "rating": "bad"
   },
   {
     "type": "effect_type",
@@ -119,6 +120,7 @@
     "name": [ "Short of Breath" ],
     "desc": [ "You're having a hard time getting enough air." ],
     "remove_message": "You finally manage to catch your breath",
+    "rating": "bad",
     "base_mods": { "cough_chance": [ 20 ], "cough_tick": [ 120 ] },
     "limb_score_mods": [ { "limb_score": "breathing", "modifier": 0.5 }, { "limb_score": "lift", "modifier": 0.8 } ],
     "flags": [ "EFFECT_LIMB_SCORE_MOD" ]
@@ -129,6 +131,7 @@
     "name": [ "Feverish" ],
     "desc": [ "You feel feverish and weak." ],
     "remove_message": "Your fever finally breaks.",
+    "rating": "bad",
     "enchantments": [
       {
         "values": [
@@ -165,13 +168,24 @@
   },
   {
     "type": "effect_type",
-    "id": "effect_kelvinist_anti_cold",
+    "id": "effect_nether_attunement_pyrokinetic_fog",
     "//": "Hidden effect, used as a tracker",
     "name": [ "" ],
     "desc": [ "" ],
     "apply_message": "A roiling fog coalesces out of the surrounding air.",
     "remove_message": "The roiling fog surrounding you dissipates.",
+    "rating": "bad",
     "enchantments": [ { "emitter": "emit_fog_plume" } ]
+  },
+  {
+    "type": "effect_type",
+    "id": "effect_nether_attunement_sensory_deprivation",
+    "name": [ "Oubliette" ],
+    "desc": [ "Your are alone in darkness and silence." ],
+    "remove_message": "You suddenly can see once again.",
+    "rating": "bad",
+    "limb_score_mods": [ { "limb_score": "night_vis", "modifier": 0.0 }, { "limb_score": "vision", "modifier": 0.0 } ],
+    "flags": [ "EFFECT_LIMB_SCORE_MOD", "BLIND", "DEAF" ]
   },
   {
     "type": "effect_type",

--- a/data/mods/MindOverMatter/effects/effects_nether_attunement.json
+++ b/data/mods/MindOverMatter/effects/effects_nether_attunement.json
@@ -115,6 +115,39 @@
   },
   {
     "type": "effect_type",
+    "id": "effect_psi_reduced_breathing",
+    "name": [ "Short of Breath" ],
+    "desc": [ "You're having a hard time getting enough air." ],
+    "remove_message": "You finally manage to catch your breath",
+    "base_mods": { "cough_chance": [ 20 ], "cough_tick": [ 120 ] },
+    "limb_score_mods": [ { "limb_score": "breathing", "modifier": 0.5 }, { "limb_score": "lift", "modifier": 0.8 } ],
+    "flags": [ "EFFECT_LIMB_SCORE_MOD" ]
+  },
+  {
+    "type": "effect_type",
+    "id": "effect_nether_attunement_pyrokinetic_fever",
+    "name": [ "Feverish" ],
+    "desc": [ "You feel feverish and weak." ],
+    "remove_message": "Your fever finally breaks.",
+    "enchantments": [
+      {
+        "values": [
+          { "value": "STRENGTH", "add": -2 },
+          { "value": "DEXTERITY", "add": -1 },
+          { "value": "CLIMATE_CONTROL_CHILL", "add": -10 }
+        ]
+      }
+    ],
+    "limb_score_mods": [
+      { "limb_score": "grip", "modifier": 0.8 },
+      { "limb_score": "block", "modifier": 0.8 },
+      { "limb_score": "manip", "modifier": 0.8 },
+      { "limb_score": "lift", "modifier": 0.8 }
+    ],
+    "flags": [ "EFFECT_LIMB_SCORE_MOD" ]
+  },
+  {
+    "type": "effect_type",
     "id": "effect_teleport_mishap_tindrift_warning",
     "name": [ "Hunted" ],
     "desc": [

--- a/data/mods/MindOverMatter/effects/effects_nether_attunement.json
+++ b/data/mods/MindOverMatter/effects/effects_nether_attunement.json
@@ -81,7 +81,7 @@
     "remove_message": "Your vision finally clears.",
     "rating": "bad",
     "limb_score_mods": [ { "limb_score": "night_vis", "modifier": 0.1 }, { "limb_score": "vision", "modifier": 0.2 } ],
-    "flags": [ "EFFECT_LIMB_SCORE_MOD", "HYPEROPIA", "MYOPIA" ]
+    "flags": [ "EFFECT_LIMB_SCORE_MOD", "HYPEROPIC", "MYOPIC", "MYOPIC_IN_LIGHT" ]
   },
   {
     "type": "effect_type",
@@ -176,16 +176,6 @@
     "remove_message": "The roiling fog surrounding you dissipates.",
     "rating": "bad",
     "enchantments": [ { "emitter": "emit_fog_plume" } ]
-  },
-  {
-    "type": "effect_type",
-    "id": "effect_nether_attunement_sensory_deprivation",
-    "name": [ "Oubliette" ],
-    "desc": [ "Your are alone in darkness and silence." ],
-    "remove_message": "You suddenly can see once again.",
-    "rating": "bad",
-    "limb_score_mods": [ { "limb_score": "night_vis", "modifier": 0.0 }, { "limb_score": "vision", "modifier": 0.0 } ],
-    "flags": [ "EFFECT_LIMB_SCORE_MOD", "BLIND", "DEAF" ]
   },
   {
     "type": "effect_type",

--- a/data/mods/MindOverMatter/effects/effects_nether_attunement.json
+++ b/data/mods/MindOverMatter/effects/effects_nether_attunement.json
@@ -81,6 +81,17 @@
   },
   {
     "type": "effect_type",
+    "id": "effect_nether_attunement_difficulty_breathing",
+    "name": [ "Difficulty Breathing" ],
+    "desc": [ "You're having a hard time catching your breath." ],
+    "remove_message": "You draw a full breath into your lungs.",
+    "max_intensity": 5,
+    "int_add_val": 1,
+    "limb_score_mods": [ { "limb_score": "breathing", "modifier": 0.75, "scaling": -0.1 } ],
+    "flags": [ "EFFECT_LIMB_SCORE_MOD" ]
+  },
+  {
+    "type": "effect_type",
     "id": "effect_nether_attunement_feedback",
     "name": [ "Feedback" ],
     "desc": [ "You feel a persistent itching that will not go away." ],

--- a/data/mods/MindOverMatter/effects/effects_nether_attunement.json
+++ b/data/mods/MindOverMatter/effects/effects_nether_attunement.json
@@ -137,7 +137,8 @@
         "values": [
           { "value": "STRENGTH", "add": -2 },
           { "value": "DEXTERITY", "add": -1 },
-          { "value": "CLIMATE_CONTROL_CHILL", "add": -10 }
+          { "value": "CLIMATE_CONTROL_CHILL", "add": -10 },
+          { "value": "SWEAT_MULTIPLIER", "multiply": 2 }
         ]
       }
     ],

--- a/data/mods/MindOverMatter/effects/effects_penalty.json
+++ b/data/mods/MindOverMatter/effects/effects_penalty.json
@@ -263,16 +263,6 @@
   },
   {
     "type": "effect_type",
-    "id": "effect_psi_reduced_breathing",
-    "name": [ "Short of Breath" ],
-    "desc": [ "You're having a hard time getting enough air." ],
-    "remove_message": "You finally manage to catch your breath",
-    "base_mods": { "cough_chance": [ 20 ], "cough_tick": [ 120 ] },
-    "limb_score_mods": [ { "limb_score": "breathing", "modifier": 0.5 }, { "limb_score": "lift", "modifier": 0.8 } ],
-    "flags": [ "EFFECT_LIMB_SCORE_MOD" ]
-  },
-  {
-    "type": "effect_type",
     "id": "effect_biokin_overload",
     "name": [ "Weakened" ],
     "desc": [ "Your muscles and coordination are impaired." ],

--- a/data/mods/MindOverMatter/jmath.json
+++ b/data/mods/MindOverMatter/jmath.json
@@ -45,7 +45,7 @@
     "type": "jmath_function",
     "id": "psionic_power_success_formula_proficiency_handling",
     "num_args": 0,
-    "return": " u_has_proficiency('prof_concentration_basic') ? ( u_has_proficiency('prof_concentration_intermediate') ? ( u_has_proficiency('prof_concentration_master') ? min( ( psionic_power_success_formula_base_calc() ), 40 ) : min( ( psionic_power_success_formula_base_calc() ), (37 + (u_has_trait('PSI_EXTENDED_CHANNELING_active') * 3) ) ) ) : min( ( psionic_power_success_formula_base_calc() ), 31 + (u_has_trait('PSI_EXTENDED_CHANNELING_active') * 3) ) ) : min( ( psionic_power_success_formula_base_calc() ), 24 + (u_has_trait('PSI_EXTENDED_CHANNELING_active') * 7) )"
+    "return": "u_has_proficiency('prof_concentration_basic') ? ( u_has_proficiency('prof_concentration_intermediate') ? ( u_has_proficiency('prof_concentration_master') ? min( ( psionic_power_success_formula_base_calc() ), 40 ) : min( ( psionic_power_success_formula_base_calc() ), (37 + (u_has_trait('PSI_EXTENDED_CHANNELING_active') * 3) ) ) ) : min( ( psionic_power_success_formula_base_calc() ), 31 + (u_has_trait('PSI_EXTENDED_CHANNELING_active') * 3) ) ) : min( ( psionic_power_success_formula_base_calc() ), 24 + (u_has_trait('PSI_EXTENDED_CHANNELING_active') * 7) )"
   },
   {
     "type": "jmath_function",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[MoM] More Nether Attunement backlashes"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

It is once again time to make your lives harder
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add the following backlash effects:

- Extra Weariness (minimum attunement: 3): Chunks off a bunch of extra calories (max of 2500 if you're at max Nether Attunement and get supremely unlucky), with the corresponding effects on weariness. 
- ~~Difficulty Breathing (minimum attunement 4, requires biokinetic channeling): Reduces your Breathing limb score to 75% of normal. Additional applications stack.~~ (already exists)
- Blurred Sight (minimum attunement 3, requires clairsentient channeling): Adds both the HYPEROPIC and MYOPIA flags, reducing vision range and making close combat harder and reading impossible.
- ~~Oubliette (minimum attunement 9, requires channeling the Heightened Senses, Night Eyes, Clairvoyance, Clarity, or Omniscience clarisentient powers): Totally cuts off all of your senses, rendering you unable to perceive the outside world for a short time.~~ This is what Clairsentient Overload does
- Mindshock (minimum attunement 6): Stuns you for a very short time, which isn't a big disadvantage on its face except being stunned means you lose concentration automatically. 
- Fever  (minimum attunement: 5, requires pyrokinetic channel): Raises your internal body temperature and increases the amount you sweat for a period of time afterwards. 

Also, the fog effect from pyrokinetic channeling was not actually hooked up, so I hooked it up.

Extra Weariness and Mindshock can both happen at any time if you're using Torrential Channeling.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Checked each of them, they all work.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
