### PR TITLE
Update uncraft recipes for MOLLE sustainment pouch and deployment bag

### DIFF
--- a/data/json/recipes/armor/storage.json
+++ b/data/json/recipes/armor/storage.json
@@ -145,7 +145,7 @@
     "difficulty": 3,
     "time": "6 h",
     "autolearn": true,
-    "reversible": { "time": "10 m" },
+    "reversible": { "time": "15 m" },
     "using": [ [ "tailoring_nylon_patchwork", 9 ], [ "fastener_small", 2 ], [ "strap_small", 1 ], [ "clasps", 1 ] ],
     "proficiencies": [ { "proficiency": "prof_closures" }, { "proficiency": "prof_closures_waterproofing" } ]
   },
@@ -197,18 +197,21 @@
     "skill_used": "tailor",
     "skills_required": [ "fabrication", 2 ],
     "difficulty": 4,
-    "time": "4 h",
+    "time": "6 h",
     "autolearn": true,
-    "reversible": { "time": "10 m" },
+    "reversible": true,
+    "//": "Item disassembly based on reversible craft and manually defined uncraft integration. Read ITEM_DISASSEMBLY.mb for more info.",
     "using": [
       [ "tailoring_nylon_patchwork", 10 ],
       [ "fastener_small", 1 ],
       [ "strap_small", 1 ],
-      [ "clasps", 1 ]
+      [ "clasps", 1 ],
+      [ "plastic_molding", 1 ]
     ],
     "proficiencies": [
       { "proficiency": "prof_closures" },
-      { "proficiency": "prof_closures_waterproofing" }
+      { "proficiency": "prof_closures_waterproofing" },
+      { "proficiency": "prof_plasticworking" }
     ]
   },
   {
@@ -222,7 +225,7 @@
     "difficulty": 4,
     "time": "4 h",
     "autolearn": true,
-    "reversible": { "time": "10 m" },
+    "reversible": { "time": "15 m" },
     "using": [ [ "tailoring_nylon_patchwork", 4 ], [ "fastener_small", 2 ], [ "strap_small", 1 ], [ "clasps", 4 ] ],
     "proficiencies": [ { "proficiency": "prof_closures" }, { "proficiency": "prof_closures_waterproofing" } ]
   },

--- a/data/json/recipes/armor/storage.json
+++ b/data/json/recipes/armor/storage.json
@@ -145,6 +145,7 @@
     "difficulty": 3,
     "time": "6 h",
     "autolearn": true,
+    "reversible": { "time": "10 m" },
     "using": [ [ "tailoring_nylon_patchwork", 9 ], [ "fastener_small", 2 ], [ "strap_small", 1 ], [ "clasps", 1 ] ],
     "proficiencies": [ { "proficiency": "prof_closures" }, { "proficiency": "prof_closures_waterproofing" } ]
   },
@@ -196,21 +197,18 @@
     "skill_used": "tailor",
     "skills_required": [ "fabrication", 2 ],
     "difficulty": 4,
-    "time": "6 h",
+    "time": "4 h",
     "autolearn": true,
-    "reversible": true,
-    "//": "Item disassembly based on reversible craft and manually defined uncraft integration. Read ITEM_DISASSEMBLY.mb for more info.",
+    "reversible": { "time": "10 m" },
     "using": [
       [ "tailoring_nylon_patchwork", 10 ],
       [ "fastener_small", 1 ],
       [ "strap_small", 1 ],
-      [ "clasps", 1 ],
-      [ "plastic_molding", 1 ]
+      [ "clasps", 1 ]
     ],
     "proficiencies": [
       { "proficiency": "prof_closures" },
-      { "proficiency": "prof_closures_waterproofing" },
-      { "proficiency": "prof_plasticworking" }
+      { "proficiency": "prof_closures_waterproofing" }
     ]
   },
   {
@@ -224,7 +222,7 @@
     "difficulty": 4,
     "time": "4 h",
     "autolearn": true,
-    "reversible": true,
+    "reversible": { "time": "10 m" },
     "using": [ [ "tailoring_nylon_patchwork", 4 ], [ "fastener_small", 2 ], [ "strap_small", 1 ], [ "clasps", 4 ] ],
     "proficiencies": [ { "proficiency": "prof_closures" }, { "proficiency": "prof_closures_waterproofing" } ]
   },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Update uncraft recipes for MOLLE sustainment pouch and deployment bag"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Fixes #82456 

Add `reversible.time` fields so deconstruct recipes are more in-line with other molle attachments.

~~Tactical dump pouch had plastic working requirement while the others don't, likely for the drawstring fastener. This bit isn't really required for the dump bag to be specifically used, as you could just knot the drawstrings together or use on of the fasteners in the construction of it to close. This also means we don't have to have a specific uncraft for these bags, otherwise we'd need a vacuum molder to deconstruct it.~~

~~Tactical dump pouch had an increased construct time compared with the others, likely due to the custom-made drawstring fastener. I reduced it to 4 hours to be inline with the sustainment pouch (these two bags are very similar)~~

~~Also removed an autogenerated comment while I was in there.~~

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Update json entries, reduce uncraft times to 15 minutes.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Loaded into a game with new json applied, no errors, both take 15 minutes to deconstruct.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Someone should probably come in here and update the fastener component with actual molle webbing at some point...


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
