### PR TITLE
Updated script for checking tags in translations

### DIFF
--- a/tools/check_translation_tags.py
+++ b/tools/check_translation_tags.py
@@ -1,75 +1,294 @@
 #!/usr/bin/env python3
-import polib
-import os
+
+import argparse
 import re
-import sys
+import pathlib
+
+import polib
 
 
-tags = set()
-ignore_tags = {'<1>', '<2>', '<3>', '<4>', '<f>', '<n>',
-               '<q>', '<r>', '<s>', '<u>', '<more>', '<empty>'}
-pattern = re.compile(r'<[a-z/0-9_]+>')
+CHECK_TAGS = False
+CHECK_ELLIPSES = False
+
+PATTERN_TAG = re.compile(r"<[a-z/0-9_]+>")
+PATTERN_PRINTF = re.compile(r"%[0-9$.]*[diufegxscp]")
+
+PO_PATH = pathlib.Path("lang/po/")
+PO_FILES = dict([f.stem, f] for f in sorted(PO_PATH.glob("*.po")))
+# PO_FILES = { "ar": Path("lang/po/ar.po").., }
 
 
-def init_tags():
-    global tags
-    pofile = polib.pofile("./lang/po/cataclysm-dda.pot")
-    for entry in pofile:
-        for tag in set(pattern.findall(entry.msgid)):
-            tags.add(tag)
-    tags = tags - ignore_tags
+# tags that can be safely omitted in translation
+TAGS_OPTIONAL = (
+    "<zombie>", "<zombies>",
+    "<name_b>", "<name_g>",
+    "<freaking>", "<the_cataclysm>",
+    "<granny_name_g>",
+    "<mypronoun>", "<mypossesivepronoun>",
+)
+
+# known false-positive strings. FIXME?
+SKIP_STRINGS = (
+    "<empty>",
+    "Even if you climb down safely, you will fall "
+    "<color_yellow>at least %d story</color>.",
+    "Pointed in your direction, the %s emits an IFF warning beep.",
+    "%s points in your direction and emits an IFF warning beep.",
+    "You hear a warning beep.",
+)
 
 
-def extract_tags(msg):
-    matches = pattern.findall(msg)
-    result = set()
-    for match in matches:
-        if match in tags:
-            result.add(match)
-    return result
+def _f(input_list):
+    """Formats list"""
+    """ ['a', 'b'] => `a b` """
+
+    if not input_list:
+        return "none"
+    if type(input_list) is str:
+        return f"`{input_list}`"
+    return f"`{' '.join(input_list)}`"
 
 
-def check_message(entry):
-    msgid = entry.msgid
-    msgstr = entry.msgstr
-    if not msgstr:
-        return set()
-    tags_msgid = extract_tags(msgid)
-    tags_msgstr = extract_tags(msgstr)
-    return tags_msgid - tags_msgstr
+##########################
+# ELLIPSES CHECK         #
+##########################
 
 
-def check_po_file(file):
-    pofile = polib.pofile(file)
-    errors = 0
-    for entry in pofile.translated_entries():
-        missing_tags = check_message(entry)
-        if missing_tags:
-            print("Tag(s) {} missing in translation: {} => {}".format(
-                missing_tags,
-                entry.msgid.replace("\n", "\\n"),
-                entry.msgstr.replace("\n", "\\n")))
-            errors += 1
-    return errors
+def check_ellipses(entry):
+    """Checks if translations use three dots instead of the ellipsis symbol"""
+
+    msgstr = entry.msgstr or entry.msgstr_plural[0]
+    if ("…" in entry.msgid) and \
+       ("..." in msgstr):
+        return [" * It's recommended to use the `…` symbol "
+                "instead of three dots."]
+    return []
 
 
-init_tags()
-po_files = []
-for file in sorted(os.listdir("lang/po")):
-    if file.endswith(".po") and not file.endswith("en.po"):
-        po_files.append(file)
-files_to_check = []
-if len(sys.argv) == 1:
-    files_to_check = po_files
-else:
-    for i in range(1, len(sys.argv)):
-        if sys.argv[i] + ".po" in po_files:
-            files_to_check.append(sys.argv[i] + ".po")
+##########################
+# PRINTF CHECK           #
+##########################
+
+
+def _is_mixed(tags):
+    """Checks if the list of tags contains mixed arguments,"""
+    """non-positional %s and positional %1$s at the same time."""
+
+    have_positional = 0
+    have_nonpositional = 0
+
+    for tag in tags:
+        if "$" in tag:
+            have_positional += 1
         else:
