### PR TITLE
Fix some issues with extracting/showing translations

### DIFF
--- a/src/basecamp.cpp
+++ b/src/basecamp.cpp
@@ -886,7 +886,7 @@ void basecamp::handle_takeover_by( faction_id new_owner, bool violent_takeover )
     camp_workers.clear();
 
     add_msg_debug( debugmode::DF_CAMPS, "Camp %s owned by %s is being taken over by %s!",
-                   name, fac()->name, new_owner->name );
+                   name, fac()->get_name(), new_owner->get_name() );
 
     if( !violent_takeover ) {
         set_owner( new_owner );
@@ -913,7 +913,8 @@ void basecamp::handle_takeover_by( faction_id new_owner, bool violent_takeover )
         if( checked_camp->get_owner() == get_owner() ) {
             add_msg_debug( debugmode::DF_CAMPS,
                            "Camp %s at %s is owned by %s, adding it to plunder calculations.",
-                           checked_camp->camp_name(), checked_camp->camp_omt_pos().to_string_writable(), get_owner()->name );
+                           checked_camp->camp_name(), checked_camp->camp_omt_pos().to_string_writable(),
+                           get_owner()->get_name() );
             num_of_owned_camps++;
         }
     }
@@ -933,7 +934,7 @@ void basecamp::handle_takeover_by( faction_id new_owner, bool violent_takeover )
     camp_food_supply( taken_from_camp );
     add_msg_debug( debugmode::DF_CAMPS,
                    "Food supplies of %s plundered by %d kilocalories!  Total food supply reduced to %d kilocalories after losing %.1f%% of their camps.",
-                   fac()->name, captured_with_camp.kcal(), fac()->food_supply().kcal(),
+                   fac()->get_name(), captured_with_camp.kcal(), fac()->food_supply().kcal(),
                    1.0 / static_cast<double>( num_of_owned_camps ) * 100.0 );
     set_owner( new_owner );
     int previous_days_of_food = camp_food_supply_days( MODERATE_EXERCISE );
@@ -943,7 +944,7 @@ void basecamp::handle_takeover_by( faction_id new_owner, bool violent_takeover )
     fac()->add_to_food_supply( added );
     add_msg_debug( debugmode::DF_CAMPS,
                    "Food supply of new owner %s has increased to %d kilocalories due to takeover of camp %s!",
-                   fac()->name, new_owner->food_supply().kcal(), name );
+                   fac()->get_name(), new_owner->food_supply().kcal(), name );
     if( new_owner == get_player_character().get_faction()->id ) {
         popup( _( "Through your looting of %s you found %d days worth of food and other resources." ),
                name, camp_food_supply_days( MODERATE_EXERCISE ) - previous_days_of_food );

--- a/src/basecamp.cpp
+++ b/src/basecamp.cpp
@@ -886,7 +886,7 @@ void basecamp::handle_takeover_by( faction_id new_owner, bool violent_takeover )
     camp_workers.clear();
 
     add_msg_debug( debugmode::DF_CAMPS, "Camp %s owned by %s is being taken over by %s!",
-                   name, fac()->get_name(), new_owner->get_name() );
+                   name, fac()->id.c_str(), new_owner->id.c_str() );
 
     if( !violent_takeover ) {
         set_owner( new_owner );
@@ -914,7 +914,7 @@ void basecamp::handle_takeover_by( faction_id new_owner, bool violent_takeover )
             add_msg_debug( debugmode::DF_CAMPS,
                            "Camp %s at %s is owned by %s, adding it to plunder calculations.",
                            checked_camp->camp_name(), checked_camp->camp_omt_pos().to_string_writable(),
-                           get_owner()->get_name() );
+                           get_owner()->id.c_str() );
             num_of_owned_camps++;
         }
     }
@@ -934,7 +934,7 @@ void basecamp::handle_takeover_by( faction_id new_owner, bool violent_takeover )
     camp_food_supply( taken_from_camp );
     add_msg_debug( debugmode::DF_CAMPS,
                    "Food supplies of %s plundered by %d kilocalories!  Total food supply reduced to %d kilocalories after losing %.1f%% of their camps.",
-                   fac()->get_name(), captured_with_camp.kcal(), fac()->food_supply().kcal(),
+                   fac()->id.c_str(), captured_with_camp.kcal(), fac()->food_supply().kcal(),
                    1.0 / static_cast<double>( num_of_owned_camps ) * 100.0 );
     set_owner( new_owner );
     int previous_days_of_food = camp_food_supply_days( MODERATE_EXERCISE );
