### PR TITLE
[cmake] honor `$VCPKG_ROOT` from env

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -24,9 +24,6 @@
       "displayName": "Windows x64 MSVC",
       "description": "Target Windows (64-bit) with the Visual Studio development environment.",
       "generator": "Visual Studio 17 2022",
-      "environment": {
-        "VCPKG_ROOT": "C:/vcpkg"
-      },
       "cacheVariables": {
         "DYNAMIC_LINKING": "False",
         "CURSES": "True", "LOCALIZE": "True", "TILES": "False", "SOUND": "False", "TESTS": "True",
@@ -55,9 +52,6 @@
       "description": "Target Windows (64-bit) with the Visual Studio development environment.",
       "generator": "Visual Studio 17 2022",
       "inherits": "windows-tiles-sounds-x64",
-      "environment": {
-        "VCPKG_ROOT": "C:/vcpkg"
-      },
       "cacheVariables": {
         "CMAKE_PROJECT_INCLUDE_BEFORE": "${sourceDir}/build-scripts/${presetName}.cmake",
         "CMAKE_TOOLCHAIN_FILE": "${sourceDir}/build-scripts/MSVC.cmake",

--- a/build-scripts/MSVC.cmake
+++ b/build-scripts/MSVC.cmake
@@ -85,9 +85,17 @@ set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 # Where is vcpkg.json ?
 set(VCPKG_MANIFEST_DIR ${CMAKE_SOURCE_DIR}/msvc-full-features)
 
-set(VCPKG_ROOT "" CACHE PATH "Path to VCPKG installation")
-if (NOT $ENV{VCPKG_ROOT} STREQUAL "")
-    include($ENV{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake)
-elseif(NOT $CACHE{VCPKG_ROOT} STREQUAL "")
-    include($CACHE{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake)
+set(VCPKG_ROOT "$ENV{VCPKG_ROOT}" CACHE PATH "Path to VCPKG installation")
+if(NOT VCPKG_ROOT)
+    set(VCPKG_ROOT "C:/vcpkg" CACHE PATH "Path to VCPKG installation" FORCE)
 endif()
+
+set(_vcpkg_toolchain "${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake")
+if(NOT EXISTS "${_vcpkg_toolchain}")
+  message(FATAL_ERROR
+    "Could not find vcpkg toolchain file at:\n  ${_vcpkg_toolchain}\n"
+    "Check that VCPKG_ROOT points to a valid vcpkg checkout "
+    "(it should contain scripts/buildsystems/vcpkg.cmake).")
+endif()
+
+include("${_vcpkg_toolchain}")


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Build "Honor env's `$VCPKG_ROOT` when building with CMake"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

vcpkg install location is up to the individual developer and is typically signaled using `$VCPKG_ROOT`. I believe the intent of the existing CMake config was to read this value, but the current implementation (via `CMakePresets.json`) effectively hard-codes it, which means developers who want to build using CMake are required to place their vcpkg in `C:\` or to tinker with build scripts.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

This PR updates `MSVC.cmake` to first consider the environment's `$VCPKG_ROOT` value, falling back to the current default (`C:\vcpkg`). It should have no impact on developers using `C:\vcpkg`, while opening up other locations to easy development.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Overwriting values in my local config (error prone)
Moving my system's vcpkg install (seems like an unnecessary imposition)

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Clean CMake reconfigure, with both valid and invalid values to confirm it works correctly and displays coherent errors with bad config

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
