### PR TITLE
Load recipe `using` with optional

### DIFF
--- a/data/json/recipes/food/canned.json
+++ b/data/json/recipes/food/canned.json
@@ -18,7 +18,7 @@
     "container": "jar_glass_sealed",
     "charges": 2,
     "qualities": [ { "id": "CUT", "level": 2 }, { "id": "COOK", "level": 3 } ],
-    "using": [ [ "canning_high_heat", 1, "LIST" ] ],
+    "using": [ [ "canning_high_heat", 1 ] ],
     "//1": "pressure canning is measured in 0.5 liter quantities, so 1u of canning_high_heat.",
     "components": [ [ [ "jar_glass_sealed", 1 ] ], [ [ "meat_offal", 2, "LIST" ] ], [ [ "water_clean", 1 ] ] ]
   },
@@ -38,7 +38,7 @@
     "book_learn": [ [ "manual_canning", 3 ] ],
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_preservation" }, { "proficiency": "prof_food_canning" } ],
     "batch_time_factors": [ 83, 5 ],
-    "using": [ [ "canning_high_heat", 1, "LIST" ] ],
+    "using": [ [ "canning_high_heat", 1 ] ],
     "//1": "pressure canning is measured in 0.5 liter quantities, so 1u of canning_high_heat.",
     "components": [
       [ [ "water_clean", 1 ] ],
@@ -64,7 +64,7 @@
     "book_learn": [ [ "manual_canning", 3 ] ],
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_preservation" }, { "proficiency": "prof_food_canning" } ],
     "batch_time_factors": [ 83, 5 ],
-    "using": [ [ "canning_high_heat", 6, "LIST" ] ],
+    "using": [ [ "canning_high_heat", 6 ] ],
     "//1": "pressure canning is measured in 0.5 liter quantities, so 6u of canning_high_heat.",
     "components": [
       [ [ "water_clean", 6 ] ],
@@ -90,7 +90,7 @@
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_preservation" }, { "proficiency": "prof_food_canning" } ],
     "batch_time_factors": [ 83, 5 ],
     "charges": 2,
-    "using": [ [ "canning_high_heat", 1, "LIST" ] ],
+    "using": [ [ "canning_high_heat", 1 ] ],
     "//1": "pressure canning is measured in 0.5 liter quantities, so 1u of canning_high_heat.",
     "components": [
       [ [ "water_clean", 1 ] ],
@@ -115,7 +115,7 @@
     "book_learn": [ [ "manual_canning", 3 ] ],
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_preservation" }, { "proficiency": "prof_food_canning" } ],
     "batch_time_factors": [ 83, 5 ],
-    "using": [ [ "canning_high_heat", 6, "LIST" ] ],
+    "using": [ [ "canning_high_heat", 6 ] ],
     "//1": "pressure canning is measured in 0.5 liter quantities, so 6u of canning_high_heat.",
     "components": [
       [ [ "water_clean", 6 ] ],
@@ -141,7 +141,7 @@
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_preservation" }, { "proficiency": "prof_food_canning" } ],
     "batch_time_factors": [ 80, 4 ],
     "//1": "pressure canning is measured in 0.5 liter quantities, so 1u of canning_high_heat.",
-    "using": [ [ "mushroom_soup_ingredients", 2 ], [ "canning_high_heat", 1, "LIST" ] ],
+    "using": [ [ "mushroom_soup_ingredients", 2 ], [ "canning_high_heat", 1 ] ],
     "components": [ [ [ "jar_glass_sealed", 1 ] ], [ [ "water_clean", 1 ] ] ]
   },
   {
@@ -162,7 +162,7 @@
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_preservation" }, { "proficiency": "prof_food_canning" } ],
     "batch_time_factors": [ 80, 4 ],
     "//1": "pressure canning is measured in 0.5 liter quantities, so 6u of canning_high_heat.",
-    "using": [ [ "mushroom_soup_ingredients", 12 ], [ "canning_high_heat", 6, "LIST" ] ],
+    "using": [ [ "mushroom_soup_ingredients", 12 ], [ "canning_high_heat", 6 ] ],
     "components": [ [ [ "jar_3l_glass_sealed", 1 ] ], [ [ "water_clean", 10 ] ] ]
   },
   {
@@ -182,7 +182,7 @@
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_preservation" }, { "proficiency": "prof_food_canning" } ],
     "batch_time_factors": [ 83, 5 ],
     "charges": 2,
-    "using": [ [ "canning_high_heat", 1, "LIST" ] ],
+    "using": [ [ "canning_high_heat", 1 ] ],
     "//1": "pressure canning is measured in 0.5 liter quantities, so 1u of canning_high_heat.",
     "components": [ [ [ "water_clean", 1 ] ], [ [ "jar_glass_sealed", 1 ] ], [ [ "meat_red_raw", 2, "LIST" ] ] ]
   },
@@ -203,7 +203,7 @@
     "book_learn": [ [ "manual_canning", 3 ] ],
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_preservation" }, { "proficiency": "prof_food_canning" } ],
     "batch_time_factors": [ 83, 5 ],
-    "using": [ [ "canning_high_heat", 1, "LIST" ] ],
+    "using": [ [ "canning_high_heat", 1 ] ],
     "//1": "pressure canning is measured in 0.5 liter quantities, so 1u of canning_high_heat.",
     "components": [ [ [ "water_clean", 1 ] ], [ [ "jar_glass_sealed", 1 ] ], [ [ "fish", 2 ] ] ]
   },
@@ -224,7 +224,7 @@
     "book_learn": [ [ "manual_canning", 3 ] ],
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_preservation" }, { "proficiency": "prof_food_canning" } ],
     "batch_time_factors": [ 83, 5 ],
-    "using": [ [ "canning_high_heat", 1, "LIST" ] ],
+    "using": [ [ "canning_high_heat", 1 ] ],
     "//1": "pressure canning is measured in 0.5 liter quantities, so 1u of canning_high_heat.",
     "components": [ [ [ "water_clean", 1 ] ], [ [ "jar_glass_sealed", 1 ] ], [ [ "lobster", 2 ] ] ]
   },
@@ -245,7 +245,7 @@
     "book_learn": [ [ "cookbook", 4 ], [ "manual_canning", 3 ] ],
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_preservation" }, { "proficiency": "prof_food_canning" } ],
     "batch_time_factors": [ 83, 5 ],
-    "using": [ [ "canning_high_heat", 1, "LIST" ] ],
+    "using": [ [ "canning_high_heat", 1 ] ],
     "//1": "pressure canning is measured in 0.5 liter quantities, so 1u of canning_high_heat.",
     "components": [ [ [ "water_clean", 1 ] ], [ [ "jar_glass_sealed", 1 ] ], [ [ "mushroom", 4 ], [ "veggy_any_uncooked", 2, "LIST" ] ] ]
   },
@@ -266,7 +266,7 @@
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_preservation" }, { "proficiency": "prof_food_canning" } ],
     "batch_time_factors": [ 83, 5 ],
     "charges": 2,
-    "using": [ [ "canning_high_heat", 1, "LIST" ] ],
+    "using": [ [ "canning_high_heat", 1 ] ],
     "//1": "pressure canning is measured in 0.5 liter quantities, so 1u of canning_high_heat.",
     "components": [ [ [ "water_clean", 1 ] ], [ [ "jar_glass_sealed", 1 ] ], [ [ "poultry_raw_any", 4, "LIST" ] ] ]
   },
@@ -287,7 +287,7 @@
     "book_learn": [ [ "manual_canning", 3 ] ],
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_preservation" }, { "proficiency": "prof_food_canning" } ],
     "batch_time_factors": [ 80, 4 ],
-    "using": [ [ "woods_soup_ingredients", 1 ], [ "canning_high_heat", 1, "LIST" ] ],
+    "using": [ [ "woods_soup_ingredients", 1 ], [ "canning_high_heat", 1 ] ],
     "//1": "pressure canning is measured in 0.5 liter quantities, so 1u of canning_high_heat.",
     "components": [ [ [ "jar_glass_sealed", 1 ] ] ]
   },
@@ -308,7 +308,7 @@
     "book_learn": [ [ "manual_canning", 3 ] ],
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_preservation" }, { "proficiency": "prof_food_canning" } ],
     "batch_time_factors": [ 80, 4 ],
-    "using": [ [ "meat_soup_ingredients", 1 ], [ "canning_high_heat", 1, "LIST" ] ],
+    "using": [ [ "meat_soup_ingredients", 1 ], [ "canning_high_heat", 1 ] ],
     "//1": "pressure canning is measured in 0.5 liter quantities, so 1u of canning_high_heat.",
     "components": [ [ [ "jar_glass_sealed", 1 ] ] ]
   },
@@ -329,7 +329,7 @@
     "book_learn": [ [ "cookbook", 4 ], [ "manual_canning", 3 ] ],
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_preservation" }, { "proficiency": "prof_food_canning" } ],
     "batch_time_factors": [ 80, 4 ],
-    "using": [ [ "veggy_soup_ingredients", 2 ], [ "canning_high_heat", 1, "LIST" ] ],
+    "using": [ [ "veggy_soup_ingredients", 2 ], [ "canning_high_heat", 1 ] ],
     "//1": "pressure canning is measured in 0.5 liter quantities, so 1u of canning_high_heat.",
     "components": [ [ [ "jar_glass_sealed", 1 ] ] ]
   },
@@ -350,7 +350,7 @@
     "book_learn": [ [ "manual_canning", 3 ] ],
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_preservation" }, { "proficiency": "prof_food_canning" } ],
     "batch_time_factors": [ 80, 4 ],
-    "using": [ [ "fish_soup_ingredients", 1 ], [ "canning_high_heat", 1, "LIST" ] ],
+    "using": [ [ "fish_soup_ingredients", 1 ], [ "canning_high_heat", 1 ] ],
     "//1": "pressure canning is measured in 0.5 liter quantities, so 1u of canning_high_heat.",
     "components": [ [ [ "jar_glass_sealed", 1 ] ] ]
   },
@@ -371,7 +371,7 @@
     "book_learn": [ [ "cookbook", 4 ], [ "manual_canning", 3 ] ],
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_preservation" }, { "proficiency": "prof_food_canning" } ],
     "batch_time_factors": [ 80, 4 ],
-    "using": [ [ "broth_ingredients", 2 ], [ "canning_high_heat", 1, "LIST" ] ],
+    "using": [ [ "broth_ingredients", 2 ], [ "canning_high_heat", 1 ] ],
     "//1": "pressure canning is measured in 0.5 liter quantities, so 1u of canning_high_heat.",
     "components": [ [ [ "jar_glass_sealed", 1 ] ] ]
   },
@@ -392,7 +392,7 @@
     "book_learn": [ [ "cookbook", 4 ], [ "manual_canning", 3 ] ],
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_preservation" }, { "proficiency": "prof_food_canning" } ],
     "batch_time_factors": [ 80, 4 ],
-    "using": [ [ "broth_meat_ingredients", 2 ], [ "canning_high_heat", 1, "LIST" ] ],
+    "using": [ [ "broth_meat_ingredients", 2 ], [ "canning_high_heat", 1 ] ],
     "//1": "pressure canning is measured in 0.5 liter quantities, so 1u of canning_high_heat.",
     "components": [ [ [ "jar_glass_sealed", 1 ] ] ]
   },
@@ -414,7 +414,7 @@
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_preservation" }, { "proficiency": "prof_food_canning" } ],
     "batch_time_factors": [ 80, 4 ],
     "//": "this was using 20 bones (2.3kg), so it was lowered.  Bone broth uses 1:2-1:4 bone:water per weight.",
-    "using": [ [ "canning_high_heat", 1, "LIST" ] ],
+    "using": [ [ "canning_high_heat", 1 ] ],
     "//1": "pressure canning is measured in 0.5 liter quantities, so 1u of canning_high_heat.",
     "components": [ [ [ "jar_glass_sealed", 1 ] ], [ [ "water_clean", 2 ] ], [ [ "bone_edible", 2, "LIST" ] ], [ [ "vinegar", 2 ] ] ]
   },
@@ -435,7 +435,7 @@
     "book_learn": [ [ "cookbook", 4 ], [ "manual_canning", 3 ] ],
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_preservation" }, { "proficiency": "prof_food_canning" } ],
     "batch_time_factors": [ 83, 5 ],
-    "using": [ [ "canning_high_heat", 1, "LIST" ] ],
+    "using": [ [ "canning_high_heat", 1 ] ],
     "components": [
       [ [ "water_clean", 1 ] ],
       [ [ "jar_glass_sealed", 1 ] ],
@@ -459,7 +459,7 @@
     "book_learn": [ [ "cookbook", 4 ], [ "manual_canning", 3 ] ],
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_preservation" }, { "proficiency": "prof_food_canning" } ],
     "batch_time_factors": [ 83, 5 ],
-    "using": [ [ "canning_high_heat", 6, "LIST" ] ],
+    "using": [ [ "canning_high_heat", 6 ] ],
     "//1": "pressure canning is measured in 0.5 liter quantities, so 6u of canning_high_heat.",
     "components": [ [ [ "water_clean", 6 ] ], [ [ "jar_3l_glass_sealed", 1 ] ], [ [ "meat_red_raw", 12, "LIST" ] ] ]
   },
@@ -480,7 +480,7 @@
     "book_learn": [ [ "cookbook", 4 ], [ "manual_canning", 3 ] ],
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_preservation" }, { "proficiency": "prof_food_canning" } ],
     "batch_time_factors": [ 83, 5 ],
