### PR TITLE
Make Scavenger's Anvil Tool Quality Less Confusing

### DIFF
--- a/data/json/items/tool/metalworking.json
+++ b/data/json/items/tool/metalworking.json
@@ -83,7 +83,6 @@
     "price_postapoc": "20 USD",
     "to_hit": { "grip": "bad", "length": "hand", "surface": "any", "balance": "clumsy" },
     "material": [ "steel" ],
-    "qualities": [ [ "ANVIL", 2 ] ],
     "symbol": ";",
     "color": "dark_gray",
     "flags": [ "DURABLE_MELEE" ],


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
I noticed that the anvil 2 quality on the scavenger's anvil item form  makes people think it only gives anvil 2 quality despite the fact it can give anvil 3 quality when properly placed through the contruction menu. So i make it less confusing.

#### Describe the solution
Yote the Scavenger's Anvil item's anvil qualities.

#### Describe alternatives you've considered
Not doing so?

#### Testing
Before
![Screenshot_20251002_103014](https://github.com/user-attachments/assets/86a9cdbd-6ea2-4935-aefa-630b933cae68)

After
![Screenshot_20251002_103200](https://github.com/user-attachments/assets/8c444429-7516-43ec-ba6b-f7d65fe39632)

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
