### PR TITLE
optional/mandatory for some iuse actors

### DIFF
--- a/src/iuse_actor.h
+++ b/src/iuse_actor.h
@@ -179,8 +179,8 @@ class sound_iuse : public iuse_actor
         translation sound_message;
 
         int sound_volume = 0;
-        std::string sound_id = "misc";
-        std::string sound_variant = "default";
+        std::string sound_id;
+        std::string sound_variant;
 
         ~sound_iuse() override = default;
         void load( const JsonObject &obj, const std::string & ) override;


### PR DESCRIPTION
#### Summary
Infrastructure "Use optional/mandatory for some iuse actors"

#### Purpose of change
Optional and mandatory have better support for extended features and better error reporting, as per https://github.com/CleverRaven/Cataclysm-DDA/pull/82165

#### Describe the solution
Replace assign and other methods of JSON reading with optional or mandatory.

#### Testing
`tools/load_all_mods.sh`
`tests/cata_test`