### PR TITLE
[MoM] Add contemplation recipes for knacks (through photokinesis)

### DIFF
--- a/data/mods/MindOverMatter/effectoncondition/eoc_learn_recipes.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_learn_recipes.json
@@ -1203,6 +1203,76 @@
   },
   {
     "type": "effect_on_condition",
+    "id": "EACH_TEACH_KNACK_RECIPES",
+    "eoc_type": "EVENT",
+    "required_event": "game_begin",
+    "condition": { "u_has_trait": "PSYCHIC_KNACK" },
+    "effect": [ { "run_eocs": "EOC_TEACH_VITAKIN_CONTEMPLATE_RECIPES" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EACH_TEACH_KNACK_CONTEMPLATION_RECIPES",
+    "effect": [
+      {
+        "if": { "math": [ "u_spell_level('biokin_flexibility_knack') >= 1" ] },
+        "then": { "u_learn_recipe": "practice_biokin_flexibility_knack" }
+      },
+      {
+        "if": { "math": [ "u_spell_level('biokin_adrenaline_knack') >= 1" ] },
+        "then": { "u_learn_recipe": "practice_biokin_adrenaline_knack" }
+      },
+      {
+        "if": { "math": [ "u_spell_level('clair_better_senses_knack') >= 1" ] },
+        "then": { "u_learn_recipe": "practice_clair_better_senses_knack" }
+      },
+      {
+        "if": { "math": [ "u_spell_level('clair_danger_sense_knack') >= 1" ] },
+        "then": { "u_learn_recipe": "practice_clair_danger_sense_knack" }
+      },
+      {
+        "if": { "math": [ "u_spell_level('clair_examine_item_knack') >= 1" ] },
+        "then": { "u_learn_recipe": "practice_clair_examine_item_knack" }
+      },
+      {
+        "if": { "math": [ "u_spell_level('clair_astral_projection_knack') >= 1" ] },
+        "then": { "u_learn_recipe": "practice_clair_astral_projection_knack" }
+      },
+      {
+        "if": { "math": [ "u_spell_level('electrokinetic_see_electric_knack') >= 1" ] },
+        "then": { "u_learn_recipe": "practice_electrokinetic_see_electric_knack" }
+      },
+      {
+        "if": { "math": [ "u_spell_level('electrokinetic_pain_immune_knack') >= 1" ] },
+        "then": { "u_learn_recipe": "practice_electrokinetic_pain_immune_knack" }
+      },
+      {
+        "if": { "math": [ "u_spell_level('electrokinetic_hacking_interface_knack') >= 1" ] },
+        "then": { "u_learn_recipe": "practice_electrokinetic_hacking_interface_knack" }
+      },
+      {
+        "if": { "math": [ "u_spell_level('photokinetic_camouflage_knack') >= 1" ] },
+        "then": { "u_learn_recipe": "practice_photokinetic_camouflage_knack" }
+      },
+      {
+        "if": { "math": [ "u_spell_level('photokinetic_hide_ugly_knack') >= 1" ] },
+        "then": { "u_learn_recipe": "practice_photokinetic_hide_ugly_knack" }
+      },
+      {
+        "if": { "math": [ "u_spell_level('photokinetic_radio_knack') >= 1" ] },
+        "then": { "u_learn_recipe": "practice_photokinetic_radio_knack" }
+      },
+      {
+        "if": { "math": [ "u_spell_level('telekinetic_pull_knack') >= 1" ] },
+        "then": { "u_learn_recipe": "practice_telekinetic_pull_knack" }
+      },
+      {
+        "if": { "math": [ "u_spell_level('telekinetic_push_knack') >= 1" ] },
+        "then": { "u_learn_recipe": "practice_telekinetic_push_knack" }
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
     "id": "EOC_PSI_LEARNING_VITAMIN_COUNTER",
     "recurrence": [
       { "math": [ "jmath_psi_learning_counter_time_low(global_insight_power_learning_time_low)" ] },

--- a/data/mods/MindOverMatter/effectoncondition/eoc_learn_recipes.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_learn_recipes.json
@@ -1203,15 +1203,15 @@
   },
   {
     "type": "effect_on_condition",
-    "id": "EACH_TEACH_KNACK_RECIPES",
+    "id": "EOC_TEACH_KNACK_RECIPES",
     "eoc_type": "EVENT",
     "required_event": "game_begin",
     "condition": { "u_has_trait": "PSYCHIC_KNACK" },
-    "effect": [ { "run_eocs": "EOC_TEACH_VITAKIN_CONTEMPLATE_RECIPES" } ]
+    "effect": [ { "run_eocs": "EOC_TEACH_KNACK_CONTEMPLATION_RECIPES" } ]
   },
   {
     "type": "effect_on_condition",
-    "id": "EACH_TEACH_KNACK_CONTEMPLATION_RECIPES",
+    "id": "EOC_TEACH_KNACK_CONTEMPLATION_RECIPES",
     "effect": [
       {
         "if": { "math": [ "u_spell_level('biokin_flexibility_knack') >= 1" ] },

--- a/data/mods/MindOverMatter/recipes/practice/photokinesis_practice.json
+++ b/data/mods/MindOverMatter/recipes/practice/photokinesis_practice.json
@@ -521,7 +521,7 @@
     "activity_level": "LIGHT_EXERCISE",
     "name": "contemplation: mirror-mask",
     "id": "practice_photokinetic_hide_ugly",
-    "description": "Contemplate your powers and improve your ability to create illusions of extra arms.\n\nPower Difficulty: 4",
+    "description": "Contemplate your powers and improve your ability to disguise your appearance behind an illusion.\n\nPower Difficulty: 4",
     "category": "CC_*",
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",

--- a/data/mods/MindOverMatter/recipes/practice/psychic_knacks.json
+++ b/data/mods/MindOverMatter/recipes/practice/psychic_knacks.json
@@ -1,0 +1,407 @@
+[
+  {
+    "id": "psychic_knack_practice",
+    "type": "nested_category",
+    "activity_level": "LIGHT_EXERCISE",
+    "category": "CC_PRACTICE",
+    "subcategory": "CSC_PRACTICE_METAPHYSICS",
+    "name": "contemplation: knacks",
+    "description": "Recipes related to practicing biokinesis.",
+    "skill_used": "metaphysics",
+    "nested_category_data": [
+      "practice_biokin_flexibility_knack",
+      "practice_biokin_adrenaline_knack",
+      "practice_clair_better_senses_knack",
+      "practice_clair_danger_sense_knack",
+      "practice_clair_examine_item_knack",
+      "practice_clair_astral_projection_knack",
+      "practice_electrokinetic_see_electric_knack",
+      "practice_electrokinetic_pain_immune_knack",
+      "practice_electrokinetic_hacking_interface_knack",
+      "practice_photokinetic_camouflage_knack",
+      "practice_photokinetic_hide_ugly_knack",
+      "practice_photokinetic_radio_knack",
+      "practice_telekinetic_pull_knack",
+      "practice_telekinetic_push_knack"
+    ],
+    "difficulty": 1
+  },
+  {
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "name": "contemplation: flexibility",
+    "id": "practice_biokin_flexibility_knack",
+    "description": "Contemplate your powers and improve your ability to move your body.",
+    "category": "CC_*",
+    "subcategory": "CSC_*_NESTED",
+    "skill_used": "metaphysics",
+    "difficulty": 0,
+    "time": "0 s",
+    "autolearn": false,
+    "proficiencies": [ { "proficiency": "prof_contemplation_biokinesis", "required": false } ],
+    "flags": [ "SECRET", "BLIND_EASY", "NO_MANIP", "AFFECTED_BY_PAIN", "NO_BENCH", "NO_ENCHANTMENT" ],
+    "result_eocs": [
+      {
+        "id": "EOC_PRACTICE_BIOKIN_FLEXIBILITY_KNACK",
+        "condition": { "u_has_trait": "PSYCHIC_KNACK" },
+        "effect": [
+          { "set_string_var": "biokin_flexibility_knack", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "run_eocs": [ "EOC_PSI_STUDYING_BIOKIN_POWER_SETUP", "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "name": "contemplation: adrenaline trigger",
+    "id": "practice_biokin_adrenaline_knack",
+    "description": "Contemplate your powers and improve your ability to trigger a burst of adrenaline on command.",
+    "category": "CC_*",
+    "subcategory": "CSC_*_NESTED",
+    "skill_used": "metaphysics",
+    "difficulty": 0,
+    "time": "0 s",
+    "autolearn": false,
+    "proficiencies": [ { "proficiency": "prof_contemplation_biokinesis", "required": false } ],
+    "flags": [ "SECRET", "BLIND_EASY", "NO_MANIP", "AFFECTED_BY_PAIN", "NO_BENCH", "NO_ENCHANTMENT" ],
+    "result_eocs": [
+      {
+        "id": "EOC_PRACTICE_BIOKIN_ADRENALINE_KNACK",
+        "condition": { "u_has_trait": "PSYCHIC_KNACK" },
+        "effect": [
+          { "set_string_var": "biokin_adrenaline_knack", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "run_eocs": [ "EOC_PSI_STUDYING_BIOKIN_POWER_SETUP", "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "name": "contemplation: heightened senses",
+    "id": "practice_clair_better_senses_knack",
+    "description": "Contemplate your powers and improve your ability to enhance your mundane senses.",
+    "category": "CC_*",
+    "subcategory": "CSC_*_NESTED",
+    "skill_used": "metaphysics",
+    "difficulty": 0,
+    "time": "0 s",
+    "autolearn": false,
+    "proficiencies": [ { "proficiency": "prof_contemplation_clairsentience", "required": false } ],
+    "flags": [ "SECRET", "BLIND_EASY", "NO_MANIP", "AFFECTED_BY_PAIN", "NO_BENCH", "NO_ENCHANTMENT" ],
+    "result_eocs": [
+      {
+        "id": "EOC_PRACTICE_CLAIR_HEIGHTENED_SENSES_KNACK",
+        "condition": { "u_has_trait": "PSYCHIC_KNACK" },
+        "effect": [
+          { "set_string_var": "clair_better_senses_knack", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "run_eocs": [ "EOC_PSI_STUDYING_CLAIR_POWER_SETUP", "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "name": "contemplation: premonition",
+    "id": "practice_clair_danger_sense_knack",
+    "description": "Contemplate your powers and improve your sense of nearby danger.",
+    "category": "CC_*",
+    "subcategory": "CSC_*_NESTED",
+    "skill_used": "metaphysics",
+    "difficulty": 0,
+    "time": "0 s",
+    "autolearn": false,
+    "proficiencies": [ { "proficiency": "prof_contemplation_clairsentience", "required": false } ],
+    "flags": [ "SECRET", "BLIND_EASY", "NO_MANIP", "AFFECTED_BY_PAIN", "NO_BENCH", "NO_ENCHANTMENT" ],
+    "result_eocs": [
+      {
+        "id": "EOC_PRACTICE_CLAIR_DANGER_SENSE_KNACK",
+        "condition": { "u_has_trait": "PSYCHIC_KNACK" },
+        "effect": [
+          { "set_string_var": "clair_danger_sense_knack", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "run_eocs": [ "EOC_PSI_STUDYING_CLAIR_POWER_SETUP", "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "name": "contemplation: psychometry",
+    "id": "practice_clair_examine_item_knack",
+    "description": "Contemplate your powers and improve your ability to determine hidden aspects of items.",
+    "category": "CC_*",
+    "subcategory": "CSC_*_NESTED",
+    "skill_used": "metaphysics",
+    "difficulty": 0,
+    "time": "0 s",
+    "autolearn": false,
+    "proficiencies": [ { "proficiency": "prof_contemplation_clairsentience", "required": false } ],
+    "flags": [ "SECRET", "BLIND_EASY", "NO_MANIP", "AFFECTED_BY_PAIN", "NO_BENCH", "NO_ENCHANTMENT" ],
+    "result_eocs": [
+      {
+        "id": "EOC_PRACTICE_CLAIR_EXAMINE_ITEM_KNACK",
+        "condition": { "u_has_trait": "PSYCHIC_KNACK" },
+        "effect": [
+          { "set_string_var": "clair_examine_item_knack", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "run_eocs": [ "EOC_PSI_STUDYING_CLAIR_POWER_SETUP", "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "name": "contemplation: astral projection",
+    "id": "practice_clair_astral_projection_knack",
+    "description": "Contemplate your powers and improve your ability to cast your spirit forth from your body.",
+    "category": "CC_*",
+    "subcategory": "CSC_*_NESTED",
+    "skill_used": "metaphysics",
+    "difficulty": 0,
+    "time": "0 s",
+    "autolearn": false,
+    "proficiencies": [ { "proficiency": "prof_contemplation_clairsentience", "required": false } ],
+    "flags": [ "SECRET", "BLIND_EASY", "NO_MANIP", "AFFECTED_BY_PAIN", "NO_BENCH", "NO_ENCHANTMENT" ],
+    "result_eocs": [
+      {
+        "id": "EOC_PRACTICE_CLAIR_ASTRAL_PROJECTION_KNACK",
+        "condition": { "u_has_trait": "PSYCHIC_KNACK" },
+        "effect": [
+          { "set_string_var": "clair_astral_projection_knack", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "run_eocs": [ "EOC_PSI_STUDYING_CLAIR_POWER_SETUP", "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "name": "contemplation: spark sight",
+    "id": "practice_electrokinetic_see_electric_knack",
+    "description": "Contemplate your powers and improve your ability to detect electrical creatures or robots.",
+    "category": "CC_*",
+    "subcategory": "CSC_*_NESTED",
+    "skill_used": "metaphysics",
+    "difficulty": 0,
+    "time": "0 s",
+    "autolearn": false,
+    "proficiencies": [ { "proficiency": "prof_contemplation_electrokinesis", "required": false } ],
+    "flags": [ "SECRET", "BLIND_EASY", "NO_MANIP", "AFFECTED_BY_PAIN", "NO_BENCH", "NO_ENCHANTMENT" ],
+    "result_eocs": [
+      {
+        "id": "EOC_PRACTICE_ELECTROKIN_SPARK_SIGHT_KNACK",
+        "condition": { "u_has_trait": "PSYCHIC_KNACK" },
+        "effect": [
+          { "set_string_var": "electrokinetic_see_electric_knack", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "run_eocs": [ "EOC_PSI_STUDYING_ELECTROKIN_POWER_SETUP", "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "name": "contemplation: analgesic block",
+    "id": "practice_electrokinetic_pain_immune_knack",
+    "description": "Contemplate your powers and improve your ability to put off the effects of pain completely until later.",
+    "category": "CC_*",
+    "subcategory": "CSC_*_NESTED",
+    "skill_used": "metaphysics",
+    "difficulty": 0,
+    "time": "0 s",
+    "autolearn": false,
+    "proficiencies": [ { "proficiency": "prof_contemplation_electrokinesis", "required": false } ],
+    "flags": [ "SECRET", "BLIND_EASY", "NO_MANIP", "AFFECTED_BY_PAIN", "NO_BENCH", "NO_ENCHANTMENT" ],
+    "result_eocs": [
+      {
+        "id": "EOC_PRACTICE_ELECTROKIN_PAIN_IMMUNE_KNACK",
+        "condition": { "u_has_trait": "PSYCHIC_KNACK" },
+        "effect": [
+          { "set_string_var": "electrokinetic_pain_immune_knack", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "run_eocs": [ "EOC_PSI_STUDYING_ELECTROKIN_POWER_SETUP", "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "name": "contemplation: hacking interface",
+    "id": "practice_electrokinetic_hacking_interface_knack",
+    "description": "Contemplate your powers and improve your ability to hack nearby devices with your powers.",
+    "category": "CC_*",
+    "subcategory": "CSC_*_NESTED",
+    "skill_used": "metaphysics",
+    "difficulty": 0,
+    "time": "0 s",
+    "autolearn": false,
+    "proficiencies": [ { "proficiency": "prof_contemplation_electrokinesis", "required": false } ],
+    "flags": [ "SECRET", "BLIND_EASY", "NO_MANIP", "AFFECTED_BY_PAIN", "NO_BENCH", "NO_ENCHANTMENT" ],
+    "result_eocs": [
+      {
+        "id": "EOC_PRACTICE_ELECTRO_HACKING_INTERFACE_KNACK",
+        "condition": { "u_has_trait": "PSYCHIC_KNACK" },
+        "effect": [
+          { "set_string_var": "electrokinetic_hacking_interface_knack", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "run_eocs": [ "EOC_PSI_STUDYING_ELECTROKIN_POWER_SETUP", "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "name": "contemplation: chameleoflage",
+    "id": "practice_photokinetic_camouflage_knack",
+    "description": "Contemplate your powers and improve your ability to hide your presence from distance observers.",
+    "category": "CC_*",
+    "subcategory": "CSC_*_NESTED",
+    "skill_used": "metaphysics",
+    "difficulty": 0,
+    "time": "0 s",
+    "autolearn": false,
+    "proficiencies": [ { "proficiency": "prof_contemplation_photokinesis", "required": false } ],
+    "flags": [ "SECRET", "BLIND_EASY", "NO_MANIP", "AFFECTED_BY_PAIN", "NO_BENCH", "NO_ENCHANTMENT" ],
+    "result_eocs": [
+      {
+        "id": "EOC_PRACTICE_PHOTOKIN_HIDE_UGLY_KNACK",
+        "condition": { "u_has_trait": "PSYCHIC_KNACK" },
+        "effect": [
+          { "set_string_var": "photokinetic_camouflage_knack", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "run_eocs": [ "EOC_PSI_STUDYING_PHOTOKIN_POWER_SETUP", "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "name": "contemplation: mirror-mask",
+    "id": "practice_photokinetic_hide_ugly_knack",
+    "description": "Contemplate your powers and improve your ability to disguise your appearance behind an illusion.",
+    "category": "CC_*",
+    "subcategory": "CSC_*_NESTED",
+    "skill_used": "metaphysics",
+    "difficulty": 0,
+    "time": "0 s",
+    "autolearn": false,
+    "proficiencies": [ { "proficiency": "prof_contemplation_photokinesis", "required": false } ],
+    "flags": [ "SECRET", "BLIND_EASY", "NO_MANIP", "AFFECTED_BY_PAIN", "NO_BENCH", "NO_ENCHANTMENT" ],
+    "result_eocs": [
+      {
+        "id": "EOC_PRACTICE_PHOTOKIN_HIDE_UGLY_KNACK",
+        "condition": { "u_has_trait": "PSYCHIC_KNACK" },
+        "effect": [
+          { "set_string_var": "photokinetic_hide_ugly_knack", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "run_eocs": [ "EOC_PSI_STUDYING_PHOTOKIN_POWER_SETUP", "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "name": "contemplation: radio transception",
+    "id": "practice_photokinetic_radio_knack",
+    "description": "Contemplate your powers and improve your ability to see, interpret, and transmit radio waves.",
+    "category": "CC_*",
+    "subcategory": "CSC_*_NESTED",
+    "skill_used": "metaphysics",
+    "difficulty": 0,
+    "time": "0 s",
+    "autolearn": false,
+    "proficiencies": [ { "proficiency": "prof_contemplation_photokinesis", "required": false } ],
+    "flags": [ "SECRET", "BLIND_EASY", "NO_MANIP", "AFFECTED_BY_PAIN", "NO_BENCH", "NO_ENCHANTMENT" ],
+    "result_eocs": [
+      {
+        "id": "EOC_PRACTICE_PHOTOKIN_RADIO_KNACK",
+        "condition": { "u_has_trait": "PSYCHIC_KNACK" },
+        "effect": [
+          { "set_string_var": "photokinetic_radio_knack", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "run_eocs": [ "EOC_PSI_STUDYING_PHOTOKIN_POWER_SETUP", "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "name": "contemplation: far hand",
+    "id": "practice_telekinetic_pull_knack",
+    "description": "Contemplate your powers and improve your manipulation of non-living matter.",
+    "category": "CC_*",
+    "subcategory": "CSC_*_NESTED",
+    "skill_used": "metaphysics",
+    "difficulty": 0,
+    "time": "0 s",
+    "autolearn": false,
+    "proficiencies": [ { "proficiency": "prof_contemplation_telekinesis", "required": false } ],
+    "flags": [ "SECRET", "BLIND_EASY", "NO_MANIP", "AFFECTED_BY_PAIN", "NO_BENCH", "NO_ENCHANTMENT" ],
+    "result_eocs": [
+      {
+        "id": "EOC_PRACTICE_TELEKIN_PULL_KNACK",
+        "condition": { "u_has_trait": "PSYCHIC_KNACK" },
+        "effect": [
+          { "set_string_var": "telekinetic_pull_knack", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "run_eocs": [ "EOC_PSI_STUDYING_TELEKIN_POWER_SETUP", "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "name": "contemplation: force shove",
+    "id": "practice_telekinetic_push_knack",
+    "description": "Contemplate your powers and improve your manipulation of living beings.",
+    "category": "CC_*",
+    "subcategory": "CSC_*_NESTED",
+    "skill_used": "metaphysics",
+    "difficulty": 0,
+    "time": "0 s",
+    "autolearn": false,
+    "proficiencies": [ { "proficiency": "prof_contemplation_telekinesis", "required": false } ],
+    "flags": [ "SECRET", "BLIND_EASY", "NO_MANIP", "AFFECTED_BY_PAIN", "NO_BENCH", "NO_ENCHANTMENT" ],
+    "result_eocs": [
+      {
+        "id": "EOC_PRACTICE_TELEKIN_PUSH_KNACK",
+        "condition": { "u_has_trait": "PSYCHIC_KNACK" },
+        "effect": [
+          { "set_string_var": "telekinetic_push_knack", "target_var": { "u_val": "latest_studied_power_name" } },
+          {
+            "run_eocs": [ "EOC_PSI_STUDYING_TELEKIN_POWER_SETUP", "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ]
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/data/mods/MindOverMatter/recipes/practice/psychic_knacks.json
+++ b/data/mods/MindOverMatter/recipes/practice/psychic_knacks.json
@@ -285,7 +285,7 @@
     "flags": [ "SECRET", "BLIND_EASY", "NO_MANIP", "AFFECTED_BY_PAIN", "NO_BENCH", "NO_ENCHANTMENT" ],
     "result_eocs": [
       {
-        "id": "EOC_PRACTICE_PHOTOKIN_HIDE_UGLY_KNACK",
+        "id": "EOC_PRACTICE_PHOTOKIN_CAMOUFLAGE_KNACK",
         "condition": { "u_has_trait": "PSYCHIC_KNACK" },
         "effect": [
           { "set_string_var": "photokinetic_camouflage_knack", "target_var": { "u_val": "latest_studied_power_name" } },

--- a/data/mods/MindOverMatter/recipes/practice/telekinesis_practice.json
+++ b/data/mods/MindOverMatter/recipes/practice/telekinesis_practice.json
@@ -35,7 +35,7 @@
     "activity_level": "LIGHT_EXERCISE",
     "name": "contemplation: far hand",
     "id": "practice_telekinetic_pull",
-    "description": "Contemplate your powers and improve your manipulation non-living matter.\n\nPower Difficulty: 1",
+    "description": "Contemplate your powers and improve your manipulation of non-living matter.\n\nPower Difficulty: 1",
     "category": "CC_*",
     "subcategory": "CSC_*_NESTED",
     "skill_used": "metaphysics",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[MoM] Add contemplation recipes for knacks (through photokinesis)"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

I figured having a lower Difficulty and starting at level 6 would be enough to make people not think they needed to grind the knacks through tons of button pressing, but [it turns out I was wrong](https://discourse.cataclysmdda.org/t/i-like-psychic-knacks-force-shove-and-use-it-a-lot-but/29810).

I didn't want to double a bunch of recipes, but, well, we do what we have to.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add contemplation recipes for knacks (through photokinesis). They work like normal contemplation recipes except they don't require a matrix crystal--if you have a knack you were born psychic, you don't need any external aids to help you train. They have their own collapse group they're all sorted into because usually you'll only have a couple (I assume).

Don't worry, `Dabbler` on the CDDA Discourse, I also threw in Far Hand and Force Shove in this first PR for you. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Started with some knacks, contemplated some knacks, got better at knacks.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
