### PR TITLE
Adds contraband to the prison safe of the Warden.

### DIFF
--- a/data/json/mapgen/prison/prison_island.json
+++ b/data/json/mapgen/prison/prison_island.json
@@ -103,6 +103,7 @@
         { "item": "pliers", "x": 81, "y": 54, "chance": 100 },
         { "item": "hammer", "x": 59, "y": 32, "chance": 100 },
         { "item": "id_industrial", "x": 42, "y": 61, "chance": 100 },
+        { "item": "contraband", "x": 42, "y": 61, "chance": 100, "repeat": [ 3, 6 ] },
         { "item": "id_military", "x": 79, "y": 50, "chance": 100 },
         { "item": "holster", "x": 79, "y": 50, "chance": 100 },
         { "item": "m9", "x": 79, "y": 50, "chance": 100 },

--- a/data/json/mapgen/prison/prison_island.json
+++ b/data/json/mapgen/prison/prison_island.json
@@ -91,8 +91,7 @@
         { "item": "plastic_knife", "x": 13, "y": 50, "repeat": [ 1, 20 ] },
         { "item": "plastic_fork", "x": 13, "y": 50, "repeat": [ 1, 20 ] },
         { "item": "tin_cup", "x": 14, "y": 50, "repeat": [ 1, 20 ] },
-        { "item": "napkin", "x": 15, "y": 50, "repeat": [ 1, 20 ] },
-        { "item": "contraband", "x": 42, "y": 61, "chance": 100, "repeat": [ 3, 6 ] }
+        { "item": "napkin", "x": 15, "y": 50, "repeat": [ 1, 20 ] }
       ],
       "place_item": [
         { "item": "stethoscope", "x": 82, "y": 56, "chance": 100 },
@@ -112,7 +111,8 @@
       ],
       "place_items": [
         { "item": "table_destruction", "x": 16, "y": 40, "chance": 100 },
-        { "item": "table_destruction", "x": 17, "y": 40, "chance": 100 }
+        { "item": "table_destruction", "x": 17, "y": 40, "chance": 100 },
+        { "item": "contraband", "x": 42, "y": 61, "chance": 100, "repeat": [ 3, 6 ] }
       ],
       "place_monster": [
         { "monster": "mon_zombie_brute_shocker", "x": 65, "y": 36, "name": "The Foreman" },

--- a/data/json/mapgen/prison/prison_island.json
+++ b/data/json/mapgen/prison/prison_island.json
@@ -91,7 +91,8 @@
         { "item": "plastic_knife", "x": 13, "y": 50, "repeat": [ 1, 20 ] },
         { "item": "plastic_fork", "x": 13, "y": 50, "repeat": [ 1, 20 ] },
         { "item": "tin_cup", "x": 14, "y": 50, "repeat": [ 1, 20 ] },
-        { "item": "napkin", "x": 15, "y": 50, "repeat": [ 1, 20 ] }
+        { "item": "napkin", "x": 15, "y": 50, "repeat": [ 1, 20 ] },
+        { "item": "contraband", "x": 42, "y": 61, "chance": 100, "repeat": [ 3, 6 ] }
       ],
       "place_item": [
         { "item": "stethoscope", "x": 82, "y": 56, "chance": 100 },
@@ -103,7 +104,6 @@
         { "item": "pliers", "x": 81, "y": 54, "chance": 100 },
         { "item": "hammer", "x": 59, "y": 32, "chance": 100 },
         { "item": "id_industrial", "x": 42, "y": 61, "chance": 100 },
-        { "item": "contraband", "x": 42, "y": 61, "chance": 100, "repeat": [ 3, 6 ] },
         { "item": "id_military", "x": 79, "y": 50, "chance": 100 },
         { "item": "holster", "x": 79, "y": 50, "chance": 100 },
         { "item": "m9", "x": 79, "y": 50, "chance": 100 },


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
The prison safe of the warden is very empty, with only their ID spawning there... Why not add some confiscated contraband from the prisoners too? :D

#### Describe the solution
Adds contraband!

#### Describe alternatives you've considered


#### Testing

#### Additional context
