### PR TITLE
Bugfix: Exempt missions in status yet_to_start from is_complete

### DIFF
--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -484,7 +484,9 @@ bool mission::is_complete( const character_id &_npc_id ) const
     if( status == mission_status::success ) {
         return true;
     }
-
+    if( status == mission_status::yet_to_start ) {
+        return true;
+    }
     avatar &player_character = get_avatar();
     switch( type->goal ) {
         case MGOAL_GO_TO: {


### PR DESCRIPTION
#### Summary
Bugfixes "missions in yet_to_start status should be exempted from is_complete checks"

#### Purpose of change
While analyzing performance issues for my crafting/sleeping, it showed that almost 70% of CPU was used by the mission:is_complete checks
<img width="1111" height="697" alt="image" src="https://github.com/user-attachments/assets/c0e5e602-036a-4ccf-b1bf-568869c19cae" />

But heck my character didn't even had any missions. Long stort short, game automatically adds hidden mission `MISSION_LEARN_ABOUT_CATTAIL_JELLY` with `MGOAL_CONDITION` type and `u_has_item` check. So effectively that does a full inventory iteration every turn.

#### Describe the solution
So why would even check for completeness a mission that hasn't even started? We have another check for yet_to_start type (which would change the mission state to the in_progress status). As soon as those are not checked there is a huge performance boost for every long task
<img width="1103" height="715" alt="image" src="https://github.com/user-attachments/assets/48d1baaf-3d1e-47fe-bd17-b1f9098f4956" />

#### Describe alternatives you've considered

Just removing MISSION_LEARN_ABOUT_CATTAIL_JELLY or modifying it to NOT check for any inventory items should work just as well

#### Testing

It compiles, it runs...

#### Additional context

No AI this time, no strange overhaul ideas, will it work this way or am I mistaken again?