### PR TITLE
Add mounted flashlight to gunmod group

### DIFF
--- a/data/json/itemgroups/Weapons_Mods_Ammo/gunmod.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/gunmod.json
@@ -52,6 +52,7 @@
       [ "hybrid_sight_4x", 30 ],
       [ "rifle_scope_high_end_mount", 20 ],
       [ "modern_handguard", 20 ],
+      [ "mounted_flashlight", 80 ],
       [ "bipod_handguard", 10 ],
       [ "high_end_folding_stock", 10 ],
       [ "muzzle_weight", 10 ]


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Continuation of #83061
Forgot to add the gunmod so it can spawn
#### Describe the solution
Add it into gunmod group, that is used in gunshops and stuff