### PR TITLE
Mutation selection stops at certain points

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -2206,7 +2206,9 @@
     "starting_trait": true,
     "cancels": [ "ROBUST", "RESTRICTED", "RESISTANT_GENETICS" ],
     "valid": false,
-    "vitamin_rates": [ [ "instability", -60 ] ]
+    "vitamin_rates": [ [ "instability", -60 ] ],
+    "category": [ "CHIMERA" ],
+    "threshreq": [ "CHIMERA" ]
   },
   {
     "type": "mutation",
@@ -7757,6 +7759,7 @@
     "purifiable": false,
     "description": "Your body alters itself rapidly, and without your intervention or conscious control.",
     "prereqs": [ "UNSTABLE", "MUT_JUNKIE" ],
+    "changes_to": [ "CHAOTIC_BAD" ],
     "category": [ "CHIMERA" ]
   },
   {

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -2208,7 +2208,7 @@
     "valid": false,
     "vitamin_rates": [ [ "instability", -60 ] ],
     "category": [ "CHIMERA" ],
-    "threshreq": [ "CHIMERA" ]
+    "threshreq": [ "THRESH_CHIMERA" ]
   },
   {
     "type": "mutation",

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -730,6 +730,24 @@ bool Character::has_martialart( const matype_id &m ) const
     return martial_arts_data->has_martialart( m );
 }
 
