### PR TITLE
Athletics helps you lift (by worm girl)

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -965,11 +965,11 @@
     "name": { "str": "Strong Back" },
     "points": 2,
     "vitamin_cost": 160,
-    "description": "You are capable of carrying far more than someone with similar strength could.  Your maximum weight carried is increased by 35%.",
+    "description": "You are capable of carrying far more than someone with similar strength could.  Your maximum weight carried is increased by 15%.",
     "starting_trait": true,
     "valid": false,
     "cancels": [ "BADBACK" ],
-    "enchantments": [ { "values": [ { "value": "CARRY_WEIGHT", "multiply": 0.35 } ] } ]
+    "enchantments": [ { "values": [ { "value": "CARRY_WEIGHT", "multiply": 0.15 } ] } ]
   },
   {
     "type": "mutation",
@@ -1633,11 +1633,11 @@
     "name": { "str": "Bad Back" },
     "points": -3,
     "vitamin_cost": 160,
-    "description": "You simply cannot carry as much as people with a similar strength could.  Your maximum weight carried is reduced by 35%.",
+    "description": "You simply cannot carry as much as people with a similar strength could.  Your maximum weight carried is reduced by 15%.",
     "starting_trait": true,
     "category": [ "BIRD", "ELFA" ],
     "cancels": [ "STRONGBACK" ],
-    "enchantments": [ { "values": [ { "value": "CARRY_WEIGHT", "multiply": -0.35 } ] } ]
+    "enchantments": [ { "values": [ { "value": "CARRY_WEIGHT", "multiply": -0.15 } ] } ]
   },
   {
     "type": "mutation",
@@ -7211,7 +7211,7 @@
         "values": [
           { "value": "MOVE_COST", "multiply": -0.2 },
           { "value": "ATTACK_SPEED", "multiply": -0.2 },
-          { "value": "CARRY_WEIGHT", "multiply": -0.4 }
+          { "value": "CARRY_WEIGHT", "multiply": -0.2 }
         ]
       }
     ]

--- a/data/json/skills.json
+++ b/data/json/skills.json
@@ -160,7 +160,7 @@
     "type": "skill",
     "id": "swimming",
     "name": { "str": "athletics" },
-    "description": "Your athletic ability, including swimming endurance and ability to swim with weight.  Athletic skill also improves your overall cardio fitness and stamina.",
+    "description": "Your athletic ability, including swimming, climbing, rowing, balancing, cycling, and how much you can carry. Athletic skill also improves your overall cardio fitness and stamina.",
     "display_category": "display_interaction",
     "sort_rank": 21000,
     "level_descriptions_theory": [

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -3392,6 +3392,8 @@ units::mass Character::weight_capacity() const
     // transiently reducing carry weight is unlikely to have any play impact besides being very annoying.
     /** @EFFECT_STR increases carrying capacity */
     ret += ( get_str_base() + get_str_bonus() ) * 4_kilogram;
+    /** Athletics skill increases carrying capacity */
+    ret *= 1.0f + 0.025f * get_skill_level( skill_swimming );
 
     ret = enchantment_cache->modify_value( enchant_vals::mod::CARRY_WEIGHT, ret );
 


### PR DESCRIPTION
https://github.com/Cataclysm-TLG/Cataclysm-TLG/pull/1225
made some adjustments to the PR description and changed the malus on hollow bones, -Abe

Summary

Athletics helps you lift
Purpose of change

    People want to become stronger
    The athletics skill has you working out
    But you don't become stronger??

Describe the solution

    Each rank of athletics now increases your carry weight limit by 2.5%. This is applied after strength but prior to any effects from traits or enchantments.
    Bad back and strong back now give 15% -/+ to your carry weight, applied at the end. Their previous figures of 20 and 35% were far too high even without this change.
    Hollow bones penalize you 20% on top of that. Also at the end. They do not stack with each other.


Testing

8 Strength, 0 Athletics: 45kg
8 Strength, 10 Athletics: 56.3kg
18 Strength, 0 Athletics: 85kg
18 Strength, 10 Athletics: 106.3kg
