### PR TITLE
Fix turret install requirements

### DIFF
--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -588,6 +588,16 @@ void vehicles::parts::finalize()
             new_part.folded_volume = item->volume;
         }
 
+        // override install requirements
+        std::vector<std::vector<tool_comp>> tools;
+        std::vector<std::vector<quality_requirement>> qualities;
+        std::vector<std::vector<item_comp>> components = { { { new_part.base_item, 1 } } };
+        requirement_data ins( tools, qualities, components );
+
+        const requirement_id ins_id( std::string( "inline_vehins_base_" ) + new_part.id.str() );
+        requirement_data::save_requirement( ins, ins_id );
+        new_part.set_install_requirements( { {ins_id, 1} } );
+
         // cap all skills at 8
         primary_req = std::min( 8, primary_req );
         mechanics_req = std::min( 8, mechanics_req );
@@ -1069,6 +1079,11 @@ int vpart_info::format_description( std::string &msg, const nc_color &format_col
 requirement_data vpart_info::install_requirements() const
 {
     return requirement_data( install_reqs );
+}
+
+void vpart_info::set_install_requirements( const std::vector<std::pair<requirement_id, int>> &reqs )
+{
+    install_reqs = reqs;
 }
 
 requirement_data vpart_info::removal_requirements() const

--- a/src/veh_type.h
+++ b/src/veh_type.h
@@ -275,6 +275,9 @@ class vpart_info
         /** Installation requirements for this component */
         requirement_data install_requirements() const;
 
+        // needed for setting turret requirements, possibly not for general use
+        void set_install_requirements( const std::vector<std::pair<requirement_id, int>> &reqs );
+
         /** Installation time (in moves) for this component accounting for player skills */
         time_duration install_time( const Character &you ) const;
 


### PR DESCRIPTION
#### Summary
Bugfixes "Fix turret install requirements"

#### Purpose of change

Fixes #82589

#### Describe the solution

Override the install requirements in finalization. This made adding a setter for install requirements to vpart_info necessary, which may or may not be a good idea.

#### Describe alternatives you've considered

Switch finalization around somehow so turret vehicle parts are added before vpart_info finalization.

#### Testing

Looked at install screen and it showed the proper gun as the required component.

#### Additional context


