### PR TITLE
Replace `std::stof` with (cata::)svtod

### DIFF
--- a/src/butchery_requirements.cpp
+++ b/src/butchery_requirements.cpp
@@ -2,8 +2,10 @@
 
 #include <cstddef>
 #include <functional>
+#include <optional>
 #include <string>
 
+#include "cata_utility.h"
 #include "creature.h"
 #include "debug.h"
 #include "enum_conversions.h"
@@ -58,7 +60,11 @@ bool butchery_requirements::is_valid() const
 void butchery_requirements::load( const JsonObject &jo, std::string_view )
 {
     for( const JsonMember member : jo.get_object( "requirements" ) ) {
-        float modifier = std::stof( member.name() );
+        std::optional<double> mod_val = svtod( member.name() );
+        if( !mod_val.has_value() ) {
+            jo.throw_error( "Invalid key for requirements, cannot convert to float" );
+        }
+        float modifier = mod_val.value();
         requirements.emplace( modifier, std::map<creature_size, std::map<butcher_type, requirement_id>> {} );
 
         int critter_size = 1;

--- a/src/cata_utility.cpp
+++ b/src/cata_utility.cpp
@@ -915,7 +915,7 @@ std::string io::enum_to_string<aggregate_type>( aggregate_type agg )
     cata_fatal( "Invalid aggregate type." );
 }
 
-std::optional<double> svtod( std::string_view token )
+std::optional<double> svtod( std::string_view token, bool debugmsg_on_fail )
 {
     char *pEnd = nullptr;
     double const val = std::strtod( token.data(), &pEnd );
@@ -929,7 +929,9 @@ std::optional<double> svtod( std::string_view token )
         unlocalized[pEnd - token.data()] = block == ',' ? '.' : ',';
         return svtod( unlocalized );
     }
-    debugmsg( R"(Failed to convert string value "%s" to double: %s)", token, std::strerror( errno ) );
+    if( debugmsg_on_fail ) {
+        debugmsg( R"(Failed to convert string value "%s" to double: %s)", token, std::strerror( errno ) );
+    }
 
     errno = 0;
 

--- a/src/cata_utility.h
+++ b/src/cata_utility.h
@@ -768,6 +768,6 @@ struct overloaded : Ts... {
 template <class... Ts>
 explicit overloaded( Ts... ) -> overloaded<Ts...>;
 
-std::optional<double> svtod( std::string_view token );
+std::optional<double> svtod( std::string_view token, bool debugmsg_on_fail = true );
 
 #endif // CATA_SRC_CATA_UTILITY_H

--- a/src/math_parser_diag_value.cpp
+++ b/src/math_parser_diag_value.cpp
@@ -362,7 +362,12 @@ void diag_value::_deserialize( const JsonValue &jsin, bool allow_legacy )
             // inf and nan
             std::string str;
             jo.read( "dbl", str );
-            data = std::stof( str );
+            std::optional<double> opt = svtod( str );
+            if( !opt.has_value() ) {
+                jo.allow_omitted_members();
+                jo.throw_error( "Invalid dbl value" );
+            }
+            data = opt.value();
         } else {
             jo.allow_omitted_members();
             throw JsonError( "invalid diag_value object" );

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -4014,7 +4014,7 @@ std::string options_manager::migrateOptionValue( const std::string &name,
 {
     //TODO: Remove after stable after world option reserialising is added
     if( name == "MONSTER_UPGRADE_FACTOR" ) {
-        const float new_value = std::stof( val ) / 4.0f;
+        const float new_value = svtod( val ).value_or( 4.0 ) / 4.0f;
         std::ostringstream ssTemp;
         ssTemp.imbue( std::locale::classic() );
         ssTemp.precision( 2 );

--- a/src/proficiency_ui.cpp
+++ b/src/proficiency_ui.cpp
@@ -4,7 +4,6 @@
 #include <optional>
 #include <ostream>
 #include <set>
-#include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>
@@ -124,14 +123,14 @@ void prof_window::filter()
     }
     float prog_val = 0.0f;
     if( prefix == _prof_filter_prefix::AS_PROGRESS ) {
-        try {
-            prog_val = std::stof( qry );
-        } catch( const std::invalid_argument &e ) {
+        std::optional<double> v = svtod( qry, false );
+        if( !v.has_value() ) {
             // User mistyped query. Not severe enough for debugmsg.
             DebugLog( DebugLevel::D_WARNING, DebugClass::D_GAME ) <<
-                    "Malformed proficiency query \"" << filter_str << "\": " << e.what();
+                    "Malformed proficiency query \"" << filter_str << "\"";
             return;
         }
+        prog_val = v.value();
     }
     for( display_prof_deps &dp : all_profs ) {
         if( prefix == _prof_filter_prefix::AS_PROGRESS ) {

--- a/src/units.cpp
+++ b/src/units.cpp
@@ -1,8 +1,10 @@
 #include "units.h"
 
 #include <cstdint>
+#include <optional>
 
 #include "calendar.h"
+#include "cata_utility.h"
 #include "json.h"
 #include "string_formatter.h"
 #include "translations.h"
@@ -64,7 +66,11 @@ void specific_energy::serialize( JsonOut &jsout ) const
 template<>
 void specific_energy::deserialize( const JsonValue &jv )
 {
-    *this = units::from_joule_per_gram( std::stof( jv.get_string() ) );
+    std::optional<double> v = svtod( jv.get_string() );
+    if( !v.has_value() ) {
+        jv.throw_error( "Invalid double" );
+    }
+    *this = units::from_joule_per_gram( v.value() );
 }
 
 template<>
@@ -85,8 +91,12 @@ void temperature_delta::deserialize( const JsonValue &jv )
     if( jv.test_int() ) {
         *this = from_legacy_bodypart_temp_delta( jv.get_int() );
     } else {
-        // super gross
-        *this = from_kelvin_delta( std::stof( jv.get_string() ) );
+        // gross
+        std::optional<double> v = svtod( jv.get_string() );
+        if( !v.has_value() ) {
+            jv.throw_error( "Invalid double" );
+        }
+        *this = from_kelvin_delta( v.value() );
     }
 }
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Better locale support & let callers explicitly handle failures, instead of relying on whatever exceptions that std::stof throws.

https://github.com/CleverRaven/Cataclysm-DDA/pull/82996#discussion_r2369661371

#### Testing
Compiles, tests pass, all mods load.