### PR TITLE
Warn if consume_drug item has unused vitamins

### DIFF
--- a/data/json/items/comestibles/med.json
+++ b/data/json/items/comestibles/med.json
@@ -149,7 +149,8 @@
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You take some %s.",
-      "effects": [ { "id": "pkill1_nsaid", "duration": 9000 } ]
+      "effects": [ { "id": "pkill1_nsaid", "duration": 9000 } ],
+      "vitamins": [ [ "vit_bloodthinner", 4320, 4320 ] ]
     },
     "vitamins": [ [ "vit_bloodthinner", 4320 ] ]
   },
@@ -173,7 +174,8 @@
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You take some %s.",
-      "effects": [ { "id": "pkill1_nsaid", "duration": 9000 } ]
+      "effects": [ { "id": "pkill1_nsaid", "duration": 9000 } ],
+      "vitamins": [ [ "vit_ibuprofen", 216, 216 ] ]
     },
     "vitamins": [ [ "vit_ibuprofen", 216 ] ]
   },
@@ -197,7 +199,8 @@
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You take some %s.",
-      "effects": [ { "id": "pkill1_nsaid", "duration": 18000 } ]
+      "effects": [ { "id": "pkill1_nsaid", "duration": 18000 } ],
+      "vitamins": [ [ "vit_ibuprofen", 432, 432 ] ]
     },
     "vitamins": [ [ "vit_ibuprofen", 432 ] ]
   },
@@ -241,7 +244,7 @@
     "container": "bottle_plastic_pill_painkiller",
     "healthy": -1,
     "flags": [ "WATER_DISSOLVE", "NO_TEMP" ],
-    "use_action": { "type": "consume_drug", "activation_message": "You take some %s." },
+    "use_action": { "type": "consume_drug", "activation_message": "You take some %s.", "vitamins": [ [ "vit_betablocker", 864, 864 ] ] },
     "vitamins": [ [ "vit_betablocker", 864 ] ]
   },
   {
@@ -492,7 +495,8 @@
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You take some %s.",
-      "effects": [ { "id": "pkill2", "duration": 1080 }, { "id": "cough_suppress", "duration": 1000 } ]
+      "effects": [ { "id": "pkill2", "duration": 1080 }, { "id": "cough_suppress", "duration": 1000 } ],
+      "vitamins": [ [ "vit_mme", 450, 450 ] ]
     }
   },
   {
@@ -1262,7 +1266,8 @@
         { "id": "pkill3", "duration": 480 },
         { "id": "pkill2", "duration": 1200 },
         { "id": "cough_suppress", "duration": 1000 }
-      ]
+      ],
+      "vitamins": [ [ "vit_mme", 3000, 3000 ] ]
     }
   },
   {
@@ -1410,7 +1415,8 @@
       "type": "consume_drug",
       "activation_message": "You shoot up.",
       "tools_needed": { "syringe": -1 },
-      "effects": [ { "id": "pkill3", "duration": 120 }, { "id": "pkill2", "duration": 1200 } ]
+      "effects": [ { "id": "pkill3", "duration": 120 }, { "id": "pkill2", "duration": 1200 } ],
+      "vitamins": [ [ "vit_mme", 3000, 3000 ] ]
     }
   },
   {
@@ -1556,7 +1562,8 @@
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You take some %s.",
-      "effects": [ { "id": "pkill3", "duration": 120 }, { "id": "pkill2", "duration": 1200 } ]
+      "effects": [ { "id": "pkill3", "duration": 120 }, { "id": "pkill2", "duration": 1200 } ],
+      "vitamins": [ [ "vit_mme", 2250, 2250 ] ]
     }
   },
   {
@@ -1614,7 +1621,8 @@
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You take some %s.",
-      "effects": [ { "id": "pkill2", "duration": 1080 } ]
+      "effects": [ { "id": "pkill2", "duration": 1080 } ],
+      "vitamins": [ [ "vit_mme", 200, 200 ] ]
     }
   },
   {
@@ -1636,7 +1644,7 @@
     "addiction_type": [ "sleeping pill", "opiate" ],
     "vitamins": [ [ "vit_mme", 200 ] ],
     "flags": [ "NO_TEMP" ],
-    "use_action": { "type": "consume_drug", "activation_message": "You take a %s." },
+    "use_action": { "type": "consume_drug", "activation_message": "You take a %s.", "vitamins": [ [ "vit_mme", 200, 200 ] ] },
     "sleepiness_mod": -40
   },
   {
@@ -1872,7 +1880,8 @@
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You take some %s.",
-      "effects": [ { "id": "pkill_l", "duration": 27000 } ]
+      "effects": [ { "id": "pkill_l", "duration": 27000 } ],
+      "vitamins": [ [ "vit_mme", 600, 600 ] ]
     }
   },
   {
@@ -1896,8 +1905,6 @@
       "activation_message": "You take the %s.",
       "vitamins": [ [ "calcium", 24, 48 ], [ "iron", 24, 48 ], [ "vitC", 24, 48 ] ]
     },
