### PR TITLE
Fix translation

### DIFF
--- a/lang/string_extractor/parsers/generic.py
+++ b/lang/string_extractor/parsers/generic.py
@@ -65,8 +65,8 @@ def parse_generic(json, origin):
                 write_text(entry["text"], origin,
                            comment="Snippet of item \"{}\"".format(name))
 
-    if "seed_data" in json:
-        write_text(json["seed_data"]["plant_name"], origin,
+    if "plant_name" in json:
+        write_text(json["plant_name"], origin,
                    comment="Plant name of seed \"{}\"".format(name))
 
     if "revert_msg" in json:

--- a/lang/string_extractor/parsers/json_flag.py
+++ b/lang/string_extractor/parsers/json_flag.py
@@ -2,6 +2,10 @@ from ..write_text import write_text
 
 
 def parse_json_flag(json, origin):
+    if "name" in json:
+        write_text(json["name"], origin,
+                   comment="Name of JSON flag \"{}\""
+                   .format(json["id"]))
     if "info" in json:
         write_text(json["info"], origin, comment=[
             "Please leave anything in <angle brackets> unchanged.",

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2307,7 +2307,8 @@ int game::inventory_item_menu( item_location locThisItem,
                     }
                     addentry( 'v', pgettext( "action", "pocket settings" ), hint_rating::good );
                 }
-                addentry( 'f', pgettext( "action", oThisItem.is_favorite ? "unfavorite" : "favorite" ),
+                addentry( 'f', oThisItem.is_favorite ? pgettext( "action", "unfavorite" ) : pgettext( "action",
+                          "favorite" ),
                           hint_rating::good );
                 addentry( 'V', pgettext( "action", "view recipe" ), rate_action_view_recipe( u, oThisItem ) );
                 addentry( '>', pgettext( "action", "hide contents" ), rate_action_collapse( oThisItem ) );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fix translations:
1. Plant names were not extracted.
<img width="344" height="48" alt="untr1" src="https://github.com/user-attachments/assets/1e7aa985-4325-43ca-a95a-bd8ca36b939d" />

2. Flag names were not extracted.
<img width="366" height="220" alt="untr2" src="https://github.com/user-attachments/assets/c7df0b29-a621-45eb-896c-01b82379d1d1" />

3. gettext ignored "favorite" in the ternary operator.
<img width="203" height="183" alt="untr7" src="https://github.com/user-attachments/assets/4598ba8a-93dc-4d50-ba45-338b0a0a2751" />

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Fix the extractor, move pgettext() outside the ternary operator
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
