### PR TITLE
Allow ignoring false positives on the Android accessability services warning

### DIFF
--- a/android/app/src/main/java/com/cleverraven/cataclysmdda/CataclysmDDA_Helpers.java
+++ b/android/app/src/main/java/com/cleverraven/cataclysmdda/CataclysmDDA_Helpers.java
@@ -10,6 +10,7 @@ import android.accessibilityservice.AccessibilityService;
 import android.accessibilityservice.AccessibilityServiceInfo;
 import android.content.pm.ServiceInfo;
 import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
 import android.widget.Toast;
 
 public class CataclysmDDA_Helpers {
@@ -22,7 +23,7 @@ public class CataclysmDDA_Helpers {
     public static String getEnabledAccessibilityServiceNames(Context context) {
         List<AccessibilityServiceInfo> enabledServicesInfo = getEnabledAccessibilityServiceInfo( context );
         String service_names = "";
-        Set<String> false_positives = context.getSharedPreferences("accessibility_service_info", Context.MODE_PRIVATE).getStringSet("accessibility_service_info_false_positives", new HashSet<String>());
+        Set<String> false_positives = PreferenceManager.getDefaultSharedPreferences(context.getApplicationContext()).getStringSet("Accessibility Service Info False Positives", new HashSet<String>());
         for (AccessibilityServiceInfo enabledService : enabledServicesInfo) {
             ServiceInfo enabledServiceInfo = enabledService.getResolveInfo().serviceInfo;
             String service_name = enabledServiceInfo.name;
@@ -35,14 +36,15 @@ public class CataclysmDDA_Helpers {
 
     public static void saveAccessibilityServiceInfoFalsePositives(Context context) {
         List<AccessibilityServiceInfo> enabledServicesInfo = getEnabledAccessibilityServiceInfo( context );
-        SharedPreferences preferences = context.getSharedPreferences("accessibility_service_info", Context.MODE_PRIVATE);
-        Set<String> false_positives = preferences.getStringSet("accessibility_service_info_false_positives", new HashSet<String>());
+        SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context.getApplicationContext());
+        // Purposeful copy to avoid some nonsense
+        Set<String> false_positives = new HashSet<String>(preferences.getStringSet("Accessibility Service Info False Positives", new HashSet<String>()));
         for (AccessibilityServiceInfo enabledService : enabledServicesInfo) {
             ServiceInfo enabledServiceInfo = enabledService.getResolveInfo().serviceInfo;
             false_positives.add( enabledServiceInfo.name );
         }
         SharedPreferences.Editor editor = preferences.edit();
-        editor.putStringSet("accessibility_service_info_false_positives", false_positives);
+        editor.putStringSet("Accessibility Service Info False Positives", false_positives);
         editor.commit();        
     }
 }

--- a/android/app/src/main/java/com/cleverraven/cataclysmdda/CataclysmDDA_Helpers.java
+++ b/android/app/src/main/java/com/cleverraven/cataclysmdda/CataclysmDDA_Helpers.java
@@ -1,12 +1,15 @@
 package com.cleverraven.cataclysmdda;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import android.content.Context;
 import android.view.accessibility.AccessibilityManager;
 import android.accessibilityservice.AccessibilityService;
 import android.accessibilityservice.AccessibilityServiceInfo;
 import android.content.pm.ServiceInfo;
+import android.content.SharedPreferences;
 import android.widget.Toast;
 
 public class CataclysmDDA_Helpers {
@@ -19,11 +22,27 @@ public class CataclysmDDA_Helpers {
     public static String getEnabledAccessibilityServiceNames(Context context) {
         List<AccessibilityServiceInfo> enabledServicesInfo = getEnabledAccessibilityServiceInfo( context );
         String service_names = "";
+        Set<String> false_positives = context.getSharedPreferences("accessibility_service_info", Context.MODE_PRIVATE).getStringSet("accessibility_service_info_false_positives", new HashSet<String>());
         for (AccessibilityServiceInfo enabledService : enabledServicesInfo) {
             ServiceInfo enabledServiceInfo = enabledService.getResolveInfo().serviceInfo;
             String service_name = enabledServiceInfo.name;
-            service_names = service_names + "\n" + service_name;
+            if( !false_positives.contains( service_name ) ) {
+                service_names = service_names + "\n" + service_name;
+            }
         }
         return service_names;
+    }
+
+    public static void saveAccessibilityServiceInfoFalsePositives(Context context) {
+        List<AccessibilityServiceInfo> enabledServicesInfo = getEnabledAccessibilityServiceInfo( context );
+        SharedPreferences preferences = context.getSharedPreferences("accessibility_service_info", Context.MODE_PRIVATE);
+        Set<String> false_positives = preferences.getStringSet("accessibility_service_info_false_positives", new HashSet<String>());
+        for (AccessibilityServiceInfo enabledService : enabledServicesInfo) {
+            ServiceInfo enabledServiceInfo = enabledService.getResolveInfo().serviceInfo;
+            false_positives.add( enabledServiceInfo.name );
+        }
+        SharedPreferences.Editor editor = preferences.edit();
+        editor.putStringSet("accessibility_service_info_false_positives", false_positives);
+        editor.commit();        
     }
 }

--- a/android/app/src/main/java/com/cleverraven/cataclysmdda/SplashScreen.java
+++ b/android/app/src/main/java/com/cleverraven/cataclysmdda/SplashScreen.java
@@ -162,6 +162,13 @@ public class SplashScreen extends Activity {
                         dialog.dismiss();
                         return;
                     }
+            })
+            .setNeutralButton(getString(R.string.ignoreFalsePostives), new DialogInterface.OnClickListener() {
+                    public void onClick(DialogInterface dialog, int id) {
+                        CataclysmDDA_Helpers.saveAccessibilityServiceInfoFalsePositives(getApplicationContext());
+                        SplashScreen.this.installOrRun();
+                        return;
+                    }
             }).create();
     }
 

--- a/android/app/src/main/java/com/cleverraven/cataclysmdda/SplashScreen.java
+++ b/android/app/src/main/java/com/cleverraven/cataclysmdda/SplashScreen.java
@@ -163,7 +163,7 @@ public class SplashScreen extends Activity {
                         return;
                     }
             })
