### PR TITLE
Remove character field from eoc documentation

### DIFF
--- a/doc/JSON/EFFECT_ON_CONDITION.md
+++ b/doc/JSON/EFFECT_ON_CONDITION.md
@@ -296,9 +296,9 @@ Checks there is portal storm **and** you have `MAKAYLA_MUTATOR` mutation **and**
 
 #### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- | 
-| ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- | 
+| ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
 
 #### Examples
 return true if beta talker exists
@@ -312,9 +312,9 @@ return true if beta talker exists
 
 #### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 #### Examples
 return true if alpha talker is female
@@ -338,9 +338,9 @@ Creature ---> Character ---> avatar
 
 #### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
 
 #### Examples
 return true if alpha talker is character (avatar or NPC)
@@ -356,9 +356,9 @@ return true if alpha talker is character (avatar or NPC)
 
 #### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
 
 #### Examples
 return true if alpha talker at the `field`
@@ -383,9 +383,9 @@ return true if alpha talker at location that can be transformed to faction camp
 
 #### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 #### Examples
 checks do alpha talker have `EAGLEEYED` trait
@@ -408,9 +408,9 @@ using `_has_any_trait` with single trait is also possible
 
 #### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 #### Examples
 Checks do alpha talker has `FEATHERS` mutation
@@ -425,9 +425,9 @@ Checks do alpha talker has `FEATHERS` mutation
 
 #### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 #### Examples
 Checks if the `FEATHERS` trait is purifiable for the character (returns true as per the trait definition unless another effect set the trait non-purifiable for the target)
