### PR TITLE
Add zzip tool to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ logg.txt
 json_formatter
 *.output
 .cache/
+zzip
 
 # Visual Studio files
 *.code-workspace


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Prevent someone from committing the compiled binary.

#### Additional context
It's now built with the default make target https://github.com/CleverRaven/Cataclysm-DDA/pull/83059