### PR TITLE
Update tilesets to display smaller hordes

### DIFF
--- a/gfx/ASCII_Overmap/tile_config.json
+++ b/gfx/ASCII_Overmap/tile_config.json
@@ -15,6 +15,7 @@
       "file": "ASCIITiles.png",
       "//": "range 1 to 191",
       "tiles": [
+        { "id": [ "overmap_horde_1", "overmap_horde_2" ], "fg": 185, "rotates": false },
         { "id": [ "overmap_horde_3", "overmap_horde_4", "overmap_horde_5", "overmap_horde_6" ], "fg": 185, "rotates": false },
         {
           "id": [ "overmap_horde_7", "overmap_horde_8", "overmap_horde_9", "overmap_horde_10" ],

--- a/gfx/Altica/tile_config.json
+++ b/gfx/Altica/tile_config.json
@@ -5956,6 +5956,7 @@
         { "id": "helipad_nw", "fg": [ 5427, 5426, 5428, 5429 ], "rotates": true },
         { "id": "helipad_se", "fg": [ 5431, 5430, 5432, 5433 ], "rotates": true },
         { "id": "helipad_sw", "fg": [ 5435, 5434, 5436, 5437 ], "rotates": true },
+        { "id": [ "overmap_horde_1", "overmap_horde_2" ], "fg": 5439, "rotates": false },
         { "id": [ "overmap_horde_3", "overmap_horde_4" ], "fg": 5439, "rotates": false },
         { "id": [ "overmap_horde_5", "overmap_horde_6" ], "fg": 5440, "rotates": false },
         { "id": [ "overmap_horde_7", "overmap_horde_8" ], "fg": 5441, "rotates": false },

--- a/gfx/ChibiUltica/tile_config.json
+++ b/gfx/ChibiUltica/tile_config.json
@@ -11008,6 +11008,7 @@
         { "id": "helipad_nw", "fg": [ 9378, 9377, 9379, 9380 ], "rotates": true },
         { "id": "helipad_se", "fg": [ 9382, 9381, 9383, 9384 ], "rotates": true },
         { "id": "helipad_sw", "fg": [ 9386, 9385, 9387, 9388 ], "rotates": true },
+        { "id": [ "overmap_horde_1", "overmap_horde_2" ], "fg": 9390, "rotates": false },
         { "id": [ "overmap_horde_3", "overmap_horde_4" ], "fg": 9390, "rotates": false },
         { "id": [ "overmap_horde_5", "overmap_horde_6" ], "fg": 9391, "rotates": false },
         { "id": [ "overmap_horde_7", "overmap_horde_8" ], "fg": 9392, "rotates": false },

--- a/gfx/Larwick_Overmap/tile_config.json
+++ b/gfx/Larwick_Overmap/tile_config.json
@@ -5234,6 +5234,7 @@
       "sprite_offset_x": 0,
       "sprite_offset_y": -4,
       "tiles": [
+        { "id": [ "overmap_horde_1", "overmap_horde_2" ], "fg": 416, "rotates": false },
         { "id": [ "overmap_horde_3", "overmap_horde_4" ], "fg": 416, "rotates": false },
         { "id": [ "overmap_horde_5", "overmap_horde_6" ], "fg": 417, "rotates": false },
         { "id": [ "overmap_horde_7", "overmap_horde_8" ], "fg": 418, "rotates": false },

--- a/gfx/MshockXotto+/tile_config.json
+++ b/gfx/MshockXotto+/tile_config.json
@@ -15754,6 +15754,8 @@
         { "id": "wizardtower1_roof", "fg": 9927 },
         { "id": "wizardtower2_roof", "fg": 9929 },
         { "id": "overmap_horde_10", "fg": 10014 },
+        { "id": "overmap_horde_1", "fg": 10015 },
+        { "id": "overmap_horde_2", "fg": 10015 },
         { "id": "overmap_horde_3", "fg": 10015 },
         { "id": "overmap_horde_4", "fg": 10016 },
         { "id": "overmap_horde_5", "fg": 10017 },

--- a/gfx/RetroDaysTileset/tile_config.json
+++ b/gfx/RetroDaysTileset/tile_config.json
@@ -5663,6 +5663,11 @@
           ]
         },
         {
+          "id": [ "overmap_horde_1", "overmap_horde_2" ],
+          "fg": 2719,
+          "rotates": false
+        },
+        {
           "id": [ "overmap_horde_3", "overmap_horde_4", "overmap_horde_5", "overmap_horde_6" ],
           "fg": 2719,
           "rotates": false

--- a/gfx/SurveyorsMap/tile_config.json
+++ b/gfx/SurveyorsMap/tile_config.json
@@ -3928,6 +3928,7 @@
       "sprite_offset_x": 0,
       "sprite_offset_y": -10,
       "tiles": [
+        { "id": [ "overmap_horde_1", "overmap_horde_2" ], "fg": 8368, "rotates": false },
         { "id": [ "overmap_horde_3", "overmap_horde_4" ], "fg": 8368, "rotates": false },
         { "id": [ "overmap_horde_5", "overmap_horde_6" ], "fg": 8369, "rotates": false },
         { "id": [ "overmap_horde_7", "overmap_horde_8" ], "fg": 8370, "rotates": false },

--- a/gfx/UltimateCataclysm/tile_config.json
+++ b/gfx/UltimateCataclysm/tile_config.json
@@ -5572,6 +5572,7 @@
         { "id": "helipad_nw", "fg": [ 5048, 5047, 5049, 5050 ], "rotates": true },
         { "id": "helipad_se", "fg": [ 5052, 5051, 5053, 5054 ], "rotates": true },
         { "id": "helipad_sw", "fg": [ 5056, 5055, 5057, 5058 ], "rotates": true },
+        { "id": [ "overmap_horde_1", "overmap_horde_2" ], "fg": 5060, "rotates": false },
         { "id": [ "overmap_horde_3", "overmap_horde_4" ], "fg": 5060, "rotates": false },
         { "id": [ "overmap_horde_5", "overmap_horde_6" ], "fg": 5061, "rotates": false },
         { "id": [ "overmap_horde_7", "overmap_horde_8" ], "fg": 5062, "rotates": false },


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
New hordes (see #81077) use the full range of overmap_horde_X sprites now, but the old system only used the ones 3 and higher, so tilesets only supported those.
As a result smaller hordes (less than about 12 per OMT) were not being displayed at all.

#### Describe the solution
Alias overmap_horde_1 and overmap_horde_2 to use whatever sprite a given tileset was using for oveermap_horde_3

#### Describe alternatives you've considered
These might not be ideal, but this at least fixes "smaller hordes are completely invisible" issue.

#### Testing
Made the change, was able to see smaller hordes in overmap view.