### PR TITLE
Makeshift metalworking tongs

### DIFF
--- a/data/json/items/tool/metalworking.json
+++ b/data/json/items/tool/metalworking.json
@@ -473,7 +473,7 @@
     "use_action": [ "HEAT_SOLID_ITEMS" ],
     "flags": [ "BELT_CLIP", "ALLOWS_REMOTE_USE" ],
     "to_hit": { "grip": "solid", "length": "short", "surface": "any", "balance": "uneven" },
-    "melee_damage": { "bash": 9 }
+    "melee_damage": { "bash": 6 }
   },
   {
     "id": "sandpaper",

--- a/data/json/items/tool/metalworking.json
+++ b/data/json/items/tool/metalworking.json
@@ -456,6 +456,26 @@
     "//": "Based on https://www.amazon.com/dp/B0BGPJ5HQD"
   },
   {
+    "id": "makeshift_metalworking_tongs",
+    "type": "ITEM",
+    "subtypes": [ "TOOL" ],
+    "name": { "str_sp": "makeshift metalworking tongs" },
+    "description": "A pair of locking pliers whose handles are extended with pipes and small sheets of metal welded onto the gripping sides of the pliers for a larger gripping area, making a rather makeshift albeit adequate metalworking tongs.",
+    "weight": "730 g",
+    "volume": "662 ml",
+    "longest_side": "44 cm",
+    "price": "12 USD",
+    "price_postapoc": "1 USD",
+    "material": [ "mc_steel" ],
+    "symbol": ";",
+    "color": "light_gray",
+    "qualities": [ [ "COOK", 1 ] ],
+    "use_action": [ "HEAT_SOLID_ITEMS" ],
+    "flags": [ "BELT_CLIP", "ALLOWS_REMOTE_USE" ],
+    "to_hit": { "grip": "solid", "length": "short", "surface": "any", "balance": "uneven" },
+    "melee_damage": { "bash": 9 }
+  },
+  {
     "id": "sandpaper",
     "type": "ITEM",
     "subtypes": [ "TOOL" ],

--- a/data/json/recipes/tools/tools_hand.json
+++ b/data/json/recipes/tools/tools_hand.json
@@ -185,6 +185,31 @@
   },
   {
     "type": "recipe",
+    "activity_level": "MODERATE_EXERCISE",
+    "result": "makeshift_metalworking_tongs",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_TOOLS",
+    "skill_used": "fabrication",
+    "difficulty": 3,
+    "time": "30 m",
+    "autolearn": true,
+    "proficiencies": [ { "proficiency": "prof_metalworking" }, { "proficiency": "prof_welding_basic" }, { "proficiency": "prof_welding" } ],
+    "using": [ [ "welding_standard", 60 ] ],
+    "qualities": [ { "id": "SAW_M", "level": 1 }, { "id": "HAMMER", "level": 3 } ],
+    "components": [
+      [ [ "pliers_locking", 1 ] ],
+      [ [ "pipe", 2 ] ],
+      [
+        [ "sheet_metal_small", 2 ],
+        [ "hc_sheet_metal_small", 2 ],
+        [ "qt_sheet_metal_small", 2 ],
+        [ "ch_sheet_metal_small", 2 ],
+        [ "mc_sheet_metal_small", 2 ]
+      ]
+    ]
+  },
+  {
+    "type": "recipe",
     "activity_level": "BRISK_EXERCISE",
     "result": "chisel",
     "category": "CC_OTHER",

--- a/data/json/requirements/toolsets.json
+++ b/data/json/requirements/toolsets.json
@@ -514,7 +514,7 @@
   {
     "id": "metalworking_tongs_any",
     "type": "requirement",
-    "tools": [ [ [ "metalworking_tongs", -1 ], [ "metalworking_tongs_bronze", -1 ] ] ]
+    "tools": [ [ [ "metalworking_tongs", -1 ], [ "metalworking_tongs_bronze", -1 ], [ "makeshift_metalworking_tongs", -1 ] ] ]
   },
   {
     "id": "metal_file_any",


### PR DESCRIPTION

#### Summary
None

#### Purpose of change
I've been told that locking pliers could work as a metalworking tongs with some modifications, so i added it.

#### Describe the solution
Adds the item, the recipe to craft it, and put in the `metalworking_tongs_any` crafting requirements.

#### Describe alternatives you've considered

Not doing so?

#### Testing
![Screenshot_20250822_033402](https://github.com/user-attachments/assets/775829dc-444a-4384-8fff-1a9e64044a4c)
![Screenshot_20250822_031344](https://github.com/user-attachments/assets/0070a6b5-631d-42d9-8d90-8d26658e2d18)


#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
