### PR TITLE
fix dialogue trying to pick nonexistent NPC

### DIFF
--- a/src/dialogue_chatbin.h
+++ b/src/dialogue_chatbin.h
@@ -134,7 +134,7 @@ struct dialogue_chatbin_snippets {
 
     // talk from npctalk.cpp(can use snippets in json)
     translation snip_acknowledged = no_translation( "<acknowledged>" );
-    translation snip_bye = to_translation( "<end_talking_bye>" );
+    translation snip_bye = no_translation( "<end_talking_bye>" );
 
     // talk from talker_npc.cpp(can use snippets in json)
     translation snip_consume_cant_accept =

--- a/src/npc_class.cpp
+++ b/src/npc_class.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <iterator>
+#include <optional>
 #include <set>
 #include <string>
 #include <utility>

--- a/src/npc_class.h
+++ b/src/npc_class.h
@@ -4,6 +4,7 @@
 
 #include <functional>
 #include <map>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <utility>

--- a/src/npc_class.h
+++ b/src/npc_class.h
@@ -114,7 +114,8 @@ class npc_class
         item_group_id carry_override;
         item_group_id weapon_override;
 
-        translation bye_message_override;
+        // category of snippet, from which bye message should be picked, if should be replaced
+        std::optional<std::string> bye_message_override;
 
         std::map<mutation_category_id, distribution> mutation_rounds;
         trait_group::Trait_group_tag traits = trait_group::Trait_group_tag( "EMPTY_GROUP" );

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -1597,6 +1597,29 @@ void npc::handle_sound( const sounds::sound_t spriority, const std::string &desc
     }
 }
 
+static std::string bye_message( const npc *npc_actor )
+{
+    // some dialogues do not have beta actor
+    if( npc_actor ) {
+        const std::optional<std::string> bye_snippet = npc_actor->myclass->bye_message_override;
+        // if no bye_snippet, use default bye snippet
+        if( !bye_snippet.has_value() ) {
+            return npc_actor->chat_snippets().snip_bye.translated();
+            // if null, we want npc to mute bye message
+            // snippet categories do not have their own type,
+            // therefore do not have type::NULL_ID(), so check it against plain string
+        } else if( bye_snippet.value() != "null" ) {
+            return "";
+        } else {
+            const std::optional<translation> &bye_message = SNIPPET.random_from_category( bye_snippet.value() );
+            if( bye_message.has_value() ) {
+                return bye_message.value().translated();
+            }
+        }
+    }
+    return "";
+}
+
 void avatar::talk_to( std::unique_ptr<talker> talk_with, bool radio_contact,
                       bool is_computer, bool is_not_conversation, const std::string &debug_topic )
 {
@@ -1638,13 +1661,7 @@ void avatar::talk_to( std::unique_ptr<talker> talk_with, bool radio_contact,
             } while( cat != -1 && topic_category( d.topic_stack.back() ) == cat );
         }
         if( next.id == "TALK_DONE" || d.topic_stack.empty() ) {
-            npc *npc_actor = d.actor( true )->get_npc();
-            if( npc_actor->myclass->bye_message_override.empty() ) {
-                d.actor( true )->say( npc_actor->chat_snippets().snip_bye.translated() );
-            } else if( npc_actor->myclass->bye_message_override.translated() !=
-                       string_id<translation>::NULL_ID().str() ) {
-                d.actor( true )->say( npc_actor->myclass->bye_message_override.translated() );
-            }
+            d.actor( true )->say( bye_message( d.actor( true )->get_npc() ) );
             d.done = true;
         } else if( next.id != "TALK_NONE" ) {
             d.add_topic( next );
@@ -1765,12 +1782,7 @@ std::string dialogue::dynamic_line( const talk_topic &the_topic )
     }
 
     if( topic == "TALK_NONE" || topic == "TALK_DONE" ) {
-        npc *guy = actor( true )->get_npc();
-        if( guy->myclass->bye_message_override.empty() ) {
-            return guy->chat_snippets().snip_bye.translated();
-        } else {
-            return guy->myclass->bye_message_override.translated();
-        }
+        return bye_message( actor( true )->get_npc() );
     } else if( topic == "TALK_TRAIN" ) {
         if( !player_character.backlog.empty() && player_character.backlog.front().id() == ACT_TRAIN ) {
             return _( "Shall we resume?" );

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -1615,7 +1615,8 @@ static std::string bye_message( const npc *npc_actor )
         return "";
     }
     const std::optional<translation> &bye_message = SNIPPET.random_from_category( bye_snippet.value() );
-    return bye_message.value_or( no_translation( string_format( "No snippet value for %s", bye_snippet.value() ) ) ).translated();
+    return bye_message.value_or( no_translation( string_format( "No snippet value for %s",
+                                 bye_snippet.value() ) ) ).translated();
 }
 
 void avatar::talk_to( std::unique_ptr<talker> talk_with, bool radio_contact,

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -1600,24 +1600,22 @@ void npc::handle_sound( const sounds::sound_t spriority, const std::string &desc
 static std::string bye_message( const npc *npc_actor )
 {
     // some dialogues do not have beta actor
-    if( npc_actor ) {
-        const std::optional<std::string> bye_snippet = npc_actor->myclass->bye_message_override;
-        // if no bye_snippet, use default bye snippet
-        if( !bye_snippet.has_value() ) {
-            return npc_actor->chat_snippets().snip_bye.translated();
-            // if null, we want npc to mute bye message
-            // snippet categories do not have their own type,
-            // therefore do not have type::NULL_ID(), so check it against plain string
-        } else if( bye_snippet.value() != "null" ) {
-            return "";
-        } else {
-            const std::optional<translation> &bye_message = SNIPPET.random_from_category( bye_snippet.value() );
-            if( bye_message.has_value() ) {
-                return bye_message.value().translated();
-            }
-        }
+    if( !npc_actor ) {
+        return "";
     }
-    return "";
+    const std::optional<std::string> bye_snippet = npc_actor->myclass->bye_message_override;
+    // if no bye_snippet, use default bye snippet
+    if( !bye_snippet.has_value() ) {
+        return npc_actor->chat_snippets().snip_bye.translated();
+    }
+    // if null, we want npc to mute bye message
+    // snippet categories do not have their own type,
+    // therefore do not have type::NULL_ID(), so check it against plain string
+    if( bye_snippet.value() == "null" ) {
+        return "";
+    }
+    const std::optional<translation> &bye_message = SNIPPET.random_from_category( bye_snippet.value() );
+    return bye_message.value_or( no_translation( string_format( "No snippet value for %s", bye_snippet.value() ) ) ).translated();
 }
 
 void avatar::talk_to( std::unique_ptr<talker> talk_with, bool radio_contact,


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
The bug happened because in #83236 Balthazar removed `if( npc_actor )` guard, that prevented the game from checking anything npc related if npc was not presented. This resulted in dialogues with no beta actor (like used in bomb perks, but also in many another stuff that should not be dialogue but for some reason are) segfault
Fix #83249
#### Describe the solution
Return guard, generally polish the surrounding code
#### Testing
Bombastic perks works fine now
#### Additional context
It's not clear for me why stuff like `struct dialogue_chatbin_snippets` uses 
```c++
translation snip_bye = no_translation( "<end_talking_bye>" );
```
instead of just 
```c++
std::string snip_bye = "<end_talking_bye>";
```
(or even adding it's own type to snippet groups and using it instead) except for parity with the rest of instances
```c++
translation snip_lost_blood = to_translation( "I've lost lot of blood." )
```