### PR TITLE
[MoM] Matrix crystals must be wielded to awaken

### DIFF
--- a/data/mods/MindOverMatter/items/matrix_crystals.json
+++ b/data/mods/MindOverMatter/items/matrix_crystals.json
@@ -17,6 +17,7 @@
     "use_action": {
       "type": "effect_on_conditions",
       "consume": true,
+      "need_wielding": true,
       "description": "The pink glow calls to you.",
       "effect_on_conditions": [ "EOC_BIOKIN_MATRIX_AWAKENING" ]
     }
@@ -72,6 +73,7 @@
     "use_action": {
       "type": "effect_on_conditions",
       "consume": true,
+      "need_wielding": true,
       "description": "The gray glow calls to you.",
       "effect_on_conditions": [ "EOC_CLAIR_MATRIX_AWAKENING" ]
     }
@@ -104,6 +106,7 @@
     "use_action": {
       "type": "effect_on_conditions",
       "consume": true,
+      "need_wielding": true,
       "description": "The cyan glow calls to you.",
       "effect_on_conditions": [ "EOC_ELECTRO_MATRIX_AWAKENING" ]
     }
@@ -136,6 +139,7 @@
     "use_action": {
       "type": "effect_on_conditions",
       "consume": true,
+      "need_wielding": true,
       "description": "The golden glow calls to you.",
       "effect_on_conditions": [ "EOC_PHOTOKIN_MATRIX_AWAKENING" ]
     }
@@ -168,6 +172,7 @@
     "use_action": {
       "type": "effect_on_conditions",
       "consume": true,
+      "need_wielding": true,
       "description": "The red glow calls to you.",
       "effect_on_conditions": [ "EOC_PYROKIN_MATRIX_AWAKENING" ]
     }
@@ -200,6 +205,7 @@
     "use_action": {
       "type": "effect_on_conditions",
       "consume": true,
+      "need_wielding": true,
       "description": "The yellow glow calls to you.",
       "effect_on_conditions": [ "EOC_TELEKIN_MATRIX_AWAKENING" ]
     }
@@ -232,6 +238,7 @@
     "use_action": {
       "type": "effect_on_conditions",
       "consume": true,
+      "need_wielding": true,
       "description": "The white glow calls to you.",
       "effect_on_conditions": [ "EOC_TEEP_MATRIX_AWAKENING" ]
     }
@@ -264,6 +271,7 @@
     "use_action": {
       "type": "effect_on_conditions",
       "consume": true,
+      "need_wielding": true,
       "description": "The blue glow calls to you.",
       "effect_on_conditions": [ "EOC_TELEPORT_MATRIX_AWAKENING" ]
     }
@@ -296,6 +304,7 @@
     "use_action": {
       "type": "effect_on_conditions",
       "consume": true,
+      "need_wielding": true,
       "description": "The green glow calls to you.",
       "effect_on_conditions": [ "EOC_VITAKIN_MATRIX_AWAKENING" ]
     }

--- a/doc/JSON/ITEM.md
+++ b/doc/JSON/ITEM.md
@@ -1443,6 +1443,8 @@ The contents of `use_action` fields can either be a string indicating a built-in
 "use_action": {
   "type": "effect_on_conditions",          // Activate effect_on_conditions
   "consume": true,                         // defaults false: whether the iuse function should return 1 and attempt to consume the item
+  "need_worn": true,          // (optional) If the item has to be worn to activate the EoC
+  "need_wielding": true,      // (optional) If the item has to be wielded to activate the EoC
   "menu_text": "Infuse saline",            // (optional) Text displayed in the activation screen. Defaults to "Activate item"
   "description": "This debugs the game",   // Usage description
   "effect_on_conditions": [ "test_cond" ]  // IDs of the effect_on_conditions to activate


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[MoM] Matrix crystals must be wielded to awaken"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

As title. You have to wield it to activate it.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Apply the `"need_wielding": true` flag to the crystals.

Document this flag (it's mentioned in the general use_action documentation that it works on EoC use_actions but not in the EoC use_action section.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Stuffed matrix crystal in messenger bag, tried to use it to awaken, could not.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

I wanted to do this with all matrix crystal activated abilities but there's no infrastructure for artifacts doing it yet.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
