### PR TITLE
Fix deep frying calories

### DIFF
--- a/data/json/recipes/food/junkfood.json
+++ b/data/json/recipes/food/junkfood.json
@@ -48,7 +48,7 @@
     "activity_level": "LIGHT_EXERCISE",
     "batch_time_factors": [ 70, 1 ],
     "qualities": [ { "id": "CUT", "level": 2 }, { "id": "COOK", "level": 2 } ],
-    "tools": [ [ [ "surface_heat", 8, "LIST" ] ], [ [ "cooking_oil", 20 ] ] ],
+    "tools": [ [ [ "surface_heat", 8, "LIST" ] ], [ [ "cooking_oil", 19 ] ] ],
     "proficiencies": [
       { "proficiency": "prof_food_prep", "time_multiplier": 1 },
       { "proficiency": "prof_knife_skills", "time_multiplier": 1 },
@@ -176,7 +176,7 @@
     "time": "16 m",
     "batch_time_factors": [ 70, 1 ],
     "qualities": [ { "id": "CUT", "level": 2 }, { "id": "COOK", "level": 2 } ],
-    "tools": [ [ [ "surface_heat", 8, "LIST" ] ], [ [ "cooking_oil", 50 ] ] ],
+    "tools": [ [ [ "surface_heat", 8, "LIST" ] ], [ [ "cooking_oil", 47 ] ] ],
     "proficiencies": [
       { "proficiency": "prof_food_prep", "time_multiplier": 1 },
       { "proficiency": "prof_knife_skills", "time_multiplier": 1 },

--- a/data/json/recipes/food/junkfood.json
+++ b/data/json/recipes/food/junkfood.json
@@ -48,13 +48,13 @@
     "activity_level": "LIGHT_EXERCISE",
     "batch_time_factors": [ 70, 1 ],
     "qualities": [ { "id": "CUT", "level": 2 }, { "id": "COOK", "level": 2 } ],
-    "tools": [ [ [ "surface_heat", 8, "LIST" ] ] ],
+    "tools": [ [ [ "surface_heat", 8, "LIST" ] ], [ [ "cooking_oil", 20 ] ] ],
     "proficiencies": [
       { "proficiency": "prof_food_prep", "time_multiplier": 1 },
       { "proficiency": "prof_knife_skills", "time_multiplier": 1 },
       { "proficiency": "prof_frying", "time_multiplier": 1.2 }
     ],
-    "components": [ [ [ "veggy_potatolike", 1, "LIST" ] ], [ [ "salt", 2 ], [ "seasoning_salt", 2 ] ], [ [ "cooking_oil", 20 ] ] ],
+    "components": [ [ [ "veggy_potatolike", 1, "LIST" ] ], [ [ "salt", 2 ], [ "seasoning_salt", 2 ] ], [ [ "cooking_oil", 1 ] ] ],
     "byproducts": [ [ "cooking_oil", 19 ] ],
     "charges": 2
   },
@@ -176,7 +176,7 @@
     "time": "16 m",
     "batch_time_factors": [ 70, 1 ],
     "qualities": [ { "id": "CUT", "level": 2 }, { "id": "COOK", "level": 2 } ],
-    "tools": [ [ [ "surface_heat", 8, "LIST" ] ] ],
+    "tools": [ [ [ "surface_heat", 8, "LIST" ] ], [ [ "cooking_oil", 50 ] ] ],
     "proficiencies": [
       { "proficiency": "prof_food_prep", "time_multiplier": 1 },
       { "proficiency": "prof_knife_skills", "time_multiplier": 1 },
@@ -185,7 +185,7 @@
     "components": [
       [ [ "veggy_potatolike", 1, "LIST" ], [ "carrot", 3 ], [ "carrot_wild", 3 ] ],
       [ [ "salt", 2 ], [ "seasoning_salt", 2 ] ],
-      [ [ "cooking_oil", 50 ] ]
+      [ [ "cooking_oil", 3 ] ]
     ],
     "byproducts": [ [ "cooking_oil", 47 ] ],
     "charges": 3

--- a/data/json/recipes/food/offal_dishes.json
+++ b/data/json/recipes/food/offal_dishes.json
@@ -321,7 +321,7 @@
     "batch_time_factors": [ 70, 1 ],
     "book_learn": [ [ "cookbook", 1 ], [ "scots_cookbook", 2 ] ],
     "qualities": [ { "id": "CUT", "level": 2 }, { "id": "COOK", "level": 3 } ],
-    "tools": [ [ [ "surface_heat", 11, "LIST" ] ], [ [ "cooking_oil", 20 ] ] ],
+    "tools": [ [ [ "surface_heat", 11, "LIST" ] ], [ [ "cooking_oil", 19 ] ] ],
     "//1": "70g of tripe, so roughly 5 (2.5 scraps' worth) plus 6 for the batter and oil",
     "proficiencies": [
       { "proficiency": "prof_food_prep", "time_multiplier": 1 },

--- a/data/json/recipes/food/offal_dishes.json
+++ b/data/json/recipes/food/offal_dishes.json
@@ -321,7 +321,7 @@
     "batch_time_factors": [ 70, 1 ],
     "book_learn": [ [ "cookbook", 1 ], [ "scots_cookbook", 2 ] ],
     "qualities": [ { "id": "CUT", "level": 2 }, { "id": "COOK", "level": 3 } ],
-    "tools": [ [ [ "surface_heat", 11, "LIST" ] ] ],
+    "tools": [ [ [ "surface_heat", 11, "LIST" ] ], [ [ "cooking_oil", 20 ] ] ],
     "//1": "70g of tripe, so roughly 5 (2.5 scraps' worth) plus 6 for the batter and oil",
     "proficiencies": [
       { "proficiency": "prof_food_prep", "time_multiplier": 1 },
@@ -329,7 +329,7 @@
       { "proficiency": "prof_frying", "time_multiplier": 1.2 },
       { "proficiency": "prof_frying_bread", "time_multiplier": 1 }
     ],
-    "components": [ [ [ "stewed_tripe", 1 ] ], [ [ "batter", 3, "LIST" ] ], [ [ "cooking_oil", 20 ] ] ],
+    "components": [ [ [ "stewed_tripe", 1 ] ], [ [ "batter", 3, "LIST" ] ], [ [ "cooking_oil", 1 ] ] ],
     "byproducts": [ [ "cooking_oil", 19 ] ]
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
The way deep frying is simulated in the fries/chips/tripe recipes is by using oil as component which massively inflates the calories even though it gives most of it back as byproduct, which is wrong.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Finally I came up with a template for deep frying that should work, total cooking oil used as tool, so no calories from there, some is consumed hence put in the components list, and then most of it is given back as byproducts. This should do everything we want.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
We still can't use generic oil as a tool due to byproducts necessitating a specific item as output.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Checked the recipe in game, it may be a bit hard to read but it should **finally** work as intended.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Please let me be free of this.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
