### PR TITLE
Move map extra list creation out of optional json loading check

### DIFF
--- a/src/map_extras.cpp
+++ b/src/map_extras.cpp
@@ -1538,6 +1538,13 @@ void map_extra::load( const JsonObject &jo, std::string_view )
     }
 }
 
+void map_extra::finalize() const
+{
+    if( generator_method != map_extra_method::null ) {
+        MapExtras::all_function_names.push_back( id );
+    }
+}
+
 void map_extra::check() const
 {
     switch( generator_method ) {
@@ -1545,13 +1552,7 @@ void map_extra::check() const
             const map_extra_pointer mx_func = MapExtras::get_function( map_extra_id( generator_id ) );
             if( mx_func == nullptr ) {
                 debugmsg( "invalid map extra function (%s) defined for map extra (%s)", generator_id, id.str() );
-                break;
             }
-            MapExtras::all_function_names.push_back( id );
-            break;
-        }
-        case map_extra_method::mapgen: {
-            MapExtras::all_function_names.push_back( id );
             break;
         }
         case map_extra_method::update_mapgen: {
@@ -1560,11 +1561,10 @@ void map_extra::check() const
                 update_mapgen_func->second.funcs().empty() ) {
                 debugmsg( "invalid update mapgen function (%s) defined for map extra (%s)", generator_id,
                           id.str() );
-                break;
             }
-            MapExtras::all_function_names.push_back( id );
             break;
         }
+        case map_extra_method::mapgen:
         case map_extra_method::null:
         default:
             break;

--- a/src/map_extras.h
+++ b/src/map_extras.h
@@ -72,6 +72,7 @@ class map_extra
         bool was_loaded = false;
         void load( const JsonObject &jo, std::string_view src );
         static void finalize_all();
+        void finalize() const;
         void check() const;
     private:
         translation name_;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Map extra debug menu and tile report work with json checks disabled"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
The debug menu for spawning map extras doesn't work at all, and the tile report can't iterate map extras, because the population of the list for looking them up is currently done in the optional json check step for the map extra type.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
Move the list population to a new finalize step that will always run.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
The list could be eliminated in favor of accessing the generic_factory directly. This is a viable option, but I finished implementing the current solution before it occurred to me.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->
Confirmed the debug menu works correctly. Did not test the tile report.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