-    "using": [ [ "canning_high_heat", 6, "LIST" ] ],
+    "using": [ [ "canning_high_heat", 6 ] ],
     "//1": "pressure canning is measured in 0.5 liter quantities, so 6u of canning_high_heat.",
     "components": [
       [ [ "water_clean", 6 ] ],
@@ -505,7 +505,7 @@
     "book_learn": [ [ "manual_canning", 3 ] ],
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_preservation" }, { "proficiency": "prof_food_canning" } ],
     "batch_time_factors": [ 83, 5 ],
-    "using": [ [ "canning_high_heat", 6, "LIST" ] ],
+    "using": [ [ "canning_high_heat", 6 ] ],
     "//1": "pressure canning is measured in 0.5 liter quantities, so 6u of canning_high_heat.",
     "components": [ [ [ "water_clean", 6 ] ], [ [ "jar_3l_glass_sealed", 1 ] ], [ [ "fish", 12 ] ] ]
   },
@@ -526,7 +526,7 @@
     "book_learn": [ [ "manual_canning", 3 ] ],
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_preservation" }, { "proficiency": "prof_food_canning" } ],
     "batch_time_factors": [ 83, 5 ],
-    "using": [ [ "canning_high_heat", 6, "LIST" ] ],
+    "using": [ [ "canning_high_heat", 6 ] ],
     "//1": "pressure canning is measured in 0.5 liter quantities, so 6u of canning_high_heat.",
     "components": [ [ [ "water_clean", 6 ] ], [ [ "jar_3l_glass_sealed", 1 ] ], [ [ "lobster", 12 ] ] ]
   },
@@ -547,7 +547,7 @@
     "book_learn": [ [ "cookbook", 4 ], [ "manual_canning", 3 ] ],
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_preservation" }, { "proficiency": "prof_food_canning" } ],
     "container": "jar_3l_glass_sealed",
-    "using": [ [ "canning_high_heat", 6, "LIST" ] ],
+    "using": [ [ "canning_high_heat", 6 ] ],
     "//1": "pressure canning is measured in 0.5 liter quantities, so 6u of canning_high_heat.",
     "components": [ [ [ "water_clean", 6 ] ], [ [ "jar_3l_glass_sealed", 1 ] ], [ [ "meat_offal", 12, "LIST" ] ] ]
   },
@@ -568,7 +568,7 @@
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_preservation" }, { "proficiency": "prof_food_canning" } ],
     "batch_time_factors": [ 83, 5 ],
     "charges": 12,
-    "using": [ [ "canning_high_heat", 6, "LIST" ] ],
+    "using": [ [ "canning_high_heat", 6 ] ],
     "//1": "pressure canning is measured in 0.5 liter quantities, so 6u of canning_high_heat.",
     "components": [
       [ [ "water_clean", 6 ] ],
@@ -593,7 +593,7 @@
     "book_learn": [ [ "cookbook", 4 ], [ "manual_canning", 3 ] ],
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_preservation" }, { "proficiency": "prof_food_canning" } ],
     "batch_time_factors": [ 83, 5 ],
-    "using": [ [ "canning_high_heat", 6, "LIST" ] ],
+    "using": [ [ "canning_high_heat", 6 ] ],
     "//1": "pressure canning is measured in 0.5 liter quantities, so 6u of canning_high_heat.",
     "components": [ [ [ "water_clean", 6 ] ], [ [ "jar_3l_glass_sealed", 1 ] ], [ [ "poultry_raw_any", 24, "LIST" ] ] ]
   },
@@ -614,7 +614,7 @@
     "book_learn": [ [ "manual_canning", 3 ] ],
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_preservation" }, { "proficiency": "prof_food_canning" } ],
     "batch_time_factors": [ 80, 4 ],
-    "using": [ [ "woods_soup_ingredients", 6 ], [ "canning_high_heat", 6, "LIST" ] ],
+    "using": [ [ "woods_soup_ingredients", 6 ], [ "canning_high_heat", 6 ] ],
     "//1": "pressure canning is measured in 0.5 liter quantities, so 6u of canning_high_heat.",
     "components": [ [ [ "jar_3l_glass_sealed", 1 ] ] ]
   },
@@ -635,7 +635,7 @@
     "book_learn": [ [ "manual_canning", 3 ] ],
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_preservation" }, { "proficiency": "prof_food_canning" } ],
     "batch_time_factors": [ 80, 4 ],
-    "using": [ [ "meat_soup_ingredients", 6 ], [ "canning_high_heat", 6, "LIST" ] ],
+    "using": [ [ "meat_soup_ingredients", 6 ], [ "canning_high_heat", 6 ] ],
     "//1": "pressure canning is measured in 0.5 liter quantities, so 6u of canning_high_heat.",
     "components": [ [ [ "jar_3l_glass_sealed", 1 ] ] ]
   },
@@ -656,7 +656,7 @@
     "book_learn": [ [ "cookbook", 4 ], [ "manual_canning", 3 ] ],
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_preservation" }, { "proficiency": "prof_food_canning" } ],
     "batch_time_factors": [ 80, 4 ],
-    "using": [ [ "veggy_soup_ingredients", 12 ], [ "canning_high_heat", 6, "LIST" ] ],
+    "using": [ [ "veggy_soup_ingredients", 12 ], [ "canning_high_heat", 6 ] ],
     "//1": "pressure canning is measured in 0.5 liter quantities, so 6u of canning_high_heat.",
     "components": [ [ [ "jar_3l_glass_sealed", 1 ] ] ]
   },
@@ -677,7 +677,7 @@
     "book_learn": [ [ "manual_canning", 3 ] ],
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_preservation" }, { "proficiency": "prof_food_canning" } ],
     "batch_time_factors": [ 80, 4 ],
-    "using": [ [ "fish_soup_ingredients", 6 ], [ "canning_high_heat", 6, "LIST" ] ],
+    "using": [ [ "fish_soup_ingredients", 6 ], [ "canning_high_heat", 6 ] ],
     "//1": "pressure canning is measured in 0.5 liter quantities, so 6u of canning_high_heat.",
     "components": [ [ [ "jar_3l_glass_sealed", 1 ] ] ]
   },
@@ -698,7 +698,7 @@
     "book_learn": [ [ "cookbook", 4 ], [ "manual_canning", 3 ] ],
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_preservation" }, { "proficiency": "prof_food_canning" } ],
     "batch_time_factors": [ 80, 4 ],
-    "using": [ [ "broth_ingredients", 12 ], [ "canning_high_heat", 6, "LIST" ] ],
+    "using": [ [ "broth_ingredients", 12 ], [ "canning_high_heat", 6 ] ],
     "//1": "pressure canning is measured in 0.5 liter quantities, so 6u of canning_high_heat.",
     "components": [ [ [ "jar_3l_glass_sealed", 1 ] ], [ [ "water_clean", 10 ] ] ]
   },
@@ -719,7 +719,7 @@
     "book_learn": [ [ "cookbook", 4 ], [ "manual_canning", 3 ] ],
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_preservation" }, { "proficiency": "prof_food_canning" } ],
     "batch_time_factors": [ 80, 4 ],
-    "using": [ [ "broth_meat_ingredients", 12 ], [ "canning_high_heat", 6, "LIST" ] ],
+    "using": [ [ "broth_meat_ingredients", 12 ], [ "canning_high_heat", 6 ] ],
     "//1": "pressure canning is measured in 0.5 liter quantities, so 6u of canning_high_heat.",
     "components": [ [ [ "jar_3l_glass_sealed", 1 ] ], [ [ "water_clean", 10 ] ] ]
   },
@@ -741,7 +741,7 @@
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_preservation" }, { "proficiency": "prof_food_canning" } ],
     "batch_time_factors": [ 80, 4 ],
     "//": "this was using 120 bones (13.8kg), so it was lowered.  Bone broth uses 1:2-1:4 bone:water per weight.",
