### PR TITLE
Update magiclysm list of authors and maintainers

### DIFF
--- a/data/mods/Magiclysm/modinfo.json
+++ b/data/mods/Magiclysm/modinfo.json
@@ -3,8 +3,8 @@
     "type": "MOD_INFO",
     "id": "magiclysm",
     "name": "Magiclysm",
-    "authors": [ "KorGgenT", "GuardianDll", "Aptronym", "LaVeyanFiend" ],
-    "maintainers": [ "KorGgenT" ],
+    "authors": [ "KorGgenT", "GuardianDll", "Aptronym", "LaVeyanFiend", "Maleclypse", "Standing-Storm" ],
+    "maintainers": [ "Maleclypse", "Standing-Storm" ],
     "description": "Cataclysm but with magic spells!",
     "category": "content",
     "dependencies": [ "dda" ]


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Maleclypse asked, so i did
#### Describe the solution
Add Mal and Storm to list of magiclysm authors, for massive contributions they made to mod
Removed KorgGent from mod maintainers due to inactivity
Added Mal to mod maintainers, by his request
Added Storm to same list, tho i didn't receive his approval yet, i will update if he decides he doesn't want to be listed