### PR TITLE
Add TFLAG_REGION_PSEUDO flag for region terrain/furniture

### DIFF
--- a/data/json/furniture_and_terrain/furniture-regional-pseudo.json
+++ b/data/json/furniture_and_terrain/furniture-regional-pseudo.json
@@ -1,112 +1,93 @@
 [
   {
     "type": "furniture",
-    "id": "f_region_flower",
-    "name": "this should never actually show up, it's a pseudo furniture",
-    "description": "This is pseudo-furniture and should never actually show up.  Please report this bug.",
+    "abstract": "f_region_pseudo",
+    "name": "pseudo furniture",
+    "description": "This should never actually show up, it should have been replaced with regional furniture.",
     "symbol": " ",
     "color": "black",
     "move_cost_mod": 0,
     "required_str": 0,
-    "flags": [ "TRANSPARENT" ]
+    "flags": [ "TRANSPARENT", "REGION_PSEUDO" ]
+  },
+  {
+    "type": "furniture",
+    "id": "f_region_flower",
+    "copy-from": "f_region_pseudo",
+    "name": "pseudo furniture",
+    "description": "This should never actually show up, it should have been replaced with regional furniture.",
+    "move_cost_mod": 0
   },
   {
     "type": "furniture",
     "id": "f_region_weed",
-    "name": "this should never actually show up, it's a pseudo furniture",
-    "description": "This is pseudo-furniture and should never actually show up.  Please report this bug.",
-    "symbol": " ",
-    "color": "black",
-    "move_cost_mod": 0,
-    "required_str": 0,
-    "flags": [ "TRANSPARENT" ]
+    "copy-from": "f_region_pseudo",
+    "name": "pseudo furniture",
+    "description": "This should never actually show up, it should have been replaced with regional furniture.",
+    "move_cost_mod": 0
   },
   {
     "type": "furniture",
     "id": "f_region_water_plant",
-    "name": "this should never actually show up, it's a pseudo furniture",
-    "description": "This is pseudo-furniture and should never actually show up.  Please report this bug.",
-    "symbol": " ",
-    "color": "black",
-    "move_cost_mod": 0,
-    "required_str": 0,
-    "flags": [ "TRANSPARENT" ]
+    "copy-from": "f_region_pseudo",
+    "name": "pseudo furniture",
+    "description": "This should never actually show up, it should have been replaced with regional furniture.",
+    "move_cost_mod": 0
   },
   {
     "type": "furniture",
     "id": "f_region_plain",
-    "name": "this should never actually show up, it's a pseudo furniture",
-    "description": "This is pseudo-furniture and should never actually show up.  Please report this bug.",
-    "symbol": " ",
-    "color": "black",
-    "move_cost_mod": 0,
-    "required_str": 0,
-    "flags": [ "TRANSPARENT" ]
+    "copy-from": "f_region_pseudo",
+    "name": "pseudo furniture",
+    "description": "This should never actually show up, it should have been replaced with regional furniture.",
+    "move_cost_mod": 0
   },
   {
     "type": "furniture",
     "id": "f_region_forest",
-    "name": "this should never actually show up, it's a pseudo furniture",
-    "description": "This is pseudo-furniture and should never actually show up.  Please report this bug.",
-    "symbol": " ",
-    "color": "black",
-    "move_cost_mod": 0,
-    "required_str": 0,
-    "flags": [ "TRANSPARENT" ]
+    "copy-from": "f_region_pseudo",
+    "name": "pseudo furniture",
+    "description": "This should never actually show up, it should have been replaced with regional furniture.",
+    "move_cost_mod": 0
   },
   {
     "type": "furniture",
     "id": "f_region_forest_dense",
-    "name": "this should never actually show up, it's a pseudo furniture",
-    "description": "This is pseudo-furniture and should never actually show up.  Please report this bug.",
-    "symbol": " ",
-    "color": "black",
-    "move_cost_mod": 0,
-    "required_str": 0,
-    "flags": [ "TRANSPARENT" ]
+    "copy-from": "f_region_pseudo",
+    "name": "pseudo furniture",
+    "description": "This should never actually show up, it should have been replaced with regional furniture.",
+    "move_cost_mod": 0
   },
   {
     "type": "furniture",
     "id": "f_region_forest_water",
-    "name": "this should never actually show up, it's a pseudo furniture",
-    "description": "This is pseudo-furniture and should never actually show up.  Please report this bug.",
-    "symbol": " ",
-    "color": "black",
-    "move_cost_mod": 0,
-    "required_str": 0,
-    "flags": [ "TRANSPARENT" ]
+    "copy-from": "f_region_pseudo",
+    "name": "pseudo furniture",
+    "description": "This should never actually show up, it should have been replaced with regional furniture.",
+    "move_cost_mod": 0
   },
   {
     "type": "furniture",
     "id": "f_region_flower_decorative",
-    "name": "this should never actually show up, it's a pseudo furniture",
-    "description": "This is pseudo-furniture and should never actually show up.  Please report this bug.",
-    "symbol": " ",
-    "color": "black",
-    "move_cost_mod": 0,
-    "required_str": 0,
-    "flags": [ "TRANSPARENT" ]
+    "copy-from": "f_region_pseudo",
+    "name": "pseudo furniture",
+    "description": "This should never actually show up, it should have been replaced with regional furniture.",
+    "move_cost_mod": 0
   },
   {
     "type": "furniture",
     "id": "f_region_lake_bed",
-    "name": "this should never actually show up, it's a pseudo furniture",
-    "description": "This is pseudo-furniture and should never actually show up.  Please report this bug.",
-    "symbol": " ",
-    "color": "black",
-    "move_cost_mod": 0,
-    "required_str": 0,
-    "flags": [ "TRANSPARENT" ]
+    "copy-from": "f_region_pseudo",
+    "name": "pseudo furniture",
+    "description": "This should never actually show up, it should have been replaced with regional furniture.",
+    "move_cost_mod": 0
   },
   {
     "type": "furniture",
     "id": "f_region_ocean_bed",
-    "name": "this should never actually show up, it's a pseudo furniture",
-    "description": "This is pseudo-furniture and should never actually show up.  Please report this bug.",
-    "symbol": " ",
-    "color": "black",
-    "move_cost_mod": 0,
-    "required_str": 0,
-    "flags": [ "TRANSPARENT" ]
+    "copy-from": "f_region_pseudo",
+    "name": "pseudo furniture",
+    "description": "This should never actually show up, it should have been replaced with regional furniture.",
+    "move_cost_mod": 0
   }
 ]

