### PR TITLE
Filter out vertical movements for hordes

### DIFF
--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -4316,7 +4316,8 @@ void overmap::move_hordes()
             // Call up to overmapbuffer in case it needs to dispatch to an adjacent overmap.
             for( const tripoint_abs_ms &candidate :
                  squares_closer_to( mon->first, mon->second.destination ) ) {
-                if( overmap_buffer.passable( candidate ) ) {
+                // Just filter out cross-level candidates for now.
+                if( candidate.z() == mon->first.z() && overmap_buffer.passable( candidate ) ) {
                     viable_candidates.push_back( candidate );
                 }
             }


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Fixes an issue reported on discord (Thanks Telkoth) where lab inhabitants were moving to the surface.
Introduced in #83085

#### Describe the solution
Filter candidate move locations for horde entities to exclude vertical moves.

#### Describe alternatives you've considered
Fix wise this is pretty straightforward, in order to *allow* vertical movement we would need to hoist stair or ramp locations tot he overmap, which is feasible but I don't think it's a high priority.

#### Testing
Reproduced reported issue by:
Visiting a lab.
Spawning a bunch of zombies in an underground room.
Returning to the surface,
Moving several OMTs away.
Triggering a very loud noise with debug.
Returning to area near the lab.

Before fix:
Zombies popped into existence around the lab.

After fix:
No zombies appearing, they remained stuck underground.