-    "using": [ [ "canning_high_heat", 6, "LIST" ] ],
+    "using": [ [ "canning_high_heat", 6 ] ],
     "//1": "pressure canning is measured in 0.5 liter quantities, so 6u of canning_high_heat.",
     "components": [
       [ [ "jar_3l_glass_sealed", 1 ] ],
@@ -775,7 +775,7 @@
     "batch_time_factors": [ 80, 4 ],
     "//": "6192g of milk is dehydrated halfway before canning giving 310u of dehydrating",
     "tools": [ [ [ "dehydrating_heat", 310, "LIST" ] ] ],
-    "using": [ [ "canning_high_heat", 6, "LIST" ] ],
+    "using": [ [ "canning_high_heat", 6 ] ],
     "//1": "pressure canning is measured in 0.5 liter quantities, so 6u of canning_high_heat.",
     "components": [
       [ [ "jar_3l_glass_sealed", 1 ] ],
@@ -808,7 +808,7 @@
     "batch_time_factors": [ 80, 4 ],
     "//": "1032g of milk is dehydrated halfway before canning giving 52u of dehydrating",
     "tools": [ [ [ "dehydrating_heat", 26, "LIST" ] ] ],
-    "using": [ [ "canning_high_heat", 1, "LIST" ] ],
+    "using": [ [ "canning_high_heat", 1 ] ],
     "//1": "pressure canning is measured in 0.5 liter quantities, so 1u of canning_high_heat.",
     "components": [ [ [ "jar_glass_sealed", 1 ] ], [ [ "milk_standard_raw_fresh", 4, "LIST" ] ], [ [ "sugar_standard", 6, "LIST" ] ] ]
   },
@@ -825,7 +825,7 @@
     "difficulty": 5,
     "time": "30 m",
     "batch_time_factors": [ 83, 5 ],
-    "using": [ [ "canning_high_heat", 1, "LIST" ] ],
+    "using": [ [ "canning_high_heat", 1 ] ],
     "//1": "pressure canning is measured in 0.5 liter quantities, so 1u of canning_high_heat.",
     "book_learn": [ [ "cookbook", 6 ], [ "manual_canning", 4 ] ],
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_preservation" }, { "proficiency": "prof_food_canning" } ],
@@ -850,7 +850,7 @@
     "difficulty": 5,
     "time": "60 m",
     "batch_time_factors": [ 83, 5 ],
-    "using": [ [ "canning_high_heat", 6, "LIST" ] ],
+    "using": [ [ "canning_high_heat", 6 ] ],
     "//1": "pressure canning is measured in 0.5 liter quantities, so 6u of canning_high_heat.",
     "book_learn": [ [ "cookbook", 6 ], [ "manual_canning", 4 ] ],
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_preservation" }, { "proficiency": "prof_food_canning" } ],
@@ -875,7 +875,7 @@
     "difficulty": 5,
     "time": "30 m",
     "batch_time_factors": [ 83, 5 ],
-    "using": [ [ "canning_high_heat", 1, "LIST" ] ],
+    "using": [ [ "canning_high_heat", 1 ] ],
     "//1": "pressure canning is measured in 0.5 liter quantities, so 1u of canning_high_heat.",
     "book_learn": [ [ "cookbook", 6 ], [ "manual_canning", 4 ] ],
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_preservation" }, { "proficiency": "prof_food_canning" } ],
@@ -900,7 +900,7 @@
     "difficulty": 5,
     "time": "60 m",
     "batch_time_factors": [ 83, 5 ],
-    "using": [ [ "canning_high_heat", 6, "LIST" ] ],
+    "using": [ [ "canning_high_heat", 6 ] ],
     "//1": "pressure canning is measured in 0.5 liter quantities, so 6u of canning_high_heat.",
     "book_learn": [ [ "cookbook", 6 ], [ "manual_canning", 4 ] ],
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_preservation" }, { "proficiency": "prof_food_canning" } ],
@@ -929,7 +929,7 @@
     "book_learn": [ [ "manual_canning", 3 ] ],
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_preservation" }, { "proficiency": "prof_food_canning" } ],
     "batch_time_factors": [ 83, 5 ],
-    "using": [ [ "canning_high_heat", 6, "LIST" ] ],
+    "using": [ [ "canning_high_heat", 6 ] ],
     "//1": "pressure canning is measured in 0.5 liter quantities, so 6u of canning_high_heat. Minor acid addition for safety of an aqueous solution.",
     "components": [
       [ [ "jar_3l_glass_sealed", 1 ] ],
@@ -957,7 +957,7 @@
     "book_learn": [ [ "cookbook_italian", 4 ], [ "manual_canning", 3 ] ],
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_preservation" }, { "proficiency": "prof_food_canning" } ],
     "batch_time_factors": [ 80, 4 ],
-    "using": [ [ "canning_low_heat", 6, "LIST" ] ],
+    "using": [ [ "canning_low_heat", 6 ] ],
     "//": "https://www.clemson.edu/extension/food/canning/canning-tips/32acidifying-pressure-canned-tomatoes.html",
     "//1": "Tomatoes are borderline and should be pressure canned and acidified for maximum safety.",
     "//2": "pressure canning is measured in 0.5 liter quantities, so 6u of canning_high_heat.",
@@ -985,7 +985,7 @@
     "book_learn": [ [ "cookbook_italian", 4 ], [ "manual_canning", 3 ] ],
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_preservation" }, { "proficiency": "prof_food_canning" } ],
     "batch_time_factors": [ 80, 4 ],
-    "using": [ [ "canning_low_heat", 1, "LIST" ] ],
+    "using": [ [ "canning_low_heat", 1 ] ],
     "//": "https://www.clemson.edu/extension/food/canning/canning-tips/32acidifying-pressure-canned-tomatoes.html",
     "//1": "Tomatoes are borderline and should be pressure canned and acidified for maximum safety.",
     "//2": "pressure canning is measured in 0.5 liter quantities, so 1u of canning_high_heat.",
@@ -1013,7 +1013,7 @@
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_preservation" }, { "proficiency": "prof_food_canning" } ],
     "charges": 4,
     "batch_time_factors": [ 83, 5 ],
-    "using": [ [ "canning_low_heat", 1, "LIST" ] ],
+    "using": [ [ "canning_low_heat", 1 ] ],
     "//": "https://www.clemson.edu/extension/food/canning/canning-tips/32acidifying-pressure-canned-tomatoes.html",
     "//1": "Tomatoes are borderline and should be pressure canned and acidified for maximum safety.",
     "//2": "pressure canning is measured in 0.5 liter quantities, so 1u of canning_high_heat.",
@@ -1041,7 +1041,7 @@
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_preservation" }, { "proficiency": "prof_food_canning" } ],
     "batch_time_factors": [ 83, 5 ],
     "charges": 24,
-    "using": [ [ "canning_low_heat", 6, "LIST" ] ],
+    "using": [ [ "canning_low_heat", 6 ] ],
     "//": "https://www.clemson.edu/extension/food/canning/canning-tips/32acidifying-pressure-canned-tomatoes.html",
     "//1": "Tomatoes are borderline and should be pressure canned and acidified for maximum safety.",
     "//2": "pressure canning is measured in 0.5 liter quantities, so 6u of canning_high_heat.",
@@ -1070,7 +1070,7 @@
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_preservation" }, { "proficiency": "prof_food_canning" } ],
     "container": "jar_glass_sealed",
     "charges": 2,
-    "using": [ [ "canning_low_heat", 1, "LIST" ] ],
+    "using": [ [ "canning_low_heat", 1 ] ],
     "//1": "waterbath canning is measured in 0.5 liter quantities, so 1u of canning_low_heat. Due to pickling, ordinarily pressure canned meat can be water bathed.",
     "components": [
       [ [ "salt", 10 ], [ "saline", 10 ] ],
@@ -1096,7 +1096,7 @@
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_preservation" }, { "proficiency": "prof_food_canning" } ],
     "container": "jar_3l_glass_sealed",
     "charges": 12,
-    "using": [ [ "canning_low_heat", 6, "LIST" ] ],
+    "using": [ [ "canning_low_heat", 6 ] ],
     "//1": "waterbath canning is measured in 0.5 liter quantities, so 6u of canning_low_heat. Due to pickling, ordinarily pressure canned meat can be water bathed.",
     "components": [
       [ [ "salt", 60 ], [ "saline", 60 ] ],
@@ -1122,7 +1122,7 @@
     "book_learn": [ [ "manual_canning", 4 ] ],
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_preservation" }, { "proficiency": "prof_food_canning" } ],
     "batch_time_factors": [ 83, 5 ],
-    "using": [ [ "canning_low_heat", 1, "LIST" ] ],
+    "using": [ [ "canning_low_heat", 1 ] ],
     "//": "Canned tomatoes aren't an option as they've already been preserved.",
     "//1": "waterbath canning is measured in 0.5 liter quantities, so 1u of canning_low_heat. Due to pickling, ordinarily pressure canned veggy can be water bathed.",
     "components": [
@@ -1169,7 +1169,7 @@
     "book_learn": [ [ "manual_canning", 4 ] ],
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_preservation" }, { "proficiency": "prof_food_canning" } ],
     "batch_time_factors": [ 83, 5 ],
-    "using": [ [ "canning_low_heat", 6, "LIST" ] ],
+    "using": [ [ "canning_low_heat", 6 ] ],
     "//": "Canned tomatoes aren't an option as they've already been preserved.",
     "//1": "waterbath canning is measured in 0.5 liter quantities, so 6u of canning_low_heat. Due to pickling, ordinarily pressure canned veggy can be water bathed.",
     "components": [
@@ -1216,7 +1216,7 @@
     "book_learn": [ [ "manual_canning", 4 ] ],
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_preservation" }, { "proficiency": "prof_food_canning" } ],
     "batch_time_factors": [ 83, 5 ],
-    "using": [ [ "canning_low_heat", 1, "LIST" ] ],
+    "using": [ [ "canning_low_heat", 1 ] ],
     "//1": "waterbath canning is measured in 0.5 liter quantities, so 1u of canning_low_heat. Due to pickling, ordinarily pressure canned veggy can be water bathed.",
     "components": [
       [ [ "salt", 10 ], [ "saline", 10 ] ],
@@ -1242,7 +1242,7 @@
     "book_learn": [ [ "manual_canning", 4 ] ],
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_preservation" }, { "proficiency": "prof_food_canning" } ],
     "batch_time_factors": [ 83, 5 ],
-    "using": [ [ "canning_low_heat", 6, "LIST" ] ],
+    "using": [ [ "canning_low_heat", 6 ] ],
     "//1": "waterbath canning is measured in 0.5 liter quantities, so 6u of canning_low_heat. Due to pickling, ordinarily pressure canned veggy can be water bathed.",
     "components": [
       [ [ "salt", 60 ], [ "saline", 60 ] ],
@@ -1268,7 +1268,7 @@
     "book_learn": [ [ "manual_canning", 4 ] ],
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_preservation" }, { "proficiency": "prof_food_canning" } ],
     "batch_time_factors": [ 83, 5 ],
-    "using": [ [ "canning_low_heat", 1, "LIST" ] ],
+    "using": [ [ "canning_low_heat", 1 ] ],
     "//1": "waterbath canning is measured in 0.5 liter quantities, so 1u of canning_low_heat. Due to pickling, ordinarily pressure canned veggy can be water bathed.",
     "components": [ [ [ "salt", 10 ], [ "saline", 10 ] ], [ [ "jar_glass_sealed", 1 ] ], [ [ "fish", 2 ] ], [ [ "vinegar", 16 ] ] ]
   },
@@ -1289,7 +1289,7 @@
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_preservation" }, { "proficiency": "prof_food_canning" } ],
     "book_learn": [ [ "manual_canning", 4 ] ],
     "batch_time_factors": [ 83, 5 ],
-    "using": [ [ "canning_low_heat", 6, "LIST" ] ],
+    "using": [ [ "canning_low_heat", 6 ] ],
     "//1": "waterbath canning is measured in 0.5 liter quantities, so 6u of canning_low_heat. Due to pickling, ordinarily pressure canned veggy can be water bathed.",
     "components": [ [ [ "salt", 60 ], [ "saline", 60 ] ], [ [ "jar_3l_glass_sealed", 1 ] ], [ [ "fish", 12 ] ], [ [ "vinegar", 96 ] ] ]
   },
@@ -1310,7 +1310,7 @@
     "book_learn": [ [ "manual_canning", 2 ] ],
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_preservation" }, { "proficiency": "prof_food_canning" } ],
     "batch_time_factors": [ 80, 4 ],
-    "using": [ [ "canning_low_heat", 6, "LIST" ] ],
+    "using": [ [ "canning_low_heat", 6 ] ],
     "//": "Close but potentially not acidic enough by itself, so requires canning_acid",
     "//1": "waterbath canning is measured in 0.5 liter quantities, so 6u of canning_low_heat.",
     "components": [
@@ -1338,7 +1338,7 @@
     "book_learn": [ [ "manual_canning", 3 ] ],
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_preservation" }, { "proficiency": "prof_food_canning" } ],
     "batch_time_factors": [ 80, 4 ],
-    "using": [ [ "canning_low_heat", 1, "LIST" ] ],
+    "using": [ [ "canning_low_heat", 1 ] ],
     "//": "Close but potentially not acidic enough by itself, so requires canning_acid",
     "//1": "waterbath canning is measured in 0.5 liter quantities, so 1u of canning_low_heat.",
     "components": [
@@ -1366,7 +1366,7 @@
     "book_learn": [ [ "manual_canning", 3 ] ],
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_preservation" }, { "proficiency": "prof_food_canning" } ],
     "batch_time_factors": [ 80, 4 ],
-    "using": [ [ "canning_high_heat", 6, "LIST" ] ],
+    "using": [ [ "canning_high_heat", 6 ] ],
     "//": "Close but potentially not acidic enough by itself, so requires canning_acid",
     "//1": "waterbath canning is measured in 0.5 liter quantities, so 6u of canning_low_heat.",
     "components": [
@@ -1394,7 +1394,7 @@
     "book_learn": [ [ "manual_canning", 2 ] ],
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_preservation" }, { "proficiency": "prof_food_canning" } ],
     "batch_time_factors": [ 80, 4 ],
-    "using": [ [ "canning_low_heat", 1, "LIST" ] ],
+    "using": [ [ "canning_low_heat", 1 ] ],
     "//": "Close but potentially not acidic enough by itself, so requires canning_acid",
     "//1": "waterbath canning is measured in 0.5 liter quantities, so 1u of canning_low_heat.",
     "components": [
@@ -1423,7 +1423,7 @@
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_preservation" }, { "proficiency": "prof_food_canning" } ],
     "batch_time_factors": [ 80, 4 ],
     "qualities": [ { "id": "HAMMER", "level": 1 }, { "id": "CONTAIN", "level": 1 }, { "id": "STRAIN", "level": 2 } ],
-    "using": [ [ "canning_low_heat", 6, "LIST" ] ],
+    "using": [ [ "canning_low_heat", 6 ] ],
     "//": "Acidic enough on their own that no canning_acid is needed",
     "//1": "waterbath canning is measured in 0.5 liter quantities, so 6u of canning_low_heat.",
     "components": [ [ [ "jar_3l_glass_sealed", 1 ] ], [ [ "cranberries", 36 ] ], [ [ "water_clean", 12 ] ] ]
@@ -1446,7 +1446,7 @@
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_preservation" }, { "proficiency": "prof_food_canning" } ],
     "batch_time_factors": [ 80, 4 ],
     "qualities": [ { "id": "HAMMER", "level": 1 }, { "id": "CONTAIN", "level": 1 }, { "id": "STRAIN", "level": 2 } ],
-    "using": [ [ "canning_low_heat", 1, "LIST" ] ],
+    "using": [ [ "canning_low_heat", 1 ] ],
     "//": "Acidic enough on their own that no canning_acid is needed",
     "//1": "waterbath canning is measured in 0.5 liter quantities, so 6u of canning_low_heat.",
     "components": [ [ [ "jar_glass_sealed", 1 ] ], [ [ "sweet_fruit", 2, "LIST" ] ], [ [ "water_clean", 2 ] ] ]
@@ -1469,7 +1469,7 @@
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_preservation" }, { "proficiency": "prof_food_canning" } ],
     "batch_time_factors": [ 80, 4 ],
     "qualities": [ { "id": "HAMMER", "level": 1 }, { "id": "CONTAIN", "level": 1 }, { "id": "STRAIN", "level": 2 } ],
-    "using": [ [ "canning_low_heat", 6, "LIST" ] ],
+    "using": [ [ "canning_low_heat", 6 ] ],
     "//": "Acidic enough on their own that no canning_acid is needed",
     "//1": "waterbath canning is measured in 0.5 liter quantities, so 6u of canning_low_heat.",
     "components": [ [ [ "jar_3l_glass_sealed", 1 ] ], [ [ "sweet_fruit", 12, "LIST" ] ], [ [ "water_clean", 12 ] ] ]
@@ -1492,7 +1492,7 @@
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_preservation" }, { "proficiency": "prof_food_canning" } ],
     "batch_time_factors": [ 80, 4 ],
     "qualities": [ { "id": "HAMMER", "level": 1 }, { "id": "CONTAIN", "level": 1 }, { "id": "STRAIN", "level": 2 } ],
-    "using": [ [ "canning_low_heat", 6, "LIST" ] ],
+    "using": [ [ "canning_low_heat", 6 ] ],
     "//": "Acidic enough on their own that no canning_acid is needed",
     "//1": "waterbath canning is measured in 0.5 liter quantities, so 6u of canning_low_heat.",
     "components": [ [ [ "jar_3l_glass_sealed", 1 ] ], [ [ "orange", 48 ] ], [ [ "water_clean", 6 ] ] ]
@@ -1515,7 +1515,7 @@
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_preservation" }, { "proficiency": "prof_food_canning" } ],
     "batch_time_factors": [ 80, 4 ],
     "qualities": [ { "id": "HAMMER", "level": 1 }, { "id": "CONTAIN", "level": 1 }, { "id": "STRAIN", "level": 2 } ],
-    "using": [ [ "canning_low_heat", 1, "LIST" ] ],
+    "using": [ [ "canning_low_heat", 1 ] ],
     "//": "Acidic enough on their own that no canning_acid is needed",
     "//1": "waterbath canning is measured in 0.5 liter quantities, so 6u of canning_low_heat.",
     "components": [ [ [ "jar_glass_sealed", 1 ] ], [ [ "cranberries", 6 ] ], [ [ "water_clean", 1 ] ] ]
@@ -1538,7 +1538,7 @@
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_preservation" }, { "proficiency": "prof_food_canning" } ],
     "batch_time_factors": [ 80, 4 ],
     "qualities": [ { "id": "HAMMER", "level": 1 }, { "id": "CONTAIN", "level": 1 }, { "id": "STRAIN", "level": 2 } ],
-    "using": [ [ "canning_low_heat", 1, "LIST" ] ],
+    "using": [ [ "canning_low_heat", 1 ] ],
     "//": "Acidic enough on their own that no canning_acid is needed",
     "//1": "waterbath canning is measured in 0.5 liter quantities, so 1u of canning_low_heat.",
     "components": [ [ [ "jar_glass_sealed", 1 ] ], [ [ "apple", 4 ], [ "crabapple", 20 ] ], [ [ "water_clean", 1 ] ] ]
@@ -1562,7 +1562,7 @@
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_preservation" }, { "proficiency": "prof_food_canning" } ],
     "batch_time_factors": [ 80, 4 ],
     "qualities": [ { "id": "HAMMER", "level": 1 }, { "id": "CONTAIN", "level": 1 }, { "id": "STRAIN", "level": 2 } ],
-    "using": [ [ "canning_low_heat", 6, "LIST" ] ],
+    "using": [ [ "canning_low_heat", 6 ] ],
     "//": "Acidic enough on their own that no canning_acid is needed",
     "//1": "waterbath canning is measured in 0.5 liter quantities, so 1u of canning_low_heat.",
     "components": [
@@ -1588,7 +1588,7 @@
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_preservation" }, { "proficiency": "prof_food_canning" } ],
     "charges": 4,
     "batch_time_factors": [ 83, 5 ],
-    "using": [ [ "canning_low_heat", 1, "LIST" ] ],
+    "using": [ [ "canning_low_heat", 1 ] ],
     "//": "Acidic enough on their own that no canning_acid is needed",
     "//1": "waterbath canning is measured in 0.5 liter quantities, so 1u of canning_low_heat.",
     "components": [
@@ -1615,7 +1615,7 @@
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_preservation" }, { "proficiency": "prof_food_canning" } ],
     "charges": 24,
     "batch_time_factors": [ 83, 5 ],
-    "using": [ [ "canning_low_heat", 6, "LIST" ] ],
+    "using": [ [ "canning_low_heat", 6 ] ],
     "//": "Acidic enough on their own that no canning_acid is needed",
     "//1": "waterbath canning is measured in 0.5 liter quantities, so 6u of canning_low_heat.",
     "components": [
@@ -1643,7 +1643,7 @@
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_preservation" }, { "proficiency": "prof_food_canning" } ],
     "batch_time_factors": [ 80, 4 ],
     "qualities": [ { "id": "HAMMER", "level": 1 }, { "id": "CONTAIN", "level": 1 }, { "id": "STRAIN", "level": 2 } ],
-    "using": [ [ "canning_low_heat", 1, "LIST" ] ],
+    "using": [ [ "canning_low_heat", 1 ] ],
     "//": "Acidic enough on their own that no canning_acid is needed",
     "//1": "waterbath canning is measured in 0.5 liter quantities, so 1u of canning_low_heat.",
     "components": [ [ [ "jar_glass_sealed", 1 ] ], [ [ "orange", 8 ] ], [ [ "water_clean", 1 ] ] ]
@@ -1666,7 +1666,7 @@
     "contained": true,
     "charges": 2,
     "components": [ [ [ "water_clean", 1 ] ], [ [ "meat_offal", 2, "LIST" ] ] ],
-    "using": [ [ "canning_metal", 2, "LIST" ], [ "tincan_medium", 1 ] ],
+    "using": [ [ "canning_metal", 2 ], [ "tincan_medium", 1 ] ],
     "//1": "tincan canning is measured in 0.25 liter quantities, so 2u of canning_metal.",
     "byproducts": [ [ "water_clean", 1 ] ]
   },
@@ -1687,7 +1687,7 @@
     "container": "can_food",
     "//": "300g of flesh * double heat = 40u + 1u for the can",
     "components": [ [ [ "water_clean", 1 ] ], [ [ "meat_offal", 1, "LIST" ] ] ],
-    "using": [ [ "canning_metal", 1, "LIST" ], [ "tincan_small", 1 ] ],
+    "using": [ [ "canning_metal", 1 ], [ "tincan_small", 1 ] ],
     "//1": "tincan canning is measured in 0.25 liter quantities, so 1u of canning_metal.",
     "byproducts": [ [ "water_clean", 1 ] ]
   },
@@ -1708,7 +1708,7 @@
     "container": "can_food_big",
     "charges": 12,
     "components": [ [ [ "water_clean", 6 ] ], [ [ "meat_offal", 12, "LIST" ] ] ],
-    "using": [ [ "canning_metal", 12, "LIST" ], [ "tincan_large", 1 ] ],
+    "using": [ [ "canning_metal", 12 ], [ "tincan_large", 1 ] ],
     "//1": "tincan canning is measured in 0.25 liter quantities, so 12u of canning_metal.",
     "byproducts": [ [ "water_clean", 6 ] ]
   },
@@ -1732,7 +1732,7 @@
       [ [ "meat_nofish", 1, "LIST" ], [ "fish", 1 ], [ "lobster", 1 ] ],
       [ [ "veggy_green", 1, "LIST" ] ]
     ],
-    "using": [ [ "canning_metal", 2, "LIST" ], [ "tincan_medium", 1 ] ],
+    "using": [ [ "canning_metal", 2 ], [ "tincan_medium", 1 ] ],
     "//1": "tincan canning is measured in 0.25 liter quantities, so 2u of canning_metal.",
     "byproducts": [ [ "water_clean", 1 ] ]
   },
@@ -1757,7 +1757,7 @@
       [ [ "meat_nofish", 6, "LIST" ], [ "fish", 6 ], [ "lobster", 6 ] ],
       [ [ "veggy_green", 6, "LIST" ] ]
     ],
-    "using": [ [ "canning_metal", 12, "LIST" ], [ "tincan_large", 1 ] ],
+    "using": [ [ "canning_metal", 12 ], [ "tincan_large", 1 ] ],
     "//1": "tincan canning is measured in 0.25 liter quantities, so 12u of canning_metal.",
     "byproducts": [ [ "water_clean", 6 ] ]
   },
@@ -1777,7 +1777,7 @@
     "contained": true,
     "batch_time_factors": [ 83, 5 ],
     "components": [ [ [ "water_clean", 1 ] ], [ [ "meat_nofish", 2, "LIST" ], [ "fish", 2 ], [ "lobster", 2 ] ] ],
-    "using": [ [ "canning_metal", 1, "LIST" ], [ "tincan_small", 1 ] ],
+    "using": [ [ "canning_metal", 1 ], [ "tincan_small", 1 ] ],
     "//1": "tincan canning is measured in 0.25 liter quantities, so 1u of canning_metal.",
     "byproducts": [ [ "water_clean", 1 ] ]
   },
@@ -1797,7 +1797,7 @@
     "charges": 2,
     "batch_time_factors": [ 83, 5 ],
     "components": [ [ [ "water_clean", 1 ] ], [ [ "meat_nofish", 4, "LIST" ], [ "fish", 4 ], [ "lobster", 4 ] ] ],
-    "using": [ [ "canning_metal", 2, "LIST" ], [ "tincan_medium", 1 ] ],
+    "using": [ [ "canning_metal", 2 ], [ "tincan_medium", 1 ] ],
     "//1": "tincan canning is measured in 0.25 liter quantities, so 2u of canning_metal.",
     "byproducts": [ [ "water_clean", 1 ] ]
   },
@@ -1819,7 +1819,7 @@
     "batch_time_factors": [ 83, 5 ],
     "tools": [ [ [ "surface_heat", 60, "LIST" ] ] ],
     "components": [ [ [ "water_clean", 1 ] ], [ [ "meat_nofish", 24, "LIST" ], [ "fish", 24 ], [ "lobster", 24 ] ] ],
-    "using": [ [ "canning_metal", 12, "LIST" ], [ "tincan_large", 1 ] ],
+    "using": [ [ "canning_metal", 12 ], [ "tincan_large", 1 ] ],
     "//1": "tincan canning is measured in 0.25 liter quantities, so 12u of canning_metal.",
     "byproducts": [ [ "water_clean", 6 ] ]
   },
@@ -1838,7 +1838,7 @@
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_preservation" }, { "proficiency": "prof_food_canning" } ],
     "contained": true,
     "batch_time_factors": [ 83, 5 ],
-    "using": [ [ "mushroom_soup_ingredients", 2 ], [ "canning_metal", 2, "LIST" ], [ "tincan_medium", 1 ] ],
+    "using": [ [ "mushroom_soup_ingredients", 2 ], [ "canning_metal", 2 ], [ "tincan_medium", 1 ] ],
     "//1": "tincan canning is measured in 0.25 liter quantities, so 2u of canning_metal.",
     "components": [ [ [ "water_clean", 2 ] ] ],
     "byproducts": [ [ "water_clean", 1 ] ]
@@ -1859,7 +1859,7 @@
     "container": "can_food",
     "charges": 1,
     "batch_time_factors": [ 83, 5 ],
-    "using": [ [ "mushroom_soup_ingredients", 1 ], [ "canning_metal", 1, "LIST" ], [ "tincan_small", 1 ] ],
+    "using": [ [ "mushroom_soup_ingredients", 1 ], [ "canning_metal", 1 ], [ "tincan_small", 1 ] ],
     "//1": "tincan canning is measured in 0.25 liter quantities, so 1u of canning_metal.",
     "components": [ [ [ "water_clean", 1 ] ] ],
     "byproducts": [ [ "water_clean", 1 ] ]
@@ -1880,7 +1880,7 @@
     "container": "can_food_big",
     "charges": 12,
     "batch_time_factors": [ 83, 5 ],
-    "using": [ [ "mushroom_soup_ingredients", 12 ], [ "canning_metal", 12, "LIST" ], [ "tincan_large", 1 ] ],
+    "using": [ [ "mushroom_soup_ingredients", 12 ], [ "canning_metal", 12 ], [ "tincan_large", 1 ] ],
     "//1": "tincan canning is measured in 0.25 liter quantities, so 12u of canning_metal.",
     "components": [ [ [ "water_clean", 6 ] ] ],
     "byproducts": [ [ "water_clean", 6 ] ]
@@ -1900,7 +1900,7 @@
     "contained": true,
     "batch_time_factors": [ 83, 5 ],
     "components": [ [ [ "water_clean", 1 ] ], [ [ "meat_red_raw", 1, "LIST" ] ] ],
-    "using": [ [ "canning_metal", 1, "LIST" ], [ "tincan_small", 1 ] ],
+    "using": [ [ "canning_metal", 1 ], [ "tincan_small", 1 ] ],
     "//1": "tincan canning is measured in 0.25 liter quantities, so 1u of canning_metal.",
     "byproducts": [ [ "water_clean", 1 ] ]
   },
@@ -1921,7 +1921,7 @@
     "charges": 2,
     "batch_time_factors": [ 83, 5 ],
     "components": [ [ [ "water_clean", 1 ] ], [ [ "meat_red_raw", 2, "LIST" ] ] ],
-    "using": [ [ "canning_metal", 2, "LIST" ], [ "tincan_medium", 1 ] ],
+    "using": [ [ "canning_metal", 2 ], [ "tincan_medium", 1 ] ],
     "//1": "tincan canning is measured in 0.25 liter quantities, so 2u of canning_metal.",
     "byproducts": [ [ "water_clean", 1 ] ]
   },
@@ -1942,7 +1942,7 @@
     "charges": 12,
     "batch_time_factors": [ 83, 5 ],
     "components": [ [ [ "water_clean", 1 ] ], [ [ "meat_red_raw", 12, "LIST" ] ] ],
-    "using": [ [ "canning_metal", 12, "LIST" ], [ "tincan_large", 1 ] ],
+    "using": [ [ "canning_metal", 12 ], [ "tincan_large", 1 ] ],
     "//1": "tincan canning is measured in 0.25 liter quantities, so 12u of canning_metal.",
     "byproducts": [ [ "water_clean", 6 ] ]
   },
