### PR TITLE
Adjust mannequin decoy existence and related small fixes

### DIFF
--- a/data/json/items/generic/toys_and_sports.json
+++ b/data/json/items/generic/toys_and_sports.json
@@ -22,7 +22,7 @@
       {
         "pocket_type": "MAGAZINE_WELL",
         "rigid": true,
-        "flag_restriction": [ "BATTERY_LIGHT", "BATTERY_ULTRA_LIGHT" ],
+        "flag_restriction": [ "BATTERY_LIGHT" ],
         "default_magazine": "light_minus_disposable_cell"
       }
     ],
@@ -273,7 +273,7 @@
     "color": "dark_gray",
     "name": { "str": "mannequin" },
     "category": "other",
-    "description": "A figure of an adult human, as seen in the display case at the mall.  It might be able to fool some zombies if it could attract their attention.",
+    "description": "A figure of an adult human, as seen in the display case at the mall.",
     "price": "150 USD",
     "price_postapoc": "5 USD",
     "material": [ "wood" ],
@@ -282,42 +282,5 @@
     "longest_side": "180 cm",
     "melee_damage": { "bash": 18 },
     "use_action": [ { "type": "deploy_furn", "furn_type": "f_mannequin" } ]
-  },
-  {
-    "type": "ITEM",
-    "subtypes": [ "TOOL" ],
-    "id": "mannequin_decoy",
-    "symbol": "@",
-    "color": "light_gray",
-    "name": { "str": "mannequin decoy" },
-    "category": "other",
-    "description": "A figure of an adult human, as seen in the display case at the mall.  This one is cradling a talking doll.  It can make sound when powered by batteries and can be used to distract some zombies.",
-    "price": "150 USD",
-    "price_postapoc": "5 USD",
-    "material": [ "wood" ],
-    "weight": "81500 g",
-    "volume": "62500 ml",
-    "longest_side": "180 cm",
-    "flags": [ "WATER_BREAK", "SINGLE_USE", "ELECTRONIC" ],
-    "faults": [ { "fault_group": "electronic_general" } ],
-    "pocket_data": [
-      {
-        "pocket_type": "MAGAZINE_WELL",
-        "rigid": true,
-        "flag_restriction": [ "BATTERY_ULTRA_LIGHT" ],
-        "default_magazine": "light_minus_disposable_cell"
-      }
-    ],
-    "use_action": {
-      "type": "place_monster",
-      "monster_id": "mon_mannequin_decoy",
-      "friendly_msg": "You activate the talking doll on the mannequin.",
-      "hostile_msg": "Your mannequin seems to have a mind of its own!  If you see this, an error has occurred.",
-      "difficulty": 0,
-      "need_charges": 100,
-      "moves": 200
-    },
-    "melee_damage": { "bash": 18 },
-    "tool_ammo": [ "battery" ]
   }
 ]

--- a/data/json/items/generic/toys_and_sports.json
+++ b/data/json/items/generic/toys_and_sports.json
@@ -23,7 +23,7 @@
         "pocket_type": "MAGAZINE_WELL",
         "rigid": true,
         "flag_restriction": [ "BATTERY_LIGHT" ],
-        "default_magazine": "light_minus_disposable_cell"
+        "default_magazine": "light_battery_cell"
       }
     ],
     "tool_ammo": [ "battery" ]

--- a/data/json/monsters/misc.json
+++ b/data/json/monsters/misc.json
@@ -374,34 +374,5 @@
     "special_attacks": [ [ "DISAPPEAR", 200 ] ],
     "death_function": { "message": "The %s disappears.", "corpse_type": "NO_CORPSE" },
     "flags": [ "FLIES", "NO_BREATHE", "NOT_HALLUCINATION", "HARDTOSHOOT" ]