-            .setNeutralButton(getString(R.string.ignoreFalsePostives), new DialogInterface.OnClickListener() {
+            .setNegativeButton(getString(R.string.ignoreFalsePostives), new DialogInterface.OnClickListener() {
                     public void onClick(DialogInterface dialog, int id) {
                         CataclysmDDA_Helpers.saveAccessibilityServiceInfoFalsePositives(getApplicationContext());
                         SplashScreen.this.installOrRun();

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -6,7 +6,7 @@
     <string name="helpMessage">"Swipe" for directional movement (hold for virtual joystick). "Tap" to confirm selection in menu or Pause one turn in-game (hold to Pause several turns in-game). "Double tap" to cancel or go back in menus (works like Escape key). "Pinch" to zoom in/out (in-game). Use hardware "Back" button to toggle virtual keyboard (hold to toggle keyboard shortcuts).</string>
     <string name="accessibilityServicesTitle">Accessibility Services Warning</string>
     <string name="accessibilityServicesMessage">If swipe commands and shortcuts menus are not working in game, you might want to disable one of the following accessibility services/software that interact with touchscreen (swipe assists, auto-clickers, one-handed mode, etc.):\n%1$s</string>
-    <string name="ignoreFalsePostives">Mark as false positives</string>
+    <string name="ignoreFalsePostives">Mark as false positive(s)</string>
     <string name="softwareRendering">Software rendering</string>
     <string name="forceFullscreen">Force fullscreen</string>
     <string name="trapBackButton">Trap Back button</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -6,6 +6,7 @@
     <string name="helpMessage">"Swipe" for directional movement (hold for virtual joystick). "Tap" to confirm selection in menu or Pause one turn in-game (hold to Pause several turns in-game). "Double tap" to cancel or go back in menus (works like Escape key). "Pinch" to zoom in/out (in-game). Use hardware "Back" button to toggle virtual keyboard (hold to toggle keyboard shortcuts).</string>
     <string name="accessibilityServicesTitle">Accessibility Services Warning</string>
     <string name="accessibilityServicesMessage">If swipe commands and shortcuts menus are not working in game, you might want to disable one of the following accessibility services/software that interact with touchscreen (swipe assists, auto-clickers, one-handed mode, etc.):\n%1$s</string>
+    <string name="ignoreFalsePostives">Mark as false positives</string>
     <string name="softwareRendering">Software rendering</string>
     <string name="forceFullscreen">Force fullscreen</string>
     <string name="trapBackButton">Trap Back button</string>


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Closes #59759
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Adds an extra button to the warning to mark the running services as false positives which it remembers and doesn't warn you about again while still warning about new services.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
The preference stuff we use is deprecated but I'm not sure if moving to the newer stuff makes it no longer support older versions or what (this is my first non trivial change to the Android Java stuff I have 0 experience with any of this)
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Built a release apk on my repo, tested with 2 accessibility apps (KDE connect and some random autoclicker), enabling both and pressing ok and relaunching resulted in the current behaviour, enabling only 1 and marking it and then relaunching doesn't prompt the second time as intended, enabling the 2nd and relaunching prompts about the 2nd, marking that as false positive and relaunching results in no prompt as intended
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
