### PR TITLE
revert kill_xp updates removal to preserve functionality of in-repo mods

### DIFF
--- a/src/kill_tracker.cpp
+++ b/src/kill_tracker.cpp
@@ -104,6 +104,9 @@ static Character *get_avatar_or_follower( const character_id &id )
     return nullptr;
 }
 
+// Legacy value, maintained until kill_xp rework/removal from dependent in-repo mods
+static constexpr int npc_kill_xp = 10;
+
 void kill_tracker::notify( const cata::event &e )
 {
     switch( e.type() ) {
@@ -112,6 +115,8 @@ void kill_tracker::notify( const cata::event &e )
             if( Character *killer = get_avatar_or_follower( killer_id ) ) {
                 const mtype_id victim_type = e.get<mtype_id>( "victim_type" );
                 kills[victim_type]++;
+                // Legacy value update, maintained until kill_xp rework/removal from dependent in-repo mods
+                killer->kill_xp += e.get<int>( "exp" );
                 victim_type.obj().families.practice_kill( *killer );
             }
             break;
@@ -122,6 +127,8 @@ void kill_tracker::notify( const cata::event &e )
             if( get_avatar_or_follower( killer_id ) ) {
                 const std::string victim_name = e.get<cata_variant_type::string>( "victim_name" );
                 npc_kills.push_back( victim_name );
+                // Legacy value update, maintained until kill_xp rework/removal from dependent in-repo mods
+                killer->kill_xp += npc_kill_xp;
             }
             break;
         }

--- a/src/kill_tracker.cpp
+++ b/src/kill_tracker.cpp
@@ -124,7 +124,7 @@ void kill_tracker::notify( const cata::event &e )
         case event_type::character_kills_character: {
             const character_id killer_id = e.get<character_id>( "killer" );
             // player is credited for NPC kills they or their followers make
-            if( get_avatar_or_follower( killer_id ) ) {
+            if( Character *killer = get_avatar_or_follower( killer_id ) ) {
                 const std::string victim_name = e.get<cata_variant_type::string>( "victim_name" );
                 npc_kills.push_back( victim_name );
                 // Legacy value update, maintained until kill_xp rework/removal from dependent in-repo mods

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -777,6 +777,9 @@ void Character::load( const JsonObject &data )
     data.read( "stim", stim );
     data.read( "stamina", stamina );
 
+    //legacy value, maintained until kill_xp dependency removed from in-repo mods
+    data.read( "kill_xp", kill_xp );
+
     data.read( "moncams", moncams );
 
     data.read( "magic", magic );
@@ -1410,6 +1413,9 @@ void Character::store( JsonOut &json ) const
     json.member( "stim", stim );
     json.member( "type_of_scent", type_of_scent );
     json.member( "focus_pool", focus_pool );
+
+    //legacy value, maintained until kill_xp dependency removed from in-repo mods
+    json.member( "kill_xp", kill_xp );
 
     // breathing
     json.member( "underwater", underwater );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "kill_xp Update on Kill Reversion"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Issue: #82881
Re: #82843

While the decision was made to preserve `kill_xp` for the time being due to in-repo mod dependencies, the removal of the update lines mean that the value no longer updates as expected.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Restore the removed lines, and comment for future reference on eventual removal.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Identifying and removing all existing dependencies from in-repo mods. While I have found most of these dependences, it's probably more desirable to have each mod update as a separate PR before `kill_xp` support is removed entirely.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Code compiles and `kill_xp` now updates as expected.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
