### PR TITLE
You can trade stuff directly from your car

### DIFF
--- a/src/trade_ui.cpp
+++ b/src/trade_ui.cpp
@@ -16,6 +16,7 @@
 #include "inventory_ui.h"
 #include "item.h"
 #include "item_category.h"
+#include "map.h"
 #include "npc.h"
 #include "npc_opinion.h"
 #include "npctrade.h"
@@ -26,8 +27,12 @@
 #include "ret_val.h"
 #include "string_formatter.h"
 #include "type_id.h"
+#include "vehicle.h"
+
+static const faction_id faction_your_followers( "your_followers" );
 
 static const flag_id json_flag_NO_UNWIELD( "NO_UNWIELD" );
+
 static const item_category_id item_category_ITEMS_WORN( "ITEMS_WORN" );
 static const item_category_id item_category_WEAPON_HELD( "WEAPON_HELD" );
 
@@ -138,6 +143,16 @@ trade_ui::trade_ui( party_t &you, npc &trader, currency_t cost, std::string titl
         }
     } else if( !trader.is_player_ally() ) {
         _panes[_trader]->add_nearby_items( 1 );
+    }
+
+    const map &here = get_map();
+
+    for( const wrapped_vehicle &wv : get_map().get_vehicles() ) {
+        if( wv.v->owner == faction_your_followers ) {
+            for( const tripoint_abs_ms &veh_pt : wv.v->get_points() ) {
+                _panes[_you]->add_vehicle_items( here.get_bub( veh_pt ) );
+            }
+        }
     }
 
     if( trader.will_exchange_items_freely() ) {

--- a/src/trade_ui.cpp
+++ b/src/trade_ui.cpp
@@ -6,6 +6,7 @@
 #include <cstdlib>
 #include <functional>
 #include <memory>
+#include <set>
 #include <unordered_set>
 
 #include "character.h"


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
I remembered a while ago i wished i didn't need to drag all the stuff to the trader, and just sell stuff directly from my car
Today i suddenly realised i can do it
#### Describe the solution
Make exactly it, if car is within the reality bub and your faction own it, all it's cargo is part of a trading UI
#### Describe alternatives you've considered
Highlight them somehow? I assume it won't be really possible without some invasive changes
#### Testing
Testing with anvils
Before:
<img width="2560" height="869" alt="image" src="https://github.com/user-attachments/assets/5fa39476-0561-4f17-a9e6-34f86138926e" />

After:
<img width="1155" height="543" alt="image" src="https://github.com/user-attachments/assets/f4a64158-e073-4fdd-a5b5-267319439082" />

Stuff is properly sold, properly disappear from the vehicle, and properly appear in trader storages

#### Additional context

I would like stuff being combined in this menu, but i could not find the function needed