### PR TITLE
Add `SUPPRESS_INVISIBILITY` flag, add an item in XE that uses it

### DIFF
--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -2585,6 +2585,11 @@
     "info": "The character can see through CAMOUFLAGE, NIGHT_INVISIBILITY, or the invisibility effect."
   },
   {
+    "id": "SUPPRESS_INVISIBILITY",
+    "type": "json_flag",
+    "info": "If you're invisible, now you're not"
+  },
+  {
     "id": "ANIMALEMPATH2",
     "type": "json_flag",
     "info": "The character is intensely liked by natural animals."

--- a/data/mods/Xedra_Evolved/effects/effects.json
+++ b/data/mods/Xedra_Evolved/effects/effects.json
@@ -3591,6 +3591,15 @@
   },
   {
     "type": "effect_type",
+    "//": "Hidden, reveals invisible monsters",
+    "id": "effect_xe_reveal_invisibility",
+    "name": [ "" ],
+    "desc": [ "" ],
+    "show_in_info": false,
+    "flags": [ "SUPPRESS_INVISIBILITY" ]
+  },
+  {
+    "type": "effect_type",
     "//": "Checks if you have every single vampiric power when trying to learn new ones.",
     "id": "effect_vampire_all_gift_check",
     "name": [ "" ],

--- a/data/mods/Xedra_Evolved/emitters.json
+++ b/data/mods/Xedra_Evolved/emitters.json
@@ -19,5 +19,12 @@
     "field": "fd_hot_air4",
     "intensity": 3,
     "qty": 100
+  },
+  {
+    "id": "emit_powder_of_revelation",
+    "type": "emit",
+    "field": "fd_powder_of_revelation",
+    "intensity": 1,
+    "qty": 50
   }
 ]

--- a/data/mods/Xedra_Evolved/field_type.json
+++ b/data/mods/Xedra_Evolved/field_type.json
@@ -451,14 +451,12 @@
     "intensity_levels": [
       {
         "name": "floating powder",
-        "sym": "8",
-        "dangerous": true,
+        "sym": "%",
         "translucency": 1,
         "concentration": 1,
         "effects": [
           {
             "effect_id": "effect_xe_reveal_invisibility",
-            "intensity": 1,
             "min_duration": "2 minutes",
             "max_duration": "2 minutes",
             "immune_inside_vehicle": true,
@@ -469,7 +467,6 @@
       }
     ],
     "percent_spread": 30,
-    "has_fume": true,
     "priority": 8,
     "half_life": "30 seconds",
     "phase": "gas",

--- a/data/mods/Xedra_Evolved/field_type.json
+++ b/data/mods/Xedra_Evolved/field_type.json
@@ -444,5 +444,37 @@
     "percent_spread": 20,
     "phase": "gas",
     "looks_like": "fd_dust"
+  },
+  {
+    "id": "fd_powder_of_revelation",
+    "type": "field_type",
+    "intensity_levels": [
+      {
+        "name": "floating powder",
+        "sym": "8",
+        "dangerous": true,
+        "translucency": 1,
+        "concentration": 1,
+        "effects": [
+          {
+            "effect_id": "effect_xe_reveal_invisibility",
+            "intensity": 1,
+            "min_duration": "2 minutes",
+            "max_duration": "2 minutes",
+            "immune_inside_vehicle": true,
+            "message": "The powder coats you.",
+            "message_type": "bad"
+          }
+        ]
+      }
+    ],
+    "percent_spread": 30,
+    "has_fume": true,
+    "priority": 8,
+    "half_life": "30 seconds",
+    "phase": "gas",
+    "display_items": true,
+    "display_field": true,
+    "looks_like": "fd_dust"
   }
 ]

--- a/data/mods/Xedra_Evolved/itemgroups/nests_itemgroups.json
+++ b/data/mods/Xedra_Evolved/itemgroups/nests_itemgroups.json
@@ -179,7 +179,8 @@
       { "item": "alchemy_recipe_scorpion_periapta", "prob": 1 },
       { "item": "alchemy_recipe_butterfly_periapta", "prob": 1 },
       { "item": "alchemy_recipe_spider_periapta", "prob": 1 },
