### PR TITLE
Don't arbitrarily turn crops into steel bushes

### DIFF
--- a/data/json/furniture_and_terrain/furniture-domestic_plants.json
+++ b/data/json/furniture_and_terrain/furniture-domestic_plants.json
@@ -80,7 +80,7 @@
     "symbol": "#",
     "color": "red",
     "coverage": 50,
-    "move_cost_mod": 2,
+    "move_cost_mod": 0,
     "required_str": -1,
     "flags": [
       "PLANT",
@@ -105,7 +105,7 @@
     "symbol": "#",
     "color": "light_green",
     "coverage": 30,
-    "move_cost_mod": 1,
+    "move_cost_mod": 0,
     "required_str": -1,
     "flags": [
       "PLANT",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fix #83161, i.e. crops arbitrarily turns into steel bushes once they mature. This makes field previously traversable by vehicles suddenly filled with vehicle destroying obstacles at the day the crops mature. This, in turn, renders the in-game harvesting machinery unusable for two reasons:
1. The harvesters are designed for single lines of crops, while the fields use double lines, so harvesters will crash into the second line.
2. Crops are planted in curves at the corners of the field, but the game vehicles can't move like that, thus guaranteeing collisions.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Change "move_cost_mod" to 0 for f_plant_harvest and f_plant_unharvested_overgrown. This allows harvesters (and other vehicles) to drive over the crops and harvest them.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
- Redesign all farm fields to use straight alternating lines of crops and free space.
- Redesign farming vehicles to conform to a double line crop planting regime, and redesign all farm fields to use straight double lines (no curves).
- Redesign the tractor harvester to use 5 lines of auto harvesters, or at least use auto harvesters in front of the wheels. This is the closest to what real world harvesters look like.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
- Teleported to a wheat field.
- Debug advanced tile to allow the wheat to reach the harvest state.
- Teleported away and back to get the growth to take effect.
- Debug spawned a reaper tractor.
- Drove into the field with the reapers engaged and crashed into the wheat where harvesters are absent.
- backed out of the field.
- Debug advanced time to when the wheat would be overgrown.
- Teleported away and back.
- Drove into the overgrown field and crashed into the overgrown wheat.
- Made the changes and repeated the above. The harvester could drive through the field and cut down the crops with the reapers, driving over the crops where no reapers were mounted. Also crushed the harvested wheat (in the harvestable case only, of course) when turning (again showing that curving fields aren't compatible with any reapers that don't collect the harvest in some fashion).

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
- Fields should be changed to a straight configuration regardless in order to work with the game vehicle mechanics. This will most likely still cause issues, as many of these probably would end up in configurations where there is no way to actually enter the field with a proper orientation (due to adjacent forest or fences, etc.).
- Farming vehicle configuration should match field configuration regardless, i.e. both using single row or both using double row configurations.
- I'm not opposed to the introduction of logic to "trample" fields with vehicles, destroying crops with the wheels, as long as the damage is to the crops only, not the wheels.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
