### PR TITLE
eoc: use typed variables in run_eocs

### DIFF
--- a/.github/comment-commands.yml
+++ b/.github/comment-commands.yml
@@ -23,7 +23,6 @@ users:
     - Jan-Blasiak
     - MNG-cataclysm
     - mqrause
-    - andrei8l
     - haveric
     - MylieDaniels
     - nopenoperson 

--- a/.github/reviewers.yml
+++ b/.github/reviewers.yml
@@ -67,5 +67,3 @@ files:
     - Qrox
   'data/raw/keybindings{.json,/**}':
     - Qrox
-  'src/math_parser*':
-    - andrei8l

--- a/data/json/effects_on_condition/example_eocs.json
+++ b/data/json/effects_on_condition/example_eocs.json
@@ -11,7 +11,7 @@
         "names": [ "name_1", "name_2", "<context_val:name>", "should_fail" ],
         "keys": [ "a", "b", "c", "d" ],
         "descriptions": [ "option 1", "option 2", "<context_val:description>", "should not be available" ],
-        "variables": [ { "val": "8" } ],
+        "variables": [ { "val": 8 } ],
         "title": "<context_val:title>",
         "allow_cancel": true
       }
@@ -47,7 +47,7 @@
         "names": [ "name_1", "name_2", "name_3", "should_fail" ],
         "keys": [ "a", "b", "c", "d" ],
         "descriptions": [ "option 1", "option 2", "option 3", "should not be available" ],
-        "variables": [ { "val": "8" } ],
+        "variables": [ { "val": 8 } ],
         "hide_failing": true
       }
     ]

--- a/data/json/effects_on_condition/mutation_eocs/mutation_activation_eocs.json
+++ b/data/json/effects_on_condition/mutation_eocs/mutation_activation_eocs.json
@@ -37,7 +37,7 @@
       {
         "run_eocs": "EOC_GENERIC_SPELL_MUTATION",
         "variables": {
-          "prep_time": "3",
+          "prep_time": 3,
           "spell_to_cast": "spell_spit_flare",
           "message_success": { "i18n": true, "str": "You launch a glob of bioluminescent material!" },
           "message_fail": { "i18n": true, "str": "Your body is too starved to activate your bioluminescent flare." }
@@ -52,7 +52,7 @@
       {
         "run_eocs": "EOC_GENERIC_SPELL_MUTATION",
         "variables": {
-          "prep_time": "1",
+          "prep_time": 1,
           "spell_to_cast": "spell_slime_spray",
           "message_success": { "i18n": true, "str": "You spit out some goo onto your enemies!" },
           "message_fail": { "i18n": true, "str": "Your body is too starved to activate your slime spray." }
@@ -67,8 +67,8 @@
       {
         "run_eocs": "EOC_GENERIC_SPELL_MUTATION",
         "variables": {
-          "energy_amount": "2000",
-          "prep_time": "1",
+          "energy_amount": 2000,
+          "prep_time": 1,
           "spell_to_cast": "spell_feline_leap",
           "message_success": {
             "i18n": true,
@@ -86,8 +86,8 @@
       {
         "run_eocs": "EOC_GENERIC_SPELL_MUTATION",
         "variables": {
-          "energy_amount": "2000",
-          "prep_time": "2",
+          "energy_amount": 2000,
+          "prep_time": 2,
           "spell_to_cast": "spell_short_leap",
           "message_success": {
             "i18n": true,
@@ -105,8 +105,8 @@
       {
         "run_eocs": "EOC_GENERIC_SPELL_MUTATION",
         "variables": {
-          "energy_amount": "6000",
-          "prep_time": "3",
+          "energy_amount": 6000,
+          "prep_time": 3,
           "spell_to_cast": "spell_crushing_leap",
           "message_success": { "i18n": true, "str": "You squat down, build up tension in your legs and release.  Death from above." },
           "message_fail": { "i18n": true, "str": "Your legs are too tired to perform a jump." }
@@ -121,8 +121,8 @@
       {
         "run_eocs": "EOC_GENERIC_SPELL_MUTATION",
         "variables": {
-          "energy_amount": "2500",
-          "prep_time": "1",
+          "energy_amount": 2500,
+          "prep_time": 1,
           "spell_to_cast": "spell_avian_leap",
           "message_success": {
             "i18n": true,

--- a/data/json/encounters/randec_independent_travelers.json
+++ b/data/json/encounters/randec_independent_travelers.json
@@ -12,8 +12,8 @@
           "omt": "roadstop_a",
           "map_update": "nest_RandEnc_campervan_traveler_add",
           "map_removal": "nest_RandEnc_campervan_traveler_remove",
-          "chance": "10",
-          "days_till_spawn": "7"
+          "chance": 10,
+          "days_till_spawn": 7
         }
       }
     ]

--- a/data/json/encounters/randenc_caravans.json
+++ b/data/json/encounters/randenc_caravans.json
@@ -12,8 +12,8 @@
           "omt": "roadstop_a",
           "map_update": "nest_RandEnc_roadstop_a_add",
           "map_removal": "nest_RandEnc_roadstop_a_remove",
-          "chance": "10",
-          "days_till_spawn": "7"
+          "chance": 10,
+          "days_till_spawn": 7
         }
       }
     ]
@@ -62,8 +62,8 @@
           "omt": "roadstop_a",
           "map_update": "nest_RandEnc_roadstop_a_refugee_add",
           "map_removal": "nest_RandEnc_roadstop_a_refugee_remove",
-          "chance": "10",
-          "days_till_spawn": "7"
+          "chance": 10,
+          "days_till_spawn": 7
         }
       }
     ]

--- a/data/json/items/chemicals_and_resources.json
+++ b/data/json/items/chemicals_and_resources.json
@@ -1254,7 +1254,7 @@
     "volume": "2 ml",
     "flags": [ "NO_INGEST", "WATER_DISSOLVE" ],
     "//6": "The ratio of how much water can be purified per tablet (maximum).  Should match the water_purifying recipe",
-    "variables": { "water_per_tablet": "4" }
+    "variables": { "water_per_tablet": 4 }
   },
   {
     "type": "ITEM",

--- a/data/json/items/comestibles/med.json
+++ b/data/json/items/comestibles/med.json
@@ -574,7 +574,7 @@
             "id": "EOC_myopia_contacts_weekly",
             "effect": {
               "run_eocs": "EOC_CONTACTS",
-              "variables": { "flag1": "MYOPIC", "flag2": "MYOPIC_IN_LIGHT", "effect": "contacts", "time": "604800" }
+              "variables": { "flag1": "MYOPIC", "flag2": "MYOPIC_IN_LIGHT", "effect": "contacts", "time": 604800 }
             }
           }
         ]
@@ -602,7 +602,7 @@
             "id": "EOC_myopia_transition_contacts_weekly",
             "effect": {
               "run_eocs": "EOC_CONTACTS",
-              "variables": { "flag1": "MYOPIC", "flag2": "MYOPIC_IN_LIGHT", "effect": "transition_contacts", "time": "604800" }
+              "variables": { "flag1": "MYOPIC", "flag2": "MYOPIC_IN_LIGHT", "effect": "transition_contacts", "time": 604800 }
             }
           }
         ]
@@ -628,7 +628,7 @@
             "id": "EOC_myopia_contacts_daily",
             "effect": {
               "run_eocs": "EOC_CONTACTS",
-              "variables": { "flag1": "MYOPIC", "flag2": "MYOPIC_IN_LIGHT", "effect": "contacts", "time": "57600" }
+              "variables": { "flag1": "MYOPIC", "flag2": "MYOPIC_IN_LIGHT", "effect": "contacts", "time": 57600 }
             }
           }
         ]
@@ -654,7 +654,7 @@
             "id": "EOC_myopia_transition_contacts_daily",
             "effect": {
               "run_eocs": "EOC_CONTACTS",
-              "variables": { "flag1": "MYOPIC", "flag2": "MYOPIC_IN_LIGHT", "effect": "transition_contacts", "time": "57600" }
+              "variables": { "flag1": "MYOPIC", "flag2": "MYOPIC_IN_LIGHT", "effect": "transition_contacts", "time": 57600 }
             }
           }
         ]
@@ -678,7 +678,7 @@
         "effect_on_conditions": [
           {
             "id": "EOC_hyperopia_contacts_weekly",
-            "effect": { "run_eocs": "EOC_CONTACTS", "variables": { "flag1": "HYPEROPIC", "effect": "contacts", "time": "604800" } }
+            "effect": { "run_eocs": "EOC_CONTACTS", "variables": { "flag1": "HYPEROPIC", "effect": "contacts", "time": 604800 } }
           }
         ]
       }
@@ -701,7 +701,7 @@
         "effect_on_conditions": [
           {
             "id": "EOC_hyperopia_transition_contacts_weekly",
-            "effect": { "run_eocs": "EOC_CONTACTS", "variables": { "flag1": "HYPEROPIC", "effect": "transition_contacts", "time": "604800" } }
+            "effect": { "run_eocs": "EOC_CONTACTS", "variables": { "flag1": "HYPEROPIC", "effect": "transition_contacts", "time": 604800 } }
           }
         ]
       }
@@ -724,7 +724,7 @@
         "effect_on_conditions": [
           {
             "id": "EOC_hyperopia_contacts_daily",
-            "effect": { "run_eocs": "EOC_CONTACTS", "variables": { "flag1": "HYPEROPIC", "effect": "contacts", "time": "57600" } }
+            "effect": { "run_eocs": "EOC_CONTACTS", "variables": { "flag1": "HYPEROPIC", "effect": "contacts", "time": 57600 } }
           }
         ]
       }
@@ -747,7 +747,7 @@
         "effect_on_conditions": [
           {
             "id": "EOC_hyperopia_transition_contacts_daily",
-            "effect": { "run_eocs": "EOC_CONTACTS", "variables": { "flag1": "HYPEROPIC", "effect": "transition_contacts", "time": "57600" } }
+            "effect": { "run_eocs": "EOC_CONTACTS", "variables": { "flag1": "HYPEROPIC", "effect": "transition_contacts", "time": 57600 } }
           }
         ]
       }
@@ -772,7 +772,7 @@
             "id": "EOC_bifocal_contacts_weekly",
             "effect": {
               "run_eocs": "EOC_CONTACTS",
-              "variables": { "flag1": "MYOPIC", "flag2": "MYOPIC_IN_LIGHT", "flag3": "HYPEROPIC", "effect": "contacts", "time": "604800" }
+              "variables": { "flag1": "MYOPIC", "flag2": "MYOPIC_IN_LIGHT", "flag3": "HYPEROPIC", "effect": "contacts", "time": 604800 }
             }
           }
         ]
@@ -798,13 +798,7 @@
             "id": "EOC_bifocal_transition_contacts_weekly",
             "effect": {
               "run_eocs": "EOC_CONTACTS",
-              "variables": {
-                "flag1": "MYOPIC",
-                "flag2": "MYOPIC_IN_LIGHT",
-                "flag3": "HYPEROPIC",
-                "effect": "transition_contacts",
-                "time": "604800"
-              }
+              "variables": { "flag1": "MYOPIC", "flag2": "MYOPIC_IN_LIGHT", "flag3": "HYPEROPIC", "effect": "transition_contacts", "time": 604800 }
             }
           }
         ]
@@ -830,7 +824,7 @@
             "id": "EOC_bifocal_contacts_daily",
             "effect": {
               "run_eocs": "EOC_CONTACTS",
-              "variables": { "flag1": "MYOPIC", "flag2": "MYOPIC_IN_LIGHT", "flag3": "HYPEROPIC", "effect": "contacts", "time": "57600" }
+              "variables": { "flag1": "MYOPIC", "flag2": "MYOPIC_IN_LIGHT", "flag3": "HYPEROPIC", "effect": "contacts", "time": 57600 }
             }
           }
         ]
@@ -856,13 +850,7 @@
             "id": "EOC_bifocal_transition_contacts_daily",
             "effect": {
               "run_eocs": "EOC_CONTACTS",
-              "variables": {
-                "flag1": "MYOPIC",
-                "flag2": "MYOPIC_IN_LIGHT",
-                "flag3": "HYPEROPIC",
-                "effect": "transition_contacts",
-                "time": "57600"
-              }
+              "variables": { "flag1": "MYOPIC", "flag2": "MYOPIC_IN_LIGHT", "flag3": "HYPEROPIC", "effect": "transition_contacts", "time": 57600 }
             }
           }
         ]
@@ -886,7 +874,7 @@
         "effect_on_conditions": [
           {
             "id": "EOC_plano_transition_contacts_weekly",
-            "effect": { "run_eocs": "EOC_CONTACTS", "variables": { "effect": "transition_contacts_plano", "plano": "1", "time": "604800" } }
+            "effect": { "run_eocs": "EOC_CONTACTS", "variables": { "effect": "transition_contacts_plano", "plano": 1, "time": 604800 } }
           }
         ]
       }
@@ -909,7 +897,7 @@
         "effect_on_conditions": [
           {
             "id": "EOC_plano_transition_contacts_daily",
-            "effect": { "run_eocs": "EOC_CONTACTS", "variables": { "plano": "1", "effect": "transition_contacts_plano", "time": "57600" } }
+            "effect": { "run_eocs": "EOC_CONTACTS", "variables": { "plano": 1, "effect": "transition_contacts_plano", "time": 57600 } }
           }
         ]
       }

--- a/data/json/items/tool/cooking.json
+++ b/data/json/items/tool/cooking.json
@@ -96,10 +96,10 @@
             "effect": {
               "run_eocs": "EOC_toolweapon_activate",
               "variables": {
-                "turn_cost": "0.8",
+                "turn_cost": 0.8,
                 "transform_target": "carver_on",
                 "success_message": { "i18n": true, "str": "The electric carver's serrated blades start buzzing!" },
-                "volume": "20",
+                "volume": 20,
                 "failure_message": { "i18n": true, "str": "You pull the trigger, but nothing happens." }
               }
             }
@@ -145,9 +145,9 @@
           "effect": {
             "run_eocs": "EOC_toolweapon_running",
             "variables": {
-              "sound_chance": "10",
+              "sound_chance": 10,
               "sound_message": { "i18n": true, "str": "Your electric carver buzzes." },
-              "volume": "8",
+              "volume": 8,
               "revert_to": "carver_off"
             }
           }

--- a/data/json/items/tool/electronics.json
+++ b/data/json/items/tool/electronics.json
@@ -1218,9 +1218,9 @@
           "effect": {
             "run_eocs": "EOC_toolweapon_running",
             "variables": {
-              "sound_chance": "0",
+              "sound_chance": 0,
               "sound_message": { "i18n": true, "str": "Your super noise emitter produces an unholy blast of sonic chaos." },
-              "volume": "300",
+              "volume": 300,
               "revert_to": "noise_emitter_super"
             }
           }

