### PR TITLE
Add NO_BODY_HEAT flag for characters who don't show up on infrared

### DIFF
--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -2247,6 +2247,11 @@
     "info": "Allows movement in open air."
   },
   {
+    "id": "NO_BODY_HEAT",
+    "type": "json_flag",
+    "info": "The character produces no body heat and is not visible on infrared (for characters only, for monsters use the WARM flag to enable infrared visibility)."
+  },
+  {
     "id": "ALL_TERRAIN_NAVIGATION",
     "type": "json_flag",
     "info": "Allows movement over rough and sharp terrain without penalty."

--- a/data/mods/Magiclysm/mutations/spell_triggering_mutations.json
+++ b/data/mods/Magiclysm/mutations/spell_triggering_mutations.json
@@ -26,7 +26,8 @@
         "intermittent_activation": { "effects": [ { "frequency": "5 seconds", "spell_effects": [ { "id": "boreal_mage_cold_damage" } ] } ] }
       }
     ],
-    "transform": { "target": "COLD_AURA_OFF", "msg_transform": "You suppress your frozen powers.", "active": false, "moves": 10 }
+    "transform": { "target": "COLD_AURA_OFF", "msg_transform": "You suppress your frozen powers.", "active": false, "moves": 10 },
+    "flags": [ "NO_BODY_HEAT" ]
   },
   {
     "type": "mutation",

--- a/data/mods/Xedra_Evolved/effects/effects.json
+++ b/data/mods/Xedra_Evolved/effects/effects.json
@@ -968,7 +968,7 @@
     "remove_message": "You end your imitation of death.",
     "rating": "mixed",
     "enchantments": [ { "mutations": [ "WINTER_FEIGN_DEATH_TRAITS" ], "ench_effects": [ { "effect": "downed", "intensity": 1 } ] } ],
-    "flags": [ "CANNOT_ATTACK", "CANNOT_MOVE" ]
+    "flags": [ "CANNOT_ATTACK", "CANNOT_MOVE", "NO_BODY_HEAT" ]
   },
   {
     "type": "effect_type",

--- a/data/mods/Xedra_Evolved/mutations/mutation_thresh.json
+++ b/data/mods/Xedra_Evolved/mutations/mutation_thresh.json
@@ -5,7 +5,7 @@
     "name": { "str": "Ierde" },
     "points": 1,
     "description": "You have ascended into your fae nature.",
-    "flags": [ "FAEBLOOD" ],
+    "flags": [ "FAEBLOOD", "NO_BODY_HEAT" ],
     "valid": false,
     "purifiable": false,
     "threshold": true
@@ -16,7 +16,7 @@
     "name": { "str": "Arvore" },
     "points": 1,
     "description": "You have ascended into your fae nature.",
-    "flags": [ "FAEBLOOD" ],
+    "flags": [ "FAEBLOOD", "NO_BODY_HEAT" ],
     "valid": false,
     "purifiable": false,
     "threshold": true
@@ -27,7 +27,7 @@
     "name": { "str": "Undine" },
     "points": 1,
     "description": "You have ascended into your fae nature.",
-    "flags": [ "FAEBLOOD" ],
+    "flags": [ "FAEBLOOD", "NO_BODY_HEAT" ],
     "valid": false,
     "purifiable": false,
     "threshold": true
@@ -49,7 +49,7 @@
     "name": { "str": "Sylph" },
     "points": 1,
     "description": "You have ascended into your fae nature.",
-    "flags": [ "FAEBLOOD" ],
+    "flags": [ "FAEBLOOD", "NO_BODY_HEAT" ],
     "valid": false,
     "purifiable": false,
     "threshold": true

--- a/data/mods/Xedra_Evolved/mutations/mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/mutations.json
@@ -1455,7 +1455,7 @@
     "purifiable": false,
     "valid": false,
     "can_only_eat": [ "blood", "hblood", "fae_blood", "vampire_blood" ],
-    "flags": [ "CANNIBAL", "DAYFEAR", "NO_THIRST" ],
+    "flags": [ "CANNIBAL", "DAYFEAR", "NO_THIRST", "NO_BODY_HEAT" ],
     "vitamin_rates": [ [ "vitC", -500 ], [ "iron", -500 ], [ "calcium", -500 ] ],
     "//": "When weariness can be modified through Json, this mutation should make the player immune to it.",
     "enchantments": [

--- a/data/mods/Xedra_Evolved/mutations/mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/mutations.json
@@ -1729,7 +1729,8 @@
           { "value": "SPEED", "add": { "math": [ "temperature_speed_mod(65, 0.5)" ] } }
         ]
       }
