### PR TITLE
Use optional/mandatory in mapdata, recipe, mod manager, and monster groups

### DIFF
--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -8,7 +8,6 @@
 #include <unordered_map>
 #include <utility>
 
-#include "assign.h"
 #include "avatar.h"
 #include "calendar.h"
 #include "character.h"
@@ -514,9 +513,9 @@ bool furn_workbench_info::load( const JsonObject &jsobj, std::string_view member
 {
     JsonObject j = jsobj.get_object( member );
 
-    assign( j, "multiplier", multiplier );
-    assign( j, "mass", allowed_mass );
-    assign( j, "volume", allowed_volume );
+    optional( j, false, "multiplier", multiplier, 1.0f );
+    optional( j, false, "mass", allowed_mass, units::mass::max() );
+    optional( j, false, "volume", allowed_volume, units::volume::max() );
 
     return true;
 }
@@ -528,10 +527,10 @@ bool plant_data::load( const JsonObject &jsobj, std::string_view member )
 {
     JsonObject j = jsobj.get_object( member );
 
-    assign( j, "transform", transform );
-    assign( j, "base", base );
-    assign( j, "growth_multiplier", growth_multiplier );
-    assign( j, "harvest_multiplier", harvest_multiplier );
+    optional( j, false, "transform", transform, furn_str_id::NULL_ID() );
+    optional( j, false, "base", base, furn_str_id::NULL_ID() );
+    optional( j, false, "growth_multiplier", growth_multiplier, 1.0f );
+    optional( j, false, "harvest_multiplier", harvest_multiplier, 1.0f );
 
     return true;
 }
@@ -1196,7 +1195,7 @@ void ter_t::load( const JsonObject &jo, const std::string &src )
 {
     map_data_common_t::load( jo, src );
     optional( jo, was_loaded, "move_cost", movecost );
-    assign( jo, "max_volume", max_volume, src == "dda" );
+    optional( jo, was_loaded, "max_volume", max_volume, DEFAULT_TILE_VOLUME );
     optional( jo, was_loaded, "trap", trap_id_str );
     optional( jo, was_loaded, "heat_radiation", heat_radiation );
 

--- a/src/mod_manager.cpp
+++ b/src/mod_manager.cpp
@@ -9,12 +9,12 @@
 #include <queue>
 #include <stdexcept>
 
-#include "assign.h"
 #include "cata_utility.h"
 #include "debug.h"
 #include "dependency_tree.h"
 #include "filesystem.h"
 #include "flexbuffer_json.h"
+#include "generic_factory.h"
 #include "input_context.h"
 #include "json.h"
 #include "localized_comparator.h"
@@ -280,21 +280,22 @@ void mod_manager::load_modfile( const JsonObject &jo, const cata_path &path )
     modfile.category = p_cat;
 
     std::string mod_json_path;
-    if( assign( jo, "path", mod_json_path ) ) {
+    if( jo.has_member( "path" ) ) {
+        optional( jo, false, "path", mod_json_path );
         modfile.path = path / mod_json_path;
     } else {
         modfile.path = path;
     }
 
-    assign( jo, "authors", modfile.authors );
-    assign( jo, "maintainers", modfile.maintainers );
-    assign( jo, "description", modfile.description );
-    assign( jo, "version", modfile.version );
-    assign( jo, "dependencies", modfile.dependencies );
-    assign( jo, "conflicts", modfile.conflicts );
-    assign( jo, "core", modfile.core );
-    assign( jo, "obsolete", modfile.obsolete );
-    assign( jo, "loading_images", modfile.loading_images );
+    optional( jo, false, "authors", modfile.authors );
+    optional( jo, false, "maintainers", modfile.maintainers );
+    optional( jo, false, "description", modfile.description );
+    optional( jo, false, "version", modfile.version );
+    optional( jo, false, "dependencies", modfile.dependencies );
+    optional( jo, false, "conflicts", modfile.conflicts );
+    optional( jo, false, "core", modfile.core, false );
+    optional( jo, false, "obsolete", modfile.obsolete, false );
+    optional( jo, false, "loading_images", modfile.loading_images );
 
     if( std::find( modfile.dependencies.begin(), modfile.dependencies.end(),
                    modfile.ident ) != modfile.dependencies.end() ) {

--- a/src/mongroup.cpp
+++ b/src/mongroup.cpp
@@ -4,12 +4,12 @@
 #include <string>
 #include <utility>
 
-#include "assign.h"
 #include "calendar.h"
 #include "cata_utility.h"
 #include "debug.h"
 #include "enum_conversions.h"
 #include "flexbuffer_json.h"
+#include "generic_factory.h"
 #include "mtype.h"
 #include "options.h"
 #include "rng.h"
@@ -554,7 +554,9 @@ void MonsterGroupManager::LoadMonsterGroup( const JsonObject &jo )
     g.replace_monster_group = jo.get_bool( "replace_monster_group", false );
     g.new_monster_group = mongroup_id( jo.get_string( "new_monster_group_id",
                                        mongroup_id::NULL_ID().str() ) );
-    assign( jo, "replacement_time", g.monster_group_time, false, 1_days );
+    if( jo.has_member( "replacement_time" ) ) {
+        mandatory( jo, false, "replacement_time", g.monster_group_time, time_bound_reader{ 1_days } );
+    }
     g.is_safe = jo.get_bool( "is_safe", false );
 
     g.freq_total = jo.get_int( "freq_total", ( extending ? g.freq_total : 0 ) + freq_total );

--- a/src/recipe.h
+++ b/src/recipe.h
@@ -9,6 +9,7 @@
 #include <optional>
 #include <set>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -98,7 +99,7 @@ class recipe
         float exertion = 0.0f;
 
     public:
-        recipe();
+        recipe() = default;
 
         bool is_null() const {
             return id.is_null();
@@ -269,7 +270,7 @@ class recipe
             return reversible;
         }
 
-        void load( const JsonObject &jo, const std::string &src );
+        void load( const JsonObject &jo, std::string_view src );
         void finalize();
 
         /** Returns a non-empty string describing an inconsistency (if any) in the recipe. */


### PR DESCRIPTION
#### Summary
Infrastructure "Use optional/mandatory in mapdata, recipe, mod manager, and monster groups instead of assign"

#### Purpose of change
Optional and mandatory have better support for extended features and better error reporting, as per https://github.com/CleverRaven/Cataclysm-DDA/pull/82165.

#### Describe the solution
Replace `assign` with `optional` or `mandatory`. Delete an unnecessary constructor too.

#### Testing
`tools/load_all_mods.sh`