### PR TITLE
do not list items that can be installed in vehicles if they cannot be

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -6216,7 +6216,9 @@ void item::final_info( std::vector<iteminfo> &info, const iteminfo_query *parts,
 
         print_parts( vparts, _( "You could install it in a vehicle: %s" ),
         []( const vpart_info & vp ) {
-            return !vp.has_flag( vpart_bitflags::VPFLAG_APPLIANCE );
+            return !vp.has_flag( vpart_bitflags::VPFLAG_APPLIANCE ) &&
+                   !vp.has_flag( "NO_INSTALL_HIDDEN" ) &&
+                   !vp.has_flag( "NO_INSTALL_PLAYER" );
         } );
 
         print_parts( vparts, _( "You could install it as an appliance: %s" ),


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
<img width="1433" height="891" alt="image" src="https://github.com/user-attachments/assets/511366fd-5fa8-4990-8fb4-bc8bc88a6e27" />

#### Describe the solution
Exclude parts that have NO_INSTALL_HIDDEN or NO_INSTALL_PLAYER flags
#### Describe alternatives you've considered
Making proper vehiclepart migration, but that would be too big to be backported anyway
#### Testing

Food truck fridge, can be installed, shows it can be installed
<img width="652" height="732" alt="image" src="https://github.com/user-attachments/assets/19a457ff-e644-4aca-a327-a1e8f1f67046" />
Household fridge, cannot be installed, doesn't show it can be installed anymore
<img width="656" height="752" alt="image" src="https://github.com/user-attachments/assets/9bd62c9e-6ada-49f0-aa4a-74f6e9e5dc11" />
