### PR TITLE
Activate menu fix for non-relic items

### DIFF
--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -1120,7 +1120,7 @@ class activatable_inventory_preset : public pickup_inventory_preset
             const item &it = *loc;
             const auto &uses = it.type->use_methods;
 
-            if( it.is_relic() && !it.can_use_relic( you ) ) {
+            if( it.has_relic_activation() && !it.can_use_relic( you ) ) {
                 return string_format( _( "The %s can't be used like that." ), it.tname() );
             }
 

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -1120,7 +1120,7 @@ class activatable_inventory_preset : public pickup_inventory_preset
             const item &it = *loc;
             const auto &uses = it.type->use_methods;
 
-            if( !it.can_use_relic( you ) ) {
+            if( it.is_relic() && !it.can_use_relic( you ) ) {
                 return string_format( _( "The %s can't be used like that." ), it.tname() );
             }
 


### PR DESCRIPTION
#### Summary
Bugfixes "Activating non-relic items is forbidden from the (a)ctivate menu"


#### Purpose of change

Resulting from #83238, attempting to activate non-relic items from the (a)ctivate menu is blocked, with the message "The %s can't be used like that". This is likely due to a slight oversight in the following addition to `game_inventory.cpp`:

```
if( !it.can_use_relic( you ) ) {
    return string_format( _( "The %s can't be used like that." ), it.tname() );
}
```

The fix should just be the addition of a check for `it.is_relic()` as part of the condition, so non-relic items are not blocked.


#### Describe the solution

Added the condition, compiled the project, verified that I could again activate non-relic items from the (a)ctivate menu

#### Describe alternatives you've considered

Modifying `can_use_relic` to return true for non-relic usable items, but that might cause issues elsewhere.

#### Testing

Compiled the project with the change, and observed the expected behaviour.

#### Additional context

Before:
<img width="1790" height="686" alt="TestActive" src="https://github.com/user-attachments/assets/b9234b4c-01f3-4db8-afab-798ddf4324bd" />

After:
<img width="1436" height="692" alt="TestActiveCheck" src="https://github.com/user-attachments/assets/0892f91d-2410-406c-bf2a-191f0fa0d3ad" />
