### PR TITLE
Bring back the missing NPC Pickup Rules talk_ally talk topic

### DIFF
--- a/data/json/npcs/common_chat/TALK_COMMON_ALLY.json
+++ b/data/json/npcs/common_chat/TALK_COMMON_ALLY.json
@@ -228,6 +228,7 @@
         "topic": "TALK_DONE",
         "effect": "dismount"
       },
+      { "text": "Set up pickup rules.", "topic": "TALK_FRIEND", "effect": "set_npc_pickup" },
       { "text": "Let's talk about your current activity.", "topic": "TALK_ACTIVITIES" },
       { "text": "Let's talk about the camp.", "topic": "TALK_CAMP" },
       { "text": "Change your martial arts style.", "topic": "TALK_DONE", "effect": "pick_style" },


### PR DESCRIPTION


#### Summary
None

#### Purpose of change
Brings back the one ally npc talk topic that was lost some far experimentals ago: the ability to set the npc ally's pickup rules.

#### Describe the solution

Puts the talk topic into the npc ally order talk topic.

#### Describe alternatives you've considered
Put it somewhere else?

#### Testing
![Screenshot_20250925_221331](https://github.com/user-attachments/assets/8291980b-47ef-4646-bfab-0a961aa219ce)


#### Additional context

Cant believe im the only one that still remembered this menu existed. good thing the fix was simple.