### PR TITLE
Relic active effects can require being wielded/worn/held

### DIFF
--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -1391,7 +1391,7 @@ bool avatar::invoke_item( item *used, const tripoint_bub_ms &pt, int pre_obtain_
         return false;
     } else if( num_methods == 1 && !has_relic ) {
         return invoke_item( used, use_methods.begin()->first, pt, pre_obtain_moves );
-    } else if( num_methods == 0 && has_relic ) {
+    } else if( num_methods == 0 && has_relic && used->can_use_relic( *this ) ) {
         return used->use_relic( *this, pt );
     }
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2406,7 +2406,8 @@ int game::inventory_item_menu( item_location locThisItem,
                         avatar_action::use_item( u, locThisItem );
                     } else if( locThisItem.get_item()->item_has_uses_recursive() ) {
                         game::item_action_menu( locThisItem );
-                    } else if( locThisItem.get_item()->has_relic_activation() ) {
+                    } else if( locThisItem.get_item()->has_relic_activation() &&
+                               locThisItem.get_item()->can_use_relic( u ) ) {
                         avatar_action::use_item( u, locThisItem );
                     } else {
                         add_msg( m_info, _( "You can't use a %s there." ), locThisItem->tname() );

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -1113,7 +1113,7 @@ class activatable_inventory_preset : public pickup_inventory_preset
         }
 
         bool is_shown( const item_location &loc ) const override {
-            return loc->type->has_use() || loc->has_relic_activation();
+            return loc->type->has_use() || ( loc->has_relic_activation() && loc->can_use_relic( you ) );
         }
 
         std::string get_denial( const item_location &loc ) const override {

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -4900,6 +4900,11 @@ bool item::has_relic_activation() const
     return is_relic() && relic_data->has_activation();
 }
 
