### PR TITLE
Prevent segfault when cancelling completed butchery

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -9061,6 +9061,9 @@ bool butchery_activity_actor::initiate_butchery( player_activity &act, Character
 
 const activity_id &butchery_activity_actor::get_type() const
 {
+    if( bd.empty() ) {
+        return ACT_BUTCHER;
+    }
     switch( bd.back().b_type ) {
         case butcher_type::BLEED: {
             return ACT_BLEED;
@@ -9150,6 +9153,9 @@ void butchery_activity_actor::finish( player_activity &act, Character & /* you *
 
 void butchery_activity_actor::canceled( player_activity &, Character & )
 {
+    if( bd.empty() ) {
+        return;
+    }
     butchery_data *this_bd = &bd.back();
     item_location &target = this_bd->corpse;
     item &corpse_item = *target;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Prevent segfault when cancelling completed butchery"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Prevents segfault when cancelling a butchery that has been completed on the same turn.
* Fixes #82289
* Fixes #82310

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

According to the documentation of `butchery_activity_actor::bd`, when the list is empty, we are done:
https://github.com/CleverRaven/Cataclysm-DDA/blob/ac0235d1bbb957395c958f693d660f779cc689cb/src/activity_actor_definitions.h#L2535-L2538

The previous segfault happened because we took `bd.back()` and used that object, but the list of butcheries was empty. This might happen if, for example, we cancelled the activity on the same turn that the last butchery was `pop_back()`-ed - e.g. the activity was to be finished on the same turn that we cancelled.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

A future version could add a helper method in `butchery_activity_actor` that returns the next or current `butchery_data`, and have it return an `optional` to force the caller to handle the case where there are no more butcheries to do. 

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

* Managed to reproduce the issue in #82310 using that provided save. Can no longer reproduce the issue with this change applied.
* Also managed to cause the following segfault when testing, which is now also resolved:
```
Thread 1 "cataclysm-tiles" received signal SIGABRT, Aborted.
__pthread_kill_implementation (threadid=<optimized out>, signo=signo@entry=6, no_tid=no_tid@entry=0) at ./nptl/pthread_kill.c:44
warning: 44     ./nptl/pthread_kill.c: No such file or directory

(gdb) bt
#0  __pthread_kill_implementation (threadid=<optimized out>, signo=signo@entry=6, no_tid=no_tid@entry=0) at ./nptl/pthread_kill.c:44
#1  0x00007fcaefead9ff in __pthread_kill_internal (threadid=<optimized out>, signo=6) at ./nptl/pthread_kill.c:89
#2  0x00007fcaefe58cc2 in __GI_raise (sig=sig@entry=6) at ../sysdeps/posix/raise.c:26
#3  0x00007fcaefe414ac in __GI_abort () at ./stdlib/abort.c:73
#4  0x00007fcaf020145e in std::__glibcxx_assert_fail(char const*, int, char const*, char const*) () from /lib/x86_64-linux-gnu/libstdc++.so.6
#5  0x000055f496c2cb46 in std::vector<butchery_data, std::allocator<butchery_data> >::back (this=<optimized out>) at /usr/include/c++/14/bits/stl_vector.h:1249
#6  std::vector<butchery_data, std::allocator<butchery_data> >::back (this=<optimized out>) at /usr/include/c++/14/bits/stl_vector.h:1247
#7  butchery_activity_actor::get_type (this=<optimized out>) at src/activity_actor.cpp:9064
#8  0x000055f4979924fd in player_activity::do_turn (this=this@entry=0x55f4cbc9dd00, you=...) at src/player_activity.cpp:333
#9  0x000055f49702803d in do_turn () at src/do_turn.cpp:552
#10 0x000055f496a09956 in main (argc=<optimized out>, argv=<optimized out>) at src/main.cpp:864
```

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
