### PR TITLE
[Magiclysm] Add a few more spells

### DIFF
--- a/data/mods/Magiclysm/Spells/biomancer.json
+++ b/data/mods/Magiclysm/Spells/biomancer.json
@@ -839,5 +839,27 @@
     "base_energy_cost": 1200,
     "extra_effects": [ { "id": "eoc_enhancement_setup", "hit_self": true }, { "id": "biomantic_pain_caused_light", "hit_self": true } ],
     "base_casting_time": 6000
+  },
+  {
+    "id": "biomancer_pull_items_from_distance",
+    "type": "SPELL",
+    "name": "Monstrous Grasp",
+    "description": "Extend a tentacle with a myriad of grasping appendages, grasping an item and dragging it back to you.  This spell is slightly painful due to the rapidity of the transformation.",
+    "valid_targets": [ "ally", "hostile", "item", "ground" ],
+    "spell_class": "BIOMANCER",
+    "flags": [ "TRANSFORMATION_SPELL", "CONCENTRATE", "VERBAL", "SOMATIC", "NO_HANDS" ],
+    "extra_effects": [ { "id": "eoc_transformation_setup", "hit_self": true }, { "id": "biomantic_pain_caused_light", "hit_self": true } ],
+    "difficulty": 4,
+    "max_level": 10,
+    "effect": "pickup",
+    "shape": "blast",
+    "min_damage": { "math": [ "350 - (u_spell_level('biomancer_pull_items_from_distance') * 12)" ] },
+    "max_damage": { "math": [ "350 - (u_spell_level('biomancer_pull_items_from_distance') * 12)" ] },
+    "min_range": 3,
+    "max_range": 8,
+    "range_increment": 0.5,
+    "magic_type": "magiclysm_generic_magic",
+    "base_energy_cost": 100,
+    "base_casting_time": 150
   }
 ]

--- a/data/mods/Magiclysm/Spells/earthshaper.json
+++ b/data/mods/Magiclysm/Spells/earthshaper.json
@@ -1316,5 +1316,59 @@
         "else": { "u_message": "You must be on the living earth to use Earth Gate.", "type": "bad" }
       }
     ]
+  },
+  {
+    "id": "earthshaper_remove_corpses",
+    "type": "SPELL",
+    "name": "The Last Embrace",
+    "description": "A truly ancient spell, its use attested in funeral rites from prehistoric times, The Last Embrace causes all bodies within its area of effect to sinkn within the living earth, coming to rest in a natural tomb.  It only works on earth or stone.",
+    "valid_targets": [ "self" ],
+    "flags": [ "CHANNELING_SPELL", "SOMATIC", "LOUD", "NO_PROJECTILE" ],
+    "extra_effects": [ { "id": "eoc_channeling_setup", "hit_self": true } ],
+    "effect": "effect_on_condition",
+    "effect_str": "EOC_EARTHSHAPER_REMOVE_CORPSES",
+    "shape": "blast",
+    "difficulty": 4,
+    "spell_class": "EARTHSHAPER",
+    "teachable": false,
+    "max_level": 15,
+    "magic_type": "magiclysm_generic_magic",
+    "base_energy_cost": 150,
+    "base_casting_time": 1200
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_EARTHSHAPER_REMOVE_CORPSES",
+    "effect": [
+      {
+        "u_query_tile": "line_of_sight",
+        "target_var": { "context_val": "earthshaper_target_point" },
+        "range": { "math": [ "(u_spell_level('earthshaper_remove_corpses') + 3)" ] },
+        "z_level": false,
+        "message": "Select diggable ground."
+      },
+      {
+        "u_map_run_eocs": [
+          {
+            "id": "EOC_EARTHSHAPER_REMOVE_CORPSES_PER_TILE",
+            "effect": [
+              {
+                "u_map_run_item_eocs": "all",
+                "loc": { "context_val": "earthshaper_digging_point" },
+                "min_radius": 0,
+                "max_radius": 0,
+                "search_data": [ { "flags": [ "CORPSE" ] } ],
+                "true_eocs": [ { "id": "EOC_EARTHSHAPER_REMOVE_CORPSES_HIT_CORPSES", "effect": [ "npc_die" ] } ]
+              }
+            ]
+          }
+        ],
+        "range": { "math": [ "( (u_spell_level('earthshaper_remove_corpses') * 0.15) + 1)" ] },
+        "store_coordinates_in": { "context_val": "earthshaper_digging_point" },
+        "stop_at_first": false,
+        "target_var": { "context_val": "earthshaper_target_point" },
+        "condition": { "map_terrain_with_flag": "DIGGABLE", "loc": { "context_val": "earthshaper_target_point" } }
+      }
+    ]
   }
 ]

