### PR TITLE
Fix balthazar eoc checks

### DIFF
--- a/data/json/effects_on_condition/npc_eocs/balthazar_fac_eocs.json
+++ b/data/json/effects_on_condition/npc_eocs/balthazar_fac_eocs.json
@@ -24,13 +24,7 @@
     "type": "effect_on_condition",
     "id": "EOC_BALTHAZAR_CHECK_PROGRESS",
     "global": true,
-    "condition": {
-      "and": [
-        { "u_near_om_location": "balthazar_bunker_02", "range": 30 },
-        { "not": { "u_near_om_location": "balthazar_bunker_02", "range": 4 } },
-        { "math": [ "balthazar_destroyed != 1" ] }
-      ]
-    },
+    "condition": { "math": [ "balthazar_destroyed != 1" ] },
     "effect": [
       { "if": { "math": [ "balthazar_power <= 0" ] }, "then": { "run_eocs": "EOC_BALTHAZAR_GONE" } },
       {

--- a/data/mods/Backrooms/vanilla_override_eocs.json
+++ b/data/mods/Backrooms/vanilla_override_eocs.json
@@ -1,0 +1,9 @@
+[
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_BALTHAZAR_CHECK_PROGRESS",
+    "//": "override, so the game would not track balthazar location progress",
+    "global": true,
+    "effect": [  ]
+  }
+]

--- a/data/mods/Isolation-Protocol/vanilla_override_eocs.json
+++ b/data/mods/Isolation-Protocol/vanilla_override_eocs.json
@@ -1,0 +1,9 @@
+[
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_BALTHAZAR_CHECK_PROGRESS",
+    "//": "override, so the game would not track balthazar location progress",
+    "global": true,
+    "effect": [  ]
+  }
+]

--- a/data/mods/aftershock_exoplanet/EOC/vanilla_override_eocs.json
+++ b/data/mods/aftershock_exoplanet/EOC/vanilla_override_eocs.json
@@ -1,0 +1,9 @@
+[
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_BALTHAZAR_CHECK_PROGRESS",
+    "//": "override, so the game would not track balthazar location progress",
+    "global": true,
+    "effect": [  ]
+  }
+]

--- a/data/mods/innawood/vanilla_override_eocs.json
+++ b/data/mods/innawood/vanilla_override_eocs.json
@@ -1,0 +1,9 @@
+[
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_BALTHAZAR_CHECK_PROGRESS",
+    "//": "override, so the game would not track balthazar location progress",
+    "global": true,
+    "effect": [  ]
+  }
+]


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Fix #83226 (at least in new saves)
#### Describe the solution
Replace the proximity checks for balthazar bunker with just a plain override of location in mods where it is needed to be overriden
#### Describe alternatives you've considered
Find some smarter way
#### Testing
Created a new world, waited 24 hours, EOC_BALTHAZAR_CHECK_PROGRESS works fine
Teleported to bunker, waited 24 hours again, no crash
Debug (so without a killer) killed one turret (should run EOC_BALTHAZAR_CHECK_PROGRESS on death), no segfault either
Attached save file still errors about not being able to find a location, but there is something deeply wrong with it in some another way that i cannot figure