### PR TITLE
Migration fix for old saves using new region settings

### DIFF
--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -567,7 +567,11 @@ void overmap::unserialize( const JsonObject &jsobj )
             std::string new_region_id;
             om_member.read( new_region_id );
             if( settings->id.str() != new_region_id ) {
-                const region_settings_id new_region_set( new_region_id );
+                region_settings_id new_region_set( new_region_id );
+                //migrate old save region settings to new saves (remove in 0.J)
+                if( new_region_id == "default" ) {
+                    new_region_set = overmap_buffer.get_default_settings( pos() ).id;
+                }
                 if( new_region_set.is_valid() ) {
                     settings = new_region_set;
                 }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "migration fix for old saves using new region settings"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Comment on #83033 I verified as a bug.

Region settings for mods all used "id": "default" and no longer do. When overmaps are loaded, there's a check for non-default region settings; if the region settings aren't default, they are set to the loaded region settings. 

For e.g. Aftershock, overmaps were seeing the old "default" `region_settings_id` and since it's now different from Aftershock's default "default_aftershock", the region was set to the vanilla "default" region settings when it shouldn't be.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

If `region_settings_id` "default" is loaded from a save, set region settings to default defined by the `EXTERNAL_OPTION` `DEFAULT_REGION`.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Made an Aftershock save from an experimental from July, verified bug occurred (weather too hot) when loaded into current experimental, tested with this fix and weather was normal. Loaded a vanilla world too, seemed fine.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
