### PR TITLE
Replace hardcoded check for Oversensitive System with flag check

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -10715,7 +10715,8 @@
     "player_display": true,
     "points": -8,
     "starting_trait": true,
-    "cancels": [ "CBM_Interface" ]
+    "cancels": [ "CBM_Interface" ],
+    "flags": [ "NO_CBM_INSTALLATION" ]
   },
   {
     "type": "mutation",

--- a/data/json/npcs/exodii/exodii_merchant_talk.json
+++ b/data/json/npcs/exodii/exodii_merchant_talk.json
@@ -384,7 +384,7 @@
           "and": [
             { "compare_string": [ "yes", { "u_val": "mission_completed_anusfetick" } ] },
             { "not": { "u_has_trait": "CBM_Interface" } },
-            { "not": { "u_has_trait": "NO_CBM_INSTALLATION" } }
+            { "not": { "u_has_flag": "NO_CBM_INSTALLATION" } }
           ]
         },
         "topic": "TALK_EXODII_MERCHANT_ExodizeMe2"

--- a/data/mods/Isolation-Protocol/Player/Perks/perks.json
+++ b/data/mods/Isolation-Protocol/Player/Perks/perks.json
@@ -72,7 +72,7 @@
     "purifiable": false,
     "valid": false,
     "//": "Idea here is they can't have any NEW bionics because they're full up (and so they can't just cheat by finding fuel bionics)",
-    "no_cbm_on_bp": [ "torso", "head", "eyes", "mouth", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ]
+    "flags": [ "NO_CBM_INSTALLATION" ]
   },
   {
     "type": "mutation",

--- a/data/mods/My_Sweet_Cataclysm/sweet_mutations.json
+++ b/data/mods/My_Sweet_Cataclysm/sweet_mutations.json
@@ -55,7 +55,6 @@
     "starting_trait": true,
     "anger_relations": [ [ "MARSHMALLOW", 20 ], [ "GUMMY", 5 ], [ "CHEWGUM", 20 ] ],
     "allowed_category": [ "SUGAR" ],
-    "no_cbm_on_bp": [ "torso", "head", "eyes", "mouth", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
     "armor": [
       {
         "parts": [ "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r", "mouth", "eyes" ],
@@ -63,7 +62,7 @@
         "bash": 5
       }
     ],
-    "flags": [ "NO_THIRST", "NO_DISEASE", "NO_RADIATION", "BLEED_IMMUNE", "INFECTION_IMMUNE" ]
+    "flags": [ "NO_THIRST", "NO_DISEASE", "NO_RADIATION", "BLEED_IMMUNE", "INFECTION_IMMUNE", "NO_CBM_INSTALLATION" ]
   },
   {
     "type": "overlay_order",

--- a/data/mods/Xedra_Evolved/mutations/bloodthorne_druid_traits.json
+++ b/data/mods/Xedra_Evolved/mutations/bloodthorne_druid_traits.json
@@ -21,9 +21,8 @@
         ]
       }
     ],
