### PR TITLE
Use int_id for horde_entity

### DIFF
--- a/src/horde_entity.cpp
+++ b/src/horde_entity.cpp
@@ -1,5 +1,6 @@
 #include "horde_entity.h"
 
+#include "mtype.h"
 #include "monster.h"
 #include "point.h"
 
@@ -14,18 +15,18 @@ horde_entity::horde_entity( const monster &original )
         tracking_intensity = original.wandf;
     }
     moves = original.get_moves();
-    type_id = original.type;
+    type_id = original.type->id.id();
     monster_data = std::make_unique<monster>( original );
 }
 
 horde_entity::horde_entity( const mtype_id &original )
 {
-    type_id = &original.obj();
+    type_id = original.id();
 }
 
 const mtype *horde_entity::get_type() const
 {
-    return type_id ? type_id : monster_data->type;
+    return type_id ? &type_id.obj() : monster_data->type;
 }
 
 bool horde_entity::is_active() const

--- a/src/horde_entity.h
+++ b/src/horde_entity.h
@@ -35,8 +35,7 @@ struct horde_entity {
     time_point last_processed;
     // Same here, this could probably be a byte.
     int moves = 0;
-    // TODO: int_id<mtype> is smaller and more idiomatic.
-    const mtype *type_id;
+    mtype_int_id type_id;
     // If this monster was never spawned, this member can be empty.
     // If it was, it has this populated to capture all the random bits of state that a monster can accumulate.
     // The vast majority of entities in an overmap have never actually been spawned,

--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -108,6 +108,24 @@ std::string enum_to_string<mdeath_type>( mdeath_type data )
 
 } // namespace io
 
+template<>
+const mtype &int_id<mtype>::obj() const
+{
+    return MonsterGenerator::generator().mon_templates->obj( *this );
+}
+
+template<>
+bool int_id<mtype>::is_valid() const
+{
+    return MonsterGenerator::generator().mon_templates->is_valid( *this );
+}
+
+template<>
+const string_id<mtype> &int_id<mtype>::id() const
+{
+    return MonsterGenerator::generator().mon_templates->convert( *this );
+}
+
 /** @relates string_id */
 template<>
 const mtype &string_id<mtype>::obj() const
@@ -120,6 +138,12 @@ template<>
 bool string_id<mtype>::is_valid() const
 {
     return MonsterGenerator::generator().mon_templates->is_valid( *this );
+}
+
+template<>
+int_id<mtype> string_id<mtype>::id() const
+{
+    return MonsterGenerator::generator().mon_templates->convert( *this, int_id<mtype>( 0 ) );
 }
 
 /** @relates string_id */

--- a/src/monstergenerator.h
+++ b/src/monstergenerator.h
@@ -106,6 +106,7 @@ class MonsterGenerator
         void validate_species_ids( mtype &mon );
         void finalize_pathfinding_settings( mtype &mon );
 
+        friend class int_id<mtype>;
         friend class string_id<mtype>;
         friend class string_id<species_type>;
         friend class string_id<mattack_actor>;

--- a/src/type_id.h
+++ b/src/type_id.h
@@ -192,6 +192,7 @@ using morale_type = string_id<morale_type_data>;
 
 struct mtype;
 using mtype_id = string_id<mtype>;
+using mtype_int_id = int_id<mtype>;
 
 class nested_mapgen;
 using nested_mapgen_id = string_id<nested_mapgen>;


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Resolves https://github.com/CleverRaven/Cataclysm-DDA/issues/83079

Reduce the memory footprint for `horde_entity` by 4 bytes.

This leaves us with:
tripoint (3 int = 12 bytes)
tracking intensity (int = 4 bytes)
last_processed (int = 4 bytes)
moves (int = 4 bytes)
type_id (int = 4 bytes)
padding = 4 bytes (to be 8-byte aligned)
monster data (pointer = 8 bytes)

#### Describe the solution
Implement the necessary functions to use `int_id<mtype>`: `int_id<mtype>::obj`, `int_id<mtype>::is_valid`, `int_id<mtype>::id`, and `string_id<mtype>::id`.

Replace the mtype pointer with an int id.