### PR TITLE
[Magiclysm] Regularize goblin and lizardfolk attack techniques

### DIFF
--- a/data/mods/Magiclysm/mutations/mutation_paths/fantasy_species.json
+++ b/data/mods/Magiclysm/mutations/mutation_paths/fantasy_species.json
@@ -655,6 +655,7 @@
     "category": [ "SPECIES_LIZARDFOLK" ],
     "enchantments": [
       { "condition": { "u_has_trait": "SLIT_NOSTRILS" }, "encumbrance_modifier": [ { "part": "mouth", "add": -10 } ] },
+      { "condition": { "u_has_trait": "SCALES" }, "encumbrance_modifier": [ { "part": "mouth", "add": -1 } ] },
       {
         "values": [
           { "value": "MOVECOST_SWIM_MOD", "multiply": -0.1 },

--- a/data/mods/Magiclysm/mutations/mutation_paths/fantasy_species.json
+++ b/data/mods/Magiclysm/mutations/mutation_paths/fantasy_species.json
@@ -654,6 +654,7 @@
     "description": "Lizardfolk are taller and stronger than humans but not much thicker and are surprisingly fast for their size (+1 STR, +1 DEX).",
     "category": [ "SPECIES_LIZARDFOLK" ],
     "enchantments": [
+      { "condition": { "u_has_trait": "SLIT_NOSTRILS" }, "encumbrance_modifier": [ { "part": "mouth", "add": -10 } ] },
       {
         "values": [
           { "value": "MOVECOST_SWIM_MOD", "multiply": -0.1 },

--- a/data/mods/Magiclysm/mutations/mutation_paths/fantasy_species.json
+++ b/data/mods/Magiclysm/mutations/mutation_paths/fantasy_species.json
@@ -755,7 +755,7 @@
     "ugliness": 8,
     "mixed_effect": true,
     "description": "Your face and jaws are those of a predatory lizard, with a set of sharp teeth to go with them.  They look NASTY--as do the bite wounds they can inflict--but prevent wearing mouthgear.",
-    "types": [ "MUZZLE" ],
+    "types": [ "TEETH" ],
     "prereqs": [ "SNOUT" ],
     "restricts_gear": [ "mouth" ],
     "social_modifiers": { "intimidate": 10 },

--- a/data/mods/Magiclysm/techniques_fantasy_species.json
+++ b/data/mods/Magiclysm/techniques_fantasy_species.json
@@ -27,7 +27,7 @@
     "messages": [ "You bite %s", "<npcname> bites %s" ],
     "description": "Bite someone with a goblin's naturally-sharp teeth.",
     "unarmed_allowed": true,
-    "weighting": -2,
+    "weighting": 1,
     "reach_ok": false,
     "attack_vectors": [ "vector_bite" ],
     "condition": { "and": [ { "npc_has_flag": "GRAB_FILTER" }, { "u_has_flag": "GRAB" } ] },

--- a/data/mods/Magiclysm/techniques_fantasy_species.json
+++ b/data/mods/Magiclysm/techniques_fantasy_species.json
@@ -11,11 +11,10 @@
     "reach_ok": false,
     "attack_vectors": [ "vector_bite" ],
     "condition": { "and": [ { "not": { "npc_has_flag": "GRAB_FILTER" } }, { "not": { "u_has_effect": "GRAB" } } ] },
-    "//": "The bonuses below are based on the natural anatomy of a non-human creature and should not be used for mutant attack scaling.",
     "flat_bonuses": [
-      { "stat": "damage", "type": "stab", "scaling-stat": "unarmed", "scale": 1.1 },
-      { "stat": "damage", "type": "bash", "scaling-stat": "str", "scale": 0.8 },
-      { "stat": "damage", "type": "bash", "scaling-stat": "unarmed", "scale": 0.065 },
+      { "stat": "damage", "type": "cut", "scaling-stat": "unarmed", "scale": 1.0 },
+      { "stat": "damage", "type": "bash", "scaling-stat": "str", "scale": 0.75 },
+      { "stat": "damage", "type": "bash", "scaling-stat": "unarmed", "scale": 0.06 },
       { "stat": "movecost", "scaling-stat": "melee", "scale": -1.25 },
       { "stat": "movecost", "scaling-stat": "dex", "scale": -0.5 }
     ]
@@ -32,11 +31,10 @@
     "reach_ok": false,
     "attack_vectors": [ "vector_bite" ],
     "condition": { "and": [ { "npc_has_flag": "GRAB_FILTER" }, { "u_has_flag": "GRAB" } ] },
-    "//": "The bonuses below are based on the natural anatomy of a non-human creature and should not be used for mutant attack scaling.",
     "flat_bonuses": [
-      { "stat": "damage", "type": "stab", "scaling-stat": "unarmed", "scale": 1.1 },
-      { "stat": "damage", "type": "bash", "scaling-stat": "str", "scale": 0.8 },
-      { "stat": "damage", "type": "bash", "scaling-stat": "unarmed", "scale": 0.065 },
+      { "stat": "damage", "type": "cut", "scaling-stat": "unarmed", "scale": 1.0 },
+      { "stat": "damage", "type": "bash", "scaling-stat": "str", "scale": 0.75 },
+      { "stat": "damage", "type": "bash", "scaling-stat": "unarmed", "scale": 0.06 },
       { "stat": "movecost", "scaling-stat": "melee", "scale": -1.25 },
       { "stat": "movecost", "scaling-stat": "dex", "scale": -0.5 }
     ]
@@ -69,14 +67,13 @@
     "messages": [ "You bite %s", "<npcname> bites %s" ],
     "description": "Bite someone with a lizardfolk's naturally-sharp teeth.",
     "unarmed_allowed": true,
-    "weighting": -2,
+    "weighting": -1,
     "reach_ok": false,
     "attack_vectors": [ "vector_bite" ],
-    "//": "The bonuses below are based on the natural anatomy of a non-human creature and should not be used for mutant attack scaling.",
     "flat_bonuses": [
-      { "stat": "damage", "type": "stab", "scaling-stat": "unarmed", "scale": 1.1 },
-      { "stat": "damage", "type": "bash", "scaling-stat": "str", "scale": 0.8 },
-      { "stat": "damage", "type": "bash", "scaling-stat": "unarmed", "scale": 0.065 },
+      { "stat": "damage", "type": "cut", "scaling-stat": "unarmed", "scale": 1.0 },
+      { "stat": "damage", "type": "bash", "scaling-stat": "str", "scale": 0.75 },
+      { "stat": "damage", "type": "bash", "scaling-stat": "unarmed", "scale": 0.06 },
       { "stat": "movecost", "scaling-stat": "melee", "scale": -1.25 },
       { "stat": "movecost", "scaling-stat": "dex", "scale": -0.5 }
     ]
@@ -93,7 +90,6 @@
     "crit_tec": true,
     "attack_vectors": [ "vector_bite" ],
     "condition": { "and": [ { "not": { "npc_has_flag": "GRAB_FILTER" } }, { "not": { "u_has_effect": "GRAB" } } ] },
-    "//": "The bonuses below are based on the natural anatomy of a non-human creature and should not be used for mutant attack scaling.",
     "flat_bonuses": [
       { "stat": "damage", "type": "stab", "scaling-stat": "unarmed", "scale": 4.4 },
       { "stat": "damage", "type": "bash", "scaling-stat": "str", "scale": 0.75 },

--- a/data/mods/Magiclysm/techniques_fantasy_species.json
+++ b/data/mods/Magiclysm/techniques_fantasy_species.json
@@ -85,7 +85,7 @@
     "melee_allowed": true,
     "messages": [ "You viciously tear into %s", "<npcname> viciously tears %s" ],
     "unarmed_allowed": true,
-    "weighting": -2,
+    "weighting": 1,
     "reach_ok": false,
     "crit_tec": true,
     "attack_vectors": [ "vector_bite" ],


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[Magiclysm] Regularize goblin and lizardfolk attack techniques"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

When I made the goblin and lizardfolk bite/claw techniques, I put them on a slightly higher scaling level than mutation techniques because I thought that since they were purely natural attacks from creatures that were never human, they'd have a better mastery of their natural weapons. Since then, though, I gave werewolves the same scaling on their attacks as mutants get, so let's just make that the standard.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Slightly lower the scaling on the techniques and up their weight.

Counteract `SLIT_NOSTRILS` and `SCALES` mouth encumbrance to enable their bite attack again for lizardfolk.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Techniques still work but see below.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Found #82536 while working on this, that's why lizardfolk (and I assume raptor and lizard mutants) don't bite. I'm not sure what a good general solution for that problem is.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
