### PR TITLE
READY dimensional travel for vehicles

### DIFF
--- a/data/json/debug/teleportation.json
+++ b/data/json/debug/teleportation.json
@@ -1,0 +1,70 @@
+[
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PERAMBULATE_VEHICLE",
+    "//": "Example EOC that shifts a vehicle to the test dimension",
+    "effect": [
+      {
+        "if": { "current_dimension": "" },
+        "then": { "set_string_var": "test", "target_var": { "u_val": "destination_dimension" } },
+        "else": { "set_string_var": "", "target_var": { "u_val": "destination_dimension" } }
+      },
+      {
+        "u_travel_to_dimension": { "u_val": "destination_dimension" },
+        "region_type": { "u_val": "test" },
+        "take_vehicle": true,
+        "fail_message": "The Perambulator shivers but does not move.",
+        "success_message": "In a flash of light the surroundings outside the Perambulator are changed!."
+      },
+      { "u_message": { "u_val": "destination_dimension" } },
+      { "if": { "current_dimension": "" }, "then": { "u_message": "home sweet home" } }
+    ]
+  },
+  {
+    "id": "dimensional_perambulator",
+    "type": "ITEM",
+    "category": "veh_parts",
+    "name": { "str": "dimensional perambulator" },
+    "description": "A perambulator, for perambulating through dimensions",
+    "weight": "1 kg",
+    "volume": "5 L",
+    "material": [ "lc_steel" ],
+    "symbol": "#",
+    "color": "dark_gray"
+  },
+  {
+    "id": "dimensional_perambulator",
+    "type": "vehicle_part",
+    "name": { "str": "Dimensional Perambulator" },
+    "item": "dimensional_perambulator",
+    "location": "center",
+    "categories": [ "utility" ],
+    "durability": 100,
+    "description": "A perambulator, for perambulating through dimensions",
+    "flags": [ "EOC_ACTIVATION" ],
+    "activatable_eoc": "EOC_PERAMBULATE_VEHICLE",
+    "variants": [ { "symbols": "#", "symbols_broken": "X" } ]
+  },
+  {
+    "id": "dimensional_bathyscape",
+    "//": "Test vehicle for dimensional travel",
+    "type": "vehicle",
+    "name": "Sir Pemberton Smythe's Dimensional Bathyscape",
+    "blueprint": [
+      [ "---" ],
+      [ "+#|" ],
+      [ "---" ]
+    ],
+    "parts": [
+      { "x": -1, "y": -1, "parts": [ "hdframe", "board", "roof" ] },
+      { "x": -1, "y": 0, "parts": [ "hdframe", { "part": "tank", "fuel": "gasoline" }, "roof" ] },
+      { "x": -1, "y": 1, "parts": [ "hdframe", "engine_v6", "alternator_car", "roof" ] },
+      { "x": 0, "y": -1, "parts": [ "hdframe", "door", "roof", "battery_car" ] },
+      { "x": 0, "y": 0, "parts": [ "hdframe", "seat", "controls" ] },
+      { "x": 0, "y": 1, "parts": [ "hdframe", "roof", "dimensional_perambulator" ] },
+      { "x": 1, "y": -1, "parts": [ "hdframe", "board", "roof" ] },
+      { "x": 1, "y": 0, "parts": [ "hdframe", "board", "roof" ] },
+      { "x": 1, "y": 1, "parts": [ "hdframe", "board", "roof" ] }
+    ]
+  }
+]

