### PR TITLE
Aftershock: Harvest snow with shovels

### DIFF
--- a/data/mods/aftershock_exoplanet/EOC/tool_iuse_eoc.json
+++ b/data/mods/aftershock_exoplanet/EOC/tool_iuse_eoc.json
@@ -1,0 +1,31 @@
+[
+  {
+    "type": "ter_furn_transform",
+    "id": "f_snow_bowl",
+    "furniture": [ { "result": "f_snow_bowl", "valid_furniture": [ "f_null" ] } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_SHOVEL_SNOW",
+    "effect": [
+      {
+        "u_choose_adjacent_highlight": { "context_val": "_dig_loc" },
+        "condition": {
+          "and": [
+            { "map_terrain_with_flag": "SNOW_SOURCE", "loc": { "context_val": "loc" } },
+            { "map_furniture_id": "f_null", "loc": { "context_val": "loc" } }
+          ]
+        },
+        "message": "Select ice or snow to harvest from.",
+        "failure_message": "There's no frozen terrain nearby"
+      },
+      { "u_transform_radius": 0, "ter_furn_transform": "f_snow_bowl", "target_var": { "context_val": "_dig_loc" } },
+      {
+        "map_spawn_item": "water",
+        "loc": { "context_val": "_dig_loc" },
+        "count": 5,
+        "flags": [ "SHREDDED", "FROZEN" ]
+      }
+    ]
+  }
+]

--- a/data/mods/aftershock_exoplanet/items/tools.json
+++ b/data/mods/aftershock_exoplanet/items/tools.json
@@ -41,6 +41,52 @@
     ]
   },
   {
+    "id": "g_shovel",
+    "type": "ITEM",
+    "subtypes": [ "TOOL" ],
+    "copy-from": "g_shovel",
+    "name": { "str": "trowel" },
+    "description": "A small, sharp shovel, perfect for breaking off chunks of ice.",
+    "material": [ "mc_steel", "plastic" ],
+    "use_action": {
+      "type": "effect_on_conditions",
+      "ammo_scale": 1,
+      "menu_text": "Harvest ice",
+      "effect_on_conditions": [ "EOC_SHOVEL_SNOW" ]
+    }
+  },
+  {
+    "id": "shovel",
+    "type": "ITEM",
+    "subtypes": [ "TOOL" ],
+    "copy-from": "shovel",
+    "name": { "str": "shovel" },
+    "description": "A shovel with a steel blade.",
+    "material": [ "mc_steel", "plastic" ],
+    "use_action": {
+      "type": "effect_on_conditions",
+      "ammo_scale": 1,
+      "menu_text": "Harvest ice",
+      "effect_on_conditions": [ "EOC_SHOVEL_SNOW" ]
+    }
+  },
+  {
+    "id": "shovel_snow",
+    "looks_like": "shovel",
+    "type": "ITEM",
+    "copy-from": "shovel_snow",
+    "subtypes": [ "TOOL" ],
+    "name": { "str": "snow shovel" },
+    "description": "A sturdy metal shovel used for picking up snow and moving it somewhere else.",
+    "material": [ "mc_steel", "plastic" ],
+    "use_action": {
+      "type": "effect_on_conditions",
+      "ammo_scale": 1,
+      "menu_text": "Harvest ice",
+      "effect_on_conditions": [ "EOC_SHOVEL_SNOW" ]
+    }
+  },
+  {
     "id": "afs_imager",
     "type": "ITEM",
     "subtypes": [ "TOOL" ],

--- a/data/mods/aftershock_exoplanet/maps/furniture_and_terrain/terrain_groundxeno.json
+++ b/data/mods/aftershock_exoplanet/maps/furniture_and_terrain/terrain_groundxeno.json
@@ -34,7 +34,7 @@
     "symbol": ".",
     "color": "light_blue",
     "move_cost": 2,
-    "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT", "ROUGH" ],
+    "flags": [ "TRANSPARENT", "DIGGABLE", "SNOW_SOURCE", "FLAT", "ROUGH" ],
     "bash": {
       "str_min": 50,
       "str_max": 100,
@@ -196,7 +196,7 @@
     "symbol": ".",
     "color": "light_blue",
     "move_cost": 2,
-    "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT", "ROUGH" ],
+    "flags": [ "TRANSPARENT", "DIGGABLE", "SNOW_SOURCE", "FLAT", "ROUGH" ],
     "bash": {
       "str_min": 8,
       "str_max": 100,
@@ -215,7 +215,7 @@
     "symbol": ".",
     "color": "light_blue",
     "move_cost": 4,
-    "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT" ],
+    "flags": [ "TRANSPARENT", "DIGGABLE", "SNOW_SOURCE", "FLAT" ],
     "bash": {
       "str_min": 8,
       "str_max": 100,
@@ -234,7 +234,7 @@
     "symbol": ".",
     "color": "light_blue",
     "move_cost": 4,
-    "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT" ],
+    "flags": [ "TRANSPARENT", "DIGGABLE", "SNOW_SOURCE", "FLAT" ],
     "bash": {
       "str_min": 80,
       "str_max": 100,
@@ -435,6 +435,21 @@
     "required_str": 32,
     "flags": [ "NOITEM", "MINEABLE", "BLOCK_WIND" ],
     "bash": { "str_min": 64, "str_max": 160, "sound": "smash!", "sound_fail": "thump." }
+  },
+  {
+    "type": "furniture",
+    "id": "f_snow_bowl",
+    "name": "snow bowl",
+    "symbol": "o",
+    "description": "A small depression dug from mostly clean snow.  Can hold small amounts of liquid.",
+    "color": "white",
+    "move_cost_mod": 2,
+    "coverage": 30,
+    "required_str": -1,
+    "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "CONTAINER", "PLACE_ITEM", "LIQUIDCONT", "UNSTABLE", "MOUNTABLE", "TINY" ],
+    "max_volume": "8 L",
+    "examine_action": "keg",
+    "keg_capacity": "8 L"
   },
   {
     "type": "terrain",


### PR DESCRIPTION
#### Summary
Mods  "Aftershock: Harvest snow with shovels"

#### Purpose of change

The exoplanet is full of frozen water, it shouldnt be easy to die of thirst on it.

#### Describe the solution
Expand the active use menu of shovels with an EOC action that lets you dig out some ice.  You can collect 5 pieces of ice from each tile of frozen earth once.

This doesnt take any time for now.

#### Describe alternatives you've considered
Let players directly craft water using snow tiles as water sources but that took more code than what I wanted to write (0)

#### Testing

Used the shovel