### PR TITLE
[Magiclysm] Blood mages cannot bleed.

### DIFF
--- a/data/mods/Magiclysm/mutations/magic_classes/attunements.json
+++ b/data/mods/Magiclysm/mutations/magic_classes/attunements.json
@@ -162,7 +162,7 @@
       "WITHER_MAGE",
       "MAGIC_EMPTY"
     ],
-    "flags": [ "ATTUNEMENT", "BLEEDSLOW2" ]
+    "flags": [ "ATTUNEMENT", "BLEED_IMMUNE" ]
   },
   {
     "id": "BOREAL_MAGE",


### PR DESCRIPTION
#### Summary
Mods "[Magiclysm] Blood mages cannot bleed."

#### Purpose of change

The description for the blood mage attunement promises immunity to bleeding, despite it only granting reduced bleeding.
I'm fixing that.

#### Describe the solution

Change the BLEEDSLOW2 flag by BLEED_IMMUNE.

#### Describe alternatives you've considered

Changing the description instead. Due to how hard attunements are to attain now, it was decided to make it fit what it said.

#### Testing

Blood mages now have the flag that prevents bleeding.

#### Additional context