### PR TITLE
[0.I] Revert unwanted parts of #82376

### DIFF
--- a/src/basecamp.h
+++ b/src/basecamp.h
@@ -204,8 +204,7 @@ class basecamp
         void set_name( const std::string &new_name );
         void query_new_name( bool force = false );
         // remove the camp without safety checks; use abandon_camp() for in-game
-        // normally always removes from overmap, but when mass-removing via overmap::clear_camps() we don't so we can iterate it properly
-        void remove_camp( bool remove_from_overmap = true ) const;
+        void remove_camp( const tripoint_abs_omt &omt_pos ) const;
         // remove the camp from an in-game context
         void abandon_camp();
         void scan_pseudo_items();

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -725,10 +725,15 @@ void talk_function::start_camp( npc &p )
 
     for( const auto &om_near : om_building_region( omt_pos, 3 ) ) {
         const oter_id &om_type = oter_id( om_near.first );
-        if( is_ot_match( "faction_base", om_type, ot_match_type::contains ) ||
-            overmap_buffer.has_camp( om_near.second ) ) {
-            popup( _( "You are too close to another camp!" ) );
-            return;
+        if( is_ot_match( "faction_base", om_type, ot_match_type::contains ) ) {
+            tripoint_abs_omt const &building_omt_pos = om_near.second;
+            std::vector<basecamp> const &camps = overmap_buffer.get_om_global( building_omt_pos ).om->camps;
+            if( std::any_of( camps.cbegin(), camps.cend(), [&building_omt_pos]( const basecamp & camp ) {
+            return camp.camp_omt_pos() == building_omt_pos;
+            } ) ) {
+                popup( _( "You are too close to another camp!" ) );
+                return;
+            }
         }
     }
     const recipe &making = camp_type.obj();
@@ -2151,28 +2156,19 @@ void basecamp::start_upgrade( const mission_id &miss_id )
     }
 }
 
-void basecamp::remove_camp( bool remove_from_overmap ) const
+void basecamp::remove_camp( const tripoint_abs_omt &omt_pos ) const
 {
     std::set<tripoint_abs_omt> &known_camps = get_player_character().camps;
     known_camps.erase( omt_pos );
 
-    if( remove_from_overmap ) {
-        overmap_buffer.remove_camp( omt_pos.xy() );
-    }
+    overmap_buffer.remove_camp( *this );
 
     map &here = get_map();
-    tripoint_bub_ms pos_bub;
-    // bb_pos may be {0,0,0} if you haven't examined the bulletin board on camp ever
-    if( bb_pos != tripoint_abs_ms::zero ) {
-        pos_bub = here.get_bub( bb_pos );
-    } else {
-        const tripoint_abs_sm sm_pos = coords::project_to<coords::sm>( omt_pos );
-        const tripoint_abs_ms ms_pos = coords::project_to<coords::ms>( sm_pos );
-        pos_bub = here.get_bub( ms_pos );
-    }
-    if( here.inbounds( pos_bub ) ) {
-        here.remove_submap_camp( pos_bub );
-    }
+    const tripoint_abs_sm sm_pos = coords::project_to<coords::sm>( omt_pos );
+    const tripoint_abs_ms ms_pos = coords::project_to<coords::ms>( sm_pos );
+    // We cannot use bb_pos here, because bb_pos may be {0,0,0} if you haven't examined the bulletin board on camp ever.
+    // here.remove_submap_camp( here.getlocal( bb_pos ) );
+    here.remove_submap_camp( here.get_bub( ms_pos ) );
 }
 
 void basecamp::abandon_camp()
@@ -2191,7 +2187,7 @@ void basecamp::abandon_camp()
     }
     // We must send this message early, before the name is erased.
     add_msg( m_info, _( "You abandon %s." ), name );
-    remove_camp();
+    remove_camp( omt_pos );
 }
 
 void basecamp::scan_pseudo_items()

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -6677,6 +6677,20 @@ computer *map::computer_at( const tripoint_bub_ms &p )
     return sm->get_computer( l );
 }
 
