### PR TITLE
[XE] Fix vampire recipe gotchas and Sky Island death loop.

### DIFF
--- a/data/mods/Sky_Island/mod_interactions/xedra_evolved/eocs_healing.json
+++ b/data/mods/Sky_Island/mod_interactions/xedra_evolved/eocs_healing.json
@@ -11,8 +11,23 @@
         ]
       },
       {
-        "if": { "and": [ { "u_has_trait": "VAMPIRE" }, { "math": [ "u_vitamin('human_blood_vitamin') <= -4800" ] } ] },
-        "then": { "math": [ "u_vitamin('human_blood_vitamin')", "=", "0" ] }
+        "if": {
+          "and": [
+            { "u_has_trait": "VAMPIRE" },
+            {
+              "math": [
+                "u_vitamin('human_blood_vitamin') <= 200 + (200 * u_has_trait('VAMPIRE2') ) + (200 * u_has_trait('VAMPIRE3') ) + (200 * u_has_trait('VAMPIRE4') ) + (200 * u_has_trait('BLOOD_DRINKER') )"
+              ]
+            }
+          ]
+        },
+        "then": {
+          "math": [
+            "u_vitamin('human_blood_vitamin')",
+            "=",
+            "200 + (200 * u_has_trait('VAMPIRE2') ) + (200 * u_has_trait('VAMPIRE3') ) + (200 * u_has_trait('VAMPIRE4') ) + (200 * u_has_trait('BLOOD_DRINKER') )"
+          ]
+        }
       },
       {
         "u_lose_effect": [

--- a/data/mods/Xedra_Evolved/recipes/vampire.json
+++ b/data/mods/Xedra_Evolved/recipes/vampire.json
@@ -38,7 +38,7 @@
     "result_eocs": [
       {
         "id": "EOC_XE_VAMPIRE_BLOOD_RESEARCH_BEGIN",
-        "condition": { "math": [ "u_vitamin('human_blood_vitamin') >= 500" ] },
+        "condition": { "math": [ "u_vitamin('human_blood_vitamin') >= 3000" ] },
         "effect": [
           { "math": [ "u_vitamin('human_blood_vitamin') -= 3000" ] },
           { "u_add_effect": "effect_vampire_studying_blood_gifts", "duration": "8 hours" },
@@ -273,7 +273,7 @@
     "result_eocs": [
       {
         "id": "EOC_XE_VAMPIRE_WEAKNESS_RESHUFFLE_BEGIN",
-        "condition": { "math": [ "u_vitamin('human_blood_vitamin') >= 500" ] },
+        "condition": { "math": [ "u_vitamin('human_blood_vitamin') >= 3000" ] },
         "effect": [
           { "math": [ "u_vitamin('human_blood_vitamin') -= 3000" ] },
           { "u_add_effect": "effect_vampire_reshuffling_weaknesses", "duration": "8 hours" },
@@ -415,7 +415,7 @@
     "result_eocs": [
       {
         "id": "EOC_XE_VAMPIRE_BLOOD_REFINEMENT_RESEARCH_BEGIN",
-        "condition": { "math": [ "u_vitamin('human_blood_vitamin') >= 500" ] },
+        "condition": { "math": [ "u_vitamin('human_blood_vitamin') >= 4500" ] },
         "effect": [
           { "math": [ "u_vitamin('human_blood_vitamin') -= 4500" ] },
           { "u_add_effect": "effect_vampire_studying_blood_gifts", "duration": "8 hours" },


### PR DESCRIPTION
#### Summary
Mods "[XE] Fix vampire recipe gotchas and Sky Island death loop."

#### Purpose of change

The EOC that gave some blood to the player if they died in sky island as a vampire still checked for a stolen blood amount below -4800, which is impossible to reach and locked the player in an eternal slumber death loop.

The three vampire improvement recipes share a similar issue: it takes at least 500 units to start it, which drains at least 3000 units. If a player starts it with 1000 stolen blood, they are instantly set to eternal slumber levels and assigned a long-lasting activity which will kill them.

I'm fixing both.

#### Describe the solution

Vampires get their stolen blood set to (200 * amount of vampire tiers) if they die and have less than that. 
Tier 2 and 3 increase blood drain, tier 4 makes containing stolen blood their only way to passively heal the massive wounds they now have and tier 5 players are likely to have the blood drain weakness. This is why the amount increases over the tiers.

Can't start the vampire improvement unless you have at least the amount the recipe drains when it starts.

#### Describe alternatives you've considered

Give vampires a fixed 3 days' worth of blood when respawning, like the lilin get. Vampires get less as they can stockpile blood on the island with a proper setup, unlike lilin who will find it hard to gain ruach without going on expeditions.

Set their stolen blood to zero if it's lower than that. This would result in them immediately suffering from the withering, forcing them to accumulate penalties or go on expeditions with their almost-shredded body without time to heal, so I decided against it.

#### Testing

Dying on the island give blood if you're below the threshold it checks. No blood is gained or lost otherwise.

Can't start research/reshuffle/refinement at 2000 blood, can start them at 5000. No blood is lost if the recipe fails to start.

#### Additional context

Dying results in the player being grieviously injured, making attempts to not need blood by dying constantly excessidingly impractical.
