### PR TITLE
Unload stack fix

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -8077,7 +8077,7 @@ void unload_loot_activity_actor::do_turn( player_activity &act, Character &you )
         bool unload_mods = false;
         bool unload_molle = false;
         bool unload_sparse_only = false;
-        int unload_sparse_threshold = 20;
+        int unload_sparse_threshold = 0;
 
         std::vector<zone_data const *> const zones = mgr.get_zones_at( src, zone_type_UNLOAD_ALL,
                 fac_id );
@@ -8088,7 +8088,9 @@ void unload_loot_activity_actor::do_turn( player_activity &act, Character &you )
             unload_molle |= options.unload_molle();
             unload_mods |= options.unload_mods();
             unload_sparse_only |= options.unload_sparse_only();
-            unload_sparse_threshold |= options.unload_sparse_threshold();
+            if (options.unload_sparse_only() && options.unload_sparse_threshold() > unload_sparse_threshold) {
+                unload_sparse_threshold = options.unload_sparse_threshold();
+            }
         }
 
         //Skip items that have already been processed

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -8088,7 +8088,7 @@ void unload_loot_activity_actor::do_turn( player_activity &act, Character &you )
             unload_molle |= options.unload_molle();
             unload_mods |= options.unload_mods();
             unload_sparse_only |= options.unload_sparse_only();
-            if (options.unload_sparse_only() && options.unload_sparse_threshold() > unload_sparse_threshold) {
+            if( options.unload_sparse_only() && options.unload_sparse_threshold() > unload_sparse_threshold ) {
                 unload_sparse_threshold = options.unload_sparse_threshold();
             }
         }

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -2320,7 +2320,7 @@ void activity_on_turn_move_loot( player_activity &act, Character &you )
         bool unload_mods = false;
         bool unload_molle = false;
         bool unload_sparse_only = false;
-        int unload_sparse_threshold = 20;
+        int unload_sparse_threshold = 0;
         bool unload_always = false;
 
         std::vector<zone_data const *> const zones = mgr.get_zones_at( src, zone_type_UNLOAD_ALL,
@@ -2332,7 +2332,9 @@ void activity_on_turn_move_loot( player_activity &act, Character &you )
             unload_molle |= options.unload_molle();
             unload_mods |= options.unload_mods();
             unload_sparse_only |= options.unload_sparse_only();
-            unload_sparse_threshold |= options.unload_sparse_threshold();
+            if (options.unload_sparse_only() && options.unload_sparse_threshold() > unload_sparse_threshold) {
+                unload_sparse_threshold = options.unload_sparse_threshold();
+            }
             unload_always |= options.unload_always();
         }
 

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -2332,7 +2332,7 @@ void activity_on_turn_move_loot( player_activity &act, Character &you )
             unload_molle |= options.unload_molle();
             unload_mods |= options.unload_mods();
             unload_sparse_only |= options.unload_sparse_only();
-            if (options.unload_sparse_only() && options.unload_sparse_threshold() > unload_sparse_threshold) {
+            if( options.unload_sparse_only() && options.unload_sparse_threshold() > unload_sparse_threshold ) {
                 unload_sparse_threshold = options.unload_sparse_threshold();
             }
             unload_always |= options.unload_always();


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Fix stack size limit for unload zones"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
I noticed that the setting in unload zones to control the max stack size that should be unloaded doesn't actually work. The stack size is initialized to 20 and then has a bitwise-or applied between that default value and the setting on the zone, which is a completely inappropriate operation to use. It results in a minimum size of 20 and very inconsistent behavior as to what the final stack size ends up being. E.g. putting in a size of 1 results in the game using 21 and putting in a size of 4 results in the game just using 20.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
To fix this I have the default value initialized to zero, then as the game iterates over each possible zone it will replace that value if it encounters a larger stack size setting on a matching zone that is configured to use a max stack size.

Note: I don't work with C++ much, so if there's a syntactically-better way to do this please let me know.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Let it continue not working?
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
I repeated similar things to what was outlined in #76216 . That issue wasn't quite right on what was happening (it's not straightforwardly adding 20), but it was at least right that it was broken. I've played around with various stack sizes and overlapping unload zones and everything seems to be working as expected now.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
fixes #76216
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