+bool map::point_within_camp( const tripoint_abs_ms &point_check ) const
+{
+    const tripoint_abs_omt omt_check( coords::project_to<coords::omt>( point_check ) );
+    const point_abs_omt p = omt_check.xy();
+    for( int x2 = -2; x2 < 2; x2++ ) {
+        for( int y2 = -2; y2 < 2; y2++ ) {
+            if( std::optional<basecamp *> bcp = overmap_buffer.find_camp( p + point( x2, y2 ) ) ) {
+                return ( *bcp )->point_within_camp( omt_check );
+            }
+        }
+    }
+    return false;
+}
+
 void map::remove_submap_camp( const tripoint_bub_ms &p )
 {
     submap *const current_submap = get_submap_at( p );

--- a/src/map.h
+++ b/src/map.h
@@ -1609,6 +1609,7 @@ class map
                        bool need_validate = true );
         void remove_submap_camp( const tripoint_bub_ms & );
         basecamp hoist_submap_camp( const tripoint_bub_ms &p );
+        bool point_within_camp( const tripoint_abs_ms &point_check ) const;
         // Graffiti
         bool has_graffiti_at( const tripoint_bub_ms &p ) const;
         const std::string &graffiti_at( const tripoint_bub_ms &p ) const;

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -2497,6 +2497,21 @@ bool npc::is_leader() const
     return attitude == NPCATT_LEAD;
 }
 
