### PR TITLE
Allows to install glass and curtains on a broken window with bars.

### DIFF
--- a/data/json/construction/windows.json
+++ b/data/json/construction/windows.json
@@ -1037,5 +1037,28 @@
     "components": [ [ [ "nails", 4, "LIST" ] ], [ [ "sheet", 2 ] ], [ [ "stick", 1 ] ], [ [ "string_36", 1 ], [ "cordage_36", 1 ] ] ],
     "pre_terrain": "t_window_empty",
     "post_terrain": "t_window_empty_curtains_closed"
+  },
+  {
+    "type": "construction",
+    "id": "constr_window_bars_add_glass",
+    "group": "install_glass_onto_window_bars",
+    "category": "WINDOWS",
+    "required_skills": [ [ "fabrication", 5 ] ],
+    "time": "30 m",
+    "components": [ [ [ "glass_sheet", 1 ] ] ],
+    "pre_terrain": "t_window_bars_noglass",
+    "post_terrain": "t_window_bars"
+  },
+  {
+    "type": "construction",
+    "id": "constr_window_galass_bars_add_curtains",
+    "group": "install_glass_onto_window_bars",
+    "category": "WINDOWS",
+    "required_skills": [ [ "fabrication", 2 ] ],
+    "time": "30 m",
+    "qualities": [ [ { "id": "SAW_W", "level": 1 } ], [ { "id": "HAMMER", "level": 2 } ] ],
+    "components": [ [ [ "nails", 4, "LIST" ] ], [ [ "sheet", 2 ] ], [ [ "stick", 1 ] ], [ [ "string_36", 1 ], [ "cordage_36", 1 ] ] ],
+    "pre_terrain": "t_window_bars",
+    "post_terrain": "t_window_bars_curtains"
   }
 ]

--- a/data/json/construction_group.json
+++ b/data/json/construction_group.json
@@ -2129,5 +2129,10 @@
     "type": "construction_group",
     "id": "place_oil_press_industrial",
     "name": "Place an industrial oil press"
+  },
+  {
+    "type": "construction_group",
+    "id": "install_glass_onto_window_bars",
+    "name": "Install glass onto window with bars"
   }
 ]


### PR DESCRIPTION
#### Summary
Content "Repair window with bars"

#### Purpose of change
At the moment, it is impossible to restore a window with bars after a breakdown, for example, in buildings at the entrance to the mine, without breaking the bars. This PR allows you to restore the glazing and curtains without destroying the bars. The alarm system is not being restored.

#### Describe the solution
Added 2 construction entries and one construction group.

#### Describe alternatives you've considered
A living without a glass?

#### Testing
Break a window in the Mine Entrance (or let Z's break it).
Add a glass.
Add a curtains.

#### Additional context
Nope.