### PR TITLE
Spill items toward actor first, randomly otherwise

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -414,7 +414,7 @@ void activity_handlers::fill_liquid_do_turn( player_activity *act, Character *yo
                 if( iexamine::has_keg( here.get_bub( act_ref.coords.at( 1 ) ) ) ) {
                     iexamine::pour_into_keg( here.get_bub( act_ref.coords.at( 1 ) ), liquid, false );
                 } else {
-                    here.add_item_or_charges( here.get_bub( act_ref.coords.at( 1 ) ), liquid );
+                    here.add_item_or_charges( here.get_bub( act_ref.coords.at( 1 ) ), liquid, you->pos_bub() );
                     you->add_msg_if_player( _( "You pour %1$s onto the ground." ), liquid.tname() );
                     liquid.charges = 0;
                 }
@@ -738,7 +738,7 @@ void activity_handlers::start_fire_do_turn( player_activity *act, Character *you
                 tinder->charges--;
                 copy.charges = 1;
             }
-            here.add_item_or_charges( where, copy );
+            here.add_item_or_charges( where, copy, you->pos_bub() );
             if( !count_by_charges || tinder->charges <= 0 ) {
                 tinder.remove_item();
             }
@@ -2062,7 +2062,7 @@ void activity_handlers::plant_seed_finish( player_activity *act, Character *you 
             used_seed.front().erase_var( "activity_var" );
         }
         used_seed.front().set_flag( json_flag_HIDDEN_ITEM );
-        here.add_item_or_charges( examp, used_seed.front() );
+        here.add_item_or_charges( examp, used_seed.front(), you->pos_bub() );
         if( here.has_flag_furn( seed_id->seed->required_terrain_flag, examp ) ) {
             here.furn_set( examp, furn_str_id( here.furn( examp )->plant->transform ) );
         } else if( seed_id->seed->required_terrain_flag == ter_furn_flag::TFLAG_PLANTABLE ) {

--- a/src/butchery.cpp
+++ b/src/butchery.cpp
@@ -880,8 +880,9 @@ bool butchery_drops_harvest( butchery_data bt, Character &you )
                 }
             } else if( drop->count_by_charges() ) {
                 std::vector<item> objs = create_charge_items( drop, roll, entry, &corpse_item, you );
+                const tripoint_bub_ms you_pos = you.pos_bub();
                 for( item &obj : objs ) {
-                    item_location loc = here.add_item_or_charges_ret_loc( corpse_loc, obj );
+                    item_location loc = here.add_item_or_charges_ret_loc( corpse_loc, obj, you_pos );
                     if( loc ) {
                         you.may_activity_occupancy_after_end_items_loc.push_back( loc );
                     }
@@ -904,8 +905,9 @@ bool butchery_drops_harvest( butchery_data bt, Character &you )
                 if( !you.backlog.empty() && you.backlog.front().id() == ACT_MULTIPLE_BUTCHER ) {
                     obj.set_var( "activity_var", you.name );
                 }
+                const tripoint_bub_ms you_pos = you.pos_bub();
                 for( int i = 0; i != roll; ++i ) {
-                    item_location loc = here.add_item_or_charges_ret_loc( corpse_loc, obj );
+                    item_location loc = here.add_item_or_charges_ret_loc( corpse_loc, obj, you_pos );
                     if( loc ) {
                         you.may_activity_occupancy_after_end_items_loc.push_back( loc );
                     }
@@ -948,8 +950,9 @@ bool butchery_drops_harvest( butchery_data bt, Character &you )
             if( !you.backlog.empty() && you.backlog.front().id() == ACT_MULTIPLE_BUTCHER ) {
                 ruined_parts.set_var( "activity_var", you.name );
             }
+            const tripoint_bub_ms you_pos = you.pos_bub();
             for( int i = 0; i < item_charges; ++i ) {
-                item_location loc = here.add_item_or_charges_ret_loc( corpse_loc, ruined_parts );
+                item_location loc = here.add_item_or_charges_ret_loc( corpse_loc, ruined_parts, you_pos );
                 if( loc ) {
                     you.may_activity_occupancy_after_end_items_loc.push_back( loc );
                 }
@@ -1026,6 +1029,7 @@ bool butchery_drops_harvest( butchery_data bt, Character &you )
     // and the liquid handling was interrupted, then the activity was canceled,
     // therefore operations on this activity's targets and values may be invalidated.
     // reveal hidden items / hidden content
+    const tripoint_bub_ms you_pos = you.pos_bub();
     if( action != butcher_type::FIELD_DRESS && action != butcher_type::SKIN &&
         action != butcher_type::BLEED && action != butcher_type:: DISMEMBER ) {
         for( item *content : corpse_item.all_items_top( pocket_type::CONTAINER ) ) {
@@ -1034,9 +1038,9 @@ bool butchery_drops_harvest( butchery_data bt, Character &you )
                 //~ %1$s - item name, %2$s - monster name
                 you.add_msg_if_player( m_good, _( "You discover a %1$s in the %2$s!" ), content->tname(),
                                        corpse_item.get_mtype()->nname() );
-                here.add_item_or_charges( you.pos_bub(), *content );
+                here.add_item_or_charges( you_pos, *content );
             } else if( content->is_bionic() ) {
-                here.spawn_item( you.pos_bub(), itype_burnt_out_bionic, 1, 0, calendar::turn );
+                here.spawn_item( you_pos, itype_burnt_out_bionic, 1, 0, calendar::turn );
             }
         }
     }
@@ -1054,9 +1058,10 @@ void butchery_quarter( item *corpse_item, const Character &you )
     map &here = get_map();
     tripoint_bub_ms pos = you.pos_bub();
 
+    const tripoint_bub_ms you_pos = you.pos_bub();
     // 4 quarters (one exists, add 3, flag does the rest)
     for( int i = 1; i <= 3; i++ ) {
-        here.add_item_or_charges( pos, *corpse_item, true );
+        here.add_item_or_charges( pos, *corpse_item, you_pos, true );
     }
 }
 

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -13107,15 +13107,16 @@ void Character::on_worn_item_transform( const item &old_it, const item &new_it )
 void Character::leak_items()
 {
     map &here = get_map();
+    const tripoint_bub_ms pos = pos_bub( here );
 
     std::vector<item_location> removed_items;
     if( weapon.is_container() ) {
-        if( weapon.leak( here, this, pos_bub() ) ) {
-            weapon.spill_contents( pos_bub() );
+        if( weapon.leak( here, this, pos ) ) {
+            weapon.spill_contents( pos );
         }
     } else if( weapon.made_of( phase_id::LIQUID ) ) {
-        if( weapon.leak( here, this, pos_bub() ) ) {
-            here.add_item_or_charges( pos_bub(), weapon );
+        if( weapon.leak( here, this, pos ) ) {
+            here.add_item_or_charges( pos, weapon );
             removed_items.emplace_back( *this, &weapon );
             add_msg_if_player( m_warning, _( "%s spilled from your hand." ), weapon.tname() );
         }
@@ -13125,8 +13126,8 @@ void Character::leak_items()
         if( !it || ( !it->is_container() && !it->made_of( phase_id::LIQUID ) ) ) {
             continue;
         }
-        if( it->leak( here, this, pos_bub() ) ) {
-            it->spill_contents( pos_bub() );
+        if( it->leak( here, this, pos ) ) {
+            it->spill_contents( pos );
             removed_items.push_back( it );
         }
     }

--- a/src/character_armor.cpp
+++ b/src/character_armor.cpp
@@ -202,8 +202,9 @@ const weakpoint *Character::absorb_hit( const weakpoint_attack &, const bodypart
         elem.amount = std::max( elem.amount, 0.0f );
     }
     map &here = get_map();
+    const tripoint_bub_ms pos = pos_bub();
     for( item &remain : worn_remains ) {
-        here.add_item_or_charges( pos_bub(), remain );
+        here.add_item_or_charges( pos, remain );
     }
     if( armor_destroyed ) {
         drop_invalid_inventory();

--- a/src/computer_session.cpp
+++ b/src/computer_session.cpp
@@ -1104,7 +1104,7 @@ void computer_session::action_data_anal()
                 if( items.only_item().typeId() == itype_black_box ) {
                     print_line( _( "Memory Bank: Military Hexron Encryption\nPrinting Transcript\n" ) );
                     item transcript( itype_black_box_transcript, calendar::turn );
-                    here.add_item_or_charges( player_character.pos_bub(), transcript );
+                    here.add_item_or_charges( player_character.pos_bub( here ), transcript );
                 } else {
                     print_line( _( "Memory Bank: Unencrypted\nNothing of interest.\n" ) );
                 }

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -3732,7 +3732,7 @@ std::pair<size_t, std::string> basecamp::farm_action( const point_rel_omt &dir, 
                             int seed_cnt = std::max( 1, rng( plant_count / 4, plant_count / 2 ) );
                             for( item &i : iexamine::get_harvest_items( *seed->type, plant_count,
                                     seed_cnt, true ) ) {
-                                here.add_item_or_charges( player_character.pos_bub(), i );
+                                here.add_item_or_charges( player_character.pos_bub( here ), i );
                             }
                             farm_map.i_clear( pos );
                             farm_map.furn_set( pos, furn_str_id::NULL_ID() );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1,4 +1,5 @@
 #include "game.h"
+#include "coords_fwd.h"
 
 #include <algorithm>
 #include <bitset>
@@ -1575,7 +1576,7 @@ void game::catch_a_monster( monster *fish, const tripoint_bub_ms &pos, Character
 
     //spawn the corpse, rotten by a part of the duration
     here.add_item_or_charges( pos, item::make_corpse( fish->type->id, calendar::turn + rng( 0_turns,
-                              catch_duration ) ) );
+                              catch_duration ) ), p ? p->pos_bub( here ) : tripoint_bub_ms::invalid );
     if( u.sees( here, pos ) ) {
         u.add_msg_if_player( m_good, _( "You caught a %s." ), fish->type->nname() );
     }
@@ -12689,7 +12690,7 @@ void game::vertical_move( int movez, bool force, bool peeking )
     }
 
     if( here.ter( stairs ) == ter_t_manhole_cover ) {
-        here.spawn_item( stairs + point( rng( -1, 1 ), rng( -1, 1 ) ), itype_manhole_cover );
+        here.spawn_item( stairs + point( rng( -1, 1 ), rng( -1, 1 ) ), itype_manhole_cover, stairs );
         here.ter_set( stairs, ter_t_manhole );
     }
 

--- a/src/gates.cpp
+++ b/src/gates.cpp
@@ -364,10 +364,11 @@ void doors::close_door( map &m, Creature &who, const tripoint_bub_ms &closep )
                 who.mod_moves( -std::min( items_in_way.stored_volume() / ( max_nudge / 50 ), 100 ) );
 
                 if( m.has_flag( ter_furn_flag::TFLAG_NOITEM, closep ) ) {
+                    const tripoint_bub_ms who_pos = who.pos_bub();
                     // Just plopping items back on their origin square will displace them to adjacent squares
                     // since the door is closed now.
                     for( item &elem : items_in_way ) {
-                        m.add_item_or_charges( closep, elem );
+                        m.add_item_or_charges( closep, elem, who_pos );
                     }
                     m.i_clear( closep );
                 }

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -1022,7 +1022,8 @@ avatar::smash_result avatar::smash( tripoint_bub_ms &smashp )
                            "smash",
                            "field" );
             here.remove_field( smashp, fd_to_smsh.first );
-            here.spawn_items( smashp, item_group::items_from( bash_info->drop_group, calendar::turn ) );
+            here.spawn_items( smashp, item_group::items_from( bash_info->drop_group, calendar::turn ),
+                              pos_bub( here ) );
             if( !bash_info->destroyed_field.first.is_null() ) {
                 here.add_field( smashp, bash_info->destroyed_field.first, bash_info->destroyed_field.second );
             }

--- a/src/handle_liquid.cpp
+++ b/src/handle_liquid.cpp
@@ -139,7 +139,7 @@ void handle_npc_liquid( item liquid, Character &who )
     std::vector<int> priorities;
 
     map &here = get_map();
-    const tripoint_bub_ms char_pos = who.pos_bub();
+    const tripoint_bub_ms char_pos = who.pos_bub( here );
     // Look for containers in adjacent tiles or in the character's inventory
     for( const tripoint_bub_ms &pos : closest_points_first( char_pos, 1 ) ) {
         for( item &it : here.i_at( pos ) ) {
@@ -478,7 +478,7 @@ static bool handle_keg_or_ground_target( Character &player_character, item &liqu
         if( target.dest_opt == LD_KEG ) {
             iexamine::pour_into_keg( target.pos, liquid, silent );
         } else {
-            get_map().add_item_or_charges( target.pos, liquid );
+            get_map().add_item_or_charges( target.pos, liquid, player_character.pos_bub() );
             liquid.charges = 0;
         }
         player_character.mod_moves( -100 );

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -14072,14 +14072,16 @@ bool item::process_litcig( map &here, Character *carrier, const tripoint_bub_ms 
             ( carrier->has_trait( trait_JITTERY ) && one_in( 200 ) ) ) {
             carrier->add_msg_if_player( m_bad, _( "Your shaking hand causes you to drop your %s." ),
                                         type_name() );
-            here.add_item_or_charges( pos + point( rng( -1, 1 ), rng( -1, 1 ) ), *this );
+            here.add_item_or_charges( pos + point( rng( -1, 1 ), rng( -1, 1 ) ), *this,
+                                      carrier->pos_bub( here ) );
             return true; // removes the item that has just been added to the map
         }
 
         if( carrier->has_effect( effect_sleep ) ) {
             carrier->add_msg_if_player( m_bad, _( "You fall asleep and drop your %s." ),
                                         type_name() );
-            here.add_item_or_charges( pos + point( rng( -1, 1 ), rng( -1, 1 ) ), *this );
+            here.add_item_or_charges( pos + point( rng( -1, 1 ), rng( -1, 1 ) ), *this,
+                                      carrier->pos_bub( here ) );
             return true; // removes the item that has just been added to the map
         }
     } else {

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -1856,7 +1856,7 @@ std::optional<int> iuse::fish_trap( Character *p, item *it, const tripoint_bub_m
     }
     it->active = true;
     it->set_age( 0_turns );
-    here.add_item_or_charges( pnt, *it );
+    here.add_item_or_charges( pnt, *it, p->pos_bub( here ) );
     p->i_rem( it );
     p->add_msg_if_player( m_info,
                           _( "You place the fish trap; in three hours or so, you may catch some fish." ) );
@@ -1915,6 +1915,7 @@ std::optional<int> iuse::fish_trap_tick( Character *p, item *it, const tripoint_
             return 0;
         }
 
+        const tripoint_bub_ms p_pos = p ? p->pos_bub( here ) : tripoint_bub_ms::invalid;
         //get the fishables around the trap's spot
         std::unordered_set<tripoint_bub_ms> fishable_locations = g->get_fishable_locations_bub( 60, pos );
         std::vector<monster *> fishables = g->get_fishable_monsters( fishable_locations );
@@ -1929,7 +1930,7 @@ std::optional<int> iuse::fish_trap_tick( Character *p, item *it, const tripoint_
                 } else {
                     here.add_item_or_charges( pos, item::make_corpse( chosen_fish->type->id,
                                               calendar::turn + rng( 0_turns,
-                                                      3_hours ) ) );
+                                                      3_hours ) ), p_pos ) ;
                 }
             } else {
                 //there will always be a chance that the player will get lucky and catch a fish
@@ -1945,7 +1946,7 @@ std::optional<int> iuse::fish_trap_tick( Character *p, item *it, const tripoint_
                     //Also: corpses and comestibles do not rot in containers like this, but on the ground they will rot.
                     //we don't know when it was caught so use a random turn
                     here.add_item_or_charges( pos, item::make_corpse( fish_mon, it->birthday() + rng( 0_turns,
-                                              3_hours ) ) );
+                                              3_hours ) ), p_pos );
                     break; //this can happen only once
                 }
             }
