### PR TITLE
Balance: Overhaul scrap armor values

### DIFF
--- a/data/json/items/armor/arms_armor.json
+++ b/data/json/items/armor/arms_armor.json
@@ -636,11 +636,11 @@
     "subtypes": [ "ARMOR" ],
     "category": "armor",
     "name": { "str_sp": "scrap arm guards (pair)" },
-    "description": "A pair of arm guards made from scraps of metal secured by simple strings.",
-    "weight": "3064 g",
-    "volume": "4750 ml",
-    "price": "200 USD",
-    "price_postapoc": "5 USD",
+    "description": "Jagged metal scraps crudely strapped to lower arms. Gaps expose skin and swinging feels like lifting weights.",
+    "weight": "2500 g",
+    "volume": "1800 ml",
+    "price": "4 USD",
+    "price_postapoc": "2 USD",
     "to_hit": { "grip": "bad", "length": "hand", "surface": "any", "balance": "uneven" },
     "material": [ "budget_steel", "cotton" ],
     "symbol": "[",
@@ -651,12 +651,12 @@
     "armor": [
       {
         "material": [
-          { "type": "budget_steel", "covered_by_mat": 75, "thickness": 1.5 },
+          { "type": "budget_steel", "covered_by_mat": 60, "thickness": 1.5 },
           { "type": "cotton", "covered_by_mat": 100, "thickness": 1.0 }
         ],
         "covers": [ "arm_l", "arm_r" ],
-        "encumbrance": 6,
-        "coverage": 95,
+        "encumbrance": 8,
+        "coverage": 70,
         "specifically_covers": [ "arm_lower_r", "arm_lower_l" ]
       }
     ],

--- a/data/json/items/armor/arms_armor.json
+++ b/data/json/items/armor/arms_armor.json
@@ -636,7 +636,7 @@
     "subtypes": [ "ARMOR" ],
     "category": "armor",
     "name": { "str_sp": "scrap arm guards (pair)" },
-    "description": "Jagged metal scraps crudely strapped to lower arms. Gaps expose skin and swinging feels like lifting weights.",
+    "description": "Jagged metal scraps crudely strapped to lower arms.  Gaps expose skin and swinging feels like lifting weights.",
     "weight": "2500 g",
     "volume": "1800 ml",
     "price": "4 USD",

--- a/data/json/items/armor/boots.json
+++ b/data/json/items/armor/boots.json
@@ -794,11 +794,11 @@
     "subtypes": [ "ARMOR" ],
     "category": "armor",
     "name": { "str_sp": "scrap boots (pair)" },
-    "description": "Boots made of random metal scraps attached to simple cloth wraps.  They're uncomfortable, but provide decent protection.",
-    "weight": "1845 g",
-    "volume": "3 L",
-    "price": "120 USD",
-    "price_postapoc": "5 USD",
+    "description": "Boots made of random metal scraps attached to simple cloth wraps.  They're very uncomfortable, but provide some level of protection.",
+    "weight": "2400 g",
+    "volume": "2 L",
+    "price": "4 USD",
+    "price_postapoc": "2 USD",
     "to_hit": { "grip": "none", "length": "hand", "surface": "any", "balance": "clumsy" },
     "material": [ "budget_steel", "cotton" ],
     "symbol": "[",
@@ -820,20 +820,20 @@
           "foot_arch_l"
         ],
         "material": [
-          { "type": "budget_steel", "covered_by_mat": 75, "thickness": 1.5 },
+          { "type": "budget_steel", "covered_by_mat": 55, "thickness": 1.8 },
           { "type": "cotton", "covered_by_mat": 100, "thickness": 1.0 }
         ],
-        "encumbrance": 6,
-        "coverage": 80
+        "encumbrance": 24,
+        "coverage": 65
       },
       {
         "covers": [ "foot_l", "foot_r" ],
         "specifically_covers": [ "foot_sole_r", "foot_sole_l" ],
         "material": [
-          { "type": "budget_steel", "covered_by_mat": 75, "thickness": 1.5 },
+          { "type": "budget_steel", "covered_by_mat": 55, "thickness": 1.5 },
           { "type": "cotton", "covered_by_mat": 100, "thickness": 1.0 }
         ],
-        "coverage": 80
+        "coverage": 65
       }
     ],
     "melee_damage": { "bash": 2 }

--- a/data/json/items/armor/helmets.json
+++ b/data/json/items/armor/helmets.json
@@ -1843,7 +1843,7 @@
     "subtypes": [ "ARMOR" ],
     "category": "armor",
     "name": { "str": "scrap helmet" },
