### PR TITLE
JSONize mission-related topic IDs (TALK_MISSION_INQUIRE / TALK_MISSION_DESCRIBE_URGENT)

### DIFF
--- a/doc/JSON/NPCs.md
+++ b/doc/JSON/NPCs.md
@@ -222,6 +222,8 @@ Field | Default topic ID  | Uses for...
 `talk_stranger_wary` | `TALK_STRANGER_WARY` | see "success and failure" section
 `talk_stranger_friendly` | `TALK_STRANGER_FRIENDLY` | see "success and failure" section
 `talk_stranger_neutral` | `TALK_STRANGER_NEUTRAL` | see "success and failure" section
+`talk_mission_inqure` | `TALK_MISSION_INQUIRE` | see [the missions docs](MISSIONS_JSON.md)
+`talk_mission_describe_urgent` | `TALK_MISSION_DESCRIBE_URGENT` | see [the missions docs](MISSIONS_JSON.md)
 
 ---
 

--- a/src/dialogue_chatbin.h
+++ b/src/dialogue_chatbin.h
@@ -76,6 +76,8 @@ struct dialogue_chatbin {
     std::string talk_stranger_friendly = "TALK_STRANGER_FRIENDLY";
     std::string talk_stranger_neutral = "TALK_STRANGER_NEUTRAL";
     std::string talk_friend_guard = "TALK_FRIEND_GUARD";
+    std::string talk_mission_inquire = "TALK_MISSION_INQUIRE";
+    std::string talk_mission_describe_urgent = "TALK_MISSION_DESCRIBE_URGENT";
 };
 
 struct dialogue_chatbin_snippets {

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -389,7 +389,7 @@ void npc_template::load( const JsonObject &jsobj, std::string_view src )
         guy.chatbin.talk_mission_inquire = jsobj.get_string( "talk_mission_inquire" );
     }
     if( jsobj.has_string( "talk_mission_describe_urgent" ) ) {
-        guy.chatbin.talk_mission_describe_urgent= jsobj.get_string( "talk_mission_describe_urgent" );
+        guy.chatbin.talk_mission_describe_urgent = jsobj.get_string( "talk_mission_describe_urgent" );
     }
     jsobj.read( "<acknowledged>", tem.snippets.snip_acknowledged );
     jsobj.read( "<camp_food_thanks>", tem.snippets.snip_camp_food_thanks );

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -385,6 +385,12 @@ void npc_template::load( const JsonObject &jsobj, std::string_view src )
     if( jsobj.has_string( "talk_friend_guard" ) ) {
         guy.chatbin.talk_friend_guard = jsobj.get_string( "talk_friend_guard" );
     }
+    if( jsobj.has_string( "talk_mission_inquire" ) ) {
+        guy.chatbin.talk_mission_inquire = jsobj.get_string( "talk_mission_inquire" );
+    }
+    if( jsobj.has_string( "talk_mission_describe_urgent" ) ) {
+        guy.chatbin.talk_mission_describe_urgent= jsobj.get_string( "talk_mission_describe_urgent" );
+    }
     jsobj.read( "<acknowledged>", tem.snippets.snip_acknowledged );
     jsobj.read( "<camp_food_thanks>", tem.snippets.snip_camp_food_thanks );
     jsobj.read( "<camp_larder_empty>", tem.snippets.snip_camp_larder_empty );
@@ -565,6 +571,8 @@ void npc::load_npc_template( const string_id<npc_template> &ident )
     chatbin.talk_stranger_friendly = tguy.chatbin.talk_stranger_friendly;
     chatbin.talk_stranger_neutral = tguy.chatbin.talk_stranger_neutral;
     chatbin.talk_friend_guard = tguy.chatbin.talk_friend_guard;
