### PR TITLE
`bye_message_override` field with value of "<null>" make npcs not say goodbye

### DIFF
--- a/doc/JSON/NPCs.md
+++ b/doc/JSON/NPCs.md
@@ -57,7 +57,7 @@ Format:
   "carry_override": "NC_EXAMPLE_carried",                                  // Optional. Defines an item group that replaces their carried items (in pockets, etc). Items which cannot
                                                                            // be carried will overflow(fall to the ground) when the NPC is loaded.
   "weapon_override": "NC_EXAMPLE_weapon",                                  // Optional. Defines an item group that replaces their wielded weapon.
-  "bye_message_override": "<fuck_you>",                                    // Optional. If used, overrides the default bye message (picked from <bye> snippet) to any another custom snippet, if set to "<null>" will make the npc not say anything when leaving dialogue.
+  "bye_message_override": "<fuck_you>",                                    // Optional. If used, overrides the default bye message (picked from <bye> snippet) to any another custom snippet, if set to "null" will make the npc not say anything when leaving dialogue.
   "shopkeeper_item_group": [                                               // Optional. See [Shopkeeper NPC configuration](#shopkeeper-npc-configuration) below.
     { "group": "example_shopkeeper_itemgroup1" },
     { "group": "example_shopkeeper_itemgroup2", "trust": 10 },

--- a/doc/JSON/NPCs.md
+++ b/doc/JSON/NPCs.md
@@ -57,7 +57,7 @@ Format:
   "carry_override": "NC_EXAMPLE_carried",                                  // Optional. Defines an item group that replaces their carried items (in pockets, etc). Items which cannot
                                                                            // be carried will overflow(fall to the ground) when the NPC is loaded.
   "weapon_override": "NC_EXAMPLE_weapon",                                  // Optional. Defines an item group that replaces their wielded weapon.
-  "bye_message_override": "<fuck_you>",                                    // Optional. If used, overrides the default bye message (picked from <bye> snippet) to any another custom snippet
+  "bye_message_override": "<fuck_you>",                                    // Optional. If used, overrides the default bye message (picked from <bye> snippet) to any another custom snippet, if set to "<null>" will make the npc not say anything when leaving dialogue.
   "shopkeeper_item_group": [                                               // Optional. See [Shopkeeper NPC configuration](#shopkeeper-npc-configuration) below.
     { "group": "example_shopkeeper_itemgroup1" },
     { "group": "example_shopkeeper_itemgroup2", "trust": 10 },

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -1641,7 +1641,8 @@ void avatar::talk_to( std::unique_ptr<talker> talk_with, bool radio_contact,
             npc *npc_actor = d.actor( true )->get_npc();
             if( npc_actor->myclass->bye_message_override.empty() ) {
                 d.actor( true )->say( npc_actor->chat_snippets().snip_bye.translated() );
-            } else if( npc_actor->myclass->bye_message_override.translated() != "<null>" ) {
+            } else if( npc_actor->myclass->bye_message_override.translated() !=
+                       string_id<translation>::NULL_ID().str() ) {
                 d.actor( true )->say( npc_actor->myclass->bye_message_override.translated() );
             }
             d.done = true;

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -1639,12 +1639,10 @@ void avatar::talk_to( std::unique_ptr<talker> talk_with, bool radio_contact,
         }
         if( next.id == "TALK_DONE" || d.topic_stack.empty() ) {
             npc *npc_actor = d.actor( true )->get_npc();
-            if( npc_actor ) {
-                if( npc_actor->myclass->bye_message_override.empty() ) {
-                    d.actor( true )->say( npc_actor->chat_snippets().snip_bye.translated() );
-                } else {
-                    d.actor( true )->say( npc_actor->myclass->bye_message_override.translated() );
-                }
+            if( npc_actor->myclass->bye_message_override.empty() ) {
+                d.actor( true )->say( npc_actor->chat_snippets().snip_bye.translated() );
+            } else if( npc_actor->myclass->bye_message_override.translated() != "<null>" ) {
+                d.actor( true )->say( npc_actor->myclass->bye_message_override.translated() );
             }
             d.done = true;
         } else if( next.id != "TALK_NONE" ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Infrastructure "Empty `bye_message_override` fields make npcs not say goodbye"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Currently all npcs will either use a generic goodby snippet, or a custom string if a `bye_message_override` field is present in their class, when closing a dialogue.

We should be able to have npcs actually not say anything when you leave a conversation because that's how some humans behave.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Refactor the `TALK_DONE` part of the dialogue loop slightly:

- Remove a redundant IF statement
- We check if there is a `bye_message_override`, if not we use the generic goodbye, if there is but its value is **not** `"<null>"` we use that instead, else we don't make the npc say anything and the dialogue is marked as done

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

- "null"? "[null]"? "(null)"?

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Closed a conversation with an npc with different values for `bye_message_override` or without the field.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
