### PR TITLE
Bugfix for #82869

### DIFF
--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -1011,6 +1011,7 @@ void add_msg( const game_message_params &params, std::string msg )
     Messages::add_msg( params, std::move( msg ) );
 }
 
+// msg argument will not expand name place holders
 void add_msg_if_player_sees( const tripoint_bub_ms &target, std::string msg )
 {
     const map &here = get_map();

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1544,7 +1544,8 @@ bool npc::wield( item &it )
         return false;
     }
     if( get_wielded_item() ) {
-        add_msg_if_player_sees( *this, m_info, _( "<npcname> wields a %s." ),
+        // add_msg_if_player_sees does no internal npc name replacement 
+        add_msg_if_player_sees( *this, m_info, replace_with_npc_name( _( "<npcname> wields a %s." ) ),
                                 get_wielded_item()->tname() );
     }
 
@@ -1559,7 +1560,8 @@ bool npc::wield( item_location loc, bool remove_old )
         return false;
     }
     if( get_wielded_item() ) {
-        add_msg_if_player_sees( *this, m_info, _( "<npcname> wields a %s." ),
+        // add_msg_if_player_sees does no internal npc name replacement 
+        add_msg_if_player_sees( *this, m_info, replace_with_npc_name(_( "<npcname> wields a %s." )),
                                 get_wielded_item()->tname() );
     }
 

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1544,7 +1544,7 @@ bool npc::wield( item &it )
         return false;
     }
     if( get_wielded_item() ) {
-        // add_msg_if_player_sees does no internal npc name replacement 
+        // add_msg_if_player_sees does no internal npc name replacement
         add_msg_if_player_sees( *this, m_info, replace_with_npc_name( _( "<npcname> wields a %s." ) ),
                                 get_wielded_item()->tname() );
     }

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1560,8 +1560,8 @@ bool npc::wield( item_location loc, bool remove_old )
         return false;
     }
     if( get_wielded_item() ) {
-        // add_msg_if_player_sees does no internal npc name replacement 
-        add_msg_if_player_sees( *this, m_info, replace_with_npc_name(_( "<npcname> wields a %s." )),
+        // add_msg_if_player_sees does no internal npc name replacement
+        add_msg_if_player_sees( *this, m_info, replace_with_npc_name( _( "<npcname> wields a %s." ) ),
                                 get_wielded_item()->tname() );
     }
 


### PR DESCRIPTION
#### Summary
Bugfixes "<npcname> token will be replaced with NPC name"

#### Purpose of change

Closes #82869 

#### Describe the solution

Added ```replace_with_npc_name``` wrapping at the relevant lines.

#### Describe alternatives you've considered

- adding ```replace_with_npc_name``` to all the different implementation of ```add_msg_if_player_sees```. 
  But this looked like an overkill to me, because currently only two calls are affected.

#### Testing

- verified that the bug could be reproduced in a build before applying the fix
- verified that the bug could no longer be reproduced in a build after the fix

#### Additional context
