### PR TITLE
Several text corrections

### DIFF
--- a/data/json/monster_special_attacks/monster_attacks.json
+++ b/data/json/monster_special_attacks/monster_attacks.json
@@ -704,12 +704,12 @@
     "effects": [ { "id": "dermatik", "duration": 86400, "affect_hit_bp": true } ],
     "cooldown": 25,
     "move_cost": 300,
-    "hit_dmg_u": "The %1$s sinks its ovipositor into your %2$s!",
-    "hit_dmg_npc": "The %1$s sinks its ovipositor into <npcname>'s %2$s!",
-    "miss_msg_u": "The %s tries to land on you, but you dodge!",
-    "miss_msg_npc": "The %1$s tries to land on <npcname>, but they dodge!",
-    "no_dmg_msg_u": "The %1$s lands on your %2$s, but can't penetrate your armor!",
-    "no_dmg_msg_npc": "The %1$s lands on <npcname>'s %2$s, but can't penetrate their armor!"
+    "hit_dmg_u": "%1$s sinks its ovipositor into your %2$s!",
+    "hit_dmg_npc": "%1$s sinks its ovipositor into <npcname>'s %2$s!",
+    "miss_msg_u": "%s tries to land on you, but you dodge!",
+    "miss_msg_npc": "%s tries to land on <npcname>, but they dodge!",
+    "no_dmg_msg_u": "%1$s lands on your %2$s, but can't penetrate your armor!",
+    "no_dmg_msg_npc": "%1$s lands on <npcname>'s %2$s, but can't penetrate their armor!"
   },
   {
     "type": "monster_attack",
@@ -732,12 +732,12 @@
       ]
     },
     "effects": [ { "id": "venom_pain", "duration": 54000, "affect_hit_bp": true } ],
-    "hit_dmg_u": "Using its filaments, the %s pulls you close.",
-    "hit_dmg_npc": "Using its filaments, the %s pulls <npcname> close.",
-    "miss_msg_u": "The %s spews filaments at you but misses.",
-    "miss_msg_npc": "The %s spews filaments at <npcname> but misses.",
-    "no_dmg_msg_u": "Using its filaments, the %s pulls you close but can't penetrate your armor.",
-    "no_dmg_msg_npc": "Using its filaments, the %s pulls <npcname> close but can't penetrate their armor."
+    "hit_dmg_u": "%s pulls you close using its filaments.",
+    "hit_dmg_npc": "%s pulls <npcname> close using its filaments.",
+    "miss_msg_u": "%s spews filaments at you but misses.",
+    "miss_msg_npc": "%s spews filaments at <npcname> but misses.",
+    "no_dmg_msg_u": "%s pulls you close using its filaments, but can't penetrate your armor.",
+    "no_dmg_msg_npc": "%s pulls <npcname> close using its filaments, but can't penetrate their armor."
   },
   {
     "type": "monster_attack",
@@ -752,12 +752,12 @@
     "max_mul": 1.5,
     "condition": { "not": { "u_has_effect": "sectioned_filaments" } },
     "effects": [ { "id": "venom_pain", "duration": 54000, "affect_hit_bp": true } ],
-    "hit_dmg_u": "The %s lashes at your %2$s.",
-    "hit_dmg_npc": "The %s lashes at <npcname> %2$s.",
-    "miss_msg_u": "The %s lashes at your %2$s but misses.",
-    "miss_msg_npc": "The %s lashes at <npcname> %2$s but misses.",
-    "no_dmg_msg_u": "The %s lashes at your %2$s but can't penetrate your armor.",
-    "no_dmg_msg_npc": "The %s lashes at <npcname> %2$s but can't penetrate their armor."
+    "hit_dmg_u": "%1$s lashes at your %2$s.",
+    "hit_dmg_npc": "%1$s lashes at <npcname>'s %2$s.",
+    "miss_msg_u": "%1$s lashes at your %2$s but misses.",
+    "miss_msg_npc": "%1$s lashes at <npcname>'s %2$s but misses.",
+    "no_dmg_msg_u": "%1$s lashes at your %2$s, but can't penetrate your armor.",
+    "no_dmg_msg_npc": "%1$s lashes at <npcname>'s %2$s, but can't penetrate their armor."
   },
   {
     "type": "monster_attack",
@@ -779,12 +779,12 @@
       ]
     },
     "effects": [ { "id": "venom_pain", "duration": 54000, "affect_hit_bp": true } ],
