### PR TITLE
Better feedback on planting failures + plants need sunlight

### DIFF
--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -1219,7 +1219,7 @@ void basecamp::get_available_missions_by_dir( mission_data &mission_key, const p
             // FIXME/HACK: Always checks buckwheat seeds!
             mission_key.add_start( miss_id,
                                    name_display_of( miss_id ), entry,
-                                   plots > 0 && warm_enough_to_plant( omt_pos + dir, itype_seed_buckwheat ) );
+                                   plots > 0 && warm_enough_to_plant( omt_pos + dir, itype_seed_buckwheat ).success() );
         }
         if( !npc_list.empty() ) {
             entry = action_of( miss_id.id );

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -1216,10 +1216,12 @@ void basecamp::get_available_missions_by_dir( mission_data &mission_key, const p
                   &plots]() {
                 return farm_description( dir, plots, farm_ops::plant );
             } ) );
+            const tripoint_abs_omt target_omt = omt_pos + dir;
+            const tripoint_bub_ms target_pnt = get_map().get_bub( project_to<coords::ms>( target_omt ) );
             // FIXME/HACK: Always checks buckwheat seeds!
             mission_key.add_start( miss_id,
                                    name_display_of( miss_id ), entry,
-                                   plots > 0 && warm_enough_to_plant( omt_pos + dir, itype_seed_buckwheat ).success() );
+                                   plots > 0 && warm_enough_to_plant( target_pnt, itype_seed_buckwheat ).success() );
         }
         if( !npc_list.empty() ) {
             entry = action_of( miss_id.id );

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -2799,8 +2799,9 @@ void iexamine::dirtmound( Character &you, const tripoint_bub_ms &examp )
     }
     const itype_id &seed_id = std::get<0>( seed_entries[seed_index] );
 
-    if( !warm_enough_to_plant( you.pos_bub(), seed_id ) ) {
-        you.add_msg_if_player( m_info, _( "It is too cold to plant that now." ) );
+    ret_val<void>can_plant = warm_enough_to_plant( you.pos_bub(), seed_id );
+    if( !can_plant.success() ) {
+        you.add_msg_if_player( m_info, can_plant.c_str() );
         return;
     }
 

--- a/src/mission_companion.cpp
+++ b/src/mission_companion.cpp
@@ -60,6 +60,7 @@
 #include "overmap.h"
 #include "overmapbuffer.h"
 #include "point.h"
+#include "ret_val.h"
 #include "rng.h"
 #include "skill.h"
 #include "string_formatter.h"

--- a/src/mission_companion.cpp
+++ b/src/mission_companion.cpp
@@ -1577,8 +1577,9 @@ void talk_function::field_plant( npc &p, const std::string &place )
     }
 
     const itype_id &seed_id = seed_types[seed_index];