--- a/data/json/items/tool/landscaping.json
+++ b/data/json/items/tool/landscaping.json
@@ -375,10 +375,10 @@
           "effect": {
             "run_eocs": "EOC_toolweapon_activate",
             "variables": {
-              "turn_cost": "0.8",
+              "turn_cost": 0.8,
               "transform_target": "trimmer_on",
               "success_message": { "i18n": true, "str": "With a roar, the hedge trimmer leaps to life!" },
-              "volume": "15",
+              "volume": 15,
               "failure_message": { "i18n": true, "str": "You yank the cord, but nothing happens." }
             }
           },
@@ -419,9 +419,9 @@
           "effect": {
             "run_eocs": "EOC_toolweapon_running",
             "variables": {
-              "sound_chance": "15",
+              "sound_chance": 15,
               "sound_message": { "i18n": true, "str": "Your hedge trimmer rumbles." },
-              "volume": "10",
+              "volume": 10,
               "revert_to": "trimmer_off"
             }
           }

--- a/data/json/items/tool/masonry.json
+++ b/data/json/items/tool/masonry.json
@@ -27,10 +27,10 @@
           "effect": {
             "run_eocs": "EOC_toolweapon_activate",
             "variables": {
-              "turn_cost": "0.8",
+              "turn_cost": 0.8,
               "transform_target": "masonrysaw_on",
               "success_message": { "i18n": true, "str": "With a roar, the <npc_name> screams to life!" },
-              "volume": "20",
+              "volume": 20,
               "failure_message": { "i18n": true, "str": "You yank the cord, but nothing happens." }
             }
           },
@@ -74,9 +74,9 @@
           "effect": {
             "run_eocs": "EOC_toolweapon_running",
             "variables": {
-              "sound_chance": "15",
+              "sound_chance": 15,
               "sound_message": { "i18n": true, "str": "Your masonry saw buzzes." },
-              "volume": "7",
+              "volume": 7,
               "revert_to": "masonrysaw_off"
             }
           }
@@ -162,9 +162,9 @@
           "effect": {
             "run_eocs": "EOC_toolweapon_running",
             "variables": {
-              "sound_chance": "15",
+              "sound_chance": 15,
               "sound_message": { "i18n": true, "str": "Your electric masonry saw buzzes." },
-              "volume": "7",
+              "volume": 7,
               "revert_to": "electric_masonrysaw_off"
             }
           }

--- a/data/json/items/tool/med.json
+++ b/data/json/items/tool/med.json
@@ -448,7 +448,7 @@
           {
             "id": "SALINE_INFUSION_250",
             "condition": { "math": [ "u_skill('firstaid') >= 3" ] },
-            "effect": { "run_eocs": "SALINE_INFUSION", "variables": { "volume_of_saline": "250" } },
+            "effect": { "run_eocs": "SALINE_INFUSION", "variables": { "volume_of_saline": 250 } },
             "false_effect": [ { "u_message": "You don't actually know how to use it properly.", "type": "bad" } ]
           }
         ]
@@ -477,7 +477,7 @@
           {
             "id": "SALINE_INFUSION_500",
             "condition": { "math": [ "u_skill('firstaid') >= 4" ] },
-            "effect": { "run_eocs": "SALINE_INFUSION", "variables": { "volume_of_saline": "500" } },
+            "effect": { "run_eocs": "SALINE_INFUSION", "variables": { "volume_of_saline": 500 } },
             "false_effect": [ { "u_message": "You don't actually know how to use it properly.", "type": "bad" } ]
           }
         ]
@@ -506,7 +506,7 @@
           {
             "id": "SALINE_INFUSION_1000",
             "condition": { "math": [ "u_skill('firstaid') >= 4" ] },
-            "effect": { "run_eocs": "SALINE_INFUSION", "variables": { "volume_of_saline": "1000" } },
+            "effect": { "run_eocs": "SALINE_INFUSION", "variables": { "volume_of_saline": 1000 } },
             "false_effect": [ { "u_message": "You don't actually know how to use it properly.", "type": "bad" } ]
           }
         ]
@@ -535,7 +535,7 @@
           {
             "id": "SALINE_INFUSION_2000",
             "condition": { "math": [ "u_skill('firstaid') >= 4" ] },
-            "effect": { "run_eocs": "SALINE_INFUSION", "variables": { "volume_of_saline": "2000" } },
+            "effect": { "run_eocs": "SALINE_INFUSION", "variables": { "volume_of_saline": 2000 } },
             "false_effect": [ { "u_message": "You don't actually know how to use it properly.", "type": "bad" } ]
           }
         ]

--- a/data/json/items/tool/woodworking.json
+++ b/data/json/items/tool/woodworking.json
@@ -115,9 +115,9 @@
           "effect": {
             "run_eocs": "EOC_toolweapon_running",
             "variables": {
-              "sound_chance": "15",
+              "sound_chance": 15,
               "sound_message": { "i18n": true, "str": "Your chainsaw rumbles." },
-              "volume": "12",
+              "volume": 12,
               "revert_to": "chainsaw_off"
             }
           }
@@ -155,10 +155,10 @@
           "effect": {
             "run_eocs": "EOC_toolweapon_activate",
             "variables": {
-              "turn_cost": "0.8",
+              "turn_cost": 0.8,
               "transform_target": "polesaw_on",
               "success_message": { "i18n": true, "str": "With a roar, the pole saw screams to life!" },
-              "volume": "15",
+              "volume": 15,
               "failure_message": { "i18n": true, "str": "You yank the cord, but nothing happens." }
             }
           }
@@ -201,9 +201,9 @@
           "effect": {
             "run_eocs": "EOC_toolweapon_running",
             "variables": {
-              "sound_chance": "15",
+              "sound_chance": 15,
               "sound_message": { "i18n": true, "str": "Your pole saw rumbles." },
-              "volume": "12",
+              "volume": 12,
               "revert_to": "polesaw_off"
             }
           }
@@ -238,10 +238,10 @@
           "effect": {
             "run_eocs": "EOC_toolweapon_activate",
             "variables": {
-              "turn_cost": "0.6",
+              "turn_cost": 0.6,
               "transform_target": "circsaw_on",
               "success_message": { "i18n": true, "str": "With a loud buzz, the <npc_name> roars to life!" },
-              "volume": "15",
+              "volume": 15,
               "failure_message": { "i18n": true, "str": "You flip the switch, but nothing happens." }
             }
           }
@@ -286,9 +286,9 @@
           "effect": {
             "run_eocs": "EOC_toolweapon_running",
             "variables": {
-              "sound_chance": "15",
+              "sound_chance": 15,
               "sound_message": { "i18n": true, "str": "Your circular saw buzzes." },
-              "volume": "7",
+              "volume": 7,
               "revert_to": "circsaw_off"
             }
           }
@@ -406,10 +406,10 @@
           "effect": {
             "run_eocs": "EOC_toolweapon_activate",
             "variables": {
-              "turn_cost": "0.6",
+              "turn_cost": 0.6,
               "transform_target": "elec_chainsaw_on",
               "success_message": { "i18n": true, "str": "With a roar, the electric chainsaw screams to life!" },
-              "volume": "20",
+              "volume": 20,
               "failure_message": { "i18n": true, "str": "You flip the switch, but nothing happens." }
             }
           },
@@ -455,9 +455,9 @@
           "effect": {
             "run_eocs": "EOC_toolweapon_running",
             "variables": {
-              "sound_chance": "5",
+              "sound_chance": 5,
               "sound_message": { "i18n": true, "str": "Your electric chainsaw rumbles." },
-              "volume": "12",
+              "volume": 12,
               "revert_to": "elec_chainsaw_off"
             }
           }
@@ -487,10 +487,10 @@
             "effect": {
               "run_eocs": "EOC_toolweapon_activate",
               "variables": {
-                "turn_cost": "0.6",
+                "turn_cost": 0.6,
                 "transform_target": "elec_chainsaw_cord_on",
                 "success_message": { "i18n": true, "str": "With a roar, the corded electric chainsaw screams to life!" },
-                "volume": "20",
+                "volume": 20,
                 "failure_message": { "i18n": true, "str": "You flip the switch, but nothing happens." }
               }
             },
@@ -531,9 +531,9 @@
           "effect": {
             "run_eocs": "EOC_toolweapon_running",
             "variables": {
-              "sound_chance": "5",
+              "sound_chance": 5,
               "sound_message": { "i18n": true, "str": "Your corded electric chainsaw rumbles." },
-              "volume": "12",
+              "volume": 12,
               "revert_to": "elec_chainsaw_cord_off"
             }
           }

--- a/data/json/npcs/isolated_road/isolated_road_cody_weaponsmith.json
+++ b/data/json/npcs/isolated_road/isolated_road_cody_weaponsmith.json
@@ -42,85 +42,82 @@
       },
       {
         "text": "[200 merch, 3 days] I need a mace.",
-        "effect": { "run_eocs": "EOC_blacksmith_weapon_choose_type", "variables": { "name": "mace", "cost": "200", "wait": "3" } },
+        "effect": { "run_eocs": "EOC_blacksmith_weapon_choose_type", "variables": { "name": "mace", "cost": 200, "wait": 3 } },
         "topic": "TALK_BLACKSMITH_WEAPONSMITH_STEEL"
       },
       {
         "text": "[200 merch, 3 days] I need a steelshod quarterstaff.",
-        "effect": { "run_eocs": "EOC_blacksmith_weapon_choose_type", "variables": { "name": "steel_staff", "cost": "200", "wait": "3" } },
+        "effect": { "run_eocs": "EOC_blacksmith_weapon_choose_type", "variables": { "name": "steel_staff", "cost": 200, "wait": 3 } },
         "topic": "TALK_BLACKSMITH_WEAPONSMITH_STEEL"
       },
       {
         "text": "[250 merch, 4 days] I need a battle axe.",
-        "effect": { "run_eocs": "EOC_blacksmith_weapon_choose_type", "variables": { "name": "battleaxe", "cost": "250", "wait": "4" } },
+        "effect": { "run_eocs": "EOC_blacksmith_weapon_choose_type", "variables": { "name": "battleaxe", "cost": 250, "wait": 4 } },
         "topic": "TALK_BLACKSMITH_WEAPONSMITH_STEEL"
       },
       {
         "text": "[250 merch, 4 days] I need a longsword.",
-        "effect": { "run_eocs": "EOC_blacksmith_weapon_choose_type", "variables": { "name": "longsword", "cost": "250", "wait": "4" } },
+        "effect": { "run_eocs": "EOC_blacksmith_weapon_choose_type", "variables": { "name": "longsword", "cost": 250, "wait": 4 } },
         "topic": "TALK_BLACKSMITH_WEAPONSMITH_STEEL"
       },
       {
         "text": "[250 merch, 4 days] I need a nodachi.",
-        "effect": { "run_eocs": "EOC_blacksmith_weapon_choose_type", "variables": { "name": "nodachi", "cost": "250", "wait": "4" } },
+        "effect": { "run_eocs": "EOC_blacksmith_weapon_choose_type", "variables": { "name": "nodachi", "cost": 250, "wait": 4 } },
         "topic": "TALK_BLACKSMITH_WEAPONSMITH_STEEL"
       },
       {
         "text": "[250 merch, 4 days] I need a zweihander.",
-        "effect": { "run_eocs": "EOC_blacksmith_weapon_choose_type", "variables": { "name": "zweihander", "cost": "250", "wait": "4" } },
+        "effect": { "run_eocs": "EOC_blacksmith_weapon_choose_type", "variables": { "name": "zweihander", "cost": 250, "wait": 4 } },
         "topic": "TALK_BLACKSMITH_WEAPONSMITH_STEEL"
       },
       {
         "text": "[200 merch, 3 days] I need an arming sword.",
-        "effect": { "run_eocs": "EOC_blacksmith_weapon_choose_type", "variables": { "name": "arming_sword", "cost": "200", "wait": "3" } },
+        "effect": { "run_eocs": "EOC_blacksmith_weapon_choose_type", "variables": { "name": "arming_sword", "cost": 200, "wait": 3 } },
         "topic": "TALK_BLACKSMITH_WEAPONSMITH_STEEL"
       },
       {
         "text": "[200 merch, 3 days] I need a broadsword.",
-        "effect": { "run_eocs": "EOC_blacksmith_weapon_choose_type", "variables": { "name": "broadsword", "cost": "200", "wait": "3" } },
+        "effect": { "run_eocs": "EOC_blacksmith_weapon_choose_type", "variables": { "name": "broadsword", "cost": 200, "wait": 3 } },
         "topic": "TALK_BLACKSMITH_WEAPONSMITH_STEEL"
       },
       {
         "text": "[200 merch, 3 days] I need a cavalry saber.",
-        "effect": {
-          "run_eocs": "EOC_blacksmith_weapon_choose_type",
-          "variables": { "name": "cavalry_sabre", "cost": "200", "wait": "3" }
-        },
+        "effect": { "run_eocs": "EOC_blacksmith_weapon_choose_type", "variables": { "name": "cavalry_sabre", "cost": 200, "wait": 3 } },
         "topic": "TALK_BLACKSMITH_WEAPONSMITH_STEEL"
       },
       {
         "text": "[200 merch, 3 days] I need a cutlass.",
-        "effect": { "run_eocs": "EOC_blacksmith_weapon_choose_type", "variables": { "name": "cutlass", "cost": "200", "wait": "3" } },
+        "effect": { "run_eocs": "EOC_blacksmith_weapon_choose_type", "variables": { "name": "cutlass", "cost": 200, "wait": 3 } },
         "topic": "TALK_BLACKSMITH_WEAPONSMITH_STEEL"
       },
       {
         "text": "[200 merch, 3 days] I need a katana.",
-        "effect": { "run_eocs": "EOC_blacksmith_weapon_choose_type", "variables": { "name": "katana", "cost": "200", "wait": "3" } },
+        "effect": { "run_eocs": "EOC_blacksmith_weapon_choose_type", "variables": { "name": "katana", "cost": 200, "wait": 3 } },
         "topic": "TALK_BLACKSMITH_WEAPONSMITH_STEEL"
       },
       {
         "text": "[170 merch, 3 days] I need a wakizashi.",
-        "effect": { "run_eocs": "EOC_blacksmith_weapon_choose_type", "variables": { "name": "wakizashi", "cost": "170", "wait": "3" } },
+        "effect": { "run_eocs": "EOC_blacksmith_weapon_choose_type", "variables": { "name": "wakizashi", "cost": 170, "wait": 3 } },
         "topic": "TALK_BLACKSMITH_WEAPONSMITH_STEEL"
       },
       {
         "text": "[150 merch, 2 days] I need a kukri.",
-        "effect": { "run_eocs": "EOC_blacksmith_weapon_choose_type", "variables": { "name": "kukri", "cost": "150", "wait": "2" } },
+        "effect": { "run_eocs": "EOC_blacksmith_weapon_choose_type", "variables": { "name": "kukri", "cost": 150, "wait": 2 } },
         "topic": "TALK_BLACKSMITH_WEAPONSMITH_STEEL"
       },
       {
         "text": "[250 merch, 4 days] I need an estoc.",
-        "effect": { "run_eocs": "EOC_blacksmith_weapon_choose_type", "variables": { "name": "estoc", "cost": "250", "wait": "4" } },
+        "effect": { "run_eocs": "EOC_blacksmith_weapon_choose_type", "variables": { "name": "estoc", "cost": 250, "wait": 4 } },
         "topic": "TALK_BLACKSMITH_WEAPONSMITH_STEEL"
       },
       {
         "text": "[200 merch, 3 days] I need a rapier.",
-        "effect": { "run_eocs": "EOC_blacksmith_weapon_choose_type", "variables": { "name": "rapier", "cost": "200", "wait": "3" } },
+        "effect": { "run_eocs": "EOC_blacksmith_weapon_choose_type", "variables": { "name": "rapier", "cost": 200, "wait": 3 } },
         "topic": "TALK_BLACKSMITH_WEAPONSMITH_STEEL"
       },
       {
         "text": "[70 merch, 2 days] I need a trench knife.",
-        "effect": { "run_eocs": "EOC_blacksmith_weapon_choose_type", "variables": { "name": "knife_trench", "cost": "70", "wait": "2" } },
+        "effect": { "run_eocs": "EOC_blacksmith_weapon_choose_type", "variables": { "name": "knife_trench", "cost": 70, "wait": 2 } },
         "topic": "TALK_BLACKSMITH_WEAPONSMITH_STEEL"
       }
     ]

