### PR TITLE
[MoM] Matrix crystal active abilities require wielding

### DIFF
--- a/data/mods/MindOverMatter/effects/effects_artifact.json
+++ b/data/mods/MindOverMatter/effects/effects_artifact.json
@@ -61,7 +61,7 @@
     "id": "effect_mom_artifact_perception_boost",
     "name": [ "Enhanced Perception" ],
     "desc": [ "Your senses are enhanced." ],
-    "apply_message": "",
+    "apply_message": "All your senses suddenly sharpen.",
     "remove_message": "Your enhanced senses fade away.",
     "rating": "good",
     "enchantments": [ { "values": [ { "value": "PERCEPTION", "add": 3 } ] } ]

--- a/data/mods/MindOverMatter/powers/artifacts.json
+++ b/data/mods/MindOverMatter/powers/artifacts.json
@@ -289,7 +289,7 @@
     "type": "SPELL",
     "name": { "str": "MoM AEA Add Perception Boost", "//~": "NO_I18N" },
     "description": { "str": "Add a Perception boost.", "//~": "NO_I18N" },
-    "message": "You feel more capable.",
+    "message": "",
     "valid_targets": [ "self" ],
     "skill": "metaphysics",
     "spell_class": "NONE",

--- a/data/mods/MindOverMatter/procgen/biokinetic_artifacts.json
+++ b/data/mods/MindOverMatter/procgen/biokinetic_artifacts.json
@@ -13,19 +13,19 @@
       }
     ],
     "active_procgen_values": [
-      { "weight": 100, "spell_id": "MoM_AEA_ADRENALINE", "base_power": 250 },
-      { "weight": 100, "spell_id": "MoM_AEA_REMOVE_PAIN", "base_power": 150 },
-      { "weight": 100, "spell_id": "MoM_AEA_ATTENTION", "base_power": -150 },
-      { "weight": 100, "spell_id": "MoM_AEA_VOMIT", "base_power": -50 },
-      { "weight": 100, "spell_id": "MoM_AEA_STAMINA_EMPTY", "base_power": -250 },
-      { "weight": 100, "spell_id": "MoM_AEA_STAMINA_BURST", "base_power": 250 },
-      { "weight": 100, "spell_id": "MoM_AEA_MUTATE", "base_power": -500 },
-      { "weight": 100, "spell_id": "MoM_AEA_NETHER_ATTUNEMENT", "base_power": -100 },
-      { "weight": 100, "spell_id": "MoM_AEA_PHYSICAL_ENHANCEMENT", "base_power": 150 },
-      { "weight": 100, "spell_id": "MoM_AEA_SPEED_BURST", "base_power": 400 },
-      { "weight": 100, "spell_id": "MoM_AEA_HARDEN_SKIN", "base_power": 300 },
-      { "weight": 100, "spell_id": "MoM_AEA_EXTRA_CALORIE_COST", "base_power": -150 },
-      { "weight": 100, "spell_id": "MoM_AEA_EXTRA_MOVEMENT_EXERTION", "base_power": -50 }
+      { "weight": 100, "spell_id": "MoM_AEA_ADRENALINE", "base_power": 250, "ench_has": "WIELD" },
+      { "weight": 100, "spell_id": "MoM_AEA_REMOVE_PAIN", "base_power": 150, "ench_has": "WIELD" },
+      { "weight": 100, "spell_id": "MoM_AEA_ATTENTION", "base_power": -150, "ench_has": "WIELD" },
+      { "weight": 100, "spell_id": "MoM_AEA_VOMIT", "base_power": -50, "ench_has": "WIELD" },
+      { "weight": 100, "spell_id": "MoM_AEA_STAMINA_EMPTY", "base_power": -250, "ench_has": "WIELD" },
+      { "weight": 100, "spell_id": "MoM_AEA_STAMINA_BURST", "base_power": 250, "ench_has": "WIELD" },
+      { "weight": 100, "spell_id": "MoM_AEA_MUTATE", "base_power": -500, "ench_has": "WIELD" },
+      { "weight": 100, "spell_id": "MoM_AEA_NETHER_ATTUNEMENT", "base_power": -100, "ench_has": "WIELD" },
+      { "weight": 100, "spell_id": "MoM_AEA_PHYSICAL_ENHANCEMENT", "base_power": 150, "ench_has": "WIELD" },
+      { "weight": 100, "spell_id": "MoM_AEA_SPEED_BURST", "base_power": 400, "ench_has": "WIELD" },
+      { "weight": 100, "spell_id": "MoM_AEA_HARDEN_SKIN", "base_power": 300, "ench_has": "WIELD" },
+      { "weight": 100, "spell_id": "MoM_AEA_EXTRA_CALORIE_COST", "base_power": -150, "ench_has": "WIELD" },
+      { "weight": 100, "spell_id": "MoM_AEA_EXTRA_MOVEMENT_EXERTION", "base_power": -50, "ench_has": "WIELD" }
     ],
     "passive_mult_procgen_values": [
       {
@@ -71,7 +71,7 @@
         "type": "REGEN_HP",
         "increment": 0.1,
         "power_per_increment": 50,
-        "ench_has": "HELD"
+        "ench_has": "WIELD"
       },
       {
         "weight": 100,
@@ -107,7 +107,7 @@
         "type": "REGEN_STAMINA",
         "increment": 0.1,
         "power_per_increment": 100,
-        "ench_has": "HELD"
+        "ench_has": "WIELD"
       },
       {
         "weight": 35,
@@ -193,7 +193,7 @@
         "ench_has": "HELD"
       },
       {
-        "weight": 50,
+        "weight": 25,
         "min_value": -2500,
         "max_value": 10000,
         "type": "MAX_STAMINA",
@@ -217,7 +217,7 @@
         "type": "CLIMATE_CONTROL_HEAT",
         "increment": 1,
         "power_per_increment": 50,
-        "ench_has": "HELD"
+        "ench_has": "WIELD"
       },
       {
         "weight": 100,
@@ -226,7 +226,7 @@
         "type": "CLIMATE_CONTROL_CHILL",
         "increment": 1,
         "power_per_increment": 50,
-        "ench_has": "HELD"
+        "ench_has": "WIELD"
       },
       {
         "weight": 100,
@@ -253,7 +253,7 @@
         "type": "MAX_STAMINA",
         "increment": 500,
         "power_per_increment": 500,
-        "ench_has": "HELD"
+        "ench_has": "WIELD"
       },
       {
         "weight": 10,
@@ -262,7 +262,7 @@
         "type": "MUT_INSTABILITY_MOD",
         "increment": 1,
         "power_per_increment": 750,
-        "ench_has": "HELD"
+        "ench_has": "WIELD"
       }
     ],
     "type_weights": [
@@ -335,7 +335,7 @@
         "type": "REGEN_HP",
         "increment": 0.1,
         "power_per_increment": 50,
-        "ench_has": "HELD"
+        "ench_has": "WIELD"
       },
       {
         "weight": 100,
@@ -371,7 +371,7 @@
         "type": "REGEN_STAMINA",
         "increment": 0.1,
         "power_per_increment": 100,
-        "ench_has": "HELD"
+        "ench_has": "WIELD"
       },
       {
         "weight": 35,
@@ -457,13 +457,13 @@
         "ench_has": "HELD"
       },
       {
-        "weight": 50,
+        "weight": 25,
         "min_value": -2500,
         "max_value": 10000,
         "type": "MAX_STAMINA",
         "increment": 250,
         "power_per_increment": 50,
-        "ench_has": "HELD"
+        "ench_has": "WIELD"
       },
       {
         "weight": 50,
@@ -481,7 +481,7 @@
         "type": "CLIMATE_CONTROL_HEAT",
         "increment": 1,
         "power_per_increment": 50,
-        "ench_has": "HELD"
+        "ench_has": "WIELD"
       },
       {
         "weight": 100,
@@ -490,7 +490,7 @@
         "type": "CLIMATE_CONTROL_CHILL",
         "increment": 1,
         "power_per_increment": 50,
-        "ench_has": "HELD"
+        "ench_has": "WIELD"
       },
       {
         "weight": 100,
@@ -517,7 +517,7 @@
         "type": "MAX_STAMINA",
         "increment": 500,
         "power_per_increment": 500,
-        "ench_has": "HELD"
+        "ench_has": "WIELD"
       },
       {
         "weight": 10,
@@ -526,7 +526,7 @@
         "type": "MUT_INSTABILITY_MOD",
         "increment": 1,
         "power_per_increment": 750,
-        "ench_has": "HELD"
+        "ench_has": "WIELD"
       }
     ],
     "type_weights": [ { "weight": 100, "value": "passive_enchantment_add" }, { "weight": 100, "value": "passive_enchantment_mult" } ],

