### PR TITLE
Energy remaining now looks for battery ammo_types

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -11504,7 +11504,7 @@ units::energy item::energy_remaining( const Character *carrier, bool ignoreExter
     if( is_magazine() ) {
         ret += energy;
         for( const item *e : contents.all_items_top( pocket_type::MAGAZINE ) ) {
-            if( e->typeId() == itype_battery ) {
+            if( e->ammo_type() == ammo_battery ) {
                 ret += units::from_kilojoule( static_cast<std::int64_t>( e->charges ) );
             }
         }


### PR DESCRIPTION
#### Summary

Bugfixes "Energy remaining now looks for battery ammo_types"

#### Purpose of change
The `energy_remaining` function was checking battery magazines were loaded with `id: battery` items  this has been replaced and int now checks magazines are loaded with `ammo_type: battery` allowing mods to define custom electric charge items.

This allows chromoelectric cartridges to work in aftershock.

#### Testing
Fired lasers with normal and chromoelectric cartridges. Items using normal batteries still draw charge.
