### PR TITLE
Fix dungeon structures not appearing.

### DIFF
--- a/data/json/effects_on_condition/nether_eocs/portal_storm_effect_on_condition.json
+++ b/data/json/effects_on_condition/nether_eocs/portal_storm_effect_on_condition.json
@@ -871,7 +871,7 @@
       { "assign_mission": "MISSION_INVESTIGATE_PORTAL_DUNGEON" },
       {
         "revert_location": { "global_val": "portal_dungeon" },
-        "time_in_future": "infinite",
+        "time_in_future": "172800 s",
         "key": "portal_dungeon_entrance"
       },
       { "mapgen_update": "portal_dungeon_entrance", "target_var": { "global_val": "portal_dungeon" } }
@@ -884,7 +884,7 @@
       { "u_location_variable": { "global_val": "original_loc" } },
       { "u_location_variable": { "global_val": "dungeon_loc" }, "z_adjust": 6, "z_override": true },
       { "u_location_variable": { "global_val": "dungeon_roof_loc" }, "z_adjust": 7, "z_override": true },
-      { "revert_location": { "global_val": "dungeon_loc" }, "key": "portal_dungeon", "time_in_future": "infinite" },
+      { "revert_location": { "global_val": "dungeon_loc" }, "key": "portal_dungeon", "time_in_future": "172800 s" },
       {
         "set_string_var": [ "Somewhere", "Nowhere", "Everywhere", "Yesterday", "Tomorrow" ],
         "target_var": { "global_val": "place_name" },
@@ -893,11 +893,11 @@
       {
         "place_override": { "global_val": "place_name", "default": "Error" },
         "key": "portal_dungeon",
-        "length": "infinite"
+        "length": "172800 s"
       },
       {
         "revert_location": { "global_val": "dungeon_roof_loc" },
-        "time_in_future": "infinite",
+        "time_in_future": "172800 s",
         "key": "portal_dungeon"
       },
       { "mapgen_update": "portal_dungeon_roof", "target_var": { "global_val": "dungeon_roof_loc" } },

--- a/data/json/effects_on_condition/nether_eocs/vitrification_effect_on_condition.json
+++ b/data/json/effects_on_condition/nether_eocs/vitrification_effect_on_condition.json
@@ -128,47 +128,47 @@
       },
       {
         "revert_location": { "global_val": "vitrified_farm_ground" },
-        "time_in_future": "infinite",
+        "time_in_future": "172800 s",
         "key": "vitrified_farm_escape_key"
       },
       {
         "revert_location": { "global_val": "vitrified_farm_upper" },
-        "time_in_future": "infinite",
+        "time_in_future": "172800 s",
         "key": "vitrified_farm_escape_key"
       },
       {
         "revert_location": { "global_val": "vitrified_farm_basement" },
-        "time_in_future": "infinite",
+        "time_in_future": "172800 s",
         "key": "vitrified_farm_escape_key"
       },
       {
         "revert_location": { "global_val": "vitrified_farm_roof" },
-        "time_in_future": "infinite",
+        "time_in_future": "172800 s",
         "key": "vitrified_farm_escape_key"
       },
       {
         "revert_location": { "global_val": "vitrified_sky_1" },
-        "time_in_future": "infinite",
+        "time_in_future": "172800 s",
         "key": "vitrified_farm_escape_key"
       },
       {
         "revert_location": { "global_val": "vitrified_apples" },
-        "time_in_future": "infinite",
+        "time_in_future": "172800 s",
         "key": "vitrified_farm_escape_key"
       },
       {
         "revert_location": { "global_val": "vitrified_apples_sky_lower" },
-        "time_in_future": "infinite",
+        "time_in_future": "172800 s",
         "key": "vitrified_farm_escape_key"
       },
       {
         "revert_location": { "global_val": "vitrified_apples_sky_upper" },
-        "time_in_future": "infinite",
+        "time_in_future": "172800 s",
         "key": "vitrified_farm_escape_key"
       },
       {
         "revert_location": { "global_val": "vitrified_sky_2" },
-        "time_in_future": "infinite",
+        "time_in_future": "172800 s",
         "key": "vitrified_farm_escape_key"
       },
       { "mapgen_update": "vitrified_farm_0", "target_var": { "global_val": "vitrified_farm_ground" } },

