### PR TITLE
Helper struct for overmapbuffer state data

### DIFF
--- a/src/overmap_highway.cpp
+++ b/src/overmap_highway.cpp
@@ -761,7 +761,7 @@ std::vector<Highway_path> overmap::place_highways(
     }
 
     // guaranteed intersection close to (but not at) avatar start location
-    if( overmap_buffer.highway_global_offset.is_invalid() ) {
+    if( overmap_buffer.global_state.highway_global_offset.is_invalid() ) {
         overmap_buffer.set_highway_global_offset();
         overmap_buffer.generate_highway_intersection_point( overmap_buffer.get_highway_global_offset() );
     }

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -1710,7 +1710,7 @@ void game::unserialize_master( const JsonValue &jv )
         } else if( name == "timed_events" ) {
             timed_event_manager::unserialize_all( jsin );
         } else if( name == "overmapbuffer" ) {
-            overmap_buffer.deserialize_overmap_global_state( jsin );
+            overmap_buffer.global_state.deserialize( jsin );
         } else if( name == "placed_unique_specials" ) {
             overmap_buffer.deserialize_placed_unique_specials( jsin );
         }
@@ -1737,7 +1737,7 @@ void game::unserialize_dimension_data( const JsonValue &jv )
         if( name == "weather" ) {
             weather_manager::unserialize_all( jsin );
         } else if( name == "overmapbuffer" ) {
-            overmap_buffer.deserialize_overmap_global_state( jsin );
+            overmap_buffer.global_state.deserialize( jsin );
         } else if( name == "placed_unique_specials" ) {
             overmap_buffer.deserialize_placed_unique_specials( jsin );
         } else if( name == "region_type" ) {
@@ -1890,7 +1890,7 @@ void game::serialize_dimension_data( std::ostream &fout )
         json.start_object();
 
         json.member( "overmapbuffer" );
-        overmap_buffer.serialize_overmap_global_state( json );
+        overmap_buffer.global_state.serialize( json );
 
         json.member( "weather" );
         weather_manager::serialize_all( json );
@@ -2020,12 +2020,12 @@ void creature_tracker::serialize( JsonOut &jsout ) const
     jsout.end_array();
 }
 
-void overmapbuffer::serialize_overmap_global_state( JsonOut &json ) const
+void overmap_global_state::serialize( JsonOut &json ) const
 {
     json.start_object();
     json.member( "placed_unique_specials" );
     json.write_as_array( placed_unique_specials );
-    json.member( "overmap_count", overmap_buffer.overmap_count );
+    json.member( "overmap_count", overmap_count );
     json.member( "unique_special_count", unique_special_count );
     json.member( "overmap_highway_intersections", highway_intersections );
     json.member( "overmap_highway_offset", highway_global_offset );
@@ -2034,7 +2034,7 @@ void overmapbuffer::serialize_overmap_global_state( JsonOut &json ) const
     json.end_object();
 }
 
-void overmapbuffer::deserialize_overmap_global_state( const JsonObject &json )
+void overmap_global_state::deserialize( const JsonObject &json )
 {
     placed_unique_specials.clear();
     JsonArray ja = json.get_array( "placed_unique_specials" );
@@ -2053,10 +2053,10 @@ void overmapbuffer::deserialize_overmap_global_state( const JsonObject &json )
 
 void overmapbuffer::deserialize_placed_unique_specials( const JsonValue &jsin )
 {
-    placed_unique_specials.clear();
+    global_state.placed_unique_specials.clear();
     JsonArray ja = jsin.get_array();
     for( const JsonValue &special : ja ) {
-        placed_unique_specials.emplace( special.get_string() );
+        global_state.placed_unique_specials.emplace( special.get_string() );
     }
 }
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Small organizational issue: most overmap global data is floating around in overmapbuffer, and serialization of that data is a separate function in overmapbuffer. Adding fields in the future will perpetuate this issue.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Move overmap global data into struct `overmap_global_state`; overmapbuffer has exactly one `overmap_global_state` object.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Built locally, loaded world, generated some overmaps, saved world, loaded again, no errors. Look for related test errors in CI.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
