### PR TITLE
Fix zombie overspawning

### DIFF
--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -4262,7 +4262,7 @@ void overmap::spawn_mongroup( const tripoint_om_sm &p, const mongroup_id &type, 
 {
     tripoint_om_ms submap_origin = project_to<coords::ms>( p );
     point_rel_ms cursor{ 0, 0 };
-    while( count ) {
+    while( count > 0 ) {
         for( MonsterGroupResult &result : MonsterGroupManager::GetResultFromGroup( type, &count ) ) {
             for( int i = 0; i < result.pack_size; ++i ) {
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
I've been noticing throughout hordes development (see #81077) that too many zombies were spawning, I thought it was because of a bug I noticed in the group spawn code where it wasn't looping when placing monsters out of groups, but it turns out that was completely overshadowed by this logic error.

#### Describe the solution
Fix the logic error.

#### Describe alternatives you've considered
Leave the game spawning 20,000 zombies per overmap, sounds like fun.

#### Testing
Made a new world, saved, examined save to count number of horde entities, booring 500 zombies per overmap.
Used debug -> map -> edit overmap to scroll around in some towns and look at hordes, they're about as expected, a half dozen here, a dozen there, etc.