### PR TITLE
[Magiclysm] Add Seeing the Unseen animist spell

### DIFF
--- a/data/mods/Magiclysm/Spells/animist.json
+++ b/data/mods/Magiclysm/Spells/animist.json
@@ -1195,5 +1195,26 @@
     "magic_type": "magiclysm_generic_magic",
     "base_casting_time": 150,
     "base_energy_cost": 275
+  },
+  {
+    "id": "animist_see_invisibility",
+    "type": "SPELL",
+    "name": "Seeing the Unseen",
+    "description": "Rather than relying on your eyes, use your soul to also detect nearby beings, allowing you to see even creatures that are invisible to normal sight.",
+    "valid_targets": [ "self" ],
+    "spell_class": "ANIMIST",
+    "flags": [ "ENHANCEMENT_SPELL", "CONCENTRATE", "VERBAL", "SOMATIC", "NO_LEGS" ],
+    "effect": "attack",
+    "effect_str": "effect_animist_see_invisibility",
+    "shape": "blast",
+    "magic_type": "magiclysm_generic_magic",
+    "difficulty": 6,
+    "max_level": 15,
+    "base_energy_cost": 350,
+    "min_duration": 30000,
+    "max_duration": 480000,
+    "duration_increment": 30000,
+    "base_casting_time": 350,
+    "extra_effects": [ { "id": "eoc_enhancement_setup", "hit_self": true } ]
   }
 ]

--- a/data/mods/Magiclysm/Spells/animist.json
+++ b/data/mods/Magiclysm/Spells/animist.json
@@ -1208,6 +1208,7 @@
     "effect_str": "effect_animist_see_invisibility",
     "shape": "blast",
     "magic_type": "magiclysm_generic_magic",
+    "components": "spell_components_animist_see_invisibility",
     "difficulty": 6,
     "max_level": 15,
     "base_energy_cost": 350,

--- a/data/mods/Magiclysm/effects/effects.json
+++ b/data/mods/Magiclysm/effects/effects.json
@@ -1222,6 +1222,17 @@
   },
   {
     "type": "effect_type",
+    "id": "effect_animist_see_invisibility",
+    "name": [ "Seeing the Unseen" ],
+    "desc": [ "You can detect nearby invisible creatures." ],
+    "apply_message": "",
+    "remove_message": "Your awareness of the invisible fades.",
+    "rating": "good",
+    "max_duration": 19200,
+    "flags": [ "TRUE_SEEING" ]
+  },
+  {
+    "type": "effect_type",
     "id": "effect_animist_add_evasion",
     "name": [ "Guardian Spirit" ],
     "desc": [ "A protective spirit is looking out for you." ],

--- a/data/mods/Magiclysm/itemgroups/itemgroups.json
+++ b/data/mods/Magiclysm/itemgroups/itemgroups.json
@@ -1284,6 +1284,7 @@
           { "item": "spell_scroll_animist_vocalize", "prob": 35 },
           { "item": "spell_scroll_animist_luck_bone", "prob": 30 },
           { "item": "spell_scroll_animist_add_evasion_spell", "prob": 40 },
+          { "item": "spell_scroll_animist_see_invisibility", "prob": 40 },
           { "item": "spell_scroll_animist_do_psionic_damage_to_head", "prob": 30 }
         ],
         "prob": 35

--- a/data/mods/Magiclysm/itemgroups/spellbooks.json
+++ b/data/mods/Magiclysm/itemgroups/spellbooks.json
@@ -166,6 +166,7 @@
       [ "spell_scroll_vicious_tentacle", 40 ],
       [ "spell_scroll_bio_bonespear", 20 ],
       [ "spell_scroll_megablast", 10 ],
+      [ "spell_scroll_animist_see_invisibility", 15 ],
       [ "spell_scroll_baleful_polymorph", 20 ],
       [ "spell_scroll_eshaper_shardstorm", 50 ],
       [ "spell_scroll_eshaper_impalement", 45 ],

--- a/data/mods/Magiclysm/items/spell_scrolls.json
+++ b/data/mods/Magiclysm/items/spell_scrolls.json
@@ -2456,7 +2456,17 @@
     "id": "spell_scroll_magus_push_nearby_enemies_back",
     "//": "Magus spell",
     "name": { "str": "Scroll of Repulsion Wave", "str_pl": "Scrolls of Repulsion Wave" },
-    "description": "Unless a wave of force to hurl anyone nearby backwards.  Great for the commute.",
+    "description": "Unleash a wave of force to hurl anyone nearby backwards.  Great for the commute.",
     "use_action": { "type": "learn_spell", "spells": [ "magus_push_nearby_enemies_back" ] }
+  },
+  {
+    "type": "ITEM",
+    "subtypes": [ "BOOK" ],
+    "copy-from": "spell_scroll",
+    "id": "spell_scroll_animist_see_invisibility",
+    "//": "Animist spell",
+    "name": { "str": "Scroll of Seeing the Unseen", "str_pl": "Scrolls of Seeing the Unseen" },
+    "description": "Detect nearby beings with your soul rather than your eyes, allowing you to see invisible creatures.",
+    "use_action": { "type": "learn_spell", "spells": [ "animist_see_invisibility" ] }
   }
 ]

--- a/data/mods/Magiclysm/requirements/spell_components.json
+++ b/data/mods/Magiclysm/requirements/spell_components.json
@@ -336,5 +336,11 @@
     "type": "requirement",
     "//": "Ruby for the Flames of the Apocalypse spell.  Add crimsonite once discrete chunks of it exist",
     "components": [ [ [ "ruby", 1 ] ] ]
+  },
+  {
+    "id": "spell_components_animist_see_invisibility",
+    "type": "requirement",
+    "//": "Silver for the Seeing the Unseen spell",
+    "components": [ [ [ "silver_small", 5 ] ] ]
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[Magiclysm] Add Seeing the Unseen animist spell"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Animists are the ones who deal with non-physical things, so they should get detect invisibility
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add Seeing the Unseen. When cast, it allows you to see invisible creatures.

It needs silver bits to cast

(I looked up the D&D spell for inspiration and it's another spell where the components are **literally** a joke. In D&D, Detect Invisibility requires talc and powdered silver to cast. You know, because you blow them around and they coat invisible creatures and then you can see them. Har har har)
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

It works

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Was going to give this to feral high animists but the odds that they'd happen to have silver on them are low
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