-    "hit_dmg_u": "The %s wraps its filaments around your %2$s.",
-    "hit_dmg_npc": "The %s wraps its filaments around <npcname>'s %2$s.",
-    "miss_msg_u": "The %s tries to wrap its filaments around your %2$s but misses.",
-    "miss_msg_npc": "The %s tries to wrap its filaments around <npcname> %2$s but misses.",
-    "no_dmg_msg_u": "The %s wraps its filaments around your %2$s but can't penetrate your armor.",
-    "no_dmg_msg_npc": "The %s wraps its filaments around <npcname>'s %2$s but can't penetrate their armor."
+    "hit_dmg_u": "%1$s wraps its filaments around your %2$s.",
+    "hit_dmg_npc": "%1$s wraps its filaments around <npcname>'s %2$s.",
+    "miss_msg_u": "%1$s tries to wrap its filaments around your %2$s but misses.",
+    "miss_msg_npc": "%1$s tries to wrap its filaments around <npcname>'s %2$s but misses.",
+    "no_dmg_msg_u": "%1$s wraps its filaments around your %2$s, but can't penetrate your armor.",
+    "no_dmg_msg_npc": "%1$s wraps its filaments around <npcname>'s %2$s, but can't penetrate their armor."
   },
   {
     "type": "monster_attack",
@@ -801,11 +801,11 @@
     "condition": {
       "and": [ { "u_has_flag": "GRAB_FILTER" }, { "npc_has_flag": "GRAB" }, { "not": { "u_has_effect": "sectioned_filaments" } } ]
     },
-    "hit_dmg_u": "The %s pulls your %2$s in its orifice and starts crushing it.",
-    "hit_dmg_npc": "The %s pulls <npcname>'s %2$s in its orifice and starts crushing it.",
-    "miss_msg_u": "The %s tries to pulls your %2$s in its orifice but misses.",
-    "miss_msg_npc": "The %s tries to pulls <npcname>'s %2$s in its orifice but misses.",
-    "no_dmg_msg_u": "The %s pulls your %2$s in its orifice and starts crushing it but can't penetrate your armor.",
-    "no_dmg_msg_npc": "The %s pulls <npcname>'s %2$s in its orifice and starts crushing it but can't penetrate their armor."
+    "hit_dmg_u": "%1$s pulls your %2$s in its orifice and starts crushing it.",
+    "hit_dmg_npc": "%1$s pulls <npcname>'s %2$s in its orifice and starts crushing it.",
+    "miss_msg_u": "%1$s tries to pulls your %2$s in its orifice but misses.",
+    "miss_msg_npc": "%1$s tries to pulls <npcname>'s %2$s in its orifice but misses.",
+    "no_dmg_msg_u": "%1$s pulls your %2$s in its orifice and starts crushing it, but can't penetrate your armor.",
+    "no_dmg_msg_npc": "%1$s pulls <npcname>'s %2$s in its orifice and starts crushing it, but can't penetrate their armor."
   }
 ]

--- a/data/mods/MindOverMatter/monsters/animal_psychics.json
+++ b/data/mods/MindOverMatter/monsters/animal_psychics.json
@@ -325,7 +325,7 @@
         "spell_data": { "id": "telepathic_fear_blast_monster", "min_level": 2 },
         "cooldown": { "math": [ "9 + rand(18)" ] },
         "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
-        "monster_message": "%1$'s third eye opens and it coos!"
+        "monster_message": "%s's third eye opens and it coos!"
       },
       { "id": "pigeon_aura", "type": "spell", "spell_data": { "id": "pigeon_aura", "min_level": 4 }, "cooldown": 200 }
     ],

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -260,7 +260,8 @@ static std::vector<item_location> try_to_put_into_vehicle( Character &c, item_dr
                 result.emplace_back( c.get_wielded_item() );
             } else {
                 const std::string ter_name = here.name( where );
-                add_msg( _( "The %s falls to the %s." ), it.tname(), ter_name );
+                //~ %1$s - item name, %2$s - terrain name
+                add_msg( _( "The %1$s falls to the %2$s." ), it.tname(), ter_name );
                 result.push_back( here.add_item_or_charges_ret_loc( where, it ) );
             }
         }