@@ -1961,7 +1961,7 @@
     "contained": true,
     "batch_time_factors": [ 83, 5 ],
     "components": [ [ [ "water_clean", 1 ] ], [ [ "fish", 1 ] ] ],
-    "using": [ [ "canning_metal", 1, "LIST" ], [ "tincan_small", 1 ] ],
+    "using": [ [ "canning_metal", 1 ], [ "tincan_small", 1 ] ],
     "//1": "tincan canning is measured in 0.25 liter quantities, so 1u of canning_metal.",
     "byproducts": [ [ "water_clean", 1 ] ]
   },
@@ -1982,7 +1982,7 @@
     "charges": 2,
     "batch_time_factors": [ 83, 5 ],
     "components": [ [ [ "water_clean", 1 ] ], [ [ "fish", 2 ] ] ],
-    "using": [ [ "canning_metal", 2, "LIST" ], [ "tincan_medium", 1 ] ],
+    "using": [ [ "canning_metal", 2 ], [ "tincan_medium", 1 ] ],
     "//1": "tincan canning is measured in 0.25 liter quantities, so 2u of canning_metal.",
     "byproducts": [ [ "water_clean", 1 ] ]
   },
@@ -2003,7 +2003,7 @@
     "charges": 12,
     "batch_time_factors": [ 83, 5 ],
     "components": [ [ [ "water_clean", 6 ] ], [ [ "fish", 12 ] ] ],
-    "using": [ [ "canning_metal", 12, "LIST" ], [ "tincan_large", 1 ] ],
+    "using": [ [ "canning_metal", 12 ], [ "tincan_large", 1 ] ],
     "//1": "tincan canning is measured in 0.25 liter quantities, so 12u of canning_metal.",
     "byproducts": [ [ "water_clean", 6 ] ]
   },
@@ -2022,7 +2022,7 @@
     "contained": true,
     "batch_time_factors": [ 83, 5 ],
     "components": [ [ [ "water_clean", 1 ] ], [ [ "lobster", 1 ] ] ],
-    "using": [ [ "canning_metal", 1, "LIST" ], [ "tincan_small", 1 ] ],
+    "using": [ [ "canning_metal", 1 ], [ "tincan_small", 1 ] ],
     "//1": "tincan canning is measured in 0.25 liter quantities, so 1u of canning_metal.",
     "byproducts": [ [ "water_clean", 1 ] ]
   },
@@ -2043,7 +2043,7 @@
     "charges": 2,
     "batch_time_factors": [ 83, 5 ],
     "components": [ [ [ "water_clean", 1 ] ], [ [ "lobster", 2 ] ] ],
-    "using": [ [ "canning_metal", 1, "LIST" ], [ "tincan_medium", 1 ] ],
+    "using": [ [ "canning_metal", 1 ], [ "tincan_medium", 1 ] ],
     "//1": "tincan canning is measured in 0.25 liter quantities, so 2u of canning_metal.",
     "byproducts": [ [ "water_clean", 1 ] ]
   },
@@ -2064,7 +2064,7 @@
     "charges": 12,
     "batch_time_factors": [ 83, 5 ],
     "components": [ [ [ "water_clean", 6 ] ], [ [ "lobster", 12 ] ] ],
