### PR TITLE
Set and show default values for most query_int

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -4526,7 +4526,7 @@ bool workout_activity_actor::query_keep_training( player_activity &act, Characte
         act.moves_left = act.moves_total;
         return true;
     }
-    int length;
+    int length = 0;
     uilist workout_query;
     workout_query.text = _( "You have finished your training cycle, keep training?" );
     workout_query.addentry( 1, true, 'S', _( "Stop training." ) );

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -11472,7 +11472,7 @@ bool Character::has_weapon() const
 int Character::get_lowest_hp() const
 {
     // Set lowest_hp to an arbitrarily large number.
-    int lowest_hp = 999;
+    int lowest_hp = INT_MAX;
     for( const std::pair<const bodypart_str_id, bodypart> &elem : get_body() ) {
         const int cur_hp = elem.second.get_hp_cur();
         if( cur_hp < lowest_hp ) {
@@ -11480,6 +11480,19 @@ int Character::get_lowest_hp() const
         }
     }
     return lowest_hp;
+}
+
+int Character::get_highest_hp() const
+{
+    // Set lowest_hp to an arbitrarily large number.
+    int highest_hp = INT_MIN;
+    for( const std::pair<const bodypart_str_id, bodypart> &elem : get_body() ) {
+        const int cur_hp = elem.second.get_hp_cur();
+        if( cur_hp > highest_hp ) {
+            highest_hp = cur_hp;
+        }
+    }
+    return highest_hp;
 }
 
 Creature::Attitude Character::attitude_to( const Creature &other ) const

--- a/src/character.h
+++ b/src/character.h
@@ -3858,6 +3858,8 @@ class Character : public Creature, public visitable
 
         // used in debugging all health
         int get_lowest_hp() const;
