### PR TITLE
[Xedra Evolved] Add the triffid greenseer

### DIFF
--- a/data/mods/Xedra_Evolved/monsters/changeling.json
+++ b/data/mods/Xedra_Evolved/monsters/changeling.json
@@ -1015,6 +1015,7 @@
     "id": "mon_changeling_wisp",
     "type": "MONSTER",
     "name": "will-o'-the-wisp",
+    "looks_like": "mon_wisp",
     "description": "Drifting lights in the distance, moving slowly, seeming to light the way.  But to what?",
     "default_faction": "changeling",
     "bodytype": "blob",

--- a/data/mods/Xedra_Evolved/monsters/monster.json
+++ b/data/mods/Xedra_Evolved/monsters/monster.json
@@ -567,5 +567,59 @@
     "aggro_character": false,
     "melee_training_cap": 5,
     "extend": { "species": "GRACKEN" }
+  },
+  {
+    "type": "MONSTER",
+    "id": "mon_solar_spirit",
+    "name": "solar spirit",
+    "looks_like": "mon_wisp",
+    "description": "A blazing mote of light, so bright that it's impossible to look at directly.",
+    "default_faction": "nether",
+    "bodytype": "blob",
+    "species": [ "NATURE_SPIRIT" ],
+    "volume": "1500 ml",
+    "weight": "136 g",
+    "hp": 40,
+    "speed": 125,
+    "luminance": 6000,
+    "material": [ "powder" ],
+    "symbol": "o",
+    "color": "yellow",
+    "aggression": -5,
+    "morale": 40,
+    "melee_skill": 1,
+    "melee_dice": 1,
+    "melee_dice_sides": 1,
+    "dodge": 5,
+    "vision_day": 45,
+    "vision_night": 3,
+    "harvest": "exempt",
+    "tracking_distance": 10,
+    "emit_fields": [ { "emit_id": "emit_hot_air4_blast", "delay": "1 s" } ],
+    "special_attacks": [
+      {
+        "id": "solar_spirit_solar_flare",
+        "type": "spell",
+        "spell_data": { "id": "solar_spirit_flare_spell_monster", "min_level": 5 },
+        "cooldown": 10,
+        "monster_message": "%1$s emits a pulse of brilliant light!"
+      }
+    ],
+    "anger_triggers": [ "HURT", "FRIEND_ATTACKED", "PLAYER_CLOSE", "SOUND" ],
+    "path_settings": { "max_dist": 30, "avoid_traps": false, "avoid_sharp": false },
+    "death_function": { "message": "The %s disintegrates!", "corpse_type": "NO_CORPSE" },
+    "flags": [
+      "SEES",
+      "HEARS",
+      "FLIES",
+      "FIREY",
+      "FLASHBANGPROOF",
+      "PATH_AVOID_DANGER",
+      "KEEP_DISTANCE",
+      "BULLETPROOF",
+      "NOGIB",
+      "NOHEAD",
+      "NO_BREATHE"
+    ]
   }
 ]

--- a/data/mods/Xedra_Evolved/monsters/monster.json
+++ b/data/mods/Xedra_Evolved/monsters/monster.json
@@ -581,7 +581,7 @@
     "weight": "136 g",
     "hp": 40,
     "speed": 125,
-    "luminance": 6000,
+    "luminance": 1250,
     "material": [ "powder" ],
     "symbol": "o",
     "color": "yellow",
@@ -600,7 +600,7 @@
       {
         "id": "solar_spirit_solar_flare",
         "type": "spell",
-        "spell_data": { "id": "solar_spirit_flare_spell_monster", "min_level": 5 },
+        "spell_data": { "id": "solar_spirit_flare_spell_monster", "min_level": 5, "hit_self": true },
         "cooldown": 10,
         "monster_message": "%1$s emits a pulse of brilliant light!"
       }

--- a/data/mods/Xedra_Evolved/monsters/monster_spells.json
+++ b/data/mods/Xedra_Evolved/monsters/monster_spells.json
@@ -744,7 +744,7 @@
     "name": { "str": "Summon solar spirit", "//~": "NO_I18N" },
     "description": { "str": "Summons a solar spirit if you are a triffid.", "//~": "NO_I18N" },
     "flags": [ "HOSTILE_SUMMON", "RANDOM_DAMAGE", "NO_EXPLOSION_SFX" ],
