### PR TITLE
Don't filter ineligible artifacts from game uis

### DIFF
--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -1386,12 +1386,12 @@ bool avatar::invoke_item( item *used, const tripoint_bub_ms &pt, int pre_obtain_
     const std::map<std::string, use_function> &use_methods = used->type->use_methods;
     const int num_methods = use_methods.size();
 
-    const bool has_relic = used->has_relic_activation();
+    const bool has_relic = used->has_relic_activation() && used->can_use_relic( *this );
     if( use_methods.empty() && !has_relic ) {
         return false;
     } else if( num_methods == 1 && !has_relic ) {
         return invoke_item( used, use_methods.begin()->first, pt, pre_obtain_moves );
-    } else if( num_methods == 0 && has_relic && used->can_use_relic( *this ) ) {
+    } else if( num_methods == 0 && has_relic ) {
         return used->use_relic( *this, pt );
     }
 

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -1113,12 +1113,16 @@ class activatable_inventory_preset : public pickup_inventory_preset
         }
 
         bool is_shown( const item_location &loc ) const override {
-            return loc->type->has_use() || ( loc->has_relic_activation() && loc->can_use_relic( you ) );
+            return loc->type->has_use() || loc->has_relic_activation();
         }
 
         std::string get_denial( const item_location &loc ) const override {
             const item &it = *loc;
             const auto &uses = it.type->use_methods;
+
+            if( !it.can_use_relic( you ) ) {
+                return string_format( _( "The %s can't be used like that." ), it.tname() );
+            }
 
             const auto &comest = it.get_comestible();
             if( comest && !comest->tool.is_null() ) {


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Fix confusing UI.
Follow-up on https://github.com/CleverRaven/Cataclysm-DDA/pull/83219

#### Describe the solution
Instead, just prevent using them.

#### Testing
<img width="1877" height="37" alt="Activation menu showing 'The hollow, transparent cube (1/2) can't be used like that'" src="https://github.com/user-attachments/assets/82645f36-b5d6-4d18-a1e4-5d93b302b106" />
