### PR TITLE
Make armor value displays into a table

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -3898,11 +3898,12 @@ void item::armor_protection_info( std::vector<iteminfo> &info, const iteminfo_qu
 
         if( display_median ) {
             info.emplace_back( "SPECIAL_ARMOR_GRAPH",
-                               string_format( "<bold>%s</bold>: <bad>%d%%</bad>, <color_c_yellow>Median</color>, <good>%d%%</good>",
+                               string_format( "<bold>%s</bold>: <bad>%d%%</bad> chance, <color_c_yellow>Median</color> chance, <good>%d%%</good> chance",
                                               _( "Protection" ), percent_worst, percent_best ) );
         } else if( percent_worst > 0 ) {
             info.emplace_back( "SPECIAL_ARMOR_GRAPH",
-                               string_format( "<bold>%s</bold>: <bad>%d%%</bad>, <good>%d%%</good>", _( "Protection" ),
+                               string_format( "<bold>%s</bold>: <bad>%d%%</bad> chance, <good>%d%%</good> chance",
+                                              _( "Protection" ),
                                               percent_worst, percent_best ) );
         } else {
             info.emplace_back( "SPECIAL_ARMOR_GRAPH", string_format( "<bold>%s</bold>:", _( "Protection" ) ) );

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -3896,15 +3896,15 @@ void item::armor_protection_info( std::vector<iteminfo> &info, const iteminfo_qu
         bool display_median = percent_best < 50 && percent_worst < 50;
 
         if( display_median ) {
-            info.emplace_back( "DESCRIPTION",
+            info.emplace_back( "SPECIAL_ARMOR_GRAPH",
                                string_format( "<bold>%s</bold>: <bad>%d%%</bad>, <color_c_yellow>Median</color>, <good>%d%%</good>",
                                               _( "Protection" ), percent_worst, percent_best ) );
         } else if( percent_worst > 0 ) {
-            info.emplace_back( "DESCRIPTION",
+            info.emplace_back( "SPECIAL_ARMOR_GRAPH",
                                string_format( "<bold>%s</bold>: <bad>%d%%</bad>, <good>%d%%</good>", _( "Protection" ),
                                               percent_worst, percent_best ) );
         } else {
-            info.emplace_back( "DESCRIPTION", string_format( "<bold>%s</bold>:", _( "Protection" ) ) );
+            info.emplace_back( "SPECIAL_ARMOR_GRAPH", string_format( "<bold>%s</bold>:", _( "Protection" ) ) );
         }
 
         for( const damage_info_order &dio : damage_info_order::get_all(

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -3770,7 +3770,7 @@ bool item::armor_full_protection_info( std::vector<iteminfo> &info,
             for( const translation &entry : to_print ) {
                 coverage += string_format( _( " The <info>%s</info>." ), entry );
             }
-            info.emplace_back( "ARMOR", coverage );
+            info.emplace_back( "DESCRIPTION", coverage );
 
             // the following function need one representative sub limb from which to query data
             armor_material_info( info, parts, 0, false, *p.sub_coverage.begin() );
@@ -3855,7 +3855,8 @@ void item::armor_protection_info( std::vector<iteminfo> &info, const iteminfo_qu
             layering += string_format( " <stat>%s</stat>.", item::layer_to_string( ll ) );
         }
         //~ Limb-specific coverage (%s = name of limb)
-        info.emplace_back( "DESCRIPTION", string_format( _( "<bold>Coverage</bold>:%s" ), layering ) );
+        info.emplace_back( "SPECIAL_ARMOR_GRAPH", string_format( _( "<bold>Coverage</bold>:%s" ),
+                           layering ) );
         //~ Regular/Default coverage
         info.emplace_back( bp_cat, string_format( "%s%s%s", space, _( "Default:" ), space ), "",
                            iteminfo::no_flags, get_coverage( sbp ) );
@@ -3976,7 +3977,7 @@ void item::armor_material_info( std::vector<iteminfo> &info, const iteminfo_quer
     if( parts->test( iteminfo_parts::ARMOR_MATERIALS ) ) {
         const std::string space = "  ";
         // NOLINTNEXTLINE(cata-translate-string-literal)
-        std::string bp_cat = string_format( "ARMOR" );
+        std::string bp_cat = string_format( "DESCRIPTION" );
         std::string materials_list;
         std::string units_info = pgettext( "length unit: milimeter", "mm" );
         for( const part_material *mat : armor_made_of( sbp ) ) {

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -1271,7 +1271,8 @@ static nc_color get_comparison_color( const iteminfo &i,
 static std::vector<std::string> delimit_armor_text( const iteminfo &i )
 {
     const std::string &raw_text = i.sName;
-    // The various types of text that can be passed in from item::armor_protection_info():
+    // The various lines of text that can be passed in from item::armor_protection_info():
+    //
     // Protection:
     // Bash: 2.00, 8.00, 20.00
     // Foo: 6.00, 12.00
@@ -1279,8 +1280,9 @@ static std::vector<std::string> delimit_armor_text( const iteminfo &i )
     // Yes that first one has no numbers. It puts the value into sValue.
     // So we need multiple passes.
     std::vector<std::string> first_pass = string_split( raw_text, ':' );
-    if( first_pass.size() == 2 ) {
+    if( first_pass.size() == 2 && i.sValue != "-999" ) {
         // Then the value is in sValue and we need to extract it.
+        // So just overwrite the second (empty) string that we just split off.
         first_pass[1] = i.sValue;
     }
     const std::string mega_string = string_join( first_pass, ", " );
@@ -1288,10 +1290,9 @@ static std::vector<std::string> delimit_armor_text( const iteminfo &i )
     return delimited_strings;
 }
 
-static void draw_armor_graph( const std::vector<iteminfo> &vItemDisplay, const iteminfo &i )
+static void draw_armor_table( const std::vector<iteminfo> &vItemDisplay, const iteminfo &i )
 {
-    const int max_columns = 4;
-    if( ImGui::BeginTable( "##ITEMINFO_ARMOR_GRAPH", max_columns,
+    if( ImGui::BeginTable( "##ITEMINFO_ARMOR_TABLE", delimit_armor_text( i ).size(),
                            ImGuiTableFlags_BordersH | ImGuiTableFlags_BordersV ) ) {
         auto info_iter = vItemDisplay.begin() + std::distance( vItemDisplay.data(), &i );
         if( info_iter == vItemDisplay.end() ) {
@@ -1315,11 +1316,6 @@ static void draw_armor_graph( const std::vector<iteminfo> &vItemDisplay, const i
                 cataimgui::draw_colored_text( text, c_unset );
                 ImGui::TableNextColumn();
             }
-            // dumb hack. if you see this, it should not be mergeable.
-            for( int i = 0; i < max_columns - delimited_strings.size(); i++ ) {
-                ImGui::TableNextRow();
-                ImGui::TableNextColumn();
-            }
             info_iter++;
         }
 
@@ -1337,7 +1333,7 @@ void display_item_info( const std::vector<iteminfo> &vItemDisplay,
             cataimgui::PushMonoFont();
         }
         if( i.sType == "SPECIAL_ARMOR_GRAPH" ) {
-            draw_armor_graph( vItemDisplay, i );
+            draw_armor_table( vItemDisplay, i );
         } else if( i.sType == "DESCRIPTION" ) {
             if( i.bDrawName ) {
                 if( i.sName == "--" ) {
@@ -1360,7 +1356,7 @@ void display_item_info( const std::vector<iteminfo> &vItemDisplay,
                     bAlreadyHasNewLine = false;
                 }
             }
-        } else if( i.sType != "ARMOR" ) { // handled by draw_armor_graph()
+        } else if( i.sType != "ARMOR" ) { // handled by draw_armor_table()
             if( i.bDrawName ) {
                 cataimgui::TextColoredParagraph( c_light_gray, i.sName );
                 bAlreadyHasNewLine = false;

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -1303,10 +1303,23 @@ static void draw_armor_table( const std::vector<iteminfo> &vItemDisplay, const i
 
         const std::vector<std::string> chopped_up = delimit_armor_text( *info_iter );
         for( const std::string &cell_text : chopped_up ) {
-            ImGui::TableSetupColumn( cell_text.c_str(), ImGuiTableColumnFlags_WidthStretch );
+            // this prefix prevents imgui from drawing the text. We still have color tags, which imgui won't parse, so we don't want those exposed to the user.
+            // But we still want proper column IDs. So we put them in, but we *hide them* with this.
+            // This results in a column with an ID of e.g.
+            // ##<color_white>Protection:</color>
+            //
+            // Not great for debugging, but better than having a column with default (randomly generated number) ID!
+            const std::string invisible_ID_label = "##" + cell_text;
+            ImGui::TableSetupColumn( invisible_ID_label.c_str(), ImGuiTableColumnFlags_WidthStretch );
         }
         ImGui::TableHeadersRow();
+        for( int i = 0; i < chopped_up.size(); i++ ) {
+            ImGui::TableSetColumnIndex( i );
+            cataimgui::draw_colored_text( chopped_up[i], c_unset );
+        }
+        // This advances us past the last column, which we just reiterated. Since there are no more columns, it increments to the next row. Easy, huh?
         ImGui::TableNextColumn();
+
 
         info_iter++;
 

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -1313,7 +1313,7 @@ static void draw_armor_table( const std::vector<iteminfo> &vItemDisplay, const i
             ImGui::TableSetupColumn( invisible_ID_label.c_str(), ImGuiTableColumnFlags_WidthStretch );
         }
         ImGui::TableHeadersRow();
-        for( int i = 0; i < chopped_up.size(); i++ ) {
+        for( size_t i = 0; i < chopped_up.size(); i++ ) {
             ImGui::TableSetColumnIndex( i );
             cataimgui::draw_colored_text( chopped_up[i], c_unset );
         }

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -1313,6 +1313,8 @@ static void draw_armor_table( const std::vector<iteminfo> &vItemDisplay, const i
             ImGui::TableSetupColumn( invisible_ID_label.c_str(), ImGuiTableColumnFlags_WidthStretch );
         }
         ImGui::TableHeadersRow();
+        // After putting in the invisible labels in the last for-loop, this writes the actual text. Just the same text without the ## marker, and
+        // with our native functions doing the drawing. (So we parse color tags)
         for( size_t i = 0; i < chopped_up.size(); i++ ) {
             ImGui::TableSetColumnIndex( i );
             cataimgui::draw_colored_text( chopped_up[i], c_unset );
@@ -1321,6 +1323,7 @@ static void draw_armor_table( const std::vector<iteminfo> &vItemDisplay, const i
         info_iter++;
 
         while( info_iter != vItemDisplay.end() && info_iter->sType == "ARMOR" ) {
+            ImGui::TableNextRow();
             const std::vector<std::string> delimited_strings = delimit_armor_text( *info_iter );
             for( const std::string &text : delimited_strings ) {
                 ImGui::TableNextColumn();

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -1317,17 +1317,14 @@ static void draw_armor_table( const std::vector<iteminfo> &vItemDisplay, const i
             ImGui::TableSetColumnIndex( i );
             cataimgui::draw_colored_text( chopped_up[i], c_unset );
         }
-        // This advances us past the last column, which we just reiterated. Since there are no more columns, it increments to the next row. Easy, huh?
-        ImGui::TableNextColumn();
-
 
         info_iter++;
 
         while( info_iter != vItemDisplay.end() && info_iter->sType == "ARMOR" ) {
             const std::vector<std::string> delimited_strings = delimit_armor_text( *info_iter );
             for( const std::string &text : delimited_strings ) {
-                cataimgui::draw_colored_text( text, c_unset );
                 ImGui::TableNextColumn();
+                cataimgui::draw_colored_text( text, c_unset );
             }
             info_iter++;
         }

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -1268,16 +1268,21 @@ static nc_color get_comparison_color( const iteminfo &i,
     return thisColor;
 }
 
-static std::vector<std::string> delimit_armor_text( std::string raw_text )
+static std::vector<std::string> delimit_armor_text( const iteminfo &i )
 {
+    const std::string &raw_text = i.sName;
     // The various types of text that can be passed in from item::armor_protection_info():
     // Protection:
     // Bash: 2.00, 8.00, 20.00
     // Foo: 6.00, 12.00
     //
-	// Yes that first one has no numbers.
+    // Yes that first one has no numbers. It puts the value into sValue.
     // So we need multiple passes.
-    const std::vector<std::string> first_pass = string_split( raw_text, ':' );
+    std::vector<std::string> first_pass = string_split( raw_text, ':' );
+    if( first_pass.size() == 2 ) {
+        // Then the value is in sValue and we need to extract it.
+        first_pass[1] = i.sValue;
+    }
     const std::string mega_string = string_join( first_pass, ", " );
     const std::vector<std::string> delimited_strings = string_split( mega_string, ',' );
     return delimited_strings;
@@ -1295,7 +1300,7 @@ static void draw_armor_graph( const std::vector<iteminfo> &vItemDisplay, const i
             return;
         }
 
-        const std::vector<std::string> chopped_up = delimit_armor_text( info_iter->sName );
+        const std::vector<std::string> chopped_up = delimit_armor_text( *info_iter );
         for( const std::string &cell_text : chopped_up ) {
             ImGui::TableSetupColumn( cell_text.c_str(), ImGuiTableColumnFlags_WidthStretch );
         }
@@ -1305,8 +1310,7 @@ static void draw_armor_graph( const std::vector<iteminfo> &vItemDisplay, const i
         info_iter++;
 
         while( info_iter != vItemDisplay.end() && info_iter->sType == "ARMOR" ) {
-            const std::string &raw_text = info_iter->sName;
-            const std::vector<std::string> delimited_strings = delimit_armor_text( raw_text );
+            const std::vector<std::string> delimited_strings = delimit_armor_text( *info_iter );
             for( const std::string &text : delimited_strings ) {
                 cataimgui::draw_colored_text( text, c_unset );
                 ImGui::TableNextColumn();

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -1356,7 +1356,7 @@ void display_item_info( const std::vector<iteminfo> &vItemDisplay,
                     bAlreadyHasNewLine = false;
                 }
             }
-        } else if( i.sType != "ARMOR" ) { // handled by draw_armor_table()
+        } else if( i.sType != "ARMOR" ) { // ARMOR is handled by draw_armor_table()
             if( i.bDrawName ) {
                 cataimgui::TextColoredParagraph( c_light_gray, i.sName );
                 bAlreadyHasNewLine = false;

--- a/src/ui_iteminfo.h
+++ b/src/ui_iteminfo.h
@@ -12,7 +12,7 @@ class iteminfo_window : public cataimgui::window
 {
     public:
         iteminfo_window( item_info_data &info, point pos, int width, int height,
-                         ImGuiWindowFlags flags = ImGuiWindowFlags_None );
+                         ImGuiWindowFlags flags = ImGuiWindowFlags_NoNavInputs );
         void execute();
 
     protected:

--- a/tests/iteminfo_test.cpp
+++ b/tests/iteminfo_test.cpp
@@ -1542,7 +1542,7 @@ TEST_CASE( "armor_protection", "[iteminfo][armor][protection]" )
             "<color_c_white>Coverage</color>: <color_c_light_blue>Close to skin</color>.\n"
             "  Default:  <color_c_yellow>100</color>\n";
         const std::string protection_str =
-            "<color_c_white>Protection</color>: <color_c_red>4%</color>, <color_c_yellow>Median</color>, <color_c_green>4%</color>\n";
+            "<color_c_white>Protection</color>: <color_c_red>4%</color> chance, <color_c_yellow>Median</color> chance, <color_c_green>4%</color> chance\n";
         const std::string bash_str =
             "  Bash:  <color_c_red>1.00</color>, <color_c_yellow>12.00</color>, <color_c_green>23.00</color>\n";
         const std::string cut_str =


### PR DESCRIPTION
#### Summary
Interface "Make armor value displays into a table"

#### Purpose of change
Many, many people ask "What does these numbers mean?" when it comes to the armor display.

#### Describe the solution

Instead of printing lines with no clear relationship, make it into a pretty table with imgui.

Because tables are a native imgui widget it already has features we could enable, such as sorting the resulting values. (Note that none of them are enabled in this PR. Just a basic table with text alignment.)

#### Describe alternatives you've considered
@mqrause provided enormously helpful feedback and advice, and proposed an alternate implementation:
https://github.com/CleverRaven/Cataclysm-DDA/compare/master...mqrause:Cataclysm-DDA:poc

Because it would require changes to item::armor_protection_info() and follow-on changes to "old UI" displays to accommodate the changes, I didn't go ahead with it. But there is definitely an argument to be made for assembling the strings into a desired format 'at the source'. 

#### Testing
<img width="636" height="241" alt="image" src="https://github.com/user-attachments/assets/4666b8b4-34e9-425c-93ac-c3e0305208e7" />
<img width="626" height="460" alt="image" src="https://github.com/user-attachments/assets/bcb24a8e-2e91-4c43-86a0-15c1085666b0" />
<img width="637" height="420" alt="image" src="https://github.com/user-attachments/assets/de00b13e-000e-4267-b345-7d34c8d2a772" />

Old UI iteminfo panels continue to display without a table (intentional, they're using ncurses):
<img width="638" height="193" alt="image" src="https://github.com/user-attachments/assets/733b62dc-3c1a-4be9-845b-751361f7d0fb" />


#### Additional context

Known issues:
Commits are still kind of nonsensical, but squashing them properly would be a pain. I can squash for the mergers if desired. (I know we don't like squashed merge commits)