-    "no_cbm_on_bp": [ "torso", "head", "eyes", "mouth", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
     "anger_relations": [ [ "THORNBEAST", -100 ] ],
-    "flags": [ "ATTUNEMENT", "TREE_COMMUNION_PLUS" ],
+    "flags": [ "ATTUNEMENT", "TREE_COMMUNION_PLUS", "NO_CBM_INSTALLATION" ],
     "chargen_allow_npc": false
   },
   {

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/paraclesian_mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/paraclesian_mutations.json
@@ -46,8 +46,7 @@
     "vitamin_rates": [ [ "mutagen_human", 1 ] ],
     "empathize_with": [ "IERDE" ],
     "no_empathize_with": [ "HUMAN" ],
-    "no_cbm_on_bp": [ "torso", "head", "eyes", "mouth", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
-    "flags": [ "HERITAGE" ],
+    "flags": [ "HERITAGE", "NO_CBM_INSTALLATION" ],
     "chargen_allow_npc": false
   },
   {
@@ -97,8 +96,7 @@
     "vitamin_rates": [ [ "mutagen_human", 1 ] ],
     "empathize_with": [ "ARVORE" ],
     "no_empathize_with": [ "HUMAN" ],
-    "no_cbm_on_bp": [ "torso", "head", "eyes", "mouth", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
-    "flags": [ "TREE_COMMUNION_PLUS", "ARVORE_POLLEN_IMMUNE", "HERITAGE" ],
+    "flags": [ "TREE_COMMUNION_PLUS", "ARVORE_POLLEN_IMMUNE", "HERITAGE", "NO_CBM_INSTALLATION" ],
     "chargen_allow_npc": false,
     "enchantments": [
       {
@@ -170,8 +168,7 @@
     "vitamin_rates": [ [ "mutagen_human", 1 ] ],
     "empathize_with": [ "SALAMANDER" ],
     "no_empathize_with": [ "HUMAN" ],
-    "no_cbm_on_bp": [ "torso", "head", "eyes", "mouth", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
-    "flags": [ "HERITAGE" ],
+    "flags": [ "HERITAGE", "NO_CBM_INSTALLATION" ],
     "chargen_allow_npc": false
   },
   {
@@ -231,8 +228,7 @@
     "vitamin_rates": [ [ "mutagen_human", 1 ] ],
     "empathize_with": [ "UNDINE" ],
     "no_empathize_with": [ "HUMAN" ],
-    "no_cbm_on_bp": [ "torso", "head", "eyes", "mouth", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
-    "flags": [ "HERITAGE" ],
+    "flags": [ "HERITAGE", "NO_CBM_INSTALLATION" ],
     "chargen_allow_npc": false
   },
   {
@@ -330,8 +326,7 @@
     "vitamin_rates": [ [ "mutagen_human", 1 ] ],
     "empathize_with": [ "SYLPH" ],
     "no_empathize_with": [ "HUMAN" ],
-    "no_cbm_on_bp": [ "torso", "head", "eyes", "mouth", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
-    "flags": [ "HERITAGE" ],
+    "flags": [ "HERITAGE", "NO_CBM_INSTALLATION" ],
     "chargen_allow_npc": false
   },
   {

--- a/data/mods/Xedra_Evolved/mutations/playable_changeling.json
+++ b/data/mods/Xedra_Evolved/mutations/playable_changeling.json
@@ -41,8 +41,8 @@
     "purifiable": false,
     "types": [ "HERITAGE" ],
     "player_display": false,
-    "no_cbm_on_bp": [ "torso", "head", "eyes", "mouth", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
-    "chargen_allow_npc": false
+    "chargen_allow_npc": false,
+    "flags": [ "NO_CBM_INSTALLATION" ]
   },
   {
     "type": "mutation",
@@ -196,7 +196,6 @@
     "allowed_category": [ "FAIR_FOLK_NOBLE" ],
     "category": [ "FAIR_FOLK_NOBLE" ],
     "types": [ "HERITAGE" ],
-    "no_cbm_on_bp": [ "torso", "head", "eyes", "mouth", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
     "enchantments": [
       {
         "values": [
@@ -208,7 +207,7 @@
         ]
       }
     ],
-    "flags": [ "HERITAGE" ],
+    "flags": [ "HERITAGE", "NO_CBM_INSTALLATION" ],
     "chargen_allow_npc": false
   },
   {

--- a/data/mods/Xedra_Evolved/mutations/shapeshifters.json
+++ b/data/mods/Xedra_Evolved/mutations/shapeshifters.json
@@ -38,8 +38,7 @@
       [ "mutagen_troglobite", 1 ],
       [ "mutagen_ursine", 1 ]
     ],
-    "no_cbm_on_bp": [ "torso", "head", "eyes", "mouth", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ],
-    "flags": [ "MEND_ALL", "HERITAGE" ],
+    "flags": [ "MEND_ALL", "HERITAGE", "NO_CBM_INSTALLATION" ],
     "enchantments": [ { "values": [ { "value": "REGEN_HP", "multiply": 0.25 }, { "value": "REGEN_HP_AWAKE", "multiply": 0.1 } ] } ],
     "cancels": [ "DREAMER", "DREAMSMITH", "EATER", "INVENTOR" ],
     "chargen_allow_npc": false

--- a/data/mods/Xedra_Evolved/mutations/xe_playable_gracken.json
+++ b/data/mods/Xedra_Evolved/mutations/xe_playable_gracken.json
@@ -47,8 +47,7 @@
     "cancels": [ "DREAMER", "DREAMSMITH", "EATER", "INVENTOR" ],
     "empathize_with": [ "GRACKEN" ],
     "no_empathize_with": [ "HUMAN" ],
-    "flags": [ "HERITAGE" ],
-    "no_cbm_on_bp": [ "torso", "head", "eyes", "mouth", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ]
+    "flags": [ "HERITAGE", "NO_CBM_INSTALLATION" ]
   },
   {
     "type": "mutation",

--- a/doc/JSON/JSON_FLAGS.md
+++ b/doc/JSON/JSON_FLAGS.md
@@ -409,6 +409,7 @@ Character flags can be `trait_id`, `json_flag_id` or `flag_id`.  Some of these a
 - ```MYOPIC_SUPERNATURAL``` You are nearsighted in such a way that glasses cannot fix it, such as by magic.
 - ```MYOPIC_IN_LIGHT_SUPERNATURAL``` You are nearsighted in light in such a way that glasses cannot fix it, such as by magic.
 - ```NIGHT_VISION``` You can see in the dark.
+- ```NO_CBM_INSTALLATION``` You are unable to install any CBMs.
 - ```NO_DISEASE``` This mutation grants immunity to diseases.
 - ```NO_RADIATION``` This mutation grants immunity to radiations.
 - ```NO_SCENT``` You have no scent.

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -146,6 +146,7 @@ static const json_character_flag json_flag_BIONIC_TOGGLED( "BIONIC_TOGGLED" );
 static const json_character_flag json_flag_BIONIC_WEAPON( "BIONIC_WEAPON" );
 static const json_character_flag json_flag_ENHANCED_VISION( "ENHANCED_VISION" );
 static const json_character_flag json_flag_MANUAL_CBM_INSTALLATION( "MANUAL_CBM_INSTALLATION" );
+static const json_character_flag json_flag_NO_CBM_INSTALLATION( "NO_CBM_INSTALLATION" );
 static const json_character_flag json_flag_PAIN_IMMUNE( "PAIN_IMMUNE" );
 
 static const material_id fuel_type_metabolism( "metabolism" );
@@ -174,7 +175,6 @@ static const trait_id trait_CENOBITE( "CENOBITE" );
 static const trait_id trait_DEBUG_BIONICS( "DEBUG_BIONICS" );
 static const trait_id trait_MASOCHIST_MED( "MASOCHIST_MED" );
 static const trait_id trait_NONE( "NONE" );
-static const trait_id trait_NO_CBM_INSTALLATION( "NO_CBM_INSTALLATION" );
 static const trait_id trait_PROF_AUTODOC( "PROF_AUTODOC" );
 static const trait_id trait_PROF_MED( "PROF_MED" );
 static const trait_id trait_THRESH_MEDICAL( "THRESH_MEDICAL" );
@@ -2338,7 +2338,7 @@ bool Character::can_install_bionics( const itype &type, Character &installer, bo
     if( is_mounted() ) {
         return false;
     }
-    if( has_trait( trait_NO_CBM_INSTALLATION ) ) {
+    if( has_flag( json_flag_NO_CBM_INSTALLATION ) ) {
         return false;
     }
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Content "Replace hardcoded check for Oversensitive System with flag check"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

I sure love flags, and this could be useful in mods. It also prevents installing power modules, which have no bodypart and thus cannot be stopped by `no_cbm_on_bodypart`
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Replace the hardcoded check in #83073 for the specific Oversensitive System trait with checking for a `NO_CBM_INSTALLATION` flag. Apply that flag to the various supernatural creatures in XE that can't get CBMs, to Made of Sugar from My Sweet Cataclysm, and to the Bionic Vampire in Isolation Protocol (who has a bunch of CBMs and can't get any more), replacing `no_cbm_on_bodypart` where appropriate.

Change Rubik's dialogue to check for the flag, not the trait.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Started as a werewolf, tried to install a power system (which has no associated bodypart), was told it was incompatible. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