--- a/data/mods/Magiclysm/Spells/earthshaper.json
+++ b/data/mods/Magiclysm/Spells/earthshaper.json
@@ -1321,7 +1321,7 @@
     "id": "earthshaper_remove_corpses",
     "type": "SPELL",
     "name": "The Last Embrace",
-    "description": "A truly ancient spell, its use attested in funeral rites from prehistoric times, The Last Embrace causes all bodies within its area of effect to sinkn within the living earth, coming to rest in a natural tomb.  It only works on earth or stone.",
+    "description": "A truly ancient spell, its use attested in funeral rites from prehistoric times, The Last Embrace causes all bodies within its area of effect to sink within the living earth, coming to rest in a natural tomb.  It only works on earth or stone.",
     "valid_targets": [ "self" ],
     "flags": [ "CHANNELING_SPELL", "SOMATIC", "LOUD", "NO_PROJECTILE" ],
     "extra_effects": [ { "id": "eoc_channeling_setup", "hit_self": true } ],
@@ -1334,6 +1334,8 @@
     "max_level": 15,
     "magic_type": "magiclysm_generic_magic",
     "base_energy_cost": 150,
+    "final_energy_cost": 50,
+    "energy_increment": -7,
     "base_casting_time": 1200
   },
   {
@@ -1367,7 +1369,13 @@
         "store_coordinates_in": { "context_val": "earthshaper_digging_point" },
         "stop_at_first": false,
         "target_var": { "context_val": "earthshaper_target_point" },
-        "condition": { "map_terrain_with_flag": "DIGGABLE", "loc": { "context_val": "earthshaper_target_point" } }
+        "condition": {
+          "or": [
+            { "map_terrain_id": "t_rock_floor_no_roof", "loc": { "context_val": "earthshaper_target_point" } },
+            { "map_terrain_id": "t_rock_floor", "loc": { "context_val": "earthshaper_target_point" } },
+            { "map_terrain_with_flag": "DIGGABLE", "loc": { "context_val": "earthshaper_target_point" } }
+          ]
+        }
       }
     ]
   }

--- a/data/mods/Magiclysm/Spells/magus.json
+++ b/data/mods/Magiclysm/Spells/magus.json
@@ -678,12 +678,9 @@
         "then": {
           "run_eocs": {
             "id": "EOC_MAGUS_FAR_HAND_PULL_CREATURE",
-            "effect": [ { "npc_cast_spell": { "id": "magus_far_hand_pull_creatures" }, "loc": { "context_val": "pos" } } ]
-          },
-          "alpha_loc": { "context_val": "pos" },
-          "false_eocs": {
-            "id": "EOC_MAGUS_FAR_HAND_PULL_ITEMS",
-            "effect": { "npc_cast_spell": { "id": "magus_far_hand_pull_items" }, "loc": { "context_val": "pos" } }
+            "condition": "has_alpha",
+            "effect": [ { "npc_cast_spell": { "id": "magus_far_hand_pull_creatures" }, "loc": { "context_val": "pos" } } ],
+            "false_effect": [ { "npc_cast_spell": { "id": "magus_far_hand_pull_items" }, "loc": { "context_val": "pos" } } ]
           }
         }
       }

