### PR TITLE
Use optional/mandatory for more vpart_info fields

### DIFF
--- a/src/generic_factory.h
+++ b/src/generic_factory.h
@@ -1389,9 +1389,10 @@ struct T_has_do_delete<T, std::void_t<decltype( &T::do_delete )>> : std::true_ty
 template<typename Derived>
 class generic_typed_reader
 {
+public:
     static constexpr bool read_objects = false;
     static constexpr bool check_extend_delete_copy_from = true;
-public:
+
     template<typename C, typename Fn>
     // I tried using a member function pointer and couldn't work it out
     void apply_all_values( JsonValue &jv, C &container, Fn apply ) const {
@@ -1659,6 +1660,8 @@ template<typename T>
 class json_read_reader : public generic_typed_reader<json_read_reader<T>>
 {
 public:
+    static constexpr bool read_objects = true;
+
     T get_next( const JsonValue &jv ) const {
         T ret;
         if( !jv.read( ret ) ) {

--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -386,21 +386,14 @@ void vpart_info::load( const JsonObject &jo, const std::string &src )
     }
 
     if( has_flag( "WORKBENCH" ) ) {
-        if( !workbench_info ) {
-            workbench_info.emplace();
-        }
-
-        JsonObject wb_jo = jo.get_object( "workbench" );
-        assign( wb_jo, "multiplier", workbench_info->multiplier, strict );
-        assign( wb_jo, "mass", workbench_info->allowed_mass, strict );
-        assign( wb_jo, "volume", workbench_info->allowed_volume, strict );
+        mandatory( jo, was_loaded, "workbench", workbench_info );
     }
 
     if( has_flag( "VEH_TOOLS" ) ) {
         if( !toolkit_info ) {
             toolkit_info.emplace();
         }
-        assign( jo, "allowed_tools", toolkit_info->allowed_types, strict );
+        toolkit_info->deserialize( jo );
     }
 
     if( has_flag( "TRANSFORM_TERRAIN" ) || has_flag( "CRASH_TERRAIN_AROUND" ) ) {
@@ -462,6 +455,20 @@ void vpslot_wheel::deserialize( const JsonObject &jo )
 void vpslot_rotor::deserialize( const JsonObject &jo )
 {
     optional( jo, was_loaded, "rotor_diameter", rotor_diameter, 1 );
+
+    was_loaded = true;
+}
+
+void vpslot_workbench::deserialize( const JsonObject &jo )
+{
+    optional( jo, false, "multiplier", multiplier, 1.f );
+    optional( jo, false, "mass", allowed_mass, 0_gram );
+    optional( jo, false, "volume", allowed_volume, 0_ml );
+}
+
+void vpslot_toolkit::deserialize( const JsonObject &jo )
+{
+    optional( jo, was_loaded, "allowed_tools", allowed_types, string_id_reader<itype> {} );
 
     was_loaded = true;
 }

--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -363,18 +363,12 @@ void vpart_info::load( const JsonObject &jo, const std::string &src )
         damage_reduction = load_damage_map( dred );
     }
 
+    // TODO?: move this into an object?
     if( has_flag( "ENGINE" ) ) {
         if( !engine_info ) {
             engine_info.emplace();
         }
-        assign( jo, "backfire_threshold", engine_info->backfire_threshold, strict );
-        assign( jo, "backfire_freq", engine_info->backfire_freq, strict );
-        assign( jo, "noise_factor", engine_info->noise_factor, strict );
-        assign( jo, "damaged_power_factor", engine_info->damaged_power_factor, strict );
-        assign( jo, "m2c", engine_info->m2c, strict );
-        assign( jo, "muscle_power_factor", engine_info->muscle_power_factor, strict );
-        assign( jo, "exclusions", engine_info->exclusions, strict );
-        assign( jo, "fuel_options", engine_info->fuel_opts, strict );
+        engine_info->deserialize( jo );
     }
 
     if( has_flag( "WHEEL" ) ) {
@@ -435,6 +429,20 @@ void vpart_info::load( const JsonObject &jo, const std::string &src )
             mandatory( jttd, was_loaded, "post_field_age", vtt.post_field_age );
         }
     }
+}
+
+void vpslot_engine::deserialize( const JsonObject &jo )
+{
+    optional( jo, was_loaded, "backfire_threshold", backfire_threshold, 0.f );
+    optional( jo, was_loaded, "backfire_freq", backfire_freq, 1 );
+    optional( jo, was_loaded, "noise_factor", noise_factor, 0 );
+    optional( jo, was_loaded, "damaged_power_factor", damaged_power_factor, 0.f );
+    optional( jo, was_loaded, "m2c", m2c, 100 );
+    optional( jo, was_loaded, "muscle_power_factor", muscle_power_factor, 0 );
+    optional( jo, was_loaded, "exclusions", exclusions, string_reader{} );
+    optional( jo, was_loaded, "fuel_options", fuel_opts, string_id_reader<itype> {} );
+
+    was_loaded = true;
 }
 
 void vpart_info::set_flag( const std::string &flag )

--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -400,16 +400,7 @@ void vpart_info::load( const JsonObject &jo, const std::string &src )
         if( !transform_terrain_info ) {
             transform_terrain_info.emplace();
         }
-        JsonObject jttd = jo.get_object( "transform_terrain" );
-        vpslot_terrain_transform &vtt = *transform_terrain_info;
-        optional( jttd, was_loaded, "pre_flags", vtt.pre_flags, {} );
-        optional( jttd, was_loaded, "post_terrain", vtt.post_terrain );
-        optional( jttd, was_loaded, "post_furniture", vtt.post_furniture );
-        if( jttd.has_string( "post_field" ) ) {
-            mandatory( jttd, was_loaded, "post_field", vtt.post_field );
-            mandatory( jttd, was_loaded, "post_field_intensity", vtt.post_field_intensity );
-            mandatory( jttd, was_loaded, "post_field_age", vtt.post_field_age );
-        }
+        mandatory( jo, was_loaded, "transform_terrain", transform_terrain_info );
     }
 }
 
