### PR TITLE
[Xedra Evolved] Add the Vampire Anathema sun weakness

### DIFF
--- a/data/mods/Xedra_Evolved/effects/effects.json
+++ b/data/mods/Xedra_Evolved/effects/effects.json
@@ -3748,11 +3748,14 @@
     "id": "effect_slain_by_the_sun",
     "name": [ "Slain by the Sun" ],
     "desc": [ "The sun is burning you like a dry leaf in a wildfire." ],
-    "miss_messages": [ [ "The sun is burning you.", 2 ] ],
-    "rating": "bad",
-    "main_parts_only": true,
-    "base_mods": { "pain_min": [ 2 ], "pain_tick": [ 10 ], "hurt_min": [ 1 ], "hurt_max": [ 2 ], "hurt_tick": [ 10 ] },
-    "show_in_info": false
+    "rating": "bad"
+  },
+  {
+    "type": "effect_type",
+    "id": "effect_slain_by_the_sun_limiter",
+    "//": "Hidden effect, prevents the sun fire anathema EoC from firing new copies on every step.",
+    "name": [ "" ],
+    "desc": [ "" ]
   },
   {
     "type": "effect_type",

--- a/data/mods/Xedra_Evolved/effects/vampvirus.json
+++ b/data/mods/Xedra_Evolved/effects/vampvirus.json
@@ -617,20 +617,6 @@
       {
         "u_roll_remainder": [ "ANATHEMA_WEAKNESS_SUN_BURN", "ANATHEMA_WEAKNESS_MIND_CHAOS", "ANATHEMA_WEAKNESS_NEED_VAMPIRE_BLOOD" ],
         "type": "mutation"
-      },
-      {
-        "run_eocs": {
-          "id": "EOC_VAMPIRE_ANATHEMA_ADD_SUN_GRACE_PERIOD",
-          "//": "As suddenly gaining this weakness in the wild or otherwise away from shelter is a death sentence, its effects won't trigger instantly after gaining the weakness.",
-          "condition": { "u_has_trait": "ANATHEMA_WEAKNESS_SUN_BURN" },
-          "effect": [
-            {
-              "u_message": "You have a sudden feeling of dread.  In a few hours, the sun will burn you to a crisp if you ever stand under its unblocked rays.",
-              "type": "bad"
-            },
-            { "u_add_effect": "effect_sun_burn_grace_period", "intensity": 1, "duration": "5 hours" }
-          ]
-        }
       }
     ]
   },

--- a/data/mods/Xedra_Evolved/mutations/vampire_trait_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/vampire_trait_eocs.json
@@ -711,7 +711,7 @@
         ]
       },
       {
-        "u_message": "You are burning in the sunlight! Your burn chance is 1 in <context_val:vampire_burning_chance>.",
+        "u_message": "You are burning in the sunlight!  Your burn chance is 1 in <context_val:vampire_burning_chance>.",
         "type": "debug"
       },
       { "run_eocs": "EOC_VAMPIRE_ANATHEMA_BURN_IN_SUNLIGHT_CONTINUAL", "time_in_future": 1 }
@@ -2284,11 +2284,22 @@
                 "rng(0.75,1.25) * (300 + (vampire_total_tier_one_traits_plus_potency() * 33) + (vampire_total_tier_two_traits() * 75) + (vampire_total_tier_three_traits() * 125) + (vampire_total_tier_four_traits_plus_potence() * 200) + (vampire_total_tier_five_traits_plus_cauldron() * 270))"
               ]
             },
+            {
+              "if": { "and": [ { "u_has_trait": "VAMPIRE_ANATHEMA" }, { "u_has_trait": "ANATHEMA_WEAKNESS_SUN_BURN" } ] },
+              "then": { "math": [ "sunless_time /= 100" ] }
+            },
             { "run_eocs": [ "EOC_BLOT_THE_SUN" ] },
             { "run_eocs": "EOC_UNBLOT_THE_SUN", "time_in_future": { "math": [ "sunless_time" ] } },
             {
-              "u_message": "Using your mastery over the Shadowed Path, you blot out the sun, covering the region around you in darkness for a short period of time.",
-              "type": "good"
+              "if": { "and": [ { "u_has_trait": "VAMPIRE_ANATHEMA" }, { "u_has_trait": "ANATHEMA_WEAKNESS_SUN_BURN" } ] },
+              "then": {
+                "u_message": "Using your mastery over the Shadowed Path, you blot out the sun, covering the region around you in darkness for a short period of time.  But you can already see the hateful sun burning through the shadows; you had better find shelter immediately.",
+                "type": "mixed"
+              },
+              "else": {
+                "u_message": "Using your mastery over the Shadowed Path, you blot out the sun, covering the region around you in darkness for a short period of time.",
+                "type": "good"
+              }
             }
           ]
         }