+int Character::count_threshold_substitute_traits() const
+{
+    int count = 0;
+    for( const mutation_branch &mut : mutation_branch::get_all() ) {
+        if( !mut.threshold_substitutes.empty() ) {
+            if( has_trait( mut.id ) ) {
+                for( const trait_id &thresh_sub : mut.threshold_substitutes ) {
+                    if( has_trait( thresh_sub ) ) {
+                        ++count;
+                        break;
+                    }
+                }
+            }
+        }
+    }
+    return count;
+}
+
 int Character::get_oxygen_max() const
 {
     return 30 + ( has_bionic( bio_synlungs ) ? 30 : 2 * str_cur );

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -736,7 +736,9 @@ int Character::count_threshold_substitute_traits() const
     for( const mutation_branch &mut : mutation_branch::get_all() ) {
         if( !mut.threshold_substitutes.empty() && has_trait( mut.id ) &&
             std::find_if( mut.threshold_substitutes.begin(), mut.threshold_substitutes.end(),
-                          [this](const trait_id &t) { return has_trait( t ); } ) != mut.threshold_substitutes.end() ) {
+        [this]( const trait_id & t ) {
+        return has_trait( t );
+        } ) != mut.threshold_substitutes.end() ) {
             ++count;
             break;
         }

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -734,15 +734,11 @@ int Character::count_threshold_substitute_traits() const
 {
     int count = 0;
     for( const mutation_branch &mut : mutation_branch::get_all() ) {
-        if( !mut.threshold_substitutes.empty() ) {
-            if( has_trait( mut.id ) ) {
-                for( const trait_id &thresh_sub : mut.threshold_substitutes ) {
-                    if( has_trait( thresh_sub ) ) {
-                        ++count;
-                        break;
-                    }
-                }
-            }
+        if( !mut.threshold_substitutes.empty() && has_trait( mut.id ) &&
+            std::find_if( mut.threshold_substitutes.begin(), mut.threshold_substitutes.end(),
+                          [this](const trait_id &t) { return has_trait( t ); } ) != mut.threshold_substitutes.end() ) {
+            ++count;
+            break;
         }
     }
     return count;

--- a/src/character.h
+++ b/src/character.h
@@ -648,6 +648,8 @@ class Character : public Creature, public visitable
         int get_arm_str() const;
         // Defines distance from which CAMOUFLAGE mobs are visible
         int get_eff_per() const override;
+        // Counts how many traits a character has via threshold substitution
+        int count_threshold_substitute_traits() const;
 
         // Penalty modifiers applied for ranged attacks due to low stats
         int ranged_dex_mod() const;

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -1351,7 +1351,7 @@ void Character::mutate( const int &true_random_chance, bool use_vitamins )
                         if( rng( 1, 100 ) <= chance ) {
                             mutate_towards( trait_CHAOTIC );
                         }
-                    } else if( has_trait( trait_CHAOTIC ) ) && !has_trait( trait_CHAOTIC_BAD ) {
+                   else if( has_trait( trait_CHAOTIC ) && !has_trait( trait_CHAOTIC_BAD ) ) {
                         if( rng( 1, 100 ) <= chance ) {
                             mutate_towards( trait_CHAOTIC_BAD );
                         }
@@ -1432,7 +1432,7 @@ void Character::mutate_category( const mutation_category_id &cat )
 bool Character::mutation_selector( const std::vector<trait_id> &prospective_traits,
                                    const mutation_category_id &cat, const bool &use_vitamins )
 {
-    if( has_trait( trait_CHAOTIC ) ) || has_trait( trait_CHAOTIC_BAD ) ) ) {
+    if( has_trait( trait_CHAOTIC ) || has_trait( trait_CHAOTIC_BAD ) ) {
         add_msg_if_player( m_bad,
                            _( "Your genetic degeneration prevent you from selecting a mutation directly!" ) );
         return false;

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -1350,9 +1350,11 @@ void Character::mutate( const int &true_random_chance, bool use_vitamins )
                     if( !has_trait( trait_CHAOTIC ) && !has_trait( trait_CHAOTIC_BAD ) ) {
                         if( rng( 1, 100 ) <= chance ) {
                             mutate_towards( trait_CHAOTIC );
+                            add_msg_if_player( m_bad, _( "You will mutate uncontrollably from now on!" ) );
                         } else if( has_trait( trait_CHAOTIC ) && !has_trait( trait_CHAOTIC_BAD ) ) {
                             if( rng( 1, 100 ) <= chance ) {
                                 mutate_towards( trait_CHAOTIC_BAD );
+                                add_msg_if_player( m_bad, _( "Your genetics have become irreparably damaged!" ) );
                             }
                         }
                     }

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -1360,6 +1360,8 @@ void Character::mutate( const int &true_random_chance, bool use_vitamins )
             }
             return;
         }
+        } while( valid.empty() );
+}
 
 void Character::mutate( )
 {

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -1350,16 +1350,16 @@ void Character::mutate( const int &true_random_chance, bool use_vitamins )
                     if( !has_trait( trait_CHAOTIC ) && !has_trait( trait_CHAOTIC_BAD ) ) {
                         if( rng( 1, 100 ) <= chance ) {
                             mutate_towards( trait_CHAOTIC );
-                        }
-                   else if( has_trait( trait_CHAOTIC ) && !has_trait( trait_CHAOTIC_BAD ) ) {
-                        if( rng( 1, 100 ) <= chance ) {
-                            mutate_towards( trait_CHAOTIC_BAD );
+                        } else if( has_trait( trait_CHAOTIC ) && !has_trait( trait_CHAOTIC_BAD ) ) {
+                            if( rng( 1, 100 ) <= chance ) {
+                                mutate_towards( trait_CHAOTIC_BAD );
+                            }
                         }
                     }
+                    return;
                 }
                 return;
             }
-            return;
         }
     } while( valid.empty() );
 }
@@ -1429,13 +1429,8 @@ void Character::mutate_category( const mutation_category_id &cat )
     mutate_category( cat, !mutation_category_trait::get_category( cat ).vitamin.is_null() );
 }
 
