### PR TITLE
Present dispersion as MOA in item UI

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -3002,18 +3002,17 @@ void item::ammo_info( std::vector<iteminfo> &info, const iteminfo_query *parts, 
                                iteminfo::is_decimal, ammo.range_multiplier );
         }
         if( parts->test( iteminfo_parts::AMMO_DAMAGE_DISPERSION ) ) {
-            info.emplace_back( "AMMO", _( "Dispersion: " ), "",
-                               iteminfo::lower_is_better, ammo.dispersion );
+            info.emplace_back( "AMMO", _( "Dispersion: " ), "<num> MOA",
+                               iteminfo::is_decimal | iteminfo::lower_is_better, ammo.dispersion / 100.0 );
         }
         if( parts->test( iteminfo_parts::AMMO_DAMAGE_RECOIL ) ) {
-            info.emplace_back( "AMMO", _( "Recoil: " ), "",
-                               iteminfo::lower_is_better | iteminfo::no_newline, ammo.recoil );
+            info.emplace_back( "AMMO", _( "Recoil: " ), "<num> MOA",
+                               iteminfo::is_decimal | iteminfo::lower_is_better | iteminfo::no_newline, ammo.recoil / 100.0 );
         }
         if( parts->test( iteminfo_parts::AMMO_DAMAGE_CRIT_MULTIPLIER ) ) {
             info.emplace_back( "AMMO", space + _( "Critical multiplier: " ), ammo.critical_multiplier );
         }
         if( parts->test( iteminfo_parts::AMMO_BARREL_DETAILS ) ) {
-            std::string barrel_details;
             const units::length small = 150_mm;
             const units::length medium = 400_mm;
             const units::length large = 600_mm;
@@ -3032,24 +3031,27 @@ void item::ammo_info( std::vector<iteminfo> &info, const iteminfo_query *parts, 
                 const std::string small_string = string_format( " <info>%d %s</info>: ",
                                                  convert_length( small ),
                                                  length_units( small ) );
-                info.emplace_back( "AMMO", small_string, _( " damage:  <num>" ), iteminfo::no_newline,
+                info.emplace_back( "AMMO", small_string, _( " damage = <num>" ), iteminfo::no_newline,
                                    small_damage );
-                info.emplace_back( "AMMO", "", _( " dispersion:  <num>" ),
-                                   iteminfo::no_name | iteminfo::lower_is_better, small_dispersion );
+                info.emplace_back( "AMMO", "", _( " dispersion = <num> MOA" ),
+                                   iteminfo::no_name | iteminfo::is_decimal | iteminfo::lower_is_better,
+                                   small_dispersion / 100.0 );
                 const std::string medium_string = string_format( " <info>%d %s</info>: ",
                                                   convert_length( medium ),
                                                   length_units( medium ) );
-                info.emplace_back( "AMMO", medium_string, _( " damage:  <num>" ), iteminfo::no_newline,
+                info.emplace_back( "AMMO", medium_string, _( " damage = <num>" ), iteminfo::no_newline,
                                    medium_damage );
-                info.emplace_back( "AMMO", "", _( " dispersion:  <num>" ),
-                                   iteminfo::no_name  | iteminfo::lower_is_better, medium_dispersion );
+                info.emplace_back( "AMMO", "", _( " dispersion = <num> MOA" ),
+                                   iteminfo::no_name  | iteminfo::is_decimal | iteminfo::lower_is_better,
+                                   medium_dispersion / 100.0 );
                 const std::string large_string = string_format( " <info>%d %s</info>: ",
                                                  convert_length( large ),
                                                  length_units( large ) );
-                info.emplace_back( "AMMO", large_string, _( " damage:  <num>" ), iteminfo::no_newline,
+                info.emplace_back( "AMMO", large_string, _( " damage = <num>" ), iteminfo::no_newline,
                                    large_damage );
-                info.emplace_back( "AMMO", "", _( " dispersion:  <num>" ),
-                                   iteminfo::no_name | iteminfo::lower_is_better, large_dispersion );
+                info.emplace_back( "AMMO", "", _( " dispersion = <num> MOA" ),
+                                   iteminfo::no_name | iteminfo::is_decimal | iteminfo::lower_is_better,
+                                   large_dispersion / 100.0 );
             }
         }
     }
@@ -3288,22 +3290,22 @@ void item::gun_info( const item *mod, std::vector<iteminfo> &info, const iteminf
 
     if( parts->test( iteminfo_parts::GUN_DISPERSION ) ) {
         info.emplace_back( "GUN", _( "Dispersion: " ), "",
-                           iteminfo::no_newline | iteminfo::lower_is_better,
-                           mod->gun_dispersion( false, false ) );
+                           iteminfo::is_decimal | iteminfo::lower_is_better | iteminfo::no_newline,
+                           mod->gun_dispersion( false, false ) / 100.0 );
     }
     if( mod->ammo_required() ) {
         int ammo_dispersion = curammo->ammo->dispersion_considering_length( barrel_length() );
         // ammo_dispersion and sum_of_dispersion don't need to translate.
         if( parts->test( iteminfo_parts::GUN_DISPERSION_LOADEDAMMO ) ) {
             info.emplace_back( "GUN", "ammo_dispersion", "",
-                               iteminfo::no_newline | iteminfo::lower_is_better |
-                               iteminfo::no_name | iteminfo::show_plus,
-                               ammo_dispersion );
+                               iteminfo::is_decimal |  iteminfo::lower_is_better | iteminfo::no_name | iteminfo::no_newline |
+                               iteminfo::show_plus,
+                               ammo_dispersion / 100.0 );
         }
         if( parts->test( iteminfo_parts::GUN_DISPERSION_TOTAL ) ) {
-            info.emplace_back( "GUN", "sum_of_dispersion", _( " = <num>" ),
-                               iteminfo::lower_is_better | iteminfo::no_name,
-                               loaded_mod->gun_dispersion( true, false ) );
+            info.emplace_back( "GUN", "sum_of_dispersion", _( " = <num> MOA" ),
+                               iteminfo::is_decimal |  iteminfo::lower_is_better | iteminfo::no_name,
+                               loaded_mod->gun_dispersion( true, false ) / 100.0 );
         }
     }
     info.back().bNewLine = true;
@@ -3318,20 +3320,20 @@ void item::gun_info( const item *mod, std::vector<iteminfo> &info, const iteminf
     if( parts->test( iteminfo_parts::GUN_DISPERSION_SIGHT ) ) {
         if( point_shooting_limit <= eff_disp ) {
             info.emplace_back( "GUN", _( "Sight dispersion (point shooting): " ), "",
-                               iteminfo::no_newline | iteminfo::lower_is_better,
-                               point_shooting_limit );
+                               iteminfo::is_decimal | iteminfo::no_newline | iteminfo::lower_is_better,
+                               point_shooting_limit / 100.0 );
         } else {
             info.emplace_back( "GUN", _( "Sight dispersion: " ), "",
-                               iteminfo::no_newline | iteminfo::lower_is_better,
-                               act_disp );
+                               iteminfo::is_decimal | iteminfo::no_newline | iteminfo::lower_is_better,
+                               act_disp / 100.0 );
 
             if( adj_disp ) {
                 info.emplace_back( "GUN", "sight_adj_disp", "",
-                                   iteminfo::no_newline | iteminfo::lower_is_better |
-                                   iteminfo::no_name | iteminfo::show_plus, adj_disp );
-                info.emplace_back( "GUN", "sight_eff_disp", _( " = <num>" ),
-                                   iteminfo::lower_is_better | iteminfo::no_name,
-                                   eff_disp );
+                                   iteminfo::is_decimal | iteminfo::no_newline | iteminfo::lower_is_better |
+                                   iteminfo::no_name | iteminfo::show_plus, adj_disp / 100.0 );
+                info.emplace_back( "GUN", "sight_eff_disp", _( " = <num> MOA" ),
+                                   iteminfo::is_decimal | iteminfo::lower_is_better | iteminfo::no_name,
+                                   eff_disp / 100.0 );
             }
         }
     }
