### PR TITLE
[Xedra_Evolved] Fixed Tailors Kit conflict with Xedra/Magiclysm

### DIFF
--- a/data/mods/Xedra_Evolved/mod_interactions/magiclysm/tools.json
+++ b/data/mods/Xedra_Evolved/mod_interactions/magiclysm/tools.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "tailors_kit",
+    "type": "ITEM",
+    "subtypes": [ "TOOL" ],
+    "name": { "str": "tailor's kit" },
+    "description": "This is a high quality kit consisting of a variety of needles, some wooden spools for thread, some small scissors, and an awl.  Use a tailor's kit to customize your clothing and armor.  This uses your tailoring skill.",
+    "weight": "100 g",
+    "volume": "500 ml",
+    "price": "10 USD",
+    "price_postapoc": "10 USD",
+    "material": [ "wood", "steel" ],
+    "symbol": ";",
+    "color": "red",
+    "sub": "sewing_kit",
+    "charges_per_use": 1,
+    "qualities": [ [ "SEW", 4 ], [ "SEW_CURVED", 1 ], [ "KNIT", 1 ], [ "LEATHER_AWL", 2 ], [ "CUT", 2 ], [ "FABRIC_CUT", 2 ] ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "ammo_restriction": { "thread": 400 } } ],
+    "use_action": [
+      {
+        "type": "repair_item",
+        "item_action_type": "repair_fabric",
+        "materials": [
+          "cotton",
+          "leather",
+          "lycra",
+          "nylon",
+          "wool",
+          "fur",
+          "faux_fur",
+          "nomex",
+          "kevlar",
+          "kevlar_layered",
+          "neoprene",
+          "gutskin",
+          "canvas",
+          "denim",
+          "black_dragon_hide",
+          "fae_fur"
+        ],
+        "skill": "tailor",
+        "tool_quality": 1,
+        "cost_scaling": 0.1,
+        "move_cost": 800
+      }
+    ],
+    "flags": [ "ALLOWS_REMOTE_USE" ],
+    "tool_ammo": [ "thread" ]
+  }
+]


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

When a game uses both the Xedra_Evolved and Magiclysm mods tailors kits can no longer be used to repair items made of dragonhide. This fixes that.

#### Describe the solution

Created a new "tools.json" file in the "mod_interactions/magiclysm" folder of Xedra_Evolved. It contains a version of tailors kit item that contains both the fae fur and black dragon hide materials.

#### Describe alternatives you've considered

Initially I tried to find a way to rewrite the way both mods change the tailors kit so they only add materials it can use, not override the list, but I couldn't figure out how to do this. 

#### Testing

I spawned in a dragonhide armor and the debug item that damages other items. After damaging the item I tried to repair it with both the sewing kit (works) and tailors kit (fails).

After making the change I redid the test, and now both kits can repair the armor.

#### Additional context


