### PR TITLE
Tiny cleanup to horde motion

### DIFF
--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -4304,8 +4304,9 @@ void overmap::move_hordes()
          mon_end = hordes.end(); mon != mon_end; ) {
         // This might have an issue where a monster prevented from acting possibly should
         // get another chance to act?
-        if( mon->second.last_processed == calendar::turn ||
-            mon->second.get_type()->has_flag( mon_flag_DORMANT ) ) {
+        // This is here so that when a entity moves from one bucket to another it doesn't
+        // get a second set of moves.
+        if( mon->second.last_processed == calendar::turn ) {
             mon++;
             continue;
         }


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Noticed this leftover check that doesn't do anything anymore (DORMANT monsters are already filtered out), also added comment.