### PR TITLE
[MoM] Add Far Hand and Fountain of Flames as psychic knacks

### DIFF
--- a/data/mods/MindOverMatter/effectoncondition/eoc_awakening.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_awakening.json
@@ -1222,6 +1222,14 @@
     "condition": { "u_has_trait": "PSYCHIC_KNACK" },
     "effect": [
       {
+        "if": { "math": [ "u_spell_level('pyrokinetic_eruption_knack') > 0" ] },
+        "then": [
+          { "math": [ "_temp_var = u_spell_level('pyrokinetic_eruption_knack')" ] },
+          { "math": [ "u_spell_level('pyrokinetic_eruption') = _temp_var" ] },
+          { "math": [ "u_spell_level('pyrokinetic_eruption_knack') = -1" ] }
+        ]
+      },
+      {
         "if": { "math": [ "u_spell_level('pyrokinetic_flash_knack') > 0" ] },
         "then": [
           { "math": [ "_temp_var = u_spell_level('pyrokinetic_flash_knack')" ] },
@@ -1256,6 +1264,14 @@
     "id": "EOC_TELEKINETIC_AWAKENING_KNACK_HANDLING",
     "condition": { "u_has_trait": "PSYCHIC_KNACK" },
     "effect": [
+      {
+        "if": { "math": [ "u_spell_level('telekinetic_pull_knack') > 0" ] },
+        "then": [
+          { "math": [ "_temp_var = u_spell_level('telekinetic_pull_knack')" ] },
+          { "math": [ "u_spell_level('telekinetic_pull') = _temp_var" ] },
+          { "math": [ "u_spell_level('telekinetic_pull_knack') = -1" ] }
+        ]
+      },
       {
         "if": { "math": [ "u_spell_level('telekinetic_push_knack') > 0" ] },
         "then": [

--- a/data/mods/MindOverMatter/hobbies.json
+++ b/data/mods/MindOverMatter/hobbies.json
@@ -682,9 +682,19 @@
   {
     "type": "profession",
     "subtype": "hobby",
+    "id": "knack_pyrokinetic_eruption",
+    "name": "Psychic Knack (Fountain of Flames)",
+    "description": "Before the Cataclysm you had an easy time starting a fire no matter the conditions, and that ability has been greatly heightened after the world ended.  While you are not a fully awakened psion, you have a single trick you can use.  Hopefully it helps you survive.",
+    "points": 4,
+    "traits": [ "PSYCHIC_KNACK" ],
+    "spells": [ { "id": "pyrokinetic_eruption_knack", "level": 6 } ]
+  },
+  {
+    "type": "profession",
+    "subtype": "hobby",
     "id": "knack_pyrokinetic_call_flames",
     "name": "Psychic Knack (Banked Flames)",
-    "description": "Before the Cataclysm you had an easy time starting a fire no matter the conditions, and that ability has been greatly heightened after the world ended.  While you are not a fully awakened psion, you have a single trick you can use.  Hopefully it helps you survive.",
+    "description": "Before the Cataclysm your hands never really got cold even in the harshest winter, and that ability has been greatly heightened after the world ended.  While you are not a fully awakened psion, you have a single trick you can use.  Hopefully it helps you survive.",
     "points": 3,
     "traits": [ "PSYCHIC_KNACK" ],
     "spells": [ { "id": "pyrokinetic_call_flames_knack", "level": 6 } ]
@@ -698,6 +708,16 @@
     "points": 3,
     "traits": [ "PSYCHIC_KNACK" ],
     "spells": [ { "id": "pyrokinetic_cloak_knack", "level": 6 } ]
+  },
+  {
+    "type": "profession",
+    "subtype": "hobby",
+    "id": "knack_telekinetic_pull",
+    "name": "Psychic Knack (Far Hand)",
+    "description": "Before the Cataclysm you could basically always make a coin come up the way you needed to when it counted, and sometimes got lucky with autolocking doors not quite closing or things you dropped falling in just the perfect way to easily retrieve them, and that ability has been greatly heightened after the world ended.  While you are not a fully awakened psion, you have a single trick you can use.  Hopefully it helps you survive.",
+    "points": 3,
+    "traits": [ "PSYCHIC_KNACK" ],
+    "spells": [ { "id": "telekinetic_pull_knack", "level": 6 } ]
   },
   {
     "type": "profession",

--- a/data/mods/MindOverMatter/powers/psychic_knacks.json
+++ b/data/mods/MindOverMatter/powers/psychic_knacks.json
@@ -133,6 +133,13 @@
     "difficulty": { "math": [ "ceil(max( (u_spell_difficulty('pyrokinetic_blast') / 2), 1) )" ] }
   },
   {
+    "id": "telekinetic_pull_knack",
+    "copy-from": "telekinetic_pull",
+    "type": "SPELL",
+    "spell_class": "PSYCHIC_KNACK",
+    "difficulty": { "math": [ "ceil(max( (u_spell_difficulty('telekinetic_pull') / 2), 1) )" ] }
+  },
+  {
     "id": "telekinetic_push_knack",
     "copy-from": "telekinetic_push",
     "type": "SPELL",

--- a/data/mods/MindOverMatter/powers/telekinesis.json
+++ b/data/mods/MindOverMatter/powers/telekinesis.json
@@ -41,32 +41,32 @@
     "shape": "blast",
     "min_damage": {
       "math": [
-        "max( 50 - ( ( u_spell_level('telekinetic_pull') * 3 ) * ( scaling_factor( u_val('intelligence') ) ) * u_nether_attunement_power_scaling ), 0 )"
+        "max( 50 - ( ( (u_spell_level('telekinetic_pull') + u_spell_level('telekinetic_pull_knack') ) * 3 ) * ( scaling_factor( u_val('intelligence') ) ) * u_nether_attunement_power_scaling ), 0 )"
       ]
     },
     "max_damage": {
       "math": [
-        "max( 100 - ( ( u_spell_level('telekinetic_pull') * 4 ) * ( scaling_factor( u_val('intelligence') ) ) * u_nether_attunement_power_scaling ), 0 )"
+        "max( 100 - ( ( (u_spell_level('telekinetic_pull') + u_spell_level('telekinetic_pull_knack') ) * 4 ) * ( scaling_factor( u_val('intelligence') ) ) * u_nether_attunement_power_scaling ), 0 )"
       ]
     },
     "min_aoe": {
       "math": [
-        "( u_spell_level('telekinetic_pull') * 0.2 ) * ( scaling_factor( u_val('intelligence') ) ) * u_nether_attunement_power_scaling"
+        "( (u_spell_level('telekinetic_pull') + u_spell_level('telekinetic_pull_knack') ) * 0.2 ) * ( scaling_factor( u_val('intelligence') ) ) * u_nether_attunement_power_scaling"
       ]
     },
     "max_aoe": {
       "math": [
-        "( u_spell_level('telekinetic_pull') * 0.2 ) * ( scaling_factor( u_val('intelligence') ) ) * u_nether_attunement_power_scaling"
+        "( (u_spell_level('telekinetic_pull') + u_spell_level('telekinetic_pull_knack') ) * 0.2 ) * ( scaling_factor( u_val('intelligence') ) ) * u_nether_attunement_power_scaling"
       ]
     },
     "min_range": {
       "math": [
-        "min( ( ( ( u_spell_level('telekinetic_pull') * 0.9 ) + 2 ) * ( scaling_factor( u_val('intelligence') ) ) * u_nether_attunement_power_scaling ), 40 )"
+        "min( ( ( ( (u_spell_level('telekinetic_pull') + u_spell_level('telekinetic_pull_knack') ) * 0.9 ) + 2 ) * ( scaling_factor( u_val('intelligence') ) ) * u_nether_attunement_power_scaling ), 40 )"
       ]
     },
     "max_range": {
       "math": [
-        "min( ( ( ( u_spell_level('telekinetic_pull') * 0.9 ) + 2 ) * ( scaling_factor( u_val('intelligence') ) ) * u_nether_attunement_power_scaling ), 40 )"
+        "min( ( ( ( (u_spell_level('telekinetic_pull') + u_spell_level('telekinetic_pull_knack') ) * 0.9 ) + 2 ) * ( scaling_factor( u_val('intelligence') ) ) * u_nether_attunement_power_scaling ), 40 )"
       ]
     }
   },
@@ -86,22 +86,22 @@
     "shape": "blast",
     "min_damage": {
       "math": [
-        "min( (( (u_spell_level('telekinetic_pull') * 0.4) + 1) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling), 40)"
+        "min( ( ( ( (u_spell_level('telekinetic_pull') + u_spell_level('telekinetic_pull_knack') ) * 0.4) + 1) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling), 40)"
       ]
     },
     "max_damage": {
       "math": [
-        "min( (( (u_spell_level('telekinetic_pull') * 0.9) + 4) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling), 40)"
+        "min( ( ( ( (u_spell_level('telekinetic_pull') + u_spell_level('telekinetic_pull_knack') ) * 0.9) + 4) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling), 40)"
       ]
     },
     "min_range": {
       "math": [
-        "min( (( (u_spell_level('telekinetic_pull') * 0.9) + 2) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling ), 40)"
+        "min( ( ( ( (u_spell_level('telekinetic_pull') + u_spell_level('telekinetic_pull_knack') ) * 0.9) + 2) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling ), 40)"
       ]
     },
     "max_range": {
       "math": [
-        "min( (( (u_spell_level('telekinetic_pull') * 0.9) + 2) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling), 40)"
+        "min( ( ( ( (u_spell_level('telekinetic_pull') + u_spell_level('telekinetic_pull_knack') ) * 0.9) + 2) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling), 40)"
       ]
     }
   },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[MoM] Add Far Hand and Fountain of Flames as psychic knacks"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Was waiting for Far Hand to have the pickup menu functionality before I made it a knack, and now it does, so here it is.

Also making Fountain of Flames a general knack since the firestarter is a classic popular fiction archetype. The other pyrokinetic combat powers will be awakened psion only (or Heart of Fire Scenario)
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add the telekinetic power Far Hand and the pyrokinetic power Fountain of Flames as knacks.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Loaded game, took knacks, checked that they worked. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

I wonder how many people actually use the knacks?
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
