### PR TITLE
Add debug command to print overmap noise layers

### DIFF
--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -1279,6 +1279,13 @@
   },
   {
     "type": "keybinding",
+    "id": "PRINT_NOISE_MAPS",
+    "category": "OVERMAP",
+    "name": "Print noise maps",
+    "bindings": [ { "input_method": "keyboard_any", "key": "," } ]
+  },
+  {
+    "type": "keybinding",
     "name": "View missions",
     "category": "OVERMAP",
     "id": "MISSIONS",

--- a/src/overmap_debug.cpp
+++ b/src/overmap_debug.cpp
@@ -1,0 +1,125 @@
+#include "overmap_debug.h"
+
+#include <cstddef>
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <optional>
+#include <utility>
+#include <vector>
+
+#include "coordinates.h"
+#include "game.h"
+#include "output.h"
+#include "overmapbuffer.h"
+#include "overmap_noise.h"
+#include "point.h"
+#include "regional_settings.h"
+#include "string_id.h"
+#include "translations.h"
+#include "uilist.h"
+
+namespace om_debug
+{
+
+void print_noise_maps( const tripoint_abs_omt &curs )
+{
+    constexpr int WIDTH = 900;
+    point_rel_omt offset( WIDTH / 2, WIDTH / 2 );
+    const region_settings &settings = overmap_buffer.get_settings( curs );
+    om_noise::om_noise_layer_forest forest( curs.xy() - offset, g->get_seed() );
+    om_noise::om_noise_layer_floodplain floodplain( curs.xy() - offset, g->get_seed() );
+    om_noise::om_noise_layer_lake lake( curs.xy() - offset, g->get_seed() );
+    om_noise::om_noise_layer_ocean ocean( curs.xy() - offset, g->get_seed() );
+    std::vector<std::pair<om_noise::om_noise_layer *, std::string>> layers{
+        {&forest, _( "Forest" ) },
+        {&floodplain, _( "Floodplain" ) },
+        {&lake, _( "Lake" ) },
+        {&ocean, _( "Ocean" ) }
+    };
+    uilist menu;
+    menu.text = _( "Which noise map?  (Centered at the cursor)" );
+    for( size_t i = 0; i < layers.size(); ++i ) {
+        menu.addentry( i, true, -1, layers[i].second );
+    }
+    menu.query();
+
+    if( menu.ret < 0 || menu.ret >= static_cast<int>( layers.size() ) ) {
+        return;
+    }
+
+    float threshold = 0.f;
+    bool invert = false;
+    if( menu.ret == 0 && settings.overmap_forest ) {
+        threshold = settings.overmap_forest->obj().noise_threshold_forest;
+    } else if( menu.ret == 1 && settings.place_swamps ) {
+        threshold = settings.overmap_forest->obj().noise_threshold_swamp_isolated;
+    } else if( menu.ret == 2 && settings.overmap_lake ) {
+        if( settings.overmap_lake->obj().invert_lakes ) {
+            invert = true;
+        }
+        threshold = settings.overmap_lake->obj().noise_threshold_lake;
+    } else if( menu.ret == 3 && settings.overmap_ocean ) {
+        threshold = settings.overmap_ocean->obj().noise_threshold_ocean;
+    }
+
+
+    std::string raw_name = layers[menu.ret].second + "-noise.pgm";
+    std::string interp_name = layers[menu.ret].second + "-interp.pgm";
+
+    export_raw_noise( raw_name, *layers[menu.ret].first, 900, 900 );
+    export_interpreted_noise( interp_name, *layers[menu.ret].first, 900, 900, threshold, invert );
+    popup( _( "Exported noise to %s (raw) and %s." ), raw_name, interp_name );
+}
+
+void export_raw_noise( const std::string &filename, const om_noise::om_noise_layer &noise,
+                       int width, int height )
+{
+    std::ofstream testfile;
+    testfile.open( std::filesystem::u8path( filename ), std::ofstream::trunc );
+    testfile << "P2" << std::endl;
+    testfile << width << " " << height << std::endl;
+    testfile << "255" << std::endl;
+
+    for( int y = 0; y < height; y++ ) {
+        for( int x = 0; x < width; x++ ) {
+            if( x == width / 2 && y == width / 2 ) {
+                testfile << 255 << " ";
+            } else {
+                testfile << static_cast<int>( noise.noise_at( {x, y} ) * 255 ) << " ";
+            }
+        }
+        testfile << std::endl;
+    }
+
+    testfile.close();
+}
+
+void export_interpreted_noise(
+    const std::string &filename, const om_noise::om_noise_layer &noise, int width, int height,
+    float threshold, bool invert )
+{
+    std::ofstream testfile;
+    testfile.open( std::filesystem::u8path( filename ), std::ofstream::trunc );
+    testfile << "P2" << std::endl;
+    testfile << width << " " << height << std::endl;
+    testfile << "255" << std::endl;
+
+    // invert swaps what is empty and what is full
+    const int full = invert ? 0 : 255;
+    const int empty = invert ? 255 : 0;
+    for( int y = 0; y < height; y++ ) {
+        for( int x = 0; x < width; x++ ) {
+            if( invert ^ ( noise.noise_at( {x, y} ) > threshold ) ) {
+                testfile << full << " ";
+            } else {
+                testfile << empty << " ";
+            }
+        }
+        testfile << std::endl;
+    }
+
+    testfile.close();
+}
+
+}; // namespace om_debug

--- a/src/overmap_debug.h
+++ b/src/overmap_debug.h
@@ -1,0 +1,27 @@
+#pragma once
+#ifndef CATA_SRC_OVERMAP_DEBUG_H
+#define CATA_SRC_OVERMAP_DEBUG_H
+
+#include <string>
+
+#include "coords_fwd.h"
+
+namespace om_noise
+{
+class om_noise_layer;
+}; // namespace om_noise
+
+namespace om_debug
+{
+
+void print_noise_maps( const tripoint_abs_omt &cursor );
+
+void export_raw_noise( const std::string &filename, const om_noise::om_noise_layer &noise,
+                       int width, int height );
+
+void export_interpreted_noise( const std::string &filename, const om_noise::om_noise_layer &noise,
+                               int width, int height, float threshold, bool invert );
+
+}; // namespace om_debug
+
+#endif // CATA_SRC_OVERMAP_DEBUG_H

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -63,6 +63,7 @@
 #include "options.h"
 #include "output.h"
 #include "overmap.h"
+#include "overmap_debug.h"
 #include "overmap_types.h"
 #include "overmapbuffer.h"
 #include "point.h"
@@ -1178,6 +1179,7 @@ static void draw_om_sidebar( ui_adaptor &ui,
         print_hint( "PLACE_TERRAIN", c_light_blue );
         print_hint( "SET_SPECIAL_ARGS", c_light_blue );
         print_hint( "MODIFY_HORDE", c_light_blue );
+        print_hint( "PRINT_NOISE_MAPS", c_light_blue );
         lines--;
     } else {
         lines = 11;
@@ -2075,6 +2077,7 @@ static tripoint_abs_omt display()
     if( data.debug_editor ) {
         ictxt.register_action( "PLACE_TERRAIN" );
         ictxt.register_action( "PLACE_SPECIAL" );
+        ictxt.register_action( "PRINT_NOISE_MAPS" );
         ictxt.register_action( "SET_SPECIAL_ARGS" );
         ictxt.register_action( "LONG_TELEPORT" );
         ictxt.register_action( "MODIFY_HORDE" );
@@ -2290,6 +2293,8 @@ static tripoint_abs_omt display()
             action = "QUIT";
         } else if( action == "MODIFY_HORDE" ) {
             modify_horde_func( curs );
+        } else if( action == "PRINT_NOISE_MAPS" ) {
+            om_debug::print_noise_maps( curs );
         } else if( action == "REVEAL_MAP" ) {
             debug_menu::prompt_map_reveal( curs );
         } else if( action == "MISSIONS" ) {

--- a/tests/overmap_noise_test.cpp
+++ b/tests/overmap_noise_test.cpp
@@ -1,71 +1,27 @@
-#include <filesystem>
-#include <fstream>
 #include <string>
 
 #include "cata_catch.h"
 #include "coordinates.h"
 #include "map_scale_constants.h"
+#include "overmap_debug.h"
 #include "overmap_noise.h"
 #include "point.h"
-
-static void export_raw_noise( const std::string &filename, const om_noise::om_noise_layer &noise,
-                              int width, int height )
-{
-    std::ofstream testfile;
-    testfile.open( std::filesystem::u8path( filename ), std::ofstream::trunc );
-    testfile << "P2" << std::endl;
-    testfile << width << " " << height << std::endl;
-    testfile << "255" << std::endl;
-
-    for( int x = 0; x < width; x++ ) {
-        for( int y = 0; y < height; y++ ) {
-            testfile << static_cast<int>( noise.noise_at( {x, y} ) * 255 ) << " ";
-        }
-        testfile << std::endl;
-    }
-
-    testfile.close();
-}
-
-static void export_interpreted_noise(
-    const std::string &filename, const om_noise::om_noise_layer &noise, int width, int height,
-    float threshold )
-{
-    std::ofstream testfile;
-    testfile.open( std::filesystem::u8path( filename ), std::ofstream::trunc );
-    testfile << "P2" << std::endl;
-    testfile << width << " " << height << std::endl;
-    testfile << "255" << std::endl;
-
-    for( int x = 0; x < width; x++ ) {
-        for( int y = 0; y < height; y++ ) {
-            if( noise.noise_at( {x, y} ) > threshold ) {
-                testfile << 255 << " ";
-            } else {
-                testfile << 0 << " ";
-            }
-        }
-        testfile << std::endl;
-    }
-
-    testfile.close();
-}
 
 TEST_CASE( "om_noise_layer_forest_export", "[.]" )
 {
     const om_noise::om_noise_layer_forest f( point_abs_omt(), 1920237457 );
-    export_raw_noise( "forest-map-raw.pgm", f, OMAPX, OMAPY );
+    om_debug::export_raw_noise( "forest-map-raw.pgm", f, OMAPX, OMAPY );
 }
 
 TEST_CASE( "om_noise_layer_floodplain_export", "[.]" )
 {
     const om_noise::om_noise_layer_floodplain f( point_abs_omt(), 1920237457 );
-    export_raw_noise( "floodplain-map-raw.pgm", f, OMAPX, OMAPY );
+    om_debug::export_raw_noise( "floodplain-map-raw.pgm", f, OMAPX, OMAPY );
 }
 
 TEST_CASE( "om_noise_layer_lake_export", "[.]" )
 {
     const om_noise::om_noise_layer_lake f( point_abs_omt(), 1920237457 );
-    export_raw_noise( "lake-map-raw.pgm", f, OMAPX * 5, OMAPY * 5 );
-    export_interpreted_noise( "lake-map-interp.pgm", f, OMAPX * 5, OMAPY * 5, 0.25 );
+    om_debug::export_raw_noise( "lake-map-raw.pgm", f, OMAPX * 5, OMAPY * 5 );
+    om_debug::export_interpreted_noise( "lake-map-interp.pgm", f, OMAPX * 5, OMAPY * 5, 0.25, false );
 }


### PR DESCRIPTION
#### Summary
Infrastructure "Add debug command to print overmap noise maps"

#### Purpose of change
Make it easier to debug overmap noise changes.

#### Describe the solution
Move the noise export functions from the tests, and add a keybind to choose a noise layer and export it from the overmap debug menu.

Because the noise maps are fixed by seed to a game world, but the settings are loaded from JSON, this allows comparison of how a world would generate with different noise settings.

#### Testing
<img width="942" height="341" alt="Choosing noise layer to export" src="https://github.com/user-attachments/assets/5ef1f019-f653-42cd-9ef5-a5f5993ee09c" />
<img width="420" height="90" alt="Noise layer exported popup" src="https://github.com/user-attachments/assets/4c18c1c7-13fe-435a-9e63-bfc059b491be" />


The world examined:
<img alt="Screenshot of the world that the noise layer was exported from. Islands similar to those shown in the noise layers below are shown." src="https://github.com/user-attachments/assets/213ea607-49d9-4357-b8f0-02a8d7179ca5" />
|Raw noise|Interpreted Noise|Interpreted Noise overlaid with Raw Noise|
|-|-|-|
|<img width="900" height="900" alt="A perlin noise map" src="https://github.com/user-attachments/assets/51a35993-b18e-4475-9afc-689494cc2cc0" />|<img width="900" height="900" alt="The same perlin noise map, but interpreted with the same threshold as is used in the world above, highlighting islands in white, and leaving the rest in black" src="https://github.com/user-attachments/assets/2b68dd6e-c784-435b-9f57-2c828b4d3b2d" />|<img width="900" height="900" alt="The noise map overlaid on the interpreted map, showing the islands with noise falling off around them" src="https://github.com/user-attachments/assets/23c94041-3e48-46f4-b8c4-ad622a779d84" />|
