### PR TITLE
Avoid dereferencing wrong horde_entity

### DIFF
--- a/src/horde_map.cpp
+++ b/src/horde_map.cpp
@@ -123,7 +123,12 @@ std::unordered_map<tripoint_abs_ms, horde_entity>::iterator horde_map::spawn_ent
     bool inserted;
     // The [] operator creates a nested std::map if not present already.
     std::tie( result, inserted ) = target_map[sm].emplace( p, mon );
-    result->second.monster_data->set_pos_abs_only( p );
+    if( inserted ) {
+        result->second.monster_data->set_pos_abs_only( p );
+    } else {
+        debugmsg( "Attempted to insert a %s at %s, but there's already a %s there!",
+                  mon.name(), p.to_string(), result->second.get_type() );
+    }
     return result;
 }
 

--- a/src/horde_map.cpp
+++ b/src/horde_map.cpp
@@ -1,8 +1,10 @@
 #include "horde_map.h"
 
 #include <memory>
+#include <string>
 #include <tuple>
 
+#include "debug.h"
 #include "map_scale_constants.h"
 #include "monster.h"
 #include "mtype.h"


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
See #83087 
It seems that there is a situation where two horde entities can end up being stored in the same location, and while attempting to insert monster B into the horde data structure it collides with the pre-existing monster A, resulting in attempting to access aspects of monster A that do not exist.

#### Describe the solution
Check for insertion success, if it fails refrain from attempting to edit the entry, which prevents the crash at least.
Also issue a debugmsg that might tell us something about it

#### Describe alternatives you've considered
Better debugging would be good, but I have no idea how to reproduce this.

#### Testing
Compiles and loads with no issues.