### PR TITLE
Fix conjuring void potatoes into existence through the fries recipe

### DIFF
--- a/data/json/recipes/food/junkfood.json
+++ b/data/json/recipes/food/junkfood.json
@@ -173,7 +173,7 @@
     "time": "16 m",
     "autolearn": true,
     "qualities": [ { "id": "CUT", "level": 2 }, { "id": "COOK", "level": 2 } ],
-    "tools": [ [ [ "surface_heat", 8, "LIST" ] ], [ [ "fry_oil", 4, "LIST" ] ] ],
+    "tools": [ [ [ "surface_heat", 8, "LIST" ] ], [ [ "frying_oil", 4, "LIST" ] ] ],
     "proficiencies": [
       { "proficiency": "prof_food_prep" },
       { "proficiency": "prof_knife_skills", "time_multiplier": 2 },
@@ -182,7 +182,7 @@
     "components": [
       [ [ "veggy_potatolike", 1, "LIST" ], [ "carrot", 3 ], [ "carrot_wild", 2 ] ],
       [ [ "salt", 2 ], [ "seasoning_salt", 2 ] ],
-      [ [ "frying_oil", 1, "LIST" ] ]
+      [ [ "fry_oil", 1, "LIST" ] ]
     ]
   },
   {

--- a/data/json/recipes/food/junkfood.json
+++ b/data/json/recipes/food/junkfood.json
@@ -173,7 +173,7 @@
     "time": "16 m",
     "autolearn": true,
     "qualities": [ { "id": "CUT", "level": 2 }, { "id": "COOK", "level": 2 } ],
-    "tools": [ [ [ "surface_heat", 8, "LIST" ] ], [ "fry_oil", 4, "LIST" ] ],
+    "tools": [ [ [ "surface_heat", 8, "LIST" ] ], [ [ "fry_oil", 4, "LIST" ] ] ],
     "proficiencies": [
       { "proficiency": "prof_food_prep" },
       { "proficiency": "prof_knife_skills", "time_multiplier": 2 },
@@ -182,7 +182,7 @@
     "components": [
       [ [ "veggy_potatolike", 1, "LIST" ], [ "carrot", 3 ], [ "carrot_wild", 2 ] ],
       [ [ "salt", 2 ], [ "seasoning_salt", 2 ] ],
-      [ [ [ "frying_oil", 1, "LIST" ] ] ]
+      [ [ "frying_oil", 1, "LIST" ] ]
     ]
   },
   {

--- a/data/json/recipes/food/junkfood.json
+++ b/data/json/recipes/food/junkfood.json
@@ -166,7 +166,6 @@
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",
     "result": "fries",
-    "charges": 3,
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_VEGGI",
     "skill_used": "cooking",
@@ -174,7 +173,7 @@
     "time": "16 m",
     "autolearn": true,
     "qualities": [ { "id": "CUT", "level": 2 }, { "id": "COOK", "level": 2 } ],
-    "tools": [ [ [ "surface_heat", 8, "LIST" ] ], [ [ "frying_oil", 1, "LIST" ] ] ],
+    "tools": [ [ [ "surface_heat", 8, "LIST" ] ], [ "fry_oil", 4, "LIST" ] ],
     "proficiencies": [
       { "proficiency": "prof_food_prep" },
       { "proficiency": "prof_knife_skills", "time_multiplier": 2 },
@@ -183,7 +182,7 @@
     "components": [
       [ [ "veggy_potatolike", 1, "LIST" ], [ "carrot", 3 ], [ "carrot_wild", 2 ] ],
       [ [ "salt", 2 ], [ "seasoning_salt", 2 ] ],
-      [ [ "fry_oil", 4, "LIST" ] ]
+      [ [ [ "frying_oil", 1, "LIST" ] ] ]
     ]
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Our fries recipe makes 3 fries from 1 potato, fries are 250 ml, 1 potato is 250 ml implying that the player is a potato wizard, which doesn't seem to fit the lore, although maybe I should check the lore docs again.

Also the `fry_oil` and `frying_oil` values should be the other way around, currently you lose like 1 L of oil from the 1.25 L used in the recipe. Only ~10% of the oil should be absorbed by the fries.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Reduce the fries amount being cooked. Swap the aformentioned values.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Spend more time wondering if the recipe is actually somehow right and I've gone crazy.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
