### PR TITLE
Allow dimensions to have their own defined region settings

### DIFF
--- a/data/json/effects_on_condition/example_eocs.json
+++ b/data/json/effects_on_condition/example_eocs.json
@@ -535,8 +535,18 @@
         "target_var": { "u_val": "destination_dimension" }
       },
       {
+        "set_string_var": "default",
+        "string_input": {
+          "title": { "str": "region type for the dimension?" },
+          "description": { "str": "empty for default region." },
+          "width": 30
+        },
+        "target_var": { "u_val": "region_type" }
+      },
+      {
         "u_travel_to_dimension": { "u_val": "destination_dimension" },
         "npc_travel_radius": 5,
+        "region_type": { "u_val": "region_type" },
         "npc_travel_filter": "follower",
         "fail_message": "your body doesn't move",
         "success_message": "This place feels different."

--- a/data/json/effects_on_condition/example_eocs.json
+++ b/data/json/effects_on_condition/example_eocs.json
@@ -526,10 +526,10 @@
     "global": true,
     "effect": [
       {
-        "set_string_var": "",
+        "set_string_var": "default",
         "string_input": {
           "title": { "str": "teleport to dimension named:" },
-          "description": { "str": "'default' returns you to main dimension" },
+          "description": { "str": "empty for main dimension" },
           "width": 30
         },
         "target_var": { "u_val": "destination_dimension" }

--- a/data/json/region_settings/region_settings/test_regional_map_settings.json
+++ b/data/json/region_settings/region_settings/test_regional_map_settings.json
@@ -1,0 +1,66 @@
+[
+  {
+    "type": "region_settings_new",
+    "id": "test",
+    "rivers": "no_rivers",
+    "lakes": "no_lakes",
+    "ocean": "no_ocean",
+    "ravines": "default",
+    "forests": "no_forests",
+    "forest_composition": "default",
+    "forest_trails": "no_forest_trails",
+    "highways": "default",
+    "cities": "default",
+    "map_extras": "no_map_extras",
+    "terrain_furniture": "default",
+    "weather": "extreme_weather",
+    "default_oter": [
+      "open_air",
+      "open_air",
+      "open_air",
+      "open_air",
+      "open_air",
+      "open_air",
+      "open_air",
+      "open_air",
+      "open_air",
+      "open_air",
+      "field",
+      "solid_earth",
+      "empty_rock",
+      "empty_rock",
+      "deep_rock",
+      "deep_rock",
+      "deep_rock",
+      "deep_rock",
+      "deep_rock",
+      "deep_rock",
+      "deep_rock"
+    ],
+    "default_groundcover": [ [ "t_region_groundcover", 1 ] ],
+    "feature_flag_settings": { "blacklist": [  ], "whitelist": [  ] },
+    "connections": {
+      "intra_city_road_connection": "local_road",
+      "inter_city_road_connection": "local_road",
+      "trail_connection": "forest_trail",
+      "sewer_connection": "sewer_tunnel",
+      "subway_connection": "subway_tunnel",
+      "rail_connection": "local_railroad"
+    }
+  },
+  {
+    "type": "region_settings_map_extras",
+    "id": "no_map_extras",
+    "extras": [  ]
+  },
+  {
+    "type": "weather_generator",
+    "id": "extreme_weather",
+    "base_temperature": 60.5,
+    "base_humidity": 70.0,
+    "base_pressure": 1015.0,
+    "base_wind": 90.0,
+    "base_wind_distrib_peaks": 80,
+    "base_wind_season_variation": 50
+  }
+]

--- a/doc/JSON/EFFECT_ON_CONDITION.md
+++ b/doc/JSON/EFFECT_ON_CONDITION.md
@@ -4378,6 +4378,7 @@ Unloads the current dimension and loads the dimension with the specific ID, opti
 | "u_travel_to_dimension" | **mandatory** | string | Will teleport the player to a dimension with the ID. |
 | "npc_travel_radius" | optional | int or [variable object](#variable-object) | default 0; if a value above 0 is specified, the NPCs within that radius around the player will be transported with them when dimension hopping. |
 | "npc_travel_filter" | optional | string or [variable object](#variable-object) | default `all`; Acceps the following values: `all`, `follower`, `enemy`. Does nothing if `npc_travel_radius` is 0. |
+| "region_type" | optional | string or [variable object](#variable-object) | default `default`; The dimension is generated with the region settings of a `region_settings_new` object. |
 
 ##### Valid talkers:
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -923,6 +923,7 @@ bool game::start_game()
     refresh_display();
 
     load_master();
+    overmap_buffer.current_region_type = "default";
     u.setID( assign_npc_id() ); // should be as soon as possible, but *after* load_master
 
     // Make sure the items are added after the calendar is started
@@ -3191,6 +3192,8 @@ void game::load_master()
 bool game::load_dimension_data()
 {
     const cata_path datafile = PATH_INFO::current_dimension_save_path() / SAVE_DIMENSION_DATA;
+    // if for whatever reason the dimension data file doesn't have a set region_type, use the default one
+    overmap_buffer.current_region_type = "default";
     // If dimension_data.gsav doesn't exist, return false
     return read_from_file_optional( datafile, [this, &datafile]( std::istream & is ) {
         unserialize_dimension_data( datafile, is );
@@ -12745,6 +12748,7 @@ void game::vertical_move( int movez, bool force, bool peeking )
 }
 
 bool game::travel_to_dimension( const std::string &new_prefix,
+                                const std::string &region_type,
                                 const std::vector<npc *> &npc_travellers )
 {
     map &here = get_map();
@@ -12796,12 +12800,12 @@ bool game::travel_to_dimension( const std::string &new_prefix,
         dimension_prefix.clear();
     }
     // Load in data specific to the dimension (like weather)
-    //if( !load_dimension_data() ) {
-    // dimension data file not found/created yet
-    /* handle weather instance switching when I have dimensions with different region settings,
-     right now they're all the same and it's hard to tell if it's working or not. */
-    // weather.set_nextweather( calendar::turn );
-    //}
+    if( !load_dimension_data() ) {
+        // dimension data file not found/created yet
+
+        // Only allow `region_type` input for new dimensions.
+        overmap_buffer.current_region_type = region_type;
+    }
     // Clear the immediate game area around the player
     MAPBUFFER.clear();
     // hack to prevent crashes from temperature checks
@@ -12824,6 +12828,9 @@ bool game::travel_to_dimension( const std::string &new_prefix,
     load_npcs();
     // Handle static monsters
     here.spawn_monsters( true, true );
+    // updates the weather, if the weather settings are different in the new world
+    weather.weather_override = WEATHER_NULL;
+    weather.set_nextweather( calendar::turn );
     update_overmap_seen();
     return true;
 }

--- a/src/game.h
+++ b/src/game.h
@@ -334,7 +334,7 @@ class game
          * @param prefix identifies the dimension and its properties.
          * @param npc_travellers vector of NPCs that should be brought along when travelling to another dimension
          */
-        bool travel_to_dimension( const std::string &prefix,
+        bool travel_to_dimension( const std::string &prefix, const std::string &region_type,
                                   const std::vector<npc *> &npc_travellers );
         /**
          * Retrieve the identifier of the current dimension.

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -7692,10 +7692,14 @@ talk_effect_fun_t::func f_travel_to_dimension( const JsonObject &jo, std::string
     dbl_or_var npc_travel_radius;
     optional( jo, false, "npc_travel_radius", npc_travel_radius, 0 );
 
+    str_or_var region_type_var;
+    optional( jo, false, "region_type", region_type_var, "default" );
+
     return [fail_message, success_message, dimension_prefix, npc_travel_filter,
-                  npc_travel_radius]( dialogue const & d ) {
+                  npc_travel_radius, region_type_var]( dialogue const & d ) {
         Creature *teleporter = d.actor( false )->get_creature();
         if( teleporter ) {
+            std::string region_type = region_type_var.evaluate( d );
             std::string prefix = dimension_prefix.evaluate( d );
             std::string temp_dimension_prefix = ( prefix == "default" ) ? "" : prefix;
             if( temp_dimension_prefix != g->get_dimension_prefix() ) {
@@ -7721,7 +7725,7 @@ talk_effect_fun_t::func f_travel_to_dimension( const JsonObject &jo, std::string
                     } );
                 }
                 // returns False if fail
-                if( g->travel_to_dimension( prefix, travellers ) ) {
+                if( g->travel_to_dimension( prefix, region_type, travellers ) ) {
                     teleporter->add_msg_if_player( success_message.evaluate( d ) );
                 } else {
                     teleporter->add_msg_if_player( fail_message.evaluate( d ) );

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -2812,8 +2812,13 @@ void overmap_special::check() const
 // *** BEGIN overmap FUNCTIONS ***
 overmap::overmap( const point_abs_om &p ) : loc( p )
 {
-    const region_settings_id default_settings = overmap_buffer.get_default_settings( p ).id;
-    settings = default_settings;
+    const region_settings_id region_type( overmap_buffer.current_region_type );
+    if( overmap_buffer.current_region_type == "default" || !region_type.is_valid() ) {
+        const region_settings_id default_settings = overmap_buffer.get_default_settings( p ).id;
+        settings = default_settings;
+    } else {
+        settings = region_type;
+    }
     init_layers();
     hordes.set_location( loc );
 }

--- a/src/overmapbuffer.h
+++ b/src/overmapbuffer.h
@@ -226,6 +226,7 @@ class overmapbuffer
         std::string get_vehicle_tile_id( const tripoint_abs_omt &omt );
         const region_settings &get_settings( const tripoint_abs_omt &p );
         const region_settings &get_default_settings( const point_abs_om &p );
+        std::string current_region_type;
         /**
          * Accessors for horde introspection into overmaps.
          * Probably also useful for NPC overmap-scale navigation.

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -75,7 +75,7 @@ extern std::map<std::string, std::list<input_event>> quick_shortcuts_map;
  * Changes that break backwards compatibility should bump this number, so the game can
  * load a legacy format loader.
  */
-const int savegame_version = 37;
+const int savegame_version = 38;
 
 /*
  * This is a global set by detected version header in .sav, maps.txt, or overmap.
@@ -1740,6 +1740,8 @@ void game::unserialize_dimension_data( const JsonValue &jv )
             overmap_buffer.deserialize_overmap_global_state( jsin );
         } else if( name == "placed_unique_specials" ) {
             overmap_buffer.deserialize_placed_unique_specials( jsin );
+        } else if( name == "region_type" ) {
+            jsin.read( overmap_buffer.current_region_type );
         }
     }
 }
@@ -1893,6 +1895,7 @@ void game::serialize_dimension_data( std::ostream &fout )
         json.member( "weather" );
         weather_manager::serialize_all( json );
 
+        json.member( "region_type", overmap_buffer.current_region_type );
         json.end_object();
     } catch( const JsonError &e ) {
         debugmsg( "error saving to %s: %s", SAVE_DIMENSION_DATA, e.c_str() );

--- a/tests/submap_load_test.cpp
+++ b/tests/submap_load_test.cpp
@@ -874,7 +874,7 @@ static JsonValue submap_fd_pre_migration = json_loader::from_string( submap_fd_p
 static void load_from_jsin( submap &sm, const JsonValue &jsin )
 {
     // Ensure that the JSON is up to date for our savegame version
-    REQUIRE( savegame_version == 37 );
+    REQUIRE( savegame_version == 38 );
     int version = 0;
     JsonObject sm_json = jsin.get_object();
     if( sm_json.has_member( "version" ) ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Features "Custom region settings for dimensions"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Allow people to do weird and fun stuff with the dimension system.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
A new variable has been made, `current_region_type`, that dictates what region settings will be used when generating Overmap terrain. 
You can only set region types for new dimensions, with `u_travel_to_dimension` having a new `region_type` variable that accepts the IDs of `region_settings_new` objects. Examples include `default` and (the region i introduced for testing) `test`.
`EOC_dimension_swap_test` also now has a second input field for region type.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Not doing it
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Loaded game, used the `EOC_dimension_swap_test` to warp to a dimension with the region type of `test`. The weather there was a hurricane, it was incredibly warm and alot of the regular world's features were absent.
<img width="1362" height="960" alt="image" src="https://github.com/user-attachments/assets/8db3a5eb-62ef-493b-99c7-6e04a61e4715" />
I used the same eoc to return to the main dimension, while intentionally trying to set it's region type to `test`. That successfully didn't change the region type of the main dimension. 
The weather there was calm and the temperature was alot cooler than 60 celsius.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Thank you [ShnitzelX2](https://github.com/ShnitzelX2) for your work on [region settings overhaul](https://github.com/CleverRaven/Cataclysm-DDA/pull/82631). While it wasn't required for this PR, I certainly welcome not having each region definition be so fking big.
I might in the future also try allowing people to disable most region features, so we can have "empty" worlds for other fun stuff.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
