### PR TITLE
Revert overmapbuffer::find_camp() to searching an area

### DIFF
--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -1435,11 +1435,14 @@ shared_ptr_fast<npc> overmapbuffer::find_npc_by_unique_id( const std::string &un
 
 std::optional<basecamp *> overmapbuffer::find_camp( const point_abs_omt &p )
 {
-    const overmap_with_local_coords om_loc = get_existing_om_global( p );
-    if( !!om_loc.om ) {
-        std::optional<basecamp *> camp = om_loc.om->find_camp( p );
-        if( !!camp ) {
-            return camp;
+    for( auto &it : overmaps ) {
+        const point_abs_omt p2( p );
+        for( int x2 = p2.x() - 3; x2 < p2.x() + 3; x2++ ) {
+            for( int y2 = p2.y() - 3; y2 < p2.y() + 3; y2++ ) {
+                if( std::optional<basecamp *> camp = it.second->find_camp( point_abs_omt( x2, y2 ) ) ) {
+                    return camp;
+                }
+            }
         }
     }
     return std::nullopt;


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
* Fixes #82466

This change from #81506 caused the issue

> overmapbuffer::find_camp is now exact, it was made to check a range here https://github.com/CleverRaven/Cataclysm-DDA/commit/c3dfa49df14ca62d553f56e95301ab542c51bdb1 but double dipped in being ranged leading to it checking more than it should have. As far as I can see nowhere is expecting this to be non-exact anymore bc we track NPC's assigned camp location

#### Describe the solution

In fact tons of places still expect it to be searching an area. So just revert that.

#### Describe alternatives you've considered
I don't believe this was ever a safe change to make - we still don't want to place camps near each other so anything in the area SHOULD be considered one.

#### Testing
Ownership is properly applied to all parts of the refugee center building

#### Additional context
