### PR TITLE
[Mods] Add MYOPIC_SUPERNATURAL and MYOPIC_IN_LIGHT_SUPERNATURAL flags

### DIFF
--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -489,6 +489,16 @@
     "info": "This gear <good>corrects nearsightedness</good>."
   },
   {
+    "id": "MYOPIC_SUPERNATURAL",
+    "type": "json_flag",
+    "//": "Like MYOPIC, but can't be fixed by glasses."
+  },
+  {
+    "id": "MYOPIC_IN_LIGHT_SUPERNATURAL",
+    "type": "json_flag",
+    "//": "Like MYOPIC_IN_LIGHT, but can't be fixed by glasses."
+  },
+  {
     "id": "FILTHY",
     "type": "json_flag",
     "//": "Zombie-dropped clothing giving various penalties if Filthy mod is active.  Also CBMs harvested from zombies.",

--- a/data/mods/Magiclysm/mutations/mutation_paths/fantasy_species.json
+++ b/data/mods/Magiclysm/mutations/mutation_paths/fantasy_species.json
@@ -577,7 +577,7 @@
     "description": "Your people have always had an easier time operating at night, away from the hated light of the sun.",
     "mixed_effect": true,
     "valid": false,
-    "flags": [ "MYOPIC_IN_LIGHT" ],
+    "flags": [ "MYOPIC_IN_LIGHT_SUPERNATURAL" ],
     "category": [ "SPECIES_GOBLIN" ],
     "enchantments": [
       {

--- a/data/mods/MindOverMatter/effects/effects_nether_attunement.json
+++ b/data/mods/MindOverMatter/effects/effects_nether_attunement.json
@@ -81,7 +81,7 @@
     "remove_message": "Your vision finally clears.",
     "rating": "bad",
     "limb_score_mods": [ { "limb_score": "night_vis", "modifier": 0.1 }, { "limb_score": "vision", "modifier": 0.2 } ],
-    "flags": [ "EFFECT_LIMB_SCORE_MOD", "HYPEROPIC", "MYOPIC", "MYOPIC_IN_LIGHT" ]
+    "flags": [ "EFFECT_LIMB_SCORE_MOD", "HYPEROPIC", "MYOPIC_SUPERNATURAL" ]
   },
   {
     "type": "effect_type",

--- a/data/mods/MindOverMatter/effects/effects_penalty.json
+++ b/data/mods/MindOverMatter/effects/effects_penalty.json
@@ -357,7 +357,7 @@
     "show_in_info": true,
     "limb_score_mods": [ { "limb_score": "vision", "modifier": 0.5 }, { "limb_score": "night_vis", "modifier": 0.5 } ],
     "base_mods": { "hit_mod": [ -2 ] },
-    "flags": [ "MYOPIC_IN_LIGHT", "EFFECT_LIMB_SCORE_MOD" ]
+    "flags": [ "MYOPIC_SUPERNATURAL", "EFFECT_LIMB_SCORE_MOD" ]
   },
   {
     "type": "effect_type",

--- a/doc/JSON/JSON_FLAGS.md
+++ b/doc/JSON/JSON_FLAGS.md
@@ -406,6 +406,8 @@ Character flags can be `trait_id`, `json_flag_id` or `flag_id`.  Some of these a
 - ```MYCUS_IMMUNE``` Critter is immune to fungal hase field (`fd_fungal_haze`)
 - ```MYOPIC``` You are nearsighted: vision range is severely reduced without glasses.
 - ```MYOPIC_IN_LIGHT``` You are nearsighted in light, but can see normally in low-light conditions.
+- ```MYOPIC_SUPERNATURAL``` You are nearsighted in such a way that glasses cannot fix it, such as by magic.
+- ```MYOPIC_IN_LIGHT_SUPERNATURAL``` You are nearsighted in light in such a way that glasses cannot fix it, such as by magic.
 - ```NIGHT_VISION``` You can see in the dark.
 - ```NO_DISEASE``` This mutation grants immunity to diseases.
 - ```NO_RADIATION``` This mutation grants immunity to radiations.

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -2679,8 +2679,8 @@ void Character::recalc_sight_limits()
                !worn_with_flag( flag_FIX_NEARSIGHT ) && !has_effect( effect_contacts ) &&
                !has_effect( effect_transition_contacts ) ||
                ( in_light &&
-                 has_flag( json_flag_MYOPIC_IN_LIGHT_SUPERNATURAL) ) ||
-               has_flag( json_flag_MYOPIC_SUPERNATURAL ) 
+                 has_flag( json_flag_MYOPIC_IN_LIGHT_SUPERNATURAL ) ) ||
+               has_flag( json_flag_MYOPIC_SUPERNATURAL )
              ) {
         sight_max = 12;
     } else if( has_effect( effect_darkness ) ) {

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -2679,8 +2679,8 @@ void Character::recalc_sight_limits()
                !worn_with_flag( flag_FIX_NEARSIGHT ) && !has_effect( effect_contacts ) &&
                !has_effect( effect_transition_contacts ) ) || 
                ( in_light &&
-                has_flag( json_flag_MYOPIC_IN_LIGHT_SUPERNATURAL ) ) ||
-                has_flag( json_flag_MYOPIC_SUPERNATURAL )
+                 has_flag( json_flag_MYOPIC_IN_LIGHT_SUPERNATURAL ) ) ||
+               has_flag( json_flag_MYOPIC_SUPERNATURAL )
              ) {
         sight_max = 12;
     } else if( has_effect( effect_darkness ) ) {

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -2673,10 +2673,10 @@ void Character::recalc_sight_limits()
         sight_max = 2;
     } else if( has_trait( trait_PER_SLIME ) ) {
         sight_max = 8;
-    } else if( ( has_flag( json_flag_MYOPIC ) || ( in_light &&
+    } else if( ( ( has_flag( json_flag_MYOPIC ) || ( in_light &&
                  has_flag( json_flag_MYOPIC_IN_LIGHT ) ) ) &&
                !worn_with_flag( flag_FIX_NEARSIGHT ) && !has_effect( effect_contacts ) &&
-               !has_effect( effect_transition_contacts ) || 
+               !has_effect( effect_transition_contacts ) ) || 
                ( in_light &&
                  has_flag( json_flag_MYOPIC_IN_LIGHT_SUPERNATURAL) ) ||
                has_flag( json_flag_MYOPIC_SUPERNATURAL ) 

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -2675,12 +2675,12 @@ void Character::recalc_sight_limits()
     } else if( has_trait( trait_PER_SLIME ) ) {
         sight_max = 8;
     } else if( ( ( has_flag( json_flag_MYOPIC ) || ( in_light &&
-                 has_flag( json_flag_MYOPIC_IN_LIGHT ) ) ) &&
+                has_flag( json_flag_MYOPIC_IN_LIGHT ) ) ) &&
                !worn_with_flag( flag_FIX_NEARSIGHT ) && !has_effect( effect_contacts ) &&
                !has_effect( effect_transition_contacts ) ) || 
                ( in_light &&
-                 has_flag( json_flag_MYOPIC_IN_LIGHT_SUPERNATURAL ) ) ||
-               has_flag( json_flag_MYOPIC_SUPERNATURAL )
+                has_flag( json_flag_MYOPIC_IN_LIGHT_SUPERNATURAL ) ) ||
+                has_flag( json_flag_MYOPIC_SUPERNATURAL )
              ) {
         sight_max = 12;
     } else if( has_effect( effect_darkness ) ) {

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -2675,11 +2675,11 @@ void Character::recalc_sight_limits()
     } else if( has_trait( trait_PER_SLIME ) ) {
         sight_max = 8;
     } else if( ( ( has_flag( json_flag_MYOPIC ) || ( in_light &&
-                 has_flag( json_flag_MYOPIC_IN_LIGHT ) ) ) &&
-                !worn_with_flag( flag_FIX_NEARSIGHT ) && !has_effect( effect_contacts ) &&
-                !has_effect( effect_transition_contacts ) ) || 
-                ( in_light && has_flag( json_flag_MYOPIC_IN_LIGHT_SUPERNATURAL ) ) ||
-                has_flag( json_flag_MYOPIC_SUPERNATURAL )
+                   has_flag( json_flag_MYOPIC_IN_LIGHT ) ) ) &&
+                 !worn_with_flag( flag_FIX_NEARSIGHT ) && !has_effect( effect_contacts ) &&
+                 !has_effect( effect_transition_contacts ) ) ||
+               ( in_light && has_flag( json_flag_MYOPIC_IN_LIGHT_SUPERNATURAL ) ) ||
+               has_flag( json_flag_MYOPIC_SUPERNATURAL )
              ) {
         sight_max = 12;
     } else if( has_effect( effect_darkness ) ) {

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -2677,7 +2677,7 @@ void Character::recalc_sight_limits()
     } else if( ( has_flag( json_flag_MYOPIC ) || ( in_light &&
                  has_flag( json_flag_MYOPIC_IN_LIGHT ) ) ) &&
                !worn_with_flag( flag_FIX_NEARSIGHT ) && !has_effect( effect_contacts ) &&
-               !has_effect( effect_transition_contacts ) || 
+               !has_effect( effect_transition_contacts ) ||
                ( in_light &&
                  has_flag( json_flag_MYOPIC_IN_LIGHT_SUPERNATURAL) ) ||
                has_flag( json_flag_MYOPIC_SUPERNATURAL ) 

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -329,10 +329,10 @@ static const json_character_flag json_flag_INSECTBLOOD( "INSECTBLOOD" );
 static const json_character_flag json_flag_INVERTEBRATEBLOOD( "INVERTEBRATEBLOOD" );
 static const json_character_flag json_flag_INVISIBLE( "INVISIBLE" );
 static const json_character_flag json_flag_MYOPIC( "MYOPIC" );
-static const json_character_flag json_flag_MYOPIC_SUPERNATURAL( "MYOPIC_SUPERNATURAL" );
 static const json_character_flag json_flag_MYOPIC_IN_LIGHT( "MYOPIC_IN_LIGHT" );
 static const json_character_flag
 json_flag_MYOPIC_IN_LIGHT_SUPERNATURAL( "MYOPIC_IN_LIGHT_SUPERNATURAL" );
+static const json_character_flag json_flag_MYOPIC_SUPERNATURAL( "MYOPIC_SUPERNATURAL" );
 static const json_character_flag json_flag_NIGHT_VISION( "NIGHT_VISION" );
 static const json_character_flag json_flag_NON_THRESH( "NON_THRESH" );
 static const json_character_flag json_flag_NO_RADIATION( "NO_RADIATION" );

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -331,7 +331,8 @@ static const json_character_flag json_flag_INVISIBLE( "INVISIBLE" );
 static const json_character_flag json_flag_MYOPIC( "MYOPIC" );
 static const json_character_flag json_flag_MYOPIC_SUPERNATURAL( "MYOPIC_SUPERNATURAL" );
 static const json_character_flag json_flag_MYOPIC_IN_LIGHT( "MYOPIC_IN_LIGHT" );
-static const json_character_flag json_flag_MYOPIC_IN_LIGHT_SUPERNATURAL( "MYOPIC_IN_LIGHT_SUPERNATURAL");
+static const json_character_flag
+json_flag_MYOPIC_IN_LIGHT_SUPERNATURAL( "MYOPIC_IN_LIGHT_SUPERNATURAL" );
 static const json_character_flag json_flag_NIGHT_VISION( "NIGHT_VISION" );
 static const json_character_flag json_flag_NON_THRESH( "NON_THRESH" );
 static const json_character_flag json_flag_NO_RADIATION( "NO_RADIATION" );

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1461,7 +1461,7 @@ bool Character::sight_impaired() const
              !has_effect( effect_transition_contacts ) &&
              !has_flag( json_flag_ENHANCED_VISION ) ) ||
            ( in_light && has_flag( json_flag_MYOPIC_IN_LIGHT_SUPERNATURAL ) ) ||