+bool npc::within_boundaries_of_camp() const
+{
+    const point_abs_omt p( pos_abs_omt().xy() );
+    for( int x2 = -3; x2 < 3; x2++ ) {
+        for( int y2 = -3; y2 < 3; y2++ ) {
+            const point_abs_omt nearby = p + point( x2, y2 );
+            std::optional<basecamp *> bcp = overmap_buffer.find_camp( nearby );
+            if( bcp ) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
 bool npc::is_enemy() const
 {
     return attitude == NPCATT_KILL || attitude == NPCATT_FLEE || attitude == NPCATT_FLEE_TEMP;

--- a/src/npc.h
+++ b/src/npc.h
@@ -916,6 +916,7 @@ class npc : public Character
         bool is_guarding() const;
         // Has a guard patrol mission
         bool is_patrolling() const;
+        bool within_boundaries_of_camp() const;
         /** is performing a player_activity */
         bool has_player_activity() const;
         bool is_travelling() const;

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -3385,14 +3385,11 @@ void npc::worker_downtime()
         if( !is_mounted() ) {
             for( const tripoint_bub_ms &elem : here.points_in_radius( pos_bub(), 30 ) ) {
                 if( here.has_flag_furn( ter_furn_flag::TFLAG_CAN_SIT, elem ) && !creatures.creature_at( elem ) &&
-                    could_move_onto( elem ) && !!assigned_camp ) {
-                    std::optional<basecamp *> camp = overmap_buffer.find_camp( assigned_camp->xy() );
-                    if( !!camp && !!( *camp ) &&
-                        ( *camp )->point_within_camp( project_to<coords::omt>( here.get_abs( elem ) ) ) ) {
-                        // this one will do
-                        chair_pos = here.get_abs( elem );
-                        return;
-                    }
+                    could_move_onto( elem ) &&
+                    here.point_within_camp( here.get_abs( elem ) ) ) {
+                    // this one will do
+                    chair_pos = here.get_abs( elem );
+                    return;
                 }
             }
         }

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -8013,6 +8013,15 @@ shared_ptr_fast<npc> overmap::find_npc_by_unique_id( const std::string &id ) con
     return nullptr;
 }
 
+void overmap::add_camp( const point_abs_omt &p, const basecamp &camp )
+{
+    if( std::find_if( camps.begin(), camps.end(), [&p]( const basecamp & existing ) {
+    return existing.camp_omt_pos().xy() == p;
+    } ) == camps.end() ) {
+        camps.push_back( camp );
+    }
+}
+
 std::optional<basecamp *> overmap::find_camp( const point_abs_omt &p )
 {
     for( basecamp &v : camps ) {

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -8013,40 +8013,14 @@ shared_ptr_fast<npc> overmap::find_npc_by_unique_id( const std::string &id ) con
     return nullptr;
 }
 
-void overmap::add_camp( const point_abs_omt &p, const basecamp &camp )
-{
-    //TODO: After 0.I stable this should debugmsg on failed emplace
-    //auto it = camps.emplace( p, camp );
-    //if( !it.second ) {
-    //  debugmsg( "Tried to add a basecamp %s at %s when basecamp %s is already present", camp.camp_name(), p.to_string(), it.first->second.camp_name() );
-    //}
-    camps.emplace( p, camp );
-}
-
 std::optional<basecamp *> overmap::find_camp( const point_abs_omt &p )
 {
-    const auto it = camps.find( p );
-    if( it != camps.end() ) {
-        return &( it->second );
+    for( basecamp &v : camps ) {
+        if( v.camp_omt_pos().xy() == p ) {
+            return &v;
+        }
     }
     return std::nullopt;
-}
-
-void overmap::remove_camp( const point_abs_omt &p )
-{
-    const auto it = camps.find( p );
-    if( it != camps.end() ) {
-        camps.erase( it );
-    }
-}
-
-void overmap::clear_camps()
-{
-    auto iter = camps.begin();
-    while( iter != camps.end() ) {
-        iter->second.remove_camp( false );
-        iter = camps.erase( iter );
-    }
 }
 
 bool overmap::is_omt_generated( const tripoint_om_omt &loc ) const

--- a/src/overmap.h
+++ b/src/overmap.h
@@ -401,6 +401,7 @@ class overmap
         std::vector<city> cities;
         std::vector<overmap_river_node> rivers;
         std::map<string_id<overmap_connection>, std::vector<tripoint_om_omt>> connections_out;
+        void add_camp( const point_abs_omt &p, const basecamp &camp );
         std::optional<basecamp *> find_camp( const point_abs_omt &p );
         /// Adds the npc to the contained list of npcs ( @ref npcs ).
         void insert_npc( const shared_ptr_fast<npc> &who );

--- a/src/overmap.h
+++ b/src/overmap.h
@@ -389,7 +389,6 @@ class overmap
         // Fill in any gaps in city_tiles that don't connect to the map edge
         void flood_fill_city_tiles();
         std::multimap<tripoint_om_sm, mongroup> zg; // NOLINT(cata-serialize)
-        std::map<point_abs_omt, basecamp> camps;
     public:
         /** Unit test enablers to check if a given mongroup is present. */
         bool mongroup_check( const mongroup &candidate ) const;
@@ -398,16 +397,11 @@ class overmap
         // TODO: make private
         std::vector<radio_tower> radios;
         std::map<int, om_vehicle> vehicles;
+        std::vector<basecamp> camps;
         std::vector<city> cities;
         std::vector<overmap_river_node> rivers;
         std::map<string_id<overmap_connection>, std::vector<tripoint_om_omt>> connections_out;
-        void add_camp( const point_abs_omt &p, const basecamp &camp );
         std::optional<basecamp *> find_camp( const point_abs_omt &p );
-        void clear_camps();
-        const std::map<point_abs_omt, basecamp> &get_camps() const {
-            return camps;
-        }
-        void remove_camp( const point_abs_omt &p );
         /// Adds the npc to the contained list of npcs ( @ref npcs ).
         void insert_npc( const shared_ptr_fast<npc> &who );
         /// Removes the npc and returns it ( or returns nullptr if not found ).

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -490,8 +490,18 @@ bool overmapbuffer::has_camp( const tripoint_abs_omt &p )
         return false;
     }
 
-    const auto camp = find_camp( p.xy() );
-    return !!camp;
+    const overmap_with_local_coords om_loc = get_existing_om_global( p );
+    if( !om_loc ) {
+        return false;
+    }
+
+    for( const basecamp &v : om_loc.om->camps ) {
+        if( v.camp_omt_pos().xy() == p.xy() ) {
+            return true;
+        }
+    }
+
+    return false;
 }
 
 bool overmapbuffer::has_vehicle( const tripoint_abs_omt &p )
@@ -720,11 +730,16 @@ void overmapbuffer::move_vehicle( vehicle *veh, const point_abs_ms &old_msp )
     }
 }
 
-void overmapbuffer::remove_camp( const point_abs_omt &p )
+void overmapbuffer::remove_camp( const basecamp &camp )
 {
-    const overmap_with_local_coords om_loc = get_existing_om_global( p );
-    if( !!om_loc.om ) {
-        om_loc.om->remove_camp( p );
+    const point_abs_omt omt = camp.camp_omt_pos().xy();
+    const overmap_with_local_coords om_loc = get_om_global( omt );
+    std::vector<basecamp> &camps = om_loc.om->camps;
+    for( auto it = camps.begin(); it != camps.end(); ++it ) {
+        if( it->camp_omt_pos().xy() == omt ) {
+            camps.erase( it );
+            return;
+        }
     }
 }
 
@@ -762,7 +777,7 @@ void overmapbuffer::add_camp( const basecamp &camp )
 {
     const point_abs_omt omt = camp.camp_omt_pos().xy();
     const overmap_with_local_coords om_loc = get_om_global( omt );
-    om_loc.om->add_camp( omt, camp );
+    om_loc.om->camps.push_back( camp );
 }
 
 om_vision_level overmapbuffer::seen( const tripoint_abs_omt &p )
@@ -1409,22 +1424,17 @@ shared_ptr_fast<npc> overmapbuffer::find_npc_by_unique_id( const std::string &un
 
 std::optional<basecamp *> overmapbuffer::find_camp( const point_abs_omt &p )
 {
-    const overmap_with_local_coords om_loc = get_existing_om_global( p );
-    if( !!om_loc.om ) {
-        std::optional<basecamp *> camp = om_loc.om->find_camp( p );
-        if( !!camp ) {
-            return camp;
+    for( auto &it : overmaps ) {
+        const point_abs_omt p2( p );
+        for( int x2 = p2.x() - 3; x2 < p2.x() + 3; x2++ ) {
+            for( int y2 = p2.y() - 3; y2 < p2.y() + 3; y2++ ) {
+                if( std::optional<basecamp *> camp = it.second->find_camp( point_abs_omt( x2, y2 ) ) ) {
+                    return camp;
+                }
+            }
         }
     }
     return std::nullopt;
-}
-
-void overmapbuffer::clear_camps( const point_abs_omt &p )
-{
-    const overmap_with_local_coords om_loc = get_existing_om_global( p );
-    if( !!om_loc.om ) {
-        om_loc.om->clear_camps();
-    }
 }
 
 void overmapbuffer::insert_npc( const shared_ptr_fast<npc> &who )
@@ -1574,15 +1584,15 @@ std::vector<camp_reference> overmapbuffer::get_camps_near( const tripoint_abs_sm
 {
     std::vector<camp_reference> result;
     for( overmap *om : get_overmaps_near( location, radius ) ) {
-        for( const std::pair<const point_abs_omt, basecamp> &camp : om->get_camps() ) {
-            const tripoint_abs_omt camp_pt = camp.second.camp_omt_pos();
+        result.reserve( result.size() + om->camps.size() );
+        std::transform( om->camps.begin(), om->camps.end(), std::back_inserter( result ),
+        [&]( basecamp & element ) {
+            const tripoint_abs_omt camp_pt = element.camp_omt_pos();
             const tripoint_abs_sm camp_sm = project_to<coords::sm>( camp_pt );
             const int distance = rl_dist( camp_sm, location );
-            if( distance <= radius ) {
-                //This is very ugly but camp.second is const and camps should be private and the overmap can't pass back a camp_reference as it would be a circular include
-                result.push_back( camp_reference{ om->find_camp( camp_pt.xy() ).value(), camp_sm, distance } );
-            }
-        }
+
+            return camp_reference{ &element, camp_sm, distance };
+        } );
     }
     std::sort( result.begin(), result.end(), []( const camp_reference & lhs,
     const camp_reference & rhs ) {

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -777,7 +777,7 @@ void overmapbuffer::add_camp( const basecamp &camp )
 {
     const point_abs_omt omt = camp.camp_omt_pos().xy();
     const overmap_with_local_coords om_loc = get_om_global( omt );
-    om_loc.om->camps.push_back( camp );
+    om_loc.om->add_camp( omt, camp );
 }
 
 om_vision_level overmapbuffer::seen( const tripoint_abs_omt &p )

--- a/src/overmapbuffer.h
+++ b/src/overmapbuffer.h
@@ -269,7 +269,7 @@ class overmapbuffer
         /**
          * Remove basecamp
          */
-        void remove_camp( const point_abs_omt &p );
+        void remove_camp( const basecamp &camp );
         /**
          * Remove the vehicle from being tracked in the overmap.
          */
@@ -280,8 +280,6 @@ class overmapbuffer
         void add_camp( const basecamp &camp );
 
         std::optional<basecamp *> find_camp( const point_abs_omt &p );
-        // Remove all basecamps in the inbound overmap
-        void clear_camps( const point_abs_omt &p );
         /**
          * Get all npcs in a area with given radius around given central point.
          * All z-levels are considered.

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -673,7 +673,7 @@ void overmap::unserialize( const JsonObject &jsobj )
             for( JsonObject camp_json : camps_json ) {
                 basecamp new_camp;
                 new_camp.deserialize( camp_json );
-                add_camp( new_camp.camp_omt_pos().xy(), new_camp );
+                camps.push_back( new_camp );
             }
         } else if( name == "overmap_special_placements" ) {
             JsonArray special_placements_json = om_member;
@@ -1384,8 +1384,8 @@ void overmap::serialize( std::ostream &fout ) const
 
     json.member( "camps" );
     json.start_array();
-    for( const auto &i : camps ) {
-        json.write( i.second );
+    for( const basecamp &i : camps ) {
+        json.write( i );
     }
     json.end_array();
     fout << std::endl;

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -673,7 +673,7 @@ void overmap::unserialize( const JsonObject &jsobj )
             for( JsonObject camp_json : camps_json ) {
                 basecamp new_camp;
                 new_camp.deserialize( camp_json );
-                camps.push_back( new_camp );
+                add_camp( new_camp.camp_omt_pos().xy(), new_camp );
             }
         } else if( name == "overmap_special_placements" ) {
             JsonArray special_placements_json = om_member;

--- a/tests/faction_camp_test.cpp
+++ b/tests/faction_camp_test.cpp
@@ -39,7 +39,6 @@ TEST_CASE( "camp_calorie_counting", "[camp]" )
     clear_map();
     map &m = get_map();
     const tripoint_abs_ms zone_loc = m.get_abs( tripoint_bub_ms{ 5, 5, 0 } );
-    REQUIRE( m.inbounds( zone_loc ) );
     mapgen_place_zone( zone_loc, zone_loc, zone_type_CAMP_FOOD, your_fac, {},
                        "food" );
     mapgen_place_zone( zone_loc, zone_loc, zone_type_CAMP_STORAGE, your_fac, {},
@@ -48,7 +47,6 @@ TEST_CASE( "camp_calorie_counting", "[camp]" )
     const tripoint_abs_omt this_omt = project_to<coords::omt>( zone_loc );
     m.add_camp( this_omt, "faction_camp" );
     std::optional<basecamp *> bcp = overmap_buffer.find_camp( this_omt.xy() );
-    REQUIRE( !!bcp );
     basecamp *test_camp = *bcp;
     test_camp->set_owner( your_fac );
     WHEN( "a base item is added to larder" ) {
@@ -157,6 +155,5 @@ TEST_CASE( "camp_calorie_counting", "[camp]" )
 
         CHECK( camp_faction->food_supply().kcal() == 0 );
     }
-    overmap_buffer.clear_camps( this_omt.xy() );
 }
 // TODO: Tests for: Check calorie display at various activity levels, camp crafting works as expected (consumes inputs, returns outputs+byproducts, costs calories)

--- a/tests/map_helpers.cpp
+++ b/tests/map_helpers.cpp
@@ -1,9 +1,11 @@
 #include "map_helpers.h"
 
 #include <memory>
+#include <optional>
 #include <vector>
 
 #include "avatar.h"
+#include "basecamp.h"
 #include "calendar.h"
 #include "cata_catch.h"
 #include "character.h"
@@ -128,7 +130,14 @@ void clear_zones()
 
 void clear_basecamps()
 {
-    overmap_buffer.clear_camps( get_avatar().pos_abs_omt().xy() );
+    std::optional<basecamp *> camp;
+    do {
+        const tripoint_abs_omt &avatar_pos = get_avatar().pos_abs_omt();
+        camp = overmap_buffer.find_camp( avatar_pos.xy() );
+        if( camp && *camp != nullptr ) {
+            ( **camp ).remove_camp( avatar_pos );
+        }
+    } while( camp );
 }
 
 void clear_map( int zmin, int zmax )


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
This wasn't intended to be backported as is I started it before the split
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Balthazar bunker has correct labels still. Made a save with a full revert save/loading until there were several duplicate tags, loaded save on this branch, saved and save no longer contained duplicates
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Sorry for the pings I forgor to target 0.I
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
