### PR TITLE
Fix cody's other dialogue option for joining the coop

### DIFF
--- a/data/json/npcs/isolated_road/isolated_road_cody_dialogue.json
+++ b/data/json/npcs/isolated_road/isolated_road_cody_dialogue.json
@@ -300,6 +300,7 @@
         "effect": [
           { "u_sell_item": "FMCNote", "count": 100 },
           { "u_spawn_item": "id_artisan_member" },
+          { "u_set_fac_relation": "share public goods" },
           { "u_add_var": "dialogue_artisans_blacksmith_can_buy_coop", "value": "no" }
         ],
         "topic": "TALK_BLACKSMITH_BOUGHT_COOP"


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
* Fixes #82815

#### Describe the solution
Add the relationship change to the *other* topic that buys into the coop

#### Describe alternatives you've considered
Having these effects in two separate places is a fun way to get bugs, so rewriting the dialogue to fix that would be nice.

#### Testing
Bought coop membership from each of the dialogue options, confirmed each properly allowed access to the workshop

#### Additional context
<img width="314" height="72" alt="image" src="https://github.com/user-attachments/assets/8010dc59-8475-4ffd-ba57-eae98e180276" />