--- a/data/json/npcs/isolated_road/isolated_road_jay_convert.json
+++ b/data/json/npcs/isolated_road/isolated_road_jay_convert.json
@@ -80,403 +80,403 @@
       {
         "text": "[<color_light_green>+$48</color>, <color_light_red>-100 <item_name:223></color>]",
         "condition": { "u_has_items": { "item": "223", "count": 100 } },
-        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "223", "coeff": "48" } },
+        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "223", "coeff": 48 } },
         "topic": "TALK_GUNSMITH_CONVERT_FROM_TYPE"
       },
       {
         "text": "[<color_light_green>+$50</color>, <color_light_red>-100 <item_name:556></color>]",
         "condition": { "u_has_items": { "item": "556", "count": 100 } },
-        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "556", "coeff": "50" } },
+        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "556", "coeff": 50 } },
         "topic": "TALK_GUNSMITH_CONVERT_FROM_TYPE"
       },
       {
         "text": "[<color_light_green>+$50</color>, <color_light_red>-100 <item_name:556_incendiary></color>]",
         "condition": { "u_has_items": { "item": "556_incendiary", "count": 100 } },
-        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "556_incendiary", "coeff": "50" } },
+        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "556_incendiary", "coeff": 50 } },
         "topic": "TALK_GUNSMITH_CONVERT_FROM_TYPE"
       },
       {
         "text": "[<color_light_green>+$52</color>, <color_light_red>-100 <item_name:556_mk262></color>]",
         "condition": { "u_has_items": { "item": "556_mk262", "count": 100 } },
-        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "556_mk262", "coeff": "52" } },
+        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "556_mk262", "coeff": 52 } },
         "topic": "TALK_GUNSMITH_CONVERT_FROM_TYPE"
       },
       {
         "text": "[<color_light_green>+$52</color>, <color_light_red>-100 <item_name:556_mk318></color>]",
         "condition": { "u_has_items": { "item": "556_mk318", "count": 100 } },
-        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "556_mk318", "coeff": "52" } },
+        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "556_mk318", "coeff": 52 } },
         "topic": "TALK_GUNSMITH_CONVERT_FROM_TYPE"
       },
       {
         "text": "[<color_light_green>+$56</color>, <color_light_red>-100 <item_name:556_m855a1></color>]",
         "condition": { "u_has_items": { "item": "556_m855a1", "count": 100 } },
-        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "556_m855a1", "coeff": "56" } },
+        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "556_m855a1", "coeff": 56 } },
         "topic": "TALK_GUNSMITH_CONVERT_FROM_TYPE"
       },
       {
         "text": "[<color_light_green>+$70</color>, <color_light_red>-100 <item_name:556_m995></color>]",
         "condition": { "u_has_items": { "item": "556_m995", "count": 100 } },
-        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "556_m995", "coeff": "70" } },
+        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "556_m995", "coeff": 70 } },
         "topic": "TALK_GUNSMITH_CONVERT_FROM_TYPE"
       },
       {
         "text": "[<color_light_green>+$65</color>, <color_light_red>-100 <item_name:308></color>]",
         "condition": { "u_has_items": { "item": "308", "count": 100 } },
-        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "308", "coeff": "65" } },
+        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "308", "coeff": 65 } },
         "topic": "TALK_GUNSMITH_CONVERT_FROM_TYPE"
       },
       {
         "text": "[<color_light_green>+$70</color>, <color_light_red>-100 <item_name:762_51></color>]",
         "condition": { "u_has_items": { "item": "762_51", "count": 100 } },
-        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "762_51", "coeff": "70" } },
+        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "762_51", "coeff": 70 } },
         "topic": "TALK_GUNSMITH_CONVERT_FROM_TYPE"
       },
       {
         "text": "[<color_light_green>+$70</color>, <color_light_red>-100 <item_name:762_51_incendiary></color>]",
         "condition": { "u_has_items": { "item": "762_51_incendiary", "count": 100 } },
-        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "762_51_incendiary", "coeff": "70" } },
+        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "762_51_incendiary", "coeff": 70 } },
         "topic": "TALK_GUNSMITH_CONVERT_FROM_TYPE"
       },
       {
         "text": "[<color_light_green>+$90</color>, <color_light_red>-100 <item_name:762_51_m993></color>]",
         "condition": { "u_has_items": { "item": "762_51_m993", "count": 100 } },
-        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "762_51_m993", "coeff": "90" } },
+        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "762_51_m993", "coeff": 90 } },
         "topic": "TALK_GUNSMITH_CONVERT_FROM_TYPE"
       },
       {
         "text": "[<color_light_green>+$30</color>, <color_light_red>-100 <item_name:300blk_ss></color>]",
         "condition": { "u_has_items": { "item": "300blk_ss", "count": 100 } },
-        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "300blk_ss", "coeff": "30" } },
+        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "300blk_ss", "coeff": 30 } },
         "topic": "TALK_GUNSMITH_CONVERT_FROM_TYPE"
       },
       {
         "text": "[<color_light_green>+$50</color>, <color_light_red>-100 <item_name:300blk></color>]",
         "condition": { "u_has_items": { "item": "300blk", "count": 100 } },
-        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "300blk", "coeff": "50" } },
+        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "300blk", "coeff": 50 } },
         "topic": "TALK_GUNSMITH_CONVERT_FROM_TYPE"
       },
       {
         "text": "[<color_light_green>+$20</color>, <color_light_red>-100 <item_name:9mm></color>]",
         "condition": { "u_has_items": { "item": "9mm", "count": 100 } },
-        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "9mm", "coeff": "20" } },
+        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "9mm", "coeff": 20 } },
         "topic": "TALK_GUNSMITH_CONVERT_FROM_TYPE"
       },
       {
         "text": "[<color_light_green>+$23</color>, <color_light_red>-100 <item_name:9mmfmj></color>]",
         "condition": { "u_has_items": { "item": "9mmfmj", "count": 100 } },
-        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "9mmfmj", "coeff": "23" } },
+        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "9mmfmj", "coeff": 23 } },
         "topic": "TALK_GUNSMITH_CONVERT_FROM_TYPE"
       },
       {
         "text": "[<color_light_green>+$23</color>, <color_light_red>-100 <item_name:9mmP></color>]",
         "condition": { "u_has_items": { "item": "9mmP", "count": 100 } },
-        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "9mmP", "coeff": "23" } },
+        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "9mmP", "coeff": 23 } },
         "topic": "TALK_GUNSMITH_CONVERT_FROM_TYPE"
       },
       {
         "text": "[<color_light_green>+$26</color>, <color_light_red>-100 <item_name:9mmP2></color>]",
         "condition": { "u_has_items": { "item": "9mmP2", "count": 100 } },
-        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "9mmP2", "coeff": "26" } },
+        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "9mmP2", "coeff": 26 } },
         "topic": "TALK_GUNSMITH_CONVERT_FROM_TYPE"
       },
       {
         "text": "[<color_light_green>+$10</color>, <color_light_red>-100 <item_name:22_lr></color>]",
         "condition": { "u_has_items": { "item": "22_lr", "count": 100 } },
-        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "22_lr", "coeff": "10" } },
+        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "22_lr", "coeff": 10 } },
         "topic": "TALK_GUNSMITH_CONVERT_FROM_TYPE"
       },
       {
         "text": "[<color_light_green>+$11</color>, <color_light_red>-100 <item_name:22_fmj></color>]",
         "condition": { "u_has_items": { "item": "22_fmj", "count": 100 } },
-        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "22_fmj", "coeff": "11" } },
+        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "22_fmj", "coeff": 11 } },
         "topic": "TALK_GUNSMITH_CONVERT_FROM_TYPE"
       },
       {
         "text": "[<color_light_green>+$50</color>, <color_light_red>-100 <item_name:545></color>]",
         "condition": { "u_has_items": { "item": "545", "count": 100 } },
-        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "545", "coeff": "50" } },
+        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "545", "coeff": 50 } },
         "topic": "TALK_GUNSMITH_CONVERT_FROM_TYPE"
       },
       {
         "text": "[<color_light_green>+$70</color>, <color_light_red>-100 <item_name:545_ap></color>]",
         "condition": { "u_has_items": { "item": "545_ap", "count": 100 } },
-        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "545_ap", "coeff": "70" } },
+        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "545_ap", "coeff": 70 } },
         "topic": "TALK_GUNSMITH_CONVERT_FROM_TYPE"
       },
       {
         "text": "[<color_light_green>+$80</color>, <color_light_red>-100 <item_name:762_jhp></color>]",
         "condition": { "u_has_items": { "item": "762_jhp", "count": 100 } },
-        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "762_jhp", "coeff": "80" } },
+        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "762_jhp", "coeff": 80 } },
         "topic": "TALK_GUNSMITH_CONVERT_FROM_TYPE"
       },
       {
         "text": "[<color_light_green>+$100</color>, <color_light_red>-100 <item_name:762_m87></color>]",
         "condition": { "u_has_items": { "item": "762_m87", "count": 100 } },
-        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "762_m87", "coeff": "100" } },
+        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "762_m87", "coeff": 100 } },
         "topic": "TALK_GUNSMITH_CONVERT_FROM_TYPE"
       },
       {
         "text": "[<color_light_green>+$20</color>, <color_light_red>-100 <item_name:shot_bird></color>]",
         "condition": { "u_has_items": { "item": "shot_bird", "count": 100 } },
-        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "shot_bird", "coeff": "20" } },
+        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "shot_bird", "coeff": 20 } },
         "topic": "TALK_GUNSMITH_CONVERT_FROM_TYPE"
       },
       {
         "text": "[<color_light_green>+$35</color>, <color_light_red>-100 <item_name:shot_00></color>]",
         "condition": { "u_has_items": { "item": "shot_00", "count": 100 } },
-        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "shot_00", "coeff": "35" } },
+        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "shot_00", "coeff": 35 } },
         "topic": "TALK_GUNSMITH_CONVERT_FROM_TYPE"
       },
       {
         "text": "[<color_light_green>+$50</color>, <color_light_red>-100 <item_name:shot_slug></color>]",
         "condition": { "u_has_items": { "item": "shot_slug", "count": 100 } },
-        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "shot_slug", "coeff": "50" } },
+        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "shot_slug", "coeff": 50 } },
         "topic": "TALK_GUNSMITH_CONVERT_FROM_TYPE"
       },
       {
         "text": "[<color_light_green>+$23</color>, <color_light_red>-100 <item_name:40sw></color>]",
         "condition": { "u_has_items": { "item": "40sw", "count": 100 } },
-        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "40sw", "coeff": "23" } },
+        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "40sw", "coeff": 23 } },
         "topic": "TALK_GUNSMITH_CONVERT_FROM_TYPE"
       },
       {
         "text": "[<color_light_green>+$26</color>, <color_light_red>-100 <item_name:40fmj></color>]",
         "condition": { "u_has_items": { "item": "40fmj", "count": 100 } },
-        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "40fmj", "coeff": "26" } },
+        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "40fmj", "coeff": 26 } },
         "topic": "TALK_GUNSMITH_CONVERT_FROM_TYPE"
       },
       {
         "text": "[<color_light_green>+$30</color>, <color_light_red>-100 <item_name:44magnum></color>]",
         "condition": { "u_has_items": { "item": "44magnum", "count": 100 } },
-        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "44magnum", "coeff": "30" } },
+        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "44magnum", "coeff": 30 } },
         "topic": "TALK_GUNSMITH_CONVERT_FROM_TYPE"
       },
       {
         "text": "[<color_light_green>+$35</color>, <color_light_red>-100 <item_name:44fmj></color>]",
         "condition": { "u_has_items": { "item": "44fmj", "count": 100 } },
-        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "44fmj", "coeff": "35" } },
+        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "44fmj", "coeff": 35 } },
         "topic": "TALK_GUNSMITH_CONVERT_FROM_TYPE"
       },
       {
         "text": "[<color_light_green>+$20</color>, <color_light_red>-100 <item_name:45_jhp></color>]",
         "condition": { "u_has_items": { "item": "45_jhp", "count": 100 } },
-        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "45_jhp", "coeff": "20" } },
+        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "45_jhp", "coeff": 20 } },
         "topic": "TALK_GUNSMITH_CONVERT_FROM_TYPE"
       },
       {
         "text": "[<color_light_green>+$23</color>, <color_light_red>-100 <item_name:45_acp></color>]",
         "condition": { "u_has_items": { "item": "45_acp", "count": 100 } },
-        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "45_acp", "coeff": "23" } },
+        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "45_acp", "coeff": 23 } },
         "topic": "TALK_GUNSMITH_CONVERT_FROM_TYPE"
       },
       {
         "text": "[<color_light_green>+$23</color>, <color_light_red>-100 <item_name:45_super></color>]",
         "condition": { "u_has_items": { "item": "45_super", "count": 100 } },
-        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "45_super", "coeff": "23" } },
+        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "45_super", "coeff": 23 } },
         "topic": "TALK_GUNSMITH_CONVERT_FROM_TYPE"
       },
       {
         "text": "[<color_light_green>+$13</color>, <color_light_red>-100 <item_name:380_JHP></color>]",
         "condition": { "u_has_items": { "item": "380_JHP", "count": 100 } },
-        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "380_JHP", "coeff": "13" } },
+        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "380_JHP", "coeff": 13 } },
         "topic": "TALK_GUNSMITH_CONVERT_FROM_TYPE"
       },
       {
         "text": "[<color_light_green>+$13</color>, <color_light_red>-100 <item_name:380_FMJ></color>]",
         "condition": { "u_has_items": { "item": "380_FMJ", "count": 100 } },
-        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "380_FMJ", "coeff": "13" } },
+        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "380_FMJ", "coeff": 13 } },
         "topic": "TALK_GUNSMITH_CONVERT_FROM_TYPE"
       },
       {
         "text": "[<color_light_green>+$15</color>, <color_light_red>-100 <item_name:380_p></color>]",
         "condition": { "u_has_items": { "item": "380_p", "count": 100 } },
-        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "380_p", "coeff": "15" } },
+        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "380_p", "coeff": 15 } },
         "topic": "TALK_GUNSMITH_CONVERT_FROM_TYPE"
       },
       {
         "text": "[<color_light_green>+$15</color>, <color_light_red>-100 <item_name:57mm_ss></color>]",
         "condition": { "u_has_items": { "item": "57mm_ss", "count": 100 } },
-        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "57mm_ss", "coeff": "15" } },
+        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "57mm_ss", "coeff": 15 } },
         "topic": "TALK_GUNSMITH_CONVERT_FROM_TYPE"
       },
       {
         "text": "[<color_light_green>+$25</color>, <color_light_red>-100 <item_name:57mm_lf></color>]",
         "condition": { "u_has_items": { "item": "57mm_lf", "count": 100 } },
-        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "57mm_lf", "coeff": "25" } },
+        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "57mm_lf", "coeff": 25 } },
         "topic": "TALK_GUNSMITH_CONVERT_FROM_TYPE"
       },
       {
         "text": "[<color_light_green>+$30</color>, <color_light_red>-100 <item_name:57mm></color>]",
         "condition": { "u_has_items": { "item": "57mm", "count": 100 } },
-        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "57mm", "coeff": "30" } },
+        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "57mm", "coeff": 30 } },
         "topic": "TALK_GUNSMITH_CONVERT_FROM_TYPE"
       },
       {
         "text": "[<color_light_green>+$20</color>, <color_light_red>-100 <item_name:10mm_jhp></color>]",
         "condition": { "u_has_items": { "item": "10mm_jhp", "count": 100 } },
-        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "10mm_jhp", "coeff": "20" } },
+        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "10mm_jhp", "coeff": 20 } },
         "topic": "TALK_GUNSMITH_CONVERT_FROM_TYPE"
       },
       {
         "text": "[<color_light_green>+$23</color>, <color_light_red>-100 <item_name:10mm_fmj></color>]",
         "condition": { "u_has_items": { "item": "10mm_fmj", "count": 100 } },
-        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "10mm_fmj", "coeff": "23" } },
+        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "10mm_fmj", "coeff": 23 } },
         "topic": "TALK_GUNSMITH_CONVERT_FROM_TYPE"
       },
       {
         "text": "[<color_light_green>+$25</color>, <color_light_red>-100 <item_name:10mmP></color>]",
         "condition": { "u_has_items": { "item": "10mmP", "count": 100 } },
-        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "10mmP", "coeff": "25" } },
+        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "10mmP", "coeff": 25 } },
         "topic": "TALK_GUNSMITH_CONVERT_FROM_TYPE"
       },
       {
         "text": "[<color_light_green>+$20</color>, <color_light_red>-100 <item_name:38_special></color>]",
         "condition": { "u_has_items": { "item": "38_special", "count": 100 } },
-        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "38_special", "coeff": "20" } },
+        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "38_special", "coeff": 20 } },
         "topic": "TALK_GUNSMITH_CONVERT_FROM_TYPE"
       },
       {
         "text": "[<color_light_green>+$22</color>, <color_light_red>-100 <item_name:38_fmj></color>]",
         "condition": { "u_has_items": { "item": "38_fmj", "count": 100 } },
-        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "38_fmj", "coeff": "22" } },
+        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "38_fmj", "coeff": 22 } },
         "topic": "TALK_GUNSMITH_CONVERT_FROM_TYPE"
       },
       {
         "text": "[<color_light_green>+$24</color>, <color_light_red>-100 <item_name:38_special_p></color>]",
         "condition": { "u_has_items": { "item": "38_special_p", "count": 100 } },
-        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "38_special_p", "coeff": "24" } },
+        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "38_special_p", "coeff": 24 } },
         "topic": "TALK_GUNSMITH_CONVERT_FROM_TYPE"
       },
       {
         "text": "[<color_light_green>+$23</color>, <color_light_red>-100 <item_name:357sig_jhp></color>]",
         "condition": { "u_has_items": { "item": "357sig_jhp", "count": 100 } },
-        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "357sig_jhp", "coeff": "23" } },
+        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "357sig_jhp", "coeff": 23 } },
         "topic": "TALK_GUNSMITH_CONVERT_FROM_TYPE"
       },
       {
         "text": "[<color_light_green>+$25</color>, <color_light_red>-100 <item_name:357sig_fmj></color>]",
         "condition": { "u_has_items": { "item": "357sig_fmj", "count": 100 } },
-        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "357sig_fmj", "coeff": "25" } },
+        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "357sig_fmj", "coeff": 25 } },
         "topic": "TALK_GUNSMITH_CONVERT_FROM_TYPE"
       },
       {
         "text": "[<color_light_green>+$23</color>, <color_light_red>-100 <item_name:357mag_jhp></color>]",
         "condition": { "u_has_items": { "item": "357mag_jhp", "count": 100 } },
-        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "357mag_jhp", "coeff": "23" } },
+        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "357mag_jhp", "coeff": 23 } },
         "topic": "TALK_GUNSMITH_CONVERT_FROM_TYPE"
       },
       {
         "text": "[<color_light_green>+$25</color>, <color_light_red>-100 <item_name:357mag_fmj></color>]",
         "condition": { "u_has_items": { "item": "357mag_fmj", "count": 100 } },
-        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "357mag_fmj", "coeff": "25" } },
+        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "357mag_fmj", "coeff": 25 } },
         "topic": "TALK_GUNSMITH_CONVERT_FROM_TYPE"
       },
       {
         "text": "[<color_light_green>+$50</color>, <color_light_red>-100 <item_name:460sw></color>]",
         "condition": { "u_has_items": { "item": "460sw", "count": 100 } },
-        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "460sw", "coeff": "50" } },
+        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "460sw", "coeff": 50 } },
         "topic": "TALK_GUNSMITH_CONVERT_FROM_TYPE"
       },
       {
         "text": "[<color_light_green>+$50</color>, <color_light_red>-100 <item_name:500_Magnum></color>]",
         "condition": { "u_has_items": { "item": "500_Magnum", "count": 100 } },
-        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "500_Magnum", "coeff": "50" } },
+        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "500_Magnum", "coeff": 50 } },
         "topic": "TALK_GUNSMITH_CONVERT_FROM_TYPE"
       },
       {
         "text": "[<color_light_green>+$48</color>, <color_light_red>-100 <item_name:270win_jsp></color>]",
         "condition": { "u_has_items": { "item": "270win_jsp", "count": 100 } },
-        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "270win_jsp", "coeff": "48" } },
+        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "270win_jsp", "coeff": 48 } },
         "topic": "TALK_GUNSMITH_CONVERT_FROM_TYPE"
       },
       {
         "text": "[<color_light_green>+$50</color>, <color_light_red>-100 <item_name:300_winmag></color>]",
         "condition": { "u_has_items": { "item": "300_winmag", "count": 100 } },
-        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "300_winmag", "coeff": "50" } },
+        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "300_winmag", "coeff": 50 } },
         "topic": "TALK_GUNSMITH_CONVERT_FROM_TYPE"
       },
       {
         "text": "[<color_light_green>+$80</color>, <color_light_red>-100 <item_name:458wm></color>]",
         "condition": { "u_has_items": { "item": "458wm", "count": 100 } },
-        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "458wm", "coeff": "80" } },
+        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "458wm", "coeff": 80 } },
         "topic": "TALK_GUNSMITH_CONVERT_FROM_TYPE"
       },
       {
         "text": "[<color_light_green>+$48</color>, <color_light_red>-100 <item_name:454_Casull></color>]",
         "condition": { "u_has_items": { "item": "454_Casull", "count": 100 } },
-        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "454_Casull", "coeff": "48" } },
+        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "454_Casull", "coeff": 48 } },
         "topic": "TALK_GUNSMITH_CONVERT_FROM_TYPE"
       },
       {
         "text": "[<color_light_green>+$48</color>, <color_light_red>-100 <item_name:3006_jsp></color>]",
         "condition": { "u_has_items": { "item": "3006_jsp", "count": 100 } },
-        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "3006_jsp", "coeff": "48" } },
+        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "3006_jsp", "coeff": 48 } },
         "topic": "TALK_GUNSMITH_CONVERT_FROM_TYPE"
       },
       {
         "text": "[<color_light_green>+$50</color>, <color_light_red>-100 <item_name:3006></color>]",
         "condition": { "u_has_items": { "item": "3006", "count": 100 } },
-        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "3006", "coeff": "50" } },
+        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "3006", "coeff": 50 } },
         "topic": "TALK_GUNSMITH_CONVERT_FROM_TYPE"
       },
       {
         "text": "[<color_light_green>+$50</color>, <color_light_red>-100 <item_name:3006_incendiary></color>]",
         "condition": { "u_has_items": { "item": "3006_incendiary", "count": 100 } },
-        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "3006_incendiary", "coeff": "50" } },
+        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "3006_incendiary", "coeff": 50 } },
         "topic": "TALK_GUNSMITH_CONVERT_FROM_TYPE"
       },
       {
         "text": "[<color_light_green>+$53</color>, <color_light_red>-100 <item_name:3006fmj></color>]",
         "condition": { "u_has_items": { "item": "3006fmj", "count": 100 } },
-        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "3006fmj", "coeff": "53" } },
+        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "3006fmj", "coeff": 53 } },
         "topic": "TALK_GUNSMITH_CONVERT_FROM_TYPE"
       },
       {
         "text": "[<color_light_green>+$15</color>, <color_light_red>-100 <item_name:410shot_bird></color>]",
         "condition": { "u_has_items": { "item": "410shot_bird", "count": 100 } },
-        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "410shot_bird", "coeff": "15" } },
+        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "410shot_bird", "coeff": 15 } },
         "topic": "TALK_GUNSMITH_CONVERT_FROM_TYPE"
       },
       {
         "text": "[<color_light_green>+$20</color>, <color_light_red>-100 <item_name:410shot_000></color>]",
         "condition": { "u_has_items": { "item": "410shot_000", "count": 100 } },
-        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "410shot_000", "coeff": "20" } },
+        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "410shot_000", "coeff": 20 } },
         "topic": "TALK_GUNSMITH_CONVERT_FROM_TYPE"
       },
       {
         "text": "[<color_light_green>+$30</color>, <color_light_red>-100 <item_name:410shot_slug></color>]",
         "condition": { "u_has_items": { "item": "410shot_slug", "count": 100 } },
-        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "410shot_slug", "coeff": "30" } },
+        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "410shot_slug", "coeff": 30 } },
         "topic": "TALK_GUNSMITH_CONVERT_FROM_TYPE"
       },
       {
         "text": "[<color_light_green>+$140</color>, <color_light_red>-100 <item_name:50bmg></color>]",
         "condition": { "u_has_items": { "item": "50bmg", "count": 100 } },
-        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "50bmg", "coeff": "140" } },
+        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "50bmg", "coeff": 140 } },
         "topic": "TALK_GUNSMITH_CONVERT_FROM_TYPE"
       },
       {
         "text": "[<color_light_green>+$140</color>, <color_light_red>-100 <item_name:50_incendiary></color>]",
         "condition": { "u_has_items": { "item": "50_incendiary", "count": 100 } },
-        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "50_incendiary", "coeff": "140" } },
+        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "50_incendiary", "coeff": 140 } },
         "topic": "TALK_GUNSMITH_CONVERT_FROM_TYPE"
       },
       {
         "text": "[<color_light_green>+$140</color>, <color_light_red>-100 <item_name:50match></color>]",
         "condition": { "u_has_items": { "item": "50match", "count": 100 } },
-        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "50match", "coeff": "140" } },
+        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "50match", "coeff": 140 } },
         "topic": "TALK_GUNSMITH_CONVERT_FROM_TYPE"
       },
       {
         "text": "[<color_light_green>+$210</color>, <color_light_red>-100 <item_name:50ss></color>]",
         "condition": { "u_has_items": { "item": "50ss", "count": 100 } },
-        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "50ss", "coeff": "210" } },
+        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "50ss", "coeff": 210 } },
         "topic": "TALK_GUNSMITH_CONVERT_FROM_TYPE"
       },
       {
         "text": "[<color_light_green>+$210</color>, <color_light_red>-100 <item_name:50_mk211></color>]",
         "condition": { "u_has_items": { "item": "50_mk211", "count": 100 } },
-        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "50_mk211", "coeff": "210" } },
+        "effect": { "run_eocs": "EOC_gunsmith_source", "variables": { "item": "50_mk211", "coeff": 210 } },
         "topic": "TALK_GUNSMITH_CONVERT_FROM_TYPE"
       }
     ]
