### PR TITLE
Update planting to 'forward look' conditions for each growth stage

### DIFF
--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -1358,7 +1358,7 @@ static activity_reason_info can_do_activity_there( const activity_id &act, Chara
                 // If its a farm zone with no specified seed, and we've checked for tilling and harvesting.
                 // then it means no further work can be done here
             } else if( !seed.is_empty() &&
-                       warm_enough_to_plant( src_loc ) &&
+                       warm_enough_to_plant( src_loc, seed ) &&
                        here.has_flag_ter_or_furn( seed->seed->required_terrain_flag, src_loc ) ) {
                 if( here.has_items( src_loc ) ) {
                     return activity_reason_info::fail( do_activity_reason::BLOCKING_TILE );

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -131,6 +131,7 @@ static const itype_id itype_duffelbag( "duffelbag" );
 static const itype_id itype_fungal_seeds( "fungal_seeds" );
 static const itype_id itype_log( "log" );
 static const itype_id itype_marloss_seed( "marloss_seed" );
+static const itype_id itype_seed_buckwheat( "seed_buckwheat" );
 static const itype_id itype_stick_long( "stick_long" );
 
 static const mongroup_id GROUP_CAMP_HUNTING( "GROUP_CAMP_HUNTING" );
@@ -1344,9 +1345,10 @@ void basecamp::get_available_missions_by_dir( mission_data &mission_key, const p
                        "Intensity: Moderate\n"
                        "Time: 1 Min / Plot\n"
                        "Positions: 0/1\n" );
+            // FIXME/HACK: Always checks buckwheat seeds!
             mission_key.add_start( miss_id,
                                    name_display_of( miss_id ), entry,
-                                   plots > 0 && warm_enough_to_plant( omt_pos + dir ) );
+                                   plots > 0 && warm_enough_to_plant( omt_pos + dir, itype_seed_buckwheat ) );
         } else {
             entry = action_of( miss_id.id );
             bool avail = update_time_left( entry, npc_list );

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -2772,11 +2772,6 @@ void iexamine::plant_seed( Character &you, const tripoint_bub_ms &examp, const i
  */
 void iexamine::dirtmound( Character &you, const tripoint_bub_ms &examp )
 {
-
-    if( !warm_enough_to_plant( get_player_character().pos_bub() ) ) {
-        add_msg( m_info, _( "It is too cold to plant anything now." ) );
-        return;
-    }
     map &here = get_map();
     /* ambient_light_at() not working?
     if (here.ambient_light_at(examp) < LIGHT_AMBIENT_LOW) {
@@ -2802,7 +2797,12 @@ void iexamine::dirtmound( Character &you, const tripoint_bub_ms &examp )
         add_msg( _( "You saved your seeds for later." ) );
         return;
     }
-    const auto &seed_id = std::get<0>( seed_entries[seed_index] );
+    const itype_id &seed_id = std::get<0>( seed_entries[seed_index] );
+
+    if( !warm_enough_to_plant( you.pos_bub(), seed_id ) ) {
+        you.add_msg_if_player( m_info, _( "It is too cold to plant that now." ) );
+        return;
+    }
 
     if( !here.has_flag_ter_or_furn( seed_id->seed->required_terrain_flag, examp ) ) {
         add_msg( _( "This type of seed can not be planted in this location." ) );

--- a/src/mission_companion.cpp
+++ b/src/mission_companion.cpp
@@ -1546,10 +1546,6 @@ npc_ptr talk_function::temp_npc( const string_id<npc_template> &type )
 void talk_function::field_plant( npc &p, const std::string &place )
 {
     Character &player_character = get_player_character();
-    if( !warm_enough_to_plant( player_character.pos_bub() ) ) {
-        popup( _( "It is too cold to plant anything now." ) );
-        return;
-    }
     std::vector<item *> seed_inv = player_character.cache_get_items_with( "is_seed", &item::is_seed,
     []( const item & itm ) {
         return itm.typeId() != itype_marloss_seed && itm.typeId() != itype_fungal_seeds;
@@ -1578,7 +1574,11 @@ void talk_function::field_plant( npc &p, const std::string &place )
         return;
     }
 
-    const auto &seed_id = seed_types[seed_index];
+    const itype_id &seed_id = seed_types[seed_index];
+    if( !warm_enough_to_plant( player_character.pos_bub(), seed_id ) ) {
+        popup( _( "It is too cold to plant that now." ) );
+        return;
+    }
     if( item::count_by_charges( seed_id ) ) {
         free_seeds = player_character.charges_of( seed_id );
     } else {

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -122,6 +122,7 @@ static const itype_id itype_battery( "battery" );
 static const itype_id itype_generic_folded_vehicle( "generic_folded_vehicle" );
 static const itype_id itype_plut_cell( "plut_cell" );
 static const itype_id itype_plut_slurry_dense( "plut_slurry_dense" );
+static const itype_id itype_seed_buckwheat( "seed_buckwheat" );
 static const itype_id itype_wall_wiring( "wall_wiring" );
 static const itype_id itype_water( "water" );
 static const itype_id itype_water_clean( "water_clean" );
@@ -6071,7 +6072,8 @@ void vehicle::idle( map &here, bool on_map )
         engine_on = false;
     }
 
-    if( !warm_enough_to_plant( player_character.pos_bub( here ) ) ) {
+    // FIXME/HACK: Always checks buckwheat seeds!
+    if( !warm_enough_to_plant( player_character.pos_bub( here ), itype_seed_buckwheat ) ) {
         for( int i : planters ) {
             vehicle_part &vp = parts[ i ];
             if( vp.enabled ) {

--- a/src/vehicle_part.cpp
+++ b/src/vehicle_part.cpp
@@ -33,6 +33,7 @@ static const itype_id fuel_type_battery( "battery" );
 static const itype_id fuel_type_none( "null" );
 
 static const itype_id itype_battery( "battery" );
+static const itype_id itype_seed_buckwheat( "seed_buckwheat" );
 
 /*-----------------------------------------------------------------------------
  *                              VEHICLE_PART
@@ -726,9 +727,11 @@ bool vehicle::can_enable( map &here, const vehicle_part &pt, bool alert ) const
         return false;
     }
 
-    if( pt.info().has_flag( "PLANTER" ) && !warm_enough_to_plant( get_player_character().pos_bub() ) ) {
+    // FIXME/HACK: Always checks buckwheat seeds!
+    if( pt.info().has_flag( "PLANTER" ) &&
+        !warm_enough_to_plant( get_player_character().pos_bub(), itype_seed_buckwheat ) ) {
         if( alert ) {
-            add_msg( m_bad, _( "It is too cold to plant anything now." ) );
+            add_msg( m_bad, _( "It is too cold to plant most things now." ) );
         }
         return false;
     }

--- a/src/weather.h
+++ b/src/weather.h
@@ -166,13 +166,12 @@ std::string get_wind_desc( double );
 nc_color get_wind_color( double );
 
 /**
- * Is it warm enough to plant seeds?
+ * Is it warm enough to plant seeds? Will it be warm enough during the type's grow periods?
  *
- * The first overload is in map-square coords, the second for larger scale
- * queries.
+ * The first overload is simply a forwarding helper.
  */
-bool warm_enough_to_plant( const tripoint_bub_ms &pos );
-bool warm_enough_to_plant( const tripoint_abs_omt &pos );
+bool warm_enough_to_plant( const tripoint_bub_ms &pos, const itype_id &it );
+bool warm_enough_to_plant( const tripoint_abs_omt &pos, const itype_id &it );
 
 bool is_wind_blocker( const tripoint_bub_ms &location );
 


### PR DESCRIPTION
#### Summary
Balance "Update planting to 'forward look' conditions for each growth stage"

#### Purpose of change
* Closes #82702

Fixes the related exploit which has been around for many years.

#### Describe the solution
When planting, check the current area temperature (ignoring fires etc). 'Forward look' each time the plant would grow for each cycle, check what the temperature would be then.

If any of those cycles would be unsuitable, planting cannot occur.

#### Describe alternatives you've considered
Also check weather when updating growth stages themselves in map::grow_plant() and kill them if the weather's not warm enough then.

Could be reasonable, but then it depends on when the update is triggered. The player arriving back at their base/growing area in the middle of the night shouldn't trigger plant death just because it's cold at that time.

#### Testing
<img width="350" height="141" alt="image" src="https://github.com/user-attachments/assets/80e7d8d5-ec4f-4f78-a70e-8f9065d32d51" />


#### Additional context

Known issues:
-Currently this doesn't give any effective feedback outside of the existing feedback. "It's too cold to plant right now!" or similar, depending on the exact call site.

 -Currently always assuming we're using wheat seeds, except for zone planting where it properly sends the seed type. This is not a huge issue right now (all plants respond to temperature the exact same way) but absolutely needs to be resolved when individual plants handle winter differently.
--Currently this matters if planting any seed type *with a different growth duration*. Since it always checks wheat's duration, it could incorrectly look "too far ahead" or "not far enough", depending on whether the actual seed's growth is shorter or longer than wheat's.

-Can't overwinter crops that could do so IRL