### PR TITLE
Implement new region settings

### DIFF
--- a/data/mods/Backrooms/modinfo.json
+++ b/data/mods/Backrooms/modinfo.json
@@ -10,5 +10,11 @@
     "conflicts": [ "desertpack", "tropicata" ],
     "dependencies": [ "dda" ],
     "version": "0.1"
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "DEFAULT_REGION",
+    "stype": "string_input",
+    "value": "default_backrooms"
   }
 ]

--- a/data/mods/Isolation-Protocol/modinfo.json
+++ b/data/mods/Isolation-Protocol/modinfo.json
@@ -15,5 +15,11 @@
     "name": "DEFAULT_REGION",
     "stype": "string_input",
     "value": "default_isolation"
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "OVERMAP_PLACE_HIGHWAYS",
+    "stype": "bool",
+    "value": false
   }
 ]

--- a/data/mods/Isolation-Protocol/modinfo.json
+++ b/data/mods/Isolation-Protocol/modinfo.json
@@ -9,5 +9,11 @@
     "category": "total_conversion",
     "dependencies": [ "dda" ],
     "conflicts": [ "generic_guns", "aftershock_exoplanet", "innawood", "skyisland", "backrooms", "defense_mode", "MA", "tropicata" ]
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "DEFAULT_REGION",
+    "stype": "string_input",
+    "value": "default_isolation"
   }
 ]

--- a/data/mods/TropiCataclysm/modinfo.json
+++ b/data/mods/TropiCataclysm/modinfo.json
@@ -29,5 +29,11 @@
     "name": "OVERMAP_PLACE_HIGHWAYS",
     "stype": "bool",
     "value": false
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "DEFAULT_REGION",
+    "stype": "string_input",
+    "value": "default_tropicataclysm"
   }
 ]

--- a/data/mods/aftershock_exoplanet/modinfo.json
+++ b/data/mods/aftershock_exoplanet/modinfo.json
@@ -10,5 +10,11 @@
     "dependencies": [ "dda" ],
     "conflicts": [ "mindovermatter", "generic_guns", "skyisland" ],
     "loading_images": [ "aftershock.png" ]
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "DEFAULT_REGION",
+    "stype": "string_input",
+    "value": "default_aftershock"
   }
 ]

--- a/data/mods/aftershock_exoplanet/options.json
+++ b/data/mods/aftershock_exoplanet/options.json
@@ -34,5 +34,11 @@
     "name": "CAPITALISM",
     "stype": "bool",
     "value": true
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "OVERMAP_PLACE_HIGHWAYS",
+    "stype": "bool",
+    "value": false
   }
 ]

--- a/data/mods/classic_zombies/modinfo.json
+++ b/data/mods/classic_zombies/modinfo.json
@@ -101,5 +101,11 @@
     "name": "OVERMAP_URBAN_INCREASE_SOUTH",
     "stype": "int",
     "value": 0
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "DEFAULT_REGION",
+    "stype": "string_input",
+    "value": "default_classiczombies"
   }
 ]

--- a/data/mods/desert_region/modinfo.json
+++ b/data/mods/desert_region/modinfo.json
@@ -30,5 +30,11 @@
     "name": "OVERMAP_PLACE_HIGHWAYS",
     "stype": "bool",
     "value": false
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "DEFAULT_REGION",
+    "stype": "string_input",
+    "value": "default_desert"
   }
 ]

--- a/data/mods/innawood/modinfo.json
+++ b/data/mods/innawood/modinfo.json
@@ -10,5 +10,11 @@
     "dependencies": [ "dda" ],
     "loading_images": [ "innawoods1.png" ],
     "obsolete": false
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "DEFAULT_REGION",
+    "stype": "string_input",
+    "value": "default_innawood"
   }
 ]

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -821,6 +821,7 @@ void DynamicDataLoader::finalize_loaded_data()
             { _( "Damage info orders" ), &damage_info_order::finalize_all },
             { _( "Diseases" ), &disease_type::finalize_all },
             { _( "Weather types" ), &weather_types::finalize_all },
+            { _( "Weather generators" ), &weather_generator::finalize_all },
             { _( "Effect on conditions" ), &effect_on_conditions::finalize_all },
             { _( "Field types" ), &field_types::finalize_all },
             { _( "Ammo effects" ), &ammo_effects::finalize_all },

--- a/src/map_extras.cpp
+++ b/src/map_extras.cpp
@@ -104,6 +104,8 @@ static const mtype_id mon_fungaloid_queen( "mon_fungaloid_queen" );
 
 static const oter_type_str_id oter_type_road( "road" );
 
+static const region_settings_id region_settings_default( "default" );
+
 static const relic_procgen_id relic_procgen_data_alien_reality( "alien_reality" );
 
 static const ter_str_id ter_t_coast_rock_surf( "t_coast_rock_surf" );
