### PR TITLE
More monster type to optional/mandatory

### DIFF
--- a/data/json/monsters/insect_spider.json
+++ b/data/json/monsters/insect_spider.json
@@ -2370,7 +2370,7 @@
     "weakpoints": [ { "id": "abdomen", "name": "the abdomen", "coverage": 30 } ],
     "vision_night": 8,
     "zombify_into": "mon_meat_cocoon_tiny",
-    "delete": { "weakpoints": [ { "id": "stinger" } ], "flags": [ "FLIES" ], "special_attacks": [ "DERMATIK" ] }
+    "delete": { "weakpoints": [ { "id": "stinger" } ], "flags": [ "FLIES" ], "special_attacks": [ "dermatik_impale" ] }
   },
   {
     "id": "mon_dermatik_incubator_deer",

--- a/data/json/monsters/zed_nomex.json
+++ b/data/json/monsters/zed_nomex.json
@@ -32,7 +32,7 @@
       "families": [ "prof_wp_syn_armored", "prof_wp_nat_armored" ],
       "flags": [ "ACIDPROOF", "FIREPROOF" ]
     },
-    "delete": { "special_attacks": [ "bite_humanoid" ] }
+    "delete": { "special_attacks": [ "bite" ] }
   },
   {
     "id": "mon_zombie_fireproof_grappler",

--- a/data/mods/No_Hope/monsters.json
+++ b/data/mods/No_Hope/monsters.json
@@ -503,6 +503,7 @@
     "weight": "386 kg",
     "hp": 120,
     "speed": 200,
+    "weakpoint_sets": [ "wps_animal_quadruped" ],
     "material": [ "flesh" ],
     "symbol": "M",
     "color": "brown",

--- a/data/mods/Xedra_Evolved/monsters/zombies.json
+++ b/data/mods/Xedra_Evolved/monsters/zombies.json
@@ -96,7 +96,7 @@
       "corpse_type": "NO_CORPSE"
     },
     "emit_fields": [ { "emit_id": "xedra_monochrome_boomer_frozen_time", "delay": "1 s" } ],
-    "delete": { "special_attacks": [ "BOOMER" ] },
+    "delete": { "special_attacks": [ "boomer_bile" ] },
     "extend": { "flags": [ "STABILIZED_TIMELINE" ] },
     "upgrades": false
   }

--- a/src/mattack_actors.cpp
+++ b/src/mattack_actors.cpp
@@ -93,6 +93,17 @@ static const skill_id skill_throw( "throw" );
 static const trait_id trait_TOXICFLESH( "TOXICFLESH" );
 static const trait_id trait_VAMPIRE( "VAMPIRE" );
 
