### PR TITLE
Allow NPCs to travel with you across dimensions

### DIFF
--- a/data/json/effects_on_condition/example_eocs.json
+++ b/data/json/effects_on_condition/example_eocs.json
@@ -538,6 +538,7 @@
       {
         "u_teleport": { "u_val": "tele_test" },
         "dimension_prefix": { "u_val": "destination_dimension" },
+        "npc_radius": 5,
         "fail_message": "your body doesn't move",
         "success_message": "This place feels different."
       },

--- a/doc/JSON/EFFECT_ON_CONDITION.md
+++ b/doc/JSON/EFFECT_ON_CONDITION.md
@@ -4350,6 +4350,7 @@ You or NPC is teleported to `target_var` coordinates
 | "force" | optional | boolean | default false; if true, teleportation can't fail - any creature, that stand on target coordinates, would be brutally telefragged, and if impassable obstacle occur, the closest point would be picked instead |
 | "force_safe" | optional | boolean | default false; if true, teleportation cannot^(tm) fail.  If there is a creature or obstacle at the target coordinate, the closest passable point within 5 horizontal tiles is picked instead.  If there is no point, the creature remains where they are.
 | "dimension_prefix" | optional | string | default ""; if a value is specified, will teleport the player to a dimension named after the prefix. |
+| "npc_radius" | optional | int or [variable object](#variable-object) | default 0; if a value above 0 is specified, the NPCs within that radius around the player will be transported with them when dimension hopping. Does nothing if "dimension_prefix" isn't set. |
 
 ##### Valid talkers:
 
@@ -4372,6 +4373,18 @@ You teleport to `grass_place` with message `Yay!`; as `force` boolean is `true`,
   "fail_message": "Something is very wrong!",
   "force": true
 }
+```
+
+You teleport to a dimension with the ID of `test`, at the same position you're in currently, bringing any NPC within 5 tiles of you along.
+```jsonc
+  {
+  "u_location_variable": { "u_val": "tele_test" },
+  "u_teleport": { "u_val":"tele_test" },
+  "dimension_prefix": "test",
+  "npc_radius": 5,
+  "fail_message": "your body doesn't move",
+  "success_message": "This place feels different."
+  }
 ```
 
 #### `u_explosion`, `npc_explosion`

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -12736,11 +12736,23 @@ void game::vertical_move( int movez, bool force, bool peeking )
     cata_event_dispatch::avatar_moves( old_abs_pos, u, here );
 }
 
-bool game::travel_to_dimension( const std::string &new_prefix )
+bool game::travel_to_dimension( const std::string &new_prefix, const int &npc_radius )
 {
     map &here = get_map();
     avatar &player = get_avatar();
-    unload_npcs();
+    if( npc_radius > 0 ) {
+        for( auto it = critter_tracker->active_npc.begin(); it != critter_tracker->active_npc.end(); ) {
+            const int distance_to_player = rl_dist( ( *it )->pos_abs(), player.pos_abs() );
+            if( distance_to_player > npc_radius ) {
+                ( *it )->on_unload();
+                it = critter_tracker->active_npc.erase( it );
+            } else {
+                it++;
+            }
+        }
+    } else {
+        unload_npcs();
+    }
     save_dimension_data();
     for( monster &critter : all_monsters() ) {
         despawn_monster( critter );

--- a/src/game.h
+++ b/src/game.h
@@ -331,9 +331,10 @@ class game
 
         /**
          * Moves the player to an alternate dimension.
-         * The prefix identifies the dimension and its properties.
+         * @param prefix identifies the dimension and its properties.
+         * @param npc_radius if not 0, bring any NPCs within distance with the player
          */
-        bool travel_to_dimension( const std::string &prefix );
+        bool travel_to_dimension( const std::string &prefix, const int &npc_radius );
         /**
          * Retrieve the identifier of the current dimension.
          * TODO: this should be a dereferencable id that gives properties of the dimension.


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Features "NPCs can travel through dimensions with you"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Don't want to leave friends behind.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add a variable to `u_teleport` EOC function `npc_radius`. If bigger than 0, any NPC within that distance of the player during the dimension hop isn't unloaded. Meaning they get to come along.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Saving the NPCs to a folder in the save file directory, clearing all of them out and then loading them back in in the new world. This (hopefully) seems to be unnecessary, compared to just not unloading them.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
https://github.com/user-attachments/assets/587a7e8a-d1ee-49de-889c-adf1036a3f49


<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Besides the radius, there's no other filtering. Meaning any NPC near you gets brought along. This can probably be alleviated with EOCs, by moving the unwanted NPCs away from the player or even just banishing them before transfer. 

I could look for a way to filter NPCs through the `f_teleport` call if people really want that?
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
