### PR TITLE
manually converted new region settings JSON

### DIFF
--- a/data/mods/No_Hope/region_overlay.json
+++ b/data/mods/No_Hope/region_overlay.json
@@ -62,5 +62,135 @@
       "subway": { "extras": { "mx_casings": 10, "mx_bandits_ambush": 5 } }
     },
     "weather": { "base_humidity": 90.0, "base_temperature": 6.5, "base_pressure": 1015.0, "base_wind": 3.4 }
+  },
+  {
+    "type": "region_settings_new",
+    "id": "default_nohope",
+    "copy-from": "default",
+    "map_extras": "default_nohope",
+    "weather": "default_nohope"
+  },
+  {
+    "type": "map_extra_collection",
+    "id": "forest_nohope",
+    "copy-from": "forest",
+    "extend": {
+      "extras": [
+        [ "mx_science", 20 ],
+        [ "mx_crater", 10 ],
+        [ "mx_supplydrop", 8 ],
+        [ "mx_military", 8 ],
+        [ "mx_bandits_ambush", 5 ],
+        [ "mx_bandits_grave", 2 ],
+        [ "mx_bandits_outpost", 2 ]
+      ]
+    }
+  },
+  {
+    "type": "map_extra_collection",
+    "id": "forest_thick_nohope",
+    "copy-from": "forest_thick",
+    "extend": {
+      "extras": [
+        [ "mx_science", 20 ],
+        [ "mx_collegekids", 25 ],
+        [ "mx_crater", 10 ],
+        [ "mx_supplydrop", 5 ],
+        [ "mx_bandits_ambush", 5 ],
+        [ "mx_bandits_grave", 2 ],
+        [ "mx_bandits_outpost", 2 ]
+      ]
+    }
+  },
+  {
+    "type": "map_extra_collection",
+    "id": "forest_water_nohope",
+    "copy-from": "forest_water",
+    "extend": {
+      "extras": [
+        [ "mx_science", 50 ],
+        [ "mx_military", 25 ],
+        [ "mx_supplydrop", 25 ],
+        [ "mx_crater", 20 ],
+        [ "mx_bandits_ambush", 5 ],
+        [ "mx_bandits_grave", 2 ],
+        [ "mx_bandits_outpost", 2 ]
+      ]
+    }
+  },
+  {
+    "type": "map_extra_collection",
+    "id": "field_nohope",
+    "copy-from": "field",
+    "extend": {
+      "extras": [
+        [ "mx_crater", 150 ],
+        [ "mx_supplydrop", 40 ],
+        [ "mx_bandits_ambush", 10 ],
+        [ "mx_bandits_campsite", 10 ],
+        [ "mx_bandits_grave", 10 ],
+        [ "mx_bandits_outpost", 10 ]
+      ]
+    }
+  },
+  {
+    "type": "map_extra_collection",
+    "id": "road_nohope",
+    "copy-from": "road",
+    "extend": {
+      "extras": [
+        [ "mx_helicopter", 10 ],
+        [ "mx_military", 50 ],
+        [ "mx_science", 400 ],
+        [ "mx_bandits_block", 800 ],
+        [ "mx_drugdeal", 300 ],
+        [ "mx_supplydrop", 100 ],
+        [ "mx_crater", 100 ],
+        [ "mx_bandits_ambush", 100 ]
+      ]
+    }
+  },
+  {
+    "type": "map_extra_collection",
+    "id": "build_nohope",
+    "copy-from": "build",
+    "extend": {
+      "extras": [
+        [ "mx_bugout", 20 ],
+        [ "mx_science", 12 ],
+        [ "mx_crater", 60 ],
+        [ "mx_bandits_ambush", 10 ],
+        [ "mx_bandits_hideout", 10 ]
+      ]
+    }
+  },
+  {
+    "type": "map_extra_collection",
+    "id": "subway_nohope",
+    "copy-from": "subway",
+    "extend": { "extras": [ [ "mx_casings", 10 ], [ "mx_bandits_ambush", 5 ] ] }
+  },
+  {
+    "type": "region_settings_map_extras",
+    "id": "default_nohope",
+    "copy-from": "default",
+    "delete": { "extras": [ "forest", "forest_thick", "forest_water", "field", "road", "build", "subway" ] },
+    "extend": {
+      "extras": [
+        "forest_nohope",
+        "forest_thick_nohope",
+        "forest_water_nohope",
+        "field_nohope",
+        "road_nohope",
+        "build_nohope",
+        "subway_nohope"
+      ]
+    }
+  },
+  {
+    "type": "weather_generator",
+    "id": "default_nohope",
+    "copy-from": "default",
+    "base_humidity": 90.0
   }
 ]