-    "using": [ [ "canning_metal", 12, "LIST" ], [ "tincan_large", 1 ] ],
+    "using": [ [ "canning_metal", 12 ], [ "tincan_large", 1 ] ],
     "//1": "tincan canning is measured in 0.25 liter quantities, so 12u of canning_metal.",
     "byproducts": [ [ "water_clean", 6 ] ]
   },
@@ -2083,7 +2083,7 @@
     "contained": true,
     "batch_time_factors": [ 83, 5 ],
     "components": [ [ [ "water_clean", 1 ] ], [ [ "mushroom", 2 ], [ "veggy_any_uncooked", 1, "LIST" ] ] ],
-    "using": [ [ "canning_metal", 1, "LIST" ], [ "tincan_small", 1 ] ],
+    "using": [ [ "canning_metal", 1 ], [ "tincan_small", 1 ] ],
     "//1": "tincan canning is measured in 0.25 liter quantities, so 1u of canning_metal.",
     "byproducts": [ [ "water_clean", 1 ] ]
   },
@@ -2104,7 +2104,7 @@
     "charges": 2,
     "batch_time_factors": [ 83, 5 ],
     "components": [ [ [ "water_clean", 1 ] ], [ [ "mushroom", 4 ], [ "veggy_any_uncooked", 2, "LIST" ] ] ],
-    "using": [ [ "canning_metal", 2, "LIST" ], [ "tincan_medium", 1 ] ],
+    "using": [ [ "canning_metal", 2 ], [ "tincan_medium", 1 ] ],
     "//1": "tincan canning is measured in 0.25 liter quantities, so 2u of canning_metal.",
     "byproducts": [ [ "water_clean", 1 ] ]
   },
@@ -2125,7 +2125,7 @@
     "charges": 12,
     "batch_time_factors": [ 83, 5 ],
     "components": [ [ [ "water_clean", 1 ] ], [ [ "mushroom", 24 ], [ "veggy_any_uncooked", 12, "LIST" ] ] ],
-    "using": [ [ "canning_metal", 12, "LIST" ], [ "tincan_large", 1 ] ],
+    "using": [ [ "canning_metal", 12 ], [ "tincan_large", 1 ] ],
     "//1": "tincan canning is measured in 0.25 liter quantities, so 12u of canning_metal.",
     "byproducts": [ [ "water_clean", 6 ] ]
   },
@@ -2145,7 +2145,7 @@
     "contained": true,
     "batch_time_factors": [ 83, 5 ],
     "components": [ [ [ "water_clean", 1 ] ], [ [ "sweet_fruit", 2, "LIST" ] ], [ [ "sugar_standard", 1, "LIST" ] ] ],
-    "using": [ [ "canning_metal", 1, "LIST" ], [ "tincan_small", 1 ] ],
+    "using": [ [ "canning_metal", 1 ], [ "tincan_small", 1 ] ],
     "//1": "tincan canning is measured in 0.25 liter quantities, so 1u of canning_metal.",
     "byproducts": [ [ "water_clean", 1 ] ]
   },
@@ -2166,7 +2166,7 @@
     "container": "can_medium",
     "batch_time_factors": [ 83, 5 ],
     "components": [ [ [ "water_clean", 1 ] ], [ [ "sweet_fruit", 4, "LIST" ] ], [ [ "sugar_standard", 2, "LIST" ] ] ],
-    "using": [ [ "canning_metal", 2, "LIST" ], [ "tincan_medium", 1 ] ],
+    "using": [ [ "canning_metal", 2 ], [ "tincan_medium", 1 ] ],
     "//1": "tincan canning is measured in 0.25 liter quantities, so 2u of canning_metal.",
     "byproducts": [ [ "water_clean", 1 ] ]
   },
@@ -2187,7 +2187,7 @@
     "container": "can_food_big",
     "batch_time_factors": [ 83, 5 ],
     "components": [ [ [ "water_clean", 1 ] ], [ [ "sweet_fruit", 24, "LIST" ] ], [ [ "sugar_standard", 12, "LIST" ] ] ],
-    "using": [ [ "canning_metal", 12, "LIST" ], [ "tincan_large", 1 ] ],
+    "using": [ [ "canning_metal", 12 ], [ "tincan_large", 1 ] ],
     "//1": "tincan canning is measured in 0.25 liter quantities, so 12u of canning_metal.",
     "byproducts": [ [ "water_clean", 6 ] ]
   },
@@ -2207,7 +2207,7 @@
     "batch_time_factors": [ 83, 5 ],
     "charges": 2,
     "components": [ [ [ "water_clean", 1 ] ], [ [ "tomato", 2 ], [ "tomato_cut", 2 ] ] ],
-    "using": [ [ "canning_metal", 1, "LIST" ], [ "tincan_small", 1 ] ],
+    "using": [ [ "canning_metal", 1 ], [ "tincan_small", 1 ] ],
     "//1": "tincan canning is measured in 0.25 liter quantities, so 1u of canning_metal.",
     "byproducts": [ [ "water_clean", 1 ] ]
   },
@@ -2228,7 +2228,7 @@
     "batch_time_factors": [ 83, 5 ],
     "charges": 4,
     "components": [ [ [ "water_clean", 1 ] ], [ [ "tomato", 4 ], [ "tomato_cut", 4 ] ] ],
-    "using": [ [ "canning_metal", 2, "LIST" ], [ "tincan_medium", 1 ] ],
+    "using": [ [ "canning_metal", 2 ], [ "tincan_medium", 1 ] ],
     "//1": "tincan canning is measured in 0.25 liter quantities, so 2u of canning_metal.",
     "byproducts": [ [ "water_clean", 1 ] ]
   },
@@ -2249,7 +2249,7 @@
     "batch_time_factors": [ 83, 5 ],
     "charges": 24,
     "components": [ [ [ "water_clean", 1 ] ], [ [ "tomato", 24 ], [ "tomato_cut", 24 ] ] ],
-    "using": [ [ "canning_metal", 12, "LIST" ], [ "tincan_large", 1 ] ],
+    "using": [ [ "canning_metal", 12 ], [ "tincan_large", 1 ] ],
     "//1": "tincan canning is measured in 0.25 liter quantities, so 12u of canning_metal.",
     "byproducts": [ [ "water_clean", 6 ] ]
   },
@@ -2268,7 +2268,7 @@
     "contained": true,
     "batch_time_factors": [ 83, 5 ],
     "components": [ [ [ "water_clean", 1 ] ], [ [ "beans_cooked", 2 ], [ "dry_beans", 2 ], [ "raw_beans", 2 ] ] ],
-    "using": [ [ "canning_metal", 2, "LIST" ], [ "tincan_medium", 1 ] ],
+    "using": [ [ "canning_metal", 2 ], [ "tincan_medium", 1 ] ],
     "//1": "tincan canning is measured in 0.25 liter quantities, so 2u of canning_metal.",
     "byproducts": [ [ "water_clean", 1 ] ],
     "charges": 2
@@ -2290,7 +2290,7 @@
     "charges": 12,
     "batch_time_factors": [ 83, 5 ],
     "components": [ [ [ "water_clean", 1 ] ], [ [ "beans_cooked", 12 ], [ "dry_beans", 12 ], [ "raw_beans", 12 ] ] ],
-    "using": [ [ "canning_metal", 12, "LIST" ], [ "tincan_large", 1 ] ],
+    "using": [ [ "canning_metal", 12 ], [ "tincan_large", 1 ] ],
     "//1": "tincan canning is measured in 0.25 liter quantities, so 12u of canning_metal.",
     "byproducts": [ [ "water_clean", 6 ] ]
   },
@@ -2310,7 +2310,7 @@
     "contained": true,
     "batch_time_factors": [ 83, 5 ],
     "components": [ [ [ "water_clean", 1 ] ], [ [ "poultry_raw_any", 2, "LIST" ] ] ],
-    "using": [ [ "canning_metal", 1, "LIST" ], [ "tincan_small", 1 ] ],
+    "using": [ [ "canning_metal", 1 ], [ "tincan_small", 1 ] ],
     "//1": "tincan canning is measured in 0.25 liter quantities, so 1u of canning_metal.",
     "byproducts": [ [ "water_clean", 1 ] ]
   },
@@ -2331,7 +2331,7 @@
     "charges": 2,
     "batch_time_factors": [ 83, 5 ],
     "components": [ [ [ "water_clean", 1 ] ], [ [ "poultry_raw_any", 4, "LIST" ] ] ],
-    "using": [ [ "canning_metal", 2, "LIST" ], [ "tincan_medium", 1 ] ],
+    "using": [ [ "canning_metal", 2 ], [ "tincan_medium", 1 ] ],
     "//1": "tincan canning is measured in 0.25 liter quantities, so 2u of canning_metal.",
     "byproducts": [ [ "water_clean", 1 ] ]
   },
@@ -2352,7 +2352,7 @@
     "charges": 12,
     "batch_time_factors": [ 83, 5 ],
     "components": [ [ [ "water_clean", 1 ] ], [ [ "poultry_raw_any", 24, "LIST" ] ] ],
-    "using": [ [ "canning_metal", 12, "LIST" ], [ "tincan_large", 1 ] ],
+    "using": [ [ "canning_metal", 12 ], [ "tincan_large", 1 ] ],
     "//1": "tincan canning is measured in 0.25 liter quantities, so 12u of canning_metal.",
     "byproducts": [ [ "water_clean", 6 ] ]
   },
@@ -2371,7 +2371,7 @@
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_preservation" }, { "proficiency": "prof_food_canning" } ],
     "contained": true,
     "batch_time_factors": [ 83, 5 ],
-    "using": [ [ "woods_soup_ingredients", 1 ], [ "canning_metal", 2, "LIST" ], [ "tincan_medium", 1 ] ],
+    "using": [ [ "woods_soup_ingredients", 1 ], [ "canning_metal", 2 ], [ "tincan_medium", 1 ] ],
     "//1": "tincan canning is measured in 0.25 liter quantities, so 2u of canning_metal.",
     "components": [ [ [ "water_clean", 1 ] ] ],
     "byproducts": [ [ "water_clean", 1 ] ]
@@ -2392,7 +2392,7 @@
     "container": "can_food_big",
     "charges": 12,
     "batch_time_factors": [ 83, 5 ],
-    "using": [ [ "woods_soup_ingredients", 6 ], [ "canning_metal", 12, "LIST" ], [ "tincan_large", 1 ] ],
+    "using": [ [ "woods_soup_ingredients", 6 ], [ "canning_metal", 12 ], [ "tincan_large", 1 ] ],
     "//1": "tincan canning is measured in 0.25 liter quantities, so 12u of canning_metal.",
     "components": [ [ [ "water_clean", 6 ] ] ],
     "byproducts": [ [ "water_clean", 6 ] ]
@@ -2412,7 +2412,7 @@
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_preservation" }, { "proficiency": "prof_food_canning" } ],
     "contained": true,
     "batch_time_factors": [ 83, 5 ],
-    "using": [ [ "veggy_soup_ingredients", 2 ], [ "canning_metal", 2, "LIST" ], [ "tincan_medium", 1 ] ],
+    "using": [ [ "veggy_soup_ingredients", 2 ], [ "canning_metal", 2 ], [ "tincan_medium", 1 ] ],
     "//1": "tincan canning is measured in 0.25 liter quantities, so 2u of canning_metal.",
     "components": [ [ [ "water_clean", 1 ] ] ],
     "byproducts": [ [ "water_clean", 1 ] ]
@@ -2433,7 +2433,7 @@
     "container": "can_food_big",
     "charges": 12,
     "batch_time_factors": [ 83, 5 ],
-    "using": [ [ "veggy_soup_ingredients", 12 ], [ "canning_metal", 12, "LIST" ], [ "tincan_large", 1 ] ],
+    "using": [ [ "veggy_soup_ingredients", 12 ], [ "canning_metal", 12 ], [ "tincan_large", 1 ] ],
     "//1": "tincan canning is measured in 0.25 liter quantities, so 12u of canning_metal.",
     "components": [ [ [ "water_clean", 6 ] ] ],
     "byproducts": [ [ "water_clean", 6 ] ]
@@ -2453,7 +2453,7 @@
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_preservation" }, { "proficiency": "prof_food_canning" } ],
     "contained": true,
     "batch_time_factors": [ 83, 5 ],
-    "using": [ [ "meat_soup_ingredients", 1 ], [ "canning_metal", 2, "LIST" ], [ "tincan_medium", 1 ] ],
+    "using": [ [ "meat_soup_ingredients", 1 ], [ "canning_metal", 2 ], [ "tincan_medium", 1 ] ],
     "//1": "tincan canning is measured in 0.25 liter quantities, so 2u of canning_metal.",
     "components": [ [ [ "water_clean", 1 ] ] ],
     "byproducts": [ [ "water_clean", 1 ] ]
@@ -2474,7 +2474,7 @@
     "container": "can_food_big",
     "charges": 12,
     "batch_time_factors": [ 83, 5 ],
-    "using": [ [ "meat_soup_ingredients", 6 ], [ "canning_metal", 12, "LIST" ], [ "tincan_large", 1 ] ],
+    "using": [ [ "meat_soup_ingredients", 6 ], [ "canning_metal", 12 ], [ "tincan_large", 1 ] ],
     "//1": "tincan canning is measured in 0.25 liter quantities, so 12u of canning_metal.",
     "components": [ [ [ "water_clean", 6 ] ] ],
     "byproducts": [ [ "water_clean", 6 ] ]
@@ -2494,7 +2494,7 @@
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_preservation" }, { "proficiency": "prof_food_canning" } ],
     "contained": true,
     "batch_time_factors": [ 83, 5 ],
