### PR TITLE
Turn the electric oil press into an appliance

### DIFF
--- a/data/json/construction/appliances.json
+++ b/data/json/construction/appliances.json
@@ -899,5 +899,17 @@
     "pre_special": "check_empty",
     "post_special": "done_appliance",
     "activity_level": "LIGHT_EXERCISE"
+  },
+  {
+    "type": "construction",
+    "id": "app_oil_press_industrial",
+    "group": "place_oil_press_industrial",
+    "category": "APPLIANCE",
+    "required_skills": [ [ "fabrication", 0 ] ],
+    "time": "5 m",
+    "components": [ [ [ "oil_press_electric", 1 ] ] ],
+    "pre_special": "check_empty",
+    "post_special": "done_appliance",
+    "activity_level": "LIGHT_EXERCISE"
   }
 ]

--- a/data/json/construction_group.json
+++ b/data/json/construction_group.json
@@ -2124,5 +2124,10 @@
     "type": "construction_group",
     "id": "place_deep_fryer",
     "name": "Place a deep fryer"
+  },
+  {
+    "type": "construction_group",
+    "id": "place_oil_press_industrial",
+    "name": "Place an industrial oil press"
   }
 ]

--- a/data/json/furniture_and_terrain/appliances.json
+++ b/data/json/furniture_and_terrain/appliances.json
@@ -1141,5 +1141,35 @@
       { "item": "element", "count": [ 1, 2 ] },
       { "item": "cable", "charges": [ 1, 2 ] }
     ]
+  },
+  {
+    "id": "ap_oil_press_industrial",
+    "type": "vehicle_part",
+    "categories": [ "utility" ],
+    "name": "industrial oil press",
+    "description": "A heavy-duty press used to create vegetable oil from nuts or seeds.",
+    "looks_like": "f_machinery_light",
+    "variants": [ { "symbols": "Y", "symbols_broken": "#" } ],
+    "color": "green",
+    "flags": [ "OBSTACLE", "APPLIANCE" ],
+    "pseudo_tools": [ { "id": "fake_oil_press_industrial" } ],
+    "item": "oil_press_electric",
+    "damage_modifier": 10,
+    "damage_reduction": { "all": 30 },
+    "durability": 80,
+    "breaks_into": [
+      { "item": "funnel", "count": [ 0, 1 ] },
+      { "item": "frame", "count": [ 0, 1 ] },
+      { "item": "sheet_metal", "count": [ 0, 2 ] },
+      { "item": "element", "count": [ 0, 2 ] },
+      { "item": "crude_heating_element", "count": [ 0, 3 ] },
+      { "item": "motor_tiny", "count": [ 0, 1 ] },
+      { "item": "cable", "count": [ 0, 10 ] },
+      { "item": "power_supply", "count": [ 0, 1 ] },
+      { "item": "pipe_fittings", "count": [ 0, 2 ] },
+      { "item": "pipe", "count": [ 0, 2 ] },
+      { "item": "wire_mesh", "count": [ 0, 1 ] },
+      { "item": "metal_tank_little", "count": [ 0, 1 ] }
+    ]
   }
 ]

--- a/data/json/furniture_and_terrain/furniture-tools.json
+++ b/data/json/furniture_and_terrain/furniture-tools.json
@@ -1690,5 +1690,29 @@
       "items": [ { "item": "chain", "count": 1 }, { "item": "block_and_tackle", "count": 1 }, { "item": "nuts_bolts", "charges": 2 } ]
     },
     "crafting_pseudo_item": "fake_lift_heavy"
+  },
+  {
+    "type": "furniture",
+    "id": "f_oil_press_electric",
+    "name": "industrial oil press",
+    "looks_like": "f_machinery_light",
+    "description": "A heavy-duty press used to create vegetable oil from nuts or seeds. You could take this down and use it for your own purposes if you wanted.",
+    "symbol": "Y",
+    "color": "green",
+    "move_cost_mod": -1,
+    "coverage": 40,
+    "required_str": 12,
+    "flags": [
+      "TRANSPARENT",
+      "FLAMMABLE_HARD",
+      "CONTAINER",
+      "PLACE_ITEM",
+      "BLOCKSDOOR",
+      "MOUNTABLE",
+      "LIQUIDCONT",
+      "EASY_DECONSTRUCT"
+    ],
+    "examine_action": { "type": "appliance_convert", "furn_set": "f_null", "item": "oil_press_electric" },
+    "item": "oil_press_electric"
   }
 ]