-    "valid_targets": [ "ground", "self" ],
+    "valid_targets": [ "ground", "self", "hostile" ],
     "effect": "summon",
     "effect_str": "mon_solar_spirit_triffid_summon",
     "shape": "blast",
@@ -781,8 +781,8 @@
     "id": "solar_spirit_flare_spell_monster",
     "name": { "str": "Solar spirit flare", "//~": "NO_I18N" },
     "description": { "str": "Unleashes a flare if you are a solar spirit.", "//~": "NO_I18N" },
-    "flags": [ "SILENT", "NO_EXPLOSION_SFX" ],
-    "valid_targets": [ "ground", "self" ],
+    "flags": [ "SILENT" ],
+    "valid_targets": [ "ground", "hostile" ],
     "effect": "effect_on_condition",
     "effect_str": "EOC_SOLAR_SPIRIT_AOE_FLARE",
     "shape": "blast",
@@ -792,19 +792,43 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_SOLAR_SPIRIT_AOE_FLARE",
-    "condition": { "and": [ { "not": { "u_has_species": "PLANT" } } ] },
+    "condition": "has_alpha",
     "effect": [
-      { "if": { "not": { "u_has_effect": "blind" } }, "then": { "u_add_effect": "blind", "duration": "1 minutes" } },
+      {
+        "if": {
+          "and": [
+            { "not": { "u_has_species": "PLANT" } },
+            { "not": { "u_has_effect": "blind" } },
+            { "not": { "u_has_flag": "GLARE_RESIST" } },
+            { "not": { "u_has_worn_with_flag": "SUN_GLASSES" } }
+          ]
+        },
+        "then": { "u_add_effect": "blind", "duration": [ "15 seconds", "45 seconds" ] }
+      },
       {
         "if": { "or": [ { "u_has_flag": "SUNDEATH" }, { "u_has_flag": "SUNBURN" } ] },
-        "then": [
-          { "math": [ "u_val('morale') -= 200" ] },
-          {
-            "u_cast_spell": { "id": "changeling_summer_powerful_sunlight_spell_sundeath_self_damage", "hit_self": true }
-          },
-          { "message": "The <u_name> is seared by the brilliant light!", "type": "neutral" }
-        ]
+        "then": [ { "u_cast_spell": { "id": "solar_spirit_flare_spell_sundeath_hit_monster", "hit_self": true } } ]
       }
     ]
+  },
+  {
+    "id": "solar_spirit_flare_spell_sundeath_hit_monster",
+    "type": "SPELL",
+    "name": { "str": "Solar spirit flare Sundeath damage", "//~": "NO_I18N" },
+    "description": {
+      "str": "Used because auras are not currently possible.  Causes enemies with the SUNDEATH flag to burn.",
+      "//~": "NO_I18N"
+    },
+    "message": "",
+    "flags": [ "SILENT", "NO_EXPLOSION_SFX", "NO_LEGS", "SPLIT_DAMAGE" ],
+    "valid_targets": [ "self" ],
+    "teachable": false,
+    "skill": "deduction",
+    "max_level": 1,
+    "shape": "blast",
+    "effect": "attack",
+    "damage_type": "pure",
+    "min_damage": 60,
+    "max_damage": 120
   }
 ]

