### PR TITLE
Changed restock time display

### DIFF
--- a/data/json/npcs/godco/members/NPC_Kostas_Walsman.json
+++ b/data/json/npcs/godco/members/NPC_Kostas_Walsman.json
@@ -168,8 +168,8 @@
     "id": "TALK_GODCO_Kostas_Interval",
     "type": "talk_topic",
     "dynamic_line": [
-      "I'm afraid I haven't gone out there for a while, maybe come back on <restock_time_point>.  These are all I have, care to take a look?",
-      "Sorry these are all I have.  However I'll be back from my next run on <restock_time_point>.  Care to take a look in the meanwhile?"
+      "I'm afraid I haven't gone out there for a while, maybe come back after <restock_time_point>.  These are all I have, care to take a look?",
+      "Sorry these are all I have.  However I'll be back from my next run after <restock_time_point>.  Care to take a look in the meanwhile?"
     ],
     "responses": [
       { "text": "Alright, I'll take a look.", "effect": "start_trade", "topic": "TALK_GODCO_Kostas_1" },

--- a/data/json/npcs/lumbermill_employees/TALK_lumbermill_merchant.json
+++ b/data/json/npcs/lumbermill_employees/TALK_lumbermill_merchant.json
@@ -75,7 +75,7 @@
   {
     "type": "talk_topic",
     "id": "TALK_LUMBERMILL_RESTOCK",
-    "dynamic_line": "Workers will bring in a new shipment of lumber on <restock_time_point>."
+    "dynamic_line": "Workers will bring in a new shipment of lumber after <restock_time_point>."
   },
   {
     "type": "talk_topic",

--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom.json
@@ -1069,8 +1069,8 @@
     "id": "TALK_ROBOFAC_INTERCOM_ASK_INTERVAL",
     "type": "talk_topic",
     "dynamic_line": [
-      "We have no other disposable equipment right now.  You'll have to come back on <restock_time_point>.",
-      "No. Come back on <restock_time_point>."
+      "We have no other disposable equipment right now.  You'll have to come back after <restock_time_point>.",
+      "No. Come back after <restock_time_point>."
     ],
     "responses": [ { "text": "Right…", "topic": "TALK_ROBOFAC_INTERCOM_SERVICES" } ]
   }

--- a/data/json/npcs/scrap_trader/scrap_trader.json
+++ b/data/json/npcs/scrap_trader/scrap_trader.json
@@ -363,7 +363,7 @@
   {
     "id": "TALK_SCRAP_TRADER_ASK_INTERVAL",
     "type": "talk_topic",
-    "dynamic_line": "Nope, although I have a really good claim by the river.  Gonna go fetch them soon, be right back on <restock_time_point>.",
+    "dynamic_line": "Nope, although I have a really good claim by the river.  Gonna go fetch them soon, be right back after <restock_time_point>.",
     "responses": [ { "text": "Well, good luck.", "topic": "TALK_NPC_SCRAP_TRADER" } ]
   }
 ]

--- a/data/json/npcs/tacoma_ranch/NPC_ranch_scavenger.json
+++ b/data/json/npcs/tacoma_ranch/NPC_ranch_scavenger.json
@@ -42,7 +42,7 @@
   {
     "type": "talk_topic",
     "id": "TALK_RANCH_SCAVENGER_ASK_RESTOCK",
-    "dynamic_line": "Nope, current run hasn't returned yet.  Come back on <restock_time_point>.  You might find something you like.",
+    "dynamic_line": "Nope, current run hasn't returned yet.  Come back after <restock_time_point>.  You might find something you like.",
     "responses": [ { "text": "Alright, thanks.", "topic": "TALK_RANCH_SCAVENGER_1" } ]
   },
   {

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -2452,13 +2452,15 @@ void parse_tags( std::string &phrase, const_talker const &u, const_talker const 
             } else if( get_option<bool>( "SHOW_MONTHS" ) && calendar::year_length() ==  364_days ) {
                 std::pair<month, int> month_day = month_and_day( guy->restock_time() );
                 //~ 1 is month, 2 is day
-                phrase.replace( fa, l, string_format( pgettext( "month and day", "%1$s %2$d" ),
-                                                      to_string( month_day.first ), month_day.second ) );
+                phrase.replace( fa, l, string_format( pgettext( "month, day and time", "%1$s %2$d, %3$s" ),
+                                                      to_string( month_day.first ), month_day.second,
+                                                      to_string_time_of_day( guy->restock_time() ) ) );
             } else {
                 //~ 1 is season, 2 is day
-                phrase.replace( fa, l, string_format( pgettext( "season and day", "%1$s %2$d" ),
+                phrase.replace( fa, l, string_format( pgettext( "season, day, and time", "%1$s %2$d, %3$s" ),
                                                       calendar::name_season( season_of_year( guy->restock_time() ) ),
-                                                      day_of_season<int>( guy->restock_time() ) ) );
+                                                      day_of_season<int>( guy->restock_time() ) + 1,
+                                                      to_string_time_of_day( guy->restock_time() ) ) );
             }
         } else if( tag.find( "<u_val:" ) == 0 ) {
             //adding a user variable to the string


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fix #82710, i.e. lying about when restocking happens and hiding the time.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
- Correct the display of day of month. Humans start at 1. Computers and C programmers start at 0.
- Add time of day and adjusted JSON texts to match.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
- Adjust all restock JSON texts.
- Find a way to trim down the time of day display to hours, while still respecting the time convention used (1 PM vs 13, etc.)
- Leave a day resolution, but adjust JSON texts to make it clear change over would happen at some time during that day.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Teleported to the Refugee Center and spoke to Smokes. Tried using both day of season + military format and day of month + 12h format (but only one screenshot). Didn't bother with the third time format, as the function used is assumed to have been tested, so it should be sufficient to verify changing format takes effect.
<img width="3440" height="1440" alt="Screenshot (2)" src="https://github.com/user-attachments/assets/04975c54-eb36-4088-86ca-2990b8baa26b" />
Haven't tested the JSON string changes apart from them not blowing up on loading the save.

Tested that Smokes' time was correct (within a minute) by debug waiting to the minute before the changeover (but not adjusting the seconds), asking about restocking, receiving the same answer (i.e. less than a minute into the future), debug waited a minute, and asked again, when he gives a restock time slightly further than 6 days from the previous one into the future, at exactly 6 days from the conversation.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Giving the exact time down to seconds is artificial, but just giving a stock change over day is rather nebulous, in particular since it seems the change over time is dependent on the time of your last visit if within the restock interval and time of arrival outside of it (based on teleporting to the Refugee Center, which hasn't been visited for over a week). Thus, I don't think the current JSON texts would cut it with a day resolution: you'd have to indicate changeover happens sometime during that day in a manner that doesn't have the player expect it to be at midnight or any other specific time.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