--- a/data/json/furniture_and_terrain/furniture-tools.json
+++ b/data/json/furniture_and_terrain/furniture-tools.json
@@ -1693,10 +1693,10 @@
   },
   {
     "type": "furniture",
-    "id": "f_oil_press_electric",
+    "id": "f_oil_press_industrial",
     "name": "industrial oil press",
     "looks_like": "f_machinery_light",
-    "description": "A heavy-duty press used to create vegetable oil from nuts or seeds. You could take this down and use it for your own purposes if you wanted.",
+    "description": "A heavy-duty press used to create vegetable oil from nuts or seeds.  You could take this down and use it for your own purposes if you wanted.",
     "symbol": "Y",
     "color": "green",
     "move_cost_mod": -1,

--- a/data/json/items/appliances.json
+++ b/data/json/items/appliances.json
@@ -417,5 +417,21 @@
     "longest_side": "115 cm",
     "volume": "368 L",
     "weight": "86 kg"
+  },
+  {
+    "type": "ITEM",
+    "id": "oil_press_electric",
+    "//": "based on YZS-68 oil press: http://www.oilpressmachine.com/6yl-68-oil-press.html",
+    "name": { "str": "disconnected industrial oil press", "str_pl": "disconnected industrial oil presses" },
+    "description": "A heavy-duty press used to create vegetable oil from nuts or seeds.  Needs to be placed and plugged into a power source.",
+    "looks_like": "f_machinery_light",
+    "symbol": "Y",
+    "color": "green",
+    "material": [ "iron" ],
+    "longest_side": "88 cm",
+    "volume": "370 L",
+    "weight": "140 kg",
+    "price": "1 kUSD",
+    "price_postapoc": "10 USD"
   }
 ]

--- a/data/json/items/fake.json
+++ b/data/json/items/fake.json
@@ -527,5 +527,12 @@
     "type": "ITEM",
     "subtypes": [ "TOOL" ],
     "name": { "str": "deep fryer" }
+  },
+  {
+    "id": "fake_oil_press_industrial",
+    "copy-from": "fake_appliance_tool",
+    "type": "ITEM",
+    "subtypes": [ "TOOL" ],
+    "name": { "str": "industrial oil press", "str_pl": "industrial oil presses" }
   }
 ]

--- a/data/json/items/vehicle/utilities.json
+++ b/data/json/items/vehicle/utilities.json
@@ -228,24 +228,5 @@
     "price": "30 USD",
     "price_postapoc": "50 cent",
     "melee_damage": { "bash": 2 }
-  },
-  {
-    "type": "ITEM",
-    "subtypes": [ "TOOL" ],
-    "id": "oil_press_electric",
-    "name": { "str": "electric oil press", "str_pl": "electric oil presses" },
-    "//": "based on YZS-68C oil press",
-    "description": "A heavy-duty press used to create vegetable oil from nuts or seeds.  It needs to be mounted on a vehicle due to its high power draw.",
-    "weight": "140 kg",
-    "volume": "370 L",
-    "longest_side": "88 cm",
-    "material": [ "lc_steel", "hc_steel" ],
-    "category": "veh_parts",
-    "color": "green",
-    "symbol": "Y",
-    "use_action": [ { "type": "link_up", "cable_length": 3, "charge_rate": "5500 W" } ],
-    "price": "1 kUSD",
-    "price_postapoc": "10 USD",
-    "tool_ammo": "battery"
   }
 ]

--- a/data/json/recipes/food/drink_other.json
+++ b/data/json/recipes/food/drink_other.json
@@ -53,7 +53,7 @@
     "//": "capacity: 50kg/hour * 40% efficiency = 20 L/hour -> 45s / 250 mL",
     "time": "45 s",
     "//2": "45 s * 5.5kW = 250 kJ",
