### PR TITLE
Fix text alignment in bandaging menu

### DIFF
--- a/src/character_body.cpp
+++ b/src/character_body.cpp
@@ -1125,9 +1125,9 @@ bodypart_id Character::body_window( const std::string &menu_header,
         parts.push_back( { false, part, part->name.translated(), normal_bonus } );
     }
 
-    int max_bp_name_len = 0;
+    float max_bp_name_len = 0;
     for( const healable_bp &e : parts ) {
-        max_bp_name_len = std::max( max_bp_name_len, utf8_width( e.name ) );
+        max_bp_name_len = std::max( max_bp_name_len, ImGui::CalcTextSize( e.name.c_str() ).x );
     }
 
     uilist bmenu;
@@ -1194,7 +1194,10 @@ bodypart_id Character::body_window( const std::string &menu_header,
         }
         int new_d_power = static_cast<int>( std::floor( disinfectant_power ) );
 
-        const auto &aligned_name = std::string( max_bp_name_len - utf8_width( e.name ), ' ' ) + e.name;
+        const float width_to_fill = max_bp_name_len - ImGui::CalcTextSize( e.name.c_str() ).x;
+        const int num_padding_spaces = std::ceil( width_to_fill / ImGui::CalcTextSize( " " ).x );
+
+        const auto &aligned_name = std::string( num_padding_spaces, ' ' ) + e.name;
         std::string hp_str;
         if( limb_is_mending ) {
             desc += colorize( _( "It is broken, but has been set, and just needs time to heal." ),


### PR DESCRIPTION
#### Summary
Interface "Fix text alignment in bandaging menu"

#### Purpose of change
Before (Roboto-Medium):

<img width="230" height="210" alt="image" src="https://github.com/user-attachments/assets/d1656a91-1462-4534-98bd-b8ae28c35f0a" />

Before(Unifont):

<img width="272" height="226" alt="image" src="https://github.com/user-attachments/assets/41bebcb0-3de5-4855-b696-77f7ddac6264" />

#### Describe the solution

After(Roboto-Medium):
<img width="248" height="221" alt="image" src="https://github.com/user-attachments/assets/1397c00d-b2ae-48c5-8bf6-500b4bc14512" />


After(Unifont):
<img width="285" height="215" alt="image" src="https://github.com/user-attachments/assets/699fcf64-e10b-4c91-8314-f78b99893b02" />


Swap out the utf8width calls with imgui's width calculations.


#### Describe alternatives you've considered
Why does Roboto-Medium die like this? No idea

https://github.com/CleverRaven/Cataclysm-DDA/pull/76529#issuecomment-3341608516

#### Testing
This would really really like some testing in curses

We have cataimgui::window::get_text_width() which explicitly falls back to utf8width when imtui(curses) is being used. Is that the actual correct behavior? It's possible this menu looks fine on curses currently but this PR (fixing it for tiles) will break it for curses.

#### Additional context