-    "using": [ [ "fish_soup_ingredients", 1 ], [ "canning_metal", 2, "LIST" ], [ "tincan_medium", 1 ] ],
+    "using": [ [ "fish_soup_ingredients", 1 ], [ "canning_metal", 2 ], [ "tincan_medium", 1 ] ],
     "//1": "tincan canning is measured in 0.25 liter quantities, so 2u of canning_metal.",
     "components": [ [ [ "water_clean", 1 ] ] ],
     "byproducts": [ [ "water_clean", 1 ] ]
@@ -2515,7 +2515,7 @@
     "container": "can_food_big",
     "charges": 12,
     "batch_time_factors": [ 83, 5 ],
-    "using": [ [ "fish_soup_ingredients", 6 ], [ "canning_metal", 12, "LIST" ], [ "tincan_large", 1 ] ],
+    "using": [ [ "fish_soup_ingredients", 6 ], [ "canning_metal", 12 ], [ "tincan_large", 1 ] ],
     "//1": "tincan canning is measured in 0.25 liter quantities, so 12u of canning_metal.",
     "components": [ [ [ "water_clean", 6 ] ] ],
     "byproducts": [ [ "water_clean", 6 ] ]
@@ -2536,7 +2536,7 @@
     "contained": true,
     "batch_time_factors": [ 83, 5 ],
     "components": [ [ [ "any_tomato", 4, "LIST" ] ], [ [ "water_clean", 5 ] ] ],
-    "using": [ [ "canning_metal", 2, "LIST" ], [ "tincan_medium", 1 ] ],
+    "using": [ [ "canning_metal", 2 ], [ "tincan_medium", 1 ] ],
     "//1": "tincan canning is measured in 0.25 liter quantities, so 2u of canning_metal.",
     "byproducts": [ [ "water_clean", 1 ] ]
   },
@@ -2557,7 +2557,7 @@
     "charges": 4,
     "batch_time_factors": [ 83, 5 ],
     "components": [ [ [ "any_tomato", 2, "LIST" ] ], [ [ "water_clean", 3 ] ] ],
-    "using": [ [ "canning_metal", 1, "LIST" ], [ "tincan_small", 1 ] ],
+    "using": [ [ "canning_metal", 1 ], [ "tincan_small", 1 ] ],
     "//1": "tincan canning is measured in 0.25 liter quantities, so 1u of canning_metal.",
     "byproducts": [ [ "water_clean", 1 ] ]
   },
@@ -2578,7 +2578,7 @@
     "charges": 48,
     "batch_time_factors": [ 83, 5 ],
     "components": [ [ [ "any_tomato", 24, "LIST" ] ], [ [ "water_clean", 30 ] ] ],
-    "using": [ [ "canning_metal", 12, "LIST" ], [ "tincan_large", 1 ] ],
+    "using": [ [ "canning_metal", 12 ], [ "tincan_large", 1 ] ],
     "//1": "tincan canning is measured in 0.25 liter quantities, so 12u of canning_metal.",
     "byproducts": [ [ "water_clean", 6 ] ]
   },
@@ -2607,7 +2607,7 @@
     "//": "1032g of milk is dehydrated halfway before canning giving 52u of dehydrating",
     "tools": [ [ [ "dehydrating_heat", 52, "LIST" ] ] ],
     "components": [ [ [ "milk_standard_raw_fresh", 4, "LIST" ] ], [ [ "sugar_standard", 6, "LIST" ] ], [ [ "water_clean", 1 ] ] ],
-    "using": [ [ "canning_metal", 2, "LIST" ], [ "tincan_medium", 1 ] ],
+    "using": [ [ "canning_metal", 2 ], [ "tincan_medium", 1 ] ],
     "//1": "tincan canning is measured in 0.25 liter quantities, so 2u of canning_metal.",
     "byproducts": [ [ "water_clean", 1 ] ]
   },
@@ -2637,7 +2637,7 @@
     "//": "516g of milk is dehydrated halfway before canning giving 26u of dehydrating",
     "tools": [ [ [ "dehydrating_heat", 26, "LIST" ] ] ],
     "components": [ [ [ "milk_standard_raw_fresh", 2, "LIST" ] ], [ [ "sugar_standard", 3, "LIST" ] ], [ [ "water_clean", 1 ] ] ],
-    "using": [ [ "canning_metal", 1, "LIST" ], [ "tincan_small", 1 ] ],
+    "using": [ [ "canning_metal", 1 ], [ "tincan_small", 1 ] ],
     "//1": "tincan canning is measured in 0.25 liter quantities, so 1u of canning_metal.",
     "byproducts": [ [ "water_clean", 1 ] ]
   },
@@ -2667,7 +2667,7 @@
     "//": "6192g of milk is dehydrated halfway before canning giving 310u of dehydrating",
     "tools": [ [ [ "dehydrating_heat", 310, "LIST" ] ] ],
     "components": [ [ [ "milk_standard_raw_fresh", 24, "LIST" ] ], [ [ "sugar_standard", 36, "LIST" ] ], [ [ "water_clean", 6 ] ] ],
-    "using": [ [ "canning_metal", 12, "LIST" ], [ "tincan_large", 1 ] ],
+    "using": [ [ "canning_metal", 12 ], [ "tincan_large", 1 ] ],
     "//1": "tincan canning is measured in 0.25 liter quantities, so 12u of canning_metal.",
     "byproducts": [ [ "water_clean", 6 ] ]
   },
@@ -2686,7 +2686,7 @@
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_preservation" }, { "proficiency": "prof_food_canning" } ],
     "contained": true,
     "batch_time_factors": [ 83, 5 ],
-    "using": [ [ "broth_ingredients", 2 ], [ "canning_metal", 2, "LIST" ], [ "tincan_medium", 1 ] ],
+    "using": [ [ "broth_ingredients", 2 ], [ "canning_metal", 2 ], [ "tincan_medium", 1 ] ],
     "//1": "tincan canning is measured in 0.25 liter quantities, so 2u of canning_metal.",
     "components": [ [ [ "water_clean", 3 ] ] ],
     "byproducts": [ [ "water_clean", 6 ] ]
@@ -2707,7 +2707,7 @@
     "container": "can_food",
     "charges": 1,
     "batch_time_factors": [ 83, 5 ],
-    "using": [ [ "broth_ingredients", 1 ], [ "canning_metal", 1, "LIST" ], [ "tincan_small", 1 ] ],
+    "using": [ [ "broth_ingredients", 1 ], [ "canning_metal", 1 ], [ "tincan_small", 1 ] ],
     "//1": "tincan canning is measured in 0.25 liter quantities, so 1u of canning_metal.",
     "components": [ [ [ "water_clean", 2 ] ] ],
     "byproducts": [ [ "water_clean", 1 ] ]
@@ -2728,7 +2728,7 @@
     "container": "can_food_big",
     "charges": 12,
     "batch_time_factors": [ 83, 5 ],
-    "using": [ [ "broth_ingredients", 12 ], [ "canning_metal", 12, "LIST" ], [ "tincan_large", 1 ] ],
+    "using": [ [ "broth_ingredients", 12 ], [ "canning_metal", 12 ], [ "tincan_large", 1 ] ],
     "//1": "tincan canning is measured in 0.25 liter quantities, so 12u of canning_metal.",
     "components": [ [ [ "water_clean", 13 ] ] ],
     "byproducts": [ [ "water_clean", 6 ] ]
@@ -2748,7 +2748,7 @@
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_preservation" }, { "proficiency": "prof_food_canning" } ],
     "contained": true,
     "batch_time_factors": [ 83, 5 ],
-    "using": [ [ "broth_meat_ingredients", 2 ], [ "canning_metal", 2, "LIST" ], [ "tincan_medium", 1 ] ],
+    "using": [ [ "broth_meat_ingredients", 2 ], [ "canning_metal", 2 ], [ "tincan_medium", 1 ] ],
     "//1": "tincan canning is measured in 0.25 liter quantities, so 2u of canning_metal.",
     "components": [ [ [ "water_clean", 3 ] ] ],
     "byproducts": [ [ "water_clean", 6 ] ]
@@ -2769,7 +2769,7 @@
     "container": "can_food",
     "charges": 1,
     "batch_time_factors": [ 83, 5 ],
-    "using": [ [ "broth_meat_ingredients", 1 ], [ "canning_metal", 1, "LIST" ], [ "tincan_small", 1 ] ],
+    "using": [ [ "broth_meat_ingredients", 1 ], [ "canning_metal", 1 ], [ "tincan_small", 1 ] ],
     "//1": "tincan canning is measured in 0.25 liter quantities, so 1u of canning_metal.",
     "components": [ [ [ "water_clean", 2 ] ] ],
     "byproducts": [ [ "water_clean", 1 ] ]
@@ -2790,7 +2790,7 @@
     "container": "can_food_big",
     "charges": 12,
     "batch_time_factors": [ 83, 5 ],
-    "using": [ [ "broth_meat_ingredients", 12 ], [ "canning_metal", 12, "LIST" ], [ "tincan_large", 1 ] ],
+    "using": [ [ "broth_meat_ingredients", 12 ], [ "canning_metal", 12 ], [ "tincan_large", 1 ] ],
     "//1": "tincan canning is measured in 0.25 liter quantities, so 12u of canning_metal.",
     "components": [ [ [ "water_clean", 13 ] ] ],
     "byproducts": [ [ "water_clean", 6 ] ]
@@ -2813,7 +2813,7 @@
     "batch_time_factors": [ 83, 5 ],
     "components": [ [ [ "bone_edible", 2, "LIST" ] ], [ [ "water_clean", 3 ] ], [ [ "vinegar", 2 ] ] ],
     "//1": "tincan canning is measured in 0.25 liter quantities, so 2u of canning_metal.",
-    "using": [ [ "canning_metal", 2, "LIST" ], [ "tincan_medium", 1 ] ]
+    "using": [ [ "canning_metal", 2 ], [ "tincan_medium", 1 ] ]
   },
   {
     "type": "recipe",
@@ -2834,7 +2834,7 @@
     "batch_time_factors": [ 83, 5 ],
     "components": [ [ [ "bone_edible", 2, "LIST" ] ], [ [ "water_clean", 2 ] ], [ [ "vinegar", 2 ] ] ],
     "//1": "tincan canning is measured in 0.25 liter quantities, so 1u of canning_metal.",
-    "using": [ [ "canning_metal", 1, "LIST" ], [ "tincan_small", 1 ] ]
+    "using": [ [ "canning_metal", 1 ], [ "tincan_small", 1 ] ]
   },
   {
     "type": "recipe",
@@ -2855,7 +2855,7 @@
     "batch_time_factors": [ 83, 5 ],
     "components": [ [ [ "bone_edible", 12, "LIST" ] ], [ [ "water_clean", 16 ] ], [ [ "vinegar", 12 ] ] ],
     "//1": "tincan canning is measured in 0.25 liter quantities, so 12u of canning_metal.",
-    "using": [ [ "canning_metal", 12, "LIST" ], [ "tincan_large", 1 ] ]
+    "using": [ [ "canning_metal", 12 ], [ "tincan_large", 1 ] ]
   },
   {
     "type": "recipe",
@@ -2878,7 +2878,7 @@
     "qualities": [ { "id": "STRAIN", "level": 2 } ],
     "components": [ [ [ "water_clean", 1 ] ], [ [ "apple", 4 ], [ "crabapple", 20 ] ] ],
     "//1": "tincan canning is measured in 0.25 liter quantities, so 2u of canning_metal.",
-    "using": [ [ "canning_metal", 2, "LIST" ], [ "tincan_medium", 1 ] ]
+    "using": [ [ "canning_metal", 2 ], [ "tincan_medium", 1 ] ]
   },
   {
     "type": "recipe",
@@ -2901,7 +2901,7 @@
     "qualities": [ { "id": "STRAIN", "level": 2 } ],
     "components": [ [ [ "water_clean", 1 ] ], [ [ "apple", 2 ], [ "crabapple", 10 ] ] ],
     "//1": "tincan canning is measured in 0.25 liter quantities, so 1u of canning_metal.",
-    "using": [ [ "canning_metal", 1, "LIST" ], [ "tincan_small", 1 ] ]
+    "using": [ [ "canning_metal", 1 ], [ "tincan_small", 1 ] ]
   },
   {
     "type": "recipe",
@@ -2924,7 +2924,7 @@
     "qualities": [ { "id": "STRAIN", "level": 2 } ],
     "components": [ [ [ "water_clean", 6 ] ], [ [ "apple", 24 ], [ "crabapple", 120 ] ] ],
     "//1": "tincan canning is measured in 0.25 liter quantities, so 12u of canning_metal.",
-    "using": [ [ "canning_metal", 12, "LIST" ], [ "tincan_large", 1 ] ]
+    "using": [ [ "canning_metal", 12 ], [ "tincan_large", 1 ] ]
   },
   {
     "type": "recipe",
@@ -2947,7 +2947,7 @@
     "qualities": [ { "id": "STRAIN", "level": 2 } ],
     "components": [ [ [ "water_clean", 1 ] ], [ [ "orange", 8 ] ] ],
     "//1": "tincan canning is measured in 0.25 liter quantities, so 2u of canning_metal.",
-    "using": [ [ "canning_metal", 2, "LIST" ], [ "tincan_medium", 1 ] ]
+    "using": [ [ "canning_metal", 2 ], [ "tincan_medium", 1 ] ]
   },
   {
     "type": "recipe",
@@ -2970,7 +2970,7 @@
     "qualities": [ { "id": "STRAIN", "level": 2 } ],
     "components": [ [ [ "water_clean", 1 ] ], [ [ "orange", 4 ] ] ],
     "//1": "tincan canning is measured in 0.25 liter quantities, so 1u of canning_metal.",
-    "using": [ [ "canning_metal", 1, "LIST" ], [ "tincan_small", 1 ] ]
+    "using": [ [ "canning_metal", 1 ], [ "tincan_small", 1 ] ]
   },
   {
     "type": "recipe",
@@ -2993,7 +2993,7 @@
     "qualities": [ { "id": "STRAIN", "level": 2 } ],
     "components": [ [ [ "water_clean", 6 ] ], [ [ "orange", 48 ] ] ],
     "//1": "tincan canning is measured in 0.25 liter quantities, so 12u of canning_metal.",
-    "using": [ [ "canning_metal", 12, "LIST" ], [ "tincan_large", 1 ] ]
+    "using": [ [ "canning_metal", 12 ], [ "tincan_large", 1 ] ]
   },
   {
     "type": "recipe",
@@ -3016,7 +3016,7 @@
     "qualities": [ { "id": "STRAIN", "level": 2 } ],
     "components": [ [ [ "sweet_fruit", 2, "LIST" ] ], [ [ "water_clean", 3 ] ] ],
     "//1": "tincan canning is measured in 0.25 liter quantities, so 2u of canning_metal.",
-    "using": [ [ "canning_metal", 2, "LIST" ], [ "tincan_medium", 1 ] ]
+    "using": [ [ "canning_metal", 2 ], [ "tincan_medium", 1 ] ]
   },
   {
     "type": "recipe",
@@ -3039,7 +3039,7 @@
     "qualities": [ { "id": "STRAIN", "level": 2 } ],
     "components": [ [ [ "sweet_fruit", 1, "LIST" ] ], [ [ "water_clean", 2 ] ] ],
     "//1": "tincan canning is measured in 0.25 liter quantities, so 1u of canning_metal.",
-    "using": [ [ "canning_metal", 1, "LIST" ], [ "tincan_small", 1 ] ]
+    "using": [ [ "canning_metal", 1 ], [ "tincan_small", 1 ] ]
   },
   {
     "type": "recipe",
@@ -3062,7 +3062,7 @@
     "qualities": [ { "id": "STRAIN", "level": 2 } ],
     "components": [ [ [ "sweet_fruit", 12, "LIST" ] ], [ [ "water_clean", 13 ] ] ],
     "//1": "tincan canning is measured in 0.25 liter quantities, so 12u of canning_metal.",
-    "using": [ [ "canning_metal", 12, "LIST" ], [ "tincan_large", 1 ] ]
+    "using": [ [ "canning_metal", 12 ], [ "tincan_large", 1 ] ]
   },
   {
     "type": "recipe",
@@ -3083,7 +3083,7 @@
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_preservation" }, { "proficiency": "prof_food_canning" } ],
     "charges": 5,
     "//1": "tincan canning is measured in 0.25 liter quantities, so 2u of canning_metal.",
-    "using": [ [ "canning_metal", 1, "LIST" ], [ "tincan_small", 1 ] ]
+    "using": [ [ "canning_metal", 1 ], [ "tincan_small", 1 ] ]
   },
   {
     "type": "recipe",
@@ -3103,7 +3103,7 @@
     "book_learn": [ [ "cookbook", 6 ], [ "manual_canning", 4 ] ],
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_preservation" }, { "proficiency": "prof_food_canning" } ],
     "charges": 10,
-    "using": [ [ "canning_metal", 2, "LIST" ], [ "tincan_medium", 1 ] ],
+    "using": [ [ "canning_metal", 2 ], [ "tincan_medium", 1 ] ],
     "//1": "tincan canning is measured in 0.25 liter quantities, so 2u of canning_metal.",
     "byproducts": [ [ "water_clean", 1 ] ]
   },
