### PR TITLE
Revert "Add batch multiplier to crafting UI"

### DIFF
--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -772,13 +772,6 @@
   },
   {
     "type": "keybinding",
-    "id": "TOGGLE_BATCH_MULTIPLIER",
-    "category": "CRAFTING",
-    "name": "Toggle size of batch selection steps between 1 and 10",
-    "bindings": [ { "input_method": "keyboard_any", "key": [ "b" ] } ]
-  },
-  {
-    "type": "keybinding",
     "id": "SCROLL_ITEM_INFO_UP",
     "category": "CRAFTING",
     "name": "Scroll item info up",


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
This reverts commit 86cd2e789ec19aed7255e3db0185cfbfedfb7494 (https://github.com/CleverRaven/Cataclysm-DDA/pull/82779).

I do not think the crafting system is built to handle such large batches. Crafting models a person creating things in a workshop, and batch time scalings represent being able to amortize setup costs, or being able to process multiple things at once (because your pot is large enough, etc).
This assumption breaks at large batch sizes (50 is already generous), and processes which are legitimately batch-able at high rates deserve simulation of that process, instead of extending the entire system to something it is not built to handle.

I think the appropriate solution(s) for https://github.com/CleverRaven/Cataclysm-DDA/issues/82744 are
1. Make the catch-up logic apply for multiple recipes
2. Add an increased batch-size recipe for threshing, see below

#### Additional context
For the batch timing issue mentioned in https://github.com/CleverRaven/Cataclysm-DDA/issues/82744, I looked at splitting recipe time into `setup time` - which can be amortized, and other time, which cannot, but that requires a more considered look at how batching works and the specific recipe than I will do for this PR.

```diff
diff --git a/src/recipe.cpp b/src/recipe.cpp
index a9290ac49b..4555a391da 100644
--- a/src/recipe.cpp
+++ b/src/recipe.cpp
@@ -99,10 +99,14 @@ time_duration recipe::time_to_craft( const Character &guy, recipe_time_flag flag

 int64_t recipe::time_to_craft_moves( const Character &guy, recipe_time_flag flags ) const
 {
-    if( flags == recipe_time_flag::ignore_proficiencies ) {
-        return time;
+    int64_t ret = time;
+    if( flags & recipe_time_flag::no_setup_time ) {
+        ret -= setup_time;
     }
-    return time * proficiency_time_maluses( guy );
+    if( !( flags & recipe_time_flag::ignore_proficiencies ) ) {
+        ret *= proficiency_time_maluses( guy );
+    }
+    return ret;
 }

 int64_t recipe::batch_time( const Character &guy, int batch, float multiplier,
@@ -115,11 +119,12 @@ int64_t recipe::batch_time( const Character &guy, int batch, float multiplier,
         multiplier = 1.0f;
     }

-    const double local_time = static_cast<double>( time_to_craft_moves( guy ) ) / multiplier;
+    const double local_time = static_cast<double>( time_to_craft_moves( guy,
+                              recipe_time_flag::no_setup_time ) ) / multiplier;

     // if recipe does not benefit from batching and we have no assistants, don't do unnecessary additional calculations
     if( batch_rscale == 0.0 && assistants == 0 ) {
-        return static_cast<int64_t>( local_time ) * batch;
+        return ( static_cast<int64_t>( local_time ) * batch ) + setup_time;
     }

     double total_time = 0.0;
@@ -147,7 +152,7 @@ int64_t recipe::batch_time( const Character &guy, int batch, float multiplier,
         total_time = local_time;
     }

-    return static_cast<int64_t>( total_time );
+    return static_cast<int64_t>( total_time ) + setup_time;
 }

 bool recipe::has_flag( const std::string &flag_name ) const
@@ -155,6 +160,14 @@ bool recipe::has_flag( const std::string &flag_name ) const
     return flags.count( flag_name );
 }

+struct time_duration_as_moves_reader : public generic_typed_reader<time_duration_as_moves_reader> {
+    int64_t get_next( const JsonValue &jv ) const {
+        time_duration ret;
+        return to_moves<int64_t>( ret );
+    }
+};
+
 void recipe::load( const JsonObject &jo, const std::string &src )
 {
     bool strict = src == "dda";
@@ -226,10 +239,9 @@ void recipe::load( const JsonObject &jo, const std::string &src )
         return;
     }

-    if( jo.has_string( "time" ) ) {
-        time = to_moves<int>( read_from_json_string<time_duration>( jo.get_member( "time" ),
-                              time_duration::units ) );
-    }
+    optional( jo, was_loaded, "setup_time", setup_time, time_duration_as_moves_reader{}, 0 );
+    optional( jo, was_loaded, "time", time, time_duration_as_moves_reader{}, 0 );
+
     assign( jo, "difficulty", difficulty, strict, 0, MAX_SKILL );
     assign( jo, "flags", flags );

diff --git a/src/recipe.h b/src/recipe.h
index 1d227b3c98..fbd7e1213b 100644
--- a/src/recipe.h
+++ b/src/recipe.h
@@ -35,6 +35,7 @@ enum class recipe_filter_flags : int {
 enum class recipe_time_flag : int {
     none = 0,
     ignore_proficiencies = 1,
+    no_setup_time = 2,
 };

 template<>
@@ -92,6 +93,7 @@ class recipe
         itype_id result_ = itype_id::NULL_ID();
         std::string variant_;

+        int64_t setup_time;
         int64_t time = 0; // in movement points (100 per turn)

         std::string  exertion_str;
```