### PR TITLE
Put monster difficulty and difficulty_base behind a getter

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -2420,7 +2420,7 @@ void activity_handlers::robot_control_finish( player_activity *act, Character *y
     /** @EFFECT_COMPUTER increases chance of successful robot reprogramming, vs difficulty */
     const float computer_skill = you->get_skill_level( skill_computer );
     const float randomized_skill = rng( 2, you->int_cur ) + computer_skill;
-    float success = computer_skill - 3 * z->type->difficulty / randomized_skill;
+    float success = computer_skill - 3 * z->type->get_total_difficulty() / randomized_skill;
     if( z->has_flag( mon_flag_RIDEABLE_MECH ) ) {
         success = randomized_skill - rng( 1, 11 );
     }

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -738,7 +738,7 @@ static float rate_critter( const Creature &c )
     }
 
     const monster *m = dynamic_cast<const monster *>( &c );
-    return m->type->difficulty;
+    return m->type->get_total_difficulty();
 }
 
 void avatar_action::autoattack( avatar &you, map &m )

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -1376,11 +1376,11 @@ std::string display::colorized_compass_legend_text( int width, int max_height, i
     }
     for( const auto &m : mlist ) {
         nc_color danger = c_dark_gray;
-        if( m.first->difficulty >= 30 ) {
+        if( m.first->get_total_difficulty() >= 30 ) {
             danger = c_red;
-        } else if( m.first->difficulty >= 16 ) {
+        } else if( m.first->get_total_difficulty() >= 16 ) {
             danger = c_light_red;
-        } else if( m.first->difficulty >= 8 ) {
+        } else if( m.first->get_total_difficulty() >= 8 ) {
             danger = c_white;
         } else if( m.first->agro > 0 ) {
             danger = c_light_gray;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -6732,7 +6732,8 @@ void item::handle_pickup_ownership( Character &c )
                     const monster *const lmon = lhs->as_monster();
                     const monster *const rmon = rhs->as_monster();
                     // Sort more difficult monsters first
-                    return ( lmon ? lmon->type->difficulty : 0 ) > ( rmon ? rmon->type->difficulty : 0 );
+                    return ( lmon ? lmon->type->get_total_difficulty() : 0 ) >
+                           ( rmon ? rmon->type->get_total_difficulty() : 0 );
                 } else if( lnpc && !rnpc ) {
                     return true;
                 } else if( !lnpc && rnpc ) {

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -696,7 +696,7 @@ static void magical_polymorph( monster &victim, Creature &caster, const spell &s
 
     // if effect_str is empty, we become a random monster of close difficulty
     if( new_id.is_empty() ) {
-        int victim_diff = victim.type->difficulty;
+        int victim_diff = victim.type->get_total_difficulty();
         const std::vector<mtype> &mtypes = MonsterGenerator::generator().get_all_mtypes();
         for( int difficulty_variance = 1; difficulty_variance < 2048; difficulty_variance *= 2 ) {
             unsigned int random_entry = rng( 0, mtypes.size() );
@@ -705,8 +705,8 @@ static void magical_polymorph( monster &victim, Creature &caster, const spell &s
                 if( iter >= mtypes.size() ) {
                     iter = 0;
                 }
-                if( ( mtypes[iter].id != victim.type->id ) && ( std::abs( mtypes[iter].difficulty - victim_diff )
-                        <= difficulty_variance ) ) {
+                if( ( mtypes[iter].id != victim.type->id ) &&
+                    ( std::abs( mtypes[iter].get_total_difficulty() - victim_diff ) <= difficulty_variance ) ) {
                     if( !mtypes[iter].in_species( species_HALLUCINATION ) &&
                         mtypes[iter].id != mon_generator ) {
                         new_id = mtypes[iter].id;

--- a/src/memorial_logger.cpp
+++ b/src/memorial_logger.cpp
@@ -614,7 +614,7 @@ void memorial_logger::notify( const cata::event &e )
             character_id ch = e.get<character_id>( "killer" );
             if( ch == avatar_id ) {
                 mtype_id victim_type = e.get<mtype_id>( "victim_type" );
-                if( victim_type->difficulty >= 30 ) {
+                if( victim_type->get_total_difficulty() >= 30 ) {
                     add( pgettext( "memorial_male", "Killed a %s." ),
                          pgettext( "memorial_female", "Killed a %s." ),
                          victim_type->nname() );

--- a/src/mission_companion.cpp
+++ b/src/mission_companion.cpp
@@ -1531,7 +1531,7 @@ int talk_function::combat_score( const std::vector< monster * > &group )
     int score = 0;
     for( monster * const &elem : group ) {
         if( elem->get_hp() > 0 ) {
-            score += elem->type->difficulty;
+            score += elem->type->get_total_difficulty();
         }
     }
     return score;
@@ -2286,7 +2286,7 @@ bool talk_function::companion_om_combat_check( const std::vector<npc_ptr> &group
         if( mons->get_hp() <= 0 ) {
             continue;
         }
-        int d_modifier = avg_survival - mons->type->difficulty;
+        int d_modifier = avg_survival - mons->type->get_total_difficulty();
         int roll = rng( 1, 20 ) + d_modifier;
         if( roll > 10 ) {
             if( try_engage ) {

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -240,7 +240,7 @@ static const std::map<monster_attitude, std::pair<std::string, color_id>> attitu
 
 static int compute_kill_xp( const mtype_id &mon_type )
 {
-    return mon_type->difficulty + mon_type->difficulty_base;
+    return mon_type->get_total_difficulty() + mon_type->get_difficulty_adjustment();
 }
 
 monster::monster()
@@ -1133,17 +1133,17 @@ std::vector<std::string> monster::extended_description() const
 
     std::string difficulty_str;
     if( debug_mode ) {
-        difficulty_str = _( "Difficulty " ) + std::to_string( type->difficulty );
+        difficulty_str = _( "Difficulty " ) + std::to_string( type->get_total_difficulty() );
     } else {
-        if( type->difficulty < 3 ) {
+        if( type->get_total_difficulty() < 3 ) {
             difficulty_str = _( "<color_light_gray>Minimal threat.</color>" );
-        } else if( type->difficulty < 10 ) {
+        } else if( type->get_total_difficulty() < 10 ) {
             difficulty_str = _( "<color_light_gray>Mildly dangerous.</color>" );
-        } else if( type->difficulty < 20 ) {
+        } else if( type->get_total_difficulty() < 20 ) {
             difficulty_str = _( "<color_light_red>Dangerous.</color>" );
-        } else if( type->difficulty < 30 ) {
+        } else if( type->get_total_difficulty() < 30 ) {
             difficulty_str = _( "<color_red>Very dangerous.</color>" );
-        } else if( type->difficulty < 50 ) {
+        } else if( type->get_total_difficulty() < 50 ) {
             difficulty_str = _( "<color_red>Extremely dangerous.</color>" );
         } else {
             difficulty_str = _( "<color_red>Fatally dangerous!</color>" );

--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -393,7 +393,7 @@ void MonsterGenerator::finalize_mtypes()
         }
         mon.difficulty = ( mon.melee_skill + 1 ) * mon.melee_dice * ( melee_dmg_total + mon.melee_sides ) *
                          0.04 + ( mon.sk_dodge + 1 ) * armor_diff * 0.04 +
-                         ( mon.difficulty_base + special_attacks_diff + 8 * mon.emit_fields.size() );
+                         ( mon.get_difficulty_adjustment() + special_attacks_diff + 8 * mon.emit_fields.size() );
         mon.difficulty *= ( mon.hp + mon.speed - mon.attack_cost + ( mon.morale + mon.agro ) * 0.1 ) * 0.01
                           + ( mon.vision_day + 2 * mon.vision_night ) * 0.01;
 
@@ -862,7 +862,7 @@ void mtype::load( const JsonObject &jo, const std::string_view src )
     optional( jo, was_loaded, "phase", phase, make_flag_reader( gen.phase_map, "phase id" ),
               phase_id::SOLID );
 
-    optional( jo, was_loaded, "diff", difficulty_base, numeric_bound_reader<int> {0}, 0 );
+    optional( jo, was_loaded, "diff", difficulty_adjustment, numeric_bound_reader<int> {0}, 0 );
     optional( jo, was_loaded, "hp", hp, numeric_bound_reader<int> {1} );
     optional( jo, was_loaded, "speed", speed, numeric_bound_reader<int> {0}, 0 );
     optional( jo, was_loaded, "aggression", agro, numeric_bound_reader<int> {-100, 100}, 0 );

--- a/src/mtype.cpp
+++ b/src/mtype.cpp
@@ -478,6 +478,16 @@ field_type_id mtype::gibType() const
     return fd_null;
 }
 
+int mtype::get_total_difficulty() const
+{
+    return difficulty;
+}
+
+int mtype::get_difficulty_adjustment() const
+{
+    return difficulty_adjustment;
+}
+
 itype_id mtype::get_meat_itype() const
 {
     if( has_flag( mon_flag_POISON ) ) {

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -458,14 +458,20 @@ struct mtype {
 
     private:
         ::weakpoints weakpoints_deferred_inline;
+        // How dangerous is this thing?
+        int difficulty = 0;
+        // Manually-defined adjustment in JSON. *Not* additive, use the getter functions.
+        int difficulty_adjustment = 0;
     public:
         int mat_portion_total = 0;
         units::volume volume;
         creature_size size;
         phase_id phase;
-        int difficulty = 0;     /** many uses; 30 min + (diff-3)*30 min = earliest appearance */
-        // difficulty from special attacks instead of from melee attacks, defenses, HP, etc.
-        int difficulty_base = 0;
+
+        // Return the total difficulty as used to determine monster coloring etc
+        int get_total_difficulty() const;
+        // You should probably not be using this!! This was already factored into the difficulty calculation!
+        int get_difficulty_adjustment() const;
 
         int hp = 0;
         int speed = 0;          /** e.g. human = 100 */

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -494,7 +494,8 @@ float npc::evaluate_monster( const monster &target, int dist ) const
     float speed = target.speed_rating();
     float scaled_distance = std::max( 1.0f, dist * dist / ( speed * 250.0f ) );
     float hp_percent = static_cast<float>( target.get_hp() ) / target.get_hp_max();
-    float diff = std::max( static_cast<float>( target.type->difficulty ), NPC_DANGER_VERY_LOW );
+    float diff = std::max( static_cast<float>( target.type->get_total_difficulty() ),
+                           NPC_DANGER_VERY_LOW );
     add_msg_debug( debugmode::DF_NPC_COMBATAI,
                    "<color_yellow>evaluate_monster </color><color_dark_gray>%s thinks %s threat level is <color_light_gray>%1.2f</color><color_dark_gray> before considering situation.  Speed rating: %1.2f; dist: %i; scaled_distance: %1.0f; HP: %1.0f%%</color>",
                    name, target.type->nname(), diff, speed, dist, scaled_distance, hp_percent * 100 );

--- a/src/overmap_water.cpp
+++ b/src/overmap_water.cpp
@@ -552,7 +552,7 @@ void overmap::place_rivers( const std::vector<const overmap *> &neighbor_overmap
     // ..closer to end point
     std::array<point_om_omt, max_rivers> control_end = { point_om_omt::invalid, point_om_omt::invalid };
 
-    auto bound_control_point = []( const point_om_omt & p, const point_rel_omt & init_diff ) {
+    auto bound_control_point = [&]( const point_om_omt & p, const point_rel_omt & init_diff ) {
         point_rel_omt diff = init_diff;
         point_om_omt continue_line = p + diff;
         while( !inbounds( continue_line ) ) {

--- a/src/talker_monster.cpp
+++ b/src/talker_monster.cpp
@@ -166,7 +166,7 @@ int talker_monster_const::get_friendly() const
 
 int talker_monster_const::get_difficulty() const
 {
-    return me_mon_const->type->difficulty;
+    return me_mon_const->type->get_total_difficulty();
 }
 
 int talker_monster_const::get_size() const


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
This came up (again) when removing Stats Through Kills. These variables are very confusingly named! And also, they're public, ew.

#### Describe the solution
For extra safety and a little bit of clarity, put mtype's `difficulty` and `difficulty_base` behind getters

Because `difficulty_base` was only used in 3 places I also went ahead and renamed it for extra clarity, to `difficulty_adjustment`.

Also add some comments

No functional changes

#### Describe alternatives you've considered


#### Testing
Compiles, launches, loads

#### Additional context
Accidentally slipped in a change to overmap_water.cpp which suppresses a warning in VS2019... well, it's fine, it can stay if nobody has a problem with it.