-            print("Warning: Unknown language", sys.argv[i])
-num_errors = 0
-for file in sorted(files_to_check):
-    print("Checking {}".format(file))
-    num_errors += check_po_file("lang/po/" + file)
+            have_nonpositional += 1
+
+    return have_positional and have_nonpositional
+
+
+def _make_pos_arg(tags):
+    """Changes arguments to positional ones."""
+
+    pos_tags = []
+
+    for i, tag in enumerate(tags, 1):
+        if "$" in tag:
+            pos_tags.append(tag)
+            continue
+        tag = f"%{i}${tag.split('%')[1]}"
+        pos_tags.append(tag)
+
+    return sorted(pos_tags)
+
+
+def check_printf(entry):
+    """Checks whether formatting arguments %s/%1$d"""
+    """in the source string and in the translation match."""
+
+    # error messages
+    msgs = []
+
+    # find all <tags> in the original string
+    tags_msgid = PATTERN_PRINTF.findall(entry.msgid)
+    # find all <tags> in the translated string
+    if entry.msgstr:
+        tags_msgstr = PATTERN_PRINTF.findall(entry.msgstr)
+    # find all <tags> for the plural translated strings
+    elif entry.msgstr_plural:
+        tags_msgstr_pl = [PATTERN_PRINTF.findall(v)
+                          for v in entry.msgstr_plural.values()]
+        tags_msgstr = tags_msgstr_pl[0]
+
+        # assume that all strings should have the same set of arguments
+        for tag in tags_msgstr_pl:
+            if tag != tags_msgstr:
+                msgs.append(" * Plural strings have"
+                            " different sets of arguments;")
+                break
+
+    # strings must not have %s and %1$s at the same time
+    if _is_mixed(tags_msgid) or _is_mixed(tags_msgstr):
+        msgs.append(" * Cannot mix positional and non-positional "
+                    "arguments in format string;")
+    if msgs:
+        return msgs
+
+    # if everything else is good
+    if tags_msgid == tags_msgstr:
+        return msgs
+    # and if everything is ok when replacing with positional arguments
+    tags_msgid_pos = _make_pos_arg(tags_msgid)
+    if tags_msgid_pos == _make_pos_arg(tags_msgstr):
+        return msgs
+
+    # check if the number of arguments matches
+    if len(tags_msgid) == len(tags_msgstr):
+        # if non-positional arguments are swapped
+        # then suggest positional syntax
+        if sorted(tags_msgid) == sorted(tags_msgstr):
+            msgs.append(" * The types of arguments differ;\n"
+                        "   Use positional syntax:"
+                        f" {_f(tags_msgid)} => {_f(tags_msgid_pos)};")
+        # otherwise it's most likely just a typo
+        else:
+            msgs.append(" * The types of arguments differ:"
+                        f" {_f(tags_msgid)} and {_f(tags_msgstr)};")
+    else:
+        msgs.append(" * The number of arguments differ:"
+                    f" {_f(tags_msgid)} and {_f(tags_msgstr)};")
+
+    return msgs
+
+
+##########################
+# TAGS CHECK             #
+##########################
+
+
+def check_tags(entry):
+    """Checks if <tags> in the source string match those in the translation."""
+
+    # error messages
+    msgs = []
+
+    # find all <tags> in the original string
+    tags_msgid = sorted(PATTERN_TAG.findall(entry.msgid))
+    # find all <tags> in the translated string
+    if entry.msgstr:
+        tags_msgstr = sorted(PATTERN_TAG.findall(entry.msgstr))
+    # find all <tags> for the plural translated strings
+    elif entry.msgstr_plural:
+        tags_msgstr_pl = [sorted(PATTERN_TAG.findall(v))
+                          for v in entry.msgstr_plural.values()]
+        tags_msgstr = tags_msgstr_pl[0]
+
+        # assume that all strings should have the same set of tags
+        for tag in tags_msgstr_pl:
+            if tag != tags_msgstr:
+                msgs.append(" * Plural strings have different sets of tags;")
+                break
+
+    # if everything else is good
+    if tags_msgid == tags_msgstr:
+        return msgs
+
+    # remove common <tags>
+    # both lists will contain only tags that are unique to them
+    for tag in reversed(tags_msgid):
+        if tag in reversed(tags_msgstr):
+            tags_msgid.remove(tag)
+            tags_msgstr.remove(tag)
+
+    # filter optional <tags>
+    for tag in reversed(tags_msgid):
+        if tag in TAGS_OPTIONAL:
+            if CHECK_TAGS:
+                msgs.append(f" * Missing OPTIONAL tag(s): {_f(tag)};")
+            tags_msgid.remove(tag)
+
+    # gather error messages to the list and return it
+    if tags_msgid:
+        msgs.append(f" * Missing tag(s): {_f(tags_msgid)};")
+    if tags_msgstr:
+        msgs.append(f" * Bad/extra tag(s): {_f(tags_msgstr)};")
+    return msgs
+
+
+##########################
+# MAIN FUNCTIONS         #
+##########################
+
+
+def check_po_file(input_path):
+    """Loads a file and checks each line."""
+
+    print(f"## Checking {input_path}")
+    po = polib.pofile(input_path)
+
+    error_list = []
+
+    for entry in po.translated_entries():
+
+        # skip known false-positive strings
+        if entry.msgid in SKIP_STRINGS:
+            continue
+
+        msgs = []
+        if error := check_tags(entry):
+            msgs += error
+        if error := check_printf(entry):
+            msgs += error
+        if CHECK_ELLIPSES:
+            if error := check_ellipses(entry):
+                msgs += error
+
+        if msgs:
+            msgs.append(f"```\n{entry}```")
+            error_list.append("\n".join(msgs))
+
+    if error_list:
+        print(f" > Total: {len(error_list)} warnings.")
+        print("\n".join(error_list), end="")
+    else:
+        print(" * Everything looks fine.")
     print()