-    "//": "Yes, the vitamins are intentionally duplicated here. The consume/use/iteminfo UI needs them in use_action, but to actually pass on the vitamins they need to be in the comestible data, as below.",
-    "//2": "TODO: Fix this...",
     "vitamins": [ [ "calcium", 36 ], [ "iron", 36 ], [ "vitC", 36 ] ]
   },
   {
@@ -1916,6 +1923,7 @@
     "symbol": "!",
     "color": "magenta",
     "container": "bottle_plastic_pill_supplement",
+    "vitamins": [ [ "calcium", 75 ] ],
     "use_action": { "type": "consume_drug", "activation_message": "You take the %s.", "vitamins": [ [ "calcium", 75 ] ] }
   },
   {
@@ -1936,8 +1944,12 @@
     "color": "white",
     "looks_like": "calcium_tablet",
     "flags": [ "NO_TEMP" ],
-    "use_action": { "type": "consume_drug", "activation_message": "You take the %s.", "vitamins": [ [ "calcium", 24 ] ] },
-    "vitamins": [ [ "meat_allergen", 1 ] ]
+    "use_action": {
+      "type": "consume_drug",
+      "activation_message": "You take the %s.",
+      "vitamins": [ [ "calcium", 24 ], [ "meat_allergen", 1 ] ]
+    },
+    "vitamins": [ [ "calcium", 24 ], [ "meat_allergen", 1 ] ]
   },
   {
     "id": "flavored_bonemeal_tablet",
@@ -1957,8 +1969,12 @@
     "color": "yellow",
     "looks_like": "calcium_tablet",
     "flags": [ "NO_TEMP" ],
-    "use_action": { "type": "consume_drug", "activation_message": "You take the %s.", "vitamins": [ [ "calcium", 23 ] ] },
-    "vitamins": [ [ "meat_allergen", 1 ] ]
+    "use_action": {
+      "type": "consume_drug",
+      "activation_message": "You take the %s.",
+      "vitamins": [ [ "calcium", 23 ], [ "meat_allergen", 1 ] ]
+    },
+    "vitamins": [ [ "calcium", 23 ], [ "meat_allergen", 1 ] ]
   },
   {
     "id": "vitc_tablet",
@@ -1975,7 +1991,8 @@
     "flags": [ "IRREPLACEABLE_CONSUMABLE", "NO_TEMP" ],
     "symbol": "!",
     "color": "magenta",
-    "use_action": { "type": "consume_drug", "activation_message": "You take the %s.", "vitamins": [ [ "vitC", 556 ] ] }
+    "use_action": { "type": "consume_drug", "activation_message": "You take the %s.", "vitamins": [ [ "vitC", 556 ] ] },
+    "vitamins": [ [ "vitC", 556 ] ]
   },
   {
     "id": "vitc_fragment",
@@ -1992,7 +2009,8 @@
     "flags": [ "IRREPLACEABLE_CONSUMABLE", "NO_TEMP" ],
     "symbol": "!",
     "color": "magenta",
-    "use_action": { "type": "consume_drug", "activation_message": "You take the %s.", "vitamins": [ [ "vitC", 92 ] ] }
+    "use_action": { "type": "consume_drug", "activation_message": "You take the %s.", "vitamins": [ [ "vitC", 92 ] ] },
+    "vitamins": [ [ "vitC", 92 ] ]
   },
   {
     "id": "gummy_vitamins",
@@ -2078,6 +2096,7 @@
     "symbol": "!",
     "color": "magenta",
     "flags": [ "NO_INGEST", "IRREPLACEABLE_CONSUMABLE", "NO_TEMP" ],
+    "vitamins": [ [ "iron", 100 ] ],
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You inject some iron.",
@@ -2113,7 +2132,8 @@
       "fields_produced": { "fd_weedsmoke": 2 },
       "charges_needed": { "fire": 1 },
       "tools_needed": { "apparatus": -1 },
-      "moves": 420
+      "moves": 420,
+      "vitamins": [ [ "veggy_allergen", 1 ] ]
     },
     "vitamins": [ [ "veggy_allergen", 1 ] ]
   },