-  },
-  {
-    "id": "mon_mannequin_decoy",
-    "type": "MONSTER",
-    "name": { "str": "mannequin decoy" },
-    "description": "A human-sized mannequin, speaking pre-recorded phrases.",
-    "looks_like": "mon_hallucinator",
-    "default_faction": "factionless",
-    "species": [ "UNKNOWN" ],
-    "volume": "62500 ml",
-    "weight": "81500 g",
-    "hp": 20,
-    "speed": 1,
-    "symbol": "@",
-    "material": [ "wood" ],
-    "aggression": -99,
-    "morale": 100,
-    "special_attacks": [ [ "PARROT", 1 ], [ "DISAPPEAR", 2000 ] ],
-    "death_drops": {
-      "subtype": "collection",
-      "items": [
-        { "item": "mannequin", "prob": 100, "damage": [ 2, 4 ] },
-        { "item": "talking_doll", "prob": 100, "damage": [ 2, 4 ] }
-      ]
-    },
-    "death_function": { "message": "The %s falls over!", "corpse_type": "NO_CORPSE" },
-    "harvest": "exempt",
-    "revert_to_itype": "mannequin_decoy",
-    "flags": [ "IMMOBILE", "NO_BREATHE", "NOT_HALLUCINATION" ]
   }
 ]

--- a/data/json/recipes/tools/tool.json
+++ b/data/json/recipes/tools/tool.json
@@ -1255,18 +1255,6 @@
     "tools": [ [ [ "swage", -1 ] ] ]
   },
   {
-    "result": "mannequin_decoy",
-    "type": "recipe",
-    "activity_level": "NO_EXERCISE",
-    "category": "CC_OTHER",
-    "subcategory": "CSC_OTHER_TOOLS",
-    "skill_used": "fabrication",
-    "time": "10 s",
-    "reversible": true,
-    "autolearn": true,
-    "components": [ [ [ "talking_doll", 1 ], [ "creepy_doll", 1 ] ], [ [ "mannequin", 1 ] ] ]
-  },
-  {
     "type": "recipe",
     "activity_level": "BRISK_EXERCISE",
     "result": "kevlar_shears",

--- a/data/json/speech.json
+++ b/data/json/speech.json
@@ -2228,7 +2228,7 @@
   },
   {
     "type": "speech",
-    "speaker": [ "talking_doll", "mon_mi_go", "mon_mi_go_slaver", "mon_mannequin_decoy" ],
+    "speaker": [ "talking_doll", "mon_mi_go", "mon_mi_go_slaver" ],
     "sound": "\"Wanna play with me?\"",
     "volume": 10
   },
