### PR TITLE
Prevent a static initialization order fiasco

### DIFF
--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -1740,10 +1740,7 @@ void Item_factory::load_item_blacklist( const JsonObject &json )
 
 Item_factory::~Item_factory() = default;
 
-Item_factory::Item_factory()
-{
-    init();
-}
+Item_factory::Item_factory() = default;
 
 class iuse_function_wrapper : public iuse_actor
 {


### PR DESCRIPTION
#### Summary

None

#### Purpose of change

Fixes #82111

#### Describe the solution

`item_controller` is statically initialized. As it itself contains static members like `iuse_function_list`, having the constructor touch them is undefined behaviour and will indeed crash the program depending on which order the compiler decides to run them.

As `items::load` calls `init()` anyway, I removed the unnecessary call to it in the constructor.

#### Testing

Built with LTO, it now runs without segfaulting.