@@ -1210,10 +1212,12 @@ void debug_spawn_test()
 {
     uilist mx_menu;
     std::vector<std::string> mx_names;
-    for( std::pair<const std::string, map_extras> &region_extra :
-         region_settings_map["default"].region_extras ) {
-        mx_menu.addentry( -1, true, -1, region_extra.first );
-        mx_names.push_back( region_extra.first );
+    const region_settings_map_extras &settings_map_extras =
+        region_settings_default->get_settings_map_extras();
+    for( const map_extra_collection_id &region_extra : settings_map_extras.extras ) {
+        const std::string &mx_name = region_extra.str();
+        mx_menu.addentry( -1, true, -1, mx_name );
+        mx_names.push_back( mx_name );
     }
 
     mx_menu.text = _( "Test which map extra list?" );
@@ -1228,9 +1232,13 @@ void debug_spawn_test()
         map_extra_id mx_null = map_extra_id::NULL_ID();
 
         for( size_t a = 0; a < 32400; a++ ) {
-            map_extras ex = region_settings_map["default"].region_extras[mx_names[index]];
+            auto mx_iter = settings_map_extras.extras.find( map_extra_collection_id( mx_names[index] ) );
+            if( mx_iter == settings_map_extras.extras.end() ) {
+                continue;
+            }
+            const map_extra_collection &ex = **mx_iter;
             if( ex.chance > 0 && one_in( ex.chance ) ) {
-                map_extra_id *extra = ex.values.pick();
+                const map_extra_id *extra = ex.values.pick();
                 if( extra == nullptr ) {
                     results[mx_null]++;
                 } else {

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -206,6 +206,8 @@ static const oter_str_id oter_tower_lab_stairs( "tower_lab_stairs" );
 static const oter_type_str_id oter_type_road( "road" );
 static const oter_type_str_id oter_type_sewer( "sewer" );
 
+static const region_settings_id region_settings_default( "default" );
+
 static const ter_str_id ter_t_bars( "t_bars" );
 static const ter_str_id ter_t_card_science( "t_card_science" );
 static const ter_str_id ter_t_concrete_wall( "t_concrete_wall" );
@@ -914,22 +916,26 @@ void map::generate( const tripoint_abs_omt &p, const time_point &when, bool save
         }
 
         if( any_missing || !save_results ) {
-
+            const region_settings_map_extras settings_mx =
+                region_settings_default->get_settings_map_extras();
             // At some point, we should add region information so we can grab the appropriate extras
-            map_extras &this_ex = region_settings_map["default"].region_extras[terrain_type->get_extras()];
-            map_extras ex = this_ex.filtered_by( dat );
-            if( this_ex.chance > 0 && ex.values.empty() && !this_ex.values.empty() ) {
-                DebugLog( D_WARNING, D_MAP_GEN ) << "Overmap terrain " << terrain_type->get_type_id().str() <<
-                                                 " (extra type \"" << terrain_type->get_extras() <<
-                                                 "\") zlevel = " << p.z() <<
-                                                 " is out of range of all assigned map extras.  Skipping map extra generation.";
-            } else if( ex.chance > 0 && one_in( ex.chance ) ) {
-                map_extra_id *extra = ex.values.pick();
-                if( extra == nullptr ) {
-                    debugmsg( "failed to pick extra for type %s (ter = %s)", terrain_type->get_extras(),
-                              terrain_type->get_type_id().str() );
-                } else {
-                    MapExtras::apply_function( *ex.values.pick(), *this, tripoint_abs_sm( abs_sub ) );
+            auto mx_iter = settings_mx.extras.find( map_extra_collection_id( terrain_type->get_extras() ) );
+            if( mx_iter != settings_mx.extras.end() ) {
+                const map_extra_collection &this_ex = **mx_iter;
+                map_extra_collection ex = this_ex.filtered_by( dat );
+                if( this_ex.chance > 0 && ex.values.empty() && !this_ex.values.empty() ) {
+                    DebugLog( D_WARNING, D_MAP_GEN ) << "Overmap terrain " << terrain_type->get_type_id().str() <<
+                                                     " (extra type \"" << terrain_type->get_extras() <<
+                                                     "\") zlevel = " << p.z() <<
+                                                     " is out of range of all assigned map extras.  Skipping map extra generation.";
+                } else if( ex.chance > 0 && one_in( ex.chance ) ) {
+                    map_extra_id *extra = ex.values.pick();
+                    if( extra == nullptr ) {
+                        debugmsg( "failed to pick extra for type %s (ter = %s)", terrain_type->get_extras(),
+                                  terrain_type->get_type_id().str() );
+                    } else {
+                        MapExtras::apply_function( *ex.values.pick(), *this, tripoint_abs_sm( abs_sub ) );
+                    }
                 }
             }
 

--- a/src/mapgen_functions.cpp
+++ b/src/mapgen_functions.cpp
@@ -8,6 +8,7 @@
 #include <iterator>
 #include <map>
 #include <optional>
+#include <set>
 #include <string>
 #include <unordered_set>
 #include <utility>
@@ -644,6 +645,10 @@ void mapgen_forest( mapgendata &dat )
 {
     map *const m = &dat.m;
 
+    const region_settings_forest_mapgen &settings_forest_comp =
+        dat.region.get_settings_forest_composition();
+    const std::set<forest_biome_mapgen_id> &biomes =
+        dat.region.get_settings_forest_composition().biomes;
     // perimeter_size is a useful shorthand that should not be changed:
     static constexpr int perimeter_size = SEEX * 4 + SEEY * 4;
     // The following constexpr terms would do well to be json-ized.
@@ -676,7 +681,7 @@ void mapgen_forest( mapgendata &dat )
     /**
     * Determines the density of natural features in \p ot.
     *
-    * If there is no defind biome for \p ot, returns a sparsity factor
+    * If there is no defined biome for \p ot, returns a sparsity factor
     * of 0. It's possible to specify biomes in the forest regional settings
     * that are not rendered by this forest map gen method, in order to control
     * how terrains are blended together (e.g. specify roads with an equal
@@ -685,23 +690,25 @@ void mapgen_forest( mapgendata &dat )
     * @param ot The type of terrain to determine the sparseness of.
     * @return A discrete scale of the density of natural features occurring in \p ot.
     */
-    const auto get_sparseness_adjacency_factor = [&dat]( const oter_id & ot ) {
-        const auto biome = dat.region.forest_composition.biomes.find( ot->get_type_id() );
-        if( biome == dat.region.forest_composition.biomes.end() ) {
+    const auto get_sparseness_adjacency_factor = [&settings_forest_comp]( const oter_id & ot ) {
+
+        const auto biome = settings_forest_comp.oter_to_biomes.find( ot->get_type_id() );
+        if( biome == settings_forest_comp.oter_to_biomes.end() ) {
             return 0;
         }
-        return biome->second.sparseness_adjacency_factor;
+        const forest_biome_mapgen_id &found_biome = biome->second;
+        return found_biome->sparseness_adjacency_factor;
     };
 
     const ter_furn_id no_ter_furn = ter_furn_id();
 
     // Calculate the maximum possible sparseness factor (density) for the region.
     int max_factor = 0;
-    if( !dat.region.forest_composition.biomes.empty() ) {
+    if( !biomes.empty() ) {
         std::vector<int> factors;
-        factors.reserve( dat.region.forest_composition.biomes.size() );
-        for( const auto &b : dat.region.forest_composition.biomes ) {
-            factors.push_back( b.second.sparseness_adjacency_factor );
+        factors.reserve( biomes.size() );
+        for( const auto &b : biomes ) {
+            factors.push_back( b->sparseness_adjacency_factor );
         }
         max_factor = *max_element( std::begin( factors ), std::end( factors ) );
     }
@@ -726,11 +733,12 @@ void mapgen_forest( mapgendata &dat )
 
     // In order to feather (blend) this overmap tile with adjacent ones, the general composition thereof must be known.
     // This can be calculated once from dat.t_nesw, and stored here:
-    std::array<const forest_biome *, 8> adjacent_biomes;
+    std::array<const forest_biome_mapgen *, 8> adjacent_biomes;
     for( int d = 0; d <= 7; d++ ) {
-        auto lookup = dat.region.forest_composition.biomes.find( dat.t_nesw[d]->get_type_id() );
-        if( lookup != dat.region.forest_composition.biomes.end() ) {
-            adjacent_biomes[d] = &( lookup->second );
+        auto lookup = settings_forest_comp.oter_to_biomes.find( dat.t_nesw[d]->get_type_id() );
+        if( lookup != settings_forest_comp.oter_to_biomes.end() ) {
+            const forest_biome_mapgen_id &found_biome = lookup->second;
+            adjacent_biomes[d] = &( *found_biome );
         } else {
             adjacent_biomes[d] = nullptr;
         }
@@ -829,17 +837,17 @@ void mapgen_forest( mapgendata &dat )
     }
 
     // Get the current biome definition for this terrain.
-    const auto current_biome_def_it = dat.region.forest_composition.biomes.find(
+    const auto current_biome_def_it = settings_forest_comp.oter_to_biomes.find(
                                           dat.terrain_type()->get_type_id() );
 
     // If there is no biome definition for this terrain, fill in with the region's default ground cover
     // and bail--nothing more to be done. Should not continue with terrain feathering if there is
     // nothing to feather into. Generally, this should never happen.
-    if( current_biome_def_it == dat.region.forest_composition.biomes.end() ) {
+    if( current_biome_def_it == settings_forest_comp.oter_to_biomes.end() ) {
         dat.fill_groundcover();
         return;
     }
-    forest_biome self_biome = current_biome_def_it->second;
+    forest_biome_mapgen self_biome = *current_biome_def_it->second;
 
     /**
     * Modifies border weights to conform to biome conditions along corners.
@@ -855,8 +863,9 @@ void mapgen_forest( mapgendata &dat )
     * @param cw_weight The relative impact of the clockwise biome on generation.
     * @param self_weight The relative impact of the original biome on generation.
     */
-    const auto unify_continuous_border = [&self_biome]( const forest_biome * ccw,
-                                         const forest_biome * corner, const forest_biome * cw, float * ccw_weight, float * cw_weight,
+    const auto unify_continuous_border = [&self_biome]( const forest_biome_mapgen * ccw,
+                                         const forest_biome_mapgen * corner, const forest_biome_mapgen * cw, float * ccw_weight,
+                                         float * cw_weight,
     float * self_weight ) {
         if( ccw != cw ) {
             if( ccw == corner && cw == &self_biome ) {
@@ -1066,7 +1075,7 @@ void mapgen_forest( mapgendata &dat )
             return;
         }
 
-        const forest_biome_terrain_dependent_furniture tdf = terrain_dependent_furniture_it->second;
+        const forest_biome_terrain_dependent_furniture_new tdf = terrain_dependent_furniture_it->second;
         if( tdf.furniture.get_weight() <= 0 ) {
             // We've got furnitures, but their weight is 0 or less.
             return;
@@ -1114,6 +1123,7 @@ void mapgen_forest( mapgendata &dat )
 void mapgen_lake_shore( mapgendata &dat )
 {
     map *const m = &dat.m;
+    const region_settings_lake &settings_lake = dat.region.get_settings_lake();
     // Our lake shores may "extend" adjacent terrain, if the adjacent types are defined as being
     // extendable in our regional settings. What this effectively means is that if the lake shore is
     // adjacent to one of these, e.g. a forest, then rather than the lake shore simply having the
@@ -1128,7 +1138,7 @@ void mapgen_lake_shore( mapgendata &dat )
     // NOTE: Presently this treats ocean and lake shore as identical.  Some, but not all, of the
     // ocean checks should eventually be refactored into mapgen_ocean_shore.
     bool did_extend_adjacent_terrain = false;
-    if( !dat.region.overmap_lake.shore_extendable_overmap_terrain.empty() ) {
+    if( !settings_lake.shore_extendable_overmap_terrain.empty() ) {
         std::map<oter_id, int> adjacent_type_count;
         for( oter_id &adjacent : dat.t_nesw ) {
             // Define the terrain we'll look for a match on.
@@ -1136,16 +1146,17 @@ void mapgen_lake_shore( mapgendata &dat )
 
             // Check if this terrain has an alias to something we actually will extend, and if so, use it.
             for( const shore_extendable_overmap_terrain_alias &alias :
-                 dat.region.overmap_lake.shore_extendable_overmap_terrain_aliases ) {
+                 settings_lake.shore_extendable_overmap_terrain_aliases ) {
                 if( is_ot_match( alias.overmap_terrain, adjacent, alias.match_type ) ) {
                     match = alias.alias;
                     break;
                 }
             }
 
-            if( std::find( dat.region.overmap_lake.shore_extendable_overmap_terrain.begin(),
-                           dat.region.overmap_lake.shore_extendable_overmap_terrain.end(),
-                           match ) != dat.region.overmap_lake.shore_extendable_overmap_terrain.end() ) {
+            const oter_str_id &match_copy = match.id();
+            if( std::find( settings_lake.shore_extendable_overmap_terrain.begin(),
+                           settings_lake.shore_extendable_overmap_terrain.end(),
+                           match_copy ) != settings_lake.shore_extendable_overmap_terrain.end() ) {
                 adjacent_type_count[match] += 1;
             }
         }
@@ -1576,10 +1587,12 @@ void mapgen_lake_shore( mapgendata &dat )
 void mapgen_ocean_shore( mapgendata &dat )
 {
     map *const m = &dat.m;
+    const region_settings_lake &settings_lake = dat.region.get_settings_lake();
+    const region_settings_ocean &settings_ocean = dat.region.get_settings_ocean();
     // This is the same as lake shore but saltier.
     // Read documetation above
     bool did_extend_adjacent_terrain = false;
-    if( !dat.region.overmap_lake.shore_extendable_overmap_terrain.empty() ) {
+    if( !settings_lake.shore_extendable_overmap_terrain.empty() ) {
         std::map<oter_id, int> adjacent_type_count;
         for( oter_id &adjacent : dat.t_nesw ) {
             // Define the terrain we'll look for a match on.
@@ -1588,16 +1601,17 @@ void mapgen_ocean_shore( mapgendata &dat )
             // Check if this terrain has an alias to something we actually will extend, and if so, use it.
             // for now, these are the same as lake. They may need to be changed eventually.
             for( const shore_extendable_overmap_terrain_alias &alias :
-                 dat.region.overmap_lake.shore_extendable_overmap_terrain_aliases ) {
+                 settings_lake.shore_extendable_overmap_terrain_aliases ) {
                 if( is_ot_match( alias.overmap_terrain, adjacent, alias.match_type ) ) {
                     match = alias.alias;
                     break;
                 }
             }
 
-            if( std::find( dat.region.overmap_lake.shore_extendable_overmap_terrain.begin(),
-                           dat.region.overmap_lake.shore_extendable_overmap_terrain.end(),
-                           match ) != dat.region.overmap_lake.shore_extendable_overmap_terrain.end() ) {
+            const oter_str_id &match_copy = match.id();
+            if( std::find( settings_lake.shore_extendable_overmap_terrain.begin(),
+                           settings_lake.shore_extendable_overmap_terrain.end(),
+                           match_copy ) != settings_lake.shore_extendable_overmap_terrain.end() ) {
                 adjacent_type_count[match] += 1;
             }
         }
@@ -1696,7 +1710,7 @@ void mapgen_ocean_shore( mapgendata &dat )
     std::vector<std::vector<point_bub_ms>> line_segments;
     int ns_direction_adjust = 0;
     int ew_direction_adjust = 0;
-    int sand_margin = dat.region.overmap_ocean.sandy_beach_width / 2;
+    int sand_margin = settings_ocean.sandy_beach_width / 2;
     // This section is about pushing the straight N, S, E, or W borders inward when adjacent to an actual ocean.
     if( n_ocean ) {
         nw.y() += sector_length;
@@ -2042,6 +2056,7 @@ void mapgen_ocean_shore( mapgendata &dat )
 void mapgen_ravine_edge( mapgendata &dat )
 {
     map *const m = &dat.m;
+    const region_settings_ravine &settings_ravine = dat.region.get_settings_ravine();
     // A solid chunk of z layer appropriate wall or floor is first generated to carve the cliffside off from
     if( dat.zlevel() == 0 ) {
         dat.fill_groundcover();
@@ -2170,7 +2185,7 @@ void mapgen_ravine_edge( mapgendata &dat )
     }
     // The placed t_null terrains are converted into the regional groundcover in the ravine's bottom level,
     // in the other levels they are converted into open air to generate the cliffside.
-    if( dat.zlevel() == dat.region.overmap_ravine.ravine_depth ) {
+    if( dat.zlevel() == settings_ravine.ravine_depth ) {
         m->translate( ter_str_id::NULL_ID(), dat.groundcover() );
     } else {
         m->translate( ter_str_id::NULL_ID(), ter_t_open_air );
@@ -2222,19 +2237,23 @@ void mremove_fields( map *m, const tripoint_bub_ms &p )
 
 void resolve_regional_terrain_and_furniture( const mapgendata &dat )
 {
-    for( const tripoint_bub_ms &p : dat.m.points_on_zlevel() ) {
-        const ter_id &tid_before = dat.m.ter( p );
-        if( !tid_before.id().is_null() && tid_before->has_flag( ter_furn_flag::TFLAG_REGION_PSEUDO ) ) {
-            const ter_id &tid_after = dat.region.region_terrain_and_furniture.resolve( tid_before );
-            if( tid_after != tid_before ) {
-                dat.m.ter_set( p, tid_after );
+    if( dat.region.id.is_valid() ) {
+        const region_settings_terrain_furniture &settings_terfurn =
+            dat.region.get_settings_terrain_furniture();
+        for( const tripoint_bub_ms &p : dat.m.points_on_zlevel() ) {
+            const ter_id &tid_before = dat.m.ter( p );
+            if( !tid_before.id().is_null() && tid_before->has_flag( ter_furn_flag::TFLAG_REGION_PSEUDO ) ) {
+                const ter_id &tid_after = settings_terfurn.resolve( tid_before );
+                if( tid_after != tid_before ) {
+                    dat.m.ter_set( p, tid_after );
+                }
             }
-        }
-        const furn_id &fid_before = dat.m.furn( p );
-        if( !fid_before.id().is_null() && fid_before->has_flag( ter_furn_flag::TFLAG_REGION_PSEUDO ) ) {
-            const furn_id &fid_after = dat.region.region_terrain_and_furniture.resolve( fid_before );
-            if( fid_after != fid_before ) {
-                dat.m.furn_set( p, fid_after );
+            const furn_id &fid_before = dat.m.furn( p );
+            if( !fid_before.id().is_null() && fid_before->has_flag( ter_furn_flag::TFLAG_REGION_PSEUDO ) ) {
+                const furn_id &fid_after = settings_terfurn.resolve( fid_before );
+                if( fid_after != fid_before ) {
+                    dat.m.furn_set( p, fid_after );
+                }
             }
         }
     }

--- a/src/mapgendata.cpp
+++ b/src/mapgendata.cpp
@@ -47,7 +47,7 @@ size_t std::hash<mapgen_arguments>::operator()( const mapgen_arguments &args ) c
     return h( args.map );
 }
 
-static const regional_settings dummy_regional_settings;
+static const region_settings dummy_regional_settings;
 
 mapgendata::mapgendata( map &mp, dummy_settings_t )
     : pos_( tripoint_abs_omt::zero )

--- a/src/mapgendata.h
+++ b/src/mapgendata.h
@@ -29,7 +29,7 @@ class map;
 class mission;
 enum class direction : unsigned int;
 enum class mapgen_phase;
-struct regional_settings;
+struct region_settings;
 
 namespace om_direction
 {
@@ -141,7 +141,7 @@ class mapgendata
 
         std::unordered_map<cube_direction, std::string> joins;
 
-        const regional_settings &region;
+        const region_settings &region;
 
         map &m;
 

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -345,9 +345,6 @@ static size_t from_dir( om_direction::type dir )
 
 } // namespace om_lines
 
-//const regional_settings default_region_settings;
-t_regional_settings_map region_settings_map;
-
 namespace
 {
 
@@ -1302,16 +1299,6 @@ void overmap_terrains::check_consistency()
 void overmap_terrains::finalize()
 {
     terrain_types.finalize();
-
-    if( region_settings_map.find( "default" ) == region_settings_map.end() ) {
-        debugmsg( "ERROR: can't find default overmap settings (region_map_settings 'default'), "
-                  "Cataclysm pending.  And not the fun kind." );
-    }
-
-    for( auto &elem : region_settings_map ) {
-        elem.second.finalize();
-    }
-
     set_oter_ids();
 }
 
@@ -2825,7 +2812,8 @@ void overmap_special::check() const
 // *** BEGIN overmap FUNCTIONS ***
 overmap::overmap( const point_abs_om &p ) : loc( p )
 {
-    settings = &overmap_buffer.get_default_settings( p );
+    const region_settings_id default_settings = overmap_buffer.get_default_settings( p ).id;
+    settings = default_settings;
     init_layers();
     hordes.set_location( loc );
 }
@@ -2844,7 +2832,7 @@ void overmap::populate( overmap_special_batch &enabled_specials )
 void overmap::populate()
 {
     overmap_special_batch enabled_specials = overmap_specials::get_default_batch( loc );
-    const overmap_feature_flag_settings &overmap_feature_flag = settings->overmap_feature_flag;
+    const region_settings_feature_flag &overmap_feature_flag = settings->overmap_feature_flag;
 
     const bool should_blacklist = !overmap_feature_flag.blacklist.empty();
     const bool should_whitelist = !overmap_feature_flag.whitelist.empty();
@@ -4611,7 +4599,7 @@ void overmap::place_forest_trails()
         return current_terrain == oter_forest || current_terrain == oter_forest_thick ||
                current_terrain == oter_forest_water;
     };
-    const forest_trail_settings &forest_trail = settings->forest_trail;
+    const region_settings_forest_trail &forest_trail = settings->get_settings_forest_trail();
 
     for( int i = 0; i < OMAPX; i++ ) {
         for( int j = 0; j < OMAPY; j++ ) {
@@ -4732,6 +4720,8 @@ void overmap::place_forest_trailheads()
         return;
     }
 
+    const region_settings_forest_trail &settings_forest_trail = settings->get_settings_forest_trail();
+
     // Trailheads may be placed if all of the following are true:
     // 1. we're at a forest_trail_end_north/south/west/east,
     // 2. we're within trailhead_road_distance from an existing road
@@ -4742,7 +4732,7 @@ void overmap::place_forest_trailheads()
         bool close = false;
         for( const tripoint_om_omt &nearby_point : closest_points_first(
                  trailhead,
-                 settings->forest_trail.trailhead_road_distance
+                 settings_forest_trail.trailhead_road_distance
              ) ) {
             if( check_ot( "road", ot_match_type::contains, nearby_point ) ) {
                 close = true;
@@ -4753,8 +4743,8 @@ void overmap::place_forest_trailheads()
 
     const auto try_place_trailhead_special = [&]( const tripoint_om_omt & trail_end,
     const om_direction::type & dir ) {
-        overmap_special_id trailhead = settings->forest_trail.trailheads.pick();
-        if( one_in( settings->forest_trail.trailhead_chance ) &&
+        overmap_special_id trailhead = settings_forest_trail.trailheads.pick();
+        if( one_in( settings_forest_trail.trailhead_chance ) &&
             trailhead_close_to_road( trail_end ) &&
             can_place_special( *trailhead, trail_end, dir, false ) ) {
             const city &nearest_city = get_nearest_city( trail_end );
@@ -4775,6 +4765,7 @@ void overmap::place_forest_trailheads()
 
 void overmap::place_forests()
 {
+    const region_settings_forest &settings_forest = settings->get_settings_forest();
     const oter_id default_oter_id( settings->default_oter[OVERMAP_DEPTH] );
     const om_noise::om_noise_layer_forest f( global_base_point(), g->get_seed() );
 
@@ -4792,9 +4783,9 @@ void overmap::place_forests()
             const float n = f.noise_at( p.xy() );
 
             // If the noise here meets our threshold, turn it into a forest.
-            if( n + forest_size_adjust > settings->overmap_forest.noise_threshold_forest_thick ) {
+            if( n + forest_size_adjust > settings_forest.noise_threshold_forest_thick ) {
                 ter_set( p, oter_forest_thick );
-            } else if( n + forest_size_adjust > settings->overmap_forest.noise_threshold_forest ) {
+            } else if( n + forest_size_adjust > settings_forest.noise_threshold_forest ) {
                 ter_set( p, oter_forest );
             }
         }
@@ -4834,6 +4825,7 @@ bool overmap::guess_has_lake( const point_abs_om &p, const double noise_threshol
 
 void overmap::place_swamps()
 {
+    const region_settings_forest &settings_forest = settings->get_settings_forest();
     // Buffer our river terrains by a variable radius and increment a counter for the location each
     // time it's included in a buffer. It's a floodplain that we'll then intersect later with some
     // noise to adjust how frequently it occurs.
@@ -4848,8 +4840,8 @@ void overmap::place_swamps()
                 std::vector<point_om_omt> buffered_points =
                     closest_points_first(
                         pos.xy(),
-                        rng( settings->overmap_forest.river_floodplain_buffer_distance_min,
-                             settings->overmap_forest.river_floodplain_buffer_distance_max ) );
+                        rng( settings_forest.river_floodplain_buffer_distance_min,
+                             settings_forest.river_floodplain_buffer_distance_max ) );
                 for( const point_om_omt &p : buffered_points )  {
                     if( !inbounds( p ) ) {
                         continue;
@@ -4875,12 +4867,12 @@ void overmap::place_swamps()
             // If this was a part of our buffered floodplain, and the noise here meets the threshold, and the one_in rng
             // triggers, then we should flood this location and make it a swamp.
             const bool should_flood = ( floodplain[x][y] > 0 && !one_in( floodplain[x][y] ) && f.noise_at( { x, y } )
-                                        > settings->overmap_forest.noise_threshold_swamp_adjacent_water );
+                                        > settings_forest.noise_threshold_swamp_adjacent_water );
 
             // If this location meets our isolated swamp threshold, regardless of floodplain values, we'll make it
             // into a swamp.
             const bool should_isolated_swamp = f.noise_at( pos.xy() ) >
-                                               settings->overmap_forest.noise_threshold_swamp_isolated;
+                                               settings_forest.noise_threshold_swamp_isolated;
             if( should_flood || should_isolated_swamp )  {
                 ter_set( pos, oter_forest_water );
             }
@@ -5062,6 +5054,7 @@ std::vector<tripoint_om_omt> overmap::get_border( const point_rel_om &direction,
 
 void overmap::calculate_forestosity()
 {
+    const region_settings_forest &settings_forest = settings->get_settings_forest();
     float northern_forest_increase = get_option<float>( "OVERMAP_FOREST_INCREASE_NORTH" );
     float eastern_forest_increase = get_option<float>( "OVERMAP_FOREST_INCREASE_EAST" );
     float western_forest_increase = get_option<float>( "OVERMAP_FOREST_INCREASE_WEST" );
@@ -5084,7 +5077,7 @@ void overmap::calculate_forestosity()
     // make sure forest size never totally overwhelms the map
     forest_size_adjust = std::min( forest_size_adjust,
                                    get_option<float>( "OVERMAP_FOREST_LIMIT" ) - static_cast<float>
-                                   ( settings->overmap_forest.noise_threshold_forest ) );
+                                   ( settings_forest.noise_threshold_forest ) );
 }
 
 void overmap::calculate_urbanity()
@@ -5318,7 +5311,8 @@ bool overmap::build_lab(
 
 void overmap::place_ravines()
 {
-    if( settings->overmap_ravine.num_ravines == 0 ) {
+    const region_settings_ravine &settings_ravine = settings->get_settings_ravine();
+    if( settings_ravine.num_ravines == 0 ) {
         return;
     }
 
@@ -5338,20 +5332,24 @@ void overmap::place_ravines()
     // A path is generated for each of ravine, and all its constituent points are stored within the
     // rift_points set. In the code block below, the set is then used to determine edges and place the
     // actual terrain pieces of the ravine.
-    for( int n = 0; n < settings->overmap_ravine.num_ravines; n++ ) {
-        const point_rel_omt offset( rng( -settings->overmap_ravine.ravine_range,
-                                         settings->overmap_ravine.ravine_range ),
-                                    rng( -settings->overmap_ravine.ravine_range, settings->overmap_ravine.ravine_range ) );
+    const int ravine_range = settings_ravine.ravine_range;
+    const int ravine_width = settings_ravine.ravine_width;
+    const int ravine_depth = settings_ravine.ravine_depth;
+
+    for( int n = 0; n < settings_ravine.num_ravines; n++ ) {
+        const point_rel_omt offset( rng( -ravine_range,
+                                         ravine_range ),
+                                    rng( -ravine_range, ravine_range ) );
         const point_om_omt origin( rng( 0, OMAPX ), rng( 0, OMAPY ) );
         const point_om_omt destination = origin + offset;
-        if( !inbounds( destination, settings->overmap_ravine.ravine_width * 3 ) ) {
+        if( !inbounds( destination, ravine_width * 3 ) ) {
             continue;
         }
         const auto path = pf::greedy_path( origin, destination, point_om_omt( OMAPX, OMAPY ), estimate );
         for( const auto &node : path.nodes ) {
-            for( int i = 1 - settings->overmap_ravine.ravine_width; i < settings->overmap_ravine.ravine_width;
+            for( int i = 1 - ravine_width; i < ravine_width;
                  i++ ) {
-                for( int j = 1 - settings->overmap_ravine.ravine_width; j < settings->overmap_ravine.ravine_width;
+                for( int j = 1 - ravine_width; j < ravine_width;
                      j++ ) {
                     const point_om_omt n = node.pos + point( j, i );
                     if( inbounds( n, 1 ) ) {
@@ -5375,8 +5373,8 @@ void overmap::place_ravines()
                 }
             }
         }
-        for( int z = 0; z >= settings->overmap_ravine.ravine_depth; z-- ) {
-            if( z == settings->overmap_ravine.ravine_depth ) {
+        for( int z = 0; z >= ravine_depth; z-- ) {
+            if( z == ravine_depth ) {
                 ter_set( tripoint_om_omt( p, z ), edge ? rift_floor_edge : rift_floor );
             } else {
                 ter_set( tripoint_om_omt( p, z ), edge ? rift_edge : rift );
@@ -6383,12 +6381,13 @@ void overmap::place_mongroups()
     }
     if( get_option<bool>( "OVERMAP_PLACE_OCEANS" ) ) {
         // Now place ocean mongroup. Weights may need to be altered.
+        const region_settings_ocean &settings_ocean = settings->get_settings_ocean();
         const om_noise::om_noise_layer_ocean f( global_base_point(), g->get_seed() );
         const point_abs_om this_om = pos();
-        const int northern_ocean = settings->overmap_ocean.ocean_start_north;
-        const int eastern_ocean = settings->overmap_ocean.ocean_start_east;
-        const int western_ocean = settings->overmap_ocean.ocean_start_west;
-        const int southern_ocean = settings->overmap_ocean.ocean_start_south;
+        const int northern_ocean = settings_ocean.ocean_start_north;
+        const int eastern_ocean = settings_ocean.ocean_start_east;
+        const int western_ocean = settings_ocean.ocean_start_west;
+        const int southern_ocean = settings_ocean.ocean_start_south;
 
         // noise threshold adjuster for deep ocean. Increase to make deep ocean move further from the shore.
         constexpr float DEEP_OCEAN_THRESHOLD_ADJUST = 1.25;
@@ -6409,7 +6408,7 @@ void overmap::place_mongroups()
                 // It's too soon!  Too soon for an ocean!!  ABORT!!!
                 return false;
             }
-            return f.noise_at( p ) + ocean_adjust > settings->overmap_ocean.noise_threshold_ocean *
+            return f.noise_at( p ) + ocean_adjust > settings_ocean.noise_threshold_ocean *
                    DEEP_OCEAN_THRESHOLD_ADJUST;
         };
 

--- a/src/overmap.h
+++ b/src/overmap.h
@@ -55,7 +55,7 @@ class npc;
 class overmap_connection;
 struct horde_entity;
 struct map_data_summary;
-struct regional_settings;
+struct region_settings;
 template <typename T> struct enum_traits;
 
 struct om_note {
@@ -433,7 +433,7 @@ class overmap
         point_abs_omt global_base_point() const;
 
         // TODO: Should depend on coordinates
-        const regional_settings &get_settings() const {
+        const region_settings &get_settings() const {
             return *settings;
         }
 
@@ -531,7 +531,7 @@ class overmap
         // special, so that it can be queried later by mapgen
         std::unordered_map<om_pos_dir, std::string> joins_used;
 
-        const regional_settings *settings;
+        region_settings_id settings;
 
         oter_id get_default_terrain( int z ) const;
 

--- a/src/overmap_city.cpp
+++ b/src/overmap_city.cpp
@@ -23,8 +23,8 @@
 #include "overmap_connection.h"
 #include "overmapbuffer.h"
 #include "point.h"
-#include "rng.h"
 #include "regional_settings.h"
+#include "rng.h"
 #include "simple_pathfinding.h"
 #include "type_id.h"
 
@@ -206,7 +206,7 @@ void overmap::build_cities()
 overmap_special_id overmap::pick_random_building_to_place( int town_dist, int town_size,
         const std::unordered_set<overmap_special_id> &placed_unique_buildings ) const
 {
-    const city_settings &city_spec = settings->city_spec;
+    const region_settings_city &city_spec = settings->get_settings_city();
     int shop_radius = city_spec.shop_radius;
     int park_radius = city_spec.park_radius;
 
@@ -226,11 +226,11 @@ overmap_special_id overmap::pick_random_building_to_place( int town_dist, int to
     }
     auto building_type_to_pick = [&]() {
         if( shop_normal > town_dist ) {
-            return std::mem_fn( &city_settings::pick_shop );
+            return std::mem_fn( &region_settings_city::pick_shop );
         } else if( park_normal > town_dist ) {
-            return std::mem_fn( &city_settings::pick_park );
+            return std::mem_fn( &region_settings_city::pick_park );
         } else {
-            return std::mem_fn( &city_settings::pick_house );
+            return std::mem_fn( &region_settings_city::pick_house );
         }
     };
     auto pick_building = building_type_to_pick();
@@ -277,6 +277,7 @@ void overmap::place_building( const tripoint_om_omt &p, om_direction::type dir, 
 pf::directed_path<point_om_omt> overmap::lay_out_street( const overmap_connection &connection,
         const point_om_omt &source, om_direction::type dir, size_t len )
 {
+    const int &highway_width = settings->get_settings_highway().width_of_segments;
     auto valid_placement = [this]( const overmap_connection & connection, const tripoint_om_omt pos,
     om_direction::type dir ) {
         if( !inbounds( pos, 1 ) ) {
@@ -328,7 +329,6 @@ pf::directed_path<point_om_omt> overmap::lay_out_street( const overmap_connectio
                 if( are_parallel( dir, ter_id.obj().get_dir() ) ) {
                     break;
                 }
-                const int &highway_width = settings->overmap_highway.width_of_segments;
                 const tripoint_om_omt pos_after_highway = pos + om_direction::displace( dir, highway_width );
                 // Ensure we can pass fully through
                 if( !valid_placement( connection, pos_after_highway, dir ) ) {

--- a/src/overmap_highway.cpp
+++ b/src/overmap_highway.cpp
@@ -97,7 +97,7 @@ static bool special_on_water( const overmap *om, const overmap_special_id &speci
     return false;
 }
 
-static overmap_special_id segment_special( const overmap_highway_settings &highway_settings,
+static overmap_special_id segment_special( const region_settings_highway &highway_settings,
         bool raised )
 {
     return raised ? highway_settings.segment_bridge :
@@ -189,7 +189,7 @@ Highway_path overmap::place_highway_reserved_path( const tripoint_om_omt &p1,
         int dir1, int dir2, int base_z )
 {
 
-    const overmap_highway_settings &highway_settings = settings->overmap_highway;
+    const region_settings_highway &highway_settings = settings->get_settings_highway();
     // base-level segment OMT to use until finalize_highways()
     const oter_type_str_id &reserved_terrain_id = highway_settings.reserved_terrain_id;
     // upper-level segment OMT to use until finalize_highways()
@@ -334,7 +334,7 @@ Highway_path overmap::place_highway_line(
     const tripoint_om_omt &sp1, const tripoint_om_omt &sp2,
     const om_direction::type &draw_direction, int base_z )
 {
-    const overmap_highway_settings &highway_settings = settings->overmap_highway;
+    const region_settings_highway &highway_settings = settings->get_settings_highway();
     const int longest_slant_length = highway_settings.clockwise_slant.obj().longest_side();
 
     const point_rel_omt draw_direction_vector =
@@ -442,7 +442,7 @@ void overmap::place_highway_lines_with_bends( Highway_path &highway_path,
         om_direction::type direction, int base_z )
 {
 
-    const overmap_highway_settings &highway_settings = settings->overmap_highway;
+    const region_settings_highway &highway_settings = settings->get_settings_highway();
     const building_bin &bends = highway_settings.bends;
     const overmap_special_id &fallback_onramp = highway_settings.fallback_onramp;
 
@@ -530,17 +530,18 @@ std::pair<bool, std::bitset<HIGHWAY_MAX_CONNECTIONS>> overmap::highway_handle_oc
 {
     std::bitset<HIGHWAY_MAX_CONNECTIONS> ocean_adjacent;
     const point_abs_om this_om = pos();
+    const region_settings_ocean &settings_ocean = settings->get_settings_ocean();
 
     if( get_option<bool>( "OVERMAP_PLACE_OCEANS" ) ) {
         // Not ideal as oceans can start later than these settings but it's at least reliably stopping before them
-        const int ocean_start_north = settings->overmap_ocean.ocean_start_north == 0 ? INT_MAX :
-                                      settings->overmap_ocean.ocean_start_north;
-        const int ocean_start_east = settings->overmap_ocean.ocean_start_east == 0 ? INT_MAX :
-                                     settings->overmap_ocean.ocean_start_east;
-        const int ocean_start_west = settings->overmap_ocean.ocean_start_west == 0 ? INT_MAX :
-                                     settings->overmap_ocean.ocean_start_west;
-        const int ocean_start_south = settings->overmap_ocean.ocean_start_south == 0 ? INT_MAX :
-                                      settings->overmap_ocean.ocean_start_south;
+        const int ocean_start_north = settings_ocean.ocean_start_north == 0 ? INT_MAX :
+                                      settings_ocean.ocean_start_north;
+        const int ocean_start_east = settings_ocean.ocean_start_east == 0 ? INT_MAX :
+                                     settings_ocean.ocean_start_east;
+        const int ocean_start_west = settings_ocean.ocean_start_west == 0 ? INT_MAX :
+                                     settings_ocean.ocean_start_west;
+        const int ocean_start_south = settings_ocean.ocean_start_south == 0 ? INT_MAX :
+                                      settings_ocean.ocean_start_south;
         // Don't place highways over the ocean
         if( this_om.y() <= -ocean_start_north || this_om.x() >= ocean_start_east ||
             this_om.y() >= ocean_start_south || this_om.x() <= -ocean_start_west ) {
@@ -563,8 +564,7 @@ std::pair<bool, std::bitset<HIGHWAY_MAX_CONNECTIONS>> overmap::highway_handle_oc
 //handle ramp placement given z-levels of path nodes
 void overmap::highway_handle_ramps( Highway_path &path, int base_z )
 {
-
-    const overmap_highway_settings &highway_settings = settings->overmap_highway;
+    const region_settings_highway &highway_settings = settings->get_settings_highway();
     const overmap_special_id &segment_bridge = highway_settings.segment_bridge;
     const overmap_special_id &segment_ramp = highway_settings.segment_ramp;
     const int range = path.size();
@@ -631,7 +631,7 @@ void overmap::highway_handle_ramps( Highway_path &path, int base_z )
 
 void overmap::highway_handle_special_z( Highway_path &highway_path, int base_z )
 {
-    const overmap_highway_settings &highway_settings = settings->overmap_highway;
+    const region_settings_highway &highway_settings = settings->get_settings_highway();
 
     const int path_size = highway_path.size();
     for( int i = 1; i < path_size - 1; i++ ) {
@@ -659,7 +659,7 @@ bool overmap::highway_select_end_points( const std::vector<const overmap *> &nei
         const std::bitset<HIGHWAY_MAX_CONNECTIONS> &ocean_neighbors, int base_z )
 {
 
-    const overmap_highway_settings &highway_settings = settings->overmap_highway;
+    const region_settings_highway &highway_settings = settings->get_settings_highway();
     const int HIGHWAY_MAX_DEVIANCE = highway_settings.HIGHWAY_MAX_DEVIANCE;
     //used until intersections can be safely placed at corners of the overmap with two-bend pathing
     const int SAFE_DEVIANCE = HIGHWAY_MAX_DEVIANCE * 2;
@@ -740,7 +740,7 @@ std::vector<Highway_path> overmap::place_highways(
     std::vector<Highway_path> paths;
     const int base_z = RIVER_Z;
 
-    const overmap_highway_settings &highway_settings = settings->overmap_highway;
+    const region_settings_highway &highway_settings = settings->get_settings_highway();
     // Base distance in overmaps between vertical highways ( whole overmap gap of column_seperation - 1 )
     const int c_seperation = highway_settings.grid_column_seperation;
     // Base distance in overmaps between horizontal highways ( whole overmap gap of row_seperation - 1 )
@@ -826,8 +826,8 @@ std::vector<Highway_path> overmap::place_highways(
                                         RIVER_Z ) );
                 }
             }
-            fallback_special = settings->overmap_highway.fallback_three_way_intersection;
-            special = settings->overmap_highway.three_way_intersections.pick();
+            fallback_special = highway_settings.fallback_three_way_intersection;
+            special = highway_settings.three_way_intersections.pick();
             highway_special_offset( three_point, empty_direction );
             place_highway_supported_special( special, three_point, empty_direction );
             break;
@@ -857,7 +857,7 @@ std::vector<Highway_path> overmap::place_highways(
                 const int THREE_WAY_COUNT = 2;
                 std::array<tripoint_om_omt, THREE_WAY_COUNT> three_way_intersections;
                 std::array<om_direction::type, THREE_WAY_COUNT> three_way_direction;
-                special = settings->overmap_highway.three_way_intersections.pick();
+                special = highway_settings.three_way_intersections.pick();
                 for( int i = 0; i < HIGHWAY_MAX_CONNECTIONS; i++ ) {
                     if( corners_close[i] ) {
                         const int dir1 = i;
@@ -888,10 +888,10 @@ std::vector<Highway_path> overmap::place_highways(
                 break;
             }
 
-            special = settings->overmap_highway.four_way_intersections.pick();
+            special = highway_settings.four_way_intersections.pick();
             bool fallback = !check_intersection_inbounds( special, four_point, HIGHWAY_MAX_DEVIANCE );
             if( fallback ) {
-                special = settings->overmap_highway.fallback_four_way_intersection;
+                special = highway_settings.fallback_four_way_intersection;
             }
             om_direction::type intersection_dir = om_direction::type::north;
             four_point = find_highway_intersection_point( special, four_point, intersection_dir,
@@ -935,8 +935,9 @@ overmap::get_highway_segment_points( const pf::directed_node<tripoint_om_omt> &n
 
 void overmap::finalize_highways( std::vector<Highway_path> &paths )
 {
+    const region_settings_highway &highway_settings = settings->get_settings_highway();
     // Segment of flat highway with a road bridge
-    const overmap_special_id &segment_road_bridge = settings->overmap_highway.segment_road_bridge;
+    const overmap_special_id &segment_road_bridge = highway_settings.segment_road_bridge;
 
     // Replace roads that travelled over reserved highway segments
     auto handle_road_bridges = [this, &segment_road_bridge]( Highway_path & path ) {
@@ -1057,7 +1058,8 @@ void interhighway_node::generate_offset( int intersection_max_radius )
 {
     auto no_lakes = []( const point_abs_om & pt ) {
         //TODO: this can't be correct usage of default region settings...
-        const overmap_lake_settings &lake_settings = overmap_buffer.get_default_settings( pt ).overmap_lake;
+        const region_settings_lake &lake_settings = overmap_buffer.get_default_settings(
+                    pt ).get_settings_lake();
         return !overmap::guess_has_lake( pt, lake_settings.noise_threshold_lake,
                                          lake_settings.lake_size_min );
     };
@@ -1099,15 +1101,17 @@ void overmap::place_highway_supported_special( const overmap_special_id &special
     if( placement.is_invalid() ) {
         return;
     }
+    const region_settings_highway &highway_settings = settings->get_settings_highway();
+
     place_special_forced( special, placement, dir );
     const std::vector<overmap_special_terrain> locs = special->get_terrains();
 
-    const oter_id fallback_supports = settings->overmap_highway.fallback_supports.obj().get_first();
+    const oter_id fallback_supports = highway_settings.fallback_supports.obj().get_first();
 
     for( const overmap_special_terrain &loc : locs ) {
         const tripoint_om_omt rotated = placement + om_direction::rotate( loc.p, dir );
         if( loc.terrain.id() == fallback_supports ) {
-            place_special_forced( settings->overmap_highway.segment_bridge_supports,
+            place_special_forced( highway_settings.segment_bridge_supports,
                                   rotated, dir );
         }
     }
@@ -1115,6 +1119,7 @@ void overmap::place_highway_supported_special( const overmap_special_id &special
 
 void overmap::place_highway_interchanges( std::vector<Highway_path> &highway_path )
 {
+    const region_settings_highway &highway_settings = settings->get_settings_highway();
     // slightly higher than it should realistically be for convenience's sake
     const int HIGHWAY_INTERCHANGE_SPACING = OMAPX / 4;
     const int HIGHWAY_INTERCHANGE_VARIANCE = HIGHWAY_INTERCHANGE_SPACING / 10;
@@ -1123,7 +1128,7 @@ void overmap::place_highway_interchanges( std::vector<Highway_path> &highway_pat
                          HIGHWAY_INTERCHANGE_VARIANCE );
         for( intrahighway_node &node : path ) {
             if( node.is_segment && node_count == 0 ) {
-                const overmap_special_id interchange = settings->overmap_highway.interchanges.pick();
+                const overmap_special_id interchange = highway_settings.interchanges.pick();
                 const tripoint_om_omt &node_pos = node.path_node.pos;
                 const om_direction::type node_dir = node.get_effective_dir();
                 if( can_place_special( *interchange, node_pos, node_dir, false ) ) {

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -252,8 +252,8 @@ weather_type_id get_weather_at_point( const tripoint_abs_omt &pos )
     auto iter = weather_cache.find( pos );
     if( iter == weather_cache.end() ) {
         const tripoint_abs_ms abs_ms_pos = project_to<coords::ms>( pos );
-        const weather_generator &wgen = overmap_buffer.get_settings( pos ).weather;
-        const weather_type_id weather = wgen.get_weather_conditions( abs_ms_pos, calendar::turn,
+        const weather_generator_id &wgen = overmap_buffer.get_settings( pos ).weather;
+        const weather_type_id weather = wgen->get_weather_conditions( abs_ms_pos, calendar::turn,
                                         g->get_seed() );
         iter = weather_cache.insert( std::make_pair( pos, weather ) ).first;
     }

--- a/src/overmap_water.cpp
+++ b/src/overmap_water.cpp
@@ -44,6 +44,7 @@ static const oter_str_id oter_river_west( "river_west" );
 void overmap::place_river( const std::vector<const overmap *> &neighbor_overmaps,
                            const overmap_river_node &initial_points, int river_scale, bool major_river )
 {
+    const region_settings_river &settings_river = settings->get_settings_river();
     const int OMAPX_edge = OMAPX - 1;
     const int OMAPY_edge = OMAPY - 1;
     const int directions = 4;
@@ -182,14 +183,14 @@ void overmap::place_river( const std::vector<const overmap *> &neighbor_overmaps
     for( int i = 0; i < curve_size; i++ ) {
         const point_om_omt &bezier_point = segmented_curve.at( i );
         if( inbounds( bezier_point, river_scale + 1 ) &&
-            one_in( settings->overmap_river.river_branch_chance ) ) {
+            one_in( settings_river.river_branch_chance ) ) {
             point_om_omt branch_end_point = point_om_omt::invalid;
 
             //pick an end point from later along the curve
             //TODO: make remerge branches have control points that aren't straight;
             // remerges are less common because they get stopped by the already-generated river
             if( i > branch_last_end ) {
-                if( one_in( settings->overmap_river.river_branch_remerge_chance ) ) {
+                if( one_in( settings_river.river_branch_remerge_chance ) ) {
                     int end_branch_node = rng( i + branch_ahead_points, i + branch_ahead_points * 2 );
                     if( end_branch_node < curve_size ) {
                         branch_end_point = segmented_curve.at( end_branch_node );
@@ -206,7 +207,7 @@ void overmap::place_river( const std::vector<const overmap *> &neighbor_overmaps
             // if the end point is valid, place a new, smaller, overmap-local branch river
             if( !branch_end_point.is_invalid() && inbounds( branch_end_point ) ) {
                 place_river( neighbor_overmaps, overmap_river_node{ bezier_point, branch_end_point },
-                             river_scale - settings->overmap_river.river_branch_scale_decrease );
+                             river_scale - settings_river.river_branch_scale_decrease );
             }
         }
     }
@@ -256,7 +257,9 @@ void overmap::place_lakes( const std::vector<const overmap *> &neighbor_overmaps
 {
     const point_abs_omt origin = global_base_point();
     const om_noise::om_noise_layer_lake noise_func( origin, g->get_seed() );
-    double noise_threshold = settings->overmap_lake.noise_threshold_lake;
+    const region_settings_lake &settings_lake = settings->get_settings_lake();
+    double noise_threshold = settings_lake.noise_threshold_lake;
+    const int lake_depth = settings_lake.lake_depth;
 
     const auto is_lake = [&]( const point_om_omt & p ) {
         return omt_lake_noise_threshold( origin, p, noise_threshold );
@@ -291,7 +294,7 @@ void overmap::place_lakes( const std::vector<const overmap *> &neighbor_overmaps
             // exclude the tiny lakes that don't provide interesting map features and exist mostly as a
             // noise artifact.
             if( lake_points.size() < static_cast<size_t>
-                ( settings->overmap_lake.lake_size_min ) ) {
+                ( settings_lake.lake_size_min ) ) {
                 continue;
             }
 
@@ -351,10 +354,10 @@ void overmap::place_lakes( const std::vector<const overmap *> &neighbor_overmaps
 
                 // If this is not a shore, we'll make our subsurface lake cubes and beds.
                 if( !shore ) {
-                    for( int z = -1; z > settings->overmap_lake.lake_depth; z-- ) {
+                    for( int z = -1; z > lake_depth; z-- ) {
                         ter_set( tripoint_om_omt( p, z ), lake_water_cube );
                     }
-                    ter_set( tripoint_om_omt( p, settings->overmap_lake.lake_depth ), lake_bed );
+                    ter_set( tripoint_om_omt( p, lake_depth ), lake_bed );
                 }
             }
         }
@@ -364,10 +367,11 @@ void overmap::place_lakes( const std::vector<const overmap *> &neighbor_overmaps
 // helper function for code deduplication, as it is needed multiple times
 float overmap::calculate_ocean_gradient( const point_om_omt &p, const point_abs_om this_om )
 {
-    const int northern_ocean = settings->overmap_ocean.ocean_start_north;
-    const int eastern_ocean = settings->overmap_ocean.ocean_start_east;
-    const int western_ocean = settings->overmap_ocean.ocean_start_west;
-    const int southern_ocean = settings->overmap_ocean.ocean_start_south;
+    const region_settings_ocean &settings_ocean = settings->get_settings_ocean();
+    const int northern_ocean = settings_ocean.ocean_start_north;
+    const int eastern_ocean = settings_ocean.ocean_start_east;
+    const int western_ocean = settings_ocean.ocean_start_west;
+    const int southern_ocean = settings_ocean.ocean_start_south;
 
     float ocean_adjust_N = 0.0f;
     float ocean_adjust_E = 0.0f;
@@ -393,10 +397,12 @@ float overmap::calculate_ocean_gradient( const point_om_omt &p, const point_abs_
 
 void overmap::place_oceans( const std::vector<const overmap *> &neighbor_overmaps )
 {
-    int northern_ocean = settings->overmap_ocean.ocean_start_north;
-    int eastern_ocean = settings->overmap_ocean.ocean_start_east;
-    int western_ocean = settings->overmap_ocean.ocean_start_west;
-    int southern_ocean = settings->overmap_ocean.ocean_start_south;
+    const region_settings_ocean &settings_ocean = settings->get_settings_ocean();
+    const int northern_ocean = settings_ocean.ocean_start_north;
+    const int eastern_ocean = settings_ocean.ocean_start_east;
+    const int western_ocean = settings_ocean.ocean_start_west;
+    const int southern_ocean = settings_ocean.ocean_start_south;
+    const int ocean_depth = settings_ocean.ocean_depth;
 
     const om_noise::om_noise_layer_ocean f( global_base_point(), g->get_seed() );
     const point_abs_om this_om = pos();
@@ -416,7 +422,7 @@ void overmap::place_oceans( const std::vector<const overmap *> &neighbor_overmap
             // It's too soon!  Too soon for an ocean!!  ABORT!!!
             return false;
         }
-        return f.noise_at( p ) + ocean_adjust > settings->overmap_ocean.noise_threshold_ocean;
+        return f.noise_at( p ) + ocean_adjust > settings_ocean.noise_threshold_ocean;
     };
 
     const oter_id ocean_surface( "ocean_surface" );
@@ -445,7 +451,7 @@ void overmap::place_oceans( const std::vector<const overmap *> &neighbor_overmap
             // you could change this, if you want little tiny oceans all over the place.
             // I'm not sure why you'd want that.  Use place_lakes, my friend.
             if( ocean_points.size() < static_cast<size_t>
-                ( settings->overmap_ocean.ocean_size_min ) ) {
+                ( settings_ocean.ocean_size_min ) ) {
                 continue;
             }
 
@@ -478,10 +484,10 @@ void overmap::place_oceans( const std::vector<const overmap *> &neighbor_overmap
                 ter_set( tripoint_om_omt( p, 0 ), shore ? ocean_shore : ocean_surface );
 
                 if( !shore ) {
-                    for( int z = -1; z > settings->overmap_ocean.ocean_depth; z-- ) {
+                    for( int z = -1; z > ocean_depth; z-- ) {
                         ter_set( tripoint_om_omt( p, z ), ocean_water_cube );
                     }
-                    ter_set( tripoint_om_omt( p, settings->overmap_ocean.ocean_depth ), ocean_bed );
+                    ter_set( tripoint_om_omt( p, ocean_depth ), ocean_bed );
                 }
             }
 
@@ -538,7 +544,8 @@ void overmap::place_rivers( const std::vector<const overmap *> &neighbor_overmap
     const int OMAPY_edge = OMAPY - 1;
     const int directions = neighbor_overmaps.size();
     const int max_rivers = 2;
-    int river_scale = settings->overmap_river.river_scale;
+    const region_settings_river &settings_river = settings->get_settings_river();
+    int river_scale = settings_river.river_scale;
     if( river_scale == 0 ) {
         return;
     }
@@ -600,7 +607,7 @@ void overmap::place_rivers( const std::vector<const overmap *> &neighbor_overmap
     //if there wasn't an neighboring river, 1 / (river frequency ^ rivers generated) chance to continue
     bool no_neighboring_rivers = preset_start_nodes == 0 && preset_end_nodes == 0;
     if( no_neighboring_rivers ) {
-        if( !x_in_y( 1.0, std::pow( settings->overmap_river.river_frequency,
+        if( !x_in_y( 1.0, std::pow( settings_river.river_frequency,
                                     overmap_buffer.get_major_river_count() ) ) ) {
             return;
         }

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -265,22 +265,22 @@ void overmapbuffer::clear()
     last_requested_overmap = nullptr;
 }
 
-const regional_settings &overmapbuffer::get_settings( const tripoint_abs_omt &p )
+const region_settings &overmapbuffer::get_settings( const tripoint_abs_omt &p )
 {
     overmap *om = get_om_global( p ).om;
     return om->get_settings();
 }
 
-const regional_settings &overmapbuffer::get_default_settings( const point_abs_om &p )
+const region_settings &overmapbuffer::get_default_settings( const point_abs_om &p )
 {
     const std::string rsettings_id = get_option<std::string>( "DEFAULT_REGION" );
-    t_regional_settings_map_citr rsit = region_settings_map.find( rsettings_id );
+    const region_settings_id region_settings_default( rsettings_id );
 
-    if( rsit == region_settings_map.end() ) {
+    if( !region_settings_default.is_valid() ) {
         debugmsg( "overmap%s: can't find region '%s'", p.to_string(),
                   rsettings_id.c_str() ); // gonna die now =[
     }
-    return rsit->second;
+    return *region_settings_default;
 }
 
 void overmapbuffer::add_note( const tripoint_abs_omt &p, const std::string &message )
@@ -1792,8 +1792,8 @@ point_abs_om overmapbuffer::get_highway_global_offset() const
 std::vector<interhighway_node>
 overmapbuffer::find_highway_adjacent_intersections( const point_abs_om &generated_om_pos )
 {
-    const overmap_highway_settings &highway_settings = get_default_settings(
-                generated_om_pos ).overmap_highway;
+    const region_settings_highway &highway_settings = get_default_settings(
+                generated_om_pos ).get_settings_highway();
     const int c_seperation = highway_settings.grid_column_seperation;
     const int r_seperation = highway_settings.grid_row_seperation;
 
@@ -1831,8 +1831,8 @@ bool overmapbuffer::highway_intersection_exists( const point_abs_om &intersectio
 
 void overmapbuffer::generate_highway_intersection_point( const point_abs_om &generated_om_pos )
 {
-    const overmap_highway_settings &highway_settings = get_default_settings(
-                generated_om_pos ).overmap_highway;
+    const region_settings_highway &highway_settings = get_default_settings(
+                generated_om_pos ).get_settings_highway();
     const int intersection_max_radius = highway_settings.intersection_max_radius;
     if( !highway_intersection_exists( generated_om_pos ) ) {
         interhighway_node new_intersection( generated_om_pos );
@@ -1846,8 +1846,8 @@ void overmapbuffer::generate_highway_intersection_point( const point_abs_om &gen
 std::vector<point_abs_om> overmapbuffer::find_highway_intersection_bounds( const point_abs_om
         & generated_om_pos )
 {
-    const overmap_highway_settings &highway_settings = get_default_settings(
-                generated_om_pos ).overmap_highway;
+    const region_settings_highway &highway_settings = get_default_settings(
+                generated_om_pos ).get_settings_highway();
     const int c_seperation = highway_settings.grid_column_seperation;
     const int r_seperation = highway_settings.grid_row_seperation;
 

--- a/src/overmapbuffer.h
+++ b/src/overmapbuffer.h
@@ -46,7 +46,7 @@ struct horde_entity;
 struct map_data_summary;
 struct mapgen_arguments;
 struct mongroup;
-struct regional_settings;
+struct region_settings;
 
 struct overmap_path_params {
     std::map<oter_travel_cost_type, int> travel_cost_per_type;
@@ -224,8 +224,8 @@ class overmapbuffer
         std::vector<om_vehicle> get_vehicle( const tripoint_abs_omt &p );
         std::string get_vehicle_ter_sym( const tripoint_abs_omt &omt );
         std::string get_vehicle_tile_id( const tripoint_abs_omt &omt );
-        const regional_settings &get_settings( const tripoint_abs_omt &p );
-        const regional_settings &get_default_settings( const point_abs_om &p );
+        const region_settings &get_settings( const tripoint_abs_omt &p );
+        const region_settings &get_default_settings( const point_abs_om &p );
         /**
          * Accessors for horde introspection into overmaps.
          * Probably also useful for NPC overmap-scale navigation.

--- a/src/regional_settings.h
+++ b/src/regional_settings.h
@@ -33,9 +33,9 @@ class building_bin
 {
     private:
         bool finalized = false; // NOLINT(cata-serialize)
-        std::map<overmap_special_id, int> unfinalized_buildings; // NOLINT(cata-serialize)
     public:
         building_bin() = default;
+        //TODO: remove add
         void add( const overmap_special_id &building, int weight );
         overmap_special_id pick() const;
         std::vector<std::string> all; // NOLINT(cata-serialize)
@@ -133,15 +133,15 @@ struct region_settings_city {
     building_bin parks;
 
     overmap_special_id pick_house() const {
-        return houses.pick()->id;
+        return houses.pick();
     }
 
     overmap_special_id pick_shop() const {
-        return shops.pick()->id;
+        return shops.pick();
     }
 
     overmap_special_id pick_park() const {
-        return parks.pick()->id;
+        return parks.pick();
     }
 
     weighted_int_list<overmap_special_id> get_all_houses() const {

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -566,11 +566,10 @@ void overmap::unserialize( const JsonObject &jsobj )
         if( name == "region_id" ) {
             std::string new_region_id;
             om_member.read( new_region_id );
-            if( settings->id != new_region_id ) {
-                t_regional_settings_map_citr rit = region_settings_map.find( new_region_id );
-                if( rit != region_settings_map.end() ) {
-                    // TODO: optimize
-                    settings = &rit->second;
+            if( settings->id.str() != new_region_id ) {
+                const region_settings_id new_region_set( new_region_id );
+                if( new_region_set.is_valid() ) {
+                    settings = new_region_set;
                 }
             }
         } else if( name == "mongroups" ) {
@@ -898,6 +897,11 @@ void overmap::unserialize( const JsonObject &jsobj )
 // MA mod's pregenerated overmaps that are shimmed in by overmap::generate.
 void overmap::unserialize_omap( const JsonValue &jsin, const cata_path &json_path )
 {
+    const region_settings_lake &settings_lake = settings->get_settings_lake();
+    const region_settings_ocean &settings_ocean = settings->get_settings_ocean();
+    const int lake_depth = settings_lake.lake_depth;
+    const int ocean_depth = settings_ocean.ocean_depth;
+
     JsonArray ja = jsin.get_array();
     JsonObject jo = ja.next_object();
 
@@ -981,10 +985,10 @@ void overmap::unserialize_omap( const JsonValue &jsin, const cata_path &json_pat
 
         // If this is not a shore, we'll make our subsurface lake cubes and beds.
         if( !shore ) {
-            for( int z = -1; z > settings->overmap_lake.lake_depth; z-- ) {
+            for( int z = -1; z > lake_depth; z-- ) {
                 ter_set( tripoint_om_omt( p.xy(), z ), oter_lake_water_cube );
             }
-            ter_set( tripoint_om_omt( p.xy(), settings->overmap_lake.lake_depth ), oter_lake_bed );
+            ter_set( tripoint_om_omt( p.xy(), lake_depth ), oter_lake_bed );
             layer[p.z() + OVERMAP_DEPTH].terrain[p.x()][p.y()] = oter_lake_surface;
         }
     }
@@ -1011,10 +1015,10 @@ void overmap::unserialize_omap( const JsonValue &jsin, const cata_path &json_pat
 
         // If this is not a shore, we'll make our subsurface ocean cubes and beds.
         if( !shore ) {
-            for( int z = -1; z > settings->overmap_ocean.ocean_depth; z-- ) {
+            for( int z = -1; z > ocean_depth; z-- ) {
                 ter_set( tripoint_om_omt( p.xy(), z ), oter_ocean_water_cube );
             }
-            ter_set( tripoint_om_omt( p.xy(), settings->overmap_ocean.ocean_depth ), oter_ocean_bed );
+            ter_set( tripoint_om_omt( p.xy(), ocean_depth ), oter_ocean_bed );
             layer[p.z() + OVERMAP_DEPTH].terrain[p.x()][p.y()] = oter_ocean_surface;
         }
     }

--- a/src/weather.cpp
+++ b/src/weather.cpp
@@ -946,8 +946,7 @@ weather_manager::weather_manager()
 const weather_generator &weather_manager::get_cur_weather_gen() const
 {
     const overmap &om = g->get_cur_om();
-    const regional_settings &settings = om.get_settings();
-    return settings.weather;
+    return om.get_settings().get_settings_weather();
 }
 
 void weather_manager::update_weather()

--- a/src/weather_gen.cpp
+++ b/src/weather_gen.cpp
@@ -64,7 +64,10 @@ void weather_generator::reset()
 {
     weather_generator_factory.reset();
 }
-
+void weather_generator::finalize()
+{
+    sort_weather();
+}
 void weather_generator::finalize_all()
 {
     weather_generator_factory.finalize();

--- a/src/weather_gen.h
+++ b/src/weather_gen.h
@@ -78,6 +78,7 @@ class weather_generator
 
         bool was_loaded = false;
         void load( const JsonObject &jo, std::string_view );
+        void finalize();
         static void load_weather_generator( const JsonObject &jo, const std::string &src );
         static void reset();
         static void finalize_all();

--- a/tests/overmap_test.cpp
+++ b/tests/overmap_test.cpp
@@ -660,8 +660,8 @@ TEST_CASE( "highway_find_intersection_bounds", "[overmap]" )
     overmap_buffer.clear();
     overmap_buffer.set_highway_global_offset();
     point_abs_om pos = overmap_buffer.get_highway_global_offset();
-    const overmap_highway_settings &highway_settings = overmap_buffer.get_default_settings(
-                pos ).overmap_highway;
+    const region_settings_highway &highway_settings = overmap_buffer.get_default_settings(
+                pos ).get_settings_highway();
 
     const int c_seperation = highway_settings.grid_column_seperation;
     const int r_seperation = highway_settings.grid_row_seperation;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Infrastructure "region settings overhaul"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

- From #82631
- Fixes #60394 (only just found this today)

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

This is it, this is the big one! Swaps out all old region settings classes/structs for the new ones.

Also:
- Assigns `EXTERNAL_OPTION`: `DEFAULT_REGION` for each mod's new default region settings
- Dedupes a bunch of accesses to region settings where applicable.
- Aftershock is throwing a bunch of highway generation errors, probably because of how highways find lakes, so I'm temporarily disabling highways in Aftershock until they can get fixed.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Built locally, loaded a vanilla world and aftershock without errors, CI pending

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

👍Big thanks👍 to the mergers for their work managing all of my PRs, I know it's a lot 

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
