### PR TITLE
Give boomer head NO_TURRET

### DIFF
--- a/data/json/monster_special_attacks/monster_gun.json
+++ b/data/json/monster_special_attacks/monster_gun.json
@@ -361,7 +361,7 @@
     "name": { "str": "boomer head", "//~": "NO_I18N" },
     "description": { "str": "The head of a boomer, if you see this item it's a bug.", "//~": "NO_I18N" },
     "material": [ "flesh" ],
-    "flags": [ "NEVER_JAMS", "NON_FOULING" ],
+    "flags": [ "NEVER_JAMS", "NON_FOULING", "NO_TURRET" ],
     "ammo_effects": [ "NEVER_MISFIRES", "NO_PENETRATE_OBSTACLES", "LIQUID" ],
     "ammo": [ "bile" ],
     "skill": "rifle",


### PR DESCRIPTION


#### Summary
None

#### Purpose of change
Someone in the devcord find out that the boomer head can be mounted onto a turret mount, so i fix this

#### Describe the solution

Give the boomer head NO_TURRET flag.

#### Describe alternatives you've considered

Nah

#### Testing
Before "NO_TURRET"
![Screenshot_20250826_015445](https://github.com/user-attachments/assets/929f291b-1e0f-4a2a-bb1c-7f840512c63f)

After "NO_TURRET"
![Screenshot_20250826_020333](https://github.com/user-attachments/assets/082da53c-68c4-4f37-995c-fde7fc108dc8)


#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
