### PR TITLE
Appease clang

### DIFF
--- a/src/generic_factory.h
+++ b/src/generic_factory.h
@@ -36,11 +36,12 @@
 #include "string_formatter.h"
 #include "string_id.h"
 #include "units.h"
-#include "weighted_list.h"
 
 class quantity;
 
 template <typename E> class enum_bitset;
+template<typename T> struct weighted_int_list;
+template <typename T, typename W> struct weighted_list;
 
 /**
 A generic class to store objects identified by a `string_id`.

--- a/src/magic_ter_fur_transform.cpp
+++ b/src/magic_ter_fur_transform.cpp
@@ -20,7 +20,8 @@
 #include "translation.h"
 #include "trap.h"
 #include "type_id.h"
-#include "weighted_list.h"
+
+template<typename T> struct weighted_int_list;
 
 namespace
 {

--- a/src/mapgen_functions.cpp
+++ b/src/mapgen_functions.cpp
@@ -21,6 +21,7 @@
 #include "debug.h"
 #include "flood_fill.h"
 #include "map.h"
+#include "mapdata.h"
 #include "map_iterator.h"
 #include "map_scale_constants.h"
 #include "mapgen.h"

--- a/src/weighted_list.h
+++ b/src/weighted_list.h
@@ -235,6 +235,8 @@ template <typename T, typename W> struct weighted_list {
         }
 
         void deserialize( const JsonValue &jv ) {
+            // this function does things in a way that makes clang-tidy unhappy
+            // CATA_DO_NOT_CHECK_SERIALIZE
             if( jv.test_array() ) {
                 for( const JsonValue entry : jv.get_array() ) {
                     if( entry.test_array() ) {
@@ -248,7 +250,7 @@ template <typename T, typename W> struct weighted_list {
                     }
                 }
             } else {
-                jv.throw_error( "weighted list must be in format [[a, b], ...]" );
+                jv.throw_error( "weighted list must be in format [[a, b], …]" );
             }
         }
 
@@ -264,7 +266,7 @@ template <typename T, typename W> struct weighted_list {
 template <typename T> struct weighted_int_list : public weighted_list<T, int> {
 
         weighted_int_list() = default;
-        weighted_int_list( int default_weight ) : default_weight( default_weight ) {};
+        explicit weighted_int_list( int default_weight ) : default_weight( default_weight ) {};
         // populate the precalc_array for O(1) lookups
         void precalc() {
             precalc_array.clear();
@@ -314,7 +316,7 @@ template <typename T> struct weighted_float_list : public weighted_list<T, doubl
 
         // TODO: precalc using alias method
         weighted_float_list() = default;
-        weighted_float_list( int default_weight ) : default_weight( default_weight ) {};
+        explicit weighted_float_list( int default_weight ) : default_weight( default_weight ) {};
 
     protected:
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Clang-tidy errors that snuck in from https://github.com/CleverRaven/Cataclysm-DDA/pull/82773

#### Describe the solution
clang-tidy doesn't understand the deserialize function and is giving false positives, so silence the check for that function.

#### Testing
See CI.
