### PR TITLE
Use optional/mandatory for vpart_info and vpart_reqs.

### DIFF
--- a/build-scripts/get_all_mods.py
+++ b/build-scripts/get_all_mods.py
@@ -10,6 +10,7 @@ import json
 import os
 
 mods_this_time = []
+mods_lists = []
 
 exclusions = [
     # Tuple of (mod_id, mod_id) - these two mods will be incompatible
@@ -49,7 +50,7 @@ def add_mods(mods):
 
 
 def print_modlist(modlist, master_list):
-    print(','.join(modlist))
+    mods_lists.append(','.join(modlist))
     master_list -= set(modlist)
     modlist.clear()
 
@@ -92,7 +93,7 @@ for r, d, f in os.walk('data/mods'):
         if ident in obsolete_mods:
             continue
         mods_this_time.append(os.path.basename(mod.path))
-    print(','.join(mods_this_time))
+    mods_lists.append(','.join(mods_this_time))
     mods_this_time.clear()
 
 mods_remaining = set(all_mod_dependencies)
@@ -107,3 +108,6 @@ while mods_remaining:
         raise RuntimeError(
             'mods remain ({}) but none could be added'.format(mods_remaining))
     print_modlist(mods_this_time, mods_remaining)
+
+for list in sorted(mods_lists, key=len, reverse=True):
+    print(list)

--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -181,25 +181,11 @@ static void parse_vp_reqs( const JsonObject &obj, const vpart_id &id, const std:
     }
     JsonObject src = obj.get_object( key );
 
-    JsonArray sk = src.get_array( "skills" );
-    if( !sk.empty() ) {
-        skills.clear();
-        for( JsonArray cur : sk ) {
-            if( cur.size() != 2 ) {
-                debugmsg( "vpart '%s' has requirement with invalid skill entry", id.str() );
-                continue;
-            }
-            skills.emplace( skill_id( cur.get_string( 0 ) ), cur.get_int( 1 ) );
-        }
-    }
+    optional( src, false, "skills", skills, weighted_string_id_reader<skill_id, int> { std::nullopt } );
 
-    if( src.has_string( "time" ) ) {
-        assign( src, "time", time, /* strict = */ false );
-    } else if( src.has_int( "time" ) ) { // remove in 0.H
-        time = time_duration::from_moves( src.get_int( "time" ) );
-        debugmsg( "vpart '%s' defines requirement time as integer, use time units string", id.str() );
-    }
+    optional( src, false, "time", time, time );
 
+    // FIXME: generic typed reader for requirements
     if( src.has_string( "using" ) ) {
         reqs = { { requirement_id( src.get_string( "using" ) ), 1 } };
     } else if( src.has_array( "using" ) ) {


### PR DESCRIPTION
#### Summary
Infrastructure "Move vpart_info to mostly use optional/mandatory instead of assign"

#### Purpose of change
Optional and mandatory have better support for extended features and better error reporting, as per https://github.com/CleverRaven/Cataclysm-DDA/pull/82165

#### Describe the solution
Replace assign with optional. Add support for weighted_string_id_reader to require a weight.

#### Testing
`tools/load_all_mods.py`
`tests/cata_test [vehicle]`

#### Additional context
I also changed the order that get_all_mods.py gets mods to return lists in order of length, for a higher chance that any given mod is loaded sooner.