### PR TITLE
Add bodypart type white and black list fields for wounds

### DIFF
--- a/doc/JSON/WOUNDS.md
+++ b/doc/JSON/WOUNDS.md
@@ -16,6 +16,8 @@ Wound is a type, that affects specific bodyparts. It's similar in this to effect
     "pain": [ 1, 10 ], // when wound is applied, it would give character this random amount of pain rolled between this two numbers. Default 0
     "healing_time": [ "2 hours", "25 days" ], // how long this wound need time to be fully healed. Rolled randomly when applied, supposed to be adjusted by wound_fix.
             // Default infinite duration
+    "whitelist_body_part_types": [ "leg", "arm" ], // if used, this wound can be applied only at bodyparts of this type. Possible values are: head, torso, sensor, mouth, arm, hand, leg, foot, wing, tail, other
+    "blacklist_body_part_types": [ "torso", "sensor" ], // if used, this wound cannot be applied on bodyparts of this type.
     "whitelist_bp_with_flag": "LIMB_UPPER", // only body parts with this flag can receive the wound.
     "blacklist_bp_with_flag": "CYBERNETIC_OR_WHATEVER_IT_DOESNT_EXIST_YET", // Bodyparts with this flag cannot receive this wound.
   }

--- a/src/wound.cpp
+++ b/src/wound.cpp
@@ -6,6 +6,8 @@
 #include "json.h"
 #include "rng.h"
 
+enum class bp_type;
+
 void wound_type::load( const JsonObject &jo, const std::string_view & )
 {
     name_.make_plural();
@@ -20,9 +22,9 @@ void wound_type::load( const JsonObject &jo, const std::string_view & )
     optional( jo, was_loaded, "weight", weight, 1 );
 
     optional( jo, was_loaded, "whitelist_bp_with_flag", whitelist_bp_with_flag );
-    // optional( jo, was_loaded, "whitelist_body_part_type", whitelist_body_part_types );
+    optional( jo, was_loaded, "whitelist_body_part_types", whitelist_body_part_types );
     optional( jo, was_loaded, "blacklist_bp_with_flag", blacklist_bp_with_flag );
-    // optional( jo, was_loaded, "blacklist_body_part_type", blacklist_body_part_types );
+    optional( jo, was_loaded, "blacklist_body_part_types", blacklist_body_part_types );
 }
 
 wound::wound( wound_type_id wd ) :
@@ -89,11 +91,11 @@ bool wound_type::allowed_on_bodypart( bodypart_str_id bp_id ) const
 {
 
     // doesn't have bp type we want
-    // for( const body_part_type::type &bp_type : whitelist_body_part_types ) {
-    //     if( !bp_id->has_type( bp_type ) ) {
-    //         return false;
-    //     }
-    // }
+    for( const bp_type &bp_type : whitelist_body_part_types ) {
+        if( !bp_id->has_type( bp_type ) ) {
+            return false;
+        }
+    }
 
     // has no flag we want
     if( !bp_id->has_flag( whitelist_bp_with_flag ) &&
@@ -102,11 +104,11 @@ bool wound_type::allowed_on_bodypart( bodypart_str_id bp_id ) const
     }
 
     // has type we do not want
-    // for( const body_part_type::type &bp_type : blacklist_body_part_types ) {
-    //     if( bp_id->has_type( bp_type ) ) {
-    //         return false;
-    //     }
-    // }
+    for( const bp_type &bp_type : blacklist_body_part_types ) {
+        if( bp_id->has_type( bp_type ) ) {
+            return false;
+        }
+    }
 
     // has flag we do not want
     if( bp_id->has_flag( blacklist_bp_with_flag ) ) {

--- a/src/wound.h
+++ b/src/wound.h
@@ -14,6 +14,8 @@
 class JsonObject;
 class JsonOut;
 
+enum class bp_type;
+
 class wound_type
 {
     public:
@@ -48,9 +50,8 @@ class wound_type
         json_character_flag whitelist_bp_with_flag;
         json_character_flag blacklist_bp_with_flag;
 
-        // desired, but requires circular include to be fixed
-        // std::vector<body_part_type::type> whitelist_body_part_types;
-        // std::vector<body_part_type::type> blacklist_body_part_types;
+        std::vector<bp_type> whitelist_body_part_types;
+        std::vector<bp_type> blacklist_body_part_types;
 
     private:
         translation name_;


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Continuation of wound work
#### Describe the solution
Apply #82900, add a field that allow to black and whitelist specific bodypart types (only legs, only arms, only tails etc) when wound is rolled and applied
#### Testing
Test wound properly applied only at limb used in test (leg)