### PR TITLE
Refactor map extra functions

### DIFF
--- a/src/action.cpp
+++ b/src/action.cpp
@@ -37,7 +37,6 @@
 #include "point.h"
 #include "popup.h"
 #include "ret_val.h"
-#include "string_formatter.h"
 #include "translations.h"
 #include "type_id.h"
 #include "uilist.h"

--- a/src/animation.cpp
+++ b/src/animation.cpp
@@ -31,7 +31,6 @@
 #include "output.h"
 #include "point.h"
 #include "popup.h"
-#include "string_formatter.h"
 #include "translations.h"
 #include "type_id.h"
 #include "ui_manager.h"

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -56,7 +56,6 @@
 #include "ranged.h"
 #include "ret_val.h"
 #include "rng.h"
-#include "string_formatter.h"
 #include "translations.h"
 #include "type_id.h"
 #include "ui_manager.h"

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -10618,7 +10618,7 @@ void Character::place_corpse( const tripoint_abs_omt &om_target )
     bay.load( om_target, false );
     // Redundant as long as map operations aren't using get_map() in a transitive call chain. Added for future proofing.
     swap_map swap( *bay.cast_to_map() );
-    point_omt_ms fin( rng( 1, SEEX * 2 - 2 ), rng( 1, SEEX * 2 - 2 ) );
+    point_omt_ms fin = rng_map_point<point_omt_ms>( 1 );
     // This makes no sense at all. It may find a random tile without furniture, but
     // if the first try to find one fails, it will go through all tiles of the map
     // and essentially select the last one that has no furniture.

--- a/src/coordinates.h
+++ b/src/coordinates.h
@@ -265,6 +265,10 @@ class coord_point_ob : public
             return coord_point_ob( this->raw().rotate( turns, dim ) );
         }
 
+        constexpr auto rotate_in_map( int turns ) const {
+            return coord_point_ob( this->raw().rotate_in_map( turns ) );
+        }
+
         friend inline this_as_ob operator+( const coord_point_ob &l, const point &r ) {
             return this_as_ob( l.raw() + r );
         }

