### PR TITLE
Caseless weapons failure to feed

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -204,6 +204,8 @@ static const efftype_id effect_worked_on( "worked_on" );
 
 static const faction_id faction_your_followers( "your_followers" );
 
+static const fault_id fault_gun_fail_to_feed( "fault_fail_to_feed" );
+
 static const flag_id json_flag_ALWAYS_AIMED( "ALWAYS_AIMED" );
 static const flag_id json_flag_NO_RELOAD( "NO_RELOAD" );
 
@@ -367,7 +369,14 @@ bool aim_activity_actor::check_gun_ability_to_shoot( Character &who, item &it )
         // it would be safer to limit it somewhat
         who.mod_moves( -who.get_speed() );
         who.recoil = MAX_RECOIL;
-        if( one_in( std::max( 7.0f, ( 15.0f - ( 4.0f * who.get_skill_level( skill_gun ) ) ) ) ) ) {
+        if( it.has_fault( fault_gun_fail_to_feed ) ) {
+            who.add_msg_if_player( m_good,
+                                   _( "You manually cycle your %s, and load a new round." ),
+                                   it.tname() );
+            it.remove_fault( fault_gun_fail_to_feed );
+            it.set_var( "u_know_round_in_chamber", true );
+        }
+        else if( one_in( std::max( 7.0f, ( 15.0f - ( 4.0f * who.get_skill_level( skill_gun ) ) ) ) ) ) {
             who.add_msg_if_player( m_good,
                                    _( "Your %s has some mechanical malfunction.  You tried to quickly fix it, and it works now!" ),
                                    it.tname() );

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -375,8 +375,7 @@ bool aim_activity_actor::check_gun_ability_to_shoot( Character &who, item &it )
                                    it.tname() );
             it.remove_fault( fault_gun_fail_to_feed );
             it.set_var( "u_know_round_in_chamber", true );
-        }
-        else if( one_in( std::max( 7.0f, ( 15.0f - ( 4.0f * who.get_skill_level( skill_gun ) ) ) ) ) ) {
+        } else if( one_in( std::max( 7.0f, ( 15.0f - ( 4.0f * who.get_skill_level( skill_gun ) ) ) ) ) ) {
             who.add_msg_if_player( m_good,
                                    _( "Your %s has some mechanical malfunction.  You tried to quickly fix it, and it works now!" ),
                                    it.tname() );

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -204,7 +204,7 @@ static const efftype_id effect_worked_on( "worked_on" );
 
 static const faction_id faction_your_followers( "your_followers" );
 
-static const fault_id fault_gun_fail_to_feed( "fault_fail_to_feed" );
+static const fault_id fault_fail_to_feed( "fault_fail_to_feed" );
 
 static const flag_id json_flag_ALWAYS_AIMED( "ALWAYS_AIMED" );
 static const flag_id json_flag_NO_RELOAD( "NO_RELOAD" );
@@ -369,11 +369,11 @@ bool aim_activity_actor::check_gun_ability_to_shoot( Character &who, item &it )
         // it would be safer to limit it somewhat
         who.mod_moves( -who.get_speed() );
         who.recoil = MAX_RECOIL;
-        if( it.has_fault( fault_gun_fail_to_feed ) ) {
+        if( it.has_fault( fault_fail_to_feed ) ) {
             who.add_msg_if_player( m_good,
                                    _( "You manually cycle your %s, and load a new round." ),
                                    it.tname() );
-            it.remove_fault( fault_gun_fail_to_feed );
+            it.remove_fault( fault_fail_to_feed );
             it.set_var( "u_know_round_in_chamber", true );
         } else if( one_in( std::max( 7.0f, ( 15.0f - ( 4.0f * who.get_skill_level( skill_gun ) ) ) ) ) ) {
             who.add_msg_if_player( m_good,

--- a/src/flag.cpp
+++ b/src/flag.cpp
@@ -59,6 +59,7 @@ const flag_id flag_CANT_HEAL_EVERYONE( "CANT_HEAL_EVERYONE" );
 const flag_id flag_CANT_WEAR( "CANT_WEAR" );
 const flag_id flag_CAN_USE_IN_DARK( "CAN_USE_IN_DARK" );
 const flag_id flag_CARNIVORE_OK( "CARNIVORE_OK" );
+const flag_id flag_CASELESS_ROUNDS( "CASELESS_ROUNDS" );
 const flag_id flag_CASING( "CASING" );
 const flag_id flag_CATTLE( "CATTLE" );
 const flag_id flag_CHALLENGE( "CHALLENGE" );

--- a/src/flag.h
+++ b/src/flag.h
@@ -72,6 +72,7 @@ extern const flag_id flag_CANT_WEAR;
 extern const flag_id flag_CAN_USE_IN_DARK;
 extern const flag_id flag_CARNIVORE_DIET;
 extern const flag_id flag_CARNIVORE_OK;
+extern const flag_id flag_CASELESS_ROUNDS;
 extern const flag_id flag_CASING;
 extern const flag_id flag_CATTLE;
 extern const flag_id flag_CHALLENGE;

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -150,6 +150,7 @@ static const efftype_id effect_quadruped_full( "quadruped_full" );
 static const fault_id fault_gun_blackpowder( "fault_gun_blackpowder" );
 static const fault_id fault_gun_chamber_spent( "fault_gun_chamber_spent" );
 static const fault_id fault_gun_dirt( "fault_gun_dirt" );
+static const fault_id fault_gun_fail_to_feed( "fault_fail_to_feed" );
 static const fault_id fault_overheat_explosion( "fault_overheat_explosion" );
 static const fault_id fault_overheat_melting( "fault_overheat_melting" );
 static const fault_id fault_overheat_safety( "fault_overheat_safety" );
@@ -699,6 +700,11 @@ bool Character::handle_gun_damage( item &it )
         return false;
     }
 
+    // This causes subsequent rounds in a burst to fail if any of the shots apply a failure to feed error.
+    if ( it.has_fault_of_type( gun_mechanical_simple ) ) {
+        return false;
+    }
+
     int dirt = it.get_var( "dirt", 0 );
     int dirtadder = 0;
     double dirt_dbl = static_cast<double>( dirt );
@@ -857,7 +863,9 @@ bool Character::handle_gun_damage( item &it )
             add_msg_player_or_npc( m_bad, _( "Your %s fails to cycle!" ),
                                    _( "<npcname>'s %s fails to cycle!" ),
                                    it.tname() );
-            it.set_fault( fault_gun_chamber_spent );
+            it.ammo_data()->has_flag(  flag_CASELESS_ROUNDS )? it.set_fault( fault_gun_fail_to_feed) :
+                it.set_fault( fault_gun_chamber_spent ); 
+
             // Don't return false in this case; this shot happens, follow-up ones won't.
         }
         // These are the dirtying/fouling mechanics

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -701,7 +701,7 @@ bool Character::handle_gun_damage( item &it )
     }
 
     // This causes subsequent rounds in a burst to fail if any of the shots apply a failure to feed error.
-    if ( it.has_fault_of_type( gun_mechanical_simple ) ) {
+    if( it.has_fault_of_type( gun_mechanical_simple ) ) {
         return false;
     }
 
@@ -863,8 +863,8 @@ bool Character::handle_gun_damage( item &it )
             add_msg_player_or_npc( m_bad, _( "Your %s fails to cycle!" ),
                                    _( "<npcname>'s %s fails to cycle!" ),
                                    it.tname() );
-            it.ammo_data()->has_flag(  flag_CASELESS_ROUNDS )? it.set_fault( fault_gun_fail_to_feed) :
-                it.set_fault( fault_gun_chamber_spent ); 
+            it.ammo_data()->has_flag( flag_CASELESS_ROUNDS ) ? it.set_fault( fault_gun_fail_to_feed ) :
+            it.set_fault( fault_gun_chamber_spent );
 
             // Don't return false in this case; this shot happens, follow-up ones won't.
         }

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -147,10 +147,10 @@ static const efftype_id effect_hit_by_player( "hit_by_player" );
 static const efftype_id effect_on_roof( "on_roof" );
 static const efftype_id effect_quadruped_full( "quadruped_full" );
 
+static const fault_id fault_fail_to_feed( "fault_fail_to_feed" );
 static const fault_id fault_gun_blackpowder( "fault_gun_blackpowder" );
 static const fault_id fault_gun_chamber_spent( "fault_gun_chamber_spent" );
 static const fault_id fault_gun_dirt( "fault_gun_dirt" );
-static const fault_id fault_gun_fail_to_feed( "fault_fail_to_feed" );
 static const fault_id fault_overheat_explosion( "fault_overheat_explosion" );
 static const fault_id fault_overheat_melting( "fault_overheat_melting" );
 static const fault_id fault_overheat_safety( "fault_overheat_safety" );
@@ -863,7 +863,7 @@ bool Character::handle_gun_damage( item &it )
             add_msg_player_or_npc( m_bad, _( "Your %s fails to cycle!" ),
                                    _( "<npcname>'s %s fails to cycle!" ),
                                    it.tname() );
-            it.ammo_data()->has_flag( flag_CASELESS_ROUNDS ) ? it.set_fault( fault_gun_fail_to_feed ) :
+            it.ammo_data()->has_flag( flag_CASELESS_ROUNDS ) ? it.set_fault( fault_fail_to_feed ) :
             it.set_fault( fault_gun_chamber_spent );
 
             // Don't return false in this case; this shot happens, follow-up ones won't.


### PR DESCRIPTION
#### Summary
Features "Caseless weapons now have a simpler fault when they fail to feed"

#### Purpose of change
Noticed that caseless weapons refered to an unexistent casing when they failed to feed due to firing rounds with insufficient recoil.

#### Describe the solution
Apply either `fault_fail_to_feed` or `fault_gun_chamber_spent` based on wether the gun is firing caseless rounds.

The failure to feed fault also has a auto clear action that consumes a second but always succeeds (you just pull on the charging handle)

#### Testing
Fired guns.
