### PR TITLE
Animal Discord/Empathy as starting traits in Tamable Wildlife

### DIFF
--- a/data/mods/Tamable_Wildlife/mutations/mutations.json
+++ b/data/mods/Tamable_Wildlife/mutations/mutations.json
@@ -1,0 +1,14 @@
+[
+  {
+    "type": "mutation",
+    "id": "ANIMALEMPATH",
+    "copy-from": "ANIMALEMPATH",
+    "starting_trait": true
+  },
+  {
+    "type": "mutation",
+    "id": "ANIMALDISCORD",
+    "copy-from": "ANIMALDISCORD",
+    "starting_trait": true
+  }
+]


### PR DESCRIPTION
#### Summary
Mods "Re-Adds the animal empathy/discord traits as starting traits when using Tamable Wildlife"

#### Purpose of change
#82892 removed these traits as starting traits in the main game, but they are very useful and thematically appropriate when using the mod.

#### Describe the solution
Adding the traits as possible starting traits when enabling the mod.

#### Describe alternatives you've considered
Creating a new pair of traits with the same effects but exclusive for the mod?

#### Testing
It works!

#### Additional context