### PR TITLE
Allow `extend/delete` for non-container types with optional

### DIFF
--- a/data/json/monsters/insect_spider.json
+++ b/data/json/monsters/insect_spider.json
@@ -206,7 +206,7 @@
     "dissect": "dissect_troglobite_sample_single",
     "upgrades": { "age_grow": 30, "into": "mon_worm" },
     "extend": { "flags": [ "DIGS", "GOODHEARING", "SMALL_HIDER" ] },
-    "delete": { "flags": [ "SEES", "SMELLS" ], "move_skills": { "climb": 4 } }
+    "delete": { "flags": [ "SEES", "SMELLS" ], "move_skills": { "climb": 2 } }
   },
   {
     "id": "mon_large_cockroach",

--- a/data/json/monsters/mollusk.json
+++ b/data/json/monsters/mollusk.json
@@ -87,7 +87,7 @@
     "color": "brown",
     "harvest": "mutant_mollusk",
     "upgrades": { "age_grow": 30, "into": "mon_snail_small" },
-    "delete": { "move_skills": { "climb": 6 } }
+    "delete": { "move_skills": { "climb": 2 } }
   },
   {
     "id": "mon_snail_giant",
@@ -186,7 +186,7 @@
     "color": "brown",
     "harvest": "mutant_mollusk",
     "upgrades": { "age_grow": 30, "into": "mon_slug_small" },
-    "delete": { "flags": [ "HEARS" ], "move_skills": { "climb": 6 } }
+    "delete": { "flags": [ "HEARS" ], "move_skills": { "climb": 2 } }
   },
   {
     "id": "mon_slug_giant",

--- a/doc/JSON/MONSTERS.md
+++ b/doc/JSON/MONSTERS.md
@@ -754,9 +754,9 @@ Field                | Description
 
 Field                | Description
 ---                  | ---
-`swim`               | (int, 0-10,optional) swimming monsters ignore SWIMMABLE terrain-cost. Instead it applies a flat movecost penalty inversly related to the skill.
-`dig`                | (int, 0-10, optional) swimming monsters ignore DIGGABLE terrain-cost. Instead it applies a flat movecost penalty inversly related to the skill.
-`climb`              | (int, 0-10, optional) climbing monsters can climb CLIMBABLE ter/furn and can use DIFFICULT_Z ter/furn (i.e. ladders). The ter/furn cost gets multiplied by the skill modifier
+`swim`               | (int or null, 0-10,optional) swimming monsters ignore SWIMMABLE terrain-cost. Instead it applies a flat movecost penalty inversly related to the skill.
+`dig`                | (int or null, 0-10, optional) swimming monsters ignore DIGGABLE terrain-cost. Instead it applies a flat movecost penalty inversly related to the skill.
+`climb`              | (int or null, 0-10, optional) climbing monsters can climb CLIMBABLE ter/furn and can use DIFFICULT_Z ter/furn (i.e. ladders). The ter/furn cost gets multiplied by the skill modifier
 
 
 ## "special_attacks"

--- a/src/generic_factory.h
+++ b/src/generic_factory.h
@@ -722,6 +722,18 @@ template<typename T>
 struct supports_relative < T, std::void_t < decltype( std::declval<T &>() += std::declval<T &>() )
 >> : std::true_type {};
 
+template<typename T, typename = void>
+struct supports_extend_handler : std::false_type {};
+
+template<typename T>
+struct supports_extend_handler<T, std::void_t<decltype( &T::handle_extend )>> : std::true_type {};
+
+template<typename T, typename = void>
+struct supports_delete_handler : std::false_type {};
+
+template<typename T>
+struct supports_delete_handler<T, std::void_t<decltype( &T::handle_delete )>> : std::true_type {};
+
 // Explicitly specialize these templates for a couple types
 // So the compiler does not attempt to use a template that it should not
 template<>
@@ -885,6 +897,44 @@ inline bool handle_relative( const JsonObject &jo, const std::string_view name, 
     return false;
 }
 
+template<typename MemberType>
+void handle_extend( const JsonObject &jo, const std::string_view name, MemberType &member )
+{
+    if constexpr( supports_extend_handler<MemberType>::value ) {
+        if( jo.has_object( "extend" ) ) {
+            JsonObject tmp = jo.get_object( "extend" );
+            tmp.allow_omitted_members();
+            if( tmp.has_member( name ) ) {
+                member.handle_extend( tmp.get_member( name ) );
+            }
+        }
+    } else {
+        // the most common reason to see this is because you're trying to use this feature on
+        // something that is in a container, but is not using a reader.
+        // If the type is not in a container, it should implement a handle_feature function
+        warn_disabled_feature( jo, "extend", name, "does not use reader" );
+    }
+}
+
+template<typename MemberType>
+void handle_delete( const JsonObject &jo, const std::string_view name, MemberType &member )
+{
+    if constexpr( supports_delete_handler<MemberType>::value ) {
+        if( jo.has_object( "delete" ) ) {
+            JsonObject tmp = jo.get_object( "delete" );
+            tmp.allow_omitted_members();
+            if( tmp.has_member( name ) ) {
+                member.handle_delete( tmp.get_member( name ) );
+            }
+        }
+    } else {
+        // the most common reason to see this is because you're trying to use this feature on
+        // something that is in a container, but is not using a reader.
+        // If the type is not in a container, it should implement a handle_feature function
+        warn_disabled_feature( jo, "delete", name, "does not use reader" );
+    }
+}
+
 // No template magic here, yay!
 template<typename MemberType>
 inline void optional( const JsonObject &jo, const bool was_loaded, const std::string_view name,
@@ -893,6 +943,8 @@ inline void optional( const JsonObject &jo, const bool was_loaded, const std::st
     if( !was_loaded ) {
         warn_disabled_feature( jo, "relative", name, "no copy-from" );
         warn_disabled_feature( jo, "proportional", name, "no copy-from" );
+        warn_disabled_feature( jo, "extend", name, "no copy-from" );
+        warn_disabled_feature( jo, "delete", name, "no copy-from" );
     }
     if( !jo.read( name, member ) && !handle_proportional( jo, name, member ) &&
         !handle_relative( jo, name, member ) ) {
@@ -900,8 +952,8 @@ inline void optional( const JsonObject &jo, const bool was_loaded, const std::st
             member = MemberType();
         }
     }
-    warn_disabled_feature( jo, "extend", name, "does not use reader" );
-    warn_disabled_feature( jo, "delete", name, "does not use reader" );
+    handle_extend( jo, name, member );
+    handle_delete( jo, name, member );
 }
 /*
 Template trickery, not for the faint of heart. It is required because there are two functions
@@ -921,6 +973,8 @@ template<typename MemberType, typename DefaultType = MemberType,
     if( !was_loaded ) {
         warn_disabled_feature( jo, "relative", name, "no copy-from" );
         warn_disabled_feature( jo, "proportional", name, "no copy-from" );
+        warn_disabled_feature( jo, "extend", name, "no copy-from" );
+        warn_disabled_feature( jo, "delete", name, "no copy-from" );
     }
     if( !jo.read( name, member ) && !handle_proportional( jo, name, member ) &&
         !handle_relative( jo, name, member ) ) {
@@ -928,8 +982,8 @@ template<typename MemberType, typename DefaultType = MemberType,
             member = default_value;
         }
     }
-    warn_disabled_feature( jo, "extend", name, "does not use reader" );
-    warn_disabled_feature( jo, "delete", name, "does not use reader" );
+    handle_extend( jo, name, member );
+    handle_delete( jo, name, member );
 }
 template < typename MemberType, typename ReaderType, typename DefaultType = MemberType,
            typename = std::enable_if_t <
@@ -1285,6 +1339,18 @@ struct handler<std::unordered_map<Key, Val>> {
 };
 } // namespace reader_detail
 
+template<typename T, typename = void>
+struct T_has_do_extend : std::false_type {};
+
+template<typename T>
+struct T_has_do_extend<T, std::void_t<decltype( &T::do_extend )>> : std::true_type {};
+
+template<typename T, typename = void>
+struct T_has_do_delete : std::false_type {};
+
+template<typename T>
+struct T_has_do_delete<T, std::void_t<decltype( &T::do_delete )>> : std::true_type {};
+
 /**
  * Base class for reading generic objects from JSON.
  * It can load members being certain containers or being a single value.
@@ -1500,6 +1566,37 @@ public:
         return false;
     }
 
+    // These functions enable readers for non-container types to implement extend/delete functions
+    template<typename T>
+    bool do_extend( const JsonObject &jo, const std::string_view name, T &member ) const {
+        if( !jo.has_member( name ) ) {
+            return false;
+        }
+        if constexpr( T_has_do_extend<Derived>::value ) {
+            const Derived &derived = static_cast<const Derived &>( *this );
+            return derived.do_extend( jo, name, member );
+        } else {
+            jo.throw_error( string_format( "%s (reader %s) does not support extend outside of a container",
+                                           name, demangle( typeid( Derived ).name() ) ) );
+        }
+        return false;
+    }
+
+    template<typename T>
+    bool do_delete( const JsonObject &jo, const std::string_view name, T &member ) const {
+        if( !jo.has_member( name ) ) {
+            return false;
+        }
+        if constexpr( T_has_do_delete<Derived>::value ) {
+            const Derived &derived = static_cast<const Derived &>( *this );
+            return derived.do_delete( jo, name, member );
+        } else {
+            jo.throw_error( string_format( "%s (reader %s) does not support delete outside of a container",
+                                           name, demangle( typeid( Derived ).name() ) ) );
+        }
+        return false;
+    }
+
     template<typename C>
     bool read_normal( const JsonObject &jo, const std::string_view name, C &member ) const {
         if( jo.has_member( name ) ) {
@@ -1521,11 +1618,21 @@ public:
                      C &member, bool was_loaded ) const {
         const Derived &derived = static_cast<const Derived &>( *this );
         // or no handler for the container
-        warn_disabled_feature( jo, "extend", member_name, "not container" );
-        warn_disabled_feature( jo, "delete", member_name, "not container" );
         if( !was_loaded ) {
+            warn_disabled_feature( jo, "extend", member_name, "no copy-from" );
+            warn_disabled_feature( jo, "delete", member_name, "no copy-from" );
             warn_disabled_feature( jo, "relative", member_name, "no copy-from" );
             warn_disabled_feature( jo, "proportional", member_name, "no copy-from" );
+        }
+        if( jo.has_object( "extend" ) ) {
+            JsonObject tmp = jo.get_object( "extend" );
+            tmp.allow_omitted_members();
+            do_extend( tmp, member_name, member );
+        }
+        if( jo.has_object( "delete" ) ) {
+            JsonObject tmp = jo.get_object( "delete" );
+            tmp.allow_omitted_members();
+            do_delete( tmp, member_name, member );
         }
         return derived.read_normal( jo, member_name, member ) ||
                // not every reader handles proportional
@@ -1553,6 +1660,32 @@ public:
             jv.throw_error( string_format( "Couldn't read %s", demangle( typeid( T ).name() ) ) );
         }
         return ret;
+    }
+
+    bool do_extend( const JsonObject &jo, const std::string_view name, T &member ) const {
+        if( !jo.has_member( name ) ) {
+            return false;
+        }
+        if constexpr( supports_extend_handler<T>::value ) {
+            return member.handle_extend( jo.get_member( name ) );
+        } else {
+            jo.throw_error( string_format( "%s (type %s) does not implement handle_extend", name,
+                                           demangle( typeid( T ).name() ) ) );
+        }
+        return false;
+    }
+
+    bool do_delete( const JsonObject &jo, const std::string_view name, T &member ) const {
+        if( !jo.has_member( name ) ) {
+            return false;
+        }
+        if constexpr( supports_delete_handler<T>::value ) {
+            return member.handle_delete( jo.get_member( name ) );
+        } else {
+            jo.throw_error( string_format( "%s (type %s) does not implement handle_delete", name,
+                                           demangle( typeid( T ).name() ) ) );
+        }
+        return false;
     }
 };
 

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -26,6 +26,7 @@
 #include "weakpoint.h"
 
 class Creature;
+class JsonValue;
 class monster;
 enum class creature_size : int;
 enum class phase_id : int;
@@ -263,6 +264,8 @@ struct move_skills_data {
     bool was_loaded = false;
     void load( const JsonObject &jo );
     void deserialize( const JsonObject &data );
+    bool handle_extend( const JsonValue &jv );
+    bool handle_delete( const JsonValue &jv );
 };
 
 enum class mdeath_type {

--- a/tools/load_all_mods.sh
+++ b/tools/load_all_mods.sh
@@ -26,8 +26,14 @@ else
     printf "Using test executable '%s'\n" "$test_exe"
 fi
 
+if ! $test_exe 'force_load_game'
+then
+	echo "Test failure with dda"
+	exit
+fi
 for mod_set in `./build-scripts/get_all_mods.py`
 do
+	printf "Running %s\n", "$mod_set"
 	if ! $test_exe --mods="$mod_set" 'force_load_game'
 	then
 		printf "Test failure with mods '%s'\n" "$mod_set"


### PR DESCRIPTION
#### Summary
Infrastructure "Allow using extend/delete on non-container types with optional/mandatory"

#### Purpose of change
There's a lot of hand-rolled support for various extended features in monstergenerator.cpp. This will be needed to convert it to `optional`/`mandatory`, as per https://github.com/CleverRaven/Cataclysm-DDA/pull/82165

#### Describe the solution
Allow types to define `handle_extend` and `handle_delete` functions that take in a `JsonValue` (the value at `"delete": { "key_for_load": value }`). Non-reader optional forwards to these.

readers can define `do_extend` and `do_delete` functions, to enable doing this for types that cannot be extended to have these functions.

The `json_read_reader` provides an example implementation, simply forwarding to the `handle_extend`/`handle_delete` function of the type, if it has one. 

Apply this to `move_skills_data`. I originally supported both the extend and delete syntax, but the delete syntax is redundant, so I simply migrated it all to `extend`.

#### Testing
`tools/load_all_mods.sh`