### PR TITLE
silence data loss warnings

### DIFF
--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -1811,7 +1811,7 @@ static void add_map( std::map<damage_type_id, int> &to, const std::map<damage_ty
                      double divisor )
 {
     for( const std::pair<const damage_type_id, int> &dam : from ) {
-        auto ret = to.emplace( dam.first, dam.second / divisor );
+        auto ret = to.emplace( dam.first, static_cast<int>( dam.second / divisor ) );
         // add to existing, emplace had no effect
         if( !ret.second ) {
             ret.first->second += dam.second / divisor;

--- a/src/pathfinding.cpp
+++ b/src/pathfinding.cpp
@@ -267,7 +267,7 @@ int map::cost_to_pass( const tripoint_bub_ms &cur, const tripoint_bub_ms &p,
             } else if( !bash.empty() ) {
                 int damage = std::accumulate( bash.begin(), bash.end(), 0, []( int so_far,
                 const std::pair<damage_type_id, int> &pr ) {
-                    return so_far + ( pr.second * pr.first->bash_conversion_factor );
+                    return so_far + static_cast<int>( pr.second * pr.first->bash_conversion_factor );
                 } );
                 // Car obstacle that isn't a door
                 // TODO: Account for armor

--- a/tests/npc_test.cpp
+++ b/tests/npc_test.cpp
@@ -424,7 +424,7 @@ TEST_CASE( "npc-board-player-vehicle" )
                     int bash = std::accumulate( companion->path_settings->bash_strength.begin(),
                                                 companion->path_settings->bash_strength.end(), 0,
                     []( int so_far, const std::pair<damage_type_id, int> &dam ) {
-                        return so_far + ( dam.second * dam.first->bash_conversion_factor );
+                        return so_far + static_cast<int>( dam.second * dam.first->bash_conversion_factor );
                     } );
                     UNSCOPED_INFO( "part hp: " << hp << " - bash strength: " << bash );
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Silence warnings about potential data loss when they're not relevant.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Explicitly cast the results to int.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Clean the build and compile again to see the warnings are gone.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
No functional change. Just using explicit type conversion rather than implicit with warnings.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