--- a/data/mods/Xedra_Evolved/monsters/monster_spells.json
+++ b/data/mods/Xedra_Evolved/monsters/monster_spells.json
@@ -151,6 +151,23 @@
     "max_range": 5
   },
   {
+    "id": "kill_summoned_creature_monster",
+    "type": "SPELL",
+    "name": { "str": "Summoned Dispel Monster", "//~": "NO_I18N" },
+    "description": { "str": "Destroys a summoned monster, cast by monsters.", "//~": "NO_I18N" },
+    "valid_targets": [ "hostile" ],
+    "flags": [ "SILENT", "NO_PROJECTILE", "PERCENTAGE_DAMAGE", "NO_EXPLOSION_SFX" ],
+    "effect": "attack",
+    "damage_type": "pure",
+    "shape": "blast",
+    "min_damage": 300,
+    "max_damage": 300,
+    "min_range": 5,
+    "max_range": 25,
+    "range_increment": 1,
+    "targeted_monster_species": [ "SUMMONED_CREATURE" ]
+  },
+  {
     "id": "death_shadowman",
     "type": "SPELL",
     "name": { "str": "Shadowman Death", "//~": "NO_I18N" },
@@ -737,6 +754,27 @@
     "max_aoe": 4,
     "min_duration": 5000,
     "max_duration": 5000
+  },
+  {
+    "type": "SPELL",
+    "id": "summon_vinebeast_triffid_monster",
+    "name": { "str": "Summon vinebeast", "//~": "NO_I18N" },
+    "description": { "str": "Summons a vinebeast if you are a triffid.", "//~": "NO_I18N" },
+    "flags": [ "HOSTILE_SUMMON", "NO_EXPLOSION_SFX" ],
+    "valid_targets": [ "ground", "self", "hostile" ],
+    "max_level": 20,
+    "effect": "summon",
+    "effect_str": "mon_vinebeast_summon",
+    "shape": "blast",
+    "min_damage": 1,
+    "max_damage": 1,
+    "min_aoe": 4,
+    "max_aoe": 4,
+    "min_range": 5,
+    "max_range": 25,
+    "range_increment": 1,
+    "min_duration": 4000,
+    "max_duration": 4000
   },
   {
     "type": "SPELL",

--- a/data/mods/Xedra_Evolved/monsters/monster_spells.json
+++ b/data/mods/Xedra_Evolved/monsters/monster_spells.json
@@ -698,5 +698,75 @@
         ]
       }
     ]
+  },
+  {
+    "id": "summon_grass_field_monster",
+    "type": "SPELL",
+    "name": { "str": "Commanding the Grasses Monster", "//~": "NO_I18N" },
+    "description": { "str": "Grow grass in an instant, if you are a monster.", "//~": "NO_I18N" },
+    "valid_targets": [ "hostile", "ground" ],
+    "flags": [ "VERBAL", "SOMATIC", "NO_PROJECTILE", "NO_HANDS", "NO_LEGS" ],
+    "max_level": 20,
+    "skill": "deduction",
+    "teachable": false,
+    "difficulty": 1,
+    "effect": "ter_transform",
+    "effect_str": "ter_arvore_command_grasses",
+    "shape": "blast",
+    "min_range": 5,
+    "max_range": 25,
+    "range_increment": 1,
+    "min_aoe": 1,
+    "max_aoe": 10,
+    "aoe_increment": 0.25,
+    "magic_type": "xedra_arvore_magick"
+  },
+  {
+    "type": "SPELL",
+    "id": "summon_solar_spirit_triffid_monster",
+    "name": { "str": "Summon solar spirit", "//~": "NO_I18N" },
+    "description": { "str": "Summons a solar spirit if you are a triffid.", "//~": "NO_I18N" },
+    "flags": [ "HOSTILE_SUMMON", "RANDOM_DAMAGE", "NO_EXPLOSION_SFX" ],
+    "valid_targets": [ "ground", "self" ],
+    "effect": "summon",
+    "effect_str": "mon_solar_spirit_triffid_summon",
+    "shape": "blast",
+    "min_damage": 1,
+    "max_damage": 1,
+    "min_aoe": 4,
+    "max_aoe": 4,
+    "min_duration": 5000,
+    "max_duration": 5000
+  },
+  {
+    "type": "SPELL",
+    "id": "solar_spirit_flare_spell_monster",
+    "name": { "str": "Solar spirit flare", "//~": "NO_I18N" },
+    "description": { "str": "Unleashes a flare if you are a solar spirit.", "//~": "NO_I18N" },
+    "flags": [ "SILENT", "NO_EXPLOSION_SFX" ],
+    "valid_targets": [ "ground", "self" ],
+    "effect": "effect_on_condition",
+    "effect_str": "EOC_SOLAR_SPIRIT_AOE_FLARE",
+    "shape": "blast",
+    "min_aoe": 45,
+    "max_aoe": 45
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_SOLAR_SPIRIT_AOE_FLARE",
+    "condition": { "and": [ { "not": { "u_has_species": "PLANT" } } ] },
+    "effect": [
+      { "if": { "not": { "u_has_effect": "blind" } }, "then": { "u_add_effect": "blind", "duration": "1 minutes" } },
+      {
+        "if": { "or": [ { "u_has_flag": "SUNDEATH" }, { "u_has_flag": "SUNBURN" } ] },
+        "then": [
+          { "math": [ "u_val('morale') -= 200" ] },
+          {
+            "u_cast_spell": { "id": "changeling_summer_powerful_sunlight_spell_sundeath_self_damage", "hit_self": true }
+          },
+          { "message": "The <u_name> is seared by the brilliant light!", "type": "neutral" }
+        ]
+      }
+    ]
   }
 ]

