### PR TITLE
[XE] Torpor works without a do_turn_eoc now.

### DIFF
--- a/data/mods/Xedra_Evolved/mutations/vampire_trait_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/vampire_trait_eocs.json
@@ -1724,6 +1724,8 @@
     "type": "effect_on_condition",
     "id": "EOC_VAMPIRE_TORPOR_activated",
     "effect": [
+      { "math": [ "u_val('sleepiness') = 0" ] },
+      { "math": [ "u_val('sleep_deprivation') = 0" ] },
       { "u_assign_activity": "ACT_VAMPIRE_TORPOR", "duration": "8 hours" },
       { "u_add_effect": "effect_vampire_torpor", "duration": "8 hours" }
     ]
@@ -1738,13 +1740,16 @@
     "interruptable": false,
     "interruptable_with_kb": false,
     "rooted": true,
-    "do_turn_eoc": "EOC_VAMPIRE_TORPOR_RECOVER",
-    "completion_eoc": "EOC_EARTH_SLEEP_CHECK_REAL"
+    "completion_eoc": "EOC_REGAIN_SLEEP_AND_EARTH_SLEEP_CHECK_REAL"
   },
   {
     "type": "effect_on_condition",
-    "id": "EOC_VAMPIRE_TORPOR_RECOVER",
-    "effect": [ { "math": [ "u_val('sleepiness') = 0" ] }, { "math": [ "u_val('sleep_deprivation') = 0" ] } ]
+    "id": "EOC_REGAIN_SLEEP_AND_EARTH_SLEEP_CHECK_REAL",
+    "effect": [
+      { "math": [ "u_val('sleepiness') = 0" ] },
+      { "math": [ "u_val('sleep_deprivation') = 0" ] },
+      { "run_eocs": "EOC_EARTH_SLEEP_CHECK_REAL" }
+    ]
   },
   {
     "type": "effect_type",
@@ -1773,7 +1778,9 @@
               ]
             }
           },
-          { "value": "REGEN_HP_AWAKE", "multiply": 1 }
+          { "value": "REGEN_HP_AWAKE", "multiply": 1 },
+          { "value": "SLEEPINESS_REGEN", "multiply": 0.99 },
+          { "value": "SLEEPINESS", "multiply": -0.99 }
         ]
       }
     ]

--- a/data/mods/Xedra_Evolved/mutations/vampire_trait_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/vampire_trait_eocs.json
@@ -1779,7 +1779,7 @@
             }
           },
           { "value": "REGEN_HP_AWAKE", "multiply": 1 },
-          { "value": "SLEEPINESS_REGEN", "multiply": 0.99 },
+          { "value": "SLEEPINESS_REGEN", "multiply": 20 },
           { "value": "SLEEPINESS", "multiply": -0.99 }
         ]
       }

--- a/data/mods/Xedra_Evolved/obsoletion_and_migration/eocs.json
+++ b/data/mods/Xedra_Evolved/obsoletion_and_migration/eocs.json
@@ -142,5 +142,10 @@
     "type": "effect_on_condition",
     "id": "EOC_SUN_BURN_CHECK",
     "effect": [  ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_VAMPIRE_TORPOR_RECOVER",
+    "effect": [ { "math": [ "u_val('sleepiness') = 0" ] }, { "math": [ "u_val('sleep_deprivation') = 0" ] } ]
   }
 ]


### PR DESCRIPTION
#### Summary
Mods "[XE] Torpor works without a do_turn_eoc now."

#### Purpose of change

Calling an EOC every second during eight consecutive hours works, but it could be far better.

#### Describe the solution

Remove the do_turn_eoc that made it reset sleepiness every second.
Starting and completing torpor both reset sleepiness.
The torpor effect effectively stops sleepiness increase.

#### Describe alternatives you've considered

Let torpor use excessively inefficient mechanisms.

#### Testing

Became exhausted, entered torpor, lost all fatigue, torpor ends and I have no fatigue.

#### Additional context