### PR TITLE
[XE] Fix some ordinary humans being immune to vampire mind control + remove another blood gotcha.

### DIFF
--- a/data/mods/Xedra_Evolved/npc/vampire_master_mortal_mind.json
+++ b/data/mods/Xedra_Evolved/npc/vampire_master_mortal_mind.json
@@ -18,8 +18,16 @@
       "TALK_meteorologist_1",
       "TALK_NPC_HOMELESS_SURVIVOR",
       "TALK_NPC_APARTMENT_SURVIVOR",
-      "TALK_NPC_CAMPER",
-      "TALK_CITY_COP_INTRO"
+      "TALK_CITY_COP",
+      "TALK_FRIEND_Liam",
+      "TALK_FRIEND_Luo",
+      "TALK_NPC_EVAC_SURVIVOR",
+      "TALK_NPC_CAMPER_SURVIVOR",
+      "TALK_CARAVAN_REFUGEE_B1",
+      "TALK_CARAVAN_REFUGEE_B2",
+      "TALK_MI-GO_PRISONER1",
+      "TALK_COWBOYN_MAIN",
+      "TALK_COWBOYFR_MAIN"
     ],
     "//": "This should include all NPCs the player can immediately ask to follow them for free, and those who already follow.",
     "type": "talk_topic",

--- a/data/mods/Xedra_Evolved/npc/vampire_master_mortal_mind.json
+++ b/data/mods/Xedra_Evolved/npc/vampire_master_mortal_mind.json
@@ -81,7 +81,7 @@
       {
         "text": "[Spend a massive amount of blood to make them your renfield]",
         "topic": "TALK_YOUR_NEW_RENFIELD",
-        "condition": { "math": [ "u_vitamin('human_blood_vitamin') > -501" ] },
+        "condition": { "math": [ "u_vitamin('human_blood_vitamin') > 2501" ] },
         "effect": [
           {
             "if": { "u_has_trait": "VAMPIRE_MASTER_MORTAL_MIND_UPGRADE" },


### PR DESCRIPTION
#### Summary
Mods "[XE] Fix some ordinary humans being immune to vampire mind control + remove another blood gotcha."

#### Purpose of change

Liam, Luo and some other NPCs were immune to Master the Mortal Mind despite otherwise being valid targets.
Renfielding someone could bring you at eternal slumber levels.

#### Describe the solution

Add more dialogues where MMM can be used on the NPC.
Increase the minimal required blood to renfield someone. The cost is unchanged.

#### Describe alternatives you've considered

#### Testing

Could renfield Liam and Luo

#### Additional context