### PR TITLE
Allow floating-point <1 bandage power

### DIFF
--- a/src/effect.cpp
+++ b/src/effect.cpp
@@ -1726,20 +1726,23 @@ void effect::deserialize( const JsonObject &jo )
     jo.read( "source", source );
 }
 
-std::string texitify_base_healing_power( const int power )
+std::string texitify_base_healing_power( const float power )
 {
-    if( power == 1 ) {
-        return colorize( _( "very poor" ), c_red );
-    } else if( power == 2 ) {
-        return colorize( _( "poor" ), c_light_red );
-    } else if( power == 3 ) {
-        return colorize( _( "average" ), c_yellow );
-    } else if( power == 4 ) {
-        return colorize( _( "good" ), c_light_green );
-    } else if( power >= 5 ) {
+    if( power >= 5 ) {
         return colorize( _( "great" ), c_green );
+    } else if( power >= 4 ) {
+        return colorize( _( "good" ), c_light_green );
+    } else if( power >= 3 ) {
+        return colorize( _( "average" ), c_yellow );
+    } else if( power >= 2 ) {
+        return colorize( _( "poor" ), c_light_red );
+    } else if( power >= 1 ) {
+        return colorize( _( "very poor" ), c_red );
+    } else if( power > 0 ) {
+        return colorize( _( "awful" ), c_red );
     }
-    if( power < 1 ) {
+
+    if( power <= 0 ) {
         debugmsg( "Tried to convert zero or negative value." );
     }
     return "";

--- a/src/effect.h
+++ b/src/effect.h
@@ -471,7 +471,7 @@ void load_effect_type( const JsonObject &jo, std::string_view src );
 void reset_effect_types();
 const std::map<efftype_id, effect_type> &get_effect_types();
 
-std::string texitify_base_healing_power( int power );
+std::string texitify_base_healing_power( float power );
 std::string texitify_healing_power( int power );
 std::string texitify_bandage_power( int power );
 nc_color colorize_bleeding_intensity( int intensity );

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -4025,7 +4025,7 @@ void heal_actor::info( const item &, std::vector<iteminfo> &dump ) const
 
     if( bandages_power > 0 ) {
         dump.emplace_back( "HEAL", _( "Base bandaging quality: " ),
-                           texitify_base_healing_power( static_cast<int>( bandages_power ) ) );
+                           texitify_base_healing_power( bandages_power ) );
         if( g != nullptr ) {
             dump.emplace_back( "HEAL", _( "Actual bandaging quality: " ),
                                texitify_healing_power( get_bandaged_level( player_character ) ) );
@@ -4034,7 +4034,7 @@ void heal_actor::info( const item &, std::vector<iteminfo> &dump ) const
 
     if( disinfectant_power > 0 ) {
         dump.emplace_back( "HEAL", _( "Base disinfecting quality: " ),
-                           texitify_base_healing_power( static_cast<int>( disinfectant_power ) ) );
+                           texitify_base_healing_power( disinfectant_power ) );
         if( g != nullptr ) {
             dump.emplace_back( "HEAL", _( "Actual disinfecting quality: " ),
                                texitify_healing_power( get_disinfected_level( player_character ) ) );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Fixes https://github.com/CleverRaven/Cataclysm-DDA/issues/75712

#### Describe the solution
Stop casting in the display function and don't throw a debugmsg for floating-point values < 1.

#### Testing
See reproduction steps in issue.