@@ -2270,85 +2270,85 @@
   },
   {
     "type": "speech",
-    "speaker": [ "talking_doll", "mon_mi_go", "mon_mi_go_slaver", "mon_mannequin_decoy" ],
+    "speaker": [ "talking_doll", "mon_mi_go", "mon_mi_go_slaver" ],
     "sound": "\"Sing with me!\"",
     "volume": 10
   },
   {
     "type": "speech",
-    "speaker": [ "talking_doll", "mon_mi_go", "mon_mi_go_slaver", "mon_mannequin_decoy" ],
+    "speaker": [ "talking_doll", "mon_mi_go", "mon_mi_go_slaver" ],
     "sound": "\"I love you!\"",
     "volume": 10
   },
   {
     "type": "speech",
-    "speaker": [ "talking_doll", "mon_mi_go", "mon_mi_go_slaver", "mon_mannequin_decoy" ],
+    "speaker": [ "talking_doll", "mon_mi_go", "mon_mi_go_slaver" ],
     "sound": "\"Please take me with you!\"",
     "volume": 10
   },
   {
     "type": "speech",
-    "speaker": [ "talking_doll", "mon_mi_go", "mon_mi_go_slaver", "mon_mannequin_decoy" ],
+    "speaker": [ "talking_doll", "mon_mi_go", "mon_mi_go_slaver" ],
     "sound": "\"May I have a cookie?\"",
     "volume": 10
   },
   {
     "type": "speech",
-    "speaker": [ "talking_doll", "mon_mi_go", "mon_mi_go_slaver", "mon_mannequin_decoy" ],
+    "speaker": [ "talking_doll", "mon_mi_go", "mon_mi_go_slaver" ],
     "sound": "\"Let's play together!\"",
     "volume": 10
   },
   {
     "type": "speech",
-    "speaker": [ "talking_doll", "mon_mi_go", "mon_mi_go_slaver", "mon_mannequin_decoy" ],
+    "speaker": [ "talking_doll", "mon_mi_go", "mon_mi_go_slaver" ],
     "sound": "\"Time to play!\"",
     "volume": 10
   },
   {
     "type": "speech",
-    "speaker": [ "talking_doll", "mon_mi_go", "mon_mi_go_slaver", "mon_mannequin_decoy" ],
+    "speaker": [ "talking_doll", "mon_mi_go", "mon_mi_go_slaver" ],
     "sound": "\"Om nom nom!  Delicious!\"",
     "volume": 10
   },
   {
     "type": "speech",
-    "speaker": [ "talking_doll", "mon_mi_go", "mon_mi_go_slaver", "mon_mannequin_decoy" ],
+    "speaker": [ "talking_doll", "mon_mi_go", "mon_mi_go_slaver" ],
     "sound": "\"Are you my mommy?\"",
     "volume": 10
   },
   {
     "type": "speech",
-    "speaker": [ "talking_doll", "mon_mi_go", "mon_mi_go_slaver", "mon_mannequin_decoy" ],
+    "speaker": [ "talking_doll", "mon_mi_go", "mon_mi_go_slaver" ],
     "sound": "\"Oh, how fun!\"",
     "volume": 10
   },
   {
     "type": "speech",
-    "speaker": [ "talking_doll", "mon_mi_go", "mon_mi_go_slaver", "mon_mannequin_decoy" ],
+    "speaker": [ "talking_doll", "mon_mi_go", "mon_mi_go_slaver" ],
     "sound": "\"You're my best friend!\"",
     "volume": 10
   },
   {
     "type": "speech",
-    "speaker": [ "talking_doll", "mon_mi_go", "mon_mi_go_slaver", "mon_mannequin_decoy" ],
+    "speaker": [ "talking_doll", "mon_mi_go", "mon_mi_go_slaver" ],
     "sound": "\"Heehee!\"",
     "volume": 10
   },
   {
     "type": "speech",
-    "speaker": [ "talking_doll", "mon_mi_go", "mon_mi_go_slaver", "mon_mannequin_decoy" ],
+    "speaker": [ "talking_doll", "mon_mi_go", "mon_mi_go_slaver" ],
     "sound": "\"Let's have fun!\"",
     "volume": 10
   },
   {
     "type": "speech",
-    "speaker": [ "talking_doll", "mon_mi_go", "mon_mi_go_slaver", "mon_mannequin_decoy" ],
+    "speaker": [ "talking_doll", "mon_mi_go", "mon_mi_go_slaver" ],
     "sound": "\"Let's have a tea party!\"",
     "volume": 10
   },
   {
     "type": "speech",
-    "speaker": [ "talking_doll", "mon_mi_go", "mon_mi_go_slaver", "mon_mannequin_decoy" ],
+    "speaker": [ "talking_doll", "mon_mi_go", "mon_mi_go_slaver" ],
     "sound": "\"You're the best!\"",
     "volume": 10
   },

--- a/data/mods/TEST_DATA/known_bad_density.json
+++ b/data/mods/TEST_DATA/known_bad_density.json
@@ -403,7 +403,6 @@
       "firehelmet",
       "wild_herbs",
       "base_plastic_silverware",
-      "mannequin_decoy",
       "corpse_generic_female",
       "demihuman_cracklins",
       "condensor_coil",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
The mannequin decoy implementation is all kinds of awful, I started fixing it but then I realized that the concept itself is kinda stupid, according to the description and recipe you just put a talking doll in the arms of a mannequin, turn it on and that magically makes a way more effective decoy compared to the talking doll or the mannequin by themselves?

We already have a decoy item, it's called a noise emitter and if your character can't make one and you absolutely need some kind of "decoy" then just use the talking doll by themselves.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

- Remove the mannequin decoy item, monster and recipe.
- Adjust the mannequin description to not imply that you can use it to make a decoy.
- Adjust the accepted doll battery format, source uses AAA batteries yet the implementation accepts ultra lights.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

1. Make the mannequin decoy into a worse noise emitter item, I think the concept is stupid but if requested that's the route I'll go to rework this.
2. Keep the accepted doll battery formats, I think some talking dolls nowadays can accept button batteries so it depends how much we want to abstract away from the literal source used.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Loaded fine.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Fixes #82484.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
