### PR TITLE
Rename a get_temperature function and add some header comments

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -8381,7 +8381,8 @@ void map::handle_decayed_corpse( const item &it, const tripoint_abs_ms &pnt )
         anything_left = roll > 0;
         for( int i = 0; i < roll; i++ ) {
             if( harvest.has_temperature() ) {
-                harvest.set_item_temperature( get_weather().get_temperature( project_to<coords::omt>( pnt ) ) );
+                harvest.set_item_temperature( get_weather().get_area_temperature( project_to<coords::omt>
+                                              ( pnt ) ) );
             }
             add_item_or_charges( get_bub( pnt ), harvest, false );
             if( anything_left && notify_player ) {

--- a/src/weather.cpp
+++ b/src/weather.cpp
@@ -883,7 +883,7 @@ bool warm_enough_to_plant( const tripoint_abs_omt &pos, const itype_id &it )
     std::map<time_point, units::temperature> planting_times;
     // initialize the first...
     time_point check_date = calendar::turn;
-    planting_times[check_date] = get_weather().get_temperature( pos );
+    planting_times[check_date] = get_weather().get_area_temperature( pos );
     bool okay_to_plant = true;
     const int num_epochs = 3; // FIXME. Should be stored on the seed ptr and read from there!
     // and now iterate a copy of the weather into the future to see if they'll be plantable then as well.
@@ -1011,7 +1011,7 @@ units::temperature weather_manager::get_temperature( const tripoint_bub_ms &loca
     return temp;
 }
 
-units::temperature weather_manager::get_temperature( const tripoint_abs_omt &location ) const
+units::temperature weather_manager::get_area_temperature( const tripoint_abs_omt &location ) const
 {
     return location.z() < 0 ? units::from_celsius(
                get_weather().get_cur_weather_gen().base_temperature ) : temperature;

--- a/src/weather.h
+++ b/src/weather.h
@@ -220,10 +220,16 @@ class weather_manager
         time_point nextweather;
         /** temperature cache, cleared every turn, sparse map of map tripoints to temperatures */
         std::unordered_map< tripoint_bub_ms, units::temperature > temperature_cache;
-        // Returns outdoor or indoor temperature of given location
+        /*
+        * Returns current temperature of given tile. Includes temperature modifications from
+        * radiative and convective sources, such as fires or hot air from heaters.
+        */
         units::temperature get_temperature( const tripoint_bub_ms &location );
-        // Returns outdoor or indoor temperature of given location
-        units::temperature get_temperature( const tripoint_abs_omt &location ) const;
+        /*
+        * Returns temperature of given OMT. Does not include any modifications from local sourecs,
+        * this is essentially the "natural" temperature.
+        */
+        units::temperature get_area_temperature( const tripoint_abs_omt &location ) const;
         void clear_temp_cache();
         static void serialize_all( JsonOut &json );
         static void unserialize_all( const JsonObject &w );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
<img width="1109" height="839" alt="image" src="https://github.com/user-attachments/assets/6e090e4d-b8e5-4df3-b5c0-6d82196d890b" />

These two functions are(were, prior to this PR) named the same, but do very different things! The former includes heat modifications from sources such as fires or heaters.

This caused one mistake in the past, where these two functions checked entirely different things ( Context #82812 ):

The first function allowed one to 'cheat' by building fires before planting.
<img width="967" height="270" alt="image" src="https://github.com/user-attachments/assets/e703c41f-330f-4659-824a-2c2e71c11a71" />


#### Describe the solution
Rename one of the functions and add some explanatory comments.

No functional changes.

#### Describe alternatives you've considered
1) Also renaming the untouched get_temperature() to get_local_temperature() or similar, to make it very explicit.

2) While making this PR I had to get through all existing uses of get_temperature() in the code (33 cases including tests).

There are some which are quite iffy if they should be using local temperature with convective/radiative modifications. But I did not change any in this PR. Maybe it's worth specifically looking at them.

#### Testing
If it builds it should be good to go.

#### Additional context