@@ -442,9 +442,9 @@ Checks if the `FEATHERS` trait is purifiable for the character (returns true as 
 
 #### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 #### Examples
 ```jsonc
@@ -457,9 +457,9 @@ Checks if the `FEATHERS` trait is purifiable for the character (returns true as 
 
 #### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 #### Examples
 ```jsonc
@@ -472,9 +472,9 @@ Checks if the `FEATHERS` trait is purifiable for the character (returns true as 
 
 #### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ✔️ | ❌ | ✔️ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ✔️ | ❌ | ✔️ | ❌ |
 
 Note: For terrain and furniture, [map_terrain_with_flag, map_furniture_with_flag](#map_terrain_with_flagmap_furniture_with_flag) can also be used.
 
@@ -491,9 +491,9 @@ Alpha talker has `GRAB` flag, and beta talker has `GRAB_FILTER` flag; monster us
 
 #### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✔️ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ❌ | ❌ | ❌ | ❌ | ❌ | ✔️ |
 
 #### Examples
 
@@ -513,9 +513,9 @@ Beta talker is a vehicle with a stereo which is activated
 
 #### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ❌ | ❌ | ❌ | ✔️ | ❌ | ❌ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ❌ | ❌ | ✔️ | ❌ | ❌ | ❌ |
 
 #### Examples
 alpha talker is `SLIME`
@@ -530,9 +530,9 @@ alpha talker is `SLIME`
 
 #### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 #### Examples
 alpha talker has bodytype `migo` , and beta has bodytype `human`
@@ -547,9 +547,9 @@ alpha talker has bodytype `migo` , and beta has bodytype `human`
 
 #### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
 
 #### Examples
 checks this var exists
@@ -614,9 +614,9 @@ Check if two variables are `yes`
 
 #### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ❌ | ❌ | ❌ | ❌ | ❌ |
 
 #### Examples
 True if the talker has the Heist Driver profession
@@ -642,9 +642,9 @@ Print a message if the character selected Fisher profession or the Fishing backg
 
 #### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 #### Examples
 True, if alpha talker has str 7 or more
@@ -659,9 +659,9 @@ True, if alpha talker has str 7 or more
 
 #### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 #### Examples
 check is your torso is 37 centigrade
@@ -676,9 +676,9 @@ check is your torso is 37 centigrade
 
 #### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 #### Examples
 check do you have a guitar
@@ -698,9 +698,9 @@ check do you have 6 ropes
 
 #### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 #### Examples
 check do you have manual in inventory
@@ -724,9 +724,9 @@ check do you have 3 manuals in inventory
 
 #### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 #### Examples
 check do you have 10 blankets of any type in the list
@@ -786,9 +786,9 @@ Variables are also supported
 
 #### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 #### Examples
 check do you have `bio_synlungs`
@@ -810,9 +810,9 @@ check do you have any bionic presented
 
 #### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 #### Examples
 checks are you infected
@@ -841,9 +841,9 @@ checks are you hot or cold
 
 #### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 #### Examples
 check do you have `Principles of Chemistry`
@@ -857,9 +857,9 @@ check do you have `Principles of Chemistry`
 
 #### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 #### Examples
 You have equipped an item that you can stow
@@ -878,9 +878,9 @@ You have equipped an item that you can not stow, either because it's bionic pseu
 
 #### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 #### Examples
 
@@ -905,9 +905,9 @@ You have equipped an item that you can not stow, either because it's bionic pseu
 
 #### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 #### Examples
 
@@ -926,9 +926,9 @@ You don't wield anything
 
 #### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 #### Examples
 
@@ -947,9 +947,9 @@ true if you do not drive
 
 #### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 #### Examples
 
@@ -969,9 +969,9 @@ true if you do not drive
 
 #### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ❌ | ❌ | ❌ | ❌ | ❌ |
 
 #### Examples
 check do you memorize `meat_hunk` recipe
@@ -985,9 +985,9 @@ check do you memorize `meat_hunk` recipe
 
 #### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 #### Examples
 check do you wear something with `RAD_DETECT` flag
@@ -1001,9 +1001,9 @@ check do you wear something with `RAD_DETECT` flag
 
 #### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 #### Examples
 check do you wield something with `WHIP` flag
@@ -1017,9 +1017,9 @@ check do you wield something with `WHIP` flag
 
 #### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 #### Examples
 check do you wield something with `LONG_SWORDS` weapon category
@@ -1035,9 +1035,9 @@ check do you wield something with `LONG_SWORDS` weapon category
 
 #### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 #### Examples
 check do you wield a gun with `pistol` skill
@@ -1052,9 +1052,9 @@ check do you wield a gun with `pistol` skill
 
 #### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 #### Examples
 check do you wield a gun with `22` ammo type (.22 LR)
@@ -1068,9 +1068,9 @@ check do you wield a gun with `22` ammo type (.22 LR)
 
 #### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ |
 
 #### Examples
 
@@ -1089,9 +1089,9 @@ You can't see
 
 #### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ |
 
 #### Examples
 
@@ -1110,9 +1110,9 @@ You can hear
 
 #### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ |
 
 #### Examples
 
@@ -1131,9 +1131,9 @@ NPC is dead
 
 #### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ |
 
 #### Examples
 
@@ -1147,9 +1147,9 @@ NPC is dead
 
 #### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
 
 ### `u_is_on_terrain`, `npc_is_on_terrain`
 - type: string or [variable object](#variable-object)
@@ -1157,9 +1157,9 @@ NPC is dead
 
 #### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
 
 #### Examples
 check do you stand on grass
@@ -1173,9 +1173,9 @@ check do you stand on grass
 
 #### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
 
 #### Examples
 check do you stand on terrain with `SHRUB` flag
@@ -1189,9 +1189,9 @@ check do you stand on terrain with `SHRUB` flag
 
 #### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
 
 #### Examples
 check do you stand in a cloud of smoke
@@ -1207,9 +1207,9 @@ check do you stand in a cloud of smoke
 
 #### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 #### Examples
 Create a popup with message `You have died.  Continue as one of your followers?`
@@ -1323,9 +1323,9 @@ Each time the avatar enters an OMT display a message as to whether or not they'r
 
 #### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
 
 #### Examples
 Will give a message if you're in the main dimension.
@@ -1345,9 +1345,9 @@ Will give a message if you're in the dimension with the ID of "test".
 
 #### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
 
 #### Examples
 return true if player can see NPC.
@@ -1361,9 +1361,9 @@ return true if player can see NPC.
 
 #### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ |
 
 #### Examples
 
@@ -1389,9 +1389,9 @@ You can see selected location.
 
 #### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ |
 
 ### `u_is_driven`, `npc_is_driven`
 - type: simple string
@@ -1399,9 +1399,9 @@ You can see selected location.
 
 #### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✔️ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ❌ | ❌ | ❌ | ❌ | ❌ | ✔️ |
 
 #### Examples
 
@@ -1421,9 +1421,9 @@ You can see selected location.
 
 #### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- | 
-| ✔️ | ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- | 
+| ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ |
 
 #### Examples
 
@@ -1470,9 +1470,9 @@ You can see selected location.
 
 #### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✔️ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ❌ | ❌ | ❌ | ❌ | ❌ | ✔️ |
 
 #### Examples
 
@@ -1486,9 +1486,9 @@ You can see selected location.
 
 #### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✔️ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ❌ | ❌ | ❌ | ❌ | ❌ | ✔️ |
 
 #### Examples
 
@@ -1502,9 +1502,9 @@ You can see selected location.
 
 #### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✔️ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ❌ | ❌ | ❌ | ❌ | ❌ | ✔️ |
 
 #### Examples
 
@@ -1518,9 +1518,9 @@ You can see selected location.
 
 #### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✔️ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ❌ | ❌ | ❌ | ❌ | ❌ | ✔️ |
 
 #### Examples
 
@@ -1534,9 +1534,9 @@ You can see selected location.
 
 #### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✔️ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ❌ | ❌ | ❌ | ❌ | ❌ | ✔️ |
 
 #### Examples
 
@@ -1551,9 +1551,9 @@ You can see selected location.
 
 #### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✔️ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ❌ | ❌ | ❌ | ❌ | ❌ | ✔️ |
 
 #### Examples
 
@@ -1567,9 +1567,9 @@ You can see selected location.
 
 #### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✔️ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ❌ | ❌ | ❌ | ❌ | ❌ | ✔️ |
 
 #### Examples
 
@@ -1583,9 +1583,9 @@ You can see selected location.
 
 #### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✔️ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ❌ | ❌ | ❌ | ❌ | ❌ | ✔️ |
 
 #### Examples
 
@@ -1599,9 +1599,9 @@ You can see selected location.
 
 #### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✔️ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ❌ | ❌ | ❌ | ❌ | ❌ | ✔️ |
 
 #### Examples
 
@@ -1615,9 +1615,9 @@ You can see selected location.
 
 #### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✔️ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ❌ | ❌ | ❌ | ❌ | ❌ | ✔️ |
 
 #### Examples
 
@@ -1635,9 +1635,9 @@ You can see selected location.
 
 #### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
 
 #### Examples
 Check whether the eoc `test_condition` would use its true or false effect 
@@ -1649,7 +1649,7 @@ Check whether the eoc `test_condition` would use its true or false effect
 The code base supports the use of reusable EOCs, you can use these to get guaranteed effects by passing in specific variables. The codebase supports the following:
 
 | EOC Name | Description | Variables |
-| --------------------- | --------- | ----------- |
+| ---------------------  ----------- |
 | EOC_RandEnc | Spawns a random encounter at the specified `omt` with mapgen update `map_update` that is later removed with `map_removal`. It has a 1 in `chance` chance of happening and can only occur after `days_till_spawn`. Can optionally only happen if `random_enc_condition` is true | `map_update`: a mapgen update ID <br/> `omt`: overmap tile ID where this happens <br/> `map_removal`: a mapgen update ID <br/> `chance`: an integer <br/> `days_till_spawn`: an integer <br/> `random_enc_condition`: a set condition |
 
 # EVENT EOCs:
@@ -1799,9 +1799,9 @@ Play a sound effect from sound pack `"type": "sound_effect"`
 
 ##### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
 
 ##### Examples
 
@@ -1821,9 +1821,9 @@ Opens up a dialog between the participants; this should only be used in effect_o
 
 ##### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
 
 ##### Examples
 Opens dialogue with topic `TALK_PERK_MENU_MAIN`
@@ -1851,9 +1851,9 @@ If beta talker is NPC, take control of it
 
 ##### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ❌ | ❌ | ✔️ | ❌ | ❌ | ❌ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ❌ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 ##### Examples
 Takes control of NPC
@@ -1872,9 +1872,9 @@ Works only with your followers
 
 ##### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ❌ | ❌ | ❌ | ❌ | ❌ |
 
 ##### Examples
 Opens the menu to swap the avatar
@@ -1892,9 +1892,9 @@ Marks the given achievement as complete
 
 ##### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ❌ | ❌ | ❌ | ❌ | ❌ |
 
 ##### Examples
 Gives achievement `escaped_the_cataclysm`
@@ -1914,9 +1914,9 @@ Will assign mission to the player
 
 ##### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ❌ | ❌ | ❌ | ❌ | ❌ |
 
 ##### Examples
 Assign you a `MISSION_REACH_FAKE_DAVE` mission which must be completed within the next 17 hours
@@ -1933,9 +1933,9 @@ Will remove mission from the player's active mission list without failing it.
 
 ##### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | 
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | 
 
 ##### Examples
 removes `MISSION_BONUS_KILL_BOSS` mission from your list
@@ -1956,9 +1956,9 @@ Will complete mission the player has, in one way or another
 
 ##### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
 
 ##### Examples
 Complete the mission `DID_I_WIN` as failed
@@ -1986,9 +1986,9 @@ Adds this mission on a list NPC can offer
 
 ##### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ❌ | ❌ | ✔️ | ❌ | ❌ | ❌ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ❌ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 ##### Examples
 NPC can offer mission `MISSION_GET_RELIC` now
@@ -2042,9 +2042,9 @@ Variable values can be declared inline and must use the correct type:
 
 ##### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
 
 ##### Examples
 
@@ -2317,9 +2317,9 @@ If you or NPC does not have all of the listed bionics, mutations, spells or reci
 
 ##### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 ##### Examples
 Tries to give you a mutation `A`, `B` or `C`, if you don't have one, with message `You got %s!`; If roll is successful, `EOC_SUCCESS` is run, otherwise `EOC_FAIL` is run
@@ -2345,9 +2345,9 @@ Set effects to be executed when conditions are met and when conditions are not m
 
 ##### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
 
 ##### Examples
 Displays a different message the first time it is run and the second time onwards
@@ -2379,9 +2379,9 @@ Check the value, and, depending on it, pick the case that would be run
 
 ##### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 ##### Examples
 Checks the level of `some_spell` spell, and, related to this, do something: for spell level 0 it casts another_spell, for spell level 3 it adds effect "drunk", and so on.
@@ -2427,9 +2427,9 @@ The correspondence between "foreach" and "target" is as follows.
 
 ##### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
 
 ##### Examples
 Resets all of your vitamins.
@@ -2466,9 +2466,9 @@ and using `place_npcs`:
 
 ##### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ❌ | ❌ | ✔️ | ❌ | ❌ | ❌ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ❌ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 ##### Examples
 
@@ -2521,9 +2521,9 @@ Monsters run EoCs, provided by this effect; only works inside reality bubble
 
 ##### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ❌ | ❌ | ❌ | ✔️ | ❌ | ❌ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ❌ | ❌ | ✔️ | ❌ | ❌ | ❌ |
 
 ##### Examples
 
@@ -2568,9 +2568,9 @@ Run EOCs on items in your or NPC's inventory
 
 ##### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ❌ | ❌ | ❌ | ❌ | ❌ | ✔️ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ❌ | ❌ | ❌ | ❌ | ✔️ | ❌ |
 
 ##### Examples
 Picks an item in character's hands, and run `EOC_DESTROY_ITEM` EoC on it
@@ -2691,9 +2691,9 @@ Search items around you on the map, and run EoC on them
 
 ##### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
 
 ##### Examples
 
@@ -2949,9 +2949,9 @@ Open a menu, that allow to select one of multiple options
 | "variables" | optional | pair of `"variable_name": "variable"` | variables, that would be passed to the EoCs; can be either a [variable object](#variable-object), or an [inline variable](#inline-variables); `expects_vars` condition can be used to ensure every variable exist before the EoC is run | 
 ##### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ❌ | ❌ | ❌ | ❌ | ❌ |
 
 ##### Examples
 you can pick one of four options from `Choose your destiny` list; 
@@ -2991,9 +2991,9 @@ Deal damage, the same way melee attack deals damage; it can't be dodged, but it 
 
 ##### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- | 
-| ✔️ | ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- | 
+| ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ |
 
 ##### Examples
 
@@ -3017,9 +3017,9 @@ Your character or the NPC will attempt to mutate; used in mutation system, for o
 
 ##### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 ##### Examples
 ```jsonc
@@ -3101,9 +3101,9 @@ Some effect would be applied on you or NPC
 
 ##### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ |
 
 ##### Examples
 Apply effect `drunk` for 4.5 hours:
@@ -3137,9 +3137,9 @@ You or NPC would have some bionic installed
 
 ##### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 ##### Examples
 Install 1 `bio_power_storage` onto your character:
@@ -3162,9 +3162,9 @@ You or NPC would have some bionic uninstalled from your body
 
 ##### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 ##### Examples
 Uninstall 1 `bio_power_storage` from your character:
@@ -3188,9 +3188,9 @@ Give character or NPC some mutation/trait
 
 ##### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 ##### Examples
 Adds `TELEPATH` trait to the character:
@@ -3218,9 +3218,9 @@ Character or NPC got trait or mutation removed, if it has one
 
 ##### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 ##### Examples
 
@@ -3245,9 +3245,9 @@ Remove effect from character or NPC, if it has one
 
 ##### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ |
 
 ##### Examples
 Removes `infection` effect from player:
@@ -3284,9 +3284,9 @@ Your character or the NPC will activate the trait.
 
 ##### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 ##### Examples
 `process_mutation` mutation would be activated, which trigger all effect it can cause, including `activated_eocs` inside the mutation
@@ -3309,9 +3309,9 @@ Your character or the NPC will deactivate the trait.
 
 ##### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 ##### Examples
 Deactivate `BIOLUM1_active` trait:
@@ -3334,9 +3334,9 @@ Your character or the NPC will learn the martial art style.
 
 ##### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 ##### Examples
 The character learn Eskrima 
@@ -3359,9 +3359,9 @@ Your character or the NPC will forget the martial art style.
 
 ##### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 ##### Examples
 Character forget Eskrima 
@@ -3388,9 +3388,9 @@ Save a string as personal variable, that you can check later using `compare_stri
 
 ##### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
 
 Note: numeric vars can be set (and check) to monsters via `math` functions.  See the example below.
 
@@ -3473,9 +3473,9 @@ Your character or the NPC will clear any stored variable that has the same name,
 
 ##### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
 
 ##### Examples
 
@@ -3532,9 +3532,9 @@ Store string from `set_string_var` in the variable object `target_var`
 
 ##### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |  
-| ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |  
+| ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
 
 ##### Examples
 Replace value of variable `foo` with value `bar`
@@ -3591,9 +3591,9 @@ Create a context value with condition, that you can pass down the next topic or 
 
 ##### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
 
 ##### Examples
 Save the condition  `season is not winter, and it is a daytime` into `random_enc_condition` variable, then call the EoC `second_test`. Second EoC uses `random_enc_condition` to check and print message
@@ -3633,9 +3633,9 @@ Search a specific coordinates of map around `u_`, `npc_` or `target_params` and 
 
 ##### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
 
 ##### Examples
 Saves the current location into `i_am_here` variable:
@@ -3703,9 +3703,9 @@ Allow adjust location value, obtained by `u_location_variable`, and share the sa
 
 ##### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
 
 ##### Examples
 Move coordinates in `location_var` value one tile to the right
@@ -3729,9 +3729,9 @@ Opens a menu allowing the player to choose a new hair style
 
 ##### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ❌ | ❌ | ❌ | ❌ | ❌ |
 
 ##### Examples
 
@@ -3753,9 +3753,9 @@ Opens a menu allowing the player to choose a new beard style.
 
 ##### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ❌ | ❌ | ❌ | ❌ | ❌ |
 
 ##### Examples
 ```jsonc
@@ -3788,9 +3788,9 @@ Your character or the npc will learn and memorize the recipe
 
 ##### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 ##### Examples
 You learn a recipe of cattail_jelly
@@ -3815,9 +3815,9 @@ Your character or the npc will forget the recipe
 
 ##### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 ##### Examples
 You forget the recipe `inventor_research_base_1`
@@ -3850,9 +3850,9 @@ Changes the initial talk_topic of the NPC in all future dialogues.
 
 ##### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ❌ | ❌ | ✔️ | ❌ | ❌ | ❌ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ❌ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 ##### Examples
 Override the initial lighthouse girl topic `TALK_lighthouse_girl_start` with `TALK_lighthouse_girl_safe`
@@ -3871,9 +3871,9 @@ Your character or the NPC will be wet as if they were in the rain.
 
 ##### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 ##### Examples
 Makes you 10% wet (whatever that means)
@@ -3896,9 +3896,9 @@ Emit a sound
 
 ##### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
 
 ##### Examples
 Generate a sound `Hi there!` 15 tiles around the NPC
@@ -3932,9 +3932,9 @@ Increases or decreases your healthiness (respond for disease immunity and regene
 
 ##### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 ##### Examples
 Your health is decreased by 1, but not smaller than -200
@@ -3958,9 +3958,9 @@ Your character or the NPC will gain a morale bonus
 
 ##### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 ##### Examples
 Gives `morale_afs_drugs` thought with +1 mood bonus
@@ -3991,9 +3991,9 @@ Your character or the NPC will lose picked `morale_type`
 
 ##### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 ##### Examples
 removes `bad_mood` morale from you
@@ -4021,9 +4021,9 @@ See examples for more info
 
 ##### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |   
-| ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |   
+| ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 ##### Examples
 Consume 10 blankets. Effect allows to be consumed any item, so in this case player may have 3 `blanket`, 2 `blanket_fur`, and 5 `electric_blanket`, and effect would consume all of it
@@ -4096,9 +4096,9 @@ Can be used only in `talk_topic`, as the code relies on the NPC you talk with to
 
 ##### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |    
-| ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |    
+| ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 ##### Examples
 Adds the "share public goods" rule 
@@ -4120,9 +4120,9 @@ Removes the "kill on sight" rule
 
 ##### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ❌ | ❌ | ✔️ | ❌ | ❌ | ❌ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ❌ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 ##### Examples
 adds 5 points to faction trust
@@ -4154,9 +4154,9 @@ Display a text message in the log. `u_message` and `npc_message` display a mess
 
 ##### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
 
 ##### popup_flag
 `PF_GET_KEY` - Cancels the popup on any user input as opposed to being limited to Return, Space and Escape.
@@ -4201,9 +4201,9 @@ You or NPC cast a spell. The spell uses fake spell data (ignore `energy_cost`, `
 
 ##### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ |
 
 ##### Examples
 You cast `spell_1` spell
@@ -4254,9 +4254,9 @@ Modifies the levels of all known spells of a given class.
 
 ##### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 ##### Examples
 
@@ -4281,9 +4281,9 @@ NPC or character will start an activity
 
 ##### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 ##### Examples
 
@@ -4298,9 +4298,9 @@ NPC or character will stop their current activity
 
 ##### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |     
-| ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |     
+| ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 ##### Examples
 
@@ -4324,9 +4324,9 @@ You or NPC is teleported to `target_var` coordinates
 
 ##### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ❌ | ❌ | ✔️ | ✔️ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ❌ | ❌ | ✔️ | ✔️ |
 
 ##### Examples
 
@@ -4360,9 +4360,9 @@ Creates an explosion at talker position or at passed coordinate
 
 ##### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |    
-| ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |    
+| ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
 
 ##### Examples
 
@@ -4439,7 +4439,7 @@ Pushes the creature on the tile in specific direction
 ##### Valid talkers:
 
 | Avatar | Character | NPC | Monster |  Furniture | Item |
-| ------ | --------- | --------- | ---- | ------- | --- | 
+| ------  --------- | ---- | ------- | --- | 
 | ✔️ | ✔️ | ✔️ | ✔️ | ❌ | ❌ |
 
 ##### Examples
@@ -4490,9 +4490,9 @@ Opens a map, and allow you to pick an overmap tile to store in variable
 
 ##### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ❌ | ❌ | ❌ | ❌ | ❌ |
 
 ##### Examples
 
@@ -4560,8 +4560,8 @@ Ask the player to select a tile. If tile is selected, variable with coordinates 
 #### Valid talkers:
 
 | Avatar | Character | NPC | Monster |  Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ❌ | ❌ | ❌ | ❌ | ❌ |
 
 #### Examples
 Display coordinates of selected tile.
@@ -4591,7 +4591,7 @@ Allows to pick 9 tiles in close proximity to player
 #### Valid talkers:
 
 | Avatar | Character | NPC | Monster |  Furniture | Item |
-| ------ | --------- | --------- | ---- | ------- | --- | 
+| ------  --------- | ---- | ------- | --- | 
 | ✔️ | ❌ | ❌ | ❌ | ❌ | ❌ |
 
 #### Examples
@@ -4646,7 +4646,7 @@ Picks two coordinates, and create a third one in opposite direction
 ##### Valid talkers:
 
 | Avatar | Character | NPC | Monster |  Furniture | Item |
-| ------ | --------- | --------- | ---- | ------- | --- | 
+| ------  --------- | ---- | ------- | --- | 
 | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
 
 ##### Examples
@@ -4684,9 +4684,9 @@ If the target is an item, it will be deleted.
 
 ##### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ✔️ | ❌ | ✔️ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ✔️ | ❌ | ✔️ | ❌ |
 
 ##### Examples
 
@@ -4713,9 +4713,9 @@ You or NPC will be prevented from death. Intended for use in EoCs has `NPC_DEATH
 
 ##### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 ##### Examples
 
@@ -4755,9 +4755,9 @@ Alpha or beta talker forced to use a technique or special attack
 
 ##### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 ##### Examples
 you use autoattack
@@ -4813,9 +4813,9 @@ Give item a flag
 
 ##### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ❌ | ❌ | ❌ | ❌ | ❌ | ✔️ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ❌ | ❌ | ❌ | ❌ | ✔️ | ❌ |
 
 ##### Examples
 Make item filthy
@@ -4832,9 +4832,9 @@ Remove a flag from item
 
 ##### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ❌ | ❌ | ❌ | ❌ | ❌ | ✔️ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ❌ | ❌ | ❌ | ❌ | ✔️ | ❌ |
 
 ##### Examples
 Make item clean
@@ -4852,9 +4852,9 @@ You activate beta talker / NPC activates alpha talker. One must be a Character a
 
 ##### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 ##### Examples
 Force you consume drug item
@@ -4873,9 +4873,9 @@ Applies a fault on item
 
 ##### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ❌ | ❌ | ❌ | ❌ | ❌ | ✔️ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ❌ | ❌ | ❌ | ❌ | ✔️ | ❌ |
 
 ##### Examples
 Beta talker adds `fault_electronic_blown_capacitor` as it's fault
@@ -4894,9 +4894,9 @@ Picks a random fault from a type, and applies it onto item
 
 ##### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ❌ | ❌ | ❌ | ❌ | ❌ | ✔️ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ❌ | ❌ | ❌ | ❌ | ✔️ | ❌ |
 
 ##### Examples
 Beta talker adds a random fault from `shorted` type as it's fault
@@ -5280,9 +5280,9 @@ Subtract this many turns from the alpha talker's moves.
 
 ##### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ❌ | ❌ | ❌ | ❌ | ❌ |
 
 
 #### `transform_item`
@@ -5309,9 +5309,9 @@ Convert the beta talker (which must be an item) into a different item, optionall
 
 ##### Valid talkers:
 
-| Avatar | Character | NPC | Monster | Furniture | Item | Vehicle |
-| ------ | --------- | --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ❌ | ❌ | ❌ | ❌ | ❌ |
 
 
 ## Mics


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Having more knowledge of the game, i realised that `Character` is a meta class that combines both avatar and npc, therefore, it is redundant for eoc documentation to specify if character can use it or not
#### Describe the solution
Remove the field from the documentation
#### Describe alternatives you've considered
I thought about some more explanatory way like
<img width="607" height="85" alt="image" src="https://github.com/user-attachments/assets/33bcf027-b175-448f-809e-f53139914216" />

But decided against it because it is not supported by markdown out of the box