### PR TITLE
In rain, do not get wet if under the roof

### DIFF
--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -365,8 +365,9 @@ input_context game::get_player_input( std::string &action )
                     const point map( iRand + offset );
 
                     const tripoint_bub_ms mapp( map.x, map.y, pos.z() );
-
+                    const bool no_roof_above = here.has_flag( ter_furn_flag::TFLAG_NO_FLOOR, mapp + tripoint::above );
                     if( here.inbounds( mapp ) && here.is_outside( mapp ) &&
+                        no_roof_above &&
                         here.get_visibility( visibility_cache[mapp.x()][mapp.y()], cache ) ==
                         visibility_type::CLEAR &&
                         !creatures.creature_at( mapp, true ) ) {

--- a/src/weather.cpp
+++ b/src/weather.cpp
@@ -463,7 +463,9 @@ void handle_weather_effects( const weather_type_id &w )
         }
         here.decay_fields_and_scent( decay_time );
         // Coarse correction to get us back to previously intended soaking rate.
-        if( calendar::once_every( 6_seconds ) && is_creature_outside( target ) ) {
+        const bool no_roof_above = here.has_flag( ter_furn_flag::TFLAG_NO_FLOOR,
+                                   target.pos_bub() + tripoint::above );
+        if( calendar::once_every( 6_seconds ) && is_creature_outside( target ) && no_roof_above ) {
             wet_character( target, wetness );
         }
     }


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Suddenly realised that the game renders rain animation under the bridge
After more investigation found that it doesn't protect you against wetness effects either
#### Describe the solution
Also check if there is a roof above you when checking for animation and when checking if wetness effects should be applied
#### Testing
Before:
![old](https://github.com/user-attachments/assets/703b88f5-f07e-4af4-9b82-17b6eb5da104)

After:
![new](https://github.com/user-attachments/assets/ef7de328-fcc5-41a1-a435-73ddf390c1e1)
