### PR TITLE
Car owner manual

### DIFF
--- a/data/json/itemgroups/vehicles_fuel_related.json
+++ b/data/json/itemgroups/vehicles_fuel_related.json
@@ -126,7 +126,8 @@
       [ "jumper_cable", 30 ],
       [ "hand_pump", 30 ],
       [ "folding_solar_panel_v2", 2 ],
-      { "group": "bugout_bag", "prob": 3 }
+      { "group": "bugout_bag", "prob": 3 },
+      { "item": "manual_mechanics_car_owner", "prob": 90 }
     ]
   },
   {

--- a/data/json/items/book/mechanics.json
+++ b/data/json/items/book/mechanics.json
@@ -149,6 +149,26 @@
     "read_skill": "mechanics"
   },
   {
+    "id": "manual_mechanics_car_owner",
+    "type": "ITEM",
+    "subtypes": [ "BOOK" ],
+    "category": "manuals",
+    "name": { "str": "car owner manual", "str_pl": "copies of car owner manual" },
+    "description": "A manual detailing how to do maintenance and light repairs to a car, ranging from changing a tire to changing oil and general checks of engine health.",
+    "weight": "454 g",
+    "volume": "750 ml",
+    "price": "30 USD",
+    "price_postapoc": "2 USD",
+    "material": [ "paper", "cardboard" ],
+    "symbol": "?",
+    "looks_like": "textbook_botany",
+    "color": "green",
+    "max_level": 2,
+    "intelligence": 8,
+    "time": "20 m",
+    "read_skill": "mechanics"
+  },
+  {
     "id": "textbook_atomic_lab",
     "type": "ITEM",
     "subtypes": [ "BOOK" ],


### PR DESCRIPTION

#### Summary
None

#### Purpose of change
One of the things that usually comes with when buying a new car is its car owner manual. I figure it would be a useful enough read for any aspiring mechanics or just doing general maintenance for the car so i added it.

#### Describe the solution
Makes the car owner manual's json and put it in the car boot like the other tools in a car.

#### Describe alternatives you've considered
Not doing so?
Make it a digital only manual?

#### Testing
Made it as a small mod, i put it in a new fresh world, jump into the new world and go find a car. it has the manual there as expected.
![Screenshot_20250929_190002](https://github.com/user-attachments/assets/201f1355-df18-4dd3-bc40-13c3e36ad340)
![Screenshot_20250929_185950](https://github.com/user-attachments/assets/9ccc324e-ee30-40c4-bf1d-0e14097582cb)

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