-exit(num_errors)
+
+
+def main(locale_list):
+    """Main function."""
+
+    if not pathlib.Path(".").cwd().match("Cataclysm-DDA/"):
+        print("You must run the script from"
+              " the root directory 'Cataclysm-DDA/'")
+        return
+
+    if locale_list:
+        for locale in locale_list:
+            if f := PO_FILES.get(locale):
+                check_po_file(f)
+            else:
+                print(f"## Can't find locale '{locale}'. Skip.")
+    else:
+        for f in PO_FILES.values():
+            check_po_file(f)
+
+
+def _parse_args():
+    argparser = argparse.ArgumentParser(
+        description="Validates translation files.",
+        epilog=f"Available locales: {', '.join(PO_FILES.keys())}")
+    argparser.add_argument("locale", nargs="*",
+                           metavar="locale-name",
+                           help="locale or list of locales")
+    argparser.add_argument("-c1", "--check-tags", action="store_true",
+                           help="also check optional tags")
+    argparser.add_argument("-c2", "--check-ellipses", action="store_true",
+                           help="also check ellipses")
+    return argparser.parse_args()
+
+
+if __name__ == "__main__":
+    args = _parse_args()
+    CHECK_TAGS = args.check_tags
+    CHECK_ELLIPSES = args.check_ellipses
+    main(args.locale)


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
I wanted to write a script to check if tags in the original string match the ones in the translated string, like `<npcname>` and `<color_*>`, but it turns out we already have one in the repository. But it could work better.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Updated script
Merged with tools/check_po_printf_format.py
Improved checks (57 vs 44 for Japanese)
Output in Markdown format
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Eliminate a few false positive checks for plural strings. But this script is meant to be a one-time check, so I think it's fine, otherwise I'd have to write some pretty complex logic.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
```
usage: check_translation_tags.py [-h] [-c1] [-c2] [locale-name ...]

Validates translation files.

positional arguments:
  locale-name           locale or list of locales

options:
  -h, --help            show this help message and exit
  -c1, --check-tags     also check optional tags
  -c2, --check-ellipses
                        also check ellipses

Available locales: ar, cs, da, de, el, es_AR, es_ES, fil_PH, fr, ga_IE, hu,
id, is, it_IT, ja, ko, nb, nl, pl, pt, pt_BR, ro, ru, sr, tr, uk_UA, zh_CN,
zh_TW
```

