### PR TITLE
[XE] Vampires have a baseline night vision.

### DIFF
--- a/data/mods/Xedra_Evolved/mutations/mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/mutations.json
@@ -577,6 +577,16 @@
           "not": { "or": [ { "u_has_effect": "vampire_attacked_vampire_or_renfield" }, { "u_has_trait": "VAMPIRE_ANATHEMA" } ] }
         },
         "mutations": [ "VAMPIRE_TRUCE" ]
+      },
+      {
+        "values": [
+          {
+            "value": "NIGHT_VIS",
+            "add": {
+              "math": [ "1 + u_has_trait('VAMPIRE2') + u_has_trait('VAMPIRE3') + (u_has_trait('VAMPIRE4') + (u_has_trait('BLOOD_DRINKER')" ]
+            }
+          }
+        ]
       }
     ]
   },

--- a/data/mods/Xedra_Evolved/mutations/mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/mutations.json
@@ -583,7 +583,7 @@
           {
             "value": "NIGHT_VIS",
             "add": {
-              "math": [ "1 + u_has_trait('VAMPIRE2') + u_has_trait('VAMPIRE3') + (u_has_trait('VAMPIRE4') + (u_has_trait('BLOOD_DRINKER')" ]
+              "math": [ "1 + u_has_trait('VAMPIRE2') + u_has_trait('VAMPIRE3') + u_has_trait('VAMPIRE4') + u_has_trait('BLOOD_DRINKER')" ]
             }
           }
         ]


### PR DESCRIPTION
#### Summary
Mods "[XE] Vampires have a baseline night vision."

#### Purpose of change

The feedback I've got on vampires is that high tier vampires without gleaming eyes are in for a rough time.
Now that they are forced to avoid the day, they need some minimum of night vision so they can try to operate at night.

#### Describe the solution

Each tier of vampirism the player has gives +1 night vision range.

#### Describe alternatives you've considered

Make all vampires certain to gain gleaming eyes. This would be against the disease's base randomness.

#### Testing

Gained the first tier, gained +1 night vision.
Gained 1 more for each tier above.

#### Additional context

Gleaming eyes still has its place both as an upgrade for the baseline and the ability to read and craft without light.

The baseline gives no overmap sight due to inactive gleaming eyes only giving a flat 2.