### PR TITLE
Cap maximum vehicle bash vs terrain

### DIFF
--- a/src/game_constants.h
+++ b/src/game_constants.h
@@ -89,6 +89,12 @@ constexpr int MAX_SKILL = 10;
 // Maximum (effective) level for a stat.
 constexpr int MAX_STAT = 14;
 
+// Maximum bashing damage for many regular actions.
+// This number is somewhat arbitrary and meant to be 1 less than the minimum bash damage to destroy a concrete wall.
+// Intended for use in "regular" actions within the scope of expected gameplay. i.e. tree felling uses this, because a tree bursting through a concrete wall is absurd
+// It is also used to cap vehicle bash damage (vs terrain only) for the same reason.
+constexpr int MAX_REGULAR_BASH = 69;
+
 // Accuracy levels which a shots tangent must be below.
 constexpr double accuracy_headshot = 0.1;
 constexpr double accuracy_critical = 0.2;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -8643,7 +8643,8 @@ void map::cut_down_tree( tripoint_bub_ms p, point_rel_ms dir )
     // TODO: make line_to type aware.
     std::vector<tripoint_bub_ms> tree = line_to( p, to, rng( 1, 8 ) );
     bool shattered_tree = false;
-    const int bash_strength = 79; // arbitrary bash strength, not enough to ever destroy concrete wall
+    // arbitrary bash strength, not enough to ever destroy concrete wall
+    const int bash_strength = MAX_REGULAR_BASH;
     const int bash_attempts = 1;
     for( tripoint_bub_ms &elem : tree ) {
         const ter_id original_terrain_at = ter( elem.xy() );

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -828,7 +828,7 @@ static void terrain_collision_data( map &here, const tripoint_bub_ms &p, bool ba
     elastic = 0.30;
     // Just a rough rescale for now to obtain approximately equal numbers
     const int bash_min = here.bash_resistance( p, bash_floor );
-    const int bash_max = here.bash_strength( p, bash_floor );
+    const int bash_max = std::min( here.bash_strength( p, bash_floor ), MAX_REGULAR_BASH ) ;
     mass = ( bash_min + bash_max ) / 2.0;
     density = bash_min;
 }


### PR DESCRIPTION
#### Summary
Balance "Cap maximum vehicle bash vs terrain (to prevent bashing thru concrete etc)"

#### Purpose of change
I have been told that someone drove a forklift straight through concrete walls. What.

#### Describe the solution
There is no vehicle depicted ingame that can reasonably survive a collision with a concrete wall of any type. So cap the maximum bash damage so this doesn't happen.

I also upgraded the bash damage from #82498 to a constant at the same time, rather than leaving it as a "magic number". (it also got reduced by 10, from 79--->69. Because I was wrongly looking at the reinforced concrete walls before.)

#### Describe alternatives you've considered
Also, make sure that it always just kills the player at higher speed?

#### Testing
Haven't even compiled. But does need testing.

#### Additional context