@@ -2210,6 +2230,7 @@
     "color": "white",
     "container": "bottle_plastic_small",
     "flags": [ "IRREPLACEABLE_CONSUMABLE", "WATER_DISSOLVE", "NPC_SAFE", "NO_TEMP" ],
+    "vitamins": [ [ "calcium", 25 ] ],
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You take an antacid tablet.",

--- a/data/json/items/comestibles/mutagen.json
+++ b/data/json/items/comestibles/mutagen.json
@@ -55,6 +55,7 @@
     "healthy": -10,
     "stim": -10,
     "addiction_potential": 12,
+    "vitamins": [ [ "mutagen", 800 ] ],
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You inject the %s.",
@@ -75,6 +76,7 @@
     "looks_like": "iv_mutagen",
     "color": "red",
     "healthy": -4,
+    "vitamins": [ [ "mutagen_alpha", 500 ] ],
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You inject the %s.",
@@ -91,6 +93,7 @@
     "description": "A processed mutagenic primer as red as a matador's cape.",
     "looks_like": "iv_mutagen",
     "color": "red",
+    "vitamins": [ [ "mutagen_beast", 500 ] ],
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You inject the %s.",
@@ -107,6 +110,7 @@
     "description": "A processed mutagenic primer the color of the pre-Cataclysmic skies.",
     "looks_like": "iv_mutagen",
     "color": "cyan",
+    "vitamins": [ [ "mutagen_bird", 500 ] ],
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You inject the %s.",
@@ -123,6 +127,7 @@
     "description": "A processed mutagenic primer the color of grass.",
     "looks_like": "iv_mutagen",
     "color": "light_green",
+    "vitamins": [ [ "mutagen_cattle", 500 ] ],
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You inject the %s.",
@@ -139,6 +144,7 @@
     "description": "A processed mutagenic primer as black as ink.",
     "looks_like": "iv_mutagen",
     "color": "dark_gray",
+    "vitamins": [ [ "mutagen_cephalopod", 500 ] ],
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You inject the %s.",
@@ -159,6 +165,7 @@
     "healthy": -15,
     "stim": -10,
     "addiction_potential": 4,
+    "vitamins": [ [ "mutagen_chimera", 500 ] ],
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You inject the %s.",
@@ -176,6 +183,7 @@
     "price": "4 kUSD",
     "looks_like": "iv_mutagen",
     "color": "light_green",
+    "vitamins": [ [ "mutagen_elfa", 500 ] ],
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You inject the %s.",
@@ -192,6 +200,7 @@
     "description": "A processed mutagenic primer, yellow and highly reflective.",
     "looks_like": "iv_mutagen",
     "color": "yellow",
+    "vitamins": [ [ "mutagen_feline", 500 ] ],
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You inject the %s.",
@@ -208,6 +217,7 @@
     "description": "A processed mutagenic primer the color of the ocean, with white foam at the top.",
     "looks_like": "iv_mutagen",
     "color": "light_blue",
+    "vitamins": [ [ "mutagen_fish", 500 ] ],
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You inject the %s.",
@@ -224,6 +234,7 @@
     "description": "A processed mutagenic primer that's a beautiful amber color.",
     "looks_like": "iv_mutagen",
     "color": "yellow",
+    "vitamins": [ [ "mutagen_insect", 500 ] ],
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You inject the %s.",
@@ -240,6 +251,7 @@
     "description": "A processed mutagenic primer that shifts between various shades of green.",
     "looks_like": "iv_mutagen",
     "color": "light_green",
+    "vitamins": [ [ "mutagen_lizard", 500 ] ],
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You inject the %s.",
@@ -256,6 +268,7 @@
     "description": "A processed mutagenic primer as white as a full moon.",
     "looks_like": "iv_mutagen",
     "color": "white",
+    "vitamins": [ [ "mutagen_lupine", 500 ] ],
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You inject the %s.",
@@ -274,6 +287,7 @@
     "looks_like": "iv_mutagen",
     "color": "light_red",
     "healthy": -4,