@@ -499,266 +499,266 @@
         "text": "[$0.55, <item_name:reloaded_556>]",
         "show_always": true,
         "condition": { "math": [ "u_number_artisans_gunsmith_credit >= 55 / 2" ] },
-        "effect": { "run_eocs": "EOC_gunsmith_target", "variables": { "item": "reloaded_556", "coeff": "55" } },
+        "effect": { "run_eocs": "EOC_gunsmith_target", "variables": { "item": "reloaded_556", "coeff": 55 } },
         "topic": "TALK_GUNSMITH_CONVERT_CONFIRM"
       },
       {
         "text": "[$0.77, <item_name:reloaded_762_51>]",
         "show_always": true,
         "condition": { "math": [ "u_number_artisans_gunsmith_credit >= 77 / 2" ] },
-        "effect": { "run_eocs": "EOC_gunsmith_target", "variables": { "item": "reloaded_762_51", "coeff": "77" } },
+        "effect": { "run_eocs": "EOC_gunsmith_target", "variables": { "item": "reloaded_762_51", "coeff": 77 } },
         "topic": "TALK_GUNSMITH_CONVERT_CONFIRM"
       },
       {
         "text": "[$0.55, <item_name:reloaded_300blk>]",
         "show_always": true,
         "condition": { "math": [ "u_number_artisans_gunsmith_credit >= 55 / 2" ] },
-        "effect": { "run_eocs": "EOC_gunsmith_target", "variables": { "item": "reloaded_300blk", "coeff": "55" } },
+        "effect": { "run_eocs": "EOC_gunsmith_target", "variables": { "item": "reloaded_300blk", "coeff": 55 } },
         "topic": "TALK_GUNSMITH_CONVERT_CONFIRM"
       },
       {
         "text": "[$0.33, <item_name:reloaded_300blk_ss>]",
         "show_always": true,
         "condition": { "math": [ "u_number_artisans_gunsmith_credit >= 33 / 2" ] },
-        "effect": { "run_eocs": "EOC_gunsmith_target", "variables": { "item": "reloaded_300blk_ss", "coeff": "33" } },
+        "effect": { "run_eocs": "EOC_gunsmith_target", "variables": { "item": "reloaded_300blk_ss", "coeff": 33 } },
         "topic": "TALK_GUNSMITH_CONVERT_CONFIRM"
       },
       {
         "text": "[$0.22, <item_name:reloaded_9mm>]",
         "show_always": true,
         "condition": { "math": [ "u_number_artisans_gunsmith_credit >= 22 / 2" ] },
-        "effect": { "run_eocs": "EOC_gunsmith_target", "variables": { "item": "reloaded_9mm", "coeff": "22" } },
+        "effect": { "run_eocs": "EOC_gunsmith_target", "variables": { "item": "reloaded_9mm", "coeff": 22 } },
         "topic": "TALK_GUNSMITH_CONVERT_CONFIRM"
       },
       {
         "text": "[$0.25, <item_name:reloaded_9mmfmj>]",
         "show_always": true,
         "condition": { "math": [ "u_number_artisans_gunsmith_credit >= 25 / 2" ] },
-        "effect": { "run_eocs": "EOC_gunsmith_target", "variables": { "item": "reloaded_9mmfmj", "coeff": "25" } },
+        "effect": { "run_eocs": "EOC_gunsmith_target", "variables": { "item": "reloaded_9mmfmj", "coeff": 25 } },
         "topic": "TALK_GUNSMITH_CONVERT_CONFIRM"
       },
       {
         "text": "[$0.28, <item_name:reloaded_9mmP2>]",
         "show_always": true,
         "condition": { "math": [ "u_number_artisans_gunsmith_credit >= 28 / 2" ] },
-        "effect": { "run_eocs": "EOC_gunsmith_target", "variables": { "item": "reloaded_9mmP2", "coeff": "28" } },
+        "effect": { "run_eocs": "EOC_gunsmith_target", "variables": { "item": "reloaded_9mmP2", "coeff": 28 } },
         "topic": "TALK_GUNSMITH_CONVERT_CONFIRM"
       },
       {
         "text": "[$0.12, <item_name:22_fmj>]",
         "show_always": true,
         "condition": { "math": [ "u_number_artisans_gunsmith_credit >= 12 / 2" ] },
-        "effect": { "run_eocs": "EOC_gunsmith_target", "variables": { "item": "22_fmj", "coeff": "12" } },
+        "effect": { "run_eocs": "EOC_gunsmith_target", "variables": { "item": "22_fmj", "coeff": 12 } },
         "topic": "TALK_GUNSMITH_CONVERT_CONFIRM"
       },
       {
         "text": "[$0.55, <item_name:reloaded_545>]",
         "show_always": true,
         "condition": { "math": [ "u_number_artisans_gunsmith_credit >= 55 / 2" ] },
-        "effect": { "run_eocs": "EOC_gunsmith_target", "variables": { "item": "reloaded_545", "coeff": "55" } },
+        "effect": { "run_eocs": "EOC_gunsmith_target", "variables": { "item": "reloaded_545", "coeff": 55 } },
         "topic": "TALK_GUNSMITH_CONVERT_CONFIRM"
       },
       {
         "text": "[$0.77, <item_name:reloaded_545_ap>]",
         "show_always": true,
         "condition": { "math": [ "u_number_artisans_gunsmith_credit >= 77 / 2" ] },
-        "effect": { "run_eocs": "EOC_gunsmith_target", "variables": { "item": "reloaded_545_ap", "coeff": "77" } },
+        "effect": { "run_eocs": "EOC_gunsmith_target", "variables": { "item": "reloaded_545_ap", "coeff": 77 } },
         "topic": "TALK_GUNSMITH_CONVERT_CONFIRM"
       },
       {
         "text": "[$0.22, <item_name:reloaded_shot_bird>]",
         "show_always": true,
         "condition": { "math": [ "u_number_artisans_gunsmith_credit >= 22 / 2" ] },
-        "effect": { "run_eocs": "EOC_gunsmith_target", "variables": { "item": "reloaded_shot_bird", "coeff": "22" } },
+        "effect": { "run_eocs": "EOC_gunsmith_target", "variables": { "item": "reloaded_shot_bird", "coeff": 22 } },
         "topic": "TALK_GUNSMITH_CONVERT_CONFIRM"
       },
       {
         "text": "[$0.38, <item_name:reloaded_shot_00>]",
         "show_always": true,
         "condition": { "math": [ "u_number_artisans_gunsmith_credit >= 38 / 2" ] },
-        "effect": { "run_eocs": "EOC_gunsmith_target", "variables": { "item": "reloaded_shot_00", "coeff": "38" } },
+        "effect": { "run_eocs": "EOC_gunsmith_target", "variables": { "item": "reloaded_shot_00", "coeff": 38 } },
         "topic": "TALK_GUNSMITH_CONVERT_CONFIRM"
       },
       {
         "text": "[$0.55, <item_name:reloaded_shot_slug>]",
         "show_always": true,
         "condition": { "math": [ "u_number_artisans_gunsmith_credit >= 55 / 2" ] },
-        "effect": { "run_eocs": "EOC_gunsmith_target", "variables": { "item": "reloaded_shot_slug", "coeff": "55" } },
+        "effect": { "run_eocs": "EOC_gunsmith_target", "variables": { "item": "reloaded_shot_slug", "coeff": 55 } },
         "topic": "TALK_GUNSMITH_CONVERT_CONFIRM"
       },
       {
         "text": "[$0.30, <item_name:reloaded_shot_dragon>]",
         "show_always": true,
         "condition": { "math": [ "u_number_artisans_gunsmith_credit >= 30 / 2" ] },
-        "effect": { "run_eocs": "EOC_gunsmith_target", "variables": { "item": "reloaded_shot_dragon", "coeff": "30" } },
+        "effect": { "run_eocs": "EOC_gunsmith_target", "variables": { "item": "reloaded_shot_dragon", "coeff": 30 } },
         "topic": "TALK_GUNSMITH_CONVERT_CONFIRM"
       },
       {
         "text": "[$0.25, <item_name:reloaded_40sw>]",
         "show_always": true,
         "condition": { "math": [ "u_number_artisans_gunsmith_credit >= 25 / 2" ] },
-        "effect": { "run_eocs": "EOC_gunsmith_target", "variables": { "item": "reloaded_40sw", "coeff": "25" } },
+        "effect": { "run_eocs": "EOC_gunsmith_target", "variables": { "item": "reloaded_40sw", "coeff": 25 } },
         "topic": "TALK_GUNSMITH_CONVERT_CONFIRM"
       },
       {
         "text": "[$0.28, <item_name:reloaded_40fmj>]",
         "show_always": true,
         "condition": { "math": [ "u_number_artisans_gunsmith_credit >= 28 / 2" ] },
-        "effect": { "run_eocs": "EOC_gunsmith_target", "variables": { "item": "reloaded_40fmj", "coeff": "28" } },
+        "effect": { "run_eocs": "EOC_gunsmith_target", "variables": { "item": "reloaded_40fmj", "coeff": 28 } },
         "topic": "TALK_GUNSMITH_CONVERT_CONFIRM"
       },
       {
         "text": "[$0.33, <item_name:reloaded_44magnum>]",
         "show_always": true,
         "condition": { "math": [ "u_number_artisans_gunsmith_credit >= 33 / 2" ] },
-        "effect": { "run_eocs": "EOC_gunsmith_target", "variables": { "item": "reloaded_44magnum", "coeff": "33" } },
+        "effect": { "run_eocs": "EOC_gunsmith_target", "variables": { "item": "reloaded_44magnum", "coeff": 33 } },
         "topic": "TALK_GUNSMITH_CONVERT_CONFIRM"
       },
       {
         "text": "[$0.38, <item_name:reloaded_44fmj>]",
         "show_always": true,
         "condition": { "math": [ "u_number_artisans_gunsmith_credit >= 38 / 2" ] },
-        "effect": { "run_eocs": "EOC_gunsmith_target", "variables": { "item": "reloaded_44fmj", "coeff": "38" } },
+        "effect": { "run_eocs": "EOC_gunsmith_target", "variables": { "item": "reloaded_44fmj", "coeff": 38 } },
         "topic": "TALK_GUNSMITH_CONVERT_CONFIRM"
       },
       {
         "text": "[$0.22, <item_name:reloaded_45_jhp>]",
         "show_always": true,
         "condition": { "math": [ "u_number_artisans_gunsmith_credit >= 22 / 2" ] },
-        "effect": { "run_eocs": "EOC_gunsmith_target", "variables": { "item": "reloaded_45_jhp", "coeff": "22" } },
+        "effect": { "run_eocs": "EOC_gunsmith_target", "variables": { "item": "reloaded_45_jhp", "coeff": 22 } },
         "topic": "TALK_GUNSMITH_CONVERT_CONFIRM"
       },
       {
         "text": "[$0.25, <item_name:reloaded_45_acp>]",
         "show_always": true,
         "condition": { "math": [ "u_number_artisans_gunsmith_credit >= 25 / 2" ] },
-        "effect": { "run_eocs": "EOC_gunsmith_target", "variables": { "item": "reloaded_45_acp", "coeff": "25" } },
+        "effect": { "run_eocs": "EOC_gunsmith_target", "variables": { "item": "reloaded_45_acp", "coeff": 25 } },
         "topic": "TALK_GUNSMITH_CONVERT_CONFIRM"
       },
       {
         "text": "[$0.25, <item_name:reloaded_45_super>]",
         "show_always": true,
         "condition": { "math": [ "u_number_artisans_gunsmith_credit >= 25 / 2" ] },
-        "effect": { "run_eocs": "EOC_gunsmith_target", "variables": { "item": "reloaded_45_super", "coeff": "25" } },
+        "effect": { "run_eocs": "EOC_gunsmith_target", "variables": { "item": "reloaded_45_super", "coeff": 25 } },
         "topic": "TALK_GUNSMITH_CONVERT_CONFIRM"
       },
       {
         "text": "[$0.14, <item_name:reloaded_380_JHP>]",
         "show_always": true,
         "condition": { "math": [ "u_number_artisans_gunsmith_credit >= 14 / 2" ] },
-        "effect": { "run_eocs": "EOC_gunsmith_target", "variables": { "item": "reloaded_380_JHP", "coeff": "14" } },
+        "effect": { "run_eocs": "EOC_gunsmith_target", "variables": { "item": "reloaded_380_JHP", "coeff": 14 } },
         "topic": "TALK_GUNSMITH_CONVERT_CONFIRM"
       },
       {
         "text": "[$0.14, <item_name:reloaded_380_FMJ>]",
         "show_always": true,
         "condition": { "math": [ "u_number_artisans_gunsmith_credit >= 14 / 2" ] },
-        "effect": { "run_eocs": "EOC_gunsmith_target", "variables": { "item": "reloaded_380_FMJ", "coeff": "14" } },
+        "effect": { "run_eocs": "EOC_gunsmith_target", "variables": { "item": "reloaded_380_FMJ", "coeff": 14 } },
         "topic": "TALK_GUNSMITH_CONVERT_CONFIRM"
       },
       {
         "text": "[$0.16, <item_name:reloaded_380_p>]",
         "show_always": true,
         "condition": { "math": [ "u_number_artisans_gunsmith_credit >= 16 / 2" ] },
-        "effect": { "run_eocs": "EOC_gunsmith_target", "variables": { "item": "reloaded_380_p", "coeff": "16" } },
+        "effect": { "run_eocs": "EOC_gunsmith_target", "variables": { "item": "reloaded_380_p", "coeff": 16 } },
         "topic": "TALK_GUNSMITH_CONVERT_CONFIRM"
       },
       {
         "text": "[$0.33, <item_name:reloaded_57mm>]",
         "show_always": true,
         "condition": { "math": [ "u_number_artisans_gunsmith_credit >= 33 / 2" ] },
-        "effect": { "run_eocs": "EOC_gunsmith_target", "variables": { "item": "reloaded_57mm", "coeff": "33" } },
+        "effect": { "run_eocs": "EOC_gunsmith_target", "variables": { "item": "reloaded_57mm", "coeff": 33 } },
         "topic": "TALK_GUNSMITH_CONVERT_CONFIRM"
       },
       {
         "text": "[$0.22, <item_name:reloaded_10mm_jhp>]",
         "show_always": true,
         "condition": { "math": [ "u_number_artisans_gunsmith_credit >= 22 / 2" ] },
-        "effect": { "run_eocs": "EOC_gunsmith_target", "variables": { "item": "reloaded_10mm_jhp", "coeff": "22" } },
+        "effect": { "run_eocs": "EOC_gunsmith_target", "variables": { "item": "reloaded_10mm_jhp", "coeff": 22 } },
         "topic": "TALK_GUNSMITH_CONVERT_CONFIRM"
       },
       {
         "text": "[$0.25, <item_name:reloaded_10mm_fmj>]",
         "show_always": true,
         "condition": { "math": [ "u_number_artisans_gunsmith_credit >= 25 / 2" ] },
-        "effect": { "run_eocs": "EOC_gunsmith_target", "variables": { "item": "reloaded_10mm_fmj", "coeff": "25" } },
+        "effect": { "run_eocs": "EOC_gunsmith_target", "variables": { "item": "reloaded_10mm_fmj", "coeff": 25 } },
         "topic": "TALK_GUNSMITH_CONVERT_CONFIRM"
       },
       {
         "text": "[$0.27, <item_name:reloaded_10mmP>]",
         "show_always": true,
         "condition": { "math": [ "u_number_artisans_gunsmith_credit >= 27 / 2" ] },
-        "effect": { "run_eocs": "EOC_gunsmith_target", "variables": { "item": "reloaded_10mmP", "coeff": "27" } },
+        "effect": { "run_eocs": "EOC_gunsmith_target", "variables": { "item": "reloaded_10mmP", "coeff": 27 } },
         "topic": "TALK_GUNSMITH_CONVERT_CONFIRM"
       },
       {
         "text": "[$0.22, <item_name:reloaded_38_special>]",
         "show_always": true,
         "condition": { "math": [ "u_number_artisans_gunsmith_credit >= 22 / 2" ] },
-        "effect": { "run_eocs": "EOC_gunsmith_target", "variables": { "item": "reloaded_38_special", "coeff": "22" } },
+        "effect": { "run_eocs": "EOC_gunsmith_target", "variables": { "item": "reloaded_38_special", "coeff": 22 } },
         "topic": "TALK_GUNSMITH_CONVERT_CONFIRM"
       },
       {
         "text": "[$0.24, <item_name:reloaded_38_fmj>]",
         "show_always": true,
         "condition": { "math": [ "u_number_artisans_gunsmith_credit >= 24 / 2" ] },
-        "effect": { "run_eocs": "EOC_gunsmith_target", "variables": { "item": "reloaded_38_fmj", "coeff": "24" } },
+        "effect": { "run_eocs": "EOC_gunsmith_target", "variables": { "item": "reloaded_38_fmj", "coeff": 24 } },
         "topic": "TALK_GUNSMITH_CONVERT_CONFIRM"
       },
       {
         "text": "[$0.26, <item_name:reloaded_38_special_p>]",
         "show_always": true,
         "condition": { "math": [ "u_number_artisans_gunsmith_credit >= 26 / 2" ] },
-        "effect": { "run_eocs": "EOC_gunsmith_target", "variables": { "item": "reloaded_38_special_p", "coeff": "26" } },
+        "effect": { "run_eocs": "EOC_gunsmith_target", "variables": { "item": "reloaded_38_special_p", "coeff": 26 } },
         "topic": "TALK_GUNSMITH_CONVERT_CONFIRM"
       },
       {
         "text": "[$0.52, <item_name:reloaded_270win_jsp>]",
         "show_always": true,
         "condition": { "math": [ "u_number_artisans_gunsmith_credit >= 52 / 2" ] },
-        "effect": { "run_eocs": "EOC_gunsmith_target", "variables": { "item": "reloaded_270win_jsp", "coeff": "52" } },
+        "effect": { "run_eocs": "EOC_gunsmith_target", "variables": { "item": "reloaded_270win_jsp", "coeff": 52 } },
         "topic": "TALK_GUNSMITH_CONVERT_CONFIRM"
       },
       {
         "text": "[$0.55, <item_name:reloaded_270win_fmj>]",
         "show_always": true,
         "condition": { "math": [ "u_number_artisans_gunsmith_credit >= 55 / 2" ] },
-        "effect": { "run_eocs": "EOC_gunsmith_target", "variables": { "item": "reloaded_270win_fmj", "coeff": "55" } },
+        "effect": { "run_eocs": "EOC_gunsmith_target", "variables": { "item": "reloaded_270win_fmj", "coeff": 55 } },
         "topic": "TALK_GUNSMITH_CONVERT_CONFIRM"
       },
       {
         "text": "[$0.55, <item_name:reloaded_300_winmag>]",
         "show_always": true,
         "condition": { "math": [ "u_number_artisans_gunsmith_credit >= 55 / 2" ] },
-        "effect": { "run_eocs": "EOC_gunsmith_target", "variables": { "item": "reloaded_300_winmag", "coeff": "55" } },
+        "effect": { "run_eocs": "EOC_gunsmith_target", "variables": { "item": "reloaded_300_winmag", "coeff": 55 } },
         "topic": "TALK_GUNSMITH_CONVERT_CONFIRM"
       },
       {
         "text": "[$0.52, <item_name:reloaded_3006_jsp>]",
         "show_always": true,
         "condition": { "math": [ "u_number_artisans_gunsmith_credit >= 52 / 2" ] },
-        "effect": { "run_eocs": "EOC_gunsmith_target", "variables": { "item": "reloaded_3006_jsp", "coeff": "52" } },
+        "effect": { "run_eocs": "EOC_gunsmith_target", "variables": { "item": "reloaded_3006_jsp", "coeff": 52 } },
         "topic": "TALK_GUNSMITH_CONVERT_CONFIRM"
       },
       {
         "text": "[$0.58, <item_name:reloaded_3006fmj>]",
         "show_always": true,
         "condition": { "math": [ "u_number_artisans_gunsmith_credit >= 58 / 2" ] },
-        "effect": { "run_eocs": "EOC_gunsmith_target", "variables": { "item": "reloaded_3006fmj", "coeff": "58" } },
+        "effect": { "run_eocs": "EOC_gunsmith_target", "variables": { "item": "reloaded_3006fmj", "coeff": 58 } },
         "topic": "TALK_GUNSMITH_CONVERT_CONFIRM"
       },
       {
         "text": "[$1.54, <item_name:reloaded_50bmg>]",
         "show_always": true,
         "condition": { "math": [ "u_number_artisans_gunsmith_credit >= 154 / 2" ] },
-        "effect": { "run_eocs": "EOC_gunsmith_target", "variables": { "item": "reloaded_50bmg", "coeff": "154" } },
+        "effect": { "run_eocs": "EOC_gunsmith_target", "variables": { "item": "reloaded_50bmg", "coeff": 154 } },
         "topic": "TALK_GUNSMITH_CONVERT_CONFIRM"
       },
       {
         "text": "[$2.31, <item_name:reloaded_50ss>]",
         "show_always": true,
         "condition": { "math": [ "u_number_artisans_gunsmith_credit >= 231 / 2" ] },
-        "effect": { "run_eocs": "EOC_gunsmith_target", "variables": { "item": "reloaded_50ss", "coeff": "231" } },
+        "effect": { "run_eocs": "EOC_gunsmith_target", "variables": { "item": "reloaded_50ss", "coeff": 231 } },
         "topic": "TALK_GUNSMITH_CONVERT_CONFIRM"
       }
     ]

