### PR TITLE
Move monster constructor initializations to header

### DIFF
--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -246,27 +246,12 @@ static int compute_kill_xp( const mtype_id &mon_type )
 monster::monster()
 {
     unset_dest();
-    wandf = 0;
-    hp = 60;
     moves = 0;
-    friendly = 0;
-    anger = 0;
-    morale = 2;
     faction = mfaction_id( 0 );
-    no_extra_death_drops = false;
-    dead = false;
-    death_drops = true;
-    made_footstep = false;
-    hallucination = false;
-    ignoring = 0;
-    upgrades = false;
-    upgrade_time = -1;
     stomach_timer = calendar::turn;
     last_updated = calendar::turn_zero;
     biosig_timer = calendar::before_time_starts;
     udder_timer = calendar::turn;
-    horde_attraction = MHA_NULL;
-    aggro_character = true;
     set_anatomy( anatomy_default_anatomy );
     set_body();
 }
@@ -3853,7 +3838,7 @@ void monster::init_from_item( item &itm )
             hp = type->hp;
             set_speed_base( type->speed );
         }
-        upgrade_time = itm.get_var( "upgrade_time", 0 );
+        upgrade_time = itm.get_var( "upgrade_time", -1 );
         for( item *it : itm.all_items_top( pocket_type::CONTAINER ) ) {
             if( it->is_armor() ) {
                 it->set_flag( json_flag_FILTHY );

--- a/src/monster.h
+++ b/src/monster.h
@@ -554,7 +554,7 @@ class monster : public Creature
         // DEFINING VALUES
         int friendly = 0;
         int anger = 0;
-        int morale = 0;
+        int morale = 2;
     private:
         int amount_eaten = 0;
         void recheck_fed_status();
@@ -638,14 +638,14 @@ class monster : public Creature
         void process_trigger( mon_trigger trig, int amount );
         void process_trigger( mon_trigger trig, const std::function<int()> &amount_func );
 
-        int hp = 0;
+        int hp = 60;
         std::map<std::string, mon_special_attack, std::less<>> special_attacks;
         std::optional<tripoint_abs_ms> goal;
         bool dead = false;
         /** Normal upgrades **/
         int next_upgrade_time();
         bool upgrades = false;
-        int upgrade_time = 0;
+        int upgrade_time = -1;
         bool reproduces = false;
         std::optional<time_point> baby_timer;
         bool biosignatures = false;


### PR DESCRIPTION
#### Summary
Bugfixes "Fix incorrect evolution timer on monsters generated from corpses without evolution timer set"

#### Purpose of change
Many monster class values are initialized in the header with different values than are set in the constructor, after initializations were added in c98bbcbc43b52635ba9a12fbee8bf29bb4236c1b (2020).

For example, that initialized upgrade_time to 0, whereas it was set to -1 in the constructor in 028cf26bdfda76345811f7aa017408f8871af611 (2015).

Because of the incorrect header value, the wrong default value was set in 4813012dc17fdfeb8f238b40b40b59b06da3f049 (2025) when reading from a corpse _without_ the variable already set.

#### Describe the solution
Fix that bug, and move trivial initializations to the header.

#### Testing
I haven't tested this, the specific bug it fixes seems very rare, and otherwise it should match existing behavior. I believe the test suite should provide sufficient coverage.

#### Additional context
From discussion on https://github.com/CleverRaven/Cataclysm-DDA/issues/80959