--- a/data/mods/Sky_Island/missions_and_mapgen.json
+++ b/data/mods/Sky_Island/missions_and_mapgen.json
@@ -117,7 +117,7 @@
       { "run_eocs": [ "EOC_Random_Loc_Mission" ] },
       {
         "revert_location": { "global_val": "OM_missionspot" },
-        "time_in_future": "infinite",
+        "time_in_future": "172800 s",
         "key": "return_portal_close"
       },
       {

--- a/data/mods/Xedra_Evolved/eocs/abyssal_hunger_eocs.json
+++ b/data/mods/Xedra_Evolved/eocs/abyssal_hunger_eocs.json
@@ -10,7 +10,7 @@
       {
         "place_override": { "global_val": "place_name", "default": "Inside the Abyssal Hunger" },
         "key": "abyssal_hunger",
-        "length": "172800 s"
+        "length": "infinite"
       },
       {
         "revert_location": { "global_val": "dungeon_roof_loc" },

--- a/data/mods/Xedra_Evolved/eocs/abyssal_hunger_eocs.json
+++ b/data/mods/Xedra_Evolved/eocs/abyssal_hunger_eocs.json
@@ -6,15 +6,15 @@
       { "u_location_variable": { "global_val": "original_loc" } },
       { "u_location_variable": { "global_val": "dungeon_loc" }, "z_adjust": 6, "z_override": true },
       { "u_location_variable": { "global_val": "dungeon_roof_loc" }, "z_adjust": 7, "z_override": true },
-      { "revert_location": { "global_val": "dungeon_loc" }, "key": "abyssal_hunger", "time_in_future": "infinite" },
+      { "revert_location": { "global_val": "dungeon_loc" }, "key": "abyssal_hunger", "time_in_future": "172800 s" },
       {
         "place_override": { "global_val": "place_name", "default": "Inside the Abyssal Hunger" },
         "key": "abyssal_hunger",
-        "length": "infinite"
+        "length": "172800 s"
       },
       {
         "revert_location": { "global_val": "dungeon_roof_loc" },
-        "time_in_future": "infinite",
+        "time_in_future": "172800 s",
         "key": "abyssal_hunger"
       },
       { "mapgen_update": "abyssal_hunger_roof", "target_var": { "global_val": "dungeon_roof_loc" } },

--- a/data/mods/Xedra_Evolved/mapgen/abyssal_hunger_zone.json
+++ b/data/mods/Xedra_Evolved/mapgen/abyssal_hunger_zone.json
@@ -47,7 +47,7 @@
       "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN", "NO_UNDERLYING_ROTATE" ],
       "set": [
         { "square": "furniture", "id": "f_null", "x": 0, "x2": 23, "y": 0, "y2": 23 },
-        { "point": "variable", "id": "dungeon_start", "x": 1, "y": 2 },
+        { "point": "variable", "id": "dungeon_start", "x": [ 1, 22 ], "y": 2 },
         { "point": "trap", "id": "tr_abyssal_hunger_next_level", "x": [ 1, 22 ], "y": 22 }
       ]
     }
@@ -86,7 +86,7 @@
       "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN", "NO_UNDERLYING_ROTATE" ],
       "set": [
         { "square": "furniture", "id": "f_null", "x": 0, "x2": 23, "y": 0, "y2": 23 },
-        { "point": "variable", "id": "dungeon_start", "x": 1, "y": 2 }
+        { "point": "variable", "id": "dungeon_start", "x": [ 1, 22 ], "y": 2 }
       ]
     }
   },
@@ -108,17 +108,7 @@
     "name": "Hole to elsewhere",
     "color": "blue",
     "copy-from": "tr_swirling_vortex",
-    "action": "spell",
-    "spell_data": { "id": "abyssal_hunger_next_level" }
-  },
-  {
-    "type": "SPELL",
-    "id": "abyssal_hunger_next_level",
-    "name": "abyssal hunger next level",
-    "description": "abyssal hunger next level",
-    "shape": "blast",
-    "valid_targets": [ "hostile", "ground", "self", "ally" ],
-    "effect": "effect_on_condition",
-    "effect_str": "EOC_ENTER_ABYSSAL_HUNGER_NEXT_LEVEL"
+    "action": "eocs",
+    "eocs": [ "EOC_ENTER_ABYSSAL_HUNGER_NEXT_LEVEL" ]
   }
 ]

--- a/data/mods/Xedra_Evolved/obsoletion_and_migration/spells.json
+++ b/data/mods/Xedra_Evolved/obsoletion_and_migration/spells.json
@@ -760,5 +760,15 @@
       ]
     },
     "targeted_monster_species": [ "HUMAN", "FERAL", "CYBORG" ]
+  },
+  {
+    "type": "SPELL",
+    "id": "abyssal_hunger_next_level",
+    "name": "abyssal hunger next level",
+    "description": "abyssal hunger next level",
+    "shape": "blast",
+    "valid_targets": [ "hostile", "ground", "self", "ally" ],
+    "effect": "effect_on_condition",
+    "effect_str": "EOC_ENTER_ABYSSAL_HUNGER_NEXT_LEVEL"
   }
 ]


### PR DESCRIPTION
#### Summary
Bugfixes "Fix dungeon structures not appearing."

#### Purpose of change

Fix #82861 and #83151

#### Describe the solution

Apply the fix used in #83074 on portal dungeons, the quiet farm, Sky Island's shard-find mission and XE's Abyssal Hunger area.

Also fix the Abyssal Hunger area's teleports.

#### Describe alternatives you've considered

Let these stay in a broken state

#### Testing

Entered all of these locations, they worked as intended.

#### Additional context