### PR TITLE
Use optional/mandatory for overmap data

### DIFF
--- a/src/omdata.h
+++ b/src/omdata.h
@@ -14,7 +14,6 @@
 #include <utility>
 #include <vector>
 
-#include "assign.h"
 #include "color.h"
 #include "common_types.h"
 #include "coordinates.h"
@@ -140,7 +139,7 @@ class overmap_land_use_code
 
         // Used by generic_factory
         bool was_loaded = false;
-        void load( const JsonObject &jo, const std::string &src );
+        void load( const JsonObject &jo, std::string_view src );
         void finalize();
         void check() const;
 };
@@ -369,7 +368,7 @@ struct oter_type_t {
             flags.set( flag, value );
         }
 
-        void load( const JsonObject &jo, const std::string &src );
+        void load( const JsonObject &jo, std::string_view src );
         void check() const;
         void finalize();
 
@@ -635,14 +634,7 @@ struct overmap_special_connection {
     string_id<overmap_connection> connection;
     bool existing = false;
 
-    void deserialize( const JsonValue &jsin ) {
-        JsonObject jo = jsin.get_object();
-        jo.read( "point", p );
-        jo.read( "terrain", terrain );
-        jo.read( "existing", existing );
-        jo.read( "connection", connection );
-        assign( jo, "from", from );
-    }
+    void deserialize( const JsonObject &jo );
 };
 
 struct overmap_special_placement_constraints {
@@ -729,7 +721,7 @@ class overmap_special
 
         // Used by generic_factory
         bool was_loaded = false;
-        void load( const JsonObject &jo, const std::string &src );
+        void load( const JsonObject &jo, std::string_view src );
         void finalize();
         void finalize_mapgen_parameters();
         void check() const;


### PR DESCRIPTION
#### Summary
Infrastructure "Use optional/mandatory for overmap data"

#### Purpose of change
Optional/mandatory have the best support of features for JSON reading, as per https://github.com/CleverRaven/Cataclysm-DDA/pull/82165.

#### Describe the solution
Replace `assign` with `optional` or `mandatory`. Add some load/deserialize functions. 

#### Testing
`tools/load_all_mods.sh`