@@ -944,7 +944,7 @@ void basecamp::handle_takeover_by( faction_id new_owner, bool violent_takeover )
     fac()->add_to_food_supply( added );
     add_msg_debug( debugmode::DF_CAMPS,
                    "Food supply of new owner %s has increased to %d kilocalories due to takeover of camp %s!",
-                   fac()->get_name(), new_owner->food_supply().kcal(), name );
+                   fac()->id.c_str(), new_owner->food_supply().kcal(), name );
     if( new_owner == get_player_character().get_faction()->id ) {
         popup( _( "Through your looting of %s you found %d days worth of food and other resources." ),
                name, camp_food_supply_days( MODERATE_EXERCISE ) - previous_days_of_food );

--- a/src/calendar.cpp
+++ b/src/calendar.cpp
@@ -15,6 +15,7 @@
 #include "options.h"
 #include "rng.h"
 #include "string_formatter.h"
+#include "translation.h"
 #include "translations.h"
 #include "units.h"
 #include "units_utility.h"
@@ -907,13 +908,13 @@ std::pair<month, int> month_and_day( time_point turn )
 
 std::string to_string( month m )
 {
-    static std::array<std::string, 12> months = {
-        translate_marker_context( "month", "Jan" ), translate_marker_context( "month", "Feb" ),
-        translate_marker_context( "month", "Mar" ), translate_marker_context( "month", "Apr" ),
-        translate_marker_context( "month", "May" ), translate_marker_context( "month", "Jun" ),
-        translate_marker_context( "month", "Jul" ), translate_marker_context( "month", "Aug" ),
-        translate_marker_context( "month", "Sep" ), translate_marker_context( "month", "Oct" ),
-        translate_marker_context( "month", "Nov" ), translate_marker_context( "month", "Dec" )
+    static std::array<translation, 12> months = {
+        to_translation( "month", "Jan" ), to_translation( "month", "Feb" ),
+        to_translation( "month", "Mar" ), to_translation( "month", "Apr" ),
+        to_translation( "month", "May" ), to_translation( "month", "Jun" ),
+        to_translation( "month", "Jul" ), to_translation( "month", "Aug" ),
+        to_translation( "month", "Sep" ), to_translation( "month", "Oct" ),
+        to_translation( "month", "Nov" ), to_translation( "month", "Dec" )
     };
 
     static_assert( static_cast<month>( 0 ) == month::JANUARY, "month enum out of phase" );
@@ -922,7 +923,7 @@ std::string to_string( month m )
         return _( "Cataclysm" );
     }
 
-    return _( months[static_cast<int>( m )] );
+    return months[static_cast<int>( m )].translated();
 }
 
 std::string get_diary_time_since_str( const time_duration &turn_diff, time_accuracy acc,

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -2339,7 +2339,7 @@ static faction *select_faction()
     uilist factionlist;
     int facnum = 0;
     for( const faction *faction : factions ) {
-        factionlist.addentry( facnum++, true, MENU_AUTOASSIGN, "%s", faction->name.c_str() );
+        factionlist.addentry( facnum++, true, MENU_AUTOASSIGN, "%s", faction->get_name() );
     }
 
     factionlist.query();
@@ -2886,7 +2886,7 @@ static void faction_edit_menu()
     uilist nmenu;
 
     std::stringstream data;
-    data << fac->name << std::endl;
+    data << fac->get_name() << std::endl;
     data << fac->describe() << std::endl;
     data << string_format( _( "Id: %s" ), fac->id.c_str() ) << std::endl;
     data << string_format( _( "Wealth: %d" ), fac->wealth ) << " | "
@@ -4428,7 +4428,7 @@ void debug()
                 std::cout << std::to_string( count ) << " Faction_id key in factions map = " << elem.first.str() <<
                           std::endl;
                 std::cout << std::to_string( count ) << " Faction name associated with this id is " <<
-                          elem.second.name << std::endl;
+                          elem.second.get_name() << std::endl;
                 std::cout << std::to_string( count ) << " the id of that faction object is " << elem.second.id.str()
                           << std::endl;
                 count++;

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -954,9 +954,8 @@ std::pair<std::string, nc_color> display::vehicle_cruise_text_color( const Chara
     if( veh ) {
         const double target = convert_velocity( veh->cruise_velocity, VU_VEHICLE );
         const double current = convert_velocity( veh->velocity, VU_VEHICLE );
-        const std::string units = get_option<std::string> ( "USE_METRIC_SPEEDS" );
         vel_text = string_format( "%s < %s %s", three_digit_display( target ),
-                                  three_digit_display( current ), units );
+                                  three_digit_display( current ), velocity_units( VU_VEHICLE ) );
 
         const float strain = veh->strain( here );
         if( strain <= 0 ) {

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -835,7 +835,7 @@ std::pair<std::string, nc_color> display::faction_text( const Character &u )
     if( owner->limited_area_claim && u.pos_abs_omt() != actual_camp->camp_omt_pos() ) {
         return std::pair( display_name, display_color );
     }
-    display_name = owner->name;
+    display_name = owner->get_name();
     // TODO: Make this magic number into a constant
     if( owner->likes_u < -10 ) {
         display_color = c_red;

--- a/src/faction.cpp
+++ b/src/faction.cpp
@@ -96,6 +96,16 @@ void faction_template::reset()
     npc_factions::all_templates.clear();
 }
 
+std::string faction_template::get_name() const
+{
+    return _( name );
+}
+
+void faction_template::set_name( std::string new_name )
+{
+    name = std::move( new_name );
+}
+
 void faction_template::load_relations( const JsonObject &jsobj )
 {
     for( const JsonMember fac : jsobj.get_object( "relations" ) ) {
@@ -536,7 +546,7 @@ faction *faction_manager::add_new_faction( const std::string &name_new, const fa
     for( const faction_template &fac_temp : npc_factions::all_templates ) {
         if( template_id == fac_temp.id ) {
             faction fac( fac_temp );
-            fac.name = name_new;
+            fac.set_name( name_new );
             fac.id = id_new;
             factions[fac.id] = fac;
             return &factions[fac.id];
@@ -559,7 +569,7 @@ faction *faction_manager::get( const faction_id &id, const bool complain )
                         elem.second.price_rules = fac_temp.price_rules;
                         elem.second.lone_wolf_faction = fac_temp.lone_wolf_faction;
                         elem.second.limited_area_claim = fac_temp.limited_area_claim;
-                        elem.second.name = fac_temp.name;
+                        elem.second.set_name( fac_temp.get_name() );
                         elem.second.desc = fac_temp.desc;
                         elem.second.mon_faction = fac_temp.mon_faction;
                         elem.second.epilogue_data = fac_temp.epilogue_data;
@@ -994,7 +1004,7 @@ void faction_manager::display() const
                 const std::string no_fac = _( "You don't know of any factions." );
                 if( active_vec_size > 0 ) {
                     draw_list( std::function( [&valfac]( size_t i ) {
-                        return _( valfac[i]->name );
+                        return valfac[i]->get_name();
                     } ) );
                     if( cur_fac ) {
                         cur_fac->faction_display( w_missions, 31 );

--- a/src/faction.h
+++ b/src/faction.h
@@ -123,7 +123,6 @@ class faction_template
     private:
         explicit faction_template( const JsonObject &jsobj );
 
-
     public:
         static void load( const JsonObject &jsobj );
         static void check_consistency();
@@ -141,7 +140,16 @@ class faction_template
         // debug access to food supply
         cata::list<std::pair<time_point, nutrients>> &debug_food_supply();
 
+        // Returns (hopefully) translated version of the faction's name.
+        std::string get_name() const;
+        // TODO: Move to faction constructor?
+        void set_name( std::string new_name );
+
+    protected:
+        // TODO: Shouldn't this be a translation object...
         std::string name;
+
+    public:
         int likes_u;
         int respects_u;
         int trusts_u; // Determines which item groups are available for trading
@@ -154,6 +162,7 @@ class faction_template
         // Sorted list of nutrients and when they expire
         // The time_point == 0 mod 1_days, and calendar::turn_zero is non-perishable food
         cata::list<std::pair<time_point, nutrients>> _food_supply; //Total nutritional value held
+
     public:
         bool consumes_food; //Whether this faction actually draws down the food_supply when eating from it
         int wealth;  //Total trade currency

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3838,7 +3838,7 @@ void game::display_faction_epilogues()
                                                point( std::max( 0, ( TERMX - FULL_SCREEN_WIDTH ) / 2 ),
                                                       std::max( 0, ( TERMY - FULL_SCREEN_HEIGHT ) / 2 ) ) );
                 };
-                scrollable_text( new_win, elem.second.name,
+                scrollable_text( new_win, elem.second.get_name(),
                                  std::accumulate( epilogue.begin() + 1, epilogue.end(), epilogue.front(),
                 []( std::string lhs, const std::string & rhs ) -> std::string {
                     return std::move( lhs ) + "\n" + rhs;
@@ -6443,7 +6443,7 @@ bool game::warn_player_maybe_anger_local_faction( bool really_bad_offense,
     // Else there's a camp, and we're doing something we're not supposed to! Time to warn the player.
     if( !query_yn(
             _( "You're in the territory of %s, they probably won't appreciate your actions.  Continue anyway?" ),
-            actual_camp->get_owner()->name ) ) {
+            actual_camp->get_owner()->get_name() ) ) {
         return false;
     } else {
         faction *owner_fac_pointer = g->faction_manager_ptr->get( actual_camp->get_owner() );

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -2202,7 +2202,7 @@ void iexamine::bulletin_board( Character &you, const tripoint_bub_ms &examp )
                           temp_camp->camp_name() ) ) {
                 bool plunder = query_yn(
                                    _( "Take whatever you can find from the stores?  This may anger %s and their allies." ),
-                                   temp_camp->get_owner()->name );
+                                   temp_camp->get_owner()->get_name() );
                 temp_camp->handle_takeover_by( you.get_faction()->id, plunder );
                 return;
             }

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1625,7 +1625,7 @@ std::string item::get_old_owner_name() const
         debugmsg( "item::get_owner_name() item %s has no valid nor null faction id", tname() );
         return "no owner";
     }
-    return g->faction_manager_ptr->get( get_old_owner() )->name;
+    return g->faction_manager_ptr->get( get_old_owner() )->get_name();
 }
 
 std::string item::get_owner_name() const
@@ -1634,7 +1634,7 @@ std::string item::get_owner_name() const
         debugmsg( "item::get_owner_name() item %s has no valid nor null faction id ", tname() );
         return "no owner";
     }
-    return g->faction_manager_ptr->get( get_owner() )->name;
+    return g->faction_manager_ptr->get( get_owner() )->get_name();
 }
 
 void item::set_owner( const faction_id &new_owner )

--- a/src/item_info.cpp
+++ b/src/item_info.cpp
@@ -1733,14 +1733,19 @@ void item::armor_protection_info( std::vector<iteminfo> &info, const iteminfo_qu
         bool display_median = percent_best < 50 && percent_worst < 50;
 
         std::string protection_table;
+        const std::string worst_chance_string = string_format( _( "<bad>%d%%</bad> chance" ),
+                                                percent_worst );
+        const std::string median_chance = _( "<color_c_yellow>Median</color> chance" );
+        const std::string best_chance_string = string_format( _( "<good>%d%%</good> chance" ),
+                                               percent_best );
         if( display_median ) {
             protection_table +=
-                string_format( "<bold>%s</bold>;<bad>%d%%</bad> chance;<color_c_yellow>Median</color> chance;<good>%d%%</good> chance\n",
-                               _( "Protection" ), percent_worst, percent_best );
+                string_format( "<bold>%s</bold>;%s;%s;%s\n",
+                               _( "Protection" ), worst_chance_string, median_chance, best_chance_string );
         } else if( percent_worst > 0 ) {
             protection_table +=
-                string_format( "<bold>%s</bold>;<bad>%d%%</bad> chance;<good>%d%%</good> chance\n",
-                               _( "Protection" ), percent_worst, percent_best );
+                string_format( "<bold>%s</bold>;%s;%s\n",
+                               _( "Protection" ), worst_chance_string, best_chance_string );
         } else {
             protection_table += string_format( "<bold>%s</bold>\n", _( "Protection" ) );
         }

--- a/src/item_info.cpp
+++ b/src/item_info.cpp
@@ -283,7 +283,7 @@ void item::basic_info( std::vector<iteminfo> &info, const iteminfo_query *parts,
     }
     if( parts->test( iteminfo_parts::BASE_OWNER ) && !owner.is_null() ) {
         info.emplace_back( "BASE", string_format( _( "Owner: %s" ),
-                           _( get_owner_name() ) ) );
+                           get_owner_name() ) );
     }
     if( parts->test( iteminfo_parts::BASE_CATEGORY ) ) {
         info.emplace_back( "BASE", _( "Category: " ),
@@ -394,7 +394,7 @@ void item::debug_info( std::vector<iteminfo> &info, const iteminfo_query *parts,
                                typeId().str() ) );
             if( !old_owner.is_null() ) {
                 info.emplace_back( "BASE", string_format( _( "Old owner: %s" ),
-                                   _( get_old_owner_name() ) ) );
+                                   get_old_owner_name() ) );
             }
             info.emplace_back( "BASE", _( "age (hours): " ), "", iteminfo::lower_is_better,
                                to_hours<int>( age() ) );

--- a/src/item_info.cpp
+++ b/src/item_info.cpp
@@ -2720,7 +2720,7 @@ void item::tool_info( std::vector<iteminfo> &info, const iteminfo_query *parts, 
     std::string &eport = type->tool->e_port;
     if( !eport.empty() ) {
         std::string compat;
-        compat += _( "* This device has electronic port type: " + colorize( eport, c_light_green ) );
+        compat += _( "* This device has electronic port type: " ) + colorize( _( eport ), c_light_green ) ;
         std::vector<std::string> &eport_banned = type->tool->e_ports_banned;
         if( !eport_banned.empty() ) {
             compat += _( "\n* This device does not support transfer to e-port types: " );

--- a/src/mission_companion.cpp
+++ b/src/mission_companion.cpp
@@ -2327,7 +2327,7 @@ bool talk_function::force_on_force( const std::vector<npc_ptr> &defender,
     faction *yours = player_character.get_faction();
     //Find out why your followers don't have your faction...
     popup( _( "Engagement between %d members of %s %s and %d %s%s!" ), defender.size(),
-           yours->name, def_desc, monsters_fighting.size(), att_desc, adv );
+           yours->get_name(), def_desc, monsters_fighting.size(), att_desc, adv );
     int defense = 0;
     int attack = 0;
     int att_init = 0;
@@ -2353,10 +2353,10 @@ bool talk_function::force_on_force( const std::vector<npc_ptr> &defender,
             attack_random( remaining_mon, remaining_def );
             if( defense == 0 || ( remaining_def.size() == 1 && remaining_def[0]->is_dead() ) ) {
                 //Here too...
-                popup( _( "%s forces are destroyed!" ), yours->name );
+                popup( _( "%s forces are destroyed!" ), yours->get_name() );
             } else {
                 //Again, no faction for your followers
-                popup( _( "%s forces retreat from combat!" ), yours->name );
+                popup( _( "%s forces retreat from combat!" ), yours->get_name() );
             }
             return false;
         } else if( attack * 3 < defense ) {
@@ -2392,8 +2392,8 @@ void talk_function::force_on_force( const std::vector<npc_ptr> &defender,
         adv = ", defender advantage";
     }
     popup( _( "Engagement between %d members of %s %s and %d members of %s %s%s!" ),
-           defender.size(), defender[0]->get_faction()->name, def_desc, attacker.size(),
-           attacker[0]->get_faction()->name, att_desc, adv );
+           defender.size(), defender[0]->get_faction()->get_name(), def_desc, attacker.size(),
+           attacker[0]->get_faction()->get_name(), att_desc, adv );
     int defense = 0;
     int attack = 0;
     int att_init = 0;
@@ -2418,18 +2418,18 @@ void talk_function::force_on_force( const std::vector<npc_ptr> &defender,
             attack_random( remaining_att, remaining_def );
             if( defense == 0 || ( remaining_def.size() == 1 &&
                                   remaining_def[0]->get_part_hp_cur( bodypart_id( "torso" ) ) == 0 ) ) {
-                popup( _( "%s forces are destroyed!" ), defender[0]->get_faction()->name );
+                popup( _( "%s forces are destroyed!" ), defender[0]->get_faction()->get_name() );
             } else {
-                popup( _( "%s forces retreat from combat!" ), defender[0]->get_faction()->name );
+                popup( _( "%s forces retreat from combat!" ), defender[0]->get_faction()->get_name() );
             }
             return;
         } else if( attack * 3 < defense ) {
             attack_random( remaining_def, remaining_att );
             if( attack == 0 || ( remaining_att.size() == 1 &&
                                  remaining_att[0]->get_part_hp_cur( bodypart_id( "torso" ) ) == 0 ) ) {
-                popup( _( "%s forces are destroyed!" ), attacker[0]->get_faction()->name );
+                popup( _( "%s forces are destroyed!" ), attacker[0]->get_faction()->get_name() );
             } else {
-                popup( _( "%s forces retreat from combat!" ), attacker[0]->get_faction()->name );
+                popup( _( "%s forces retreat from combat!" ), attacker[0]->get_faction()->get_name() );
             }
             return;
         } else {

--- a/src/mission_ui.cpp
+++ b/src/mission_ui.cpp
@@ -249,13 +249,13 @@ void mission_ui_impl::draw_controls()
 
     if( ( selected_tab != mission_ui_tab_enum::POINTS_OF_INTEREST && umissions.empty() ) ||
         ( selected_tab == mission_ui_tab_enum::POINTS_OF_INTEREST && upoints_of_interest.empty() ) ) {
-        static const std::map< mission_ui_tab_enum, std::string > nope = {
-            { mission_ui_tab_enum::ACTIVE, translate_marker( "You have no active missions!" ) },
-            { mission_ui_tab_enum::COMPLETED, translate_marker( "You haven't completed any missions!" ) },
-            { mission_ui_tab_enum::FAILED, translate_marker( "You haven't failed any missions!" ) },
-            {mission_ui_tab_enum::POINTS_OF_INTEREST, translate_marker( "You don't have any points of interest.  Add those from the overmap." )}
+        static const std::map< mission_ui_tab_enum, translation > nope = {
+            { mission_ui_tab_enum::ACTIVE, to_translation( "You have no active missions!" ) },
+            { mission_ui_tab_enum::COMPLETED, to_translation( "You haven't completed any missions!" ) },
+            { mission_ui_tab_enum::FAILED, to_translation( "You haven't failed any missions!" ) },
+            { mission_ui_tab_enum::POINTS_OF_INTEREST, to_translation( "You don't have any points of interest.  Add those from the overmap." ) }
         };
-        ImGui::TextWrapped( "%s", nope.at( selected_tab ).c_str() );
+        ImGui::TextWrapped( "%s", nope.at( selected_tab ).translated().c_str() );
         return;
     }
 
@@ -373,21 +373,26 @@ void mission_ui_impl::draw_selected_description( std::vector<mission *> missions
 {
     mission *miss = missions[selected_mission];
     ImGui::TextWrapped( _( "Mission: %s" ), miss->name().c_str() );
+    npc *mission_giver = nullptr;
     if( miss->get_npc_id().is_valid() ) {
-        npc *guy = g->find_npc( miss->get_npc_id() );
-        if( guy ) {
-            draw_label_with_value( _( "Given by:" ), guy->disp_name() );
-            if( guy->get_faction() && guy->get_fac_id() != faction_no_faction ) {
-                draw_label_with_value( _( "Faction:" ), guy->get_faction()->name );
+        mission_giver = g->find_npc( miss->get_npc_id() );
+        if( mission_giver ) {
+            draw_label_with_value( _( "Given by:" ), mission_giver->disp_name() );
+            if( mission_giver->get_faction() && mission_giver->get_fac_id() != faction_no_faction ) {
+                draw_label_with_value( _( "Faction:" ), mission_giver->get_faction()->name );
             }
-            const tripoint_abs_omt npc_location = guy->pos_abs_omt();
+            const tripoint_abs_omt npc_location = mission_giver->pos_abs_omt();
             draw_location( _( "Map location:" ), npc_location );
         }
     }
     ImGui::Separator();
     static std::string raw_description;
     static std::string parsed_description;
-    // Avoid replacing expanded snippets with other valid snippet text on redraw
+    // We do this to avoid replacing expanded snippets with other valid snippet text on redraw. The raw description includes un-parsed snippet tags.
+    // The parsed description is, obviously, after they've been parsed. So "<zombie_name>" becomes "undead thing" or "zed" or whatever.
+    // Whenever the user changes which mission they're looking at, this will update to parse the description *once* and keep displaying that parsed version
+    // until the mission changes again. The raw_description string is stored for as long as the program is running.
+    // This hinges on the 'static' keyword influencing storage duration. See https://en.cppreference.com/w/cpp/language/storage_duration.html etc
     if( raw_description != miss->get_description() ) {
         raw_description = miss->get_description();
         parsed_description = raw_description;
@@ -400,7 +405,9 @@ void mission_ui_impl::draw_selected_description( std::vector<mission *> missions
             parsed_description = string_replace( parsed_description, token, string_format( "%g",
                                                  reward.first.evaluate( d ) ) );
         }
-        parse_tags( parsed_description, get_player_character(), get_player_character() );
+        const Character &other_talker = mission_giver ? *mission_giver : get_player_character();
+        // parse_tags() modifies the argument string directly, no return value.
+        parse_tags( parsed_description, get_player_character(), other_talker );
     }
     cataimgui::draw_colored_text( parsed_description, c_unset, table_column_width * 1.15 );
     if( miss->has_deadline() ) {
@@ -427,12 +434,15 @@ void mission_ui_impl::draw_selected_description( std::vector<mission *> missions
             }
             if( deadline != calendar::turn_zero ) {
                 if( selected_tab == mission_ui_tab_enum::COMPLETED ) {
+                    //~The replaced string is a calendar date, such as "Year 1, May 12, 08:04:32"
                     cataimgui::draw_colored_text( string_format( _( "Completed: %s" ),
                                                   to_string( deadline ) ), c_green );
                 } else if( selected_tab == mission_ui_tab_enum::FAILED ) {
+                    //~The replaced string is a calendar date, such as "Year 1, May 12, 08:04:32"
                     cataimgui::draw_colored_text( string_format( _( "Failed at: %s" ),
                                                   to_string( deadline ).c_str() ), c_red );
                 }
+                //~The replaced string is a time duration, such as "12 hours", or "5 minutes"
                 cataimgui::draw_colored_text( string_format( _( "%s ago" ), time_in_past_string ), c_unset );
             }
         }
@@ -454,11 +464,6 @@ void mission_ui_impl::draw_selected_description( std::vector<point_of_interest> 
     point_of_interest selected_point_of_interest = points_of_interest[selected_mission];
     ImGui::TextWrapped( _( "Point of Interest: %s" ), selected_point_of_interest.text.c_str() );
     ImGui::Separator();
-    static std::string raw_description;
-    static std::string parsed_description;
-    // Avoid replacing expanded snippets with other valid snippet text on redraw
-    cataimgui::draw_colored_text( parsed_description, c_unset, table_column_width * 1.15 );
-    // TODO: target does not contain a z-component, targets are assumed to be on z=0
     draw_location( _( "Target:" ), selected_point_of_interest.pos );
 }
 

--- a/src/mission_ui.cpp
+++ b/src/mission_ui.cpp
@@ -379,7 +379,7 @@ void mission_ui_impl::draw_selected_description( std::vector<mission *> missions
         if( mission_giver ) {
             draw_label_with_value( _( "Given by:" ), mission_giver->disp_name() );
             if( mission_giver->get_faction() && mission_giver->get_fac_id() != faction_no_faction ) {
-                draw_label_with_value( _( "Faction:" ), mission_giver->get_faction()->name );
+                draw_label_with_value( _( "Faction:" ), mission_giver->get_faction()->get_name() );
             }
             const tripoint_abs_omt npc_location = mission_giver->pos_abs_omt();
             draw_location( _( "Map location:" ), npc_location );

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -2335,8 +2335,7 @@ static std::string faction_or_fallback( const_talker const &guy )
     if( !fac ) {
         return guy.get_name();
     }
-    // Note: Check for translation, don't just return raw name.
-    return _( fac->name );
+    return fac->get_name();
 }
 
 void parse_tags( std::string &phrase, const Character &u, const Creature &me,

--- a/src/translations.h
+++ b/src/translations.h
@@ -13,6 +13,7 @@
  * Marks a string literal to be extracted for translation. This is only for running `xgettext` via
  * "lang/update_pot.sh". Use `_` to extract *and* translate at run time. The macro itself does not
  * do anything, the argument is passed through it without any changes.
+ * That means, this does NOT return a translated string. Calling translate_marker on an English string in any UI code is likely a mistake! Use `_` or to_translation etc.
  */
 #define translate_marker(x) x
 #endif

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -544,7 +544,7 @@ void veh_interact::do_main_loop( map &here )
                 do_rename();
             } else {
                 if( owner_fac ) {
-                    popup( _( "You cannot rename this vehicle as it is owned by: %s." ), _( owner_fac->name ) );
+                    popup( _( "You cannot rename this vehicle as it is owned by: %s." ), owner_fac->get_name() );
                 }
             }
         } else if( action == "SIPHON" ) {
@@ -570,7 +570,7 @@ void veh_interact::do_main_loop( map &here )
             } else {
                 if( owner_fac ) {
                     popup( _( "You cannot assign crew on this vehicle as it is owned by: %s." ),
-                           _( owner_fac->name ) );
+                           owner_fac->get_name() );
                 }
             }
         } else if( action == "RELABEL" ) {
@@ -578,7 +578,7 @@ void veh_interact::do_main_loop( map &here )
                 do_relabel( here );
             } else {
                 if( owner_fac ) {
-                    popup( _( "You cannot relabel this vehicle as it is owned by: %s." ), _( owner_fac->name ) );
+                    popup( _( "You cannot relabel this vehicle as it is owned by: %s." ), owner_fac->get_name() );
                 }
             }
         } else if( action == "FUEL_LIST_DOWN" ) {

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -2988,7 +2988,7 @@ std::vector<std::string> optional_vpart_position::extended_description() const
     ret.emplace_back( get_origin( v.type->src ) );
     ret.emplace_back( "--" );
 
-    ret.emplace_back( string_format( _( "%s (%s)" ), v.name, v.owner->name ) );
+    ret.emplace_back( string_format( _( "%s (%s)" ), v.name, v.owner->get_name() ) );
     ret.emplace_back( "--" );
 
     for( int idx : v.parts_at_relative( value().mount_pos(), true ) ) {
@@ -4991,7 +4991,7 @@ std::string vehicle::get_owner_name() const
         debugmsg( "vehicle::get_owner_name() vehicle %s has no valid nor null faction id ", disp_name() );
         return _( "no owner" );
     }
-    return _( g->faction_manager_ptr->get( owner )->name );
+    return g->faction_manager_ptr->get( owner )->get_name();
 }
 
 void vehicle::set_owner( const Character &c )
@@ -5044,7 +5044,7 @@ bool vehicle::handle_potential_theft( Character const &you, bool check_only, boo
     if( prompt ) {
         if( !you.query_yn(
                 _( "This vehicle belongs to: %s, there may be consequences if you are observed interacting with it, continue?" ),
-                _( get_owner_name() ) ) ) {
+                get_owner_name() ) ) {
             return false;
         }
     }


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
* Fixes #83194

#### Describe the solution
Replace some translate_marker calls with the `_` macro instead of just discarding the translation.

Expanded some comments in mission_ui/translations.h after finding the previous comments insufficient. The comment in mission_ui was from me previously; I expanded it greatly because of the cargo culting of raw_description and parsed_description for POIs. That code was totally dead, always drawing an empty string. So I figured it was worth explaining. (It is *not* intuitive behavior!)

Removed that dead code from mission_ui.

Also fixed a bug the description parse_tags() call, in case anyone writes a mission that uses snippets that reference the NPC.

Fix faction name displays by making name a protected variable and adding a getter. The getter returns the a translated version of the name.

#### Describe alternatives you've considered


#### Testing
Month/date and faction names:
<img width="1295" height="705" alt="image" src="https://github.com/user-attachments/assets/143038a5-d5be-494d-8b73-7ca642ef1616" />

Speed widget:
<img width="199" height="102" alt="image" src="https://github.com/user-attachments/assets/41f1fff7-67bc-4d94-9535-08126d706482" />

Item armor table still works (extracts new translations so no screenshots of it translated)



#### Additional context

Known defects:
-Haven't done anything for the e-port stuff mentioned in the linked issue