### PR TITLE
Replace assign with optional/mandatory in veh_type

### DIFF
--- a/doc/JSON/VEHICLES_JSON.md
+++ b/doc/JSON/VEHICLES_JSON.md
@@ -116,14 +116,12 @@ and describes the items that may spawn at that location.
 TYPE and DATA may be one of:
 ```jsonc
 "items": "itemid"                                   // single item of that type
-"items": [ "itemid1", "itemid2", /* ... */ ]        // all the items in the array
+"items": [ "itemid1", { "id": "itemid2", "variant": "foo" }, /* ... */ ]        // all the items in the array
 "item_groups": "groupid"                            // one or more items in the group, depending on
                                                     // whether the group is a collection or distribution
 "item_groups": [ "groupid1", "groupid2" /* ... */ ] // one or more items for each group
 ```
 the optional keyword "chance" provides an X in 100 chance that a particular item definition will spawn.
-
-If a single item is specified through `"items"`, an itype variant for it can be specified through `"variant"`.
 
 Multiple lines of items may share the same X and Y values.
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -335,7 +335,7 @@ void DynamicDataLoader::initialize()
     } );
 
     add( "vehicle_part",  &vehicles::parts::load );
-    add( "vehicle_part_category",  &vpart_category::load );
+    add( "vehicle_part_category",  &vpart_category::load_all );
     add( "vehicle_part_migration", &vpart_migration::load );
     add( "vehicle", &vehicles::load_prototype );
     add( "vehicle_group",  &VehicleGroup::load );
@@ -779,7 +779,7 @@ void DynamicDataLoader::finalize_loaded_data()
                     requirement_data::finalize();
                 }
             },
-            { _( "Vehicle part categories" ), &vpart_category::finalize },
+            { _( "Vehicle part categories" ), &vpart_category::finalize_all },
             { _( "Vehicle parts" ), &vehicles::parts::finalize },
             { _( "Traps" ), &trap::finalize_all },
             { _( "Terrain" ), &set_ter_ids },

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -1614,7 +1614,10 @@ void Item_factory::finalize_item_blacklist()
         vehicle_prototype &prototype = const_cast<vehicle_prototype &>( const_prototype );
         for( vehicle_item_spawn &vis : prototype.item_spawns ) {
             auto &vec = vis.item_ids;
-            const auto iter = std::remove_if( vec.begin(), vec.end(), item_is_blacklisted );
+            auto is_blacklisted = []( const std::pair<itype_id, std::string> &pair ) {
+                return item_is_blacklisted( pair.first );
+            };
+            const auto iter = std::remove_if( vec.begin(), vec.end(), is_blacklisted );
             vec.erase( iter, vec.end() );
         }
     }