--- a/data/mods/Xedra_Evolved/monsters/monster_spells.json
+++ b/data/mods/Xedra_Evolved/monsters/monster_spells.json
@@ -804,7 +804,7 @@
             { "not": { "u_has_worn_with_flag": "SUN_GLASSES" } }
           ]
         },
-        "then": { "u_add_effect": "blind", "duration": [ "15 seconds", "45 seconds" ] }
+        "then": { "u_add_effect": "blind", "duration": [ "5 seconds", "12 seconds" ] }
       },
       {
         "if": { "or": [ { "u_has_flag": "SUNDEATH" }, { "u_has_flag": "SUNBURN" } ] },

--- a/data/mods/Xedra_Evolved/monsters/monster_spells.json
+++ b/data/mods/Xedra_Evolved/monsters/monster_spells.json
@@ -155,6 +155,7 @@
     "type": "SPELL",
     "name": { "str": "Summoned Dispel Monster", "//~": "NO_I18N" },
     "description": { "str": "Destroys a summoned monster, cast by monsters.", "//~": "NO_I18N" },
+    "message": "",
     "valid_targets": [ "hostile" ],
     "flags": [ "SILENT", "NO_PROJECTILE", "PERCENTAGE_DAMAGE", "NO_EXPLOSION_SFX" ],
     "effect": "attack",

--- a/data/mods/Xedra_Evolved/monsters/monstergroup.json
+++ b/data/mods/Xedra_Evolved/monsters/monstergroup.json
@@ -498,6 +498,6 @@
     "type": "monstergroup",
     "id": "GROUP_TRIFFID_MAGES",
     "default": "mon_triffid",
-    "monsters": [ { "group": "mon_triffid_greenseer", "weight": 1 } ]
+    "monsters": [ { "monster": "mon_triffid_greenseer", "weight": 1 } ]
   }
 ]

--- a/data/mods/Xedra_Evolved/monsters/monstergroup.json
+++ b/data/mods/Xedra_Evolved/monsters/monstergroup.json
@@ -475,5 +475,29 @@
       { "monster": "mon_gozu", "weight": 25, "cost_multiplier": 0 },
       { "monster": "mon_nether_huntsman", "weight": 15, "cost_multiplier": 0 }
     ]
+  },
+  {
+    "type": "monstergroup",
+    "id": "GROUP_TRIFFID",
+    "default": "mon_triffid",
+    "monsters": [ { "group": "GROUP_TRIFFID_MAGES", "weight": 25, "cost_multiplier": 5 } ]
+  },
+  {
+    "type": "monstergroup",
+    "id": "GROUP_TRIFFID_OUTER",
+    "default": "mon_triffid",
+    "monsters": [ { "group": "GROUP_TRIFFID_MAGES", "weight": 50, "cost_multiplier": 2 } ]
+  },
+  {
+    "type": "monstergroup",
+    "id": "GROUP_TRIFFID_HEARTGUARDS",
+    "default": "mon_triffid",
+    "monsters": [ { "group": "GROUP_TRIFFID_MAGES", "weight": 150, "cost_multiplier": 2 } ]
+  },
+  {
+    "type": "monstergroup",
+    "id": "GROUP_TRIFFID_MAGES",
+    "default": "mon_triffid",
+    "monsters": [ { "group": "mon_triffid_greenseer", "weight": 1 } ]
   }
 ]

--- a/data/mods/Xedra_Evolved/monsters/species.json
+++ b/data/mods/Xedra_Evolved/monsters/species.json
@@ -62,6 +62,11 @@
   },
   {
     "type": "SPECIES",
+    "id": "NATURE_SPIRIT",
+    "description": "A spirit of nature"
+  },
+  {
+    "type": "SPECIES",
     "id": "THORNBEAST",
     "description": "A magickally-animated mass of thorns, born to kill vampires"
   },