--- a/data/mods/Magiclysm/Spells/magus.json
+++ b/data/mods/Magiclysm/Spells/magus.json
@@ -668,30 +668,30 @@
     "id": "EOC_MAGUS_FAR_HAND_PULL",
     "effect": [
       {
-        "u_query_tile": "line_of_sight",
-        "range": { "math": [ "u_spell_level('magus_far_hand_pull')" ] },
-        "target_var": { "context_val": "pos" },
-        "message": "Select target"
-      },
-      {
-        "if": { "math": [ "has_var(_pos)" ] },
-        "then": {
-          "run_eocs": {
-            "id": "EOC_MAGUS_FAR_HAND_PULL_CREATURE",
-            "condition": "has_alpha",
-            "effect": [ { "npc_cast_spell": { "id": "magus_far_hand_pull_creatures" }, "loc": { "context_val": "pos" } } ],
-            "false_effect": [ { "npc_cast_spell": { "id": "magus_far_hand_pull_items" }, "loc": { "context_val": "pos" } } ]
-          }
-        }
+        "run_eoc_selector": [ "EOC_MAGUS_FAR_HAND_PULL_ITEM", "EOC_MAGUS_FAR_HAND_PULL_CREATURE" ],
+        "names": [ "Grab Item", "Pull Creature" ],
+        "keys": [ "a", "b" ],
+        "allow_cancel": true,
+        "descriptions": [ "Pick up an item and pull it to you", "Target a creature and pull it toward you" ]
       }
     ]
   },
   {
+    "type": "effect_on_condition",
+    "id": "EOC_MAGUS_FAR_HAND_PULL_ITEM",
+    "effect": [ { "u_cast_spell": { "id": "magus_far_hand_pull_items" }, "targeted": true } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_MAGUS_FAR_HAND_PULL_CREATURE",
+    "effect": [ { "u_cast_spell": { "id": "magus_far_hand_pull_creatures" }, "targeted": true } ]
+  },
+  {
     "id": "magus_far_hand_pull_creatures",
     "type": "SPELL",
-    "name": "Sorcerer's Hand",
-    "description": "Pull a target or set of items to you.",
-    "valid_targets": [ "ally", "hostile", "item", "ground" ],
+    "name": { "str": "Sorcerer's Hand Creature", "//~": "NO_I18N" },
+    "description": { "str": "Pull a target to you.", "//~": "NO_I18N" },
+    "valid_targets": [ "ally", "hostile" ],
     "spell_class": "MAGUS",
     "flags": [ "CONCENTRATE", "VERBAL", "SOMATIC", "NO_HANDS" ],
     "difficulty": 2,
@@ -700,15 +700,15 @@
     "shape": "blast",
     "min_damage": { "math": [ "u_spell_level('magus_far_hand_pull') * -1" ] },
     "max_damage": { "math": [ "u_spell_level('magus_far_hand_pull') * -1" ] },
-    "min_range": 50,
-    "max_range": 50,
+    "min_range": { "math": [ "(u_spell_level('magus_far_hand_pull') * 1) + 3" ] },
+    "max_range": { "math": [ "(u_spell_level('magus_far_hand_pull') * 1) + 3" ] },
     "magic_type": "magiclysm_generic_magic"
   },
   {
     "id": "magus_far_hand_pull_items",
     "type": "SPELL",
-    "name": "Sorcerer's Hand",
-    "description": "Pull a target or set of items to you.",
+    "name": { "str": "Sorcerer's Hand Items", "//~": "NO_I18N" },
+    "description": { "str": "Pull an items to you.", "//~": "NO_I18N" },
     "valid_targets": [ "ally", "hostile", "item", "ground" ],
     "spell_class": "MAGUS",
     "flags": [ "CONCENTRATE", "VERBAL", "SOMATIC", "NO_HANDS" ],
@@ -718,8 +718,8 @@
     "shape": "blast",
     "min_damage": { "math": [ "250 - (u_spell_level('magus_far_hand_pull') * 10)" ] },
     "max_damage": { "math": [ "250 - (u_spell_level('magus_far_hand_pull') * 10)" ] },
-    "min_range": 50,
-    "max_range": 50,
+    "min_range": { "math": [ "(u_spell_level('magus_far_hand_pull') * 1) + 3" ] },
+    "max_range": { "math": [ "(u_spell_level('magus_far_hand_pull') * 1) + 3" ] },
     "magic_type": "magiclysm_generic_magic"
   },
   {

--- a/data/mods/Magiclysm/Spells/magus.json
+++ b/data/mods/Magiclysm/Spells/magus.json
@@ -646,20 +646,15 @@
     "type": "SPELL",
     "name": "Sorcerer's Hand",
     "description": "Pull a target or set of items to you.",
-    "valid_targets": [ "ally", "hostile", "item", "ground" ],
+    "valid_targets": [ "self" ],
     "spell_class": "MAGUS",
     "flags": [ "EVOCATION_SPELL", "CONCENTRATE", "VERBAL", "SOMATIC", "NO_HANDS" ],
     "extra_effects": [ { "id": "eoc_evocation_setup", "hit_self": true } ],
     "difficulty": 2,
     "max_level": 10,
-    "effect": "directed_push",
+    "effect": "effect_on_condition",
+    "effect_str": "EOC_MAGUS_FAR_HAND_PULL",
     "shape": "blast",
-    "min_damage": -1,
-    "max_damage": -10,
-    "damage_increment": -1,
-    "min_range": 1,
-    "max_range": 10,
-    "range_increment": 1,
     "magic_type": "magiclysm_generic_magic",
     "base_energy_cost": 200,
     "final_energy_cost": 50,
@@ -667,6 +662,68 @@
     "base_casting_time": 150,
     "final_casting_time": 50,
     "casting_time_increment": -10
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_MAGUS_FAR_HAND_PULL",
+    "effect": [
+      {
+        "u_query_tile": "line_of_sight",
+        "range": { "math": [ "u_spell_level('magus_far_hand_pull')" ] },
+        "target_var": { "context_val": "pos" },
+        "message": "Select target"
+      },
+      {
+        "if": { "math": [ "has_var(_pos)" ] },
+        "then": {
+          "run_eocs": {
+            "id": "EOC_MAGUS_FAR_HAND_PULL_CREATURE",
+            "effect": [ { "npc_cast_spell": { "id": "magus_far_hand_pull_creatures" }, "loc": { "context_val": "pos" } } ]
+          },
+          "alpha_loc": { "context_val": "pos" },
+          "false_eocs": {
+            "id": "EOC_MAGUS_FAR_HAND_PULL_ITEMS",
+            "effect": { "npc_cast_spell": { "id": "magus_far_hand_pull_items" }, "loc": { "context_val": "pos" } }
+          }
+        }
+      }
+    ]
+  },
+  {
+    "id": "magus_far_hand_pull_creatures",
+    "type": "SPELL",
+    "name": "Sorcerer's Hand",
+    "description": "Pull a target or set of items to you.",
+    "valid_targets": [ "ally", "hostile", "item", "ground" ],
+    "spell_class": "MAGUS",
+    "flags": [ "CONCENTRATE", "VERBAL", "SOMATIC", "NO_HANDS" ],
+    "difficulty": 2,
+    "max_level": 10,
+    "effect": "directed_push",
+    "shape": "blast",
+    "min_damage": { "math": [ "u_spell_level('magus_far_hand_pull') * -1" ] },
+    "max_damage": { "math": [ "u_spell_level('magus_far_hand_pull') * -1" ] },
+    "min_range": 50,
+    "max_range": 50,
+    "magic_type": "magiclysm_generic_magic"
+  },
+  {
+    "id": "magus_far_hand_pull_items",
+    "type": "SPELL",
+    "name": "Sorcerer's Hand",
+    "description": "Pull a target or set of items to you.",
+    "valid_targets": [ "ally", "hostile", "item", "ground" ],
+    "spell_class": "MAGUS",
+    "flags": [ "CONCENTRATE", "VERBAL", "SOMATIC", "NO_HANDS" ],
+    "difficulty": 2,
+    "max_level": 10,
+    "effect": "pickup",
+    "shape": "blast",
+    "min_damage": { "math": [ "250 - (u_spell_level('magus_far_hand_pull') * 10)" ] },
+    "max_damage": { "math": [ "250 - (u_spell_level('magus_far_hand_pull') * 10)" ] },
+    "min_range": 50,
+    "max_range": 50,
+    "magic_type": "magiclysm_generic_magic"
   },
   {
     "id": "magus_ranged_increase",

--- a/data/mods/Magiclysm/itemgroups/itemgroups.json
+++ b/data/mods/Magiclysm/itemgroups/itemgroups.json
@@ -1481,7 +1481,8 @@
           { "item": "spell_scroll_biomancer_visceral_projection", "prob": 50 },
           { "item": "spell_scroll_biomancer_swim_frog", "prob": 35 },
           { "item": "spell_scroll_biomancer_cure_disease_minor", "prob": 50 },
-          { "item": "spell_scroll_biomancer_eat_tons_of_food", "prob": 30 }
+          { "item": "spell_scroll_biomancer_eat_tons_of_food", "prob": 30 },
+          { "item": "spell_scroll_biomancer_pull_items_from_distance", "prob": 30 }
         ],
         "prob": 45
       },