+    "vitamins": [ [ "mutagen_medical", 500 ] ],
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You inject the %s.",
@@ -290,6 +304,7 @@
     "description": "A processed mutagenic primer that looks like pureed spinach.",
     "looks_like": "iv_mutagen",
     "color": "green",
+    "vitamins": [ [ "mutagen_plant", 500 ] ],
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You inject the %s.",
@@ -307,6 +322,7 @@
     "price": "4 kUSD",
     "looks_like": "iv_mutagen",
     "color": "green",
+    "vitamins": [ [ "mutagen_raptor", 500 ] ],
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You inject the %s.",
@@ -323,6 +339,7 @@
     "description": "A processed mutagenic primer that's a rather unappealing beige.",
     "looks_like": "iv_mutagen",
     "color": "brown",
+    "vitamins": [ [ "mutagen_rat", 500 ] ],
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You inject the %s.",
@@ -339,6 +356,7 @@
     "description": "A processed mutagenic primer, black as night.",
     "looks_like": "iv_mutagen",
     "color": "dark_gray",
+    "vitamins": [ [ "mutagen_chiropteran", 500 ] ],
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You inject the %s.",
@@ -355,6 +373,7 @@
     "description": "A processed mutagenic primer, oily and viscous.",
     "looks_like": "iv_mutagen",
     "color": "dark_gray",
+    "vitamins": [ [ "mutagen_slime", 500 ] ],
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You inject the %s.",
@@ -371,6 +390,7 @@
     "description": "A processed mutagenic primer with pale filaments suspended in it.",
     "looks_like": "iv_mutagen",
     "color": "light_gray",
+    "vitamins": [ [ "mutagen_spider", 500 ] ],
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You inject the %s.",
@@ -387,6 +407,7 @@
     "description": "A processed mutagenic primer with the consistency of snot.",
     "looks_like": "iv_mutagen",
     "color": "light_gray",
+    "vitamins": [ [ "mutagen_gastropod", 500 ] ],
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You inject the %s.",
@@ -403,6 +424,7 @@
     "description": "A processed mutagenic primer that looks like pond water… are the shadows in it moving?",
     "looks_like": "iv_mutagen",
     "color": "light_gray",
+    "vitamins": [ [ "mutagen_batrachian", 500 ] ],
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You inject the %s.",
@@ -419,6 +441,7 @@
     "description": "A processed mutagenic primer that seems to recoil from the light.",
     "looks_like": "iv_mutagen",
     "color": "dark_gray",
+    "vitamins": [ [ "mutagen_troglobite", 500 ] ],
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You inject the %s.",
@@ -435,6 +458,7 @@
     "description": "A processed mutagenic primer that's the color of honey, and is just as thick.",
     "looks_like": "iv_mutagen",
     "color": "yellow",
+    "vitamins": [ [ "mutagen_ursine", 500 ] ],
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You inject the %s.",
@@ -451,6 +475,7 @@
     "description": "A processed mutagenic primer resembling liquefied metal.",
     "looks_like": "iv_mutagen",
     "color": "light_gray",
+    "vitamins": [ [ "mutagen_mouse", 500 ] ],
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You inject the %s.",
@@ -466,6 +491,7 @@
     "name": { "str_sp": "rabbit mutagenic primer" },
     "description": "An orange colored mutagenic primer.",
     "looks_like": "iv_mutagen",
+    "vitamins": [ [ "mutagen_rabbit", 500 ] ],
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You inject the %s.",
@@ -482,6 +508,7 @@
     "description": " A red colored mutagenic primer.",
     "color": "red",
     "looks_like": "iv_mutagen",
+    "vitamins": [ [ "mutagen_crustacean", 500 ] ],
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You inject the %s.",
@@ -497,6 +524,7 @@
     "name": { "str_sp": "mutagenic slurry" },
     "description": "A slurry of organic chemicals and compounds, used as the foundation for making primers and mutagenic catalyst.  In this baseline form, it is highly toxic, and dangerous to consume on its own.",
     "addiction_potential": 6,
