### PR TITLE
create `DIMENSIONS.md` doc file

### DIFF
--- a/doc/JSON/DIMENSIONS.md
+++ b/doc/JSON/DIMENSIONS.md
@@ -1,6 +1,6 @@
 # Dimensions
-Dimensions are worlds that are stored within a save folder, they are mostly disconnected from the "main dimension." 
-When travelling between them, you aren't travelling as much as you are "switching" which world data folder is loaded right now.
+Dimensions are stored within a save folder, they are mostly disconnected from the "main" dimension, aka the dimension stored above `/dimensions` folder. 
+When travelling between them, you aren't travelling as much as you are "switching" which dimension data folder is loaded right now.
 
 There's almost no distinction between creating a dimension and loading into it. `u_travel_to_dimension` will just create a dimension if the ID you gave it doesn't correspond to an existing dimension.
 The one exception is `region_type`, you're only allowed to change a dimension's `region_settings` object when creating a new dimension. If you're loading into an already existing dimension, the `region_type` variable in `u_travel_to_dimension` will be ignored.  
@@ -26,7 +26,7 @@ Warping player to a dimension `portal_cell`, updating the location they teleport
 
 ## NPCs
 
-When using `u_travel_to_dimension` EOC, you can choose to take the nearby NPCs with you. In technical terms, When the world is being unloaded, the chosen NPCs aren't unloaded and they get to come with you.
+When using `u_travel_to_dimension` EOC, you can choose to take the nearby NPCs with you. In technical terms, When the dimension is being unloaded, the chosen NPCs aren't unloaded and they get to come with you.
 
 Travel to dimension `test`, take any follower within 10 tiles of your avatar with you.
 ```jsonc
@@ -48,7 +48,7 @@ Creating a new dimension `test_dimension` with the `region_settings` object with
 If travelling to an already created dimension, the `region_type` variable won't change the dimension's `region_settings` object. If you want that, you need to `clear_dimension` the dimension first.
 ## Cleanup
 
-If you're going for a temporary dimension or maybe you want to the overworld terrain to be regenerated. You can use `clear_dimension` EOC func.
+If you're going for a temporary dimension or maybe you want the overworld terrain to be regenerated. You can use `clear_dimension` EOC func.
 
 ```jsonc
 {"clear_dimension":"test"}

--- a/doc/JSON/DIMENSIONS.md
+++ b/doc/JSON/DIMENSIONS.md
@@ -2,8 +2,8 @@
 Dimensions are worlds that are stored within a save folder, they are mostly disconnected from the "main dimension." 
 When travelling between them, you aren't travelling as much as you are "switching" which world data folder is loaded right now.
 
-There's almost no distinction between creating a dimension and loading into it. `u_travel_to_dimension` will create a dimension if the ID you gave it doesn't correspond to an existing dimension.
-The one exception is `region_type`, you're only allowed to change a dimension's `region_settings` object when creating a new dimension. If you're loading into a dimension the `region_type` variable in `u_travel_to_dimension` will be ignored.  
+There's almost no distinction between creating a dimension and loading into it. `u_travel_to_dimension` will just create a dimension if the ID you gave it doesn't correspond to an existing dimension.
+The one exception is `region_type`, you're only allowed to change a dimension's `region_settings` object when creating a new dimension. If you're loading into an already existing dimension, the `region_type` variable in `u_travel_to_dimension` will be ignored.  
 
 By design, you aren't allowed to alter world data of unloaded dimensions. Meaning you can't place down structures in unloaded dimensions, place down NPCs, assign missions requiring a location inside the dimension, you can't even view the unloaded dimensions on an in-game map.
 

--- a/doc/JSON/DIMENSIONS.md
+++ b/doc/JSON/DIMENSIONS.md
@@ -1,9 +1,9 @@
 # Dimensions
 Dimensions are worlds that are stored within a save folder, they are mostly disconnected from the "main dimension." 
 When travelling between them, you aren't travelling as much as you are "switching" which world data folder is loaded right now.
-By design, you aren't allowed to alter world data of unloaded dimensions. Meaning you can't place down structures in unloaded dimensions, place down NPCs, assign missions there, you can't even view the unloaded dimensions on an in-game map.
+By design, you aren't allowed to alter world data of unloaded dimensions. Meaning you can't place down structures in unloaded dimensions, place down NPCs, assign missions requiring a location inside the dimension, you can't even view the unloaded dimensions on an in-game map.
 
