### PR TITLE
Prevent segfault from teleport trap

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -8899,7 +8899,7 @@ void map::spawn_monsters_submap_group( const tripoint_rel_sm &gp, mongroup &grou
         ignore_sight = true;
     }
 
-    static const auto allow_on_terrain = [&]( const tripoint_bub_ms & p ) {
+    const auto allow_on_terrain = [&]( const tripoint_bub_ms & p ) {
         // TODO: flying creatures should be allowed to spawn without a floor,
         // but the new creature is created *after* determining the terrain, so
         // we can't check for it here.


### PR DESCRIPTION


<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Prevent segfault from teleport trap"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Prevents segfault when a monster steps on a teleport trap and gets teleported outside the map bubble. Fixes #82483 .

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

When a monster gets teleported outside the map bubble, a temporary `map` is created for the destination, in `teleport::teleport_to_point`. Previously, the `this`-reference to the temporary map got lost in the lambda being modified by this commit, since the lambda was `static` and thus retained the `this`-reference to the `map` from where it was first invoked.

<details>
<summary>Segfault being fixed</summary>

```
Thread 1 "cataclysm-tiles" received signal SIGSEGV, Segmentation fault.
getsubmap_helper<std::vector<submap*> > (grid=std::vector of length -50598, capacity -41876 = {...}, grididx=113263841) at /usr/include/c++/14/bits/stl_vector.h:1149
1149            __glibcxx_requires_subscript(__n);

(gdb) bt
#0  getsubmap_helper<std::vector<submap*> > (grid=std::vector of length -50598, capacity -41876 = {...}, grididx=113263841) at /usr/include/c++/14/bits/stl_vector.h:1149
#1  0x000056187f534acd in map::getsubmap (this=0x7ffe76517b90, grididx=<optimized out>) at src/map.cpp:9782
#2  map::get_submap_at_grid (this=0x7ffe76517b90, gridp=...) at src/map.cpp:9834
#3  0x000056187f53adfe in map::unsafe_get_submap_at (this=<optimized out>, p=...) at src/map.cpp:9799
#4  0x000056187f564464 in map::unsafe_get_submap_at (this=this@entry=0x7ffe76517b90, p=..., offset_p=...) at src/map.h:1975
#5  0x000056187f53dab7 in map::move_cost (this=0x7ffe76517b90, p=..., ignored_vehicle=ignored_vehicle@entry=0x0, ignore_fields=ignore_fields@entry=false) at src/map.cpp:2397
#6  0x000056187f53dc2c in map::passable (this=<optimized out>, p=...) at src/map.cpp:2422
#7  0x000056187f54064d in operator() (p=..., __closure=0x5618807770e8 <map::spawn_monsters_submap_group(coords::coord_point_ob<tripoint, (coords::origin)0, (coords::scale)1> const&, mongroup&, bool)::allow_on_terrain>) at src/map.cpp:8907
#8  0x000056187f5587ee in map::spawn_monsters_submap_group (this=this@entry=0x7ffe76517a30, gp=..., group=..., ignore_sight=ignore_sight@entry=true) at src/map.cpp:8923
#9  0x000056187f55946d in map::spawn_monsters_submap (this=this@entry=0x7ffe76517a30, gp=..., ignore_sight=ignore_sight@entry=true, spawn_nonlocal=spawn_nonlocal@entry=true) at src/map.cpp:9041
#10 0x000056187f559e2c in map::spawn_monsters (this=this@entry=0x7ffe76517a30, ignore_sight=ignore_sight@entry=true, spawn_nonlocal=spawn_nonlocal@entry=true) at src/map.cpp:9120
#11 0x000056187fbeef36 in teleport::teleport_to_point (critter=..., target=..., safe=safe@entry=true, add_teleglow=add_teleglow@entry=false, display_message=display_message@entry=false, force=false, force_safe=false) at src/teleport.cpp:218
#12 0x000056187f8df13f in operator() (__closure=0x5618c3468f50, d=...) at src/npctalk.cpp:7736
#13 std::__invoke_impl<void, talk_effect_fun::(anonymous namespace)::f_teleport(const JsonObject&, std::string_view, std::string_view, bool)::<lambda(const dialogue&)>&, dialogue&> (__f=...) at /usr/include/c++/14/bits/invoke.h:61
#14 std::__invoke_r<void, talk_effect_fun::(anonymous namespace)::f_teleport(const JsonObject&, std::string_view, std::string_view, bool)::<lambda(const dialogue&)>&, dialogue&> (__fn=...) at /usr/include/c++/14/bits/invoke.h:111
#15 std::_Function_handler<void(dialogue&), talk_effect_fun::(anonymous namespace)::f_teleport(const JsonObject&, std::string_view, std::string_view, bool)::<lambda(const dialogue&)> >::_M_invoke(const std::_Any_data &, dialogue &) (__functor=..., __args#0=...) at /usr/include/c++/14/bits/std_function.h:290
#16 0x000056187f8b05ef in talk_effect_t::apply (this=this@entry=0x5618c5e1b048, d=...) at src/npctalk.cpp:7866
#17 0x000056187f0d61c4 in effect_on_condition::activate (this=this@entry=0x5618c5e1afd0, d=..., require_callstack_check=require_callstack_check@entry=true) at src/effect_on_condition.cpp:329
#18 0x000056187f0d64da in effect_on_condition::activate_activation_only (this=this@entry=0x5618c5e1afd0, d=..., text1="activation", text2="item's involvement", text3="item", require_callstack_check=require_callstack_check@entry=true) at src/effect_on_condition.cpp:353
#19 0x000056187fd31483 in trapfunc::eocs (p=..., critter=0x5618ff6a7470) at src/trapfunc.cpp:394
#20 0x000056187fd201b6 in std::function<bool(coords::coord_point_ob<tripoint, (coords::origin)5, (coords::scale)0> const&, Creature*, item*)>::operator() (this=0x5618c7c69e58, __args#0=..., __args#1=0x5618ff6a7470, __args#2=0x0) at /usr/include/c++/14/bits/std_function.h:591
#21 trap::trigger (this=this@entry=0x5618c7c69df8, pos=..., creature=creature@entry=0x5618ff6a7470, item=item@entry=0x0) at src/trap.cpp:342
#22 0x000056187fd204ad in trap::trigger (this=this@entry=0x5618c7c69df8, pos=..., creature=...) at src/trap.cpp:327
#23 0x000056187f54356d in map::maybe_trigger_trap (this=this@entry=0x5618c19ce940, pos=..., c=..., may_avoid=may_avoid@entry=true) at src/map.cpp:10247
#24 0x000056187f543727 in map::creature_on_trap (this=this@entry=0x5618c19ce940, c=..., may_avoid=may_avoid@entry=true) at src/map.cpp:10046
#25 0x000056187f759878 in monster::move_to (this=this@entry=0x5618ff6a7470, p=..., force=force@entry=true, step_on_critter=step_on_critter@entry=false, stagger_adjustment=stagger_adjustment@entry=1) at src/monmove.cpp:2062
#26 0x000056187f75b0e4 in monster::stumble (this=this@entry=0x5618ff6a7470) at src/monmove.cpp:2332
#27 0x000056187f75d0a0 in monster::move (this=0x5618ff6a7470) at src/monmove.cpp:1296
#28 0x000056187f09a1b8 in (anonymous namespace)::monmove () at src/do_turn.cpp:328
#29 do_turn () at src/do_turn.cpp:668
#30 0x000056187ea7a7d6 in main (argc=<optimized out>, argv=<optimized out>) at src/main.cpp:864
```

</details>

Evidence of invalid `map` references from the above stacktrace, by showing garbage values in `my_MAPSIZE`:
```
(gdb) set print static-members off
(gdb) frame 5
(gdb) print p
$3 = (const tripoint_bub_ms &) @0x7ffe76516ce0: {<coords::coord_point_mut<tripoint, coords::coord_point_ob<point, (coords::origin)5, (coords::scale)0> >> = {<coords::coord_point_base<tripoint>> = {raw_ = {x = 12, y = 24, z = -2}}, <No data fields>}, <coords::coord_point_ob_not_rel> = {<No data fields>}, <coords::coord_point_ob_not_3d> = {<No data fields>}, }

(gdb) frame 7
(gdb) print my_MAPSIZE
$11 = 56631920

(gdb) frame 8
(gdb) print my_MAPSIZE
$12 = 11
```

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Was able to consistently reproduce the issue in #82483 before this change. With this change, can no longer reproduce it.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Stacktrace looked similar to #78772 .

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
