### PR TITLE
Cap multiplication factor in NPC weapon evaluation.

### DIFF
--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -4140,7 +4140,7 @@ item *npc::evaluate_best_weapon() const
     double best_value = evaluate_weapon( weap );
 
     // To prevent changing to barely better stuff
-    best_value *= std::max<float>( 1.0f, ai_cache.danger_assessment / 10.0f );
+    best_value *= std::max<float>( 1.0f, std::min<float>( 2.0, ai_cache.danger_assessment / 10.0f ) );
 
     // Fists aren't checked below
     double fist_value = evaluate_weapon( null_item_reference() );

--- a/tests/npc_test.cpp
+++ b/tests/npc_test.cpp
@@ -670,7 +670,10 @@ TEST_CASE( "npc_prefers_guns", "[npc_ai]" )
     hostile.regen_ai_cache();
     float danger_around = hostile.danger_assessment();
     CHECK( danger_around > 1.0f );
+    CAPTURE( hostile.evaluate_weapon( null_item_reference() ) );
+    CAPTURE( hostile.evaluate_weapon( item( itype_bat ) ) );
     hostile.wield_better_weapon();
+    REQUIRE( hostile.get_wielded_item() );
     CAPTURE( hostile.get_wielded_item().get_item()->tname() );
     CHECK( !hostile.get_wielded_item().get_item()->is_gun() );
     // Now give them a gun and some magazines


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
There's been an intermittent CI failure, terminating in this stack trace:
https://gist.github.com/kevingranade/31da85914b441714e41ec52e1941a6cd
In short, we crash dereferencing an item.
The real issue though is that the NPC is refusing to switch from no weapon to a baseball bat even though unarmed evauates with a score around 3 and the bat evaluates at around 18.
Traced this down to the changed line of code, which requires a higher ratio of improvement for switching to a new weapon based on how scary the NPC thinks their enemy is.

#### Describe the solution
Cap the scaling factor at 2.0 so that NPCs don't tolerate absurdly poor weapons just because they're up against a really scary opponent.
Prevent the failure from segfaulting and give some debug info when it happens.

#### Describe alternatives you've considered
This scaling is pretty straight up wrong, if there's hesitancy to switch it should be based on comparing "time spent switching" to "expected improvement of switching", not just "be ridiculously conservative about switching if your opponent is scary".
I don't feel like tackling that though, it would be a massive tarpit.

#### Testing
I had this reproducing at a rate of about 1 run out of 10 across about a hundred test invocations.  After this tweak I'm at ~~30~~ ~~50~~ 80 consecutive passes and counting.

#### Additional context
RNG seeding is broken, I need to look into that too.
