### PR TITLE
weather_generator generic factory support

### DIFF
--- a/data/mods/No_Hope/region_overlay.json
+++ b/data/mods/No_Hope/region_overlay.json
@@ -61,6 +61,6 @@
       "build": { "extras": { "mx_bugout": 20, "mx_science": 12, "mx_crater": 60, "mx_bandits_ambush": 10, "mx_bandits_hideout": 10 } },
       "subway": { "extras": { "mx_casings": 10, "mx_bandits_ambush": 5 } }
     },
-    "weather": { "base_humidity": 90.0 }
+    "weather": { "base_humidity": 90.0, "base_temperature": 6.5, "base_pressure": 1015.0, "base_wind": 3.4 }
   }
 ]

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -119,6 +119,7 @@
 #include "vehicle_group.h"
 #include "vitamin.h"
 #include "weakpoint.h"
+#include "weather_gen.h"
 #include "weather_type.h"
 #include "widget.h"
 #include "worldfactory.h"
@@ -275,6 +276,7 @@ void DynamicDataLoader::initialize()
     add( "field_type", &field_types::load );
     add( "field_type_migration", &field_type_migrations::load );
     add( "weather_type", &weather_types::load );
+    add( "weather_generator", &weather_generator::load_weather_generator );
     add( "ammo_effect", &ammo_effects::load );
     add( "emit", &emit::load_emit );
     add( "help", &help::load );
@@ -715,6 +717,7 @@ void DynamicDataLoader::unload_data()
     vpart_category::reset();
     vpart_migration::reset();
     weakpoints::reset();
+    weather_generator::reset();
     weather_types::reset();
     widget::reset();
     zone_type::reset();

--- a/src/regional_settings.cpp
+++ b/src/regional_settings.cpp
@@ -703,7 +703,7 @@ void load_region_settings( const JsonObject &jo )
         jo.throw_error( "\"weather\": { … } required for default" );
     } else {
         JsonObject wjo = jo.get_object( "weather" );
-        new_region.weather.load( wjo, false );
+        new_region.weather.load( wjo, "dda" );
     }
 
     load_overmap_feature_flag_settings( jo, new_region.overmap_feature_flag, strict, false );
@@ -862,7 +862,7 @@ void apply_region_overlay( const JsonObject &jo, regional_settings &region )
 
     if( jo.has_object( "weather" ) ) {
         JsonObject wjo = jo.get_object( "weather" );
-        region.weather.load( wjo, true );
+        region.weather.load( wjo, "dda" );
     }
 
     load_overmap_feature_flag_settings( jo, region.overmap_feature_flag, false, true );

--- a/src/string_id_null_ids.cpp
+++ b/src/string_id_null_ids.cpp
@@ -53,6 +53,7 @@ MAKE_NULL_ID( update_mapgen, "null" )
 MAKE_NULL_ID( VehicleGroup, "null" )
 MAKE_NULL_ID( vitamin, "null" )
 MAKE_NULL_ID( vpart_info, "null" )
+MAKE_NULL_ID( weather_generator, "" )
 MAKE_NULL_ID( widget, "null" )
 MAKE_NULL_ID( zone_type, "null" )
 

--- a/src/type_id.h
+++ b/src/type_id.h
@@ -321,6 +321,9 @@ using vpart_id = string_id<vpart_info>;
 struct vehicle_prototype;
 using vproto_id = string_id<vehicle_prototype>;
 
+class weather_generator;
+using weather_generator_id = string_id<weather_generator>;
+
 struct weather_type;
 using weather_type_id = string_id<weather_type>;
 

--- a/src/weather_gen.cpp
+++ b/src/weather_gen.cpp
@@ -41,6 +41,34 @@ constexpr double noise_magnitude_K = 8;
 weather_generator::weather_generator() = default;
 int weather_generator::current_winddir = 1000;
 
+namespace
+{
+generic_factory<weather_generator> weather_generator_factory( "weather_generator" );
+} // namespace
+template<>
+const weather_generator &string_id<weather_generator>::obj() const
+{
+    return weather_generator_factory.obj( *this );
+}
+template<>
+bool string_id<weather_generator>::is_valid() const
+{
+    return weather_generator_factory.is_valid( *this );
+}
+void weather_generator::load_weather_generator( const JsonObject &jo,
+        const std::string &src )
+{
+    weather_generator_factory.load( jo, src );
+}
+void weather_generator::reset()
+{
+    weather_generator_factory.reset();
+}
+
+void weather_generator::finalize_all()
+{
+    weather_generator_factory.finalize();
+}
 struct weather_gen_common {
     double x = 0;
     double y = 0;
@@ -342,14 +370,14 @@ void weather_generator::sort_weather()
     } );
 }
 
-void weather_generator::load( const JsonObject &jo, const bool was_loaded )
+void weather_generator::load( const JsonObject &jo, std::string_view )
 {
     mandatory( jo, was_loaded, "base_temperature", base_temperature );
     mandatory( jo, was_loaded, "base_humidity", base_humidity );
     mandatory( jo, was_loaded, "base_pressure", base_pressure );
     mandatory( jo, was_loaded, "base_wind", base_wind );
-    mandatory( jo, was_loaded, "base_wind_distrib_peaks", base_wind_distrib_peaks );
-    mandatory( jo, was_loaded, "base_wind_season_variation", base_wind_season_variation );
+    optional( jo, was_loaded, "base_wind_distrib_peaks", base_wind_distrib_peaks );
+    optional( jo, was_loaded, "base_wind_season_variation", base_wind_season_variation );
     optional( jo, was_loaded, "summer_temp_manual_mod", summer_temp_manual_mod, 0 );
     optional( jo, was_loaded, "spring_temp_manual_mod", spring_temp_manual_mod, 0 );
     optional( jo, was_loaded, "autumn_temp_manual_mod", autumn_temp_manual_mod, 0 );

--- a/src/weather_gen.h
+++ b/src/weather_gen.h
@@ -3,6 +3,7 @@
 #define CATA_SRC_WEATHER_GEN_H
 
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "calendar.h"
@@ -27,6 +28,8 @@ struct w_point {
 class weather_generator
 {
     public:
+        weather_generator_id id = weather_generator_id::NULL_ID();
+
         // Average temperature
         double base_temperature = 0;
         // Average humidity
@@ -73,7 +76,11 @@ class weather_generator
         units::temperature get_weather_temperature( const tripoint_abs_ms &, const time_point &,
                 unsigned ) const;
 
-        void load( const JsonObject &jo, bool was_loaded );
+        bool was_loaded = false;
+        void load( const JsonObject &jo, std::string_view );
+        static void load_weather_generator( const JsonObject &jo, const std::string &src );
+        static void reset();
+        static void finalize_all();
 };
 
 #endif // CATA_SRC_WEATHER_GEN_H


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Infrastructure "weather_generator generic factory support"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

- From #82631; load weather as separate object

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Mostly complete already, just added a generic factory object and init.cpp loading functions.

There aren't any weather_generator JSON objects yet, so this PR doesn't make any functional changes.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

The `mandatory` -> `optional` change is for inheritance. 

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Works in #82631. Built separately anyways, weather seems fine in base game (and aftershock just for extra testing).

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
