### PR TITLE
mace recipe audit

### DIFF
--- a/data/json/recipes/weapon/bashing.json
+++ b/data/json/recipes/weapon/bashing.json
@@ -1217,12 +1217,12 @@
     "skill_used": "fabrication",
     "difficulty": 4,
     "time": "3 h",
-    "book_learn": [ [ "textbook_weapwest", 3 ], [ "recipe_melee", 4 ] ],
+    "autolearn": true,
+    "book_learn": [ [ "textbook_weapwest", 2 ], [ "recipe_melee", 2 ], [ "textbook_weparabic", 2 ], [ "textbook_armschina", 2 ] ],
     "using": [ [ "blacksmithing_standard", 12 ], [ "steel_standard", 3 ] ],
     "proficiencies": [
       { "proficiency": "prof_metalworking" },
       { "proficiency": "prof_blacksmithing" },
-      { "proficiency": "prof_toolsmithing" },
       { "proficiency": "prof_carving", "skill_penalty": 0 },
       { "proficiency": "prof_leatherworking_basic", "skill_penalty": 0 }
     ],
@@ -1238,12 +1238,12 @@
     "skill_used": "fabrication",
     "difficulty": 3,
     "time": "2 h",
-    "book_learn": [ [ "textbook_weapwest", 2 ], [ "recipe_melee", 3 ], [ "textbook_weparabic", 2 ], [ "textbook_armschina", 2 ] ],
+    "autolearn": true,
+    "book_learn": [ [ "textbook_weapwest", 2 ], [ "recipe_melee", 2 ], [ "textbook_weparabic", 2 ], [ "textbook_armschina", 2 ] ],
     "using": [ [ "blacksmithing_standard", 12 ], [ "lc_steel_standard", 3 ] ],
     "proficiencies": [
       { "proficiency": "prof_metalworking" },
       { "proficiency": "prof_blacksmithing" },
-      { "proficiency": "prof_toolsmithing" },
       { "proficiency": "prof_carving", "skill_penalty": 0 },
       { "proficiency": "prof_leatherworking_basic", "skill_penalty": 0 }
     ],
@@ -1259,12 +1259,12 @@
     "skill_used": "fabrication",
     "difficulty": 4,
     "time": "3 h",
-    "book_learn": [ [ "textbook_weapwest", 3 ], [ "recipe_melee", 4 ], [ "textbook_weparabic", 3 ], [ "textbook_armschina", 3 ] ],
+    "autolearn": true,
+    "book_learn": [ [ "textbook_weapwest", 3 ], [ "recipe_melee", 3 ], [ "textbook_weparabic", 3 ], [ "textbook_armschina", 3 ] ],
     "using": [ [ "blacksmithing_standard", 12 ], [ "mc_steel_standard", 3 ] ],
     "proficiencies": [
       { "proficiency": "prof_metalworking" },
       { "proficiency": "prof_blacksmithing" },
-      { "proficiency": "prof_toolsmithing" },
       { "proficiency": "prof_carving", "skill_penalty": 0 },
       { "proficiency": "prof_leatherworking_basic", "skill_penalty": 0 }
     ],
@@ -1280,12 +1280,12 @@
     "skill_used": "fabrication",
     "difficulty": 4,
     "time": "3 h",
-    "book_learn": [ [ "textbook_weapwest", 3 ], [ "recipe_melee", 4 ], [ "textbook_weparabic", 3 ], [ "textbook_armschina", 3 ] ],
+    "autolearn": true,
+    "book_learn": [ [ "textbook_weapwest", 3 ], [ "recipe_melee", 3 ], [ "textbook_weparabic", 3 ], [ "textbook_armschina", 3 ] ],
     "using": [ [ "blacksmithing_standard", 12 ], [ "hc_steel_standard", 3 ] ],
     "proficiencies": [
       { "proficiency": "prof_metalworking" },
       { "proficiency": "prof_blacksmithing" },
-      { "proficiency": "prof_toolsmithing" },
       { "proficiency": "prof_carving", "skill_penalty": 0 },
       { "proficiency": "prof_leatherworking_basic", "skill_penalty": 0 }
     ],
@@ -1301,12 +1301,12 @@
     "skill_used": "fabrication",
     "difficulty": 5,
     "time": "15 h",
-    "book_learn": [ [ "textbook_weapwest", 4 ], [ "recipe_melee", 5 ], [ "textbook_weparabic", 4 ], [ "textbook_armschina", 4 ] ],
+    "autolearn": true,
+    "book_learn": [ [ "textbook_weapwest", 4 ], [ "recipe_melee", 4 ], [ "textbook_weparabic", 4 ], [ "textbook_armschina", 4 ] ],
     "using": [ [ "blacksmithing_standard", 12 ], [ "lc_steel_standard", 3 ] ],
     "proficiencies": [
       { "proficiency": "prof_metalworking" },
       { "proficiency": "prof_blacksmithing" },
-      { "proficiency": "prof_toolsmithing" },
       { "proficiency": "prof_carving", "skill_penalty": 0 },
       { "proficiency": "prof_leatherworking_basic", "skill_penalty": 0 },
       { "proficiency": "prof_case_hardening", "skill_penalty": 0 }
@@ -1323,12 +1323,12 @@
     "skill_used": "fabrication",
     "difficulty": 6,
     "time": "19 h",
-    "book_learn": [ [ "textbook_weapwest", 5 ], [ "recipe_melee", 6 ], [ "textbook_weparabic", 5 ], [ "textbook_armschina", 5 ] ],
+    "autolearn": true,
+    "book_learn": [ [ "textbook_weapwest", 5 ], [ "recipe_melee", 5 ], [ "textbook_weparabic", 5 ], [ "textbook_armschina", 5 ] ],
     "using": [ [ "blacksmithing_standard", 12 ], [ "mc_steel_standard", 3 ] ],
     "proficiencies": [
       { "proficiency": "prof_metalworking" },
       { "proficiency": "prof_blacksmithing" },
-      { "proficiency": "prof_toolsmithing" },
       { "proficiency": "prof_carving", "skill_penalty": 0 },
       { "proficiency": "prof_leatherworking_basic", "skill_penalty": 0 },
       { "proficiency": "prof_quenching", "skill_penalty": 1 }
@@ -1437,14 +1437,13 @@
     "category": "CC_*",
     "subcategory": "CSC_*_NESTED",
     "skill_used": "fabrication",
-    "difficulty": 5,
+    "difficulty": 3,
     "time": "3 h",
-    "book_learn": [ [ "bronze_book", 4 ], [ "bronze_mag", 4 ] ],
+    "book_learn": [ [ "bronze_book", 2 ], [ "bronze_mag", 2 ] ],
     "autolearn": true,
     "proficiencies": [
       { "proficiency": "prof_metalworking" },
       { "proficiency": "prof_redsmithing" },
-      { "proficiency": "prof_redsmithing_adv" },
       { "proficiency": "prof_carving", "skill_penalty": 0 }
     ],
     "using": [ [ "forging_standard", 1 ], [ "bronzesmithing_tools", 1 ] ],


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Audit mace recipes"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

I'm no blacksmith, but I figure that a mace is pretty simply a thing of metal on a stick, not something that should be gated behind books. They also had a toolsmithing prof assigned to them which feels like an error. 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Make maces autolearnt, remove extra prof, bronze mace isn't adv redsmithing. Also some difficulty tweaks here and there. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/ab21ee4c-f201-4447-bb16-cba22975587d" />

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
