### PR TITLE
Even MORE debug power for imgui

### DIFF
--- a/src/cata_imgui.cpp
+++ b/src/cata_imgui.cpp
@@ -19,6 +19,16 @@
 
 static ImGuiKey cata_key_to_imgui( int cata_key );
 
+namespace cataimgui
+{
+ImGuiWindowFlags default_cataimgui_window_flags =
+    ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoResize |
+    ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoMove |
+    ImGuiWindowFlags_NoNavFocus | ImGuiWindowFlags_NoBringToFrontOnFocus;
+}
+
+
+
 #ifdef TUI
 #include "wcwidth.h"
 #include <curses.h>
@@ -854,9 +864,7 @@ cataimgui::window::window( int window_flags )
 {
     p_impl = nullptr;
 
-    this->window_flags = window_flags | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoResize |
-                         ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoNavFocus |
-                         ImGuiWindowFlags_NoBringToFrontOnFocus;
+    this->window_flags = window_flags | default_cataimgui_window_flags;
 }
 
 cataimgui::window::window( const std::string &id_, int window_flags ) : window( window_flags )

--- a/src/cata_imgui.h
+++ b/src/cata_imgui.h
@@ -31,6 +31,11 @@ class input_context;
 
 namespace cataimgui
 {
+
+// Stored here so they can be manipulated by debug functions.
+// This should go without saying but you are expected not to modify these outside of pure debug functions.
+extern ImGuiWindowFlags default_cataimgui_window_flags;
+
 struct bounds {
     float x;
     float y;

--- a/src/cata_imgui_debug.cpp
+++ b/src/cata_imgui_debug.cpp
@@ -21,7 +21,10 @@ void cataimgui::TableSetupColumn( const char *label, ImGuiTableColumnFlags flags
 
 void cataimgui::add_cataimgui_debug_checkboxes()
 {
+    // TODO: Replace with collapsibles/tree nodes??
     if( debug_mode ) {
+        draw_colored_text( "Not every flag is necessarily here, just anything I thought you might need to use. Feel free to add any missing, or ask if you need help." );
+        ImGui::SeparatorText( "TABLE FLAGS" );
         ImGui::CheckboxFlags( "ImGuiTableFlags_SizingFixedFit##xx", &DEBUG_IMGUI_table_flags,
                               ImGuiTableFlags_SizingFixedFit );
         ImGui::CheckboxFlags( "ImGuiTableFlags_SizingFixedSame##xx", &DEBUG_IMGUI_table_flags,
@@ -37,6 +40,7 @@ void cataimgui::add_cataimgui_debug_checkboxes()
         ImGui::CheckboxFlags( "ImGuiTableFlags_PadOuterX##xx", &DEBUG_IMGUI_table_flags,
                               ImGuiTableFlags_PadOuterX );
         ImGui::NewLine();
+        ImGui::SeparatorText( "COLUMN FLAGS" );
         ImGui::CheckboxFlags( "ImGuiTableColumnFlags_WidthStretch##xx", &DEBUG_IMGUI_column_flags,
                               ImGuiTableColumnFlags_WidthStretch );
         ImGui::CheckboxFlags( "ImGuiTableColumnFlags_WidthFixed##xx", &DEBUG_IMGUI_column_flags,
@@ -47,5 +51,27 @@ void cataimgui::add_cataimgui_debug_checkboxes()
                               ImGuiTableColumnFlags_NoHeaderLabel );
         ImGui::CheckboxFlags( "ImGuiTableColumnFlags_NoHeaderWidth##xx", &DEBUG_IMGUI_column_flags,
                               ImGuiTableColumnFlags_NoHeaderWidth );
+        ImGui::NewLine();
+        ImGui::SeparatorText( "WINDOW FLAGS" );
+        ImGui::CheckboxFlags( "ImGuiWindowFlags_NoTitleBar##xx", &default_cataimgui_window_flags,
+                              ImGuiWindowFlags_NoTitleBar );
+        ImGui::CheckboxFlags( "ImGuiWindowFlags_NoCollapse##xx", &default_cataimgui_window_flags,
+                              ImGuiWindowFlags_NoCollapse );
+        ImGui::CheckboxFlags( "ImGuiWindowFlags_NoResize##xx", &default_cataimgui_window_flags,
+                              ImGuiWindowFlags_NoResize );
+        ImGui::CheckboxFlags( "ImGuiWindowFlags_NoSavedSettings##xx", &default_cataimgui_window_flags,
+                              ImGuiWindowFlags_NoSavedSettings );
+        ImGui::CheckboxFlags( "ImGuiWindowFlags_NoMove##xx", &default_cataimgui_window_flags,
+                              ImGuiWindowFlags_NoMove );
+        ImGui::CheckboxFlags( "ImGuiWindowFlags_NoNavInputs##xx", &default_cataimgui_window_flags,
+                              ImGuiWindowFlags_NoNavInputs );
+        ImGui::CheckboxFlags( "ImGuiWindowFlags_NoNavFocus##xx", &default_cataimgui_window_flags,
+                              ImGuiWindowFlags_NoNavFocus );
+        ImGui::CheckboxFlags( "ImGuiWindowFlags_NoBringToFrontOnFocus##xx", &default_cataimgui_window_flags,
+                              ImGuiWindowFlags_NoBringToFrontOnFocus );
+        ImGui::CheckboxFlags( "ImGuiWindowFlags_AlwaysAutoResize##xx", &default_cataimgui_window_flags,
+                              ImGuiWindowFlags_AlwaysAutoResize );
+        ImGui::CheckboxFlags( "ImGuiWindowFlags_NoBackground##xx", &default_cataimgui_window_flags,
+                              ImGuiWindowFlags_NoBackground );
     }
 }

--- a/src/cata_imgui_debug.cpp
+++ b/src/cata_imgui_debug.cpp
@@ -1,0 +1,51 @@
+#include "cata_imgui_debug.h"
+
+bool    cataimgui::BeginTable( const char *str_id, int columns_count, ImGuiTableFlags flags,
+                               const ImVec2 &outer_size, float inner_width )
+{
+    flags = flags | DEBUG_IMGUI_table_flags;
+    return ImGui::BeginTable( str_id, columns_count, flags, outer_size, inner_width );
+}
+
+void cataimgui::EndTable()
+{
+    ImGui::EndTable();
+}
+
+void cataimgui::TableSetupColumn( const char *label, ImGuiTableColumnFlags flags,
+                                  float init_width_or_weight, ImGuiID user_id )
+{
+    flags = flags | DEBUG_IMGUI_column_flags;
+    ImGui::TableSetupColumn( label, flags, init_width_or_weight, user_id );
+}
+
+void cataimgui::add_cataimgui_debug_checkboxes()
+{
+    if( debug_mode ) {
+        ImGui::CheckboxFlags( "ImGuiTableFlags_SizingFixedFit##xx", &DEBUG_IMGUI_table_flags,
+                              ImGuiTableFlags_SizingFixedFit );
+        ImGui::CheckboxFlags( "ImGuiTableFlags_SizingFixedSame##xx", &DEBUG_IMGUI_table_flags,
+                              ImGuiTableFlags_SizingFixedSame );
+        ImGui::CheckboxFlags( "ImGuiTableFlags_SizingStretchProp##xx", &DEBUG_IMGUI_table_flags,
+                              ImGuiTableFlags_SizingStretchProp );
+        ImGui::CheckboxFlags( "ImGuiTableFlags_SizingStretchSame##xx", &DEBUG_IMGUI_table_flags,
+                              ImGuiTableFlags_SizingStretchSame );
+        ImGui::CheckboxFlags( "ImGuiTableFlags_NoHostExtendX##xx", &DEBUG_IMGUI_table_flags,
+                              ImGuiTableFlags_NoHostExtendX );
+        ImGui::CheckboxFlags( "ImGuiTableFlags_PreciseWidths##xx", &DEBUG_IMGUI_table_flags,
+                              ImGuiTableFlags_PreciseWidths );
+        ImGui::CheckboxFlags( "ImGuiTableFlags_PadOuterX##xx", &DEBUG_IMGUI_table_flags,
+                              ImGuiTableFlags_PadOuterX );
+        ImGui::NewLine();
+        ImGui::CheckboxFlags( "ImGuiTableColumnFlags_WidthStretch##xx", &DEBUG_IMGUI_column_flags,
+                              ImGuiTableColumnFlags_WidthStretch );
+        ImGui::CheckboxFlags( "ImGuiTableColumnFlags_WidthFixed##xx", &DEBUG_IMGUI_column_flags,
+                              ImGuiTableColumnFlags_WidthFixed );
+        ImGui::CheckboxFlags( "ImGuiTableColumnFlags_NoResize##xx", &DEBUG_IMGUI_column_flags,
+                              ImGuiTableColumnFlags_NoResize );
+        ImGui::CheckboxFlags( "ImGuiTableColumnFlags_NoHeaderLabel##xx", &DEBUG_IMGUI_column_flags,
+                              ImGuiTableColumnFlags_NoHeaderLabel );
+        ImGui::CheckboxFlags( "ImGuiTableColumnFlags_NoHeaderWidth##xx", &DEBUG_IMGUI_column_flags,
+                              ImGuiTableColumnFlags_NoHeaderWidth );
+    }
+}

--- a/src/cata_imgui_debug.h
+++ b/src/cata_imgui_debug.h
@@ -1,0 +1,30 @@
+#pragma once
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <vector>
+#include <unordered_map>
+
+#include "cata_imgui.h"
+#include "color.h"
+#include "font_loader.h"
+
+static ImGuiTableFlags DEBUG_IMGUI_table_flags;
+
+static ImGuiTableColumnFlags DEBUG_IMGUI_column_flags;
+
+namespace cataimgui
+{
+// Simple forwarder to append debug flags
+bool BeginTable( const char *str_id, int columns, ImGuiTableFlags flags = 0,
+                 const ImVec2 &outer_size = ImVec2( 0.0f, 0.0f ), float inner_width = 0.0f );
+// to match the BeginTable forwarder.
+void EndTable();
+
+// Simple forwarder to append debug flags
+void TableSetupColumn( const char *label, ImGuiTableColumnFlags flags = 0,
+                       float init_width_or_weight = 0.0f, ImGuiID user_id = 0 );
+
+void add_cataimgui_debug_checkboxes();
+
+} // namespace cataimgui

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -19,6 +19,7 @@
 
 #include "cached_options.h" // IWYU pragma: keep
 #include "cata_imgui.h"
+#include "cata_imgui_debug.h"
 #include "cata_utility.h"
 #include "catacharset.h"
 #include "color.h"
@@ -1326,8 +1327,8 @@ static void draw_table( std::string_view s )
         return;
     }
 
-    if( ImGui::BeginTable( "##ITEMINFO_TABLE", num_cols,
-                           ImGuiTableFlags_BordersH | ImGuiTableFlags_BordersV ) ) {
+    if( cataimgui::BeginTable( "##ITEMINFO_TABLE", num_cols,
+                               ImGuiTableFlags_BordersH | ImGuiTableFlags_BordersV ) ) {
         const std::vector<std::string> chopped_up = string_split( rows.front(), ';' );
         for( const std::string &cell_text : chopped_up ) {
             // this prefix prevents imgui from drawing the text. We still have color tags, which imgui won't parse, so we don't want those exposed to the user.
@@ -1337,7 +1338,7 @@ static void draw_table( std::string_view s )
             //
             // Not great for debugging, but better than having a column with default (randomly generated number) ID!
             const std::string invisible_ID_label = "##" + cell_text;
-            ImGui::TableSetupColumn( invisible_ID_label.c_str(), ImGuiTableColumnFlags_WidthStretch );
+            cataimgui::TableSetupColumn( invisible_ID_label.c_str(), ImGuiTableColumnFlags_WidthStretch );
         }
         ImGui::TableHeadersRow();
         // After putting in the invisible labels in the last for-loop, this writes the actual text. Just the same text without the ## marker, and
@@ -1359,13 +1360,14 @@ static void draw_table( std::string_view s )
             }
         }
 
-        ImGui::EndTable();
+        cataimgui::EndTable();
     }
 }
 
 void display_item_info( const std::vector<iteminfo> &vItemDisplay,
                         const std::vector<iteminfo> &vItemCompare )
 {
+    cataimgui::add_cataimgui_debug_checkboxes();
     bool bAlreadyHasNewLine = true;
     for( const iteminfo &i : vItemDisplay ) {
         if( i.bIsArt ) {


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Recently I've been testing some really silly imgui stuff, which has required repeatedly setting/unsetting flags.

I copied off the imgui demo for a checkbox, but I stepped back and thought "why do I need to *re-implement* my checkbox every time I'm playing with one of imgui's default widgets?"

#### Describe the solution
Setup some generic globally-accessible/includable debug functions

Implement a cataimgui::BeginTable() alias for ImGui::BeginTable() so we can inject debug flags

add a generic set of flag checkboxes that can be inserted into imgui windows to tune behavior (gated behind debug mode so they can be safely inserted anywhere)

Move the default cataimgui::window flags to be governed by the debug settings so future imgui windows can be rapidly prototyped

(Not done) Add a simple dedicated window to access the flag settings

(Not done) Move more imgui default widgets to aliases and audit all existing calls to them

#### Describe alternatives you've considered


#### Testing
It's for debug! Testing is all I do!

#### Additional context

As we move to more and more windows having been ported to imgui some of these options (controlling the default window flags) may need to be removed or made more specific. But until then they should be used as much as possible
