### PR TITLE
Add another bucket for horde_map and filter ineligible monsters out o…

### DIFF
--- a/src/horde_map.h
+++ b/src/horde_map.h
@@ -18,7 +18,8 @@ namespace horde_map_flavors
 enum {
     active = 1,
     idle = 1 << 1,
-    dormant = 1 << 2
+    dormant = 1 << 2,
+    immobile = 1 << 3
 };
 } // namespace horde_map_flavors
 
@@ -44,6 +45,7 @@ class horde_map
         // ignored by overmap::move_hordes but is otherwise handled the same.
         map_type idle_monster_map;
         map_type dormant_monster_map;
+        map_type immobile_monster_map;
         point_abs_om location;
 
     public:
@@ -79,7 +81,8 @@ class horde_map
                 map_type *outer_map = nullptr;
                 map_type::iterator outer_iter;
                 std::unordered_map<tripoint_abs_ms, horde_entity>::iterator inner_iter;
-                int filter = horde_map_flavors::active | horde_map_flavors::idle | horde_map_flavors::dormant;
+                int filter = horde_map_flavors::active | horde_map_flavors::idle | horde_map_flavors::dormant |
+                             horde_map_flavors::immobile;
             public:
                 friend horde_map;
                 // TODO: ideally these would be private, no use case for constructing them outside of horde_map


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Fixes #83117 
Fixes #83122 
Fixes #83101 
In short, hordes were slurping up every monster, not just the zombies and ferals as intended, and applying zombie/feral style movement rules to them.
Also, DORMANT monsters were still getting sent and reacting to audible events.

#### Describe the solution
Add another "bucket" to horde_map for "unresponsive" monsters that don't react to auditory signals, and filter everything except species( ZOMBIE) and species( FERAL ) that has_flag( HEARS ) into it.  They "occupy space", but they don't react to sounds or attempt to move, all they really do is get spawned back onto the map once the map overlaps their location.
Removed the DORMANT bucket from signal_hordes, dormant monsters don't react yet, though a later PR may move them back and have some kind of "wake up" logic.

#### Describe alternatives you've considered
I was agonizing over trying to filter in a bunch of different ways, but only filtering ZOMBIES and FERALS into the bucket that does respond to noises is more straightforward than trying to filter for aggression toward the player which is what I was trying to do.

#### Testing
Find some monsters that shouldn't move, like fish or turrets or spotlights
Walk away until they're out of the reality bubble.
Use the debug menu to trigger a loud noise.
Wait a while.
Observe the fish aren't marching on your position.
Go back and check that they haven't moved at all.