+    "vitamins": [ [ "mutagenic_slurry", 25 ] ],
     "use_action": { "type": "consume_drug", "activation_message": "You drink the %s.", "vitamins": [ [ "mutagenic_slurry", 25 ] ] }
   },
   {
@@ -512,6 +540,7 @@
     "charges": 5,
     "weight": "50 g",
     "fun": -10,
+    "vitamins": [ [ "mutagen_beast", 160 ], [ "mutagen", 160 ] ],
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You choke down the congealed blood.",
@@ -528,6 +557,7 @@
     "price": "5000 USD",
     "looks_like": "mutagen",
     "//": "*May* have gotten a dose smuggled out.",
+    "vitamins": [ [ "mutagen_alpha", 225 ], [ "mutagen", 125 ] ],
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You drink the %s.",
@@ -541,6 +571,7 @@
     "subtypes": [ "COMESTIBLE" ],
     "name": { "str_sp": "beast mutagen" },
     "looks_like": "mutagen",
+    "vitamins": [ [ "mutagen_beast", 225 ], [ "mutagen", 125 ] ],
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You drink the %s.",
@@ -554,6 +585,7 @@
     "subtypes": [ "COMESTIBLE" ],
     "name": { "str_sp": "bird mutagen" },
     "looks_like": "mutagen",
+    "vitamins": [ [ "mutagen_bird", 225 ], [ "mutagen", 125 ] ],
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You drink the %s.",
@@ -567,6 +599,7 @@
     "subtypes": [ "COMESTIBLE" ],
     "name": { "str_sp": "cattle mutagen" },
     "looks_like": "mutagen",
+    "vitamins": [ [ "mutagen_cattle", 225 ], [ "mutagen", 125 ] ],
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You drink the %s.",
@@ -580,6 +613,7 @@
     "subtypes": [ "COMESTIBLE" ],
     "name": { "str_sp": "cephalopod mutagen" },
     "looks_like": "mutagen",
+    "vitamins": [ [ "mutagen_cephalopod", 225 ], [ "mutagen", 125 ] ],
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You drink the %s.",
@@ -595,6 +629,7 @@
     "description": "An extremely rare mutagen cocktail.",
     "price": "2000 USD",
     "looks_like": "mutagen",
+    "vitamins": [ [ "mutagen_chimera", 225 ], [ "mutagen", 125 ] ],
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You drink the %s.",
@@ -610,6 +645,7 @@
     "description": "An extremely rare mutagen cocktail.",
     "price": "2000 USD",
     "looks_like": "mutagen",
+    "vitamins": [ [ "mutagen_elfa", 225 ], [ "mutagen", 125 ] ],
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You drink the %s.",
@@ -623,6 +659,7 @@
     "subtypes": [ "COMESTIBLE" ],
     "name": { "str_sp": "feline mutagen" },
     "looks_like": "mutagen",
+    "vitamins": [ [ "mutagen_feline", 225 ], [ "mutagen", 125 ] ],
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You drink the %s.",
@@ -636,6 +673,7 @@
     "subtypes": [ "COMESTIBLE" ],
     "name": { "str_sp": "fish mutagen" },
     "looks_like": "mutagen",
+    "vitamins": [ [ "mutagen_fish", 225 ], [ "mutagen", 125 ] ],
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You drink the %s.",
@@ -649,6 +687,7 @@
     "subtypes": [ "COMESTIBLE" ],
     "name": { "str_sp": "insect mutagen" },
     "looks_like": "mutagen",
+    "vitamins": [ [ "mutagen_insect", 225 ], [ "mutagen", 125 ] ],
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You drink the %s.",
@@ -662,6 +701,7 @@
     "subtypes": [ "COMESTIBLE" ],
     "name": { "str_sp": "lizard mutagen" },
     "looks_like": "mutagen",
+    "vitamins": [ [ "mutagen_lizard", 225 ], [ "mutagen", 125 ] ],
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You drink the %s.",
@@ -675,6 +715,7 @@
     "subtypes": [ "COMESTIBLE" ],
     "name": { "str_sp": "lupine mutagen" },
     "looks_like": "mutagen",
+    "vitamins": [ [ "mutagen_lupine", 225 ], [ "mutagen", 125 ] ],
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You drink the %s.",
@@ -690,6 +731,7 @@
     "price": "1 kUSD 500 USD",
     "looks_like": "mutagen",
     "//": "*May* have been considered for commercial trading.",
+    "vitamins": [ [ "mutagen_medical", 225 ], [ "mutagen", 125 ] ],
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You drink the %s.",
@@ -703,6 +745,7 @@
     "subtypes": [ "COMESTIBLE" ],
     "name": { "str_sp": "plant mutagen" },
     "looks_like": "mutagen",
+    "vitamins": [ [ "mutagen_plant", 225 ], [ "mutagen", 125 ] ],
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You drink the %s.",
@@ -718,6 +761,7 @@
     "description": "An extremely rare mutagen cocktail.",
     "price": "2000 USD",
     "looks_like": "mutagen",
+    "vitamins": [ [ "mutagen_raptor", 225 ], [ "mutagen", 125 ] ],
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You drink the %s.",
@@ -731,6 +775,7 @@
     "subtypes": [ "COMESTIBLE" ],
     "name": { "str_sp": "rat mutagen" },
     "looks_like": "mutagen",
+    "vitamins": [ [ "mutagen_rat", 225 ], [ "mutagen", 125 ] ],
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You drink the %s.",
@@ -745,6 +790,7 @@
     "name": { "str_sp": "chiropteran mutagen" },
     "description": "A murky black liquid that smells of blood.",
     "looks_like": "mutagen",
+    "vitamins": [ [ "mutagen_chiropteran", 225 ], [ "mutagen", 125 ] ],
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You drink the %s.",
@@ -758,6 +804,7 @@
     "subtypes": [ "COMESTIBLE" ],
     "name": { "str_sp": "slime mutagen" },
     "looks_like": "mutagen",
+    "vitamins": [ [ "mutagen_slime", 225 ], [ "mutagen", 125 ] ],
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You drink the %s.",
@@ -771,6 +818,7 @@
     "subtypes": [ "COMESTIBLE" ],
     "name": { "str_sp": "spider mutagen" },
     "looks_like": "mutagen",
+    "vitamins": [ [ "mutagen_spider", 225 ], [ "mutagen", 125 ] ],
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You drink the %s.",
@@ -785,6 +833,7 @@
     "name": { "str_sp": "batrachian mutagen" },
     "description": "A shadowy mutagen that looks like it might be full of tiny swimming tadpoles.",
     "looks_like": "mutagen",
+    "vitamins": [ [ "mutagen_batrachian", 225 ], [ "mutagen", 125 ] ],
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You drink the %s.",
@@ -799,6 +848,7 @@
     "name": { "str_sp": "snail mutagen" },
     "description": "A mutagen that looks awfully like the slime from an old children's network.",
     "looks_like": "mutagen",
+    "vitamins": [ [ "mutagen_gastropod", 225 ], [ "mutagen", 125 ] ],
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You drink the %s.",
@@ -812,6 +862,7 @@
     "subtypes": [ "COMESTIBLE" ],
     "name": { "str_sp": "troglobite mutagen" },
     "looks_like": "mutagen",
+    "vitamins": [ [ "mutagen_troglobite", 225 ], [ "mutagen", 125 ] ],
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You drink the %s.",
@@ -825,6 +876,7 @@
     "subtypes": [ "COMESTIBLE" ],
     "name": { "str_sp": "ursine mutagen" },
     "looks_like": "mutagen",
+    "vitamins": [ [ "mutagen_ursine", 225 ], [ "mutagen", 125 ] ],
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You drink the %s.",
@@ -838,6 +890,7 @@
     "subtypes": [ "COMESTIBLE" ],
     "name": { "str_sp": "mouse mutagen" },
     "looks_like": "mutagen",
+    "vitamins": [ [ "mutagen_mouse", 225 ], [ "mutagen", 125 ] ],
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You drink the %s.",
@@ -852,6 +905,7 @@
     "name": { "str_sp": "rabbit mutagen" },
     "description": "A white, clear colored mutagen.  You can drink it… if you really want to?",
     "looks_like": "mutagen",
+    "vitamins": [ [ "mutagen_rabbit", 225 ], [ "mutagen", 125 ] ],
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You drink the %s.",
@@ -867,6 +921,7 @@
     "description": "A crustacean mutagen.",
     "looks_like": "mutagen",
     "color": "red",
+    "vitamins": [ [ "mutagen_crustacean", 225 ], [ "mutagen", 125 ] ],
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You drink the %s.",
@@ -885,6 +940,7 @@
     "color": "pink",
     "healthy": -3,
     "addiction_potential": 8,
+    "vitamins": [ [ "mutagen_human", 225 ], [ "mutagen", 125 ] ],
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You drink the %s.",
@@ -902,6 +958,7 @@
     "price_postapoc": "5 USD",
     "color": "pink",
     "addiction_potential": 8,
+    "vitamins": [ [ "mutagen_human", 500 ] ],
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You inject the %s.",
@@ -931,6 +988,7 @@
     "material": [ "water" ],
     "freezing_point": -8,
     "tool": "syringe",
+    "vitamins": [ [ "mutagen_chelator", 250 ] ],
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You inject the %s.",

--- a/data/json/items/comestibles/raw_grain.json
+++ b/data/json/items/comestibles/raw_grain.json
@@ -18,7 +18,12 @@
     "volume": "195 ml",
     "flags": [ "EATEN_HOT", "RAW" ],
     "vitamins": [ [ "vitC", 12 ], [ "iron", 4 ], [ "veggy_allergen", 1 ] ],
-    "use_action": { "type": "consume_drug", "used_up_item": "empty_corn_cob", "moves": 500 }
+    "use_action": {
+      "type": "consume_drug",
+      "used_up_item": "empty_corn_cob",
+      "moves": 500,
+      "vitamins": [ [ "vitC", 12 ], [ "iron", 4 ], [ "veggy_allergen", 1 ] ]
+    }
   },
   {
     "type": "ITEM",
@@ -80,7 +85,12 @@
     "copy-from": "corn",
     "fun": -2,
     "description": "A popcorn cob full of popcorn kernels.  You can eat them on the cob or shell it for cooking.",
-    "use_action": { "type": "consume_drug", "used_up_item": "empty_corn_cob", "moves": 500 }
+    "use_action": {
+      "type": "consume_drug",
+      "used_up_item": "empty_corn_cob",
+      "moves": 500,
+      "vitamins": [ [ "vitC", 12 ], [ "iron", 4 ], [ "veggy_allergen", 1 ] ]
+    }
   },
   {
     "type": "ITEM",

--- a/data/json/items/comestibles/raw_veggy.json
+++ b/data/json/items/comestibles/raw_veggy.json
@@ -1027,7 +1027,8 @@
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You chew the wintergreen leaves.",
-      "effects": [ { "id": "pkill_wintergreen", "duration": "30 m" } ]
+      "effects": [ { "id": "pkill_wintergreen", "duration": "30 m" } ],
+      "vitamins": [ [ "veggy_allergen", 1 ] ]
     },
     "material": [ "veggy" ],
     "primary_material": "dried_vegetable",

