### PR TITLE
Enchantment cache save corruption fix

### DIFF
--- a/src/magic_enchantment.cpp
+++ b/src/magic_enchantment.cpp
@@ -199,11 +199,11 @@ bool string_id<enchantment>::is_valid() const
 }
 
 template<typename TKey>
-void load_add_and_multiply( const JsonObject &jo, const bool &is_child,
-                            std::string_view array_key, const std::string &type_key, std::map<TKey, dbl_or_var> &add_map,
-                            std::map<TKey, dbl_or_var> &mult_map )
+void load_add_and_multiply_dbl_or_var( const JsonObject &jo, std::string_view array_key,
+                                       const std::string &type_key, std::map<TKey, dbl_or_var> &add_map,
+                                       std::map<TKey, dbl_or_var> &mult_map )
 {
-    if( !is_child && jo.has_array( array_key ) ) {
+    if( jo.has_array( array_key ) ) {
         for( const JsonObject value_obj : jo.get_array( array_key ) ) {
 
             TKey value;
@@ -568,25 +568,29 @@ void enchantment::load( const JsonObject &jo, std::string_view,
     optional( jo, was_loaded, "name", name );
     optional( jo, was_loaded, "description", description );
 
-    load_add_and_multiply<enchant_vals::mod>( jo, is_child, "values", "value", values_add,
+    if( is_child ) {
+        return;
+    }
+
+    load_add_and_multiply_dbl_or_var<enchant_vals::mod>( jo, "values", "value", values_add,
             values_multiply );
 
-    load_add_and_multiply<skill_id>( jo, is_child, "skills", "value",
-                                     skill_values_add, skill_values_multiply );
+    load_add_and_multiply_dbl_or_var<skill_id>( jo, "skills", "value", skill_values_add,
+            skill_values_multiply );
 
-    load_add_and_multiply<bodypart_str_id>( jo, is_child, "encumbrance_modifier", "part",
-                                            encumbrance_values_add, encumbrance_values_multiply );
+    load_add_and_multiply_dbl_or_var<bodypart_str_id>( jo, "encumbrance_modifier", "part",
+            encumbrance_values_add, encumbrance_values_multiply );
 
-    load_add_and_multiply<damage_type_id>( jo, is_child, "melee_damage_bonus", "type",
-                                           damage_values_add, damage_values_multiply );
+    load_add_and_multiply_dbl_or_var<damage_type_id>( jo, "melee_damage_bonus", "type",
+            damage_values_add, damage_values_multiply );
 
-    load_add_and_multiply<damage_type_id>( jo, is_child, "incoming_damage_mod", "type",
-                                           armor_values_add, armor_values_multiply );
+    load_add_and_multiply_dbl_or_var<damage_type_id>( jo, "incoming_damage_mod", "type",
+            armor_values_add, armor_values_multiply );
 
-    load_add_and_multiply<damage_type_id>( jo, is_child, "incoming_damage_mod_post_absorbed", "type",
-                                           extra_damage_add, extra_damage_multiply );
+    load_add_and_multiply_dbl_or_var<damage_type_id>( jo, "incoming_damage_mod_post_absorbed", "type",
+            extra_damage_add, extra_damage_multiply );
 
-    if( !is_child && jo.has_array( "special_vision" ) ) {
+    if( jo.has_array( "special_vision" ) ) {
         for( const JsonObject vision_obj : jo.get_array( "special_vision" ) ) {
             special_vision _vision;
             special_vision_descriptions _desc;

--- a/src/magic_enchantment.cpp
+++ b/src/magic_enchantment.cpp
@@ -246,7 +246,11 @@ void load_add_and_multiply( const JsonObject &jo, std::string_view array_key,
     if( jo.has_array( array_key ) ) {
         for( const JsonObject value_obj : jo.get_array( array_key ) ) {
 
-            const TKey value = TKey( value_obj.get_string( type_key ) );
+            // Migration from accidental corruption, remove after 0.J
+            const TKey value = !value_obj.has_string( type_key ) && value_obj.has_string( "value" ) ?
+                               TKey( value_obj.get_string( "value" ) ) :
+                               TKey( value_obj.get_string( type_key ) );
+            // Values of 0 used to be serialised exist (removed in 0.J exp) so for now load based on != 0 rather than on member existance
             const double add = value_obj.get_float( "add", 0.0 );
             const double mult = value_obj.get_float( "multiply", 0.0 );
 

--- a/src/magic_enchantment.cpp
+++ b/src/magic_enchantment.cpp
@@ -293,7 +293,7 @@ void enchant_cache::save_add_and_multiply( JsonOut &jsout, const std::string_vie
             continue;
         }
         jsout.start_object();
-        jsout.member( "value", type );
+        jsout.member( type_key, type );
         jsout.member( "multiply", multiply );
         jsout.end_object();
     }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Fix enchantment cache load issue (If your save didn't load right hopefully it will now)"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Made a whoopsie in #82371
Fixes #82607
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Fixes serialising under the wrong key and add a temporary legacy load for borked saves as well as very minor touchups to some things that confused me
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
I were going to remove type_key and just have them all serialise as "type" but I forgot the json enchantment stuff uses the same syntax and don't want to touch that here, might do it in a followup PR bc it's pretty ugly that they have different ones for no particular reason
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Compiles, error from linked issue's save doesn't pop up anymore and upon saving the syntax is corrected
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