-    "description": "Loose metal scraps tied precariously to your head with frayed cords. Gaps leave critical areas exposed and the uneven weight causes constant neck strain.",
+    "description": "Loose metal scraps tied precariously to your head with frayed cords.  Gaps leave critical areas exposed and the uneven weight causes constant neck strain.",
     "weight": "2400 g",
     "volume": "1600 ml",
     "price": "4 USD",

--- a/data/json/items/armor/helmets.json
+++ b/data/json/items/armor/helmets.json
@@ -1843,11 +1843,11 @@
     "subtypes": [ "ARMOR" ],
     "category": "armor",
     "name": { "str": "scrap helmet" },
-    "description": "A helmet made from scraps of metal secured by simple strings; the loose collection of plates provides decent but not the most convenient protection.",
-    "weight": "1692 g",
-    "volume": "2750 ml",
-    "price": "350 USD",
-    "price_postapoc": "5 USD",
+    "description": "Loose metal scraps tied precariously to your head with frayed cords. Gaps leave critical areas exposed and the uneven weight causes constant neck strain.",
+    "weight": "2400 g",
+    "volume": "1600 ml",
+    "price": "4 USD",
+    "price_postapoc": "2 USD",
     "to_hit": { "grip": "none", "length": "hand", "surface": "any", "balance": "clumsy" },
     "material": [ "budget_steel", "cotton" ],
     "symbol": "[",
@@ -1858,12 +1858,12 @@
     "armor": [
       {
         "material": [
-          { "type": "budget_steel", "covered_by_mat": 75, "thickness": 2 },
+          { "type": "budget_steel", "covered_by_mat": 60, "thickness": 2.2 },
           { "type": "cotton", "covered_by_mat": 100, "thickness": 1.0 }
         ],
         "covers": [ "head" ],
         "specifically_covers": [ "head_crown", "head_ear_l", "head_ear_r", "head_ear_r" ],
-        "coverage": 100,
+        "coverage": 70,
         "encumbrance_modifiers": [ "IMBALANCED" ]
       }
     ],

--- a/data/json/items/armor/legs_armor.json
+++ b/data/json/items/armor/legs_armor.json
@@ -1247,7 +1247,7 @@
     "subtypes": [ "ARMOR" ],
     "category": "armor",
     "name": { "str_sp": "scrap leg guards (pair)" },
-    "description": "Jagged metal scraps crudely lashed to legs with frayed strings. Gaps leave skin exposed, and walking feels like dragging anvils, but they're better than nothing.",
+    "description": "Jagged metal scraps crudely lashed to legs with frayed strings.  Gaps leave skin exposed, and walking feels like dragging anvils, but they're better than nothing.",
     "weight": "3800 g",
     "volume": "3 L",
     "price": "4 USD",

--- a/data/json/items/armor/legs_armor.json
+++ b/data/json/items/armor/legs_armor.json
@@ -1247,11 +1247,11 @@
     "subtypes": [ "ARMOR" ],
     "category": "armor",
     "name": { "str_sp": "scrap leg guards (pair)" },
-    "description": "A pair of leg guards made from scraps of metal secured by simple strings.",
-    "weight": "3104 g",
-    "volume": "5 L",
-    "price": "200 USD",
-    "price_postapoc": "50 cent",
+    "description": "Jagged metal scraps crudely lashed to legs with frayed strings. Gaps leave skin exposed, and walking feels like dragging anvils, but they're better than nothing.",
+    "weight": "3800 g",
+    "volume": "3 L",
+    "price": "4 USD",
+    "price_postapoc": "2 USD",
     "to_hit": { "grip": "none", "length": "short", "surface": "any", "balance": "clumsy" },
     "material": [ "budget_steel", "cotton" ],
     "symbol": "[",
@@ -1262,11 +1262,11 @@
     "armor": [
       {
         "material": [
-          { "type": "budget_steel", "covered_by_mat": 75, "thickness": 1.5 },
+          { "type": "budget_steel", "covered_by_mat": 60, "thickness": 1.8 },
           { "type": "cotton", "covered_by_mat": 100, "thickness": 1.0 }
         ],
         "covers": [ "leg_l", "leg_r" ],
-        "coverage": 95,
+        "coverage": 70,
         "encumbrance": 15
       }
     ],

