### PR TITLE
Fix pathfinder zigzagging by only pathing between OMT centers

### DIFF
--- a/tests/simple_pathfinding_test.cpp
+++ b/tests/simple_pathfinding_test.cpp
@@ -51,6 +51,7 @@ static void test_greedy_u_bend()
     const pf::two_node_scoring_fn<Point> estimate =
     [&]( pf::directed_node<Point> cur, std::optional<pf::directed_node<Point>> ) {
         if( cur.pos.x() == 1 && cur.pos.y() != 2 ) {
+            // x terrain is impassable
             return pf::node_score::rejected;
         }
         return pf::node_score( 0, manhattan_dist( cur.pos, finish ) );
@@ -94,13 +95,15 @@ TEST_CASE( "find_overmap_path_u_bend", "[pathfinding]" )
 
     const pf::omt_scoring_fn estimate = [&]( Point cur ) {
         if( !bounds.contains( cur ) || ( cur.x() == 1 && cur.y() != 2 ) ) {
+            // out of bounds and x terrain are impassable
             return pf::omt_score::rejected;
         }
-        return pf::omt_score( 10, false );
+        return pf::omt_score( 24, false );
     };
 
     const pf::simple_path<Point> pth = pf::find_overmap_path( start, finish, 2, estimate, noop_fn );
     REQUIRE( pth.points.size() == 7 );
+    REQUIRE( pth.dist == 144 );
     CHECK( pth.points[6] == Point( 0, 0, 0 ) );
     CHECK( pth.points[5] == Point( 0, 1, 0 ) );
     CHECK( pth.points[4] == Point( 0, 2, 0 ) );
@@ -110,27 +113,58 @@ TEST_CASE( "find_overmap_path_u_bend", "[pathfinding]" )
     CHECK( pth.points[0] == Point( 2, 0, 0 ) );
 }
 
+TEST_CASE( "find_overmap_path_u_bend_diagonal", "[pathfinding]" )
+{
+    using Point = tripoint_abs_omt;
+    const Point start( 0, 0, 0 );
+    const Point finish( 2, 0, 0 );
+    const inclusive_cuboid<Point> bounds( start, Point( 2, 2, 0 ) );
+    // Test area and expected path:
+    // SxF    4x0
+    // .x.    3x1
+    // ...    .2.
+
+    const pf::omt_scoring_fn estimate = [&]( Point cur ) {
+        if( !bounds.contains( cur ) || ( cur.x() == 1 && cur.y() != 2 ) ) {
+            // out of bounds and x terrain are impassable
+            return pf::omt_score::rejected;
+        }
+        return pf::omt_score( 24, false );
+    };
+
+    const pf::simple_path<Point> pth = pf::find_overmap_path( start, finish, 2, estimate, noop_fn,
+                                       std::nullopt, true );
+    REQUIRE( pth.points.size() == 5 );
+    REQUIRE( pth.dist == 116 );
+    CHECK( pth.points[4] == Point( 0, 0, 0 ) );
+    CHECK( pth.points[3] == Point( 0, 1, 0 ) );
+    CHECK( pth.points[2] == Point( 1, 2, 0 ) );
+    CHECK( pth.points[1] == Point( 2, 1, 0 ) );
+    CHECK( pth.points[0] == Point( 2, 0, 0 ) );
+}
+
 TEST_CASE( "find_overmap_path_bridge", "[pathfinding]" )
 {
     using Point = tripoint_abs_omt;
     const Point start( 0, 0, 0 );
     const Point finish( 2, 0, 0 );
-    const inclusive_cuboid<Point> bounds( start, Point( 2, 2, 1 ) );
+    const inclusive_cuboid<Point> bounds( start, Point( 2, 1, 1 ) );
     // Test area and expected path:
     // SxF    6x0
     // ^x^    5x1
-    // .x.    .x.
     // ( points 2, 3, 4 are at z=1 )
 
     const pf::omt_scoring_fn estimate = [&]( Point cur ) {
         if( !bounds.contains( cur ) || ( cur.x() == 1 && cur.z() == 0 ) ) {
+            // out of bounds and x terrain are impassable
             return pf::omt_score::rejected;
         }
-        return pf::omt_score( 10, ( cur.y() == 1 && cur.x() != 1 ) );
+        return pf::omt_score( 24, ( cur.y() == 1 && cur.x() != 1 ) );
     };
 
     const pf::simple_path<Point> pth = pf::find_overmap_path( start, finish, 2, estimate, noop_fn );
     REQUIRE( pth.points.size() == 7 );
+    REQUIRE( pth.dist == 98 );
     CHECK( pth.points[6] == Point( 0, 0, 0 ) );
     CHECK( pth.points[5] == Point( 0, 1, 0 ) );
     CHECK( pth.points[4] == Point( 0, 1, 1 ) );
@@ -140,3 +174,70 @@ TEST_CASE( "find_overmap_path_bridge", "[pathfinding]" )
     CHECK( pth.points[0] == Point( 2, 0, 0 ) );
 }
 
