### PR TITLE
Prevent segfault when purifying water with connected vehicles

### DIFF
--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -2412,7 +2412,7 @@ void vehicle::build_interact_menu( veh_menu &menu, map *here, const tripoint_bub
         .enable( fuel_left( *here, itype_water ) &&
                  fuel_left( *here, itype_battery ) >= itype_water_purifier->charges_to_use() )
         .hotkey( "PURIFY_WATER" )
-        .on_submit( [this, &here] {
+        .on_submit( [this, here] {
             const auto sel = []( const map &, const vehicle_part & pt )
             {
                 return pt.is_tank() && pt.ammo_current() == itype_water;


### PR DESCRIPTION

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Prevent segfault when purifying water with connected vehicles"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Prevents segfault when using vehicle water purifier on a vehicle connected to another vehicle.
* Fixes #82119 .
* Fixes #81281 .

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

The previous segfault happened because the reference to the `map` became invalid in the call-chain that includes `vehicle::fuel_left`. The reason for an invalid reference was that the vehicle interact menu incorrectly passed the map as a reference to a pointer, and the reference likely fell out of scope when `build_interact_menu` completed. This commit instead changes the `here` parameter so that the pointer is passed by value, which is how other vehicle interaction menu options pass it.

<details>
<summary>Stacktrace being fixed</summary>

```
Thread 1 "cataclysm-tiles" received signal SIGSEGV, Segmentation fault.
0x0000563ebf9c1cfc in map::get_bub (this=this@entry=0xea8e523d, p=...) at src/map.cpp:9748
9748        return tripoint_bub_ms { p.x() - abs_ms.x(), p.y() - abs_ms.y(), p.z()};

(gdb) bt
#0  0x0000563ebf9c1cfc in map::get_bub (this=this@entry=0xea8e523d, p=...) at src/map.cpp:9748
#1  0x0000563ebf9c9c3b in map::veh_at (this=this@entry=0xea8e523d, p=...) at src/map.cpp:1347
#2  0x0000563ec0249af2 in vehicle::find_vehicle_using_parts (here=..., where=...) at src/vehicle.cpp:5749
#3  0x0000563ec027452a in vehicle::search_connected_vehicles<vehicle const> (here=..., start=<optimized out>, start@entry=0x563f41fdd7f0) at src/vehicle.cpp:5800
#4  0x0000563ec0262146 in vehicle::search_connected_vehicles (this=0x563f41fdd7f0, here=...) at src/vehicle.cpp:5825
#5  vehicle::fuel_left (this=0x563f41fdd7f0, here=..., ftype=..., filter=...) at src/vehicle.cpp:3864
#6  0x0000563ec02aeb32 in operator() (__closure=0x563f467f53c0) at /usr/include/c++/14/bits/std_function.h:150
#7  std::__invoke_impl<void, vehicle::build_interact_menu(veh_menu&, map*, const tripoint_bub_ms&, bool)::<lambda()>&> (__f=...) at /usr/include/c++/14/bits/invoke.h:61
#8  std::__invoke_r<void, vehicle::build_interact_menu(veh_menu&, map*, const tripoint_bub_ms&, bool)::<lambda()>&> (__fn=...) at /usr/include/c++/14/bits/invoke.h:111
#9  std::_Function_handler<void(), vehicle::build_interact_menu(veh_menu&, map*, const tripoint_bub_ms&, bool)::<lambda()> >::_M_invoke(const std::_Any_data &) (__functor=...) at /usr/include/c++/14/bits/std_function.h:290
#10 0x0000563ec023a86b in veh_menu::query (this=this@entry=0x7ffc08f03f18) at src/veh_utils.cpp:493
#11 0x0000563ec02b8e80 in vehicle::interact_with (this=0x563f41fdd7f0, here=here@entry=0x563f02b0d200, p=..., with_pickup=with_pickup@entry=false) at src/vehicle_use.cpp:2606
#12 0x0000563ebf671d28 in game::examine (this=this@entry=0x563f02b0cae0, examp=..., with_pickup=with_pickup@entry=false) at /usr/include/c++/14/bits/refwrap.h:350
#13 0x0000563ebf6723c7 in game::examine (this=this@entry=0x563f02b0cae0, with_pickup=with_pickup@entry=false) at src/game.cpp:6221
#14 0x0000563ebf6c492e in game::do_regular_action (this=this@entry=0x563f02b0cae0, act=@0x7ffc08f04ad0: ACTION_EXAMINE, player_character=..., mouse_target=std::optional [no contained value]) at src/handle_action.cpp:2567
#15 0x0000563ebf6c7b30 in game::handle_action (this=0x563f02b0cae0) at src/handle_action.cpp:3323
#16 0x0000563ebf52d30e in do_turn () at src/do_turn.cpp:596
#17 0x0000563ebef0e956 in main (argc=<optimized out>, argv=<optimized out>) at src/main.cpp:864
```

</details>

Evidence of invalid `here`-reference from the above stacktrace, by trying to print `map::my_MAPSIZE`:
```
(gdb) frame 10
(gdb) p here->my_MAPSIZE
$2 = 11

(gdb) frame 6
(gdb) p here->my_MAPSIZE
Cannot access memory at address 0xea8e52a5
```

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Can consistently reproduce the issue by following the save and steps provided in #82119 . Can no longer reproduce the issue with this change applied. Instead, the water is purified as expected:

<img width="350" height="64" alt="snapshot10" src="https://github.com/user-attachments/assets/2a1d7f63-b1b2-41a0-b234-79eeb6216efc" />

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
