### PR TITLE
Spell use actions respect SINGLE_USE

### DIFF
--- a/data/mods/Xedra_Evolved/spells/dreamer_spells.json
+++ b/data/mods/Xedra_Evolved/spells/dreamer_spells.json
@@ -396,23 +396,7 @@
     "max_range": 1,
     "message": "",
     "damage_type": "bash",
-    "sound_description": "a smash",
-    "extra_effects": [ { "id": "constructed_hammer_self_destruct" } ]
-  },
-  {
-    "id": "constructed_hammer_self_destruct",
-    "type": "SPELL",
-    "shape": "blast",
-    "name": { "str": "Constructed Hammer Self destruct", "//~": "NO_I18N" },
-    "description": { "str": "Removes constructed hammer.  You can't see it except in debug mode.", "//~": "NO_I18N" },
-    "valid_targets": [ "ground" ],
-    "effect": "effect_on_condition",
-    "effect_str": "EOC_REMOVE_CONSTRUCTED_HAMMER"
-  },
-  {
-    "id": "EOC_REMOVE_CONSTRUCTED_HAMMER",
-    "type": "effect_on_condition",
-    "effect": [ { "npc_remove_item_with": "constructed_hammer" } ]
+    "sound_description": "a smash"
   },
   {
     "id": "summon_duplicator",

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -2606,7 +2606,10 @@ void activity_handlers::spellcasting_finish( player_activity *act, Character *yo
 
             if( !act->targets.empty() ) {
                 item *it = act->targets.front().get_item();
-                if( it && !it->has_flag( flag_USE_PLAYER_ENERGY ) ) {
+                if( it != nullptr && it->has_flag( flag_SINGLE_USE ) ) {
+                    you->i_rem( it );
+                    act->targets.erase( act->targets.end() - 1 );
+                } else if( it && !it->has_flag( flag_USE_PLAYER_ENERGY ) ) {
                     you->consume_charges( *it, it->type->charges_to_use() );
                 }
             }


### PR DESCRIPTION
#### Summary
Bugfixes "Spell use actions respect SINGLE_USE"

#### Purpose of change
Fixes https://github.com/CleverRaven/Cataclysm-DDA/issues/82080

#### Describe the solution
Remove single use targets at the end of a spell.

#### Testing
Make a world with Xedra Evolved, spawn a constructed hammer, activate it. Once the spell is cast, it disappears.

#### Additional context
Related: https://github.com/CleverRaven/Cataclysm-DDA/pull/81731

iuse functions should return something like:
```rs
enum iuse_ret {
    unused,
    destroyed,
    deferred(i32),
    used(i32)
}
```
But handling deferred seems... complex.