-             has_flag( json_flag_MYOPIC_SUPERNATURAL ) ||
+           has_flag( json_flag_MYOPIC_SUPERNATURAL ) ||
            has_trait( trait_PER_SLIME ) || is_blind();
 }
 

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -2675,12 +2675,11 @@ void Character::recalc_sight_limits()
     } else if( has_trait( trait_PER_SLIME ) ) {
         sight_max = 8;
     } else if( ( ( has_flag( json_flag_MYOPIC ) || ( in_light &&
-                has_flag( json_flag_MYOPIC_IN_LIGHT ) ) ) &&
-               !worn_with_flag( flag_FIX_NEARSIGHT ) && !has_effect( effect_contacts ) &&
-               !has_effect( effect_transition_contacts ) ) || 
-               ( in_light &&
-                 has_flag( json_flag_MYOPIC_IN_LIGHT_SUPERNATURAL ) ) ||
-               has_flag( json_flag_MYOPIC_SUPERNATURAL )
+                 has_flag( json_flag_MYOPIC_IN_LIGHT ) ) ) &&
+                !worn_with_flag( flag_FIX_NEARSIGHT ) && !has_effect( effect_contacts ) &&
+                !has_effect( effect_transition_contacts ) ) || 
+                ( in_light && has_flag( json_flag_MYOPIC_IN_LIGHT_SUPERNATURAL ) ) ||
+                has_flag( json_flag_MYOPIC_SUPERNATURAL )
              ) {
         sight_max = 12;
     } else if( has_effect( effect_darkness ) ) {

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -329,7 +329,9 @@ static const json_character_flag json_flag_INSECTBLOOD( "INSECTBLOOD" );
 static const json_character_flag json_flag_INVERTEBRATEBLOOD( "INVERTEBRATEBLOOD" );
 static const json_character_flag json_flag_INVISIBLE( "INVISIBLE" );
 static const json_character_flag json_flag_MYOPIC( "MYOPIC" );
+static const json_character_flag json_flag_MYOPIC_SUPERNATURAL( "MYOPIC_SUPERNATURAL" );
 static const json_character_flag json_flag_MYOPIC_IN_LIGHT( "MYOPIC_IN_LIGHT" );
+static const json_character_flag json_flag_MYOPIC_IN_LIGHT_SUPERNATURAL( "MYOPIC_IN_LIGHT_SUPERNATURAL");
 static const json_character_flag json_flag_NIGHT_VISION( "NIGHT_VISION" );
 static const json_character_flag json_flag_NON_THRESH( "NON_THRESH" );
 static const json_character_flag json_flag_NO_RADIATION( "NO_RADIATION" );
@@ -1457,6 +1459,8 @@ bool Character::sight_impaired() const
              !has_effect( effect_contacts ) &&
              !has_effect( effect_transition_contacts ) &&
              !has_flag( json_flag_ENHANCED_VISION ) ) ||
