### PR TITLE
Aftershock: Clear variants in several copy-from items

### DIFF
--- a/data/mods/aftershock_exoplanet/items/armor/civilian_blue_collar.json
+++ b/data/mods/aftershock_exoplanet/items/armor/civilian_blue_collar.json
@@ -93,6 +93,7 @@
     "copy-from": "vest",
     "looks_like": "vest",
     "name": { "str": "hi-vis vest" },
+    "variants": [  ],
     "description": "A bright orange winter vest with several front facing pockets.  Not even close to warm enough.",
     "material": [ "cotton", "plastic" ],
     "warmth": 70,
@@ -106,6 +107,7 @@
     "copy-from": "jacket_windbreaker",
     "looks_like": "jacket_windbreaker",
     "name": { "str": "company jacket" },
+    "variants": [  ],
     "description": "A synthetic jacket adorned with the logos and colors of some interstellar corporation.  Impermeable, but not very warm.",
     "color": "blue"
   },
@@ -116,6 +118,7 @@
     "copy-from": "jacket_windbreaker",
     "looks_like": "jacket_windbreaker",
     "name": { "str": "supervisor jacket" },
+    "variants": [  ],
     "description": "A variant company jacket tailored to slightly recall a business suit, often issued to low level managers.  Some might think it looks nicer, but it's just as cheaply made.",
     "color": "blue"
   },
@@ -126,6 +129,7 @@
     "copy-from": "tie_skinny",
     "looks_like": "tie_skinny",
     "name": { "str": "worker's tie" },
+    "variants": [  ],
     "description": "Calling this thin strip of dark fabric a tie would do it a favor."
   },
   {
@@ -136,6 +140,7 @@
     "looks_like": "jumpsuit",
     "name": { "str": "crew jumpsuit" },
     "description": "A lightweight cloth jumpsuit adorned with the faded corporate regalia of some freight hauling association or another.  This one is a standard design favored by spacers, with ample, easy access pockets.",
+    "variants": [  ],
     "color": "brown"
   },
   {
@@ -192,6 +197,7 @@
     "copy-from": "hat_cotton",
     "material": [ "plastic", "cotton" ],
     "looks_like": "powered_earmuffs",
+    "variants": [  ],
     "flags": [ "OVERSIZE", "BELTED", "ALLOWS_NATURAL_ATTACKS", "PARTIAL_DEAF" ],
     "name": { "str": "communications cap" },
     "description": "A padded cotton cap built around an augmented reality headset.  During normal operation it would provide visual information about a ship subsystems and a communications link with the rest of the crew, but severed from a spaceship, only their hearing protection function retains any utility.",

--- a/data/mods/aftershock_exoplanet/items/armor/exosuit/exosuit_underlayers.json
+++ b/data/mods/aftershock_exoplanet/items/armor/exosuit/exosuit_underlayers.json
@@ -14,6 +14,7 @@
     "environmental_protection": 5,
     "charges_per_use": 1,
     "tool_ammo": "battery",
+    "variants": [  ],
     "use_action": {
       "type": "transform",
       "msg": "You activate your %s.",
@@ -92,6 +93,7 @@
     "charges_per_use": 1,
     "tool_ammo": "battery",
     "environmental_protection": 5,
+    "variants": [  ],
     "use_action": {
       "type": "transform",
       "msg": "You activate your %s.",
@@ -170,6 +172,7 @@
     "charges_per_use": 1,
     "tool_ammo": "battery",
     "environmental_protection": 100,
+    "variants": [  ],
     "use_action": {
       "type": "transform",
       "msg": "You activate your %s.",
@@ -250,6 +253,7 @@
     "charges_per_use": 1,
     "tool_ammo": "battery",
     "environmental_protection": 16,
+    "variants": [  ],
     "use_action": {
       "type": "transform",
       "msg": "You activate your %s.",

--- a/data/mods/aftershock_exoplanet/items/armor/military_clothing.json
+++ b/data/mods/aftershock_exoplanet/items/armor/military_clothing.json
@@ -8,6 +8,7 @@
     "name": { "str_sp": "military overalls" },
     "description": "A sturdy Nomex jumpsuit, normally worn by armed forces during transit or beneath combat armor while in the field.",
     "material": [ { "type": "nylon", "portion": 7 }, { "type": "nomex", "portion": 3 } ],
+    "variants": [  ],
     "material_thickness": 0.4,
     "color": "light_gray"
   },
@@ -29,6 +30,7 @@
         "volume_encumber_modifier": 0.25
       }
     ],
+    "variants": [  ],
     "pocket_data": [
       {
         "description": "Rifle attachment point.",

--- a/data/mods/aftershock_exoplanet/items/gun/40mm_grenade.json
+++ b/data/mods/aftershock_exoplanet/items/gun/40mm_grenade.json
@@ -12,6 +12,7 @@
     "clip_size": 3,
     "reload": 200,
     "extend": { "flags": [ "RELOAD_ONE" ] },
+    "variants": [  ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "40x46mm": 3 } } ],
     "melee_damage": { "bash": 6 }
   }

--- a/data/mods/aftershock_exoplanet/items/gun/7.50mm.json
+++ b/data/mods/aftershock_exoplanet/items/gun/7.50mm.json
@@ -21,6 +21,7 @@
     "min_strength": 16,
     "clip_size": 9,
     "flags": [ "WATERPROOF_GUN", "RELOAD_ONE", "NEVER_JAMS" ],
+    "variants": [  ],
     "valid_mod_locations": [
       [ "barrel", 1 ],
       [ "brass catcher", 1 ],
@@ -60,6 +61,7 @@
     "durability": 5,
     "blackpowder_tolerance": 60,
     "ammo": [ "afs_7.50mm" ],
+    "variants": [  ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "afs_7.50mm": 1 } } ],
     "faults": [ { "fault": "fault_gun_blackpowder" }, { "fault": "fault_gun_dirt" } ]
   },
@@ -86,6 +88,7 @@
     "reload": 400,
     "modes": [ [ "DEFAULT", "burst", 4 ] ],
     "built_in_mods": [ "bipod" ],
+    "variants": [  ],
     "valid_mod_locations": [
       [ "barrel", 1 ],
       [ "brass catcher", 1 ],
@@ -132,6 +135,7 @@
     "dispersion": 150,
     "durability": 10,
     "min_cycle_recoil": 1350,
+    "variants": [  ],
     "pocket_data": [
       {
         "pocket_type": "MAGAZINE_WELL",
@@ -245,6 +249,7 @@
     "blackpowder_tolerance": 0,
     "min_cycle_recoil": 0,
     "handling": 25,
+    "variants": [  ],
     "pocket_data": [
       {
         "pocket_type": "MAGAZINE_WELL",

--- a/data/mods/aftershock_exoplanet/items/gun/shot.json
+++ b/data/mods/aftershock_exoplanet/items/gun/shot.json
@@ -54,6 +54,7 @@
       [ "sights", 1 ],
       [ "underbarrel mount", 1 ]
     ],
+    "variants": [  ],
     "price": "4 kUSD",
     "price_postapoc": "4 kUSD",
     "built_in_mods": [ "afs_magnetic_choke", "afs_shotgun_gauss" ]


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Variants were causing the names and descriptions of aftershock items to be overwritten.

#### Describe the solution
Overwrite variants with an empty field.

#### Testing
Loaded
