### PR TITLE
[Xedra Evolved] Fix Inventor's Welder having migration pocket

### DIFF
--- a/data/mods/Xedra_Evolved/items/inventor/misc.json
+++ b/data/mods/Xedra_Evolved/items/inventor/misc.json
@@ -62,12 +62,35 @@
     "volume": "2500 ml",
     "material": [ "lc_steel", "plastic" ],
     "extend": { "flags": [ "INVENTOR_CRAFTED" ] },
-    "pocket_data": [
+    "use_action": [
       {
-        "pocket_type": "MAGAZINE_WELL",
-        "rigid": true,
-        "flag_restriction": [ "BATTERY_MEDIUM", "BATTERY_HEAVY" ],
-        "default_magazine": "medium_battery_cell"
+        "type": "repair_item",
+        "item_action_type": "repair_metal",
+        "materials": [
+          "iron",
+          "steel",
+          "aluminum",
+          "copper",
+          "bronze",
+          "fancy_bronze",
+          "silver",
+          "gold",
+          "budget_steel",
+          "lc_steel",
+          "mc_steel",
+          "hc_steel",
+          "ch_steel",
+          "lc_steel_chain",
+          "mc_steel_chain",
+          "hc_steel_chain",
+          "ch_steel_chain",
+          "platinum",
+          "superalloy"
+        ],
+        "skill": "fabrication",
+        "tool_quality": 10,
+        "cost_scaling": 0.1,
+        "move_cost": 500
       },
       {
         "type": "link_up",
@@ -75,6 +98,14 @@
         "ammo_scale": 0,
         "cable_length": 10,
         "charge_rate": "100 W"
+      }
+    ],
+    "pocket_data": [
+      {
+        "pocket_type": "MAGAZINE_WELL",
+        "rigid": true,
+        "flag_restriction": [ "BATTERY_MEDIUM", "BATTERY_HEAVY" ],
+        "default_magazine": "medium_battery_cell"
       }
     ]
   },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Fix Inventor's Welder having the migration pocket"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

You're able to insert stuff into the Inventor's Welder due to migration pocket, and doing so makes it not work

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

The problem is that the JSON syntax puts "link_up" inside of the pocket_data field, causing it to transform into a TARDIS for reasons I presume make sense to people more aware of migration logic. I just adjusted it so it works more like other welders, which unfortunately means it needs a bunch of additional lines to specify materials and what not since copy_from doesn't grant these things. Thank you to Holli for pointing out where the issue was.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Adjusting the code in C++ that puts migration pockets on stuff based on the link_up logic. I decided not to touch it because it scares me and I'm not fully versed in migration logic. Last time I touched that stuff, I broke everything, and that was just with JSON.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Spawned an Inventor's Welder before fixing. It had the "insert" option in the item menu, and I was able to squeeze just about anything into it as seen here:

<img width="587" height="467" alt="image" src="https://github.com/user-attachments/assets/12b0db72-14ce-4e51-806c-a50690fb1eb2" />

<img width="384" height="84" alt="image" src="https://github.com/user-attachments/assets/d44bbb37-2215-485a-bdda-65cb14b7e090" />

After applying my fix, the "insert" option is gone and I can only put batteries in it. You can still plug it into stuff if you feel like it, and it has a repair option.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

The syntax for this is a bit messy and I feel like there is probably some better way. I find it a sort of yucky having to specify every single material that can be used. I could be wrong, since I haven't looked into it much, but maybe there could be an array for materials to make it easier to implement tools later on?

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
