### PR TITLE
Use semicolon for column separators in iteminfo table drawing

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -3861,24 +3861,24 @@ void item::armor_protection_info( std::vector<iteminfo> &info, const iteminfo_qu
 
         std::string coverage_table;
         //~ Limb-specific coverage (%s = name of limb)
-        coverage_table += string_format( _( "<bold>Coverage</bold>,%s\n" ), layering );
+        coverage_table += string_format( _( "<bold>Coverage</bold>;%s\n" ), layering );
         //~ Regular/Default coverage
-        coverage_table += string_format( "%s,<color_c_yellow>%d</color>\n", _( "Default" ),
+        coverage_table += string_format( "%s;<color_c_yellow>%d</color>\n", _( "Default" ),
                                          get_coverage( sbp ) );
         if( get_coverage( sbp ) != get_coverage( sbp, item::cover_type::COVER_MELEE ) ) {
             //~ Melee coverage
-            coverage_table += string_format( "%s,<color_c_yellow>%d</color>\n", _( "Melee" ), get_coverage( sbp,
+            coverage_table += string_format( "%s;<color_c_yellow>%d</color>\n", _( "Melee" ), get_coverage( sbp,
                                              item::cover_type::COVER_MELEE ) );
         }
         if( get_coverage( sbp ) != get_coverage( sbp, item::cover_type::COVER_RANGED ) ) {
             //~ Ranged coverage
-            coverage_table += string_format( "%s,<color_c_yellow>%d</color>\n", _( "Ranged" ),
+            coverage_table += string_format( "%s;<color_c_yellow>%d</color>\n", _( "Ranged" ),
                                              get_coverage( sbp,
                                                      item::cover_type::COVER_RANGED ) );
         }
         if( get_coverage( sbp, item::cover_type::COVER_VITALS ) > 0 ) {
             //~ Vitals coverage
-            coverage_table += string_format( "%s,<color_c_yellow>%d</color>\n", _( "Vitals" ),
+            coverage_table += string_format( "%s;<color_c_yellow>%d</color>\n", _( "Vitals" ),
                                              get_coverage( sbp,
                                                      item::cover_type::COVER_VITALS ) );
         }
@@ -3908,11 +3908,11 @@ void item::armor_protection_info( std::vector<iteminfo> &info, const iteminfo_qu
         std::string protection_table;
         if( display_median ) {
             protection_table +=
-                string_format( "<bold>%s</bold>,<bad>%d%%</bad> chance,<color_c_yellow>Median</color> chance,<good>%d%%</good> chance\n",
+                string_format( "<bold>%s</bold>;<bad>%d%%</bad> chance;<color_c_yellow>Median</color> chance;<good>%d%%</good> chance\n",
                                _( "Protection" ), percent_worst, percent_best );
         } else if( percent_worst > 0 ) {
             protection_table +=
-                string_format( "<bold>%s</bold>,<bad>%d%%</bad> chance,<good>%d%%</good> chance\n",
+                string_format( "<bold>%s</bold>;<bad>%d%%</bad> chance;<good>%d%%</good> chance\n",
                                _( "Protection" ), percent_worst, percent_best );
         } else {
             protection_table += string_format( "<bold>%s</bold>\n", _( "Protection" ) );
@@ -3928,12 +3928,12 @@ void item::armor_protection_info( std::vector<iteminfo> &info, const iteminfo_qu
             if( dio.info_display == damage_info_order::info_disp::DETAILED ) {
                 if( display_median ) {
                     protection_table +=
-                        string_format( "%s,<bad>%.2f</bad>,<color_c_yellow>%.2f</color>,<good>%.2f</good>\n",
+                        string_format( "%s;<bad>%.2f</bad>;<color_c_yellow>%.2f</color>;<good>%.2f</good>\n",
                                        uppercase_first_letter( dio.dmg_type->name.translated() ), worst_res.type_resist( dio.dmg_type ),
                                        median_res.type_resist( dio.dmg_type ), best_res.type_resist( dio.dmg_type ) );
                     printed_any = true;
                 } else if( percent_worst > 0 ) {
-                    protection_table += string_format( "%s,<bad>%.2f</bad>,<good>%.2f</good>\n",
+                    protection_table += string_format( "%s;<bad>%.2f</bad>;<good>%.2f</good>\n",
                                                        uppercase_first_letter( dio.dmg_type->name.translated() ), worst_res.type_resist( dio.dmg_type ),
                                                        best_res.type_resist( dio.dmg_type ) );
                     printed_any = true;
@@ -3942,14 +3942,14 @@ void item::armor_protection_info( std::vector<iteminfo> &info, const iteminfo_qu
                 }
             }
             if( skipped_detailed || dio.info_display == damage_info_order::info_disp::BASIC ) {
-                protection_table += string_format( "%s,<color_c_yellow>%.2f</color>\n",
+                protection_table += string_format( "%s;<color_c_yellow>%.2f</color>\n",
                                                    uppercase_first_letter( dio.dmg_type->name.translated() ),
                                                    best_res.type_resist( dio.dmg_type ) );
                 printed_any = true;
             }
         }
         if( get_base_env_resist( *this ) >= 1 ) {
-            protection_table += string_format( "%s,<color_c_yellow>%d</color>\n", _( "Environmental" ),
+            protection_table += string_format( "%s;<color_c_yellow>%d</color>\n", _( "Environmental" ),
                                                get_base_env_resist( *this ) );
             printed_any = true;
         }

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -1163,7 +1163,7 @@ static std::string format_table( std::string_view s )
         return table;
     }
 
-    std::vector<std::string> header = string_split( rows[0], ',' );
+    std::vector<std::string> header = string_split( rows[0], ';' );
     table += header[0] + ":";
     for( size_t col = 1; col < header.size(); col++ ) {
         table += ( col == 1 ? " " : ", " ) + header[col];
@@ -1176,7 +1176,7 @@ static std::string format_table( std::string_view s )
         if( rows[row].empty() ) {
             continue;
         }
-        std::vector<std::string> cols = string_split( rows[row], ',' );
+        std::vector<std::string> cols = string_split( rows[row], ';' );
         table += "  " + cols[0] + ":";
         for( size_t i = 1; i < cols.size(); i++ ) {
             table += ( i == 1 ? " " : ", " ) + cols[i];
@@ -1311,7 +1311,7 @@ static int get_num_cols( std::vector<std::string> &rows )
     int cols = 0;
 
     for( const std::string &row : rows ) {
-        cols = std::max( cols, static_cast<int>( string_split( row, ',' ).size() ) );
+        cols = std::max( cols, static_cast<int>( string_split( row, ';' ).size() ) );
     }
 
     return cols;
@@ -1328,7 +1328,7 @@ static void draw_table( std::string_view s )
 
     if( ImGui::BeginTable( "##ITEMINFO_TABLE", num_cols,
                            ImGuiTableFlags_BordersH | ImGuiTableFlags_BordersV ) ) {
-        const std::vector<std::string> chopped_up = string_split( rows.front(), ',' );
+        const std::vector<std::string> chopped_up = string_split( rows.front(), ';' );
         for( const std::string &cell_text : chopped_up ) {
             // this prefix prevents imgui from drawing the text. We still have color tags, which imgui won't parse, so we don't want those exposed to the user.
             // But we still want proper column IDs. So we put them in, but we *hide them* with this.
@@ -1352,7 +1352,7 @@ static void draw_table( std::string_view s )
                 continue;
             }
             ImGui::TableNextRow();
-            const std::vector<std::string> delimited_strings = string_split( rows[i], ',' );
+            const std::vector<std::string> delimited_strings = string_split( rows[i], ';' );
             for( const std::string &text : delimited_strings ) {
                 ImGui::TableNextColumn();
                 cataimgui::draw_colored_text( text, c_unset );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Fixes #82591

#### Describe the solution

Use semicolon instead of comma.

#### Describe alternatives you've considered



#### Testing

Looked at tables in German instead of English.

#### Additional context

This was an oversight from #82558.