### PR TITLE
Streamline reduce_tests.sh a bit

### DIFF
--- a/tools/reduce_tests.sh
+++ b/tools/reduce_tests.sh
@@ -12,9 +12,14 @@
 
 set -ue
 
-if ! which singledelta &>/dev/null
+DELTA=singledelta
+if !which $DELTA &> /dev/null && which delta &> /dev/null
 then
-    echo "singledelta not found.  Please install it to use this script" >&2
+    DELTA=delta
+fi
+if ! which $DELTA &> /dev/null
+then
+    echo "delta/singledelta not found.  Please install it to use this script" >&2
     exit 1
 fi
 
@@ -60,6 +65,6 @@ export REDUCE_TESTS_TEST_EXE=$test_exe
 # We have to add braces around the lines to avoid topformflat messing up the file.
 # The braces are removed again inside our helper script.
 "$test_exe" --list-test-names-only '~[.]' | grep '[^ ]' | sed 's/.*/{&}/' > list_of_tests || true
-singledelta -in_place -test=tools/reduce_tests_helper.sh list_of_tests
+$DELTA -in_place -test=tools/reduce_tests_helper.sh list_of_tests
 
 # vim:tw=0

--- a/tools/reduce_tests.sh
+++ b/tools/reduce_tests.sh
@@ -1,21 +1,20 @@
 #!/bin/bash
 
-# A helper script to use multidelta to reduce to a minimal set of tests to
-# reproduce a failure.
+# A helper script to use delta/singledelta to reduce to a minimal set of
+# tests to reproduce a failure.
 # Sometimes the tests interact in unexpected ways, so you need to run two
 # or three tests in order to cause the failure to occur.  It's tiresome to
 # determine a minimal subset of tests by hand; this script automates it.
 
 # I think https://github.com/DRMacIver/structureshrink would be better than
-# multidelta for this; multidelta requires strange workarounds.  But
-# multidelta is readily available in most distributions' packages, so using
-# that.
+# delta for this; delta requires strange workarounds.  But delta is readily
+# available in most distributions' packages, so using that.
 
 set -ue
 
-if ! which multidelta &>/dev/null
+if ! which singledelta &>/dev/null
 then
-    echo "multidelta not found.  Please install it to use this script" >&2
+    echo "singledelta not found.  Please install it to use this script" >&2
     exit 1
 fi
 
@@ -60,8 +59,7 @@ export REDUCE_TESTS_TEST_EXE=$test_exe
 
 # We have to add braces around the lines to avoid topformflat messing up the file.
 # The braces are removed again inside our helper script.
-"$test_exe" --list-test-names-only '~[.]' | \
-    grep '[^ ]' | sed 's/.*/{&}/' > list_of_tests || true
-multidelta tools/reduce_tests_helper.sh list_of_tests
+"$test_exe" --list-test-names-only '~[.]' | grep '[^ ]' | sed 's/.*/{&}/' > list_of_tests || true
+singledelta -in_place -test=tools/reduce_tests_helper.sh list_of_tests
 
 # vim:tw=0

--- a/tools/reduce_tests_helper.sh
+++ b/tools/reduce_tests_helper.sh
@@ -5,10 +5,18 @@
 set -uex
 
 # Disallow empty test list
-if [ ! -s "$multidelta_all_files" ]
+if [ ! -s "$1" ]
 then
     exit 1
 fi
+
+# return 0 iff the expected error is emitted
+
+# If you have a test string to watch for, add it here and comment out the later check for test success.
+#"$REDUCE_TESTS_TEST_EXE" -d yes --rng-seed "$rng_seed" \
+#    $REDUCE_TESTS_EXTRA_OPTS \
+#    -f <(tr -d '{}' < <(cat $1)) 2>&1 | tee -a reduce_tests.log | grep -q '../tests/monster_test.cpp:1008: FAILED:'
+
 
 if "$REDUCE_TESTS_TEST_EXE" -d yes --abort --rng-seed "$rng_seed" \
     $REDUCE_TESTS_EXTRA_OPTS \


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
When I tried to use reduce_tests.sh on #81077 I found it to be quite fragile and require a lot of babysitting for false positives (a positive in this case is the test fails in an expected way).

Also I found that the multidelta wrapper script was re-running the test suite redundantly under the assumption that it was doing test case reduction across multiple files and using a tool to semantically group c/c++ expressions, neither of which we were doing.

#### Describe the solution
Adds a stub showing how to test for a target output string instead of test success. This is the recommended way to use delta to avoid false negatives, I *think* it can handle false negatives from "this makes the build fail" or "this makes the whole thing crash", but false positives seem to make it wander off into un-fruitful directions.

Swaps from multidelta that makes things slower without giving any new features to singledelta.

#### Describe alternatives you've considered
Ideally this would be goverened by an argument or something instead of requiring manual editing, but I really do not have the brain juice for that right now.
Since this isn't running through the "flatten" process any more, I don't think adding and removing curly brackets around the test cases is necessary anymore, but it's also not breaking anything so whatever.
Possibly the "match against a string" workflow should be the default, but that requires parameter handling so bleh.

#### Testing
Ran it a bunch of times against #81077 and it was pretty reliable once I had it searching for the error string.