### PR TITLE
Jabberwock buffs

### DIFF
--- a/data/json/monsters/jabberwock.json
+++ b/data/json/monsters/jabberwock.json
@@ -88,11 +88,48 @@
     "bleed_rate": 40,
     "vision_day": 50,
     "vision_night": 3,
-    "special_attacks": [ [ "FLESH_GOLEM", 5 ] ],
+    "grab_strength": 60,
+    "//": "Forest of limbs and heads mean multiple grabs and bites",
+    "special_attacks": [
+      [ "FLESH_GOLEM", 5 ],
+      {
+        "type": "monster_attack",
+        "attack_type": "bite",
+        "id": "bite_jabberwock_1",
+        "condition": { "and": [ { "u_has_flag": "GRAB_FILTER" }, { "npc_has_flag": "GRAB" } ] },
+        "damage_max_instance": [ { "damage_type": "stab", "amount": 10 } ],
+        "infection_chance": 5,
+        "cooldown": 4,
+        "move_cost": 100
+      },
+      {
+        "type": "monster_attack",
+        "attack_type": "bite",
+        "id": "bite_jabberwock_2",
+        "condition": { "and": [ { "u_has_flag": "GRAB_FILTER" }, { "npc_has_flag": "GRAB" } ] },
+        "damage_max_instance": [ { "damage_type": "stab", "amount": 15, "armor_penetration": 5 } ],
+        "infection_chance": 15,
+        "cooldown": 5,
+        "move_cost": 100
+      },
+      {
+        "type": "monster_attack",
+        "attack_type": "bite",
+        "id": "bite_jabberwock_3",
+        "condition": { "and": [ { "u_has_flag": "GRAB_FILTER" }, { "npc_has_flag": "GRAB" } ] },
+        "damage_max_instance": [ { "damage_type": "stab", "amount": 25, "armor_penetration": 15 } ],
+        "infection_chance": 30,
+        "cooldown": 8,
+        "move_cost": 100
+      },
+      { "id": "grab", "cooldown": 4 },
+      { "id": "grab_2", "cooldown": 4 },
+      { "id": "grab_3", "cooldown": 4 }
+    ],
     "harvest": "jabberwock",
     "dissect": "dissect_beast_sample_large",
     "zombify_into": "mon_meat_cocoon_med",
-    "flags": [ "SEES", "HEARS", "SMELLS", "STUMBLES", "WARM", "BASHES", "DESTROYS", "ATTACKMON", "POISON", "NEVER_WANDER" ],
+    "flags": [ "SEES", "HEARS", "SMELLS", "GRABS", "STUMBLES", "WARM", "BASHES", "DESTROYS", "ATTACKMON", "POISON", "NEVER_WANDER" ],
     "armor": { "bash": 12, "cut": 8, "bullet": 6, "electric": 3 }
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Balance "Jabberwock buffs"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Jabberwocks are described as some of the most horrible monsters out there by NPCs but they're really not that difficult. Sure, they have high melee skill and hit hard, but that's all they do (well, they also roar, I guess).  So I thought, what should they do considering their stated makeup (a bunch of writhing limbs and heads and other body parts) and came up with--grabs and bites.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Give the jabberwock three separate grabs and three separate bites (of varying strength, representing bites from different sorts of heads). The three grabs are because it has multiple limbs to grab you with. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Loaded up the combat test suite with the medium character, spawned a jabberwock, picked up the AR-15, and shot it to death.

Dropped the AR-15, spawned in another jabberwock, picked up a melee weapon, and proceeded to have a real bad time. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Looking into this I realized fleshy shamblers etc don't actually spawn anywhere. Some kind of weird map special where you can find them might be neat. 
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
