### PR TITLE
Add "autopeek" behaviour to safe mode movement

### DIFF
--- a/data/core/help.json
+++ b/data/core/help.json
@@ -20,7 +20,7 @@
       "Each step will take 100 movement points (or more, depending on the terrain); you will then replenish a variable amount of movement points, depending on many factors (press <press_player_data> to see the exact amount).",
       "To attempt to hit a monster with your weapon, simply move into it.",
       "You may find doors, ('+'); these may be opened with <press_open> or closed with <press_close>.  Some doors are locked.  Locked doors, windows, and some other obstacles can be destroyed by smashing them (<press_smash>, then choose a direction).  Smashing down obstacles is much easier with a good weapon or a strong character.",
-      "There may be times when you want to move more quickly by holding down a movement key.  However, fast movement in this fashion may lead to the player getting into a dangerous situation or even killed before they have a chance to react.  Pressing <press_safemode> will toggle \"safe mode.\"  While this is on, any movement will be ignored if new monsters enter the player's view."
+      "There may be times when you want to move more quickly by holding down a movement key.  However, fast movement in this fashion may quickly put you in a dangerous situation, or even kill you before you've had a chance to react.  Pressing <press_safemode> will toggle \"safe mode.\"  While this is on, the game will stop you from moving further if you've spotted an enemy, and let you step back unnoticed if you weren't running."
     ]
   },
   {

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -535,6 +535,17 @@ bool avatar_action::move( avatar &you, map &m, const tripoint_rel_ms &d )
         return true;
     }
     if( g->walk_move( dest_loc, via_ramp ) ) {
+        // If safe mode would be triggered after the move, move back and peek
+        if( g->safe_mode == SAFE_MODE_ON && !you.is_running() ) {
+            here.build_map_cache ( dest_loc.z() );
+            here.update_visibility_cache( dest_loc.z() );
+            g->mon_info_update();
+            if( g->safe_mode == SAFE_MODE_STOP ) {
+                g->look_around();
+                g->walk_move( you_pos, via_ramp );
+                return false; // cancel automove
+            }
+        }
         return true;
     }
     if( g->phasing_move_enchant( dest_loc, you.calculate_by_enchantment( 0,

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -543,7 +543,7 @@ bool avatar_action::move( avatar &you, map &m, const tripoint_rel_ms &d )
     const tripoint_abs_ms abs_dest_loc = here.get_abs( dest_loc );
     if( g->walk_move( dest_loc, via_ramp ) ) {
         // AUTOPEEK: If safe mode would be triggered after the move, look around and move back
-        if( get_option<bool>( "SAFEMODEAUTOPEEK" ) && g->safe_mode == SAFE_MODE_ON && !you.is_running() &&
+        if( g->safe_mode == SAFE_MODE_ON && !you.is_running() &&
             you.pos_abs() == abs_dest_loc ) {
             here.build_map_cache( dest_loc.z() );
             here.update_visibility_cache( dest_loc.z() );

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -537,7 +537,7 @@ bool avatar_action::move( avatar &you, map &m, const tripoint_rel_ms &d )
     }
     if( g->walk_move( dest_loc, via_ramp ) ) {
         // If safe mode would be triggered after the move, move back and peek
-        if( g->safe_mode == SAFE_MODE_ON && !you.is_running() ) {
+        if( g->safe_mode == SAFE_MODE_ON && !you.is_running() && !you.is_hauling() ) {
             here.build_map_cache( dest_loc.z() );
             here.update_visibility_cache( dest_loc.z() );
             // Need to get bub coords again after build_map_cache

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -538,9 +538,13 @@ bool avatar_action::move( avatar &you, map &m, const tripoint_rel_ms &d )
         }
         return true;
     }
+
+    const tripoint_abs_ms old_abs_pos = you.pos_abs();
+    const tripoint_abs_ms abs_dest_loc = here.get_abs( dest_loc );
     if( g->walk_move( dest_loc, via_ramp ) ) {
         // AUTOPEEK: If safe mode would be triggered after the move, look around and move back
-        if( get_option<bool>( "SAFEMODEAUTOPEEK" ) && g->safe_mode == SAFE_MODE_ON && !you.is_running() ) {
+        if( get_option<bool>( "SAFEMODEAUTOPEEK" ) && g->safe_mode == SAFE_MODE_ON && !you.is_running() &&
+            you.pos_abs() == abs_dest_loc ) {
             here.build_map_cache( dest_loc.z() );
             here.update_visibility_cache( dest_loc.z() );
             g->mon_info_update();
@@ -553,9 +557,8 @@ bool avatar_action::move( avatar &you, map &m, const tripoint_rel_ms &d )
                                ctxt.get_desc( "CONFIRM" ) ).on_top( true );
                 ui_manager::redraw();
                 // Get bub coords again after build_map_cache
-                const tripoint_bub_ms new_pos = you.pos_bub( here );
-                const tripoint_bub_ms src_loc = new_pos - d;
-                tripoint_bub_ms center = src_loc;
+                const tripoint_bub_ms src_loc = here.get_bub( old_abs_pos );
+                tripoint_bub_ms center( src_loc.x(), src_loc.y(), dest_loc.z() );
                 const look_around_result result = g->look_around( false, center, center, false, false, true );
                 if( result.peek_action != PA_MOVE ) {
                     g->walk_move( src_loc, via_ramp );

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -537,12 +537,17 @@ bool avatar_action::move( avatar &you, map &m, const tripoint_rel_ms &d )
     if( g->walk_move( dest_loc, via_ramp ) ) {
         // If safe mode would be triggered after the move, move back and peek
         if( g->safe_mode == SAFE_MODE_ON && !you.is_running() ) {
-            here.build_map_cache ( dest_loc.z() );
+            here.build_map_cache( dest_loc.z() );
             here.update_visibility_cache( dest_loc.z() );
+            // Need to get bub coords again after build_map_cache
+            const tripoint_bub_ms new_pos = you.pos_bub( here );
+            const tripoint_bub_ms src_loc = new_pos - d;
+            tripoint_bub_ms center = src_loc;
             g->mon_info_update();
-            if( g->safe_mode == SAFE_MODE_STOP ) {
-                g->look_around();
-                g->walk_move( you_pos, via_ramp );
+
+            if( !g->check_safe_mode_allowed() ) {
+                g->look_around( false, center, center, false, false, true );
+                g->walk_move( src_loc, via_ramp );
                 return false; // cancel automove
             }
         }

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -546,8 +546,14 @@ bool avatar_action::move( avatar &you, map &m, const tripoint_rel_ms &d )
             g->mon_info_update();
 
             if( !g->check_safe_mode_allowed() ) {
-                g->look_around( false, center, center, false, false, true );
-                g->walk_move( src_loc, via_ramp );
+                input_context ctxt( "LOOK" );
+                add_msg( game_message_params{ m_info, gmf_bypass_cooldown },
+                         _( "Press %s to move here anyway." ),
+                         ctxt.get_desc( "CONFIRM" ) );
+                const look_around_result result = g->look_around( false, center, center, false, false, true );
+                if( result.peek_action != PA_MOVE ) {
+                    g->walk_move( src_loc, via_ramp );
+                }
                 return false; // cancel automove
             }
         }

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -56,6 +56,7 @@
 #include "ranged.h"
 #include "ret_val.h"
 #include "rng.h"
+#include "string_formatter.h"
 #include "translations.h"
 #include "type_id.h"
 #include "ui_manager.h"

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -28,6 +28,7 @@
 #include "game_constants.h"
 #include "game_inventory.h"
 #include "gun_mode.h"
+#include "input_context.h"
 #include "inventory.h"
 #include "item.h"
 #include "item_location.h"

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -8225,6 +8225,8 @@ look_around_result game::look_around(
             result.peek_action = PA_BLIND_THROW;
         } else if( action == "throw_blind_wielded" ) {
             result.peek_action = PA_BLIND_THROW_WIELDED;
+        } else if( action == "CONFIRM" && peeking ) {
+            result.peek_action = PA_MOVE;
         } else if( action == "zoom_in" ) {
             center.xy() = lp.xy();
             zoom_in();

--- a/src/game.h
+++ b/src/game.h
@@ -108,6 +108,7 @@ using item_location_filter = std::function<bool ( const item_location & )>;
 enum peek_act : int {
     PA_BLIND_THROW,
     PA_BLIND_THROW_WIELDED,
+    PA_MOVE,
     // obvious future additional value is PA_BLIND_FIRE
 };
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1634,6 +1634,11 @@ void options_manager::add_options_general()
              to_translation( "Number of turns an ignored monster stays ignored after it is no longer seen.  0 disables this option and monsters are permanently ignored." ),
              0, 3600, 200
            );
+
+        add( "SAFEMODEAUTOPEEK", page_id, to_translation( "Safe mode auto peek" ),
+             to_translation( "If true, safe mode preemptively peeks the next tile when not running. This option doesn't negatively impact speed." ),
+             true
+           );
     } );
 
     add_empty_line();

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1636,7 +1636,7 @@ void options_manager::add_options_general()
            );
 
         add( "SAFEMODEAUTOPEEK", page_id, to_translation( "Safe mode auto peek" ),
-             to_translation( "If true, safe mode preemptively peeks the next tile when not running. This option doesn't negatively impact speed." ),
+             to_translation( "If true, safe mode preemptively peeks the next tile when not running.  This option doesn't negatively impact speed." ),
              true
            );
     } );

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1634,11 +1634,6 @@ void options_manager::add_options_general()
              to_translation( "Number of turns an ignored monster stays ignored after it is no longer seen.  0 disables this option and monsters are permanently ignored." ),
              0, 3600, 200
            );
-
-        add( "SAFEMODEAUTOPEEK", page_id, to_translation( "Safe mode auto peek" ),
-             to_translation( "If true, safe mode preemptively peeks the next tile when not running.  This option doesn't negatively impact speed." ),
-             true
-           );
     } );
 
     add_empty_line();


### PR DESCRIPTION
#### Summary
Features "Make player go back to previous position when safemode is triggered"

https://github.com/user-attachments/assets/0425a8e1-cb8a-4242-adbd-d94c2eacb30f

#### Purpose of change

The current "optimal" way to move safely through the world is to peek before any movement, which is slow, clunky and unfun. This change offers a smoother alternative, hopefully making manual peeking obsolete for regular movement outside of more specific cases.

#### Describe the solution

On any on-foot or mounted walking movement that isn't a run (walk, crouch, and crawl), the game checks if safe mode would be triggered. If it does, the usual alert message appears and the player is given an opportunity to look around. If the player exits the "look around" mode, they will then move backwards to their previous spot **before** enemies had time to notice. They can commit to the move anyway by pressing `CONFIRM` (return or keypad_enter by default).

 **Conceptually**, the behaviour of the player in safe_mode I'm going for isn't that *they crane their head forward every meter traveled*, but rather that they're keeping it on a swivel, *ready to duck back into cover if needed*. As such, both the move outside *and* back into cover **happen** and therefore contribute to move expended. This is comparable but not identical to `PEEK`, which costs a flat `player_speed * 2` moves. Also unlike peeking before every move, traveling around is done at an uninterrupted pace until the effect is triggered. Another reason for using the cost of the move is to not make the player's action cost unpredictable.

This has no effect when running, driving, swimming, phasing, ascending/descending, grabbing, or doing any other special movement.
However it does if mounted, or if hauling items and the player decided to stop (`Monster spotted! Stop moving items?`).

#### Describe alternatives you've considered

As far as the approach used:
- **Actually use the peek function instead of moving.** The code would need to be reordered to avoid redundant checks, and there would still be extraneous costly calls which can be skipped by simply moving first.
- ~Give the player the choice to either commit to the movement or step back. This could either be presented as a keypress option~ (done) or letting the player move back to the original position before updating enemy logic (**this might even be extended outside of safe mode**, but wouldn't be trivial).

For other approaches suggested by the community:
- An additional movement mode, or even completely separate mode, which would slow down the player for the same effect. This has the advantage of not changing how safe mode works.
- Making repeated peeks more convenient (allow to move & peek straight from the peek menu). This is less opinionated but would still makes regular play clumsy and unintuitive.

#### Testing

I've tested everything that immediately came to mind: each walk mode, mounting, swimming, vehicles (checking if the rollback behaves properly if it triggers while **you're moving inside of a moving vehicle and spot an enemy during that movement**). Everything seems to work as expected across Z-levels, while climbing, and with the couple teleporting spells I tried (which shouldn't affect it anyway). Any additional ideas on how this could break are welcome, and if you're kind enough to test it for yourself, this savefile is setup for testing the basics (mounted, swimming, climbing, hauling, grabbing, ...etc) :

[TESTING SAVEFILE](https://github.com/user-attachments/files/22029023/Danielsville.zip)
 
$${\color{red}\Huge \textsf{IMPORTANT NOTE}}$$

Keep in mind that the check for enemies is done after you've already spent the moves, which means that you can absolutely move out of cover without being stopped, only for safe mode to trigger right after because while **the way was clear when you moved out**, an enemy moved into your new field of view on their turn. 

**THIS IS EXPECTED**, for the exact same reason that you might peek, see the way is clear, and finally move right in the line of sight of a zombie who shuffled out on their own turn. Fixing this would require time traveling (or even worse existential violations, such as moving the player during monster logic).

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
