### PR TITLE
Modernizing Stats Through Kills - RPG Leveling Initial Implementation

### DIFF
--- a/data/mods/RPGLeveling/eocs/rpgl_eocs.json
+++ b/data/mods/RPGLeveling/eocs/rpgl_eocs.json
@@ -1,0 +1,71 @@
+[
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_rpgl_open_menu",
+    "effect": [ { "open_dialogue": { "topic": "TALK_RPGL_MENU_MAIN" } } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_rpgl_game_start",
+    "eoc_type": "EVENT",
+    "required_event": "game_begin",
+    "condition": { "and": [ { "not": { "u_has_trait": "rpgl_container" } } ] },
+    "effect": [
+      {
+        "u_message": "RPG Leveling loaded!  You should now have a mutation called \"RPG Leveling\" that can be activated at any time to access the level-up and configuration menus.  If you do not, you can enable the mod manually by activating the \"EOC_rpgl_init\" EOC in debug."
+      },
+      { "run_eocs": "EOC_rpgl_init" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_rpgl_init",
+    "condition": { "and": [ { "not": { "u_has_trait": "rpgl_container" } } ] },
+    "effect": [
+      { "math": [ "u_rpgl_exp_to_level = 1000" ] },
+      { "math": [ "u_rpgl_exp_const = 1000" ] },
+      { "math": [ "u_rpgl_exp_current = 0" ] },
+      { "math": [ "u_rpgl_exp_spent = 0" ] },
+      { "math": [ "u_rpgl_level = 0" ] },
+      { "math": [ "u_rpgl_max_level = 20" ] },
+      { "math": [ "u_rpgl_points = 0" ] },
+      { "math": [ "u_rpgl_silent = 0" ] },
+      { "u_add_trait": "rpgl_container" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_rpgl_on_kill_update",
+    "eoc_type": "EVENT",
+    "required_event": "character_kills_monster",
+    "effect": [ { "math": [ "u_rpgl_exp_current = u_val('exp') - u_rpgl_exp_spent" ] }, { "run_eocs": "EOC_rpgl_level_up" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_rpgl_exp_to_level",
+    "effect": [ { "math": [ "u_rpgl_exp_to_level = u_rpgl_exp_const * (u_rpgl_level + 1)" ] } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_rpgl_level_up",
+    "condition": {
+      "and": [
+        { "math": [ "u_rpgl_exp_current >= u_rpgl_exp_to_level" ] },
+        { "or": [ { "math": [ "u_rpgl_level < u_rpgl_max_level" ] }, { "math": [ "u_rpgl_max_level < 0" ] } ] }
+      ]
+    },
+    "effect": [
+      { "math": [ "u_rpgl_points++" ] },
+      { "math": [ "u_rpgl_level++" ] },
+      { "math": [ "u_rpgl_exp_spent += u_rpgl_exp_to_level" ] },
+      { "math": [ "u_rpgl_exp_current -= u_rpgl_exp_to_level" ] },
+      { "run_eocs": [ "EOC_rpgl_exp_to_level", "EOC_rpgl_level_up_notification" ] }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_rpgl_level_up_notification",
+    "condition": { "math": [ "u_rpgl_silent != 1" ] },
+    "effect": [ { "open_dialogue": { "topic": "TALK_RPGL_MENU_MAIN" } } ]
+  }
+]

--- a/data/mods/RPGLeveling/menus/rpgl_menus.json
+++ b/data/mods/RPGLeveling/menus/rpgl_menus.json
@@ -86,7 +86,7 @@
         "text": "Disable",
         "effect": { "math": [ "u_rpgl_max_level = -1" ] },
         "condition": { "math": [ "u_rpgl_max_level >= 0" ] },
-        "failure_explanation": "Max level aready disabled",
+        "failure_explanation": "Max level already disabled",
         "failure_topic": "TALK_RPGL_MENU_MAX_LEVEL",
         "topic": "TALK_RPGL_MENU_MAX_LEVEL"
       },

--- a/data/mods/RPGLeveling/menus/rpgl_menus.json
+++ b/data/mods/RPGLeveling/menus/rpgl_menus.json
@@ -1,0 +1,128 @@
+[
+  {
+    "type": "talk_topic",
+    "id": "TALK_RPGL_MENU_MAIN",
+    "dynamic_line": "Level: <u_val:rpgl_level> (Max: <u_val:rpgl_max_level>)\nPoints: <u_val:rpgl_points>\nEXP: <u_val:rpgl_exp_current>.\nEXP for next level: <u_val:rpgl_exp_to_level>",
+    "responses": [
+      {
+        "condition": { "and": [ { "math": [ "u_rpgl_points > 0" ] }, { "math": [ "u_val('strength_base') < 20" ] } ] },
+        "text": "Gain Strength",
+        "failure_explanation": "Requirements: at least 1 point, base stat < 20",
+        "failure_topic": "TALK_RPGL_MENU_FAIL",
+        "effect": [ { "math": [ "u_val('strength_base')++" ] }, { "math": [ "u_rpgl_points--" ] } ],
+        "topic": "TALK_RPGL_MENU_MAIN"
+      },
+      {
+        "condition": { "and": [ { "math": [ "u_rpgl_points > 0" ] }, { "math": [ "u_val('dexterity_base') < 20" ] } ] },
+        "text": "Gain Dexterity",
+        "failure_explanation": "Requirements: at least 1 point, base stat < 20",
+        "failure_topic": "TALK_RPGL_MENU_FAIL",
+        "effect": [ { "math": [ "u_val('dexterity_base')++" ] }, { "math": [ "u_rpgl_points--" ] } ],
+        "topic": "TALK_RPGL_MENU_MAIN"
+      },
+      {
+        "condition": { "and": [ { "math": [ "u_rpgl_points > 0" ] }, { "math": [ "u_val('intelligence_base') < 20" ] } ] },
+        "text": "Gain Intelligence",
+        "failure_explanation": "Requirements: at least 1 point, base stat < 20",
+        "failure_topic": "TALK_RPGL_MENU_FAIL",
+        "effect": [ { "math": [ "u_val('intelligence_base')++" ] }, { "math": [ "u_rpgl_points--" ] } ],
+        "topic": "TALK_RPGL_MENU_MAIN"
+      },
+      {
+        "condition": { "and": [ { "math": [ "u_rpgl_points > 0" ] }, { "math": [ "u_val('perception_base') < 20" ] } ] },
+        "text": "Gain Perception",
+        "failure_explanation": "Requirements: at least 1 point, base stat < 20",
+        "failure_topic": "TALK_RPGL_MENU_FAIL",
+        "effect": [ { "math": [ "u_val('perception_base')++" ] }, { "math": [ "u_rpgl_points--" ] } ],
+        "topic": "TALK_RPGL_MENU_MAIN"
+      },
+      { "text": "Settings", "topic": "TALK_RPGL_MENU_CONFIG" },
+      { "text": "Quit", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_RPGL_MENU_CONFIG",
+    "dynamic_line": "Choose settings to modify",
+    "responses": [
+      { "text": "Notifications", "topic": "TALK_RPGL_MENU_LEVEL_NOTIFICATIONS" },
+      { "text": "Max Level", "topic": "TALK_RPGL_MENU_MAX_LEVEL" },
+      { "text": "Exp Formula", "topic": "TALK_RPGL_MENU_EXP_FORMULA" },
+      { "text": "Back", "topic": "TALK_RPGL_MENU_MAIN" },
+      { "text": "Quit", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_RPGL_MENU_LEVEL_NOTIFICATIONS",
+    "dynamic_line": "Should the menu pop up on level up?",
+    "responses": [
+      {
+        "text": "Yes",
+        "effect": { "math": [ "u_rpgl_silent = 0" ] },
+        "condition": { "math": [ "u_rpgl_silent != 0" ] },
+        "failure_explanation": "Pop-up already enabled",
+        "failure_topic": "TALK_RPGL_MENU_CONFIG",
+        "topic": "TALK_RPGL_MENU_CONFIG"
+      },
+      {
+        "text": "No",
+        "effect": { "math": [ "u_rpgl_silent = 1" ] },
+        "condition": { "math": [ "u_rpgl_silent != 1" ] },
+        "failure_explanation": "Pop-up already disabled",
+        "failure_topic": "TALK_RPGL_MENU_CONFIG",
+        "topic": "TALK_RPGL_MENU_CONFIG"
+      },
+      { "text": "Back", "topic": "TALK_RPGL_MENU_CONFIG" },
+      { "text": "Quit", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_RPGL_MENU_MAX_LEVEL",
+    "dynamic_line": "Set max level for RPG leveling (-1 = disabled). (Default: 20; Current: <u_val:rpgl_max_level>)",
+    "responses": [
+      {
+        "text": "Disable",
+        "effect": { "math": [ "u_rpgl_max_level = -1" ] },
+        "condition": { "math": [ "u_rpgl_max_level >= 0" ] },
+        "failure_explanation": "Max level aready disabled",
+        "failure_topic": "TALK_RPGL_MENU_MAX_LEVEL",
+        "topic": "TALK_RPGL_MENU_MAX_LEVEL"
+      },
+      {
+        "text": "Enter custom value",
+        "effect": { "math": [ "u_rpgl_max_level = max(num_input('Enter max level', 20), 0)" ] },
+        "topic": "TALK_RPGL_MENU_MAX_LEVEL"
+      },
+      { "text": "Back", "topic": "TALK_RPGL_MENU_CONFIG" },
+      { "text": "Quit", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_RPGL_MENU_EXP_FORMULA",
+    "dynamic_line": "Edit exp formula for leveling. Format: (constant) * (level + 1).\nDefault: 1000\nCurrent Formula: (<u_val:rpgl_exp_const>) * (<u_val:rpgl_level> + 1)\nEXP: <u_val:rpgl_exp_current>.\nEXP for next level: <u_val:rpgl_exp_to_level>\nNote: any changes to the formula will not affect levels already earned, and future levels are only determined on exp gain.",
+    "responses": [
+      {
+        "text": "Enter custom value",
+        "effect": [
+          { "math": [ "u_rpgl_exp_const = max(num_input('Enter constant multiplier for exp to next level', 1000), 0)" ] },
+          { "run_eocs": "EOC_rpgl_exp_to_level" }
+        ],
+        "condition": { "math": [ "u_rpgl_exp_const >= 0" ] },
+        "failure_explanation": "Cannot set a constant multiplier below 0",
+        "failure_topic": "TALK_RPGL_MENU_EXP_FORMULA",
+        "topic": "TALK_RPGL_MENU_EXP_FORMULA"
+      },
+      { "text": "Back", "topic": "TALK_RPGL_MENU_CONFIG" },
+      { "text": "Quit", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_RPGL_MENU_FAIL",
+    "dynamic_line": "You don't have a level point, or don't meet the requirements for this upgrade.",
+    "responses": [ { "text": "Back", "topic": "TALK_RPGL_MENU_MAIN" }, { "text": "Quit", "topic": "TALK_DONE" } ]
+  }
+]

--- a/data/mods/RPGLeveling/menus/rpgl_menus.json
+++ b/data/mods/RPGLeveling/menus/rpgl_menus.json
@@ -80,7 +80,7 @@
   {
     "type": "talk_topic",
     "id": "TALK_RPGL_MENU_MAX_LEVEL",
-    "dynamic_line": "Set max level for RPG leveling (-1 = disabled). (Default: 20; Current: <u_val:rpgl_max_level>)",
+    "dynamic_line": "Set max level for RPG leveling (-1 = disabled).  (Default: 20; Current: <u_val:rpgl_max_level>)",
     "responses": [
       {
         "text": "Disable",
@@ -102,7 +102,7 @@
   {
     "type": "talk_topic",
     "id": "TALK_RPGL_MENU_EXP_FORMULA",
-    "dynamic_line": "Edit exp formula for leveling. Format: (constant) * (level + 1).\nDefault: 1000\nCurrent Formula: (<u_val:rpgl_exp_const>) * (<u_val:rpgl_level> + 1)\nEXP: <u_val:rpgl_exp_current>.\nEXP for next level: <u_val:rpgl_exp_to_level>\nNote: any changes to the formula will not affect levels already earned, and future levels are only determined on exp gain.",
+    "dynamic_line": "Edit exp formula for leveling.  Format: (constant) * (level + 1)\nDefault: 1000\nCurrent Formula: (<u_val:rpgl_exp_const>) * (<u_val:rpgl_level> + 1)\nEXP: <u_val:rpgl_exp_current>.\nEXP for next level: <u_val:rpgl_exp_to_level>\nNote: any changes to the formula will not affect levels already earned, and future levels are only determined on exp gain.",
     "responses": [
       {
         "text": "Enter custom value",

--- a/data/mods/RPGLeveling/modinfo.json
+++ b/data/mods/RPGLeveling/modinfo.json
@@ -1,0 +1,12 @@
+[
+  {
+    "type": "MOD_INFO",
+    "id": "rpg_leveling",
+    "name": "RPG Leveling (formerly Stats Through Kills)",
+    "authors": [ "KamikazieBoater" ],
+    "maintainers": [ "KamikazieBoater" ],
+    "description": "Modernization of the Stats Through Kills mod, taking design inspiration from Bombastic Perks, while avoiding using mutations to modify attributes, instead using math functions to modify base stats. Perhaps expansion could add enchantment data to the primary mutation, allowing for more than simple stat changes on level up without bloating traits.",
+    "category": "misc_additions",
+    "dependencies": [ "dda" ]
+  }
+]

--- a/data/mods/RPGLeveling/modinfo.json
+++ b/data/mods/RPGLeveling/modinfo.json
@@ -5,7 +5,7 @@
     "name": "RPG Leveling (formerly Stats Through Kills)",
     "authors": [ "KamikazieBoater" ],
     "maintainers": [ "KamikazieBoater" ],
-    "description": "Modernization of the Stats Through Kills mod, taking design inspiration from Bombastic Perks, while avoiding using mutations to modify attributes, instead using math functions to modify base stats. Perhaps expansion could add enchantment data to the primary mutation, allowing for more than simple stat changes on level up without bloating traits.",
+    "description": "Modernization of the Stats Through Kills mod, taking design inspiration from Bombastic Perks.",
     "category": "misc_additions",
     "dependencies": [ "dda" ]
   }

--- a/data/mods/RPGLeveling/traits/rpgl_traits.json
+++ b/data/mods/RPGLeveling/traits/rpgl_traits.json
@@ -6,7 +6,7 @@
     "points": 0,
     "purifiable": false,
     "valid": false,
-    "description": "Container trait for RPG leveling mechanics. Activate to access the main RPG leveling menu.",
+    "description": "Container trait for RPG leveling mechanics.  Activate to access the main RPG leveling menu.",
     "active": true,
     "activated_eocs": [ "EOC_rpgl_open_menu" ]
   }

--- a/data/mods/RPGLeveling/traits/rpgl_traits.json
+++ b/data/mods/RPGLeveling/traits/rpgl_traits.json
@@ -1,0 +1,13 @@
+[
+  {
+    "type": "mutation",
+    "id": "rpgl_container",
+    "name": { "str": "RPG Leveling" },
+    "points": 0,
+    "purifiable": false,
+    "valid": false,
+    "description": "Container trait for RPG leveling mechanics. Activate to access the main RPG leveling menu.",
+    "active": true,
+    "activated_eocs": [ "EOC_rpgl_open_menu" ]
+  }
+]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "Modernize/JSONize Stats Through Kills in a new mod: RPG Leveling"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

The current version of Stats Through Kills, last updated 5 years ago, is showing its age and is no longer consistent with the updated design principles of modern CDDA. Using mods like Bombastic Perks and Martial Mastery as a baseline, which implement their own iterations of experience and leveling mechanics, I've put together the basic components of a new leveling mod, RPG Leveling, whose initial implementation will be functionally equivalent to Stats Through Kills, so named in order to allow for eventual expansion beyond simple stat increases.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Implement the basic functionality of Stats Through Kills using the design paradigm of Bombastic Perks. An EOC on game start gives the character a trait/mutation, "RPG Leveling", that sets up the essential variables and gives the player access to the level-up and configuration menus via activation of the mutation. Experience updates on monster kill, and a point/level is gained once current experience >= exp to next level.

Experience per level and max level are configurable values, and points can currently be spent to upgrade a character's base stats to a max of 20 for each stat. By default, the max level is 20 (same as Stats Through Kills), and the experience required for a level is based on the D&D 3/3.5 leveling formula below:

EXP to level N = 1000 * N + (EXP to level N-1)

The constant (1000) is also configurable in the menus. Experience tracks how much has been spent (added on level-up) and how much has been gained since achieving the previous level, in the same way as Bombastic Perks.

Additionally, the level-up menu can be configured to pop-up automatically on gaining a level, or silenced so as to only be accessed via activation of the mutation (again, same as Bombastic Perks).

Stat increases are currently implemented via direct increase of the associated u_val (u_val('<STAT>_base')++) in order to best mirror the functionality of Stats Through Kills.


<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

While the current implementation is designed to closely resemble a hybrid of Stats Through Kills functionality and Bombastic Perks design, there are a number of possible alternative implementations of this functionality. The decisions made for this initial implementation were aimed at minimizing deviation from the existing mods while providing a stable platform to support future maintenance and expansion. Any feedback on alternate design direction is appreciated.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

- Started several games, ensuring components and variables initialized properly.
- Trait is added correctly at game start, menus accessible by activating the RPG Leveling mutation.
- Modified configuration options, ensuring values updated correctly and observed expected behaviours.
- Killed various monsters to validate exp is gained, level-ups occur appropriately, and points are gained/spent as expected.
- Validated constraints are properly respected (max level, base stats capped at 20).

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

As with any new mod, it's easier to make changes to the fundamental structure and implementation now when we have a clean slate rather than later after however many updates and expansions, so feedback is welcome.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
