### PR TITLE
Remove Roboto as a default font

### DIFF
--- a/data/fontdata.json
+++ b/data/fontdata.json
@@ -5,7 +5,6 @@
     "data/font/unifont.ttf"
   ],
   "gui_typeface": [
-    { "path": "data/font/Roboto-Medium.ttf", "hinting": "Light" },
     { "path": "data/font/Terminus.ttf", "hinting": "Bitmap" },
     "data/font/unifont.ttf"
   ],


### PR DESCRIPTION
#### Summary
Bugfixes "Stop breaking alignment with Roboto"

#### Purpose of change
It's proportional and breaks a bunch of menus because we use fixed-width alignment pervasively.

#### Describe the solution
Just go back to Terminus/unifont

#### Describe alternatives you've considered
If we're going to use a proportional font it requires overhauling a ton of the UI code to do alignment manually first.
Maybe just Unifont? IDK.