### PR TITLE
Change "The first day of the rest of their unlives" achievement time passed requirement from 24h to 16h

### DIFF
--- a/data/json/achievements.json
+++ b/data/json/achievements.json
@@ -84,7 +84,7 @@
     "type": "achievement",
     "name": "The first day of the rest of their unlives",
     "description": "Survive for a day and find a safe place to sleep",
-    "time_constraint": { "since": "game_start", "is": ">=", "target": "1 day" },
+    "time_constraint": { "since": "game_start", "is": ">=", "target": "16 hours" },
     "requirements": [ { "event_statistic": "num_avatar_wake_ups", "is": "anything" } ]
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Balance "Change "The first day of the rest of their unlives" achievement time passed requirement from 24h to 16h"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Currently, assuming default starting time of 8AM, if the player goes to sleep the first night and wakes up any time before 8AM, they will not get this achievement, instead likely getting it the next time they wake up. This makes the achievement description (Survive for a day and find a safe place to sleep) often inaccurate, as the player will usually have survived 2 days and 2 nights, not 1 day and 1 night.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Change the required time from "1 day" to "16 hours". This makes it so (again, assuming default starting time) if the player wakes up any time after 12AM at the start of the second day, they'll get the achievement. And if the starting time is changed, the player will still likely get it the first time they go to sleep from natural tiredness.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
A simple, different solution would be to just change the description of the achievement to say "Survive for a full 24 hours, then find a safe place to sleep." Makes the description more accurate, but still leaves it feeling like an achievement for sleeping twice in most cases, which seems like it's not the intention.
A different solution might be to give the achievement only if it's no longer the day the player started the game, however this would mean starts at 1AM couldn't get it when they get naturally tired, and starts at 11PM could get it without actually surviving a day by using sedatives.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Slept in evac shelter for up to 2 nights before and after changing achievements.json. Got achievement from first wakeup in the modified version.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Before change, get achievement on second wakeup, morning of May 22.
<img width="1366" height="768" alt="Screenshot (849)" src="https://github.com/user-attachments/assets/56a8f557-52d8-487a-9f5e-a2aae13ed367" />
After change, get achievement on first wakeup, morning of May 21
<img width="1366" height="768" alt="Screenshot (863)" src="https://github.com/user-attachments/assets/96d70802-ec20-4556-93a1-95ac3b53a5ea" />

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
