### PR TITLE
Mission UI: Update how locations are displayed

### DIFF
--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -234,7 +234,7 @@ bool avatar::is_map_memory_valid() const
 
 bool avatar::should_show_map_memory() const
 {
-    if( get_timed_events().get( timed_event_type::OVERRIDE_PLACE ) ) {
+    if( !you_know_where_you_are() ) {
         return false;
     }
     return show_map_memory;

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -1232,11 +1232,7 @@ std::string display::colorized_overmap_text( const avatar &u, const int width, c
 
 std::string display::overmap_position_text( const tripoint_abs_omt &loc )
 {
-    point_abs_omt abs_omt = loc.xy();
-    point_abs_om om;
-    point_om_omt omt;
-    std::tie( om, omt ) = project_remain<coords::om>( abs_omt );
-    return string_format( _( "LEVEL %i, %d'%d, %d'%d" ), loc.z(), om.x(), omt.x(), om.y(), omt.y() );
+    return loc.to_string();
 }
 
 std::string display::current_position_text( const tripoint_abs_omt &loc )

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -2929,7 +2929,7 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
             if( !here.is_outside( player_character.pos_bub() ) ) {
                 uistate.overmap_visible_weather = false;
             }
-            if( !get_timed_events().get( timed_event_type::OVERRIDE_PLACE ) ) {
+            if( you_know_where_you_are() ) {
                 ui::omap::display();
             } else {
                 add_msg( m_info, _( "You have no idea where you are." ) );

--- a/src/timed_event.cpp
+++ b/src/timed_event.cpp
@@ -485,3 +485,8 @@ void timed_event_manager::set_all( const std::string &key, time_duration time_in
         }
     }
 }
+
+bool you_know_where_you_are()
+{
+    return !get_timed_events().get( timed_event_type::OVERRIDE_PLACE );
+}

--- a/src/timed_event.h
+++ b/src/timed_event.h
@@ -118,5 +118,6 @@ class timed_event_manager
 };
 
 timed_event_manager &get_timed_events();
+bool you_know_where_you_are();
 
 #endif // CATA_SRC_TIMED_EVENT_H


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Interface "Mission UI: Update how locations are displayed"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

* ~Show overmap coords in the mission UI using the same way we show them in the overmap UI.~ Edit: Show overmap coords in the map UI (`m`) using absolute coords. The map UI (`m`) and the mission UI (`M`) now display locations the same way.
* Display unicode arrow pointing to the mission target location
* Prevent exploit: Do not reveal your location by using the mission UI when "You have no idea where you are".
* Align mission UI labels and values.
* Fixes #82148 

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

<img width="549" height="572" alt="mission_ui_coords2" src="https://github.com/user-attachments/assets/401dc541-1d8c-4408-ae10-da04d13e7256" />

* Adds new function `mission_ui_impl::draw_location` that formats all omt coords in the mission ui. Used for NPC locations, mission targets, and POI locations. This new function reuses existing `display::overmap_position_text` to do the actual formatting.
* Uses `ImGui::SameLine` for aligning values according to label widths across several lines.
* Refactor "You have no idea where you are" (such as when reaching the lost level from the physics lab elevator) to new function `you_know_where_you_are`. Don't display "Distance:" or direction arrow if we don't know where we are
* Reuse existing function `direction_arrow` from `line.h` for adding a unicode arrow that points to locations in the mission ui.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

* There were some nice ideas in #82148 about formatting omt positions like real-world gps coordinates. If we want to go that route in the future, this change makes it easier to do so since we now reuse the same formatting function both in the overmap UI and in the mission UI.
* Considered using imgui tables for label-value alignment but decided not to because of old haunted memories of using html tables for layout back in the days.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

* See screenshot above.
* Also verified that going to the lost level from the physics department lab now no longer reveals your location in the mission ui.
* Also verified that POI locations are formatted this way.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
