### PR TITLE
ter_furn_id uses std::variant, deserialize

### DIFF
--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -150,6 +150,37 @@ int_id<furn_t>::int_id( const string_id<furn_t> &id ) : _id( id.id() )
 {
 }
 
+ter_furn_id::ter_furn_id()
+{
+    ter_furn = ter_str_id::NULL_ID().id();
+}
+
+ter_furn_id::ter_furn_id( const std::string &name )
+{
+    resolve( name );
+}
+
+bool ter_furn_id::resolve( const std::string &name )
+{
+    ter_str_id temp_ter( name );
+    furn_str_id temp_furn( name );
+    bool resolved = false;
+    if( temp_ter.is_valid() && !temp_ter.is_null() ) {
+        ter_furn = ter_id( name );
+        resolved = true;
+    } else if( temp_furn.is_valid() && !temp_furn.is_null() ) {
+        ter_furn = furn_id( name );
+        resolved = true;
+    }
+    return resolved;
+}
+
+void ter_furn_id::deserialize( const JsonValue &jo )
+{
+    std::string name = jo.get_string();
+    resolve( name );
+}
+
 namespace io
 {
 

--- a/src/mapdata.h
+++ b/src/mapdata.h
@@ -10,6 +10,7 @@
 #include <string>
 #include <string_view>
 #include <utility>
+#include <variant>
 #include <vector>
 
 #include "calendar.h"
@@ -27,6 +28,7 @@
 
 class Character;
 class JsonObject;
+class JsonValue;
 struct connect_group;
 struct furn_t;
 struct itype;
@@ -767,6 +769,18 @@ struct furn_t : map_data_common_t {
 
     void load( const JsonObject &jo, const std::string &src ) override;
     void check() const override;
+};
+
+//holds either a ter_id OR furn_id (not both!), for loading JSON
+struct ter_furn_id {
+    std::variant<ter_id, furn_id> ter_furn;
+    void deserialize( const JsonValue &jo );
+    ter_furn_id();
+    explicit ter_furn_id( const std::string &name );
+    bool operator==( const ter_furn_id &rhs ) const {
+        return ter_furn == rhs.ter_furn;
+    }
+    bool resolve( const std::string &name );
 };
 
 void load_furniture( const JsonObject &jo, const std::string &src );

--- a/src/mapgen_functions.cpp
+++ b/src/mapgen_functions.cpp
@@ -11,6 +11,7 @@
 #include <string>
 #include <unordered_set>
 #include <utility>
+#include <variant>
 #include <vector>
 
 #include "calendar.h"
@@ -1038,7 +1039,7 @@ void mapgen_forest( mapgendata &dat )
     * @param p the point to check to place a feature at.
     */
     const auto get_feathered_feature = [&no_ter_furn, &max_factor, &factor, &self_biome,
-                                                      &adjacent_biomes, &nesw_weights, &get_feathered_groundcover, &unify_all_borders,
+                                                      &adjacent_biomes, &nesw_weights, &unify_all_borders,
                   &dat]( const point & p ) {
         std::array<float, 4> adj_weights;
         float net_weight = nesw_weights( p, factor, adj_weights );
@@ -1079,9 +1080,6 @@ void mapgen_forest( mapgendata &dat )
                 }
                 break;
         }
-        if( feature.ter == no_ter_furn.ter ) {
-            feature.ter = get_feathered_groundcover( p );
-        }
         return feature;
     };
 
@@ -1118,10 +1116,24 @@ void mapgen_forest( mapgendata &dat )
     // Lay groundcover, place a feature, and place terrain dependent furniture.
     for( int x = 0; x < SEEX * 2; x++ ) {
         for( int y = 0; y < SEEY * 2; y++ ) {
-            const ter_furn_id feature = get_feathered_feature( point( x, y ) );
-            m->ter_set( point_bub_ms( x, y ), feature.ter );
-            m->furn_set( point_bub_ms( x, y ), feature.furn );
-            set_terrain_dependent_furniture( feature.ter, point_bub_ms( x, y ) );
+            const point pos_raw = point( x, y );
+            const point_bub_ms pos = point_bub_ms( x, y );
+
+            ter_furn_id feature = get_feathered_feature( pos_raw );
+            ter_id groundcover = get_feathered_groundcover( pos_raw );
+
+            const ter_id *is_ter = std::get_if<ter_id>( &feature.ter_furn );
+            const furn_id *is_furniture = std::get_if<furn_id>( &feature.ter_furn );
+            ter_id resolved_ter = is_ter == nullptr ? groundcover : *is_ter;
+            const furn_id resolved_furn = is_furniture == nullptr ? furn_str_id::NULL_ID().id() : *is_furniture;
+
+            if( resolved_ter == ter_str_id::NULL_ID().id() ) {
+                resolved_ter = groundcover;
+            }
+
+            m->ter_set( pos, resolved_ter );
+            m->furn_set( pos, resolved_furn );
+            set_terrain_dependent_furniture( resolved_ter, pos );
         }
     }
 

--- a/src/regional_settings.h
+++ b/src/regional_settings.h
@@ -81,12 +81,6 @@ struct city_settings {
     void finalize();
 };
 
-struct ter_furn_id {
-    ter_id ter;
-    furn_id furn;
-    ter_furn_id();
-};
-
 /*
  * template for random bushes and such.
  * supports occasional boost to a single ter/furn type (clustered blueberry bushes for example)


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

For #82631 (notably, this code is different from d6dee11), to support loading `ter_furn_id` with `generic_factory`

To recap, `ter_furn_id` is a struct holding one `ter_id` and one `furn_id`, which is never necessary for loading JSON. Using an std::variant instead of two separate ids was at the request of ehughsbaird.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

See title, adds `ter_furn_id::deserialize()`
Notably, there was exactly one instance where `ter_furn_id` could hold both a `ter_id` and a `furn_id`: in `mapgen_forest()`, which was correctable.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Loaded game successfully, forest and swamp terrain looks normal.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
