### PR TITLE
Various sunken heli fixes and adjustments

### DIFF
--- a/data/json/furniture_and_terrain/special_use/sunken_helicopter_furniture.json
+++ b/data/json/furniture_and_terrain/special_use/sunken_helicopter_furniture.json
@@ -1,62 +1,63 @@
 [
   {
-    "type": "terrain",
     "id": "t_sunkenhelicopter_floor",
+    "copy-from": "t_scrap_floor",
+    "type": "terrain",
+    "extend": { "flags": [ "LIQUID", "SWIMMABLE", "DEEP_WATER", "WATER_CUBE" ] },
     "name": "waterlogged aisle",
     "description": "A waterlogged aisle.  It has started to degrade after some time spent underwater.  Absolutely unrecoverable.",
-    "connect_groups": [ "INDOORFLOOR", "MULCHFLOOR" ],
-    "copy-from": "t_scrap_floor"
+    "connect_groups": [ "INDOORFLOOR", "MULCHFLOOR" ]
   },
   {
-    "type": "terrain",
     "id": "t_sunkenhelicopter_floor_rotator",
-    "connect_groups": [ "INDOORFLOOR", "MULCHFLOOR" ],
-    "copy-from": "t_sunkenhelicopter_floor"
+    "copy-from": "t_sunkenhelicopter_floor",
+    "type": "terrain",
+    "connect_groups": [ "INDOORFLOOR", "MULCHFLOOR" ]
   },
   {
-    "type": "terrain",
     "id": "t_sunkenhelicopter_wall_nw",
-    "name": "waterlogged board",
     "copy-from": "t_scrap_wall",
+    "type": "terrain",
+    "name": "waterlogged board",
     "description": "A waterlogged metal wall.  Keeps zombies outside the vehicle and prevents people from seeing through it.  It has started to degrade after some time spent underwater.  Absolutely unrecoverable."
   },
   {
-    "type": "terrain",
     "id": "t_sunkenhelicopter_wall_ne",
+    "type": "terrain",
     "copy-from": "t_sunkenhelicopter_wall_nw"
   },
   {
-    "type": "terrain",
     "id": "t_sunkenhelicopter_wall_w",
+    "type": "terrain",
     "copy-from": "t_sunkenhelicopter_wall_nw"
   },
   {
-    "type": "terrain",
     "id": "t_sunkenhelicopter_wall_e",
+    "type": "terrain",
     "copy-from": "t_sunkenhelicopter_wall_nw"
   },
   {
-    "type": "terrain",
     "id": "t_sunkenhelicopter_wall_s",
+    "type": "terrain",
     "copy-from": "t_sunkenhelicopter_wall_nw"
   },
   {
-    "type": "terrain",
     "id": "t_sunkenhelicopter_wall_sw",
+    "type": "terrain",
     "copy-from": "t_sunkenhelicopter_wall_nw"
   },
   {
-    "type": "terrain",
     "id": "t_sunkenhelicopter_wall_se",
+    "type": "terrain",
     "copy-from": "t_sunkenhelicopter_wall_nw"
   },
   {
-    "type": "terrain",
     "id": "t_sunkenhelicopter_quarterpanel_n_middle",
+    "copy-from": "t_drystone_wall_half",
+    "type": "terrain",
     "name": "waterlogged quarterpanel",
     "description": "A waterlogged half-height metal wall.  Keeps zombies outside the vehicle but allows people to see over it.  It has started to degrade after some time spent underwater.  Absolutely unrecoverable.",
-    "copy-from": "t_drystone_wall_half",
-    "flags": [ "TRANSPARENT", "NOITEM", "THIN_OBSTACLE" ],
+    "flags": [ "TRANSPARENT", "NOITEM", "THIN_OBSTACLE", "LIQUID", "SWIMMABLE", "DEEP_WATER", "WATER_CUBE" ],
     "bash": {
       "str_min": 80,
       "str_max": 200,
@@ -67,19 +68,19 @@
     }
   },
   {
-    "type": "terrain",
     "id": "t_sunkenhelicopter_quarterpanel_n_left",
+    "type": "terrain",
     "copy-from": "t_sunkenhelicopter_quarterpanel_n_middle"
   },
   {
-    "type": "terrain",
     "id": "t_sunkenhelicopter_quarterpanel_n_right",
+    "type": "terrain",
     "copy-from": "t_sunkenhelicopter_quarterpanel_n_middle"
   },
   {
-    "type": "terrain",
     "id": "t_sunkenhelicopter_windshield_n",
     "copy-from": "t_window",
+    "type": "terrain",
     "name": "waterlogged windshield",
     "description": "A waterlogged sheet of glass that lets you see outside the vehicle.  It has started to degrade after some time spent underwater.  Absolutely unrecoverable.",
     "roof": "t_flat_roof",
@@ -87,11 +88,13 @@
     "shoot": { "reduce_damage": [ 1, 4 ], "reduce_damage_laser": [ 0, 4 ], "destroy_damage": [ 1, 4 ], "no_laser_destroy": true }
   },
   {
-    "type": "terrain",
     "id": "t_sunkenhelicopter_frame",
+    "copy-from": "t_junk_floor",
+    "extend": { "flags": [ "LIQUID", "SWIMMABLE", "DEEP_WATER", "WATER_CUBE" ] },
+    "type": "terrain",
     "name": "waterlogged frame",
     "description": "A waterlogged metal framework.  Other vehicle components can be mounted on it, and it can be attached to other frames to increase the vehicle's size.  It has started to degrade after some time spent underwater.  Absolutely unrecoverable.",
-    "copy-from": "t_junk_floor"
+    "flags": [ "TRANSPARENT", "NOITEM" ]
   },
   {
     "type": "furniture",
@@ -102,17 +105,18 @@
     "rotates_to": "MULCHFLOOR"
   },
   {
-    "type": "terrain",
     "id": "t_sunkenhelicopter_roof",
+    "copy-from": "t_sunkenhelicopter_floor",
+    "extend": { "flags": [ "LIQUID", "SWIMMABLE", "DEEP_WATER", "WATER_CUBE" ] },
+    "type": "terrain",
     "name": "waterlogged roof",
-    "description": "A waterlogged metal roof.  Absolutely unrecoverable.",
-    "copy-from": "t_sunkenhelicopter_floor"
+    "description": "A waterlogged metal roof.  Absolutely unrecoverable."
   },
   {
-    "type": "terrain",
     "id": "t_sunkenhelicopter_rotor",
+    "copy-from": "t_sunkenhelicopter_floor",
+    "type": "terrain",
     "name": "waterlogged heavy-duty military Blackhawk rotors",
-    "description": "A set of four military-grade helicopter rotor blades, used to provide lift by rotation.  It has started to degrade after some time spent underwater.  Absolutely unrecoverable.",
-    "copy-from": "t_sunkenhelicopter_floor"
+    "description": "A set of four military-grade helicopter rotor blades, used to provide lift by rotation.  It has started to degrade after some time spent underwater.  Absolutely unrecoverable."
   }
 ]