+bool item::can_use_relic( const Character &guy ) const
+{
+    return is_relic() && relic_data->can_activate( *this, guy );
+}
+
 std::vector<enchant_cache> item::get_proc_enchantments() const
 {
     if( !is_relic() ) {

--- a/src/item.h
+++ b/src/item.h
@@ -1956,6 +1956,7 @@ class item : public visitable
          */
         void on_contents_changed();
 
+        bool can_use_relic( const Character &guy ) const;
         bool use_relic( Character &guy, const tripoint_bub_ms &pos );
         bool has_relic_recharge() const;
         bool has_relic_activation() const;

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -2222,7 +2222,8 @@ class exosuit_interact
                 amenu.addentry( -1, true, MENU_AUTOASSIGN, _( "Unload everything from this %s" ),
                                 get_pocket_name( pkt ) );
                 amenu.addentry( -1, true, MENU_AUTOASSIGN, _( "Replace the %s" ), mod_name );
-                amenu.addentry( -1, mod_it->has_relic_activation() || mod_it->type->has_use(), MENU_AUTOASSIGN,
+                amenu.addentry( -1, ( mod_it->has_relic_activation() && mod_it->can_use_relic( c ) ) ||
+                                mod_it->type->has_use(), MENU_AUTOASSIGN,
                                 mod_it->active ? _( "Deactivate the %s" ) : _( "Activate the %s" ), mod_name );
                 amenu.addentry( -1, mod_it->is_reloadable() && c.can_reload( *mod_it ), MENU_AUTOASSIGN,
                                 _( "Reload the %s" ), mod_name );

--- a/src/relic.cpp
+++ b/src/relic.cpp
@@ -69,14 +69,14 @@ std::string enum_to_string<relic_recharge_type>( relic_recharge_type type )
 }
 
 template<>
-std::string enum_to_string<relic_recharge_has>( relic_recharge_has has )
+std::string enum_to_string<relic_has>( relic_has has )
 {
     // *INDENT-OFF*
     switch (has) {
-    case relic_recharge_has::WIELD: return "wield";
-    case relic_recharge_has::WORN: return "worn";
-    case relic_recharge_has::HELD: return "held";
-    case relic_recharge_has::NUM: break;
+    case relic_has::WIELD: return "wield";
+    case relic_has::WORN: return "worn";
+    case relic_has::HELD: return "held";
+    case relic_has::NUM: break;
     }
     // *INDENT-ON*
     cata_fatal( "Invalid relic recharge has condition" );
@@ -545,19 +545,19 @@ bool relic::can_recharge( item &parent, Character *carrier ) const
 
     switch( charge.has ) {
 
-        case relic_recharge_has::HELD: {
+        case relic_has::HELD: {
             return carrier->has_item( parent );
         }
 
-        case relic_recharge_has::WORN: {
+        case relic_has::WORN: {
             return carrier->is_worn( parent ) || carrier->is_wielding( parent );
         }
 
-        case relic_recharge_has::WIELD: {
+        case relic_has::WIELD: {
             return carrier->is_wielding( parent );
         }
 
-        case relic_recharge_has::NUM: {
+        case relic_has::NUM: {
             return true;
         }
 

--- a/src/relic.cpp
+++ b/src/relic.cpp
@@ -112,9 +112,26 @@ void relic_procgen_data::finalize_all()
 
 relic::~relic() = default;
 
-void relic::add_active_effect( const fake_spell &sp )
+// me when
+static relic_has ench_to_relic_has( enchantment::has from )
+{
+    switch( from ) {
+        case enchantment::has::WIELD:
+            return relic_has::WIELD;
+        case enchantment::has::WORN:
+            return relic_has::WORN;
+        case enchantment::has::HELD:
+            return relic_has::HELD;
+        case enchantment::has::NUM_HAS:
+            break;
+    }
+    return relic_has::NUM;
+}
+
+void relic::add_active_effect( const fake_spell &sp, enchantment::has req )
 {
     active_effects.emplace_back( sp );
+    activation_req = ench_to_relic_has( req );
 }
 
 void relic::add_passive_effect( const enchant_cache &nench )
@@ -345,13 +362,33 @@ void relic_charge_info::accumulate_charge( item &parent )
     }
 }
 
+// me when
+static enchantment::has relic_has_to_ench( relic_has to )
+{
+    switch( to ) {
+        case relic_has::WIELD:
+            return enchantment::has::WIELD;
+        case relic_has::WORN:
+            return enchantment::has::WORN;
+        case relic_has::HELD:
+            return enchantment::has::HELD;
+        case relic_has::NUM:
+            break;
+    }
+    return enchantment::has::NUM_HAS;
+}
+
 void relic::load( const JsonObject &jo )
 {
+    relic_has act_req = relic_has::NUM;
+    if( jo.has_member( "activation_requirement" ) ) {
+        jo.read( "activation_requirement", act_req );
+    }
     if( jo.has_array( "active_effects" ) ) {
         for( JsonObject jobj : jo.get_array( "active_effects" ) ) {
             fake_spell sp;
             sp.load( jobj );
-            add_active_effect( sp );
+            add_active_effect( sp, relic_has_to_ench( act_req ) );
         }
     }
     if( jo.has_array( "passive_effects" ) ) {
@@ -414,9 +451,15 @@ void relic::serialize( JsonOut &jsout ) const
         jsout.end_array();
     }
 
+    jsout.member( "activation_requirement", activation_req );
     jsout.member( "charge_info", charge );
 
     jsout.end_object();
+}
+
+bool relic::can_activate( const item &parent, const Creature &caster ) const
+{
+    return satisfies_has( activation_req, &parent, dynamic_cast<const Character *>( &caster ) );
 }
 
 int relic::activate( Creature &caster, const tripoint_bub_ms &target )
@@ -536,35 +579,32 @@ void relic::try_recharge( item &parent, Character *carrier, const tripoint_bub_m
     }
 }
 
-bool relic::can_recharge( item &parent, Character *carrier ) const
+bool relic::satisfies_has( relic_has req, const item *parent, const Character *carrier )
 {
-
-    if( carrier == nullptr && charge.has != relic_recharge_has::NUM ) {
+    if( ( parent == nullptr || carrier == nullptr ) && req != relic_has::NUM ) {
         return false;
     }
 
-    switch( charge.has ) {
-
+    switch( req ) {
         case relic_has::HELD: {
-            return carrier->has_item( parent );
+            return carrier->has_item( *parent );
         }
-
         case relic_has::WORN: {
-            return carrier->is_worn( parent ) || carrier->is_wielding( parent );
+            return carrier->is_worn( *parent ) || carrier->is_wielding( *parent );
         }
-
         case relic_has::WIELD: {
-            return carrier->is_wielding( parent );
+            return carrier->is_wielding( *parent );
         }
-
-        case relic_has::NUM: {
-            return true;
-        }
-
+        case relic_has::NUM:
+            break;
     }
 
     return true;
+}
 
+bool relic::can_recharge( item &parent, Character *carrier ) const
+{
+    return satisfies_has( charge.has, &parent, carrier );
 }
 
 void relic::overwrite_charge( const relic_charge_info &info )
@@ -679,7 +719,7 @@ relic relic_procgen_data::generate( const relic_procgen_data::generation_rules &
                         negative_attribute_power += power;
                     }
                     num_attributes++;
-                    ret.add_active_effect( active_sp );
+                    ret.add_active_effect( active_sp, active->ench_has );
                 }
                 break;
             }

--- a/src/relic.h
+++ b/src/relic.h
@@ -137,7 +137,7 @@ class relic_procgen_data
         void deserialize( const JsonObject &jobj );
 };
 
-enum class relic_recharge_has : int {
+enum class relic_has : int {
     WIELD,
     WORN,
     HELD,
@@ -161,7 +161,7 @@ struct relic_charge_template {
     std::pair<int, int> charges_per_use;
     std::pair<time_duration, time_duration> time;
     relic_recharge_type type = relic_recharge_type::NUM;
-    relic_recharge_has has = relic_recharge_has::NUM;
+    relic_has has = relic_has::NUM;
 
     int power_level = 0;
 
@@ -177,7 +177,7 @@ struct relic_charge_info {
     int charges_per_use = 0;
     int max_charges = 0;
     relic_recharge_type type = relic_recharge_type::NUM;
-    relic_recharge_has has = relic_recharge_has::NUM;
+    relic_has has = relic_has::NUM;
 
     time_duration activation_accumulator = 0_seconds;
     time_duration activation_time = 0_seconds;
@@ -268,8 +268,8 @@ struct enum_traits<relic_recharge_type> {
 };
 
 template<>
-struct enum_traits<relic_recharge_has> {
-    static constexpr relic_recharge_has last = relic_recharge_has::NUM;
+struct enum_traits<relic_has> {
+    static constexpr relic_has last = relic_has::NUM;
 };
 
 #endif // CATA_SRC_RELIC_H

--- a/src/relic.h
+++ b/src/relic.h
@@ -211,15 +211,19 @@ class relic
 
         // activating an artifact overrides all spell casting costs
         int moves = 0;
+        relic_has activation_req = relic_has::NUM;
 
         // passive enchantments to add by id in finalize once we can guarantee that they have loaded
         std::vector<enchantment_id> passive_enchant_ids; // NOLINT(cata-serialize)
+
+        static bool satisfies_has( relic_has req, const item *parent, const Character *carrier );
     public:
         ~relic();
 
         std::string name() const;
         // returns number of charges that should be consumed
         int activate( Creature &caster, const tripoint_bub_ms &target );
+        bool can_activate( const item &parent, const Creature &caster ) const;
         int charges() const;
         int charges_per_use() const;
         int max_charges() const;
@@ -242,7 +246,7 @@ class relic
 
         void add_passive_effect( const enchant_cache &ench );
         void add_passive_effect( const enchantment &ench );
-        void add_active_effect( const fake_spell &sp );
+        void add_active_effect( const fake_spell &sp, enchantment::has req );
 
         std::vector<enchant_cache> get_proc_enchantments() const;
         std::vector<enchantment> get_defined_enchantments() const;


### PR DESCRIPTION
#### Summary
Infrastructure "Artifacts can require being worn/wielded/held before activation"

#### Purpose of change
Fixes https://github.com/CleverRaven/Cataclysm-DDA/issues/83171

#### Describe the solution
Rename `relic_recharge_has` to simply `relic_has` and add a `relic_has` member describing the activation conditions. Add a function to check the has conditions, and check for activation conditions anywhere a relic could be used.

This can already be specified in the procgen data, but there are multiple activation effects, and can only be one condition. This uses the most recently added effect's condition.

#### Describe alternatives you've considered
Other methods for handling the multiple activation effect problem.

#### Testing
Add a wielding requirement to all active effects for relic procgen data, and spawn an artifact. It can only be used when wielded.