### PR TITLE
Weighted list improvements

### DIFF
--- a/src/anatomy.cpp
+++ b/src/anatomy.cpp
@@ -237,8 +237,8 @@ bodypart_id anatomy::select_body_part( int min_hit, int max_hit, bool can_attack
     }
 
     // Debug for seeing weights.
-    for( const weighted_object<double, bodypart_id> &pr : hit_weights ) {
-        add_msg_debug( debugmode::DF_ANATOMY_BP, "%s = %.3f", pr.obj.obj().name, pr.weight );
+    for( const std::pair<bodypart_id, double> &pr : hit_weights ) {
+        add_msg_debug( debugmode::DF_ANATOMY_BP, "%s = %.3f", pr.first.obj().name, pr.second );
     }
 
     const bodypart_id *ret = hit_weights.pick();
@@ -303,8 +303,8 @@ bodypart_id anatomy::select_blocking_part( const Creature *blocker, bool arm, bo
     }
 
     // Debug for seeing weights.
-    for( const weighted_object<double, bodypart_id> &pr : block_scores ) {
-        add_msg_debug( debugmode::DF_MELEE, "%s = %.3f", pr.obj.obj().name, pr.weight );
+    for( const std::pair<bodypart_id, double > &pr : block_scores ) {
+        add_msg_debug( debugmode::DF_MELEE, "%s = %.3f", pr.first.obj().name, pr.second );
     }
 
     const bodypart_id *ret = block_scores.pick();

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1011,14 +1011,14 @@ void tileset_cache::loader::process_variations_after_loading(
     // loop through all of the variations
     for( auto &v : vs ) {
         // in a given variation, erase any invalid sprite ids
-        v.obj.erase(
+        v.first.erase(
             std::remove_if(
-                v.obj.begin(),
-                v.obj.end(),
+                v.first.begin(),
+                v.first.end(),
         [&]( int id ) {
             return id >= offset || id < 0;
         } ),
-        v.obj.end()
+        v.first.end()
         );
     }
     // erase any variations with no valid sprite ids left
@@ -1026,8 +1026,8 @@ void tileset_cache::loader::process_variations_after_loading(
         std::remove_if(
             vs.begin(),
             vs.end(),
-    [&]( const weighted_object<int, std::vector<int>> &o ) {
-        return o.obj.empty();
+    [&]( const std::pair<std::vector<int>, int> &o ) {
+        return o.first.empty();
     }
         ),
     vs.end()

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -2605,10 +2605,10 @@ void item::debug_info( std::vector<iteminfo> &info, const iteminfo_query *parts,
             }
 
             std::string faults;
-            for( const weighted_object<int, fault_id> &fault : type->faults ) {
-                const int weight_percent = static_cast<float>( fault.weight ) / type->faults.get_weight() * 100;
-                faults += colorize( fault.obj.str() + string_format( " (%d, %d%%)\n", fault.weight,
-                                    weight_percent ), has_fault( fault.obj ) ? c_yellow : c_white );
+            for( const std::pair<fault_id, int> &fault : type->faults ) {
+                const int weight_percent = static_cast<float>( fault.second ) / type->faults.get_weight() * 100;
+                faults += colorize( fault.first.str() + string_format( " (%d, %d%%)\n", fault.second,
+                                    weight_percent ), has_fault( fault.first ) ? c_yellow : c_white );
             }
             info.emplace_back( "BASE", string_format( "faults: %s", faults ) );
         }
@@ -7878,9 +7878,9 @@ void item::set_random_fault_of_type( const std::string &fault_type, bool force, 
     }
 
     weighted_int_list<fault_id> faults_by_type;
-    for( const weighted_object<int, fault_id> &f : type->faults ) {
-        if( f.obj.obj().type() == fault_type && can_have_fault( f.obj ) ) {
-            faults_by_type.add( f.obj, f.weight );
+    for( const std::pair<fault_id, int> &f : type->faults ) {
+        if( f.first.obj().type() == fault_type && can_have_fault( f.first ) ) {
+            faults_by_type.add( f.first, f.second );
         }
 
     }
@@ -10439,8 +10439,8 @@ int item::wind_resist() const
 std::set<fault_id> item::faults_potential() const
 {
     std::set<fault_id> res;
-    for( const weighted_object<int, fault_id> &fault_pair : type->faults ) {
-        res.insert( fault_pair.obj );
+    for( const std::pair<fault_id, int> &fault_pair : type->faults ) {
+        res.insert( fault_pair.first );
     }
     return res;
 }
@@ -10448,9 +10448,9 @@ std::set<fault_id> item::faults_potential() const
 std::set<fault_id> item::faults_potential_of_type( const std::string &fault_type ) const
 {
     std::set<fault_id> res;
-    for( const weighted_object<int, fault_id> &some_fault : type->faults ) {
-        if( some_fault.obj->type() == fault_type ) {
-            res.emplace( some_fault.obj );
+    for( const std::pair<fault_id, int> &some_fault : type->faults ) {
+        if( some_fault.first->type() == fault_type ) {
+            res.emplace( some_fault.first );
         }
     }
     return res;

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -925,12 +925,13 @@ void Item_factory::finalize_post( itype &obj )
             const int weight_add = std::get<1>( fault_groups );
             const float weight_mult = std::get<2>( fault_groups );
             for( const auto &id_and_weight : fault_g.obj().get_weighted_list() ) {
-                obj.faults.add_or_replace( id_and_weight.obj, ( id_and_weight.weight + weight_add ) * weight_mult );
+                obj.faults.add_or_replace( id_and_weight.first,
+                                           ( id_and_weight.second + weight_add ) * weight_mult );
             }
         } else {
             // weight_override is not -1, override the weight
-            for( const weighted_object<int, fault_id> &id_and_weight : fault_g.obj().get_weighted_list() ) {
-                obj.faults.add( id_and_weight.obj, std::get<0>( fault_groups ) );
+            for( const std::pair<fault_id, int> &id_and_weight : fault_g.obj().get_weighted_list() ) {
+                obj.faults.add( id_and_weight.first, std::get<0>( fault_groups ) );
             }
         }
     }
@@ -2466,8 +2467,8 @@ void Item_factory::check_definitions() const
         }
 
         for( const auto &f : type->faults ) {
-            if( !f.obj.is_valid() ) {
-                msg += string_format( "invalid item fault %s\n", f.obj.c_str() );
+            if( !f.first.is_valid() ) {
+                msg += string_format( "invalid item fault %s\n", f.first.c_str() );
             }
         }
 

--- a/src/magic_ter_fur_transform.cpp
+++ b/src/magic_ter_fur_transform.cpp
@@ -72,7 +72,7 @@ static void load_transform_results( const JsonObject &jsi, const std::string &js
         list.add( T( jsi.get_string( json_key ) ), 1 );
         return;
     }
-    load_weighted_list( jsi.get_member( json_key ), list, 1 );
+    list.deserialize( jsi.get_member( json_key ) );
 }
 
 void ter_furn_transform::reset()

--- a/src/mapgendata.cpp
+++ b/src/mapgendata.cpp
@@ -244,7 +244,7 @@ void mapgendata::fill_groundcover() const
 bool mapgendata::is_groundcover( const ter_id &iid ) const
 {
     for( const auto &pr : default_groundcover ) {
-        if( pr.obj == iid ) {
+        if( pr.first == iid ) {
             return true;
         }
     }

--- a/src/regional_settings.cpp
+++ b/src/regional_settings.cpp
@@ -748,8 +748,8 @@ void check_region_settings()
                 } else {
                     std::string list_of_values =
                         enumerate_as_string( values,
-                    []( const weighted_object<int, map_extra_id> &w ) {
-                        return '"' + w.obj.str() + '"';
+                    []( const std::pair<map_extra_id, int> &w ) {
+                        return '"' + w.first.str() + '"';
                     } );
                     debugmsg( "Invalid map extras for region \"%s\", extras \"%s\".  "
                               "Extras %s are listed, but all have zero weight.",
@@ -1093,7 +1093,7 @@ void overmap_highway_settings::finalize()
     auto find_longest_special = []( const building_bin & b ) {
         int longest_length = 0;
         for( const auto &weighted_pair : b.get_all_buildings() ) {
-            const overmap_special_id &special = weighted_pair.obj;
+            const overmap_special_id &special = weighted_pair.first;
             int spec_length = special.obj().longest_side();
             if( spec_length > longest_length ) {
                 longest_length = spec_length;
@@ -1119,10 +1119,10 @@ void overmap_highway_settings::finalize()
 map_extras map_extras::filtered_by( const mapgendata &dat ) const
 {
     map_extras result( chance );
-    for( const weighted_object<int, map_extra_id> &obj : values ) {
-        const map_extra_id &extra_id = obj.obj;
+    for( const std::pair<map_extra_id, int> &obj : values ) {
+        const map_extra_id &extra_id = obj.first;
         if( extra_id->is_valid_for( dat ) ) {
-            result.values.add( extra_id, obj.weight );
+            result.values.add( extra_id, obj.second );
         }
     }
     if( !values.empty() && result.values.empty() ) {
@@ -1197,7 +1197,7 @@ void regional_settings::finalize()
 {
     if( default_groundcover_str != nullptr ) {
         for( const auto &pr : *default_groundcover_str ) {
-            default_groundcover.add( pr.obj.id(), pr.weight );
+            default_groundcover.add( pr.first.id(), pr.second );
         }
 
         default_groundcover_str.reset();

--- a/src/relic.cpp
+++ b/src/relic.cpp
@@ -609,20 +609,20 @@ int relic_procgen_data::power_level( const enchant_cache &ench ) const
 {
     int power = 0;
 
-    for( const weighted_object<int, relic_procgen_data::enchantment_value_passive<int>>
+    for( const std::pair<relic_procgen_data::enchantment_value_passive<int>, int>
          &add_val_passive : passive_add_procgen_values ) {
-        int val = ench.get_value_add( add_val_passive.obj.type );
+        int val = ench.get_value_add( add_val_passive.first.type );
         if( val != 0 ) {
-            power += static_cast<float>( add_val_passive.obj.power_per_increment ) /
-                     static_cast<float>( add_val_passive.obj.increment ) * val;
+            power += static_cast<float>( add_val_passive.first.power_per_increment ) /
+                     static_cast<float>( add_val_passive.first.increment ) * val;
         }
     }
 
-    for( const weighted_object<int, relic_procgen_data::enchantment_value_passive<float>>
+    for( const std::pair<relic_procgen_data::enchantment_value_passive<float>, int>
          &mult_val_passive : passive_mult_procgen_values ) {
-        float val = ench.get_value_multiply( mult_val_passive.obj.type );
+        float val = ench.get_value_multiply( mult_val_passive.first.type );
         if( val != 0.0f ) {
-            power += mult_val_passive.obj.power_per_increment / mult_val_passive.obj.increment * val;
+            power += mult_val_passive.first.power_per_increment / mult_val_passive.first.increment * val;
         }
     }
 
@@ -631,10 +631,10 @@ int relic_procgen_data::power_level( const enchant_cache &ench ) const
 
 int relic_procgen_data::power_level( const fake_spell &sp ) const
 {
-    for( const weighted_object<int, relic_procgen_data::enchantment_active> &vals :
+    for( const std::pair<relic_procgen_data::enchantment_active, int> &vals :
          active_procgen_values ) {
-        if( vals.obj.activated_spell == sp.id ) {
-            return vals.obj.calc_power( sp.level );
+        if( vals.first.activated_spell == sp.id ) {
+            return vals.first.calc_power( sp.level );
         }
     }
     return 0;

--- a/src/vehicle_group.cpp
+++ b/src/vehicle_group.cpp
@@ -70,8 +70,8 @@ std::vector<vproto_id> VehicleGroup::all_possible_results() const
 {
     std::vector<vproto_id> result;
     result.reserve( vehicles.size() );
-    for( const weighted_object<int, vproto_id> &wo : vehicles ) {
-        result.push_back( wo.obj );
+    for( const std::pair<vproto_id, int> &wo : vehicles ) {
+        result.push_back( wo.first );
     }
     return result;
 }

--- a/src/weighted_dbl_or_var_list.h
+++ b/src/weighted_dbl_or_var_list.h
@@ -48,16 +48,16 @@ template <typename T> struct weighted_dbl_or_var_list {
             }
             objects.emplace_back( obj, weight );
             invalidate_precalc();
-            return &( objects[objects.size() - 1].obj );
+            return &( objects[objects.size() - 1].first );
         }
 
         void precalc() {
-            for( const weighted_object<dbl_or_var, T>  &object : objects ) {
-                _is_constant &= object.weight.is_constant();
+            for( const std::pair<T, dbl_or_var> &object : objects ) {
+                _is_constant &= object.second.is_constant();
             }
             if( _is_constant ) {
-                for( const weighted_object<dbl_or_var, T>  &object : objects ) {
-                    _constant_total_weight += object.weight.evaluate( d() );
+                for( const std::pair<T, dbl_or_var> &object : objects ) {
+                    _constant_total_weight += object.second.evaluate( d() );
                 }
             }
             _precalced = true;
@@ -75,7 +75,7 @@ template <typename T> struct weighted_dbl_or_var_list {
         void remove( const T &obj ) {
             auto itr_end = std::remove_if( objects.begin(),
             objects.end(), [&obj]( typename decltype( objects )::value_type const & itr ) {
-                return itr.obj == obj;
+                return itr.first == obj;
             } );
             objects.erase( itr_end, objects.end() );
             invalidate_precalc();
@@ -96,13 +96,13 @@ template <typename T> struct weighted_dbl_or_var_list {
                 invalidate_precalc();
                 return nullptr;
             }
-            for( weighted_object<dbl_or_var, T> &itr : objects ) {
-                if( itr.obj == obj ) {
-                    if( itr.weight != weight ) {
-                        itr.weight = weight;
+            for( std::pair<T, dbl_or_var> &itr : objects ) {
+                if( itr.first == obj ) {
+                    if( itr.second != weight ) {
+                        itr.second = weight;
                         invalidate_precalc();
                     }
-                    return &( itr.obj );
+                    return &( itr.first );
                 }
             }
             // if not found, add to end of list
@@ -115,8 +115,8 @@ template <typename T> struct weighted_dbl_or_var_list {
          * @param func The callback function.
          */
         void apply( std::function<void( const T & )> func ) const {
-            for( const weighted_object<dbl_or_var, T> &itr : objects ) {
-                func( itr.obj );
+            for( const std::pair<T, dbl_or_var> &itr : objects ) {
+                func( itr.first );
             }
         }
 
@@ -126,8 +126,8 @@ template <typename T> struct weighted_dbl_or_var_list {
          * @param func The callback function.
          */
         void apply( std::function<void( T & )> func ) {
-            for( const weighted_object<dbl_or_var, T> &itr : objects ) {
-                func( itr.obj );
+            for( const std::pair<T, dbl_or_var> &itr : objects ) {
+                func( itr.first );
             }
         }
 
@@ -139,7 +139,7 @@ template <typename T> struct weighted_dbl_or_var_list {
          */
         const T *pick( unsigned int randi ) const {
             if( get_weight() > 0 ) {
-                return &( objects[pick_ent( randi )].obj );
+                return &( objects[pick_ent( randi )].first );
             }
             return nullptr;
         }
@@ -155,7 +155,7 @@ template <typename T> struct weighted_dbl_or_var_list {
          */
         T *pick( unsigned int randi ) {
             if( get_weight() > 0 ) {
-                return &( objects[pick_ent( randi )].obj );
+                return &( objects[pick_ent( randi )].first );
             }
             return nullptr;
         }
@@ -176,9 +176,9 @@ template <typename T> struct weighted_dbl_or_var_list {
          * in the weighted list it will return 0.
          */
         double get_specific_weight( const T &obj ) const {
-            for( const weighted_object<dbl_or_var, T> &itr : objects ) {
-                if( itr.obj == obj ) {
-                    return itr.weight.evaluate( d() );
+            for( const std::pair<T, dbl_or_var> &itr : objects ) {
+                if( itr.first == obj ) {
+                    return itr.second.evaluate( d() );
                 }
             }
             return 0;
@@ -192,8 +192,8 @@ template <typename T> struct weighted_dbl_or_var_list {
                 return _constant_total_weight;
             } else {
                 double ret = 0.0;
-                for( const weighted_object<dbl_or_var, T> &itr : objects ) {
-                    ret += itr.weight.evaluate( d() );
+                for( const std::pair<T, dbl_or_var> &itr : objects ) {
+                    ret += itr.second.evaluate( d() );
                 }
                 return ret;
             }
@@ -203,21 +203,21 @@ template <typename T> struct weighted_dbl_or_var_list {
             return !is_constant() || _constant_total_weight > 0.0;
         }
 
-        typename std::vector<weighted_object<dbl_or_var, T> >::iterator begin() {
+        typename std::vector<std::pair<T, dbl_or_var> >::iterator begin() {
             return objects.begin();
         }
-        typename std::vector<weighted_object<dbl_or_var, T> >::iterator end() {
+        typename std::vector<std::pair<T, dbl_or_var> >::iterator end() {
             return objects.end();
         }
-        typename std::vector<weighted_object<dbl_or_var, T> >::const_iterator begin() const {
+        typename std::vector<std::pair<T, dbl_or_var> >::const_iterator begin() const {
             return objects.begin();
         }
-        typename std::vector<weighted_object<dbl_or_var, T> >::const_iterator end() const {
+        typename std::vector<std::pair<T, dbl_or_var> >::const_iterator end() const {
             return objects.end();
         }
-        typename std::vector<weighted_object<dbl_or_var, T> >::iterator erase(
-            typename std::vector<weighted_object<dbl_or_var, T> >::iterator first,
-            typename std::vector<weighted_object<dbl_or_var, T> >::iterator last ) {
+        typename std::vector<std::pair<T, dbl_or_var> >::iterator erase(
+            typename std::vector<std::pair<T, dbl_or_var> >::iterator first,
+            typename std::vector<std::pair<T, dbl_or_var> >::iterator last ) {
             return objects.erase( first, last );
         }
         size_t size() const noexcept {
@@ -230,8 +230,8 @@ template <typename T> struct weighted_dbl_or_var_list {
         std::string to_debug_string() const {
             std::ostringstream os;
             os << "[ ";
-            for( const weighted_object<dbl_or_var, T> &o : objects ) {
-                os << o.obj << ":" << o.weight.evaluate( d() ) << ", ";
+            for( const std::pair<T, dbl_or_var> &o : objects ) {
+                os << o.first << ":" << o.second.evaluate( d() ) << ", ";
             }
             os << "]";
             return os.str();
@@ -249,7 +249,7 @@ template <typename T> struct weighted_dbl_or_var_list {
         double _constant_total_weight = 0.0;
         bool _precalced = true; // True for empty lists
         bool _is_constant = true;
-        std::vector<weighted_object<dbl_or_var, T>> objects;
+        std::vector<std::pair<T, dbl_or_var>> objects;
 
         size_t pick_ent( unsigned int randi ) const {
             const double picked = static_cast<double>( randi ) / UINT_MAX * get_weight();
@@ -257,14 +257,14 @@ template <typename T> struct weighted_dbl_or_var_list {
             size_t i;
             if( is_constant() ) {
                 for( i = 0; i < objects.size(); i++ ) {
-                    accumulated_weight += objects[i].weight.constant();
+                    accumulated_weight += objects[i].second.min.dbl_val.value();
                     if( accumulated_weight >= picked ) {
                         break;
                     }
                 }
             } else {
                 for( i = 0; i < objects.size(); i++ ) {
-                    accumulated_weight += objects[i].weight.evaluate( d() );
+                    accumulated_weight += objects[i].second.evaluate( d() );
                     if( accumulated_weight >= picked ) {
                         break;
                     }

--- a/src/weighted_dbl_or_var_list.h
+++ b/src/weighted_dbl_or_var_list.h
@@ -257,7 +257,7 @@ template <typename T> struct weighted_dbl_or_var_list {
             size_t i;
             if( is_constant() ) {
                 for( i = 0; i < objects.size(); i++ ) {
-                    accumulated_weight += objects[i].second.min.dbl_val.value();
+                    accumulated_weight += objects[i].second.constant();
                     if( accumulated_weight >= picked ) {
                         break;
                     }

--- a/src/weighted_list.h
+++ b/src/weighted_list.h
@@ -2,6 +2,7 @@
 #ifndef CATA_SRC_WEIGHTED_LIST_H
 #define CATA_SRC_WEIGHTED_LIST_H
 
+#include "flexbuffer_json.h"
 #include "json.h"
 #include "rng.h"
 
@@ -12,19 +13,8 @@
 #include <sstream>
 #include <vector>
 
-template <typename W, typename T> struct weighted_object {
-    weighted_object( const T &obj, const W &weight ) : obj( obj ), weight( weight ) {}
-
-    T obj;
-    W weight;
-
-    friend bool operator==( const weighted_object &l, const weighted_object &r ) {
-        return l.obj == r.obj && l.weight == r.weight;
-    }
-};
-
-template <typename W, typename T> struct weighted_list {
-        weighted_list() : total_weight( 0 ) { }
+template <typename T, typename W> struct weighted_list {
+        weighted_list() : total_weight( 0 ) {}
 
         weighted_list( const weighted_list & ) = default;
         weighted_list( weighted_list && ) noexcept = default;
@@ -43,16 +33,39 @@ template <typename W, typename T> struct weighted_list {
                 objects.emplace_back( obj, weight );
                 total_weight += weight;
                 invalidate_precalc();
-                return &( objects[objects.size() - 1].obj );
+                return &( objects[objects.size() - 1].first );
             }
             return nullptr;
+        }
+
+        T *add( const std::pair<T, W> &obj_and_weight ) {
+            return add( obj_and_weight.first, obj_and_weight.second );
+        }
+
+        /**
+        * Adds a new object to the weighted list.
+        * Does nothing if the object already exists.
+        * Returns a pointer to the added object, or nullptr if it already existed.
+        */
+        T *try_add( const T &obj, const W &weight ) {
+            if( std::find_if( objects.begin(), objects.end(),
+            [&obj]( const std::pair<T, W> &element ) {
+            return element.first == obj;
+        } ) == objects.end() ) {
+                return add( obj, weight );
+            }
+            return nullptr;
+        }
+
+        T *try_add( const std::pair<T, W> &obj_and_weight ) {
+            return try_add( obj_and_weight.first, obj_and_weight.second );
         }
 
         void remove( const T &obj ) {
             const auto remove_with_weight = [&obj, this]
             ( typename decltype( objects )::value_type const & itr ) {
-                if( itr.obj == obj ) {
-                    total_weight -= itr.weight;
+                if( itr.first == obj ) {
+                    total_weight -= itr.second;
                     return true;
                 }
                 return false;
@@ -78,10 +91,10 @@ template <typename W, typename T> struct weighted_list {
             if( weight > 0 ) {
                 invalidate_precalc();
                 for( auto &itr : objects ) {
-                    if( itr.obj == obj ) {
-                        total_weight += ( weight - itr.weight );
-                        itr.weight = weight;
-                        return &( itr.obj );
+                    if( itr.first == obj ) {
+                        total_weight += ( weight - itr.second );
+                        itr.second = weight;
+                        return &( itr.first );
                     }
                 }
 
@@ -97,7 +110,7 @@ template <typename W, typename T> struct weighted_list {
          */
         void apply( std::function<void( const T & )> func ) const {
             for( auto &itr : objects ) {
-                func( itr.obj );
+                func( itr.first );
             }
         }
 
@@ -108,7 +121,7 @@ template <typename W, typename T> struct weighted_list {
          */
         void apply( std::function<void( T & )> func ) {
             for( auto &itr : objects ) {
-                func( itr.obj );
+                func( itr.first );
             }
         }
 
@@ -119,7 +132,7 @@ template <typename W, typename T> struct weighted_list {
          */
         const T *pick( unsigned int randi ) const {
             if( total_weight > 0 ) {
-                return &( objects[pick_ent( randi )].obj );
+                return &( objects[pick_ent( randi )].first );
             } else {
                 return nullptr;
             }
@@ -136,7 +149,7 @@ template <typename W, typename T> struct weighted_list {
          */
         T *pick( unsigned int randi ) {
             if( total_weight > 0 ) {
-                return &( objects[pick_ent( randi )].obj );
+                return &( objects[pick_ent( randi )].first );
             } else {
                 return nullptr;
             }
@@ -159,9 +172,9 @@ template <typename W, typename T> struct weighted_list {
          * in the weighted list it will return 0.
          */
         W get_specific_weight( const T &obj ) const {
-            for( auto &itr : objects ) {
-                if( itr.obj == obj ) {
-                    return itr.weight;
+            for( const std::pair<T, W> &itr : objects ) {
+                if( itr.first == obj ) {
+                    return itr.second;
                 }
             }
             return 0;
@@ -178,21 +191,21 @@ template <typename W, typename T> struct weighted_list {
             return get_weight() > 0;
         }
 
-        typename std::vector<weighted_object<W, T> >::iterator begin() {
+        typename std::vector<std::pair<T, W> >::iterator begin() {
             return objects.begin();
         }
-        typename std::vector<weighted_object<W, T> >::iterator end() {
+        typename std::vector<std::pair<T, W> >::iterator end() {
             return objects.end();
         }
-        typename std::vector<weighted_object<W, T> >::const_iterator begin() const {
+        typename std::vector<std::pair<T, W> >::const_iterator begin() const {
             return objects.begin();
         }
-        typename std::vector<weighted_object<W, T> >::const_iterator end() const {
+        typename std::vector<std::pair<T, W> >::const_iterator end() const {
             return objects.end();
         }
-        typename std::vector<weighted_object<W, T> >::iterator erase(
-            typename std::vector<weighted_object<W, T> >::iterator first,
-            typename std::vector<weighted_object<W, T> >::iterator last ) {
+        typename std::vector<std::pair<T, W> >::iterator erase(
+            typename std::vector<std::pair<T, W> >::iterator first,
+            typename std::vector<std::pair<T, W> >::iterator last ) {
             invalidate_precalc();
             return objects.erase( first, last );
         }
@@ -206,8 +219,8 @@ template <typename W, typename T> struct weighted_list {
         std::string to_debug_string() const {
             std::ostringstream os;
             os << "[ ";
-            for( const weighted_object<W, T> &o : objects ) {
-                os << o.obj << ":" << o.weight << ", ";
+            for( const std::pair<T, W> &o : objects ) {
+                os << o.first << ":" << o.second << ", ";
             }
             os << "]";
             return os.str();
@@ -221,16 +234,37 @@ template <typename W, typename T> struct weighted_list {
             return !( l == r );
         }
 
+        void deserialize( const JsonValue &jv ) {
+            if( jv.test_array() ) {
+                for( const JsonValue entry : jv.get_array() ) {
+                    if( entry.test_array() ) {
+                        std::pair<T, W> p;
+                        entry.read( p, true );
+                        add( p.first, p.second );
+                    } else {
+                        T val;
+                        entry.read( val );
+                        add( val, default_weight );
+                    }
+                }
+            } else {
+                jv.throw_error( "weighted list must be in format [[a, b], ...]" );
+            }
+        }
+
     protected:
-        W total_weight;
-        std::vector<weighted_object<W, T> > objects;
+        W total_weight = 0;
+        W default_weight = 1;
+        std::vector<std::pair<T, W> > objects;
 
         virtual size_t pick_ent( unsigned int ) const = 0;
         virtual void invalidate_precalc() {}
 };
 
-template <typename T> struct weighted_int_list : public weighted_list<int, T> {
+template <typename T> struct weighted_int_list : public weighted_list<T, int> {
 
+        weighted_int_list() = default;
+        weighted_int_list( int default_weight ) : default_weight( default_weight ) {};
         // populate the precalc_array for O(1) lookups
         void precalc() {
             precalc_array.clear();
@@ -238,7 +272,7 @@ template <typename T> struct weighted_int_list : public weighted_list<int, T> {
             precalc_array.reserve( this->total_weight );
             // weights [3,1,5] will produce vector of indices [0,0,0,1,2,2,2,2,2]
             for( size_t i = 0; i < this->objects.size(); i++ ) {
-                precalc_array.resize( precalc_array.size() + this->objects[i].weight, i );
+                precalc_array.resize( precalc_array.size() + this->objects[i].second, i );
             }
         }
 
@@ -257,7 +291,7 @@ template <typename T> struct weighted_int_list : public weighted_list<int, T> {
                 // otherwise do O(N) search through items
                 int accumulated_weight = 0;
                 for( i = 0; i < this->objects.size(); i++ ) {
-                    accumulated_weight += this->objects[i].weight;
+                    accumulated_weight += this->objects[i].second;
                     if( accumulated_weight >= picked ) {
                         break;
                     }
@@ -270,14 +304,17 @@ template <typename T> struct weighted_int_list : public weighted_list<int, T> {
             precalc_array.clear();
         }
 
+        int default_weight = 1;
         std::vector<int> precalc_array;
 };
 
 static_assert( std::is_nothrow_move_constructible_v<weighted_int_list<int>> );
 
-template <typename T> struct weighted_float_list : public weighted_list<double, T> {
+template <typename T> struct weighted_float_list : public weighted_list<T, double> {
 
         // TODO: precalc using alias method
+        weighted_float_list() = default;
+        weighted_float_list( int default_weight ) : default_weight( default_weight ) {};
 
     protected:
 
@@ -286,7 +323,7 @@ template <typename T> struct weighted_float_list : public weighted_list<double, 
             double accumulated_weight = 0;
             size_t i;
             for( i = 0; i < this->objects.size(); i++ ) {
-                accumulated_weight += this->objects[i].weight;
+                accumulated_weight += this->objects[i].second;
                 if( accumulated_weight >= picked ) {
                     break;
                 }
@@ -294,22 +331,7 @@ template <typename T> struct weighted_float_list : public weighted_list<double, 
             return i;
         }
 
+        float default_weight = 1;
 };
-
-template<typename W, typename T>
-void load_weighted_list( const JsonValue &jsv, weighted_list<W, T> &list, W default_weight )
-{
-    for( const JsonValue entry : jsv.get_array() ) {
-        if( entry.test_array() ) {
-            std::pair<T, W> p;
-            entry.read( p, true );
-            list.add( p.first, p.second );
-        } else {
-            T val;
-            entry.read( val );
-            list.add( val, default_weight );
-        }
-    }
-}
 
 #endif // CATA_SRC_WEIGHTED_LIST_H


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Infrastructure "Weighted list improvements"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

- Part of #82631

Loading weighted lists with `generic_factory` functions was not possible.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

- swaps template typename order to be consistent with JSON: (key, value) format
- moves static load function to a local deserialize function
- adds default weight to weighted lists
- `generic_factory` handler
- replaces weighted_object with std::pair because it is one

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Loads weighted lists correctly in #82631
Loaded game successfully after rebase, overmaps looked normal

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