-To get around this, we need to do all our world alterations when travelling into the dimension.
+To get around this, we need to do all our world alterations/queries when travelling into the dimension.
 
 Warping player to a dimension `portal_cell`, updating the location they teleported with a portal_cell structure and then teleporting the player inside:
 ```jsonc

--- a/doc/JSON/DIMENSIONS.md
+++ b/doc/JSON/DIMENSIONS.md
@@ -1,6 +1,10 @@
 # Dimensions
 Dimensions are worlds that are stored within a save folder, they are mostly disconnected from the "main dimension." 
 When travelling between them, you aren't travelling as much as you are "switching" which world data folder is loaded right now.
+
+There's almost no distinction between creating a dimension and loading into it. `u_travel_to_dimension` will create a dimension if the ID you gave it doesn't correspond to an existing dimension.
+The one exception is `region_type`, you're only allowed to change a dimension's `region_settings` object when creating a new dimension. If you're loading into a dimension the `region_type` variable in `u_travel_to_dimension` will be ignored.  
+
 By design, you aren't allowed to alter world data of unloaded dimensions. Meaning you can't place down structures in unloaded dimensions, place down NPCs, assign missions requiring a location inside the dimension, you can't even view the unloaded dimensions on an in-game map.
 
 To get around this, we need to do all our world alterations/queries when travelling into the dimension.
@@ -20,9 +24,36 @@ Warping player to a dimension `portal_cell`, updating the location they teleport
     { "u_teleport": { "context_val": "player_teleport_loc" } }
 ```
 
-## NPCS
+## NPCs
 
+When using `u_travel_to_dimension` EOC, you can choose to take the nearby NPCs with you. In technical terms, When the world is being unloaded, the chosen NPCs aren't unloaded and they get to come with you.
 
+Travel to dimension `test`, take any follower within 10 tiles of your avatar with you.
+```jsonc
+{"u_travel_to_dimension":"test","npc_travel_radius":10,"npc_travel_filter":"follower"}
+```
+There are also `all` and `enemy` filters you can use.
 
+There's a quirk with NPCs right now, that causes issues when attempting to take them with you to another dimension and then attempt to teleport them to some location within the same turn, you probably have to delay the npc teleportation stage by a turn to get around this. This might get fixed in the future.
 
-There's a quirk with NPCs right now, that causes issues when attempting to take them with you to another dimension and then attempt to teleport them to some location within the same turn, that might get fixed in the future.
+## Region Settings
+
+When generating a new dimension, you have the option to supply a [region_settings](REGION_SETTINGS.md) object which the dimension will use to generate it's terrain.
+
+Creating a new dimension `test_dimension` with the `region_settings` object with id `test`.
+```jsonc
+{"u_travel_to_dimension":"test_dimension","region_type":"test"}
+```
+
+If travelling to an already created dimension, the `region_type` variable won't change the dimension's `region_settings` object. If you want that, you need to `clear_dimension` the dimension first.
+## Cleanup
+
+If you're going for a temporary dimension or maybe you want to the overworld terrain to be regenerated. You can use `clear_dimension` EOC func.
+
+```jsonc
+{"clear_dimension":"test"}
+```
+
+This will delete the dimension's folder inside `/SAVEFOLDER/dimensions/<dimension_id>`.
+You can still `u_travel_to_dimension` into it, but the overworld terrain, items, vehicles, monsters, NPCs, faction hubs and all that will be regenerated in different locations.
+You can also supply a different `region_type` value when re-generating a dimension, if for some reason you want that.

--- a/doc/JSON/DIMENSIONS.md
+++ b/doc/JSON/DIMENSIONS.md
@@ -1,0 +1,28 @@
+# Dimensions
+Dimensions are worlds that are stored within a save folder, they are mostly disconnected from the "main dimension." 
+When travelling between them, you aren't travelling as much as you are "switching" which world data folder is loaded right now.
+By design, you aren't allowed to alter world data of unloaded dimensions. Meaning you can't place down structures in unloaded dimensions, place down NPCs, assign missions there, you can't even view the unloaded dimensions on an in-game map.
+
+To get around this, we need to do all our world alterations when travelling into the dimension.
+
+Warping player to a dimension `portal_cell`, updating the location they teleported with a portal_cell structure and then teleporting the player inside:
+```jsonc
+    { "u_location_variable": { "global_val": "cell_loc" }, "z_adjust": 0, "z_override": true },
+    { "u_location_variable": { "global_val": "cell_roof_loc" }, "z_adjust": 1, "z_override": true },
+    { "u_travel_to_dimension": "portal_cell" },
+    { "mapgen_update": "portal_cell_roof", "target_var": { "global_val": "cell_roof_loc" } },
+    { "mapgen_update": "portal_cell", "target_var": { "global_val": "cell_loc" } },
+    {
+    "u_location_variable": { "context_val": "player_teleport_loc" },
+    "terrain": "t_floor_warped",
+    "target_max_radius": 60
+    },
+    { "u_teleport": { "context_val": "player_teleport_loc" } }
+```
+
+## NPCS
+
+
+
+
+There's a quirk with NPCs right now, that causes issues when attempting to take them with you to another dimension and then attempt to teleport them to some location within the same turn, that might get fixed in the future.


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Recently I realized that the way I implemented the dimension system might not be too intuitive to people not deep into the inner workings of CDDA.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Attempt to write down my spotty knowledge about what I implemented, and some solutions to problems people might encounter.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
direct people to the PRs and code 
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
I read it and my brain didn't crash.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Would be nice if people proof-readed this, maybe pointed out things I missed or that are unnecessary.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
