### PR TITLE
[XEDRA Evolved] Devariant gossamer dress

### DIFF
--- a/data/mods/Xedra_Evolved/items/clothes.json
+++ b/data/mods/Xedra_Evolved/items/clothes.json
@@ -178,7 +178,8 @@
     "proportional": { "weight": 0.6666, "price": 2 },
     "color": "white",
     "material": [ "fae_cotton" ],
-    "armor": [ { "encumbrance": 5, "coverage": 85, "covers": [ "torso", "leg_l", "leg_r" ] } ]
+    "armor": [ { "encumbrance": 5, "coverage": 85, "covers": [ "torso", "leg_l", "leg_r" ] } ],
+    "variants": [  ]
   },
   {
     "id": "gown_gossamer",
@@ -190,7 +191,8 @@
     "proportional": { "weight": 0.6666, "price": 2 },
     "color": "white",
     "material": [ "fae_cotton" ],
-    "armor": [ { "encumbrance": 9, "coverage": 75, "covers": [ "torso", "leg_l", "leg_r" ] } ]
+    "armor": [ { "encumbrance": 9, "coverage": 75, "covers": [ "torso", "leg_l", "leg_r" ] } ],
+    "variants": [  ]
   },
   {
     "id": "cloak_gossamer",


### PR DESCRIPTION

#### Summary
None



#### Purpose of change
While i was testing long dress sprite, i notice theres a buncha of the same long dresses, which i found out that it came from gossamer dress in XE. so i fix that.

#### Describe the solution

Devariant the gossamer dress

#### Describe alternatives you've considered

Give it their own variants instead? sounds like something that needs to ask mal about later.

#### Testing
Before
![Screenshot_20250822_192137](https://github.com/user-attachments/assets/5a2e4445-e4c3-4105-8b6b-0fe86946e5ac)

After
![Screenshot_20250822_192417](https://github.com/user-attachments/assets/5cf7c004-7a47-4989-b5f2-1e2706228067)



#### Additional context

there might be some other gosammer thing that have variants it supposed to not have, but that's future problem.


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