--- a/data/json/furniture_and_terrain/terrain-regional-pseudo.json
+++ b/data/json/furniture_and_terrain/terrain-regional-pseudo.json
@@ -1,232 +1,205 @@
 [
   {
     "type": "terrain",
-    "id": "t_region_groundcover",
+    "abstract": "t_region_pseudo",
     "name": "pseudo terrain",
-    "description": "This should never actually show up, it's a pseudo terrain.",
+    "description": "This should never actually show up, it should have been replaced with regional terrain.",
     "symbol": " ",
     "color": "black",
     "move_cost": 1,
-    "flags": [ "TRANSPARENT" ]
+    "flags": [ "TRANSPARENT", "REGION_PSEUDO" ]
+  },
+  {
+    "type": "terrain",
+    "abstract": "t_region_pseudo_noitem",
+    "copy-from": "t_region_pseudo",
+    "name": "pseudo terrain",
+    "description": "This should never actually show up, it should have been replaced with regional terrain.",
+    "move_cost": 1,
+    "extend": { "flags": [ "NOITEM" ] }
+  },
+  {
+    "type": "terrain",
+    "id": "t_region_groundcover",
+    "copy-from": "t_region_pseudo",
+    "name": "pseudo terrain",
+    "description": "This should never actually show up, it should have been replaced with regional terrain.",
+    "move_cost": 1
   },
   {
     "type": "terrain",
     "id": "t_region_groundcover_urban",
+    "copy-from": "t_region_pseudo",
     "name": "pseudo terrain",
-    "description": "This should never actually show up, it's a pseudo terrain.",
-    "symbol": " ",
-    "color": "black",
-    "move_cost": 1,
-    "flags": [ "TRANSPARENT" ]
+    "description": "This should never actually show up, it should have been replaced with regional terrain.",
+    "move_cost": 1
   },
   {
     "type": "terrain",
     "id": "t_region_groundcover_forest",
+    "copy-from": "t_region_pseudo",
     "name": "pseudo terrain",
-    "description": "This should never actually show up, it's a pseudo terrain.",
-    "symbol": " ",
-    "color": "black",
-    "move_cost": 1,
-    "flags": [ "TRANSPARENT" ]
+    "description": "This should never actually show up, it should have been replaced with regional terrain.",
+    "move_cost": 1
   },
   {
     "type": "terrain",
     "id": "t_region_groundcover_swamp",
+    "copy-from": "t_region_pseudo",
     "name": "pseudo terrain",
-    "description": "This should never actually show up, it's a pseudo terrain.",
-    "symbol": " ",
-    "color": "black",
-    "move_cost": 1,
-    "flags": [ "TRANSPARENT" ]
+    "description": "This should never actually show up, it should have been replaced with regional terrain.",
+    "move_cost": 1
   },
   {
     "type": "terrain",
     "id": "t_region_groundcover_barren",
-    "name": "pseudo terrain",
     "description": "This should never actually show up, it's a pseudo terrain.  For use where people have trampled away grass, or otherwise cleared plant life.",
-    "symbol": " ",
-    "color": "black",
-    "move_cost": 1,
-    "flags": [ "TRANSPARENT" ]
+    "copy-from": "t_region_pseudo",
+    "name": "pseudo terrain",
+    "move_cost": 1
   },
   {
     "type": "terrain",
     "id": "t_region_grass",
-    "name": "pseudo terrain",
     "description": "This should never actually show up, it's a pseudo terrain.  For use where clean, curated grass is the only expected terrain - modified by whatever the biome equivalent is.",
-    "symbol": " ",
-    "color": "black",
-    "move_cost": 1,
-    "flags": [ "TRANSPARENT" ]
+    "copy-from": "t_region_pseudo",
+    "name": "pseudo terrain",
+    "move_cost": 1
   },
   {
     "type": "terrain",
     "id": "t_region_soil",
-    "name": "pseudo terrain",
     "description": "This should never actually show up, it's a pseudo terrain.  For use where plants have been planted and grass/groundcover kept clear.",
-    "symbol": " ",
-    "color": "black",
-    "move_cost": 1,
-    "flags": [ "TRANSPARENT" ]
+    "copy-from": "t_region_pseudo",
+    "name": "pseudo terrain",
+    "move_cost": 1
   },
   {
     "type": "terrain",
     "id": "t_region_tree",
+    "copy-from": "t_region_pseudo_noitem",
     "name": "pseudo terrain",
-    "description": "This should never actually show up, it's a pseudo terrain.",
-    "symbol": " ",
-    "color": "black",
-    "move_cost": 1,
-    "flags": [ "TRANSPARENT", "NOITEM" ]
+    "description": "This should never actually show up, it should have been replaced with regional terrain.",
+    "move_cost": 1
   },
   {
     "type": "terrain",
     "id": "t_region_tree_forest_dense",
+    "copy-from": "t_region_pseudo_noitem",
     "name": "pseudo terrain",
-    "description": "This should never actually show up, it's a pseudo terrain.",
-    "symbol": " ",
-    "color": "black",
-    "move_cost": 1,
-    "flags": [ "TRANSPARENT", "NOITEM" ]
+    "description": "This should never actually show up, it should have been replaced with regional terrain.",
+    "move_cost": 1
   },
   {
     "type": "terrain",
     "id": "t_region_tree_forest",
+    "copy-from": "t_region_pseudo_noitem",
     "name": "pseudo terrain",
-    "description": "This should never actually show up, it's a pseudo terrain.",
-    "symbol": " ",
-    "color": "black",
-    "move_cost": 1,
-    "flags": [ "TRANSPARENT", "NOITEM" ]
+    "description": "This should never actually show up, it should have been replaced with regional terrain.",
+    "move_cost": 1
   },
   {
     "type": "terrain",
     "id": "t_region_tree_forest_other",
+    "copy-from": "t_region_pseudo_noitem",
     "name": "pseudo terrain",
-    "description": "This should never actually show up, it's a pseudo terrain.",
-    "symbol": " ",
-    "color": "black",
-    "move_cost": 1,
-    "flags": [ "TRANSPARENT", "NOITEM" ]
+    "description": "This should never actually show up, it should have been replaced with regional terrain.",
+    "move_cost": 1
   },
   {
     "type": "terrain",
     "id": "t_region_tree_evergreen",
+    "copy-from": "t_region_pseudo_noitem",
     "name": "pseudo terrain",
-    "description": "This should never actually show up, it's a pseudo terrain.",
-    "symbol": " ",
-    "color": "black",
-    "move_cost": 1,
-    "flags": [ "TRANSPARENT", "NOITEM" ]
+    "description": "This should never actually show up, it should have been replaced with regional terrain.",
+    "move_cost": 1
   },
   {
     "type": "terrain",
     "id": "t_region_tree_fruit",
+    "copy-from": "t_region_pseudo_noitem",
     "name": "pseudo terrain",
-    "description": "This should never actually show up, it's a pseudo terrain.",
-    "symbol": " ",
-    "color": "black",
-    "move_cost": 1,
-    "flags": [ "TRANSPARENT", "NOITEM" ]
+    "description": "This should never actually show up, it should have been replaced with regional terrain.",
+    "move_cost": 1
   },
   {
     "type": "terrain",
     "id": "t_region_tree_nut",
+    "copy-from": "t_region_pseudo_noitem",
     "name": "pseudo terrain",
-    "description": "This should never actually show up, it's a pseudo terrain.",
-    "symbol": " ",
-    "color": "black",
-    "move_cost": 1,
-    "flags": [ "TRANSPARENT", "NOITEM" ]
+    "description": "This should never actually show up, it should have been replaced with regional terrain.",
+    "move_cost": 1
   },
   {
     "type": "terrain",
     "id": "t_region_tree_shade",
+    "copy-from": "t_region_pseudo_noitem",
     "name": "pseudo terrain",
-    "description": "This should never actually show up, it's a pseudo terrain.",
-    "symbol": " ",
-    "color": "black",
-    "move_cost": 1,
-    "flags": [ "TRANSPARENT", "NOITEM" ]
+    "description": "This should never actually show up, it should have been replaced with regional terrain.",
+    "move_cost": 1
   },
   {
     "type": "terrain",
     "id": "t_region_tree_dead",
+    "copy-from": "t_region_pseudo_noitem",
     "name": "pseudo terrain",
-    "description": "This should never actually show up, it's a pseudo terrain.",
-    "symbol": " ",
-    "color": "black",
-    "move_cost": 1,
-    "flags": [ "TRANSPARENT", "NOITEM" ]
+    "description": "This should never actually show up, it should have been replaced with regional terrain.",
+    "move_cost": 1
   },
   {
     "type": "terrain",
     "id": "t_region_shrub",
+    "copy-from": "t_region_pseudo",
     "name": "pseudo terrain",
-    "description": "This should never actually show up, it's a pseudo terrain.",
-    "symbol": " ",
-    "color": "black",
-    "move_cost": 1,
-    "flags": [ "TRANSPARENT" ]
+    "description": "This should never actually show up, it should have been replaced with regional terrain.",
+    "move_cost": 1
   },
   {
     "type": "terrain",
     "id": "t_region_shrub_fruit",
+    "copy-from": "t_region_pseudo",
     "name": "pseudo terrain",
-    "description": "This should never actually show up, it's a pseudo terrain.",
-    "symbol": " ",
-    "color": "black",
-    "move_cost": 1,
-    "flags": [ "TRANSPARENT" ]
+    "description": "This should never actually show up, it should have been replaced with regional terrain.",
+    "move_cost": 1
   },
   {
     "type": "terrain",
     "id": "t_region_shrub_plains",
+    "copy-from": "t_region_pseudo",
     "name": "pseudo terrain",
-    "description": "This should never actually show up, it's a pseudo terrain.",
-    "symbol": " ",
-    "color": "black",
-    "move_cost": 1,
-    "flags": [ "TRANSPARENT" ]
+    "description": "This should never actually show up, it should have been replaced with regional terrain.",
+    "move_cost": 1
   },
   {
     "type": "terrain",
     "id": "t_region_shrub_swamp",
+    "copy-from": "t_region_pseudo",
     "name": "pseudo terrain",
-    "description": "This should never actually show up, it's a pseudo terrain.",
-    "symbol": " ",
-    "color": "black",
-    "move_cost": 1,
-    "flags": [ "TRANSPARENT" ]
+    "description": "This should never actually show up, it should have been replaced with regional terrain.",
+    "move_cost": 1
   },
   {
     "type": "terrain",
     "id": "t_region_shrub_forest_dense",
+    "copy-from": "t_region_pseudo",
     "name": "pseudo terrain",
-    "description": "This should never actually show up, it's a pseudo terrain.",
-    "symbol": " ",
-    "color": "black",
-    "move_cost": 1,
-    "flags": [ "TRANSPARENT" ]
+    "description": "This should never actually show up, it should have been replaced with regional terrain.",
+    "move_cost": 1
   },
   {
     "type": "terrain",
     "id": "t_region_shrub_forest",
+    "copy-from": "t_region_pseudo",
     "name": "pseudo terrain",
-    "description": "This should never actually show up, it's a pseudo terrain.",
-    "symbol": " ",
-    "color": "black",
-    "move_cost": 1,
-    "flags": [ "TRANSPARENT" ]
+    "description": "This should never actually show up, it should have been replaced with regional terrain.",
+    "move_cost": 1
   },
   {
     "type": "terrain",
     "id": "t_region_shrub_decorative",
+    "copy-from": "t_region_pseudo",
     "name": "pseudo terrain",
-    "description": "This should never actually show up, it's a pseudo terrain.",
-    "symbol": " ",
-    "color": "black",
-    "move_cost": 1,
-    "flags": [ "TRANSPARENT" ]
+    "description": "This should never actually show up, it should have been replaced with regional terrain.",
+    "move_cost": 1
   }
 ]