--- a/data/mods/Magiclysm/itemgroups/itemgroups.json
+++ b/data/mods/Magiclysm/itemgroups/itemgroups.json
@@ -1435,7 +1435,8 @@
           { "item": "spell_scroll_earthshaper_danger_sense", "prob": 50 },
           { "item": "spell_scroll_earthshaper_fortitude_of_stone", "prob": 50 },
           { "item": "spell_scroll_earthshaper_turning_of_earth", "prob": 50 },
-          { "item": "spell_scroll_earthshaper_repair_metal_stone", "prob": 25 }
+          { "item": "spell_scroll_earthshaper_repair_metal_stone", "prob": 25 },
+          { "item": "spell_scroll_earthshaper_remove_corpses", "prob": 35 }
         ],
         "prob": 45
       },

--- a/data/mods/Magiclysm/itemgroups/spellbooks.json
+++ b/data/mods/Magiclysm/itemgroups/spellbooks.json
@@ -20,6 +20,7 @@
       [ "spell_scroll_stonefist", 20 ],
       [ "spell_scroll_eshaper_piercing_bolt", 40 ],
       [ "spell_scroll_eshaper_rockbolt", 50 ],
+      [ "spell_scroll_earthshaper_remove_corpses", 50 ],
       [ "spell_scroll_reactive_armor", 25 ],
       [ "spell_scroll_pertifying_touch", 25 ],
       [ "spell_scroll_kelvinist_firebolt", 40 ],

