### PR TITLE
Make smartphone recovery interruptable

### DIFF
--- a/data/json/effects_on_condition/computer_eocs.json
+++ b/data/json/effects_on_condition/computer_eocs.json
@@ -88,7 +88,17 @@
     "type": "effect_on_condition",
     "id": "EOC_SMARTPHONE_RECOVERY_BASIC",
     "effect": [
-      { "u_assign_activity": "ACT_GENERIC_EOC", "duration": "15 minutes" },
+      {
+        "u_assign_activity": "ACT_PHONE_RECOVERY_BASIC",
+        "//": "15 min + 5 minute for each smartphone if more than 1",
+        "duration": { "math": [ "time('15 m') + ( (u_item_count('smart_phone_locked') - 1 ) * time('5 m') )" ] }
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_SMARTPHONE_RECOVERY_BASIC_2",
+    "effect": [
       {
         "u_run_inv_eocs": "all",
         "search_data": [ { "id": "smart_phone_locked" } ],
@@ -116,12 +126,22 @@
     "condition": {
       "and": [
         { "u_has_item": "software_hacking" },
-        { "u_has_items": { "item": "laptop", "charges": 10 } },
+        { "u_has_items": { "item": "laptop", "charges": 20 } },
         { "math": [ "u_skill('computer') >= 4" ] }
       ]
     },
     "effect": [
-      { "u_assign_activity": "ACT_GENERIC_EOC", "duration": "60 minutes" },
+      {
+        "u_assign_activity": "ACT_PHONE_RECOVERY_ADVANCED",
+        "//": "90 min + 15 minute for each smartphone if more than 1",
+        "duration": { "math": [ "time('90 m') + ( (u_item_count('smart_phone_locked') - 1 ) * time('15 m') )" ] }
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_SMARTPHONE_RECOVERY_ADVANCED_2",
+    "effect": [
       {
         "u_run_inv_eocs": "all",
         "search_data": [ { "id": "smart_phone_locked" } ],
@@ -135,7 +155,7 @@
       {
         "u_run_inv_eocs": "random",
         "search_data": [ { "id": "laptop" } ],
-        "true_eocs": [ { "id": "EOC_CONSUME_POWER", "effect": [ { "math": [ "n_val('power') -= 100" ] } ] } ]
+        "true_eocs": [ { "id": "EOC_CONSUME_POWER", "effect": [ { "math": [ "n_val('power') -= 20" ] } ] } ]
       },
       {
         "if": { "math": [ "_amount_of_smartphones_recovered == 1" ] },

--- a/data/json/player_activities.json
+++ b/data/json/player_activities.json
@@ -1137,6 +1137,28 @@
     "interruptable_with_kb": false
   },
   {
+    "id": "ACT_PHONE_RECOVERY_BASIC",
+    "type": "activity_type",
+    "activity_level": "NO_EXERCISE",
+    "verb": "recovering",
+    "based_on": "time",
+    "interruptable": true,
+    "can_resume": false,
+    "interruptable_with_kb": true,
+    "completion_eoc": "EOC_SMARTPHONE_RECOVERY_BASIC_2"
+  },
+  {
+    "id": "ACT_PHONE_RECOVERY_ADVANCED",
+    "type": "activity_type",
+    "activity_level": "NO_EXERCISE",
+    "verb": "recovering",
+    "based_on": "time",
+    "interruptable": true,
+    "can_resume": false,
+    "interruptable_with_kb": true,
+    "completion_eoc": "EOC_SMARTPHONE_RECOVERY_ADVANCED_2"
+  },
+  {
     "id": "ACT_SALINE_INFUSE",
     "type": "activity_type",
     "activity_level": "NO_EXERCISE",


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Saw a report in discord. Even if it is dumb to recover smartphone in dangerous area, it's still a bug that you cannot interrupt it
#### Describe the solution
Instead of just assigning generic activity, you are assigned specific activity that can be interrupted, and on finishing it the recovery effect happens
Also added a formula so the more smartphones = more time spent