### PR TITLE
Adjust the 'hide inside' capability of some furnitures

### DIFF
--- a/data/json/furniture_and_terrain/furniture-storage.json
+++ b/data/json/furniture_and_terrain/furniture-storage.json
@@ -218,7 +218,7 @@
     "id": "f_cardboard_box",
     "name": "large cardboard box",
     "symbol": "X",
-    "description": "A large box made of brown corrugated paper.  Could contain a number of things, and you could even hide inside.  Considering it only has two small flaps for carrying, it's very hard to see out of, and won't do anything to protect you if you're found.",
+    "description": "A large box made of brown corrugated paper.  Could contain a number of things.",
     "color": "brown",
     "move_cost_mod": 7,
     "coverage": 90,
@@ -229,7 +229,7 @@
     "max_volume": "324 L",
     "deployed_item": "box_large",
     "examine_action": "deployed_furniture",
-    "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "PLACE_ITEM", "ORGANIC", "EASY_DECONSTRUCT", "HIDE_PLACE", "NO_SIGHT", "CONTAINER" ],
+    "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "PLACE_ITEM", "ORGANIC", "EASY_DECONSTRUCT", "CONTAINER" ],
     "bash": { "str_min": 2, "str_max": 15, "sound": "crumple!", "sound_fail": "thud." }
   },
   {
@@ -237,7 +237,7 @@
     "id": "f_cardboard_box_large_reinforced",
     "name": "reinforced large cardboard box",
     "symbol": "X",
-    "description": "A large box made of brown corrugated paper that was doubled up for extra strength.  Could contain a number of things, and you could even hide inside.  Considering it only has two small flaps for carrying, it's very hard to see out of, and won't do anything to protect you if you're found.",
+    "description": "A large box made of brown corrugated paper that was doubled up for extra strength.  Could contain a number of things.",
     "color": "brown",
     "looks_like": "f_cardboard_box",
     "move_cost_mod": 7,
@@ -249,7 +249,7 @@
     "max_volume": "324 L",
     "deployed_item": "box_large_reinforced",
     "examine_action": "deployed_furniture",
-    "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "PLACE_ITEM", "ORGANIC", "EASY_DECONSTRUCT", "HIDE_PLACE", "NO_SIGHT", "CONTAINER" ],
+    "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "PLACE_ITEM", "ORGANIC", "EASY_DECONSTRUCT", "CONTAINER" ],
     "bash": { "str_min": 3, "str_max": 16, "sound": "crumple!", "sound_fail": "thud." }
   },
   {

--- a/data/json/furniture_and_terrain/furniture-terrains.json
+++ b/data/json/furniture_and_terrain/furniture-terrains.json
@@ -65,7 +65,7 @@
     "coverage": 95,
     "comfort": 4,
     "floor_bedding_warmth": 700,
-    "required_str": 3,
+    "required_str": -1,
     "deconstruct": {
       "items": [
         { "item": "box_large", "count": 1 },


### PR DESCRIPTION


#### Summary
None

#### Purpose of change
Adjust cardboard box furnitures to not let things to be hidden inside them especially characters and monsters due to the fact that it is too small of a cardboard box for it to let monsters and characters hide inside them with such ease as it is currently present ingame.

Also tweaked the cardboard fort to be not draggable for consistency, as pillow fort also isnt draggable and i dont trust these cardboard fort to be intact when dragging.

#### Describe the solution
Yote the `HIDE_PLACE` and `NO_SIGHT` on the cardboard box furnitures.

Adjust the required strength to drag the cardboard fort to -1 (not moveable)
#### Describe alternatives you've considered

Make it work only on tiny characters? that's out of my paygrade but someone else can make that a thing.

#### Testing


https://github.com/user-attachments/assets/27d8014d-45d5-49e8-a142-5b9fafd4a834


#### Additional context
Heh.