### PR TITLE
fix spellcasting_adjustment('caster_level'), [Sorcerer] Makes Sorcerer only boost Magiclysm and Sorcerer spells, add 2 more spells from Magiclysm

### DIFF
--- a/data/mods/Sorcerer/bloodlines/bloodrager.json
+++ b/data/mods/Sorcerer/bloodlines/bloodrager.json
@@ -6,9 +6,11 @@
     "required_event": "opens_spellbook",
     "condition": { "and": [ { "u_has_trait": "SORCERER" }, { "compare_string": [ { "u_val": "power_source" }, "strength" ] } ] },
     "effect": [
-      { "math": [ "u_spell_level_adjustment('null') += floor( u_val('strength') / 2 ) - 3" ] },
-      { "math": [ "u_spell_level_adjustment('null') += (u_effect_intensity('adrenaline') == 2) * 3" ] },
-      { "math": [ "u_spell_level_adjustment('null') -= u_effect_intensity('redcells_anemia')" ] }
+      { "math": [ "u_temp_bloodrager_boost = floor( u_val('strength') / 2 ) - 3" ] },
+      { "math": [ "u_temp_bloodrager_boost += (u_effect_intensity('adrenaline') == 2) * 3" ] },
+      { "math": [ "u_temp_bloodrager_boost -= u_effect_intensity('redcells_anemia')" ] },
+      { "math": [ "u_spellcasting_adjustment('caster_level', 'mod': 'magiclysm') = u_temp_bloodrager_boost" ] },
+      { "math": [ "u_spellcasting_adjustment('caster_level', 'mod': 'sorcerer') = u_temp_bloodrager_boost" ] }
     ]
   }
 ]

--- a/data/mods/Sorcerer/bloodlines/spelldander.json
+++ b/data/mods/Sorcerer/bloodlines/spelldander.json
@@ -5,7 +5,10 @@
     "eoc_type": "EVENT",
     "required_event": "opens_spellbook",
     "condition": { "and": [ { "u_has_trait": "SORCERER" }, { "compare_string": [ { "u_val": "power_source" }, "dodge" ] } ] },
-    "effect": { "math": [ "u_spell_level_adjustment('null') += floor( u_val('dodge') / 2 ) - 2" ] },
+    "effect": [
+      { "math": [ "u_spellcasting_adjustment('caster_level', 'mod': 'magiclysm') = floor( u_val('dodge') / 2 ) - 2" ] },
+      { "math": [ "u_spellcasting_adjustment('caster_level', 'mod': 'sorcerer') = floor( u_val('dodge') / 2 ) - 2" ] }
+    ],
     "//": "A freshly made min-maxed character using single pool can start with 11.9 dodge. (+3 caster level)",
     "//2": "A default character will start with 4.0 dodge. (+0 caster level)"
   }

--- a/data/mods/Sorcerer/bloodlines/standard.json
+++ b/data/mods/Sorcerer/bloodlines/standard.json
@@ -5,7 +5,12 @@
     "eoc_type": "EVENT",
     "required_event": "opens_spellbook",
     "condition": { "and": [ { "u_has_trait": "SORCERER" }, { "compare_string": [ { "u_val": "power_source" }, "intelligence" ] } ] },
-    "effect": { "math": [ "u_spell_level_adjustment('null') += floor( u_val('intelligence') / 2 ) - 3" ] },
+    "effect": [
+      { "math": [ "u_spellcasting_adjustment('caster_level', 'mod': 'magiclysm') = floor( u_val('intelligence') / 2 ) - 3" ] },
+      {
+        "math": [ "u_spellcasting_adjustment('caster_level', 'mod': 'sorcerer') = floor( u_val('intelligence') / 2 ) - 3" ]
+      }
+    ],
     "//": "A character with 14 int gets +4 caster level",
     "//2": "A default character has +1 caster level"
   }