--- a/src/map_extras.cpp
+++ b/src/map_extras.cpp
@@ -271,41 +271,42 @@ static void delete_items_at_mount( vehicle &veh, const point_rel_ms &pt )
 
 static bool mx_helicopter( map &m, const tripoint_abs_sm &abs_sub )
 {
-    point_bub_ms c( rng( 6, SEEX * 2 - 7 ), rng( 6, SEEY * 2 - 7 ) );
+    point_bub_ms c = rng_map_point<point_bub_ms>( 6 );
 
     for( int x = 0; x < SEEX * 2; x++ ) {
         for( int y = 0; y < SEEY * 2; y++ ) {
-            if( m.veh_at( tripoint_bub_ms( x,  y, abs_sub.z() ) ) &&
-                m.ter( tripoint_bub_ms( x, y, abs_sub.z() ) )->has_flag( ter_furn_flag::TFLAG_DIGGABLE ) ) {
-                m.ter_set( tripoint_bub_ms( x, y, abs_sub.z() ), ter_t_dirtmound );
+            const tripoint_bub_ms pos( x,  y, abs_sub.z() );
+            if( m.veh_at( pos ) &&
+                m.ter( pos )->has_flag( ter_furn_flag::TFLAG_DIGGABLE ) ) {
+                m.ter_set( pos, ter_t_dirtmound );
             } else {
                 if( x >= c.x() - dice( 1, 5 ) && x <= c.x() + dice( 1, 5 ) && y >= c.y() - dice( 1, 5 ) &&
                     y <= c.y() + dice( 1, 5 ) ) {
                     if( one_in( 7 ) &&
-                        m.ter( tripoint_bub_ms( x, y, abs_sub.z() ) )->has_flag( ter_furn_flag::TFLAG_DIGGABLE ) ) {
-                        m.ter_set( tripoint_bub_ms( x, y, abs_sub.z() ), ter_t_dirtmound );
+                        m.ter( pos )->has_flag( ter_furn_flag::TFLAG_DIGGABLE ) ) {
+                        m.ter_set( pos, ter_t_dirtmound );
                     }
                 }
                 if( x >= c.x() - dice( 1, 6 ) && x <= c.x() + dice( 1, 6 ) && y >= c.y() - dice( 1, 6 ) &&
                     y <= c.y() + dice( 1, 6 ) ) {
                     if( !one_in( 5 ) ) {
-                        m.make_rubble( tripoint_bub_ms( x,  y, abs_sub.z() ), furn_f_wreckage, true );
-                        if( m.ter( tripoint_bub_ms( x, y, abs_sub.z() ) )->has_flag( ter_furn_flag::TFLAG_DIGGABLE ) ) {
-                            m.ter_set( tripoint_bub_ms( x, y, abs_sub.z() ), ter_t_dirtmound );
+                        m.make_rubble( pos, furn_f_wreckage, true );
+                        if( m.ter( pos )->has_flag( ter_furn_flag::TFLAG_DIGGABLE ) ) {
+                            m.ter_set( pos, ter_t_dirtmound );
                         }
-                    } else if( m.is_bashable( tripoint_bub_ms( x, y, abs_sub.z() ) ) ) {
-                        m.destroy( tripoint_bub_ms( x,  y, abs_sub.z() ), true );
-                        if( m.ter( tripoint_bub_ms( x, y, abs_sub.z() ) )->has_flag( ter_furn_flag::TFLAG_DIGGABLE ) ) {
-                            m.ter_set( tripoint_bub_ms( x, y, abs_sub.z() ), ter_t_dirtmound );
+                    } else if( m.is_bashable( pos ) ) {
+                        m.destroy( pos, true );
+                        if( m.ter( pos )->has_flag( ter_furn_flag::TFLAG_DIGGABLE ) ) {
+                            m.ter_set( pos, ter_t_dirtmound );
                         }
                     }
 
                 } else if( one_in( 4 + ( std::abs( x - c.x() ) + std::abs( y -
                                          c.y() ) ) ) ) { // 1 in 10 chance of being wreckage anyway
-                    m.make_rubble( tripoint_bub_ms( x,  y, abs_sub.z() ), furn_f_wreckage, true );
+                    m.make_rubble( pos, furn_f_wreckage, true );
                     if( !one_in( 3 ) ) {
-                        if( m.ter( tripoint_bub_ms( x, y, abs_sub.z() ) )->has_flag( ter_furn_flag::TFLAG_DIGGABLE ) ) {
-                            m.ter_set( tripoint_bub_ms( x, y, abs_sub.z() ), ter_t_dirtmound );
+                        if( m.ter( pos )->has_flag( ter_furn_flag::TFLAG_DIGGABLE ) ) {
+                            m.ter_set( pos, ter_t_dirtmound );
                         }
                     }
                 }
@@ -470,7 +471,7 @@ static bool mx_portal_in( map &m, const tripoint_abs_sm &abs_sub )
         case 3: {
             m.add_field( portal_location, fd_fatigue, 3 );
             for( int i = 0; i < rng( 1, 10 ); i++ ) {
-                tripoint_bub_ms end_location = { rng( 0, SEEX * 2 - 1 ), rng( 0, SEEY * 2 - 1 ), abs_sub.z()};
+                tripoint_bub_ms end_location = rng_map_point<tripoint_bub_ms>( 0, abs_sub.z() );
                 std::vector<tripoint_bub_ms> failure = line_to( portal_location, end_location );
                 for( tripoint_bub_ms &i : failure ) {
                     m.ter_set( tripoint_bub_ms{ i.xy(), abs_sub.z()}, ter_t_pit );
@@ -554,20 +555,20 @@ static bool mx_portal_in( map &m, const tripoint_abs_sm &abs_sub )
     return true;
 }
 
-static bool mx_grove( map &m, const tripoint_abs_sm &abs_sub )
+static bool mx_helper_clone_plant( map &m, const tripoint_abs_sm &abs_sub, ter_furn_flag tfflag )
 {
     // From wikipedia - The main meaning of "grove" is a group of trees that grow close together,
     // generally without many bushes or other plants underneath.
 
-    // This map extra finds the first tree in the area, and then converts all trees, young trees,
-    // and shrubs in the area into that type of tree.
+    // This map extra helper finds the first appropriately flagged terrain in the area, and then
+    // converts all trees, young trees, and shrubs in the area into that type.
 
     ter_id tree;
     bool found_tree = false;
-    for( int i = 0; i < SEEX * 2; i++ ) {
-        for( int j = 0; j < SEEY * 2; j++ ) {
+    for( int i = 0; !found_tree && i < SEEX * 2; i++ ) {
+        for( int j = 0; !found_tree && j < SEEY * 2; j++ ) {
             const tripoint_bub_ms location( i, j, abs_sub.z() );
-            if( m.has_flag_ter( ter_furn_flag::TFLAG_TREE, location ) ) {
+            if( m.has_flag_ter( tfflag, location ) ) {
                 tree = m.ter( location );
                 found_tree = true;
             }
@@ -594,37 +595,12 @@ static bool mx_grove( map &m, const tripoint_abs_sm &abs_sub )
 
 static bool mx_shrubbery( map &m, const tripoint_abs_sm &abs_sub )
 {
-    // This map extra finds the first shrub in the area, and then converts all trees, young trees,
-    // and shrubs in the area into that type of shrub.
+    return mx_helper_clone_plant( m, abs_sub, ter_furn_flag::TFLAG_SHRUB );
+}
 
-    ter_id shrubbery;
-    bool found_shrubbery = false;
-    for( int i = 0; i < SEEX * 2; i++ ) {
-        for( int j = 0; j < SEEY * 2; j++ ) {
-            const tripoint_bub_ms location( i, j, abs_sub.z() );
-            if( m.has_flag_ter( ter_furn_flag::TFLAG_SHRUB, location ) ) {
-                shrubbery = m.ter( location );
-                found_shrubbery = true;
-            }
-        }
-    }
-
-    if( !found_shrubbery ) {
-        return false;
-    }
-
-    for( int i = 0; i < SEEX * 2; i++ ) {
-        for( int j = 0; j < SEEY * 2; j++ ) {
-            const tripoint_bub_ms location( i, j, abs_sub.z() );
-            if( m.has_flag_ter( ter_furn_flag::TFLAG_SHRUB, location ) ||
-                m.has_flag_ter( ter_furn_flag::TFLAG_TREE, location ) ||
-                m.has_flag_ter( ter_furn_flag::TFLAG_YOUNG, location ) ) {
-                m.ter_set( location, shrubbery );
-            }
-        }
-    }
-
-    return true;
+static bool mx_grove( map &m, const tripoint_abs_sm &abs_sub )
+{
+    return mx_helper_clone_plant( m, abs_sub, ter_furn_flag::TFLAG_TREE );
 }
 
 static bool mx_pond( map &m, const tripoint_abs_sm &abs_sub )
@@ -755,231 +731,99 @@ static bool mx_roadworks( map &m, const tripoint_abs_sm &abs_sub )
     point_bub_ms defects_from; // road defects square start
     point_bub_ms defects_to; // road defects square end
     point_bub_ms defects_centered; //  road defects centered
-    tripoint_bub_ms veh( 0, 0, abs_sub.z() ); // vehicle
+    tripoint_bub_ms veh; // vehicle
     point_bub_ms equipment; // equipment
 
+    bool straight = true;
+    int turns = -1;
     // determine placement of effects
     if( road_at_north && road_at_south && !road_at_east && !road_at_west ) {
         if( one_in( 2 ) ) { // west side of the NS road
-            // road barricade
-            line_furn( &m, furn_f_barricade_road, point_bub_ms( 4, 0 ), point_bub_ms( 11, 7 ), abs_sub.z() );
-            line_furn( &m, furn_f_barricade_road, point_bub_ms( 11, 8 ), point_bub_ms( 11, 15 ), abs_sub.z() );
-            line_furn( &m, furn_f_barricade_road, point_bub_ms( 11, 16 ), point_bub_ms( 4, 23 ), abs_sub.z() );
-            // road defects
-            defects_from = { 9, 7 };
-            defects_to = { 4, 16 };
-            defects_centered = { rng( 4, 7 ), rng( 10, 16 ) };
-            // vehicle
-            veh.x() = rng( 4, 6 );
-            veh.y() = rng( 8, 10 );
-            // equipment
-            if( one_in( 2 ) ) {
-                equipment.x() = rng( 0, 4 );
-                equipment.y() = rng( 1, 2 );
-            } else {
-                equipment.x() = rng( 0, 4 );
-                equipment.y() = rng( 21, 22 );
-            }
+            turns = 0;
         } else { // east side of the NS road
-            // road barricade
-            line_furn( &m, furn_f_barricade_road, point_bub_ms( 19, 0 ), point_bub_ms( 12, 7 ), abs_sub.z() );
-            line_furn( &m, furn_f_barricade_road, point_bub_ms( 12, 8 ), point_bub_ms( 12, 15 ), abs_sub.z() );
-            line_furn( &m, furn_f_barricade_road, point_bub_ms( 12, 16 ), point_bub_ms( 19, 23 ), abs_sub.z() );
-            // road defects
-            defects_from = { 13, 7 };
-            defects_to = { 19, 16 };
-            defects_centered = { rng( 15, 18 ), rng( 10, 14 ) };
-            // vehicle
-            veh.x() = rng( 15, 19 );
-            veh.y() = rng( 8, 10 );
-            // equipment
-            if( one_in( 2 ) ) {
-                equipment.x() = rng( 20, 24 );
-                equipment.y() = rng( 1, 2 );
-            } else {
-                equipment.x() = rng( 20, 24 );
-                equipment.y() = rng( 21, 22 );
-            }
+            turns = 2;
         }
     } else if( road_at_west && road_at_east && !road_at_north && !road_at_south ) {
         if( one_in( 2 ) ) { // north side of the EW road
-            // road barricade
-            line_furn( &m, furn_f_barricade_road, point_bub_ms( 0, 4 ), point_bub_ms( 7, 11 ), abs_sub.z() );
-            line_furn( &m, furn_f_barricade_road, point_bub_ms( 8, 11 ), point_bub_ms( 15, 11 ), abs_sub.z() );
-            line_furn( &m, furn_f_barricade_road, point_bub_ms( 16, 11 ), point_bub_ms( 23, 4 ), abs_sub.z() );
-            // road defects
-            defects_from = { 7, 9 };
-            defects_to = { 16, 4 };
-            defects_centered = { rng( 8, 14 ), rng( 3, 8 ) };
-            // vehicle
-            veh.x() = rng( 6, 8 );
-            veh.y() = rng( 4, 8 );
-            // equipment
-            if( one_in( 2 ) ) {
-                equipment.x() = rng( 1, 2 );
-                equipment.y() = rng( 0, 4 );
-            } else {
-                equipment.x() = rng( 21, 22 );
-                equipment.y() = rng( 0, 4 );
-            }
+            turns = 1;
         } else { // south side of the EW road
-            // road barricade
-            line_furn( &m, furn_f_barricade_road, point_bub_ms( 0, 19 ), point_bub_ms( 7, 12 ), abs_sub.z() );
-            line_furn( &m, furn_f_barricade_road, point_bub_ms( 8, 12 ), point_bub_ms( 15, 12 ), abs_sub.z() );
-            line_furn( &m, furn_f_barricade_road, point_bub_ms( 16, 12 ), point_bub_ms( 23, 19 ), abs_sub.z() );
-            // road defects
-            defects_from = { 7, 13 };
-            defects_to = { 16, 19 };
-            defects_centered = { rng( 8, 14 ), rng( 14, 18 ) };
-            // vehicle
-            veh.x() = rng( 6, 8 );
-            veh.y() = rng( 14, 18 );
-            // equipment
-            if( one_in( 2 ) ) {
-                equipment.x() = rng( 1, 2 );
-                equipment.y() = rng( 20, 24 );
-            } else {
-                equipment.x() = rng( 21, 22 );
-                equipment.y() = rng( 20, 24 );
-            }
+            turns = 3;
         }
     } else if( road_at_north && road_at_east && !road_at_west && !road_at_south ) {
-        // SW side of the N-E road curve
-        // road barricade
-        // NOLINTNEXTLINE(cata-use-named-point-constants)
-        line_furn( &m, furn_f_barricade_road, point_bub_ms( 1, 0 ), point_bub_ms( 11, 0 ), abs_sub.z() );
-        line_furn( &m, furn_f_barricade_road, point_bub_ms( 12, 0 ), point_bub_ms( 23, 10 ), abs_sub.z() );
-        line_furn( &m, furn_f_barricade_road, point_bub_ms( 23, 22 ), point_bub_ms( 23, 11 ), abs_sub.z() );
-        // road defects
-        switch( rng( 1, 3 ) ) {
-            case 1:
-                defects_from = { 9, 8 };
-                defects_to = { 14, 3 };
-                break;
-            case 2:
-                defects_from = { 12, 11 };
-                defects_to = { 17, 6 };
-                break;
-            case 3:
-                defects_from = { 16, 15 };
-                defects_to = { 21, 10 };
-                break;
-        }
-        defects_centered = { rng( 8, 14 ), rng( 8, 14 ) };
-        // vehicle
-        veh.x() = rng( 7, 15 );
-        veh.y() = rng( 7, 15 );
-        // equipment
-        if( one_in( 2 ) ) {
-            equipment.x() = rng( 0, 1 );
-            equipment.y() = rng( 2, 23 );
-        } else {
-            equipment.x() = rng( 0, 22 );
-            equipment.y() = rng( 22, 23 );
-        }
+        straight = false;
+        turns = 0;
     } else if( road_at_south && road_at_west && !road_at_east && !road_at_north ) {
-        // NE side of the S-W road curve
-        // road barricade
-        line_furn( &m, furn_f_barricade_road, point_bub_ms( 0, 4 ), point_bub_ms( 0, 12 ), abs_sub.z() );
-        line_furn( &m, furn_f_barricade_road, point_bub_ms( 1, 13 ), point_bub_ms( 11, 23 ), abs_sub.z() );
-        line_furn( &m, furn_f_barricade_road, point_bub_ms( 12, 23 ), point_bub_ms( 19, 23 ), abs_sub.z() );
-        // road defects
-        switch( rng( 1, 3 ) ) {
-            case 1:
-                defects_from = { 2, 7 };
-                defects_to = { 7, 12 };
-                break;
-            case 2:
-                defects_from = { 11, 22 };
-                defects_to = { 17, 6 };
-                break;
-            case 3:
-                defects_from = { 6, 17 };
-                defects_to = { 11, 13 };
-                break;
-        }
-        defects_centered = { rng( 8, 14 ), rng( 8, 14 ) };
-        // vehicle
-        veh.x() = rng( 7, 15 );
-        veh.y() = rng( 7, 15 );
-        // equipment
-        if( one_in( 2 ) ) {
-            equipment.x() = rng( 0, 23 );
-            equipment.y() = rng( 0, 3 );
-        } else {
-            equipment.x() = rng( 20, 23 );
-            equipment.y() = rng( 0, 23 );
-        }
+        straight = false;
+        turns = 2;
     } else if( road_at_north && road_at_west && !road_at_east && !road_at_south ) {
-        // SE side of the W-N road curve
-        // road barricade
-        line_furn( &m, furn_f_barricade_road, point_bub_ms( 0, 12 ), point_bub_ms( 0, 19 ), abs_sub.z() );
-        line_furn( &m, furn_f_barricade_road, point_bub_ms( 1, 11 ), point_bub_ms( 12, 0 ), abs_sub.z() );
-        line_furn( &m, furn_f_barricade_road, point_bub_ms( 13, 0 ), point_bub_ms( 19, 0 ), abs_sub.z() );
-        // road defects
-        switch( rng( 1, 3 ) ) {
-            case 1:
-                defects_from = { 11, 2 };
-                defects_to = { 16, 7 };
-                break;
-            case 2:
-                defects_from = { 5, 7 };
-                defects_to = { 11, 11 };
-                break;
-            case 3:
-                defects_from = { 1, 12 };
-                defects_to = { 6, 17 };
-                break;
-        }
-
-        defects_centered = { rng( 8, 14 ), rng( 8, 14 ) };
-        // vehicle
-        veh.x() = rng( 9, 18 );
-        veh.y() = rng( 9, 18 );
-        // equipment
-        if( one_in( 2 ) ) {
-            equipment.x() = rng( 20, 23 );
-            equipment.y() = rng( 0, 23 );
-        } else {
-            equipment.x() = rng( 0, 23 );
-            equipment.y() = rng( 20, 23 );
-        }
+        straight = false;
+        turns = 3;
     } else if( road_at_south && road_at_east && !road_at_west && !road_at_north ) {
-        // NW side of the S-E road curve
-        // road barricade
-        line_furn( &m, furn_f_barricade_road, point_bub_ms( 4, 23 ), point_bub_ms( 12, 23 ), abs_sub.z() );
-        line_furn( &m, furn_f_barricade_road, point_bub_ms( 13, 22 ), point_bub_ms( 22, 13 ), abs_sub.z() );
-        line_furn( &m, furn_f_barricade_road, point_bub_ms( 23, 4 ), point_bub_ms( 23, 12 ), abs_sub.z() );
-        // road defects
-        switch( rng( 1, 3 ) ) {
-            case 1:
-                defects_from = { 17, 7 };
-                defects_to = { 22, 12 };
-                break;
-            case 2:
-                defects_from = { 12, 12 };
-                defects_to = { 17, 17 };
-                break;
-            case 3:
-                defects_from = { 7, 17 };
-                defects_to = { 12, 22 };
-                break;
-        }
-
-        defects_centered = { rng( 10, 16 ), rng( 10, 16 ) };
-        // vehicle
-        veh.x() = rng( 6, 15 );
-        veh.y() = rng( 6, 15 );
-        // equipment
-        if( one_in( 2 ) ) {
-            equipment.x() = rng( 0, 3 );
-            equipment.y() = rng( 0, 23 );
-        } else {
-            equipment.x() = rng( 0, 23 );
-            equipment.y() = rng( 0, 3 );
-        }
+        straight = false;
+        turns = 1;
     } else {
         return false; // crossroads and strange roads - no generation, bail out
+    }
+
+    if( straight ) {
+        // road barricade
+        line_furn( &m, furn_f_barricade_road,
+                   point_bub_ms( 4, 0 ).rotate_in_map( turns ), point_bub_ms( 11, 7 ).rotate_in_map( turns ),
+                   abs_sub.z() );
+        line_furn( &m, furn_f_barricade_road,
+                   point_bub_ms( 11, 8 ).rotate_in_map( turns ), point_bub_ms( 11, 15 ).rotate_in_map( turns ),
+                   abs_sub.z() );
+        line_furn( &m, furn_f_barricade_road,
+                   point_bub_ms( 11, 16 ).rotate_in_map( turns ), point_bub_ms( 4, 23 ).rotate_in_map( turns ),
+                   abs_sub.z() );
+        // road defects
+        defects_from = point_bub_ms( 9, 7 ).rotate_in_map( turns );
+        defects_to = point_bub_ms( 4, 16 ).rotate_in_map( turns );
+        defects_centered = point_bub_ms( rng( 4, 7 ), rng( 10, 16 ) ).rotate_in_map( turns );
+        // vehicle
+        veh = tripoint_bub_ms( rng( 4, 6 ), rng( 8, 10 ), abs_sub.z() ).rotate_in_map( turns );
+        // equipment
+        if( one_in( 2 ) ) {
+            equipment = point_bub_ms( rng( 0, 4 ), rng( 1, 2 ) ).rotate_in_map( turns );
+        } else {
+            equipment = point_bub_ms( rng( 0, 4 ), rng( 21, 22 ) ).rotate_in_map( turns );
+        }
+    } else {
+        // road barricade
+        line_furn( &m, furn_f_barricade_road,
+                   // NOLINTNEXTLINE(cata-use-named-point-constants)
+                   point_bub_ms( 1, 0 ).rotate_in_map( turns ), point_bub_ms( 11, 0 ).rotate_in_map( turns ),
+                   abs_sub.z() );
+        line_furn( &m, furn_f_barricade_road,
+                   point_bub_ms( 12, 0 ).rotate_in_map( turns ), point_bub_ms( 23, 10 ).rotate_in_map( turns ),
+                   abs_sub.z() );
+        line_furn( &m, furn_f_barricade_road,
+                   point_bub_ms( 23, 22 ).rotate_in_map( turns ), point_bub_ms( 23, 11 ).rotate_in_map( turns ),
+                   abs_sub.z() );
+        // road defects
+        switch( rng( 1, 3 ) ) {
+            case 1:
+                defects_from = point_bub_ms( 9, 8 ).rotate_in_map( turns );
+                defects_to = point_bub_ms( 14, 3 ).rotate_in_map( turns );
+                break;
+            case 2:
+                defects_from = point_bub_ms( 12, 11 ).rotate_in_map( turns );
+                defects_to = point_bub_ms( 17, 6 ).rotate_in_map( turns );
+                break;
+            case 3:
+                defects_from = point_bub_ms( 16, 15 ).rotate_in_map( turns );
+                defects_to = point_bub_ms( 21, 10 ).rotate_in_map( turns );
+                break;
+        }
+        defects_centered = point_bub_ms( rng( 8, 14 ), rng( 8, 14 ) ).rotate_in_map( turns );
+        // vehicle
+        veh = tripoint_bub_ms( rng( 7, 15 ), rng( 7, 15 ), abs_sub.z() ).rotate_in_map( turns );
+        // equipment
+        if( one_in( 2 ) ) {
+            equipment = point_bub_ms( rng( 0, 1 ), rng( 2, 23 ) ).rotate_in_map( turns );
+        } else {
+            equipment = point_bub_ms( rng( 0, 22 ), rng( 22, 23 ) ).rotate_in_map( turns );
+        }
     }
     // road defects generator
     switch( rng( 1, 5 ) ) {
@@ -1023,8 +867,8 @@ static bool mx_roadworks( map &m, const tripoint_abs_sm &abs_sub )
     // equipment placer
     if( one_in( 3 ) ) {
         m.furn_set( equipment, furn_f_crate_c );
-        m.place_items( Item_spawn_data_mine_equipment, 100, tripoint_bub_ms( equipment, 0 ),
-                       tripoint_bub_ms( equipment, 0 ), true, calendar::start_of_cataclysm, 100 );
+        m.place_items( Item_spawn_data_mine_equipment, 100, tripoint_bub_ms( equipment, abs_sub.z() ),
+                       tripoint_bub_ms( equipment, abs_sub.z() ), true, calendar::start_of_cataclysm, 100 );
     }
 
     return true;
@@ -1035,37 +879,45 @@ static bool mx_casings( map &m, const tripoint_abs_sm &abs_sub )
     const std::vector<item> items = item_group::items_from( Item_spawn_data_ammo_casings,
                                     calendar::turn );
 
+    // Spawn a pile of casings around location
+    const auto spawn_casings_pile = [&m]( const tripoint_bub_ms & location,
+    const std::vector<item> &items ) {
+        for( const tripoint_bub_ms &loc : m.points_in_radius( location, rng( 1, 2 ) ) ) {
+            if( one_in( 2 ) ) {
+                m.spawn_items( loc, items );
+            }
+        }
+    };
+
+    //Spawn blood and bloody rag and sometimes trail of blood
+    const auto spawn_blood = [&m]( const tripoint_bub_ms & location, const int radius, bool trail ) {
+        if( one_in( 2 ) ) {
+            m.add_field( location, fd_blood, rng( 1, 3 ) );
+            if( one_in( 2 ) ) {
+                const tripoint_bub_ms bloody_rag_loc = random_entry( m.points_in_radius( location, radius ) );
+                m.spawn_item( bloody_rag_loc, itype_sheet_cotton, 1, 0, calendar::start_of_cataclysm, 0, { json_flag_FILTHY } );
+            }
+            if( trail && one_in( 2 ) ) {
+                m.add_splatter_trail( fd_blood, location,
+                                      random_entry( m.points_in_radius( location, rng( 1, 4 ) ) ) );
+            }
+        }
+    };
+
+    // Spawn random trash
+    const int num = rng( 1, 3 );
+    for( int i = 0; i < num; i++ ) {
+        const std::vector<item> trash =
+            item_group::items_from( Item_spawn_data_map_extra_casings, calendar::turn );
+        m.spawn_items( rng_map_point<tripoint_bub_ms>( 1, abs_sub.z() ), trash );
+    }
+
+    const tripoint_bub_ms random_loc = rng_map_point<tripoint_bub_ms>( 1, abs_sub.z() );
     switch( rng( 1, 4 ) ) {
         //Pile of random casings in random place
         case 1: {
-            const tripoint_bub_ms location = { rng( 1, SEEX * 2 - 2 ), rng( 1, SEEY * 2 - 2 ), abs_sub.z()};
-            //Spawn casings
-            for( const tripoint_bub_ms &loc : m.points_in_radius( location, rng( 1, 2 ) ) ) {
-                if( one_in( 2 ) ) {
-                    m.spawn_items( loc, items );
-                }
-            }
-            //Spawn random trash in random place
-            for( int i = 0; i < rng( 1, 3 ); i++ ) {
-                const std::vector<item> trash =
-                    item_group::items_from( Item_spawn_data_map_extra_casings, calendar::turn );
-                const tripoint_bub_ms trash_loc = random_entry( m.points_in_radius( tripoint_bub_ms{ SEEX, SEEY, abs_sub.z()},
-                                                  10 ) );
-                m.spawn_items( trash_loc, trash );
-            }
-            //Spawn blood and bloody rag and sometimes trail of blood
-            if( one_in( 2 ) ) {
-                m.add_field( location, fd_blood, rng( 1, 3 ) );
-                if( one_in( 2 ) ) {
-                    const tripoint_bub_ms bloody_rag_loc = random_entry( m.points_in_radius( location, 3 ) );
-                    m.spawn_item( bloody_rag_loc, itype_sheet_cotton, 1, 0, calendar::start_of_cataclysm, 0, { json_flag_FILTHY } );
-                }
-                if( one_in( 2 ) ) {
-                    m.add_splatter_trail( fd_blood, location,
-                                          random_entry( m.points_in_radius( location, rng( 1, 4 ) ) ) );
-                }
-            }
-
+            spawn_casings_pile( random_loc, items );
+            spawn_blood( random_loc, 3, true );
             break;
         }
         //Entire battlefield filled with casings
@@ -1078,32 +930,15 @@ static bool mx_casings( map &m, const tripoint_abs_sm &abs_sub )
                     }
                 }
             }
-            const tripoint_bub_ms location = { SEEX, SEEY, abs_sub.z()};
-            //Spawn random trash in random place
-            for( int i = 0; i < rng( 1, 3 ); i++ ) {
-                const std::vector<item> trash =
-                    item_group::items_from( Item_spawn_data_map_extra_casings, calendar::turn );
-                const tripoint_bub_ms trash_loc = random_entry( m.points_in_radius( location, 10 ) );
-                m.spawn_items( trash_loc, trash );
-            }
-            //Spawn blood and bloody rag in random place
-            if( one_in( 2 ) ) {
-                const tripoint_bub_ms random_place = random_entry( m.points_in_radius( location, rng( 1, 10 ) ) );
-                m.add_field( random_place, fd_blood, rng( 1, 3 ) );
-                if( one_in( 2 ) ) {
-                    const tripoint_bub_ms bloody_rag_loc = random_entry( m.points_in_radius( random_place, 3 ) );
-                    m.spawn_item( bloody_rag_loc, itype_sheet_cotton, 1, 0, calendar::start_of_cataclysm, 0, { json_flag_FILTHY } );
-                }
-            }
+            spawn_blood( { SEEX, SEEY, abs_sub.z() }, rng( 1, 10 ), false );
             break;
         }
         //Person moved and fired in some direction
         case 3: {
             //Spawn casings and blood trail along the direction of movement
-            const tripoint_bub_ms from = { rng( 1, SEEX * 2 - 2 ), rng( 1, SEEY * 2 - 2 ), abs_sub.z()};
-            const tripoint_bub_ms to = { rng( 1, SEEX * 2 - 2 ), rng( 1, SEEY * 2 - 2 ), abs_sub.z()};
-            std::vector<tripoint_bub_ms> casings = line_to( from, to );
-            for( tripoint_bub_ms &i : casings ) {
+            const tripoint_bub_ms to = rng_map_point<tripoint_bub_ms>( 1, abs_sub.z() );
+            std::vector<tripoint_bub_ms> casings = line_to( random_loc, to );
+            for( const tripoint_bub_ms &i : casings ) {
                 if( one_in( 2 ) ) {
                     m.spawn_items( { i.xy(), abs_sub.z()}, items );
                     if( one_in( 2 ) ) {
@@ -1111,76 +946,18 @@ static bool mx_casings( map &m, const tripoint_abs_sm &abs_sub )
                     }
                 }
             }
-            //Spawn random trash in random place
-            for( int i = 0; i < rng( 1, 3 ); i++ ) {
-                const std::vector<item> trash =
-                    item_group::items_from( Item_spawn_data_map_extra_casings, calendar::turn );
-                const tripoint_bub_ms trash_loc =
-                    random_entry( m.points_in_radius( tripoint_bub_ms{ SEEX, SEEY, abs_sub.z()}, 10 ) );
-                m.spawn_items( trash_loc, trash );
-            }
-            //Spawn blood and bloody rag at the destination
-            if( one_in( 2 ) ) {
-                m.add_field( from, fd_blood, rng( 1, 3 ) );
-                if( one_in( 2 ) ) {
-                    const tripoint_bub_ms bloody_rag_loc = random_entry( m.points_in_radius( to, 3 ) );
-                    m.spawn_item( bloody_rag_loc, itype_sheet_cotton, 1, 0, calendar::start_of_cataclysm, 0, { json_flag_FILTHY } );
-                }
-            }
+            spawn_blood( to, 3, false );
             break;
         }
         //Two persons shot and created two piles of casings
         case 4: {
-            const tripoint_bub_ms first_loc = { rng( 1, SEEX - 2 ), rng( 1, SEEY - 2 ), abs_sub.z()};
-            const tripoint_bub_ms second_loc = { rng( 1, SEEX * 2 - 2 ), rng( 1, SEEY * 2 - 2 ), abs_sub.z()};
-            const std::vector<item> first_items =
-                item_group::items_from( Item_spawn_data_ammo_casings, calendar::turn );
+            const tripoint_bub_ms second_loc = rng_map_point<tripoint_bub_ms>( 1, abs_sub.z() );
             const std::vector<item> second_items =
                 item_group::items_from( Item_spawn_data_ammo_casings, calendar::turn );
-
-            for( const tripoint_bub_ms &loc : m.points_in_radius( first_loc, rng( 1, 2 ) ) ) {
-                if( one_in( 2 ) ) {
-                    m.spawn_items( loc, first_items );
-                }
-            }
-            for( const tripoint_bub_ms &loc : m.points_in_radius( second_loc, rng( 1, 2 ) ) ) {
-                if( one_in( 2 ) ) {
-                    m.spawn_items( loc, second_items );
-                }
-            }
-            //Spawn random trash in random place
-            for( int i = 0; i < rng( 1, 3 ); i++ ) {
-                const std::vector<item> trash =
-                    item_group::items_from( Item_spawn_data_map_extra_casings, calendar::turn );
-                const tripoint_bub_ms trash_loc =
-                    random_entry( m.points_in_radius( tripoint_bub_ms{ SEEX, SEEY, abs_sub.z()}, 10 ) );
-                m.spawn_items( trash_loc, trash );
-            }
-            //Spawn blood and bloody rag at the first location, sometimes trail of blood
-            if( one_in( 2 ) ) {
-                m.add_field( first_loc, fd_blood, rng( 1, 3 ) );
-                if( one_in( 2 ) ) {
-                    const tripoint_bub_ms bloody_rag_loc = random_entry( m.points_in_radius( first_loc, 3 ) );
-                    m.spawn_item( bloody_rag_loc, itype_sheet_cotton, 1, 0, calendar::start_of_cataclysm, 0,
-                    { json_flag_FILTHY } );
-                }
-                if( one_in( 2 ) ) {
-                    m.add_splatter_trail( fd_blood, first_loc,
-                                          random_entry( m.points_in_radius( first_loc, rng( 1, 4 ) ) ) );
-                }
-            }
-            //Spawn blood and bloody rag at the second location, sometimes trail of blood
-            if( one_in( 2 ) ) {
-                m.add_field( second_loc, fd_blood, rng( 1, 3 ) );
-                if( one_in( 2 ) ) {
-                    const tripoint_bub_ms bloody_rag_loc = random_entry( m.points_in_radius( second_loc, 3 ) );
-                    m.spawn_item( bloody_rag_loc, itype_sheet_cotton, 1, 0, calendar::start_of_cataclysm, 0, { json_flag_FILTHY } );
-                }
-                if( one_in( 2 ) ) {
-                    m.add_splatter_trail( fd_blood, second_loc,
-                                          random_entry( m.points_in_radius( second_loc, rng( 1, 4 ) ) ) );
-                }
-            }
+            spawn_casings_pile( random_loc, items );
+            spawn_casings_pile( second_loc, second_items );
+            spawn_blood( random_loc, 3, true );
+            spawn_blood( second_loc, 3, true );
             break;
         }
     }
@@ -1190,23 +967,26 @@ static bool mx_casings( map &m, const tripoint_abs_sm &abs_sub )
 
 static bool mx_looters( map &m, const tripoint_abs_sm &abs_sub )
 {
-    const tripoint_bub_ms center( rng( 5, SEEX * 2 - 5 ), rng( 5, SEEY * 2 - 5 ), abs_sub.z() );
+    const tripoint_bub_ms center = rng_map_point<tripoint_bub_ms>( 4, abs_sub.z() );
     //25% chance to spawn a corpse with some blood around it
     if( one_in( 4 ) && m.passable_through( center ) ) {
         m.add_corpse( center );
-        for( int i = 0; i < rng( 1, 3 ); i++ ) {
-            m.add_field( random_entry( m.points_in_radius( center, 1 ) ), fd_blood, rng( 1, 3 ) );
+        const tripoint_range<tripoint_bub_ms> points = m.points_in_radius( center, 1 );
+        const int num = rng( 1, 3 );
+        for( int i = 0; i < num; i++ ) {
+            m.add_field( random_entry( points ), fd_blood, rng( 1, 3 ) );
         }
     }
 
     //Spawn up to 5 hostile bandits with equal chance to be ranged or melee type
     const int num_looters = rng( 1, 5 );
+    const tripoint_range<tripoint_bub_ms> looter_points = m.points_in_radius( center, rng( 1, 4 ) );
     for( int i = 0; i < num_looters; i++ ) {
-        if( const std::optional<tripoint_bub_ms> pos_ = random_point( m.points_in_radius( center, rng( 1,
-        4 ) ), [&]( const tripoint_bub_ms & p ) {
-        return m.passable_through( p );
-        } ) ) {
-            m.place_npc( pos_->xy(), string_id<npc_template>( one_in( 2 ) ? "thug" : "bandit" ) );
+        const std::optional<tripoint_bub_ms> pos_ =
+        random_point( looter_points, [&]( const tripoint_bub_ms & p ) {
+            return m.passable_through( p );
+        } );
+        if( pos_ ) {
             m.place_npc( pos_->xy(), string_id<npc_template>( one_in( 2 ) ? "thug" : "bandit" ) );
         }
     }
@@ -1219,7 +999,7 @@ static bool mx_corpses( map &m, const tripoint_abs_sm &abs_sub )
     const int num_corpses = rng( 1, 5 );
     //Spawn up to 5 human corpses in random places
     for( int i = 0; i < num_corpses; i++ ) {
-        const tripoint_bub_ms corpse_location = { rng( 1, SEEX * 2 - 1 ), rng( 1, SEEY * 2 - 1 ), abs_sub.z()};
+        const tripoint_bub_ms corpse_location = rng_map_point<tripoint_bub_ms>( 1, abs_sub.z() );
         if( m.passable_through( corpse_location ) ) {
             m.add_field( corpse_location, fd_blood, rng( 1, 3 ) );
             m.put_items_from_loc( Item_spawn_data_everyday_corpse, corpse_location );
@@ -1233,7 +1013,7 @@ static bool mx_corpses( map &m, const tripoint_abs_sm &abs_sub )
     }
     //10% chance to spawn a flock of stray dogs feeding on human flesh
     if( one_in( 10 ) && num_corpses <= 4 ) {
-        const tripoint_bub_ms corpse_location = { rng( 1, SEEX * 2 - 1 ), rng( 1, SEEY * 2 - 1 ), abs_sub.z()};
+        const tripoint_bub_ms corpse_location = rng_map_point<tripoint_bub_ms>( 1, abs_sub.z() );
         const std::vector<item> gibs =
             item_group::items_from( Item_spawn_data_remains_human_generic,
                                     calendar::start_of_cataclysm );

--- a/src/map_selector.cpp
+++ b/src/map_selector.cpp
@@ -76,6 +76,12 @@ std::optional<tripoint_bub_ms> random_point( const tripoint_range<tripoint_bub_m
     return random_entry( suitable );
 }
 
+int rng_map_coord( int border )
+{
+    // this assumes SEEY==SEEX
+    return rng( border, SEEX * 2 - 1 - border );
+}
+
 map_cursor::map_cursor( const tripoint_bub_ms &pos ) : pos_abs_( g ? get_map().get_abs(
                 pos ) : tripoint_abs_ms::zero ), pos_bub_( g ? tripoint_bub_ms::zero : pos ) { }
 

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -6689,7 +6689,7 @@ void map::draw_lab( mapgendata &dat )
                                 ter_set( p, fluid_type );
                                 furn_set( p, furn_str_id::NULL_ID() );
                             }
-                        }, point_bub_ms( rng( 1, SEEX * 2 - 2 ), rng( 1, SEEY * 2 - 2 ) ), rng( 3, 6 ) );
+                        }, rng_map_point<point_bub_ms>( 1 ), rng( 3, 6 ) );
                     }
                     break;
                 }
@@ -6765,7 +6765,7 @@ void map::draw_lab( mapgendata &dat )
                             }
                         }
                     }
-                    tripoint_bub_ms center( rng( 6, SEEX * 2 - 7 ), rng( 6, SEEY * 2 - 7 ), abs_sub.z() );
+                    tripoint_bub_ms center = rng_map_point<tripoint_bub_ms>( 6, abs_sub.z() );
 
                     // Make a portal surrounded by more dense fungal stuff and a fungaloid.
                     draw_rough_circle( [this]( const point_bub_ms & p ) {

--- a/src/mapgen_functions.cpp
+++ b/src/mapgen_functions.cpp
@@ -18,11 +18,11 @@
 #include "coordinates.h"
 #include "creature_tracker.h"
 #include "cuboid_rectangle.h"
-#include "debug.h"
 #include "flood_fill.h"
 #include "map.h"
 #include "map_iterator.h"
 #include "map_scale_constants.h"
+#include "mapdata.h"
 #include "mapgen.h"
 #include "mapgendata.h"
 #include "mapgenformat.h"
@@ -73,38 +73,6 @@ static const ter_str_id ter_t_water_moving_sh( "t_water_moving_sh" );
 static const ter_str_id ter_t_water_sh( "t_water_sh" );
 
 static const vspawn_id VehicleSpawn_default_subway_deadend( "default_subway_deadend" );
-
-tripoint_bub_ms rotate_point( const tripoint_bub_ms &p, int rotations )
-{
-    if( p.x() < 0 || p.x() >= SEEX * 2 ||
-        p.y() < 0 || p.y() >= SEEY * 2 ) {
-        debugmsg( "Point out of range: %d,%d,%d", p.x(), p.y(), p.z() );
-        // Mapgen is vulnerable, don't supply invalid points, debugmsg is enough
-        return tripoint_bub_ms( 0, 0, p.z() );
-    }
-
-    rotations = rotations % 4;
-
-    tripoint_bub_ms ret = p;
-    switch( rotations ) {
-        case 0:
-            break;
-        case 1:
-            ret.x() = p.y();
-            ret.y() = SEEX * 2 - 1 - p.x();
-            break;
-        case 2:
-            ret.x() = SEEX * 2 - 1 - p.x();
-            ret.y() = SEEY * 2 - 1 - p.y();
-            break;
-        case 3:
-            ret.x() = SEEY * 2 - 1 - p.y();
-            ret.y() = p.x();
-            break;
-    }
-
-    return ret;
-}
 
 building_gen_pointer get_mapgen_cfunction( const std::string &ident )
 {

--- a/src/mapgen_functions.h
+++ b/src/mapgen_functions.h
@@ -22,12 +22,6 @@ struct mapgen_parameters;
 using mapgen_update_func = std::function<void( const tripoint_abs_omt &map_pos3, mission *miss )>;
 class JsonObject;
 
-/**
- * Calculates the coordinates of a rotated point.
- * Should match the `mapgen_*` rotation.
- */
-tripoint_bub_ms rotate_point( const tripoint_bub_ms &p, int rotations );
-
 int terrain_type_to_nesw_array( oter_id terrain_type, std::array<bool, 4> &array );
 
 using building_gen_pointer = void ( * )( mapgendata & );

--- a/src/mission_start.cpp
+++ b/src/mission_start.cpp
@@ -234,7 +234,7 @@ void mission_start::place_deposit_box( mission *miss )
             }
         }
     }
-    const tripoint_omt_ms fallback( rng( 6, SEEX * 2 - 7 ), rng( 6, SEEY * 2 - 7 ), site.z() );
+    const tripoint_omt_ms fallback = rng_map_point<tripoint_omt_ms>( 6, site.z() );
     const tripoint_omt_ms comppoint = random_entry( valid, fallback );
     compmap.spawn_item( comppoint, itype_safe_box );
     compmap.save();

--- a/src/point.cpp
+++ b/src/point.cpp
@@ -8,6 +8,7 @@
 
 #include "cata_assert.h"
 #include "debug.h"
+#include "map_scale_constants.h"
 
 point point::from_string( const std::string &s )
 {
@@ -38,6 +39,24 @@ point point::rotate( int turns, const point &dim ) const
 
     return *this;
 }
+
+point point::rotate_in_map( int turns ) const
+{
+    cata_assert( turns >= 0 );
+    cata_assert( turns <= 4 );
+
+    switch( turns ) {
+        case 1:
+            return { SEEY * 2 - 1 - y, x };
+        case 2:
+            return { SEEX * 2 - 1 - x, SEEY * 2 - 1 - y };
+        case 3:
+            return { y, SEEX * 2 - 1 - x };
+    }
+
+    return *this;
+}
+
 
 float point::distance( const point &rhs ) const
 {

--- a/src/point.h
+++ b/src/point.h
@@ -103,6 +103,13 @@ struct point {
      * NOLINTNEXTLINE(cata-use-named-point-constants) */
     point rotate( int turns, const point &dim = { 1, 1 } ) const;
 
+    /**
+     * Rotate point clockwise @param turns times, 90 degrees per turn,
+     * around the center of a 24x24 rectangle (i.e. a map).
+     * Equivalent to hypothetical rotate(turns,{11.5,11.5})
+     */
+    point rotate_in_map( int turns ) const;
+
     float distance( const point &rhs ) const;
     int distance_manhattan( const point &rhs ) const;
 
@@ -266,10 +273,16 @@ struct tripoint {
     }
 
     /**
-     * Rotates just the x,y component of the tripoint. See point::rotate()
+     * Rotates just the x,y component of the tripoint. @ref point::rotate()
      * NOLINTNEXTLINE(cata-use-named-point-constants) */
     tripoint rotate( int turns, const point &dim = { 1, 1 } ) const {
         return tripoint( xy().rotate( turns, dim ), z );
+    }
+
+    /**
+     * Rotates just the x,y component of the tripoint. @ref point::rotate_in_map() */
+    tripoint rotate_in_map( int turns ) const {
+        return tripoint( xy().rotate_in_map( turns ), z );
     }
 
     std::string to_string() const;

--- a/src/popup.h
+++ b/src/popup.h
@@ -13,6 +13,7 @@
 #include "color.h"
 #include "input_enums.h"
 #include "point.h"
+#include "string_formatter.h"
 
 class query_popup_impl;
 

--- a/src/rng.h
+++ b/src/rng.h
@@ -208,4 +208,20 @@ std::optional<tripoint_bub_ms> random_point( const map &m,
 std::optional<tripoint_bub_ms> random_point_on_level( const map &m, int z,
         const std::function<bool( const tripoint_bub_ms & )> &predicate );
 
+// A random coordinate within a map, excluding a border
+int rng_map_coord( int border );
+template<typename Point>
+// A random point within a map, excluding a border
+Point rng_map_point( int border = 0 )
+{
+    return { rng_map_coord( border ), rng_map_coord( border ) };
+}
+// A random tripoint within a map, with a given z coordinate, excluding a border
+template<typename Tripoint>
+Tripoint rng_map_point( int border, int z )
+{
+    return { rng_map_coord( border ), rng_map_coord( border ), z };
+}
+
+
 #endif // CATA_SRC_RNG_H


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
While looking at the map extra functions I noticed some sizable blocks of copy/paste code, as well as some cryptic arithmetic repeated in a lot of places. Along the way I also ran into some bugs and easy optimizations. More details in the next section.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
1. Refactor all the places (including outside map extras) that generate a random point in a 24x24 map (with a variable excluded border) to use a function that I think is a lot easier to read and understand than the repetitive `SEEX * 2 - n` arithmetic. This also helped with consistency, where previously a call could be made with apparently accidentally asymmetric borders.
2. Replace the currently dead `tripoint_bub_ms rotate_point()` with a rotation function that works on all point types, and use it to deduplicate the 4 copies of each version of the roadworks map extra placement logic. This should make it far easier to address minor inconsistencies between the two versions, and to improve them in the future.
3. Precalculate some position constants and vectors that were being calculated repeatedly.
4. Move common functionality of mx_grove and mx_shrubbery to a helper. I chose to keep all the "tree" variable names to reduce churn.
5. Move common functionality from the mx_casings cases out to a couple of lambdas and some code outside the switch.
7. Bail out of loops early where possible.
8. Fix a bug spawning twice as many looters as intended.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
I could have promoted points to tripoints to use the existing dead rotate_point function, but that looked a lot uglier at the call sites.
I could make some improvements to the roadworks extra, including making the straight and curve versions more consistent with each other (e.g. the barriers extending past the edge of the road).

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->
Used debug menu to spawn each of the changed mapgens repeatedly. Screenshots in comment below. Currently playing with this patch to see if anything else weird happens.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
I found the bug in #82629 while testing this PR.

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