@@ -1716,7 +1719,8 @@ void Item_factory::finalize_item_blacklist()
     for( const vehicle_prototype &const_prototype : vehicles::get_all_prototypes() ) {
         vehicle_prototype &prototype = const_cast<vehicle_prototype &>( const_prototype );
         for( vehicle_item_spawn &vis : prototype.item_spawns ) {
-            for( itype_id &type_to_spawn : vis.item_ids ) {
+            for( std::pair<itype_id, std::string> &spawn_pair : vis.item_ids ) {
+                itype_id &type_to_spawn = spawn_pair.first;
                 std::map<itype_id, std::vector<migration>>::iterator replacement =
                         migrations.find( type_to_spawn );
                 if( replacement == migrations.end() ) {

--- a/src/units.cpp
+++ b/src/units.cpp
@@ -80,6 +80,17 @@ void temperature::deserialize( const JsonValue &jv )
 }
 
 template<>
+void temperature_delta::deserialize( const JsonValue &jv )
+{
+    if( jv.test_int() ) {
+        *this = from_legacy_bodypart_temp_delta( jv.get_int() );
+    } else {
+        // super gross
+        *this = from_kelvin_delta( std::stof( jv.get_string() ) );
+    }
+}
+
+template<>
 void energy::serialize( JsonOut &jsout ) const
 {
     if( value_ % 1000000 == 0 ) {

--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -1355,6 +1355,15 @@ void vehicle_item_spawn::deserialize( const JsonObject &jo )
     optional( jo, false, "item_groups", item_groups, string_id_reader<Item_spawn_data> {} );
 }
 
+void vehicle_prototype::zone_def::deserialize( const JsonObject &jo )
+{
+    mandatory( jo, false, "type", zone_type );
+    mandatory( jo, false, "x", pt.x() );
+    mandatory( jo, false, "y", pt.y() );
+    optional( jo, false, "name", name );
+    optional( jo, false, "filter", filter );
+}
+
 void vehicle_prototype::load( const JsonObject &jo, std::string_view )
 {
     vgroups[vgroup_id( id.str() )].add_vehicle( id, 100 );
@@ -1376,21 +1385,7 @@ void vehicle_prototype::load( const JsonObject &jo, std::string_view )
     }
 
     optional( jo, was_loaded, "items", item_spawns );
-
-    for( JsonObject jzi : jo.get_array( "zones" ) ) {
-        zone_type_id zone_type( jzi.get_member( "type" ).get_string() );
-        std::string name;
-        std::string filter;
-        point_rel_ms pt( jzi.get_member( "x" ).get_int(), jzi.get_member( "y" ).get_int() );
-
-        if( jzi.has_string( "name" ) ) {
-            name = jzi.get_string( "name" );
-        }
-        if( jzi.has_string( "filter" ) ) {
-            filter = jzi.get_string( "filter" );
-        }
-        zone_defs.emplace_back( zone_def{ zone_type, name, filter, pt } );
-    }
+    optional( jo, was_loaded, "zones", zone_defs, json_read_reader<zone_def> {} );
 }
 
 void vehicle_prototype::save_vehicle_as_prototype( const vehicle &veh,

--- a/src/veh_type.h
+++ b/src/veh_type.h
@@ -541,6 +541,11 @@ struct vehicle_prototype {
             std::string name;
             std::string filter;
             point_rel_ms pt;
+
+            void deserialize( const JsonObject &jo );
+            bool operator==( const zone_def &other ) const {
+                return zone_type == other.zone_type && name == other.name && filter == other.name && pt == other.pt;
+            }
         };
 
         vproto_id id;

--- a/src/veh_type.h
+++ b/src/veh_type.h
@@ -210,8 +210,9 @@ class vpart_category
     public:
         static const std::vector<vpart_category> &all();
 
-        static void load( const JsonObject &jo );
-        static void finalize();
+        static void load_all( const JsonObject &jo );
+        static void finalize_all();
+        void load( const JsonObject &jo );
         static void reset();
 
         std::string get_id() const {
@@ -272,7 +273,7 @@ class vpart_info
     public:
         vpart_id id;
 
-        void load( const JsonObject &jo, const std::string &src );
+        void load( const JsonObject &jo, std::string_view src );
         void check() const;
         void finalize();
         void handle_inheritance( const vpart_info &copy_from,

--- a/src/veh_type.h
+++ b/src/veh_type.h
@@ -527,6 +527,12 @@ struct vehicle_prototype {
             std::pair<int, int> ammo_qty = { -1, -1 };
             itype_id fuel = itype_id::NULL_ID();
             std::vector<itype_id> tools;
+
+            bool operator==( const part_def &other ) const {
+                return pos == other.pos && part == other.part && variant == other.variant &&
+                       with_ammo == other.with_ammo && ammo_types == other.ammo_types && ammo_qty == other.ammo_qty &&
+                       fuel == other.fuel && tools == other.tools;
+            }
         };
 
         struct zone_def {

--- a/src/veh_type.h
+++ b/src/veh_type.h
@@ -506,10 +506,11 @@ struct vehicle_item_spawn {
     int with_ammo = 0;
     /** Chance [0-100%] for items to spawn with their default magazine (if any) */
     int with_magazine = 0;
-    std::vector<itype_id> item_ids;
-    // item_ids, but for items with variants specified
-    std::vector<std::pair<itype_id, std::string>> variant_ids;
+    // item_ids, with variants specified (empty is ignored)
+    std::vector<std::pair<itype_id, std::string>> item_ids;
     std::vector<item_group_id> item_groups;
+
+    void deserialize( const JsonObject &jo );
 };
 
 /**

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -6405,17 +6405,13 @@ void vehicle::place_spawn_items( map &here )
                     continue;
                 }
 
-                for( const itype_id &e : spawn.item_ids ) {
-                    if( rng_float( 0, 1 ) < spawn_rate ) {
-                        item spawn( e );
-                        created.emplace_back( spawn.in_its_container() );
-                    }
-                }
-                for( const std::pair<itype_id, std::string> &e : spawn.variant_ids ) {
+                for( const std::pair<itype_id, std::string> &e : spawn.item_ids ) {
                     if( rng_float( 0, 1 ) < spawn_rate ) {
                         item spawn( e.first );
+                        if( !e.second.empty() ) {
+                            spawn.set_itype_variant( e.second );
+                        }
                         item added = spawn.in_its_container();
-                        added.set_itype_variant( e.second );
                         created.push_back( added );
                     }
                 }

--- a/tests/vehicle_export_test.cpp
+++ b/tests/vehicle_export_test.cpp
@@ -25,13 +25,6 @@ static bool operator==( const vehicle_prototype::zone_def &l, const vehicle_prot
     return l.filter == r.filter && l.name == r.name && l.pt == r.pt && l.zone_type == r.zone_type;
 }
 
-static bool operator==( const vehicle_prototype::part_def &l, const vehicle_prototype::part_def &r )
-{
-    return l.ammo_qty == r.ammo_qty && l.part == r.part && l.variant == r.variant &&
-           l.with_ammo == r.with_ammo && l.ammo_types == r.ammo_types && l.ammo_qty == r.ammo_qty &&
-           l.fuel == r.fuel && l.tools == r.tools;
-}
-
 static bool operator==( const vehicle_item_spawn &l, const vehicle_item_spawn &r )
 {
     return l.pos == r.pos && l.chance == r.chance &&

--- a/tests/vehicle_export_test.cpp
+++ b/tests/vehicle_export_test.cpp
@@ -1,4 +1,3 @@
-#include <set>
 #include <sstream>
 #include <string>
 #include <utility>
@@ -19,11 +18,6 @@
 #include "vehicle.h"
 
 static const vproto_id vehicle_prototype_veh_export_test( "veh_export_test" );
-
-static bool operator==( const vehicle_prototype::zone_def &l, const vehicle_prototype::zone_def &r )
-{
-    return l.filter == r.filter && l.name == r.name && l.pt == r.pt && l.zone_type == r.zone_type;
-}
 
 static bool operator==( const vehicle_item_spawn &l, const vehicle_item_spawn &r )
 {

--- a/tests/vehicle_export_test.cpp
+++ b/tests/vehicle_export_test.cpp
@@ -30,7 +30,7 @@ static bool operator==( const vehicle_item_spawn &l, const vehicle_item_spawn &r
     return l.pos == r.pos && l.chance == r.chance &&
            l.with_ammo == r.with_ammo && l.with_magazine == r.with_magazine && l.item_ids == r.item_ids &&
            // NOLINTNEXTLINE(misc-redundant-expression)
-           l.variant_ids == r.variant_ids && l.item_groups == r.item_groups;
+           l.item_groups == r.item_groups;
 }
 
 TEST_CASE( "export_vehicle_test" )


### PR DESCRIPTION
#### Summary
Infrastructure "Replace assign with optional/mandatory in veh_type"

#### Purpose of change
Optional and mandatory have better support for extended features and better error reporting, as per https://github.com/CleverRaven/Cataclysm-DDA/pull/82165.

#### Describe the solution
Add some deserialize functions and some readers.

#### Testing
`tools/load_all_mods.sh`
`tests/cata_test [vehicle]`
