### PR TITLE
Corrected hold the line logic

### DIFF
--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -13,6 +13,7 @@
 #include "activity_handlers.h"
 #include "activity_type.h"
 #include "auto_pickup.h"
+#include "avatar.h"
 #include "basecamp.h"
 #include "bodypart.h"
 #include "cata_assert.h"
@@ -3484,8 +3485,13 @@ std::function<bool( const tripoint_bub_ms & )> npc::get_path_avoid() const
             return true;
         }
         if( rules.has_flag( ally_rule::hold_the_line ) &&
+            rl_dist( p, get_avatar().pos_bub() ) == 1 &&
             ( here.close_door( p, true, true ) ||
-              here.move_cost( p ) > 2 ) ) {
+              ( here.move_cost( p ) > 2 ) &&
+              // Ignore if target location is on same vehicle as the avatar occupies
+              !( here.veh_at( p ).has_value() && here.veh_at( get_avatar().pos_abs() ) &&
+                 here.veh_at( p ).value().vehicle().pos_abs() == here.veh_at(
+                     get_avatar().pos_abs() ).value().vehicle().pos_abs() ) ) ) {
             return true;
         }
         if( sees_dangerous_field( p ) ) {

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -3491,14 +3491,14 @@ std::function<bool( const tripoint_bub_ms & )> npc::get_path_avoid() const
                 // Ignore if target location is on same vehicle as the avatar occupies
                 !( here.veh_at( p ).has_value() && here.veh_at( get_avatar().pos_abs() ) &&
                    here.veh_at( p ).value().vehicle().pos_abs() == here.veh_at(
-        get_avatar().pos_abs() ).value().vehicle().pos_abs() ) ) {
-        return true;
-    }
-    if( sees_dangerous_field( p ) ) {
-        return true;
-    }
-    return false;
-};
+                       get_avatar().pos_abs() ).value().vehicle().pos_abs() ) ) ) ) {
+            return true;
+        }
+        if( sees_dangerous_field( p ) ) {
+            return true;
+        }
+        return false;
+    };
 }
 
 mfaction_id npc::get_monster_faction() const

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -3487,18 +3487,18 @@ std::function<bool( const tripoint_bub_ms & )> npc::get_path_avoid() const
         if( rules.has_flag( ally_rule::hold_the_line ) &&
             rl_dist( p, get_avatar().pos_bub() ) == 1 &&
             ( here.close_door( p, true, true ) ||
-              ( here.move_cost( p ) > 2 ) &&
-              // Ignore if target location is on same vehicle as the avatar occupies
-              !( here.veh_at( p ).has_value() && here.veh_at( get_avatar().pos_abs() ) &&
-                 here.veh_at( p ).value().vehicle().pos_abs() == here.veh_at(
-                     get_avatar().pos_abs() ).value().vehicle().pos_abs() ) ) ) {
-            return true;
-        }
-        if( sees_dangerous_field( p ) ) {
-            return true;
-        }
-        return false;
-    };
+              ( here.move_cost( p ) > 2  &&
+                // Ignore if target location is on same vehicle as the avatar occupies
+                !( here.veh_at( p ).has_value() && here.veh_at( get_avatar().pos_abs() ) &&
+                   here.veh_at( p ).value().vehicle().pos_abs() == here.veh_at(
+        get_avatar().pos_abs() ).value().vehicle().pos_abs() ) ) {
+        return true;
+    }
+    if( sees_dangerous_field( p ) ) {
+        return true;
+    }
+    return false;
+};
 }
 
 mfaction_id npc::get_monster_faction() const


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Fix #82551, i.e. companion refusing to enter vehicle when "hold the line" setting is active.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
- Changed the code to do what the description says, i.e. restrict movement only to PC adjacent tiles, rather than any tile pathed through.
- Added logic to check if the target location is on the same vehicle as the PC occupies and don't restrict movement in that case.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
The logic is weird and seems to be of limited use, so it could be left to someone else to replace it with some more usable logic.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
- Verified the companion enters the vehicle. Also tried the other vehicle in the bug report save.
- Verifies the companion won't help the PC when the PC stands just inside a double doorway with the companion outside and a zombie is spawned inside within line of sight unless there's a "convenient" path through a window. The original code didn't allow the companion to help at all, while the modified code had the companion assist if the orientation was right. Presumably it's some kind of pathing cost cutoff that makes the difference. These tests were made using the bug report save, if someone's interested in investigating it further.
- The original code disallowed the companion from following the PC into a building (but still having the bugger run around the building to the other side, open the door, and then just stand there). The modified code allows it. The original behavior is thought to be a bug.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
As indicated, the logic is weird, and I don't really understand how it's intended to work. It sounds like it's intended to prevent the companion from blocking the path out of a building in case of a retreat, and I guess it sort of does that. I'm fairly sure it wasn't intended to block passages through doors completely, though.

Also note that this does not address the side issue of companions racing to hog the driver's seat of vehicles with lightning speed unless allocated a specific (different) seat. That code resides somewhere else.

It certainly wouldn't hurt to have this PR looked at by someone who knows what the behavior is supposed to be.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
