### PR TITLE
[magic_type]: Fix cannot_cast_message logic

### DIFF
--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -1886,17 +1886,17 @@ static void cast_spell( bool recast_spell = false )
         return;
     }
 
-    std::set<std::string> failure_messages = {};
+    std::map<magic_type_id, bool> success_tracker = {};
     for( const spell_id &sp : spells ) {
         spell &temp_spell = player_character.magic->get_spell( sp );
-        if( temp_spell.can_cast( player_character, failure_messages ) ) {
-            break;
-        }
+        temp_spell.can_cast( player_character, success_tracker );
     }
 
-    for( const std::string &failure_message : failure_messages ) {
+    for (auto const& [m_type, any_success] : success_tracker ) {
+        if(!any_success && m_type->cannot_cast_message.has_value() ) {
         add_msg( game_message_params{ m_bad, gmf_bypass_cooldown },
-                 failure_message );
+                 m_type->cannot_cast_message.value() );
+        }
     }
 
     if( recast_spell && player_character.magic->last_spell.is_null() ) {

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -1892,10 +1892,10 @@ static void cast_spell( bool recast_spell = false )
         temp_spell.can_cast( player_character, success_tracker );
     }
 
-    for (auto const& [m_type, any_success] : success_tracker ) {
-        if(!any_success && m_type->cannot_cast_message.has_value() ) {
-        add_msg( game_message_params{ m_bad, gmf_bypass_cooldown },
-                 m_type->cannot_cast_message.value() );
+    for( auto const& [m_type, any_success] : success_tracker ) {
+        if( !any_success && m_type->cannot_cast_message.has_value() ) {
+            add_msg( game_message_params{ m_bad, gmf_bypass_cooldown },
+                     m_type->cannot_cast_message.value() );
         }
     }
 

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -1265,16 +1265,22 @@ bool spell::can_cast( const Character &guy ) const
     return guy.magic->has_enough_energy( guy, *this );
 }
 
-bool spell::can_cast( const Character &guy, std::set<std::string> &failure_messages )
+bool spell::can_cast( const Character &guy, std::map<magic_type_id, bool> &success_tracker )
 {
-    if( can_cast( guy ) ) {
-        return true;
-    } else if( type->magic_type.has_value() &&
+    if( type->magic_type.has_value() &&
                type->magic_type.value()->cannot_cast_message.has_value() ) {
-        failure_messages.insert( type->magic_type.value()->cannot_cast_message.value() );
-        return false;
+        // Insert first occurence of magic_type_id as false since only successful casts will be tracked.
+        if( success_tracker.count( type->magic_type.value() ) == 0 ) {
+            success_tracker[type->magic_type.value()] = false;
+        }
+        if( can_cast( guy ) ) {
+            success_tracker[type->magic_type.value()] = true;
+            return true;
+        } else {
+            return false;
+        }
     } else {
-        return false;
+        return can_cast( guy );
     }
 }
 

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -1268,7 +1268,7 @@ bool spell::can_cast( const Character &guy ) const
 bool spell::can_cast( const Character &guy, std::map<magic_type_id, bool> &success_tracker )
 {
     if( type->magic_type.has_value() &&
-               type->magic_type.value()->cannot_cast_message.has_value() ) {
+        type->magic_type.value()->cannot_cast_message.has_value() ) {
         // Insert first occurence of magic_type_id as false since only successful casts will be tracked.
         if( success_tracker.count( type->magic_type.value() ) == 0 ) {
             success_tracker[type->magic_type.value()] = false;

--- a/src/magic.h
+++ b/src/magic.h
@@ -579,7 +579,7 @@ class spell
         bool has_components() const;
         // can the Character cast this spell?
         bool can_cast( const Character &guy ) const;
-        bool can_cast( const Character &guy, std::set<std::string> &failure_messages );
+        bool can_cast( const Character &guy, std::map<magic_type_id, bool> &success_tracker );
         // can the Character learn this spell?
         bool can_learn( const Character &guy ) const;
         // if spell shoots more than one projectile


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "[magic_type]: Fix cannot_cast_message logic"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
While playing I noticed that I was getting a cannot_cast message everytime I opened my spellbook despite very much being able to cast spells from that magic type.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Old Code:
- Would iterate until it found any spell of a magic type not castable and then print the cannot cast message

New Code:
- Maintains a map that stores if any spell in each magic type is castable, assuming that the magic type has a message defined
- Prints if <b>every</b> spell is not castable
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
With 1 castable, 1 not castable:
<img width="2553" height="1349" alt="spell message fixed" src="https://github.com/user-attachments/assets/047fa6c9-ebbf-4e92-95a3-8c08fa273bd2" />
With no castable:
<img width="2554" height="1360" alt="no more mana" src="https://github.com/user-attachments/assets/bc5e57b5-fa19-4163-8822-af4801a7bb11" />

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
