### PR TITLE
Massively increase dismembering time

### DIFF
--- a/src/butchery.cpp
+++ b/src/butchery.cpp
@@ -438,7 +438,6 @@ int butcher_time_to_cut( Character &you, const item &corpse_item, const butcher_
             }
             break;
         case butcher_type::DISMEMBER:
-            time_to_cut /= 10;
             if( time_to_cut < 600 ) {
                 time_to_cut = 600;
             }
@@ -461,8 +460,13 @@ int butcher_time_to_cut( Character &you, const item &corpse_item, const butcher_
     double penalty_small = 0.5;
     double penalty_big = 1.5;
 
-    int prof_butch_penalty = penalty_big * ( 1 - butch_basic ) + penalty_small * ( 1 - butch_adv );
-    int prof_skin_penalty = penalty_small * ( 1 - skin_basic );
+    double prof_butch_penalty = penalty_big * ( 1.0 - butch_basic ) + penalty_small *
+                                ( 1.0 - butch_adv );
+    double prof_skin_penalty = penalty_small * ( 1.0 - skin_basic );
+
+    add_msg_debug( debugmode::DF_ACT_BUTCHER,
+                   "Time penalties for butchering:\n Butchery proficiencies penalty: %.2f%%\n Skinning proficiency penalty: %.2f%%",
+                   prof_butch_penalty * 100.0, prof_skin_penalty * 100.0 );
 
     // there supposed to be a code for book mitigation, but we don't have any book fitting for this
 


### PR DESCRIPTION
#### Summary
Balance "Massively increase dismembering time"

#### Purpose of change
There is a well-known problem with dismembering: It doesn't take enough time. With a butchery kit and a blank 8/8/8/8 evacuee I can cut a zombie cop into little giblets in a staggeringly short 34 seconds!

#### Describe the solution
Massively increase dismembering time by removing its 10x divisor.

While I was here I also fixed an issue where the penalty for missing proficiencies was being truncated to integer, and added a debugmsg for future debugging.

#### Describe alternatives you've considered
Honestly we could just remove dismembering at some point, it isn't really serving a useful gameplay function...

#### Testing

Zombie cop:
34 seconds --> 340 seconds (almost 7 minutes)
(Pulping time with fists/random whatever in my starting inventory was slightly under 6 minutes)

Zombie hulk: 
Slightly more than 2 minutes (lol) --> 22 minutes
(Pulping time with fists: Impossible)
(Pulping time with heavy sledgehammer: About 15 minutes)

Pulping times themselves did not change, they are just for reference.

#### Additional context
