### PR TITLE
dimension npc travel filter expansion and other tweaks

### DIFF
--- a/data/json/effects_on_condition/example_eocs.json
+++ b/data/json/effects_on_condition/example_eocs.json
@@ -534,11 +534,12 @@
         },
         "target_var": { "u_val": "destination_dimension" }
       },
-      { "u_location_variable": { "u_val": "tele_test" }, "x_adjust": 0, "y_adjust": 0 },
+      { "u_location_variable": { "u_val": "tele_test" } },
       {
         "u_teleport": { "u_val": "tele_test" },
         "dimension_prefix": { "u_val": "destination_dimension" },
-        "npc_radius": 5,
+        "npc_travel_radius": 5,
+        "npc_travel_filter": "follower",
         "fail_message": "your body doesn't move",
         "success_message": "This place feels different."
       },

--- a/data/json/effects_on_condition/example_eocs.json
+++ b/data/json/effects_on_condition/example_eocs.json
@@ -534,10 +534,8 @@
         },
         "target_var": { "u_val": "destination_dimension" }
       },
-      { "u_location_variable": { "u_val": "tele_test" } },
       {
-        "u_teleport": { "u_val": "tele_test" },
-        "dimension_prefix": { "u_val": "destination_dimension" },
+        "u_travel_to_dimension": { "u_val": "destination_dimension" },
         "npc_travel_radius": 5,
         "npc_travel_filter": "follower",
         "fail_message": "your body doesn't move",

--- a/doc/JSON/EFFECT_ON_CONDITION.md
+++ b/doc/JSON/EFFECT_ON_CONDITION.md
@@ -4348,9 +4348,7 @@ You or NPC is teleported to `target_var` coordinates
 | "success_message" | optional | string or [variable object](#variable-object) | message, that would be printed, if teleportation was successful | 
 | "fail_message" | optional | string or [variable object](#variable-object) | message, that would be printed, if teleportation was failed, like if coordinates contained creature or impassable obstacle (like wall) | 
 | "force" | optional | boolean | default false; if true, teleportation can't fail - any creature, that stand on target coordinates, would be brutally telefragged, and if impassable obstacle occur, the closest point would be picked instead |
-| "force_safe" | optional | boolean | default false; if true, teleportation cannot^(tm) fail.  If there is a creature or obstacle at the target coordinate, the closest passable point within 5 horizontal tiles is picked instead.  If there is no point, the creature remains where they are.
-| "dimension_prefix" | optional | string | default ""; if a value is specified, will teleport the player to a dimension named after the prefix. |
-| "npc_radius" | optional | int or [variable object](#variable-object) | default 0; if a value above 0 is specified, the NPCs within that radius around the player will be transported with them when dimension hopping. Does nothing if "dimension_prefix" isn't set. |
+| "force_safe" | optional | boolean | default false; if true, teleportation cannot^(tm) fail.  If there is a creature or obstacle at the target coordinate, the closest passable point within 5 horizontal tiles is picked instead.  If there is no point, the creature remains where they are. |
 
 ##### Valid talkers:
 
@@ -4386,6 +4384,12 @@ You teleport to a dimension with the ID of `test`, at the same position you're i
   "success_message": "This place feels different."
   }
 ```
+
+### `u_travel_to_dimension`
+Unloads the current dimension and loads the dimension with the specific ID, optionally brings along NPCs.
+| "u_travel_to_dimension" | **mandatory** | string | Will teleport the player to a dimension with the ID. |
+| "npc_travel_radius" | optional | int or [variable object](#variable-object) | default 0; if a value above 0 is specified, the NPCs within that radius around the player will be transported with them when dimension hopping. |
+| "npc_travel_filter" | optional | string or [variable object](#variable-object) | default `all`; Acceps the following values: `all`, `follower`, `enemy`. Does nothing if `npc_travel_radius` is 0. |
 
 #### `u_explosion`, `npc_explosion`
 Creates an explosion at talker position or at passed coordinate

--- a/doc/JSON/EFFECT_ON_CONDITION.md
+++ b/doc/JSON/EFFECT_ON_CONDITION.md
@@ -4373,23 +4373,31 @@ You teleport to `grass_place` with message `Yay!`; as `force` boolean is `true`,
 }
 ```
 
-You teleport to a dimension with the ID of `test`, at the same position you're in currently, bringing any NPC within 5 tiles of you along.
-```jsonc
-  {
-  "u_location_variable": { "u_val": "tele_test" },
-  "u_teleport": { "u_val":"tele_test" },
-  "dimension_prefix": "test",
-  "npc_radius": 5,
-  "fail_message": "your body doesn't move",
-  "success_message": "This place feels different."
-  }
-```
-
-### `u_travel_to_dimension`
+#### `u_travel_to_dimension`
 Unloads the current dimension and loads the dimension with the specific ID, optionally brings along NPCs.
 | "u_travel_to_dimension" | **mandatory** | string | Will teleport the player to a dimension with the ID. |
 | "npc_travel_radius" | optional | int or [variable object](#variable-object) | default 0; if a value above 0 is specified, the NPCs within that radius around the player will be transported with them when dimension hopping. |
 | "npc_travel_filter" | optional | string or [variable object](#variable-object) | default `all`; Acceps the following values: `all`, `follower`, `enemy`. Does nothing if `npc_travel_radius` is 0. |
+
+##### Valid talkers:
+
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------  --------- | ---- | ------- | --- | ---- |
+| ✔️ | ❌ | ❌ | ❌ | ❌ | ❌ |
+
+
+##### Examples
+
+You teleport to a dimension with the ID of `test`, at the same position you're in currently, bringing any NPC following you  within 5 tiles of you along.
+```jsonc
+  {
+  "u_travel_to_dimension": "test",
+  "npc_travel_radius": 5,
+  "npc_travel_filter": "follower",
+  "fail_message": "your body doesn't move",
+  "success_message": "This place feels different."
+  }
+```
 
 #### `u_explosion`, `npc_explosion`
 Creates an explosion at talker position or at passed coordinate

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -12743,7 +12743,7 @@ void game::vertical_move( int movez, bool force, bool peeking )
     cata_event_dispatch::avatar_moves( old_abs_pos, u, here );
 }
 
-bool game::travel_to_dimension( const std::string &new_prefix, const int &npc_radius )
+bool game::travel_to_dimension( const std::string &new_prefix, const std::vector<npc *> &npc_radius )
 {
     map &here = get_map();
     avatar &player = get_avatar();

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -12772,7 +12772,6 @@ bool game::travel_to_dimension( const std::string &new_prefix,
     } else {
         unload_npcs();
     }
-    save_dimension_data();
     for( monster &critter : all_monsters() ) {
         despawn_monster( critter );
     }
@@ -12780,7 +12779,7 @@ bool game::travel_to_dimension( const std::string &new_prefix,
         here.unboard_vehicle( player.pos_bub() );
     }
     // Make sure we don't mess up savedata if for some reason maps can't be saved
-    if( !save_maps() ) {
+    if( !save_maps() || !save_dimension_data() ) {
         return false;
     }
     player.save_map_memory();

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -12743,14 +12743,26 @@ void game::vertical_move( int movez, bool force, bool peeking )
     cata_event_dispatch::avatar_moves( old_abs_pos, u, here );
 }
 
-bool game::travel_to_dimension( const std::string &new_prefix, const std::vector<npc *> &npc_radius )
+bool game::travel_to_dimension( const std::string &new_prefix,
+                                const std::vector<npc *> &npc_travellers )
 {
     map &here = get_map();
     avatar &player = get_avatar();
-    if( npc_radius > 0 ) {
+    if( !npc_travellers.empty() ) {
+        int traveller_count = npc_travellers.size();
         for( auto it = critter_tracker->active_npc.begin(); it != critter_tracker->active_npc.end(); ) {
-            const int distance_to_player = rl_dist( ( *it )->pos_abs(), player.pos_abs() );
-            if( distance_to_player > npc_radius ) {
+            // skip unloading a traveller
+            bool skip = false;
+            if( traveller_count > 0 ) {
+                for( npc *guy : npc_travellers ) {
+                    if( guy->getID() == ( *it )->getID() ) {
+                        skip = true;
+                        traveller_count--;
+                        break;
+                    }
+                }
+            }
+            if( !skip ) {
                 ( *it )->on_unload();
                 it = critter_tracker->active_npc.erase( it );
             } else {

--- a/src/game.h
+++ b/src/game.h
@@ -334,7 +334,8 @@ class game
          * @param prefix identifies the dimension and its properties.
          * @param npc_travel_condition conditions that permit NPCs to travel with player to other dimensions
          */
-        bool travel_to_dimension( const std::string &prefix, const std::vector<npc *> &npc_travel_condition );
+        bool travel_to_dimension( const std::string &prefix,
+                                  const std::vector<npc *> &npc_travellers );
         /**
          * Retrieve the identifier of the current dimension.
          * TODO: this should be a dereferencable id that gives properties of the dimension.

--- a/src/game.h
+++ b/src/game.h
@@ -332,9 +332,9 @@ class game
         /**
          * Moves the player to an alternate dimension.
          * @param prefix identifies the dimension and its properties.
-         * @param npc_radius if not 0, bring any NPCs within distance with the player
+         * @param npc_travel_condition conditions that permit NPCs to travel with player to other dimensions
          */
-        bool travel_to_dimension( const std::string &prefix, const int &npc_radius );
+        bool travel_to_dimension( const std::string &prefix, const std::vector<npc *> &npc_travel_condition );
         /**
          * Retrieve the identifier of the current dimension.
          * TODO: this should be a dereferencable id that gives properties of the dimension.

--- a/src/game.h
+++ b/src/game.h
@@ -332,7 +332,7 @@ class game
         /**
          * Moves the player to an alternate dimension.
          * @param prefix identifies the dimension and its properties.
-         * @param npc_travel_condition conditions that permit NPCs to travel with player to other dimensions
+         * @param npc_travellers vector of NPCs that should be brought along when travelling to another dimension
          */
         bool travel_to_dimension( const std::string &prefix,
                                   const std::vector<npc *> &npc_travellers );

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -7670,20 +7670,19 @@ talk_effect_fun_t::func f_teleport( const JsonObject &jo, std::string_view membe
                 std::vector<npc *> travellers;
                 std::string filter = npc_travel_filter.evaluate( d );
                 int radius = npc_travel_radius.evaluate( d );
-                if( !filter.empty() && radius > 0 ) {
-                    std::vector<npc *> travellers = g->get_npcs_if( [teleporter, filter, radius]( const npc & guy ) {
-                        const int distance_to_player = rl_dist( guy.pos_abs(), teleporter->pos_abs() );
+                if( radius > 0 ) {
+                    travellers = g->get_npcs_if( [teleporter, filter, radius]( const npc & guy ) {
+                        int distance_to_player = rl_dist( guy.pos_abs(), teleporter->pos_abs() );
                         if( distance_to_player <= radius ) {
                             if( filter == "all" ) {
                                 return true;
-                            }
-                            if( filter == "follower" ) {
+                            } else if( filter == "follower" ) {
                                 return guy.is_following();
-                            }
-                            if( filter == "enemy" ) {
+                            } else if( filter == "enemy" ) {
                                 return guy.is_enemy();
+                            } else {
+                                return false;
                             }
-                            return false;
                         } else {
                             return false;
                         }

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -7651,10 +7651,11 @@ talk_effect_fun_t::func f_teleport( const JsonObject &jo, std::string_view membe
     optional( jo, false, "dimension_prefix", dimension_prefix, g->get_dimension_prefix() );
 
     // accepts values "all"/"follower"/"enemy"
-    str_or_var npc_travel_filter = get_str_or_var( jo.get_member( "npc_travel_filter" ),
-                                   "npc_travel_filter", false, "all" );
+    str_or_var npc_travel_filter;
+    optional( jo, false, "npc_travel_filter", npc_travel_filter, "all" );
 
-    dbl_or_var npc_travel_radius = get_dbl_or_var( jo, "npc_travel_radius", false, 0 );
+    dbl_or_var npc_travel_radius;
+    optional( jo, false, "npc_travel_radius", npc_travel_radius, 0 );
 
     return [is_npc, target_var, fail_message, success_message, force,
             force_safe, dimension_prefix, npc_travel_filter, npc_travel_radius]( dialogue const & d ) {

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -7697,7 +7697,8 @@ talk_effect_fun_t::func f_travel_to_dimension( const JsonObject &jo, std::string
         Creature *teleporter = d.actor( false )->get_creature();
         if( teleporter ) {
             std::string prefix = dimension_prefix.evaluate( d );
-            if( !prefix.empty() && prefix != g->get_dimension_prefix() ) {
+            std::string temp_dimension_prefix = ( prefix == "default" ) ? "" : prefix;
+            if( temp_dimension_prefix != g->get_dimension_prefix() ) {
                 std::vector<npc *> travellers;
                 std::string filter = npc_travel_filter.evaluate( d );
                 int radius = npc_travel_radius.evaluate( d );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Features "dimension npc travel filter expansion and other tweaks"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
#83032 was quite limited since it teleported all NPCs within radius with you.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Expand on #83032 by allowing to filter what NPCs will travel with you. Can filter by `all`, `follower`, `enemy`. Also omnibus i know, but I split off dimension travel into it's own eoc function `u_travel_to_dimension`, cause it was getting really silly during my attempts to integrate this into Sky Islands.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Letting modders figure out how to use this "npc dimension travel" feature without any filters.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Spawn NPCs, befriend some of them. use dimension swap eoc with the `npc_travel_filter` set to `follower`. Observe that NPCs within the radius of `npc_travel_radius` who are following me get transported with me. And those who weren't following me or outside that radius got unloaded.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
I'm taking steps to try integrating dimension system into Sky Islands, this PR is another step toward that goal.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