--- a/data/json/mapgen/sunken_helicopter_mapgen.json
+++ b/data/json/mapgen/sunken_helicopter_mapgen.json
@@ -43,6 +43,7 @@
         "w": "t_sunkenhelicopter_quarterpanel_n_middle",
         "e": "t_sunkenhelicopter_quarterpanel_n_right",
         ".": "t_sunkenhelicopter_floor",
+        "h": "t_sunkenhelicopter_floor",
         ",": "t_sunkenhelicopter_floor_rotator",
         "x": "t_sunkenhelicopter_frame"
       },

--- a/data/json/monsters/nether.json
+++ b/data/json/monsters/nether.json
@@ -2254,16 +2254,16 @@
     "id": "mon_nether_cucumber",
     "type": "MONSTER",
     "name": { "str": "waterbed skulker" },
-    "description": "Pink and translucent, with all of its otherworldly organs visible through its skin, this meter-high conical creature creeps along the seabed with its stubby, furry legs.  It contracts some kind of retracted barbed filaments into an orifice at its rear as it aims it at potential prey.",
+    "description": "Pink and translucent, with all of its otherworldly organs visible through its skin, this meter-high conical creature creeps along the seabed with its stubby, furry legs.  It retracts some sort of barbed filaments into an orifice at its rear as it aims at potential prey.",
     "species": "NETHER",
-    "hp": 100,
+    "hp": 50,
     "diff": 15,
     "weight": "75 kg",
     "volume": "70 L",
     "symbol": "s",
     "color": "pink",
     "default_faction": "nether",
-    "speed": 100,
+    "speed": 80,
     "move_skills": { "swim": 2 },
     "melee_damage": [ { "damage_type": "bash", "amount": 0 } ],
     "special_attacks": [
@@ -2279,7 +2279,7 @@
     "bodytype": "snake",
     "harvest": "mutant_mollusk",
     "zombify_into": "mon_meat_cocoon_tiny",
-    "flags": [ "AQUATIC", "SMELLS", "SEES", "HEARS", "GRABS" ],
+    "flags": [ "AQUATIC", "SEES", "HEARS", "GRABS" ],
     "weakpoints": [
       {
         "name": "filaments",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

1. The interior of the helicopter doesn't have water
2. The waterbed skulkers are a bit too resistant and quick for aquatic animals who don't swim.
3. The seats in the helicopter don't have floors under them
4. The waterbed skulker description is a bit weird
5. I don't like how I organized the fields in the terrain objects definition

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
1. The traversable terrains inside the heli have had the water flags added to them
2. The waterbed skulkers have had their hp and speed reduce slightly
3. Floors have been added under the seats
4. Rewrote the last part of the skulker description
5. Reorganized the fields in the terrain definitions, they now go id>copy-from>extensions>type
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Loaded the game, visited the heli, swam through it.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
I still need to replace the helicopter sprites.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
