### PR TITLE
(Mostly) fix butchering activity from zones

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -16,6 +16,7 @@
 #include <vector>
 
 #include "action.h"
+#include "activity_actor.h"
 #include "activity_actor_definitions.h"
 #include "activity_handlers.h"
 #include "addiction.h"
@@ -128,8 +129,6 @@
 #include "weather.h"
 #include "weather_type.h"
 #include "wound.h"
-
-class activity_actor;
 
 static const activity_id ACT_AUTODRIVE( "ACT_AUTODRIVE" );
 static const activity_id ACT_CONSUME_DRINK_MENU( "ACT_CONSUME_DRINK_MENU" );
@@ -9120,6 +9119,13 @@ void Character::set_knows_creature_type( const mtype_id &c )
 void Character::assign_activity( const activity_id &type, int moves, int index, int pos,
                                  const std::string &name )
 {
+    // This is not a perfect safety net, but I don't know of another way to get all activity actors and what activity_ids might be associated with them.
+    for( const auto &actor_ptr : activity_actors::deserialize_functions ) {
+        if( actor_ptr.first == type ) {
+            debugmsg( "Tried to assign generic activity %s to activity that has an actor!", type.c_str() );
+            return;
+        }
+    }
     assign_activity( player_activity( type, moves, index, pos, name ) );
 }
 

--- a/src/player_activity.cpp
+++ b/src/player_activity.cpp
@@ -12,6 +12,7 @@
 #include "character.h"
 #include "construction.h"
 #include "creature.h"
+#include "debug.h"
 #include "dialogue.h"
 #include "effect_on_condition.h"
 #include "event.h"
@@ -22,6 +23,7 @@
 #include "itype.h"
 #include "magic.h"
 #include "map.h"
+#include "messages.h"
 #include "rng.h"
 #include "skill.h"
 #include "sounds.h"
@@ -382,6 +384,8 @@ void player_activity::do_turn( Character &you )
             dialogue d( get_talker_for( you ), nullptr );
             type->completion_EOC->activate_activation_only( d, "player activities" );
         }
+        add_msg_debug( debugmode::DF_ACTIVITY, "Setting activity %s to null for %s, no moves left.",
+                       type.c_str(), you.name );
         get_event_bus().send<event_type::character_finished_activity>( you.getID(), type, false );
         g->wait_popup_reset();
         if( actor ) {


### PR DESCRIPTION
#### Summary
Bugfixes "(Mostly) fix butchering activity from zones"

#### Purpose of change
Trying to butcher via zones is completely broken. For the player, this appears to have been caused by #80905. NPCs had several issues.

#### Describe the solution
Correctly assign butchery activity actor when butchering via zones

Add a big honking debugmsg if someone accidentally assigns a generic activity to one with an actor again

Check if activity_var is the person doing the activity instead of just declaring that "I can't work on that, someone(me) is already working on it!". This was the main problem NPCs were encountering.

Add some other minor safeguards for issues encountered during debugging. (If we have no corpses to cut up, don't tell me I am *missing the zone*. I spent ~15-20 minutes dissecting the coordinates for a coordinate issue before realizing there was absolutely no problem there.)

#### Describe alternatives you've considered
Completely separating actors and activities so this sort of mixing can't happen by accident / removing all legacy activities in favor of actors. Both would be a lot of work...

#### Testing
Butcher via B --> No issues
Butcher via zone orders --> Works again
Ask follower to butcher --> Previously didn't work (cancelled instantly), now completes properly but may throw errors at the end. Unsure of the exact circumstances.

#### Additional context

Known issues:
NPCs doing butchery causes errors when they finish