### PR TITLE
[XEDRA Evolved] gossamer clothing devarianting

### DIFF
--- a/data/mods/Xedra_Evolved/items/clothes.json
+++ b/data/mods/Xedra_Evolved/items/clothes.json
@@ -348,7 +348,8 @@
         "moves": 80
       }
     ],
-    "armor": [ { "encumbrance": [ 5, 7 ], "coverage": 100, "covers": [ "leg_l", "leg_r" ] } ]
+    "armor": [ { "encumbrance": [ 5, 7 ], "coverage": 100, "covers": [ "leg_l", "leg_r" ] } ],
+    "variants": [  ]
   },
   {
     "id": "pants_no_pocket_gossamer",
@@ -361,7 +362,8 @@
     "color": "white",
     "material": [ "fae_cotton" ],
     "pocket_data": [  ],
-    "armor": [ { "encumbrance": 4, "coverage": 100, "covers": [ "leg_l", "leg_r" ] } ]
+    "armor": [ { "encumbrance": 4, "coverage": 100, "covers": [ "leg_l", "leg_r" ] } ],
+    "variants": [  ]
   },
   {
     "id": "skirt_gossamer",
@@ -373,7 +375,8 @@
     "proportional": { "weight": 0.6666, "price": 2 },
     "color": "white",
     "material": [ "fae_cotton" ],
-    "pocket_data": [  ]
+    "pocket_data": [  ],
+    "variants": [  ]
   },
   {
     "id": "skirt_long_gossamer",
@@ -415,7 +418,8 @@
         "encumbrance": 3
       },
       { "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_upper_l", "leg_upper_r" ], "coverage": 60 }
-    ]
+    ],
+    "variants": [  ]
   },
   {
     "id": "slippers_gossamer",


### PR DESCRIPTION

#### Summary
None


#### Purpose of change
Found some more gossamer clothing that needs devarianting when i was working on the sprites of some, so i devariant it.

#### Describe the solution

Give it `"variants": [  ]`

#### Describe alternatives you've considered
No cuz it inteferes with the tileset work i was doing.

#### Testing
Open up debug menu and look for "gossamer", see if their item desc flickers through the variants they might have. they dont.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
