### PR TITLE
Update mod compatibility for new region settings

### DIFF
--- a/data/mods/Backrooms/modinfo.json
+++ b/data/mods/Backrooms/modinfo.json
@@ -7,7 +7,7 @@
     "maintainers": [ "onura46" ],
     "description": "A strange place between dimensions traps you.  Can you survive among endless halls of yellowed carpet and harshly humming fluorescents?\n\nReplaces all normal worldgen: no wilderness, no rivers, no cities, no farms, no sky.  Just endless, winding indoor halls of mildewy carpeting, faded drywall, desolate breakrooms and abandoned boardrooms.\n\nPlay Now!  (Default Scenario) is not supported.",
     "category": "total_conversion",
-    "conflicts": [ "desertpack", "tropicata" ],
+    "conflicts": [ "aftershock_exoplanet", "desertpack", "tropicata", "classic_zombies", "innawood", "Isolation_Protocol", "no_hope" ],
     "dependencies": [ "dda" ],
     "version": "0.1"
   },

--- a/data/mods/Isolation-Protocol/modinfo.json
+++ b/data/mods/Isolation-Protocol/modinfo.json
@@ -8,7 +8,19 @@
     "description": "A total conversion mod inspired by traditional dungeon crawler roguelikes.  Reach the bottom of an altered lab and prevent the Cataclysm from spreading to the surface!",
     "category": "total_conversion",
     "dependencies": [ "dda" ],
-    "conflicts": [ "generic_guns", "aftershock_exoplanet", "innawood", "skyisland", "backrooms", "defense_mode", "MA", "tropicata" ]
+    "conflicts": [
+      "generic_guns",
+      "aftershock_exoplanet",
+      "innawood",
+      "skyisland",
+      "backrooms",
+      "defense_mode",
+      "MA",
+      "tropicata",
+      "desertpack",
+      "classic_zombies",
+      "no_hope"
+    ]
   },
   {
     "type": "EXTERNAL_OPTION",

--- a/data/mods/No_Hope/modinfo.json
+++ b/data/mods/No_Hope/modinfo.json
@@ -8,6 +8,7 @@
     "description": "Aims to make the world more inhospitable and challenging in as many ways as possible, items needed for survival and vehicles are much harder to obtain, destruction and banditry is prevelent, even the weather has taken a turn for the worse, see in game help menu by pressing 0 once in-game for full feature list and option explanations.",
     "category": "content",
     "dependencies": [ "dda" ],
+    "conflicts": [ "aftershock_exoplanet", "backrooms", "desertpack", "tropicata", "classic_zombies", "innawood", "Isolation_Protocol" ],
     "version": "3.5"
   }
 ]

--- a/data/mods/TropiCataclysm/modinfo.json
+++ b/data/mods/TropiCataclysm/modinfo.json
@@ -7,7 +7,7 @@
     "maintainers": [ "Karol1223" ],
     "description": "Changes the setting from New England to an undisclosed region in Brazil.  Initially based out of Desert Region mod.",
     "category": "content",
-    "conflicts": [ "backrooms", "desertpack" ],
+    "conflicts": [ "aftershock_exoplanet", "backrooms", "desertpack", "classic_zombies", "innawood", "Isolation_Protocol", "no_hope" ],
     "dependencies": [ "dda" ],
     "version": "0.80"
   },

--- a/data/mods/aftershock_exoplanet/modinfo.json
+++ b/data/mods/aftershock_exoplanet/modinfo.json
@@ -8,7 +8,18 @@
     "description": "In a fateful instant, the dream of interstellar civilization was shattered in what became known as The Discontinuity, and billions were consigned to death in the far reaches of the Orion Arm.  Three hundred years later, the survivors still eke out a meager existence within the ruins of their once-great civilization, scavenging and fighting for scraps of technology they can barely understand.\n\nYou are one of these countless scavengers, come to exploit the frozen ruins of Salus IV for your own benefit.",
     "category": "total_conversion",
     "dependencies": [ "dda" ],
-    "conflicts": [ "mindovermatter", "generic_guns", "skyisland" ],
+    "conflicts": [
+      "mindovermatter",
+      "generic_guns",
+      "skyisland",
+      "backrooms",
+      "desertpack",
+      "tropicata",
+      "classic_zombies",
+      "innawood",
+      "Isolation_Protocol",
+      "no_hope"
+    ],
     "loading_images": [ "aftershock.png" ]
   },
   {

--- a/data/mods/classic_zombies/modinfo.json
+++ b/data/mods/classic_zombies/modinfo.json
@@ -6,6 +6,7 @@
     "authors": [ "Hirmuolio", "I-am-Erk" ],
     "maintainers": [ "I-am-Erk" ],
     "description": "Turns the game into a classic Romero zombie game.  You must destroy the brain.  Getting bitten is fatal.  However, zombies don't evolve, and when they're down, they're down.  Removes the sci-fi and interdimensional aspects of CDDA.",
+    "conflicts": [ "aftershock_exoplanet", "backrooms", "desertpack", "tropicata", "innawood", "Isolation_Protocol", "no_hope" ],
     "category": "total_conversion",
     "dependencies": [ "dda" ]
   },

--- a/data/mods/desert_region/modinfo.json
+++ b/data/mods/desert_region/modinfo.json
@@ -7,7 +7,7 @@
     "maintainers": [ "LovamkKicsiGazsii", "Procyonae" ],
     "description": "A testbed/WIP mod to showcase regional_map_settings JSON changes.",
     "category": "content",
-    "conflicts": [ "backrooms", "tropicata" ],
+    "conflicts": [ "aftershock_exoplanet", "backrooms", "tropicata", "classic_zombies", "innawood", "Isolation_Protocol", "no_hope" ],
     "dependencies": [ "dda" ],
     "version": "0.1",
     "obsolete": false

--- a/data/mods/innawood/modinfo.json
+++ b/data/mods/innawood/modinfo.json
@@ -7,6 +7,7 @@
     "maintainers": [ "Lightwave" ],
     "description": "An untouched land that mankind has yet to reach.  Disables most traces of civilization for that 'innawood' experience.",
     "category": "total_conversion",
+    "conflicts": [ "aftershock_exoplanet", "backrooms", "desertpack", "tropicata", "classic_zombies", "Isolation_Protocol", "no_hope" ],
     "dependencies": [ "dda" ],
     "loading_images": [ "innawoods1.png" ],
     "obsolete": false


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "update mod compatibility for new region settings"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

- Cleanup from #82631

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

The following mods have (and always had) conflicting region settings and are no longer compatible with each other: 
"aftershock_exoplanet", "backrooms", "desertpack", "tropicata", "classic_zombies", "innawood", "Isolation_Protocol", "no_hope"

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Loaded all mods, no errors.

Example with innawood:
<img width="703" height="518" alt="image" src="https://github.com/user-attachments/assets/1dc92445-a066-4620-bd5d-99a36c8798ca" />

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
