### PR TITLE
eoc: fix loading time of value_or_var

### DIFF
--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -2157,7 +2157,7 @@ void string_mutator<translation>::deserialize( JsonValue const &jsin )
         } );
         if( !ret_func ) {
             jo.allow_omitted_members();
-            jo.throw_error( "unrecognized string mutator in " + jo.str() );
+            throw JsonError( "invalid string mutator" );
         }
     }
 }
@@ -2176,7 +2176,7 @@ void string_mutator<std::string>::deserialize( JsonValue const &jsin )
         } );
         if( !ret_func ) {
             jo.allow_omitted_members();
-            jo.throw_error( "unrecognized string mutator in " + jo.str() );
+            throw JsonError( "invalid string mutator" );
         }
     }
 }
@@ -2371,7 +2371,7 @@ void deferred_math::_validate_type() const
 void eoc_math::from_json( const JsonObject &jo, std::string_view member, math_type_t type_ )
 {
     if( !jo.has_array( member ) ) {
-        jo.throw_error( "invalid math object" );
+        throw JsonError( "invalid math object" );
     }
     JsonArray const objects = jo.get_array( member );
     std::string combined;

--- a/src/dialogue_helpers.cpp
+++ b/src/dialogue_helpers.cpp
@@ -140,7 +140,7 @@ bool deserialize_variant( V &v, JsonValue const &jsin )
 template<typename valueT, typename... funcT>
 void value_or_var<valueT, funcT...>::deserialize( JsonValue const &jsin )
 {
-    if( deserialize_variant<decltype( val ), funcT..., var_info, valueT>( val, jsin ) ) {
+    if( deserialize_variant<decltype( val ), valueT, var_info, funcT...>( val, jsin ) ) {
 
         if( std::holds_alternative<var_info>( val ) ) {
             JsonObject const &jo_vi = jsin.get_object();

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -170,6 +170,7 @@
 #include "past_achievements_info.h"
 #include "path_info.h"
 #include "pathfinding.h"
+#include "perf.h"
 #include "pickup.h"
 #include "player_activity.h"
 #include "popup.h"
@@ -3427,8 +3428,10 @@ void game::load_packs( const std::string &msg, const std::vector<mod_id> &packs 
         if( mod.str() == "test_data" ) {
             check_plural = check_plural_t::none;
         }
+        cata_timer pack_timer( string_format( "%s pack load time:", mod->name() ) );
         load_mod_data_from_dir( mod->path, mod.str() );
     }
+    cata_timer::print_stats();
 
     for( const auto &mod : packs ) {
         if( !mod.is_valid() ) {

--- a/src/math_parser_diag_value.cpp
+++ b/src/math_parser_diag_value.cpp
@@ -354,7 +354,7 @@ void diag_value::deserialize( const JsonValue &jsin )
             tripoint_abs_ms t;
             jo.read( "tripoint", t );
             data = t;
-        } else if( jo.has_member( "str" ) ) {
+        } else if( jo.has_member( "str" ) && !jo.get_bool( "i18n", false ) ) {
             std::string str;
             jo.read( "str", str );
             data = str;
@@ -363,6 +363,9 @@ void diag_value::deserialize( const JsonValue &jsin )
             std::string str;
             jo.read( "dbl", str );
             data = std::stof( str );
+        } else {
+            jo.allow_omitted_members();
+            throw JsonError( "invalid diag_value object" );
         }
     }
 }


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

- `value_or_var` from #82687 uses a lot of exceptions for intermediary steps and this had a terrible effect on loading time

#### Describe the solution
- Reorder deserialization attempts so the more likely types are tried first
- types that aren't supposed to be loaded directly from human-editable files (diag_value, eoc_math, string_mutator) now throw a banal exception with no JSON unwinding

#### Describe alternatives you've considered
Listening to grugbrain for once in my life

#### Testing
Results from cata_timer, for loading the `dda` pack:
```
before this patch:  26349093us
after this patch:    1852500us
before value_or_var: 1662777us
```

Malformed variables, math, mutators, etc still show an error that points at the correct location.
#### Additional context
Test included #82688 so local numbers might be different