--- a/data/json/vehicleparts/vp_flags.json
+++ b/data/json/vehicleparts/vp_flags.json
@@ -55,6 +55,11 @@
     "info": "With a seat or saddle, you drive from here.  You can 'e'xamine the tile to access the controls, or use the vehicle control key (default '^')."
   },
   {
+    "id": "EOC_ACTIVATION",
+    "type": "json_flag",
+    "info": "Enables an associated EOC to be triggered from the vehicle control menu."
+  },
+  {
     "id": "SMART_ENGINE_CONTROLLER",
     "type": "json_flag",
     "info": "When active, turns engines on and off automatically."

--- a/data/mods/TEST_DATA/known_good_uncrafts.json
+++ b/data/mods/TEST_DATA/known_good_uncrafts.json
@@ -45,6 +45,7 @@
       "butane",
       "candle_wax",
       "default_dimension_teleport_orb",
+      "dimensional_perambulator",
       "fake_mill_vertical",
       "flare_nitrate",
       "gunpowder",

--- a/src/game.h
+++ b/src/game.h
@@ -333,9 +333,10 @@ class game
          * Moves the player to an alternate dimension.
          * @param prefix identifies the dimension and its properties.
          * @param npc_travellers vector of NPCs that should be brought along when travelling to another dimension
+         * @param veh pointer to a vehicle to bring along.
          */
         bool travel_to_dimension( const std::string &prefix, const std::string &region_type,
-                                  const std::vector<npc *> &npc_travellers );
+                                  const std::vector<npc *> &npc_travellers, vehicle *veh = nullptr );
         /**
          * Retrieve the identifier of the current dimension.
          * TODO: this should be a dereferencable id that gives properties of the dimension.

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -459,6 +459,30 @@ VehicleList map::get_vehicles()
                          tripoint_bub_ms( SEEX * my_MAPSIZE, SEEY * my_MAPSIZE, OVERMAP_HEIGHT ) );
 }
 
+bool map::place_vehicle( std::unique_ptr<vehicle> &&new_vehicle )
+{
+    bool collision = false;
+    // This works in the dimension shift case specifically because
+    // the old map origin and the new map origin are the same,
+    // if that is no longer the case something else will need to happen here.
+    tripoint_bub_ms vehicle_origin = new_vehicle->pos_bub( *this );
+    for( std::pair<const point_rel_ms, std::vector<int>> &mount_point : new_vehicle->relative_parts ) {
+        if( impassable( vehicle_origin + mount_point.first ) ) {
+            collision = true;
+            break;
+        }
+    }
+    submap *place_on_submap = get_submap_at_grid( new_vehicle->sm_pos - get_abs_sub().xy() );
+    if( place_on_submap == nullptr ) {
+        debugmsg( "Tried to add vehicle at %s but the submap is not loaded",
+                  new_vehicle->sm_pos.to_string() );
+    } else {
+        place_on_submap->ensure_nonuniform();
+        place_on_submap->vehicles.push_back( std::move( new_vehicle ) );
+    }
+    return collision;
+}
+
 void map::rebuild_vehicle_level_caches()
 {
     clear_vehicle_level_caches();

--- a/src/map.h
+++ b/src/map.h
@@ -761,6 +761,7 @@ class map
 
         // Vehicles: Common to 2D and 3D
         VehicleList get_vehicles();
+        bool place_vehicle( std::unique_ptr<vehicle> &&new_vehicle );
         void add_vehicle_to_cache( vehicle * );
         void clear_vehicle_point_from_cache( vehicle *veh, const tripoint_bub_ms &pt );
         // clears all vehicle level caches

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -7705,8 +7705,11 @@ talk_effect_fun_t::func f_travel_to_dimension( const JsonObject &jo, std::string
     str_or_var region_type_var;
     optional( jo, false, "region_type", region_type_var, "default" );
 
+    bool take_vehicle = false;;
+    optional( jo, false, "take_vehicle", take_vehicle );
+
     return [fail_message, success_message, dimension_prefix, npc_travel_filter,
-                  npc_travel_radius, region_type_var]( dialogue const & d ) {
+                  npc_travel_radius, region_type_var, take_vehicle]( dialogue const & d ) {
         Creature *teleporter = d.actor( false )->get_creature();
         if( teleporter ) {
             std::string region_type = region_type_var.evaluate( d );
@@ -7734,8 +7737,17 @@ talk_effect_fun_t::func f_travel_to_dimension( const JsonObject &jo, std::string
                         }
                     } );
                 }
+                vehicle *veh = nullptr;
+                if( take_vehicle ) {
+                    const optional_vpart_position vp_here = get_map().veh_at( teleporter->pos_bub() );
+                    if( !vp_here ) {
+                        teleporter->add_msg_if_player( fail_message.evaluate( d ) );
+                        return;
+                    }
+                    veh = &vp_here->vehicle();
+                }
                 // returns False if fail
-                if( g->travel_to_dimension( prefix, region_type, travellers ) ) {
+                if( g->travel_to_dimension( prefix, region_type, travellers, veh ) ) {
                     teleporter->add_msg_if_player( success_message.evaluate( d ) );
                 } else {
                     teleporter->add_msg_if_player( fail_message.evaluate( d ) );

--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -269,6 +269,7 @@ void vpart_info::load( const JsonObject &jo, const std::string_view src )
     optional( jo, was_loaded, "comfort", comfort, 0 );
     optional( jo, was_loaded, "floor_bedding_warmth", floor_bedding_warmth, 0_C_delta );
     optional( jo, was_loaded, "bonus_fire_warmth_feet", bonus_fire_warmth_feet, 0.6_C_delta );
+    optional( jo, was_loaded, "activatable_eoc", activatable_eoc );
 
     int enchant_num = 0;
     for( JsonValue jv : jo.get_array( "enchantments" ) ) {

--- a/src/veh_type.h
+++ b/src/veh_type.h
@@ -334,6 +334,7 @@ class vpart_info
         std::optional<vpslot_terrain_transform> transform_terrain_info;
         //Enchantments
         std::vector<enchantment_id> enchantments;
+        std::optional<effect_on_condition_id> activatable_eoc;
 
         std::set<std::pair<itype_id, int>> get_pseudo_tools() const;
 

--- a/src/veh_utils.cpp
+++ b/src/veh_utils.cpp
@@ -492,9 +492,13 @@ bool veh_menu::query()
 
     chosen._on_submit();
 
-    veh.refresh( );
-    here.invalidate_visibility_cache();
-    here.invalidate_map_cache( here.get_abs_sub().z() );
+    // There's probably a better way to detect this?
+    // If we're swapping dimensions the veh reference has been invalidated.
+    if( !g->swapping_dimensions ) {
+        veh.refresh( );
+        here.invalidate_visibility_cache();
+        here.invalidate_map_cache( here.get_abs_sub().z() );
+    }
 
     return chosen._keep_menu_open;
 }

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -19,6 +19,8 @@
 #include "creature.h"
 #include "creature_tracker.h"
 #include "debug.h"
+#include "dialogue.h"
+#include "effect_on_condition.h"
 #include "enums.h"
 #include "game.h"
 #include "game_inventory.h"
@@ -2064,6 +2066,15 @@ void vehicle::build_interact_menu( veh_menu &menu, map *here, const tripoint_bub
         .hotkey( "TOGGLE_ALARM" )
         .on_submit( [this, here] { smash_security_system( *here ); } );
     }
+    for( const vpart_reference &vp : this->get_avail_parts( "EOC_ACTIVATION" ) ) {
+        vehicle_part &part = vp.part();
+        menu.add( string_format( _( "Activate  %s" ), vp.part().name() ) )
+        .on_submit( [&part] {
+            dialogue newDialog( get_talker_for( get_player_character() ), nullptr );
+            part.info().activatable_eoc.value()->activate( newDialog );
+        } );
+    }
+
 
     if( remote ) {
         menu.add( _( "Stop controlling" ) )


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Had a request from @John-Candlebury to enable vehicles to do dimensional travel.

#### Describe the solution
Extended dimensional travel infra to optionally capture the vehicle the player is in and move it with them to their destination dimension.
Added EOC hooks that allow a vehicle part to call an EOC.
Added example vehicle, vehicle parts and EOC to tie these two together into a functional example.

TODO:
- [x] Search for a landing site, the vehicle currently evaporates if it overlaps with an obstacle.
- [x] Re-board the player on arrival.
- [x] Add a map method to add an exiting vehicle instead of exposing the submap directly.
- [x] Fix up the vehicle interaction menu to not use the hardcoded menu name.
- [x] Stash the example json somewhere it won't be mistaken for baseline content. 

#### Describe alternatives you've considered
I was trying to turn this into a thing where you could specify in the vehicle part how you want things to work, but that's not really viable since there are so many options.
I'm not clear on inline EOC vs referenced EOC like this, I don't think it's generally going to be simple enough that inlining it would be reasonable, but I'm also not the main user so if you're a heavy EOC user and disagree feel free to let me know.

#### Testing
Spawned in the new vehicle.
Boarded it, hit the drive menu, selected the new option.
Observed arrival in the new dimension.
Repeating returned me to the main dimension.