--- a/data/mods/TEST_DATA/items.json
+++ b/data/mods/TEST_DATA/items.json
@@ -3583,6 +3583,7 @@
     "color": "magenta",
     "container": "bottle_plastic_pill_supplement",
     "flags": [ "IRREPLACEABLE_CONSUMABLE", "WATER_DISSOLVE", "EDIBLE_FROZEN" ],
+    "vitamins": [ [ "calcium", 100 ], [ "iron", 100 ], [ "vitC", 100 ] ],
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You take the %s.",

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -891,6 +891,24 @@ void Item_factory::finalize_post( itype &obj )
                           obj.id.str(), dtype.str() );
             }
         }
+
+        const use_function *consume_drug = obj.get_use( "consume_drug" );
+        if( consume_drug ) {
+            const consume_drug_iuse *consume_drug_use = dynamic_cast<const consume_drug_iuse *>
+                    ( consume_drug->get_actor_ptr() );
+            // This map is actually empty (i.e no entries) if undefined
+            const bool has_drug_vitamins = !consume_drug_use->vitamins.empty();
+            // This map (nutrients) is ALWAYS filled with all vitamin types, but the entries are zero'd, so we cannot check empty()!
+            const bool has_food_vitamins = obj.comestible->default_nutrition_read_only().has_any_vitamin();
+            if( has_food_vitamins && !has_drug_vitamins ) {
+                debugmsg( "Error on item %s: You need to put food vitamins into the consume_drug use_action, for stupid technical reasons.",
+                          obj.id.c_str() );
+            }
+            if( has_drug_vitamins && !has_food_vitamins ) {
+                debugmsg( "Error on item %s: You also need to put the consume_drug vitamins into food vitamins, for stupider technical reasons.",
+                          obj.id.c_str() );
+            }
+        }
     }
 
     // weight_override, weight_add, weight_mult, group_id

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -908,6 +908,32 @@ void Item_factory::finalize_post( itype &obj )
                 debugmsg( "Error on item %s: You also need to put the consume_drug vitamins into food vitamins, for stupider technical reasons.",
                           obj.id.c_str() );
             }