-    ]
+    ],
+    "flags": [ "NO_BODY_HEAT" ]
   },
   {
     "type": "mutation",

--- a/data/mods/Xedra_Evolved/mutations/temporary.json
+++ b/data/mods/Xedra_Evolved/mutations/temporary.json
@@ -531,7 +531,8 @@
       "SALAMANDER",
       "SYLPH",
       "UNDINE"
-    ]
+    ],
+    "flags": [ "NO_BODY_HEAT" ]
   },
   {
     "type": "mutation",

--- a/doc/JSON/JSON_FLAGS.md
+++ b/doc/JSON/JSON_FLAGS.md
@@ -409,6 +409,7 @@ Character flags can be `trait_id`, `json_flag_id` or `flag_id`.  Some of these a
 - ```MYOPIC_SUPERNATURAL``` You are nearsighted in such a way that glasses cannot fix it, such as by magic.
 - ```MYOPIC_IN_LIGHT_SUPERNATURAL``` You are nearsighted in light in such a way that glasses cannot fix it, such as by magic.
 - ```NIGHT_VISION``` You can see in the dark.
+- ```NO_BODY_HEAT``` Your temperature is indistinguishable from the surrounding environmental temperature, making you not show up on infrared.
 - ```NO_CBM_INSTALLATION``` You are unable to install any CBMs.
 - ```NO_DISEASE``` This mutation grants immunity to diseases.
 - ```NO_RADIATION``` This mutation grants immunity to radiations.

--- a/src/character_health.cpp
+++ b/src/character_health.cpp
@@ -166,6 +166,7 @@ static const json_character_flag json_flag_CANNOT_TAKE_DAMAGE( "CANNOT_TAKE_DAMA
 static const json_character_flag json_flag_DEAF( "DEAF" );
 static const json_character_flag json_flag_GRAB( "GRAB" );
 static const json_character_flag json_flag_HEAL_OVERRIDE( "HEAL_OVERRIDE" );
+static const json_character_flag json_flag_NO_BODY_HEAT( "NO_BODY_HEAT" );
 static const json_character_flag json_flag_NO_RADIATION( "NO_RADIATION" );
 static const json_character_flag json_flag_NO_THIRST( "NO_THIRST" );
 static const json_character_flag json_flag_PAIN_IMMUNE( "PAIN_IMMUNE" );
@@ -248,8 +249,12 @@ bool Character::can_recover_oxygen() const
 
 bool Character::is_warm() const
 {
-    // TODO: is there a mutation (plant?) that makes a npc not warm blooded?
-    return true;
+    if( has_flag( json_flag_NO_BODY_HEAT ) ) {
+        return false;
+    }
+    else { 
+        return true;
+    }
 }
 
 int Character::get_fat_to_hp() const

--- a/src/character_health.cpp
+++ b/src/character_health.cpp
@@ -251,8 +251,7 @@ bool Character::is_warm() const
 {
     if( has_flag( json_flag_NO_BODY_HEAT ) ) {
         return false;
-    }
-    else { 
+    } else {
         return true;
     }
 }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Content "Add NO_BODY_HEAT flag for characters who don't show up on infrared"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

`Character::is_warm()` always returned true with a note about whether that's reasonable. It mentioned plant mutants, but I could think of some mod uses for targets that shouldn't have body heat.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Implement the `NO_BODY_HEAT` flag and apply it where appropriate--Tier 5 vampires, characters using the Winter fae glamour Stillness of the Tomb and the vampire blood gift Corpse's Countenance, and the threshold traits for Undines, Sylphs, Arvore, and Ierde. I haven't added it to any vanilla mutation traits yet, though maybe `COLDBLOOD3` (Cold blooded) and `COLDBLOOD4` (Ectothermic) could carry it. 

At the moment, this is of very limited utility since no monster has infrared vision, but maybe some day.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Spawned in some goggles and gave the starting NPC tier 5 vampirism. They disappeared from infrared. 

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