-    "tools": [ [ [ "oil_press_electric", 250 ] ] ],
+    "tools": [ [ [ "fake_oil_press_industrial", 250 ] ] ],
     "autolearn": true,
     "qualities": [ { "id": "CONTAIN", "level": 1 }, { "id": "BOIL", "level": 1 } ],
     "proficiencies": [ { "proficiency": "prof_food_prep" } ],

--- a/data/json/recipes/recipe_appliance.json
+++ b/data/json/recipes/recipe_appliance.json
@@ -224,5 +224,38 @@
     "qualities": [ { "id": "SCREW", "level": 1 } ],
     "proficiencies": [ { "proficiency": "prof_elec_soldering" }, { "proficiency": "prof_appliance_repair" } ],
     "components": [ [ [ "frame_wood", 1 ] ], [ [ "battery_charger", 1 ] ] ]
+  },
+  {
+    "result": "oil_press_electric",
+    "type": "recipe",
+    "activity_level": "MODERATE_EXERCISE",
+    "reversible": true,
+    "skill_used": "fabrication",
+    "difficulty": 4,
+    "time": "90 m",
+    "autolearn": true,
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_PARTS",
+    "skills_required": [ [ "electronics", 2 ] ],
+    "using": [ [ "soldering_standard", 5 ] ],
+    "qualities": [
+      { "id": "HAMMER", "level": 2 },
+      { "id": "SAW_M", "level": 1 },
+      { "id": "SCREW", "level": 1 },
+      { "id": "WRENCH", "level": 1 }
+    ],
+    "components": [
+      [ [ "funnel", 1 ], [ "metal_funnel", 1 ] ],
+      [ [ "frame", 1 ] ],
+      [ [ "sheet_metal", 4 ] ],
+      [ [ "element", 4 ], [ "crude_heating_element", 6 ] ],
+      [ [ "motor_tiny", 1 ] ],
+      [ [ "cable", 10 ] ],
+      [ [ "power_supply", 1 ] ],
+      [ [ "pipe_fittings", 2 ] ],
+      [ [ "pipe", 2 ] ],
+      [ [ "wire_mesh", 1 ], [ "cotton_patchwork", 1 ] ],
+      [ [ "metal_tank_little", 1 ], [ "jerrycan_big", 1 ], [ "jerrycan", 1 ] ]
+    ]
   }
 ]