@@ -3340,21 +3342,21 @@ void item::gun_info( const item *mod, std::vector<iteminfo> &info, const iteminf
     info.back().bNewLine = true;
     if( loaded_mod->gun_recoil( player_character ) ) {
         if( parts->test( iteminfo_parts::GUN_RECOIL ) ) {
-            info.emplace_back( "GUN", _( "Effective recoil: " ), "",
-                               iteminfo::no_newline | iteminfo::lower_is_better,
-                               loaded_mod->gun_recoil( player_character ) );
+            info.emplace_back( "GUN", _( "Effective recoil: " ), "<num> MOA",
+                               iteminfo::is_decimal | iteminfo::no_newline | iteminfo::lower_is_better,
+                               loaded_mod->gun_recoil( player_character ) / 100.0 );
         }
         if( bipod && parts->test( iteminfo_parts::GUN_RECOIL_BIPOD ) ) {
-            info.emplace_back( "GUN", "bipod_recoil", _( " (with bipod <num>)" ),
-                               iteminfo::lower_is_better | iteminfo::no_name,
-                               loaded_mod->gun_recoil( player_character, true ) );
+            info.emplace_back( "GUN", "bipod_recoil", _( " (with bipod <num> MOA)" ),
+                               iteminfo::is_decimal | iteminfo::lower_is_better | iteminfo::no_name,
+                               loaded_mod->gun_recoil( player_character, true ) / 100.0 );
         }
 
         if( parts->test( iteminfo_parts::GUN_RECOIL_THEORETICAL_MINIMUM ) ) {
             info.back().bNewLine = true;
-            info.emplace_back( "GUN", _( "Theoretical minimum recoil: " ), "",
-                               iteminfo::no_newline | iteminfo::lower_is_better, loaded_mod->gun_recoil( player_character, true,
-                                       true ) );
+            info.emplace_back( "GUN", _( "Theoretical minimum recoil: " ), "<num> MOA",
+                               iteminfo::is_decimal | iteminfo::no_newline | iteminfo::lower_is_better,
+                               loaded_mod->gun_recoil( player_character, true, true ) / 100.0 );
         }
         if( parts->test( iteminfo_parts:: GUN_IDEAL_STRENGTH ) ) {
             info.emplace_back( "GUN", "ideal_strength", _( " (when strength reaches: <num>)" ),
@@ -3576,13 +3578,13 @@ void item::gunmod_info( std::vector<iteminfo> &info, const iteminfo_query *parts
     }
 
     if( mod.dispersion != 0 && parts->test( iteminfo_parts::GUNMOD_DISPERSION ) ) {
-        info.emplace_back( "GUNMOD", _( "Dispersion modifier: " ), "",
-                           iteminfo::lower_is_better | iteminfo::show_plus,
-                           mod.dispersion );
+        info.emplace_back( "GUNMOD", _( "Dispersion modifier: " ), "<num> MOA",
+                           iteminfo::is_decimal | iteminfo::lower_is_better | iteminfo::show_plus,
+                           mod.dispersion / 100.0 );
     }
     if( mod.sight_dispersion != -1 && parts->test( iteminfo_parts::GUNMOD_DISPERSION_SIGHT ) ) {
-        info.emplace_back( "GUNMOD", _( "Sight dispersion: " ), "",
-                           iteminfo::lower_is_better, mod.sight_dispersion );
+        info.emplace_back( "GUNMOD", _( "Sight dispersion: " ), "<num> MOA",
+                           iteminfo::is_decimal | iteminfo::lower_is_better, mod.sight_dispersion / 100.0 );
     }
     if( mod.field_of_view > 0 && parts->test( iteminfo_parts::GUNMOD_FIELD_OF_VIEW ) ) {
         if( mod.field_of_view >= MAX_RECOIL ) {

--- a/tests/iteminfo_test.cpp
+++ b/tests/iteminfo_test.cpp
@@ -1816,7 +1816,7 @@ TEST_CASE( "gun_or_other_ranged_weapon_attributes", "[iteminfo][weapon][gun]" )
 
         CHECK( item_info_str( glock, recoil ) ==
                "--\n"
-               "Effective recoil: <color_c_yellow>312</color>\n" );
+               "Effective recoil: <color_c_yellow>3.12</color> MOA\n" );
     }
 
     SECTION( "gun type and current magazine" ) {
@@ -1907,7 +1907,7 @@ TEST_CASE( "gun_or_other_ranged_weapon_attributes", "[iteminfo][weapon][gun]" )
     SECTION( "weapon dispersion" ) {
         CHECK( item_info_str( compbow, { iteminfo_parts::GUN_DISPERSION } ) ==
                "--\n"
-               "Dispersion: <color_c_yellow>850</color>\n" );
+               "Dispersion: <color_c_yellow>8.50</color>\n" );
     }
 
     SECTION( "needing two hands to fire" ) {
@@ -1949,15 +1949,15 @@ TEST_CASE( "gun_armor_piercing_dispersion_and_other_stats", "[iteminfo][gun][mis
            "--\n = <color_c_yellow>0</color>\n" );
 
     CHECK( item_info_str( glock, disp_loaded ) ==
-           "--\n<color_c_yellow>+60</color>\n" );
+           "--\n<color_c_yellow>+0.60</color>\n" );
     CHECK( item_info_str( glock, disp_total ) ==
-           "--\n = <color_c_yellow>540</color>\n" );
+           "--\n = <color_c_yellow>5.40</color> MOA\n" );
 
     CHECK( item_info_str( glock, disp_sight ) ==
            "--\n"
-           "Sight dispersion: <color_c_yellow>30</color>"
-           "<color_c_yellow>+14</color>"
-           " = <color_c_yellow>44</color>\n" );
+           "Sight dispersion: <color_c_yellow>0.30</color>"
+           "<color_c_yellow>+0.14</color>"
+           " = <color_c_yellow>0.44</color> MOA\n" );
 
     // TODO: Add a test gun with thest attributes
     //CHECK( item_info_str( glock, recoil_bipod ).empty() );
@@ -2031,7 +2031,7 @@ TEST_CASE( "gunmod_info", "[iteminfo][gunmod]" )
 
     CHECK( item_info_str( supp, disp_sight ) ==
            "--\n"
-           "Sight dispersion: <color_c_yellow>11</color>\n" );
+           "Sight dispersion: <color_c_yellow>0.11</color> MOA\n" );
 
     CHECK( item_info_str( supp, field_of_view ) ==
            "--\n"
@@ -2086,8 +2086,8 @@ TEST_CASE( "ammunition", "[iteminfo][ammo]" )
                "--\n"
                "<color_c_white>Ammunition type</color>: rocks\n"
                "Damage: <color_c_yellow>7</color>  Armor-pierce: <color_c_yellow>0</color>\n"
-               "Range: <color_c_yellow>10</color>  Dispersion: <color_c_yellow>14</color>\n"
-               "Recoil: <color_c_yellow>0</color>  Critical multiplier: <color_c_yellow>2</color>\n" );
+               "Range: <color_c_yellow>10</color>  Dispersion: <color_c_yellow>0.14</color> MOA\n"
+               "Recoil: <color_c_yellow>0.00</color> MOA  Critical multiplier: <color_c_yellow>2</color>\n" );
     }
 
     SECTION( "batteries" ) {


### PR DESCRIPTION
#### Summary
Interface "Present dispersion as MOA in item UI"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

When I was studying how the ranged attack code works, I learned about MOA, and understood that the game runs with integer units representing 100s of a MOA. So, I thought that converting to MOA on our UI would be a good thing™ as people who are aware of it will have a better intuition than "ok, this is 540 dispersion, but 540 what?".

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

Just changed strings in-place on item info code. How doesn't break any string translations!

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

* In the code I saw there is a data type to store and represent unit measurements. I've considered doing the change at that level, but look too disruptive for just a UI thing (I assume everything else related works good enough)
* Maybe related to earlier point, considered changing JSON serialization so ranged code is described with units there as well, opted-out for the same reason of too big of a change.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

Fixed existing unit tests and have the screenshot below by playing the game.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

<img width="354" height="236" alt="Screenshot 2025-08-25 at 12 04 02" src="https://github.com/user-attachments/assets/b5740997-11f7-4bef-8ca9-6913c8b0e27c" />

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->