### PR TITLE
[MoM] Silent One adjustments

### DIFF
--- a/data/mods/MindOverMatter/effects/effects_monster.json
+++ b/data/mods/MindOverMatter/effects/effects_monster.json
@@ -494,7 +494,15 @@
     "id": "effect_nether_silent_one_resistances",
     "name": [ "" ],
     "desc": [ "" ],
-    "enchantments": [ { "incoming_damage_mod": [ { "type": "head", "multiply": -0.8 }, { "type": "electric", "multiply": -0.95 } ] } ]
+    "enchantments": [
+      {
+        "incoming_damage_mod": [
+          { "type": "head", "multiply": -0.45 },
+          { "type": "electric", "multiply": -0.95 },
+          { "type": "psi_telepathic_damage", "multiply": -0.5 }
+        ]
+      }
+    ]
   },
   {
     "type": "effect_type",

--- a/data/mods/MindOverMatter/monsters/monster_eoc_spells.json
+++ b/data/mods/MindOverMatter/monsters/monster_eoc_spells.json
@@ -628,9 +628,14 @@
         "decay_start": "12 hours"
       },
       { "u_add_effect": "effect_nether_attunement_health_penalty", "duration": "10 seconds" },
-      { "math": [ "u_calories()", "-=", "125" ] },
+      {
+        "if": { "math": [ "u_vitamin('vitamin_maintained_powers') >= 1" ] },
+        "then": { "math": [ "u_calories()", "-=", "rand(125) + 250" ] },
+        "else": { "math": [ "u_calories()", "-=", "125" ] }
+      },
       { "math": [ "u_calories('dont_affect_weariness': true)", "+=", "125" ] },
-      { "u_message": "You feel a sudden wave of fatigue!", "type": "bad" }
+      { "u_message": "You feel a sudden wave of fatigue!", "type": "bad" },
+      { "math": [ "n_val('anger')", "-=", "rand(5) + 2" ] }
     ],
     "false_effect": [
       { "math": [ "u_val('anger')", "-=", "rand(5) + 5" ] },
@@ -713,5 +718,37 @@
     "min_damage": 500,
     "max_damage": 500,
     "targeted_monster_ids": [ "mon_nether_silent_one_passive" ]
+  },
+  {
+    "id": "silent_one_detect_psionic_activity_aggressive",
+    "type": "SPELL",
+    "name": { "str": "[Ψ]Silent One Detect Psi Aggressive", "//~": "NO_I18N" },
+    "description": {
+      "str": "Silent One's detecting of psionic activity when it's already angry.  It's a bug if you have it.",
+      "//~": "NO_I18N"
+    },
+    "valid_targets": [ "ally", "hostile", "self" ],
+    "message": "",
+    "flags": [ "NO_PROJECTILE", "NO_EXPLOSION_SFX", "IGNORE_WALLS" ],
+    "effect": "effect_on_condition",
+    "effect_str": "EOC_SILENT_ONE_DETECT_PSIONIC_ACTIVITY_AGGRESSIVE",
+    "shape": "blast",
+    "min_aoe": 15,
+    "max_aoe": 15
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_SILENT_ONE_DETECT_PSIONIC_ACTIVITY_AGGRESSIVE",
+    "condition": "u_is_character",
+    "effect": [
+      {
+        "if": { "math": [ "u_vitamin('vitamin_maintained_powers') >= 1" ] },
+        "then": [
+          { "math": [ "n_val('anger')", "+=", "rand(10) + 2" ] },
+          { "u_message": "A chill aura enamates from the silent one.", "type": "bad" }
+        ],
+        "else": [ { "math": [ "n_val('anger')", "-=", "rand(25) + 25" ] } ]
+      }
+    ]
   }
 ]

--- a/data/mods/MindOverMatter/monsters/monster_eoc_spells.json
+++ b/data/mods/MindOverMatter/monsters/monster_eoc_spells.json
@@ -745,7 +745,7 @@
         "if": { "math": [ "u_vitamin('vitamin_maintained_powers') >= 1" ] },
         "then": [
           { "math": [ "n_val('anger')", "+=", "rand(10) + 2" ] },
-          { "u_message": "A chill aura enamates from the silent one.", "type": "bad" }
+          { "u_message": "A chill aura emanates from the silent one.", "type": "bad" }
         ],
         "else": [ { "math": [ "n_val('anger')", "-=", "rand(25) + 25" ] } ]
       }

--- a/data/mods/MindOverMatter/monsters/nether.json
+++ b/data/mods/MindOverMatter/monsters/nether.json
@@ -94,7 +94,7 @@
     "melee_dice": 1,
     "melee_dice_sides": 1,
     "dodge": 4,
-    "armor": { "bash": 10, "stab": 85, "cut": 50, "bullet": 1000, "psi_telekinetic_damage": 300 },
+    "armor": { "bash": 10, "stab": 85, "cut": 50 },
     "bleed_rate": 0,
     "vision_day": 0,
     "vision_night": 0,
@@ -143,6 +143,7 @@
       "NOHEAD",
       "FLIES",
       "BIOLOGICALPROOF",
+      "BULLETPROOF",
       "COLDPROOF",
       "HAS_MIND",
       "NO_FUNG_DMG",
@@ -188,6 +189,14 @@
         },
         "allow_no_target": true,
         "cooldown": 1,
+        "monster_message": ""
+      },
+      {
+        "id": "silent_one_detect_psionic_activity",
+        "type": "spell",
+        "spell_data": { "id": "silent_one_detect_psionic_activity_aggressive", "hit_self": true },
+        "cooldown": { "math": [ "6 + rand(10)" ] },
+        "allow_no_target": true,
         "monster_message": ""
       }
     ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[MoM] Silent One adjustments"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Working on something else and realized some changes I could make to the silent one.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Re-add the bit where silent ones lose aggression every time they drain a target. Eventually they wander away (and you're super exhausted). If you still have powers maintained when it drains you, you suffer more. If you have no powers when it drains you, its anger goes down much faster.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Anger changes work.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