--- a/doc/JSON/JSON_FLAGS.md
+++ b/doc/JSON/JSON_FLAGS.md
@@ -703,6 +703,7 @@ Can also be used as `pre_flags` for `construction`.
 - ```RAMP_UP``` The end of a ramp that leads up, walking into this moves you one z-level up.  Overrides `WALL`, while still displaying the tile as Impassable.
 - ```RAMP``` Can be used to move up a z-level.
 - ```REDUCE_SCENT``` Reduces scent diffusion (not total amount of scent in area); only works if also bashable.
+- ```REGION_PSEUDO``` Replaced by other terrain/furniture during mapgen; should not spawn.
 - ```ROAD``` Flat and hard enough to drive or skate (with rollerblades) on.
 - ```ROUGH``` May hurt the player's feet.
 - ```RUBBLE``` Furniture behaves like rubble: it can be cleared by the `CLEAR_RUBBLE` item action.  Can be applied to terrain, but it "clears up the nothing".

--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -289,6 +289,7 @@ std::string enum_to_string<ter_furn_flag>( ter_furn_flag data )
         case ter_furn_flag::TFLAG_NATURAL_UNDERGROUND: return "NATURAL_UNDERGROUND";
         case ter_furn_flag::TFLAG_WIRED_WALL: return "WIRED_WALL";
         case ter_furn_flag::TFLAG_MON_AVOID_STRICT: return "MON_AVOID_STRICT";
