### PR TITLE
Give hordes a little bit of obstacle avoidance ability

### DIFF
--- a/src/coordinates.h
+++ b/src/coordinates.h
@@ -1033,6 +1033,39 @@ std::vector < coords::coord_point_ib < Tripoint, Origin, Scale>>
     return result;
 }
 
+// Returns the coordinates adjacent to loc1 that are closer to loc2 than loc1 is.
+// Out-of-bounds version.
+template<typename Tripoint, coords::origin Origin, coords::scale Scale,
+         std::enable_if_t<std::is_same_v<Tripoint, tripoint>, int> = 0>
+std::vector < coords::coord_point < Tripoint, Origin, Scale >>
+        squares_closer_to( const coords::coord_point_ob<Tripoint, Origin, Scale> &loc1,
+                           const coords::coord_point_ob<Tripoint, Origin, Scale> &loc2 )
+{
+    std::vector<Tripoint> raw_result = squares_closer_to( loc1.raw(), loc2.raw() );
+    std::vector < coords::coord_point < Tripoint, Origin, Scale>> result;
+    std::transform( raw_result.begin(), raw_result.end(), std::back_inserter( result ),
+    []( const Tripoint & p ) {
+        return coords::coord_point < Tripoint, Origin, Scale >::make_unchecked( p );
+    } );
+    return result;
+}
+
+// Returns the coordinates adjacent to loc1 that are closer to loc2 than loc1 is.
+// Out-of-bounds version.
+template<typename Tripoint, coords::origin Origin, coords::scale Scale,
+         std::enable_if_t<std::is_same_v<Tripoint, tripoint>, int> = 0>
+std::vector < coords::coord_point_ib < Tripoint, Origin, Scale>>
+        squares_closer_to( const coords::coord_point_ib<Tripoint, Origin, Scale> &loc1,
+                           const coords::coord_point_ib<Tripoint, Origin, Scale> &loc2 )
+{
+    std::vector<Tripoint> raw_result = squares_closer_to( loc1.raw(), loc2.raw() );
+    std::vector < coords::coord_point_ib < Tripoint, Origin, Scale >> result;
+    std::transform( raw_result.begin(), raw_result.end(), std::back_inserter( result ),
+    []( const Tripoint & p ) {
+        return coords::coord_point_ib < Tripoint, Origin, Scale >::make_unchecked( p );
+    } );
+    return result;
+}
 
 template<typename Point, coords::origin Origin, coords::scale Scale>
 coords::coord_point < Point, Origin, Scale >