+TEST_CASE( "find_overmap_path_bridge_costs", "[pathfinding]" )
+{
+    using Point = tripoint_abs_omt;
+    const Point start( 0, 0, 0 );
+    const Point finish( 2, 0, 0 );
+    const inclusive_cuboid<Point> bounds( start, Point( 2, 1, 1 ) );
+    // Test area and expected path:
+    // SxF    6x0
+    // ^x^    5x1
+    // ( points 2, 3, 4 are at z=1 )
+
+    const pf::omt_scoring_fn estimate = [&]( Point cur ) {
+        if( !bounds.contains( cur ) || ( cur.x() == 1 && cur.z() == 0 ) ) {
+            // out of bounds and x terrain are impassable
+            return pf::omt_score::rejected;
+        }
+        // travel costs:
+        // z0        z1
+        // 18 24 30  24 30 36
+        // 24 30 36  30 36 42
+        return pf::omt_score( ( ( cur.x() + cur.y() + cur.z() + 1 ) * 6 ) + 12,
+                              ( cur.y() == 1 && cur.x() != 1 ) );
+    };
+
+    const pf::simple_path<Point> pth = pf::find_overmap_path( start, finish, 2, estimate, noop_fn );
+    REQUIRE( pth.points.size() == 7 );
+    REQUIRE( pth.dist == 98 );
+    // (30+36)/2 + (36/6+42/6)/2 + (42+36)/2 + (36+30)/2 + (30/6+24/6)/2 + (24+18)/2
+    REQUIRE( pth.cost == 138 );
+    CHECK( pth.points[6] == Point( 0, 0, 0 ) );
+    CHECK( pth.points[5] == Point( 0, 1, 0 ) );
+    CHECK( pth.points[4] == Point( 0, 1, 1 ) );
+    CHECK( pth.points[3] == Point( 1, 1, 1 ) );
+    CHECK( pth.points[2] == Point( 2, 1, 1 ) );
+    CHECK( pth.points[1] == Point( 2, 1, 0 ) );
+    CHECK( pth.points[0] == Point( 2, 0, 0 ) );
+}
+
+TEST_CASE( "find_overmap_path_costs", "[pathfinding]" )
+{
+    using Point = tripoint_abs_omt;
+    const Point start( 0, 0, 0 );
+    const Point finish( 2, 0, 0 );
+    const inclusive_cuboid<Point> bounds( start, Point( 2, 1, 0 ) );
+    // Test area and expected path:
+    // S!F    4!0
+    // ...    321
+
+    const pf::omt_scoring_fn estimate = [&]( Point cur ) {
+        if( !bounds.contains( cur ) ) {
+            // out of bounds is impassable
+            return pf::omt_score::rejected;
+        }
+        // ! has high cost and should be pathed around
+        return pf::omt_score( cur.x() == 1 && cur.y() == 0 ? 100 : 24, false );
+    };
+
+    const pf::simple_path<Point> pth = pf::find_overmap_path( start, finish, 2, estimate, noop_fn );
+    REQUIRE( pth.points.size() == 5 );
+    REQUIRE( pth.dist == 96 );
+    REQUIRE( pth.cost == 96 );
+    CHECK( pth.points[4] == Point( 0, 0, 0 ) );
+    CHECK( pth.points[3] == Point( 0, 1, 0 ) );
+    CHECK( pth.points[2] == Point( 1, 1, 0 ) );
+    CHECK( pth.points[1] == Point( 2, 1, 0 ) );
+    CHECK( pth.points[0] == Point( 2, 0, 0 ) );
+}


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Fix pathfinder zigzagging"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
When traveling orthogonally with a diagonal move at one end, the pathfinder will make a zigzag path. #82058 reported this and was closed when the vehicle diagonal pathfinding change was reverted, but the problem persists for foot travel.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
Undo the changes from #77556 that enabled pathfinding along map edges. Those changes improved pathfinding in rare edge cases, but also made it more expensive and introduced complexity that makes solving problems like this much harder, and would also have complicated upcoming efforts to make pathfinding compatible with highways.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
See Discord discussion below https://discord.com/channels/598523535169945603/598529174302490644/1412437256802930789 and comments on this PR for description of some prior attempted solutions.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->
Did some overmap fast travel in game, confirmed paths generally look as expected and don't zig-zag.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
The pathfinder pretends that you can travel between vertices of the submap grid. This is generally a good abstraction, despite the player not actually occupying those locations but instead a tile adjacent to those locations. The abstraction breaks down when the pathfinder wants to travel along the edge of an OMT, thinking that there is no difference in cost between the two sides of that edge. A previous effort toward a solution was to add a penalty weight to the zigzag pattern, but this did not work reliably due to other complexities.

Also the pathfinder doesn't account for the cost of crossing half of the final map to reach its center, resulting in it scoring reaching the corner of that map as equivalent to reaching its edge. This causes the pathfinder to often prioritize traveling along the edges of a line of maps, which causes a zigzag.

I also added some new pathfinding test cases and additional checks and comments in existing test cases.

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
