### PR TITLE
Fix description counts on ammo boxes

### DIFF
--- a/data/json/items/containers/ammo_boxes.json
+++ b/data/json/items/containers/ammo_boxes.json
@@ -341,7 +341,7 @@
     "copy-from": "9mm_ammo_box_20",
     "type": "ITEM",
     "name": { "str": ".357 Magnum ammo box", "str_pl": ".357 Magnum ammo boxes" },
-    "description": "This box holds 20 rounds of .357 Magnum ammo.  It's made of a thin cardboard plastered with text about the ammo, and the manufacturer's logo.",
+    "description": "This box holds 50 rounds of .357 Magnum ammo.  It's made of a thin cardboard plastered with text about the ammo, and the manufacturer's logo.",
     "weight": "18 g",
     "volume": "175 ml",
     "pocket_data": [ { "pocket_type": "CONTAINER", "max_contains_volume": "145 ml", "max_contains_weight": "650 g", "rigid": true } ]
@@ -351,7 +351,7 @@
     "copy-from": "9mm_ammo_box_20",
     "type": "ITEM",
     "name": { "str": ".357 Magnum ammo box", "str_pl": ".357 Magnum ammo boxes" },
-    "description": "This box holds 20 rounds of .357 Magnum ammo.  It's made of a thin cardboard plastered with text about the ammo, and the manufacturer's logo.",
+    "description": "This box holds 200 rounds of .357 Magnum ammo.  It's made of a thin cardboard plastered with text about the ammo, and the manufacturer's logo.",
     "weight": "73 g",
     "volume": "640 ml",
     "pocket_data": [ { "pocket_type": "CONTAINER", "max_contains_volume": "580 ml", "max_contains_weight": "2600 g", "rigid": true } ]
@@ -549,7 +549,7 @@
     "copy-from": "9mm_ammo_box_20",
     "type": "ITEM",
     "name": { "str": ".44 Magnum ammo box", "str_pl": ".44 Magnum ammo boxes" },
-    "description": "This box holds 50 rounds of .44 Magnum ammo.  It's made of a thin cardboard plastered with text about the ammo, and the manufacturer's logo.",
+    "description": "This box holds 100 rounds of .44 Magnum ammo.  It's made of a thin cardboard plastered with text about the ammo, and the manufacturer's logo.",
     "weight": "55 g",
     "volume": "570 ml",
     "pocket_data": [ { "pocket_type": "CONTAINER", "max_contains_volume": "435 ml", "max_contains_weight": "2500 g", "rigid": true } ]
@@ -586,7 +586,7 @@
       {
         "id": "762R_ammo_box_20",
         "name": { "str": "7.62x54mmR ammo box", "str_pl": "7.62x54mmR ammo boxes" },
-        "description": "This box holds 200 rounds of 7.62x54mmR ammo.  It's made of a thin cardboard plastered with text about the ammo, and the manufacturer's logo.",
+        "description": "This box holds 20 rounds of 7.62x54mmR ammo.  It's made of a thin cardboard plastered with text about the ammo, and the manufacturer's logo.",
         "weight": 0
       },
       {
@@ -753,7 +753,7 @@
       {
         "id": "458_ammo_box_20",
         "name": { "str": ".458 Winchester Magnum ammo box", "str_pl": ".458 Winchester Magnum ammo boxes" },
-        "description": "This box holds 200 rounds of .458 Winchester Magnum ammo.  It's made of a thin cardboard plastered with text about the ammo, and the manufacturer's logo.",
+        "description": "This box holds 20 rounds of .458 Winchester Magnum ammo.  It's made of a thin cardboard plastered with text about the ammo, and the manufacturer's logo.",
         "weight": 0
       },
       {
@@ -799,7 +799,7 @@
     "copy-from": "9mm_ammo_box_20",
     "type": "ITEM",
     "name": { "str": ".338 Lapua Magnum ammo box", "str_pl": ".338 Lapua Magnum ammo boxes" },
-    "description": "This box holds 10 rounds of .338 Lapua Magnum ammo.  It's made of a thin cardboard plastered with text about the ammo, and the manufacturer's logo.",
+    "description": "This box holds 20 rounds of .338 Lapua Magnum ammo.  It's made of a thin cardboard plastered with text about the ammo, and the manufacturer's logo.",
     "weight": "41 g",
     "volume": "458 ml",
     "pocket_data": [ { "pocket_type": "CONTAINER", "max_contains_volume": "327 ml", "max_contains_weight": "400 g", "rigid": true } ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Ammo box descriptions have the correct amount of ammo"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Ammo boxes were a huge slog of copy-pasting, and as such required me to go back and fix up some issues. Whoops. 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Fixes em
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Making all of them wrong
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