--- a/data/json/npcs/lumbermill_employees/TALK_lumbermill_fabricate.json
+++ b/data/json/npcs/lumbermill_employees/TALK_lumbermill_fabricate.json
@@ -93,52 +93,52 @@
     "responses": [
       {
         "text": "[<item_name:2x4>, $1 a piece, max 200]",
-        "effect": { "run_eocs": "EOC_LUMBERMILL_FABRICATE_order", "variables": { "name": "2x4", "max": "200" } },
+        "effect": { "run_eocs": "EOC_LUMBERMILL_FABRICATE_order", "variables": { "name": "2x4", "max": 200 } },
         "topic": "TALK_LUMBERMILL_FABRICATE"
       },
       {
         "text": "[<item_name:plank_short>, $0.7 a piece, max 200]",
-        "effect": { "run_eocs": "EOC_LUMBERMILL_FABRICATE_order", "variables": { "name": "plank_short", "max": "200" } },
+        "effect": { "run_eocs": "EOC_LUMBERMILL_FABRICATE_order", "variables": { "name": "plank_short", "max": 200 } },
         "topic": "TALK_LUMBERMILL_FABRICATE"
       },
       {
         "text": "[<item_name:plank_long>, $1.5 a piece, max 200]",
-        "effect": { "run_eocs": "EOC_LUMBERMILL_FABRICATE_order", "variables": { "name": "plank_long", "max": "200" } },
+        "effect": { "run_eocs": "EOC_LUMBERMILL_FABRICATE_order", "variables": { "name": "plank_long", "max": 200 } },
         "topic": "TALK_LUMBERMILL_FABRICATE"
       },
       {
         "text": "[<item_name:wooden_post>, $1 a piece, max 100]",
-        "effect": { "run_eocs": "EOC_LUMBERMILL_FABRICATE_order", "variables": { "name": "wooden_post", "max": "100" } },
+        "effect": { "run_eocs": "EOC_LUMBERMILL_FABRICATE_order", "variables": { "name": "wooden_post", "max": 100 } },
         "topic": "TALK_LUMBERMILL_FABRICATE"
       },
       {
         "text": "[<item_name:wooden_post_short>, $0.7 a piece, max 100]",
-        "effect": { "run_eocs": "EOC_LUMBERMILL_FABRICATE_order", "variables": { "name": "wooden_post_short", "max": "100" } },
+        "effect": { "run_eocs": "EOC_LUMBERMILL_FABRICATE_order", "variables": { "name": "wooden_post_short", "max": 100 } },
         "topic": "TALK_LUMBERMILL_FABRICATE"
       },
       {
         "text": "[<item_name:wooden_post_long>, $1.5 a piece, max 100]",
-        "effect": { "run_eocs": "EOC_LUMBERMILL_FABRICATE_order", "variables": { "name": "wooden_post_long", "max": "100" } },
+        "effect": { "run_eocs": "EOC_LUMBERMILL_FABRICATE_order", "variables": { "name": "wooden_post_long", "max": 100 } },
         "topic": "TALK_LUMBERMILL_FABRICATE"
       },
       {
         "text": "[<item_name:wood_panel>, $8 a piece, max 100]",
-        "effect": { "run_eocs": "EOC_LUMBERMILL_FABRICATE_order", "variables": { "name": "wood_panel", "max": "100" } },
+        "effect": { "run_eocs": "EOC_LUMBERMILL_FABRICATE_order", "variables": { "name": "wood_panel", "max": 100 } },
         "topic": "TALK_LUMBERMILL_FABRICATE"
       },
       {
         "text": "[<item_name:wood_sheet>, $16 a piece, max 100]",
-        "effect": { "run_eocs": "EOC_LUMBERMILL_FABRICATE_order", "variables": { "name": "wood_sheet", "max": "100" } },
+        "effect": { "run_eocs": "EOC_LUMBERMILL_FABRICATE_order", "variables": { "name": "wood_sheet", "max": 100 } },
         "topic": "TALK_LUMBERMILL_FABRICATE"
       },
       {
         "text": "[<item_name:wood_beam>, $25 a piece, max 50]",
-        "effect": { "run_eocs": "EOC_LUMBERMILL_FABRICATE_order", "variables": { "name": "wood_beam", "max": "50" } },
+        "effect": { "run_eocs": "EOC_LUMBERMILL_FABRICATE_order", "variables": { "name": "wood_beam", "max": 50 } },
         "topic": "TALK_LUMBERMILL_FABRICATE"
       },
       {
         "text": "[<item_name:log>, $5 a piece, max 100]",
-        "effect": { "run_eocs": "EOC_LUMBERMILL_FABRICATE_order", "variables": { "name": "log", "max": "100" } },
+        "effect": { "run_eocs": "EOC_LUMBERMILL_FABRICATE_order", "variables": { "name": "log", "max": 100 } },
         "topic": "TALK_LUMBERMILL_FABRICATE"
       },
       {

--- a/data/mods/Magiclysm/effect_on_conditions/mutation_eocs.json
+++ b/data/mods/Magiclysm/effect_on_conditions/mutation_eocs.json
@@ -170,8 +170,8 @@
       {
         "run_eocs": "EOC_GENERIC_SPELL_MUTATION",
         "variables": {
-          "energy_amount": "2500",
-          "prep_time": "1",
+          "energy_amount": 2500,
+          "prep_time": 1,
           "spell_to_cast": "spell_ravenfolk_leap",
           "message_success": { "i18n": true, "str": "You launch yourself into a powerful wing-assisted leap." },
           "message_fail": { "i18n": true, "str": "You're too tired to leap." }
@@ -186,8 +186,8 @@
       {
         "run_eocs": "EOC_GENERIC_SPELL_MUTATION",
         "variables": {
-          "energy_amount": "0",
-          "prep_time": "0",
+          "energy_amount": 0,
+          "prep_time": 0,
           "spell_to_cast": "spell_ravenfolk_screech",
           "message_success": { "i18n": true, "str": "You let out a piercing cry!" },
           "message_fail": { "i18n": true, "str": "You change your mind about screeching." }

--- a/data/mods/TEST_DATA/EOC.json
+++ b/data/mods/TEST_DATA/EOC.json
@@ -236,10 +236,7 @@
     "id": "EOC_run_with_test",
     "effect": [
       { "math": [ "u_ukey = 3" ] },
-      {
-        "run_eocs": "EOC_run_with_test_nested",
-        "variables": { "key1": "1", "key2": "2", "key3": { "u_val": "ukey" } }
-      }
+      { "run_eocs": "EOC_run_with_test_nested", "variables": { "key1": 1, "key2": 2, "key3": { "u_val": "ukey" } } }
     ]
   },
   {
@@ -249,7 +246,7 @@
       { "math": [ "u_ukey = 3" ] },
       {
         "run_eocs": "EOC_run_with_test_nested",
-        "variables": { "key1": "1", "key2": "2", "key3": { "u_val": "ukey" } },
+        "variables": { "key1": 1, "key2": 2, "key3": { "u_val": "ukey" } },
         "time_in_future": "1 seconds"
       }
     ]
@@ -264,10 +261,7 @@
     "id": "EOC_run_with_test_expects_pass",
     "effect": [
       { "math": [ "u_ukey = 3" ] },
-      {
-        "run_eocs": "EOC_run_with_test_nested2",
-        "variables": { "key1": "1", "key2": "2", "key3": { "u_val": "ukey" } }
-      }
+      { "run_eocs": "EOC_run_with_test_nested2", "variables": { "key1": 1, "key2": 2, "key3": { "u_val": "ukey" } } }
     ]
   },
   {

--- a/data/mods/TEST_DATA/effect_on_condition.json
+++ b/data/mods/TEST_DATA/effect_on_condition.json
@@ -166,6 +166,40 @@
   },
   {
     "type": "effect_on_condition",
+    "id": "EOC_copy_vars",
+    "effect": [
+      { "copy_var": { "context_val": "dbl_val" }, "target_var": { "global_val": "dbl_val" } },
+      { "copy_var": { "context_val": "str_val" }, "target_var": { "global_val": "str_val" } },
+      { "copy_var": { "context_val": "i18n_val" }, "target_var": { "global_val": "i18n_val" } },
+      { "copy_var": { "context_val": "tripoint_val" }, "target_var": { "global_val": "tripoint_val" } },
+      { "copy_var": { "context_val": "math_val" }, "target_var": { "global_val": "math_val" } },
+      { "copy_var": { "context_val": "inf_val" }, "target_var": { "global_val": "inf_val" } },
+      { "copy_var": { "context_val": "nan_val" }, "target_var": { "global_val": "nan_val" } },
+      { "copy_var": { "context_val": "copied_val" }, "target_var": { "global_val": "copied_val" } }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "run_eocs_variable_types",
+    "effect": [
+      { "set_string_var": "BLORG", "target_var": { "context_val": "blorgyvar" } },
+      {
+        "run_eocs": [ "EOC_copy_vars" ],
+        "variables": {
+          "dbl_val": 8,
+          "str_val": "blorg",
+          "i18n_val": { "i18n": true, "str": "battery" },
+          "tripoint_val": { "tripoint": [ 0, 10, 0 ] },
+          "math_val": { "math": [ "2 + 2 - 1" ] },
+          "inf_val": { "dbl": "+inf" },
+          "nan_val": { "dbl": "-nan" },
+          "copied_val": { "context_val": "blorgyvar" }
+        }
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
     "id": "EOC_compare_string_test",
     "effect": [
       { "if": { "compare_string": [ "yes", "yes" ] }, "then": { "math": [ "eoc_compare_string_test_1++" ] } },

--- a/data/mods/TEST_DATA/items.json
+++ b/data/mods/TEST_DATA/items.json
@@ -5471,10 +5471,10 @@
             "effect": {
               "run_eocs": "EOC_toolweapon_activate",
               "variables": {
-                "turn_cost": "0.8",
+                "turn_cost": 0.8,
                 "transform_target": "carver_on",
                 "success_message": { "i18n": true, "str": "The electric carver's serrated blades start buzzing!" },
-                "volume": "20",
+                "volume": 20,
                 "failure_message": { "i18n": true, "str": "You pull the trigger, but nothing happens." }
               }
             }

--- a/data/mods/Xedra_Evolved/mutations/gracken_trait_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/gracken_trait_eocs.json
@@ -23,7 +23,7 @@
       {
         "run_eocs": "EOC_GENERIC_SPELL_MUTATION",
         "variables": {
-          "prep_time": "1",
+          "prep_time": 1,
           "spell_to_cast": "gracken_arm_push_spell",
           "message_success": { "i18n": true, "str": "You lash out and push your target away!" }
         }

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/arvore_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/arvore_eocs.json
@@ -496,7 +496,7 @@
       {
         "run_eocs": "EOC_GENERIC_SPELL_MUTATION",
         "variables": {
-          "prep_time": "1",
+          "prep_time": 1,
           "spell_to_cast": "arvore_vine_drag_spell",
           "message_success": { "i18n": true, "str": "Vines lash out and drag your target in!" },
           "message_fail": { "i18n": true, "str": "You are too parched to lash out with any vines." }

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/ierde_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/ierde_eocs.json
@@ -318,7 +318,7 @@
       {
         "run_eocs": "EOC_GENERIC_SPELL_MUTATION",
         "variables": {
-          "prep_time": "0.5",
+          "prep_time": 0.5,
           "spell_to_cast": "ierde_smashing_punch_spell",
           "message_success": { "i18n": true, "str": "You gather yourself for a moment and strike." },
           "message_fail": ""
@@ -334,7 +334,7 @@
       {
         "run_eocs": "EOC_GENERIC_SPELL_MUTATION",
         "variables": {
-          "prep_time": "1",
+          "prep_time": 1,
           "spell_to_cast": "ierde_no_sleep_meditate_spell",
           "message_success": { "i18n": true, "str": "You settle down, feeling the ground beneath you, and begin your vigil" },
           "message_fail": ""

--- a/data/mods/Xedra_Evolved/mutations/xe_lilin_trait_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/xe_lilin_trait_eocs.json
@@ -438,8 +438,8 @@
       {
         "run_eocs": "EOC_GENERIC_SPELL_MUTATION",
         "variables": {
-          "energy_amount": "2000",
-          "prep_time": "1",
+          "energy_amount": 2000,
+          "prep_time": 1,
           "spell_to_cast": "lilin_strix_leap_spell",
           "message_success": {
             "i18n": true,

--- a/data/mods/aftershock_exoplanet/doc/Hacking.md
+++ b/data/mods/aftershock_exoplanet/doc/Hacking.md
@@ -24,7 +24,7 @@ To define a Hackable Furniture in Aftershock you need to give it an examine acti
             { "math": [ "_t_delay = time('20 m')" ] },
             {
               "run_eocs": "EOC_start_lock_hack",
-              "variables": { "furn_pos": { "context_val": "pos" }, "t_delay": { "context_val": "t_delay" }, "difficulty": "10", "t_radius": "0" },
+              "variables": { "furn_pos": { "context_val": "pos" }, "t_delay": { "context_val": "t_delay" }, "difficulty": 10, "t_radius": 0 },
               "alpha_talker": "avatar"
             }
           ]
@@ -46,7 +46,7 @@ To define a Hackable Furniture in Aftershock you need to give it an examine acti
             { "u_add_var": "hack_success_eoc", value: "EOC_Hack_Custom_Success" },
             {
               "run_eocs": "EOC_start_lock_hack",
-              "variables": { "furn_pos": { "context_val": "pos" }, "t_delay": { "context_val": "t_delay" }, "difficulty": "10", "t_radius": "6", "power_cost_mult": 2 },
+              "variables": { "furn_pos": { "context_val": "pos" }, "t_delay": { "context_val": "t_delay" }, "difficulty": 10, "t_radius": 6, "power_cost_mult": 2 },
               "alpha_talker": "avatar"
             }
           ]

--- a/data/mods/aftershock_exoplanet/items/armor/energy_shield.json
+++ b/data/mods/aftershock_exoplanet/items/armor/energy_shield.json
@@ -78,10 +78,10 @@
             "run_eocs": "EOC_start_shield",
             "variables": {
               "transform_target": "afs_backpack_shieldgen_on",
-              "shield_max_hp": "600",
-              "shield_regen": "2",
-              "shield_regen_rate": "1",
-              "turn_cost": "1",
+              "shield_max_hp": 600,
+              "shield_regen": 2,
+              "shield_regen_rate": 1,
+              "turn_cost": 1,
               "success_message": "a",
               "failure_message": "b"
             }

--- a/data/mods/aftershock_exoplanet/maps/furniture_and_terrain/furniture_habitat.json
+++ b/data/mods/aftershock_exoplanet/maps/furniture_and_terrain/furniture_habitat.json
@@ -415,7 +415,7 @@
             { "math": [ "_t_delay = time('20 m')" ] },
             {
               "run_eocs": "EOC_start_lock_hack",
-              "variables": { "furn_pos": { "context_val": "pos" }, "t_delay": { "context_val": "t_delay" }, "difficulty": "9", "t_radius": "0" },
+              "variables": { "furn_pos": { "context_val": "pos" }, "t_delay": { "context_val": "t_delay" }, "difficulty": 9, "t_radius": 0 },
               "alpha_talker": "avatar"
             }
           ]
@@ -481,7 +481,7 @@
             { "math": [ "_t_delay = time('20 m')" ] },
             {
               "run_eocs": "EOC_start_lock_hack",
-              "variables": { "furn_pos": { "context_val": "pos" }, "t_delay": { "context_val": "t_delay" }, "difficulty": "10", "t_radius": "0" },
+              "variables": { "furn_pos": { "context_val": "pos" }, "t_delay": { "context_val": "t_delay" }, "difficulty": 10, "t_radius": 0 },
               "alpha_talker": "avatar"
             }
           ]
@@ -680,7 +680,7 @@
             { "math": [ "_t_delay = time('20 m')" ] },
             {
               "run_eocs": "EOC_start_lock_hack",
-              "variables": { "furn_pos": { "context_val": "pos" }, "t_delay": { "context_val": "t_delay" }, "difficulty": "10", "t_radius": "6" },
+              "variables": { "furn_pos": { "context_val": "pos" }, "t_delay": { "context_val": "t_delay" }, "difficulty": 10, "t_radius": 6 },
               "alpha_talker": "avatar"
             }
           ]
@@ -714,7 +714,7 @@
             { "math": [ "_t_delay = time('20 m')" ] },
             {
               "run_eocs": "EOC_start_lock_hack",
-              "variables": { "furn_pos": { "context_val": "pos" }, "t_delay": { "context_val": "t_delay" }, "difficulty": "10", "t_radius": "10" },
+              "variables": { "furn_pos": { "context_val": "pos" }, "t_delay": { "context_val": "t_delay" }, "difficulty": 10, "t_radius": 10 },
               "alpha_talker": "avatar"
             }
           ]
@@ -795,7 +795,7 @@
             { "math": [ "_t_delay = time('1 h')" ] },
             {
               "run_eocs": "EOC_start_lock_hack",
-              "variables": { "furn_pos": { "context_val": "pos" }, "t_delay": { "context_val": "t_delay" }, "difficulty": "13", "t_radius": "1" },
+              "variables": { "furn_pos": { "context_val": "pos" }, "t_delay": { "context_val": "t_delay" }, "difficulty": 13, "t_radius": 1 },
               "alpha_talker": "avatar"
             }
           ]

--- a/data/mods/aftershock_exoplanet/maps/furniture_and_terrain/terrain_habitat_doors.json
+++ b/data/mods/aftershock_exoplanet/maps/furniture_and_terrain/terrain_habitat_doors.json
@@ -27,7 +27,7 @@
             { "math": [ "_t_delay = time('20 m')" ] },
             {
               "run_eocs": "EOC_start_lock_hack",
-              "variables": { "furn_pos": { "context_val": "pos" }, "t_delay": { "context_val": "t_delay" }, "difficulty": "9", "t_radius": "0" },
+              "variables": { "furn_pos": { "context_val": "pos" }, "t_delay": { "context_val": "t_delay" }, "difficulty": 9, "t_radius": 0 },
               "alpha_talker": "avatar"
             }
           ]

--- a/data/mods/aftershock_exoplanet/player/bionics.json
+++ b/data/mods/aftershock_exoplanet/player/bionics.json
@@ -268,9 +268,9 @@
         "effect": {
           "run_eocs": "EOC_bio_start_shield",
           "variables": {
-            "shield_max_hp": "120",
-            "shield_regen": "1",
-            "shield_regen_rate": "2",
+            "shield_max_hp": 120,
+            "shield_regen": 1,
+            "shield_regen_rate": 2,
             "success_message": "The shield activates.",
             "failure_message": "Your implant vibrates uncomfortably as the shield fails to activate."
           }
@@ -299,9 +299,9 @@
         "effect": {
           "run_eocs": "EOC_bio_start_shield",
           "variables": {
-            "shield_max_hp": "550",
-            "shield_regen": "2",
-            "shield_regen_rate": "1",
+            "shield_max_hp": 550,
+            "shield_regen": 2,
+            "shield_regen_rate": 1,
             "success_message": "The shield activates.",
             "failure_message": "Your implant vibrates uncomfortably as the shield fails to activate."
           }
@@ -329,9 +329,9 @@
         "effect": {
           "run_eocs": "EOC_bio_start_shield",
           "variables": {
-            "shield_max_hp": "10000",
-            "shield_regen": "20",
-            "shield_regen_rate": "1",
+            "shield_max_hp": 10000,
+            "shield_regen": 20,
+            "shield_regen_rate": 1,
             "success_message": "All surrounding noise is muted as the barrier coalesces.",
             "failure_message": "Your implant vibrates uncomfortably as the shield fails to activate."
           }

--- a/doc/JSON/EFFECT_ON_CONDITION.md
+++ b/doc/JSON/EFFECT_ON_CONDITION.md
@@ -1999,8 +1999,25 @@ Runs another EoC. It can be a separate EoC, or an inline EoC inside `run_eocs` e
 | "alpha_loc","beta_loc" | optional | [variable object](#variable-object) | Allows to swap talker by defining `u_location_variable`, where the EoC should be run. Set the alpha/beta talker to the creature at the location. |
 | "alpha_talker","beta_talker" | optional (If you use both "alpha_loc" and "alpha_talker", "alpha_talker" will be ignored, same for beta.) | string, [variable object](#variable-object) | Set alpha/beta talker. This can be either a `character_id` (you can get from [EOC event](#event-eocs) or result of [u_set_talker](#u_set_talkernpc_set_talker) ), or some hard-coded values: <br> `""`: null talker <br> `"u"/"npc": the alpha/beta talker of the EOC`(Should be Avatar/Character/NPC/Monster) <br> `"avatar"`: your avatar|
 | "false_eocs" | optional | string, [variable object](#variable-object), inline EoC, or range of all of them | false EOCs will run if<br>1. there is no creature at "alpha_loc"/"beta_loc",or<br>2. "alpha_talker" or "beta_talker" doesn't exist in the game (eg. dead NPC),or<br>3. alpha and beta talker are both null |
-| "variables" | optional | pair of `"variable_name": "variable"` | context variables, that would be passed to the EoC; numeric values should be specified as strings; when a variable is an object and has the `i18n` member set to true, the variable will be localized; `expects_vars` condition can be used inside running eoc to ensure every variable exist before the EoC is run | 
+| "variables" | optional | pair of `"variable_name": "variable"` | context variables, that would be passed to the EoC; can be either a [variable object](#variable-object), or an [inline variable](#inline-variables) ;<br/><br/> `expects_vars` condition can be used inside running eoc to ensure every variable exist before the EoC is run | 
 
+##### Inline Variables
+Variable values can be declared inline and must use the correct type:
+
+```jsonc
+        "variables": {
+          "dbl_val": 8,
+          "str_val": "blorg",
+          "i18n_val": { "i18n": true, "str": "battery" },
+          "tripoint_val": { "tripoint": [ 0, 10, 0 ] },
+          // quick maths
+          "math_val": { "math": [ "2 + 2 - 1" ] },
+          // inf and nan are not allowed in JSON so they're wrapped in a "dbl" object
+          "inf_val": { "dbl": "+inf" },
+          "nan_val": { "dbl": "-nan" },
+          "copied_val": { "context_val": "blorgyvar" }
+        }
+```
 
 ##### Valid talkers:
 
@@ -2081,7 +2098,7 @@ Second EoC `EOC_I_NEED_AN_AK47` aslo run `EOC_GIVE_A_GUN` with the same variable
       "run_eocs": "EOC_GIVE_A_GUN",
       "variables": {
         "gun_name": "ar15_223medium",
-        "amount_of_guns": "5"
+        "amount_of_guns": 5
       }
     }
   ]
@@ -2094,7 +2111,7 @@ Second EoC `EOC_I_NEED_AN_AK47` aslo run `EOC_GIVE_A_GUN` with the same variable
       "run_eocs": "EOC_GIVE_A_GUN",
       "variables": {
         "gun_name": "ak47",
-        "amount_of_guns": "3"
+        "amount_of_guns": 3
       }
     }
   ]
@@ -2908,7 +2925,7 @@ Open a menu, that allow to select one of multiple options
 | "hide_failing" | optional | boolean | if true, the options, that fail their check, would be completely removed from the list, instead of being grayed out | 
 | "allow_cancel" | optional | boolean | if true, you can quit the menu without selecting an option, no effect will occur | 
 | "hilight_disabled" | optional | boolean | if true, the option, that fail their check, would still be navigateable, meaning you can highlight it and read it's description. If `allow_cancel` is true, picking it would be considered same as quitting | 
-| "variables" | optional | pair of `"variable_name": "variable"` | variables, that would be passed to the EoCs; numeric values should be specified as strings; when a variable is an object and has the `i18n` member set to true, the variable will be localized; `expects_vars` condition can be used to ensure every variable exist before the EoC is run | 
+| "variables" | optional | pair of `"variable_name": "variable"` | variables, that would be passed to the EoCs; can be either a [variable object](#variable-object), or an [inline variable](#inline-variables); `expects_vars` condition can be used to ensure every variable exist before the EoC is run | 
 ##### Valid talkers:
 
 | Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
@@ -5101,7 +5118,7 @@ Spawn some monsters around you, NPC or `target_var`
 | "lifespan" | optional | int, duration, [variable object](#variable-object) or value between two | if used, critters would live that amount of time, and disappear in the end | 
 | "target_var" | optional | [variable object](#variable-object) | if used, the monster would spawn from this location instead of you or NPC | 
 | "temporary_drop_items" | optional | boolean | default false; if true, monsters summoned with a lifespan will still drop items and leave a corpse.
-| "mon_variables" | optional | string or [variable object](#variable-object) | if used, the monster would have this variables when spawned.
+| "mon_variables" | optional | [variable object](#variable-object) or [inline variables](#inline-variables) | if used, the monster would have this variables when spawned.
 | "summoner_is_alpha", "summoner_is_beta" | optional | bool | if used, the monster would define alpha/beta talker as it's summoner
 | "spawn_message", "spawn_message_plural" | optional | string or [variable object](#variable-object) | if you see monster or monsters that was spawned, related message would be printed | 
 | "true_eocs", "false_eocs" | optional | string, [variable object](#variable-object), inline EoC, or range of all of them | if at least 1 monster was spawned, all EoCs from `true_eocs` are run, otherwise all EoCs from `false_eocs` are run | 

--- a/doc/JSON/ITEM.md
+++ b/doc/JSON/ITEM.md
@@ -1546,7 +1546,7 @@ Example:
     "variables": { "browsed": "false" }
 ```
 ```jsonc
-    "variables": { "water_per_tablet": "4" }
+    "variables": { "water_per_tablet": 4 }
 ```
 
 This will make any item instantiated from that prototype get assigned this variable, once

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -240,27 +240,6 @@ translation_or_var get_translation_or_var( const JsonValue &jv, std::string_view
     return ret;
 }
 
-void str_translation_or_var::deserialize( JsonValue const &jv )
-{
-    if( jv.test_object() ) {
-        const JsonObject &jo = jv.get_object();
-        if( jo.get_bool( "i18n", false ) ) {
-            translation tov;
-            mandatory( jo, false, "str", tov );
-            val = translation_or_var{ tov };
-        } else {
-            jo.allow_omitted_members();
-            str_or_var sov;
-            sov.deserialize( jv );
-            val = sov;
-        }
-    } else {
-        str_or_var sov;
-        sov.deserialize( jv );
-        val = sov;
-    }
-}
-
 void var_info::deserialize( JsonValue const &jsin )
 {
     _deserialize( jsin.get_object() );

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -15,7 +15,6 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
-#include <variant>
 #include <vector>
 
 #include "avatar.h"
@@ -2120,16 +2119,26 @@ template<class T>
 static std::function<T( const_dialogue const & )> get_get_translation_( const JsonObject &jo,
         std::function<T( const translation & )> ret_func )
 {
+    // straight translation - used by diag_value_or_var
+    if( jo.get_bool( "i18n", false ) && jo.has_string( "str" ) ) {
+        translation tr;
+        tr.deserialize( jo.get_member( "str" ) );
+        return [tr, ret_func]( const_dialogue const &/* d */ ) {
+            return ret_func( tr );
+        };
+    }
+
     if( !jo.has_string( "mutator" ) ) {
         return nullptr;
     }
-    if( jo.get_string( "mutator" ) == "ma_technique_description" ) {
+    std::string const &mutator = jo.get_string( "mutator" );
+    if( mutator == "ma_technique_description" ) {
         str_or_var ma = get_str_or_var( jo.get_member( "matec_id" ), "matec_id" );
 
         return [ma, ret_func]( const_dialogue const & d ) {
             return ret_func( matec_id( ma.evaluate( d ) )->description );
         };
-    } else if( jo.get_string( "mutator" ) == "ma_technique_name" ) {
+    } else if( mutator == "ma_technique_name" ) {
         str_or_var ma = get_str_or_var( jo.get_member( "matec_id" ), "matec_id" );
 
         return [ma, ret_func]( const_dialogue const & d ) {

--- a/src/dialogue_helpers.cpp
+++ b/src/dialogue_helpers.cpp
@@ -64,21 +64,6 @@ var_info process_variable( const std::string &type )
     return { vt, ret_str };
 }
 
-std::string str_translation_or_var::evaluate( const_dialogue const &d, bool /* convert */ ) const
-{
-    return std::visit( overloaded{
-        [&d]( str_or_var const & tv ) -> std::string
-        {
-            return tv.evaluate( d );
-        },
-        [&d]( translation_or_var const & tv ) -> std::string
-        {
-            return tv.evaluate( d ).translated();
-        },
-    },
-    val );
-}
-
 namespace
 {
 

--- a/src/dialogue_helpers.h
+++ b/src/dialogue_helpers.h
@@ -144,12 +144,6 @@ extern template struct value_or_var<translation, string_mutator<translation>>;
 using str_or_var = value_or_var<std::string, string_mutator<std::string>>;
 using translation_or_var = value_or_var<translation, string_mutator<translation>>;
 
-struct str_translation_or_var {
-    std::variant<str_or_var, translation_or_var> val;
-    std::string evaluate( const_dialogue const &, bool convert = false ) const;
-    void deserialize( JsonValue const &jv );
-};
-
 struct talk_effect_fun_t {
     public:
         using likely_reward_t = std::pair<dbl_or_var, str_or_var>;

--- a/src/math_parser_diag_value.h
+++ b/src/math_parser_diag_value.h
@@ -83,7 +83,10 @@ struct diag_value {
     std::string to_string( bool i18n = false ) const;
 
     void serialize( JsonOut & ) const;
-    void deserialize( const JsonValue &jsin );
+    void _deserialize( const JsonValue &jsin, bool allow_legacy );
+    void deserialize( const JsonValue &jsin ) {
+        _deserialize( jsin, true );
+    }
 
     struct legacy_value {
         std::string val;

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -183,6 +183,9 @@ static std::map<std::string, json_talk_topic> json_talk_topics;
 using item_menu = std::function<item_location( const item_location_filter & )>;
 using item_menu_mul = std::function<drop_locations( const item_location_filter & )>;
 
+extern template struct value_or_var<diag_value, eoc_math, string_mutator<translation>>;
+using diag_value_or_var = value_or_var<diag_value, eoc_math, string_mutator<translation>>;
+
 struct sub_effect_parser {
     using f_t = talk_effect_fun_t::func( * )( const JsonObject &, std::string_view,
                 std::string_view src );
@@ -6200,13 +6203,13 @@ talk_effect_fun_t::func f_run_eocs( const JsonObject &jo, std::string_view membe
         random_time = jo.get_bool( "randomize_time_in_future", false );
     }
 
-    std::unordered_map<std::string, str_translation_or_var> context;
+    std::unordered_map<std::string, diag_value_or_var> context;
     if( jo.has_object( "variables" ) ) {
         const JsonObject &variables = jo.get_object( "variables" );
         for( const JsonMember &jv : variables ) {
-            str_translation_or_var stov;
-            stov.deserialize( jv );
-            context[jv.name()] = stov;
+            diag_value_or_var vov;
+            mandatory( variables, false, jv.name(), vov );
+            context[jv.name()] = vov;
         }
     }
 
@@ -6243,8 +6246,7 @@ talk_effect_fun_t::func f_run_eocs( const JsonObject &jo, std::string_view membe
                             d.get_context() };
 
         for( const auto &val : context ) {
-            // FXIXME: typed variables
-            newDialog.set_value( val.first, diag_value::legacy_value{ val.second.evaluate( d, true ) } );
+            newDialog.set_value( val.first, val.second.evaluate( d ) );
         }
 
         if( dov_time ) {
@@ -6302,15 +6304,15 @@ talk_effect_fun_t::func f_run_eoc_selector( const JsonObject &jo, std::string_vi
         jo.throw_error( "Invalid input for run_eoc_selector, size of eocs and keys needs to be identical, or keys need to be empty." );
     }
 
-    std::vector<std::unordered_map<std::string, str_translation_or_var>> context;
+    std::vector<std::unordered_map<std::string, diag_value_or_var>> context;
     if( jo.has_array( "variables" ) ) {
         for( const JsonValue &member : jo.get_array( "variables" ) ) {
             const JsonObject &variables = member.get_object();
-            std::unordered_map<std::string, str_translation_or_var> temp_context;
+            std::unordered_map<std::string, diag_value_or_var> temp_context;
             for( const JsonMember &jv : variables ) {
-                str_translation_or_var stov;
-                stov.deserialize( jv );
-                temp_context[jv.name()] = stov;
+                diag_value_or_var vov;
+                mandatory( variables, false, jv.name(), vov );
+                temp_context[jv.name()] = vov;
             }
             context.emplace_back( temp_context );
         }
@@ -6405,8 +6407,7 @@ talk_effect_fun_t::func f_run_eoc_selector( const JsonObject &jo, std::string_vi
         }
         if( !context.empty() ) {
             for( const auto &val : context[contextIndex] ) {
-                // FIXME: typed variables
-                newDialog.set_value( val.first, diag_value::legacy_value{ val.second.evaluate( d, true ) } );
+                newDialog.set_value( val.first, val.second.evaluate( d ) );
             }
         }
 
@@ -7134,11 +7135,13 @@ talk_effect_fun_t::func f_spawn_monster( const JsonObject &jo, std::string_view 
     dbl_or_var dov_max_radius = get_dbl_or_var( jo, "max_radius", false, 10 );
     bool summoner_is_alpha = jo.get_bool( "summoner_is_alpha", false );
     bool summoner_is_beta = jo.get_bool( "summoner_is_beta", false );
-    std::unordered_map<std::string, str_or_var> set_mon_var;
+    std::unordered_map<std::string, diag_value_or_var> set_mon_var;
     if( jo.has_object( "mon_variables" ) ) {
         const JsonObject &variables = jo.get_object( "mon_variables" );
         for( const JsonMember &jv : variables ) {
-            set_mon_var[jv.name()] = get_str_or_var( jv, jv.name(), true );
+            diag_value_or_var vov;
+            mandatory( variables, false, jv.name(), vov );
+            set_mon_var[jv.name()] = vov;
         }
     }
 
@@ -7290,8 +7293,7 @@ talk_effect_fun_t::func f_spawn_monster( const JsonObject &jo, std::string_view 
                     }
                     if( !set_mon_var.empty() ) {
                         for( const auto &val : set_mon_var ) {
-                            // FIXME: typed variables
-                            spawned->set_value( val.first, diag_value::legacy_value{ val.second.evaluate( d ) } );
+                            spawned->set_value( val.first, val.second.evaluate( d ) );
                         }
                     }
                     spawns++;

--- a/tests/eoc_test.cpp
+++ b/tests/eoc_test.cpp
@@ -1,3 +1,4 @@
+#include <cmath>
 #include <cstddef>
 #include <functional>
 #include <list>
@@ -48,6 +49,10 @@
 #include "talker.h"
 #include "timed_event.h"
 #include "type_id.h"
+
+#if defined(LOCALIZE)
+#include "translation_manager.h"
+#endif
 
 class recipe;
 
@@ -174,6 +179,8 @@ static const effect_on_condition_id
 effect_on_condition_run_eocs_talker_mixes( "run_eocs_talker_mixes" );
 static const effect_on_condition_id
 effect_on_condition_run_eocs_talker_mixes_loc( "run_eocs_talker_mixes_loc" );
+static const effect_on_condition_id
+effect_on_condition_run_eocs_variable_types( "run_eocs_variable_types" );
 
 static const flag_id json_flag_FILTHY( "FILTHY" );
 
@@ -1550,4 +1557,24 @@ TEST_CASE( "EOC_run_eocs", "[eoc]" )
     d2.set_value( "alpha_var", mon_loc );
     CHECK( effect_on_condition_run_eocs_talker_mixes_loc->activate( d2 ) );
     CHECK( globvars.get_global_value( "alpha_name" ) == zombie->get_name() );
+
+#if defined(LOCALIZE)
+    on_out_of_scope reset_loc( []() {
+        set_language( "en" );
+    } );
+    set_language( "ru" );
+    TranslationManager::GetInstance().LoadDocuments( { "./data/mods/TEST_DATA/lang/mo/ru/LC_MESSAGES/TEST_DATA.mo" } );
+#endif
+    dialogue d3( std::make_unique<talker>(), std::make_unique<talker>() );
+    effect_on_condition_run_eocs_variable_types->activate( d3 );
+    CHECK( globvars.get_global_value( "dbl_val" ) == 8 );
+    CHECK( globvars.get_global_value( "str_val" ) == "blorg" );
+#if defined(LOCALIZE)
+    CHECK( globvars.get_global_value( "i18n_val" ) == "батарейка" );
+#endif
+    CHECK( globvars.get_global_value( "tripoint_val" ) == tripoint_abs_ms( 0, 10, 0 ) );
+    CHECK( globvars.get_global_value( "math_val" ) == 3 );
+    CHECK( std::isinf( globvars.get_global_value( "inf_val" ).dbl() ) );
+    CHECK( std::isnan( globvars.get_global_value( "nan_val" ).dbl() ) );
+    CHECK( globvars.get_global_value( "copied_val" ) == "BLORG" );
 }


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
The `run_eocs` family of functions use legacy variable values because the solution was too large for #80455

~~Depends on, and includes, #82687~~
~~This PR starts at d51e1abcb8e6422b0c393ac5317d1e320308bdd9 `eoc: use typed variables in run_eocs`~~

#### Describe the solution
Add the bits necessary so you can declare variables in their real type instead of a string representation
You can also do math in variable declarations now

#### Describe alternatives you've considered
Localized strings are translated on set rather than on evaluate, to match existing art in `set_string_var`, though I'm not entirely sure it's the correct approach. Adding `translation` to `diag_value` would open its own can of worms though.

#### Testing
Existing and updated test units

#### Additional context
N/A