### PR TITLE
mandatory/optional for monstergenerator

### DIFF
--- a/data/json/monsters/defense_bot.json
+++ b/data/json/monsters/defense_bot.json
@@ -289,6 +289,7 @@
     "diff": 100,
     "hp": 50,
     "speed": 140,
+    "volume": "100 L",
     "material": [ "steel" ],
     "symbol": "@",
     "color": "red",

--- a/src/generic_factory.cpp
+++ b/src/generic_factory.cpp
@@ -78,6 +78,18 @@ bool unicode_codepoint_from_symbol_reader( const JsonObject &jo,
     return true;
 }
 
+bool unicode_symbol_reader( const JsonObject &jo, const std::string_view member_name,
+                            std::string &member, bool was_loaded )
+{
+    uint32_t codepoint;
+    bool read = unicode_codepoint_from_symbol_reader( jo, member_name, codepoint, was_loaded );
+    if( read ) {
+        member = utf32_to_utf8( codepoint );
+        return true;
+    }
+    return false;
+}
+
 float read_proportional_entry( const JsonObject &jo, std::string_view key )
 {
     if( jo.has_float( key ) ) {

--- a/src/generic_factory.h
+++ b/src/generic_factory.h
@@ -960,6 +960,12 @@ bool one_char_symbol_reader( const JsonObject &jo, std::string_view member_name,
 bool unicode_codepoint_from_symbol_reader(
     const JsonObject &jo, std::string_view member_name, uint32_t &member, bool );
 
+/**
+ * unicode_codepoint_from_symbol_reader, but with a string instead of a codepoint
+ */
+bool unicode_symbol_reader( const JsonObject &jo, std::string_view member_name, std::string &member,
+                            bool was_loaded );
+
 //Reads a standard single-float "proportional" entry
 float read_proportional_entry( const JsonObject &jo, std::string_view key );
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -7480,7 +7480,7 @@ units::volume item::corpse_volume( const mtype *corpse ) const
     if( corpse_volume > 0_ml ) {
         return corpse_volume;
     }
-    debugmsg( "invalid monster volume for corpse" );
+    debugmsg( "invalid monster volume for corpse of %s", corpse->id.str() );
     return 0_ml;
 }
 

--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -800,7 +800,6 @@ void mtype::load( const JsonObject &jo, const std::string &src )
     assign( jo, "aggression", agro, strict, -100, 100 );
     assign( jo, "morale", morale, strict );
     assign( jo, "stomach_size", stomach_size, strict );
-    assign( jo, "amount_eaten", amount_eaten, strict );
 
     assign( jo, "tracking_distance", tracking_distance, strict, 3 );
 

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -235,6 +235,9 @@ struct mon_effect_data {
 
     mon_effect_data();
     void load( const JsonObject &jo );
+    void deserialize( const JsonObject &jo ) {
+        load( jo );
+    }
 };
 
 /** Pet food data */
@@ -303,6 +306,8 @@ struct mount_item_data {
      * If this monster is a rideable mount that spawns with storage bags, this is the storage item id
      */
     itype_id storage;
+
+    void deserialize( const JsonObject &jo );
 };
 
 struct reproduction_type {
@@ -316,6 +321,8 @@ struct revive_type {
     std::function<bool( const_dialogue const & )> condition;
     mtype_id revive_mon = mtype_id::NULL_ID();
     mongroup_id revive_monster_group = mongroup_id::NULL_ID();
+
+    void deserialize( const JsonObject &jo );
 };
 
 struct mtype {

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -463,7 +463,6 @@ struct mtype {
         int agro = 0;           /** chance will attack [-100,100] */
         int morale = 0;         /** initial morale level at spawn */
         int stomach_size = 0;         /** how many times this monster will eat */
-        int amount_eaten = 0;         /** how many times it has eaten */
 
         // how close the monster is willing to approach its target while under the MATT_FOLLOW attitude
         int tracking_distance = 8;

--- a/src/shearing.cpp
+++ b/src/shearing.cpp
@@ -37,15 +37,12 @@ void shearing_entry::load( const JsonObject &jo )
 {
     mandatory( jo, was_loaded, "result", result );
 
-    optional( jo, was_loaded, "ratio_mass", ratio_mass );
-    ratio_mass = std::max( 0.00f, ratio_mass );
+    optional( jo, was_loaded, "ratio_mass", ratio_mass, numeric_bound_reader<float> {0.f} );
 
-    optional( jo, was_loaded, "ratio_volume", ratio_volume );
-    ratio_volume = std::max( 0.00f, ratio_volume );
+    optional( jo, was_loaded, "ratio_volume", ratio_volume, numeric_bound_reader<float> {0.f} );
 
     if( jo.has_int( "amount" ) ) {
-        mandatory( jo, was_loaded, "amount", amount );
-        amount = std::max( 0, amount );
+        mandatory( jo, was_loaded, "amount", amount, numeric_bound_reader<int> {0} );
     } else if( jo.has_array( "amount" ) ) {
         std::vector<int> amount_random = jo.get_int_array( "amount" );
         random_min = std::max( 0, amount_random[0] );
@@ -54,6 +51,12 @@ void shearing_entry::load( const JsonObject &jo )
             std::swap( random_min, random_max );
         }
     }
+}
+
+void shearing_data::deserialize( const JsonArray &ja )
+{
+    ja.read( entries_ );
+    valid_ = !entries_.empty();
 }
 
 shearing_data::shearing_data( std::vector<shearing_entry> &shearing_entries )

--- a/src/shearing.h
+++ b/src/shearing.h
@@ -1,10 +1,12 @@
 #pragma once
-#include "type_id.h"
 #ifndef CATA_SRC_SHEARING_H
 #define CATA_SRC_SHEARING_H
 
 #include <vector>
 
+#include "type_id.h"
+
+class JsonArray;
 class JsonObject;
 class monster;
 
@@ -25,6 +27,9 @@ struct shearing_entry {
 
     bool was_loaded = false;
     void load( const JsonObject &jo );
+    void deserialize( const JsonObject &jo ) {
+        load( jo );
+    }
 };
 
 class shearing_data
@@ -42,6 +47,8 @@ class shearing_data
         }
 
         std::vector<shearing_roll> roll_all( const monster &mon ) const;
+
+        void deserialize( const JsonArray &ja );
 
     private:
         bool valid_ = false;

--- a/tests/item_test.cpp
+++ b/tests/item_test.cpp
@@ -332,6 +332,7 @@ TEST_CASE( "item_length_sanity_check", "[item]" )
 TEST_CASE( "corpse_length_sanity_check", "[item]" )
 {
     for( const mtype &type : MonsterGenerator::generator().get_all_mtypes() ) {
+        INFO( type.id.str() )
         const item sample = item::make_corpse( type.id );
         assert_minimum_length_to_volume_ratio( sample );
     }


### PR DESCRIPTION
#### Summary
Infrastructure "Use mandatory/optional for many mtype members" 

#### Purpose of change
See https://github.com/CleverRaven/Cataclysm-DDA/pull/82165

#### Describe the solution
Replace lower-level loading code with mandatory/optional.

#### Testing
`tools/load_all_mods.sh`
Monster-related tests pass.