--- a/data/mods/Xedra_Evolved/monsters/species.json
+++ b/data/mods/Xedra_Evolved/monsters/species.json
@@ -14,6 +14,11 @@
   },
   {
     "type": "SPECIES",
+    "id": "SUMMONED_CREATURE",
+    "description": "a creature summoned by magic"
+  },
+  {
+    "type": "SPECIES",
     "id": "CHANGELING",
     "description": "a creature from under the hill",
     "fear_triggers": [ "HURT" ]

--- a/data/mods/Xedra_Evolved/monsters/summoned_monsters.json
+++ b/data/mods/Xedra_Evolved/monsters/summoned_monsters.json
@@ -7,6 +7,7 @@
     "looks_like": "mon_feral_armored_mace",
     "description": "Clad in ancient armor and with a mace in hand, this warrior was summoned by magic to defend you.",
     "default_faction": "player",
+    "species": [ "SUMMONED_CREATURE" ],
     "delete": { "special_attacks": [ "BROWSE", "EAT_FOOD", "PARROT" ] },
     "death_function": { "corpse_type": "NO_CORPSE", "message": "The %s fades away." }
   },
@@ -18,6 +19,7 @@
     "looks_like": "mon_feral_armored_battleaxe",
     "description": "Clad in ancient armor and with a battleaxe in hand, this warrior was summoned by magic to defend you.",
     "default_faction": "player",
+    "species": [ "SUMMONED_CREATURE" ],
     "delete": { "special_attacks": [ "BROWSE", "EAT_FOOD", "PARROT" ] },
     "death_function": { "corpse_type": "NO_CORPSE", "message": "The %s fades away." }
   },
@@ -29,6 +31,7 @@
     "looks_like": "mon_feral_sapien_spear",
     "description": "Clad in leather armor and with a spear in hand, this warrior was summoned by magic to defend you.",
     "default_faction": "player",
+    "species": [ "SUMMONED_CREATURE" ],
     "delete": { "special_attacks": [ "PARROT_AT_DANGER" ] },
     "death_function": { "corpse_type": "NO_CORPSE", "message": "The %s fades away." }
   },
@@ -40,6 +43,7 @@
     "looks_like": "mon_feral_fancy_rapier",
     "description": "Clad in leather armor and with a sword in hand, this warrior was summoned by magic to defend you.",
     "default_faction": "player",
+    "species": [ "SUMMONED_CREATURE" ],
     "extend": { "armor": { "bash": 9, "cut": 14, "acid": 4, "bullet": 18 } },
     "delete": { "special_attacks": [ "BROWSE", "EAT_FOOD", "PARROT" ] },
     "death_function": { "corpse_type": "NO_CORPSE", "message": "The %s fades away." }
@@ -52,6 +56,7 @@
     "looks_like": "mon_memory",
     "description": "A shadowy figure, only barely visible as more than a mist, but the silhouette of armor and weapons are obvious.",
     "default_faction": "player",
+    "species": [ "SUMMONED_CREATURE" ],
     "melee_skill": 5,
     "speed": 95,
     "vision_night": 15,
@@ -67,6 +72,7 @@
     "looks_like": "mon_memory",
     "description": "A shadowy figure, only barely visible as more than a mist, but the silhouette of armor and weapons are obvious.",
     "default_faction": "player",
+    "species": [ "SUMMONED_CREATURE" ],
     "melee_skill": 5,
     "speed": 95,
     "vision_night": 15,
@@ -82,6 +88,7 @@
     "description": "A shadowy figure, only barely visible as more than a mist, but the silhouette of armor and weapons are obvious.",
     "looks_like": "mon_memory",
     "default_faction": "player",
+    "species": [ "SUMMONED_CREATURE" ],
     "melee_skill": 5,
     "speed": 95,
     "vision_night": 15,
@@ -95,14 +102,15 @@
     "id": "mon_fetch_daffodil_warrior_player",
     "copy-from": "mon_fetch_daffodil_warrior",
     "looks_like": "mon_fetch_daffodil_warrior",
