### PR TITLE
Ignore enemies after autopeek confirmation

### DIFF
--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -561,6 +561,13 @@ bool avatar_action::move( avatar &you, map &m, const tripoint_rel_ms &d )
                 const look_around_result result = g->look_around( false, center, center, false, false, true );
                 if( result.peek_action != PA_MOVE ) {
                     g->walk_move( src_loc, via_ramp );
+                } else {
+                    add_msg( m_info, _( "Ignoring enemy!" ) );
+                    for( auto &elem : you.get_mon_visible().new_seen_mon ) {
+                        monster &critter = *elem;
+                        critter.ignoring = rl_dist( you.pos_bub(), critter.pos_bub() );
+                    }
+                    g->set_safe_mode( SAFE_MODE_ON );
                 }
                 return false; // cancel automove
             }


### PR DESCRIPTION
#### Summary
Interface "Enemies that trigger 'autopeek' now automatically get ignored on confirmation"

#### Purpose of change

Having to turn safemode off or manually ignoring enemies after you already confirmed the move in autopeek is bothersome. 

#### Describe the solution

All visible enemies are now ignored when you confirm the move (`RETURN`/`KEYPAD_ENTER`).
Behaviour is unchanged if you cancel (`q`/`ESC`).

#### Testing

Tested with initial PR's savefile.

#### Additional context

Initial PR #82648
Fixes #82808