### PR TITLE
Fix zzip_stack losing track of files after compaction.

### DIFF
--- a/src/zzip.cpp
+++ b/src/zzip.cpp
@@ -1151,6 +1151,11 @@ bool zzip::compact( double bloat_factor )
     return true;
 }
 
+bool zzip::clear()
+{
+    return file_->resize_file( 0 ) && rewrite_footer();
+}
+
 // Can't directly increment void*, have to cast to char* first.
 void *zzip::file_base_plus( size_t offset ) const
 {

--- a/src/zzip.h
+++ b/src/zzip.h
@@ -151,6 +151,12 @@ class zzip
         bool compact( double bloat_factor = 1.0 );
 
         /**
+         * Removes all contents and resets to a default initialized empty zzip.
+         * Returns true on success, false on error.
+         */
+        bool clear();
+
+        /**
          * Create a zzip from a folder of existing files.
          * The files in the zzip are indexed based on their relative path inside the folder.
          * See zzip::load for documentation about dictionaries.


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Noticed this logic error while doing some unrelated refactoring. After a compaction, the path to temp map will have the wrong temp value for the files that were compacted down. Fetching these compacted files later could result in retrieving an empty file because it would access the wrong internal zzip.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Set the correct temperatures during compaction after confirming the copy to the other zzip. Simplify the file handling by moving zzip truncation into an internal function on zzip instead of doing a delete-then-recreate (which is helpful for my other refactoring as well).
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
None yet because it's late and I need sleep.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