@@ -2255,7 +2256,7 @@ class exosuit_interact
                 } else if( ret == 0 ) {
                     // Unload existing module
                     pkt->remove_items_if( [&c, &here]( const item & i ) {
-                        here.add_item_or_charges( c.pos_bub(), i );
+                        here.add_item_or_charges( c.pos_bub( here ), i );
                         return true;
                     } );
                     return to_moves<int>( 5_seconds );
@@ -2316,7 +2317,7 @@ class exosuit_interact
             // Unload existing module
             if( not_empty ) {
                 pkt->remove_items_if( [&c, &here]( const item & i ) {
-                    here.add_item_or_charges( c.pos_bub(), i );
+                    here.add_item_or_charges( c.pos_bub( here ), i );
                     return true;
                 } );
                 moves += to_moves<int>( 5_seconds );
@@ -8696,16 +8697,16 @@ std::optional<int> iuse::break_stick( Character *p, item *it, const tripoint_bub
     map &here = get_map();
     if( chance <= 20 ) {
         p->add_msg_if_player( _( "You try to break the stick in two, but it shatters into splinters." ) );
-        here.spawn_item( p->pos_bub(), itype_splinter, 2 );
+        here.spawn_item( p->pos_bub( here ), itype_splinter, 2 );
         return 1;
     } else if( chance <= 40 ) {
         p->add_msg_if_player( _( "The stick breaks clean into two parts." ) );
-        here.spawn_item( p->pos_bub(), itype_stick, 2 );
+        here.spawn_item( p->pos_bub( here ), itype_stick, 2 );
         return 1;
     } else if( chance <= 100 ) {
         p->add_msg_if_player( _( "You break the stick, but one half shatters into splinters." ) );
-        here.spawn_item( p->pos_bub(), itype_stick, 1 );
-        here.spawn_item( p->pos_bub(), itype_splinter, 1 );
+        here.spawn_item( p->pos_bub( here ), itype_stick, 1 );
+        here.spawn_item( p->pos_bub( here ), itype_splinter, 1 );
         return 1;
     }
     return 0;

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -589,6 +589,7 @@ std::optional<int> unpack_actor::use( Character *p, item &it, map *here,
 
     p->add_msg_if_player( _( "You unpack the %s." ), it.tname() );
 
+    const tripoint_bub_ms p_pos = p->pos_bub( *here );
     for( item &content : items ) {
         if( content.is_armor() ) {
             if( items_fit ) {
@@ -608,7 +609,7 @@ std::optional<int> unpack_actor::use( Character *p, item &it, map *here,
             content.set_flag( flag_FILTHY );
         }
 
-        here->add_item_or_charges( p->pos_bub( *here ), content );
+        here->add_item_or_charges( p_pos, content );
     }
 
     p->i_rem( &it );

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -1225,7 +1225,7 @@ void spell_effect::spawn_ethereal_item( const spell &sp, Creature &caster,
                 it.set_var( "ethereal", to_turns<int>( sp.duration_turns( caster ) ) );
                 it.ethereal = true;
             }
-            get_map().add_item_or_charges( center, it );
+            get_map().add_item_or_charges( center, it, caster.pos_bub() );
         }
     }
     sp.make_sound( caster.pos_bub(), caster );

--- a/src/map_extras.cpp
+++ b/src/map_extras.cpp
@@ -409,7 +409,8 @@ static void place_fumarole( map &m, const point_bub_ms &p1, const point_bub_ms &
     //std::set<point_bub_ms> ignited;
 
     std::vector<point_bub_ms> fumarole = line_to( p1, p2, 0 );
-    for( point_bub_ms &i : fumarole ) {
+    for( uint64_t index = 0; index < fumarole.size(); index++ ) {
+        const point_bub_ms &i = fumarole[index];
         m.ter_set( i, ter_t_lava );
 
         // Add all adjacent tiles (even on diagonals) for possible ignition
@@ -424,7 +425,16 @@ static void place_fumarole( map &m, const point_bub_ms &p1, const point_bub_ms &
         ignited.insert( ( i + point::south_east ) );
 
         if( one_in( 6 ) ) {
-            m.spawn_item( i + point::north_west, itype_chunk_sulfur );
+            // direction to next or previous point
+            point_rel_ms delta = i - fumarole[ index == fumarole.size() - 1 ? index - 1 : index + 1 ];
+            // rotate 90 degrees
+            std::swap( delta.raw().x, delta.raw().y );
+            if( one_in( 2 ) ) {
+                delta.raw().x *= -1;
+            } else {
+                delta.raw().y *= -1;
+            }
+            m.spawn_item( i + delta, itype_chunk_sulfur, i + delta * 2 );
         }
     }
 

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -7233,7 +7233,7 @@ void map::place_vending( const tripoint_bub_ms &p, const item_group_id &type, bo
         bash( p, 9999 );
         for( const tripoint_bub_ms &loc : points_in_radius( p, 1 ) ) {
             if( one_in( 4 ) ) {
-                spawn_item( loc, itype_glass_shard, rng( 1, 25 ) );
+                spawn_item( loc, itype_glass_shard, p, rng( 1, 25 ) );
             }
         }
     } else {

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -319,6 +319,8 @@ bool Character::handle_melee_wear( item_location shield, float wear_multiplier )
                                _( "<npcname>'s %s breaks apart!" ),
                                str );
 
+        map &here = get_map();
+        const tripoint_bub_ms pos = pos_bub( here );
         for( item_components::type_vector_pair &tvp : temp.components ) {
             for( item &comp : tvp.second ) {
                 int break_chance = comp.typeId() == weak_comp ? 2 : 8;
@@ -331,7 +333,7 @@ bool Character::handle_melee_wear( item_location shield, float wear_multiplier )
                 if( comp.typeId() == big_comp && !has_wield_conflicts( comp ) ) {
                     wield( comp );
                 } else {
-                    get_map().add_item_or_charges( pos_bub(), comp );
+                    here.add_item_or_charges( pos, comp );
                 }
             }
         }
@@ -1916,7 +1918,7 @@ void Character::perform_technique( const ma_technique &technique, Creature &t,
 
     if( technique.disarms && you != nullptr && you->is_armed() && !you->is_hallucination() ) {
         item weap = you->remove_weapon();
-        here.add_item_or_charges( you->pos_bub(), weap );
+        here.add_item_or_charges( you->pos_bub( here ), weap );
         if( you->is_avatar() ) {
             add_msg_if_npc( _( "<npcname> disarms you!" ) );
         } else {
@@ -2879,8 +2881,9 @@ void avatar::disarm( npc &target )
         } else if( my_roll >= their_roll / 2 ) {
             add_msg( _( "You grab at %s and pull with all your force, but it drops nearby!" ),
                      it->tname() );
-            const tripoint_bub_ms tp = target.pos_bub() + tripoint( rng( -1, 1 ), rng( -1, 1 ), 0 );
-            here.add_item_or_charges( tp, target.i_rem( &*it ) );
+            const tripoint_bub_ms target_pos = target.pos_bub( here );
+            const tripoint_bub_ms drop_pos = target_pos + tripoint( rng( -1, 1 ), rng( -1, 1 ), 0 );
+            here.add_item_or_charges( drop_pos, target.i_rem( &*it ), target_pos );
             mod_moves( -100 );
         } else {
             add_msg( _( "You grab at %s and pull with all your force, but in vain!" ), it->tname() );
@@ -2894,8 +2897,9 @@ void avatar::disarm( npc &target )
         if( my_roll >= their_roll ) {
             add_msg( _( "You smash %s with all your might forcing their %s to drop down nearby!" ),
                      target.get_name(), it->tname() );
-            const tripoint_bub_ms tp = target.pos_bub() + tripoint( rng( -1, 1 ), rng( -1, 1 ), 0 );
-            here.add_item_or_charges( tp, target.i_rem( &*it ) );
+            const tripoint_bub_ms target_pos = target.pos_bub( here );
+            const tripoint_bub_ms drop_pos = target_pos + tripoint( rng( -1, 1 ), rng( -1, 1 ), 0 );
+            here.add_item_or_charges( drop_pos, target.i_rem( &*it ), target_pos );
         } else {
             add_msg( _( "You smash %s with all your might but %s remains in their hands!" ),
                      target.get_name(), it->tname() );

--- a/src/mission_companion.cpp
+++ b/src/mission_companion.cpp
@@ -16,6 +16,7 @@
 #include <utility>
 #include <vector>
 
+#include "avatar.h"
 #include "basecamp.h"
 #include "bodypart.h"
 #include "calendar.h"
@@ -2483,10 +2484,11 @@ void talk_function::companion_return( npc &comp )
     comp.companion_mission_time_ret = calendar::before_time_starts;
     Character &player_character = get_player_character();
     map &here = get_map();
+    const tripoint_bub_ms you_pos = player_character.pos_bub( here );
     for( size_t i = 0; i < comp.companion_mission_inv.size(); i++ ) {
         for( const item &it : comp.companion_mission_inv.const_stack( i ) ) {
             if( !it.count_by_charges() || it.charges > 0 ) {
-                here.add_item_or_charges( player_character.pos_bub(), it );
+                here.add_item_or_charges( you_pos, it );
             }
         }
     }

--- a/src/mondeath.cpp
+++ b/src/mondeath.cpp
@@ -85,12 +85,13 @@ static void scatter_chunks( map *here, const itype_id &chunk_name, int chunk_amt
     distance = std::abs( distance );
     const item chunk( chunk_name, calendar::turn );
     int placed_chunks = 0;
+    const tripoint_bub_ms &z_pos = z.pos_bub( *here );
     while( placed_chunks < chunk_amt ) {
         bool drop_chunks = true;
-        tripoint_bub_ms tarp( z.pos_bub( *here ) + point( rng( -distance, distance ),
-                              rng( -distance,
-                                   distance ) ) );
-        const std::vector<tripoint_bub_ms> traj = line_to( z.pos_bub( *here ), tarp );
+        tripoint_bub_ms tarp( z_pos + point( rng( -distance, distance ),
+                                             rng( -distance,
+                                                     distance ) ) );
+        const std::vector<tripoint_bub_ms> traj = line_to( z_pos, tarp );
 
         for( size_t j = 0; j < traj.size(); j++ ) {
             tarp = traj[j];
@@ -116,7 +117,7 @@ static void scatter_chunks( map *here, const itype_id &chunk_name, int chunk_amt
         }
         if( drop_chunks ) {
             for( int i = placed_chunks; i < chunk_amt && i < placed_chunks + pile_size; i++ ) {
-                here->add_item_or_charges( tarp, chunk );
+                here->add_item_or_charges( tarp, chunk, z_pos );
             }
         }
         placed_chunks += pile_size;

--- a/src/monexamine.cpp
+++ b/src/monexamine.cpp
@@ -242,11 +242,13 @@ void dump_items( monster &z )
     std::string pet_name = z.get_name();
     Character &player_character = get_player_character();
     map &here = get_map();
+    const tripoint_bub_ms pc_pos = player_character.pos_bub( here );
+    const tripoint_bub_ms z_pos = z.pos_bub( here );
     for( item &it : z.inv ) {
         if( it.has_var( "DESTROY_ITEM_ON_MON_DEATH" ) ) {
             continue;
         }
-        here.add_item_or_charges( player_character.pos_bub(), it );
+        here.add_item_or_charges( pc_pos, it, z_pos );
     }
     z.inv.clear();
     add_msg( _( "You dump the contents of the %s's bag on the ground." ), pet_name );
@@ -261,7 +263,7 @@ void remove_bag_from( monster &z )
             dump_items( z );
         }
         Character &player_character = get_player_character();
-        get_map().add_item_or_charges( player_character.pos_bub(), *z.storage_item );
+        get_map().add_item_or_charges( player_character.pos_bub(), *z.storage_item, z.pos_bub() );
         add_msg( _( "You remove the %1$s from %2$s." ), z.storage_item->display_name(), pet_name );
         z.storage_item.reset();
         player_character.mod_moves( -to_moves<int>( 2_seconds ) );
@@ -377,8 +379,10 @@ void remove_armor( monster &z )
 {
     std::string pet_name = z.get_name();
     if( z.armor_item ) {
+        Character &player_character = get_player_character();
+        map &here = get_map();
         z.armor_item->erase_var( "pet_armor" );
-        get_map().add_item_or_charges( z.pos_bub(), *z.armor_item );
+        get_map().add_item_or_charges( z.pos_bub( here ), *z.armor_item, player_character.pos_bub( here ) );
         add_msg( pgettext( "pet armor", "You remove the %1$s from %2$s." ), z.armor_item->display_name(),
                  pet_name );
         z.armor_item.reset();
@@ -598,7 +602,7 @@ void shear_animal( monster &z )
 
 void remove_battery( monster &z )
 {
-    get_map().add_item_or_charges( get_player_character().pos_bub(), *z.battery_item );
+    get_map().add_item_or_charges( get_player_character().pos_bub(), *z.battery_item, z.pos_bub() );
     z.battery_item.reset();
 }
 

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -2130,7 +2130,7 @@ bool monster::move_to( const tripoint_bub_ms &p, bool force, bool step_on_critte
             if( one_in( 10 ) ) {
                 // if it has more napalm, drop some and reduce ammo in tank
                 if( ammo[itype_pressurized_tank] > 0 ) {
-                    here.add_item_or_charges( pos, item( itype_napalm, calendar::turn, 50 ) );
+                    here.add_item_or_charges( pos, item( itype_napalm, calendar::turn, 50 ), p );
                     ammo[itype_pressurized_tank] -= 50;
                 } else {
                     // TODO: remove mon_flag_DRIPS_NAPALM flag since no more napalm in tank
@@ -2141,7 +2141,7 @@ bool monster::move_to( const tripoint_bub_ms &p, bool force, bool step_on_critte
         if( has_flag( mon_flag_DRIPS_GASOLINE ) ) {
             if( one_in( 5 ) ) {
                 // TODO: use same idea that limits napalm dripping
-                here.add_item_or_charges( pos, item( itype_gasoline ) );
+                here.add_item_or_charges( pos, item( itype_gasoline ), p );
             }
         }
     }

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -3654,18 +3654,20 @@ talk_effect_fun_t::func f_remove_var( const JsonObject &jo, std::string_view mem
     };
 }
 
-void map_add_item( item &it, tripoint_abs_ms target_pos )
+void map_add_item( const item &it, const tripoint_abs_ms &target_pos,
+                   const tripoint_abs_ms &preferred_spill = tripoint_abs_ms::invalid )
 {
     map &here = get_map();
 
     if( here.inbounds( target_pos ) ) {
-        here.add_item_or_charges( here.get_bub( target_pos ), it );
+        here.add_item_or_charges( here.get_bub( target_pos ), it, here.get_bub( preferred_spill ) );
     } else {
         tinymap target_bay;
         target_bay.load( project_to<coords::omt>( target_pos ), false );
         // Redundant as long as map operations aren't using get_map() in a transitive call chain. Added for future proofing.
         swap_map swap( *target_bay.cast_to_map() );
-        target_bay.add_item_or_charges( target_bay.get_omt( target_pos ), it );
+        target_bay.add_item_or_charges( target_bay.get_omt( target_pos ), it,
+                                        target_bay.get_omt( preferred_spill ) );
     }
 }
 

--- a/src/npctalk_funcs.cpp
+++ b/src/npctalk_funcs.cpp
@@ -1000,7 +1000,7 @@ bool talk_function::drop_stolen_item( item &cur_item, npc &p )
         item to_drop = player_character.i_rem( &cur_item );
         to_drop.remove_old_owner();
         to_drop.set_owner( p );
-        here.add_item_or_charges( player_character.pos_bub(), to_drop );
+        here.add_item_or_charges( player_character.pos_bub( here ), to_drop, p.pos_bub( here ) );
         dropped = true;
     } else if( cur_item.is_container() ) {
         bool changed = false;

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -2364,7 +2364,7 @@ static void cycle_action( item &weap, const itype_id &ammo, map *here, const tri
             } else if( ovp_cargo ) {
                 ovp_cargo->vehicle().add_item( *here, ovp_cargo->part(), casing );
             } else {
-                here->add_item_or_charges( eject, casing );
+                here->add_item_or_charges( eject, casing, pos );
             }
 
             // TODO: Refine critera to handle overlapping maps.
@@ -2384,7 +2384,7 @@ static void cycle_action( item &weap, const itype_id &ammo, map *here, const tri
             if( ovp_cargo ) {
                 ovp_cargo->items().insert( *here, linkage );
             } else {
-                here->add_item_or_charges( eject, linkage );
+                here->add_item_or_charges( eject, linkage, pos );
             }
         }
     }

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -1032,7 +1032,7 @@ void suffer::from_item_dropping( Character &you )
 void suffer::from_other_mutations( Character &you )
 {
     map &here = get_map();
-    const tripoint_bub_ms position = you.pos_bub();
+    const tripoint_bub_ms position = you.pos_bub( here );
     if( you.has_trait( trait_SHARKTEETH ) && one_turn_in( 24_hours ) ) {
         you.add_msg_if_player( m_neutral, _( "You shed a tooth!" ) );
         here.spawn_item( position, itype_bone, 1 );

--- a/src/trapfunc.cpp
+++ b/src/trapfunc.cpp
@@ -1251,15 +1251,16 @@ static bool sinkhole_safety_roll( Character &you, const itype_id &itemname, cons
     const int throwing_skill_level = round( you.get_skill_level( skill_throw ) );
     const int roll = rng( throwing_skill_level, throwing_skill_level + you.str_cur + you.dex_cur );
     map &here = get_map();
+    const tripoint_bub_ms you_pos = you.pos_bub( here );
     if( roll < diff ) {
         you.add_msg_if_player( m_bad, _( "You fail to attach it…" ) );
         you.use_amount( itemname, 1 );
-        here.spawn_item( random_neighbor( you.pos_bub() ), itemname );
+        here.spawn_item( random_neighbor( you_pos ), itemname, you_pos );
         return false;
     }
 
     std::vector<tripoint_bub_ms> safe;
-    for( const tripoint_bub_ms &tmp : here.points_in_radius( you.pos_bub(), 1 ) ) {
+    for( const tripoint_bub_ms &tmp : here.points_in_radius( you_pos, 1 ) ) {
         if( here.passable_through( tmp ) && here.tr_at( tmp ) != tr_pit ) {
             safe.push_back( tmp );
         }
@@ -1267,7 +1268,7 @@ static bool sinkhole_safety_roll( Character &you, const itype_id &itemname, cons
     if( safe.empty() ) {
         you.add_msg_if_player( m_bad, _( "There's nowhere to pull yourself to, and you sink!" ) );
         you.use_amount( itemname, 1 );
-        here.spawn_item( random_neighbor( you.pos_bub() ), itemname );
+        here.spawn_item( random_neighbor( you_pos ), itemname, you_pos );
         return false;
     } else {
         you.add_msg_player_or_npc( m_good, _( "You pull yourself to safety!" ),

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -8005,8 +8005,9 @@ void vehicle::leak_fuel( map &here, vehicle_part &pt ) const
         return;
     }
 
+    const tripoint_bub_ms pt_pos = bub_part_pos( here, pt );
     // leak in random directions but prefer closest tiles and avoid walls or other obstacles
-    std::vector<tripoint_bub_ms> tiles = closest_points_first( bub_part_pos( here, pt ), 1 );
+    std::vector<tripoint_bub_ms> tiles = closest_points_first( pt_pos, 1 );
     tiles.erase( std::remove_if( tiles.begin(), tiles.end(), [&here]( const tripoint_bub_ms & e ) {
         return !here.passable( e );
     } ), tiles.end() );
@@ -8015,9 +8016,9 @@ void vehicle::leak_fuel( map &here, vehicle_part &pt ) const
     const itype *fuel = item::find_type( pt.ammo_current() );
     while( !tiles.empty() && pt.ammo_remaining( ) ) {
         int qty = pt.ammo_consume( rng( 0, std::max( pt.ammo_remaining( ) / 3, 1 ) ),
-                                   &here, bub_part_pos( here, pt ) );
+                                   &here, pt_pos );
         if( qty > 0 ) {
-            here.add_item_or_charges( random_entry( tiles ), item( fuel, calendar::turn, qty ) );
+            here.add_item_or_charges( random_entry( tiles ), item( fuel, calendar::turn, qty ), pt_pos );
         }
     }
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Balance "Items spilled from an adjacent tile spill toward the actor first when appropriate, randomly otherwise"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
When the game tries to spawn items on a tile that can't hold them, they spill onto adjacent tiles. `find_point_closest_first` chooses east as the first direction, and _add_item_or_charges honors that choice. This patterned behavior is weird, and far more so when the spillage is happening near the player because they did something.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
Augment some of the item placement functions with an optional "preferred spill location" parameter.
Use that parameter when items spill because the player or an npc or monster did something, defaulting to spill towards that actor if they are adjacent to the original placement location.
Other use cases generally to spill towards the "source" of the items if it's adjacent to the spot the items are being placed in.
Make the spill location random in other cases.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
There are other ways to place items that have an actor/source less frequently but could potentially use similar augmenting:
```
place_item
drop_bash_results
bash_ter_furn
map::bash
map::shoot
put_items_from_loc
map_add_item
map_stack::insert
map::smash_items
```

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->
I'll be testing this through gameplay for a while before un-drafting.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
A previous version of this PR just changed the default spill location to be the player if they were adjacent, but that was vetoed.

I was worried about adding extra logic to the innermost _add_item_or_charges loop, but then I noticed that we do pathfinding in there which I expect far outweighs any other consideration there.

Along the way I changed a number of `pos_bub()` calls to `pos_bub(here)` where the local map had already been looked up, to avoid calling through the overload of `pos_bub` that would fetch it again. I also moved a number of those calls outside of loops where items area being spawned.

I will be making comments in the changes on specific notable changes/exceptions.

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