--- a/data/mods/classic_zombies/region_settings/region_settings/region_overlay.json
+++ b/data/mods/classic_zombies/region_settings/region_settings/region_overlay.json
@@ -52,17 +52,26 @@
   },
   {
     "type": "region_settings_city",
-    "id": "default_classiczombies",
+    "id": "default_classiczombies_temp",
     "copy-from": "default",
+    "//": "extend is processed before delete, cannot overwrite a weighted list with extend",
+    "delete": { "shops": [ "s_hunting", "s_gun_a", "s_gun_b", "mil_surplus", "mil_surplus_1", "mil_surplus_2" ] }
+  },
+  {
+    "type": "region_settings_city",
+    "id": "default_classiczombies",
+    "copy-from": "default_classiczombies_temp",
     "//": "Increased hunting store chance, decreased gun store/mil surplus chances.",
-    "shops": [
-      [ "s_hunting", 300 ],
-      [ "s_gun_a", 350 ],
-      [ "s_gun_b", 150 ],
-      [ "mil_surplus", 20 ],
-      [ "mil_surplus_1", 20 ],
-      [ "mil_surplus_2", 20 ]
-    ]
+    "extend": {
+      "shops": [
+        [ "s_hunting", 300 ],
+        [ "s_gun_a", 350 ],
+        [ "s_gun_b", 150 ],
+        [ "mil_surplus", 20 ],
+        [ "mil_surplus_1", 20 ],
+        [ "mil_surplus_2", 20 ]
+      ]
+    }
   },
   {
     "type": "weather_generator",

--- a/data/mods/innawood/region_settings/region_settings/region_overlay.json
+++ b/data/mods/innawood/region_settings/region_settings/region_overlay.json
@@ -57,76 +57,100 @@
   {
     "type": "map_extra_collection",
     "id": "forest_water_innawood",
-    "extras": [ [ "mx_pond_swamp", 240 ], [ "mx_pond_swamp_2", 240 ] ]
+    "copy-from": "forest_water",
+    "extend": { "extras": [ [ "mx_pond_swamp", 240 ], [ "mx_pond_swamp_2", 240 ] ] }
   },
   {
     "type": "region_settings_map_extras",
     "id": "default_innawood",
     "copy-from": "default",
-    "extras": [ "forest_water_innawood" ]
+    "delete": { "extras": [ "forest_water" ] },
+    "extend": { "extras": [ "forest_water_innawood" ] }
   },
   {
     "type": "region_terrain_furniture",
-    "id": "default_t_region_groundcover",
+    "id": "default_t_region_groundcover_innawood",
+    "copy-from": "default_t_region_groundcover",
     "ter_id": "t_region_groundcover",
-    "replace_with_terrain": [ [ "t_sand", 1 ] ]
+    "extend": { "replace_with_terrain": [ [ "t_sand", 1 ] ] }
   },
   {
     "type": "region_terrain_furniture",
-    "id": "default_t_region_groundcover_swamp",
+    "id": "default_t_region_groundcover_swamp_innawood",
+    "copy-from": "default_t_region_groundcover_swamp",
     "ter_id": "t_region_groundcover_swamp",
-    "replace_with_terrain": [ [ "t_bog_iron", 10 ] ]
+    "extend": { "replace_with_terrain": [ [ "t_bog_iron", 10 ] ] }
   },
   {
     "type": "region_terrain_furniture",
-    "id": "default_f_region_weed",
+    "id": "default_f_region_weed_innawood",
+    "copy-from": "default_f_region_weed",
     "furn_id": "f_region_weed",
-    "replace_with_furniture": [
-      [ "f_wildcotton", 10 ],
-      [ "f_wildsbeet", 10 ],
-      [ "f_wildweed", 10 ],
-      [ "f_wildpumpkin", 10 ],
-      [ "f_wildcorn", 10 ],
-      [ "f_wildbeans", 10 ]
-    ]
+    "extend": {
+      "replace_with_furniture": [
+        [ "f_wildcotton", 10 ],
+        [ "f_wildsbeet", 10 ],
+        [ "f_wildweed", 10 ],
+        [ "f_wildpumpkin", 10 ],
+        [ "f_wildcorn", 10 ],
+        [ "f_wildbeans", 10 ]
+      ]
+    }
   },
   {
     "type": "region_terrain_furniture",
-    "id": "default_f_region_plain",
+    "id": "default_f_region_plain_innawood",
+    "copy-from": "default_f_region_plain",
     "furn_id": "f_region_plain",
-    "replace_with_furniture": [
-      [ "f_wildcotton", 30 ],
-      [ "f_wildsbeet", 30 ],
-      [ "f_wildpumpkin", 30 ],
-      [ "f_wildcorn", 30 ],
-      [ "f_wildweed", 10 ],
-      [ "f_wildbeans", 10 ]
-    ]
+    "extend": {
+      "replace_with_furniture": [
+        [ "f_wildcotton", 30 ],
+        [ "f_wildsbeet", 30 ],
+        [ "f_wildpumpkin", 30 ],
+        [ "f_wildcorn", 30 ],
+        [ "f_wildweed", 10 ],
+        [ "f_wildbeans", 10 ]
+      ]
+    }
   },
   {
     "type": "region_terrain_furniture",
-    "id": "default_f_region_forest",
+    "id": "default_f_region_forest_innawood",
+    "copy-from": "default_f_region_forest",
     "furn_id": "f_region_forest",
-    "replace_with_furniture": [ [ "f_wildweed", 40 ], [ "f_wildcorn", 40 ], [ "f_wildbeans", 40 ] ]
+    "extend": { "replace_with_furniture": [ [ "f_wildweed", 40 ], [ "f_wildcorn", 40 ], [ "f_wildbeans", 40 ] ] }
   },
   {
     "type": "region_terrain_furniture",
-    "id": "default_f_region_forest_dense",
+    "id": "default_f_region_forest_dense_innawood",
+    "copy-from": "default_f_region_forest_dense",
     "furn_id": "f_region_forest_dense",
-    "replace_with_furniture": [ [ "f_wildweed", 30 ], [ "f_wildcorn", 30 ], [ "f_wildbeans", 30 ] ]
+    "extend": { "replace_with_furniture": [ [ "f_wildweed", 30 ], [ "f_wildcorn", 30 ], [ "f_wildbeans", 30 ] ] }
   },
   {
     "type": "region_settings_terrain_furniture",
     "id": "default_innawood",
     "copy-from": "default",
-    "ter_furn": [
-      "default_t_region_groundcover",
-      "default_t_region_groundcover_swamp",
-      "default_f_region_weed",
-      "default_f_region_plain",
-      "default_f_region_forest",
-      "default_f_region_forest_dense"
-    ]
+    "delete": {
+      "ter_furn": [
+        "default_t_region_groundcover",
+        "default_t_region_groundcover_swamp",
+        "default_f_region_weed",
+        "default_f_region_plain",
+        "default_f_region_forest",
+        "default_f_region_forest_dense"
+      ]
+    },
+    "extend": {
+      "ter_furn": [
+        "default_t_region_groundcover_innawood",
+        "default_t_region_groundcover_swamp_innawood",
+        "default_f_region_weed_innawood",
+        "default_f_region_plain_innawood",
+        "default_f_region_forest_innawood",
+        "default_f_region_forest_dense_innawood"
+      ]
+    }
   },
   {
     "type": "forest_biome_mapgen",
@@ -139,15 +163,14 @@
     "type": "forest_biome_feature",
     "id": "water_forest_water_innawood",
     "copy-from": "water_forest_water",
-    "sequence": 3,
-    "chance": 2,
     "types": [ [ "t_swater_sh", 6 ], [ "t_swater_dp", 1 ], [ "t_water_murky", 12 ] ]
   },
   {
     "type": "region_settings_forest_mapgen",
     "id": "default_innawood",
     "copy-from": "default",
-    "biomes": [ "biome_forest_water_innawood" ]
+    "delete": { "biomes": [ "biome_forest_water_default" ] },
+    "extend": { "biomes": [ "biome_forest_water_innawood" ] }
   },
   {
     "type": "region_settings_new",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

- From #82631

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

See title, these changes were not script-generated and were required to correctly convert overlays into settings. The affected mods (No_Hope, classic_zombies, innawood) were using overlays to do work that should be done using copy-from.

Along with #82985, this is the last JSON PR before the C++ gets swapped out.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Loaded all listed mods succesfully, tested in particular the buildings for classic_zombies and the replaced frequency looks correct

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
