### PR TITLE
draw nav highlight on buttons using background color in IMTUI mode

### DIFF
--- a/src/third-party/imgui/imgui.cpp
+++ b/src/third-party/imgui/imgui.cpp
@@ -3722,6 +3722,23 @@ void ImGui::RenderFrameBorder(ImVec2 p_min, ImVec2 p_max, float rounding)
     }
 }
 
+#ifdef IMTUI
+bool ImGui::ShouldRenderNavCursor(ImGuiID id, ImGuiNavRenderCursorFlags flags)
+{
+    ImGuiContext& g = *GImGui;
+    if (id != g.NavId)
+        return false;
+    if (!g.NavCursorVisible && !(flags & ImGuiNavRenderCursorFlags_AlwaysDraw))
+        return false;
+    if (id == g.LastItemData.ID && (g.LastItemData.ItemFlags & ImGuiItemFlags_NoNav))
+        return false;
+    ImGuiWindow* window = g.CurrentWindow;
+    if (window->DC.NavHideHighlightOneFrame)
+        return false;
+    return true;
+}
+#endif
+
 void ImGui::RenderNavCursor(const ImRect& bb, ImGuiID id, ImGuiNavRenderCursorFlags flags)
 {
     ImGuiContext& g = *GImGui;

--- a/src/third-party/imgui/imgui_internal.h
+++ b/src/third-party/imgui/imgui_internal.h
@@ -3365,6 +3365,9 @@ namespace ImGui
     IMGUI_API void          RenderFrame(ImVec2 p_min, ImVec2 p_max, ImU32 fill_col, bool borders = true, float rounding = 0.0f);
     IMGUI_API void          RenderFrameBorder(ImVec2 p_min, ImVec2 p_max, float rounding = 0.0f);
     IMGUI_API void          RenderColorRectWithAlphaCheckerboard(ImDrawList* draw_list, ImVec2 p_min, ImVec2 p_max, ImU32 fill_col, float grid_step, ImVec2 grid_off, float rounding = 0.0f, ImDrawFlags flags = 0);
+#ifdef IMTUI
+    IMGUI_API bool          ShouldRenderNavCursor(ImGuiID id, ImGuiNavRenderCursorFlags flags = ImGuiNavRenderCursorFlags_None); // Navigation highlight
+#endif
     IMGUI_API void          RenderNavCursor(const ImRect& bb, ImGuiID id, ImGuiNavRenderCursorFlags flags = ImGuiNavRenderCursorFlags_None); // Navigation highlight
 #ifndef IMGUI_DISABLE_OBSOLETE_FUNCTIONS
     inline    void          RenderNavHighlight(const ImRect& bb, ImGuiID id, ImGuiNavRenderCursorFlags flags = ImGuiNavRenderCursorFlags_None) { RenderNavCursor(bb, id, flags); } // Renamed in 1.91.4

--- a/src/third-party/imgui/imgui_widgets.cpp
+++ b/src/third-party/imgui/imgui_widgets.cpp
@@ -743,8 +743,13 @@ bool ImGui::ButtonEx(const char* label, const ImVec2& size_arg, ImGuiButtonFlags
     bool pressed = ButtonBehavior(bb, id, &hovered, &held, flags);
 
     // Render
+#ifdef IMTUI
+    const bool nav = ImGui::ShouldRenderNavCursor(id);
+    const ImU32 col = GetColorU32(nav ? ImGuiCol_NavCursor : (held && hovered) ? ImGuiCol_ButtonActive : hovered ? ImGuiCol_ButtonHovered : ImGuiCol_Button);
+#else
     const ImU32 col = GetColorU32((held && hovered) ? ImGuiCol_ButtonActive : hovered ? ImGuiCol_ButtonHovered : ImGuiCol_Button);
     RenderNavCursor(bb, id);
+#endif
     ImVec2 final_bb_max = bb.Max;
 #ifdef IMTUI
     final_bb_max += ImVec2(0.5f, 0.0f);


### PR DESCRIPTION
#### Summary
Interface "draw nav highlight on buttons using background color in IMTUI mode"

#### Purpose of change

The default behavior of ImGui is to draw a rectangle around the selected element. In a text UI this looks weird, and the size of the ring is much too large.

#### Describe the solution

This only changes the behavior for buttons, since so far that is the biggest problem. It just makes the background color of the button change instead.

#### Describe alternatives you've considered

Underlining the text is actually fairly annoying to implement. Drawing a box around the button either makes the buttons huge or overlaps with other elements in the window (as the ring currently does).

#### Testing

Run the game and immediately hit esc to exit. The dialog asking for confirmation has two buttons. Use the arrow keys to move the nav highlight from button to button. The selected button should be highlighted in white instead of having a white ring drawn around it.