### PR TITLE
Minor gui tweaks to mission UI

### DIFF
--- a/src/mission_ui.cpp
+++ b/src/mission_ui.cpp
@@ -146,14 +146,6 @@ void mission_ui_impl::draw_controls()
 
     if( last_action == "QUIT" ) {
         return;
-    } else if( last_action == "UP" ) {
-        adjust_selected = true;
-        ImGui::SetKeyboardFocusHere( -1 );
-        selected_mission--;
-    } else if( last_action == "DOWN" ) {
-        adjust_selected = true;
-        ImGui::SetKeyboardFocusHere( 1 );
-        selected_mission++;
     } else if( last_action == "NEXT_TAB" || last_action == "RIGHT" ) {
         adjust_selected = true;
         selected_mission = 0;
@@ -220,17 +212,29 @@ void mission_ui_impl::draw_controls()
         ImGui::EndTabBar();
     }
 
+    size_t num_entries = umissions.size();
+    if( selected_tab == mission_ui_tab_enum::POINTS_OF_INTEREST ) {
+        num_entries = upoints_of_interest.size();
+    }
+    const int last_entry = num_entries == 0 ? 0 : ( static_cast<int>( num_entries ) - 1 );
+    const int previous_selected_mission = selected_mission;
+    if( last_action == "UP" ) {
+        ImGui::SetKeyboardFocusHere( -1 );
+        selected_mission--;
+    } else if( last_action == "DOWN" ) {
+        ImGui::SetKeyboardFocusHere( 1 );
+        selected_mission++;
+    } else if( last_action == "HOME" ) {
+        selected_mission = 0;
+    } else if( last_action == "END" ) {
+        selected_mission = last_entry;
+    }
     if( selected_mission < 0 ) {
+        selected_mission = last_entry;
+    } else if( selected_mission > last_entry ) {
         selected_mission = 0;
     }
-
-    if( selected_tab != mission_ui_tab_enum::POINTS_OF_INTEREST &&
-        static_cast<size_t>( selected_mission ) > umissions.size() - 1 ) {
-        selected_mission = umissions.size() - 1;
-    } else if( selected_tab == mission_ui_tab_enum::POINTS_OF_INTEREST &&
-               static_cast<size_t>( selected_mission ) > upoints_of_interest.size() - 1 ) {
-        selected_mission = upoints_of_interest.size() - 1;
-    }
+    adjust_selected |= selected_mission != previous_selected_mission;
 
     // This action needs to be after umissions is populated
     if( last_action == "CONFIRM" ) {
@@ -268,7 +272,7 @@ void mission_ui_impl::draw_controls()
     }
 
     if( ImGui::BeginTable( "##MISSION_TABLE", 2, ImGuiTableFlags_None,
-                           ImVec2( window_width, window_height ) ) ) {
+                           ImGui::GetContentRegionAvail() ) ) {
         // Missions selection is purposefully thinner than the description, it has less to convey.
         if( selected_tab != mission_ui_tab_enum::POINTS_OF_INTEREST ) {
             ImGui::TableSetupColumn( _( "Missions" ), ImGuiTableColumnFlags_WidthStretch,
@@ -303,10 +307,8 @@ void mission_ui_impl::draw_mission_names( std::vector<mission *> missions, int &
 {
     const int num_missions = missions.size();
 
-    // roughly 6 lines of header info. title+tab+objective+table headers+2 lines worth of padding between those four
-    const float header_height = ImGui::GetTextLineHeight() * 6;
     if( ImGui::BeginListBox( "##LISTBOX", ImVec2( table_column_width * 0.75,
-                             window_height - header_height ) ) ) {
+                             ImGui::GetContentRegionAvail().y ) ) ) {
         for( int i = 0; i < num_missions; i++ ) {
             const bool is_selected = selected_mission == i;
             ImGui::PushID( i );
@@ -334,10 +336,8 @@ void mission_ui_impl::draw_point_of_interest_names( std::vector<point_of_interes
 {
     const int num_missions = points_of_interest.size();
 
-    // roughly 6 lines of header info. title+tab+objective+table headers+2 lines worth of padding between those four
-    const float header_height = ImGui::GetTextLineHeight() * 6;
     if( ImGui::BeginListBox( "##LISTBOX", ImVec2( table_column_width * 0.75,
-                             window_height - header_height ) ) ) {
+                             ImGui::GetContentRegionAvail().y ) ) ) {
         for( int i = 0; i < num_missions; i++ ) {
             const bool is_selected = selected_mission == i;
             ImGui::PushID( i );


### PR DESCRIPTION


<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

* Allows the mission UI to wrap around the list of missions so that it:
    * selects the bottom one if you press UP while already at the top
    * and likewise selects the topmost one when while pressing DOWN when at the bottom one
* Adds support for HOME and END keys in the list of missions to go to the topmost or bottom entry.
* Resizes the mission ui contents dynamically based on content height instead of a fixed (and incorrectly calculated) height offset. This removes a scrollbar that was previously visible in the mission UI, even when the contents did not require scrolling.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

* Uses `ImGui::GetContentRegionAvail()` to use remaining space, instead of calculating it.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<img width="983" height="1184" alt="mission-ui" src="https://github.com/user-attachments/assets/2e9a44e1-2302-459f-82fc-24ca2fcce835" />

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