--- a/data/json/recipes/recipe_vehicle.json
+++ b/data/json/recipes/recipe_vehicle.json
@@ -1383,39 +1383,6 @@
     "components": [ [ [ "seatbelt", 5 ] ], [ [ "nuts_bolts", 1 ] ] ]
   },
   {
-    "result": "oil_press_electric",
-    "type": "recipe",
-    "activity_level": "MODERATE_EXERCISE",
-    "reversible": true,
-    "skill_used": "fabrication",
-    "difficulty": 4,
-    "time": "90 m",
-    "autolearn": true,
-    "category": "CC_OTHER",
-    "subcategory": "CSC_OTHER_PARTS",
-    "skills_required": [ [ "electronics", 2 ] ],
-    "using": [ [ "soldering_standard", 5 ] ],
-    "qualities": [
-      { "id": "HAMMER", "level": 2 },
-      { "id": "SAW_M", "level": 1 },
-      { "id": "SCREW", "level": 1 },
-      { "id": "WRENCH", "level": 1 }
-    ],
-    "components": [
-      [ [ "funnel", 1 ], [ "metal_funnel", 1 ] ],
-      [ [ "frame", 1 ] ],
-      [ [ "sheet_metal", 4 ] ],
-      [ [ "element", 4 ], [ "crude_heating_element", 6 ] ],
-      [ [ "motor_tiny", 1 ] ],
-      [ [ "cable", 10 ] ],
-      [ [ "power_supply", 1 ] ],
-      [ [ "pipe_fittings", 2 ] ],
-      [ [ "pipe", 2 ] ],
-      [ [ "wire_mesh", 1 ], [ "cotton_patchwork", 1 ] ],
-      [ [ "metal_tank_little", 1 ], [ "jerrycan_big", 1 ], [ "jerrycan", 1 ] ]
-    ]
-  },
-  {
     "type": "recipe",
     "activity_level": "BRISK_EXERCISE",
     "result": "aluminum_boat_hull",

--- a/data/json/vehicleparts/utilities.json
+++ b/data/json/vehicleparts/utilities.json
@@ -64,42 +64,6 @@
     "variants": [ { "symbols": "&", "symbols_broken": "x" } ]
   },
   {
-    "id": "veh_oil_press_electric",
-    "type": "vehicle_part",
-    "name": { "str": "mounted electric oil press" },
-    "item": "oil_press_electric",
-    "description": "A heavy-duty press used to create vegetable oil from nuts or seeds.",
-    "categories": [ "utility" ],
-    "location": "center",
-    "color": "green",
-    "broken_color": "green",
-    "damage_modifier": 10,
-    "damage_reduction": { "all": 30 },
-    "durability": 200,
-    "flags": [ "OBSTACLE", "CARGO" ],
-    "requirements": {
-      "install": { "skills": [ [ "mechanics", 2 ] ], "time": "30 m", "using": [ [ "vehicle_wrench_2", 1 ] ] },
-      "removal": { "skills": [ [ "mechanics", 1 ] ], "time": "15 m", "using": [ [ "vehicle_wrench_2", 1 ] ] },
-      "repair": {
-        "skills": [ [ "mechanics", 3 ] ],
-        "time": "60 m",
-        "using": [ [ "repair_welding_standard", 3 ], [ "soldering_standard", 5 ] ]
-      }
-    },
-    "pseudo_tools": [ { "id": "oil_press_electric" } ],
-    "size": "5 L",
-    "breaks_into": [
-      { "item": "lc_steel_lump", "count": [ 4, 7 ] },
-      { "item": "lc_steel_chunk", "count": [ 3, 6 ] },
-      { "item": "sheet_metal_small", "count": [ 4, 8 ] },
-      { "item": "scrap", "count": [ 4, 7 ] },
-      { "item": "element", "count": [ 0, 2 ] },
-      { "item": "pipe", "prob": 50 },
-      { "item": "motor_small", "prob": 25 }
-    ],
-    "variants": [ { "symbols": "Y", "symbols_broken": "x" } ]
-  },
-  {
     "id": "door_lock",
     "type": "ITEM",
     "name": { "str": "door lock set" },

--- a/data/mods/TEST_DATA/known_bad_uncrafts.json
+++ b/data/mods/TEST_DATA/known_bad_uncrafts.json
@@ -2378,6 +2378,7 @@
       "fake_lift_light",
       "fake_lift_medium",
       "fake_milling_item",
+      "fake_oil_press_industrial",
       "fake_power_tool",
       "fake_radio",
       "fake_razor",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Our current oil press is currently a "vehicle part" that can also be used by itself as a tool item. [This ](http://www.oilpressmachine.com/6yl-68-oil-press.html)is what we're talking about btw. In reality this is supposed to be a static piece of machinery that you connect to an electric grid, so basically a perfect fit as an appliance.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

- Removed the electric oil press as a tool, basically I removed the `"use_action": [ { "type": "link_up", "cable_length": 3, "charge_rate": "5500 W" } ],` bit as well as related fields.
- Removed the electric oil press as a vehicle part.
- Added the electric oil press as an appliance, alongside construction groups etc.
- Moved the items and recipes around in the files, I know it makes the review harder but the oil press should now belong in appliance files, not in vehicle or tool files.
- Recipes, well just the one, now use the fake tool provided by the appliance.
- I renamed the "electric oil press" into "industrial oil press", that's because there is actually a domestic electric oil press and it's probably what most people think of when talking about an oil press, this one is actually made for industrial use. **This goes for the ids as well**, while I didn't touch the id of the item itself, the appliance system use `[prefix]_oil_press_industrial` ids instead of `[prefix]_oil_press_electric`, in the future I plan on adding a regular electric oil press and the id will be useful then to swap with a proper `oil_press_industrial` item id
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Made cooking oil using the whole system.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Fixes #82395.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