@@ -295,24 +296,24 @@ static std::vector<item_location> try_to_put_into_vehicle( Character &c, item_dr
             case item_drop_reason::too_large:
                 c.add_msg_if_player(
                     n_gettext(
-                        "There's no room in your inventory for the %s, so you drop it into the %s's %s.",
-                        "There's no room in your inventory for the %s, so you drop them into the %s's %s.",
+                        "There's no room in your inventory for the %1$s, so you drop it into the %2$s's %3$s.",
+                        "There's no room in your inventory for the %1$s, so you drop them into the %2$s's %3$s.",
                         dropcount ),
                     it_name, veh.name, part_name
                 );
                 break;
             case item_drop_reason::too_heavy:
                 c.add_msg_if_player(
-                    n_gettext( "The %s is too heavy to carry, so you drop it into the %s's %s.",
-                               "The %s are too heavy to carry, so you drop them into the %s's %s.", dropcount ),
+                    n_gettext( "The %1$s is too heavy to carry, so you drop it into the %2$s's %3$s.",
+                               "The %1$s are too heavy to carry, so you drop them into the %2$s's %3$s.", dropcount ),
                     it_name, veh.name, part_name
                 );
                 break;
             case item_drop_reason::tumbling:
                 c.add_msg_if_player(
                     m_bad,
-                    n_gettext( "Your %s tumbles into the %s's %s.",
-                               "Your %s tumble into the %s's %s.", dropcount ),
+                    n_gettext( "Your %1$s tumbles into the %2$s's %3$s.",
+                               "Your %1$s tumble into the %2$s's %3$s.", dropcount ),
                     it_name, veh.name, part_name
                 );
                 break;
@@ -3503,7 +3504,7 @@ bool generic_multi_activity_handler( player_activity &act, Character &you, bool 
     if( !check_only && you.is_npc() ) {
         if( src_sorted.empty() ) {
             add_msg( m_neutral,
-                     _( "%1s failed to perform the %2$s activity because no suitable locations were found." ),
+                     _( "%1$s failed to perform the %2$s activity because no suitable locations were found." ),
                      you.disp_name(), activity_to_restore.c_str() );
         } else if( reason.no_path ) {
             add_msg( m_neutral,

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -7984,7 +7984,7 @@ ret_val<void> Character::can_wield( const item &it ) const
     }
 
     if( is_armed() && !can_unwield( weapon ).success() ) {
-        return ret_val<void>::make_failure( _( "The %s prevents you from wielding the %s." ),
+        return ret_val<void>::make_failure( _( "The %1$s prevents you from wielding the %2$s." ),
                                             weapname(), it.tname() );
     }
     monster *mount = mounted_creature.get();
@@ -12408,7 +12408,7 @@ const Character *Character::get_book_reader( const item &book,
         // Low morale still permits skimming
         reasons.emplace_back( is_avatar() ?
                               _( "What's the point of studying?  (Your morale is too low!)" )  :
-                              string_format( _( "What's the point of studying?  (%s)'s morale is too low!)" ), disp_name() ) );
+                              string_format( _( "What's the point of studying?  (%s's morale is too low!)" ), disp_name() ) );
         return nullptr;
     }
     if( condition & read_condition_result::CANT_UNDERSTAND ) {

--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -410,7 +410,7 @@ static void do_blast( map *m, const Creature *source, const tripoint_bub_ms &p, 
             add_msg_debug( debugmode::DF_EXPLOSION, "%s for %d raw, %d actual", hit_part_name, part_dam,
                            res_dmg );
             if( res_dmg > 0 ) {
-                pl->add_msg_if_player( m_bad, _( "Your %s is hit for %d damage!" ), hit_part_name, res_dmg );
+                pl->add_msg_if_player( m_bad, _( "Your %1$s is hit for %2$d damage!" ), hit_part_name, res_dmg );
             }
         }
     }

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -776,9 +776,10 @@ static void grab()
         if( vp->has_loaded_furniture() ) {
             furn_str_id furn( vp->part_with_feature( "FURNITURE_TIEDOWN",
                               true )->part().get_base().get_var( "tied_down_furniture" ) );
-            if( query_yn( _( "Grab %s on %s?" ), furn->name(), veh_name ) ) {
+            //~ %1$s - furniture name, %2$s - vehicle name
+            if( query_yn( _( "Grab %1$s on %2$s?" ), furn->name(), veh_name ) ) {
                 you.grab( object_type::FURNITURE_ON_VEHICLE, grabp - you.pos_bub() );
-                add_msg( m_info, _( "You grab the %s loaded on the %s." ), furn->name(), veh_name );
+                add_msg( m_info, _( "You grab the %1$s loaded on the %2$s." ), furn->name(), veh_name );
                 return;
             }
         }
@@ -1074,7 +1075,8 @@ avatar::smash_result avatar::smash( tripoint_bub_ms &smashp )
             if( !best_part_to_smash.first->smash_message.empty() ) {
                 add_msg( best_part_to_smash.first->smash_message, name_to_bash );
             } else {
-                add_msg( _( "You use your %s to smash the %s." ),
+                //~ %1$s - bodypart name in accusative, %2$s - furniture/terrain name
+                add_msg( _( "You use your %1$s to smash the %2$s." ),
                          body_part_name_accusative( best_part_to_smash.first ), name_to_bash );
             }
         }

--- a/src/item_pocket.cpp
+++ b/src/item_pocket.cpp
@@ -821,7 +821,7 @@ void item_pocket::handle_liquid_or_spill( Character &guy, const item *avoid )
             item i_copy( *iter );
             guy.i_add_or_drop( i_copy, 1, avoid, &*iter );
             iter = contents.erase( iter );
-            guy.add_msg_if_player( m_warning, _( "The %s falls out of the %s." ), i_copy.display_name(),
+            guy.add_msg_if_player( m_warning, _( "The %1$s falls out of the %2$s." ), i_copy.display_name(),
                                    get_name() );
         }
     }

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -4236,7 +4236,8 @@ bool place_trap_actor::is_allowed( Character &p, const tripoint_bub_ms &pos,
         }
     }
     if( needs_neighbor_terrain && !has_neighbor( pos, needs_neighbor_terrain ) ) {
-        p.add_msg_if_player( m_info, _( "The %s needs a %s adjacent to it." ), name,
+        //~ %1$s - trap name, %2$s - terrain name
+        p.add_msg_if_player( m_info, _( "The %1$s needs a %2$s adjacent to it." ), name,
                              needs_neighbor_terrain.obj().name() );
         return false;
     }
@@ -4249,6 +4250,7 @@ bool place_trap_actor::is_allowed( Character &p, const tripoint_bub_ms &pos,
                                  : _( "You can't place a %s there.  It contains a trap already." ),
                                  name );
         } else {
+            //~ %s - trap name
             p.add_msg_if_player( m_bad, _( "You trigger a %s!" ), existing_trap.name() );
             existing_trap.trigger( pos, p );
         }

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -982,15 +982,15 @@ static void handle_remove_fd_fatigue_field( const std::pair<field, tripoint_bub_
                 caster.add_effect( effect_teleglow, 5_hours );
                 break;
             case 3:
-                std::string message_prefix = "A nearby";
-
-                if( caster.sees( here, field_position ) ) {
-                    message_prefix = "The";
+                if( sees_field ) {
+                    caster.add_msg_if_player( m_bad, _( "The %s pulls you in as it closes and ejects you violently!" ),
+                                              intensity_name );
+                } else {
+                    caster.add_msg_if_player( m_bad,
+                                              _( "A nearby %s pulls you in as it closes and ejects you violently!" ),
+                                              intensity_name );
                 }
 
-                caster.add_msg_if_player( m_bad,
-                                          _( "%s %s pulls you in as it closes and ejects you violently!" ),
-                                          message_prefix, intensity_name );
                 caster.as_character()->hurtall( 10, nullptr );
                 caster.add_effect( effect_teleglow, 630_minutes );
                 teleport::teleport_creature( caster );

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -2047,7 +2047,8 @@ static void poly_keep_speed( monster &mon, const mtype_id &id )
 
 static bool blobify( monster &blob, monster &target )
 {
-    add_msg_if_player_sees( target, m_warning, _( "%s is engulfed by %s!" ),
+    //~ %1$s and %2$s - monster names
+    add_msg_if_player_sees( target, m_warning, _( "%1$s is engulfed by %2$s!" ),
                             target.disp_name(), blob.disp_name() );
     switch( target.get_size() ) {
         case creature_size::tiny:

--- a/src/monexamine.cpp
+++ b/src/monexamine.cpp
@@ -105,24 +105,26 @@ void bandage_animal( monster &z )
     }
     item_location wieldede_item = get_player_character().get_wielded_item();
     if( !wieldede_item ) {
-        add_msg( _( "I need to have in hand something to stop the bleeding of %s" ), z.name() );
+        add_msg( _( "You need to wield something to stop the %s's bleeding." ), z.name() );
         return;
     }
     const use_function *usage = wieldede_item.get_item()->type->get_use( "heal" );
     if( usage == nullptr ) {
-        add_msg( _( "I'm not going to stop %s bleeding with this %s " ), z.name(),
-                 wieldede_item.get_item()->display_name() );
+        //~ %1$s - item name, %2$s - animal name
+        add_msg( _( "This %1$s won't help you stop the %2$s's bleeding." ),
+                 wieldede_item.get_item()->display_name(), z.name() );
         return;
     }
     const heal_actor *actor = dynamic_cast<const heal_actor *>( usage->get_actor_ptr() );
     if( actor->bleed ) {
         z.remove_effect( effect_bleed );
         wieldede_item.remove_item();
-        add_msg( _( "The bleeding of %s stopped" ), z.name() );
+        add_msg( _( "You stop the %s's bleeding." ), z.name() );
 
     } else {
-        add_msg( _( "I'm not going to stop %s bleeding with this %s " ), z.name(),
-                 wieldede_item.get_item()->display_name() );
+        //~ %1$s - item name, %2$s - animal name
+        add_msg( _( "This %1$s won't help you stop the %2$s's bleeding." ),
+                 wieldede_item.get_item()->display_name(), z.name() );
     }
 }
 

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -7436,7 +7436,7 @@ void vehicle::shed_loose_parts( const trinary shed_cables, map *here, const trip
 
             if( distance > max_dist || shed_cables == trinary::ALL ) {
                 add_msg_if_player_sees( bub_part_pos( *here, vp_loose ), m_warning,
-                                        _( "The %s's %s was detached!" ), name, vp_loose.name( false ) );
+                                        _( "The %1$s's %2$s was detached!" ), name, vp_loose.name( false ) );
                 remove_remote = true;
             } else {
                 // cable still has some slack to it, so update the remote part's target and continue.
@@ -7802,7 +7802,7 @@ int vehicle::break_off( map &here, vehicle_part &vp, int dmg )
                 remove_remote_part( here, vp_here );
             } else if( vp_here.is_broken() ) {
                 // Tearing off a broken part - break it up
-                add_msg_if_player_sees( pos, m_bad, _( "The %s's %s breaks into pieces!" ), name,
+                add_msg_if_player_sees( pos, m_bad, _( "The %1$s's %2$s breaks into pieces!" ), name,
                                         vp_here.name() );
                 scatter_parts( vp_here );
             } else {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
1. Transifex does not allow saving translations where `%1$s` is used instead of `%s`.
2. Some lines mix positional and non-positional arguments: `The %s pulls your %2$s`.
3. Several monster_attack messages are incorrectly formatted.
<img width="898" height="588" alt="skulk1" src="https://github.com/user-attachments/assets/96ed527d-4665-4f3d-91e1-746f361cdef2" />

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
1. Replace non-positional arguments with positional arguments for some problematic strings.
2. Rewrite some messages.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Disable all checks in Transifex. But it's still worth replacing with positional arguments as a reminder that they can be swapped.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Let's see what the tests say about c++.

<img width="360" height="81" alt="skulk2" src="https://github.com/user-attachments/assets/26913cbb-7cb3-4403-99d3-b7d59511a2ab" />
<img width="363" height="69" alt="skulk3" src="https://github.com/user-attachments/assets/6c8b25a6-766e-4f04-8c6e-157323b8a660" />
<img width="346" height="152" alt="skulk4" src="https://github.com/user-attachments/assets/912be298-5073-47b5-bd2f-2b0631b077a9" />

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
