### PR TITLE
Account for threshold_substitutes in the mutation selector

### DIFF
--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -1466,6 +1466,13 @@ bool Character::mutation_selector( const std::vector<trait_id> &prospective_trai
             if( has_permanent_trait( threshreq[i] ) ) {
                 c_has_threshreq = true;
             }
+            if( !mdata.strict_threshreq ) {
+                for( const trait_id &subst : threshreq[i]->threshold_substitutes ) {
+                    if( has_permanent_trait( subst ) ) {
+                        c_has_threshreq = true;
+                    }
+                }
+            }
         }
         if( !c_has_threshreq ) {
             continue;


### PR DESCRIPTION
#### Summary
Bugfixes "Account for threshold_substitutes in the mutation selector"

#### Purpose of change

The mutation selector – used in e.g. Guided Evolution from MoM or Morphogenic Mastery from Magiclysm – does not account for threshold_substitutes. This change makes it do so.

#### Testing

Opened the save	in the associated bug report, observed the Chimera threshold trait, took batrachian mutagen & primer, observed a post-threshold trait option (Earth Sleeper) appear.

<img width="800" height="380" alt="mutation" src="https://github.com/user-attachments/assets/eb2ce3ae-fc7d-4c89-86f6-859a80544ce2" />

#### Additional context

Fixes #82566 