### PR TITLE
Fix c-format in translation files

### DIFF
--- a/lang/string_extractor/parsers/addiction_type.py
+++ b/lang/string_extractor/parsers/addiction_type.py
@@ -14,6 +14,6 @@ def parse_addiction_type(json, origin):
                    .format(id))
 
     if "description" in json:
-        write_text(json["description"], origin, c_format=False,
+        write_text(json["description"], origin,
                    comment="Description of the \"{}\" addiction's effects as "
                    "it appears in the player's status".format(id))

--- a/lang/string_extractor/parsers/bionic.py
+++ b/lang/string_extractor/parsers/bionic.py
@@ -10,7 +10,7 @@ def parse_bionic(json, origin):
         write_text(json["name"], origin, comment="Name of a bionic")
 
     if "description" in json:
-        write_text(json["description"], origin, c_format=False,
+        write_text(json["description"], origin,
                    comment="Description of bionic \"{}\"".format(name))
 
     if "enchantments" in json:

--- a/lang/string_extractor/parsers/generic.py
+++ b/lang/string_extractor/parsers/generic.py
@@ -16,7 +16,7 @@ def parse_generic(json, origin):
     if "name" in json:
         name = get_singular_name(json["name"])
         write_text(json["name"], origin, comment=comment + ["Item name"],
-                   plural=True, c_format=False)
+                   plural=True)
     elif "id" in json:
         name = json["id"]
 
@@ -30,7 +30,7 @@ def parse_generic(json, origin):
             parse_magazine(json, origin)
 
     if "description" in json:
-        write_text(json["description"], origin, c_format=False,
+        write_text(json["description"], origin,
                    comment=comment + ["Description of \"{}\"".format(name)])
 
     if "use_action" in json:

--- a/lang/string_extractor/parsers/json_flag.py
+++ b/lang/string_extractor/parsers/json_flag.py
@@ -3,19 +3,19 @@ from ..write_text import write_text
 
 def parse_json_flag(json, origin):
     if "info" in json:
-        write_text(json["info"], origin, c_format=False, comment=[
+        write_text(json["info"], origin, comment=[
             "Please leave anything in <angle brackets> unchanged.",
             "Description of JSON flag \"{}\"".format(json["id"])
         ])
     if "restriction" in json:
-        write_text(json["restriction"], origin, c_format=False,
+        write_text(json["restriction"], origin,
                    comment="Description of restriction of JSON flag \"{}\""
                    .format(json["id"]))
     if "item_prefix" in json:
-        write_text(json["item_prefix"], origin, c_format=False,
+        write_text(json["item_prefix"], origin,
                    comment="This is custom prefix added to item name. \"{}\""
                    .format(json["id"]))
     if "item_suffix" in json:
-        write_text(json["item_suffix"], origin, c_format=False,
+        write_text(json["item_suffix"], origin,
                    comment="This is custom suffix added to item name. \"{}\""
                    .format(json["id"]))

--- a/lang/string_extractor/parsers/martial_art.py
+++ b/lang/string_extractor/parsers/martial_art.py
@@ -7,7 +7,7 @@ def parse_martial_art(json, origin):
     write_text(name, origin, comment="Name of martial art")
 
     if "description" in json:
-        write_text(json["description"], origin, c_format=False,
+        write_text(json["description"], origin,
                    comment="Description of martial art \"{}\"".format(name))
 
     if "initiate" in json:
@@ -39,6 +39,6 @@ def parse_martial_art(json, origin):
         buff_name = get_singular_name(buff["name"])
         write_text(buff_name, origin,
                    comment="Buff name of martial art \"{}\"".format(name))
-        write_text(buff["description"], origin, c_format=False,
+        write_text(buff["description"], origin,
                    comment="Description of buff \"{0}\" in martial art "
                            "\"{1}\"".format(name, buff_name))

--- a/lang/string_extractor/parsers/mod_info.py
+++ b/lang/string_extractor/parsers/mod_info.py
@@ -4,6 +4,6 @@ from ..write_text import write_text
 
 def parse_mod_info(json, origin):
     name = get_singular_name(json["name"])
-    write_text(json["name"], origin, comment="MOD name", c_format=False)
-    write_text(json["description"], origin, c_format=False,
+    write_text(json["name"], origin, comment="MOD name")
+    write_text(json["description"], origin,
                comment="Description of MOD \"{}\"".format(name))

--- a/lang/string_extractor/parsers/monster.py
+++ b/lang/string_extractor/parsers/monster.py
@@ -5,7 +5,7 @@ from .monster_attack import parse_monster_attack
 
 def parse_monster_concrete(json, origin, name):
     if "description" in json:
-        write_text(json["description"], origin, c_format=False,
+        write_text(json["description"], origin,
                    comment="Description of monster \"{}\"".format(name))
 
     if "death_function" in json:

--- a/lang/string_extractor/parsers/mutation.py
+++ b/lang/string_extractor/parsers/mutation.py
@@ -10,7 +10,7 @@ def parse_mutation(json, origin):
         write_text(json["name"], origin, comment="Mutation name")
 
     if "description" in json:
-        write_text(json["description"], origin, c_format=False,
+        write_text(json["description"], origin,
                    comment="Description of mutation \"{}\"".format(name))
 
     if "attacks" in json:

--- a/lang/string_extractor/parsers/option_slider.py
+++ b/lang/string_extractor/parsers/option_slider.py
@@ -5,7 +5,7 @@ from ..write_text import write_text
 def parse_option_slider(json, origin):
     name = get_singular_name(json["name"])
     write_text(json["name"], origin,
-               comment="Name of an option slider", c_format=False)
+               comment="Name of an option slider")
     if "levels" in json:
         for level in json["levels"]:
             if "name" in level:

--- a/lang/string_extractor/parsers/overmap_land_use_code.py
+++ b/lang/string_extractor/parsers/overmap_land_use_code.py
@@ -7,6 +7,6 @@ def parse_overmap_land_use_code(json, origin):
     if "name" in json:
         write_text(json["name"], origin,
                    comment="Name of an overmap land use code")
-    write_text(json["detailed_definition"], origin, c_format=False,
+    write_text(json["detailed_definition"], origin,
                comment="Detailed definition of overmap land use code \"{}\""
                .format(name))

--- a/lang/string_extractor/parsers/snippet.py
+++ b/lang/string_extractor/parsers/snippet.py
@@ -10,13 +10,10 @@ def parse_snippet(json, origin):
     comment_name = f"Name of a snippet in category \"{json['category']}\""
     comment_snip = append_comment([comment_snip], comment)
     comment_name = append_comment([comment_name], comment)
-    c_format = "schizophrenia" in json
     for snip in text:
         if type(snip) is str:
-            write_text(snip, origin, comment=comment_snip, c_format=c_format)
+            write_text(snip, origin, comment=comment_snip)
         elif type(snip) is dict:
             if "name" in snip:
-                write_text(snip["name"], origin, comment=comment_name,
-                           c_format=False)
-            write_text(snip["text"], origin, comment=comment_snip,
-                       c_format=c_format)
+                write_text(snip["name"], origin, comment=comment_name)
+            write_text(snip["text"], origin, comment=comment_snip)

--- a/lang/string_extractor/parsers/speech.py
+++ b/lang/string_extractor/parsers/speech.py
@@ -9,5 +9,5 @@ def parse_speech(json, origin):
         elif type(json["speaker"]) is str:
             speaker = json["speaker"]
     if "sound" in json:
-        write_text(json["sound"], origin, c_format=False,
+        write_text(json["sound"], origin,
                    comment="Speech from speaker {}".format(speaker))

--- a/lang/string_extractor/parsers/talk_topic.py
+++ b/lang/string_extractor/parsers/talk_topic.py
@@ -55,7 +55,7 @@ def parse_dynamic_line(json, origin, comment=[]):
 
     elif type(json) is dict:
         if "str" in json:
-            write_text(json, origin, comment=comment, c_format=False)
+            write_text(json, origin, comment=comment)
 
         if "gendered_line" in json:
             text = json["gendered_line"]
@@ -71,7 +71,7 @@ def parse_dynamic_line(json, origin, comment=[]):
             for context_list in itertools.product(*options):
                 context = " ".join(context_list)
                 write_text(text, origin, context=context,
-                           comment=gendered_comment, c_format=False)
+                           comment=gendered_comment)
 
         for key in dynamic_line_string_keys:
             if key in json:
@@ -79,22 +79,22 @@ def parse_dynamic_line(json, origin, comment=[]):
 
     elif type(json) is str:
         if not is_tag(json):
-            write_text(json, origin, comment=comment, c_format=False)
+            write_text(json, origin, comment=comment)
 
 
 def parse_response(json, origin):
     if "text" in json:
-        write_text(json["text"], origin, c_format=False,
+        write_text(json["text"], origin,
                    comment="Response to NPC dialogue")
 
     if "truefalsetext" in json:
-        write_text(json["truefalsetext"]["true"], origin, c_format=False,
+        write_text(json["truefalsetext"]["true"], origin,
                    comment="Affirmative response to NPC dialogue")
-        write_text(json["truefalsetext"]["false"], origin, c_format=False,
+        write_text(json["truefalsetext"]["false"], origin,
                    comment="Negative response to NPC dialogue")
 
     if "failure_explanation" in json:
-        write_text(json["failure_explanation"], origin, c_format=False,
+        write_text(json["failure_explanation"], origin,
                    comment="Failure explanation for NPC dialogue response")
 
     if "success" in json:

--- a/lang/string_extractor/parsers/technique.py
+++ b/lang/string_extractor/parsers/technique.py
@@ -9,7 +9,7 @@ def parse_technique(json, origin):
         write_text(json["name"], origin, comment="Martial technique name")
 
     if "description" in json:
-        write_text(json["description"], origin, c_format=False,
+        write_text(json["description"], origin,
                    comment="Description of martial technique \"{}\""
                    .format(name))
 
@@ -18,6 +18,6 @@ def parse_technique(json, origin):
                    comment="Message of martial technique \"{}\"".format(name))
 
     if "condition_desc" in json:
-        write_text(json["condition_desc"], origin, c_format=False,
+        write_text(json["condition_desc"], origin,
                    comment="Condition description of martial technique \"{}\""
                    .format(name))

--- a/lang/string_extractor/write_text.py
+++ b/lang/string_extractor/write_text.py
@@ -1,3 +1,5 @@
+import re
+
 from .message import Message, messages, occurrences
 
 
@@ -11,8 +13,7 @@ def append_comment(comments, new_comment):
         return comments
 
 
-def write_text(json, origin, context="", comment="",
-               plural=False, c_format=True):
+def write_text(json, origin, context="", comment="", plural=False):
     """
     Record a text for translation.
 
@@ -22,7 +23,6 @@ def write_text(json, origin, context="", comment="",
         context (str): "context" as in GNU gettext
         comment: Translation comments in either string form or list of strings
         plural (bool): Whether the text should be pluralized
-        c_format (bool): Whether the text contains C-style format string
         explicit_plural (bool): Whether the plural is specified
                                 explicitly in JSON
     """
@@ -61,12 +61,9 @@ def write_text(json, origin, context="", comment="",
     if not text or "NO_I18N" in comments:
         return
 
-    format_tag = ""
-    if "%" in text:
-        if c_format:
-            format_tag = "c-format"
-        else:
-            format_tag = "no-c-format"
+    format_tag = None
+    if re.search(r"%\w", text):
+        format_tag = "c-format"
 
     if (context, text) not in messages:
         messages[(context, text)] = list()
@@ -79,11 +76,11 @@ def write_text(json, origin, context="", comment="",
 
 # Used in parse_effect and parse_condition
 def write_translation_or_var(json, origin, context="", comment="",
-                             plural=False, c_format=True):
+                             plural=False):
     if type(json) is dict and "default_str" in json:
         write_text(json["default_str"], origin, context=context,
                    comment="default value for {}".format(comment),
-                   plural=plural, c_format=c_format)
+                   plural=plural)
     else:
         write_text(json, origin, context=context, comment=comment,
-                   plural=plural, c_format=c_format)
+                   plural=plural)

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -5548,6 +5548,7 @@ void item::melee_combat_info( std::vector<iteminfo> &info, const iteminfo_query 
             info.emplace_back( "BASE", ( stam_pct ? _( "about " ) : _( "less than " ) ), "",
                                iteminfo::no_newline | iteminfo::is_decimal | iteminfo::lower_is_better,
                                ( stam_pct > 0.1 ? stam_pct : 0.1 ) );
+            // xgettext:no-c-format
             info.emplace_back( "BASE", _( "% stamina to swing." ), "" );
         }
 

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -4229,6 +4229,7 @@ void target_ui::panel_spell_info( int &text_y )
 
     std::string fail_str;
     if( no_fail ) {
+        // xgettext:no-c-format
         fail_str = colorize( _( "0.0 % Failure Chance" ), c_light_green );
     } else {
         fail_str = casting->colorized_fail_percent( *you );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
I18N "Fix c-format in translation files"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Strings in translation files may have the `c-format` and `no-c-format` flags. These flags indicate the presence of placeholders (`%s`) in с-strings and help with msgfmt checks. These flags were placed per each string category, which is often incorrect, leading to many false positives. For example, the msgfmt considers a percent sign in a regular string to be an error.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
1. Replace explicit flag assignment with placeholder search in string.
2. `no-c-format` flag is no longer added to all strings with percent sign.
3. Add `no-c-format` to a couple of string in src/.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Also assign `no-c-format` flag to all strings with a percent sign, but that should be redundant.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Translation files can be updated and compiled successfully.

<details><summary>Here are all the warnings (line numbers may be out of date)</summary>
<p>

```sh
> for i in *.po; do msgfmt --statistics -c -v -o /dev/null ${i}; done;

es_AR.po:33: nplurals = 3...
es_AR.po:1305: ...but some messages have only 2 plural forms
msgfmt: found 1 fatal error
es_AR.po: 76987 translated messages, 28587 untranslated messages.

fr.po:59: nplurals = 3...
fr.po:35317: ...but some messages have only 2 plural forms
fr.po:5160: number of format specifications in 'msgid' and 'msgstr' does not match
fr.po:632266: number of format specifications in 'msgid' and 'msgstr' does not match
msgfmt: found 3 fatal errors
fr.po: 69286 translated messages, 36288 untranslated messages.

id.po:986: format specifications in 'msgid' and 'msgstr' for argument 1 are not the same
msgfmt: found 1 fatal error
id.po: 1310 translated messages, 104264 untranslated messages.

ja.po:636: format specifications in 'msgid' and 'msgstr' for argument 1 are not the same
ja.po:641: format specifications in 'msgid' and 'msgstr' for argument 1 are not the same
ja.po:29387: format specifications in 'msgid' and 'msgstr' for argument 1 are not the same
ja.po:31667: format specifications in 'msgid' and 'msgstr' for argument 2 are not the same
ja.po:51358: format specifications in 'msgid' and 'msgstr' for argument 1 are not the same
ja.po:614503: 'msgstr' is not a valid C format string, unlike 'msgid'. Reason: The character that terminates the directive number 2 is not a valid conversion specifier.
ja.po:614509: 'msgstr' is not a valid C format string, unlike 'msgid'. Reason: The character that terminates the directive number 2 is not a valid conversion specifier.
ja.po:631253: number of format specifications in 'msgid' and 'msgstr' does not match
msgfmt: found 8 fatal errors
ja.po: 104721 translated messages, 853 untranslated messages.

ko.po:576: format specifications in 'msgid' and 'msgstr' for argument 1 are not the same
msgfmt: found 1 fatal error
ko.po: 49386 translated messages, 56188 untranslated messages.

pl.po:36: nplurals = 4...
pl.po:1296: ...but some messages have only one plural form
msgfmt: found 1 fatal error
pl.po: 52750 translated messages, 52824 untranslated messages.

pt_BR.po:101: nplurals = 3...
pt_BR.po:1372: ...but some messages have only 2 plural forms
msgfmt: found 1 fatal error
pt_BR.po: 40729 translated messages, 64845 untranslated messages.

zh_CN.po:31458: format specifications in 'msgid' and 'msgstr' for argument 2 are not the same
zh_CN.po:597147: number of format specifications in 'msgid' and 'msgstr' does not match
zh_CN.po:597153: number of format specifications in 'msgid' and 'msgstr' does not match
zh_CN.po:613256: number of format specifications in 'msgid' and 'msgstr' does not match
msgfmt: found 4 fatal errors
zh_CN.po: 105393 translated messages, 181 untranslated messages.

zh_TW.po:4963: 'msgstr' is not a valid C format string, unlike 'msgid'. Reason: The character that terminates the directive number 2 is not a valid conversion specifier.
zh_TW.po:31394: format specifications in 'msgid' and 'msgstr' for argument 2 are not the same
zh_TW.po:598627: number of format specifications in 'msgid' and 'msgstr' does not match
zh_TW.po:598633: number of format specifications in 'msgid' and 'msgstr' does not match
zh_TW.po:615222: number of format specifications in 'msgid' and 'msgstr' does not match
msgfmt: found 5 fatal errors
zh_TW.po: 105393 translated messages, 181 untranslated messages.
```

</p>
</details> 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
msgfmt also found a few strings that use a bit of a cursed syntax, where a variable number of placeholders are used. I don't know if this can cause any troubles.

<details><summary>Details</summary>
<p>

```
#: src/mattack_actors.cpp:1173
msgid "Pointed in your direction, the %s emits an IFF warning beep."
msgid_plural "Pointed in your direction, the %s emits %d annoyed sounding beeps."

#: src/turret.cpp:654
msgid "%s points in your direction and emits an IFF warning beep."
msgid_plural "%s points in your direction and emits %d annoyed sounding beeps."

#: src/turret.cpp:659
msgid "You hear a warning beep."
msgid_plural "You hear %d annoyed sounding beeps."
```

</p>
</details> 
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
