### PR TITLE
[MoM] Add Consciousness Blip portal storm effect

### DIFF
--- a/data/mods/MindOverMatter/effectoncondition/eoc_portal_storm_effects.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_portal_storm_effects.json
@@ -33,9 +33,23 @@
           [ "EOC_PORTAL_TAUNT", 1 ],
           [ "EOC_PORTAL_SHIFTING_MASS", 1 ],
           [ "EOC_PORTAL_ARTIFACT_WEAK", 1 ],
+          [ "EOC_PORTAL_CONSCIOUSNESS_BLIP", 1 ],
           [ "EOC_PORTAL_TEMPORARY_TEARS_IN_REALITY", 1 ]
         ]
       }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PORTAL_CONSCIOUSNESS_BLIP",
+    "//": "Simulates your consciousness being interrupted by the portal storm for a variable length of time (max six seconds)",
+    "condition": { "one_in_chance": 15 },
+    "effect": [
+      { "math": [ "_value = (min( (ps_str * 0.1), 5) + 1)" ] },
+      { "u_add_effect": "psi_stunned", "duration": { "math": [ "_value" ] } },
+      { "u_assign_activity": "ACT_GENERIC_EOC", "duration": { "math": [ "_value" ] } },
+      { "math": [ "u_ire -= 3" ] },
+      { "u_message": "Your head tingles and the world suddenly lurches!", "type": "bad" }
     ]
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[MoM] Add Consciousness Blip portal storm effect"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

More spooky portal storm effects, to make portal storms more dangerous now that you can just walk away.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add the Consciousness Blip effect, where your consciousness just...shuts off for a short time (max six seconds, varies based on portal storm strength). This is done by applying psi-stunned and then forcing the avatar to perform ACT_GENERIC_EOC for the duration, so the time passes without you needing to make any actual inputs.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Ran the EoC, it works.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

This _can_ happen inside, deliberately so.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