-    "default_faction": "player"
+    "default_faction": "player",
+    "species": [ "CHANGELING", "SUMMONED_CREATURE" ]
   },
   {
     "id": "mon_spring_changeling_bashing_vine",
     "type": "MONSTER",
     "name": { "str": "tanglevine" },
     "description": "A thick mass of animated vine, lashing back and forth at anything that comes within reach.  Long thorns grow from its sides.",
-    "species": [ "PLANT" ],
+    "species": [ "PLANT", "SUMMONED_CREATURE" ],
     "default_faction": "changeling",
     "volume": "92500 ml",
     "weight": "120 kg",
@@ -162,6 +170,13 @@
     "id": "mon_solar_spirit_triffid_summon",
     "copy-from": "mon_solar_spirit",
     "looks_like": "mon_solar_spirit",
-    "default_faction": "triffid"
+    "default_faction": "triffid",
+    "species": [ "NATURE_SPIRIT", "SUMMONED_CREATURE" ]
+  },
+  {
+    "type": "MONSTER",
+    "id": "mon_vinebeast_summon",
+    "copy-from": "mon_vinebeast",
+    "species": [ "PLANT", "SUMMONED_CREATURE" ]
   }
 ]

--- a/data/mods/Xedra_Evolved/monsters/summoned_monsters.json
+++ b/data/mods/Xedra_Evolved/monsters/summoned_monsters.json
@@ -171,12 +171,14 @@
     "copy-from": "mon_solar_spirit",
     "looks_like": "mon_solar_spirit",
     "default_faction": "triffid",
+    "aggression": 15,
     "species": [ "NATURE_SPIRIT", "SUMMONED_CREATURE" ]
   },
   {
     "type": "MONSTER",
     "id": "mon_vinebeast_summon",
     "copy-from": "mon_vinebeast",
+    "death_function": { "message": "The %s rots into nothingness in moments.", "corpse_type": "NO_CORPSE" },
     "species": [ "PLANT", "SUMMONED_CREATURE" ]
   }
 ]

--- a/data/mods/Xedra_Evolved/monsters/summoned_monsters.json
+++ b/data/mods/Xedra_Evolved/monsters/summoned_monsters.json
@@ -156,5 +156,12 @@
     "death_function": { "message": "The %s rots into nothingness in moments.", "corpse_type": "NO_CORPSE" },
     "flags": [ "HEARS", "GOODHEARING", "IMMOBILE", "NOHEAD", "HARDTOSHOOT", "GRABS", "PLASTIC" ],
     "armor": { "bash": 18, "stab": 10, "electric": 3, "bullet": 22 }
+  },
+  {
+    "type": "MONSTER",
+    "id": "mon_solar_spirit_triffid_summon",
+    "copy-from": "mon_solar_spirit",
+    "looks_like": "mon_solar_spirit",
+    "default_faction": "triffid"
   }
 ]

--- a/data/mods/Xedra_Evolved/monsters/triffids.json
+++ b/data/mods/Xedra_Evolved/monsters/triffids.json
@@ -22,6 +22,29 @@
           "spell_data": { "id": "summon_solar_spirit_triffid_monster", "min_level": 5 },
           "cooldown": 60,
           "monster_message": "%1$s's fronds extend toward the sky."
+        },
+        {
+          "id": "xe_greenseer_summon_vinebeast",
+          "type": "spell",
+          "spell_data": { "id": "summon_vinebeast_triffid_monster", "min_level": 5 },
+          "cooldown": 45,
+          "condition": { "and": [ "u_is_outside", "npc_is_outside", { "npc_is_on_terrain_with_flag": "GRAZABLE" } ] },
+          "monster_message": "%1$s's fronds make wavy motions."
+        },
+        {
+          "id": "xe_greenseer_destroy_summon",
+          "type": "spell",
+          "spell_data": { "id": "kill_summoned_creature_monster", "min_level": 8 },
+          "cooldown": 15,
+          "condition": {
+            "and": [
+              "u_is_outside",
+              "npc_is_outside",
+              { "npc_is_on_terrain_with_flag": "DIGGABLE" },
+              { "npc_has_species": "SUMMONED_CREATURE" }
+            ]
+          },
+          "monster_message": "%1$s's fronds leave trails of greenish light in the air."
         }
       ]
     }

