### PR TITLE
Don't smoke whole lettuce heads

### DIFF
--- a/data/json/items/comestibles/raw_veggy.json
+++ b/data/json/items/comestibles/raw_veggy.json
@@ -672,7 +672,7 @@
     "weight": "504 g",
     "color": "light_green",
     "spoils_in": "10 days",
-    "comestible_type": "INVALID",
+    "comestible_type": "FOOD",
     "symbol": "%",
     "quench": 2,
     "calories": 70,
@@ -681,8 +681,7 @@
     "price_postapoc": "132 cent",
     "material": [ "veggy" ],
     "volume": "1850 ml",
-    "flags": [ "FREEZERBURN", "SMOKABLE", "RAW", "CATTLE", "RABBIT", "RAT", "MOUSE" ],
-    "smoking_result": "dry_veggy",
+    "flags": [ "FREEZERBURN", "INEDIBLE", "RAW", "CATTLE", "RABBIT", "RAT", "MOUSE" ],
     "vitamins": [ [ "vitC", "14 mg" ], [ "iron", "2100 μg" ], [ "calcium", "91 mg" ], [ "veggy_allergen", 1 ] ]
   },
   {

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -3406,6 +3406,10 @@ void islot_comestible::deserialize( const JsonObject &jo )
         consumption_eocs.push_back( effect_on_conditions::load_inline_eoc( jv, src ) );
     }
     optional( jo, was_loaded, "rot_spawn", rot_spawn );
+
+    if( !smoking_result.is_empty() && comesttype == "INVALID" ) {
+        jo.throw_error( "comestible_type INVALID cannot have smoking_result" );
+    }
 }
 
 void islot_brewable::deserialize( const JsonObject &jo )


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fix #83198, i.e. lettuce head smoking doesn't work.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
- Remove the ability to smoke whole lettuce heads, since the yield was 1 dry_veggy, while butchering the lettuce head first results in 7 shredded lettuce which yield 7 dry_veggy.
- Change the "comestible_type" from "INVALID" to "FOOD" and add the "INEDIBLE" flag instead, analogous to how wheat_stalks are handled (that would have allowed smoking to work, but that was removed as per the previous point).
- Add deserialization code to detect the combination of and INVALID "comestible_type" and a "smoking_result" entry, as that combination doesn't work in the game.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
- Allow ignorant or lazy players to smoke whole heads at a 7:1 loss rate.
- Change the "smoking_result" syntax and logic to allow for a yield. Smoking a whole head without cutting it up first doesn't make sense, although it could potentially be useful elsewhere.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
- Verified the game said a lettuce head didn't look edible from the 'E'eat menu.
- Verified the lettuce head could no longer be put into a smoking rack.
- Verified you can still "butcher" the lettuce head and put the results into the smoking rack.
- Compared a "butchered" shredded lettuce with a debug spawned one and saw no differences (nothing should have changed, but even if it did, the UI wouldn't show a potential switch between deriving the nutrients from the head and taking it from the shredded lettuce enty, since the latter is almost 1/7 of the former, as it should be). Nevertheless, we didn't end up without nutrients.
- Not really testing, but "lettuce_head" is used 3 times in the JSON: the definition of the head itself, its butchering, and it being the product derived from lettuce seeds. Thus, there shouldn't be any side effects from the change in the main game (and it's unlikely to be used in mods).
- Reverted the JSON changes and loaded a save.
- The game issued an error report pointing out the end of the offending ITEM entry.
- Restored the JSON changes and verified no other erroneous entries were detected for the default set of mods.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
I would have liked to also check the SMOKABLE flag against the absence of a "smoking_result" entry. However, the deserializing code does not have access to the item it's deserializing a subset of data for, and thus not the flag either, and there is no visible caller of the deserialization operation (so it's probably called via object invokation somewhere, and I don't want to spread the changes further).

Ideally, the "SMOKABLE" flag probably shouldn't be a JSON assigned flag, but rather assigned automatically as a result of the presence of a "smoking_result" entry, thus ensuring they cannot be out of sync. Alternatively, it should be possible to ditch the flag completely and instead use a check for `get_comestible() && !get_comestible().smoking_result.is_empty()`
in the limited number of places where the flag is used.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