--- a/data/mods/Magiclysm/itemgroups/spellbooks.json
+++ b/data/mods/Magiclysm/itemgroups/spellbooks.json
@@ -116,6 +116,7 @@
       [ "spell_scroll_electric_eye", 35 ],
       [ "spell_scroll_biomancer_swim_frog", 25 ],
       [ "spell_scroll_biomancer_slow_bleeding", 30 ],
+      [ "spell_scroll_biomancer_pull_items_from_distance", 30 ],
       [ "spell_scroll_holy_blade", 25 ],
       [ "spell_scroll_technomancer_welder", 20 ],
       [ "spell_scroll_spirit_armor", 25 ],

--- a/data/mods/Magiclysm/items/spell_scrolls.json
+++ b/data/mods/Magiclysm/items/spell_scrolls.json
@@ -2468,5 +2468,15 @@
     "name": { "str": "Scroll of Seeing the Unseen", "str_pl": "Scrolls of Seeing the Unseen" },
     "description": "Detect nearby beings with your soul rather than your eyes, allowing you to see invisible creatures.",
     "use_action": { "type": "learn_spell", "spells": [ "animist_see_invisibility" ] }
+  },
+  {
+    "type": "ITEM",
+    "subtypes": [ "BOOK" ],
+    "copy-from": "spell_scroll",
+    "id": "spell_scroll_earthshaper_remove_corpses",
+    "//": "Earthshaper spell",
+    "name": { "str": "Scroll of The Last Embrace", "str_pl": "Scrolls of The Last Embrace" },
+    "description": "Target a corpse and cause it to sink beneath the living earth.  A stable of prehistoric funeral rites.",
+    "use_action": { "type": "learn_spell", "spells": [ "earthshaper_remove_corpses" ] }
   }
 ]

--- a/data/mods/Magiclysm/items/spell_scrolls.json
+++ b/data/mods/Magiclysm/items/spell_scrolls.json
@@ -2476,7 +2476,17 @@
     "id": "spell_scroll_earthshaper_remove_corpses",
     "//": "Earthshaper spell",
     "name": { "str": "Scroll of The Last Embrace", "str_pl": "Scrolls of The Last Embrace" },
-    "description": "Target a corpse and cause it to sink beneath the living earth.  A stable of prehistoric funeral rites.",
+    "description": "Target a corpse and cause it to sink beneath the living earth.  A staple of prehistoric funeral rites.",
     "use_action": { "type": "learn_spell", "spells": [ "earthshaper_remove_corpses" ] }
+  },
+  {
+    "type": "ITEM",
+    "subtypes": [ "BOOK" ],
+    "copy-from": "spell_scroll",
+    "id": "spell_scroll_biomancer_pull_items_from_distance",
+    "//": "Biomancer spell",
+    "name": { "str": "Scroll of Monstrous Grasp", "str_pl": "Scrolls of Monstrous Grasp" },
+    "description": "Extend a tentacle to grab an item and drag it back to you.  Disgusting but practical.",
+    "use_action": { "type": "learn_spell", "spells": [ "biomancer_pull_items_from_distance" ] }
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[Magiclysm] Add a few more spells"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Adding more spells for things in the game, to make your mana compete for different uses.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

BIOMANCER:

- _Monstrous Grasp_ (Difficulty 4): Extend a tentacle to grab an item or group of items and drag them in. This is also slightly painful, as is the way of biomancy.

EARTHSHAPER

- _The Last Embrace_ (Difficulty 4): A part of funeral rites so ancient there are cave paintings depicting its use, The Last Embrace causes a body to sink down into the earth into a natural tomb. It only works on the living earth. Note that the body will take anything on it with it, so if you're some kind of  RPG protagonist make sure to check the body first.

MAGUS

- _The Sorcerer's Hand:_ This is an existing spell, but just updating it to use the new `pickup` functionality

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

The Last Embrace: works.
Monstrous Grasp: works.
The Sorcerer's Hand: Works but I unfortunately had to use a menu to select whether you target a creature or an item
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