@@ -471,6 +462,18 @@ void vpslot_toolkit::deserialize( const JsonObject &jo )
     optional( jo, was_loaded, "allowed_tools", allowed_types, string_id_reader<itype> {} );
 
     was_loaded = true;
+}
+
+void vpslot_terrain_transform::deserialize( const JsonObject &jo )
+{
+    optional( jo, false, "pre_flags", pre_flags, {} );
+    optional( jo, false, "post_terrain", post_terrain );
+    optional( jo, false, "post_furniture", post_furniture );
+    if( jo.has_string( "post_field" ) ) {
+        mandatory( jo, false, "post_field", post_field );
+        mandatory( jo, false, "post_field_intensity", post_field_intensity );
+        mandatory( jo, false, "post_field_age", post_field_age );
+    }
 }
 
 void vpart_info::set_flag( const std::string &flag )

--- a/src/veh_type.h
+++ b/src/veh_type.h
@@ -27,6 +27,7 @@
 class Character;
 class JsonObject;
 class JsonOut;
+class JsonValue;
 class vehicle;
 class vpart_info;
 struct vehicle_prototype;
@@ -140,17 +141,31 @@ struct veh_ter_mod {
     std::string terrain_flag; // terrain flag this mod block applies to
     int move_override;        // override when on flagged terrain, ignored if 0
     int move_penalty;         // penalty added when not on flagged terrain, ignored if 0
+
+    void deserialize( const JsonValue &jv );
+    // for generic_factory delete/extend
+    bool operator==( const veh_ter_mod &rhs ) const {
+        return terrain_flag == rhs.terrain_flag;
+    }
 };
 
 struct vpslot_wheel {
+    bool was_loaded = false;
+
     float rolling_resistance = 1.0f;
     int contact_area = 1;
     std::vector<veh_ter_mod> terrain_modifiers;
     float offroad_rating = 0.5f;
+
+    void deserialize( const JsonObject &jo );
 };
 
 struct vpslot_rotor {
+    bool was_loaded = false;
+
     int rotor_diameter = 1;
+
+    void deserialize( const JsonObject &jo );
 };
 
 struct vpslot_workbench {

--- a/src/veh_type.h
+++ b/src/veh_type.h
@@ -174,10 +174,16 @@ struct vpslot_workbench {
     // Mass/volume allowed before a crafting speed penalty is applied
     units::mass allowed_mass = 0_gram;
     units::volume allowed_volume = 0_ml;
+
+    void deserialize( const JsonObject &jo );
 };
 
 struct vpslot_toolkit {
+    bool was_loaded = false;
+
     std::set<itype_id> allowed_types;
+
+    void deserialize( const JsonObject &jo );
 };
 
 struct vpslot_terrain_transform {

--- a/src/veh_type.h
+++ b/src/veh_type.h
@@ -194,6 +194,8 @@ struct vpslot_terrain_transform {
     //Both only defined if(post_field)
     int post_field_intensity;
     time_duration post_field_age;
+
+    void deserialize( const JsonObject &jo );
 };
 
 struct vp_control_req {

--- a/src/veh_type.h
+++ b/src/veh_type.h
@@ -122,6 +122,8 @@ enum vpart_bitflags : int {
 };
 
 struct vpslot_engine {
+    bool was_loaded = false;
+
     float backfire_threshold = 0.0f;
     int backfire_freq = 1;
     int muscle_power_factor = 0;
@@ -130,6 +132,8 @@ struct vpslot_engine {
     int m2c = 100;
     std::vector<std::string> exclusions;
     std::vector<itype_id> fuel_opts;
+
+    void deserialize( const JsonObject &jo );
 };
 
 struct veh_ter_mod {

--- a/src/veh_type.h
+++ b/src/veh_type.h
@@ -201,6 +201,8 @@ struct vpslot_terrain_transform {
 struct vp_control_req {
     std::set<std::pair<skill_id, int>> skills;
     std::set<proficiency_id> proficiencies;
+
+    void deserialize( const JsonObject &jo );
 };
 
 class vpart_category


### PR DESCRIPTION
#### Summary
Infrastructure "Move vpslots to use optional/mandatory"

#### Purpose of change
Optional and mandatory have better support for extended features and better error reporting, as per https://github.com/CleverRaven/Cataclysm-DDA/pull/82165

#### Describe the solution
Add deserialize functions (and potentially `was_loaded` members) to vpslots, then call those instead of having it inline.
Move these functions to use optional/mandatory.

#### Describe alternatives you've considered
I think the flags indicating the vplots are redundant, and it should just have a `slot: { ... }` member that loads the slot or leaves it unpopulated. `extend/delete` can provide inheritance features where needed.

#### Testing
`tools/load_all_mods.sh`
`tests/cata_test [vehicle]`