### PR TITLE
move body_part_type::type to enums.h to resolve include loop

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -8909,7 +8909,7 @@ void pulp_activity_actor::send_final_message( Character &you ) const
         } else if( pd.stomps_only ) {
             tools = string_format(
                         _( "It took you some time, stomping corpses with nothing but your %1$s, and occasionally cutting it with a %2$s." ),
-                        you.get_random_body_part_of_type( body_part_type::type::leg )->accusative_multiple, pd.cut_tool );
+                        you.get_random_body_part_of_type( bp_type::leg )->accusative_multiple, pd.cut_tool );
         } else if( pd.weapon_only ) {
             tools = string_format(
                         _( "It took you some time, bashing corpses with your %1$s, with occasional cuts with a %2$s." ),
@@ -8922,7 +8922,7 @@ void pulp_activity_actor::send_final_message( Character &you ) const
     } else {
         if( pd.stomps_only ) {
             tools = string_format( _( "It took you some time, stomping corpses with nothing but your %1$s." ),
-                                   you.get_random_body_part_of_type( body_part_type::type::leg )->accusative_multiple );
+                                   you.get_random_body_part_of_type( bp_type::leg )->accusative_multiple );
         } else if( pd.weapon_only ) {
             tools = string_format( _( "It took you some time, bashing corpses with just your %1$s." ),
                                    pd.bash_tool );

--- a/src/anatomy.cpp
+++ b/src/anatomy.cpp
@@ -9,6 +9,7 @@
 #include "character.h"
 #include "creature.h"
 #include "debug.h"
+#include "enums.h"
 #include "flag.h"
 #include "generic_factory.h"
 #include "messages.h"
@@ -279,20 +280,20 @@ bodypart_id anatomy::select_blocking_part( const Creature *blocker, bool arm, bo
         }
 
         // Can we block with our normal boring arm?
-        if( bp->has_type( body_part_type::type::arm ) && !bp->has_flag( json_flag_NONSTANDARD_BLOCK ) &&
+        if( bp->has_type( bp_type::arm ) && !bp->has_flag( json_flag_NONSTANDARD_BLOCK ) &&
             !arm ) {
             add_msg_debug( debugmode::DF_MELEE, "BP %s discarded, no arm blocks allowed",
                            body_part_name( bp ) );
             continue;
             // Can we block with our normal boring legs?
-        } else if( bp->has_type( body_part_type::type::leg ) &&
+        } else if( bp->has_type( bp_type::leg ) &&
                    !bp->has_flag( json_flag_NONSTANDARD_BLOCK ) && !leg ) {
             add_msg_debug( debugmode::DF_MELEE, "BP %s discarded, no leg blocks allowed",
                            body_part_name( bp ) );
             continue;
             // Can we block with our non-normal non-arms/non-legs?
-        } else if( ( ( !bp->has_type( body_part_type::type::arm ) &&
-                       !bp->has_type( body_part_type::type::leg ) ) || bp->has_flag( json_flag_NONSTANDARD_BLOCK ) ) &&
+        } else if( ( ( !bp->has_type( bp_type::arm ) &&
+                       !bp->has_type( bp_type::leg ) ) || bp->has_flag( json_flag_NONSTANDARD_BLOCK ) ) &&
                    !nonstandard ) {
             add_msg_debug( debugmode::DF_MELEE, "BP %s discarded, no nonstandard blocks allowed",
                            body_part_name( bp ) );

--- a/src/bodypart.cpp
+++ b/src/bodypart.cpp
@@ -73,23 +73,23 @@ std::string enum_to_string<side>( side data )
 }
 
 template<>
-std::string enum_to_string<body_part_type::type>( body_part_type::type data )
+std::string enum_to_string<bp_type>( bp_type data )
 {
     switch( data ) {
         // *INDENT-OFF*
-        case body_part_type::type::arm: return "arm";
-        case body_part_type::type::other: return "other";
-        case body_part_type::type::foot: return "foot";
-        case body_part_type::type::hand: return "hand";
-        case body_part_type::type::head: return "head";
-        case body_part_type::type::leg: return "leg";
-        case body_part_type::type::mouth: return "mouth";
-        case body_part_type::type::sensor: return "sensor";
-        case body_part_type::type::tail: return "tail";
-        case body_part_type::type::torso: return "torso";
-        case body_part_type::type::wing: return "wing";
+        case bp_type::arm: return "arm";
+        case bp_type::other: return "other";
+        case bp_type::foot: return "foot";
+        case bp_type::hand: return "hand";
+        case bp_type::head: return "head";
+        case bp_type::leg: return "leg";
+        case bp_type::mouth: return "mouth";
+        case bp_type::sensor: return "sensor";
+        case bp_type::tail: return "tail";
+        case bp_type::torso: return "torso";
+        case bp_type::wing: return "wing";
             // *INDENT-ON*
-        case body_part_type::type::num_types:
+        case bp_type::num_types:
             break;
     }
     cata_fatal( "Invalid body part type." );
@@ -249,12 +249,12 @@ void body_part_type::load_bp( const JsonObject &jo, const std::string &src )
     body_part_factory.load( jo, src );
 }
 
-body_part_type::type body_part_type::primary_limb_type() const
+bp_type body_part_type::primary_limb_type() const
 {
     return _primary_limb_type;
 }
 
-bool body_part_type::has_type( const body_part_type::type &type ) const
+bool body_part_type::has_type( const bp_type &type ) const
 {
     return limbtypes.count( type ) > 0;
 }
@@ -349,21 +349,21 @@ void body_part_type::load( const JsonObject &jo, std::string_view )
     optional( jo, was_loaded, "is_vital", is_vital, false );
     if( jo.has_array( "limb_types" ) ) {
         limbtypes.clear();
-        body_part_type::type first_type = body_part_type::type::num_types;
+        bp_type first_type = bp_type::num_types;
         bool set_first_type = true;
         for( JsonValue jval : jo.get_array( "limb_types" ) ) {
             float weight = 1.0f;
-            body_part_type::type limb_type;
+            bp_type limb_type;
             if( jval.test_array() ) {
                 JsonArray jarr = jval.get_array();
-                limb_type = io::string_to_enum<body_part_type::type>( jarr.get_string( 0 ) );
+                limb_type = io::string_to_enum<bp_type>( jarr.get_string( 0 ) );
                 weight = jarr.get_float( 1 );
                 set_first_type = false;
             } else {
-                limb_type = io::string_to_enum<body_part_type::type>( jval.get_string() );
+                limb_type = io::string_to_enum<bp_type>( jval.get_string() );
             }
             limbtypes.emplace( limb_type, weight );
-            if( first_type == body_part_type::type::num_types ) {
+            if( first_type == bp_type::num_types ) {
                 first_type = limb_type;
             }
         }
@@ -373,12 +373,12 @@ void body_part_type::load( const JsonObject &jo, std::string_view )
         }
     } else {
         limbtypes.clear();
-        body_part_type::type limb_type = {};
+        bp_type limb_type = {};
         mandatory( jo, was_loaded, "limb_type", limb_type );
         limbtypes.emplace( limb_type, 1.0f );
     }
 
-    if( _primary_limb_type == body_part_type::type::num_types ) {
+    if( _primary_limb_type == bp_type::num_types ) {
         float high = 0.f;
         for( auto &bp_type : limbtypes ) {
             if( high < bp_type.second ) {

--- a/src/bodypart.h
+++ b/src/bodypart.h
@@ -183,31 +183,6 @@ struct body_part_type {
          * the different types of body parts there are.
          * this allows for the ability to group limbs or determine a limb of a certain type
          */
-        enum class type {
-            // this is where helmets go, and is a vital part.
-            head,
-            // the torso is generally the center of mass of a creature
-            torso,
-            // provides sight
-            sensor,
-            // you eat and scream with this
-            mouth,
-            // may manipulate objects to some degree, is a main part
-            arm,
-            // manipulates objects. usually is not a main part.
-            hand,
-            // provides motive power
-            leg,
-            // helps with balance. usually is not a main part
-            foot,
-            // may reduce fall damage
-            wing,
-            // may provide balance or manipulation
-            tail,
-            // more of a general purpose limb, such as horns.
-            other,
-            num_types
-        };
 
         std::vector<std::pair<bodypart_str_id, mod_id>> src;
 
@@ -238,7 +213,7 @@ struct body_part_type {
         bodypart_str_id opposite_part;
 
         // A weighted list of limb types. The type with the highest weight is the primary type
-        std::map<body_part_type::type, float> limbtypes;
+        std::map<bp_type, float> limbtypes;
 
         // Limb-specific attacks
         std::set<matec_id> techniques;
@@ -332,7 +307,7 @@ struct body_part_type {
 
     private:
         int bionic_slots_ = 0;
-        body_part_type::type _primary_limb_type = body_part_type::type::num_types;
+        bp_type _primary_limb_type = bp_type::num_types;
         // Protection from various damage types
         resistances armor;
 
@@ -346,8 +321,8 @@ struct body_part_type {
         bool was_loaded = false;
 
         bool has_flag( const json_character_flag &flag ) const;
-        body_part_type::type primary_limb_type() const;
-        bool has_type( const body_part_type::type &type ) const;
+        bp_type primary_limb_type() const;
+        bool has_type( const bp_type &type ) const;
 
         // return a random sub part from the weighted list of subparts
         // if secondary is true instead returns a part from only the secondary sublocations
@@ -391,11 +366,6 @@ struct body_part_type {
         // this version just pairs normal body parts
         static std::set<translation, localized_comparator> consolidate( std::vector<bodypart_id>
                 &covered );
-};
-
-template<>
-struct enum_traits<body_part_type::type> {
-    static constexpr body_part_type::type last = body_part_type::type::num_types;
 };
 
 struct layer_details {

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -2236,7 +2236,7 @@ bool Character::has_min_manipulators() const
 bool Character::has_two_arms_lifting() const
 {
     // 0.5f is one "standard" arm, so if you have more than that you barely qualify.
-    return get_limb_score( limb_score_lift, body_part_type::type::arm ) > 0.5f;
+    return get_limb_score( limb_score_lift, bp_type::arm ) > 0.5f;
 }
 
 std::set<matec_id> Character::get_limb_techs() const
@@ -2255,7 +2255,7 @@ std::set<matec_id> Character::get_limb_techs() const
 int Character::get_working_arm_count() const
 {
     int limb_count = 0;
-    body_part_type::type arm_type = body_part_type::type::arm;
+    bp_type arm_type = bp_type::arm;
     for( const bodypart_id &part : get_all_body_parts_of_type( arm_type ) ) {
         // Almost broken or overencumbered arms don't count
         if( get_part( part )->get_limb_score( *this,
@@ -2273,7 +2273,7 @@ bool Character::enough_working_legs() const
     int limb_count = 0;
     int working_limb_count = 0;
     for( const bodypart_id &part : get_all_body_parts() ) {
-        if( part->primary_limb_type() == body_part_type::type::leg ) {
+        if( part->primary_limb_type() == bp_type::leg ) {
             limb_count++;
             if( !is_limb_broken( part ) ) {
                 working_limb_count++;
@@ -2289,7 +2289,7 @@ int Character::get_working_leg_count() const
 {
     int working_limb_count = 0;
     for( const bodypart_id &part : get_all_body_parts() ) {
-        if( part->primary_limb_type() == body_part_type::type::leg ) {
+        if( part->primary_limb_type() == bp_type::leg ) {
             if( !is_limb_broken( part ) ) {
                 working_limb_count++;
             }
@@ -4219,7 +4219,7 @@ int layer_details::layer( const int encumbrance, bool conflicts )
     return total - current;
 }
 
-int Character::avg_encumb_of_limb_type( body_part_type::type part_type ) const
+int Character::avg_encumb_of_limb_type( bp_type part_type ) const
 {
     float limb_encumb = 0.0f;
     int num_limbs = 0;
@@ -5801,7 +5801,7 @@ bool Character::check_immunity_data( const field_immunity_data &ft ) const
         }
     }
     bool immune_by_body_part_resistance = !ft.immunity_data_body_part_env_resistance.empty();
-    for( const std::pair<body_part_type::type, int> &fide :
+    for( const std::pair<bp_type, int> &fide :
          ft.immunity_data_body_part_env_resistance ) {
         for( const bodypart_id &bp : get_all_body_parts_of_type( fide.first ) ) {
             if( get_env_resist( bp ) < fide.second ) {
@@ -5818,7 +5818,7 @@ bool Character::check_immunity_data( const field_immunity_data &ft ) const
 
     bool immune_by_worn_flags = !ft.immunity_data_part_item_flags.empty();
     // Check if all worn flags are fulfilled
-    for( const std::pair<body_part_type::type, flag_id> &fide :
+    for( const std::pair<bp_type, flag_id> &fide :
          ft.immunity_data_part_item_flags ) {
         for( const bodypart_id &bp : get_all_body_parts_of_type( fide.first ) ) {
             if( !worn_with_flag( fide.second, bp ) ) {
@@ -5835,7 +5835,7 @@ bool Character::check_immunity_data( const field_immunity_data &ft ) const
     }
 
     // Check if the optional worn flags are fulfilled
-    for( const std::pair<body_part_type::type, flag_id> &fide :
+    for( const std::pair<bp_type, flag_id> &fide :
          ft.immunity_data_part_item_flags_any ) {
         for( const bodypart_id &bp : get_all_body_parts_of_type( fide.first ) ) {
             if( worn_with_flag( fide.second, bp ) ) {
@@ -6894,7 +6894,7 @@ void Character::recalc_limb_energy_usage()
     float total_limb_count = 0.0f;
     float bionic_limb_count = 0.0f;
     float bionic_powercost = 0;
-    body_part_type::type arm_type = body_part_type::type::arm;
+    bp_type arm_type = bp_type::arm;
     for( const bodypart_id &bp : get_all_body_parts_of_type( arm_type ) ) {
         total_limb_count++;
         if( bp->has_flag( json_flag_BIONIC_LIMB ) ) {
@@ -6919,7 +6919,7 @@ void Character::recalc_limb_energy_usage()
     total_limb_count = 0.0f;
     bionic_limb_count = 0.0f;
     bionic_powercost = 0;
-    body_part_type::type leg_type = body_part_type::type::leg;
+    bp_type leg_type = bp_type::leg;
     for( const bodypart_id &bp : get_all_body_parts_of_type( leg_type ) ) {
         total_limb_count++;
         if( bp->has_flag( json_flag_BIONIC_LIMB ) ) {
@@ -7324,8 +7324,8 @@ int Character::item_handling_cost( const item &it, bool penalties, int base_cost
         // Grabbed penalty scales for grabbed arms/hands
         int pen = 2;
         for( const effect &eff : get_effects_with_flag( json_flag_GRAB ) ) {
-            if( eff.get_bp()->primary_limb_type() == body_part_type::type::arm ||
-                eff.get_bp()->primary_limb_type() == body_part_type::type::hand ) {
+            if( eff.get_bp()->primary_limb_type() == bp_type::arm ||
+                eff.get_bp()->primary_limb_type() == bp_type::hand ) {
                 pen++;
             }
         }
@@ -7336,12 +7336,12 @@ int Character::item_handling_cost( const item &it, bool penalties, int base_cost
     if( !bulk_cost ) {
         // For single handed items use the least encumbered hand
         if( it.is_two_handed( *this ) ) {
-            for( const bodypart_id &part : get_all_body_parts_of_type( body_part_type::type::hand ) ) {
+            for( const bodypart_id &part : get_all_body_parts_of_type( bp_type::hand ) ) {
                 mv += encumb( part );
             }
         } else {
             int min_encumb = INT_MAX;
-            for( const bodypart_id &part : get_all_body_parts_of_type( body_part_type::type::hand ) ) {
+            for( const bodypart_id &part : get_all_body_parts_of_type( bp_type::hand ) ) {
                 min_encumb = std::min( min_encumb, encumb( part ) );
             }
             mv += min_encumb;
@@ -13696,8 +13696,8 @@ bodypart_id Character::most_staunchable_bp( int &max_staunch )
         add_msg_debug( debugmode::DF_CHARACTER, "Wound care proficiency found, new limit %d", max_staunch );
     }
 
-    int num_broken_arms = get_num_broken_body_parts_of_type( body_part_type::type::arm );
-    int num_arms = get_num_body_parts_of_type( body_part_type::type::arm );
+    int num_broken_arms = get_num_broken_body_parts_of_type( bp_type::arm );
+    int num_arms = get_num_body_parts_of_type( bp_type::arm );
 
     // Don't warn about encumbrance if your arms are broken
     if( num_broken_arms ) {
@@ -13713,7 +13713,7 @@ bodypart_id Character::most_staunchable_bp( int &max_staunch )
     for( const bodypart_id &bp : get_all_body_parts() ) {
         intensity = get_effect_int( effect_bleed, bp );
         // Staunching a bleeding on one of your arms is hard (handle multiple arms)
-        if( bp->has_type( body_part_type::type::arm ) ) {
+        if( bp->has_type( bp_type::arm ) ) {
             intensity /= ( 1.0f - 1.0f / num_arms );
         }
         // Tourniquets make staunching easier, letting you treat arterial bleeds on your legs
@@ -13791,7 +13791,7 @@ void Character::pause()
         bodypart_id bp_id = most_staunchable_bp( max );
 
         // Don't warn about encumbrance if your arms are broken
-        int num_broken_arms = get_num_broken_body_parts_of_type( body_part_type::type::arm );
+        int num_broken_arms = get_num_broken_body_parts_of_type( bp_type::arm );
         if( num_broken_arms ) {
             add_msg_player_or_npc( m_warning,
                                    _( "Your broken limb significantly hampers your efforts to put pressure on a bleeding wound!" ),

--- a/src/character.h
+++ b/src/character.h
@@ -992,7 +992,7 @@ class Character : public Creature, public visitable
 
         /** Returns ENC provided by armor, etc. */
         int encumb( const bodypart_id &bp ) const;
-        int avg_encumb_of_limb_type( body_part_type::type part_type ) const;
+        int avg_encumb_of_limb_type( bp_type part_type ) const;
 
         /** Returns body weight plus weight of inventory and worn/wielded items */
         units::mass get_weight() const override;
@@ -1511,10 +1511,10 @@ class Character : public Creature, public visitable
         // Get the specified limb score. If bp is defined, only the scores from that body part type are summed.
         // override forces the limb score to be affected by encumbrance/wounds (-1 == no override).
         float get_limb_score( const limb_score_id &score,
-                              const body_part_type::type &bp = body_part_type::type::num_types,
+                              const bp_type &bp = bp_type::num_types,
                               int override_encumb = -1, int override_wounds = -1 ) const;
         float manipulator_score( const std::map<bodypart_str_id, bodypart> &body,
-                                 body_part_type::type type, int override_encumb, int override_wounds ) const;
+                                 bp_type type, int override_encumb, int override_wounds ) const;
 
         bool has_min_manipulators() const;
         // technically this is "has more than one arm"

--- a/src/character_attire.cpp
+++ b/src/character_attire.cpp
@@ -650,7 +650,7 @@ bool Character::is_wearing_shoes( const side &check_side ) const
 
     for( const bodypart_id &part : get_all_body_parts() ) {
         // Is any right|left foot...
-        if( !part->has_type( body_part_type::type::foot ) ) {
+        if( !part->has_type( bp_type::foot ) ) {
             continue;
         }
         side_covered = worn.is_wearing_shoes( part );

--- a/src/character_modifier.cpp
+++ b/src/character_modifier.cpp
@@ -5,6 +5,7 @@
 #include <functional>
 #include <limits>
 
+#include "bodypart.h"
 #include "character.h"
 #include "debug.h"
 #include "effect.h"
@@ -138,7 +139,7 @@ void character_modifier::load( const JsonObject &jo, std::string_view )
         optional( jobj, was_loaded, "limb_score_op", lsop, "*" );
         limbscore_modop = string_to_modtype( lsop );
 
-        optional( jobj, was_loaded, "limb_type", limbtype, body_part_type::type::num_types );
+        optional( jobj, was_loaded, "limb_type", limbtype, bp_type::num_types );
         if( jobj.has_member( "override_encumb" ) ) {
             bool over;
             mandatory( jobj, was_loaded, "override_encumb", over );
@@ -165,11 +166,11 @@ void character_modifier::load( const JsonObject &jo, std::string_view )
 
 // the total of the manipulator score in the best limb group
 float Character::manipulator_score( const std::map<bodypart_str_id, bodypart> &body,
-                                    body_part_type::type type, int override_encumb, int override_wounds ) const
+                                    bp_type type, int override_encumb, int override_wounds ) const
 {
-    std::map<body_part_type::type, std::vector<std::pair<bodypart, float>>> bodypart_groups;
+    std::map<bp_type, std::vector<std::pair<bodypart, float>>> bodypart_groups;
     std::vector<float> score_groups;
-    const bool required_type = type != body_part_type::type::num_types;
+    const bool required_type = type != bp_type::num_types;
     const bool local_effect = has_flag( flag_EFFECT_LIMB_SCORE_MOD_LOCAL );
     for( const std::pair<const bodypart_str_id, bodypart> &id : body ) {
         if( required_type ) {
@@ -178,7 +179,7 @@ float Character::manipulator_score( const std::map<bodypart_str_id, bodypart> &b
                     bodypart_groups[ bp_type.first ].emplace_back( id.second, bp_type.second );
                 }
             }
-        } else if( id.first->primary_limb_type() != body_part_type::type::num_types ) {
+        } else if( id.first->primary_limb_type() != bp_type::num_types ) {
             bodypart_groups[ id.first->primary_limb_type() ].emplace_back( id.second,
                     id.first->limbtypes.at( id.first->primary_limb_type() ) );
         }
@@ -212,7 +213,7 @@ float Character::manipulator_score( const std::map<bodypart_str_id, bodypart> &b
         }
         add_msg_debug( debugmode::DF_CHARACTER,
                        "Manipulation score of bodypart group %s %.1f",
-                       io::enum_to_string<body_part_type::type>( part.first ), total );
+                       io::enum_to_string<bp_type>( part.first ), total );
         score_groups.emplace_back( total );
     }
     const auto score_groups_max = std::max_element( score_groups.begin(), score_groups.end() );
@@ -224,7 +225,7 @@ float Character::manipulator_score( const std::map<bodypart_str_id, bodypart> &b
     }
 }
 
-float Character::get_limb_score( const limb_score_id &score, const body_part_type::type &bp,
+float Character::get_limb_score( const limb_score_id &score, const bp_type &bp,
                                  int override_encumb, int override_wounds ) const
 {
     int skill = -1;
@@ -244,7 +245,7 @@ float Character::get_limb_score( const limb_score_id &score, const body_part_typ
     bool cache_flag_EFFECT_LIMB_SCORE_MOD_LOCAL = has_flag( flag_EFFECT_LIMB_SCORE_MOD_LOCAL );
     for( const std::pair<const bodypart_str_id, bodypart> &id : body ) {
         float mod = 0.0f;
-        if( bp == body_part_type::type::num_types ) {
+        if( bp == bp_type::num_types ) {
             mod = id.second.get_limb_score( *this, score, skill, override_encumb, override_wounds );
         } else if( id.first->has_type( bp ) ) {
             mod = id.second.get_limb_score( *this, score, skill, override_encumb,

--- a/src/character_modifier.h
+++ b/src/character_modifier.h
@@ -8,7 +8,7 @@
 #include <utility>
 #include <vector>
 
-#include "bodypart.h"
+#include "enums.h"
 #include "translation.h"
 #include "type_id.h"
 
@@ -60,7 +60,7 @@ struct character_modifier {
         std::map<limb_score_id, float> limbscores;
         mod_type limbscore_modop = MULT;
         std::vector<std::pair<character_modifier_id, mod_id>> src;
-        body_part_type::type limbtype = body_part_type::type::num_types;
+        bp_type limbtype = bp_type::num_types;
         translation desc;
         mod_type modtype = mod_type::NONE;
         float max_val = 0.0f;

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -1095,11 +1095,11 @@ void projectile::apply_effects_damage( Creature &target, Creature *source,
         }
     }
 
-    if( dealt_dam.bp_hit->has_type( body_part_type::type::head ) &&
+    if( dealt_dam.bp_hit->has_type( bp_type::head ) &&
         proj_effects.count( ammo_effect_BLINDS_EYES ) ) {
         // TODO: Change this to require bp_eyes
         target.add_env_effect( effect_blind,
-                               target.get_random_body_part_of_type( body_part_type::type::sensor ), 5, rng( 3_turns, 10_turns ) );
+                               target.get_random_body_part_of_type( bp_type::sensor ), 5, rng( 3_turns, 10_turns ) );
     }
 
     if( proj_effects.count( ammo_effect_APPLY_SAP ) ) {
@@ -2485,7 +2485,7 @@ bodypart_id Creature::get_part_id( const bodypart_id &id,
     std::pair<bodypart_id, float> best = { bodypart_str_id::NULL_ID().id(), 0.0f };
     if( filter >= body_part_filter::next_best ) {
         for( const std::pair<const bodypart_str_id, bodypart> &bp : body ) {
-            for( const std::pair<const body_part_type::type, float> &mp : bp.first->limbtypes ) {
+            for( const std::pair<const bp_type, float> &mp : bp.first->limbtypes ) {
                 // if the secondary limb type matches and is better than the current
                 if( mp.first == id->primary_limb_type() && mp.second > best.second ) {
                     // give an inflated bonus if the part sides match
@@ -2912,7 +2912,7 @@ bodypart_id Creature::get_root_body_part() const
 }
 
 std::vector<bodypart_id> Creature::get_all_body_parts_of_type(
-    body_part_type::type part_type, get_body_part_flags flags ) const
+    bp_type part_type, get_body_part_flags flags ) const
 {
     const bool only_main( flags & get_body_part_flags::only_main );
     const bool primary( flags & get_body_part_flags::primary_type );
@@ -2938,7 +2938,7 @@ std::vector<bodypart_id> Creature::get_all_body_parts_of_type(
     return bodyparts;
 }
 
-bodypart_id Creature::get_random_body_part_of_type( body_part_type::type part_type ) const
+bodypart_id Creature::get_random_body_part_of_type( bp_type part_type ) const
 {
     return random_entry( get_all_body_parts_of_type( part_type ) );
 }
@@ -2986,10 +2986,10 @@ body_part_set Creature::get_drenching_body_parts( bool upper, bool mid, bool low
 
 std::vector<bodypart_id> Creature::get_ground_contact_bodyparts( bool arms_legs ) const
 {
-    std::vector<bodypart_id> arms = get_all_body_parts_of_type( body_part_type::type::arm );
-    std::vector<bodypart_id> legs = get_all_body_parts_of_type( body_part_type::type::leg );
-    std::vector<bodypart_id> hands = get_all_body_parts_of_type( body_part_type::type::hand );
-    std::vector<bodypart_id> feet = get_all_body_parts_of_type( body_part_type::type::foot );
+    std::vector<bodypart_id> arms = get_all_body_parts_of_type( bp_type::arm );
+    std::vector<bodypart_id> legs = get_all_body_parts_of_type( bp_type::leg );
+    std::vector<bodypart_id> hands = get_all_body_parts_of_type( bp_type::hand );
+    std::vector<bodypart_id> feet = get_all_body_parts_of_type( bp_type::foot );
 
     if( has_effect( effect_quadruped_full ) || has_effect( effect_quadruped_half ) ) {
         if( arms_legs == true ) {
@@ -3004,9 +3004,9 @@ std::vector<bodypart_id> Creature::get_ground_contact_bodyparts( bool arms_legs 
     } else {
         std::vector<bodypart_id> bodyparts;
         if( arms_legs == true ) {
-            bodyparts = get_all_body_parts_of_type( body_part_type::type::leg );
+            bodyparts = get_all_body_parts_of_type( bp_type::leg );
         } else {
-            bodyparts = get_all_body_parts_of_type( body_part_type::type::foot );
+            bodyparts = get_all_body_parts_of_type( bp_type::foot );
         }
         return bodyparts;
     }
@@ -3040,12 +3040,12 @@ const
     return enumerate_as_string( names );
 }
 
-int Creature::get_num_body_parts_of_type( body_part_type::type part_type ) const
+int Creature::get_num_body_parts_of_type( bp_type part_type ) const
 {
     return static_cast<int>( get_all_body_parts_of_type( part_type ).size() );
 }
 
-int Creature::get_num_broken_body_parts_of_type( body_part_type::type part_type ) const
+int Creature::get_num_broken_body_parts_of_type( bp_type part_type ) const
 {
     int ret = 0;
     for( const bodypart_id &bp : get_all_body_parts_of_type( part_type ) ) {

--- a/src/creature.h
+++ b/src/creature.h
@@ -828,9 +828,9 @@ class Creature : public viewer
         std::vector<bodypart_id> get_all_body_parts(
             get_body_part_flags = get_body_part_flags::none ) const;
         std::vector<bodypart_id> get_all_body_parts_of_type(
-            body_part_type::type part_type,
+            bp_type part_type,
             get_body_part_flags flags = get_body_part_flags::none ) const;
-        bodypart_id get_random_body_part_of_type( body_part_type::type part_type ) const;
+        bodypart_id get_random_body_part_of_type( bp_type part_type ) const;
         bodypart_id get_root_body_part() const;
         /* Returns all body parts with the given flag */
         std::vector<bodypart_id> get_all_body_parts_with_flag( const json_character_flag &flag ) const;
@@ -844,10 +844,10 @@ class Creature : public viewer
         std::string string_for_ground_contact_bodyparts( const std::vector<bodypart_id> &bps ) const;
 
         /* Returns the number of bodyparts of a given type*/
-        int get_num_body_parts_of_type( body_part_type::type part_type ) const;
+        int get_num_body_parts_of_type( bp_type part_type ) const;
 
         /* Returns the number of broken bodyparts of a given type */
-        int get_num_broken_body_parts_of_type( body_part_type::type part_type ) const;
+        int get_num_broken_body_parts_of_type( bp_type part_type ) const;
 
         const std::map<bodypart_str_id, bodypart> &get_body() const;
         void set_body();

--- a/src/enums.h
+++ b/src/enums.h
@@ -512,4 +512,35 @@ enum mut_count_type {
     ALL
 };
 
+enum class bp_type {
+    // this is where helmets go, and is a vital part.
+    head,
+    // the torso is generally the center of mass of a creature
+    torso,
+    // provides sight
+    sensor,
+    // you eat and scream with this
+    mouth,
+    // may manipulate objects to some degree, is a main part
+    arm,
+    // manipulates objects. usually is not a main part.
+    hand,
+    // provides motive power
+    leg,
+    // helps with balance. usually is not a main part
+    foot,
+    // may reduce fall damage
+    wing,
+    // may provide balance or manipulation
+    tail,
+    // more of a general purpose limb, such as horns.
+    other,
+    num_types
+};
+
+template<>
+struct enum_traits<bp_type> {
+    static constexpr bp_type last = bp_type::num_types;
+};
+
 #endif // CATA_SRC_ENUMS_H

--- a/src/field_type.cpp
+++ b/src/field_type.cpp
@@ -396,17 +396,17 @@ void field_types::load_immunity( const JsonObject &jid, field_immunity_data &fd 
     }
     for( JsonArray jao : jid.get_array( "body_part_env_resistance" ) ) {
         fd.immunity_data_body_part_env_resistance.emplace_back(
-            io::string_to_enum<body_part_type::type>
+            io::string_to_enum<bp_type>
             ( jao.get_string( 0 ) ), jao.get_int( 1 ) );
     }
     for( JsonArray jao : jid.get_array( "immunity_flags_worn" ) ) {
-        fd.immunity_data_part_item_flags.emplace_back( io::string_to_enum<body_part_type::type>
+        fd.immunity_data_part_item_flags.emplace_back( io::string_to_enum<bp_type>
                 ( jao.get_string( 0 ) ), jao.get_string( 1 ) );
     }
 
     for( JsonArray jao : jid.get_array( "immunity_flags_worn_any" ) ) {
         fd.immunity_data_part_item_flags_any.emplace_back(
-            io::string_to_enum<body_part_type::type>
+            io::string_to_enum<bp_type>
             ( jao.get_string( 0 ) ), jao.get_string( 1 ) );
     }
 }

--- a/src/field_type.h
+++ b/src/field_type.h
@@ -13,7 +13,6 @@
 #include <utility>
 #include <vector>
 
-#include "bodypart.h"
 #include "calendar.h"
 #include "catacharset.h"
 #include "color.h"
@@ -58,9 +57,9 @@ generic_factory<field_type> &get_all_field_types();
 
 struct field_immunity_data {
     std::vector<json_character_flag> immunity_data_flags;
-    std::vector<std::pair<body_part_type::type, int>> immunity_data_body_part_env_resistance;
-    std::vector < std::pair<body_part_type::type, flag_id>> immunity_data_part_item_flags;
-    std::vector < std::pair<body_part_type::type, flag_id>> immunity_data_part_item_flags_any;
+    std::vector<std::pair<bp_type, int>> immunity_data_body_part_env_resistance;
+    std::vector < std::pair<bp_type, flag_id>> immunity_data_part_item_flags;
+    std::vector < std::pair<bp_type, flag_id>> immunity_data_part_item_flags_any;
 };
 
 struct field_effect {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -13741,7 +13741,7 @@ float game::slip_down_chance( climb_maneuver, climbing_aid_id aid_id,
     bool wet_feet = false;
     bool wet_hands = false;
 
-    for( const bodypart_id &bp : u.get_all_body_parts_of_type( body_part_type::type::foot,
+    for( const bodypart_id &bp : u.get_all_body_parts_of_type( bp_type::foot,
             get_body_part_flags::primary_type ) ) {
         if( u.get_part_wetness( bp ) > 0 && !climb_flying ) {
             add_msg_debug( debugmode::DF_GAME, "Foot %s %.1f wet", body_part_name( bp ),
@@ -13751,7 +13751,7 @@ float game::slip_down_chance( climb_maneuver, climbing_aid_id aid_id,
         }
     }
 
-    for( const bodypart_id &bp : u.get_all_body_parts_of_type( body_part_type::type::hand,
+    for( const bodypart_id &bp : u.get_all_body_parts_of_type( bp_type::hand,
             get_body_part_flags::primary_type ) ) {
         if( u.get_part_wetness( bp ) > 0 && !climb_flying ) {
             add_msg_debug( debugmode::DF_GAME, "Hand %s %.1f wet", body_part_name( bp ),

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -2232,7 +2232,7 @@ double item::effective_dps( const Character &guy, Creature &mon ) const
 {
     const float mon_dodge = mon.get_dodge();
     float base_hit = guy.get_dex() / 4.0f + guy.get_hit_weapon( *this );
-    base_hit *= std::max( 0.25f, 1.0f - guy.avg_encumb_of_limb_type( body_part_type::type::torso ) /
+    base_hit *= std::max( 0.25f, 1.0f - guy.avg_encumb_of_limb_type( bp_type::torso ) /
                           100.0f );
     float mon_defense = mon_dodge + mon.size_melee_penalty() / 5.0f;
     constexpr double hit_trials = 10000.0;

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -976,7 +976,7 @@ int spell::energy_cost( const Character &guy ) const
     if( !no_hands() && !guy.has_flag( json_flag_SUBTLE_SPELL ) ) {
         // the first 10 points of combined encumbrance is ignored, but quickly adds up
         const int hands_encumb = std::max( 0,
-                                           guy.avg_encumb_of_limb_type( body_part_type::type::hand ) - 5 );
+                                           guy.avg_encumb_of_limb_type( bp_type::hand ) - 5 );
         switch( type->get_energy_source() ) {
             default:
                 cost += 10 * hands_encumb * temp_somatic_difficulty_multiplyer;
@@ -1139,13 +1139,13 @@ int spell::casting_time( const Character &guy, bool ignore_encumb ) const
         if( !has_flag( spell_flag::NO_LEGS ) ) {
             // the first 20 points of encumbrance combined is ignored
             const int legs_encumb = std::max( 0,
-                                              guy.avg_encumb_of_limb_type( body_part_type::type::leg ) - 10 );
+                                              guy.avg_encumb_of_limb_type( bp_type::leg ) - 10 );
             casting_time += legs_encumb * 3 * temp_somatic_difficulty_multiplyer;
         }
         if( has_flag( spell_flag::SOMATIC ) && !guy.has_flag( json_flag_SUBTLE_SPELL ) ) {
             // the first 20 points of encumbrance combined is ignored
             const int arms_encumb = std::max( 0,
-                                              guy.avg_encumb_of_limb_type( body_part_type::type::arm ) - 10 );
+                                              guy.avg_encumb_of_limb_type( bp_type::arm ) - 10 );
             casting_time += arms_encumb * 2 * temp_somatic_difficulty_multiplyer;
         }
     }
@@ -1252,7 +1252,7 @@ float spell::spell_fail( const Character &guy ) const
             !guy.has_flag( json_flag_SUBTLE_SPELL ) && temp_somatic_difficulty_multiplyer > 0 ) {
             // the first 20 points of encumbrance combined is ignored
             const int arms_encumb = std::max( 0,
-                                              guy.avg_encumb_of_limb_type( body_part_type::type::arm ) - 10 );
+                                              guy.avg_encumb_of_limb_type( bp_type::arm ) - 10 );
             // each encumbrance point beyond the "gray" color counts as half an additional fail %
             fail_chance += ( arms_encumb / 200.0f ) * temp_somatic_difficulty_multiplyer;
         }
@@ -1260,7 +1260,7 @@ float spell::spell_fail( const Character &guy ) const
             !guy.has_flag( json_flag_SILENT_SPELL ) && temp_sound_multiplyer > 0 ) {
             // a little bit of mouth encumbrance is allowed, but not much
             const int mouth_encumb = std::max( 0,
-                                               guy.avg_encumb_of_limb_type( body_part_type::type::mouth ) - 5 );
+                                               guy.avg_encumb_of_limb_type( bp_type::mouth ) - 5 );
             fail_chance += ( mouth_encumb / 100.0f ) * temp_sound_multiplyer;
         }
     }
@@ -2688,12 +2688,12 @@ bool spell::casting_time_encumbered( const Character &guy ) const
     int encumb = 0;
     if( !has_flag( spell_flag::NO_LEGS ) && temp_somatic_difficulty_multiplyer > 0 ) {
         // the first 20 points of encumbrance combined is ignored
-        encumb += std::max( 0, guy.avg_encumb_of_limb_type( body_part_type::type::leg ) - 10 );
+        encumb += std::max( 0, guy.avg_encumb_of_limb_type( bp_type::leg ) - 10 );
     }
     if( has_flag( spell_flag::SOMATIC ) && !guy.has_flag( json_flag_SUBTLE_SPELL ) &&
         temp_somatic_difficulty_multiplyer > 0 ) {
         // the first 20 points of encumbrance combined is ignored
-        encumb += std::max( 0, guy.avg_encumb_of_limb_type( body_part_type::type::arm ) - 10 );
+        encumb += std::max( 0, guy.avg_encumb_of_limb_type( bp_type::arm ) - 10 );
     }
     return encumb > 0;
 }
@@ -2701,7 +2701,7 @@ bool spell::casting_time_encumbered( const Character &guy ) const
 bool spell::energy_cost_encumbered( const Character &guy ) const
 {
     if( !no_hands() && !guy.has_flag( json_flag_SUBTLE_SPELL ) ) {
-        return std::max( 0, guy.avg_encumb_of_limb_type( body_part_type::type:: hand ) - 5 ) >
+        return std::max( 0, guy.avg_encumb_of_limb_type( bp_type:: hand ) - 5 ) >
                0;
     }
     return false;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2930,13 +2930,13 @@ void map::drop_items( const tripoint_bub_ms &p )
             creature_hit_chance /= sqrt( avoid_chance );
             bodypart_id hit_part;
             if( creature_hit_chance < 15 ) {
-                hit_part = creature_below->get_random_body_part_of_type( body_part_type::type::head );
+                hit_part = creature_below->get_random_body_part_of_type( bp_type::head );
             } else if( creature_hit_chance < 30 ) {
-                hit_part = creature_below->get_random_body_part_of_type( body_part_type::type::torso );
+                hit_part = creature_below->get_random_body_part_of_type( bp_type::torso );
             } else if( creature_hit_chance < 90 ) {
-                hit_part = creature_below->get_random_body_part_of_type( body_part_type::type::arm );
+                hit_part = creature_below->get_random_body_part_of_type( bp_type::arm );
             } else if( creature_hit_chance < 100 ) {
-                hit_part = creature_below->get_random_body_part_of_type( body_part_type::type::leg );
+                hit_part = creature_below->get_random_body_part_of_type( bp_type::leg );
             } else {
                 add_msg_if_player_sees( creature_below->pos_bub(), _( "Falling %1$s misses %2$s!" ), i.tname(),
                                         creature_below->disp_name() );

--- a/src/mapgen_functions.cpp
+++ b/src/mapgen_functions.cpp
@@ -24,7 +24,6 @@
 #include "mapdata.h"
 #include "map_iterator.h"
 #include "map_scale_constants.h"
-#include "mapdata.h"
 #include "mapgen.h"
 #include "mapgendata.h"
 #include "mapgenformat.h"

--- a/src/martialarts.cpp
+++ b/src/martialarts.cpp
@@ -1515,7 +1515,7 @@ std::optional<std::pair<attack_vector_id, sub_bodypart_str_id>>
         }
         // Check if we have the required limbs
         bool reqs = true;
-        for( const std::pair<body_part_type::type, int> &req : vec->limb_req ) {
+        for( const std::pair<bp_type, int> &req : vec->limb_req ) {
             int count = 0;
             for( const bodypart_id &bp : user.get_all_body_parts_of_type( req.first ) ) {
                 if( user.get_part_hp_cur( bp ) > bp->health_limit ) {
@@ -1681,13 +1681,13 @@ bool character_martial_arts::can_leg_block( const Character &owner ) const
     // Do we have boring human anatomy? Use the basic calculation
     // Legs are harder to block with, so the score thresholds stay the same
     if( !owner.has_flag( json_flag_NONSTANDARD_BLOCK ) ) {
-        return owner.get_limb_score( limb_score_block, body_part_type::type::leg ) >= 0.5f;
+        return owner.get_limb_score( limb_score_block, bp_type::leg ) >= 0.5f;
     } else {
         // Check all standard legs for the score threshold
-        for( const bodypart_id &bp : owner.get_all_body_parts_of_type( body_part_type::type::leg ) ) {
+        for( const bodypart_id &bp : owner.get_all_body_parts_of_type( bp_type::leg ) ) {
             if( !bp->has_flag( json_flag_NONSTANDARD_BLOCK ) &&
                 owner.get_part( bp )->get_limb_score( owner, limb_score_block ) * bp->limbtypes.at(
-                    body_part_type::type::leg ) >= 0.25f ) {
+                    bp_type::leg ) >= 0.25f ) {
                 return true;
             }
         }
@@ -1715,13 +1715,13 @@ bool character_martial_arts::can_arm_block( const Character &owner ) const
     // Success conditions.
     // Do we have boring human anatomy? Use the basic calculation
     if( !owner.has_flag( json_flag_NONSTANDARD_BLOCK ) ) {
-        return owner.get_limb_score( limb_score_block, body_part_type::type::arm ) >= 0.5f;
+        return owner.get_limb_score( limb_score_block, bp_type::arm ) >= 0.5f;
     } else {
         // Check all standard arms for the score threshold
-        for( const bodypart_id &bp : owner.get_all_body_parts_of_type( body_part_type::type::arm ) ) {
+        for( const bodypart_id &bp : owner.get_all_body_parts_of_type( bp_type::arm ) ) {
             if( !bp->has_flag( json_flag_NONSTANDARD_BLOCK ) &&
                 owner.get_part( bp )->get_limb_score( owner, limb_score_block ) * bp->limbtypes.at(
-                    body_part_type::type::arm ) >= 0.25f ) {
+                    bp_type::arm ) >= 0.25f ) {
                 return true;
             }
         }

--- a/src/martialarts.h
+++ b/src/martialarts.h
@@ -10,7 +10,6 @@
 #include <utility>
 #include <vector>
 
-#include "bodypart.h"
 #include "bonuses.h"
 #include "calendar.h"
 #include "flat_set.h"
@@ -26,6 +25,7 @@ class item_location;
 struct const_dialogue;
 struct itype;
 template <typename T> class generic_factory;
+enum class bp_type;
 
 const matec_id tec_none( "tec_none" );
 
@@ -81,7 +81,7 @@ struct attack_vector {
     // The actual contact area for unarmed damage calcs
     std::vector<sub_bodypart_str_id> contact_area;
     // If we have any bodypart count restrictions
-    std::vector<std::pair<body_part_type::type, int>> limb_req;
+    std::vector<std::pair<bp_type, int>> limb_req;
     // Do we care about armor damage bonuses
     bool armor_bonus = true;
 

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -455,7 +455,7 @@ std::string Character::get_miss_reason()
     // in one turn
     add_miss_reason(
         _( "Your torso encumbrance throws you off-balance." ),
-        roll_remainder( avg_encumb_of_limb_type( body_part_type::type::torso ) / 10.0 ) );
+        roll_remainder( avg_encumb_of_limb_type( bp_type::torso ) / 10.0 ) );
     const int farsightedness = 2 * ( has_flag( json_flag_HYPEROPIC ) &&
                                      !worn_with_flag( flag_FIX_FARSIGHT ) &&
                                      !has_effect( effect_contacts ) &&

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -4210,7 +4210,7 @@ bool mattack::bio_op_impale( monster *z )
         target->deal_damage( z, bodypart_id( "torso" ), damage_instance( damage_stab, dam ) );
         if( do_bleed ) {
             target->add_effect( effect_source( z ), effect_bleed, rng( 3_minutes, 10_minutes ),
-                                target->get_random_body_part_of_type( body_part_type::type::torso ) );
+                                target->get_random_body_part_of_type( bp_type::torso ) );
         }
         if( seen ) {
             add_msg( _( "The %1$s impales %2$s!" ), z->name(), target->disp_name() );

--- a/src/mutation_data.cpp
+++ b/src/mutation_data.cpp
@@ -532,8 +532,8 @@ void mutation_branch::load( const JsonObject &jo, std::string_view src )
             for( const body_part_type &bp : body_part_type::get_all() ) {
                 if( type_string == "ALL" ) {
                     armor[bp.id] += res;
-                } else if( bp.limbtypes.count( io::string_to_enum<body_part_type::type>( type_string ) ) > 0 ) {
-                    armor[bp.id] += res * bp.limbtypes.at( io::string_to_enum<body_part_type::type>( type_string ) );
+                } else if( bp.limbtypes.count( io::string_to_enum<bp_type>( type_string ) ) > 0 ) {
+                    armor[bp.id] += res * bp.limbtypes.at( io::string_to_enum<bp_type>( type_string ) );
                 }
             }
         }

--- a/src/player_hardcoded_effects.cpp
+++ b/src/player_hardcoded_effects.cpp
@@ -268,7 +268,7 @@ static void eff_fun_fungus( Character &u, effect &it )
             } else if( one_in( 36000 + bonus * 240 ) ) {
                 // determine if we have arms to channel the fungal stalks out of
                 bool has_arms_outlet = true;
-                for( const bodypart_id &part : u.get_all_body_parts_of_type( body_part_type::type::arm ) ) {
+                for( const bodypart_id &part : u.get_all_body_parts_of_type( bp_type::arm ) ) {
                     if( part->has_flag( json_flag_BIONIC_LIMB ) ) {
                         has_arms_outlet = false;
                     }

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -397,7 +397,7 @@ void suffer::while_grabbed( Character &you )
             g->cancel_activity_or_ignore_query( distraction_type::oxygen, _( "You're suffocating!" ) );
         }
         // your characters chest is being crushed and you are dying
-        you.apply_damage( nullptr, you.get_random_body_part_of_type( body_part_type::type::torso ), rng( 1,
+        you.apply_damage( nullptr, you.get_random_body_part_of_type( bp_type::torso ), rng( 1,
                           4 ) );
     } else if( you.oxygen <= 15 ) {
         you.add_msg_if_player( m_bad, _( "You can't breathe with all this weight!" ) );

--- a/src/trapfunc.cpp
+++ b/src/trapfunc.cpp
@@ -791,7 +791,7 @@ bool trapfunc::snare_species( const tripoint_bub_ms &p, Creature *critter, item 
     }
 
     if( critter ) {
-        const bodypart_id hit = critter->get_random_body_part_of_type( body_part_type::type::leg );
+        const bodypart_id hit = critter->get_random_body_part_of_type( bp_type::leg );
 
         critter->add_msg_if_player( m_bad, _( "A %1$s catches your %2$s!" ),
                                     laid_trap.name(), hit->name.translated() );

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -1122,11 +1122,11 @@ veh_collision vehicle::part_collision( map &here, int part, const tripoint_abs_m
                 if( !critter->has_flag( json_flag_CANNOT_TAKE_DAMAGE ) ) {
                     if( vpi.has_flag( "SHARP" ) ) {
                         critter->add_effect( effect_source( driver ), effect_bleed, 1_minutes * rng( 1, dam ),
-                                             critter->get_random_body_part_of_type( body_part_type::type::torso ) );
+                                             critter->get_random_body_part_of_type( bp_type::torso ) );
                     } else if( dam > 18 && rng( 1, 20 ) > 15 ) {
                         //low chance of lighter bleed even with non sharp objects.
                         critter->add_effect( effect_source( driver ), effect_bleed, 1_minutes,
-                                             critter->get_random_body_part_of_type( body_part_type::type::torso ) );
+                                             critter->get_random_body_part_of_type( bp_type::torso ) );
                     }
                 }
                 add_msg_debug( debugmode::DF_VEHICLE_MOVE, "Critter collision damage: %d", dam );

--- a/src/weather.cpp
+++ b/src/weather.cpp
@@ -131,7 +131,7 @@ void glare( const weather_type_id &w )
         }
         // Glare in all your eyes
         for( bodypart_id &bp : player_character.get_all_body_parts_of_type(
-                 body_part_type::type::sensor ) ) {
+                 bp_type::sensor ) ) {
             player_character.add_effect( *effect, dur, bp );
         }
     }

--- a/tests/martial_art_test.cpp
+++ b/tests/martial_art_test.cpp
@@ -11,6 +11,7 @@
 #include "character_martial_arts.h"
 #include "coordinates.h"
 #include "creature.h"
+#include "enums.h"
 #include "item.h"
 #include "magic_enchantment.h"
 #include "map_helpers.h"
@@ -116,7 +117,7 @@ TEST_CASE( "Attack_vector_test", "[martial_arts][limb]" )
                                        false ) );
     REQUIRE( dude.evaluate_technique( tec2, target_1, dude.used_weapon(), false, false,
                                       false ) );
-    REQUIRE( dude.get_all_body_parts_of_type( body_part_type::type::tail ).empty() );
+    REQUIRE( dude.get_all_body_parts_of_type( bp_type::tail ).empty() );
 
     SECTION( "Limb requirements" ) {
         // Grow a tail, suddenly we can use it
@@ -150,7 +151,7 @@ TEST_CASE( "Attack_vector_test", "[martial_arts][limb]" )
                                          false ) );
     }
     SECTION( "Encumbrance" ) {
-        REQUIRE( dude.get_all_body_parts_of_type( body_part_type::type::tail ).empty() );
+        REQUIRE( dude.get_all_body_parts_of_type( bp_type::tail ).empty() );
         item test_eoc_armor_suit( itype_test_eoc_armor_suit );
         REQUIRE( dude.wear_item( test_eoc_armor_suit, false ) );
         CHECK( !dude.evaluate_technique( tec, target_1, dude.used_weapon(), false, false,


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Continuation of #82525
`bodypart.h` includes `wound.h`. `wound.h` want to use `body_part_type::type`. to do this, `wound.h` have to include `bodypart.h`. Loop
#### Describe the solution
Resolve loop by moving body_part_type::type (and renaming, since it's not part of `body_part_type` now) to enums.h
#### Testing
The game compiles and works exactly the same as before, as it should be