-bool Character::mutation_selector( const std::vector<trait_id> &prospective_traits,
-                                   const mutation_category_id &cat, const bool &use_vitamins )
-{
-    if( has_trait( trait_CHAOTIC ) || has_trait( trait_CHAOTIC_BAD ) ) {
-        add_msg_if_player( m_bad,
-                           _( "Your genetic degeneration prevents you from selecting a mutation directly!" ) );
-        return false;
+    void Character::mutate_category( const mutation_category_id & cat ) {
+        mutate_category( cat, !mutation_category_trait::get_category( cat ).vitamin.is_null() );
     }
     // Setup menu
     uilist mmenu;

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -1432,11 +1432,11 @@ void Character::mutate_category( const mutation_category_id &cat )
 bool Character::mutation_selector( const std::vector<trait_id> &prospective_traits,
                                    const mutation_category_id &cat, const bool &use_vitamins )
 {
-    if (has_trait(trait_id("CHAOTIC")) || has_trait(trait_id("CHAOTIC_BAD"))) {
-        add_msg_if_player(m_bad, _("Your genetic degeneration prevent you from selecting a mutation directly!"));
+    if( has_trait( trait_id( "CHAOTIC" ) ) || has_trait( trait_id( "CHAOTIC_BAD" ) ) ) {
+        add_msg_if_player( m_bad,
+                           _( "Your genetic degeneration prevent you from selecting a mutation directly!" ) );
         return false;
     }
-    
     // Setup menu
     uilist mmenu;
     mmenu.text =

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -87,6 +87,7 @@ static const mutation_category_id mutation_category_ANY( "ANY" );
 static const trait_id trait_ARVORE_FOREST_MAPPING( "ARVORE_FOREST_MAPPING" );
 static const trait_id trait_BURROW( "BURROW" );
 static const trait_id trait_BURROWLARGE( "BURROWLARGE" );
+static const trait_id trait_CHAOTIC( "CHAOTIC" );
 static const trait_id trait_CHAOTIC_BAD( "CHAOTIC_BAD" );
 static const trait_id trait_ECHOLOCATION( "ECHOLOCATION" );
 static const trait_id trait_GASTROPOD_EXTREMITY2( "GASTROPOD_EXTREMITY2" );
@@ -1346,13 +1347,13 @@ void Character::mutate( const int &true_random_chance, bool use_vitamins )
                 int sub_count = count_threshold_substitute_traits();
                 if( sub_count > 2 ) {
                     int chance = sub_count - 2;
-                    if( !has_trait( trait_id( "CHAOTIC" ) ) && !has_trait( trait_id( "CHAOTIC_BAD" ) ) ) {
+                    if( !has_trait( trait_CHAOTIC ) ) && !has_trait( trait_CHAOTIC_BAD ) {
                         if( rng( 1, 100 ) <= chance ) {
-                            mutate_towards( trait_id( "CHAOTIC" ) );
+                            mutate_towards( trait_CHAOTIC );
                         }
-                    } else if( has_trait( trait_id( "CHAOTIC" ) ) && !has_trait( trait_id( "CHAOTIC_BAD" ) ) ) {
+                    } else if( has_trait( trait_CHAOTIC ) ) && !has_trait( trait_CHAOTIC_BAD ) {
                         if( rng( 1, 100 ) <= chance ) {
-                            mutate_towards( trait_id( "CHAOTIC_BAD" ) );
+                            mutate_towards( trait_CHAOTIC_BAD );
                         }
                     }
                 }

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -1429,15 +1429,15 @@ void Character::mutate_category( const mutation_category_id &cat )
     mutate_category( cat, !mutation_category_trait::get_category( cat ).vitamin.is_null() );
 }
 
-    bool Character::mutation_selector( const std::vector<trait_id> &prospective_traits,
+bool Character::mutation_selector( const std::vector<trait_id> &prospective_traits,
                                    const mutation_category_id &cat, const bool &use_vitamins )
 {
     if( has_trait( trait_CHAOTIC ) || has_trait( trait_CHAOTIC_BAD ) ) {
         add_msg_if_player( m_bad,
                            _( "Your genetic degeneration prevents you from selecting a mutation directly!" ) );
         return false;
-        }
-        
+    }
+
     void Character::mutate_category( const mutation_category_id & cat ) {
         mutate_category( cat, !mutation_category_trait::get_category( cat ).vitamin.is_null() );
     }

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -1360,7 +1360,7 @@ void Character::mutate( const int &true_random_chance, bool use_vitamins )
             }
             return;
         }
-        } while( valid.empty() );
+    } while( valid.empty() );
 }
 
 void Character::mutate( )

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -1434,7 +1434,7 @@ bool Character::mutation_selector( const std::vector<trait_id> &prospective_trai
 {
     if( has_trait( trait_CHAOTIC ) || has_trait( trait_CHAOTIC_BAD ) ) {
         add_msg_if_player( m_bad,
-                           _( "Your genetic degeneration prevent you from selecting a mutation directly!" ) );
+                           _( "Your genetic degeneration prevents you from selecting a mutation directly!" ) );
         return false;
     }
     // Setup menu

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -1386,9 +1386,6 @@ void Character::mutate_category( const mutation_category_id &cat, const bool use
     bool allow_bad = false;
     bool allow_neutral = true;
 
-    if (has_trait(trait_id("CHAOTIC")) || has_trait(trait_id("CHAOTIC_BAD"))) {
-        add_msg_if_player(m_bad, _("Your genetic degeneration prevent you from selecting a mutation directly!"));
-        return;
     if( select_mutation || true_random ) {
         // Mutation selector and true_random overrides good / bad mutation rolls
         allow_good = true;

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -1386,6 +1386,9 @@ void Character::mutate_category( const mutation_category_id &cat, const bool use
     bool allow_bad = false;
     bool allow_neutral = true;
 
+    if (has_trait(trait_id("CHAOTIC")) || has_trait(trait_id("CHAOTIC_BAD"))) {
+        add_msg_if_player(m_bad, _("Your genetic degeneration prevent you from selecting a mutation directly!"));
+        return;
     if( select_mutation || true_random ) {
         // Mutation selector and true_random overrides good / bad mutation rolls
         allow_good = true;

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -1432,7 +1432,7 @@ void Character::mutate_category( const mutation_category_id &cat )
 bool Character::mutation_selector( const std::vector<trait_id> &prospective_traits,
                                    const mutation_category_id &cat, const bool &use_vitamins )
 {
-    if( has_trait( trait_id( "CHAOTIC" ) ) || has_trait( trait_id( "CHAOTIC_BAD" ) ) ) {
+    if( has_trait( trait_CHAOTIC ) ) || has_trait( trait_CHAOTIC_BAD ) ) ) {
         add_msg_if_player( m_bad,
                            _( "Your genetic degeneration prevent you from selecting a mutation directly!" ) );
         return false;

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -1343,17 +1343,16 @@ void Character::mutate( const int &true_random_chance, bool use_vitamins )
             }
             if( mutate_towards( valid, cat, 2, use_vitamins ) ) {
                 add_msg_if_player( m_mixed, mutation_category_trait::get_category( cat ).mutagen_message() );
-                
                 int sub_count = count_threshold_substitute_traits();
                 if( sub_count > 2 ) {
                     int chance = sub_count - 2;
-                    if( !has_trait(trait_id("CHAOTIC")) && !has_trait(trait_id("CHAOTIC_BAD")) ) {
-                        if( rng(1, 100) <= chance ) {
-                            mutate_towards(trait_id("CHAOTIC"));
+                    if( !has_trait( trait_id( "CHAOTIC" ) ) && !has_trait( trait_id( "CHAOTIC_BAD" ) ) ) {
+                        if( rng( 1, 100 ) <= chance ) {
+                            mutate_towards( trait_id( "CHAOTIC" ) );
                         }
-                    } else if( has_trait(trait_id("CHAOTIC")) && !has_trait(trait_id("CHAOTIC_BAD")) ) {
-                        if( rng(1, 100) <= chance ) {
-                            mutate_towards(trait_id("CHAOTIC_BAD"));
+                    } else if( has_trait( trait_id( "CHAOTIC" ) ) && !has_trait( trait_id( "CHAOTIC_BAD" ) ) ) {
+                        if( rng( 1, 100 ) <= chance ) {
+                            mutate_towards( trait_id( "CHAOTIC_BAD" ) );
                         }
                     }
                 }

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -1386,8 +1386,9 @@ void Character::mutate_category( const mutation_category_id &cat, const bool use
     bool allow_bad = false;
     bool allow_neutral = true;
 
-    if (has_trait(trait_id("CHAOTIC")) || has_trait(trait_id("CHAOTIC_BAD"))) {
-        add_msg_if_player(m_bad, _("Your genetic degeneration prevent you from selecting a mutation directly!"));
+    if( has_trait( trait_id( "CHAOTIC" ) ) || has_trait( trait_id( "CHAOTIC_BAD" ) ) ) {
+        add_msg_if_player( m_bad,
+                           _( "Your genetic degeneration prevent you from selecting a mutation directly!" ) );
         return;
     if( select_mutation || true_random ) {
         // Mutation selector and true_random overrides good / bad mutation rolls

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -1343,11 +1343,24 @@ void Character::mutate( const int &true_random_chance, bool use_vitamins )
             }
             if( mutate_towards( valid, cat, 2, use_vitamins ) ) {
                 add_msg_if_player( m_mixed, mutation_category_trait::get_category( cat ).mutagen_message() );
+                
+                int sub_count = count_threshold_substitute_traits();
+                if( sub_count > 2 ) {
+                    int chance = sub_count - 2;
+                    if( !has_trait(trait_id("CHAOTIC")) && !has_trait(trait_id("CHAOTIC_BAD")) ) {
+                        if( rng(1, 100) <= chance ) {
+                            mutate_towards(trait_id("CHAOTIC"));
+                        }
+                    } else if( has_trait(trait_id("CHAOTIC")) && !has_trait(trait_id("CHAOTIC_BAD")) ) {
+                        if( rng(1, 100) <= chance ) {
+                            mutate_towards(trait_id("CHAOTIC_BAD"));
+                        }
+                    }
+                }
+                return;
             }
             return;
         }
-    } while( valid.empty() );
-}
 
 void Character::mutate( )
 {

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -1347,7 +1347,7 @@ void Character::mutate( const int &true_random_chance, bool use_vitamins )
                 int sub_count = count_threshold_substitute_traits();
                 if( sub_count > 2 ) {
                     int chance = sub_count - 2;
-                    if( !has_trait( trait_CHAOTIC ) ) && !has_trait( trait_CHAOTIC_BAD ) {
+                    if( !has_trait( trait_CHAOTIC ) && !has_trait( trait_CHAOTIC_BAD ) ) {
                         if( rng( 1, 100 ) <= chance ) {
                             mutate_towards( trait_CHAOTIC );
                         }

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -1432,6 +1432,11 @@ void Character::mutate_category( const mutation_category_id &cat )
 bool Character::mutation_selector( const std::vector<trait_id> &prospective_traits,
                                    const mutation_category_id &cat, const bool &use_vitamins )
 {
+    if (has_trait(trait_id("CHAOTIC")) || has_trait(trait_id("CHAOTIC_BAD"))) {
+        add_msg_if_player(m_bad, _("Your genetic degeneration prevent you from selecting a mutation directly!"));
+        return false;
+    }
+    
     // Setup menu
     uilist mmenu;
     mmenu.text =

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -1438,9 +1438,6 @@ bool Character::mutation_selector( const std::vector<trait_id> &prospective_trai
         return false;
     }
 
-    void Character::mutate_category( const mutation_category_id & cat ) {
-        mutate_category( cat, !mutation_category_trait::get_category( cat ).vitamin.is_null() );
-    }
     // Setup menu
     uilist mmenu;
     mmenu.text =

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -1429,6 +1429,15 @@ void Character::mutate_category( const mutation_category_id &cat )
     mutate_category( cat, !mutation_category_trait::get_category( cat ).vitamin.is_null() );
 }
 
+    bool Character::mutation_selector( const std::vector<trait_id> &prospective_traits,
+                                   const mutation_category_id &cat, const bool &use_vitamins )
+{
+    if( has_trait( trait_CHAOTIC ) || has_trait( trait_CHAOTIC_BAD ) ) {
+        add_msg_if_player( m_bad,
+                           _( "Your genetic degeneration prevents you from selecting a mutation directly!" ) );
+        return false;
+        }
+        
     void Character::mutate_category( const mutation_category_id & cat ) {
         mutate_category( cat, !mutation_category_trait::get_category( cat ).vitamin.is_null() );
     }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Balance "Chimera should live up to it's research notes"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Make genetic chaos inevitable with infinite mutations. And if you begin mutating uncontrollably it is uncontrollable.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Creates a function to check how many threshold_substitute mutations a character has.  During mutate check that number and give a percentage chance to mutate a free additional mutation and a future full of free mutations.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Tested and it works
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
