### PR TITLE
Nestening - Weapons

### DIFF
--- a/data/json/recipes/nested.json
+++ b/data/json/recipes/nested.json
@@ -8354,7 +8354,7 @@
     "description": "Recipes for making wooden swords with various purposes and levels of refinement.",
     "skill_used": "fabrication",
     "nested_category_data": [ "sword_wood", "sword_wood_large", "sword_nail", "bokken" ],
-    "difficulty": 1 
+    "difficulty": 1
   },
   {
     "id": "nested_warhammer",
@@ -8389,7 +8389,7 @@
     "name": "batons",
     "description": "Recipes for making bashing sticks known variously as batons, tonfas or truncheons.",
     "skill_used": "fabrication",
-    "nested_category_data": [ "tonfa", "tonfa_wood", "shocktonfa_off", "blackjack", "cudgel" ],
+    "nested_category_data": ["tonfa", "tonfa_wood", "shocktonfa_off", "blackjack", "cudgel" ],
     "difficulty": 1
   },
   {
@@ -8401,7 +8401,7 @@
     "name": "clubs",
     "description": "Recipes for making wooden clubs of various levels of refinement.",
     "skill_used": "fabrication",
-    "nested_category_data": [ 
+    "nested_category_data": [
       "club_wooden",
       "club_wooden_nails",
       "club_wooden_bolted",
@@ -8411,7 +8411,7 @@
       "2H_club_kanabo_studded",
       "shillelagh"
     ],
-    "difficulty": 1 
+    "difficulty": 1
   },
   {
     "id": "nested_machete",
@@ -8441,7 +8441,7 @@
     "sword_crude_large",
     "sword_sheets_welded",
     "sword_sheets_welded_large"
-  ],
+    ],
     "difficulty": 1
   },
   {
@@ -8453,7 +8453,7 @@
     "name": "speedloader chutes",
     "description": "Recipes for creating tools useful to reload high capacity shotguns faster.",
     "skill_used": "fabrication",
-    "nested_category_data": [ 
+    "nested_category_data": [
       "arredondo_chute_remington_870",
       "arredondo_chute_remington_870_simple",
       "arredondo_chute_remington_870_breacher",

--- a/data/json/recipes/nested.json
+++ b/data/json/recipes/nested.json
@@ -8389,7 +8389,7 @@
     "name": "batons",
     "description": "Recipes for making bashing sticks known variously as batons, tonfas or truncheons.",
     "skill_used": "fabrication",
-    "nested_category_data": ["tonfa", "tonfa_wood", "shocktonfa_off", "blackjack", "cudgel" ],
+    "nested_category_data": [ "tonfa", "tonfa_wood", "shocktonfa_off", "blackjack", "cudgel" ],
     "difficulty": 1
   },
   {
@@ -8435,12 +8435,12 @@
     "description": "Recipes for creating metal swords of dubious quality out of dubious materials.",
     "skill_used": "fabrication",
     "nested_category_data": [
-    "sword_metal",
-    "sword_metal_large",
-    "sword_crude",
-    "sword_crude_large",
-    "sword_sheets_welded",
-    "sword_sheets_welded_large"
+      "sword_metal",
+      "sword_metal_large",
+      "sword_crude",
+      "sword_crude_large",
+      "sword_sheets_welded",
+      "sword_sheets_welded_large"
     ],
     "difficulty": 1
   },

--- a/data/json/recipes/nested.json
+++ b/data/json/recipes/nested.json
@@ -8347,7 +8347,7 @@
   {
     "id": "nested_wood_sword",
     "type": "nested_category",
-    "activity_level": "MODERATE_EXERCISE",
+    "activity_level": "LIGHT_EXERCISE",
     "category": "CC_WEAPON",
     "subcategory": "CSC_WEAPON_BASHING",
     "name": "clubs",
@@ -8359,7 +8359,7 @@
   {
     "id": "nested_warhammer",
     "type": "nested_category",
-    "activity_level": "MODERATE_EXERCISE",
+    "activity_level": "LIGHT_EXERCISE",
     "category": "CC_WEAPON",
     "subcategory": "CSC_WEAPON_BASHING",
     "name": "warhammers",
@@ -8371,7 +8371,7 @@
   {
     "id": "nested_bat",
     "type": "nested_category",
-    "activity_level": "MODERATE_EXERCISE",
+    "activity_level": "LIGHT_EXERCISE",
     "category": "CC_WEAPON",
     "subcategory": "CSC_WEAPON_BASHING",
     "name": "bats",
@@ -8383,7 +8383,7 @@
   {
     "id": "nested_baton",
     "type": "nested_category",
-    "activity_level": "MODERATE_EXERCISE",
+    "activity_level": "LIGHT_EXERCISE",
     "category": "CC_WEAPON",
     "subcategory": "CSC_WEAPON_BASHING",
     "name": "batons",
@@ -8395,7 +8395,7 @@
   {
     "id": "nested_club",
     "type": "nested_category",
-    "activity_level": "MODERATE_EXERCISE",
+    "activity_level": "LIGHT_EXERCISE",
     "category": "CC_WEAPON",
     "subcategory": "CSC_WEAPON_BASHING",
     "name": "clubs",
@@ -8416,7 +8416,7 @@
   {
     "id": "nested_machete",
     "type": "nested_category",
-    "activity_level": "MODERATE_EXERCISE",
+    "activity_level": "LIGHT_EXERCISE",
     "category": "CC_WEAPON",
     "subcategory": "CSC_WEAPON_CUTTING",
     "name": "machetes",
@@ -8428,7 +8428,7 @@
   {
     "id": "nested_makeshift_swords",
     "type": "nested_category",
-    "activity_level": "MODERATE_EXERCISE",
+    "activity_level": "LIGHT_EXERCISE",
     "category": "CC_WEAPON",
     "subcategory": "CSC_WEAPON_CUTTING",
     "name": "improvised swords",
@@ -8440,7 +8440,7 @@
   {
     "id": "nested_speedloader_chutes",
     "type": "nested_category",
-    "activity_level": "MODERATE_EXERCISE",
+    "activity_level": "LIGHT_EXERCISE",
     "category": "CC_WEAPON",
     "subcategory": "CSC_WEAPON_MODS",
     "name": "speedloader chutes",

--- a/data/json/recipes/nested.json
+++ b/data/json/recipes/nested.json
@@ -8350,7 +8350,7 @@
     "activity_level": "LIGHT_EXERCISE",
     "category": "CC_WEAPON",
     "subcategory": "CSC_WEAPON_BASHING",
-    "name": "clubs",
+    "name": "wooden swords",
     "description": "Recipes for making wooden swords with various purposes and levels of refinement.",
     "skill_used": "fabrication",
     "nested_category_data": [ "sword_wood", "sword_wood_large", "sword_nail", "bokken" ],

--- a/data/json/recipes/nested.json
+++ b/data/json/recipes/nested.json
@@ -8436,5 +8436,30 @@
     "skill_used": "fabrication",
     "nested_category_data": [ "sword_metal", "sword_metal_large", "sword_crude", "sword_crude_large", "sword_sheets_welded", "sword_sheets_welded_large" ],
     "difficulty": 1
+  },
+  {
+    "id": "nested_speedloader_chutes",
+    "type": "nested_category",
+    "activity_level": "MODERATE_EXERCISE",
+    "category": "CC_WEAPON",
+    "subcategory": "CSC_WEAPON_MODS",
+    "name": "speedloader chutes",
+    "description": "Recipes for creating tools useful to reload high capacity shotguns faster.",
+    "skill_used": "fabrication",
+    "nested_category_data": [ 
+      "arredondo_chute_remington_870",
+      "arredondo_chute_remington_870_simple",
+      "arredondo_chute_remington_870_breacher",
+      "arredondo_chute_remington_870_breacher_simple",
+      "arredondo_chute_benelli_sa",
+      "arredondo_chute_benelli_sa_simple",
+      "arredondo_chute_mossberg_500",
+      "arredondo_chute_mossberg_500_simple",
+      "arredondo_chute_mossberg_930",
+      "arredondo_chute_mossberg_930_simple",
+      "arredondo_chute_mossberg_590",
+      "arredondo_chute_mossberg_590_simple"
+    ],
+    "difficulty": 1
   }
 ]

--- a/data/json/recipes/nested.json
+++ b/data/json/recipes/nested.json
@@ -53,12 +53,13 @@
     "description": "Recipes related to constructing different types of staffs.",
     "skill_used": "fabrication",
     "nested_category_data": [
-      "shock_staff",
       "q_staff",
-      "bo_from long stick",
-      "bo_from quarterstaff",
       "i_staff",
       "i_staff_with sheet metal",
+      "shock_staff",
+      "bo_from long stick",
+      "bo_from quarterstaff",
+      "staff_pipe",
       "nested_steelshod"
     ],
     "difficulty": 1
@@ -8342,5 +8343,74 @@
       "bp_40x53mm_slug_m169",
       "bp_40x53mm_flechette_m169"
     ]
+  },
+  {
+    "id": "nested_wood_sword",
+    "type": "nested_category",
+    "activity_level": "MODERATE_EXERCISE",
+    "category": "CC_WEAPON",
+    "subcategory": "CSC_WEAPON_BASHING",
+    "name": "clubs",
+    "description": "Recipes for making wooden swords with various purposes and levels of refinement.",
+    "skill_used": "fabrication",
+    "nested_category_data": [ "sword_wood", "sword_wood_large", "sword_nail", "bokken" ],
+    "difficulty": 1 
+  },
+  {
+    "id": "nested_warhammer",
+    "type": "nested_category",
+    "activity_level": "MODERATE_EXERCISE",
+    "category": "CC_WEAPON",
+    "subcategory": "CSC_WEAPON_BASHING",
+    "name": "warhammers",
+    "description": "Recipes for making hammers used as weapons instead of tools.",
+    "skill_used": "fabrication",
+    "nested_category_data": [ "warhammer", "lucern_hammer", "homemade_polehammer", "homewrecker" ],
+    "difficulty": 1
+  },  
+  {
+    "id": "nested_bat",
+    "type": "nested_category",
+    "activity_level": "MODERATE_EXERCISE",
+    "category": "CC_WEAPON",
+    "subcategory": "CSC_WEAPON_BASHING",
+    "name": "bats",
+    "description": "Recipes for making baseball bats and improving them with various materials.",
+    "skill_used": "fabrication",
+    "nested_category_data": [ "bat", "bat_with_lathe", "nailbat", "bwirebat", "nutboltbat" ],
+    "difficulty": 1
+  },
+  {
+    "id": "nested_baton",
+    "type": "nested_category",
+    "activity_level": "MODERATE_EXERCISE",
+    "category": "CC_WEAPON",
+    "subcategory": "CSC_WEAPON_BASHING",
+    "name": "batons",
+    "description": "Recipes for making bashing sticks known variously as batons, tonfas or truncheons.",
+    "skill_used": "fabrication",
+    "nested_category_data": [ "tonfa", "tonfa_wood", "shocktonfa_off", "blackjack", "cudgel" ],
+    "difficulty": 1
+  },
+  {
+    "id": "nested_club",
+    "type": "nested_category",
+    "activity_level": "MODERATE_EXERCISE",
+    "category": "CC_WEAPON",
+    "subcategory": "CSC_WEAPON_BASHING",
+    "name": "clubs",
+    "description": "Recipes for making wooden clubs of various levels of refinement.",
+    "skill_used": "fabrication",
+    "nested_category_data": [ 
+      "club_wooden",
+      "club_wooden_nails",
+      "club_wooden_bolted",
+      "club_wooden_large_nails",
+      "club_wooden_large_bolted",
+      "2H_club_kanabo_spiked",
+      "2H_club_kanabo_studded",
+      "shillelagh"
+    ],
+    "difficulty": 1 
   }
 ]

--- a/data/json/recipes/nested.json
+++ b/data/json/recipes/nested.json
@@ -8434,7 +8434,14 @@
     "name": "improvised swords",
     "description": "Recipes for creating metal swords of dubious quality out of dubious materials.",
     "skill_used": "fabrication",
-    "nested_category_data": [ "sword_metal", "sword_metal_large", "sword_crude", "sword_crude_large", "sword_sheets_welded", "sword_sheets_welded_large" ],
+    "nested_category_data": [
+    "sword_metal",
+    "sword_metal_large",
+    "sword_crude",
+    "sword_crude_large",
+    "sword_sheets_welded",
+    "sword_sheets_welded_large"
+  ],
     "difficulty": 1
   },
   {

--- a/data/json/recipes/nested.json
+++ b/data/json/recipes/nested.json
@@ -4694,7 +4694,7 @@
     "name": "cutlasses",
     "description": "Recipes for making cutlasses.",
     "skill_used": "fabrication",
-    "nested_category_data": [ "lc_cutlass", "mc_cutlass", "hc_cutlass", "ch_cutlass", "qt_cutlass" ],
+    "nested_category_data": [ "cutlass", "lc_cutlass", "mc_cutlass", "hc_cutlass", "ch_cutlass", "qt_cutlass" ],
     "difficulty": 7
   },
   {
@@ -4860,7 +4860,7 @@
     "name": "kukris",
     "description": "Recipes for making kukris.",
     "skill_used": "fabrication",
-    "nested_category_data": [ "lc_kukri", "mc_kukri", "hc_kukri", "ch_kukri", "qt_kukri" ],
+    "nested_category_data": [ "kukri", "lc_kukri", "mc_kukri", "hc_kukri", "ch_kukri", "qt_kukri" ],
     "difficulty": 7
   },
   {
@@ -4896,7 +4896,7 @@
     "name": "battle axes",
     "description": "Recipes for making battle axes.",
     "skill_used": "fabrication",
-    "nested_category_data": [ "lc_battleaxe", "mc_battleaxe", "hc_battleaxe", "ch_battleaxe", "qt_battleaxe" ],
+    "nested_category_data": [ "battleaxe", "lc_battleaxe", "mc_battleaxe", "hc_battleaxe", "ch_battleaxe", "qt_battleaxe", "ax_sheets_welded" ],
     "difficulty": 7
   },
   {
@@ -8367,7 +8367,7 @@
     "skill_used": "fabrication",
     "nested_category_data": [ "warhammer", "lucern_hammer", "homemade_polehammer", "homewrecker" ],
     "difficulty": 1
-  },  
+  },
   {
     "id": "nested_bat",
     "type": "nested_category",
@@ -8412,5 +8412,29 @@
       "shillelagh"
     ],
     "difficulty": 1 
+  },
+  {
+    "id": "nested_machete",
+    "type": "nested_category",
+    "activity_level": "MODERATE_EXERCISE",
+    "category": "CC_WEAPON",
+    "subcategory": "CSC_WEAPON_CUTTING",
+    "name": "machetes",
+    "description": "Recipes for making useful tools able to cut through both brush and zombie limbs.",
+    "skill_used": "fabrication",
+    "nested_category_data": [ "machete", "makeshift_machete", "survivor_machete", "survivor_machete_qt" ],
+    "difficulty": 1
+  },
+  {
+    "id": "nested_makeshift_swords",
+    "type": "nested_category",
+    "activity_level": "MODERATE_EXERCISE",
+    "category": "CC_WEAPON",
+    "subcategory": "CSC_WEAPON_CUTTING",
+    "name": "improvised swords",
+    "description": "Recipes for creating metal swords of dubious quality out of dubious materials.",
+    "skill_used": "fabrication",
+    "nested_category_data": [ "sword_metal", "sword_metal_large", "sword_crude", "sword_crude_large", "sword_sheets_welded", "sword_sheets_welded_large" ],
+    "difficulty": 1
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Content "Nesting more Weapons"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
We had quite a few weapons that could be broadly grouped together into a few new nesting categories, they are now nested, I am open to criticism on the choices made but think the nests mostly make sense.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Recipes for clubs and bats and wood swords have been grouped with other recipes that makes clubs and bats and wood swords.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
- Leaving those recipes alone.
- Making more nests but other things felt like either category scope would be too broad or the nest underpopulated.
- Doing more than weapons in a single PR, but brevity and focus made it feel like it would be good to subdivide this into multiple PR.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Launched the game with the changes and looked at the crafting menu.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