-    if( !warm_enough_to_plant( player_character.pos_bub(), seed_id ) ) {
-        popup( _( "It is too cold to plant that now." ) );
+    ret_val<void>can_plant = warm_enough_to_plant( player_character.pos_bub(), seed_id );
+    if( !can_plant.success() ) {
+        popup( can_plant.c_str() );
         return;
     }
     if( item::count_by_charges( seed_id ) ) {

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -6039,11 +6039,14 @@ void vehicle::idle( map &here, bool on_map )
     }
 
     // FIXME/HACK: Always checks buckwheat seeds!
-    if( !warm_enough_to_plant( player_character.pos_bub( here ), itype_seed_buckwheat ) ) {
+    // Returned string intentionally discarded!
+    ret_val<void>can_plant = warm_enough_to_plant( player_character.pos_bub(), itype_seed_buckwheat );
+    if( !can_plant.success() ) {
         for( int i : planters ) {
             vehicle_part &vp = parts[ i ];
             if( vp.enabled ) {
-                add_msg_if_player_sees( pos_bub( here ), _( "The %s's planter turns off due to low temperature." ),
+                add_msg_if_player_sees( pos_bub( here ),
+                                        _( "The %s's planter turns off due to unsuitable planting conditions." ),
                                         name );
                 vp.enabled = false;
             }

--- a/src/vehicle_part.cpp
+++ b/src/vehicle_part.cpp
@@ -728,10 +728,11 @@ bool vehicle::can_enable( map &here, const vehicle_part &pt, bool alert ) const
     }
 
     // FIXME/HACK: Always checks buckwheat seeds!
-    if( pt.info().has_flag( "PLANTER" ) &&
-        !warm_enough_to_plant( get_player_character().pos_bub(), itype_seed_buckwheat ) ) {
+    ret_val<void>can_plant = warm_enough_to_plant( get_player_character().pos_bub(),
+                             itype_seed_buckwheat );
+    if( pt.info().has_flag( "PLANTER" ) && !can_plant.success() ) {
         if( alert ) {
-            add_msg( m_bad, _( "It is too cold to plant most things now." ) );
+            add_msg( m_bad, can_plant.c_str() );
         }
         return false;
     }

--- a/src/weather.cpp
+++ b/src/weather.cpp
@@ -895,28 +895,47 @@ static units::temperature highest_temp_on_day( time_point &base_date, const trip
     return highest_temp;
 }
 
-ret_val<void> warm_enough_to_plant( const tripoint_bub_ms &pos, const itype_id &it )
+static bool has_sunlight_access( const tripoint_bub_ms &pos )
 {
-    const tripoint_abs_ms abs = get_map().get_abs( pos );
-    const tripoint_abs_omt target_omt = project_to<coords::omt>( abs );
-    return warm_enough_to_plant( target_omt, it );
+    tripoint_bub_ms checked_pnt = pos;
+    const map &here = get_map();
+    while( checked_pnt.z() < OVERMAP_HEIGHT ) {
+        const tripoint_bub_ms pnt_above = {checked_pnt.xy(), checked_pnt.z() + 1 };
+        const bool should_check_above = pnt_above.z() < OVERMAP_HEIGHT;
+        // If checking above would take us outside of game bounds, just assume that it's all open air up there.
+        const bool transparent_roof = should_check_above ?
+                                      here.is_outside( pnt_above ) && here.has_flag_ter( "TRANSPARENT", pnt_above ) :
+                                      true;
+        if( !here.is_outside( checked_pnt ) || !transparent_roof ) {
+            return false;
+        }
+        checked_pnt = pnt_above;
+    }
+    return true;
 }
 
-ret_val<void> warm_enough_to_plant( const tripoint_abs_omt &pos, const itype_id &it )
+ret_val<void> warm_enough_to_plant( const tripoint_bub_ms &pos, const itype_id &it )
 {
     std::map<time_point, units::temperature> planting_times;
+
+    if( !has_sunlight_access( pos ) ) {
+        return ret_val<void>::make_failure( _( "Plants need sunlight to grow!  You can't plant there." ) );
+    }
+
+    const tripoint_abs_ms abs = get_map().get_abs( pos );
+    const tripoint_abs_omt checked_omt = project_to<coords::omt>( abs );
 
     const std::vector<std::pair<flag_id, time_duration>> &growth_stages = it->seed->get_growth_stages();
     // we will iterate a copy of the weather into the future to see if they'll be plantable then as well.
     const weather_generator weather_gen = get_weather().get_cur_weather_gen();
     // initialize the first...
     time_point check_date = calendar::turn;
-    planting_times[check_date] = highest_temp_on_day( check_date, pos, weather_gen );
+    planting_times[check_date] = highest_temp_on_day( check_date, checked_omt, weather_gen );
     for( const auto &pair : growth_stages ) {
         // TODO: Replace epoch checks with data from a farmer's almanac
         check_date = check_date + pair.second;
         // The [] operator in std::map inserts an entry if it doesn't already exist.
-        planting_times[check_date] = highest_temp_on_day( check_date, pos, weather_gen );
+        planting_times[check_date] = highest_temp_on_day( check_date, checked_omt, weather_gen );
     }
     for( const std::pair<const time_point, units::temperature> &pair : planting_times ) {
         // This absolutely needs to be a time point.

--- a/src/weather.h
+++ b/src/weather.h
@@ -10,6 +10,7 @@
 #include "color.h"
 #include "coordinates.h"
 #include "pimpl.h"
+#include "ret_val.h"
 #include "type_id.h"
 #include "units.h"
 #include "weather_gen.h"
@@ -170,8 +171,8 @@ nc_color get_wind_color( double );
  *
  * The first overload is simply a forwarding helper.
  */
-bool warm_enough_to_plant( const tripoint_bub_ms &pos, const itype_id &it );
-bool warm_enough_to_plant( const tripoint_abs_omt &pos, const itype_id &it );
+ret_val<void> warm_enough_to_plant( const tripoint_bub_ms &pos, const itype_id &it );
+ret_val<void> warm_enough_to_plant( const tripoint_abs_omt &pos, const itype_id &it );
 
 bool is_wind_blocker( const tripoint_bub_ms &location );
 

--- a/src/weather.h
+++ b/src/weather.h
@@ -168,11 +168,9 @@ nc_color get_wind_color( double );
 
 /**
  * Is it warm enough to plant seeds? Will it be warm enough during the type's grow periods?
- *
- * The first overload is simply a forwarding helper.
+ * Also includes check for whether the tile is exposed to sunlight.
  */
 ret_val<void> warm_enough_to_plant( const tripoint_bub_ms &pos, const itype_id &it );
-ret_val<void> warm_enough_to_plant( const tripoint_abs_omt &pos, const itype_id &it );
 
 bool is_wind_blocker( const tripoint_bub_ms &location );
 


### PR DESCRIPTION
#### Summary
Content "Better feedback on planting failures + plants need sunlight"

#### Purpose of change
MORE improvements to planting

#### Describe the solution
Return a ret_val with an explanatory string saying why a planting failure occurred, give that to the player when possible.

During the initial planting, check if the tile is exposed to open air/sunlight. If not, can't be planted. (It is possible for that to *change* after the planting, but only really as a result of player constructions. That is a sufficiently niche scenario that I'm not worried about it.)

Ended up removing the extra overload for warm_enough_to_plant(). The sunlight checks require we check a specific tile, and only one place (faction camps) want to pass in an OMT location. So instead, we 'downcast' for that call and let everything else pass in mapsquares normally, just converting to OMT locations as needed. 

This was (IMO) a better approach than taking in a mapsquare, converting 'up' to OMT, then converting right back 'down' to check the mapsquare, with the associated loss of precision.

#### Describe alternatives you've considered
I have considered/am considering requiring that plants be **watered** once per growth stage. Can you imagine that?

has_sunlight_access() ended up being kind of nasty, requiring lots of conditional logic. Maybe there's a better way.

#### Testing
Didn't have time to test this, coding the sunlight check ended up taking much longer than I expected.

For mergers/reviewers: Try planting outside, it should succeed. Try planting in a basement, it should fail. Try planting in a botanical garden (greenhouse), it should succeed.

#### Additional context

