### PR TITLE
Fix monster spell message being printed even when it's empty

### DIFF
--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -1270,7 +1270,10 @@ std::string spell::message() const
     if( !alt_message.empty() ) {
         return alt_message.translated();
     }
-    return type->message.translated();
+    if( !type->message.empty() ) {
+        type->message.translated();
+    }
+    return {};
 }
 
 float spell::spell_fail( const Character &guy ) const


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Fix #77436
#### Describe the solution
~~I honestly have difficulties understanding why the bug was here in the first place, and how my change (made by following other examples in magic.cpp) fixed it. I'll try to re-read the code tomorrow to give a proper explanation why it works~~
So if spell has `monster_message`, the game works fine and print this message. When it has `"monster_message": ""`, the game fails to understand you want to not print any message, it understand that you want to print message anyway. Since the message itself is not defined, it uses the fallback alt_message, which is "You cast %s!". Since the first argument in the function passed is mon.disp_name(), it result in "you cast feral cop!" nonsense
The fix is just checking if message is not empty also, and if so, return empty string
#### Testing
I spawned feral elfs, and saw they do not spam "you cast feral elf!" message. They still do message about sound bombs and another their spells