### PR TITLE
Fix greeter

### DIFF
--- a/.github/workflows/greet-first-time-comment.yml
+++ b/.github/workflows/greet-first-time-comment.yml
@@ -28,7 +28,7 @@ jobs:
           echo "comment_count=$comment_count" >> $GITHUB_OUTPUT
 
       - name: Greet commenters with no previous comments
-        if: steps.pr-check.outputs.comment_count == 1
+        if: steps.pr-comment-check.outputs.comment_count == 1
         run: |
           # I have no earthly idea how to pass the commenter on from the previous run (I have tried), so let's just re-acquire it.
           commenter_name="${{ github.event.comment.user.login }}"


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
<img width="1522" height="553" alt="image" src="https://github.com/user-attachments/assets/fa3ea53e-0af0-4f1e-8e51-0b27c2ff4c10" />

It's supposed to greet if the comments are == to 1

#### Describe the solution
Instead of checking `pr-check` (which is from [a different workflow](https://github.com/CleverRaven/Cataclysm-DDA/blob/35b6c4e7df2b6dca4d5a58b192301f5c026e814d/.github/workflows/label-first-time-contributor.yml#L19) entirely!!) properly check `pr-comment-check`

On the test repository I did not have a `pr-check` job id anywhere, so it seems to have silently ignored the id and simply checked the previous step.

But since here we do have a `pr-check` job it did try to check it, as far as I can tell

#### Describe alternatives you've considered

#### Testing
I didn't try test this change but checking against the wrong ID is a pretty obvious error...

I guess the proper way to check would be to pull the pr-check workflow into my test fork and then run it all again. But effort......

#### Additional context

