### PR TITLE
Nerf mining more

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -582,12 +582,19 @@ void activity_handlers::game_do_turn( player_activity *act, Character *you )
 
 void activity_handlers::pickaxe_do_turn( player_activity *act, Character * )
 {
+    map &here = get_map();
     const tripoint_bub_ms &pos = get_map().get_bub( act->placement );
     sfx::play_activity_sound( "tool", "pickaxe", sfx::get_heard_volume( pos ) );
     // each turn is too much
     if( calendar::once_every( 1_minutes ) ) {
         //~ Sound of a Pickaxe at work!
         sounds::sound( pos, 30, sounds::sound_t::destructive_activity, _( "CHNK!  CHNK!  CHNK!" ) );
+    }
+    if( calendar::once_every( 5_minutes ) ) {
+        const int max_damage_to_set = here.bash_resistance( pos, true );
+        const int existing_damage = here.get_map_damage( pos );
+        const int set_damage_to = std::min( existing_damage + 1, max_damage_to_set );
+        here.set_map_damage( pos, set_damage_to );
     }
 }
 
@@ -2232,12 +2239,19 @@ void activity_handlers::eat_menu_finish( player_activity *, Character * )
 void activity_handlers::jackhammer_do_turn( player_activity *act, Character * )
 {
     map &here = get_map();
+    const tripoint_bub_ms &pos = get_map().get_bub( act->placement );
     sfx::play_activity_sound( "tool", "jackhammer",
-                              sfx::get_heard_volume( here.get_bub( act->placement ) ) );
+                              sfx::get_heard_volume( pos ) );
     if( calendar::once_every( 1_minutes ) ) {
-        sounds::sound( here.get_bub( act->placement ), 15, sounds::sound_t::destructive_activity,
+        sounds::sound( pos, 15, sounds::sound_t::destructive_activity,
                        //~ Sound of a jackhammer at work!
                        _( "TATATATATATATAT!" ) );
+    }
+    if( calendar::once_every( 5_minutes ) ) {
+        const int max_damage_to_set = here.bash_resistance( pos, true );
+        const int existing_damage = here.get_map_damage( pos );
+        const int set_damage_to = std::min( existing_damage + 1, max_damage_to_set );
+        here.set_map_damage( pos, set_damage_to );
     }
 }
 

--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -768,6 +768,7 @@ std::vector<std::string> map_data_common_t::extended_description() const
 {
     std::vector<std::string> tmp;
 
+    // FIXME: Does not show map damage.
     tmp.emplace_back( string_format( _( "<header>That is a %s.</header>" ), name() ) );
     tmp.emplace_back( description.translated() );
 


### PR DESCRIPTION
#### Summary
Balance "Massively increase mining time"

#### Purpose of change
The parts of #82757 which I pushed out.

#### Describe the solution
Massively increase mining time. 30 minutes ---> 2 hours for jackhammers (remember: no walls!), or 8 hours for pickaxes.

Increment map damage every 5 minutes when doing mining activities, If the activity is interrupted for any reason, that map damage stays and is 'credited' towards mining time when resuming the activity.

Show map damage in the look around menu, so that there is some indication of this. (Also works for bashing and other sources of map damage. Features!)

<img width="370" height="315" alt="image" src="https://github.com/user-attachments/assets/f8ba6560-a105-4116-a611-02cdcd3d4329" />

<img width="357" height="182" alt="image-1" src="https://github.com/user-attachments/assets/2d15bdba-74b4-477d-b220-f422634244ee" />


#### Describe alternatives you've considered
Andrei8l suggested migrating mining to be entirely construction, but I am not convinced the overhead to do that is in any way reasonable. This is much simpler and accomplishes essentially the same thing.

#### Testing
Needs some. Draft until then

#### Additional context
