### PR TITLE
ability to clear out specific dimensions (attempt 2)

### DIFF
--- a/data/json/effects_on_condition/example_eocs.json
+++ b/data/json/effects_on_condition/example_eocs.json
@@ -544,5 +544,24 @@
       { "u_message": { "u_val": "destination_dimension" } },
       { "if": { "current_dimension": "" }, "then": { "u_message": "home sweet home" } }
     ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_dimension_clear_test",
+    "//": "clears out a dimension in '/dimensions' folder",
+    "global": true,
+    "effect": [
+      {
+        "set_string_var": "",
+        "string_input": {
+          "title": { "str": "clear the dimension named:" },
+          "description": { "str": "the main dimension can't be cleared." },
+          "width": 30
+        },
+        "target_var": { "u_val": "target_dimension" }
+      },
+      { "clear_dimension": { "u_val": "target_dimension" } },
+      { "u_message": "if dimension with ID <u_val:target_dimension> existed, it doesn't anymore." }
+    ]
   }
 ]

--- a/doc/JSON/EFFECT_ON_CONDITION.md
+++ b/doc/JSON/EFFECT_ON_CONDITION.md
@@ -1339,6 +1339,35 @@ Will give a message if you're in the dimension with the ID of "test".
   "then": { "u_message": "Currently loaded dimension is the one with ID of 'test'." } }
 ```
 
+### `clear_dimension`
+- type: string or [variable object](#variable-object)
+- deletes the dimension folder with the given string ID.
+
+#### Valid talkers:
+
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
+
+#### Examples
+Deletes (if present) the dimension with ID of 'test'.
+```jsonc
+{ { "clear_dimension": "test" } }
+```
+Asks for text input, will delete the dimension that matches the string ID.
+```jsonc
+{
+    "set_string_var": "",
+    "string_input": {
+      "title": { "str": "clear the dimension named:" },
+      "description": { "str": "the main dimension can't be cleared." },
+      "width": 30
+    },
+    "target_var": { "u_val": "target_dimension" }
+},
+{ "clear_dimension": { "u_val": "target_dimension" } }
+```
+
 ### `player_see_u`, `player_see_npc`
 - type: simple string
 - return true if player can see alpha or beta talker

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -13776,14 +13776,20 @@ cata_path PATH_INFO::world_base_save_path()
     return world_generator->active_world->folder_path();
 }
 
+cata_path PATH_INFO::dimensions_save_path()
+{
+    return PATH_INFO::world_base_save_path() / "dimensions";
+}
+
 cata_path PATH_INFO::current_dimension_save_path()
 {
     std::string dimension_prefix = g->get_dimension_prefix();
     if( !dimension_prefix.empty() ) {
-        return PATH_INFO::world_base_save_path() / "dimensions" / dimension_prefix;
+        return PATH_INFO::dimensions_save_path() / dimension_prefix;
     }
     return PATH_INFO::world_base_save_path();
 }
+
 
 cata_path PATH_INFO::current_dimension_player_save_path()
 {

--- a/src/game.h
+++ b/src/game.h
@@ -1373,7 +1373,7 @@ class game
         //currently used as a hacky workaround for dimension swapping
         bool swapping_dimensions = false; // NOLINT (cata-serialize)
     private:
-        // Stores the currently occupoed dimension.
+        // Stores the currently occupied dimension.
         // TODO: should be an id instead of a string.
         std::string dimension_prefix;
 };

--- a/src/path_info.h
+++ b/src/path_info.h
@@ -93,6 +93,7 @@ cata_path user_keybindings();
 cata_path user_moddir_path();
 cata_path user_sound();
 cata_path world_base_save_path();
+cata_path dimensions_save_path();
 cata_path current_dimension_save_path();
 cata_path current_dimension_player_save_path();
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Features "add EOC functionality to clear out specific dimensions"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Might be useful to modders wanting temporary dimensions, like for Sky Island mod. Also might be useful for Portal Dungeons.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
add an EOC function called `clear_dimension` that can be called to remove a dimension folder from `dimensions` folder. You can still enter that dimension, but it'll be regenerated like it's your first time entering it.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
using a `dimension_manifest.json` file to track if a dimension has the property of `temporary`, so that when the player leaves that dimension, it's data gets removed. Comparing the EOC method to the one just described, it seems much more elegant.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
went to a test world, triggered `EOC_dimension_clear_test` and succesfully deleted several dimensions. Tried deleting dimensions with IDs of `..` or `*`, with no disastrous results.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