+        case ter_furn_flag::TFLAG_REGION_PSEUDO: return "REGION_PSEUDO";
 
         // *INDENT-ON*
         case ter_furn_flag::NUM_TFLAG_FLAGS:

--- a/src/mapdata.h
+++ b/src/mapdata.h
@@ -364,6 +364,7 @@ enum class ter_furn_flag : int {
     TFLAG_NATURAL_UNDERGROUND,
     TFLAG_WIRED_WALL,
     TFLAG_MON_AVOID_STRICT,
+    TFLAG_REGION_PSEUDO,
 
     NUM_TFLAG_FLAGS
 };

--- a/src/mapgen_functions.cpp
+++ b/src/mapgen_functions.cpp
@@ -2244,14 +2244,18 @@ void resolve_regional_terrain_and_furniture( const mapgendata &dat )
 {
     for( const tripoint_bub_ms &p : dat.m.points_on_zlevel() ) {
         const ter_id &tid_before = dat.m.ter( p );
-        const ter_id &tid_after = dat.region.region_terrain_and_furniture.resolve( tid_before );
-        if( tid_after != tid_before ) {
-            dat.m.ter_set( p, tid_after );
+        if( !tid_before.id().is_null() && tid_before->has_flag( ter_furn_flag::TFLAG_REGION_PSEUDO ) ) {
+            const ter_id &tid_after = dat.region.region_terrain_and_furniture.resolve( tid_before );
+            if( tid_after != tid_before ) {
+                dat.m.ter_set( p, tid_after );
+            }
         }
         const furn_id &fid_before = dat.m.furn( p );
-        const furn_id &fid_after = dat.region.region_terrain_and_furniture.resolve( fid_before );
-        if( fid_after != fid_before ) {
-            dat.m.furn_set( p, fid_after );
+        if( !fid_before.id().is_null() && fid_before->has_flag( ter_furn_flag::TFLAG_REGION_PSEUDO ) ) {
+            const furn_id &fid_after = dat.region.region_terrain_and_furniture.resolve( fid_before );
+            if( fid_after != fid_before ) {
+                dat.m.furn_set( p, fid_after );
+            }
         }
     }
 }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Infrastructure "add TFLAG_REGION_PSEUDO flag for region terrain/furniture"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

- Part of #82631

While working on region settings, I realized that every placed terrain/furniture (including non-regional ter/furn) gets fed into the `resolve()` functions for regional terrain/furniture. It works fine that way but isn't necessary -- we should only feed regional ter/furn into those functions. Also, regional terrain/furniture works differently enough that it should have some kind of identifier aside from only being included in a region mapping.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

See title. Applied flag to all region terrain/furniture.
Adds inheritance to dedupe some JSON fields.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Regional terrain/furniture places correctly in #82631

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