--- a/data/mods/Sorcerer/generated_code/bloodlines/standard/pick_favorite_spell.json
+++ b/data/mods/Sorcerer/generated_code/bloodlines/standard/pick_favorite_spell.json
@@ -228,6 +228,15 @@
       ]
     },
     {
+      "condition": { "math": [ "u_used_spell_slot_for_earthshaper_remove_corpses > 0" ] },
+      "text": "Pick <spell_name:earthshaper_remove_corpses> ( level <u_val:used_spell_slot_for_earthshaper_remove_corpses> )",
+      "topic": "TALK_SORCERER_MENU_MAIN",
+      "effect": [
+        { "math": [ "u_spell_level('earthshaper_remove_corpses') = max(3, u_spell_level('earthshaper_remove_corpses') )" ] },
+        { "math": [ "u_available_favorite_spells--" ] }
+      ]
+    },
+    {
       "condition": { "math": [ "u_used_spell_slot_for_kelvinist_firebolt > 0" ] },
       "text": "Pick <spell_name:kelvinist_firebolt> ( level <u_val:used_spell_slot_for_kelvinist_firebolt> )",
       "topic": "TALK_SORCERER_MENU_MAIN",

--- a/data/mods/Sorcerer/generated_code/forget_spells.json
+++ b/data/mods/Sorcerer/generated_code/forget_spells.json
@@ -1952,6 +1952,20 @@
       ]
     },
     {
+      "condition": { "math": [ "u_used_spell_slot_for_biomancer_pull_items_from_distance > 0" ] },
+      "text": "Forget <spell_name:biomancer_pull_items_from_distance> ( level <u_val:used_spell_slot_for_biomancer_pull_items_from_distance> )",
+      "topic": "TALK_SORCERER_MENU_MAIN",
+      "effect": [
+        { "math": [ "u_spell_level('biomancer_pull_items_from_distance') = -1" ] },
+        {
+          "run_eocs": "EOC_sorcerer_forget_spell_refund_slots",
+          "variables": { "forgotten_spell_level": { "u_val": "used_spell_slot_for_biomancer_pull_items_from_distance" } }
+        },
+        { "math": [ "u_used_spell_slot_for_biomancer_pull_items_from_distance = 0" ] },
+        { "math": [ "u_sorcerer_forget_spell_charge--" ] }
+      ]
+    },
+    {
       "condition": { "math": [ "u_used_spell_slot_for_protection_aura > 0" ] },
       "text": "Forget <spell_name:protection_aura> ( level <u_val:used_spell_slot_for_protection_aura> )",
       "topic": "TALK_SORCERER_MENU_MAIN",
@@ -3040,6 +3054,20 @@
           "variables": { "forgotten_spell_level": { "u_val": "used_spell_slot_for_earthshaper_turning_of_earth" } }
         },
         { "math": [ "u_used_spell_slot_for_earthshaper_turning_of_earth = 0" ] },
+        { "math": [ "u_sorcerer_forget_spell_charge--" ] }
+      ]
+    },
+    {
+      "condition": { "math": [ "u_used_spell_slot_for_earthshaper_remove_corpses > 0" ] },
+      "text": "Forget <spell_name:earthshaper_remove_corpses> ( level <u_val:used_spell_slot_for_earthshaper_remove_corpses> )",
+      "topic": "TALK_SORCERER_MENU_MAIN",
+      "effect": [
+        { "math": [ "u_spell_level('earthshaper_remove_corpses') = -1" ] },
+        {
+          "run_eocs": "EOC_sorcerer_forget_spell_refund_slots",
+          "variables": { "forgotten_spell_level": { "u_val": "used_spell_slot_for_earthshaper_remove_corpses" } }
+        },
+        { "math": [ "u_used_spell_slot_for_earthshaper_remove_corpses = 0" ] },
         { "math": [ "u_sorcerer_forget_spell_charge--" ] }
       ]
     },