+bool invalid_mattack_actor::call( monster &m ) const
+{
+    debugmsg( "%s has invalid mattack actor definition!", m.type->id.str() );
+    return false;
+}
+
+std::unique_ptr<mattack_actor> invalid_mattack_actor::clone() const
+{
+    return std::make_unique<invalid_mattack_actor>( *this );
+}
+
 void leap_actor::load_internal( const JsonObject &obj, const std::string & )
 {
     // Mandatory:

--- a/src/mattack_actors.h
+++ b/src/mattack_actors.h
@@ -22,6 +22,13 @@ class Creature;
 class JsonObject;
 class monster;
 
+class invalid_mattack_actor : public mattack_actor
+{
+        bool call( monster & ) const override;
+        std::unique_ptr<mattack_actor> clone() const override;
+        void load_internal( const JsonObject &, const std::string & ) override {}
+};
+
 class leap_actor : public mattack_actor
 {
     public:

--- a/src/mattack_common.h
+++ b/src/mattack_common.h
@@ -44,7 +44,7 @@ class mattack_actor
 struct mtype_special_attack {
     protected:
         // TODO: Remove friend
-        friend struct mtype;
+        friend struct special_attacks_reader;
         cata::clone_ptr<mattack_actor> actor;
 
     public:

--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -824,7 +824,7 @@ struct special_attacks_reader : generic_typed_reader<special_attacks_reader> {
     }
 };
 
-void mtype::load( const JsonObject &jo, const std::string &src )
+void mtype::load( const JsonObject &jo, const std::string_view src )
 {
     MonsterGenerator &gen = MonsterGenerator::generator();
 

--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -870,25 +870,7 @@ void mtype::load( const JsonObject &jo, const std::string &src )
     optional( jo, was_loaded, "status_chance_multiplier", status_chance_multiplier, numeric_bound_reader{0.0f, 5.0f},
               1.f );
 
-    if( !was_loaded || jo.has_array( "families" ) ) {
-        families.clear();
-        families.load( jo.get_array( "families" ) );
-    } else {
-        if( jo.has_object( "extend" ) ) {
-            JsonObject tmp = jo.get_object( "extend" );
-            tmp.allow_omitted_members();
-            if( tmp.has_array( "families" ) ) {
-                families.load( tmp.get_array( "families" ) );
-            }
-        }
-        if( jo.has_object( "delete" ) ) {
-            JsonObject tmp = jo.get_object( "delete" );
-            tmp.allow_omitted_members();
-            if( tmp.has_array( "families" ) ) {
-                families.remove( tmp.get_array( "families" ) );
-            }
-        }
-    }
+    optional( jo, was_loaded, "families", families );
 
     optional( jo, was_loaded, "absorb_ml_per_hp", absorb_ml_per_hp, 250 );
     optional( jo, was_loaded, "split_move_cost", split_move_cost, 200 );

--- a/src/monstergenerator.h
+++ b/src/monstergenerator.h
@@ -82,6 +82,7 @@ class MonsterGenerator
         const std::vector<mtype> &get_all_mtypes() const;
         mtype_id get_valid_hallucination() const;
         friend struct mtype;
+        friend struct special_attacks_reader;
         friend struct species_type;
         friend class mattack_actor;
 

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -605,7 +605,7 @@ struct mtype {
         void faction_display( catacurses::window &w, const point &top_left, int width ) const;
 
         // Historically located in monstergenerator.cpp
-        void load( const JsonObject &jo, const std::string &src );
+        void load( const JsonObject &jo, std::string_view src );
 };
 
 #endif // CATA_SRC_MTYPE_H

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -606,16 +606,6 @@ struct mtype {
 
         // Historically located in monstergenerator.cpp
         void load( const JsonObject &jo, const std::string &src );
-
-    private:
-
-        void add_special_attacks( const JsonObject &jo, std::string_view member_name,
-                                  const std::string &src );
-        void remove_special_attacks( const JsonObject &jo, std::string_view member_name,
-                                     std::string_view src );
-
-        void add_special_attack( const JsonArray &inner, std::string_view src );
-        void add_special_attack( const JsonObject &obj, const std::string &src );
 };
 
 #endif // CATA_SRC_MTYPE_H

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -44,7 +44,6 @@ using mon_action_death  = void ( * )( monster & );
 using mon_action_attack = bool ( * )( monster * );
 using mon_action_defend = void ( * )( monster &, Creature *, dealt_projectile_attack const * );
 using bodytype_id = std::string;
-class JsonArray;
 class JsonObject;
 
 // These are triggers which may affect the monster's anger or morale.
@@ -617,13 +616,6 @@ struct mtype {
 
         void add_special_attack( const JsonArray &inner, std::string_view src );
         void add_special_attack( const JsonObject &obj, const std::string &src );
-
-        void add_regeneration_modifiers( const JsonObject &jo, std::string_view member_name,
-                                         std::string_view src );
-        void remove_regeneration_modifiers( const JsonObject &jo, std::string_view member_name,
-                                            std::string_view src );
-
-        void add_regeneration_modifier( const JsonArray &inner, std::string_view src );
 };
 
 #endif // CATA_SRC_MTYPE_H

--- a/src/weakpoint.cpp
+++ b/src/weakpoint.cpp
@@ -200,6 +200,26 @@ void weakpoint_families::load( const JsonArray &ja )
     }
 }
 
+void weakpoint_families::deserialize( const JsonValue &jv )
+{
+    // the load function extends, which is kinda gross, but fine
+    clear();
+    load( jv.get_array() );
+}
+
+bool weakpoint_families::handle_extend( const JsonValue &jv )
+{
+    // the load function extends, which is fine I guess
+    load( jv.get_array() );
+    return true;
+}
+
+bool weakpoint_families::handle_delete( const JsonValue &jv )
+{
+    remove( jv.get_array() );
+    return true;
+}
+
 void weakpoint_families::remove( const JsonArray &ja )
 {
     for( const JsonValue jsin : ja ) {

--- a/src/weakpoint.h
+++ b/src/weakpoint.h
@@ -117,6 +117,9 @@ struct weakpoint_family {
 
     float modifier( const Character &attacker ) const;
     void load( const JsonValue &jsin );
+    void deserialize( const JsonValue &jsin ) {
+        load( jsin );
+    }
 };
 
 struct weakpoint_families {
@@ -133,6 +136,10 @@ struct weakpoint_families {
     void clear();
     void load( const JsonArray &ja );
     void remove( const JsonArray &ja );
+
+    void deserialize( const JsonValue &jv );
+    bool handle_extend( const JsonValue &jv );
+    bool handle_delete( const JsonValue &jv );
 };
 
 struct weakpoint {

--- a/src/weakpoint.h
+++ b/src/weakpoint.h
@@ -198,6 +198,10 @@ struct weakpoints {
     void finalize();
     void check() const;
 
+    void deserialize( const JsonValue &jv );
+    bool handle_extend( const JsonValue &jv );
+    bool handle_delete( const JsonValue &jv );
+
     /********************* weakpoint_set handling ****************************/
     // load standalone JSON type
     void load( const JsonObject &jo, std::string_view src );


### PR DESCRIPTION
#### Summary
Infrastructure "Use optional for monster weakpoints, regeneration modifiers, and special attacks"

#### Purpose of change
Move more things to use optional, as per https://github.com/CleverRaven/Cataclysm-DDA/pull/82165.

#### Describe the solution
Add typed readers for special attacks and weakpoints. Special attacks need to keep a secondary `names` array in sync with the attacks map, requiring a reader. `weakpoints` can delete weakpoints from `weakpoint_sets`, the contents of which are not known until finalization, and so require tracking the deleted weakpoints until then.

The weakpoints feature requires disabling the copy-from check for `delete`, so I added the ability for readers to do this.

To support deleting special attacks by id, I allowed the reader to get special attacks from just the id string, and added some special handling to ensure it can only be used for delete.

#### Testing
`tools/load_all_mods.sh`
