### PR TITLE
fix balthazar bunker trying to update yet to be generated map

### DIFF
--- a/data/json/effects_on_condition/npc_eocs/balthazar_fac_eocs.json
+++ b/data/json/effects_on_condition/npc_eocs/balthazar_fac_eocs.json
@@ -24,13 +24,21 @@
     "type": "effect_on_condition",
     "id": "EOC_BALTHAZAR_CHECK_PROGRESS",
     "global": true,
+    "condition": {
+      "and": [
+        { "u_near_om_location": "balthazar_bunker_02", "range": 30 },
+        { "not": { "u_near_om_location": "balthazar_bunker_02", "range": 4 } },
+        { "math": [ "balthazar_destroyed != 1" ] }
+      ]
+    },
     "effect": [
       { "if": { "math": [ "balthazar_power <= 0" ] }, "then": { "run_eocs": "EOC_BALTHAZAR_GONE" } },
       {
         "if": { "and": [ { "math": [ "balthazar_solar_power != 1" ] }, { "math": [ "balthazar_power >= 50" ] } ] },
         "then": { "run_eocs": "EOC_BALTHAZAR_SET_UP_SOLAR" }
       }
-    ]
+    ],
+    "deactivate_condition": { "math": [ "balthazar_destroyed == 1" ] }
   },
   {
     "type": "effect_on_condition",
@@ -51,6 +59,7 @@
     "effect": [
       { "mapgen_update": "remove_balthazar_intercom", "om_terrain": "balthazar_bunker_01" },
       { "math": [ "balthazar_power = 0" ] },
+      { "math": [ "balthazar_destroyed = 1" ] },
       { "math": [ "balthazar_daily_power_gain = 0" ] }
     ]
   },


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Fix #82534
Fix #81671
#### Describe the solution
Copy what the game uses to update ancilla bar, which is do not update the map if you are not at least 30 omt close to it
#### Testing
Have no error popping up in 82534
#### Additional context
I don't like that we have two methods to update map that do not interact with each other meaningfully - map update updates the existing maps, and cannot update maps that did not generated yet, and combination of multiple mapgens under the same id with different weight (especially math weight) can handle updating maps that are yet to be generated, but cannot deal with maps that were already generated