### PR TITLE
Remove all item<--->appliance conversions

### DIFF
--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -1877,9 +1877,12 @@ void construct::done_appliance( const tripoint_bub_ms &p, Character &who )
     }
 
     const item &base = components.front();
+    // FIXME: There might be existing/old constructions which need migration. I have no idea what to do about that.
+    /*
     const vpart_id &vpart = vpart_appliance_from_item( base.typeId() );
 
     place_appliance( here, p, vpart, who, base );
+    */
 }
 
 void construct::done_deconstruct( const tripoint_bub_ms &p, Character &player_character )

--- a/src/iexamine_actors.cpp
+++ b/src/iexamine_actors.cpp
@@ -57,12 +57,12 @@ void appliance_convert_examine_actor::load( const JsonObject &jo, const std::str
 {
     optional( jo, false, "furn_set", furn_set );
     optional( jo, false, "ter_set", ter_set );
-    mandatory( jo, false, "item", appliance_item );
+    mandatory( jo, false, "furniture", appliance_furn );
 }
 
 void appliance_convert_examine_actor::call( Character &you, const tripoint_bub_ms &examp ) const
 {
-    if( !query_yn( _( "Connect %s to grid?" ), item::nname( appliance_item ) ) ) {
+    if( !query_yn( _( "Connect %s to grid?" ), appliance_furn->name() ) ) {
         return;
     }
     map &here = get_map();
@@ -73,7 +73,7 @@ void appliance_convert_examine_actor::call( Character &you, const tripoint_bub_m
         here.ter_set( examp, *ter_set );
     }
 
-    place_appliance( here, examp, vpart_appliance_from_item( appliance_item ), you );
+    place_appliance( here, examp, vpart_appliance_from_furn( appliance_furn ), you );
 }
 
 void appliance_convert_examine_actor::finalize() const
@@ -85,12 +85,12 @@ void appliance_convert_examine_actor::finalize() const
         debugmsg( "Invalid terrain id %s in appliance_convert action", ter_set->str() );
     }
 
-    if( !appliance_item.is_valid() ) {
-        debugmsg( "Invalid appliance item %s in appliance_convert action", appliance_item.str() );
-    } else if( !vpart_appliance_from_item( appliance_item ).is_valid() ) {
+    if( !appliance_furn.is_valid() ) {
+        debugmsg( "Invalid appliance furniture %s in appliance_convert action", appliance_furn.c_str() );
+    } else if( !vpart_appliance_from_furn( appliance_furn ).is_valid() ) {
         // This will never actually trigger now, but is here if the semantics of vpart_appliance_from_item change
         debugmsg( "In appliance_convert action, %s does not correspond to an appliance",
-                  appliance_item.str() );
+                  appliance_furn.str() );
     }
 }
 

--- a/src/iexamine_actors.h
+++ b/src/iexamine_actors.h
@@ -24,7 +24,7 @@ class appliance_convert_examine_actor : public iexamine_actor
     private:
         std::optional<furn_str_id> furn_set = std::nullopt;
         std::optional<ter_str_id> ter_set = std::nullopt;
-        itype_id appliance_item;
+        furn_str_id appliance_furn;
 
     public:
         explicit appliance_convert_examine_actor( const std::string &type = "appliance_convert" )

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -2133,7 +2133,6 @@ void Item_factory::init()
     add_actor( std::make_unique<manualnoise_actor>() );
     add_actor( std::make_unique<musical_instrument_actor>() );
     add_actor( std::make_unique<deploy_furn_actor>() );
-    add_actor( std::make_unique<deploy_appliance_actor>() );
     add_actor( std::make_unique<place_monster_iuse>() );
     add_actor( std::make_unique<change_scent_iuse>() );
     add_actor( std::make_unique<place_npc_iuse>() );

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -1336,49 +1336,6 @@ std::optional<int> deploy_furn_actor::use( Character *p, item &it,
     return 0;
 }
 
