### PR TITLE
zzip improvements: constant time deletion, unit tests, better internal apis

### DIFF
--- a/src/cata_utility.cpp
+++ b/src/cata_utility.cpp
@@ -602,15 +602,15 @@ bool read_from_file_optional_json( const cata_path &path,
     return file_exist( path.get_unrelative_path() ) && read_from_file_json( path, reader );
 }
 
-bool read_from_zzip_optional( const std::shared_ptr<zzip> &z,
+bool read_from_zzip_optional( const zzip &z,
                               const std::filesystem::path &file,
                               const std::function<void( std::string_view )> &reader )
 {
-    if( !z || !z->has_file( file ) ) {
+    if( !z.has_file( file ) ) {
         return false;
     }
     try {
-        std::vector<std::byte> file_data = z->get_file( file );
+        std::vector<std::byte> file_data = z.get_file( file );
         std::string_view sv{ reinterpret_cast<const char *>( file_data.data() ), file_data.size() };
         reader( sv );
         return true;

--- a/src/cata_utility.h
+++ b/src/cata_utility.h
@@ -368,7 +368,7 @@ bool read_from_file_optional_json( const cata_path &path,
  * error handling logic.
  */
 /**@{*/
-bool read_from_zzip_optional( const std::shared_ptr<zzip> &z,
+bool read_from_zzip_optional( const zzip &z,
                               const std::filesystem::path &file,
                               const std::function<void( std::string_view )> &reader );
 bool read_from_zzip_optional( const std::shared_ptr<zzip_stack> &z,

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -484,8 +484,7 @@ void write_min_archive()
                 {
                     std::optional<zzip> min_mmr_temp_zzip = zzip::load( min_mmr_temp_zzip_path, mmr_dict );
                     if( !min_mmr_temp_zzip ||
-                        !mmr_stack->copy_files_to( trimmed_mmr_entries, *min_mmr_temp_zzip ) ||
-                        !min_mmr_temp_zzip->compact( 0 ) ) {
+                        !mmr_stack->copy_files_to( trimmed_mmr_entries, *min_mmr_temp_zzip ) ) {
                         popup( _( "Failed to create minimized archive" ) );
                         return;
                     }

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -482,9 +482,9 @@ void write_min_archive()
                         min_mmr_save_rel +
                         ".temp" ).get_unrelative_path();
                 {
-                    std::shared_ptr<zzip> min_mmr_temp_zzip = zzip::load( min_mmr_temp_zzip_path, mmr_dict );
+                    std::optional<zzip> min_mmr_temp_zzip = zzip::load( min_mmr_temp_zzip_path, mmr_dict );
                     if( !min_mmr_temp_zzip ||
-                        !mmr_stack->copy_files_to( trimmed_mmr_entries, min_mmr_temp_zzip ) ||
+                        !mmr_stack->copy_files_to( trimmed_mmr_entries, *min_mmr_temp_zzip ) ||
                         !min_mmr_temp_zzip->compact( 0 ) ) {
                         popup( _( "Failed to create minimized archive" ) );
                         return;

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -178,7 +178,10 @@ bool rename_file( const std::filesystem::path &old_path, const std::filesystem::
 {
     setFsNeedsSync();
     std::error_code ec;
-    std::filesystem::rename( old_path, new_path, ec );
+    int attempts = 0;
+    do {
+        std::filesystem::rename( old_path, new_path, ec );
+    } while( ec && ++attempts < 3 );
     return !ec;
 }
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3254,8 +3254,9 @@ bool game::load( const save_t &name )
                     u.set_save_id( name.decoded_name() );
 
                     if( world_generator->active_world->has_compression_enabled() ) {
-                        std::shared_ptr<zzip> z = zzip::load( ( save_file_path + ".zzip" ).get_unrelative_path() );
-                        abort = !read_from_zzip_optional( z, save_file_path.get_unrelative_path().filename(),
+                        std::optional<zzip> z = zzip::load( ( save_file_path + ".zzip" ).get_unrelative_path() );
+                        abort = !z.has_value() ||
+                        !read_from_zzip_optional( z.value(), save_file_path.get_unrelative_path().filename(),
                         [this]( std::string_view sv ) {
                             unserialize( std::string{ sv } );
                         } );
@@ -3519,8 +3520,8 @@ bool game::save_player_data()
     if( world_generator->active_world->has_compression_enabled() ) {
         std::stringstream save;
         serialize_json( save );
-        std::shared_ptr<zzip> z = zzip::load( ( playerfile + SAVE_EXTENSION +
-                                                ".zzip" ).get_unrelative_path() );
+        std::optional<zzip> z = zzip::load( ( playerfile + SAVE_EXTENSION +
+                                              ".zzip.tmp" ).get_unrelative_path() );
         saved_data = z->add_file( ( playerfile + SAVE_EXTENSION ).get_unrelative_path().filename(),
                                   save.str() );
         saved_data = saved_data && z->compact( 1.0 );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3524,7 +3524,8 @@ bool game::save_player_data()
                                               ".zzip.tmp" ).get_unrelative_path() );
         saved_data = z->add_file( ( playerfile + SAVE_EXTENSION ).get_unrelative_path().filename(),
                                   save.str() );
-        saved_data = saved_data && z->compact( 1.0 );
+        saved_data = saved_data && z->compact_to( ( playerfile + SAVE_EXTENSION +
+                     ".zzip" ).get_unrelative_path(), 0.0 );
     } else {
         saved_data = write_to_file( playerfile + SAVE_EXTENSION, [&]( std::ostream & fout ) {
             serialize_json( fout );

--- a/src/mapbuffer.cpp
+++ b/src/mapbuffer.cpp
@@ -5,6 +5,7 @@
 #include <exception>
 #include <filesystem>
 #include <functional>
+#include <optional>
 #include <set>
 #include <sstream>
 #include <stdexcept>
@@ -159,9 +160,9 @@ bool mapbuffer::submap_exists_approx( const tripoint_abs_sm &p )
                 if( !file_exist( zzip_name ) ) {
                     return false;
                 }
-                std::shared_ptr<zzip> z = zzip::load( zzip_name.get_unrelative_path(),
-                                                      ( PATH_INFO::world_base_save_path() / "maps.dict" ).get_unrelative_path() );
-                return z->has_file( std::filesystem::u8path( file_name ) );
+                std::optional<zzip> z = zzip::load( zzip_name.get_unrelative_path(),
+                                                    ( PATH_INFO::world_base_save_path() / "maps.dict" ).get_unrelative_path() );
+                return z && z->has_file( std::filesystem::u8path( file_name ) );
             } else {
                 return file_exist( dirname / file_name );
             }
@@ -246,7 +247,7 @@ void mapbuffer::save_quad(
     bool reverted_to_uniform = false;
     bool file_exists = false;
 
-    std::shared_ptr<zzip> z;
+    std::optional<zzip> z;
     // The number of uniform submaps is so enormous that the filesystem overhead
     // for this step of just checking if the quad exists approaches 70% of the
     // total cost of saving the mapbuffer, in one test save I had.
@@ -372,9 +373,9 @@ submap *mapbuffer::unserialize_submaps( const tripoint_abs_sm &p )
             if( !file_exist( zzip_name ) ) {
                 return false;
             }
-            std::shared_ptr<zzip> z = zzip::load( zzip_name.get_unrelative_path(),
-                                                  ( PATH_INFO::world_base_save_path() / "maps.dict" ).get_unrelative_path() );
-            if( !z->has_file( file_name_path ) ) {
+            std::optional<zzip> z = zzip::load( zzip_name.get_unrelative_path(),
+                                                ( PATH_INFO::world_base_save_path() / "maps.dict" ).get_unrelative_path() );
+            if( !z || !z->has_file( file_name_path ) ) {
                 return false;
             }
             std::vector<std::byte> contents = z->get_file( file_name_path );

--- a/src/mmap_file.h
+++ b/src/mmap_file.h
@@ -27,6 +27,13 @@ class mmap_file
         static std::unique_ptr<mmap_file> map_writeable_file( const std::filesystem::path &file_path );
 
         /**
+         * Returns a writeable memory mapping backed only by ram.
+         * The implementation is currently backed by malloc. The purpose is for writing tests.
+         * Always returns a non-null mmap_file, but base() may return nullptr if malloc ever fails.
+         */
+        static std::unique_ptr<mmap_file> map_writeable_memory( size_t initial_size );
+
+        /**
          * Sets the underlying file size to the set size, and remaps the file to that range.
          * Returns false on failure.
          * Do not assume base() or len() are unchanged across any call to this function regardless
@@ -59,6 +66,9 @@ class mmap_file
          */
         void flush( size_t offset, size_t len );
 
+        // Opaque type to platform specific mmap implementation.
+        struct impl;
+
     private:
         mmap_file();
 
@@ -66,8 +76,6 @@ class mmap_file
             const std::filesystem::path &file_path,
             bool writeable );
 
-        // Opaque type to platform specific mmap implementation.
-        struct impl;
         std::shared_ptr<impl> pimpl;
 };
 

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -6344,11 +6344,11 @@ void overmap::open( overmap_special_batch &enabled_specials )
                                     +
                                     ".zzip";
         if( file_exist( zzip_path ) ) {
-            std::shared_ptr<zzip> z = zzip::load( zzip_path.get_unrelative_path(),
-                                                  ( PATH_INFO::world_base_save_path() / "overmaps.dict" ).get_unrelative_path()
-                                                );
+            std::optional<zzip> z = zzip::load( zzip_path.get_unrelative_path(),
+                                                ( PATH_INFO::world_base_save_path() / "overmaps.dict" ).get_unrelative_path()
+                                              );
 
-            if( read_from_zzip_optional( z, terfilename_path, [this]( std::string_view sv ) {
+            if( z && read_from_zzip_optional( *z, terfilename_path, [this]( std::string_view sv ) {
             std::istringstream is{ std::string( sv ) };
             unserialize( is );
             } ) ) {
@@ -6397,9 +6397,9 @@ void overmap::save() const
         const cata_path overmaps_folder = PATH_INFO::current_dimension_save_path() / "overmaps";
         assure_dir_exist( overmaps_folder );
         const cata_path zzip_path = overmaps_folder / terfilename_path + ".zzip";
-        std::shared_ptr<zzip> z = zzip::load( zzip_path.get_unrelative_path(),
-                                              ( PATH_INFO::world_base_save_path() / "overmaps.dict" ).get_unrelative_path()
-                                            );
+        std::optional<zzip> z = zzip::load( zzip_path.get_unrelative_path(),
+                                            ( PATH_INFO::world_base_save_path() / "overmaps.dict" ).get_unrelative_path()
+                                          );
         if( !z ) {
             throw std::runtime_error(
                 string_format(

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -6416,7 +6416,11 @@ void overmap::save() const
             throw std::runtime_error( string_format( "Failed to save omap %d.%d to %s", loc.x(),
                                       loc.y(), zzip_path.get_unrelative_path().generic_u8string().c_str() ) );
         }
-        z->compact( 2.0 );
+        cata_path tmp_path = zzip_path + ".tmp";
+        if( z->compact_to( tmp_path.get_unrelative_path(), 2.0 ) ) {
+            z.reset();
+            rename_file( tmp_path, zzip_path );
+        }
     } else {
         write_to_file( PATH_INFO::current_dimension_save_path() /
                        overmapbuffer::terrain_filename(

--- a/src/worldfactory.cpp
+++ b/src/worldfactory.cpp
@@ -2158,10 +2158,10 @@ bool WORLD::set_compression_enabled( bool enabled ) const
                     inp_mngr.pump_events();
 
                     // Each overmap gets put into its own zzip indexed by its own file name.
-                    std::shared_ptr overmap_zzip = zzip::create_from_folder_with_files( (
-                                                       dimension_folder / "overmaps" / overmap_file_name + ".zzip" ).get_unrelative_path(),
-                                                   world_folder_unrelative_path, { overmap_file_path }, 0,
-                                                   overmaps_dict.get_unrelative_path() );
+                    std::optional<zzip> overmap_zzip = zzip::create_from_folder_with_files( (
+                                                           dimension_folder / "overmaps" / overmap_file_name + ".zzip" ).get_unrelative_path(),
+                                                       world_folder_unrelative_path, { overmap_file_path }, 0,
+                                                       overmaps_dict.get_unrelative_path() );
                     if( !overmap_zzip ) {
                         return false;
                     }
@@ -2243,8 +2243,8 @@ bool WORLD::set_compression_enabled( bool enabled ) const
                         savefile_contents.append( savefile_json );
                     };
 
-                    std::shared_ptr save_zzip = zzip::load( ( dimension_folder / save_file_name +
-                                                            ".zzip" ).get_unrelative_path() );
+                    std::optional<zzip> save_zzip = zzip::load( ( dimension_folder / save_file_name +
+                                                    ".zzip" ).get_unrelative_path() );
                     if( !save_zzip ) {
                         return false;
                     }

--- a/src/zzip.cpp
+++ b/src/zzip.cpp
@@ -1091,7 +1091,7 @@ bool zzip::delete_files( std::unordered_set<std::filesystem::path, std_fs_path_h
             } else {
                 content_end += tombstone_size;
             }
-            return errored;
+            return !errored;
         }
         return false;
     } ),
@@ -1102,7 +1102,7 @@ bool zzip::delete_files( std::unordered_set<std::filesystem::path, std_fs_path_h
         return false;
     }
 
-    return errored;
+    return !errored;
 }
 
 bool zzip::compact( double bloat_factor )

--- a/src/zzip.h
+++ b/src/zzip.h
@@ -7,6 +7,7 @@
 #include <cstddef>
 #include <filesystem>
 #include <memory>
+#include <optional>
 #include <string_view>
 #include <unordered_set>
 #include <vector>
@@ -183,7 +184,8 @@ class zzip
     private:
         JsonObject copy_footer() const;
         size_t ensure_capacity_for( size_t bytes );
-        size_t write_file_at( std::string_view filename, std::string_view content, size_t offset );
+        size_t write_file_at( std::string_view filename, std::string_view content, size_t offset,
+                              std::optional<uint64_t> force_checksum = std::nullopt );
 
         bool update_footer( JsonObject const &original_footer, size_t content_end,
                             const std::vector<compressed_entry> &entries, bool shrink_to_fit = false );

--- a/src/zzip.h
+++ b/src/zzip.h
@@ -55,6 +55,9 @@ class zzip
     public:
         ~zzip() noexcept;
 
+        zzip( zzip && ) noexcept /* = default */;
+        zzip &operator=( zzip && ) noexcept /* = default */;
+
         /**
          * Create a zzip at the given path, using the given dictionary to de/compress files in the zzip.
          * The same dictionary must be used every time the zzip is loaded.
@@ -62,8 +65,8 @@ class zzip
          * See https://github.com/facebook/zstd/blob/dev/programs/README.md#dictionary-builder-in-command-line-interface
          * for more details.
          */
-        static std::shared_ptr<zzip> load( std::filesystem::path const &path,
-                                           std::filesystem::path const &dictionary = {} );
+        static std::optional<zzip> load( std::filesystem::path const &path,
+                                         std::filesystem::path const &dictionary = {} );
 
         /**
          * Writes the given file contents under the given file path into the zzip.
@@ -77,7 +80,7 @@ class zzip
          * preserved.
          */
         bool copy_files( std::vector<std::filesystem::path> const &zzip_relative_paths,
-                         std::shared_ptr<zzip> const &from );
+                         zzip const &from );
 
         /**
          * Returns true if the zzip contains the given path. Paths are checked through exact string
@@ -162,11 +165,11 @@ class zzip
          * The files in the zzip are indexed based on their relative path inside the folder.
          * See zzip::load for documentation about dictionaries.
          */
-        static std::shared_ptr<zzip> create_from_folder( std::filesystem::path const &path,
+        static std::optional<zzip> create_from_folder( std::filesystem::path const &path,
                 std::filesystem::path const &folder,
                 std::filesystem::path const &dictionary = {} );
 
-        static std::shared_ptr<zzip> create_from_folder_with_files( std::filesystem::path const &path,
+        static std::optional<zzip> create_from_folder_with_files( std::filesystem::path const &path,
                 std::filesystem::path const &folder,
                 const std::vector<std::filesystem::path> &files,
                 uint64_t total_file_size,

--- a/src/zzip.h
+++ b/src/zzip.h
@@ -50,7 +50,7 @@ struct std_fs_path_hash;
  */
 class zzip
 {
-        zzip( std::filesystem::path path, std::shared_ptr<mmap_file> file, JsonObject footer );
+        zzip( std::shared_ptr<mmap_file> file, JsonObject footer );
 
     public:
         ~zzip() noexcept;
@@ -69,18 +69,30 @@ class zzip
                                          std::filesystem::path const &dictionary = {} );
 
         /**
+         * Loads a zzip from the given file, using the given dictionary to de/compress files in the zzip.
+         * The same dictionary must be used every time the zzip is loaded.
+         * A dictionary can either be arbitrary reference data or a dictionary created with the zstd cli.
+         * See https://github.com/facebook/zstd/blob/dev/programs/README.md#dictionary-builder-in-command-line-interface
+         * for more details.
+         */
+        static std::optional<zzip> load( std::shared_ptr<mmap_file> file,
+                                         std::filesystem::path const &dictionary = {} );
+
+        /**
          * Writes the given file contents under the given file path into the zzip.
          * Returns true on success, false on any error.
+         *
+         * This should really take a std::range<const std::byte> instead of a std::string_view, but
+         * we can't until c++20.
          */
         bool add_file( std::filesystem::path const &zzip_relative_path, std::string_view content );
 
         /**
-         * Directly copies a compressed entry from one zzip to another. Both zzips
-         * must have been opened using the same dictionary. The relative path is
-         * preserved.
+         * Directly copies compressed entries from one zzip to another, keeping the same path.
+         * If `from` was not opened with the same dictionary, the copied files may not be readable.
          */
         bool copy_files( std::vector<std::filesystem::path> const &zzip_relative_paths,
-                         zzip const &from );
+                         zzip const &from, bool shrink_to_fit = false );
 
         /**
          * Returns true if the zzip contains the given path. Paths are checked through exact string
@@ -109,11 +121,6 @@ class zzip
          * Returns the compressed file size of the entry including metadata.
          */
         size_t get_entry_size( std::filesystem::path const &zzip_relative_path ) const;
-
-        /**
-         * Returns the path to this zzip.
-         */
-        std::filesystem::path const &get_path() const;
 
         /**
          * Returns a vector of filesystem paths of the contained entries.
@@ -146,13 +153,19 @@ class zzip
                            &zzip_relative_paths );
 
         /**
-         * Possibly shrink the zzip by eliminating orphaned data or padding bytes.
-         * If bloat_factor passed, only shrinks the zzip if the underlying file is
-         * larger than optimal than the given ratio.
-         * If bloat_factor is 0, forces a compaction even with no expected savings.
-         * Returns true if compaction occurred.
+         * Writes a copy of the live/most recent contents of this zzip into the given file.
+         * If bloat_factor passed, only writes the copy if the current file is larger than
+         * optimal than the given ratio.
+         * If bloat_factor is 0, forces a copy even with no expected savings.
+         * Returns true on success, false on error.
          */
-        bool compact( double bloat_factor = 1.0 );
+        bool compact_to( std::filesystem::path const &dest, double bloat_factor = 1.0 );
+
+        /**
+         * Writes a copy of the live/most recent contents of this zzip into the given file.
+         * Returns true on success, false on error.
+         */
+        bool compact_to( std::shared_ptr<mmap_file> dest ) const;
 
         /**
          * Removes all contents and resets to a default initialized empty zzip.
@@ -182,8 +195,23 @@ class zzip
         static bool extract_to_folder( std::filesystem::path const &path,
                                        std::filesystem::path const &folder,
                                        std::filesystem::path const &dictionary = {} );
+        bool extract_to_folder( std::filesystem::path const &folder );
 
         struct compressed_entry;
+
+        /**
+         * Returns an unsorted vector describing the live entries and their positions in the file.
+         * The internal layout of the entries is undefined.
+         * Only really useful for tests.
+         * { entry_path, offset, length }
+         */
+        struct entry_layout {
+            std::filesystem::path path;
+            size_t offset;
+            size_t len;
+        };
+        std::vector<entry_layout> get_layout() const;
+
     private:
         JsonObject copy_footer() const;
         size_t ensure_capacity_for( size_t bytes );
@@ -193,9 +221,8 @@ class zzip
         bool update_footer( JsonObject const &original_footer, size_t content_end,
                             const std::vector<compressed_entry> &entries, bool shrink_to_fit = false );
 
-        bool rewrite_footer();
+        bool rewrite_footer( bool shrink_to_fit = false );
 
-        std::filesystem::path path_;
         std::shared_ptr<mmap_file> file_;
         JsonObject footer_;
 

--- a/src/zzip_stack.cpp
+++ b/src/zzip_stack.cpp
@@ -147,13 +147,13 @@ bool zzip_stack::extract_to_folder( std::filesystem::path const &path,
                                     std::filesystem::path const &dictionary )
 {
     std::shared_ptr<zzip_stack> stack = zzip_stack::load( path, dictionary );
-    if( !zzip::extract_to_folder( stack->cold().get_path(), folder, dictionary ) ) {
+    if( !stack->cold().extract_to_folder( folder ) ) {
         return false;
     }
-    if( !zzip::extract_to_folder( stack->warm().get_path(), folder, dictionary ) ) {
+    if( !stack->warm().extract_to_folder( folder ) ) {
         return false;
     }
-    if( !zzip::extract_to_folder( stack->hot().get_path(), folder, dictionary ) ) {
+    if( !stack->hot().extract_to_folder( folder ) ) {
         return false;
     }
     return true;
@@ -239,7 +239,11 @@ bool zzip_stack::compact( double bloat_factor )
     }
 
     // Finally normal compact on cold.
-    return cold_->compact( std::max( bloat_factor / 2.0, 1.0 ) );
+    std::filesystem::path tmp_path = path_ / "cold.zzip.tmp"; // NOLINT(cata-u8-path)
+    if( cold_->compact_to( tmp_path, std::max( bloat_factor / 2.0, 1.0 ) ) ) {
+        return rename_file( tmp_path, path_ / "cold.zzip" ); // NOLINT(cata-u8-path)
+    }
+    return true;
 }
 
 zzip &zzip_stack::cold() const

--- a/src/zzip_stack.cpp
+++ b/src/zzip_stack.cpp
@@ -36,7 +36,7 @@ std::shared_ptr<zzip_stack> zzip_stack::load( std::filesystem::path const &path,
 bool zzip_stack::add_file( std::filesystem::path const &zzip_relative_path,
                            std::string_view content )
 {
-    bool ret = hot()->add_file( zzip_relative_path, content );
+    bool ret = hot().add_file( zzip_relative_path, content );
     if( ret ) {
         path_temp_map_[zzip_relative_path] = file_temp::hot;
     }
@@ -44,7 +44,7 @@ bool zzip_stack::add_file( std::filesystem::path const &zzip_relative_path,
 }
 
 bool zzip_stack::copy_files_to( std::vector<std::filesystem::path> const &zzip_relative_paths,
-                                std::shared_ptr<zzip> const &to )
+                                zzip &to )
 {
     std::unordered_map<file_temp, std::vector<std::filesystem::path>> temp_to_paths;
     for( std::filesystem::path const &zzip_relative_path : zzip_relative_paths ) {
@@ -54,9 +54,9 @@ bool zzip_stack::copy_files_to( std::vector<std::filesystem::path> const &zzip_r
         }
         temp_to_paths[temp].emplace_back( zzip_relative_path );
     }
-    return to->copy_files( temp_to_paths[file_temp::cold], cold() ) &&
-           to->copy_files( temp_to_paths[file_temp::warm], warm() ) &&
-           to->copy_files( temp_to_paths[file_temp::hot], hot() );
+    return to.copy_files( temp_to_paths[file_temp::cold], cold() ) &&
+           to.copy_files( temp_to_paths[file_temp::warm], warm() ) &&
+           to.copy_files( temp_to_paths[file_temp::hot], hot() );
 }
 
 bool zzip_stack::has_file( std::filesystem::path const &zzip_relative_path ) const
@@ -70,7 +70,7 @@ size_t zzip_stack::get_file_size( std::filesystem::path const &zzip_relative_pat
     if( temp == file_temp::unknown ) {
         return 0;
     }
-    return zzip_of_temp( temp )->get_file_size( zzip_relative_path );
+    return zzip_of_temp( temp ).get_file_size( zzip_relative_path );
 }
 
 std::vector<std::filesystem::path> zzip_stack::get_entries() const
@@ -92,7 +92,7 @@ std::vector<std::byte> zzip_stack::get_file( std::filesystem::path const &zzip_r
     if( temp == file_temp::unknown ) {
         return std::vector<std::byte> {};
     }
-    return zzip_of_temp( temp )->get_file( zzip_relative_path );
+    return zzip_of_temp( temp ).get_file( zzip_relative_path );
 }
 
 size_t zzip_stack::get_file_to( std::filesystem::path const &zzip_relative_path, std::byte *dest,
@@ -102,7 +102,7 @@ size_t zzip_stack::get_file_to( std::filesystem::path const &zzip_relative_path,
     if( temp == file_temp::unknown ) {
         return 0;
     }
-    return zzip_of_temp( temp )->get_file_to( zzip_relative_path, dest, dest_len );
+    return zzip_of_temp( temp ).get_file_to( zzip_relative_path, dest, dest_len );
 }
 
 std::shared_ptr<zzip_stack> zzip_stack::create_from_folder( std::filesystem::path const &path,
@@ -115,7 +115,7 @@ std::shared_ptr<zzip_stack> zzip_stack::create_from_folder( std::filesystem::pat
     std::filesystem::path zzip_filename = path.filename();
     // Default everything to cold.
     zzip_filename += kColdSuffix; // NOLINT(cata-u8-path)
-    std::shared_ptr<zzip> z = zzip::create_from_folder( path / zzip_filename, folder, dictionary );
+    std::optional<zzip> z = zzip::create_from_folder( path / zzip_filename, folder, dictionary );
     if( !z ) {
         return nullptr;
     }
@@ -134,8 +134,8 @@ std::shared_ptr<zzip_stack> zzip_stack::create_from_folder_with_files(
     }
     std::filesystem::path zzip_filename = path.filename();
     zzip_filename += kColdSuffix; // NOLINT(cata-u8-path)
-    std::shared_ptr<zzip> z = zzip::create_from_folder_with_files( path / zzip_filename, folder, files,
-                              total_file_size, dictionary );
+    std::optional<zzip> z = zzip::create_from_folder_with_files( path / zzip_filename, folder, files,
+                            total_file_size, dictionary );
     if( !z ) {
         return nullptr;
     }
@@ -147,13 +147,13 @@ bool zzip_stack::extract_to_folder( std::filesystem::path const &path,
                                     std::filesystem::path const &dictionary )
 {
     std::shared_ptr<zzip_stack> stack = zzip_stack::load( path, dictionary );
-    if( !zzip::extract_to_folder( stack->cold()->get_path(), folder, dictionary ) ) {
+    if( !zzip::extract_to_folder( stack->cold().get_path(), folder, dictionary ) ) {
         return false;
     }
-    if( !zzip::extract_to_folder( stack->warm()->get_path(), folder, dictionary ) ) {
+    if( !zzip::extract_to_folder( stack->warm().get_path(), folder, dictionary ) ) {
         return false;
     }
-    if( !zzip::extract_to_folder( stack->hot()->get_path(), folder, dictionary ) ) {
+    if( !zzip::extract_to_folder( stack->hot().get_path(), folder, dictionary ) ) {
         return false;
     }
     return true;
@@ -198,7 +198,7 @@ bool zzip_stack::compact( double bloat_factor )
 
     size_t content_size = 0;
     for( const auto& [file, temp] : path_temp_map_ ) {
-        content_size += zzip_of_temp( temp )->get_entry_size( file );
+        content_size += zzip_of_temp( temp ).get_entry_size( file );
     }
 
     // Allocate approximately 1/2 of the bloat to the cold file.
@@ -218,7 +218,7 @@ bool zzip_stack::compact( double bloat_factor )
                 files_to_demote.emplace_back( entry );
             }
         }
-        if( !( cold_->copy_files( files_to_demote, warm_ ) && warm_->clear() ) ) {
+        if( !( cold_->copy_files( files_to_demote, *warm_ ) && warm_->clear() ) ) {
             return false;
         }
         for( std::filesystem::path const &entry : files_to_demote ) {
@@ -230,7 +230,7 @@ bool zzip_stack::compact( double bloat_factor )
     if( hot_->get_content_size() > warm_hot_max_size ) {
         // Definitionally, all hot files are the most recent versions.
         files_to_demote = hot_->get_entries();
-        if( !( warm_->copy_files( files_to_demote, hot_ ) && hot_->clear() ) ) {
+        if( !( warm_->copy_files( files_to_demote, *hot_ ) && hot_->clear() ) ) {
             return false;
         }
         for( std::filesystem::path const &entry : files_to_demote ) {
@@ -242,26 +242,26 @@ bool zzip_stack::compact( double bloat_factor )
     return cold_->compact( std::max( bloat_factor / 2.0, 1.0 ) );
 }
 
-std::shared_ptr<zzip> &zzip_stack::cold() const
+zzip &zzip_stack::cold() const
 {
     if( !cold_ ) {
         cold_ = load_temp( file_temp::cold );
     }
-    return cold_;
+    return *cold_;
 }
-std::shared_ptr<zzip> &zzip_stack::warm() const
+zzip &zzip_stack::warm() const
 {
     if( !warm_ ) {
         warm_ = load_temp( file_temp::warm );
     }
-    return warm_;
+    return *warm_;
 }
-std::shared_ptr<zzip> &zzip_stack::hot() const
+zzip &zzip_stack::hot() const
 {
     if( !hot_ ) {
         hot_ = load_temp( file_temp::hot );
     }
-    return hot_;
+    return *hot_;
 }
 
 zzip_stack::file_temp zzip_stack::temp_of_file( std::filesystem::path const &zzip_relative_path )
@@ -289,23 +289,23 @@ const
     return file_temp::unknown;
 }
 
-zzip *zzip_stack::zzip_of_temp( zzip_stack::file_temp temp ) const
+zzip &zzip_stack::zzip_of_temp( zzip_stack::file_temp temp ) const
 {
     switch( temp ) {
         case file_temp::cold: {
-            return cold().get();
+            return cold();
         }
         case file_temp::warm: {
-            return warm().get();
+            return warm();
         }
         default: {
             // default unknown to hot
-            return hot().get();
+            return hot();
         }
     }
 }
 
-std::shared_ptr<zzip> zzip_stack::load_temp( file_temp temp ) const
+std::optional<zzip> zzip_stack::load_temp( file_temp temp ) const
 {
     if( temp == file_temp::unknown ) {
         // default unknown to hot
@@ -327,7 +327,7 @@ std::shared_ptr<zzip> zzip_stack::load_temp( file_temp temp ) const
 
     }
     zzip_path += file_suffix; // NOLINT(cata-u8-path)
-    std::shared_ptr<zzip> z = zzip::load( path_ / zzip_path, dictionary_ );
+    std::optional<zzip> z = zzip::load( path_ / zzip_path, dictionary_ );
     if( !z ) {
         return z;
     }

--- a/src/zzip_stack.h
+++ b/src/zzip_stack.h
@@ -7,14 +7,14 @@
 #include <cstddef>
 #include <filesystem>
 #include <memory>
+#include <optional>
 #include <string_view>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
 #include "std_hash_fs_path.h"
-
-class zzip;
+#include "zzip.h"
 
 /**
  * A zzip_stack uses multiple zzips to handle frequent updates to only a small portion of the stored data.
@@ -52,7 +52,7 @@ class zzip_stack
          * Directly copies the most recent version of the given files into the destination zzip.
          */
         bool copy_files_to( std::vector<std::filesystem::path> const &zzip_relative_paths,
-                            std::shared_ptr<zzip> const &to );
+                            zzip &to );
 
         /**
          * Returns true if the zzip contains the given path. Paths are checked through exact string
@@ -129,9 +129,9 @@ class zzip_stack
                                        std::filesystem::path const &dictionary = {} );
 
     private:
-        std::shared_ptr<zzip> &hot() const;
-        std::shared_ptr<zzip> &warm() const;
-        std::shared_ptr<zzip> &cold() const;
+        zzip &hot() const;
+        zzip &warm() const;
+        zzip &cold() const;
 
         std::filesystem::path path_;
         std::filesystem::path dictionary_;
@@ -143,14 +143,14 @@ class zzip_stack
             hot,
         };
         // We use mutable members for lazy loading under const methods.
-        mutable std::shared_ptr<zzip> hot_;
-        mutable std::shared_ptr<zzip> warm_;
-        mutable std::shared_ptr<zzip> cold_;
+        mutable std::optional<zzip> hot_;
+        mutable std::optional<zzip> warm_;
+        mutable std::optional<zzip> cold_;
         mutable std::unordered_map<std::filesystem::path, file_temp, std_fs_path_hash> path_temp_map_;
         file_temp temp_of_file( std::filesystem::path const &zzip_relative_path ) const;
 
-        zzip *zzip_of_temp( file_temp temp ) const;
-        std::shared_ptr<zzip> load_temp( file_temp temp ) const;
+        zzip &zzip_of_temp( file_temp temp ) const;
+        std::optional<zzip> load_temp( file_temp temp ) const;
 };
 
 #endif // CATA_SRC_ZZIP_STACK_H

--- a/tests/zzip_test.cpp
+++ b/tests/zzip_test.cpp
@@ -1,0 +1,358 @@
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <string_view>
+#include <string>
+#include <type_traits>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include <zstd/zstd.h>
+#include <zstd/common/mem.h>
+
+#include "cata_catch.h"
+#include "mmap_file.h"
+#include "std_hash_fs_path.h"
+#include "zzip.h"
+
+namespace
+{
+std::string_view _view( const std::vector<std::byte> &bytes )
+{
+    return std::string_view( reinterpret_cast<const char *>( bytes.data() ), bytes.size() );
+}
+
+std::vector<std::byte> make_bytes( size_t count )
+{
+    std::vector<std::byte> bytes;
+    for( size_t i = 0; i < count; ++i ) {
+        // NOLINTNEXTLINE(cata-determinism,cert-msc30-c,cert-msc50-cpp)
+        bytes.push_back( static_cast<std::byte>( rand() %
+                         std::numeric_limits<std::underlying_type_t<std::byte>>::max() ) );
+    }
+    return bytes;
+}
+
+} // namespace
+
+TEST_CASE( "zzip_basic_functionality", "[.][zzip]" )
+{
+    std::shared_ptr<mmap_file> mem_file = mmap_file::map_writeable_memory( 0 );
+
+    SECTION( "Text files" ) {
+        std::unordered_map<std::filesystem::path, std::string, std_fs_path_hash> files = {
+            {std::filesystem::u8path( "first.txt" ), "first"},
+            {std::filesystem::u8path( "second.txt" ), "second"},
+            {std::filesystem::u8path( "third.txt" ), "third"},
+        };
+
+        {
+            std::optional<zzip> z = zzip::load( mem_file );
+            REQUIRE( z.has_value() );
+            for( auto& [name, contents] : files ) {
+                REQUIRE( z->add_file( name, contents ) );
+            }
+        }
+        SECTION( "zzip has all expected contents" ) {
+            std::optional<zzip> z = zzip::load( mem_file );
+            REQUIRE( z.has_value() );
+            for( auto& [name, contents] : files ) {
+                std::vector<std::byte> data = z->get_file( name );
+                REQUIRE( _view( data ) == contents );
+            }
+        }
+        SECTION( "zzip has no unexpected contents" ) {
+            std::optional<zzip> z = zzip::load( mem_file );
+            REQUIRE( z.has_value() );
+            for( std::filesystem::path const &entry : z->get_entries() ) {
+                REQUIRE( files.find( entry ) != files.end() );
+            }
+        }
+    }
+    SECTION( "Binary files" ) {
+        std::unordered_map<std::filesystem::path, std::vector<std::byte>, std_fs_path_hash> files{
+            {std::filesystem::u8path( "bytes.bin" ), make_bytes( 1024 )},
+            {std::filesystem::u8path( "bytes2.bin" ), make_bytes( 1024 )},
+            {std::filesystem::u8path( "zeroes.bin" ), std::vector<std::byte>{ 1024, static_cast<std::byte>( 0 ) }},
+        };
+
+        {
+            std::optional<zzip> z = zzip::load( mem_file );
+            REQUIRE( z.has_value() );
+            for( auto& [name, contents] : files ) {
+                z->add_file( name, _view( contents ) );
+            }
+        }
+        SECTION( "zzip has all expected contents" ) {
+            std::optional<zzip> z = zzip::load( mem_file );
+            REQUIRE( z.has_value() );
+            for( auto& [name, contents] : files ) {
+                std::vector<std::byte> data = z->get_file( name );
+                REQUIRE( _view( data ) == _view( contents ) );
+            }
+        }
+        SECTION( "zzip has no unexpected contents" ) {
+            std::optional<zzip> z = zzip::load( mem_file );
+            REQUIRE( z.has_value() );
+            for( std::filesystem::path const &entry : z->get_entries() ) {
+                REQUIRE( files.find( entry ) != files.end() );
+            }
+        }
+    }
+}
+
+TEST_CASE( "zzip_compaction", "[.][zzip]" )
+{
+    std::unordered_map<std::filesystem::path, std::vector<std::byte>, std_fs_path_hash> files{
+        {std::filesystem::u8path( "bytes.bin" ), make_bytes( 1024 )},
+        {std::filesystem::u8path( "bytes2.bin" ), make_bytes( 1024 )},
+        {std::filesystem::u8path( "zeroes.bin" ), std::vector<std::byte>{ 1024, static_cast<std::byte>( 0 ) }},
+    };
+    std::shared_ptr<mmap_file> mem_file = mmap_file::map_writeable_memory( 0 );
+
+    std::optional<zzip> z = zzip::load( mem_file );
+    REQUIRE( z.has_value() );
+    for( auto& [name, contents] : files ) {
+        REQUIRE( z->add_file( name, _view( contents ) ) );
+    }
+
+    SECTION( "Compaction" ) {
+        SECTION( "Compaction saves space" ) {
+            std::shared_ptr<mmap_file> mem_file2 = mmap_file::map_writeable_memory( 0 );
+            z->compact_to( mem_file2 );
+            CHECK( mem_file2->len() < mem_file->len() );
+        }
+        SECTION( "Compaction is deterministic" ) {
+            std::shared_ptr<mmap_file> mem_file2 = mmap_file::map_writeable_memory( 0 );
+            z->compact_to( mem_file2 );
+            std::shared_ptr<mmap_file> mem_file3 = mmap_file::map_writeable_memory( 0 );
+            z->compact_to( mem_file3 );
+            CHECK( mem_file2->len() == mem_file3->len() );
+            CHECK( memcmp( mem_file2->base(), mem_file3->base(), mem_file2->len() ) == 0 );
+        }
+    }
+}
+
+TEST_CASE( "zzip_deletion", "[.][zzip]" )
+{
+    std::unordered_map<std::filesystem::path, std::vector<std::byte>, std_fs_path_hash> files{
+        {std::filesystem::u8path( "bytes.bin" ), make_bytes( 1024 )},
+        {std::filesystem::u8path( "bytes2.bin" ), make_bytes( 1024 )},
+        {std::filesystem::u8path( "zeroes.bin" ), std::vector<std::byte>{ 1024, static_cast<std::byte>( 0 ) }},
+    };
+    std::shared_ptr<mmap_file> mem_file = mmap_file::map_writeable_memory( 0 );
+    REQUIRE( mem_file );
+
+    std::optional<zzip> z = zzip::load( mem_file );
+    REQUIRE( z.has_value() );
+    for( auto& [name, contents] : files ) {
+        REQUIRE( z->add_file( name, _view( contents ) ) );
+    }
+
+    SECTION( "Deletion" ) {
+        std::filesystem::path bytes2_path = std::filesystem::u8path( "bytes2.bin" );
+        SECTION( "Deletion works" ) {
+            REQUIRE( z->delete_files( { bytes2_path } ) );
+            files.erase( bytes2_path );
+
+            for( auto& [name, contents] : files ) {
+                std::vector<std::byte> data = z->get_file( name );
+                CHECK( _view( data ) == _view( contents ) );
+            }
+            for( std::filesystem::path const &entry : z->get_entries() ) {
+                CHECK( files.find( entry ) != files.end() );
+            }
+        }
+        SECTION( "Readding a file after deletion works" ) {
+            REQUIRE( z->delete_files( { bytes2_path } ) );
+            files[bytes2_path] = make_bytes( 512 );
+            z->add_file( bytes2_path, _view( files[bytes2_path] ) );
+
+            for( auto& [name, contents] : files ) {
+                std::vector<std::byte> data = z->get_file( name );
+                CHECK( _view( data ) == _view( contents ) );
+            }
+            for( std::filesystem::path const &entry : z->get_entries() ) {
+                CHECK( files.find( entry ) != files.end() );
+            }
+        }
+        SECTION( "Compaction skips deleted files" ) {
+            std::shared_ptr<mmap_file> mem_file2 = mmap_file::map_writeable_memory( 0 );
+            REQUIRE( z->compact_to( mem_file2 ) );
+
+            z = zzip::load( mem_file2 );
+            REQUIRE( z->delete_files( { bytes2_path } ) );
+
+            std::shared_ptr<mmap_file> mem_file3 = mmap_file::map_writeable_memory( 0 );
+            REQUIRE( z->compact_to( mem_file3 ) );
+
+            CHECK( mem_file3->len() < mem_file2->len() );
+        }
+    }
+}
+
+TEST_CASE( "zzip_corruption_recovery", "[.][zzip]" )
+{
+    std::unordered_map<std::filesystem::path, std::vector<std::byte>, std_fs_path_hash> files{
+        {std::filesystem::u8path( "bytes.bin" ), make_bytes( 1024 )},
+        {std::filesystem::u8path( "bytes2.bin" ), make_bytes( 1024 )},
+        {std::filesystem::u8path( "zeroes.bin" ), std::vector<std::byte>{ 1024, static_cast<std::byte>( 0 ) }},
+    };
+    std::shared_ptr<mmap_file> mem_file = mmap_file::map_writeable_memory( 0 );
+
+    std::optional<zzip> z = zzip::load( mem_file );
+    for( auto& [name, contents] : files ) {
+        z->add_file( name, _view( contents ) );
+    }
+
+    SECTION( "Footer truncated" ) {
+        z.reset();
+        mem_file->resize_file( mem_file->len() - 1 );
+
+        SECTION( "Recovery works" ) {
+            z = zzip::load( mem_file );
+            REQUIRE( z.has_value() );
+
+            for( auto& [name, contents] : files ) {
+                std::vector<std::byte> data = z->get_file( name );
+                CHECK( _view( data ) == _view( contents ) );
+            }
+            for( std::filesystem::path const &entry : z->get_entries() ) {
+                CHECK( files.find( entry ) != files.end() );
+            }
+        }
+    }
+
+    SECTION( "Hash corrupted" ) {
+        z.reset();
+
+        std::array<uint64_t, 2> buf;
+
+        MEM_writeLE64( &buf[0], 0 );
+        MEM_writeLE64( &buf[1], 0 );
+
+        size_t footer_frame_size = ZSTD_writeSkippableFrame(
+                                       mem_file->base(),
+                                       mem_file->len(),
+                                       buf.data(),
+                                       sizeof( buf ),
+                                       /* kFooterChecksumMagic */ 15 );
+        REQUIRE( !ZSTD_isError( footer_frame_size ) );
+
+        SECTION( "Recovery works" ) {
+            z = zzip::load( mem_file );
+            REQUIRE( z.has_value() );
+
+            for( auto& [name, contents] : files ) {
+                CAPTURE( name );
+                std::vector<std::byte> data = z->get_file( name );
+                CHECK( _view( data ) == _view( contents ) );
+            }
+            for( std::filesystem::path const &entry : z->get_entries() ) {
+                CHECK( files.find( entry ) != files.end() );
+            }
+        }
+    }
+
+    SECTION( "Content truncated" ) {
+        SECTION( "Partial recovery works" ) {
+            std::vector<zzip::entry_layout> layout = z->get_layout();
+
+            std::sort( layout.begin(), layout.end(), []( const auto & l, const auto & r ) {
+                return l.offset < r.offset;
+            } );
+
+            for( int i = layout.size() - 1; i > 0; --i ) {
+                auto& [name, offset, len] = layout[i];
+                CAPTURE( name );
+
+                std::unordered_map<std::filesystem::path, bool, std_fs_path_hash> remaining_files;
+                for( int j = 0; j < i; ++j ) {
+                    remaining_files.emplace( layout[j].path, false );
+                }
+
+                for( size_t truncated_len : std::array{ len - 1, len / 2, static_cast<size_t>( 1 ) } ) {
+                    z.reset();
+
+                    // Truncate each file one byte off the end, in the middle, and one byte from the start
+
+                    mem_file->resize_file( offset + truncated_len );
+
+                    z = zzip::load( mem_file );
+                    REQUIRE( z.has_value() );
+
+                    for( std::filesystem::path const &entry : z->get_entries() ) {
+                        CAPTURE( entry );
+                        auto it = remaining_files.find( entry );
+                        CHECK( it != remaining_files.end() );
+                        it->second = true;
+                    }
+                    for( auto& [file, found] : remaining_files ) {
+                        CAPTURE( file );
+                        CHECK( found );
+                        found = false;
+                    }
+                }
+            }
+        }
+
+        SECTION( "Older versions of files are recoverable" ) {
+            std::unordered_map<std::filesystem::path, std::vector<std::byte>, std_fs_path_hash> files2{
+                {std::filesystem::u8path( "bytes.bin" ), make_bytes( 1024 )},
+                {std::filesystem::u8path( "bytes2.bin" ), make_bytes( 1024 )},
+                {std::filesystem::u8path( "zeroes.bin" ), std::vector<std::byte>{ 1024, static_cast<std::byte>( 1 ) }},
+            };
+
+            for( auto& [name, contents] : files2 ) {
+                z->add_file( name, _view( contents ) );
+            }
+
+            std::vector<zzip::entry_layout> layout = z->get_layout();
+
+            std::sort( layout.begin(), layout.end(), []( const zzip::entry_layout & l,
+            const zzip::entry_layout & r ) {
+                return l.offset < r.offset;
+            } );
+
+            for( int i = layout.size() - 1; i > 0; --i ) {
+                auto& [name, offset, len] = layout[i];
+                CAPTURE( name );
+
+                std::unordered_map<std::filesystem::path, bool, std_fs_path_hash> remaining_new_files;
+                for( int j = 0; j < i; ++j ) {
+                    remaining_new_files.emplace( layout[j].path, false );
+                }
+
+                size_t truncated_len = len / 2;
+
+                z.reset();
+                // Truncate each overwritten file, verify when we reload we get the older copy.
+                mem_file->resize_file( offset + truncated_len );
+
+                z = zzip::load( mem_file );
+                REQUIRE( z.has_value() );
+
+                for( std::filesystem::path const &entry : z->get_entries() ) {
+                    CAPTURE( entry );
+                    auto it = remaining_new_files.find( entry );
+                    if( it == remaining_new_files.end() ) {
+                        auto it2 = files.find( entry );
+                        CHECK( it2 != files.end() );
+                        CHECK( _view( it2->second ) == _view( z->get_file( entry ) ) );
+                    } else {
+                        CHECK( _view( files2[entry] ) == _view( z->get_file( entry ) ) );
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tools/save/zzip_main.cpp
+++ b/tools/save/zzip_main.cpp
@@ -135,6 +135,14 @@ struct ExnPtr {
     template<typename E>
     ExnPtr( E &&e ) : ep{std::make_unique<ExnHolder<std::decay_t<E>>>( std::forward<E>( e ) )} {}
 
+    ExnPtr &operator=( ExnPtr &&e ) = default;
+
+    template<typename E>
+    ExnPtr &operator=( E &&e ) {
+        ep = std::make_unique<ExnHolder<std::decay_t<E>>>( std::forward<E>( e ) );
+        return *this;
+    }
+
     operator bool() const {
         return static_cast<bool>( ep );
     }
@@ -154,105 +162,151 @@ struct ExnPtr {
     std::unique_ptr<Exn> ep;
 };
 
-static std::pair<const char *, ExnPtr> for_each_zzip_entry(
-    std::filesystem::path zzip_path, const std::vector<char> &zzip_contents,
-    std::function<ExnPtr( const std::string &, uint64_t, const char *, size_t )>
-    fn )
-{
-    size_t remaining_len = zzip_contents.size();
-    const char *base = zzip_contents.data();
-    const char *end_of_last_entry = base;
+struct ZzipEntry {
+    std::string path;
+    uint64_t checksum;
+    const char *base;
+    size_t size;
+};
 
-#define RETURN_ERROR(e) return {end_of_last_entry, ExnPtr{e}}
+struct ZzipStream {
+    private:
+        std::filesystem::path zzip_path;
+        const std::vector<char> &zzip_contents;
+        const char *base;
+        ExnPtr err;
+    public:
 
-    // Skip the zzip header.
-    if( !ZSTD_isSkippableFrame( base, remaining_len ) ) {
-        RETURN_ERROR( ZzipError( zzip_path, 0, "Zzip does not start with skippable frame." ) );
-    }
+        ZzipStream( std::filesystem::path zzip_path, const std::vector<char> &zzip_contents ) : zzip_path{ zzip_path },
+            zzip_contents{ zzip_contents }, base{ zzip_contents.data() } {
+            size_t remaining_len = zzip_contents.size();
 
-    // The first frame of a zzip should be a skippable frame of two 64 bit ints
-    ZSTD_FrameHeader header;
-    size_t error_code = ZSTD_getFrameHeader( &header, base, remaining_len );
-    if( ZSTD_isError( error_code ) ||
-        header.dictID != kFooterChecksumMagic ||
-        header.frameContentSize != 2 * sizeof( uint64_t ) ) {
-        RETURN_ERROR( ZzipError( zzip_path, 0, "Error reading zzip header." ) );
-    }
-
-    base += ZSTD_SKIPPABLEHEADERSIZE + 2 * sizeof( uint64_t );
-    remaining_len -= ZSTD_SKIPPABLEHEADERSIZE + 2 * sizeof( uint64_t );
-
-    std::string filename;
-    uint64_t checksum = 0;
-
-    while( remaining_len > 0 && ZSTD_isFrame( base, remaining_len ) ) {
-        size_t offset = zzip_contents.size() - remaining_len;
-        size_t frame_size = ZSTD_findFrameCompressedSize( base, remaining_len );
-        if( ZSTD_isError( frame_size ) ) {
-            RETURN_ERROR( ZstdError( zzip_path, offset, frame_size, "Error reading frame size." ) );
-        }
-        if( frame_size > remaining_len ) {
-            RETURN_ERROR( ZzipError( zzip_path, offset, "Frame size exceeds remaining file" ) );
-        }
-        if( ZSTD_isSkippableFrame( base, remaining_len ) ) {
-            error_code = ZSTD_getFrameHeader( &header, base, remaining_len );
-            if( error_code ) {
-                RETURN_ERROR( ZstdError( zzip_path, offset, error_code, "Error reading frame header." ) );
+            // Skip the zzip header.
+            if( !ZSTD_isSkippableFrame( base, remaining_len ) ) {
+                err = ZzipError( zzip_path, 0, "Zzip does not start with skippable frame." );
+                return;
             }
-            if( header.dictID == kEntryFileNameMagic ) {
-                filename.resize( header.frameContentSize );
-                error_code = ZSTD_readSkippableFrame( filename.data(), filename.size(), nullptr, base,
-                                                      remaining_len );
-                if( ZSTD_isError( error_code ) || error_code != header.frameContentSize ) {
-                    RETURN_ERROR( ZstdError( zzip_path, offset, error_code, "Error reading filename header." ) );
+
+            // The first frame of a zzip should be a skippable frame of two 64 bit ints
+            ZSTD_FrameHeader header;
+            size_t error_code = ZSTD_getFrameHeader( &header, base, remaining_len );
+            if( ZSTD_isError( error_code ) ||
+                header.dictID != kFooterChecksumMagic ||
+                header.frameContentSize != 2 * sizeof( uint64_t ) ) {
+                err = ZzipError( zzip_path, 0, "Error reading zzip header." );
+                return;
+            }
+
+            base += ZSTD_SKIPPABLEHEADERSIZE + 2 * sizeof( uint64_t );
+        }
+
+        bool good() {
+            return !err;
+        }
+
+        ExnPtr &e() {
+            return err;
+        }
+
+        std::optional<ZzipEntry> next_entry() {
+            std::optional<ZzipEntry> entry;
+            if( err ) {
+                return entry;
+            }
+
+            size_t remaining_len = zzip_contents.size() - ( base - zzip_contents.data() );
+
+#define RETURN_ERROR(e) err = e; return entry
+
+            // Skip the zzip header.
+            if( !ZSTD_isSkippableFrame( base, remaining_len ) ) {
+                RETURN_ERROR( ZzipError( zzip_path, 0, "Zzip does not start with skippable frame." ) );
+            }
+
+            // The first frame of a zzip should be a skippable frame of two 64 bit ints
+            ZSTD_FrameHeader header;
+            size_t error_code = ZSTD_getFrameHeader( &header, base, remaining_len );
+            if( ZSTD_isError( error_code ) ||
+                header.dictID != kFooterChecksumMagic ||
+                header.frameContentSize != 2 * sizeof( uint64_t ) ) {
+                RETURN_ERROR( ZzipError( zzip_path, 0, "Error reading zzip header." ) );
+            }
+
+            base += ZSTD_SKIPPABLEHEADERSIZE + 2 * sizeof( uint64_t );
+            remaining_len -= ZSTD_SKIPPABLEHEADERSIZE + 2 * sizeof( uint64_t );
+
+            std::string filename;
+            uint64_t checksum = 0;
+
+            while( remaining_len > 0 && ZSTD_isFrame( base, remaining_len ) ) {
+                size_t offset = zzip_contents.size() - remaining_len;
+                size_t frame_size = ZSTD_findFrameCompressedSize( base, remaining_len );
+                if( ZSTD_isError( frame_size ) ) {
+                    RETURN_ERROR( ZstdError( zzip_path, offset, frame_size, "Error reading frame size." ) );
                 }
-            }
-            if( header.dictID == kEntryChecksumMagic ) {
-                uint64_t raw_checksum;
-                error_code = ZSTD_readSkippableFrame( &raw_checksum, sizeof( checksum ), nullptr, base,
-                                                      remaining_len );
-                if( ZSTD_isError( error_code ) || error_code != sizeof( uint64_t ) ) {
-                    RETURN_ERROR( ZstdError( zzip_path, offset, error_code, "Error reading checksum." ) );
+                if( frame_size > remaining_len ) {
+                    RETURN_ERROR( ZzipError( zzip_path, offset, "Frame size exceeds remaining file" ) );
                 }
-                checksum = MEM_readLE64( &raw_checksum );
+                if( ZSTD_isSkippableFrame( base, remaining_len ) ) {
+                    error_code = ZSTD_getFrameHeader( &header, base, remaining_len );
+                    if( error_code ) {
+                        RETURN_ERROR( ZstdError( zzip_path, offset, error_code, "Error reading frame header." ) );
+                    }
+                    if( header.dictID == kEntryFileNameMagic ) {
+                        filename.resize( header.frameContentSize );
+                        error_code = ZSTD_readSkippableFrame( filename.data(), filename.size(), nullptr, base,
+                                                              remaining_len );
+                        if( ZSTD_isError( error_code ) || error_code != header.frameContentSize ) {
+                            RETURN_ERROR( ZstdError( zzip_path, offset, error_code, "Error reading filename header." ) );
+                        }
+                    }
+                    if( header.dictID == kEntryChecksumMagic ) {
+                        uint64_t raw_checksum;
+                        error_code = ZSTD_readSkippableFrame( &raw_checksum, sizeof( checksum ), nullptr, base,
+                                                              remaining_len );
+                        if( ZSTD_isError( error_code ) || error_code != sizeof( uint64_t ) ) {
+                            RETURN_ERROR( ZstdError( zzip_path, offset, error_code, "Error reading checksum." ) );
+                        }
+                        checksum = MEM_readLE64( &raw_checksum );
+                    }
+                    base += frame_size;
+                    remaining_len -= frame_size;
+                    continue;
+                }
+
+                // At this point we should have read the filename and compressed frame checksums.
+                // If either is missing, the end of the zzip is corrupt.
+                if( filename.empty() || checksum == 0 ) {
+                    RETURN_ERROR( ZzipError( zzip_path, offset, "Entry metadata missing." ) );
+                }
+
+                if( frame_size > remaining_len ) {
+                    RETURN_ERROR( ZzipError( zzip_path, offset, filename + ": compressed contents truncated." ) );
+                }
+
+                uint64_t computed_checksum = XXH64( base, frame_size, kCheckumSeed );
+                if( checksum != computed_checksum ) {
+                    RETURN_ERROR( ZzipError( zzip_path, offset, filename + ": compressed frame corrupted." ) );
+                }
+
+                entry.emplace();
+                entry->base = base;
+                entry->checksum = checksum;
+                entry->path = std::move( filename );
+                entry->size = frame_size;
+
+                base += frame_size;
+
+                return entry;
             }
-            base += frame_size;
-            remaining_len -= frame_size;
-            continue;
-        }
-
-        // At this point we should have read the filename and compressed frame checksums.
-        // If either is missing, the end of the zzip is corrupt.
-        if( filename.empty() || checksum == 0 ) {
-            RETURN_ERROR( ZzipError( zzip_path, offset, "Entry metadata missing." ) );
-        }
-
-        if( frame_size > remaining_len ) {
-            RETURN_ERROR( ZzipError( zzip_path, offset, filename + ": compressed contents truncated." ) );
-        }
-
-        uint64_t computed_checksum = XXH64( base, frame_size, kCheckumSeed );
-        if( checksum != computed_checksum ) {
-            RETURN_ERROR( ZzipError( zzip_path, offset, filename + ": compressed frame corrupted." ) );
-        }
-        ExnPtr err = fn( filename, checksum, base, frame_size );
-        if( err ) {
-            return { end_of_last_entry, std::move( err ) };
-        }
-
-        filename.clear();
-        checksum = 0;
-        base += frame_size;
-        remaining_len -= frame_size;
-        end_of_last_entry = base;
-    }
-    if( !filename.empty() || checksum != 0 ) {
-        RETURN_ERROR( ZzipError( zzip_path, zzip_contents.size() - remaining_len,
-                                 "Expected a compressed frame after entry metadata." ) );
-    }
-    return { end_of_last_entry, nullptr };
+            if( !filename.empty() || checksum != 0 ) {
+                RETURN_ERROR( ZzipError( zzip_path, zzip_contents.size() - remaining_len,
+                                         "Expected a compressed frame after entry metadata." ) );
+            }
+            return entry;
 #undef RETURN_ERROR
-}
+        }
+};
 
 static int decompress_to( std::filesystem::path const &zzip_path,
                           std::filesystem::path output_folder,
@@ -302,47 +356,39 @@ static int decompress_to( std::filesystem::path const &zzip_path,
     }
 
     // Iterate through the zstd frames extracting each file as we get to it.
-    auto [after_last_entry_ptr, err] = for_each_zzip_entry(
-                                           zzip_path,
-                                           zzip_contents,
-                                           [&](
-                                                   const std::string & filename,
-                                                   uint64_t /*checksum*/,
-                                                   const char *entry_base,
-                                                   size_t frame_size
-    ) -> ExnPtr {
-#define RETURN_ERROR(e) return ExnPtr{e}
-        std::cout << zzip_path_string << ": " << filename << " -> " << ( output_folder / filename ).generic_u8string() <<
+    ZzipStream zs( zzip_path, zzip_contents );
+    while( std::optional<ZzipEntry> entry = zs.next_entry() ) {
+        const std::string &filename = entry->path;
+        const char *entry_base = entry->base;
+        size_t frame_size = entry->size;
+
+        std::cout << zzip_path_string << ": " << filename << " -> " << ( output_folder /
+                  filename ).generic_u8string() <<
                   std::endl;
 
         unsigned long long file_size = ZSTD_decompressBound( entry_base, frame_size );
         std::vector<char> buf;
         buf.resize( file_size );
         size_t actual = ZSTD_decompressDCtx( ctx, buf.data(), file_size, entry_base, frame_size );
-        if( ZSTD_isError( actual ) )
-        {
+        if( ZSTD_isError( actual ) ) {
             size_t offset = zzip_contents.data() - entry_base;
-            RETURN_ERROR( ZstdError( zzip_path, offset, actual, "Decompression error." ) );
+            throw ZstdError( zzip_path, offset, actual, "Decompression error." ) ;
         }
 
         std::filesystem::path output_file = output_folder / filename;
         std::ofstream out{ output_file, std::ios::binary };
-        if( !out )
-        {
-            RETURN_ERROR( FsError( output_file, {}, "Unable to open output file." ) );
+        if( !out ) {
+            throw FsError( output_file, {}, "Unable to open output file." );
         }
-        try
-        {
+        try {
             out.write( buf.data(), actual );
-        } catch( std::exception &e )
-        {
-            RETURN_ERROR( FsError( output_file, {}, std::string{ "Error writing output: " } + e.what() ) );
+        } catch( std::exception &e ) {
+            throw FsError( output_file, {}, std::string{ "Error writing output: " } + e.what() );
         }
         return {};
-#undef RETURN_ERROR
-    } );
-    if( err ) {
-        err.throw_exception();
+    }
+    if( !zs.good() ) {
+        zs.e().throw_exception();
     }
 
     return 0;
@@ -413,19 +459,12 @@ static int compress_to( std::filesystem::path const &zzip_path,
         }
     }
 
-
-    auto [after_last_entry_ptr, err] = for_each_zzip_entry(
-                                           zzip_path,
-                                           zzip_contents,
-                                           [&](
-                                                   const std::string & entry_filename,
-                                                   uint64_t /*checksum*/,
-                                                   const char * /*entry_base*/,
-                                                   size_t /*zzip_remaining*/
-    ) -> ExnPtr {
-        std::cout << zzip_path.generic_u8string() << ":" << entry_filename << std::endl;
-        return {};
-    } );
+    const char *after_last_entry_ptr = zzip_contents.data();
+    ZzipStream zs( zzip_path, zzip_contents );
+    while( std::optional<ZzipEntry> entry = zs.next_entry() ) {
+        std::cout << zzip_path.generic_u8string() << ":" << entry->path << std::endl;
+        after_last_entry_ptr = entry->base + entry->size;
+    };
 
     size_t write_offset = after_last_entry_ptr - zzip_contents.data();
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Some heftier but needed improvements to the zzip implementation.
- deletion requires rewriting the entire zzip to remove one file.
- no unit tests.
- the zzip api was... acceptable. But it could be better.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
- Deleting a file now writes a 'tombstone' which is an empty file entry with a magic constant checksum value `0xDE1337ED` (deleeted) which is interpreted as 'this file was deleted'. When reading a zzip from the beginning, if this magic entry is encountered, the program removes any prior instance of the file from internal datastructures. Subsequent entries however are interpreted normally.
- To validate the implementation, since it is new and moderately invasive, I added unit tests for zzip. Specifically, an in-memory 'malloc' based implementation of `mmap_file` (essentially a mock) which supports all the same operations normal `mmap_file` supports, but not backed by a real file.
- To make zzip unit testable, I had to refactor the api to remove the concept of path from zzip, because malloc based `mmap_file` does not have a 'path'. This simplified the internal apis greatly, and also resulted in a better separation of concerns for zzip. zzip does not care about filesystem anymore. Responsibility for filesystem operations like moving files is moved to the callers. Instead zzip largely just operates directly on existing `mmap_file`s. This worked out nicely.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
The new unit tests I added which will run on this PR!
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