Put [test.po](https://github.com/user-attachments/files/22066589/test.zip) into lang/po directory

<details><summary>Old tools output</summary>
<p>

```
$ python3 tools/check_po_printf_format.py test
Checking test.po => 8 error(s) detected:
problem   :The number of arguments differ
original  :BAD PRINTF 1 %s
translated:BAD PRINTF 1 %

problem   :The types of arguments differ
original  :BAD PRINTF 2 %s
translated:BAD PRINTF 2 %d

problem   :The number of arguments differ
original  :BAD PRINTF 3 %s %d
translated:BAD PRINTF 3 %s

problem   :The types of arguments differ
original  :BAD PRINTF 4 %u
translated:BAD PRINTF 4 %d

problem   :Cannot mix positional and non-positional arguments in format string
original  :BAD PRINTF 5 %1$s
translated:BAD PRINTF 5 %s %1$s5 

problem   :Cannot mix positional and non-positional arguments in format string
original  :BAD PRINTF 12 <color_%s>%2.2f%%</color>
translated:BAD PRINTF 12 <color_%s>%2$f%%</color>

problem   :Cannot mix positional and non-positional arguments in format string
original  :BAD PRINTF 15 %s %2$d %u
translated:BAD PRINTF 15 %3$u %2$d %1$s

problem   :The types of arguments differ
original  :BAD PRINTF 16 Your %s is hit for %d damage!
translated:BAD PRINTF 16 Вы получили %d урона в %s!


$ python3 tools/check_translation_tags.py test
Checking test.po
Tag(s) {'</color>'} missing in translation: <color_cyan>BAD TAG 1</color> => <color_cyan>BAD TAG 1</colo>
Tag(s) {'<color_cyan>'} missing in translation: <color_cyan>BAD TAG 2</color> => <color_cyn>BAD TAG 2</color>
Tag(s) {'<color_green>'} missing in translation: <color_cyan>BAD TAG3</color> <color_green>BAD TAG3</color> => <color_cyan>BAD TAG3</color> color_green>BAD TAG3</color>
Tag(s) {'<color_cyan>', '</color>'} missing in translation: <color_cyan>BAD TAG 4</color> => BAD TAG 4
Tag(s) {'</color>'} missing in translation: <color_cyan>BAD TAG 5</color> => <color_cyan>BAD TAG 5<//color>
Tag(s) {'<name_g>'} missing in translation: <color_cyan>OPTIONAL <name_g> TAG 1</color> => <color_cyan>OPTIONAL TAG 1</color>
Tag(s) {'<freaking>', '<zombie>'} missing in translation: <color_cyan>OPTIONAL <freaking> <zombie> TAG 2</color> => <color_cyan>OPTIONAL TAG 2</color>
Tag(s) {'<the_cataclysm>'} missing in translation: OPTIONAL <the_cataclysm> TAG 3 => OPTIONAL TAG 3
```

</p>
</details> 

<details><summary>Updated script output</summary>
<p>

$python3 tools/check_translation_tags.py test
## Checking lang/po/test.po
 > Total: 28 warnings.
 * Missing tag(s): `</color>`;
 * Bad/extra tag(s): `</colo>`;
```
msgid "<color_cyan>BAD TAG 1</color>"
msgstr "<color_cyan>BAD TAG 1</colo>"
```
 * Missing tag(s): `<color_cyan>`;
 * Bad/extra tag(s): `<color_cyn>`;
```
msgid "<color_cyan>BAD TAG 2</color>"
msgstr "<color_cyn>BAD TAG 2</color>"
```
 * Missing tag(s): `<color_green>`;
```
msgid "<color_cyan>BAD TAG3</color> <color_green>BAD TAG3</color>"
msgstr "<color_cyan>BAD TAG3</color> color_green>BAD TAG3</color>"
```
 * Missing tag(s): `</color> <color_cyan>`;
```
msgid "<color_cyan>BAD TAG 4</color>"
msgstr "BAD TAG 4"
```
 * Missing tag(s): `</color>`;
 * Bad/extra tag(s): `<//color>`;
```
msgid "<color_cyan>BAD TAG 5</color>"
msgstr "<color_cyan>BAD TAG 5<//color>"
```
 * Bad/extra tag(s): `</color>`;
```
msgid "<color_cyan>BAD TAG 6</color>"
msgstr "<color_cyan>BAD TAG 6</color></color>"
```
 * Missing tag(s): `</color> <color_cyan>`;
```
msgid "<color_cyan>BAD TAG 7</color> <color_cyan>BAD TAG 7</color>"
msgstr "<color_cyan>BAD TAG 7</color>"
```
 * Plural strings have different sets of tags;
```
msgid "<color_cyan>BAD TAG 8</color>"
msgid_plural "<color_cyan>BAD TAGS 8</color>"
msgstr[0] "<color_cyan>BAD TAG 8</color>"
msgstr[1] "<color_cyan>BAD TAGS 8</color>"
msgstr[2] "<color_cyanBAD TAGS 8</color>"
msgstr[3] "<color_cyan>BAD TAGS 8</color>"
```
 * Missing tag(s): `</color> <color_green>`;
```
msgid "<color_cyan>BAD TAG 9</color> <color_green>BAD TAG 9</color>"
msgid_plural "<color_cyan>BAD TAGS 9</color> <color_green>BAD TAGS 9</color>"
msgstr[0] "<color_cyan>BAD TAG 9</color>"
msgstr[1] "<color_cyan>BAD TAGS 9</color>"
msgstr[2] "<color_cyan>BAD TAGS 9</color>"
msgstr[3] "<color_cyan>BAD TAGS 9</color>"
```
 * Plural strings have different sets of tags;
 * Missing tag(s): `</color> <color_green>`;
 * Bad/extra tag(s): `<hi>`;
```
msgid "<color_cyan>BAD TAG 10</color> <color_green>BAD TAG 10</color>"
msgid_plural ""
"<color_cyan>BAD TAGS 10</color> <color_green>BAD TAGS 10</color>"
msgstr[0] "<color_cyan>BAD TAG 10</color> <hi>"
msgstr[1] "<color_cyan>BAD TAGS 10</color>"
msgstr[2] "<color_cyan>BAD TAGS 10</color>"
msgstr[3] "<color_cyan>BAD TAGS 10</color>"
```
 * Plural strings have different sets of tags;
```
msgid "<color_cyan>BAD TAG 11</color>"
msgid_plural "<color_cyan>BAD TAGS 11</color>"
msgstr[0] "<color_cyan>BAD TAG 11</color>"
msgstr[1] "<color_cyan>BAD TAGS 11</colo>"
msgstr[2] "<color_cyan>BAD TAGS 11</color>"
msgstr[3] "<color_cyan>BAD TAGS 11</color>"
```
 * Plural strings have different sets of tags;
```
msgid "BAD OPTIONAL <the_cataclysm> <name_g> TAG 4"
msgid_plural "BAD OPTIONAL <the_cataclysm> <name_g> TAGS 4"
msgstr[0] "BAD OPTIONAL TAG 4"
msgstr[1] "BAD OPTIONAL TAGS 4"
msgstr[2] "BAD OPTIONAL TAGS 4"
msgstr[3] "BAD OPTIONAL <the_cataclysm> <name_g> TAGS 4"
```
 * The number of arguments differ: `%s` and none;
```
msgid "BAD PRINTF 1 %s"
msgstr "BAD PRINTF 1 %"
```
 * The types of arguments differ: `%s` and `%d`;
```
msgid "BAD PRINTF 2 %s"
msgstr "BAD PRINTF 2 %d"
```
 * The number of arguments differ: `%s %d` and `%s`;
```
msgid "BAD PRINTF 3 %s %d"
msgstr "BAD PRINTF 3 %s"
```
 * The types of arguments differ: `%u` and `%d`;
```
msgid "BAD PRINTF 4 %u"
msgstr "BAD PRINTF 4 %d"
```
 * Cannot mix positional and non-positional arguments in format string;
```
msgid "BAD PRINTF 5 %1$s"
msgstr "BAD PRINTF 5 %s %1$s5 "
```
 * The types of arguments differ: `%s` and `%1s`;
```
msgid "BAD PRINTF 6 %s"
msgstr "BAD PRINTF 6 %1s"
```
 * The types of arguments differ: `%1$s` and `%12$s`;
```
msgid "BAD PRINTF 7 %1$s4.! "
msgstr "BAD PRINTF 7 %12$s "
```
 * Plural strings have different sets of arguments;
```
msgid "BAD PRINTF 8 %s "
msgid_plural "BAD PRINTF 8 %s "
msgstr[0] "BAD PRINTF 8 %s "
msgstr[1] "BAD PRINTF 8  "
msgstr[2] "BAD PRINTF 8 %s "
msgstr[3] "BAD PRINTF 8 %s "
```
 * Plural strings have different sets of arguments;
```
msgid "BAD PRINTF 9 %s "
msgid_plural "BAD PRINTF 9 %s "
msgstr[0] "BAD PRINTF 9 % "
msgstr[1] "BAD PRINTF 9 %s "
msgstr[2] "BAD PRINTF 9 %s "
msgstr[3] "BAD PRINTF 9 %s "
```
 * The types of arguments differ: `%s %2.2f` and `%s %22f`;
```
msgid "BAD PRINTF 10 <color_%s>%2.2f%%</color>"
msgstr "BAD PRINTF 10 <color_%s>%22f%%</color>"
```
 * The types of arguments differ: `%s %2.2f` and `%s %2..2f`;
```
msgid "BAD PRINTF 11 <color_%s>%2.2f%%</color>"
msgstr "BAD PRINTF 11 <color_%s>%2..2f%%</color>"
```
 * Cannot mix positional and non-positional arguments in format string;
```
msgid "BAD PRINTF 12 <color_%s>%2.2f%%</color>"
msgstr "BAD PRINTF 12 <color_%s>%2$f%%</color>"
```
 * Cannot mix positional and non-positional arguments in format string;
```
msgid "BAD PRINTF 13 %3$s %2$d %u"
msgstr "BAD PRINTF 13 %u %2$d %3$s"
```
 * Cannot mix positional and non-positional arguments in format string;
```
msgid "BAD PRINTF 14 %3$s %2$d %u %3$s %d %1$u %3$s %2$d %1$u"
msgstr "BAD PRINTF 14 %3$s %2$d %u %3$s %d %1$u %3$s %2$d %1$u"
```
 * Cannot mix positional and non-positional arguments in format string;
```
msgid "BAD PRINTF 15 %s %2$d %u"
msgstr "BAD PRINTF 15 %3$u %2$d %1$s"
```
 * The types of arguments differ;
   Use positional syntax: `%s %d` => `%1$s %2$d`;
```
msgid "BAD PRINTF 16 Your %s is hit for %d damage!"
msgstr "BAD PRINTF 16 Вы получили %d урона в %s!"
```

</p>
</details> 

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
~~tools/check_po_printf_format.py was deleted since it was merged. It wasn't used anywhere in CI/CD, right?~~ ok nevermind it's actually used

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