-std::unique_ptr<iuse_actor> deploy_appliance_actor::clone() const
-{
-    return std::make_unique<deploy_appliance_actor>( *this );
-}
-
-void deploy_appliance_actor::info( const item &, std::vector<iteminfo> &dump ) const
-{
-    dump.emplace_back( "DESCRIPTION",
-                       string_format( _( "Can be <info>activated</info> to deploy as an appliance (<stat>%s</stat>)." ),
-                                      vpart_appliance_from_item( appliance_base )->name() ) );
-}
-
-void deploy_appliance_actor::load( const JsonObject &obj, const std::string & )
-{
-    mandatory( obj, false, "base", appliance_base );
-}
-
-std::optional<int> deploy_appliance_actor::use( Character *p, item &it,
-        const tripoint_bub_ms &pos ) const
-{
-    return deploy_appliance_actor::use( p, it, &get_map(), pos );
-}
-
-std::optional<int> deploy_appliance_actor::use( Character *p, item &it,
-        map *here, const tripoint_bub_ms &pos ) const
-{
-    ret_val<tripoint_bub_ms> suitable = check_deploy_square( p, it, here, pos );
-    if( !suitable.success() ) {
-        p->add_msg_if_player( m_info, suitable.str() );
-        return std::nullopt;
-    }
-
-    // TODO: Use map aware operation when available
-    it.spill_contents( suitable.value() );
-    // TODO: Use map aware operation when available
-    if( place_appliance( *here, suitable.value(),
-                         vpart_appliance_from_item( appliance_base ), *p, it ) ) {
-        form_loc( *p, here, pos, it ).remove_item();
-        p->mod_moves( -to_moves<int>( 2_seconds ) );
-    }
-    return 0;
-}
-
 std::unique_ptr<iuse_actor> reveal_map_actor::clone() const
 {
     return std::make_unique<reveal_map_actor>( *this );

--- a/src/iuse_actor.h
+++ b/src/iuse_actor.h
@@ -421,25 +421,6 @@ class deploy_furn_actor : public iuse_actor
 };
 
 /**
- * Deployable appliances from items
- */
-class deploy_appliance_actor : public iuse_actor
-{
-    public:
-        itype_id appliance_base;
-
-        deploy_appliance_actor() : iuse_actor( "deploy_appliance" ) {}
-        ~deploy_appliance_actor() override = default;
-
-        void load( const JsonObject &obj, const std::string & ) override;
-        std::optional<int> use( Character *p, item &it, const tripoint_bub_ms &pos ) const override;
-        std::optional<int> use( Character *p, item &it, map *here,
-                                const tripoint_bub_ms &pos ) const override;
-        std::unique_ptr<iuse_actor> clone() const override;
-        void info( const item &, std::vector<iteminfo> & ) const override;
-};
-
-/**
  * Reveals specific things on the overmap.
  */
 class reveal_map_actor : public iuse_actor

