### PR TITLE
Fix growth stage progression

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -8532,20 +8532,22 @@ void map::grow_plant( const tripoint_bub_ms &p )
 
     const std::vector<std::pair<flag_id, time_duration>> &growth_stages =
                 seed->type->seed->get_growth_stages();
+
     flag_id current_stage = flag_id( io::enum_to_string<ter_furn_flag>
                                      ( ter_furn_flag::TFLAG_GROWTH_SEED ) );
     flag_id target_stage = flag_id( io::enum_to_string<ter_furn_flag>
                                     ( ter_furn_flag::TFLAG_GROWTH_SEED ) );
     time_duration time_to_grow_to_this_stage = 0_seconds;
+
     for( const auto &pair : growth_stages ) {
-        const time_duration stage_growth_time = pair.second;
-        time_to_grow_to_this_stage += stage_growth_time;
         if( has_flag_furn( pair.first.str(), p ) ) {
             current_stage = pair.first;
         }
         if( seed->age() >= time_to_grow_to_this_stage ) {
             target_stage = pair.first;
-        }
+        } // Don't break the loop for the case where time has been rewound.
+        // Advance to the time of the next stage for the next iteration.
+        time_to_grow_to_this_stage += pair.second;
     }
 
     const auto check_flag = []( const std::string & to_check ) {
@@ -8565,6 +8567,12 @@ void map::grow_plant( const tripoint_bub_ms &p )
                    seed->tname(), to_string( seed->age() ), current_stage.c_str(), target_stage.c_str(),
                    stages_to_advance );
 
+    ter_furn_flag current = io::string_to_enum<ter_furn_flag>( current_stage.str() );
+
+    if( stages_to_advance <= 0 ) {
+        // We don't have the logic to reverse growth transforms, so leave the stage as is on a time rewind.
+        return;
+    }
 
     for( int i = 0; i < stages_to_advance; i++ ) {
         // Remove fertilizer if any

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -8567,8 +8567,6 @@ void map::grow_plant( const tripoint_bub_ms &p )
                    seed->tname(), to_string( seed->age() ), current_stage.c_str(), target_stage.c_str(),
                    stages_to_advance );
 
-    ter_furn_flag current = io::string_to_enum<ter_furn_flag>( current_stage.str() );
-
     if( stages_to_advance <= 0 ) {
         // We don't have the logic to reverse growth transforms, so leave the stage as is on a time rewind.
         return;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fix #83143, i.e. growth stage progression being erroneous.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Based on the fix proposed by @EIIKaO in the bug report comments, i.e. move the advancement of the time from the current stage to the next one to the end rather than before evaluation of the current one.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
The bailing out on a negative progression doesn't seem to do anything when testing. I still kept it, though.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
- Instrumented the modified code with the "add_msg_debug" report as an additional add_msg one to verify evaluations are made and to see what the progression is.
- Loaded my game save and teleported to an open field with no crops.
- Debug created a dirt mound and planted a debug spawned garlic seed in it.
- Observed the seed state.
- Moved a tile and back to make sure time has advanced by at least one tick to avoid any issues with exactly landing on the stage time boundaries.
- Debug advanced time 16 days (one less than the time to progress to the next stage).
- Teleported away some 5 overmap and back again to make sure evaluations are triggered.
- Observed the trace message stating 0 stages were advanced and verified the stage was indeed still the seed one.
- Debug advanced time 1 day, teleported away and back.
- Observed advancement of one stage reported and the change into seedling.
- Debug advanced time 15 days (one less than the stage time), teleported away and back.
- Observed 0 stages advancement and the plant remaining in the seedling state.
- Debug advanced time 1 day, teleported away and back.
- Observed advancement of one stage reported and the change into mature plant.
- Debug advanced time 15 days (one less than the stage time), teleported away and back.
- Observed 0 stages advancement and the plant remaining in the mature state.
- Debug advanced time 1 day, teleported away and back.
- Observed advancement of 1 stage and the plant becoming ready to harvest.
- Debug advanced time 15 days (one less than the stage time), teleported away and back.
- Observed 0 stages advancement and the plant remaining in the ready to harvest state.
- Debug advanced time 1 day, teleported away and back.
- Observed advancement of 1 stage and the plant becoming overgrown.
- Restarted and teleported to a corn field to find the plants overgrown due to this bug (they weren't ready to harvest 6 days earlier. Ah well, I hadn't planned on relying on corn anyway).
- Debug would back time 22 days.
- Observed the debug report said it rewound two stages, but it actually remained overgrown (as we don't have rewind support).
- Restarted and teleported to a wheat field. Saw that the plants were mature rather than seedlings as they had been stuck as when passed by them when the save was made.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
I hope I'm not stepping too hard on any toes when stealing the solution and making a PR for it.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