@@ -3125,7 +3125,7 @@
     "book_learn": [ [ "cookbook", 6 ], [ "manual_canning", 4 ] ],
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_preservation" }, { "proficiency": "prof_food_canning" } ],
     "charges": 60,
-    "using": [ [ "canning_metal", 12, "LIST" ], [ "tincan_large", 1 ] ],
+    "using": [ [ "canning_metal", 12 ], [ "tincan_large", 1 ] ],
     "//1": "tincan canning is measured in 0.25 liter quantities, so 12u of canning_metal.",
     "byproducts": [ [ "water_clean", 6 ] ]
   },
@@ -3150,7 +3150,7 @@
     "qualities": [ { "id": "STRAIN", "level": 2 } ],
     "components": [ [ [ "water_clean", 1 ] ], [ [ "cranberries", 6 ] ] ],
     "//1": "tincan canning is measured in 0.25 liter quantities, so 2u of canning_metal.",
-    "using": [ [ "canning_metal", 2, "LIST" ], [ "tincan_medium", 1 ] ]
+    "using": [ [ "canning_metal", 2 ], [ "tincan_medium", 1 ] ]
   },
   {
     "type": "recipe",
@@ -3173,7 +3173,7 @@
     "qualities": [ { "id": "STRAIN", "level": 2 } ],
     "components": [ [ [ "water_clean", 1 ] ], [ [ "cranberries", 3 ] ] ],
     "//1": "tincan canning is measured in 0.25 liter quantities, so 1u of canning_metal.",
-    "using": [ [ "canning_metal", 1, "LIST" ], [ "tincan_small", 1 ] ]
+    "using": [ [ "canning_metal", 1 ], [ "tincan_small", 1 ] ]
   },
   {
     "type": "recipe",
@@ -3196,6 +3196,6 @@
     "qualities": [ { "id": "STRAIN", "level": 2 } ],
     "components": [ [ [ "water_clean", 6 ] ], [ [ "cranberries", 36 ] ] ],
     "//1": "tincan canning is measured in 0.25 liter quantities, so 12u of canning_metal.",
-    "using": [ [ "canning_metal", 12, "LIST" ], [ "tincan_large", 1 ] ]
+    "using": [ [ "canning_metal", 12 ], [ "tincan_large", 1 ] ]
   }
 ]

--- a/data/json/recipes/food/carnivore.json
+++ b/data/json/recipes/food/carnivore.json
@@ -752,7 +752,7 @@
     "book_learn": [ [ "vacuum_sealing", 1 ] ],
     "qualities": [ { "id": "CUT", "level": 2 }, { "id": "COOK", "level": 3 } ],
     "proficiencies": [ { "proficiency": "prof_preservation" } ],
-    "using": [ [ "vacuum_sealing_standard", 1, "LIST" ] ],
+    "using": [ [ "vacuum_sealing_standard", 1 ] ],
     "components": [ [ [ "fish", 5 ] ], [ [ "salt_preservation", 5, "LIST" ] ] ]
   },
   {

--- a/data/json/recipes/food/egg.json
+++ b/data/json/recipes/food/egg.json
@@ -285,7 +285,7 @@
     "book_learn": [ [ "vacuum_sealing", 1 ] ],
     "qualities": [ { "id": "CUT", "level": 2 }, { "id": "COOK", "level": 3 } ],
     "proficiencies": [ { "proficiency": "prof_preservation" } ],
-    "using": [ [ "vacuum_sealing_standard", 1, "LIST" ] ],
+    "using": [ [ "vacuum_sealing_standard", 1 ] ],
     "components": [ [ [ "curing_roe", 2 ] ] ]
   },
   {

--- a/data/json/recipes/food/fruit_dishes.json
+++ b/data/json/recipes/food/fruit_dishes.json
@@ -70,7 +70,7 @@
     "book_learn": [ [ "vacuum_sealing", 1 ] ],
     "qualities": [ { "id": "CUT", "level": 2 }, { "id": "COOK", "level": 3 } ],
     "proficiencies": [ { "proficiency": "prof_preservation" } ],
-    "using": [ [ "vacuum_sealing_standard", 1, "LIST" ] ],
+    "using": [ [ "vacuum_sealing_standard", 1 ] ],
     "components": [ [ [ "water_clean", 1 ] ], [ [ "sweet_fruit", 4, "LIST" ] ], [ [ "sugar_standard", 1, "LIST" ] ] ]
   },
   {

--- a/data/json/recipes/food/meat_dishes.json
+++ b/data/json/recipes/food/meat_dishes.json
@@ -952,7 +952,7 @@
     "book_learn": [ [ "vacuum_sealing", 1 ] ],
     "qualities": [ { "id": "CUT", "level": 2 }, { "id": "COOK", "level": 3 } ],
     "proficiencies": [ { "proficiency": "prof_preservation" } ],
-    "using": [ [ "vacuum_sealing_standard", 1, "LIST" ] ],
+    "using": [ [ "vacuum_sealing_standard", 1 ] ],
     "//": "since vacuum sealed meat is cooked, need 40u surface_heat - sealing in salt is not sufficient to cook it",
     "components": [
       [

--- a/data/json/recipes/food/vegetable_dishes.json
+++ b/data/json/recipes/food/vegetable_dishes.json
@@ -842,7 +842,7 @@
     "book_learn": [ [ "vacuum_sealing", 1 ] ],
     "qualities": [ { "id": "CUT", "level": 2 }, { "id": "COOK", "level": 3 } ],
     "proficiencies": [ { "proficiency": "prof_preservation" } ],
-    "using": [ [ "vacuum_sealing_standard", 1, "LIST" ] ],
+    "using": [ [ "vacuum_sealing_standard", 1 ] ],
     "components": [ [ [ "veggy_any_uncooked", 2, "LIST" ] ], [ [ "salt_preservation", 2, "LIST" ] ] ]
   },
   {

--- a/data/json/recipes/other/parts.json
+++ b/data/json/recipes/other/parts.json
@@ -334,7 +334,7 @@
     "result": "ch_sheet_metal_small",
     "type": "recipe",
     "copy-from": "sheet_metal_small",
-    "using": [ [ "blacksmithing_standard", 4 ], [ "carbon", 1 ] ],
+    "extend": { "using": [ [ "carbon", 1 ] ] },
     "components": [ [ [ "lc_steel_chunk", 1 ] ] ]
   },
   {

--- a/data/json/recipes/recipe_others.json
+++ b/data/json/recipes/recipe_others.json
@@ -3089,7 +3089,7 @@
     "autolearn": true,
     "proficiencies": [ { "proficiency": "prof_carpentry_basic" } ],
     "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SAW_W", "level": 2 } ],
-    "using": [ [ "marking_hard", 1, "LIST" ] ],
+    "using": [ [ "marking_hard", 1 ] ],
     "components": [
       [ [ "wood_panel", 1 ] ],
       [ [ "2x4", 2 ] ],
@@ -3245,7 +3245,7 @@
     "skill_used": "fabrication",
     "time": "8 m",
     "autolearn": true,
-    "using": [ [ "fabric_standard", 200 ], [ "marking_hard", 1, "LIST" ] ],
+    "using": [ [ "fabric_standard", 200 ], [ "marking_hard", 1 ] ],
     "components": [ [ [ "box_medium", 1 ] ] ]
   },
   {
@@ -3296,7 +3296,7 @@
     "//1": "80 cm weld",
     "qualities": [ { "id": "SAW_M", "level": 2 } ],
     "tools": [ [ [ "swage", -1 ] ] ],
-    "using": [ [ "steel_standard", 2 ], [ "welding_standard", 80, "LIST" ], [ "blacksmithing_standard", 8 ] ],
+    "using": [ [ "steel_standard", 2 ], [ "welding_standard", 80 ], [ "blacksmithing_standard", 8 ] ],
     "components": [ [ [ "pipe", 2 ] ], [ [ "grip_hook", 1 ] ], [ [ "sheet_metal_small", 8 ] ] ]
   },
   {

--- a/data/mods/MindOverMatter/mod_interactions/innawood/recipes.json
+++ b/data/mods/MindOverMatter/mod_interactions/innawood/recipes.json
@@ -53,7 +53,7 @@
       { "proficiency": "prof_intro_chemistry", "required": false },
       { "proficiency": "prof_inorganic_chemistry", "required": false }
     ],
-    "using": [ [ "any_strong_acid", 2, "LIST" ], [ "surface_heat", 30, "LIST" ] ],
+    "using": [ [ "any_strong_acid", 2 ], [ "surface_heat", 30 ] ],
     "components": [ [ [ "matrix_crystal_biokin_dust", 3 ] ] ],
     "flags": [ "BLIND_HARD" ]
   },
@@ -75,7 +75,7 @@
       { "proficiency": "prof_intro_chemistry", "required": false },
       { "proficiency": "prof_inorganic_chemistry", "required": false }
     ],
-    "using": [ [ "any_strong_acid", 2, "LIST" ], [ "surface_heat", 30, "LIST" ] ],
+    "using": [ [ "any_strong_acid", 2 ], [ "surface_heat", 30 ] ],
     "components": [ [ [ "matrix_crystal_clair_dust", 3 ] ] ],
     "flags": [ "BLIND_HARD" ]
   },
@@ -97,7 +97,7 @@
       { "proficiency": "prof_intro_chemistry", "required": false },
       { "proficiency": "prof_inorganic_chemistry", "required": false }
     ],
-    "using": [ [ "any_strong_acid", 2, "LIST" ], [ "surface_heat", 30, "LIST" ] ],
+    "using": [ [ "any_strong_acid", 2 ], [ "surface_heat", 30 ] ],
     "components": [ [ [ "matrix_crystal_electrokin_dust", 3 ] ] ],
     "flags": [ "BLIND_HARD" ]
   },
@@ -119,7 +119,7 @@
       { "proficiency": "prof_intro_chemistry", "required": false },
       { "proficiency": "prof_inorganic_chemistry", "required": false }
     ],
-    "using": [ [ "any_strong_acid", 2, "LIST" ], [ "surface_heat", 30, "LIST" ] ],
+    "using": [ [ "any_strong_acid", 2 ], [ "surface_heat", 30 ] ],
     "components": [ [ [ "matrix_crystal_photokin_dust", 3 ] ] ],
     "flags": [ "BLIND_HARD" ]
   },
@@ -141,7 +141,7 @@
       { "proficiency": "prof_intro_chemistry", "required": false },
       { "proficiency": "prof_inorganic_chemistry", "required": false }
     ],
