### PR TITLE
Allow deconstruct guardrails

### DIFF
--- a/data/json/furniture_and_terrain/terrain-fences-gates.json
+++ b/data/json/furniture_and_terrain/terrain-fences-gates.json
@@ -1327,37 +1327,7 @@
   },
   {
     "type": "terrain",
-    "id": "t_guardrail_hw_air",
-    "name": "guard rail",
-    "description": "A section of metal railing, put in place to prevent people from falling or taking the easy way out.",
-    "symbol": "#",
-    "color": "light_gray",
-    "looks_like": "t_guardrail_bg_dp",
-    "move_cost": 3,
-    "flags": [
-      "TRANSPARENT",
-      "NOITEM",
-      "REDUCE_SCENT",
-      "MOUNTABLE",
-      "SHORT",
-      "THIN_OBSTACLE",
-      "ROAD",
-      "CLIMBABLE",
-      "BURROWABLE",
-      "PERMEABLE"
-    ],
-    "bash": {
-      "str_min": 8,
-      "str_max": 150,
-      "sound": "crunch!",
-      "sound_fail": "clang!",
-      "ter_set": "t_pavement_hw_air",
-      "items": [ { "item": "pipe", "count": [ 1, 2 ] }, { "item": "scrap", "count": [ 3, 6 ] } ]
-    }
-  },
-  {
-    "type": "terrain",
-    "id": "t_guardrail_bg_dp",
+    "abstract": "t_abstract_guardrail",
     "name": "guard rail",
     "description": "A section of metal railing, put in place to prevent people from falling or taking the easy way out.",
     "symbol": "#",
@@ -1375,36 +1345,8 @@
       "BURROWABLE",
       "PERMEABLE"
     ],
-    "bash": {
-      "str_min": 8,
-      "str_max": 150,
-      "sound": "crunch!",
-      "sound_fail": "clang!",
-      "ter_set": "t_pavement_bg_dp",
-      "items": [ { "item": "pipe", "count": [ 1, 2 ] }, { "item": "scrap", "count": [ 3, 6 ] } ]
-    }
-  },
-  {
-    "type": "terrain",
-    "id": "t_guardrail",
-    "name": "guard rail",
-    "description": "A section of metal railing, put in place to prevent people from falling or taking the easy way out.",
-    "symbol": "#",
-    "color": "light_gray",
-    "move_cost": 3,
-    "flags": [
-      "TRANSPARENT",
-      "NOITEM",
-      "REDUCE_SCENT",
-      "MOUNTABLE",
-      "SHORT",
-      "THIN_OBSTACLE",
-      "ROAD",
-      "CLIMBABLE",
-      "BURROWABLE",
-      "PERMEABLE"
-    ],
-    "looks_like": "t_guardrail_bg_dp",
+    "looks_like": "t_guardrail",
+    "deconstruct": { "ter_set": "t_pavement", "items": [ { "item": "pipe", "count": 2 }, { "item": "scrap", "count": [ 5, 6 ] } ] },
     "bash": {
       "str_min": 8,
       "str_max": 150,
@@ -1413,6 +1355,25 @@
       "ter_set": "t_pavement",
       "items": [ { "item": "pipe", "count": [ 1, 2 ] }, { "item": "scrap", "count": [ 3, 6 ] } ]
     }
+  },
+  {
+    "type": "terrain",
+    "id": "t_guardrail",
+    "copy-from": "t_abstract_guardrail"
+  },
+  {
+    "type": "terrain",
+    "id": "t_guardrail_hw_air",
+    "copy-from": "t_abstract_guardrail",
+    "deconstruct": { "ter_set": "t_pavement_hw_air" },
+    "bash": { "ter_set": "t_pavement_hw_air" }
+  },
+  {
+    "type": "terrain",
+    "id": "t_guardrail_bg_dp",
+    "copy-from": "t_abstract_guardrail",
+    "deconstruct": { "ter_set": "t_pavement_bg_dp" },
+    "bash": { "ter_set": "t_pavement_bg_dp" }
   },
   {
     "type": "terrain",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Content "Highway guard rails can be deconstructed"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
Guard rails can only be bashed, not otherwise deconstructed.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
Since they are usually held together with a few bolts or rivets, a prying tool should be able to get them apart with much less damage than bashing. So I added a deconstruct option.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->
I'll un-draft when I've tested thoroughly.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
I also changed the three highway/road guardrail definitions to copy-from a single abstract. They are identical other than the underlying terrain type.

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
