### PR TITLE
[encumbrance] always penalize clothes that are too big

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -8395,9 +8395,13 @@ int item::get_encumber( const Character &p, const bodypart_id &bodypart,
             // non small characters have a HARD time wearing undersized clothing
             encumber *= 3;
             break;
-        case sizing::human_sized_small_char:
         case sizing::big_sized_small_char:
-            // clothes bag up around smol characters and encumber them more
+            // small characters are practically swimming in big clothing
+            encumber *= 3;
+            break;
+        case sizing::human_sized_small_char:
+        case sizing::big_sized_human_char:
+            // clothes bag up when they're bigger than the character
             encumber *= 2;
             break;
         default:

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -8393,11 +8393,9 @@ int item::get_encumber( const Character &p, const bodypart_id &bodypart,
     switch( sizing_level ) {
         case sizing::small_sized_human_char:
         case sizing::small_sized_big_char:
-            // non small characters have a HARD time wearing undersized clothing
-            encumber *= 3;
-            break;
         case sizing::big_sized_small_char:
-            // small characters are practically swimming in big clothing
+            // non small characters have a HARD time wearing undersized clothing
+            // and small characters are practically swimming in big clothing
             encumber *= 3;
             break;
         case sizing::human_sized_small_char:

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -3682,7 +3682,8 @@ static bool armor_encumb_header_info( const item &it, std::vector<iteminfo> &inf
     if( sizing_matters ) {
         const item::sizing sizing_level = it.get_sizing( player_character );
         //If we have the wrong size, we do not fit so alert the player
-        if( sizing_level == item::sizing::human_sized_small_char ) {
+        if( sizing_level == item::sizing::human_sized_small_char ||
+            sizing_level == item::sizing::big_sized_human_char ) {
             format = _( " <bad>(too big)</bad>" );
         } else if( sizing_level == item::sizing::big_sized_small_char ) {
             format = _( " <bad>(huge!)</bad>" );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Balance "Always penalize clothes that are too big"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Currently, human-sized characters are not penalized for wearing big clothing, despite the "(too big)" label. This seems to be an oversight, since small characters receive a 2x penalty for wearing human size clothing. (Similarly, small characters receive the same 2x penalty for wearing big clothing as they do for human clothing, which should perhaps scale higher with the bigger size gap.)

Penalizing "(too big)" clothing creates interesting choices especially in the early game, and gives the "(too big)" label semantic value.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

| Differential | Before | After |
| - | - | - |
| One size too big | 2x if small character | Always 2x |
| Two sizes too big | 2x | 3x |

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

1. Doing nothing
2. Removing the "(too big)" flavor text
3. Using a smaller penalty (I decided to mirror the steepness of other penalties and figured we can tune downward if needed)

I am by no means attached to the penalty multiplier values, I just think there should be a penalty of some kind to make the size difference meaningful in gameplay.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Examined items in game

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

It might also make sense to differentiate `small_sized_human_char` and `small_sized_big_char`, which currently both take a 3x penalty.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