--- a/data/json/items/armor/torso_armor.json
+++ b/data/json/items/armor/torso_armor.json
@@ -950,7 +950,7 @@
     "subtypes": [ "ARMOR" ],
     "category": "armor",
     "name": { "str": "scrap cuirass", "str_pl": "scrap cuirasses" },
-    "description": "Jagged metal scraps crudely lashed to your torso with frayed cords. Gaps leave skin exposed and movement feels really awkward.",
+    "description": "Jagged metal scraps crudely lashed to your torso with frayed cords.  Gaps leave skin exposed and movement feels really awkward.",
     "weight": "6200 g",
     "volume": "5750 ml",
     "price": "4 USD",

--- a/data/json/items/armor/torso_armor.json
+++ b/data/json/items/armor/torso_armor.json
@@ -950,11 +950,11 @@
     "subtypes": [ "ARMOR" ],
     "category": "armor",
     "name": { "str": "scrap cuirass", "str_pl": "scrap cuirasses" },
-    "description": "A cuirass made from scraps of metal secured by simple strings.",
-    "weight": "3366 g",
+    "description": "Jagged metal scraps crudely lashed to your torso with frayed cords. Gaps leave skin exposed and movement feels really awkward.",
+    "weight": "6200 g",
     "volume": "5750 ml",
-    "price": "200 USD",
-    "price_postapoc": "50 cent",
+    "price": "4 USD",
+    "price_postapoc": "2 USD",
     "to_hit": { "grip": "none", "length": "short", "surface": "any", "balance": "clumsy" },
     "material": [ "budget_steel", "cotton" ],
     "repairs_with": [ "budget_steel" ],
@@ -967,12 +967,12 @@
     "armor": [
       {
         "material": [
-          { "type": "budget_steel", "covered_by_mat": 75, "thickness": 2 },
+          { "type": "budget_steel", "covered_by_mat": 60, "thickness": 2.2 },
           { "type": "cotton", "covered_by_mat": 100, "thickness": 1.0 }
         ],
         "covers": [ "torso" ],
-        "coverage": 95,
-        "encumbrance": 18
+        "coverage": 70,
+        "encumbrance": 22
       }
     ],
     "melee_damage": { "bash": 2, "cut": 3 }


### PR DESCRIPTION
Scrap armor pieces previously had unrealistic balance compared to sheet metal equivalents: too low encumbrance, same/higher coverage, and lighter weight.

resolves #68743, see the discussion

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Balance "Overhaul scrap armor values"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Scrap armor was touched a very long time ago, and a lot of it's values become irrelevant, if not absurd, when compared to other pieces of clothing and armor. What stands out is scrap boots encumbrance, which had a value of 3/6, _which is lower than some socks_. This is probably just a mistake and it was begging for a fix for years. Some people on discord argued that this is a "weird piece of armor nobody actually crafts", but I believe there's some number of players which were abusing this, especially boots, because of their very low encumbrance with decent stats. 
Was discussed here https://github.com/CleverRaven/Cataclysm-DDA/issues/68743. Closes #68743.


<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

Bring scrap armor in line with realistic expectations for crude construction:

- Increased encumbrance by 50-70% vs sheet metal equivalents
- Reduced coverage by 25-30% to reflect gaps in crude construction
- Adjusted weight values to be more in-line with sheet metal armor and other armor sets
- Updated all descriptions to match updated values (mention gaps/awkward movement)

For example, scrap boots now have 24 encumbrance (from 6) with 65% coverage (from 80%).

#### Describe alternatives you've considered
Complete removal. I'm advocating for complete scrap armor removal, but when suggesting this some time ago, people were against this. I believe there's no way to make _reasonable_ armor by cold-hammering random, small pieces of steel, especially without any additional tools. The game had sheet metal armor armor for quite some time, which is what this set was supposed to be, judging by it's outdated description.
I've decided against the removal because:
1. Backlash when discussed in aforementioned issue
2. Save breaks
3. Magicklism dependency, possibly other mods.

Overall, I don't feel experienced enough to work with breaking changes, which is why I tried to adjust values based on general logic and sheet metal armor values.

It also seems logical to make boots into greaves, moving them to outer layer, akin to sheet metal greaves and other parts of scrap armor. I avoided this on purpose, as this again seems can affect Magicklism (or other mods) and is overall more complex, but if I get a green light I may try to do this.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

Loaded in the game, spawned the items with debug menu, checked the descriptions and adjusted values. Everything seems to work.

#### Additional context

No additional context here.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
