### PR TITLE
Appease clang

### DIFF
--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -1931,6 +1931,8 @@ void dialogue_chatbin::serialize( JsonOut &json ) const
     json.member( "talk_stranger_friendly", talk_stranger_friendly );
     json.member( "talk_stranger_neutral", talk_stranger_neutral );
     json.member( "talk_friend_guard", talk_friend_guard );
+    json.member( "talk_mission_inquire", talk_mission_inquire );
+    json.member( "talk_mission_describe_urgent", talk_mission_describe_urgent );
 
     if( mission_selected != nullptr ) {
         json.member( "mission_selected", mission_selected->get_id() );
@@ -1967,6 +1969,8 @@ void dialogue_chatbin::deserialize( const JsonObject &data )
     data.read( "talk_stranger_friendly", talk_stranger_friendly );
     data.read( "talk_stranger_neutral", talk_stranger_neutral );
     data.read( "talk_friend_guard", talk_friend_guard );
+    data.read( "talk_mission_inquire", talk_mission_inquire );
+    data.read( "talk_mission_describe_urgent", talk_mission_describe_urgent );
     data.read( "skill", skill );
     data.read( "style", style );
     data.read( "dialogue_spell", dialogue_spell );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Test failure on https://github.com/CleverRaven/Cataclysm-DDA/pull/81838

#### Describe the solution
Serialize some members of dialogue chatbin. It looks like these are separately loaded for NPC templates, so they probably did not persist after an NPC was saved/loaded.