### PR TITLE
Update IN_REPO_MODS.md for mods with dependencies

### DIFF
--- a/doc/IN_REPO_MODS.md
+++ b/doc/IN_REPO_MODS.md
@@ -49,6 +49,7 @@ Furthermore, there are additional criteria:
 *  Content mods need to be providing some kind of curated experience. Either they introduce a set of locations, encounters, equipment, or progression mechanisms that do not fit the style of the core game, or they in some fashion modify the game according to some well-defined concept.
 *  *  Mods which do not qualify as curated experiences: Grab bag mods with no defined purpose (i.e. adding a bunch of random guns), "settings" mods that just turn off a possibly undesired but working feature (acid ants).
 *  Development mods need to have an associated work-in-progress feature that they exist to mitigate.
+*  Mods that have dependencies must have their dependencies in-repo, and require the approval of the maintainer(s) of the dependencies. Having another mod be dependent on yours incurs a maintenance burden (you can't make changes without possibly breaking theirs), so the dependencies need to be on board with that.
 
 ## What are the responsibilities of a mod curator?
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
* #83213 brought up some interesting questions, namely:

Is this a burden on Magiclysm? What happens if Magiclysm wants to make fundamental changes that invalidate how the mod works (even *subsuming the mod entirely*)?

There's a lot of ways that Magiclysm could make changes that would break Sorcerer, which would prevent Magiclysm's changes from being mergeable. This seems like it could be unfair to Magiclysm. BUT, the important thing is that the Magiclysm maintainers are okay with it.

#### Describe the solution

Just in case it comes up again in the future and it does cause issues, let's get ahead of the issues by writing down a simple policy.

#### Describe alternatives you've considered
I didn't write anything for *ongoing*  maintenance concerns. There could be a situation where the mod is initially approved by the dependencies' maintainers, but then later turns into a much bigger problem than they want to deal with it. That would have to be handled on a case-by-case basis, not policy.

#### Testing
Docs change only

#### Additional context