+
+            // Now to be extra sure, we also compare the vitamins to make sure they're equal...
+            const auto &LHS_vitmap = consume_drug_use->vitamins;
+            const auto &RHS_vitmap = obj.comestible->default_nutrition_read_only().vitamins();
+            for( const std::pair<const vitamin_id, vitamin> &vit_pair : vitamin::all() ) {
+                const vitamin_id &vit = vit_pair.first;
+                const bool LHS_has_vit = LHS_vitmap.find( vit ) != LHS_vitmap.end();
+                const bool RHS_has_vit = RHS_vitmap.find( vit ) != RHS_vitmap.end();
+                if( LHS_has_vit != RHS_has_vit ) {
+                    debugmsg( "Error in item definition %s.  Food vitamins and consume_drug vitamins do not match.",
+                              obj.id.c_str() );
+                    break; // stop evaluating this itype, it's already known to be broken.
+                }
+                // Bounds check. Stupid juggling because LHS is a range, we want the midpoint. If LHS doesn't have the vitamin we can skip the rest, because we just checked that
+                // both LHS and RHS should have the vitamin.
+                const auto LHS_range = LHS_vitmap.find( vit );
+                if( LHS_range == LHS_vitmap.end() ) {
+                    continue;
+                }
+                const int LHS_vit_amt = ( LHS_range->second.first + LHS_range->second.second ) / 2;
+                const int RHS_vit_amt = RHS_has_vit ? RHS_vitmap.find( vit )->second : 0;
+                if( LHS_vit_amt != RHS_vit_amt ) {
+                    debugmsg( "Error in item definition %s.  Food vitamins and consume_drug vitamins have different vitamin amounts for %s.",
+                              obj.id.c_str(), vit.c_str() );
+                }
+            }
         }
     }
 

