### PR TITLE
Fix old cap that was limiting signalling range for hordes.

### DIFF
--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -437,7 +437,7 @@ static int get_signal_for_hordes( const centroid &centr )
     const int underground_div = 2; //Coefficient for volume reduction underground
     const int hordes_sig_div = SEEX; //Divider coefficient for hordes
     const int min_sig_cap = 8; //Signal for hordes can't be lower that this if it pass min_vol_cap
-    const int max_sig_cap = 26; //Signal for hordes can't be higher that this
+    const int max_sig_cap = 180; //Signal for hordes can't be higher that this
     //Lower the level - lower the sound
     int vol_hordes = ( ( centr.z < 0 ) ? vol / ( underground_div * std::abs( centr.z ) ) : vol );
     if( vol_hordes > min_vol_cap ) {


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Poking around at hordes perf (see #81077) I noticed not as many horde entities were being alerted by very loud noises as I expected.
After rooting around a bit I discovered the sound processing code was capping sounds it forwarded to hordes at 26 submaps worth of volume.

#### Describe the solution
Increase the cap to 180 submaps worth of volume.

#### Describe alternatives you've considered
Even bigger ranges are possible but hitting diminishing returns pretty hard.
Potentially capping the volume even higher here and just limiting propogation range would be better, this means that enemies more than about a km away aren't going to make it all the way to the player after one of these super loud sounds.

#### Testing
Started a new world.
Disabled save compression.
Triggered a very loud sound with debug menu (2000 volume)
Saved and exited.
Examined the main overmap, saw that many monsters in horde_map were targeting the same coordinates.
ran `grep -o "1020,1032,0" save/test_sound_2_the_revenge/o.0.0 | wc` to count the number of instances of that string, it was 18,160
After some more manual file munging than I want to go into, found that the total number of horde entities for that overmap is 23412, seems about right since it wouldn't reach the corners of the overmap.

#### Additional context
Very few horde entities were able to reach me, I think #83080 is pretty important. They seem to be getting stuck on buildings and such.