--- a/src/veh_appliance.cpp
+++ b/src/veh_appliance.cpp
@@ -81,7 +81,7 @@ vpart_id vpart_appliance_from_furn( const furn_str_id &furn )
 }
 
 bool place_appliance( map &here, const tripoint_bub_ms &p, const vpart_id &vpart,
-                      const Character &owner, const std::optional<item> &base )
+                      const Character &owner )
 {
 
     const vpart_info &vpinfo = vpart.obj();
@@ -95,16 +95,7 @@ bool place_appliance( map &here, const tripoint_bub_ms &p, const vpart_id &vpart
     veh->add_tag( flag_APPLIANCE );
 
     int partnum = -1;
-    if( base ) {
-        item copied = *base;
-        if( vpinfo.base_item != copied.typeId() ) {
-            // transform the deploying item into what it *should* be before storing it
-            copied.convert( vpinfo.base_item );
-        }
-        partnum = veh->install_part( here, point_rel_ms::zero, vpart, std::move( copied ) );
-    } else {
-        partnum = veh->install_part( here, point_rel_ms::zero, vpart );
-    }
+    partnum = veh->install_part( here, point_rel_ms::zero, vpart );
     if( partnum == -1 ) {
         // unrecoverable, failed to be installed somehow
         here.destroy_vehicle( veh );

--- a/src/veh_appliance.cpp
+++ b/src/veh_appliance.cpp
@@ -69,14 +69,14 @@ static const std::string flag_HALF_CIRCLE_LIGHT( "HALF_CIRCLE_LIGHT" );
 // TODO: make this dynamic in the future.
 static const int win_width = 60;
 
-vpart_id vpart_appliance_from_item( const itype_id &item_id )
+vpart_id vpart_appliance_from_furn( const furn_str_id &furn )
 {
     for( const vpart_info &vpi : vehicles::parts::get_all() ) {
-        if( vpi.base_item == item_id && vpi.has_flag( flag_APPLIANCE ) ) {
+        if( vpi.base_furn == furn && vpi.has_flag( flag_APPLIANCE ) ) {
             return vpi.id;
         }
     }
-    debugmsg( "item %s is not base item of any appliance!", item_id.c_str() );
+    debugmsg( "furniture %s is not base furniture of any appliance!", furn.c_str() );
     return vpart_ap_standing_lamp;
 }
 

--- a/src/veh_appliance.h
+++ b/src/veh_appliance.h
@@ -23,7 +23,7 @@ class vehicle;
 
 vpart_id vpart_appliance_from_furn( const furn_str_id &furn );
 bool place_appliance( map &here, const tripoint_bub_ms &p, const vpart_id &vpart,
-                      const Character &owner, const std::optional<item> &base = std::nullopt );
+                      const Character &owner );
 
 /**
  * Appliance interaction UI. Works similarly to veh_interact, but has

--- a/src/veh_appliance.h
+++ b/src/veh_appliance.h
@@ -21,7 +21,7 @@ class map;
 class ui_adaptor;
 class vehicle;
 
-vpart_id vpart_appliance_from_item( const itype_id &item_id );
+vpart_id vpart_appliance_from_furn( const furn_str_id &furn );
 bool place_appliance( map &here, const tripoint_bub_ms &p, const vpart_id &vpart,
                       const Character &owner, const std::optional<item> &base = std::nullopt );
 

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -3253,6 +3253,9 @@ void veh_interact::complete_vehicle( map &here, Character &you )
             // This will be a list of all the items which arise from this removal.
             std::list<item> resulting_items;
 
+            const bool should_make_furn = veh.is_appliance() && vp->info().base_furn;
+            const furn_str_id furn_to_make = *vp->info().base_furn;
+
             // First we get all the contents of the part
             vehicle_stack contents = veh.get_items( *vp );
             resulting_items.insert( resulting_items.end(), contents.begin(), contents.end() );
@@ -3278,7 +3281,7 @@ void veh_interact::complete_vehicle( map &here, Character &you )
                 if( smash_remove ) {
                     item_group::ItemList pieces = vp->pieces_for_broken_part();
                     resulting_items.insert( resulting_items.end(), pieces.begin(), pieces.end() );
-                } else {
+                } else if( !veh.is_appliance() ) { // appliances never have a base item to remove, only furniture.
                     resulting_items.push_back( veh.removed_part( here, *vp ) );
 
                     // damage reduces chance of success (0.8^damage_level)
@@ -3375,6 +3378,9 @@ void veh_interact::complete_vehicle( map &here, Character &you )
             std::vector<item_location> locs = put_into_vehicle_or_drop_ret_locs( you,
                                               item_drop_reason::deliberate,
                                               resulting_items );
+            if( should_make_furn ) {
+                here.furn_set( part_pos, furn_to_make );
+            }
             if( you.is_npc() ) {
                 for( const item_location &itl : locs ) {
                     you.may_activity_occupancy_after_end_items_loc.push_back( itl );

--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -275,6 +275,7 @@ void vpart_info::load( const JsonObject &jo, const std::string &src )
 
     assign( jo, "name", name_, strict );
     assign( jo, "item", base_item, strict );
+    assign( jo, "furniture", base_furn, strict );
     assign( jo, "remove_as", removed_item, strict );
     assign( jo, "location", location, strict );
     assign( jo, "durability", durability, strict );
@@ -894,6 +895,10 @@ void vpart_info::check() const
     }
     if( !item::type_is_defined( base_item ) ) {
         debugmsg( "vehicle part %s uses undefined item %s", id.str(), base_item.str() );
+    }
+
+    if( base_furn && !base_furn->is_valid() ) {
+        debugmsg( "vehicle part %s uses undefined furn %s", id.str(), base_furn->str() );
     }
 
     if( has_flag( "TURRET" ) && !base_item->gun ) {

--- a/src/veh_type.h
+++ b/src/veh_type.h
@@ -403,6 +403,9 @@ class vpart_info
         /** base item for this part */
         itype_id base_item;
 
+        /** base furniture for this part */
+        std::optional<furn_str_id> base_furn;
+
         /** item it should be removed as */
         std::optional<itype_id> removed_item;
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Currently we have items, we have furniture, we have appliances(actually just vehicles). We can convert between these entities in esoteric ways, some of the conversions are one way, and the more entity types we add to this pile the worse it gets.

This is patently AWFUL for support, it's bad for playing, and it's only gotten worse over time. Let's say you have a fridge. How can you put it into a vehicle? Well as an appliance, maybe into a bike rack? (Nope, we've specifically excluded that! Extra fun special casing!). Okay, as an item, maybe it fits into cargo spaces? Nope too large. Okay as a furniture? Well... yes, actually we do support that, I specifically wrote it.

But there is no reason to be able to pick a type to try and shove it in there, and there is no reason it should only work for some types. Supporting every single type is obviously wrong, so the answer is to specifically support one and get rid of the rest. 

Simple, easy, maintainable.

#### Describe the solution
This is the (currently, unfinished) first part of what is going to need to be an extensive amount of work. No more will appliances or furniture convert into items, except in *very specific, appropriate cases*. i.e. a folding table can fold into an item, because that is its explicit purpose. **A fridge will not become a fridge item, because that is absurd. There should not be a fridge item. Any fridge item.**

Appliances will convert from furniture, and furniture can convert to appliances. And that will be the only way to set up appliances.

#### Describe alternatives you've considered
Let's make terrain transform into appliances! We will surely not regret this.

#### Testing


#### Additional context

I would expect we have some gaps where we need work (e.g. can't take furniture/one-tile vehicles up stairs). But the answer to that is supporting those use cases. Instead of endless amounts of hacks. Reviewers should expect to see followup PRs which may or may not be mergeable/put in before this one. (It depends on which gets done first)

Known issues to solve:
-Migrating existing appliance constructions

-Figuring out what to do with existing appliance "items".

-Loading base_furn for vehicles needs more safety.

-Tons of JSON work >_<