### PR TITLE
update dimension EOC documentation and also rename an EOC function

### DIFF
--- a/data/json/effects_on_condition/example_eocs.json
+++ b/data/json/effects_on_condition/example_eocs.json
@@ -542,7 +542,7 @@
         "success_message": "This place feels different."
       },
       { "u_message": { "u_val": "destination_dimension" } },
-      { "if": { "u_in_dimension": "" }, "then": { "u_message": "home sweet home" } }
+      { "if": { "current_dimension": "" }, "then": { "u_message": "home sweet home" } }
     ]
   }
 ]

--- a/doc/JSON/EFFECT_ON_CONDITION.md
+++ b/doc/JSON/EFFECT_ON_CONDITION.md
@@ -1300,6 +1300,23 @@ Check the location is in a city.
 },
 ```
 
+Each time the avatar enters an OMT display a message as to whether or not they're in a city.
+```jsonc
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_TEST_IS_IN_CITY",
+    "eoc_type": "EVENT",
+    "required_event": "avatar_enters_omt",
+    "effect": [
+      { "u_location_variable": { "context_val": "loc" } },
+      {
+        "if": { "map_in_city": { "context_val": "loc" } },
+        "then": { "u_message": "You are in a city OMT.", "type": "good" },
+        "else": { "u_message": "You are NOT in a city OMT.", "type": "bad" }
+      }
+    ]
+  },
+
 ### `current_dimension`
 - type: string or [variable object](#variable-object)
 - return true if the string matches the id of the currently occupied dimension.

--- a/doc/JSON/EFFECT_ON_CONDITION.md
+++ b/doc/JSON/EFFECT_ON_CONDITION.md
@@ -4321,7 +4321,6 @@ You or NPC is teleported to `target_var` coordinates
 | "force" | optional | boolean | default false; if true, teleportation can't fail - any creature, that stand on target coordinates, would be brutally telefragged, and if impassable obstacle occur, the closest point would be picked instead |
 | "force_safe" | optional | boolean | default false; if true, teleportation cannot^(tm) fail.  If there is a creature or obstacle at the target coordinate, the closest passable point within 5 horizontal tiles is picked instead.  If there is no point, the creature remains where they are.
 | "dimension_prefix" | optional | string | default ""; if a value is specified, will teleport the player to a dimension named after the prefix. |
-| "dimension_prefix" | optional | string | default ""; if a value is specified, will teleport the player to a dimension named after the prefix. |
 
 ##### Valid talkers:
 

--- a/doc/JSON/EFFECT_ON_CONDITION.md
+++ b/doc/JSON/EFFECT_ON_CONDITION.md
@@ -1329,10 +1329,10 @@ Will give a message if you're in the dimension with the ID of "test".
 No talker is needed.
 
 #### Examples
-Will give a message if you're in the "default" dimension (most often the main dimension).
+Will give a message if you're in the main dimension.
 ```jsonc
 { "if": { "u_in_dimension": "" },
-  "then": { "u_message": "You're in the default dimension." } }
+  "then": { "u_message": "You're in the main dimension." } }
 ```
 Will give a message if you're in the dimension with the ID of "test".
 ```jsonc

--- a/doc/JSON/EFFECT_ON_CONDITION.md
+++ b/doc/JSON/EFFECT_ON_CONDITION.md
@@ -1300,7 +1300,7 @@ Check the location is in a city.
 },
 ```
 
-### `u_in_dimension`
+### `current_dimension`
 - type: string or [variable object](#variable-object)
 - return true if the string matches the id of the currently occupied dimension.
 
@@ -1313,13 +1313,13 @@ Check the location is in a city.
 #### Examples
 Will give a message if you're in the main dimension.
 ```jsonc
-{ "if": { "u_in_dimension": "" },
-  "then": { "u_message": "You're in the main dimension." } }
+{ "if": { "current_dimension": "" },
+  "then": { "u_message": "Currently loaded dimension is the main one." } }
 ```
 Will give a message if you're in the dimension with the ID of "test".
 ```jsonc
-{ "if": { "u_in_dimension": "test" },
-  "then": { "u_message": "You're in the test dimension." } }
+{ "if": { "current_dimension": "test" },
+  "then": { "u_message": "Currently loaded dimension is the one with ID of 'test'." } }
 ```
 
 ### `player_see_u`, `player_see_npc`

--- a/doc/JSON/EFFECT_ON_CONDITION.md
+++ b/doc/JSON/EFFECT_ON_CONDITION.md
@@ -1300,6 +1300,26 @@ Check the location is in a city.
 },
 ```
 
+### `u_in_dimension`
+- type: string or [variable object](#variable-object)
+- return true if the string matches the id of the currently occupied dimension.
+
+#### Valid talkers:
+
+No talker is needed.
+
+#### Examples
+Will give a message if you're in the "default" dimension (most often the main dimension).
+```jsonc
+{ "if": { "u_in_dimension": "" },
+  "then": { "u_message": "You're in the default dimension." } }
+```
+Will give a message if you're in the dimension with the ID of "test".
+```jsonc
+{ "if": { "u_in_dimension": "test" },
+  "then": { "u_message": "You're in the test dimension." } }
+```
+
 Each time the avatar enters an OMT display a message as to whether or not they're in a city.
 ```jsonc
   {
@@ -4299,7 +4319,7 @@ You or NPC is teleported to `target_var` coordinates
 | "fail_message" | optional | string or [variable object](#variable-object) | message, that would be printed, if teleportation was failed, like if coordinates contained creature or impassable obstacle (like wall) | 
 | "force" | optional | boolean | default false; if true, teleportation can't fail - any creature, that stand on target coordinates, would be brutally telefragged, and if impassable obstacle occur, the closest point would be picked instead |
 | "force_safe" | optional | boolean | default false; if true, teleportation cannot^(tm) fail.  If there is a creature or obstacle at the target coordinate, the closest passable point within 5 horizontal tiles is picked instead.  If there is no point, the creature remains where they are.
-| "dimension_prefix" | optional | string | default ""; if a value is specified, will teleport the player to a dimension named after the prefix. Currently very WIP |
+| "dimension_prefix" | optional | string | default ""; if a value is specified, will teleport the player to a dimension named after the prefix. |
 
 ##### Valid talkers:
 

--- a/doc/JSON/EFFECT_ON_CONDITION.md
+++ b/doc/JSON/EFFECT_ON_CONDITION.md
@@ -1320,22 +1320,24 @@ Will give a message if you're in the dimension with the ID of "test".
   "then": { "u_message": "You're in the test dimension." } }
 ```
 
-Each time the avatar enters an OMT display a message as to whether or not they're in a city.
+### `u_in_dimension`
+- type: string or [variable object](#variable-object)
+- return true if the string matches the id of the currently occupied dimension.
+
+#### Valid talkers:
+
+No talker is needed.
+
+#### Examples
+Will give a message if you're in the "default" dimension (most often the main dimension).
 ```jsonc
-  {
-    "type": "effect_on_condition",
-    "id": "EOC_TEST_IS_IN_CITY",
-    "eoc_type": "EVENT",
-    "required_event": "avatar_enters_omt",
-    "effect": [
-      { "u_location_variable": { "context_val": "loc" } },
-      {
-        "if": { "map_in_city": { "context_val": "loc" } },
-        "then": { "u_message": "You are in a city OMT.", "type": "good" },
-        "else": { "u_message": "You are NOT in a city OMT.", "type": "bad" }
-      }
-    ]
-  },
+{ "if": { "u_in_dimension": "" },
+  "then": { "u_message": "You're in the default dimension." } }
+```
+Will give a message if you're in the dimension with the ID of "test".
+```jsonc
+{ "if": { "u_in_dimension": "test" },
+  "then": { "u_message": "You're in the test dimension." } }
 ```
 
 ### `player_see_u`, `player_see_npc`
@@ -4319,6 +4321,7 @@ You or NPC is teleported to `target_var` coordinates
 | "fail_message" | optional | string or [variable object](#variable-object) | message, that would be printed, if teleportation was failed, like if coordinates contained creature or impassable obstacle (like wall) | 
 | "force" | optional | boolean | default false; if true, teleportation can't fail - any creature, that stand on target coordinates, would be brutally telefragged, and if impassable obstacle occur, the closest point would be picked instead |
 | "force_safe" | optional | boolean | default false; if true, teleportation cannot^(tm) fail.  If there is a creature or obstacle at the target coordinate, the closest passable point within 5 horizontal tiles is picked instead.  If there is no point, the creature remains where they are.
+| "dimension_prefix" | optional | string | default ""; if a value is specified, will teleport the player to a dimension named after the prefix. |
 | "dimension_prefix" | optional | string | default ""; if a value is specified, will teleport the player to a dimension named after the prefix. |
 
 ##### Valid talkers:

--- a/doc/JSON/EFFECT_ON_CONDITION.md
+++ b/doc/JSON/EFFECT_ON_CONDITION.md
@@ -1306,27 +1306,9 @@ Check the location is in a city.
 
 #### Valid talkers:
 
-No talker is needed.
-
-#### Examples
-Will give a message if you're in the "default" dimension (most often the main dimension).
-```jsonc
-{ "if": { "u_in_dimension": "" },
-  "then": { "u_message": "You're in the default dimension." } }
-```
-Will give a message if you're in the dimension with the ID of "test".
-```jsonc
-{ "if": { "u_in_dimension": "test" },
-  "then": { "u_message": "You're in the test dimension." } }
-```
-
-### `u_in_dimension`
-- type: string or [variable object](#variable-object)
-- return true if the string matches the id of the currently occupied dimension.
-
-#### Valid talkers:
-
-No talker is needed.
+| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
+| ------ | --------- | --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
 
 #### Examples
 Will give a message if you're in the main dimension.

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -673,7 +673,7 @@ conditional_t::func f_is_wearing( const JsonObject &jo, std::string_view member,
     };
 }
 
-conditional_t::func f_in_dimension( const JsonObject &jo, std::string_view member )
+conditional_t::func current_dimension( const JsonObject &jo, std::string_view member )
 {
     str_or_var dimension_prefix = get_str_or_var( jo.get_member( member ), member, true );
     return [dimension_prefix]( const_dialogue const & d ) {
@@ -2424,7 +2424,7 @@ parsers = {
     {"u_has_part_temp", "npc_has_part_temp", jarg::member | jarg::array, &conditional_fun::f_has_part_temp },
     {"u_is_wearing", "npc_is_wearing", jarg::member, &conditional_fun::f_is_wearing },
     {"is_outside", jarg::member, &conditional_fun::f_tile_is_outside },
-    {"u_in_dimension", jarg::member, &conditional_fun::f_in_dimension },
+    {"current_dimension", jarg::member, &conditional_fun::current_dimension },
     {"u_has_item", "npc_has_item", jarg::member, &conditional_fun::f_has_item },
     {"u_has_item_with_flag", "npc_has_item_with_flag", jarg::member, &conditional_fun::f_has_item_with_flag },
     {"u_has_items", "npc_has_items", jarg::member, &conditional_fun::f_has_items },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Rename EOC condition `u_in_dimension` to `current_dimension`, to reflect it not being limited to just the avatar.

Add documentation for the EOC condition `current_dimension`

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

do that
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

not
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

~~if PR checks fail then i'll have to see what broke~~
tested the dimension swap EOC and no errors popped up
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