--- a/data/mods/Sorcerer/generated_code/learn_spell/learn_spells.json
+++ b/data/mods/Sorcerer/generated_code/learn_spell/learn_spells.json
@@ -2554,6 +2554,27 @@
   },
   {
     "type": "talk_topic",
+    "id": "TALK_SORCERER_LEARN_SPELL_biomancer_pull_items_from_distance",
+    "dynamic_line": {
+      "str": "<spell_name:biomancer_pull_items_from_distance>: <spell_description:biomancer_pull_items_from_distance>",
+      "//~": "NO_I18N"
+    },
+    "responses": [
+      {
+        "text": "Select Spell.",
+        "topic": "TALK_SORCERER_MENU_MAIN",
+        "effect": [
+          { "math": [ "u_spell_level('biomancer_pull_items_from_distance') = u_current_sorcerer_level" ] },
+          { "math": [ "u_used_spell_slot_for_biomancer_pull_items_from_distance = u_picked_level" ] },
+          { "run_eocs": "EOC_incremnet_sorcerer_known_spells" }
+        ]
+      },
+      { "text": "Go Back.", "topic": "TALK_SORCERER_MENU_MAIN" },
+      { "text": "Quit.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
     "id": "TALK_SORCERER_LEARN_SPELL_protection_aura",
     "dynamic_line": { "str": "<spell_name:protection_aura>: <spell_description:protection_aura>", "//~": "NO_I18N" },
     "responses": [
@@ -3982,6 +4003,24 @@
   },
   {
     "type": "talk_topic",
+    "id": "TALK_SORCERER_LEARN_SPELL_earthshaper_remove_corpses",
+    "dynamic_line": { "str": "<spell_name:earthshaper_remove_corpses>: <spell_description:earthshaper_remove_corpses>", "//~": "NO_I18N" },
+    "responses": [
+      {
+        "text": "Select Spell.",
+        "topic": "TALK_SORCERER_MENU_MAIN",
+        "effect": [
+          { "math": [ "u_spell_level('earthshaper_remove_corpses') = u_current_sorcerer_level" ] },
+          { "math": [ "u_used_spell_slot_for_earthshaper_remove_corpses = u_picked_level" ] },
+          { "run_eocs": "EOC_incremnet_sorcerer_known_spells" }
+        ]
+      },
+      { "text": "Go Back.", "topic": "TALK_SORCERER_MENU_MAIN" },
+      { "text": "Quit.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
     "id": "TALK_SORCERER_LEARN_SPELL_kelvinist_firebolt",
     "dynamic_line": { "str": "<spell_name:kelvinist_firebolt>: <spell_description:kelvinist_firebolt>", "//~": "NO_I18N" },
     "responses": [
@@ -5229,6 +5268,16 @@
         "topic": "TALK_SORCERER_LEARN_SPELL_biomancer_eat_tons_of_food"
       },
       {
+        "condition": {
+          "and": [
+            { "math": [ "u_used_spell_slot_for_biomancer_pull_items_from_distance == 0" ] },
+            { "math": [ "u_picked_level >= 3" ] }
+          ]
+        },
+        "text": "Learn <spell_name:biomancer_pull_items_from_distance> ( level 3 )",
+        "topic": "TALK_SORCERER_LEARN_SPELL_biomancer_pull_items_from_distance"
+      },
+      {
         "condition": { "and": [ { "math": [ "u_used_spell_slot_for_protection_aura == 0" ] }, { "math": [ "u_picked_level >= 3" ] } ] },
         "text": "Learn <spell_name:protection_aura> ( level 3 )",
         "topic": "TALK_SORCERER_LEARN_SPELL_protection_aura"
@@ -5663,6 +5712,13 @@
         },
         "text": "Learn <spell_name:earthshaper_turning_of_earth> ( level 1 )",
         "topic": "TALK_SORCERER_LEARN_SPELL_earthshaper_turning_of_earth"
+      },
+      {
+        "condition": {
+          "and": [ { "math": [ "u_used_spell_slot_for_earthshaper_remove_corpses == 0" ] }, { "math": [ "u_picked_level >= 1" ] } ]
+        },
+        "text": "Learn <spell_name:earthshaper_remove_corpses> ( level 1 )",
+        "topic": "TALK_SORCERER_LEARN_SPELL_earthshaper_remove_corpses"
       },
       {
         "condition": { "and": [ { "math": [ "u_used_spell_slot_for_kelvinist_firebolt == 0" ] }, { "math": [ "u_picked_level >= 1" ] } ] },

--- a/data/mods/Sorcerer/generated_code/level_up_spells.json
+++ b/data/mods/Sorcerer/generated_code/level_up_spells.json
@@ -1413,6 +1413,19 @@
     },
     {
       "run_eocs": {
+        "id": "sorcerer_level_up_biomancer_pull_items_from_distance",
+        "condition": { "math": [ "u_used_spell_slot_for_biomancer_pull_items_from_distance > 0" ] },
+        "effect": [
+          {
+            "math": [
+              "u_spell_level('biomancer_pull_items_from_distance') = max(u_current_sorcerer_level, u_spell_level('biomancer_pull_items_from_distance') )"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "run_eocs": {
         "id": "sorcerer_level_up_protection_aura",
         "condition": { "math": [ "u_used_spell_slot_for_protection_aura > 0" ] },
         "effect": [
@@ -2148,6 +2161,19 @@
           {
             "math": [
               "u_spell_level('earthshaper_turning_of_earth') = max(u_current_sorcerer_level, u_spell_level('earthshaper_turning_of_earth') )"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "run_eocs": {
+        "id": "sorcerer_level_up_earthshaper_remove_corpses",
+        "condition": { "math": [ "u_used_spell_slot_for_earthshaper_remove_corpses > 0" ] },
+        "effect": [
+          {
+            "math": [
+              "u_spell_level('earthshaper_remove_corpses') = max(u_current_sorcerer_level, u_spell_level('earthshaper_remove_corpses') )"
             ]
           }
         ]

--- a/data/mods/Sorcerer/tools/generate_code.py
+++ b/data/mods/Sorcerer/tools/generate_code.py
@@ -3,7 +3,7 @@ import json
 
 # If you want to run this script you might need to edit this path
 # The way this file handles paths might not work on systems other than Windows.
-Magiclysm_path = "../Magiclysm"
+Magiclysm_path = "../../Magiclysm"
 
 tier_0_scroll_list = []
 tier_1_scroll_list = []

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -2527,7 +2527,7 @@ void known_magic::clear_opens_spellbook_data()
 void known_magic::evaluate_opens_spellbook_data()
 {
     for( spell *sp : get_spells() ) {
-        double raw_level_adjust = caster_level_adjustment;
+        double raw_level_adjust = caster_level_adjustment + sp->get_temp_level_adjustment();
         std::map<trait_id, double>::iterator school_it =
             caster_level_adjustment_by_school.find( sp->spell_class() );
         if( school_it != caster_level_adjustment_by_school.end() ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "[Sorcerer] Makes Sorcerer only boost Magiclysm and Sorcerer spells, add latest spells from Magiclysm"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Make it so that Sorcerer doesn't buff spells from mods like MoM. To do that, `spellcasting_adjustment('caster_level')` is needed. But it turned out that that was broken, so I fixed that too.
While I was at it, I also added two spells to Sorcerer that were created in  #83088.
Fixes #83283.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Don't throw away preexisting `temp_level_adjustment` in `evaluate_opens_spellbook_data()`.
Change Sorcerer to use `u_spellcasting_adjustment('caster_level', 'mod': 'magiclysm')` and `u_spellcasting_adjustment('caster_level', 'mod': 'sorcerer')`
Added the new spells by running `generate_code.py`. Found and fixed minor error in `generate_code.py`.
Changed Bloodrager code to only set the spell level adjustment once per mod.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Break this up into two or three pull requests? Not sure what is best practice here.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Made a Sorcerer with MoM spells before any changes, noticed Sorcerer spell bonuses were applied to all spells.
Made the .json changes, noticed Sorcerer spell bonuses were not applied to any spells at all.
Made C++ changes and compiled, noticed Sorcerer spell bonuses were applied only to the Magiclysm and Sorcerer spells as intended.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
@Standing-Storm might be happy to know that `spellcasting_adjustment('caster_level')` is now working correctly.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