--- a/data/mods/MindOverMatter/procgen/clairsentient_artifacts.json
+++ b/data/mods/MindOverMatter/procgen/clairsentient_artifacts.json
@@ -13,15 +13,15 @@
       }
     ],
     "active_procgen_values": [
-      { "weight": 100, "spell_id": "MoM_AEA_MAP", "base_power": 350 },
-      { "weight": 100, "spell_id": "MoM_AEA_CLAIRVOYANCE", "base_power": 250 },
-      { "weight": 100, "spell_id": "MoM_AEA_NETHER_ATTUNEMENT", "base_power": -100 },
-      { "weight": 100, "spell_id": "MoM_AEA_STAMINA_EMPTY", "base_power": -250 },
-      { "weight": 100, "spell_id": "MoM_AEA_VOMIT", "base_power": -50 },
-      { "weight": 100, "spell_id": "MoM_AEA_ATTENTION", "base_power": -150 },
-      { "weight": 100, "spell_id": "MoM_AEA_PERCEPTION_ENHANCEMENT", "base_power": 150 },
-      { "weight": 100, "spell_id": "MoM_AEA_EXTRA_CALORIE_COST", "base_power": -150 },
-      { "weight": 100, "spell_id": "MoM_AEA_ASTRAL_PROJECTION", "base_power": 500 }
+      { "weight": 100, "spell_id": "MoM_AEA_MAP", "base_power": 350, "ench_has": "WIELD" },
+      { "weight": 100, "spell_id": "MoM_AEA_CLAIRVOYANCE", "base_power": 250, "ench_has": "WIELD" },
+      { "weight": 100, "spell_id": "MoM_AEA_NETHER_ATTUNEMENT", "base_power": -100, "ench_has": "WIELD" },
+      { "weight": 100, "spell_id": "MoM_AEA_STAMINA_EMPTY", "base_power": -250, "ench_has": "WIELD" },
+      { "weight": 100, "spell_id": "MoM_AEA_VOMIT", "base_power": -50, "ench_has": "WIELD" },
+      { "weight": 100, "spell_id": "MoM_AEA_ATTENTION", "base_power": -150, "ench_has": "WIELD" },
+      { "weight": 100, "spell_id": "MoM_AEA_PERCEPTION_ENHANCEMENT", "base_power": 150, "ench_has": "WIELD" },
+      { "weight": 100, "spell_id": "MoM_AEA_EXTRA_CALORIE_COST", "base_power": -150, "ench_has": "WIELD" },
+      { "weight": 100, "spell_id": "MoM_AEA_ASTRAL_PROJECTION", "base_power": 500, "ench_has": "WIELD" }
     ],
     "passive_mult_procgen_values": [
       {
@@ -159,7 +159,7 @@
         "type": "MOTION_ALARM",
         "increment": 1,
         "power_per_increment": 150,
-        "ench_has": "HELD"
+        "ench_has": "WIELD"
       },
       {
         "weight": 100,
@@ -168,7 +168,7 @@
         "type": "NIGHT_VIS",
         "increment": 1,
         "power_per_increment": 150,
-        "ench_has": "HELD"
+        "ench_has": "WIELD"
       },
       {
         "weight": 50,
@@ -177,7 +177,7 @@
         "type": "OVERMAP_SIGHT",
         "increment": 1,
         "power_per_increment": 500,
-        "ench_has": "HELD"
+        "ench_has": "WIELD"
       },
       {
         "weight": 50,

--- a/doc/JSON/ARTIFACTS.md
+++ b/doc/JSON/ARTIFACTS.md
@@ -111,6 +111,16 @@ As the names suggest, these are *passive* benefits/penalties to having the artif
 - **power_per_increment:** the power value per increment
 - **ench_has:** where the artifact must be in inventory for the enchantment to take effect
 
+### active_procgen_values 
+
+These are active effects that require the artifact to be activated to be used.  It is possible for an artifact to randomly roll multiple **active_procgen_values** during random generation; if so, all of them activate simultaneously when the artifact is activated. No matter how many active abilities the artifact has, it only requires the number of charges specified in the **charges_per_use** parameter under **charge_types** to activate them all.
+
+- **spell_id:** the id of the spell cast when the artifact is activated. This uses the **fake_spell** template (ignoring casting time and resource cost)
+- **base_power:** the artifact power that choosing this active effect consumes (positive or negative)
+- **min_level:** the minimum possible level chosen for the spell to be cast at.  Defaults to 0 if unspecified.
+- **max_level:** the maximum possible level chosen for the spell to be cast at.  Defaults to 0 if unspecified. If max_level is higher than 0, the level is randomly determined between **min_level** and **max_level**
+- **ench_has:**: where the artifact must be in inventory in order to successfully activate it.  If there are multiple active effects with separate **ench_has** conditions, the last randomly-chosen activation condition takes precedence. 
+
 #### ench_has
 
 - **wield** This enchantment or spell only takes effect while the artifact is wielded

--- a/doc/JSON/ARTIFACTS.md
+++ b/doc/JSON/ARTIFACTS.md
@@ -46,7 +46,7 @@ The procedural generation of artifacts is defined in Json. The object looks like
         "time": [ "3 h", "6 h" ]
       }
     ],
-    "active_procgen_values": [ { "weight": 100, "spell_id": "AEA_PAIN" } ],
+    "active_procgen_values": [ { "weight": 100, "spell_id": "AEA_PAIN", "ench_has": "WIELD" } ],
     "passive_add_procgen_values": [
       {
         "weight": 100,


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[MoM] Matrix crystal active abilities require wielding"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

As title, now possible thanks to #83219
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add `ench_has": "WIELD"` to every activate ability in biokinetic and clairsentient crystals. Also add require it on some passive abilities (stamina/health regeneration, climate control, motion alarm, night vision, overmap sight, that kind of thing). 

Document the `active_procgen_values` artifact property, which had no documentation. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

It works.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