--- a/data/mods/Xedra_Evolved/monsters/triffids.json
+++ b/data/mods/Xedra_Evolved/monsters/triffids.json
@@ -1,0 +1,29 @@
+[
+  {
+    "id": "mon_triffid_greenseer",
+    "copy-from": "mon_triffid",
+    "type": "MONSTER",
+    "name": { "str": "triffid greenseer" },
+    "description": "A creeping mobile plant, as tall as a moose.  It has a single bark-covered stalk supporting a flowery head with a paralyzing sting concealed within.  The foliage seems to bend out of its way as it moves.",
+    "extend": {
+      "flags": [ "MAGIC_USER" ],
+      "special_attacks": [
+        {
+          "id": "xe_greenseer_create_grasses",
+          "type": "spell",
+          "spell_data": { "id": "summon_grass_field_monster", "min_level": 4 },
+          "cooldown": 25,
+          "condition": { "and": [ "u_is_outside", "npc_is_outside", { "npc_is_on_terrain_with_flag": "DIGGABLE" } ] },
+          "monster_message": "%1$s's fronds quiver."
+        },
+        {
+          "id": "xe_greenseer_summon_solar_spirit",
+          "type": "spell",
+          "spell_data": { "id": "summon_solar_spirit_triffid_monster", "min_level": 5 },
+          "cooldown": 60,
+          "monster_message": "%1$s's fronds extend toward the sky."
+        }
+      ]
+    }
+  }
+]

--- a/data/mods/Xedra_Evolved/monsters/triffids.json
+++ b/data/mods/Xedra_Evolved/monsters/triffids.json
@@ -19,7 +19,7 @@
         {
           "id": "xe_greenseer_summon_solar_spirit",
           "type": "spell",
-          "spell_data": { "id": "summon_solar_spirit_triffid_monster", "min_level": 5 },
+          "spell_data": { "id": "summon_solar_spirit_triffid_monster", "min_level": 5, "hit_self": true },
           "cooldown": 60,
           "monster_message": "%1$s's fronds extend toward the sky."
         },
@@ -28,7 +28,7 @@
           "type": "spell",
           "spell_data": { "id": "summon_vinebeast_triffid_monster", "min_level": 5 },
           "cooldown": 45,
-          "condition": { "and": [ "u_is_outside", "npc_is_outside", { "npc_is_on_terrain_with_flag": "GRAZABLE" } ] },
+          "condition": { "and": [ "npc_is_outside", { "npc_is_on_terrain_with_flag": "GRAZABLE" } ] },
           "monster_message": "%1$s's fronds make wavy motions."
         },
         {
@@ -37,12 +37,7 @@
           "spell_data": { "id": "kill_summoned_creature_monster", "min_level": 8 },
           "cooldown": 15,
           "condition": {
-            "and": [
-              "u_is_outside",
-              "npc_is_outside",
-              { "npc_is_on_terrain_with_flag": "DIGGABLE" },
-              { "npc_has_species": "SUMMONED_CREATURE" }
-            ]
+            "and": [ "npc_is_outside", { "npc_is_on_terrain_with_flag": "DIGGABLE" }, { "npc_has_species": "SUMMONED_CREATURE" } ]
           },
           "monster_message": "%1$s's fronds leave trails of greenish light in the air."
         }

--- a/data/mods/Xedra_Evolved/spells/changeling_seasonal_magic_summer.json
+++ b/data/mods/Xedra_Evolved/spells/changeling_seasonal_magic_summer.json
@@ -595,7 +595,7 @@
       "//~": "NO_I18N"
     },
     "message": "",
-    "flags": [ "SILENT", "NO_EXPLOSION_SFX", "NO_LEGS" ],
+    "flags": [ "SILENT", "NO_EXPLOSION_SFX", "NO_LEGS", "SPLIT_DAMAGE" ],
     "magic_type": "xe_fey_seasonal_magick_summer",
     "spell_class": "CHANGELING_SEASONAL_MAGIC_SUMMER",
     "valid_targets": [ "self" ],


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[Xedra Evolved] Add the triffid greenseer"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

XE needs triffid mages too. We cannot allow a mage gap.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add the triffid greenseer, a triffid mage. It can:

- Cause grass to grow under your feet, slowing you down.
- Summon a solar spirit, which unleashes flares that blind anyone nearby and cause _serious_ damage to you if you're bothered by sunlight (like being, say, a vampire). 
- Can summon a vinebeast near you, if you're on grass terrain
- Can dispel summoned monsters, if the monster is on diggable terrain

Maybe one more thing when I think of it.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Greenseer exists and behaves appropriately.

Solar spirit blinds you.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Need to PR adding the `SUMMONED_CREATURE` species to more player summons

What does a triffid Mad Genius look like, I wonder?
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