+    chatbin.talk_mission_inquire = tguy.chatbin.talk_mission_inquire;
+    chatbin.talk_mission_describe_urgent = tguy.chatbin.talk_mission_describe_urgent;
 
     for( const mission_type_id &miss_id : tguy.miss_ids ) {
         add_new_mission( mission::reserve_new( miss_id, getID() ) );

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -8743,7 +8743,9 @@ std::string const &npc::get_specified_talk_topic( std::string const &topic_id )
         {default_chatbin.talk_stranger_wary, chatbin.talk_stranger_wary},
         {default_chatbin.talk_stranger_friendly, chatbin.talk_stranger_friendly},
         {default_chatbin.talk_stranger_neutral, chatbin.talk_stranger_neutral},
-        {default_chatbin.talk_friend_guard, chatbin.talk_friend_guard}
+        {default_chatbin.talk_friend_guard, chatbin.talk_friend_guard},
+        {default_chatbin.talk_mission_inquire, chatbin.talk_mission_inquire},
+        {default_chatbin.talk_mission_describe_urgent, chatbin.talk_mission_describe_urgent}
     };
 
     const auto iter = std::find_if( talk_topics.begin(), talk_topics.end(),

--- a/src/talker_npc.cpp
+++ b/src/talker_npc.cpp
@@ -130,7 +130,7 @@ std::vector<std::string> talker_npc::get_topics( bool radio_contact ) const
     for( mission *&mission : me_npc->chatbin.missions ) {
         const mission_type &type = mission->get_type();
         if( type.urgent && type.difficulty > most_difficult_mission ) {
-            add_topics.emplace_back( "TALK_MISSION_DESCRIBE_URGENT" );
+            add_topics.emplace_back( me_npc->chatbin.talk_mission_describe_urgent );
             me_npc->chatbin.mission_selected = mission;
             most_difficult_mission = type.difficulty;
         }
@@ -146,7 +146,7 @@ std::vector<std::string> talker_npc::get_topics( bool radio_contact ) const
         if( ( type.urgent && !chosen_urgent ) || ( type.difficulty > most_difficult_mission &&
                 ( type.urgent || !chosen_urgent ) ) ) {
             chosen_urgent = type.urgent;
-            add_topics.emplace_back( "TALK_MISSION_INQUIRE" );
+            add_topics.emplace_back( me_npc->chatbin.talk_mission_inquire );
             me_npc->chatbin.mission_selected = mission;
             most_difficult_mission = type.difficulty;
         }


### PR DESCRIPTION
#### Summary
Features "JSONize mission-related topic IDs (TALK_MISSION_INQUIRE / TALK_MISSION_DESCRIBE_URGENT)"

#### Purpose of change
In PR #50361, I assumed mission dialogs were customizable via dialogue chain.
But in scenarios where the NPC is the mission giver, `TALK_MISSION_INQUIRE` and `TALK_MISSION_DESCRIBE_URGENT` also need to be JSONized for customized responses.

#### Describe the solution
- Read `TALK_MISSION_INQUIRE` and `TALK_MISSION_DESCRIBE_URGENT` from the NPC template JSON.  
- Replaced the hardcoded target topic IDs with the topic IDs specified in the NPC template’s `npc` field.
- Existing NPCs without customized topic IDs will continue to use the default TALK_MISSION_INQUIRE and TALK_MISSION_DESCRIBE_URGENT topics.
- update NPCs.md.

#### Describe alternatives you've considered
None.

#### Testing
- **TALK_MISSION_INQUIRE**  
  - **Setup:** Prepare two NPC instances that have missions, one with a customized `npc` field and the other left at the default.  
  - **Test:** After accepting the mission, start a conversation; the topic with the ID specified in the customized `npc` field is displayed.

- **TALK_MISSION_DESCRIBE_URGENT**  
  - **Setup:** Prepare an NPC instance with a mission where `"urgent": "true"`.  
  - **Test:** Talk to the NPC; the topic with the ID specified in the customized `npc` field is displayed.

#### Additional context
None.
