### PR TITLE
More improvements to planting

### DIFF
--- a/doc/JSON/ITEM.md
+++ b/doc/JSON/ITEM.md
@@ -981,6 +981,7 @@ Gun mods can be defined like this:
   { "GROWTH_HARVEST": "2 days" },         // will want at least 91 days (the length of winter) in between some stages. This example would overwinter in the GROWTH_MATURE form.
   { "GROWTH_OVERGROWN": "1 hour" }        // NOTE: GROWTH_OVERGROWN is optional, but if used should be a short duration. Or else it may fail to plant because the overgrown(dead) crops would not 'grow'!
 ],
+"growth_temp": 7.2,                       // (optional double, default 10.0). *Celsius*. Temperature required on the days this seed is planted and for every day with a growth stage. If below the required temperature it simply won't be plantable.
 "fruit_div": 2, // (optional, default is 1). Final amount of fruit charges produced is divided by this number. Works only if fruit item is counted by charges.
 "required_terrain_flag": "PLANTABLE" // A tag that terrain and furniture would need to have in order for the seed to be plantable there.
 // Default is "PLANTABLE", and using this will cause any terain the plant is wrown on to turn into dirt once the plant is planted, unless furniture is used.

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -3463,6 +3463,7 @@ void islot_seed::deserialize( const JsonObject &jo )
     mandatory( jo, was_loaded, "fruit", fruit_id );
     mandatory( jo, was_loaded, "growth_stages", growth_stages,
                vector_pair_reader<flag_id, time_duration> {} );
+    optional( jo, was_loaded, "growth_temp", growth_temp, 10.0 );
     optional( jo, was_loaded, "seeds", spawn_seeds, true );
     optional( jo, was_loaded, "byproducts", byproducts );
     optional( jo, was_loaded, "required_terrain_flag", required_terrain_flag,

--- a/src/itype.cpp
+++ b/src/itype.cpp
@@ -290,6 +290,11 @@ const std::vector<std::pair<flag_id, time_duration>> &islot_seed::get_growth_sta
     return growth_stages;
 }
 