+        // used in debugging all health
+        int get_highest_hp() const;
         bool has_weapon() const override;
         void shift_destination( const point_rel_ms &shift );
         // Auto move methods

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -668,11 +668,9 @@ static void monster_ammo_edit( monster &mon )
     itype_id new_ammo;
     new_ammo = ammos[smenu.ret];
     if( new_ammo.is_valid() ) {
-        int value = 0;
+        int value = mon.ammo[new_ammo];
         const itype *display_type = item::find_type( new_ammo );
-        if( query_int( value, false, _( "Set %s to how much ammo?  Currently: %d" ),
-                       display_type->nname( 1 ),
-                       mon.ammo[new_ammo] ) )  {
+        if( query_int( value, true, _( "Set %s to how much ammo?" ), display_type->nname( 1 ) ) )  {
             if( value < 0 ) {
                 value = 0;
             }
@@ -880,22 +878,22 @@ static void monster_edit_menu()
     nmenu.query();
     switch( nmenu.ret ) {
         case D_HP: {
-            int value = 0;
-            if( query_int( value, false, _( "Set the hitpoints to?  Currently: %d" ), critter->get_hp() ) ) {
+            int value = critter->get_hp();
+            if( query_int( value, true, _( "Set the hitpoints to?" ) ) ) {
                 critter->set_hp( value );
             }
         }
         break;
         case D_MORALE: {
-            int value = 0;
-            if( query_int( value, false, _( "Set the morale to?  Currently: %d" ), critter->morale ) ) {
+            int value = critter->morale;
+            if( query_int( value, true, _( "Set the morale to?" ) ) ) {
                 critter->morale = value;
             }
         }
         break;
         case D_AGGRO: {
-            int value = 0;
-            if( query_int( value, false, _( "Set aggression to?  Currently: %d" ), critter->anger ) ) {
+            int value = critter->anger;
+            if( query_int( value, true, _( "Set aggression to?" ) ) ) {
                 critter->anger = value;
             }
         }
@@ -925,8 +923,8 @@ static void monster_edit_menu()
             break;
         }
         case D_WANDER: {
-            int value = 0;
-            if( query_int( value, false, _( "Set wander desire to?  Currently: %d" ), critter->wandf ) ) {
+            int value = critter->wandf;
+            if( query_int( value, true, _( "Set wander desire to?" ) ) ) {
                 critter->wandf = value;
             }
             break;
@@ -1738,7 +1736,7 @@ static void change_spells( Character &character )
 
         } else if( action == "CONFIRM" ) {
             int &spell_level = std::get<1>( *spells_relative[spell_selected] );
-            query_int( spell_level, false, _( "Set spell level to?  Currently: %1$d" ), spell_level );
+            query_int( spell_level, true, _( "Set spell level to?" ) );
             spell_level = clamp( spell_level, -1,
                                  static_cast<int>( std::get<0>( *spells_relative[spell_selected] ).max_level.evaluate( d ) ) );
             set_spell( std::get<0>( *spells_relative[spell_selected] ), spell_level );
@@ -1958,8 +1956,8 @@ static void character_edit_stats_menu( Character &you )
     }
 
     if( bp_ptr != nullptr ) {
-        int value = 0;
-        if( query_int( value, false, _( "Set the stat to?  Currently: %d" ), *bp_ptr ) && value >= 0 ) {
+        int value = *bp_ptr;
+        if( query_int( value, true, _( "Set the stat to?" ) ) && value >= 0 ) {
             *bp_ptr = value;
             you.reset_stats();
         }
@@ -2025,58 +2023,63 @@ static void character_edit_needs_menu( Character &you )
     int value;
     switch( smenu.ret ) {
         case 0:
-            if( query_int( value, false, _( "Set hunger to?  Currently: %d" ), you.get_hunger() ) ) {
+            value = you.get_hunger();
+            if( query_int( value, true, _( "Set hunger to?" ) ) ) {
                 you.set_hunger( value );
             }
             break;
 
         case 1:
-            if( query_int( value, false, _( "Set stored kcal to?  Currently: %d" ), you.get_stored_kcal() ) ) {
+            value = you.get_stored_kcal();
+            if( query_int( value, true, _( "Set stored kcal to?" ) ) ) {
                 you.set_stored_kcal( value );
             }
             break;
 
         case 2:
-            if( query_int( value, false, _( "Set stomach kcal to?  Currently: %d" ),
-                           you.stomach.get_calories() ) ) {
+            value = you.stomach.get_calories();
+            if( query_int( value, true, _( "Set stomach kcal to?" ) ) ) {
                 you.stomach.mod_calories( value - you.stomach.get_calories() );
             }
             break;
 
         case 3:
-            if( query_int( value, false, _( "Set gut kcal to?  Currently: %d" ), you.guts.get_calories() ) ) {
+            value = you.guts.get_calories();
+            if( query_int( value, true, _( "Set gut kcal to?" ) ) ) {
                 you.guts.mod_calories( value - you.guts.get_calories() );
             }
             break;
 
         case 4:
-            if( query_int( value, false, _( "Set thirst to?  Currently: %d" ), you.get_thirst() ) ) {
+            value = you.get_thirst();
+            if( query_int( value, true, _( "Set thirst to?" ) ) ) {
                 you.set_thirst( value );
             }
             break;
 
         case 5:
-            if( query_int( value, false, _( "Set sleepiness to?  Currently: %d" ), you.get_sleepiness() ) ) {
+            value = you.get_sleepiness();
+            if( query_int( value, true, _( "Set sleepiness to?" ) ) ) {
                 you.set_sleepiness( value );
             }
             break;
 
         case 6:
-            if( query_int( value, false, _( "Set sleep deprivation to?  Currently: %d" ),
-                           you.get_sleep_deprivation() ) ) {
+            value = you.get_sleep_deprivation();
+            if( query_int( value, true, _( "Set sleep deprivation to?" ) ) ) {
                 you.set_sleep_deprivation( value );
             }
             break;
 
         case 7:
-            if( query_yn( _( "Reset weariness?  Currently: %d" ),
-                          you.weariness() ) ) {
+            value = you.weariness();
+            if( query_int( value, true, _( "Set weariness to?" ) ) ) {
                 you.activity_history.weary_clear();
             }
             break;
         case 8:
-            if( query_int( value, false, _( "Set weariness tracker to?  Currently: %d" ),
-                           you.activity_history.debug_get_tracker() ) ) {
+            value = you.activity_history.debug_get_tracker();
+            if( query_int( value, true, _( "Set weariness tracker to?" ) ) ) {
                 you.activity_history.debug_set_tracker( value );
             }
             break;
@@ -2097,8 +2100,9 @@ static void character_edit_needs_menu( Character &you )
             if( smenu.ret >= vitamin_entry_base &&
                 smenu.ret < vitamin_entry_base + static_cast<int>( vits.size() ) ) {
                 auto iter = std::next( vits.begin(), smenu.ret - vitamin_entry_base );
-                if( query_int( value, false, _( "Set %s to?  Currently: %d" ),
-                               iter->second.name(), you.vitamin_get( iter->first ) ) ) {
+                value = you.vitamin_get( iter->first );
+                if( query_int( value, true, _( "Set %s to?" ),
+                               iter->second.name() ) ) {
                     you.vitamin_set( iter->first, value );
                 }
             }
@@ -2116,7 +2120,8 @@ static void character_edit_hp_menu( Character &you )
         pos++;
         hotkey++;
     }
-    smenu.addentry( pos, true, hotkey, "%s: %d", _( "All" ), you.get_lowest_hp() );
+    smenu.addentry( pos, true, hotkey, "%s: %d-%d", _( "All" ), you.get_lowest_hp(),
+                    you.get_highest_hp() );
     part_ids.emplace_back( bodypart_str_id::NULL_ID().id() );
     smenu.query();
     bodypart_str_id bp = body_part_no_a_real_part;
@@ -2131,17 +2136,16 @@ static void character_edit_hp_menu( Character &you )
     }
 
     if( bp.is_valid() && bp != bodypart_str_id::NULL_ID() ) {
-        int value;
-        if( query_int( value, false, _( "Set the hitpoints to?  Currently: %d" ),
-                       you.get_part_hp_cur( bp.id() ) ) &&
+        int value = you.get_part_hp_cur( bp.id() );
+        if( query_int( value, true, _( "Set the hitpoints to?" ) ) &&
             value >= 0 )  {
             you.set_part_hp_cur( bp.id(), value );
             you.reset_stats();
         }
     } else if( all_select ) {
-        int value;
-        if( query_int( value, false, _( "Set the hitpoints to?  Currently: %d" ), you.get_lowest_hp() ) &&
-            value >= 0 ) {
+        int value = you.get_lowest_hp();
+        if( query_int( value, true, _( "Set the hitpoints to?  Current highest %d, Current lowest:" ),
+                       you.get_highest_hp() ) && value >= 0 ) {
             for( bodypart_id part_id : you.get_all_body_parts( get_body_part_flags::only_main ) ) {
                 you.set_part_hp_cur( part_id, value );
             }
@@ -2164,35 +2168,38 @@ static void character_edit_opinion_menu( npc *np )
     int value;
     switch( smenu.ret ) {
         case 0:
-            if( query_int( value, false, _( "Set trust to?  Currently: %d" ),
-                           np->op_of_u.trust ) ) {
+            value = np->op_of_u.trust;
+            if( query_int( value, true, _( "Set trust to?" ) ) ) {
                 np->op_of_u.trust = value;
             }
             break;
         case 1:
-            if( query_int( value, false, _( "Set fear to?  Currently: %d" ), np->op_of_u.fear ) ) {
+            value = np->op_of_u.fear;
+            if( query_int( value, true, _( "Set fear to?" ) ) ) {
                 np->op_of_u.fear = value;
             }
             break;
         case 2:
-            if( query_int( value, false, _( "Set value to?  Currently: %d" ),
-                           np->op_of_u.value ) ) {
+            value = np->op_of_u.value;
+            if( query_int( value, true, _( "Set value to?" ) ) ) {
                 np->op_of_u.value = value;
             }
             break;
         case 3:
-            if( query_int( value, false, _( "Set anger to?  Currently: %d" ),
-                           np->op_of_u.anger ) ) {
+            value = np->op_of_u.anger;
+            if( query_int( value, true, _( "Set anger to?" ) ) ) {
                 np->op_of_u.anger = value;
             }
             break;
         case 4:
-            if( query_int( value, false, _( "Set owed to?  Currently: %d" ), np->op_of_u.owed ) ) {
+            value = np->op_of_u.owed;
+            if( query_int( value, true, _( "Set owed to?" ) ) ) {
                 np->op_of_u.owed = value;
             }
             break;
         case 5:
-            if( query_int( value, false, _( "Set sold to?  Currently: %d" ), np->op_of_u.sold ) ) {
+            value = np->op_of_u.sold;
+            if( query_int( value, true, _( "Set sold to?" ) ) ) {
                 np->op_of_u.sold = value;
             }
             break;
@@ -2211,25 +2218,26 @@ static void character_edit_personality_menu( npc *np )
     int value;
     switch( smenu.ret ) {
         case 0:
-            if( query_int( value, false, _( "Set aggression to?  Currently: %d" ),
-                           np->personality.aggression ) ) {
+            value = static_cast<unsigned char>( np->personality.aggression );
+            if( query_int( value, true, _( "Set aggression to?" ) ) ) {
                 np->personality.aggression = value;
             }
             break;
         case 1:
-            if( query_int( value, false, _( "Set bravery to?  Currently: %d" ), np->personality.bravery ) ) {
+            value = static_cast<unsigned char>( np->personality.bravery );
+            if( query_int( value, true, _( "Set bravery to?" ) ) ) {
                 np->personality.bravery = value;
             }
             break;
         case 2:
-            if( query_int( value, false, _( "Set collector to?  Currently: %d" ),
-                           np->personality.collector ) ) {
+            value = static_cast<unsigned char>( np->personality.collector );
+            if( query_int( value, true, _( "Set collector to?" ) ) ) {
                 np->personality.collector = value;
             }
             break;
         case 3:
-            if( query_int( value, false, _( "Set altruism to?  Currently: %d" ),
-                           np->personality.altruism ) ) {
+            value = static_cast<unsigned char>( np->personality.altruism );
+            if( query_int( value, true, _( "Set altruism to?" ) ) ) {
                 np->personality.altruism = value;
             }
             break;
@@ -2514,8 +2522,8 @@ static void character_edit_menu()
         }
         break;
         case D_RADS: {
-            int value;
-            if( query_int( value, false, _( "Set rads to?  Currently: %d" ), you.get_rad() ) ) {
+            int value = you.get_rad();
+            if( query_int( value, true, _( "Set rads to?" ) ) ) {
                 you.set_rad( value );
             }
         }
@@ -2523,20 +2531,20 @@ static void character_edit_menu()
         case D_HP:
             character_edit_hp_menu( you );
             break;
-        case D_STAMINA:
-            int value;
-            if( query_int( value, false, _( "Set stamina to?  Current: %d. Max: %d." ), you.get_stamina(),
-                           you.get_stamina_max() ) ) {
+        case D_STAMINA: {
+            int value = you.get_stamina();
+            if( query_int( value, true, _( "Set stamina to?  Max: %d, Current:" ), you.get_stamina_max() ) ) {
                 if( value >= 0 && value <= you.get_stamina_max() ) {
                     you.set_stamina( value );
                 } else {
                     add_msg( m_bad, _( "Target stamina value out of bounds!" ) );
                 }
             }
-            break;
+        }
+        break;
         case D_MORALE: {
-            int value;
-            if( query_int( value, false, _( "Set the morale to?  Currently: %d" ), you.get_morale_level() ) ) {
+            int value = you.get_morale_level();
+            if( query_int( value, true, _( "Set the morale to?" ) ) ) {
                 you.rem_morale( morale_perm_debug );
                 int morale_level_delta = value - you.get_morale_level();
                 you.add_morale( morale_perm_debug, morale_level_delta );
@@ -2545,8 +2553,8 @@ static void character_edit_menu()
         }
         break;
         case D_KILL_XP: {
-            int value;
-            if( query_int( value, false, _( "Set kill XP to?  Currently: %d" ), you.kill_xp ) ) {
+            int value = you.kill_xp;
+            if( query_int( value, true, _( "Set kill XP to?" ) ) ) {
                 you.kill_xp = value;
             }
         }
@@ -2561,8 +2569,9 @@ static void character_edit_menu()
             character_edit_desc_menu( you );
             break;
         case D_PAIN: {
-            int value;
-            if( query_int( value, false, _( "Cause how much pain?  Current pain: %d" ), you.get_pain() ) ) {
+            int value = 0;
+            if( query_int( value, false, _( "Cause how much additional pain?  Current pain: %d" ),
+                           you.get_pain() ) ) {
                 you.mod_pain( value );
             }
         }
@@ -2627,19 +2636,20 @@ static void character_edit_menu()
             int value;
             switch( smenu.ret ) {
                 case 0:
-                    if( query_int( value, false, _( "Set lifestyle value to?  Currently: %d" ),
-                                   you.get_lifestyle() ) ) {
+                    value = you.get_lifestyle();
+                    if( query_int( value, true, _( "Set lifestyle value to?" ) ) ) {
                         you.set_lifestyle( value );
                     }
                     break;
                 case 1:
-                    if( query_int( value, false, _( "Set the daily health value to?  Currently: %d" ),
-                                   you.get_daily_health() ) ) {
+                    value = you.get_daily_health();
+                    if( query_int( value, true, _( "Set the daily health value to?" ) ) ) {
                         you.set_daily_health( value );
                     }
                     break;
                 case 2:
-                    if( query_int( value, false, _( "Set the radiation to?  Currently: %d" ), you.get_rad() ) ) {
+                    value = you.get_rad();
+                    if( query_int( value, true, _( "Set the radiation to?" ) ) ) {
                         you.set_rad( value );
                     }
                     break;
@@ -2790,17 +2800,20 @@ static void faction_edit_opinion_menu( faction *fac )
     int value;
     switch( smenu.ret ) {
         case 0:
-            if( query_int( value, false, _( "Change like from %d to: " ), fac->likes_u ) ) {
+            value = fac->likes_u;
+            if( query_int( value, true, _( "Change like to?" ) ) ) {
                 fac->likes_u = value;
             }
             break;
         case 1:
-            if( query_int( value, false, _( "Change respect from %d to: " ), fac->respects_u ) ) {
+            value = fac->respects_u;
+            if( query_int( value, true, _( "Change respect to?" ) ) ) {
                 fac->respects_u = value;
             }
             break;
         case 2:
-            if( query_int( value, false, _( "Change trust from %d to: " ), fac->trusts_u ) ) {
+            value = fac->trusts_u;
+            if( query_int( value, true, _( "Change trust to?" ) ) ) {
                 fac->trusts_u = value;
             }
             break;
@@ -2845,15 +2858,16 @@ static void faction_edit_larder_menu( faction *fac )
         int value;
         switch( smenu.ret ) {
             case 0:
-                if( query_int( value, false, _( "Change food from %d to: " ), entry.kcal() ) ) {
+                value = entry.kcal();
+                if( query_int( value, true, _( "Change food to?" ) ) ) {
                     entry.calories = ( value * 1000 );
                 }
                 break;
             default:
                 if( smenu.ret >= 1 && smenu.ret < static_cast<int>( vits.size() + 1 ) ) {
                     auto iter = std::next( vits.begin(), smenu.ret - 1 );
-                    if( query_int( value, false, _( "Set %s to?  Currently: %d" ),
-                                   iter->second.name(), entry.get_vitamin( iter->first ) ) ) {
+                    value = entry.get_vitamin( iter->first );
+                    if( query_int( value, true, _( "Set %s to?" ), iter->second.name() ) ) {
                         entry.set_vitamin( iter->first, value );
                     }
                 }
@@ -2904,17 +2918,20 @@ static void faction_edit_menu()
     int value;
     switch( nmenu.ret ) {
         case D_WEALTH:
-            if( query_int( value, false, _( "Change wealth from %d to: " ), fac->wealth ) ) {
+            value = fac->wealth;
+            if( query_int( value, true, _( "Change wealth to?" ) ) ) {
                 fac->wealth = value;
             }
             break;
         case D_SIZE:
-            if( query_int( value, false, _( "Change size from %d to: " ), fac->size ) ) {
+            value = fac->size;
+            if( query_int( value, true, _( "Change size to?" ) ) ) {
                 fac->size = value;
             }
             break;
         case D_POWER:
-            if( query_int( value, false, _( "Change power from %d to: " ), fac->power ) ) {
+            value = fac->power;
+            if( query_int( value, true, _( "Change power to?" ) ) ) {
                 fac->power = value;
             }
             break;
@@ -3483,8 +3500,9 @@ static void damage_self()
     int dbg_damage;
     if( smenu.ret >= 0 && static_cast<std::size_t>( smenu.ret ) <= parts.size() ) {
         part = parts[smenu.ret];
+        dbg_damage = player_character.get_part_hp_cur( part );
     }
-    if( query_int( dbg_damage, _( "Damage self for how much?  HP: %s" ), part.id().c_str() ) ) {
+    if( query_int( dbg_damage, true, _( "Damage your %s for how much?" ), part->name.translated() ) ) {
         player_character.apply_damage( nullptr, part, dbg_damage );
         if( player_character.is_dead_state() ) {
             player_character.die( &get_map(), nullptr );
@@ -4105,7 +4123,7 @@ void debug()
 
         case debug_menu_index::SPAWN_OM_NPC: {
             int num_of_npcs = 1;
-            if( query_int( num_of_npcs, false, _( "How many NPCs to try spawning?" ), num_of_npcs ) ) {
+            if( query_int( num_of_npcs, true, _( "How many NPCs to try spawning?" ) ) ) {
                 for( int i = 0; i < num_of_npcs; i++ ) {
                     g->perhaps_add_random_npc( true );
                 }

--- a/src/editmap.cpp
+++ b/src/editmap.cpp
@@ -1222,8 +1222,8 @@ void editmap::setup_fmenu( uilist &fmenu )
 void editmap::edit_rads() const
 {
     map &here = get_map();
-    int value = 0;
-    if( query_int( value, false, _( "Set rads to?  Currently: %d" ), here.get_radiation( target ) ) ) {
+    int value = here.get_radiation( target );
+    if( query_int( value, true, _( "Set rads to?" ) ) ) {
         here.set_radiation( target, value );
     }
 }

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -2458,13 +2458,13 @@ void basecamp::job_assignment_ui()
                     if( smenu.ret == 0 ) {
                         cur_npc->job.clear_all_priorities();
                     } else if( smenu.ret == 1 ) {
-                        int priority;
+                        int priority = 0;
                         query_int( priority, false, _( "Priority for all jobs " ) );
                         cur_npc->job.set_all_priorities( priority );
                     } else if( smenu.ret > 1 && smenu.ret <= static_cast<int>( job_vec.size() ) + 1 ) {
                         activity_id sel_job = job_vec[size_t( smenu.ret - 2 )];
                         player_activity test_act = player_activity( sel_job );
-                        int priority;
+                        int priority = 0;
                         query_int( priority, false, _( "Priority for %s " ), test_act.get_verb() );
                         cur_npc->job.set_task_priority( sel_job, priority );
                     } else {

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -3672,8 +3672,8 @@ std::optional<int> iuse::firecracker( Character *p, item *it, const tripoint_bub
 
 std::optional<int> iuse::mininuke( Character *p, item *it, const tripoint_bub_ms & )
 {
-    int time;
-    bool got_value = query_int( time, false, _( "Set the timer to ___ turns (0 to cancel)?" ) );
+    int time = 0;
+    bool got_value = query_int( time, false, _( "Set the timer to how many seconds (0 to cancel)?" ) );
     if( !got_value || time <= 0 ) {
         p->add_msg_if_player( _( "Never mind." ) );
         return std::nullopt;

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -4757,14 +4757,14 @@ void set_description( tab_manager &tabs, avatar &you, const bool allow_reroll,
                 }
                 case char_creation::AGE: {
                     int result = you.base_age();
-                    if( query_int( result, false, _( "Enter age in years.  Minimum 16, maximum 55" ) ) && result > 0 ) {
+                    if( query_int( result, true, _( "Enter age in years.  Minimum 16, maximum 55" ) ) && result > 0 ) {
                         you.set_base_age( clamp( result, 16, 55 ) );
                     }
                     break;
                 }
                 case char_creation::HEIGHT: {
                     int result = you.base_height();
-                    if( query_int( result, false, _( "Enter height in centimeters.  Minimum %d, maximum %d" ),
+                    if( query_int( result, true, _( "Enter height in centimeters.  Minimum %d, maximum %d" ),
                                    min_allowed_height, max_allowed_height ) && result > 0 ) {
                         you.set_base_height( clamp( result, min_allowed_height, max_allowed_height ) );
                     }

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -1818,8 +1818,7 @@ static void modify_horde_func( tripoint_abs_omt &curs )
     switch( smenu.ret ) {
         case 0:
             new_value = chosen_group.interest;
-            if( query_int( new_value, false, _( "Set interest to what value?  Currently %d" ),
-                           chosen_group.interest ) ) {
+            if( query_int( new_value, true, _( "Set interest to what value?" ) ) ) {
                 chosen_group.set_interest( new_value );
             }
             break;
@@ -1833,8 +1832,7 @@ static void modify_horde_func( tripoint_abs_omt &curs )
             break;
         case 2:
             new_value = chosen_group.population;
-            if( query_int( new_value, false, _( "Set population to what value?  Currently %d" ),
-                           chosen_group.population ) ) {
+            if( query_int( new_value, true, _( "Set population to what value?" ) ) ) {
                 chosen_group.population = new_value;
             }
             break;
@@ -1844,9 +1842,8 @@ static void modify_horde_func( tripoint_abs_omt &curs )
         case 4:
             new_value = static_cast<int>( chosen_group.behaviour );
             // Screw it we hardcode a popup, if you really want to use this you're welcome to improve it
-            popup( _( "Set behavior to which enum value?  Currently %d.  \nAccepted values:\n0 = none,\n1 = city,\n2=roam,\n3=nemesis" ),
-                   static_cast<int>( chosen_group.behaviour ) );
-            query_int( new_value, false, "" );
+            query_int( new_value, true,
+                       _( "Set behavior to which enum value?\nAccepted values:\n0 = none,\n1 = city,\n2=roam,\n3=nemesis" ) );
             chosen_group.behaviour = static_cast<mongroup::horde_behaviour>( new_value );
             break;
         case 5:

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -907,8 +907,8 @@ void vehicle::reload_seeds( map *here, const tripoint_bub_ms &pos )
 
     if( seed_index > 0 && seed_index < static_cast<int>( seed_entries.size() ) ) {
         const int count = std::get<2>( seed_entries[seed_index] );
-        int amount = 0;
-        query_int( amount, false, _( "Move how many?  [Have %d] (0 to cancel)" ), count );
+        int amount = count;
+        query_int( amount, true, _( "Move how many?  (0 to cancel)" ) );
 
         if( amount > 0 ) {
             int actual_amount = std::min( amount, count );

--- a/src/wish.cpp
+++ b/src/wish.cpp
@@ -425,35 +425,31 @@ void debug_menu::wishbionics( Character *you )
                 break;
             }
             case 3: {
-                int new_value = 0;
-                if( query_int( new_value, false, _( "Set the value to (in kJ)?  Currently: %s" ),
-                               units::display( power_max ) ) ) {
+                int new_value = units::to_kilojoule( power_max );
+                if( query_int( new_value, true, _( "Set the value to (in kJ)?" ) ) ) {
                     you->set_max_power_level( units::from_kilojoule( static_cast<std::int64_t>( new_value ) ) );
                     you->set_power_level( you->get_power_level() );
                 }
                 break;
             }
             case 4: {
-                int new_value = 0;
-                if( query_int( new_value, false, _( "Set the value to (in J)?  Currently: %s" ),
-                               units::display( power_max ) ) ) {
+                int new_value = units::to_joule( power_max );
+                if( query_int( new_value, true, _( "Set the value to (in J)?" ) ) ) {
                     you->set_max_power_level( units::from_joule( static_cast<std::int64_t>( new_value ) ) );
                     you->set_power_level( you->get_power_level() );
                 }
                 break;
             }
             case 5: {
-                int new_value = 0;
-                if( query_int( new_value, false, _( "Set the value to (in kJ)?  Currently: %s" ),
-                               units::display( power_level ) ) ) {
+                int new_value = units::to_kilojoule( power_level );
+                if( query_int( new_value, true, _( "Set the value to (in kJ)?" ) ) ) {
                     you->set_power_level( units::from_kilojoule( static_cast<std::int64_t>( new_value ) ) );
                 }
                 break;
             }
             case 6: {
-                int new_value = 0;
-                if( query_int( new_value, false, _( "Set the value to (in J)?  Currently: %s" ),
-                               units::display( power_level ) ) ) {
+                int new_value = units::to_joule( power_level );
+                if( query_int( new_value, true, _( "Set the value to (in J)?" ) ) ) {
                     you->set_power_level( units::from_joule( static_cast<std::int64_t>( new_value ) ) );
                 }
                 break;
@@ -586,7 +582,7 @@ void debug_menu::wisheffect( Creature &p )
             effect &eff = effects[efmenu.ret - offset];
 
             int duration = to_seconds<int>( eff.get_duration() );
-            query_int( duration, false, _( "Set duration (current %1$d): " ), duration );
+            query_int( duration, true, _( "Set duration to?  (seconds)" ) );
             if( duration < 0 ) {
                 continue;
             }
@@ -790,8 +786,7 @@ void debug_menu::wishmonstergroup( tripoint_abs_omt &loc )
         const mongroup_id selected_group( possible_groups[selected] );
         new_group.type = selected_group;
         int new_value = new_group.population; // default value if query declined
-        query_int( new_value, false, _( "Set population to what value?  Currently %d" ),
-                   new_group.population );
+        query_int( new_value, true, _( "Set population to what value?" ) );
         new_group.population = new_value;
         overmap &there = overmap_buffer.get( project_to<coords::om>( loc ).xy() );
         there.debug_force_add_group( new_group );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Interface "Most prompts for a number now default to the current or target value"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
Currently some uses of query_int present the player with no default value, some present a default value of 0, and some present a default value of the current value being set. Some of the ones that don't present a default value do output the current value in the query text.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
I've updated most cases to show and default to the current value of the thing being queried for.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
It might be even more useful if the default was selected, so that beginning to type would overwrite it, but our prompt ui doesn't allow selection. This can wait for imgui migration of these prompts.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->
I accessed about half of the changes in-game and confirmed they look as expected.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
The initial impetus for this was that a few of the prompts use and show uninitialized default values, which led to arbitrary values being shown in some cases.

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