--- a/src/line.cpp
+++ b/src/line.cpp
@@ -725,37 +725,37 @@ std::string direction_suffix( const tripoint_abs_ms &p, const tripoint_abs_ms &q
 // Sub-sub-cardinals are direction && abs(x) > abs(y) or vice versa.
 // Result is adjacent cardinal and sub-cardinals, plus the nearest other cardinal.
 // e.g. if the direction is NNE, also include E.
-std::vector<tripoint_bub_ms> squares_closer_to( const tripoint_bub_ms &from,
-        const tripoint_bub_ms &to )
+std::vector<tripoint> squares_closer_to( const tripoint &from,
+        const tripoint &to )
 {
-    std::vector<tripoint_bub_ms> adjacent_closer_squares;
+    std::vector<tripoint> adjacent_closer_squares;
     adjacent_closer_squares.reserve( 5 );
-    const tripoint_rel_ms d( to - from );
-    const point a( std::abs( d.x() ), std::abs( d.y() ) );
-    if( d.z() != 0 ) {
-        adjacent_closer_squares.push_back( from + tripoint( sgn( d.x() ), sgn( d.y() ), sgn( d.z() ) ) );
+    const tripoint d( to - from );
+    const point a( std::abs( d.x ), std::abs( d.y ) );
+    if( d.z != 0 ) {
+        adjacent_closer_squares.push_back( from + tripoint( sgn( d.x ), sgn( d.y ), sgn( d.z ) ) );
     }
     if( a.x > a.y ) {
         // X dominant.
-        adjacent_closer_squares.push_back( from + point( sgn( d.x() ), 0 ) );
-        adjacent_closer_squares.push_back( from + point( sgn( d.x() ), 1 ) );
-        adjacent_closer_squares.push_back( from + point( sgn( d.x() ), -1 ) );
-        if( d.y() != 0 ) {
-            adjacent_closer_squares.push_back( from + point( 0, sgn( d.y() ) ) );
+        adjacent_closer_squares.push_back( from + point( sgn( d.x ), 0 ) );
+        adjacent_closer_squares.push_back( from + point( sgn( d.x ), 1 ) );
+        adjacent_closer_squares.push_back( from + point( sgn( d.x ), -1 ) );
+        if( d.y != 0 ) {
+            adjacent_closer_squares.push_back( from + point( 0, sgn( d.y ) ) );
         }
     } else if( a.x < a.y ) {
         // Y dominant.
-        adjacent_closer_squares.push_back( from + point( 0, sgn( d.y() ) ) );
-        adjacent_closer_squares.push_back( from + point( 1, sgn( d.y() ) ) );
-        adjacent_closer_squares.push_back( from + point( -1, sgn( d.y() ) ) );
-        if( d.x() != 0 ) {
-            adjacent_closer_squares.push_back( from + point( sgn( d.x() ), 0 ) );
+        adjacent_closer_squares.push_back( from + point( 0, sgn( d.y ) ) );
+        adjacent_closer_squares.push_back( from + point( 1, sgn( d.y ) ) );
+        adjacent_closer_squares.push_back( from + point( -1, sgn( d.y ) ) );
+        if( d.x != 0 ) {
+            adjacent_closer_squares.push_back( from + point( sgn( d.x ), 0 ) );
         }
-    } else if( d.x() != 0 ) {
+    } else if( d.x != 0 ) {
         // Pure diagonal.
-        adjacent_closer_squares.push_back( from + point( sgn( d.x() ), sgn( d.y() ) ) );
-        adjacent_closer_squares.push_back( from + point( sgn( d.x() ), 0 ) );
-        adjacent_closer_squares.push_back( from + point( 0, sgn( d.y() ) ) );
+        adjacent_closer_squares.push_back( from + point( sgn( d.x ), sgn( d.y ) ) );
+        adjacent_closer_squares.push_back( from + point( sgn( d.x ), 0 ) );
+        adjacent_closer_squares.push_back( from + point( 0, sgn( d.y ) ) );
     }
 
     return adjacent_closer_squares;

--- a/src/line.h
+++ b/src/line.h
@@ -297,8 +297,7 @@ std::vector<point_bub_ms> squares_in_direction( const point_bub_ms &p1, const po
 std::vector<point_omt_ms> squares_in_direction( const point_omt_ms &p1, const point_omt_ms &p2 );
 // Returns a vector of squares adjacent to @from that are closer to @to than @from is.
 // Currently limited to the same z-level as @from.
-std::vector<tripoint_bub_ms> squares_closer_to( const tripoint_bub_ms &from,
-        const tripoint_bub_ms &to );
+std::vector<tripoint> squares_closer_to( const tripoint &from, const tripoint &to );
 void calc_ray_end( units::angle, int range, const tripoint &p, tripoint &out );
 template<typename Point, coords::origin Origin, coords::scale Scale>
 void calc_ray_end( units::angle angle, int range,

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -1132,7 +1132,8 @@ void monster::move()
         // This is a float and using trig_dist() because that Does the Right Thing(tm)
         // in both circular and roguelike distance modes.
         const float distance_to_target = trig_dist( pos_bub(), destination );
-        for( tripoint_bub_ms &candidate : squares_closer_to( pos_bub(), destination ) ) {
+        tripoint_bub_ms loc = pos_bub();
+        for( tripoint_bub_ms &candidate : squares_closer_to( loc, destination ) ) {
             // rare scenario when monster is on the border of the map and it's goal is outside of the map
             if( !here.inbounds( candidate ) ) {
                 continue;

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -4319,11 +4319,12 @@ void overmap::move_hordes()
                 continue;
             }
             std::vector<tripoint_abs_ms> viable_candidates;
-            // TODO: wandering, pathing.
-            tripoint_abs_ms candidate = line_to( mon->first, mon->second.destination ).front();
             // Call up to overmapbuffer in case it needs to dispatch to an adjacent overmap.
-            if( overmap_buffer.passable( candidate ) ) {
-                viable_candidates.push_back( candidate );
+            for( const tripoint_abs_ms &candidate :
+                 squares_closer_to( mon->first, mon->second.destination ) ) {
+                if( overmap_buffer.passable( candidate ) ) {
+                    viable_candidates.push_back( candidate );
+                }
             }
             if( viable_candidates.empty() ) {
                 // We're stuck.
@@ -4336,6 +4337,8 @@ void overmap::move_hordes()
             if( viable_candidates.front() == mon->second.destination ) {
                 mon->second.tracking_intensity = 0;
             }
+            // squares_closer_to already orders candidates by how close to the main line they are.
+            // For now just pick the first non-blocked square, later we could fuzz/stumble.
             if( get_map().inbounds( viable_candidates.front() ) ) {
                 monster *placed_monster = nullptr;
                 if( mon->second.monster_data ) {

--- a/tests/line_test.cpp
+++ b/tests/line_test.cpp
@@ -343,11 +343,11 @@ TEST_CASE( "squares_closer_to_test", "[line]" )
     expected = { tripoint_bub_ms::zero + tripoint::west, tripoint_bub_ms::zero + tripoint::south_west, tripoint_bub_ms::zero + tripoint::north_west, tripoint_bub_ms::zero + tripoint::north};
     CHECK( actual == expected );
 
-    actual = squares_closer_to( {10, -10, 0}, {10, 10, 0} );
+    actual = squares_closer_to( tripoint_bub_ms{10, -10, 0}, {10, 10, 0} );
     expected = {tripoint_bub_ms( 10, -9, 0 ), tripoint_bub_ms( 11, -9, 0 ), tripoint_bub_ms( 9, -9, 0 )};
     CHECK( actual == expected );
 
-    actual = squares_closer_to( {10, -10, 0}, {-10, -5, 0} );
+    actual = squares_closer_to( tripoint_bub_ms{10, -10, 0}, {-10, -5, 0} );
     expected = {tripoint_bub_ms( 9, -10, 0 ), tripoint_bub_ms( 9, -9, 0 ), tripoint_bub_ms( 9, -11, 0 ), tripoint_bub_ms( 10, -9, 0 )};
     CHECK( actual == expected );
 }


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
As I noted in #83083 horde entities ere having a lot of trouble getting to me, and I guessed this is because they were getting stuck on things because they would only follow a straight route to their destination.
Fixes #83080 

#### Describe the solution
Enumerate the 3-4 squares closer to the goal location than the current location and pick the first one that isn't blocked.

#### Describe alternatives you've considered
Probably will want to come back and do a weighted random thing similar to regular zombie stumbling, but this is fine for now.

#### Testing
Observed most of the horde entities from a nearby town being able to make it to my location, not just ones that could make a beeline for me.
Also observed horde entities making their way through a forest.

#### Additional context
Here are the results of triggering a volume 2,000 sound just a bit outside a middling sized town.
<img width="245" height="208" alt="Screenshot from 2025-09-28 15-29-39" src="https://github.com/user-attachments/assets/af92d730-56a4-42a9-a095-3828b8868de7" />
<img width="732" height="1262" alt="Screenshot from 2025-09-28 16-01-43" src="https://github.com/user-attachments/assets/d4d35051-838f-49a6-8c87-4ed5aa0958a1" />
