### PR TITLE
Chloromorphosis mutation now scales smoothly with irradiance instead of either on or off

### DIFF
--- a/src/player_hardcoded_effects.cpp
+++ b/src/player_hardcoded_effects.cpp
@@ -1095,13 +1095,13 @@ static void eff_fun_sleep( Character &u, effect &it )
             float factor = 0.0f;
             if( incident > irradiance_min ) {
                 const float normalized = std::clamp( ( incident - irradiance_min ) /
-                        std::max( irradiance_full - irradiance_min, 1.0f ), 0.0f, 1.0f );
+                                                     std::max( irradiance_full - irradiance_min, 1.0f ), 0.0f, 1.0f );
                 // Half-sine curve: f(x) = sin(x * π/2) on [0,1]
                 factor = std::sin( normalized * M_PI / 2.0f );
             }
             if( factor > 0.0f ) {
                 if( u.has_active_mutation( trait_CHLOROMORPH ) &&
-                        ( u.get_sleepiness() <= 25 ) ) {
+                    ( u.get_sleepiness() <= 25 ) ) {
                     u.set_sleepiness( 25 );
                 }
                 // Hunger and thirst fall before your Chloromorphic physiology!

--- a/src/player_hardcoded_effects.cpp
+++ b/src/player_hardcoded_effects.cpp
@@ -31,10 +31,10 @@
 #include "item.h"
 #include "item_location.h"
 #include "map.h"
-#include "math_defines.h"
 #include "map_iterator.h"
 #include "mapdata.h"
 #include "martialarts.h"
+#include "math_defines.h"
 #include "messages.h"
 #include "mongroup.h"
 #include "player_activity.h"
@@ -1087,7 +1087,8 @@ static void eff_fun_sleep( Character &u, effect &it )
             u.has_trait( trait_M_SKIN3 ) || u.has_trait( trait_WATERSLEEP ) ) &&
         here.is_outside( u.pos_bub() ) ) {
         if( u.has_trait( trait_CHLOROMORPH ) ) {
-            const float incident = incident_sun_irradiance( get_weather().weather_id, calendar::turn );
+            const float incident = incident_sun_irradiance( get_weather().weather_id,
+                                   calendar::turn );
             const float irradiance_min = irradiance::minimal;
             const float irradiance_full = irradiance::high;
             float factor = 0.0f;
@@ -1098,7 +1099,8 @@ static void eff_fun_sleep( Character &u, effect &it )
                 factor = std::sin( normalized * M_PI / 2.0f );
             }
             if( factor > 0.0f ) {
-                if( u.has_active_mutation( trait_CHLOROMORPH ) && ( u.get_sleepiness() <= 25 ) ) {
+                if( u.has_active_mutation( trait_CHLOROMORPH ) &&
+                        ( u.get_sleepiness() <= 25 ) ) {
                     u.set_sleepiness( 25 );
                 }
                 // Hunger and thirst fall before your Chloromorphic physiology!

--- a/src/player_hardcoded_effects.cpp
+++ b/src/player_hardcoded_effects.cpp
@@ -1,5 +1,6 @@
 #include <algorithm>
 #include <array>
+#include <cmath>
 #include <cstdlib>
 #include <functional>
 #include <iterator>

--- a/src/player_hardcoded_effects.cpp
+++ b/src/player_hardcoded_effects.cpp
@@ -31,6 +31,7 @@
 #include "item.h"
 #include "item_location.h"
 #include "map.h"
+#include "math_defines.h"
 #include "map_iterator.h"
 #include "mapdata.h"
 #include "martialarts.h"
@@ -1093,9 +1094,8 @@ static void eff_fun_sleep( Character &u, effect &it )
             if( incident > irradiance_min ) {
                 const float normalized = std::clamp( ( incident - irradiance_min ) /
                         std::max( irradiance_full - irradiance_min, 1.0f ), 0.0f, 1.0f );
-                static constexpr float pi = 3.14159265358979323846f;
                 // Half-sine curve: f(x) = sin(x * π/2) on [0,1]
-                factor = std::sin( normalized * pi / 2.0f );
+                factor = std::sin( normalized * M_PI / 2.0f );
             }
             if( factor > 0.0f ) {
                 if( u.has_active_mutation( trait_CHLOROMORPH ) && ( u.get_sleepiness() <= 25 ) ) {


### PR DESCRIPTION
#### Summary
Balance "Chloromorphosis mutation scales photosynthesis with light intensity."

#### Purpose of change

The Chloromorphosis mutation uses binary on/off behavior: full benefits above `irradiance::low`, zero below. This threshold is only exceeded for ~9 hours in spring/summer and ~3 hours in fall/winter, and almost never in non-clear weather. This makes the mutation nearly useless in realistic conditions, despite plants continuing to photosynthesize (at reduced rates) in dim or cloudy conditions.

#### Describe the solution

I changed how much kcal, thirst, and vitamins are satiated from a binary on or off at a too high of a threshold to curve based. The change did not affect the maximum values, only ramps them from a lower light level. I tried many different curves.

<img width="1280" height="800" alt="chloromorph_kcal_20251015-145248_irr_n400_max-906_C0p38_s0p6_r2p0_wcurve-half-sine" src="https://github.com/user-attachments/assets/7ae18f6f-6ed0-4ac5-9311-a0e13b157a3c" />

I chose the half-sine curve. My next choice was the cosine or sigmoid, but I felt like that didn't do anything to the lower irradiance levels, which was the whole point of my change.

#### Describe alternatives you've considered

I wanted to keep the mutation based on irradiance. A long time ago it was based only on weather and light level, but that was removed and transferred to irradiance level. I had an idea to make it, so there were different curves at different weather patterns, but to make it simple I just kept it based on irradiance, which is what I think other contributors wanted it to be.

#### Testing

Create character with Chloromorphosis mutation 
Use debug to test different times of day
Use debug to test different conditions
Sleep outside and monitor nutrition changes

Formatted with astyle.

#### Additional context

<img width="1920" height="1280" alt="chloromorph_weather_20251015-145248_irr_n400_max-906_C0p38_s0p6_r2p0_wcurve-half-sine" src="https://github.com/user-attachments/assets/85828c89-71c4-4642-946d-fe24ec27b107" />

I created a script that analyzed different curves and how much "better" they were. Even though the half-sine was 40% better, I believe it's still an acceptable change.

```
| Curve       | Area under the curve | Change vs Original |
|-------------|----------------------|--------------------|
| step        | 12250                | +0.00%             |
| cosine      | 13330                | +8.81%             |
| half-sine   | 16972                | +38.55%            |
| sigmoid     | 13330                | +8.81%             |
| exponential | 19170                | +56.49%            |
| linear      | 13330                | +8.81%             |
```

I think this will make the mutation better and less annoying to use. You still have to be sleeping and if you do almost any activity at all you still need to eat. This just makes it so during cloudy days you still have some benefits. It's still a hard to get mutation and I doubt many people ever get to use it.

P.S. This all started because I remembered in 2018 I made an edit to Chloromorphosis because it was basically useless. At some point, it changed from weather + light level to "irradiance". Though, the benefits were never on a curve. I have no opinion on how anyone wants to change this in the future. 