### PR TITLE
[MoM] Rework crystal field spawns

### DIFF
--- a/data/mods/MindOverMatter/mapgen/map_extras/glass_and_crystal.json
+++ b/data/mods/MindOverMatter/mapgen/map_extras/glass_and_crystal.json
@@ -4,8 +4,20 @@
     "update_mapgen_id": "mx_glass_and_crystal",
     "object": {
       "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA" ],
-      "place_nested": [ { "chunks": [ "glass_and_crystal_chunk" ], "x": [ 2, 15 ], "y": [ 2, 15 ] } ],
-      "monsters": { " ": { "monster": "GROUP_CRYSTAL_FIELD", "chance": 1, "density": 0.0001 } }
+      "place_nested": [
+        { "chunks": [ "glass_and_crystal_chunk" ], "x": [ 2, 15 ], "y": [ 2, 15 ] },
+        {
+          "chunks": [
+            [ "null", 1 ],
+            [ "mx_glass_and_crystal_monsters_migo", 5 ],
+            [ "mx_glass_and_crystal_monsters_nether", 8 ],
+            [ "mx_glass_and_crystal_monsters_feral_psions", 5 ],
+            [ "mx_glass_and_crystal_monsters_mixed", 3 ]
+          ],
+          "x": 0,
+          "y": 0
+        }
+      ]
     }
   },
   {
@@ -61,6 +73,41 @@
       "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
       "terrain": { "X": "t_nether_stone" },
       "place_fields": [ { "field": "fd_fatigue", "x": 0, "y": 0, "intensity": 3 } ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "mx_glass_and_crystal_monsters_migo",
+    "object": {
+      "mapgensize": [ 24, 24 ],
+      "place_monster": [
+        { "group": "GROUP_MI-GO_CAMP_OM", "x": [ 0, 23 ], "y": [ 0, 23 ], "chance": 75, "repeat": [ 3, 6 ] },
+        { "group": "GROUP_MI-GO_PSIONS", "x": [ 0, 23 ], "y": [ 0, 23 ], "chance": 65, "repeat": [ 0, 2 ] }
+      ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "mx_glass_and_crystal_monsters_nether",
+    "object": {
+      "mapgensize": [ 24, 24 ],
+      "place_monster": [ { "group": "GROUP_NETHER_PORTAL", "x": [ 0, 23 ], "y": [ 0, 23 ], "chance": 85, "repeat": [ 4, 8 ] } ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "mx_glass_and_crystal_monsters_feral_psions",
+    "object": {
+      "mapgensize": [ 24, 24 ],
+      "place_monster": [ { "group": "GROUP_FERAL_PSYCHIC", "x": [ 0, 23 ], "y": [ 0, 23 ], "chance": 85, "repeat": [ 2, 4 ] } ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "mx_glass_and_crystal_monsters_mixed",
+    "object": {
+      "mapgensize": [ 24, 24 ],
+      "place_monster": [ { "group": "GROUP_CRYSTAL_FIELD", "x": [ 0, 23 ], "y": [ 0, 23 ], "chance": 85, "repeat": [ 5, 13 ] } ]
     }
   }
 ]

--- a/data/mods/MindOverMatter/mapgen/nested/crystal_field_monster_nests.json
+++ b/data/mods/MindOverMatter/mapgen/nested/crystal_field_monster_nests.json
@@ -1,0 +1,46 @@
+[
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "nether_crystal_field_monsters_migo",
+    "object": {
+      "mapgensize": [ 24, 24 ],
+      "place_monster": [
+        { "group": "GROUP_MI-GO_CAMP_OM", "x": [ 0, 23 ], "y": [ 0, 23 ], "chance": 100, "repeat": [ 4, 15 ] },
+        { "group": "GROUP_MI-GO_PSIONS", "x": [ 0, 23 ], "y": [ 0, 23 ], "chance": 100, "repeat": [ 0, 2 ] }
+      ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "nether_crystal_field_monsters_nether",
+    "object": {
+      "mapgensize": [ 24, 24 ],
+      "place_monster": [ { "group": "GROUP_NETHER_PORTAL", "x": [ 0, 23 ], "y": [ 0, 23 ], "chance": 100, "repeat": [ 8, 15 ] } ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "nether_crystal_field_monsters_feral_psions",
+    "object": {
+      "mapgensize": [ 24, 24 ],
+      "place_monster": [ { "group": "GROUP_FERAL_PSYCHIC", "x": [ 0, 23 ], "y": [ 0, 23 ], "chance": 100, "repeat": [ 3, 6 ] } ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "nether_crystal_field_monsters_mixed",
+    "object": {
+      "mapgensize": [ 24, 24 ],
+      "place_monster": [
+        { "group": "GROUP_CRYSTAL_FIELD", "x": [ 0, 23 ], "y": [ 0, 23 ], "chance": 100, "repeat": [ 10, 16 ] },
+        {
+          "group": "GROUP_CRYSTAL_FIELD_PSYCHOACTIVE",
+          "x": [ 0, 23 ],
+          "y": [ 0, 23 ],
+          "chance": 100,
+          "repeat": [ 2, 5 ]
+        }
+      ]
+    }
+  }
+]

--- a/data/mods/MindOverMatter/mapgen/nether_crystal_field.json
+++ b/data/mods/MindOverMatter/mapgen/nether_crystal_field.json
@@ -41,15 +41,21 @@
           [ "t_nether_stone", 1 ]
         ]
       },
-      "monsters": {
-        "_": [
-          { "monster": "GROUP_CRYSTAL_FIELD", "chance": 1, "density": 0.0003 },
-          { "monster": "GROUP_CRYSTAL_FIELD_PSYCHOACTIVE", "chance": 10, "density": 0.0003 }
-        ],
-        "A": { "monster": "GROUP_CRYSTAL_FIELD", "chance": 1, "density": 0.0003 }
-      },
       "nested": { "A": { "chunks": [ [ "crystal_moss_or_trees_3x3", 1 ], [ "null", 15 ] ] } },
-      "place_nested": [ { "chunks": [ "crystal_field_central_10x10" ], "x": 7, "y": 7 } ]
+      "place_nested": [
+        { "chunks": [ "crystal_field_central_10x10" ], "x": 7, "y": 7 },
+        {
+          "chunks": [
+            [ "null", 1 ],
+            [ "mx_glass_and_crystal_monsters_migo", 8 ],
+            [ "mx_glass_and_crystal_monsters_nether", 16 ],
+            [ "mx_glass_and_crystal_monsters_feral_psions", 8 ],
+            [ "mx_glass_and_crystal_monsters_mixed", 4 ]
+          ],
+          "x": 0,
+          "y": 0
+        }
+      ]
     }
   },
   {
@@ -128,8 +134,7 @@
         "S": [ [ "t_nether_water_sh", 1 ], [ "t_nether_stone", 1 ] ],
         " ": "t_null"
       },
-      "furniture": { "S": [ [ "f_nether_crystal_structure", 1 ], [ "f_null", 3 ] ] },
-      "place_monsters": [ { "monster": "GROUP_CRYSTAL_FIELD", "x": [ 0, 9 ], "y": [ 0, 9 ], "chance": 50, "repeat": [ 2, 4 ] } ]
+      "furniture": { "S": [ [ "f_nether_crystal_structure", 1 ], [ "f_null", 3 ] ] }
     }
   },
   {
@@ -152,19 +157,14 @@
       "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
       "terrain": { "C": "t_nether_stone", "G": [ [ "t_nether_stone", 2 ], [ "t_null", 2 ] ], "N": "t_nether_stone", " ": "t_null" },
       "furniture": { "C": [ [ "f_nether_crystal_structure", 1 ], [ "f_null", 1 ] ] },
-      "place_nested": [ { "chunks": [ "crystal_field_chunk_center_2x2" ], "x": 4, "y": 4 } ],
-      "place_monsters": [ { "monster": "GROUP_CRYSTAL_FIELD", "x": [ 0, 9 ], "y": [ 0, 9 ], "chance": 50, "repeat": [ 2, 4 ] } ]
+      "place_nested": [ { "chunks": [ "crystal_field_chunk_center_2x2" ], "x": 4, "y": 4 } ]
     }
   },
   {
     "type": "mapgen",
     "nested_mapgen_id": "crystal_field_chunk_center_2x2",
     "weight": 1000,
-    "object": {
-      "mapgensize": [ 2, 2 ],
-      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
-      "place_monsters": [ { "monster": "GROUP_CRYSTAL_FIELD_PSYCHOACTIVE", "x": [ 0, 1 ], "y": [ 0, 1 ], "chance": 50, "repeat": [ 1, 3 ] } ]
-    }
+    "object": { "mapgensize": [ 2, 2 ], "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ] }
   },
   {
     "type": "mapgen",
@@ -217,7 +217,6 @@
       "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
       "terrain": { "C": "t_nether_stone" },
       "furniture": { "N": [ [ "f_nether_crystal_structure", 1 ], [ "f_null", 1 ] ] },
-      "place_monsters": [ { "monster": "GROUP_CRYSTAL_FIELD_PSYCHOACTIVE", "x": [ 0, 1 ], "y": [ 0, 1 ], "chance": 50, "repeat": [ 1, 3 ] } ],
       "items": { "C": { "item": "dist_matrix_crystals", "chance": 50 } }
     }
   },
@@ -234,7 +233,6 @@
       "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
       "terrain": { "C": "t_nether_stone" },
       "furniture": { "N": [ [ "f_nether_crystal_structure", 1 ], [ "f_null", 1 ] ] },
-      "place_monsters": [ { "monster": "GROUP_CRYSTAL_FIELD_PSYCHOACTIVE", "x": [ 0, 1 ], "y": [ 0, 1 ], "chance": 50, "repeat": [ 1, 3 ] } ],
       "items": { "C": { "item": "dist_matrix_crystals", "chance": 50 } }
     }
   }

--- a/data/mods/MindOverMatter/monstergroups/monstergroups_edited.json
+++ b/data/mods/MindOverMatter/monstergroups/monstergroups_edited.json
@@ -341,7 +341,7 @@
   },
   {
     "type": "monstergroup",
-    "id": "GROUP_MI-GO_CAMP_OM",
+    "id": "GO_CAMP_OM",
     "monsters": [
       { "monster": "mon_mi_go_telepath", "weight": 50, "cost_multiplier": 20, "starts": "35 days" },
       { "monster": "mon_mi_go_photokinetic", "weight": 50, "cost_multiplier": 2, "starts": "35 days" },
@@ -395,14 +395,5 @@
     "id": "GROUP_TRIFFID_HEARTGUARDS",
     "default": "mon_triffid",
     "monsters": [ { "group": "GROUP_TRIFFID_PSIONS", "weight": 150, "cost_multiplier": 2 } ]
-  },
-  {
-    "type": "monstergroup",
-    "id": "GROUP_TRIFFID_PSIONS",
-    "monsters": [
-      { "monster": "mon_triffid_clairsentient", "weight": 400 },
-      { "monster": "mon_triffid_pyrokinetic", "weight": 400 },
-      { "monster": "mon_triffid_teleporter", "weight": 200 }
-    ]
   }
 ]

--- a/data/mods/MindOverMatter/monstergroups/monstergroups_new.json
+++ b/data/mods/MindOverMatter/monstergroups/monstergroups_new.json
@@ -119,6 +119,24 @@
   },
   {
     "type": "monstergroup",
+    "id": "GROUP_MI-GO_PSIONS",
+    "monsters": [
+      { "monster": "mon_mi_go_telepath", "weight": 50, "cost_multiplier": 20, "starts": "35 days" },
+      { "monster": "mon_mi_go_photokinetic", "weight": 50, "cost_multiplier": 2, "starts": "35 days" },
+      { "monster": "mon_mi_go_biokinetic", "weight": 20, "cost_multiplier": 70, "starts": "35 days" }
+    ]
+  },
+  {
+    "type": "monstergroup",
+    "id": "GROUP_TRIFFID_PSIONS",
+    "monsters": [
+      { "monster": "mon_triffid_clairsentient", "weight": 400 },
+      { "monster": "mon_triffid_pyrokinetic", "weight": 400 },
+      { "monster": "mon_triffid_teleporter", "weight": 200 }
+    ]
+  },
+  {
+    "type": "monstergroup",
     "id": "GROUP_LAB_RESEARCH",
     "default": "mon_zombie_scientist_phavian",
     "monsters": [

--- a/data/mods/MindOverMatter/overmap/overmap_specials.json
+++ b/data/mods/MindOverMatter/overmap/overmap_specials.json
@@ -6,8 +6,7 @@
     "locations": [ "wilderness" ],
     "city_distance": [ 20, -1 ],
     "city_sizes": [ 0, 20 ],
-    "occurrences": [ 0, 2 ],
-    "spawns": { "group": "GROUP_CRYSTAL_FIELD", "population": [ 1, 4 ], "radius": [ 1, 3 ] }
+    "occurrences": [ 0, 2 ]
   },
   {
     "type": "overmap_special",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[MoM] Rework crystal field spawns"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

It doesn't make much sense that it's _always_ a pitched battle when you get there. Surely sometimes you'd show up when someone had already won?

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Use nests to spawn different options. The most likely option is control by Nether creatures, but you can also arrive to find it under control by the mi-go or by feral psions. You can still show up when it's a big battle, it's just less common.

If you're very lucky, you'll show up and nothing will be there.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Spawned a bunch of extras, teleported around.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
