### PR TITLE
Patch EOC duration overflow

### DIFF
--- a/data/mods/Sky_Island/missions_and_mapgen.json
+++ b/data/mods/Sky_Island/missions_and_mapgen.json
@@ -85,7 +85,7 @@
       { "run_eocs": [ "EOC_Random_Loc_Extract" ] },
       {
         "revert_location": { "global_val": "OM_missionspot" },
-        "time_in_future": "172800 s",
+        "time_in_future": "infinite",
         "key": "return_portal_close"
       },
       { "assign_mission": "MISSION_REACH_EXTRACT" }

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -2758,7 +2758,7 @@ void time_duration::deserialize( const JsonValue &jsin )
 {
     if( jsin.test_string() ) {
         if( std::string const &str = jsin.get_string(); str == "infinite" ) {
-            *this = calendar::INDEFINITELY_LONG_DURATION;
+            *this = time_duration::from_turns( calendar::INDEFINITELY_LONG );
         } else {
             *this = read_from_json_string<time_duration>( jsin, time_duration::units );
         }


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
* Fixes #82829

* Closes #82861

* Closes #83151

* Closes #83183

#### Describe the solution
Don't overflow

Also revert #83074

#### Describe alternatives you've considered
We could also move time to being a 64-bit integer.

#### Testing
I have asked one of the mergers to do so, I just wanted to put in a better fix

#### Additional context
