### PR TITLE
Big seed

### DIFF
--- a/data/json/recipes/food/seed.json
+++ b/data/json/recipes/food/seed.json
@@ -502,7 +502,7 @@
   {
     "result": "garlic_clove",
     "type": "recipe",
-    "id_suffix": "seed_extraction_designation",
+    "id_suffix": "seed_designation",
     "name": "%s from seeds",
     "copy-from": "seed_extraction_designation",
     "components": [ [ [ "seed_garlic_clove", 1 ] ] ],
@@ -511,7 +511,7 @@
   {
     "result": "garlic_clove",
     "type": "recipe",
-    "id_suffix": "bulk_seed_extraction_designatin",
+    "id_suffix": "bulk_seed_designatin",
     "name": "bulk %s from seeds",
     "result_mult": 60,
     "copy-from": "seed_extraction_designation",

--- a/data/json/recipes/food/seed.json
+++ b/data/json/recipes/food/seed.json
@@ -65,6 +65,7 @@
     "subcategory": "CSC_FOOD_SEEDS",
     "skill_used": "survival",
     "time": "1 s",
+    "batch_time_factors": { "mode": "logistic", "percent": 99, "at": 1 },
     "autolearn": true
   },
   {
@@ -82,7 +83,7 @@
     "//p": "about 450-500 seeds per pumpkin, which is about a cup. these are fairly small pumpkins.",
     "components": [ [ [ "pumpkin", 1 ] ] ],
     "byproducts": [ [ "pumpkin_cut", 4 ] ],
-    "charges": 6
+    "result_mult": 6
   },
   {
     "result": "seed_watermelon",
@@ -90,7 +91,7 @@
     "copy-from": "seed_extraction_cutting",
     "components": [ [ [ "watermelon", 1 ] ] ],
     "byproducts": [ [ "watermelon_wedge", 16 ] ],
-    "charges": 5
+    "result_mult": 5
   },
   {
     "result": "seed_melon",
@@ -98,7 +99,7 @@
     "copy-from": "seed_extraction_cutting",
     "components": [ [ [ "melon", 1 ] ] ],
     "byproducts": [ [ "melon_chunks", 4 ] ],
-    "charges": 3
+    "result_mult": 3
   },
   {
     "result": "seed_cucumber",
@@ -106,7 +107,7 @@
     "copy-from": "seed_extraction_cutting",
     "byproducts": [ [ "cucumber_cut", 1 ] ],
     "components": [ [ [ "cucumber", 1 ] ] ],
-    "charges": 2
+    "result_mult": 2
   },
   {
     "result": "seed_gherkin",
@@ -114,7 +115,7 @@
     "copy-from": "seed_extraction_cutting",
     "byproducts": [ [ "gherkin_cut", 1 ] ],
     "components": [ [ [ "gherkin", 1 ] ] ],
-    "charges": 2
+    "result_mult": 2
   },
   {
     "result": "seed_eggplant",
@@ -123,7 +124,7 @@
     "copy-from": "seed_extraction_cutting",
     "byproducts": [ [ "eggplant_cut", 2 ] ],
     "components": [ [ [ "eggplant", 1 ] ] ],
-    "charges": 2
+    "result_mult": 2
   },
   {
     "result": "seed_oats",
@@ -132,11 +133,30 @@
     "components": [ [ [ "oats", 1 ] ] ]
   },
   {
+    "result": "seed_oats",
+    "type": "recipe",
+    "id_suffix": "bulk",
+    "name": "bulk %s",
+    "result_mult": 10,
+    "copy-from": "seed_extraction_designation",
+    "components": [ [ [ "oats", 10 ] ] ]
+  },
+  {
     "result": "oats",
     "type": "recipe",
     "id_suffix": "seed_designation",
+    "name": "%s from seeds",
     "copy-from": "seed_extraction_designation",
     "components": [ [ [ "seed_oats", 1 ] ] ]
+  },
+  {
+    "result": "oats",
+    "type": "recipe",
+    "id_suffix": "bulk_seed_designation",
+    "name": "bulk %s from seeds",
+    "result_mult": 10,
+    "copy-from": "seed_extraction_designation",
+    "components": [ [ [ "seed_oats", 10 ] ] ]
   },
   {
     "result": "seed_cattail",
@@ -151,11 +171,30 @@
     "components": [ [ [ "dry_corn", 1 ] ] ]
   },
   {
+    "result": "seed_corn",
+    "type": "recipe",
+    "id_suffix": "bulk",
+    "name": "bulk %s",
+    "result_mult": 10,
+    "copy-from": "seed_extraction_designation",
+    "components": [ [ [ "dry_corn", 10 ] ] ]
+  },
+  {
     "result": "dry_corn",
     "type": "recipe",
+    "name": "%s from seeds",
     "id_suffix": "seed_designation",
     "copy-from": "seed_extraction_designation",
     "components": [ [ [ "seed_corn", 1 ] ] ]
+  },
+  {
+    "result": "dry_corn",
+    "type": "recipe",
+    "id_suffix": "bulk_seed_designation",
+    "name": "bulk %s from seeds",
+    "result_mult": 10,
+    "copy-from": "seed_extraction_designation",
+    "components": [ [ [ "seed_corn", 10 ] ] ]
   },
   {
     "result": "seed_popcorn",
@@ -164,11 +203,30 @@
     "components": [ [ [ "kernels", 1 ] ] ]
   },
   {
+    "result": "seed_popcorn",
+    "type": "recipe",
+    "id_suffix": "bulk",
+    "name": "bulk %s",
+    "result_mult": 10,
+    "copy-from": "seed_extraction_designation",
+    "components": [ [ [ "kernels", 10 ] ] ]
+  },
+  {
     "result": "kernels",
     "type": "recipe",
     "id_suffix": "seed_designation",
+    "name": "%s from seeds",
     "copy-from": "seed_extraction_designation",
     "components": [ [ [ "seed_popcorn", 1 ] ] ]
+  },
+  {
+    "result": "kernels",
+    "type": "recipe",
+    "id_suffix": "bulk_seed_designation",
+    "name": "bulk %s from seeds",
+    "result_mult": 10,
+    "copy-from": "seed_extraction_designation",
+    "components": [ [ [ "seed_popcorn", 10 ] ] ]
   },
   {
     "result": "seed_zucchini",
@@ -176,7 +234,7 @@
     "copy-from": "seed_extraction_cutting",
     "byproducts": [ [ "zucchini_cut", 1 ] ],
     "components": [ [ [ "zucchini", 1 ] ] ],
-    "charges": 2
+    "result_mult": 2
   },
   {
     "result": "seed_barley",
@@ -185,11 +243,30 @@
     "components": [ [ [ "barley", 1 ] ] ]
   },
   {
+    "result": "seed_barley",
+    "type": "recipe",
+    "id_suffix": "bulk",
+    "name": "bulk %s",
+    "result_mult": 10,
+    "copy-from": "seed_extraction_designation",
+    "components": [ [ [ "barley", 10 ] ] ]
+  },
+  {
     "result": "barley",
     "type": "recipe",
     "id_suffix": "seed_designation",
+    "name": "%s from seeds",
     "copy-from": "seed_extraction_designation",
     "components": [ [ [ "seed_barley", 1 ] ] ]
+  },
+  {
+    "result": "barley",
+    "type": "recipe",
+    "id_suffix": "bulk_seed_designation",
+    "name": "bulk %s from seeds",
+    "result_mult": 10,
+    "copy-from": "seed_extraction_designation",
+    "components": [ [ [ "seed_barley", 10 ] ] ]
   },
   {
     "result": "seed_tomato",
@@ -221,7 +298,7 @@
     "type": "recipe",
     "copy-from": "seed_extraction_cutting",
     "components": [ [ [ "poppy_bud", 4 ] ] ],
-    "charges": 2
+    "result_mult": 2
   },
   {
     "result": "seed_salsify_raw",
@@ -230,16 +307,46 @@
     "components": [ [ [ "salsify_raw", 1 ] ] ]
   },
   {
+    "result": "seed_salsify_raw",
+    "type": "recipe",
+    "id_suffix": "bulk",
+    "name": "bulk %s",
+    "time": "5 m",
+    "result_mult": 10,
+    "copy-from": "seed_extraction_base",
+    "components": [ [ [ "salsify_raw", 10 ] ] ]
+  },
+  {
     "result": "seed_chicory",
     "type": "recipe",
     "copy-from": "seed_extraction_base",
     "components": [ [ [ "chicory_raw", 1 ] ] ]
   },
   {
+    "result": "seed_chicory",
+    "type": "recipe",
+    "id_suffix": "bulk",
+    "name": "bulk %s",
+    "time": "5 m",
+    "result_mult": 10,
+    "copy-from": "seed_extraction_base",
+    "components": [ [ [ "chicory_raw", 10 ] ] ]
+  },
+  {
     "result": "seed_wildcarrot",
     "type": "recipe",
     "copy-from": "seed_extraction_base",
     "components": [ [ [ "carrot_wild", 3 ] ] ]
+  },
+  {
+    "result": "seed_wildcarrot",
+    "type": "recipe",
+    "id_suffix": "bulk",
+    "name": "bulk %s",
+    "time": "5 m",
+    "result_mult": 10,
+    "copy-from": "seed_extraction_base",
+    "components": [ [ [ "carrot_wild", 30 ] ] ]
   },
   {
     "result": "seed_raspberries",
@@ -290,7 +397,7 @@
     "copy-from": "seed_extraction_cutting",
     "components": [ [ [ "chili_pepper", 1 ] ] ],
     "byproducts": [ [ "chili_pepper_cut", 1 ] ],
-    "charges": 2
+    "result_mult": 2
   },
   {
     "result": "seed_bell_pepper",
@@ -298,7 +405,7 @@
     "copy-from": "seed_extraction_cutting",
     "components": [ [ [ "bell_pepper", 1 ] ] ],
     "byproducts": [ [ "bell_pepper_cut", 1 ] ],
-    "charges": 2
+    "result_mult": 2
   },
   {
     "result": "seed_wheat",
@@ -307,11 +414,30 @@
     "components": [ [ [ "wheat", 1 ] ] ]
   },
   {
+    "result": "seed_wheat",
+    "type": "recipe",
+    "id_suffix": "bulk",
+    "name": "bulk %s",
+    "result_mult": 10,
+    "copy-from": "seed_extraction_designation",
+    "components": [ [ [ "wheat", 10 ] ] ]
+  },
+  {
     "result": "wheat",
     "type": "recipe",
     "id_suffix": "seed_designation",
+    "name": "%s from seeds",
     "copy-from": "seed_extraction_designation",
     "components": [ [ [ "seed_wheat", 1 ] ] ]
+  },
+  {
+    "result": "wheat",
+    "type": "recipe",
+    "id_suffix": "bulk_seed_designation",
+    "name": "bulk %s from seeds",
+    "result_mult": 10,
+    "copy-from": "seed_extraction_designation",
+    "components": [ [ [ "seed_wheat", 10 ] ] ]
   },
   {
     "result": "seed_bee_balm",
@@ -326,11 +452,30 @@
     "components": [ [ [ "buckwheat", 1 ] ] ]
   },
   {
+    "result": "seed_buckwheat",
+    "type": "recipe",
+    "id_suffix": "bulk",
+    "name": "bulk %s",
+    "result_mult": 10,
+    "copy-from": "seed_extraction_designation",
+    "components": [ [ [ "buckwheat", 10 ] ] ]
+  },
+  {
     "result": "buckwheat",
     "type": "recipe",
     "id_suffix": "seed_designation",
+    "name": "%s from seeds",
     "copy-from": "seed_extraction_designation",
     "components": [ [ [ "seed_buckwheat", 1 ] ] ]
+  },
+  {
+    "result": "buckwheat",
+    "type": "recipe",
+    "id_suffix": "bulk_seed_designation",
+    "name": "bulk %s from seeds",
+    "result_mult": 10,
+    "copy-from": "seed_extraction_designation",
+    "components": [ [ [ "seed_buckwheat", 10 ] ] ]
   },
   {
     "result": "seed_dogbane",
@@ -341,16 +486,36 @@
   {
     "result": "seed_garlic_clove",
     "type": "recipe",
-    "copy-from": "seed_extraction_designation",
+    "copy-from": "seed_extraction_base",
     "components": [ [ [ "garlic_clove", 6 ] ] ]
+  },
+  {
+    "result": "seed_garlic_clove",
+    "type": "recipe",
+    "id_suffix": "bulk",
+    "name": "bulk %s",
+    "time": "5 m",
+    "result_mult": 10,
+    "copy-from": "seed_extraction_base",
+    "components": [ [ [ "garlic_clove", 60 ] ] ]
   },
   {
     "result": "garlic_clove",
     "type": "recipe",
-    "id_suffix": "seed_designation",
+    "id_suffix": "seed_extraction_designation",
+    "name": "%s from seeds",
     "copy-from": "seed_extraction_designation",
     "components": [ [ [ "seed_garlic_clove", 1 ] ] ],
-    "charges": 6
+    "result_mult": 6
+  },
+  {
+    "result": "garlic_clove",
+    "type": "recipe",
+    "id_suffix": "bulk_seed_extraction_designatin",
+    "name": "bulk %s from seeds",
+    "result_mult": 60,
+    "copy-from": "seed_extraction_designation",
+    "components": [ [ [ "seed_garlic_clove", 10 ] ] ]
   },
   {
     "result": "seed_mugwort",
@@ -377,7 +542,7 @@
     "type": "recipe",
     "copy-from": "seed_extraction_cutting",
     "components": [ [ [ "raw_dandelion", 1 ] ] ],
-    "charges": 2
+    "result_mult": 2
   },
   {
     "result": "seed_raw_burdock",
@@ -392,17 +557,46 @@
     "components": [ [ [ "japanese_knotweed_stem", 1 ] ] ]
   },
   {
+    "result": "seed_japanese_knotweed",
+    "type": "recipe",
+    "id_suffix": "bulk",
+    "name": "bulk %s",
+    "time": "5 m",
+    "result_mult": 10,
+    "copy-from": "seed_extraction_base",
+    "components": [ [ [ "japanese_knotweed_stem", 10 ] ] ]
+  },
+  {
     "result": "seed_wild_rice",
     "type": "recipe",
     "copy-from": "seed_extraction_designation",
     "components": [ [ [ "wild_rice", 1 ] ] ]
   },
   {
+    "result": "seed_wild_rice",
+    "type": "recipe",
+    "id_suffix": "bulk",
+    "name": "bulk %s",
+    "result_mult": 10,
+    "copy-from": "seed_extraction_designation",
+    "components": [ [ [ "wild_rice", 10 ] ] ]
+  },
+  {
     "result": "wild_rice",
     "type": "recipe",
     "id_suffix": "seed_designation",
+    "name": "%s from seeds",
     "copy-from": "seed_extraction_designation",
     "components": [ [ [ "seed_wild_rice", 1 ] ] ]
+  },
+  {
+    "result": "wild_rice",
+    "type": "recipe",
+    "id_suffix": "bulk_seed_designation",
+    "name": "bulk %s from seeds",
+    "result_mult": 10,
+    "copy-from": "seed_extraction_designation",
+    "components": [ [ [ "seed_wild_rice", 10 ] ] ]
   },
   {
     "result": "seed_jerusalem_artichoke",
@@ -477,11 +671,31 @@
     "components": [ [ [ "potato", 1 ] ] ]
   },
   {
+    "result": "seed_potato_raw",
+    "type": "recipe",
+    "id_suffix": "bulk",
+    "name": "bulk %s",
+    "time": "5 m",
+    "result_mult": 10,
+    "copy-from": "seed_extraction_base",
+    "components": [ [ [ "potato", 10 ] ] ]
+  },
+  {
     "result": "seed_sunflower",
     "type": "recipe",
     "copy-from": "seed_extraction_base",
     "components": [ [ [ "sunflower", 1 ] ] ],
-    "charges": 6
+    "result_mult": 6
+  },
+  {
+    "result": "seed_sunflower",
+    "type": "recipe",
+    "id_suffix": "bulk",
+    "name": "bulk %s",
+    "time": "5 m",
+    "result_mult": 60,
+    "copy-from": "seed_extraction_base",
+    "components": [ [ [ "sunflower", 10 ] ] ]
   },
   {
     "result": "seed_beans",
@@ -490,11 +704,30 @@
     "components": [ [ [ "dry_beans", 1 ] ] ]
   },
   {
+    "result": "seed_beans",
+    "type": "recipe",
+    "id_suffix": "bulk",
+    "name": "bulk %s",
+    "result_mult": 10,
+    "copy-from": "seed_extraction_designation",
+    "components": [ [ [ "dry_beans", 10 ] ] ]
+  },
+  {
     "result": "dry_beans",
     "id_suffix": "seed_designation",
+    "name": "%s from seeds",
     "type": "recipe",
     "copy-from": "seed_extraction_designation",
     "components": [ [ [ "seed_beans", 1 ] ] ]
+  },
+  {
+    "result": "dry_beans",
+    "type": "recipe",
+    "id_suffix": "bulk_seed_designation",
+    "name": "bulk %s from seeds",
+    "result_mult": 10,
+    "copy-from": "seed_extraction_designation",
+    "components": [ [ [ "seed_beans", 10 ] ] ]
   },
   {
     "result": "soybean_seed",
@@ -503,11 +736,30 @@
     "components": [ [ [ "dry_soybean", 1 ] ] ]
   },
   {
+    "result": "soybean_seed",
+    "type": "recipe",
+    "id_suffix": "bulk",
+    "name": "bulk %s",
+    "result_mult": 10,
+    "copy-from": "seed_extraction_designation",
+    "components": [ [ [ "dry_soybean", 10 ] ] ]
+  },
+  {
     "result": "dry_soybean",
     "id_suffix": "seed_designation",
+    "name": "%s from seeds",
     "type": "recipe",
     "copy-from": "seed_extraction_designation",
     "components": [ [ [ "soybean_seed", 1 ] ] ]
+  },
+  {
+    "result": "dry_soybean",
+    "type": "recipe",
+    "id_suffix": "bulk_seed_designation",
+    "name": "bulk %s from seeds",
+    "result_mult": 10,
+    "copy-from": "seed_extraction_designation",
+    "components": [ [ [ "soybean_seed", 10 ] ] ]
   },
   {
     "result": "seed_lentils",
@@ -516,11 +768,30 @@
     "components": [ [ [ "dry_lentils", 1 ] ] ]
   },
   {
+    "result": "seed_lentils",
+    "type": "recipe",
+    "id_suffix": "bulk",
+    "name": "bulk %s",
+    "result_mult": 10,
+    "copy-from": "seed_extraction_designation",
+    "components": [ [ [ "dry_lentils", 10 ] ] ]
+  },
+  {
     "result": "dry_lentils",
     "id_suffix": "seed_designation",
+    "name": "%s from seeds",
     "type": "recipe",
     "copy-from": "seed_extraction_designation",
     "components": [ [ [ "seed_lentils", 1 ] ] ]
+  },
+  {
+    "result": "dry_lentils",
+    "type": "recipe",
+    "id_suffix": "bulk_seed_designation",
+    "name": "bulk %s from seeds",
+    "result_mult": 10,
+    "copy-from": "seed_extraction_designation",
+    "components": [ [ [ "seed_lentils", 10 ] ] ]
   },
   {
     "result": "seed_chamomile",
@@ -535,9 +806,29 @@
     "components": [ [ [ "sugar_beet", 1 ] ] ]
   },
   {
+    "result": "seed_sugar_beet",
+    "type": "recipe",
+    "id_suffix": "bulk",
+    "name": "bulk %s",
+    "time": "5 m",
+    "result_mult": 10,
+    "copy-from": "seed_extraction_base",
+    "components": [ [ [ "sugar_beet", 10 ] ] ]
+  },
+  {
     "result": "seed_bottle_gourd",
     "type": "recipe",
     "copy-from": "seed_extraction_base",
     "components": [ [ [ "raw_bottle_gourd", 3 ] ] ]
+  },
+  {
+    "result": "seed_bottle_gourd",
+    "type": "recipe",
+    "id_suffix": "bulk",
+    "name": "bulk %s",
+    "time": "5 m",
+    "result_mult": 10,
+    "copy-from": "seed_extraction_base",
+    "components": [ [ [ "raw_bottle_gourd", 30 ] ] ]
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None 

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Add recipes for bulk seed conversion/extraction.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
- Added bulk recipes for designation and base based recipes.
- Changed designation abstract recipe to use batch time factors to make it almost instantaneous regardless of batch size (it's just a change of label, after all).
- Added names to back conversion recipes from seed to base "grain" for easier identification.
- Changed garlic wedge extraction to use the base abstract recipe rather than the designation one, as it takes time to pick a clove apart (you could of course give it a time different from the base recipe one if you want to be fancy and also take on all the cutting recipes). The conversion back to a "clove" is just a designation, as you say this bunch of wedges is now a clove.
- Changed all "charges" to "result_mult" (in this file only, of course),

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
- Add bulk recipes for cutting based recipes. #83006 means this can't be done without adding a work around for the tool requirement in every recipe. Also, many of these recipes have "byproducts" (arguably often the main product) that may need further processing, making very large batches problematic for the byproduct handling. Also, these recipes would probably benefit from individual times, rather than one inherited from the base recipe.
- Reorder the recipes in alphabetic order based on the basic component (so seed and "food" would be kept together, even if they aren't adjacent alphabetically).

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Looked at all the recipes (except charges change only ones) in game to see they looked OK. For the charges change I only verified it loaded correctly.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