-    "using": [ [ "any_strong_acid", 2, "LIST" ], [ "surface_heat", 30, "LIST" ] ],
+    "using": [ [ "any_strong_acid", 2 ], [ "surface_heat", 30 ] ],
     "components": [ [ [ "matrix_crystal_pyrokin_dust", 3 ] ] ],
     "flags": [ "BLIND_HARD" ]
   },
@@ -163,7 +163,7 @@
       { "proficiency": "prof_intro_chemistry", "required": false },
       { "proficiency": "prof_inorganic_chemistry", "required": false }
     ],
-    "using": [ [ "any_strong_acid", 2, "LIST" ], [ "surface_heat", 30, "LIST" ] ],
+    "using": [ [ "any_strong_acid", 2 ], [ "surface_heat", 30 ] ],
     "components": [ [ [ "matrix_crystal_telekin_dust", 3 ] ] ],
     "flags": [ "BLIND_HARD" ]
   },
@@ -185,7 +185,7 @@
       { "proficiency": "prof_intro_chemistry", "required": false },
       { "proficiency": "prof_inorganic_chemistry", "required": false }
     ],
-    "using": [ [ "any_strong_acid", 2, "LIST" ], [ "surface_heat", 30, "LIST" ] ],
+    "using": [ [ "any_strong_acid", 2 ], [ "surface_heat", 30 ] ],
     "components": [ [ [ "matrix_crystal_telepath_dust", 3 ] ] ],
     "flags": [ "BLIND_HARD" ]
   },
@@ -207,7 +207,7 @@
       { "proficiency": "prof_intro_chemistry", "required": false },
       { "proficiency": "prof_inorganic_chemistry", "required": false }
     ],
-    "using": [ [ "any_strong_acid", 2, "LIST" ], [ "surface_heat", 30, "LIST" ] ],
+    "using": [ [ "any_strong_acid", 2 ], [ "surface_heat", 30 ] ],
     "components": [ [ [ "matrix_crystal_teleport_dust", 3 ] ] ],
     "flags": [ "BLIND_HARD" ]
   },
@@ -229,7 +229,7 @@
       { "proficiency": "prof_intro_chemistry", "required": false },
       { "proficiency": "prof_inorganic_chemistry", "required": false }
     ],
-    "using": [ [ "any_strong_acid", 2, "LIST" ], [ "surface_heat", 30, "LIST" ] ],
+    "using": [ [ "any_strong_acid", 2 ], [ "surface_heat", 30 ] ],
     "components": [ [ [ "matrix_crystal_vitakin_dust", 3 ] ] ],
     "flags": [ "BLIND_HARD" ]
   },
@@ -251,7 +251,7 @@
       { "proficiency": "prof_intro_chemistry", "required": false },
       { "proficiency": "prof_inorganic_chemistry", "required": false }
     ],
-    "using": [ [ "any_strong_acid", 2, "LIST" ], [ "surface_heat", 30, "LIST" ] ],
+    "using": [ [ "any_strong_acid", 2 ], [ "surface_heat", 30 ] ],
     "components": [ [ [ "matrix_crystal_drained_dust", 3 ] ] ],
     "flags": [ "BLIND_HARD" ]
   }

--- a/data/mods/MindOverMatter/obsolete/recipes.json
+++ b/data/mods/MindOverMatter/obsolete/recipes.json
@@ -64,7 +64,7 @@
     "autolearn": false,
     "proficiencies": [ { "proficiency": "prof_matrix_technology_beginner", "required": false } ],
     "qualities": [ { "id": "SAW_M", "level": 1 }, { "id": "MATRIX_CHANNEL", "level": 1 } ],
-    "using": [ [ "volatile_explosive", 20, "LIST" ], [ "explosives_casting_standard", 1 ] ],
+    "using": [ [ "volatile_explosive", 20 ], [ "explosives_casting_standard", 1 ] ],
     "components": [
       [ [ "fuse", 1 ] ],
       [ [ "glue_strong", 4 ], [ "duct_tape", 75 ], [ "cordage", 1, "LIST" ] ],

--- a/data/mods/MindOverMatter/recipes/chemistry.json
+++ b/data/mods/MindOverMatter/recipes/chemistry.json
@@ -41,7 +41,7 @@
       { "proficiency": "prof_intro_chemistry", "required": false },
       { "proficiency": "prof_inorganic_chemistry", "required": false }
     ],
-    "using": [ [ "any_strong_acid", 2, "LIST" ], [ "surface_heat", 30, "LIST" ] ],
+    "using": [ [ "any_strong_acid", 2 ], [ "surface_heat", 30 ] ],
     "components": [ [ [ "matrix_crystal_biokin_dust", 3 ] ] ],
     "flags": [ "SECRET", "BLIND_HARD" ]
   },
@@ -76,7 +76,7 @@
       { "proficiency": "prof_intro_chemistry", "required": false },
       { "proficiency": "prof_inorganic_chemistry", "required": false }
     ],
-    "using": [ [ "any_strong_acid", 2, "LIST" ], [ "surface_heat", 30, "LIST" ] ],
+    "using": [ [ "any_strong_acid", 2 ], [ "surface_heat", 30 ] ],
     "components": [ [ [ "matrix_crystal_clair_dust", 3 ] ] ],
     "flags": [ "SECRET", "BLIND_HARD" ]
   },
@@ -111,7 +111,7 @@
       { "proficiency": "prof_intro_chemistry", "required": false },
       { "proficiency": "prof_inorganic_chemistry", "required": false }
     ],
-    "using": [ [ "any_strong_acid", 2, "LIST" ], [ "surface_heat", 30, "LIST" ] ],
+    "using": [ [ "any_strong_acid", 2 ], [ "surface_heat", 30 ] ],
     "components": [ [ [ "matrix_crystal_electrokin_dust", 3 ] ] ],
     "flags": [ "SECRET", "BLIND_HARD" ]
   },
@@ -146,7 +146,7 @@
       { "proficiency": "prof_intro_chemistry", "required": false },
       { "proficiency": "prof_inorganic_chemistry", "required": false }
     ],
-    "using": [ [ "any_strong_acid", 2, "LIST" ], [ "surface_heat", 30, "LIST" ] ],
+    "using": [ [ "any_strong_acid", 2 ], [ "surface_heat", 30 ] ],
     "components": [ [ [ "matrix_crystal_photokin_dust", 3 ] ] ],
     "flags": [ "SECRET", "BLIND_HARD" ]
   },
@@ -181,7 +181,7 @@
       { "proficiency": "prof_intro_chemistry", "required": false },
       { "proficiency": "prof_inorganic_chemistry", "required": false }
     ],
-    "using": [ [ "any_strong_acid", 2, "LIST" ], [ "surface_heat", 30, "LIST" ] ],
+    "using": [ [ "any_strong_acid", 2 ], [ "surface_heat", 30 ] ],
     "components": [ [ [ "matrix_crystal_pyrokin_dust", 3 ] ] ],
     "flags": [ "SECRET", "BLIND_HARD" ]
   },
@@ -216,7 +216,7 @@
       { "proficiency": "prof_intro_chemistry", "required": false },
       { "proficiency": "prof_inorganic_chemistry", "required": false }
     ],
-    "using": [ [ "any_strong_acid", 2, "LIST" ], [ "surface_heat", 30, "LIST" ] ],
+    "using": [ [ "any_strong_acid", 2 ], [ "surface_heat", 30 ] ],
     "components": [ [ [ "matrix_crystal_telekin_dust", 3 ] ] ],
     "flags": [ "SECRET", "BLIND_HARD" ]
   },
@@ -251,7 +251,7 @@
       { "proficiency": "prof_intro_chemistry", "required": false },
       { "proficiency": "prof_inorganic_chemistry", "required": false }
     ],
-    "using": [ [ "any_strong_acid", 2, "LIST" ], [ "surface_heat", 30, "LIST" ] ],
+    "using": [ [ "any_strong_acid", 2 ], [ "surface_heat", 30 ] ],
     "components": [ [ [ "matrix_crystal_telepath_dust", 3 ] ] ],
     "flags": [ "SECRET", "BLIND_HARD" ]
   },
@@ -286,7 +286,7 @@
       { "proficiency": "prof_intro_chemistry", "required": false },
       { "proficiency": "prof_inorganic_chemistry", "required": false }
     ],
-    "using": [ [ "any_strong_acid", 2, "LIST" ], [ "surface_heat", 30, "LIST" ] ],
+    "using": [ [ "any_strong_acid", 2 ], [ "surface_heat", 30 ] ],
     "components": [ [ [ "matrix_crystal_teleport_dust", 3 ] ] ],
     "flags": [ "SECRET", "BLIND_HARD" ]
   },
@@ -321,7 +321,7 @@
       { "proficiency": "prof_intro_chemistry", "required": false },
       { "proficiency": "prof_inorganic_chemistry", "required": false }
     ],
-    "using": [ [ "any_strong_acid", 2, "LIST" ], [ "surface_heat", 30, "LIST" ] ],
+    "using": [ [ "any_strong_acid", 2 ], [ "surface_heat", 30 ] ],
     "components": [ [ [ "matrix_crystal_vitakin_dust", 3 ] ] ],
     "flags": [ "SECRET", "BLIND_HARD" ]
   },
@@ -356,7 +356,7 @@
       { "proficiency": "prof_intro_chemistry", "required": false },
       { "proficiency": "prof_inorganic_chemistry", "required": false }
     ],
-    "using": [ [ "any_strong_acid", 2, "LIST" ], [ "surface_heat", 30, "LIST" ] ],
+    "using": [ [ "any_strong_acid", 2 ], [ "surface_heat", 30 ] ],
     "components": [ [ [ "matrix_crystal_drained_dust", 3 ] ] ],
     "flags": [ "SECRET", "BLIND_HARD" ]
   }

--- a/data/mods/MindOverMatter/recipes/medical.json
+++ b/data/mods/MindOverMatter/recipes/medical.json
@@ -82,7 +82,7 @@
       { "proficiency": "prof_psionic_containment", "required": false },
       { "proficiency": "prof_psionic_warping", "required": false }
     ],
-    "using": [ [ "serum_production_standard", 25 ], [ "matrix_dust_refined", 4, "LIST" ] ],
+    "using": [ [ "serum_production_standard", 25 ], [ "matrix_dust_refined", 4 ] ],
     "qualities": [ { "id": "MATRIX_CHANNEL", "level": 1 }, { "id": "MATRIX_FOCUS", "level": 1 } ],
     "components": [ [ [ "psionic_serum_base", 3 ] ], [ [ "thorazine", 2 ] ] ],
     "flags": [ "SECRET", "BLIND_HARD" ]

--- a/data/mods/MindOverMatter/recipes/weapons.json
+++ b/data/mods/MindOverMatter/recipes/weapons.json
@@ -14,7 +14,7 @@
     "book_learn": [ [ "schematics_grenade_inferno", 3 ] ],
     "proficiencies": [ { "proficiency": "prof_matrix_technology_beginner", "required": false }, { "proficiency": "prof_handloading" } ],
     "qualities": [ { "id": "SAW_M", "level": 1 } ],
-    "using": [ [ "volatile_explosive", 20, "LIST" ] ],
+    "using": [ [ "volatile_explosive", 20 ] ],
     "components": [
       [ [ "fuse", 1 ] ],
       [ [ "glue_strong", 4 ], [ "duct_tape", 75 ], [ "cordage", 1, "LIST" ] ],

--- a/data/mods/innawood/recipes/electronic_parts.json
+++ b/data/mods/innawood/recipes/electronic_parts.json
@@ -11,7 +11,7 @@
     "time": "30 m",
     "autolearn": true,
     "flags": [ "FULL_MAGAZINE" ],
-    "using": [ [ "surface_heat", 10, "LIST" ], [ "glazing", 2 ], [ "earthenware_firing", 120 ] ],
+    "using": [ [ "surface_heat", 10 ], [ "glazing", 2 ], [ "earthenware_firing", 120 ] ],
     "proficiencies": [ { "proficiency": "prof_plasticworking" } ],
     "qualities": [ { "id": "SCREW", "level": 1 } ],
     "components": [

--- a/src/recipe.cpp
+++ b/src/recipe.cpp
@@ -321,16 +321,7 @@ void recipe::load( const JsonObject &jo, const std::string &src )
         flags_to_delete = jo.get_tags<flag_id>( "delete_flags" );
     }
 
-    // recipes not specifying any external requirements inherit from their parent recipe (if any)
-    if( jo.has_string( "using" ) ) {
-        reqs_external = { { requirement_id( jo.get_string( "using" ) ), 1 } };
-
-    } else if( jo.has_array( "using" ) ) {
-        reqs_external.clear();
-        for( JsonArray cur : jo.get_array( "using" ) ) {
-            reqs_external.emplace_back( requirement_id( cur.get_string( 0 ) ), cur.get_int( 1 ) );
-        }
-    }
+    optional( jo, was_loaded, "using", reqs_external, weighted_string_id_reader<requirement_id, int> { 1 } );
 
     // inline requirements are always replaced (cannot be inherited)
     reqs_internal.clear();


### PR DESCRIPTION
#### Summary
Infrastructure "Allow extend/delete on using in recipes"

#### Purpose of change
https://github.com/CleverRaven/Cataclysm-DDA/pull/82596

`optional` is preferred, as per https://github.com/CleverRaven/Cataclysm-DDA/pull/82165.

#### Describe the solution
Use optional for `using`.

This results in errors for the unsupported `[ x, 1, LIST ]` syntax, which has no difference from the `[ x, 1 ]` format, so those were fixed.

Revert https://github.com/CleverRaven/Cataclysm-DDA/pull/82596 and remove the extra pair of `[]` brackets so that it is in the correct format.

#### Testing
`tools/load_all_mods.sh`