### PR TITLE
Tweaks to mounted kitchen and workshop

### DIFF
--- a/data/json/vehicleparts/modular_tools.json
+++ b/data/json/vehicleparts/modular_tools.json
@@ -98,11 +98,7 @@
     "durability": 80,
     "size": "50 L",
     "flags": [ "CARGO", "OBSTACLE", "FLAT_SURF", "WORKBENCH", "CABLE_PORTS", "VEH_TOOLS" ],
-    "workbench": {
-      "multiplier": 1.1,
-      "mass": "150 kg",
-      "volume": "20 L"
-    },
+    "workbench": { "multiplier": 1.1, "mass": "150 kg", "volume": "20 L" },
     "//": "allow tools common for both kitchen unit and workshop; unpowered or low-power and no fume hood required",
     "allowed_tools": [
       "aluminum_pan",

--- a/data/json/vehicleparts/modular_tools.json
+++ b/data/json/vehicleparts/modular_tools.json
@@ -97,7 +97,12 @@
     "damage_reduction": { "all": 30 },
     "durability": 80,
     "size": "50 L",
-    "flags": [ "CARGO", "OBSTACLE", "FLAT_SURF", "VEH_TOOLS" ],
+    "flags": [ "CARGO", "OBSTACLE", "FLAT_SURF", "WORKBENCH", "CABLE_PORTS", "VEH_TOOLS" ],
+    "workbench": {
+      "multiplier": 1.1,
+      "mass": "150 kg",
+      "volume": "20 L"
+    },
     "//": "allow tools common for both kitchen unit and workshop; unpowered or low-power and no fume hood required",
     "allowed_tools": [
       "aluminum_pan",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Balance "Add cable ports and workbench to mounted kitchen and mounted workshop"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

Add WORKBENCH flag, to crafting can be done on those. They're flat surfaces after all. Workbench specs are similar to simple table, so a dedicated workbench (like we found on some specialized trucks) still make sense.

Add CABLE_PORTS flag, so we can connect and recharge tools. Yes, now you can recharge your smartphone while in bed on the default RV. The ports make senses as you can "attach" tools to similar effect. The systems were made concurrently and do not account for each other, the reason that may have escaped from earlier audit.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

As mentioned above, add both flags. Again, WORKBECH require extra configuration which I did stole from (vehicle) table.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

- Workbench with same specs as dedicated workbenches
- Workbench with worse specs than simple tables
- Rework the attach/dettach system to be solely based on cables and ports. This one have been mentioned some times (at least one I can find on reddit) and it's sensible, but many too changes so better for another PR, also can spiral out and become scope creep.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