--- a/src/stomach.cpp
+++ b/src/stomach.cpp
@@ -113,6 +113,16 @@ void nutrients::remove_vitamin( const vitamin_id &vit )
     vitamins_.erase( vit );
 }
 
+bool nutrients::has_any_vitamin() const
+{
+    for( const auto &pair : vitamins_ ) {
+        if( std::get<int>( pair.second ) != 0 ) {
+            return true;
+        }
+    }
+    return false;
+}
+
 int nutrients::get_vitamin( const vitamin_id &vit ) const
 {
     auto it = vitamins_.find( vit );

--- a/src/stomach.h
+++ b/src/stomach.h
@@ -62,6 +62,8 @@ struct nutrients {
         // Remove a vitamin completely from the data structure
         void remove_vitamin( const vitamin_id & );
 
+        // Returns true if any vitamin has a non-zero value, including a negative value
+        bool has_any_vitamin() const;
         int get_vitamin( const vitamin_id & ) const;
         int kcal() const;
 


### PR DESCRIPTION
#### Summary
Bugfixes "Fix some cases where food with consume_drug would not give vitamins and vice versa "

#### Purpose of change
Take an aspirin. Notice that you do not receive any vit_bloodthinner.

<img width="476" height="124" alt="image" src="https://github.com/user-attachments/assets/d4e35b66-d018-4d71-b5d5-20635b2f84b0" />

Put some calcium tablets into the faction camp's larder. Notice that they do not confer any vitamins.

The consume_drug_iuse actor can contain a vitamins field to optionally give vitamins. The items with this tend to be but don't have to be (I think??) comestibles. If the item has calories/vitamins defined in comestible they won't be added to the consumer's body.

#### Describe the solution
The least worst solution: Warn on load and force people to duplicate this stuff in json


#### Describe alternatives you've considered
- Shuffle the comestible's vitamins field into the iuse actor somehow. AWFUL. Do not want.

- Pray for #76920

- Extract consume_drug iuse out into an islot? 😩 
--Force it into comestible, somehow??

#### Testing
Not done testing, but also needs some testing.

In particular this is a *fragile* solution, it relies on the finalization order of itype's use functions and comestible data. I am really not happy with this.

Currently(with only one commit) should expect to fail basic build. No JSON work has been done.

#### Additional context
