### PR TITLE
fix how selection changes are handled in a uilist with disabled entries

### DIFF
--- a/src/uilist.cpp
+++ b/src/uilist.cpp
@@ -774,49 +774,63 @@ void uilist::reposition()
     setup();
 }
 
-
-int uilist::scroll_amount_from_action( const std::string &action )
+uilist::scroll_amount uilist::scroll_amount_from_action( const std::string &action )
 {
     const int scroll_rate = vmax > 20 ? 10 : 3;
     if( action == "UILIST.UP" ) {
-        return -1;
+        return uilist::scroll_amount::wrapped( -1 );
     } else if( action == "PAGE_UP" ) {
-        return -scroll_rate;
+        return uilist::scroll_amount::clamped( -scroll_rate );
     } else if( action == "HOME" ) {
-        return -fselected;
+        return uilist::scroll_amount::abs( 0 );
     } else if( action == "END" ) {
-        return fentries.size() - fselected - 1;
+        return uilist::scroll_amount::abs( static_cast<int>( fentries.size() - 1 ) );
     } else if( action == "UILIST.DOWN" ) {
-        return 1;
+        return uilist::scroll_amount::wrapped( 1 );
     } else if( action == "PAGE_DOWN" ) {
-        return scroll_rate;
+        return uilist::scroll_amount::clamped( scroll_rate );
     } else {
-        return 0;
+        return uilist::scroll_amount::clamped( 0 );
     }
 }
 
 /**
  * check for valid scrolling keypress and handle. return false if invalid keypress
  */
-bool uilist::scrollby( const int scrollby )
+bool uilist::scrollby( const uilist::scroll_amount scrollby )
 {
-    if( scrollby == 0 ) {
+    bool is_relative = scrollby.type == uilist::scroll_amount::relative_wrapped ||
+                       scrollby.type == uilist::scroll_amount::relative_clamped;
+    if( is_relative && scrollby.qty == 0 ) {
         return false;
     }
 
-    bool looparound = scrollby == -1 || scrollby == 1;
-    bool backwards = scrollby < 0;
+    bool may_wrap = scrollby.type == uilist::scroll_amount::relative_wrapped;
+    bool backwards = false;
+    if( may_wrap ) {
+        backwards = scrollby.qty < 0;
+    } else {
+        backwards = scrollby.qty > 0;
+    }
     int recmax = static_cast<int>( fentries.size() );
 
-    fselected += scrollby;
-    if( !looparound ) {
-        if( backwards && fselected < 0 ) {
+    if( scrollby.type == uilist::scroll_amount::absolute ) {
+        fselected = scrollby.qty;
+    } else {
+        fselected += scrollby.qty;
+    }
+
+    if( !may_wrap ) {
+        // if wrapping is not allowed then clamp to the bounds of the list
+        if( fselected < 0 ) {
             fselected = 0;
         } else if( fselected >= recmax ) {
             fselected = fentries.size() - 1;
         }
     }
 
+    // if the current selected entry is disabled, find the next
+    // enabled entry in the direction of movement
     if( backwards ) {
         if( fselected < 0 ) {
             fselected = fentries.size() - 1;

--- a/src/uilist.h
+++ b/src/uilist.h
@@ -300,7 +300,20 @@ class uilist // NOLINT(cata-xy)
         void setup();
         // initialize the window or reposition it after screen size change.
         void reposition();
-        bool scrollby( int scrollby );
+        struct scroll_amount {
+            enum { relative_wrapped, relative_clamped, absolute } type;
+            int qty;
+            static scroll_amount wrapped( int qty ) {
+                return {scroll_amount::relative_wrapped, qty};
+            };
+            static scroll_amount clamped( int qty ) {
+                return {scroll_amount::relative_clamped, qty};
+            };
+            static scroll_amount abs( int idx ) {
+                return {scroll_amount::absolute, idx};
+            };
+        };
+        bool scrollby( uilist::scroll_amount scrollby );
         void query( bool loop = true, int timeout = 50, bool allow_unfiltered_hotkeys = false );
         void filterlist();
         // In add_entry/add_entry_desc/add_entry_col, int k only support letters
@@ -404,7 +417,7 @@ class uilist // NOLINT(cata-xy)
         operator int() const;
 
     private:
-        int scroll_amount_from_action( const std::string &action );
+        scroll_amount scroll_amount_from_action( const std::string &action );
         // This function assumes it's being called from `query` and should
         // not be made public.
         void inputfilter();


### PR DESCRIPTION
#### Summary
Bugfixes "fix how selection changes are handled in a uilist with disabled entries"

#### Purpose of change

Fixes #83002

#### Describe the solution

If you type HOME in a uilist and the first entry of the list happens to be disabled then it keeps searching upwards in the list to find an enabled entry to land on. But that makes it wrap around to the bottom of the list, which is surprising. So don’t do that. But of course the up arrow key should wrap around, so make sure to keep doing that. And don’t forget that a similar thing could happen if you type END and end up on a disabled item at the bottom of the list.

#### Testing

The main menu is a nice long one to test in, with no disabled entries. It should keep working exactly as it already does. The Pocket Organization window has disabled entries, and the first entry in the list is always disabled, so it makes a good place to test the fix.