+units::temperature islot_seed::get_growth_temp() const
+{
+    return units::from_celsius( growth_temp );
+}
+
 int islot_armor::avg_env_resist() const
 {
     int acc = 0;

--- a/src/itype.h
+++ b/src/itype.h
@@ -1192,11 +1192,15 @@ struct islot_seed {
         islot_seed() = default;
 
         const std::vector<std::pair<flag_id, time_duration>> &get_growth_stages() const;
+        units::temperature get_growth_temp() const;
     private:
         /**
         * What stages of growth does this plant have? How long does each stage of growth last?
         */
         std::vector<std::pair<flag_id, time_duration>> growth_stages;
+        // Temperature needs to be at or above this temp for the plant to be planted/grow. Converted to Celsius in the getter.
+        // Kind of nasty! Would prefer to load this as a temperature instead of the conversion.
+        double growth_temp = 0;
 };
 
 enum condition_type {

--- a/src/weather.cpp
+++ b/src/weather.cpp
@@ -873,6 +873,28 @@ rl_vec2d convert_wind_to_coord( const int angle )
     return rl_vec2d( 0, 0 );
 }
 
+static units::temperature highest_temp_on_day( time_point &base_date, const tripoint_abs_omt &pos,
+        const weather_generator &weather_gen )
+{
+    units::temperature highest_temp = 0_C;
+    // we search a 24 hour period around the base_date, the base_date is exactly in the center
+    const time_duration search_radius = 12_hours;
+    // how long between each check. The performance on this shouldn't be a problem, but if we want more/less granularity this is a simple lever.
+    const time_duration check_interval = 15_minutes;
+
+    // Iterate through the search window, checking temp each check_interval. Highest found value in the entire range is what ends up being returned.
+    time_point check_date = base_date - search_radius;
+    while( check_date <= base_date + search_radius ) {
+        const w_point &w = weather_gen.get_weather( project_to<coords::ms>( pos ), check_date,
+                           g->get_seed() );
+        const units::temperature checked_temp = w.temperature;
+        highest_temp = std::max( highest_temp, checked_temp );
+        check_date = check_date + check_interval;
+    }
+
+    return highest_temp;
+}
+
 bool warm_enough_to_plant( const tripoint_bub_ms &pos, const itype_id &it )
 {
     const tripoint_abs_ms abs = get_map().get_abs( pos );
@@ -883,29 +905,29 @@ bool warm_enough_to_plant( const tripoint_bub_ms &pos, const itype_id &it )
 bool warm_enough_to_plant( const tripoint_abs_omt &pos, const itype_id &it )
 {
     std::map<time_point, units::temperature> planting_times;
-    // initialize the first...
-    time_point check_date = calendar::turn;
-    planting_times[check_date] = get_weather().get_temperature( pos );
     bool okay_to_plant = true;
     const std::vector<std::pair<flag_id, time_duration>> &growth_stages = it->seed->get_growth_stages();
-    // and now iterate a copy of the weather into the future to see if they'll be plantable then as well.
+    // we will iterate a copy of the weather into the future to see if they'll be plantable then as well.
     const weather_generator weather_gen = get_weather().get_cur_weather_gen();
+    // initialize the first...
+    time_point check_date = calendar::turn;
+    planting_times[check_date] = highest_temp_on_day( check_date, pos, weather_gen );
     for( const auto &pair : growth_stages ) {
         // TODO: Replace epoch checks with data from a farmer's almanac
         check_date = check_date + pair.second;
-        const w_point &w = weather_gen.get_weather( project_to<coords::ms>( pos ), check_date,
-                           g->get_seed() );
-        planting_times[check_date] = w.temperature;
+        planting_times[check_date] = highest_temp_on_day( check_date, pos, weather_gen );
     }
     for( const std::pair<const time_point, units::temperature> &pair : planting_times ) {
         // This absolutely needs to be a time point.
         add_msg_debug( debugmode::DF_MAP,
-                       "Checking plant time %s, temperature %s F…",
+                       "Checking plant time %s, highest temperature %s…",
                        //NOLINTNEXTLINE(cata-translations-in-debug-messages)
-                       to_string( pair.first ), units::to_fahrenheit( pair.second ) );
+                       to_string( pair.first ), print_temperature( pair.second, 2 ) );
         // semi-appropriate temperature for most plants
-        if( pair.second < units::from_fahrenheit( 50 ) ) {
-            add_msg_debug( debugmode::DF_MAP, "Planting failure!" );
+        if( pair.second < it->seed->get_growth_temp() ) {
+            add_msg_debug( debugmode::DF_MAP, "Planting failure! %s needs temperature of %s but found only %s",
+                           it->nname( 1 ), print_temperature( it->seed->get_growth_temp(), 2 ),
+                           print_temperature( pair.second, 2 ) );
             okay_to_plant = false;
             break;
         }


### PR DESCRIPTION
#### Summary
Features "JSONize plant growth temp. Search entire day's temperature for planting temperature."

#### Purpose of change
Resolving some more pain points with planting.

#### Describe the solution
First: Search a 24-hour period for all growth stages (including at the time of planting) for the highest temperature, consider that the actual temperature. That way you do not encounter weird situations where on May 20, 7:59 AM it is impossible to plant but May 20, 8:01 AM is perfectly fine!

Second: JSONize the temperatures which allow planting on a per-seed basis. This used to be 50F for all plants. Now it can be different. (It still defaults to 50F if unspecified)

#### Describe alternatives you've considered
Apparently we can load Kelvin from JSON instead of loading a double as fake-temperature and converting it on the back-end. Maybe we should do that? Going to give that some thought.

I considered adding a temperature range instead of a single value, so that you must be above the minimum *and below the maximum*. But my understanding is that higher temperatures do not tend to immediately kill plants - solar irradiance does that. Lower temperatures are where the day-to-day danger is, as frost will rupture cell walls.

If desired, it could easily be switched to a range.

#### Testing
Added some debug plumbing to help. Planted some seeds when they should grow, they planted. Tried when they shouldn't, they didn't. Debug output looked good.

#### Additional context
