### PR TITLE
Remove zombie code from zzip from last refactor

### DIFF
--- a/src/zzip.cpp
+++ b/src/zzip.cpp
@@ -395,11 +395,8 @@ std::optional<zzip> zzip::load(
 
     ZSTD_CCtx *cctx;
     ZSTD_DCtx *dctx;
-    if( dictionary_path.empty() ) {
-        cctx = ZSTD_createCCtx();
-        dctx = ZSTD_createDCtx();
-    } else if( auto it = cached_contexts.find( dictionary_path.generic_u8string() );
-               it != cached_contexts.end() ) {
+    if( auto it = cached_contexts.find( dictionary_path.generic_u8string() );
+        it != cached_contexts.end() ) {
         cctx = it->second.cctx;
         dctx = it->second.dctx;
     } else {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes #83163.

zzip.exe was broken on the decompression path after the last change. I moved code around and either did too many ctrl-z's or did a bad rebase/merge, but a copy of the moved code stayed behind in the old location. This made it break trying to decompress anything because it would try to read the zzip header twice and fail the second time.

There was also a zombie early return in a loop from the earlier code which was not in a loop but in a callback invoked repeatedly, where return made sense. This broke decompressing files with multiple entries, it would only decompress one file and then quit.

There was a memory leak triggered by loading zzips without a dictionary. This happens for .sav files and for the new compact_to flow which opens the destination temporary zzip without a dictionary because we just copy entries over.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Delete the zombie code.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Manually decompress zzips of each category (sav, map, map memory, overmap) and validate the results. Recompress the same and validate.

ASAN job on this PR should be green.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
