### PR TITLE
Add serialization for TALK_MISSION_INQUIRE/TALK_MISSION_DESCRIBE_URGENT

### DIFF
--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -1931,6 +1931,8 @@ void dialogue_chatbin::serialize( JsonOut &json ) const
     json.member( "talk_stranger_friendly", talk_stranger_friendly );
     json.member( "talk_stranger_neutral", talk_stranger_neutral );
     json.member( "talk_friend_guard", talk_friend_guard );
+    json.member( "talk_mission_inquire", talk_mission_inquire );
+    json.member( "talk_mission_describe_urgent", talk_mission_describe_urgent );
 
     if( mission_selected != nullptr ) {
         json.member( "mission_selected", mission_selected->get_id() );
@@ -1971,6 +1973,8 @@ void dialogue_chatbin::deserialize( const JsonObject &data )
     data.read( "style", style );
     data.read( "dialogue_spell", dialogue_spell );
     data.read( "proficiency", proficiency );
+    data.read( "talk_mission_inquire", talk_mission_inquire );
+    data.read( "talk_mission_describe_urgent", talk_mission_describe_urgent );
 
     std::vector<int> tmpmissions;
     data.read( "missions", tmpmissions );


### PR DESCRIPTION
#### Summary
Bugfixes "Add serialization for TALK_MISSION_INQUIRE/TALK_MISSION_DESCRIBE_URGENT"

#### Purpose of change
In PR #82879, I forgot to add serialization/deserialization for these topics.
Which caused them not to be saved/loaded.


#### Describe the solution
Added serialization/deserialization entries for both topics in savegame_json.cpp:
- TALK_MISSION_INQUIRE
- TALK_MISSION_DESCRIBE_URGENT


#### Describe alternatives you've considered
None.

#### Testing
- TALK_MISSION_INQUIRE
1. Created an NPC instance with custom topic as mission giver

1. Accepted mission and confirmed that the NPC says custom topic

1. Save&Load and talked to the NPC again and confirmed he still says custom topic


- TALK_MISSION_DESCRIBE_URGENT
1. Created an NPC instance with custom topic as urgent mission giver

1. Started the game and confirmed that the NPC says custom topic
1. Save&Load and talked to the NPC again and confirmed he still says custom topic


#### Additional context
This is a fix to PR #82879.
