### PR TITLE
Add batch multiplier to crafting UI

### DIFF
--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -772,6 +772,13 @@
   },
   {
     "type": "keybinding",
+    "id": "TOGGLE_BATCH_MULTIPLIER",
+    "category": "CRAFTING",
+    "name": "Toggle size of batch selection steps between 1 and 10",
+    "bindings": [ { "input_method": "keyboard_any", "key": [ "b" ] } ]
+  },
+  {
+    "type": "keybinding",
     "id": "SCROLL_ITEM_INFO_UP",
     "category": "CRAFTING",
     "name": "Scroll item info up",

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -637,6 +637,7 @@ static input_context make_crafting_context( bool highlight_unread_recipes )
     ctxt.register_action( "HELP_RECIPE" );
     ctxt.register_action( "HELP_KEYBINDINGS" );
     ctxt.register_action( "CYCLE_BATCH" );
+    ctxt.register_action( "TOGGLE_BATCH_MULTIPLIER" );
     ctxt.register_action( "CHOOSE_CRAFTER" );
     ctxt.register_action( "RELATED_RECIPES" );
     ctxt.register_action( "HIDE_SHOW_RECIPE" );
@@ -1304,6 +1305,7 @@ std::pair<Character *, const recipe *> select_crafter_and_crafting_recipe( int &
         add_action_desc( "RELATED_RECIPES", pgettext( "crafting gui", "Related" ) );
         add_action_desc( "TOGGLE_FAVORITE", pgettext( "crafting gui", "Favorite" ) );
         add_action_desc( "CYCLE_BATCH", pgettext( "crafting gui", "Batch" ) );
+        add_action_desc( "TOGGLE_BATCH_MULTIPLIER", pgettext( "crafting gui", "Toggle Batch Multiplier" ) );
         add_action_desc( "CHOOSE_CRAFTER", pgettext( "crafting gui", "Choose crafter" ) );
         add_action_desc( "HELP_KEYBINDINGS", pgettext( "crafting gui", "Keybindings" ) );
         keybinding_x = isWide ? 5 : 2;
@@ -1367,6 +1369,7 @@ std::pair<Character *, const recipe *> select_crafter_and_crafting_recipe( int &
     bool keepline = false;
     bool done = false;
     bool batch = false;
+    int batch_multiplier = 1;
     bool show_hidden = false;
     size_t num_hidden = 0;
     int num_recipe = 0;
@@ -1497,7 +1500,7 @@ std::pair<Character *, const recipe *> select_crafter_and_crafting_recipe( int &
             std::string tmp_name = std::string( indent[i],
                                                 ' ' ) + current[i]->result_name( /*decorated=*/true );
             if( batch ) {
-                tmp_name = string_format( _( "%2dx %s" ), i + 1, tmp_name );
+                tmp_name = string_format( _( "%3dx %s" ), ( i + 1 ) * batch_multiplier, tmp_name );
             }
             const bool rcp_read = !highlight_unread_recipes ||
                                   uistate.read_recipes.count( current[i]->ident() );
@@ -1518,7 +1521,7 @@ std::pair<Character *, const recipe *> select_crafter_and_crafting_recipe( int &
                               i - istart ) ) );
         }
 
-        const int batch_size = batch ? line + 1 : 1;
+        const int batch_size = batch ? ( line + 1 ) * batch_multiplier : 1;
         if( !current.empty() ) {
             const recipe &recp = *current[line];
 
@@ -1616,7 +1619,7 @@ std::pair<Character *, const recipe *> select_crafter_and_crafting_recipe( int &
                 current.clear();
                 for( int i = 1; i <= 50; i++ ) {
                     current.push_back( chosen );
-                    available.emplace_back( *crafter, chosen, i, camp_crafting, inventory_override );
+                    available.emplace_back( *crafter, chosen, i * batch_multiplier, camp_crafting, inventory_override );
                 }
                 indent.assign( current.size(), 0 );
             } else {
@@ -1888,13 +1891,14 @@ std::pair<Character *, const recipe *> select_crafter_and_crafting_recipe( int &
                        !available[line].crafter_has_primary_skill ) {
                 popup( _( "Crafter can't craft that!" ) );
             } else if( available[line].inv_override == nullptr &&
-                       !crafter->check_eligible_containers_for_crafting( *current[line], batch ? line + 1 : 1 ) ) {
+                       !crafter->check_eligible_containers_for_crafting( *current[line],
+                               batch ? ( line + 1 ) * batch_multiplier : 1 ) ) {
                 // popup is already inside check
             } else if( crafter->lighting_craft_speed_multiplier( *current[line] ) <= 0.0f ) {
                 popup( _( "Crafter can't see!" ) );
             } else {
                 chosen = current[line];
-                batch_size_out = batch ? line + 1 : 1;
+                batch_size_out = batch ? ( line + 1 ) * batch_multiplier : 1;
                 done = true;
                 uistate.read_recipes.insert( chosen->ident() );
             }
@@ -1984,6 +1988,12 @@ std::pair<Character *, const recipe *> select_crafter_and_crafting_recipe( int &
                 keepline = true;
             }
             recalc = true;
+        } else if( action == "TOGGLE_BATCH_MULTIPLIER" ) {
+            if( batch_multiplier == 1 ) {
+                batch_multiplier = 10;
+            } else {
+                batch_multiplier = 1;
+            }
         } else if( action == "CHOOSE_CRAFTER" ) {
             // allow for switching crafter when no recipes are shown (e.g. filter)
             bool rec_valid = !current.empty();


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fix #82744, i.e. max batch crafting size too small for some usages.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add a toggle between a batch crafting multiplier of 1 and 10 for the batch crafting UI. This means we'll still have 50 lines, but each line will switch between the current state of one crafting per entry to 10 craftings per entry (so the resolution is reduced to 10 rather than 1).
If this description is confusing, look at the images in the testing section below.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
- Find a way to display what the current batch crafting multiplier is in the UI.
- Allow the player to select the batch crafting multiplier. That would complicate the UI for little practical benefit.
- Introduce a direct batch size selection rather than selection from a list. That's an option, but probably more complicated to use than a simple list selection, as you can't directly see crafting times and resource consumption in an easy way to guide your choice of batch size.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
The current batch crafting tab. Note the addition of a Batch crafting multiplier key at the bottom:
<img width="3440" height="1440" alt="Screenshot (4)" src="https://github.com/user-attachments/assets/90fa7473-69fb-46c0-b215-9076dbd49520" />

The same screen after the batch crafting multiplier has been toggled (and a different row has been selected). Note that both the batch count for the row has been changed as well as the data in the details pane to the right to match the larger size of the batch (also verified the UI is updated when the batch multiplier is toggled):
<img width="3440" height="1440" alt="Screenshot (5)" src="https://github.com/user-attachments/assets/8facef29-f3f2-4211-b69f-63ced8536c38" />

The help screen for the key bindings:
<img width="3440" height="1440" alt="Screenshot (6)" src="https://github.com/user-attachments/assets/e090e9eb-c497-47c6-8137-338e4f287e11" />

Note that I updated keybindings.json in the config directory before the version in the data\raw directory, so I don't know if the new key binding is picked up automatically.

I debug spawned a peasant flail and 100 dried oat stalks and ordered the crafting of threshed oats with a batch size of 100 (10:th entry with the batch multiplier toggled to 10). It took about 2½ hours (expected time) and generated the expected output.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