-      { "item": "alchemy_recipe_cold_iron_ingot", "prob": 1 }
+      { "item": "alchemy_recipe_cold_iron_ingot", "prob": 1 },
+      { "item": "alchemy_recipe_powder_of_revelation", "prob": 1 }
     ]
   },
   {

--- a/data/mods/Xedra_Evolved/items/alchemy.json
+++ b/data/mods/Xedra_Evolved/items/alchemy.json
@@ -166,6 +166,20 @@
     "price": "25 USD"
   },
   {
+    "id": "xe_alchemy_powder_of_revelation",
+    "name": { "str": "powder of revelation", "str_pl": "handfuls of powder of revelation" },
+    "description": "A dull grayish powder with a slight shimmering opalescence.  When thrown it will fill the air and reveal the true form and existence of any creature whose form it coats.",
+    "type": "ITEM",
+    "weight": "265 g",
+    "volume": "250 ml",
+    "symbol": ":",
+    "container": "flask_glass",
+    "color": "light_gray",
+    "material": [ "powder" ],
+    "price": "2 USD",
+    "drop_action": { "type": "emit_actor", "emits": [ "emit_powder_of_revelation" ], "scale_qty": false }
+  },
+  {
     "id": "charm_of_marzanna",
     "copy-from": "garnet_silver_pendant_necklace",
     "type": "ITEM",

--- a/data/mods/Xedra_Evolved/items/alchemy_recipes.json
+++ b/data/mods/Xedra_Evolved/items/alchemy_recipes.json
@@ -277,6 +277,23 @@
   {
     "type": "ITEM",
     "subtypes": [ "BOOK" ],
+    "id": "alchemy_recipe_powder_of_revelation",
+    "copy-from": "schematics_generic",
+    "looks_like": "spell_scroll",
+    "name": { "str_sp": "scribbled notes (powder of revelation)" },
+    "description": "An handwritten set of notes detailing an alchemical recipe for creating some sort of powder that it claims will \"Reveal that which is hidden\".",
+    "required_level": 3,
+    "max_level": 3,
+    "intelligence": 10,
+    "time": "45 m",
+    "symbol": "ç",
+    "color": "light_green",
+    "read_skill": "fabrication"
+  },
+  {
+    "//": "Tier 4 begins here",
+    "type": "ITEM",
+    "subtypes": [ "BOOK" ],
     "id": "alchemy_recipe_life_extension_potion",
     "copy-from": "schematics_generic",
     "looks_like": "spell_scroll",
@@ -355,6 +372,7 @@
     "read_skill": "fabrication"
   },
   {
+    "//": "Tier 5 begins here",
     "type": "ITEM",
     "subtypes": [ "BOOK" ],
     "id": "alchemy_recipe_plant_imbuement",

--- a/data/mods/Xedra_Evolved/recipes/alchemy.json
+++ b/data/mods/Xedra_Evolved/recipes/alchemy.json
@@ -383,7 +383,12 @@
     "book_learn": [ [ "alchemy_recipe_powder_of_revelation", 5 ] ],
     "qualities": [ { "id": "BOIL", "level": 1 } ],
     "tools": [ [ [ "water_boiling_heat", 120, "LIST" ] ] ],
-    "components": [ [ [ "lye", 6 ] ] ],
+    "components": [
+      [ [ "clay_lump", 1 ] ],
+      [ [ "edible_blood", 6, "LIST" ], [ "blank_blood", 1 ] ],
+      [ [ "water_clean", 5 ] ],
+      [ [ "corpse_ash", 25 ] ]
+    ],
     "flags": [ "SECRET" ]
   },
   {

--- a/data/mods/Xedra_Evolved/recipes/alchemy.json
+++ b/data/mods/Xedra_Evolved/recipes/alchemy.json
@@ -368,6 +368,27 @@
   {
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",
+    "result": "xe_alchemy_powder_of_revelation",
+    "category": "CC_XEDRA",
+    "subcategory": "CSC_XEDRA_ALCHEMY",
+    "skill_used": "chemistry",
+    "skills_required": [ "deduction", 4 ],
+    "difficulty": 4,
+    "time": "1 h 30 m",
+    "proficiencies": [
+      { "proficiency": "prof_intro_chemistry" },
+      { "proficiency": "prof_inorganic_chemistry" },
+      { "proficiency": "prof_intro_chem_synth" }
+    ],
+    "book_learn": [ [ "alchemy_recipe_powder_of_revelation", 5 ] ],
+    "qualities": [ { "id": "BOIL", "level": 1 } ],
+    "tools": [ [ [ "water_boiling_heat", 120, "LIST" ] ] ],
+    "components": [ [ [ "lye", 6 ] ] ],
+    "flags": [ "SECRET" ]
+  },
+  {
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
     "result": "potion_dex",
     "category": "CC_XEDRA",
     "subcategory": "CSC_XEDRA_ALCHEMY",

--- a/doc/JSON/JSON_FLAGS.md
+++ b/doc/JSON/JSON_FLAGS.md
@@ -446,6 +446,7 @@ Character flags can be `trait_id`, `json_flag_id` or `flag_id`.  Some of these a
 - ```SUNBURN``` TBD, probably related to `ALBINO`.
 - ```SUPER_CLAIRVOYANCE``` Gives a super clairvoyance effect (works with multiple z-levels), used for debug purposes.
 - ```SAFECRACK_NO_TOOL``` Allows to open safes without stethoscope.
+- ```SUPPRESS_INVISIBILITY``` Any invisibility effects on the creature, including the `PERMANENT_INVISIBILITY` flag, are ignored for the duration of the effect with this flag
 - ```TELEPORT_LOCK``` You cannot teleport.  This has none of the protective effects of `DIMENSIONAL_ANCHOR`.
 - ```TEMPORARY_SHAPESHIFT``` You are in another shape due to some supernatural effect.
 - ```TEMPORARY_SHAPESHIFT_NO_HANDS``` You do not have hands in your new shapeshifted form, and so cannot pick up or manipulate objects. 

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -138,6 +138,7 @@ static const json_character_flag json_flag_IGNORE_TEMP( "IGNORE_TEMP" );
 static const json_character_flag json_flag_INVISIBLE( "INVISIBLE" );
 static const json_character_flag json_flag_LIMB_LOWER( "LIMB_LOWER" );
 static const json_character_flag json_flag_LIMB_UPPER( "LIMB_UPPER" );
+static const json_character_flag json_flag_SUPPRESS_INVISIBILITY( "SUPPRESS_INVISIBILITY" );
 static const json_character_flag json_flag_TEEPSHIELD( "TEEPSHIELD" );
 static const json_character_flag json_flag_TRUE_SEEING( "TRUE_SEEING" );
 
@@ -557,8 +558,9 @@ bool Creature::sees( const map &here, const Creature &critter ) const
     }
 
     // Invisibility checked after stumbling and after invisibility detection methods
-    if( critter.has_effect_with_flag( json_flag_INVISIBLE ) ||
-        critter.has_flag( mon_flag_PERMANENT_INVISIBILITY ) ) {
+    if( ( critter.has_effect_with_flag( json_flag_INVISIBLE ) ||
+        critter.has_flag( mon_flag_PERMANENT_INVISIBILITY ) ) &&
+        !critter.has_effect_with_flag( json_flag_SUPPRESS_INVISIBILITY ) ) {
         return false;
     }
 

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -559,7 +559,7 @@ bool Creature::sees( const map &here, const Creature &critter ) const
 
     // Invisibility checked after stumbling and after invisibility detection methods
     if( ( critter.has_effect_with_flag( json_flag_INVISIBLE ) ||
-        critter.has_flag( mon_flag_PERMANENT_INVISIBILITY ) ) &&
+          critter.has_flag( mon_flag_PERMANENT_INVISIBILITY ) ) &&
         !critter.has_effect_with_flag( json_flag_SUPPRESS_INVISIBILITY ) ) {
         return false;
     }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Content "Add `SUPPRESS_INVISIBILITY` flag, add an item in XE that uses it"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

More invisibility work!
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add the  `SUPPRESS_INVISIBILITY` flag--a creature that has this flag and would otherwise be invisible is no longer invisible. 

Add the `powder of revelation` in XE, an alchemical item that when you throw it, coats anything in the area of dust and makes invisible creatures visible for a time. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<img width="453" height="388" alt="Untitled2" src="https://github.com/user-attachments/assets/59d17a8f-e4a2-4744-9ea9-a990b180aac9" />

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

I want to give star vampires `PERMANENT_INVISIBILITY` and then have them drinking blood apply `SUPPRESS_INVISIBILITY` but I'll do that in a different PR. 
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