--- a/data/mods/Xedra_Evolved/mutations/vampire_trait_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/vampire_trait_eocs.json
@@ -656,6 +656,73 @@
   },
   {
     "type": "effect_on_condition",
+    "id": "EOC_VAMPIRE_ANATHEMA_BURN_IN_SUNLIGHT",
+    "eoc_type": "EVENT",
+    "required_event": "avatar_moves",
+    "condition": {
+      "and": [ { "u_has_trait": "VAMPIRE_ANATHEMA" }, "is_day", "u_is_outside", { "not": { "is_weather": "blotted_sun" } } ]
+    },
+    "effect": [
+      { "u_add_effect": "effect_slain_by_the_sun", "duration": "PERMANENT" },
+      {
+        "if": { "not": { "u_has_effect": "effect_slain_by_the_sun_limiter" } },
+        "then": [ { "run_eocs": "EOC_VAMPIRE_ANATHEMA_BURN_IN_SUNLIGHT_CONTINUAL" } ]
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_VAMPIRE_ANATHEMA_BURN_IN_SUNLIGHT_GO_INDOORS",
+    "eoc_type": "EVENT",
+    "required_event": "avatar_moves",
+    "condition": {
+      "and": [
+        { "u_has_trait": "VAMPIRE_ANATHEMA" },
+        { "or": [ { "not": "is_day" }, { "not": "u_is_outside" }, { "is_weather": "blotted_sun" } ] }
+      ]
+    },
+    "effect": [ { "u_lose_effect": "effect_slain_by_the_sun" }, { "u_lose_effect": "effect_slain_by_the_sun_limiter" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_VAMPIRE_ANATHEMA_BURN_IN_SUNLIGHT_CONTINUAL",
+    "condition": { "u_has_effect": "effect_slain_by_the_sun" },
+    "effect": [
+      { "u_add_effect": "effect_slain_by_the_sun_limiter", "duration": "PERMANENT" },
+      {
+        "math": [ "_vampire_burning_chance = (30 * (u_effect_intensity('effect_vampiric_resilience') > -1 ? 4 : 1) )" ]
+      },
+      {
+        "foreach": "array",
+        "target": [ "arm_l", "arm_r", "leg_l", "leg_r", "torso", "head" ],
+        "var": { "context_val": "id" },
+        "effect": [
+          {
+            "if": { "x_in_y_chance": { "x": 1, "y": { "math": [ "_vampire_burning_chance" ] } } },
+            "then": [ { "u_add_effect": "onfire", "duration": 30, "target_part": { "context_val": "id" } } ]
+          }
+        ]
+      },
+      {
+        "u_message": "You are burning in the sunlight! Your burn chance is 1 in <context_val:vampire_burning_chance>.",
+        "type": "debug"
+      },
+      { "run_eocs": "EOC_VAMPIRE_ANATHEMA_BURN_IN_SUNLIGHT_CONTINUAL", "time_in_future": 1 }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_XE_VAMPIRE_ANATHEMA_BURN_IN_SUNLIGHT_AT_SUNRISE",
+    "recurrence": { "math": [ "time_until('sunrise')" ] },
+    "global": true,
+    "run_for_npcs": false,
+    "condition": {
+      "and": [ { "u_has_trait": "VAMPIRE_ANATHEMA" }, "is_day", "u_is_outside", { "not": { "is_weather": "blotted_sun" } } ]
+    },
+    "effect": [ { "run_eocs": "EOC_VAMPIRE_ANATHEMA_BURN_IN_SUNLIGHT_CONTINUAL" } ]
+  },
+  {
+    "type": "effect_on_condition",
     "id": "EOC_SET_VAMPIRE_TRAIT_NUMBERS_FOR_NPC_USE",
     "//": "This is necessary for powers whose effect on NPCs is variable, since the jmath equations return the avatar's traits",
     "eoc_type": "EVENT",

--- a/data/mods/Xedra_Evolved/mutations/vampire_trait_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/vampire_trait_eocs.json
@@ -661,7 +661,6 @@
     "required_event": "avatar_moves",
     "condition": {
       "and": [
-        { "u_has_trait": "VAMPIRE_ANATHEMA" },
         { "u_has_trait": "ANATHEMA_WEAKNESS_SUN_BURN" },
         "is_day",
         "u_is_outside",
@@ -683,7 +682,6 @@
     "required_event": "avatar_moves",
     "condition": {
       "and": [
-        { "u_has_trait": "VAMPIRE_ANATHEMA" },
         { "u_has_trait": "ANATHEMA_WEAKNESS_SUN_BURN" },
         { "or": [ { "not": "is_day" }, { "not": "u_is_outside" }, { "is_weather": "blotted_sun" } ] }
       ]
@@ -2284,14 +2282,11 @@
                 "rng(0.75,1.25) * (300 + (vampire_total_tier_one_traits_plus_potency() * 33) + (vampire_total_tier_two_traits() * 75) + (vampire_total_tier_three_traits() * 125) + (vampire_total_tier_four_traits_plus_potence() * 200) + (vampire_total_tier_five_traits_plus_cauldron() * 270))"
               ]
             },
-            {
-              "if": { "and": [ { "u_has_trait": "VAMPIRE_ANATHEMA" }, { "u_has_trait": "ANATHEMA_WEAKNESS_SUN_BURN" } ] },
-              "then": { "math": [ "sunless_time /= 100" ] }
-            },
+            { "if": { "u_has_trait": "ANATHEMA_WEAKNESS_SUN_BURN" }, "then": { "math": [ "sunless_time /= 100" ] } },
             { "run_eocs": [ "EOC_BLOT_THE_SUN" ] },
             { "run_eocs": "EOC_UNBLOT_THE_SUN", "time_in_future": { "math": [ "sunless_time" ] } },
             {
-              "if": { "and": [ { "u_has_trait": "VAMPIRE_ANATHEMA" }, { "u_has_trait": "ANATHEMA_WEAKNESS_SUN_BURN" } ] },
+              "if": { "u_has_trait": "ANATHEMA_WEAKNESS_SUN_BURN" },
               "then": {
                 "u_message": "Using your mastery over the Shadowed Path, you blot out the sun, covering the region around you in darkness for a short period of time.  But you can already see the hateful sun burning through the shadows; you had better find shelter immediately.",
                 "type": "mixed"

--- a/data/mods/Xedra_Evolved/mutations/vampire_trait_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/vampire_trait_eocs.json
@@ -722,7 +722,12 @@
     "global": true,
     "run_for_npcs": false,
     "condition": {
-      "and": [ { "u_has_trait": "VAMPIRE_ANATHEMA" }, "is_day", "u_is_outside", { "not": { "is_weather": "blotted_sun" } } ]
+      "and": [
+        { "u_has_trait": "ANATHEMA_WEAKNESS_SUN_BURN" },
+        "is_day",
+        "u_is_outside",
+        { "not": { "is_weather": "blotted_sun" } }
+      ]
     },
     "effect": [ { "run_eocs": "EOC_VAMPIRE_ANATHEMA_BURN_IN_SUNLIGHT_CONTINUAL" } ]
   },

--- a/data/mods/Xedra_Evolved/mutations/vampire_trait_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/vampire_trait_eocs.json
@@ -660,7 +660,13 @@
     "eoc_type": "EVENT",
     "required_event": "avatar_moves",
     "condition": {
-      "and": [ { "u_has_trait": "VAMPIRE_ANATHEMA" }, "is_day", "u_is_outside", { "not": { "is_weather": "blotted_sun" } } ]
+      "and": [
+        { "u_has_trait": "VAMPIRE_ANATHEMA" },
+        { "u_has_trait": "ANATHEMA_WEAKNESS_SUN_BURN" },
+        "is_day",
+        "u_is_outside",
+        { "not": { "is_weather": "blotted_sun" } }
+      ]
     },
     "effect": [
       { "u_add_effect": "effect_slain_by_the_sun", "duration": "PERMANENT" },
@@ -678,6 +684,7 @@
     "condition": {
       "and": [
         { "u_has_trait": "VAMPIRE_ANATHEMA" },
+        { "u_has_trait": "ANATHEMA_WEAKNESS_SUN_BURN" },
         { "or": [ { "not": "is_day" }, { "not": "u_is_outside" }, { "is_weather": "blotted_sun" } ] }
       ]
     },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[Xedra Evolved] Add the Vampire Anathema sun weakness"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

I accidentally deleted the Vampire Anathema sun weakness in my vampires and sun PR, but it doesn't matter that much because basically all vampires have that weakness now (quickly dying in the sun). But that means they need a new weakness and after consultation with SariusSkelrets here it is.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Normal vampires burn over the course of a few minutes as their flesh smolders and falls to ash. If you're a Vampire Anathema with `Anathema's Weakness: Slain by the Sun`, merely stepping into sunlight causes all the normal problems that vampires have and _also_ every second you have a chance to burst into flames. This is calculated independently per body part, and Sanguine Resilience makes it less likely as normal, but don't go out into the sun.

You can blot out the sun with your powers (if you know how), but if you have this weakness it lasts only 1% as long--it's enough to run for cover, not enough to act freely during the day.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

With Sanguine Resilience on, I got 14 squares from the door before my head burst into flames. In the run back to the door, both my legs also caught on fire. In a real game, this would absolutely have been fatal.

Blotted Sun lasts a much shorter time, and the message changes to reflect that
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
