### PR TITLE
[XE/Sky Island] Vampire progression fixes.

### DIFF
--- a/data/mods/Sky_Island/mod_interactions/xedra_evolved/eocs.json
+++ b/data/mods/Sky_Island/mod_interactions/xedra_evolved/eocs.json
@@ -91,6 +91,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_SKY_ISLAND_VAMPIRE_TIER_4",
+    "condition": { "u_has_trait": "VAMPIRE3" },
     "effect": [
       { "u_remove_item_with": "upgradekey_vampire4" },
       { "u_forget_recipe": "upgradekey_vampire4" },
@@ -98,6 +99,13 @@
       { "run_eocs": "EOC_REMOVE_DREAM_MAGIC" },
       { "u_add_effect": "vampire_virus_ascendant", "intensity": 1, "duration": "PERMANENT" },
       { "u_message": "Your eyes redden even more as you pass a point of no return.", "type": "mixed" }
+    ],
+    "false_effect": [
+      {
+        "if": { "u_has_effect": "vampire_virus" },
+        "then": { "u_message": "You lack the vampiric potency to use this.", "type": "bad" },
+        "else": { "u_message": "You cannot empower your vampirism without being a vampire.", "type": "bad" }
+      }
     ]
   },
   {

--- a/data/mods/Sky_Island/mod_interactions/xedra_evolved/eocs.json
+++ b/data/mods/Sky_Island/mod_interactions/xedra_evolved/eocs.json
@@ -97,6 +97,7 @@
       { "u_forget_recipe": "upgradekey_vampire4" },
       { "u_add_trait": "VAMPIRE4" },
       { "run_eocs": "EOC_REMOVE_DREAM_MAGIC" },
+      { "run_eocs": [ "EOC_VAMPIRE_ADD_ONE_WEAKNESS" ] },
       { "u_add_effect": "vampire_virus_ascendant", "intensity": 1, "duration": "PERMANENT" },
       { "u_message": "Your eyes redden even more as you pass a point of no return.", "type": "mixed" }
     ],
@@ -137,6 +138,8 @@
       { "u_remove_item_with": "upgradekey_vampire5" },
       { "u_forget_recipe": "upgradekey_vampire5" },
       { "u_add_trait": "BLOOD_DRINKER" },
+      { "run_eocs": [ "EOC_VAMPIRE_ADD_ONE_WEAKNESS" ] },
+      { "run_eocs": [ "EOC_VAMPIRE_ADD_ONE_WEAKNESS" ] },
       { "u_add_effect": "vampire_virus_post_mortal", "intensity": 1, "duration": "PERMANENT" },
       {
         "u_message": "Your thirst for blood grows, and so does your power, as you reach the final state of vampirism.",


### PR DESCRIPTION
#### Summary
Mods "[XE/Sky Island] Vampire progression fixes."

#### Purpose of change

Players get the Sky Island recipe to get to Tier 4 when they reach Tier 3.
Turns out they don't need Tier 3 to use it, which is a problem.

And turns out that using the items won't grant more weaknesses, so I'm also fixing that.

#### Describe the solution

Add a condition preventing the item's use unless the player has Tier 3.

Add weakness gain to the EOC granting the last two tiers.

#### Describe alternatives you've considered

See players that only have the last two tiers wander around.

#### Testing

Tried to get Tier 4 without Tier 3. Couldn't.
Tried to get Tier 4 with Tier 3. Could.
Gained weaknesses when Tier 4 was gained.

#### Additional context