+           ( in_light && has_flag( json_flag_MYOPIC_IN_LIGHT_SUPERNATURAL ) ) ||
+             has_flag( json_flag_MYOPIC_SUPERNATURAL ) ||
            has_trait( trait_PER_SLIME ) || is_blind();
 }
 
@@ -2672,7 +2676,11 @@ void Character::recalc_sight_limits()
     } else if( ( has_flag( json_flag_MYOPIC ) || ( in_light &&
                  has_flag( json_flag_MYOPIC_IN_LIGHT ) ) ) &&
                !worn_with_flag( flag_FIX_NEARSIGHT ) && !has_effect( effect_contacts ) &&
-               !has_effect( effect_transition_contacts ) ) {
+               !has_effect( effect_transition_contacts ) || 
+               ( in_light &&
+                 has_flag( json_flag_MYOPIC_IN_LIGHT_SUPERNATURAL) ) ||
+               has_flag( json_flag_MYOPIC_SUPERNATURAL ) 
+             ) {
         sight_max = 12;
     } else if( has_effect( effect_darkness ) ) {
         vision_mode_cache.set( DARKNESS );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "Add MYOPIC_SUPERNATURAL and MYOPIC_IN_LIGHT_SUPERNATURAL flags"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Re-implementation of #82719, leaving base flags alone.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add MYOPIC_SUPERNATURAL and MYOPIC_IN_LIGHT_SUPERNATURAL, which work as the base flags but are uncorrectable by glasses. Add `MYOPIC_IN_LIGHT_SUPERNATURAL` to goblins, and add `MYOPIC_SUPERNATURAL` to Clairsentient and Photokinetic overload/Nether Attunement backlash so that you can't put on some glasses and avoid the consequences of your psionic mishaps. 

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Same testing as the previous PR: 

Spawned a Magiclysm goblin for easy access to MYOPIC_IN_LIGHT_SUPERNATURAL. Put on eyeglasses, they did nothing.

Spawned a nearsighted human. Put on eyeglasses, they still worked.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
