### PR TITLE
Workflow to notify/Greet first time PR commenters

### DIFF
--- a/.github/workflows/greet-first-time-comment.yml
+++ b/.github/workflows/greet-first-time-comment.yml
@@ -1,0 +1,36 @@
+name: Greet new commenters
+
+on:
+  issue_comment:
+    types:
+      - created
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  PR_NUMBER: ${{ github.event.issue.number }}
+
+jobs:
+  triage:
+    permissions:
+       pull-requests: write
+    if: ${{ github.event.issue.pull_request }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check if user has any existing PR comments in this repository
+        id: pr-comment-check
+        run: |
+          commenter="${{ github.event.comment.user.login }}"
+          echo "Debug: Checking comment counts for... $commenter"
+          comment_count=$(gh search prs --owner=CleverRaven --repo=Cataclysm-DDA --commenter $commenter --json id | jq 'length')
+
+          echo "Debug: $commenter with $comment_count total comments, including checked comment."
+          echo "comment_count=$comment_count" >> $GITHUB_OUTPUT
+
+      - name: Greet commenters with no previous comments
+        if: steps.pr-check.outputs.comment_count == 1
+        run: |
+          # I have no earthly idea how to pass the commenter on from the previous run (I have tried), so let's just re-acquire it.
+          commenter_name="${{ github.event.comment.user.login }}"
+          # We 'hardcode' the URLs here because doing a dynamic url points to OWNER/REPO/pull/code_of_conduct.md. Why is the 'pull' there? No idea.
+          gh pr comment $PR_NUMBER --body "Hi @$commenter_name, welcome to CleverRaven! We see that this is your first time commenting here. Check out [how development works](https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/development_process.md) and be sure to follow the [code of conduct](https://github.com/CleverRaven/Cataclysm-DDA/blob/master/CODE_OF_CONDUCT.md)! We hope to see you around!"


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
I brought this up in the github moderation chamber before.

#### Describe the solution
Use a github workflow to automate this. Every time a new comment is posted *on a PR* it searches all of our PRs for comments by that user. If this is their first and only PR comment, then it posts a greeting message.

Comments on issues are ignored, both for checking and for searching

#### Describe alternatives you've considered


#### Testing
I tested it on a local fork: https://github.com/RenechCDDA/Workflow_TEST/pull/1

<img width="920" height="354" alt="image" src="https://github.com/user-attachments/assets/ce3bb348-743a-4234-8a79-399faf658f1c" />

The test environment was not a perfect replica of our actual repo, and this is my first (and hopefully last) time writing a github workflow. So review would be great.

#### Additional context

The greeting is currently set to:

"Hi @$commenter_name, welcome to CleverRaven! We see that this is your first time commenting here. Check out [how development works](https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/development_process.md) and be sure to follow the [code of conduct](https://github.com/CleverRaven/Cataclysm-DDA/blob/master/CODE_OF_CONDUCT.md)! We hope to see you around!"
