### PR TITLE
Fix a lot of markdown tables

### DIFF
--- a/doc/JSON/EFFECT_ON_CONDITION.md
+++ b/doc/JSON/EFFECT_ON_CONDITION.md
@@ -49,7 +49,7 @@ An effect_on_condition is an object allowing the combination of dialog condition
 * `AVATAR_DEATH` - automatically invoked whenever the current avatar dies (it will be run with the avatar as `u`), if after it the player is no longer dead they will not die, if there are multiple EOCs they all be run until the player is not dead.
 * `NPC_DEATH` - EOCs can only be assigned to run on the death of an npc, in which case u will be the dying npc and npc will be the killer. If after it npc is no longer dead they will not die, if there are multiple they all be run until npc is not dead.
 * `PREVENT_DEATH` - whenever the current avatar dies it will be run with the avatar as `u`, if after it the player is no longer dead they will not die, if there are multiple they all be run until the player is not dead.
-* `EVENT` - EOCs trigger when a specific event given by "required_event" takes place. 
+* `EVENT` - EOCs trigger when a specific event given by "required_event" takes place.
 
 ## Alpha and Beta Talkers
 
@@ -120,7 +120,7 @@ There is some amount of another types, that are not explained here, like "search
 
 Variable object is a value, that changes due some conditions. Variable can be int, time, string, `math` expression or location variable. Types of variables are:
 
-- `u_val` - variable, that is stored in this character, and, if player dies, the variable is lost also (or if you swap the avatar, for example; the secret one NPC told to character A would be lost for character B); 
+- `u_val` - variable, that is stored in this character, and, if player dies, the variable is lost also (or if you swap the avatar, for example; the secret one NPC told to character A would be lost for character B);
 - `npc_val` - variable, that is stored in beta talker
 - `global_val` - variable, that is store in the world, and won't be lost until you delete said world
 - `context_val` - variable, that was delivered from some another entity; For example, EVENT type EoCs can deliver specific variables contributor can use to perform specific checks:
@@ -146,8 +146,8 @@ So if you had
 | key1 | global_val | SOME TEXT |
 | key2 | u_val | SOME OTHER TEXT |
 
-- If you access "ref" as a context val it will have the value of "key1", if you access it as a var_val it will have a value of "SOME TEXT". 
-- If you access "ref2" as a context val it will have the value of "u_key2", if you access it as a var_val it will have a value of "SOME OTHER TEXT". 
+- If you access "ref" as a context val it will have the value of "key1", if you access it as a var_val it will have a value of "SOME TEXT".
+- If you access "ref2" as a context val it will have the value of "u_key2", if you access it as a var_val it will have a value of "SOME OTHER TEXT".
 
 For example, imagine you have context variable `{ "context_val": "my_best_gun" }`, and this `my_best_gun` variable contain text `any_random_gun`; also you have a `{ "global_val": "any_random_gun" }`, and this `any_random_gun` variable happened to contain text `ak47`
 With both of this, you can use effect `"u_spawn_item": { "var_val": "my_best_gun" }`, and the game will spawn `ak47`, since it is what is stored inside `my_best_gun` global variable
@@ -219,7 +219,7 @@ Important to remember that **reactivated EOCs currently lose all context variabl
 
 # Condition:
 
-Dialogue conditions is a way to check is some specific statements are true or false. Conditions can be used both in dialogue with NPC, and in Effect on Conditions. 
+Dialogue conditions is a way to check is some specific statements are true or false. Conditions can be used both in dialogue with NPC, and in Effect on Conditions.
 The following keys and strings are available:
 
 ## Boolean logic
@@ -297,7 +297,7 @@ Checks there is portal storm **and** you have `MAKAYLA_MUTATOR` mutation **and**
 #### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- | 
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
 
 #### Examples
@@ -313,7 +313,7 @@ return true if beta talker exists
 #### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 #### Examples
@@ -339,7 +339,7 @@ Creature ---> Character ---> avatar
 #### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
 
 #### Examples
@@ -351,13 +351,13 @@ return true if alpha talker is character (avatar or NPC)
 ### `u_at_om_location`, `npc_at_om_location`
 - type: string or [variable object](#variable-object)
 - return true if alpha talker stands on specific overmap tile;
-- `FACTION_CAMP_ANY` can be used, that return true if alpha or beta talker stand on faction camp tile; 
+- `FACTION_CAMP_ANY` can be used, that return true if alpha or beta talker stand on faction camp tile;
 - `FACTION_CAMP_START` can be used, that return true if alpha or beta talker stand on tile, that can be turned into faction camp
 
 #### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
 
 #### Examples
@@ -384,7 +384,7 @@ return true if alpha talker at location that can be transformed to faction camp
 #### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 #### Examples
@@ -409,7 +409,7 @@ using `_has_any_trait` with single trait is also possible
 #### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 #### Examples
@@ -426,7 +426,7 @@ Checks do alpha talker has `FEATHERS` mutation
 #### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 #### Examples
@@ -443,7 +443,7 @@ Checks if the `FEATHERS` trait is purifiable for the character (returns true as 
 #### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 #### Examples
@@ -458,7 +458,7 @@ Checks if the `FEATHERS` trait is purifiable for the character (returns true as 
 #### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 #### Examples
@@ -473,7 +473,7 @@ Checks if the `FEATHERS` trait is purifiable for the character (returns true as 
 #### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ✔️ | ❌ | ✔️ | ❌ |
 
 Note: For terrain and furniture, [map_terrain_with_flag, map_furniture_with_flag](#map_terrain_with_flagmap_furniture_with_flag) can also be used.
@@ -492,7 +492,7 @@ Alpha talker has `GRAB` flag, and beta talker has `GRAB_FILTER` flag; monster us
 #### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ❌ | ❌ | ❌ | ❌ | ❌ | ✔️ |
 
 #### Examples
@@ -514,7 +514,7 @@ Beta talker is a vehicle with a stereo which is activated
 #### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ❌ | ❌ | ✔️ | ❌ | ❌ | ❌ |
 
 #### Examples
@@ -531,7 +531,7 @@ alpha talker is `SLIME`
 #### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 #### Examples
@@ -548,7 +548,7 @@ alpha talker has bodytype `migo` , and beta has bodytype `human`
 #### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
 
 #### Examples
@@ -615,7 +615,7 @@ Check if two variables are `yes`
 #### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ❌ | ❌ | ❌ | ❌ | ❌ |
 
 #### Examples
@@ -643,7 +643,7 @@ Print a message if the character selected Fisher profession or the Fishing backg
 #### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 #### Examples
@@ -660,7 +660,7 @@ True, if alpha talker has str 7 or more
 #### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 #### Examples
@@ -677,7 +677,7 @@ check is your torso is 37 centigrade
 #### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 #### Examples
@@ -699,7 +699,7 @@ check do you have 6 ropes
 #### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 #### Examples
@@ -725,7 +725,7 @@ check do you have 3 manuals in inventory
 #### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 #### Examples
@@ -787,7 +787,7 @@ Variables are also supported
 #### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 #### Examples
@@ -811,7 +811,7 @@ check do you have any bionic presented
 #### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 #### Examples
@@ -842,7 +842,7 @@ checks are you hot or cold
 #### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 #### Examples
@@ -858,7 +858,7 @@ check do you have `Principles of Chemistry`
 #### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 #### Examples
@@ -879,7 +879,7 @@ You have equipped an item that you can not stow, either because it's bionic pseu
 #### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 #### Examples
@@ -906,7 +906,7 @@ You have equipped an item that you can not stow, either because it's bionic pseu
 #### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 #### Examples
@@ -927,7 +927,7 @@ You don't wield anything
 #### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 #### Examples
@@ -948,7 +948,7 @@ true if you do not drive
 #### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 #### Examples
@@ -970,7 +970,7 @@ true if you do not drive
 #### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ❌ | ❌ | ❌ | ❌ | ❌ |
 
 #### Examples
@@ -986,7 +986,7 @@ check do you memorize `meat_hunk` recipe
 #### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 #### Examples
@@ -1002,7 +1002,7 @@ check do you wear something with `RAD_DETECT` flag
 #### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 #### Examples
@@ -1018,7 +1018,7 @@ check do you wield something with `WHIP` flag
 #### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 #### Examples
@@ -1036,13 +1036,13 @@ check do you wield something with `LONG_SWORDS` weapon category
 #### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 #### Examples
 check do you wield a gun with `pistol` skill
 ```jsonc
-{ "u_has_wielded_with_skill": "pistol" } 
+{ "u_has_wielded_with_skill": "pistol" }
 ```
 
 ### `u_has_wielded_with_ammotype`, `npc_has_wielded_with_ammotype`
@@ -1053,13 +1053,13 @@ check do you wield a gun with `pistol` skill
 #### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 #### Examples
 check do you wield a gun with `22` ammo type (.22 LR)
 ```jsonc
-{ "u_has_wielded_with_ammotype": "22" } 
+{ "u_has_wielded_with_ammotype": "22" }
 ```
 
 ### `u_can_see`, `npc_can_see`
@@ -1069,7 +1069,7 @@ check do you wield a gun with `22` ammo type (.22 LR)
 #### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ |
 
 #### Examples
@@ -1090,7 +1090,7 @@ You can't see
 #### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ |
 
 #### Examples
@@ -1111,7 +1111,7 @@ You can hear
 #### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ |
 
 #### Examples
@@ -1132,7 +1132,7 @@ NPC is dead
 #### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ |
 
 #### Examples
@@ -1148,7 +1148,7 @@ NPC is dead
 #### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
 
 ### `u_is_on_terrain`, `npc_is_on_terrain`
@@ -1158,7 +1158,7 @@ NPC is dead
 #### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
 
 #### Examples
@@ -1174,7 +1174,7 @@ check do you stand on grass
 #### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
 
 #### Examples
@@ -1190,7 +1190,7 @@ check do you stand on terrain with `SHRUB` flag
 #### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
 
 #### Examples
@@ -1208,7 +1208,7 @@ check do you stand in a cloud of smoke
 #### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 #### Examples
@@ -1324,7 +1324,7 @@ Each time the avatar enters an OMT display a message as to whether or not they'r
 #### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
 
 #### Examples
@@ -1346,7 +1346,7 @@ Will give a message if you're in the dimension with the ID of "test".
 #### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
 
 #### Examples
@@ -1375,7 +1375,7 @@ Asks for text input, will delete the dimension that matches the string ID.
 #### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
 
 #### Examples
@@ -1391,7 +1391,7 @@ return true if player can see NPC.
 #### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ |
 
 #### Examples
@@ -1419,7 +1419,7 @@ You can see selected location.
 #### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ |
 
 ### `u_is_driven`, `npc_is_driven`
@@ -1429,7 +1429,7 @@ You can see selected location.
 #### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ❌ | ❌ | ❌ | ❌ | ❌ | ✔️ |
 
 #### Examples
@@ -1451,7 +1451,7 @@ You can see selected location.
 #### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- | 
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ |
 
 #### Examples
@@ -1469,7 +1469,7 @@ You can see selected location.
 - Works at night
 
 | Syntax | Optionality | Value  | Info |
-| --- | --- | --- | --- | 
+| --- | --- | --- | --- |
 | "line_of_sight" | **mandatory** | int,  or [variable object](#variable-object) | Distance that would be checked |
 | "loc_1" | **mandatory** | [variable object](#variable-object) | One of two points of the line |
 | "loc_2" | **mandatory** | [variable object](#variable-object) | Second of two points of the line |
@@ -1500,7 +1500,7 @@ You can see selected location.
 #### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ❌ | ❌ | ❌ | ❌ | ❌ | ✔️ |
 
 #### Examples
@@ -1516,7 +1516,7 @@ You can see selected location.
 #### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ❌ | ❌ | ❌ | ❌ | ❌ | ✔️ |
 
 #### Examples
@@ -1532,7 +1532,7 @@ You can see selected location.
 #### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ❌ | ❌ | ❌ | ❌ | ❌ | ✔️ |
 
 #### Examples
@@ -1540,7 +1540,7 @@ You can see selected location.
 ```jsonc
 "u_is_flying"
 ```
-    
+
 ### `u_can_float`, `npc_can_float`
 - type: simple string
 - return true if alpha or beta talker is a vehicle capable of floating
@@ -1548,7 +1548,7 @@ You can see selected location.
 #### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ❌ | ❌ | ❌ | ❌ | ❌ | ✔️ |
 
 #### Examples
@@ -1564,7 +1564,7 @@ You can see selected location.
 #### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ❌ | ❌ | ❌ | ❌ | ❌ | ✔️ |
 
 #### Examples
@@ -1581,7 +1581,7 @@ You can see selected location.
 #### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ❌ | ❌ | ❌ | ❌ | ❌ | ✔️ |
 
 #### Examples
@@ -1597,7 +1597,7 @@ You can see selected location.
 #### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ❌ | ❌ | ❌ | ❌ | ❌ | ✔️ |
 
 #### Examples
@@ -1613,7 +1613,7 @@ You can see selected location.
 #### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ❌ | ❌ | ❌ | ❌ | ❌ | ✔️ |
 
 #### Examples
@@ -1629,7 +1629,7 @@ You can see selected location.
 #### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ❌ | ❌ | ❌ | ❌ | ❌ | ✔️ |
 
 #### Examples
@@ -1645,7 +1645,7 @@ You can see selected location.
 #### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ❌ | ❌ | ❌ | ❌ | ❌ | ✔️ |
 
 #### Examples
@@ -1665,11 +1665,11 @@ You can see selected location.
 #### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
 
 #### Examples
-Check whether the eoc `test_condition` would use its true or false effect 
+Check whether the eoc `test_condition` would use its true or false effect
 ```jsonc
 { "test_eoc": "test_condition" }
 ```
@@ -1678,7 +1678,7 @@ Check whether the eoc `test_condition` would use its true or false effect
 The code base supports the use of reusable EOCs, you can use these to get guaranteed effects by passing in specific variables. The codebase supports the following:
 
 | EOC Name | Description | Variables |
-| ---------------------  ----------- |
+| --------------------- | ----------- |
 | EOC_RandEnc | Spawns a random encounter at the specified `omt` with mapgen update `map_update` that is later removed with `map_removal`. It has a 1 in `chance` chance of happening and can only occur after `days_till_spawn`. Can optionally only happen if `random_enc_condition` is true | `map_update`: a mapgen update ID <br/> `omt`: overmap tile ID where this happens <br/> `map_removal`: a mapgen update ID <br/> `chance`: an integer <br/> `days_till_spawn`: an integer <br/> `random_enc_condition`: a set condition |
 
 # EVENT EOCs:
@@ -1820,16 +1820,16 @@ Play a sound effect from sound pack `"type": "sound_effect"`
 
 
 | Syntax | Optionality | Value  | Info |
-| --- | --- | --- | --- | 
+| --- | --- | --- | --- |
 | "sound_effect" | **mandatory** | string or [variable object](#variable-object) | sound effect, that would be used, respond to `variant` field in `"type": "sound_effect"` |
-| "id" | optional | string or [variable object](#variable-object) | `id`, that would be used to play, respond to `id` field in `"type": "sound_effect"`  | 
-| "outdoor_event" | optional | boolean | default false; if true, and player is underground, the player is less likely to hear the sound | 
-| "volume" | optional | int or [variable object](#variable-object)  | default 80; volume at which the sound would be played; affected by hearing modifier | 
+| "id" | optional | string or [variable object](#variable-object) | `id`, that would be used to play, respond to `id` field in `"type": "sound_effect"`  |
+| "outdoor_event" | optional | boolean | default false; if true, and player is underground, the player is less likely to hear the sound |
+| "volume" | optional | int or [variable object](#variable-object)  | default 80; volume at which the sound would be played; affected by hearing modifier |
 
 ##### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
 
 ##### Examples
@@ -1844,14 +1844,14 @@ Plays sound `bionics`, variant `pixelated` with volume 50
 Opens up a dialog between the participants; this should only be used in effect_on_conditions, not in actual npc dialogue
 
 | Syntax | Optionality | Value  | Info |
-| --- | --- | --- | --- | 
+| --- | --- | --- | --- |
 | "topic" | optional | string or [variable object](#variable-object) | if used, instead of the dialogue with the participant, this topic would be used with an empty talker |
-| "true_eocs", "false_eocs" | optional | string, [variable object](#variable-object), inline EoC, or range of all of them | if was successful, all EoCs from `true_eocs` are run, otherwise all EoCs from `false_eocs` are run | 
+| "true_eocs", "false_eocs" | optional | string, [variable object](#variable-object), inline EoC, or range of all of them | if was successful, all EoCs from `true_eocs` are run, otherwise all EoCs from `false_eocs` are run |
 
 ##### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
 
 ##### Examples
@@ -1874,14 +1874,14 @@ If beta talker is NPC, take control of it
 
 
 | Syntax | Optionality | Value  | Info |
-| --- | --- | --- | --- | 
+| --- | --- | --- | --- |
 | "take_control" | **mandatory** | simple string | makes you control the NPC; works only if avatar (you) is alpha talker, and beta talker is NPC |
-| "true_eocs", "false_eocs" | optional | string, [variable object](#variable-object), inline EoC, or range of all of them | if `take_control` was successful, all `true_eocs` are run, otherwise all `false_eocs` run | 
+| "true_eocs", "false_eocs" | optional | string, [variable object](#variable-object), inline EoC, or range of all of them | if `take_control` was successful, all `true_eocs` are run, otherwise all `false_eocs` run |
 
 ##### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ❌ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 ##### Examples
@@ -1902,7 +1902,7 @@ Works only with your followers
 ##### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ❌ | ❌ | ❌ | ❌ | ❌ |
 
 ##### Examples
@@ -1916,13 +1916,13 @@ Opens the menu to swap the avatar
 Marks the given achievement as complete
 
 | Syntax | Optionality | Value  | Info |
-| --- | --- | --- | --- | 
+| --- | --- | --- | --- |
 | "give_achievement" | **mandatory** | string or [variable object](#variable-object) | the achievement that would be given |
 
 ##### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ❌ | ❌ | ❌ | ❌ | ❌ |
 
 ##### Examples
@@ -1937,14 +1937,14 @@ Gives achievement `escaped_the_cataclysm`
 Will assign mission to the player
 
 | Syntax | Optionality | Value  | Info |
-| --- | --- | --- | --- | 
+| --- | --- | --- | --- |
 | "assign_mission" | **mandatory** | string or [variable object](#variable-object) | Mission that would be assigned to the player |
 | "deadline" | optional | string or [variable object](#variable-object) | Time point when mission will be failed automatically if not already complete |
 
 ##### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ❌ | ❌ | ❌ | ❌ | ❌ |
 
 ##### Examples
@@ -1957,14 +1957,14 @@ Assign you a `MISSION_REACH_FAKE_DAVE` mission which must be completed within th
 Will remove mission from the player's active mission list without failing it.
 
 | Syntax | Optionality | Value  | Info |
-| --- | --- | --- | --- | 
+| --- | --- | --- | --- |
 | "remove_active_mission" | **mandatory** | string or [variable object](#variable-object) | mission that would be removed |
 
 ##### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
-| ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | 
+| ------ | --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
 
 ##### Examples
 removes `MISSION_BONUS_KILL_BOSS` mission from your list
@@ -1978,15 +1978,15 @@ Will complete mission the player has, in one way or another
 // todo - test how optional `success` and `step` actually are
 
 | Syntax | Optionality | Value  | Info |
-| --- | --- | --- | --- | 
+| --- | --- | --- | --- |
 | "finish_mission" | **mandatory** | string or [variable object](#variable-object) | id of the mission that would be finished |
-| "success" | optional | boolean | default false; if true, complete the mission as successful | 
-| "step" | optional | int | if used, complete mission up to this step | 
+| "success" | optional | boolean | default false; if true, complete the mission as successful |
+| "step" | optional | int | if used, complete mission up to this step |
 
 ##### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
 
 ##### Examples
@@ -2009,14 +2009,14 @@ Complete the first step of a `DID_I_WIN` mission
 Adds this mission on a list NPC can offer
 
 | Syntax | Optionality | Value  | Info |
-| --- | --- | --- | --- | 
+| --- | --- | --- | --- |
 | "offer_mission" | **mandatory** | string, [variable object](#variable-object) or array | id of a mission to offer |
 
 
 ##### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ❌ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 ##### Examples
@@ -2040,16 +2040,16 @@ NPC can offer missions `MISSION_A`, `B` and `C` now
 Runs another EoC. It can be a separate EoC, or an inline EoC inside `run_eocs` effect
 
 | Syntax | Optionality | Value  | Info |
-| --- | --- | --- | --- | 
+| --- | --- | --- | --- |
 | "run_eocs" | **mandatory** | string (eoc id or inline eoc) or [variable object](#variable-object)) or array of eocs | EoC or EoCs that would be run |
 | "iterations" | optional | int or [variable object](#variable-object)) | if used, all eocs in run_eocs would be repeated this amount of times. Eocs are repeated in order; having `"run_eocs": [ "A", "B" ], "repeat": 3` would look like `A, B, A, B, A, B`. Default 1 |
 | "condition" | optional | int or [variable object](#variable-object)) | if used, eoc would be run as long as this condition will return true. if "condition" is used, "iterations" can be used to limit amount of runs to specific amount (default is 100 runs until terminated) |
-| "time_in_future" | optional | int, duration, [variable object](#variable-object) or value between two | if used, EoC would be activated this amount of time in future; default 0, meaning it would run instantly. If eoc is global, the avatar will be u and npc will be invalid. If eoc is not global, it will be queued for the current alpha if they are a character (avatar or npc) and not be queued otherwise. Doesn't work with "condition" and "iterations" | 
-| "randomize_time_in_future" | optional | bool | used with time_in_future; if false, entire eoc array would run at the exact same moment; if true, each eoc in array would pick it's own time again and again | 
+| "time_in_future" | optional | int, duration, [variable object](#variable-object) or value between two | if used, EoC would be activated this amount of time in future; default 0, meaning it would run instantly. If eoc is global, the avatar will be u and npc will be invalid. If eoc is not global, it will be queued for the current alpha if they are a character (avatar or npc) and not be queued otherwise. Doesn't work with "condition" and "iterations" |
+| "randomize_time_in_future" | optional | bool | used with time_in_future; if false, entire eoc array would run at the exact same moment; if true, each eoc in array would pick it's own time again and again |
 | "alpha_loc","beta_loc" | optional | [variable object](#variable-object) | Allows to swap talker by defining `u_location_variable`, where the EoC should be run. Set the alpha/beta talker to the creature at the location. |
 | "alpha_talker","beta_talker" | optional (If you use both "alpha_loc" and "alpha_talker", "alpha_talker" will be ignored, same for beta.) | string, [variable object](#variable-object) | Set alpha/beta talker. This can be either a `character_id` (you can get from [EOC event](#event-eocs) or result of [u_set_talker](#u_set_talkernpc_set_talker) ), or some hard-coded values: <br> `""`: null talker <br> `"u"/"npc": the alpha/beta talker of the EOC`(Should be Avatar/Character/NPC/Monster) <br> `"avatar"`: your avatar|
 | "false_eocs" | optional | string, [variable object](#variable-object), inline EoC, or range of all of them | false EOCs will run if<br>1. there is no creature at "alpha_loc"/"beta_loc",or<br>2. "alpha_talker" or "beta_talker" doesn't exist in the game (eg. dead NPC),or<br>3. alpha and beta talker are both null |
-| "variables" | optional | pair of `"variable_name": "variable"` | context variables, that would be passed to the EoC; can be either a [variable object](#variable-object), or an [inline variable](#inline-variables) ;<br/><br/> `expects_vars` condition can be used inside running eoc to ensure every variable exist before the EoC is run | 
+| "variables" | optional | pair of `"variable_name": "variable"` | context variables, that would be passed to the EoC; can be either a [variable object](#variable-object), or an [inline variable](#inline-variables) ;<br/><br/> `expects_vars` condition can be used inside running eoc to ensure every variable exist before the EoC is run |
 
 ##### Inline Variables
 Variable values can be declared inline and must use the correct type:
@@ -2072,7 +2072,7 @@ Variable values can be declared inline and must use the correct type:
 ##### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
 
 ##### Examples
@@ -2093,7 +2093,7 @@ Run inline `are_you_strong` EoC
 ```
 
 Inline EoCs could have their own inline EoCS
-This EoC checks your str stat, and if it's less than 4, write `You are weak`; 
+This EoC checks your str stat, and if it's less than 4, write `You are weak`;
 if it's bigger, `are_you_strong` EoC is run, that checks is your str is bigger than 8; if it's less, `You are normal` is written
 if it's bigger, `are_you_super_strong` effect is run, that checks is your str is bigger than 12; If it's less, `You are strong` is written; if it's more, `You are super strong` is written
 ```jsonc
@@ -2319,15 +2319,15 @@ runs `EOC_POWER_TOGGLE_REMOVE_EFFECTS`, but current beta talker would be made al
 Store the character_id of You or NPC into a variable object
 
 | Syntax | Optionality | Value  | Info |
-| --- | --- | --- | --- | 
+| --- | --- | --- | --- |
 | "u_set_talker" / "npc_set_talker" | **mandatory** | [variable object](#variable-object) | the variable object to store the character_id |
 
 ##### Examples
 
 ```jsonc
 {
-  "effect": [ 
-    { "u_set_talker": { "global_val": "u_character_id" } }, 
+  "effect": [
+    { "u_set_talker": { "global_val": "u_character_id" } },
     { "u_message": "Your character id is <global_val:u_character_id>" }
   ]
 }
@@ -2337,17 +2337,17 @@ Store the character_id of You or NPC into a variable object
 If you or NPC does not have all of the listed bionics, mutations, spells or recipes, gives one randomly
 
 | Syntax | Optionality | Value  | Info |
-| --- | --- | --- | --- | 
+| --- | --- | --- | --- |
 | "u_roll_remainder" / "npc_roll_remainder" | **mandatory** | string, [variable](#variable-object) or array of both | thing, that would be rolled and given |
-| "type" | **mandatory** | string or [variable object](#variable-object) | type of thing that would be given; can be one of `bionic`, `mutation`, `spell` or `recipe` | 
-| "message" | optional | string or [variable object](#variable-object) | message, that would be displayed in log, once remainder is used; `%s` symbol can be used in this message to write the name of a thing, that would be given; message would be printed only if roll was successful | 
-| "true_eocs", "false_eocs" | optional | string, [variable object](#variable-object), inline EoC, or range of all of them | If reminder was positive, all EoCs in `true_eocs` run, otherwise `false_eocs` run | 
+| "type" | **mandatory** | string or [variable object](#variable-object) | type of thing that would be given; can be one of `bionic`, `mutation`, `spell` or `recipe` |
+| "message" | optional | string or [variable object](#variable-object) | message, that would be displayed in log, once remainder is used; `%s` symbol can be used in this message to write the name of a thing, that would be given; message would be printed only if roll was successful |
+| "true_eocs", "false_eocs" | optional | string, [variable object](#variable-object), inline EoC, or range of all of them | If reminder was positive, all EoCs in `true_eocs` run, otherwise `false_eocs` run |
 
 
 ##### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 ##### Examples
@@ -2367,15 +2367,15 @@ Tries to give you a mutation `A`, `B` or `C`, if you don't have one, with messag
 Set effects to be executed when conditions are met and when conditions are not met.
 
 | Syntax | Optionality | Value  | Info |
-| --- | --- | --- | --- | 
-| "if" | **mandatory** | [dialogue condition](#dialogue-conditions) | condition itself | 
-| "then" | **mandatory** | effect | Effect(s) executed when conditions are met. | 
-| "else" | optional | effect | Effect(s) executed when conditions are not met. | 
+| --- | --- | --- | --- |
+| "if" | **mandatory** | [dialogue condition](#dialogue-conditions) | condition itself |
+| "then" | **mandatory** | effect | Effect(s) executed when conditions are met. |
+| "else" | optional | effect | Effect(s) executed when conditions are not met. |
 
 ##### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
 
 ##### Examples
@@ -2402,14 +2402,14 @@ Displays a different message the first time it is run and the second time onward
 Check the value, and, depending on it, pick the case that would be run
 
 | Syntax | Optionality | Value  | Info |
-| --- | --- | --- | --- | 
+| --- | --- | --- | --- |
 | "switch" | **mandatory** | variable/math_expression | the value, that would be read; only numerical values can be used |
-| "cases" | **mandatory** | `case` and `effect` | effects, that would be run, if the value of switch is higher or equal to this case | 
+| "cases" | **mandatory** | `case` and `effect` | effects, that would be run, if the value of switch is higher or equal to this case |
 
 ##### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 ##### Examples
@@ -2457,7 +2457,7 @@ The correspondence between "foreach" and "target" is as follows.
 ##### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
 
 ##### Examples
@@ -2476,13 +2476,13 @@ Resets all of your vitamins.
 NPC run EoCs, provided by this effect; can work outside of reality bubble
 
 | Syntax | Optionality | Value  | Info |
-| --- | --- | --- | --- | 
+| --- | --- | --- | --- |
 | "u_run_npc_eocs"/ "npc_run_npc_eocs" | **mandatory** | array of eocs | EoCs that would be run by NPCs |
-| "unique_ids" | optional | string, [variable objects](#variable-object) or array | id of NPCs that would be affected; lack of ids make effect run EoC on every NPC in your reality bubble, if `"local": true`, and to every NPC in the world, if `"local": false`; unique ID of every npc is specified in mapgen, using `npcs` or `place_npcs` | 
+| "unique_ids" | optional | string, [variable objects](#variable-object) or array | id of NPCs that would be affected; lack of ids make effect run EoC on every NPC in your reality bubble, if `"local": true`, and to every NPC in the world, if `"local": false`; unique ID of every npc is specified in mapgen, using `npcs` or `place_npcs` |
 | "local" | optional | boolean | default false; if true, the effect is run for every NPC in the world; if false, effect is run only to NPC in your reality bubble |
 | "npc_range" | optional | int or [variable object](#variable-object) | if used, only NPC in this range are affected |
-| "npc_must_see" | optional | boolean | default false; if true, only NPC you can see are affected | 
- 
+| "npc_must_see" | optional | boolean | default false; if true, only NPC you can see are affected |
+
 example of specifying `unique_id` in mapgen using `npcs`:
 ```jsonc
 "npcs": { "T": { "class": "guard", "unique_id": "GUARD7" } },
@@ -2496,7 +2496,7 @@ and using `place_npcs`:
 ##### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ❌ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 ##### Examples
@@ -2542,16 +2542,16 @@ Move refugee center guards `GUARD1` - `GUARD7` to the `_First` position - EoC fo
 Monsters run EoCs, provided by this effect; only works inside reality bubble
 
 | Syntax | Optionality | Value  | Info |
-| --- | --- | --- | --- | 
+| --- | --- | --- | --- |
 | "u_run_monster_eocs"/ "npc_run_monster_eocs" | **mandatory** | array of eocs | EoCs that would be run by monsters |
 | "mtype_ids" | optional | array or [variable objects](#variable-object) | mtype_id(s) that should be affected |
 | "monster_range" | optional | int or [variable object](#variable-object) | if used, only monsters in this range are affected |
-| "monster_must_see" | optional | boolean | default false; if true, only monsters you can see are affected | 
+| "monster_must_see" | optional | boolean | default false; if true, only monsters you can see are affected |
 
 ##### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ❌ | ❌ | ✔️ | ❌ | ❌ | ❌ |
 
 ##### Examples
@@ -2589,16 +2589,16 @@ Run EOC_KILL_SHADOW on any mon_zombie_dog, mon_dog_zombie_cop or mon_dog_zombie_
 Run EOCs on items in your or NPC's inventory
 
 | Syntax | Optionality | Value  | Info |
-| --- | --- | --- | --- | 
+| --- | --- | --- | --- |
 | "u_run_inv_eocs" / "npc_run_inv_eocs" | **mandatory** | string or [variable object](#variable-object) | way the item would be picked; <br/>values can be:<br/>`all` - all items that match the conditions are picked;<br/> `random` - from all items that match the conditions, one picked;<br/>`manual` - menu is open with all items that can be picked, and you can choose one;<br/>`manual_mult` - same as `manual`, but multiple items can be picked |
-| "search_data" | optional | `search_data` | sets the condition(s) for the target item; lack of search_data means any item can be picked; see [search_data](#search_data) for syntax | 
-| "title" | optional | string or [variable object](#variable-object) | name of the menu, that would be shown, if `manual` or `manual_mult` is used | 
-| "true_eocs" / "false_eocs" | optional | string, [variable object](#variable-object), inline EoC, or range of all of them | if item was picked successfully, all EoCs from `true_eocs` are run, otherwise all EoCs from `false_eocs` are run; picked item is returned as npc; for example, `n_hp()` return hp of an item | 
+| "search_data" | optional | `search_data` | sets the condition(s) for the target item; lack of search_data means any item can be picked; see [search_data](#search_data) for syntax |
+| "title" | optional | string or [variable object](#variable-object) | name of the menu, that would be shown, if `manual` or `manual_mult` is used |
+| "true_eocs" / "false_eocs" | optional | string, [variable object](#variable-object), inline EoC, or range of all of them | if item was picked successfully, all EoCs from `true_eocs` are run, otherwise all EoCs from `false_eocs` are run; picked item is returned as npc; for example, `n_hp()` return hp of an item |
 
 ##### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ❌ | ❌ | ❌ | ❌ | ✔️ | ❌ |
 
 ##### Examples
@@ -2651,13 +2651,13 @@ Picks all tiles around you, npc or target_var, stores it's coordinates in `store
 Used if you need to check if specific furniture or terrain is around
 
 | Syntax | Optionality | Value  | Info |
-| --- | --- | --- | --- | 
+| --- | --- | --- | --- |
 | "u_map_run_eocs", "npc_map_run_eocs" | **mandatory** | string, [variable object](#variable-object) or array | EoC or EoCs that would be run |
-| "store_coordinates_in" | optional | [variable object](#variable-object) | variable, where tested coordinate is stored | 
-| "condition" | optional | condition | condition that would be checked if eoc need to be run or not. Can (and intended to) use variable from `store_coordinates_in`. Default true (run always) | 
-| "target_var" | optional | [variable object](#variable-object) | location variable, around which the game should scan; if omitted, sticks to `u_` or `npc_` position | 
-| "range" | optional | int or [variable object](#variable-object) | how big the search radius should be; default 1 ( 3x3 square with character in the middle ) | 
-| stop_at_first | optional | bool | If true, stops execution after the first `condition` is met; if false, runs EoC on all tiles that met condition. Default false | 
+| "store_coordinates_in" | optional | [variable object](#variable-object) | variable, where tested coordinate is stored |
+| "condition" | optional | condition | condition that would be checked if eoc need to be run or not. Can (and intended to) use variable from `store_coordinates_in`. Default true (run always) |
+| "target_var" | optional | [variable object](#variable-object) | location variable, around which the game should scan; if omitted, sticks to `u_` or `npc_` position |
+| "range" | optional | int or [variable object](#variable-object) | how big the search radius should be; default 1 ( 3x3 square with character in the middle ) |
+| stop_at_first | optional | bool | If true, stops execution after the first `condition` is met; if false, runs EoC on all tiles that met condition. Default false |
 
 ##### Examples
 
@@ -2710,18 +2710,18 @@ Picks all TREEs in 50 tiles range, and burn it
 Search items around you on the map, and run EoC on them
 
 | Syntax | Optionality | Value  | Info |
-| --- | --- | --- | --- | 
+| --- | --- | --- | --- |
 | "u_map_run_item_eocs", "npc_map_run_item_eocs" | **mandatory** | string or [variable object](#variable-object) | way the item would be picked; <br/>values can be:<br/>`all` - all items that match the conditions are picked;<br/> `random` - from all items that match the conditions, one picked;<br/>`manual` - menu is open with all items that can be picked, and you can choose one;<br/>`manual_mult` - same as `manual`, but multiple items can be picked |
-| "loc" | optional | location variable | location, where items would be scanned; lack of it would scan only tile the talker stands on | 
-| "min_radius", "max_radius" | optional | int or [variable object](#variable-object) | radius around the location/talker that would be searched | 
-| "title" | optional | string or [variable object](#variable-object) | name of the menu that would be shown, if `manual` or `manual_mult` values are used | 
-| "search_data" | optional | `search_data` | sets the condition(s) for the target item; lack of search_data means any item can be picked; see [search_data](#search_data) for syntax | 
-| "true_eocs", "false_eocs" | optional | string, [variable object](#variable-object), inline EoC, or range of all of them | if item was picked successfully, all EoCs from `true_eocs` are run, otherwise all EoCs from `false_eocs` are run; picked item is returned as npc | 
+| "loc" | optional | location variable | location, where items would be scanned; lack of it would scan only tile the talker stands on |
+| "min_radius", "max_radius" | optional | int or [variable object](#variable-object) | radius around the location/talker that would be searched |
+| "title" | optional | string or [variable object](#variable-object) | name of the menu that would be shown, if `manual` or `manual_mult` values are used |
+| "search_data" | optional | `search_data` | sets the condition(s) for the target item; lack of search_data means any item can be picked; see [search_data](#search_data) for syntax |
+| "true_eocs", "false_eocs" | optional | string, [variable object](#variable-object), inline EoC, or range of all of them | if item was picked successfully, all EoCs from `true_eocs` are run, otherwise all EoCs from `false_eocs` are run; picked item is returned as npc |
 
 ##### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
 
 ##### Examples
@@ -2804,7 +2804,7 @@ Teleport player to `new_map`
 Reveal the overmap area around specific location variable
 
 | Syntax | Optionality | Value  | Info |
-| --- | --- | --- | --- | 
+| --- | --- | --- | --- |
 | "reveal_map" | **mandatory** | [variable object](#variable-object) | location variable, around which the map would be revealed |
 | "radius" | **mandatory** | int or [variable object](#variable-object) | default 0; the size of revealed zone |
 
@@ -2853,7 +2853,7 @@ Find overmap tile using `target_params`, store coordinates in `loc`, and reveal 
 Reveal the route between two location variables, using closest roads
 
 | Syntax | Optionality | Value  | Info |
-| --- | --- | --- | --- | 
+| --- | --- | --- | --- |
 | "reveal_route" | **mandatory** | [variable object](#variable-object) | location variable, starting point in the route |
 | "target_var" | **mandatory** | [variable object](#variable-object) | location variable, ending point in the route |
 | "radius" |  | int or [variable object](#variable-object) | the size of revealed path |
@@ -2898,7 +2898,7 @@ Reveal the route between you and `house_02`
 Store coordinates of the closest city nearby in a variable
 
 | Syntax | Optionality | Value  | Info |
-| --- | --- | --- | --- | 
+| --- | --- | --- | --- |
 | "closest_city" | **mandatory** | [variable object](#variable-object) | location variable, center of the found city |
 | "known" | optional | boolean | default true; if true, picks the closest city you know (has yellow text of the city name on your map), otherwise picks the closest city even if you didn't visit it yet |
 
@@ -2938,7 +2938,7 @@ Same, but return any city nearby
 Will choose one of a list of eocs to activate based on it's weight
 
 | Syntax | Optionality | Value  | Info |
-| --- | --- | --- | --- | 
+| --- | --- | --- | --- |
 | "weighted_list_eocs" | **mandatory** | n/a | EoC that would be run, and it's weight; EoC can be either id or inline EoC, and weight can be int or variable object |
 
 ##### Examples
@@ -2966,24 +2966,24 @@ Run one EoC from the list
 Open a menu, that allow to select one of multiple options
 
 | Syntax | Optionality | Value  | Info |
-| --- | --- | --- | --- | 
+| --- | --- | --- | --- |
 | "run_eoc_selector" | **mandatory** | array of strings or [variable objects](#variable-object) or inline EOCs| list of EoCs, that could be picked; conditions of the listed EoCs would be checked, and one that do not pass would be grayed out |
-| "names" | optional | array of strings or [variable objects](#variable-object) | name of the option, that would be shown on the list; amount of names should be equal amount of EoCs | 
-| "descriptions" | optional | array of strings or [variable objects](#variable-object) | description of the options, that would be shown on the list; amount of descriptions should be equal amount of EoCs | 
-| "keys" | optional | single character | a character, that would be used as a shortcut to pick each EoC; amount of keys should be equal amount of EoCs | 
-| "title" | optional | string | Text, that would be shown as the name of the list; Default `Select an option.` | 
-| "hide_failing" | optional | boolean | if true, the options, that fail their check, would be completely removed from the list, instead of being grayed out | 
-| "allow_cancel" | optional | boolean | if true, you can quit the menu without selecting an option, no effect will occur | 
-| "hilight_disabled" | optional | boolean | if true, the option, that fail their check, would still be navigateable, meaning you can highlight it and read it's description. If `allow_cancel` is true, picking it would be considered same as quitting | 
-| "variables" | optional | pair of `"variable_name": "variable"` | variables, that would be passed to the EoCs; can be either a [variable object](#variable-object), or an [inline variable](#inline-variables); `expects_vars` condition can be used to ensure every variable exist before the EoC is run | 
+| "names" | optional | array of strings or [variable objects](#variable-object) | name of the option, that would be shown on the list; amount of names should be equal amount of EoCs |
+| "descriptions" | optional | array of strings or [variable objects](#variable-object) | description of the options, that would be shown on the list; amount of descriptions should be equal amount of EoCs |
+| "keys" | optional | single character | a character, that would be used as a shortcut to pick each EoC; amount of keys should be equal amount of EoCs |
+| "title" | optional | string | Text, that would be shown as the name of the list; Default `Select an option.` |
+| "hide_failing" | optional | boolean | if true, the options, that fail their check, would be completely removed from the list, instead of being grayed out |
+| "allow_cancel" | optional | boolean | if true, you can quit the menu without selecting an option, no effect will occur |
+| "hilight_disabled" | optional | boolean | if true, the option, that fail their check, would still be navigateable, meaning you can highlight it and read it's description. If `allow_cancel` is true, picking it would be considered same as quitting |
+| "variables" | optional | pair of `"variable_name": "variable"` | variables, that would be passed to the EoCs; can be either a [variable object](#variable-object), or an [inline variable](#inline-variables); `expects_vars` condition can be used to ensure every variable exist before the EoC is run |
 ##### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ❌ | ❌ | ❌ | ❌ | ❌ |
 
 ##### Examples
-you can pick one of four options from `Choose your destiny` list; 
+you can pick one of four options from `Choose your destiny` list;
 ```jsonc
 {
   "run_eoc_selector": [ "EOC_OPTION_1", "EOC_OPTION_2", "EOC_OPTION_3", "EOC_OPTION_4" ],
@@ -3006,13 +3006,13 @@ you can pick one of four options from `Choose your destiny` list;
 Deal damage, the same way melee attack deals damage; it can't be dodged, but it can be mitigated by armor
 
 | Syntax | Optionality | Value  | Info |
-| --- | --- | --- | --- | 
+| --- | --- | --- | --- |
 | "u_deal_damage" / "npc_deal_damage" | **mandatory** | string or [variable object](#variable-object) | Damage type that would be dealt |
-| "amount" | optional | int or [variable object](#variable-object) | Amount of damage that would be dealt; Default 0 | 
-| "bodypart" | optional | string or [variable object](#variable-object) | Bodypart that take the damage. Reminder that only characters can have limbs. Default is RANDOM | 
+| "amount" | optional | int or [variable object](#variable-object) | Amount of damage that would be dealt; Default 0 |
+| "bodypart" | optional | string or [variable object](#variable-object) | Bodypart that take the damage. Reminder that only characters can have limbs. Default is RANDOM |
 | "arpen" | optional | int or [variable object](#variable-object) | Armor penetration of attack; Default 0 |
-| "arpen_mult" | optional | int or [variable object](#variable-object) | Multiplier for armor penetration; Default 1 | 
-| "dmg_mult" | optional | int or [variable object](#variable-object) | Multiplier for damage amount. Default 1 | 
+| "arpen_mult" | optional | int or [variable object](#variable-object) | Multiplier for armor penetration; Default 1 |
+| "dmg_mult" | optional | int or [variable object](#variable-object) | Multiplier for damage amount. Default 1 |
 | "min_hit" | optional | int or [variable object](#variable-object) | If bodypart is RANDOM, limit body part only to bodyparts that has `hit_size` bigger than this; default -1 |
 | "max_hit" | optional | int or [variable object](#variable-object) | If bodypart is RANDOM, limit body part only to bodyparts that has `hit_size` smaller than this; default the size of your biggest body part |
 | "can_attack_high" | optional | bool | If true, can attack limbs with flag LIMB_UPPER, if false, such limbs are discarded; Default true |
@@ -3021,7 +3021,7 @@ Deal damage, the same way melee attack deals damage; it can't be dodged, but it 
 ##### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- | 
+| ------ | --- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ |
 
 ##### Examples
@@ -3040,14 +3040,14 @@ Deal 20 biological damage to your torso
 Your character or the NPC will attempt to mutate; used in mutation system, for other purposes it's better to use [`u_add_trait`](#`u_add_trait`, `npc_add_trait`)
 
 | Syntax | Optionality | Value  | Info |
-| --- | --- | --- | --- | 
+| --- | --- | --- | --- |
 | "u_mutate" / "npc_mutate" | **mandatory** | int, float or [variable object](#variable-object) | one in `int` chance of causing a random mutation, with 0 only using the highest category |
-| "use_vitamins" | optional | boolean | default true; if true, mutation require vitamins to work | 
+| "use_vitamins" | optional | boolean | default true; if true, mutation require vitamins to work |
 
 ##### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 ##### Examples
@@ -3065,9 +3065,9 @@ Your character or the NPC will attempt to mutate; used in mutation system, for o
 Similar to `u_mutate` but takes category as a parameter and guarantees mutation.
 
 | Syntax | Optionality | Value  | Info |
-| --- | --- | --- | --- | 
+| --- | --- | --- | --- |
 | "u_mutate_category" / "npc_mutate_category" | **mandatory** | string or [variable object](#variable-object) | mutation category |
-| "use_vitamins" | optional | boolean | same as in `u_mutate` | 
+| "use_vitamins" | optional | boolean | same as in `u_mutate` |
 
 ##### Examples
 
@@ -3084,10 +3084,10 @@ Similar to `u_mutate` but takes category as a parameter and guarantees mutation.
 Similar to the above, but designates a desired end-point of mutation and uses the normal mutate_towards steps to get there, respecting base traits and `changes_to/cancels/types` restrictions.
 
 | Syntax | Optionality | Value  | Info |
-| --- | --- | --- | --- | 
+| --- | --- | --- | --- |
 | "u_mutate_towards" / "npc_mutate_towards" | **mandatory** | string or [variable object](#variable-object) | Trait ID |
 | "category"     | optional | string or [variable object](#variable-object) | default ANY, defines which category to use for the mutation steps - necessary for vitamin usage
-| "use_vitamins" | optional | boolean | same as in `u_mutate`, requires a defined `category` | 
+| "use_vitamins" | optional | boolean | same as in `u_mutate`, requires a defined `category` |
 
 ##### Examples
 Mutate towards Tail Stub (removing any incompatibilities) using the category set in the variable, deprecating that vitamin and using the category's base trait removal chance/multiplier.
@@ -3104,7 +3104,7 @@ Mutate towards Tail Stub (removing any incompatibilities) using the category set
 If you have the given trait it will be added to /removed from your list of non-purifiable traits, overriding `purifiable: true` in the given trait's definition.
 
 | Syntax | Optionality | Value  | Info |
-| --- | --- | --- | --- | 
+| --- | --- | --- | --- |
 | "u/npc_set_trait_purifiablility" | **mandatory** | string or [variable object](#variable-object) | id of the trait to change
 | "purifiable" | **mandatory** | bool | `true` adds the trait to the unpurifiable trait list, `false` removes it |
 
@@ -3121,17 +3121,17 @@ If you have the given trait it will be added to /removed from your list of non-p
 Some effect would be applied on you or NPC
 
 | Syntax | Optionality | Value  | Info |
-| --- | --- | --- | --- | 
+| --- | --- | --- | --- |
 | "u_add_effect" / "npc_add_effect" | **mandatory** | string or [variable object](#variable-object) | id of effect to give |
-| "duration" | **mandatory** | int, duration or [variable object](#variable-object) | length of the effect; both int (`"duration": 60`), and duration string (`"duration": "1 m"`) works; `PERMANENT` can be used to give a permanent effect | 
-| "target_part" | optional | string or [variable object](#variable-object) | default is "whole body"; if used, only specified body part would be used. `RANDOM` can be used to pick a random body part | 
-| "intensity" | optional | int, float or [variable object](#variable-object) | default 0; intensity of the effect | 
-| "force_bool" | optional | boolean | default false; if true, all immunities would be ignored | 
+| "duration" | **mandatory** | int, duration or [variable object](#variable-object) | length of the effect; both int (`"duration": 60`), and duration string (`"duration": "1 m"`) works; `PERMANENT` can be used to give a permanent effect |
+| "target_part" | optional | string or [variable object](#variable-object) | default is "whole body"; if used, only specified body part would be used. `RANDOM` can be used to pick a random body part |
+| "intensity" | optional | int, float or [variable object](#variable-object) | default 0; intensity of the effect |
+| "force_bool" | optional | boolean | default false; if true, all immunities would be ignored |
 
 ##### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ |
 
 ##### Examples
@@ -3161,13 +3161,13 @@ Apply effect `poison`, of [your strength value] intensity, for [random number be
 You or NPC would have some bionic installed
 
 | Syntax | Optionality | Value  | Info |
-| --- | --- | --- | --- | 
-| "u_add_bionic"/ "npc_add_bionic" | **mandatory** | string or [variable object](#variable-object) | Your character or the NPC will gain the bionic; Only one bionic per effect | 
+| --- | --- | --- | --- |
+| "u_add_bionic"/ "npc_add_bionic" | **mandatory** | string or [variable object](#variable-object) | Your character or the NPC will gain the bionic; Only one bionic per effect |
 
 ##### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 ##### Examples
@@ -3186,13 +3186,13 @@ Install 1 bionic, delivered from `bionic_id` context value, onto your character:
 You or NPC would have some bionic uninstalled from your body
 
 | Syntax | Optionality | Value  | Info |
-| --- | --- | --- | --- | 
-| "u_lose_bionic" / "npc_lose_bionic"  | **mandatory** | string or [variable object](#variable-object) | Your character or the NPC will lose the bionic | 
+| --- | --- | --- | --- |
+| "u_lose_bionic" / "npc_lose_bionic"  | **mandatory** | string or [variable object](#variable-object) | Your character or the NPC will lose the bionic |
 
 ##### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 ##### Examples
@@ -3208,17 +3208,17 @@ Uninstall 1 bionic, delivered from `bionic_id` context value, onto your characte
 
 
 #### `u_add_trait`, `npc_add_trait`
-Give character or NPC some mutation/trait 
+Give character or NPC some mutation/trait
 
 | Syntax | Optionality | Value  | Info |
-| --- | --- | --- | --- | 
+| --- | --- | --- | --- |
 | "u_add_trait" / "npc_add_trait" | **mandatory** | string or [variable object](#variable-object) | id of trait that should be given |
 | "variant" | optional | string or [variable object](#variable-object) | id of the trait's variant |
 
 ##### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 ##### Examples
@@ -3242,13 +3242,13 @@ Adds `hair_mohawk` trait with the `purple` variant to the character:
 Character or NPC got trait or mutation removed, if it has one
 
 | Syntax | Optionality | Value  | Info |
-| --- | --- | --- | --- | 
+| --- | --- | --- | --- |
 | "u_lose_trait" / "npc_lose_trait" | **mandatory** | string or [variable object](#variable-object) | id of mutation to be removed; if character or NPC has no such mutation, nothing happens |
 
 ##### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 ##### Examples
@@ -3268,14 +3268,14 @@ mutation, stored in `mutation_id`  context value, is removed from character:
 Remove effect from character or NPC, if it has one
 
 | Syntax | Optionality | Value  | Info |
-| --- | --- | --- | --- | 
+| --- | --- | --- | --- |
 | "u_lose_effect" / "npc_lose_effect" | **mandatory** | string, [variable object](#variable-object), or array of both | id of effect or effects to be removed; if character or NPC has no such effect, nothing happens |
-| "target_part" | optional | string or [variable object](#variable-object) | default is "whole body"; if used, only specified body part would be used. `ALL` can be used to remove effect from all bodyparts talker has | 
+| "target_part" | optional | string or [variable object](#variable-object) | default is "whole body"; if used, only specified body part would be used. `ALL` can be used to remove effect from all bodyparts talker has |
 
 ##### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ |
 
 ##### Examples
@@ -3308,13 +3308,13 @@ Removes `infection`, `downed` and `winded` effects from player:
 Your character or the NPC will activate the trait.
 
 | Syntax | Optionality | Value  | Info |
-| --- | --- | --- | --- | 
+| --- | --- | --- | --- |
 | "u_activate_trait" / "npc_activate_trait" | **mandatory** | string or [variable object](#variable-object) | id of trait/mutation to be activated |
 
 ##### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 ##### Examples
@@ -3333,13 +3333,13 @@ Deactivate trait, which contained in `this` context value:
 Your character or the NPC will deactivate the trait.
 
 | Syntax | Optionality | Value  | Info |
-| --- | --- | --- | --- | 
+| --- | --- | --- | --- |
 | "u_deactivate_trait" / "u_deactivate_trait" | **mandatory** | string or [variable object](#variable-object) | id of trait/mutation to be deactivated |
 
 ##### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 ##### Examples
@@ -3358,17 +3358,17 @@ Deactivate trait, which contained in `that` context value:
 Your character or the NPC will learn the martial art style.
 
 | Syntax | Optionality | Value  | Info |
-| --- | --- | --- | --- | 
+| --- | --- | --- | --- |
 | "u_learn_martial_art" / "npc_learn_martial_art" | **mandatory** | string or [variable object](#variable-object) | martial art, that would be learned |
 
 ##### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 ##### Examples
-The character learn Eskrima 
+The character learn Eskrima
 ```jsonc
 { "u_learn_martial_art": "style_eskrima" }
 ```
@@ -3383,17 +3383,17 @@ Character learn martial art, stored in `ma_id` context value
 Your character or the NPC will forget the martial art style.
 
 | Syntax | Optionality | Value  | Info |
-| --- | --- | --- | --- | 
+| --- | --- | --- | --- |
 | "u_forget_martial_art" / "npc_forget_martial_art" | **mandatory** | string or [variable object](#variable-object) | id of martial art to forget |
 
 ##### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 ##### Examples
-Character forget Eskrima 
+Character forget Eskrima
 ```jsonc
 { "u_forget_martial_art": "style_eskrima" }
 ```
@@ -3408,17 +3408,17 @@ Character forget martial art, stored in `ma_id` context value
 Save a string as personal variable, that you can check later using `compare_string` (see [Player or NPC conditions](#Player_or_NPC_conditions) )
 
 | Syntax | Optionality | Value  | Info |
-| --- | --- | --- | --- | 
+| --- | --- | --- | --- |
 | "u_add_var" / "npc_add_var" | **mandatory** | string | name of variable, where the value would be stored |
-| "value" | **mandatory** | string | value, that would be stored in variable; **incompatible with "possible_values" and "time"** | 
-| "possible_values" | **mandatory** | string array | array of values, that could be picked to be stored in variable; **incompatible with "value" and "time"** | 
-| "time" | **mandatory** | boolean | **DEPRECATED. use time() math syntax instead**. default false; if true, the current time would be saved in variable; **incompatible with "value" and "possible_values"** | 
-| "type", "context" | optional | string | **DEPRECATED. JUST USE _add_var to give the name of the variable**. additional text to describe your variable, can be used in `u_lose_var` or in `math` syntax, as `type`\_`context`\_`variable_name` |  
+| "value" | **mandatory** | string | value, that would be stored in variable; **incompatible with "possible_values" and "time"** |
+| "possible_values" | **mandatory** | string array | array of values, that could be picked to be stored in variable; **incompatible with "value" and "time"** |
+| "time" | **mandatory** | boolean | **DEPRECATED. use time() math syntax instead**. default false; if true, the current time would be saved in variable; **incompatible with "value" and "possible_values"** |
+| "type", "context" | optional | string | **DEPRECATED. JUST USE _add_var to give the name of the variable**. additional text to describe your variable, can be used in `u_lose_var` or in `math` syntax, as `type`\_`context`\_`variable_name` |
 
 ##### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
 
 Note: numeric vars can be set (and check) to monsters via `math` functions.  See the example below.
@@ -3443,7 +3443,7 @@ For example:
 { "u_add_var": "number_artisans_gunsmith_ammo_ammount", "value": "800" }
 ```
 could be moved to:
-```json  
+```json
 [ "u_number_artisans_gunsmith_ammo_amount = 800" ]
 ```
 
@@ -3496,14 +3496,14 @@ Setting and checking monster vars via `math`.  The first spell targets a monster
 Your character or the NPC will clear any stored variable that has the same name, `type` and `context`
 
 | Syntax | Optionality | Value  | Info |
-| --- | --- | --- | --- | 
+| --- | --- | --- | --- |
 | "u_lose_var", "npc_lose_var" | **mandatory** | string | variable to be removed |
 | "type", "context" | optional | string | additional text to describe your variable; not mandatory, but required to remove correct variable |
 
 ##### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
 
 ##### Examples
@@ -3522,9 +3522,9 @@ Character remove variable `bio_blade_electric_on`
 Read curent value of a variable and copy it to another, regardless of its type.
 
 | Syntax | Optionality | Value  | Info |
-| --- | --- | --- | --- | 
+| --- | --- | --- | --- |
 | "copy_var" | **mandatory** | [variable object](#variable-object) | source variable |
-| "target_var" | **mandatory** | [variable object](#variable-object) | target variable | 
+| "target_var" | **mandatory** | [variable object](#variable-object) | target variable |
 
 #### Valid talkers:
 
@@ -3541,11 +3541,11 @@ Store string from `set_string_var` in the variable object `target_var`
 
 
 | Syntax | Optionality | Value  | Info |
-| --- | --- | --- | --- | 
+| --- | --- | --- | --- |
 | "set_string_var" | **mandatory** | string, [mutator](NPCs.md#mutators), or array of both | value, that would be put into `target_var` |
-| "target_var" | **mandatory** | [variable object](#variable-object) | variable, that accept the value; usually `context_val` | 
-| "parse_tags" | optional | boolean | Allo if parse [custom entries](NPCs.md#customizing-npc-speech) in string before storing | 
-| "i18n"       | optional | boolean | Whether the string values should be localized | 
+| "target_var" | **mandatory** | [variable object](#variable-object) | variable, that accept the value; usually `context_val` |
+| "parse_tags" | optional | boolean | Allo if parse [custom entries](NPCs.md#customizing-npc-speech) in string before storing |
+| "i18n"       | optional | boolean | Whether the string values should be localized |
 | "string_input" | optional | object | Accepts user input. When using `string_input`, the user will input a string and assign it to `target_var`. If the input is canceled, the value in `set_string_var` will be assigned as the default value. See details in the table below. |
 
 ##### String Input Details
@@ -3562,7 +3562,7 @@ Store string from `set_string_var` in the variable object `target_var`
 ##### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |  
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
 
 ##### Examples
@@ -3614,14 +3614,14 @@ Get the user input
 Create a context value with condition, that you can pass down the next topic or EoC, using `get_condition`. Used, if you need to have dozens of EoCs, and you don't want to copy-paste it's conditions every time (also it's easier to maintain or edit one condition, comparing to two dozens)
 
 | Syntax | Optionality | Value  | Info |
-| --- | --- | --- | --- | 
+| --- | --- | --- | --- |
 | "set_condition" | **mandatory** | string or [variable object](#variable-object) | id of condition |
-| "condition" | **mandatory** | [dialogue condition](#dialogue-conditions) | condition itself | 
+| "condition" | **mandatory** | [dialogue condition](#dialogue-conditions) | condition itself |
 
 ##### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
 
 ##### Examples
@@ -3648,22 +3648,22 @@ Save the condition  `season is not winter, and it is a daytime` into `random_enc
 Search a specific coordinates of map around `u_`, `npc_` or `target_params` and save them in [variable](#variable-object)
 
 | Syntax | Optionality | Value | Info |
-| --- | --- | --- | --- | 
-| "u_location_variable" / "npc_location_variable" | **mandatory** | [variable object](#variable-object) | variable, where the location would be saved | 
-| "min_radius", "max_radius" | optional | int, float or [variable object](#variable-object) | default 0; radius around the player or NPC, where the location would be searched | 
-| "outdoor_only" | optional | boolean | default false; if true, only outdoor values would be picked | 
-| "passable_only" | optional | boolean | default false; if true, only passable values would be picked | 
-| "target_params" | optional | assign_mission_target | if used, the search would be performed not from `u_` or `npc_` location, but from `mission_target`. it uses an [assign_mission_target](MISSIONS_JSON.md) syntax | 
-| "x_adjust", "y_adjust", "z_adjust" | optional | int, float or [variable object](#variable-object) | add this amount to `x`, `y` or `z` coordinate in the end; `"x_adjust": 2` would save the coordinate with 2 tile shift to the right from targeted | 
-| "z_override" | optional | boolean | default is false; if true, instead of adding up to `z` level, override it with absolute value; `"z_adjust": 3` with `"z_override": true` turn the value of `z` to `3` | 
-| "terrain" / "furniture" / "field" / "trap" / "monster" / "zone" / "npc" | optional | string or [variable object](#variable-object) | if used, search the entity with corresponding id between `target_min_radius` and `target_max_radius`; if empty string is used (e.g. `"monster": ""`), return any entity from the same radius  | 
-| "target_min_radius", "target_max_radius" | optional | int, float or [variable object](#variable-object) | default 0, min and max radius for search, if previous field was used | 
-| "true_eocs", "false_eocs" | optional | string, [variable object](#variable-object), inline EoC, or range of all of them | if the location was found, all EoCs from `true_eocs` are run, otherwise all EoCs from `false_eocs` are run | 
+| --- | --- | --- | --- |
+| "u_location_variable" / "npc_location_variable" | **mandatory** | [variable object](#variable-object) | variable, where the location would be saved |
+| "min_radius", "max_radius" | optional | int, float or [variable object](#variable-object) | default 0; radius around the player or NPC, where the location would be searched |
+| "outdoor_only" | optional | boolean | default false; if true, only outdoor values would be picked |
+| "passable_only" | optional | boolean | default false; if true, only passable values would be picked |
+| "target_params" | optional | assign_mission_target | if used, the search would be performed not from `u_` or `npc_` location, but from `mission_target`. it uses an [assign_mission_target](MISSIONS_JSON.md) syntax |
+| "x_adjust", "y_adjust", "z_adjust" | optional | int, float or [variable object](#variable-object) | add this amount to `x`, `y` or `z` coordinate in the end; `"x_adjust": 2` would save the coordinate with 2 tile shift to the right from targeted |
+| "z_override" | optional | boolean | default is false; if true, instead of adding up to `z` level, override it with absolute value; `"z_adjust": 3` with `"z_override": true` turn the value of `z` to `3` |
+| "terrain" / "furniture" / "field" / "trap" / "monster" / "zone" / "npc" | optional | string or [variable object](#variable-object) | if used, search the entity with corresponding id between `target_min_radius` and `target_max_radius`; if empty string is used (e.g. `"monster": ""`), return any entity from the same radius  |
+| "target_min_radius", "target_max_radius" | optional | int, float or [variable object](#variable-object) | default 0, min and max radius for search, if previous field was used |
+| "true_eocs", "false_eocs" | optional | string, [variable object](#variable-object), inline EoC, or range of all of them | if the location was found, all EoCs from `true_eocs` are run, otherwise all EoCs from `false_eocs` are run |
 
 ##### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
 
 ##### Examples
@@ -3723,17 +3723,17 @@ Check the map 26 tiles around to find `fd_fire`; if fire is presented, prints it
 Allow adjust location value, obtained by `u_location_variable`, and share the same syntax and rules
 
 | Syntax | Optionality | Value | Info |
-| --- | --- | --- | --- | 
-| "location_variable_adjust" | **mandatory** | [variable object](#variable-object) | variable, where the location would be saved | 
-| "x_adjust", "y_adjust", "z_adjust" | optional | int, float or [variable object](#variable-object) | add this amount to `x`, `y` or `z` coordinate in the end; `"x_adjust": 2` would save the coordinate with 2 tile shift to the right from targeted | 
-| "z_override" | optional | boolean | default is false; if true, instead of adding up to `z` level, override it with absolute value; `"z_adjust": 3` with `"z_override": true` turn the value of `z` to `3` | 
-| "overmap_tile" | optional | boolean | default is false; if true, the adjustments will be made in overmap tiles rather than map tiles | 
+| --- | --- | --- | --- |
+| "location_variable_adjust" | **mandatory** | [variable object](#variable-object) | variable, where the location would be saved |
+| "x_adjust", "y_adjust", "z_adjust" | optional | int, float or [variable object](#variable-object) | add this amount to `x`, `y` or `z` coordinate in the end; `"x_adjust": 2` would save the coordinate with 2 tile shift to the right from targeted |
+| "z_override" | optional | boolean | default is false; if true, instead of adding up to `z` level, override it with absolute value; `"z_adjust": 3` with `"z_override": true` turn the value of `z` to `3` |
+| "overmap_tile" | optional | boolean | default is false; if true, the adjustments will be made in overmap tiles rather than map tiles |
 
 
 ##### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
 
 ##### Examples
@@ -3759,7 +3759,7 @@ Opens a menu allowing the player to choose a new hair style
 ##### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ❌ | ❌ | ❌ | ❌ | ❌ |
 
 ##### Examples
@@ -3783,7 +3783,7 @@ Opens a menu allowing the player to choose a new beard style.
 ##### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ❌ | ❌ | ❌ | ❌ | ❌ |
 
 ##### Examples
@@ -3803,7 +3803,7 @@ Opens a menu allowing the player to choose a new beard style.
 {
   "type": "effect_on_condition",
   "id": "test",
-  "effect": [ "barber_hair", "barber_beard" ] 
+  "effect": [ "barber_hair", "barber_beard" ]
 }
 ```
 
@@ -3812,13 +3812,13 @@ Opens a menu allowing the player to choose a new beard style.
 Your character or the npc will learn and memorize the recipe
 
 | Syntax | Optionality | Value  | Info |
-| --- | --- | --- | --- | 
+| --- | --- | --- | --- |
 | "u_learn_recipe" / "npc_learn_recipe" | **mandatory** | string or [variable object](#variable-object) | Recipe, that would be learned |
 
 ##### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 ##### Examples
@@ -3837,7 +3837,7 @@ You learn a recipe, that was passes by `recipe_id` context value
 Your character or the npc will forget the recipe
 
 | Syntax | Optionality | Value  | Info |
-| --- | --- | --- | --- | 
+| --- | --- | --- | --- |
 | "u_forget_recipe" / "npc_forget_recipe" | **mandatory** | string or [variable object](#variable-object) | recipe/recipe category to be forgotten |
 | "category" | optional, defaults to false unless subcategory is specified | bool | whether the above field should be interpreted as a category instead of a singular recipe |
 | "subcategory" | optional | string or [variable object](#variable-object) | recipe subcategory of the specified category to be forgotten |
@@ -3845,7 +3845,7 @@ Your character or the npc will forget the recipe
 ##### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 ##### Examples
@@ -3874,13 +3874,13 @@ You forget a recipe, that was passes by `recipe_id` context value
 Changes the initial talk_topic of the NPC in all future dialogues.
 
 | Syntax | Optionality | Value  | Info |
-| --- | --- | --- | --- | 
+| --- | --- | --- | --- |
 | "npc_first_topic" | **mandatory** | string or [variable object](#variable-object)  | topic, that would be used |
 
 ##### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ❌ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 ##### Examples
@@ -3895,13 +3895,13 @@ Your character or the NPC will be wet as if they were in the rain.
 
 
 | Syntax | Optionality | Value  | Info |
-| --- | --- | --- | --- | 
+| --- | --- | --- | --- |
 | "u_add_wet" / "npc_add_wet" | **mandatory** | int, float or [variable object](#variable-object) | How much wetness would be added (in percent) |
 
 ##### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 ##### Examples
@@ -3915,18 +3915,18 @@ Makes you 10% wet (whatever that means)
 Emit a sound
 
 | Syntax | Optionality | Value  | Info |
-| --- | --- | --- | --- | 
+| --- | --- | --- | --- |
 | "u_make_sound" / "npc_make_sound" | **mandatory** | string or [variable object](#variable-object) | description of the sound |
-| "volume" | **mandatory** | int, float or [variable object](#variable-object) | how loud the sound is (1 unit = 1 tile around the character) | 
-| "type" | **mandatory** | string or [variable object](#variable-object) | Type of the sound; Could be one of `background`, `weather`, `music`, `movement`, `speech`, `electronic_speech`, `activity`, `destructive_activity`, `alarm`, `combat`, `alert`, or `order` | 
-| "target_var" | optional | [variable object](#variable-object) | if set, the center of the sound would be centered in this variable's coordinates instead of you or NPC | 
-| "snippet" | optional | boolean | default false; if true, `_make_sound` would use a snippet of provided id instead of a message | 
-| "same_snippet" | optional | boolean | default false; if true, it will connect the talker and snippet, and will always provide the same snippet, if used by this talker; require snippets to have id's set | 
+| "volume" | **mandatory** | int, float or [variable object](#variable-object) | how loud the sound is (1 unit = 1 tile around the character) |
+| "type" | **mandatory** | string or [variable object](#variable-object) | Type of the sound; Could be one of `background`, `weather`, `music`, `movement`, `speech`, `electronic_speech`, `activity`, `destructive_activity`, `alarm`, `combat`, `alert`, or `order` |
+| "target_var" | optional | [variable object](#variable-object) | if set, the center of the sound would be centered in this variable's coordinates instead of you or NPC |
+| "snippet" | optional | boolean | default false; if true, `_make_sound` would use a snippet of provided id instead of a message |
+| "same_snippet" | optional | boolean | default false; if true, it will connect the talker and snippet, and will always provide the same snippet, if used by this talker; require snippets to have id's set |
 
 ##### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
 
 ##### Examples
@@ -3955,14 +3955,14 @@ Would pick a random swear from `<swear>` snippet, and always would be the same (
 Increases or decreases your healthiness (respond for disease immunity and regeneration).
 
 | Syntax | Optionality | Value  | Info |
-| --- | --- | --- | --- | 
+| --- | --- | --- | --- |
 | "u_mod_healthy" / "npc_mod_healthy" | **mandatory** | int, float or [variable object](#variable-object) | Amount of health to be added |
-| "cap" | optional | int, float or [variable object](#variable-object) | cap for healthiness, beyond which it can't go further | 
+| "cap" | optional | int, float or [variable object](#variable-object) | cap for healthiness, beyond which it can't go further |
 
 ##### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 ##### Examples
@@ -3977,18 +3977,18 @@ Your character or the NPC will gain a morale bonus
 
 
 | Syntax | Optionality | Value  | Info |
-| --- | --- | --- | --- | 
+| --- | --- | --- | --- |
 | "u_add_morale" / "npc_add_morale" | **mandatory** | string or [variable object](#variable-object) | `morale_type`, that would be given by effect |
-| "bonus" | **mandatory** | int, [variable object](#variable-object) or array of both | default 1; mood bonus or penalty, that would be given by effect; can be stacked up to `max_bonus` cap, but each bonus is lower than previous (e.g. `bonus` of 100 gives mood bonus as 100, 141, 172, 198, 221 and so on) | 
-| "max_bonus" | **mandatory** | int, [variable object](#variable-object) or array of both | default false; cap, beyond which mood won't increase or decrease | 
-| "duration" | optional | int, duration or [variable object](#variable-object) | default 1 hour; how long the morale effect would last | 
-| "decay_start" | optional | int, duration or [variable object](#variable-object) | default 30 min; when the morale effect would start to decay | 
-| "capped" | optional | boolean | default false; if true, `bonus` is not decreased when stacked (e.g. `bonus` of 100 gives mood bonus as 100, 200, 300 and so on) |  
+| "bonus" | **mandatory** | int, [variable object](#variable-object) or array of both | default 1; mood bonus or penalty, that would be given by effect; can be stacked up to `max_bonus` cap, but each bonus is lower than previous (e.g. `bonus` of 100 gives mood bonus as 100, 141, 172, 198, 221 and so on) |
+| "max_bonus" | **mandatory** | int, [variable object](#variable-object) or array of both | default false; cap, beyond which mood won't increase or decrease |
+| "duration" | optional | int, duration or [variable object](#variable-object) | default 1 hour; how long the morale effect would last |
+| "decay_start" | optional | int, duration or [variable object](#variable-object) | default 30 min; when the morale effect would start to decay |
+| "capped" | optional | boolean | default false; if true, `bonus` is not decreased when stacked (e.g. `bonus` of 100 gives mood bonus as 100, 200, 300 and so on) |
 
 ##### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 ##### Examples
@@ -4015,13 +4015,13 @@ gives +20 mood `morale_feeling_good` bonus, that can be stacked up to +50, for 4
 Your character or the NPC will lose picked `morale_type`
 
 | Syntax | Optionality | Value  | Info |
-| --- | --- | --- | --- | 
+| --- | --- | --- | --- |
 | "u_lose_morale" / "npc_lose_morale" | **mandatory** | string or [variable object](#variable-object) | thought to remove |
 
 ##### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 ##### Examples
@@ -4030,7 +4030,7 @@ removes `bad_mood` morale from you
 { "u_lose_morale": "bad_mood" }
 ```
 
-removes morale type, delivered by `morale_id` 
+removes morale type, delivered by `morale_id`
 ```jsonc
 { "u_lose_morale": { "context_val": "morale_id" } }
 ```
@@ -4043,7 +4043,7 @@ Effect does not validate do player actually has enough items to consume, use `_h
 See examples for more info
 
 | Syntax | Optionality | Value  | Info |
-| ------ | ----------- | ------ | ---- | 
+| ------ | ----------- | ------ | ---- |
 | "u_unset_flag" / "npc_unset_flag" | **mandatory** | array of pairs, in pair is string or [variable object](#variable-object) | runs the effect |
 | "item"  | **mandatory** | string or [variable object](#variable-object) | id of item that should be removed |
 | "amount"  | **mandatory** | int or [variable object](#variable-object) | amount of items or charges that should be removed |
@@ -4051,7 +4051,7 @@ See examples for more info
 ##### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |   
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 ##### Examples
@@ -4117,20 +4117,20 @@ Variables are also supported
 
 #### `u_set_fac_relation`, `npc_set_fac_relation`
 Can be used only in `talk_topic`, as the code relies on the NPC you talk with to obtain info about it's faction.
- 
+
  | Syntax | Optionality | Value  | Info |
-| --- | --- | --- | --- | 
+| --- | --- | --- | --- |
 | "u_set_fac_relation" / "npc_set_fac_relation" | **mandatory** | string or [variable object](#variable-object) | Rule to set. See [the factions doc](FACTIONS.md#faction-relations) for a list of rules and what they cover.  |
-| "set_value_to" | optional | boolean | default true; Whether to set, or unset, this rule. | 
+| "set_value_to" | optional | boolean | default true; Whether to set, or unset, this rule. |
 
 ##### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |    
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 ##### Examples
-Adds the "share public goods" rule 
+Adds the "share public goods" rule
 ```jsonc
 { "u_set_fac_relation": "share public goods" }
 ```
@@ -4144,13 +4144,13 @@ Removes the "kill on sight" rule
  Your character gains trust with the speaking NPC's faction, which affects which items become available for trading from shopkeepers of that faction. Can be used only in `talk_topic`, as the code relies on the NPC you talk with to obtain info about it's faction
 
 | Syntax | Optionality | Value  | Info |
-| --- | --- | --- | --- | 
+| --- | --- | --- | --- |
 | "u_add_faction_trust" | **mandatory** | int, float or [variable object](#variable-object) | amount of trust to give or remove |
 
 ##### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ❌ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 ##### Examples
@@ -4168,23 +4168,23 @@ adds [ your strength stat ] amount of faction trust
 Display a text message in the log. `u_message` and `npc_message` display a message only if you or NPC is avatar. `message` always displays a message.
 
 | Syntax | Optionality | Value  | Info |
-| --- | --- | --- | --- | 
+| --- | --- | --- | --- |
 | "u_message" / "npc_message" / "message" | **mandatory** | string or [variable object](#variable-object) | message, that would be printed; If `snippet` is true, id of a snippet that would be printed.  Custom [tags](./NPCs.md#special-custom-entries) can be added to the message. |
-| "type" | optional | string or [variable object](#variable-object) | default neutral; how the message would be displayed in log (usually means the color); could be any of good (green), neutral (white), bad (red), mixed (purple), warning (yellow), info (blue), debug (appear only if debug mode is on), headshot (purple), critical (yellow), grazing (blue) | 
-| "sound" | optional | boolean | default false; if true, shows message only if player is not deaf | 
-| "outdoor_only" | optional | boolean | default false; if true, and `sound` is true, the message is harder to hear if you are underground | 
-| "snippet" | optional | boolean | default false; if true, the effect instead display a random snippet from `u_message` | 
-| "store_in_lore" | optional | boolean | default false; if true, and message is snippet, the snippet would be stored in lore tab | 
-| "same_snippet" | optional | boolean | default false; if true, and `snippet` is true, it will connect the talker and snippet, and will always provide the same snippet, if used by this talker; require snippets to have id's set | 
-| "popup" | optional | boolean | default false; if true, the message would generate a popup with `u_message` | 
-| "popup_flag" | optional | string | default PF_NONE; if specified, the popup is modified by the specified flag, for allowed values see below | 
-| "popup_w_interrupt_query" | optional | boolean | default false; if true, and `popup` is true, the popup will interrupt any activity to send a message | 
-| "interrupt_type" | optional | boolean | default is "neutral"; `distraction_type`, that would be used to interrupt, one that used in distraction manager; full list exist inactivity_type.cpp | 
+| "type" | optional | string or [variable object](#variable-object) | default neutral; how the message would be displayed in log (usually means the color); could be any of good (green), neutral (white), bad (red), mixed (purple), warning (yellow), info (blue), debug (appear only if debug mode is on), headshot (purple), critical (yellow), grazing (blue) |
+| "sound" | optional | boolean | default false; if true, shows message only if player is not deaf |
+| "outdoor_only" | optional | boolean | default false; if true, and `sound` is true, the message is harder to hear if you are underground |
+| "snippet" | optional | boolean | default false; if true, the effect instead display a random snippet from `u_message` |
+| "store_in_lore" | optional | boolean | default false; if true, and message is snippet, the snippet would be stored in lore tab |
+| "same_snippet" | optional | boolean | default false; if true, and `snippet` is true, it will connect the talker and snippet, and will always provide the same snippet, if used by this talker; require snippets to have id's set |
+| "popup" | optional | boolean | default false; if true, the message would generate a popup with `u_message` |
+| "popup_flag" | optional | string | default PF_NONE; if specified, the popup is modified by the specified flag, for allowed values see below |
+| "popup_w_interrupt_query" | optional | boolean | default false; if true, and `popup` is true, the popup will interrupt any activity to send a message |
+| "interrupt_type" | optional | boolean | default is "neutral"; `distraction_type`, that would be used to interrupt, one that used in distraction manager; full list exist inactivity_type.cpp |
 
 ##### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
 
 ##### popup_flag
@@ -4193,7 +4193,7 @@ Display a text message in the log. `u_message` and `npc_message` display a mess
 `PF_FULLSCREEN` makes the window have a size of `FULL_SCREEN_WIDTH` by `FULL_SCREEN_HEIGHT`. The `FULL_SCREEN` part is a misnomer from legacy code as the popup is not actually full-screen.
 
 ##### Examples
-Send a red-colored `Bad json! Bad!` message in the log 
+Send a red-colored `Bad json! Bad!` message in the log
 ```jsonc
 { "u_message": "Bad json! Bad!", "type": "bad" }
 ```
@@ -4210,28 +4210,28 @@ Print `uninvasive text` as a centre aligned popup at the top of the screen.
 
 Print a text with a context variable
 ```jsonc
-  { "u_message": "Test event with trait_id FIRE! <context_val:trait_id>", "type": "good" } 
+  { "u_message": "Test event with trait_id FIRE! <context_val:trait_id>", "type": "good" }
 ```
 
 #### `u_cast_spell`, `npc_cast_spell`
-You or NPC cast a spell. The spell uses fake spell data (ignore `energy_cost`, `energy_source`, `cast_time`, `components`, `difficulty` and `spell_class` fields), and uses additional fields 
+You or NPC cast a spell. The spell uses fake spell data (ignore `energy_cost`, `energy_source`, `cast_time`, `components`, `difficulty` and `spell_class` fields), and uses additional fields
 
 | Syntax | Optionality | Value  | Info |
-| --- | --- | --- | --- | 
+| --- | --- | --- | --- |
 | "u_cast_spell" / "npc_cast_spell" | **mandatory** | `fake_spell` | information of what spell and how it should be casted; next field can be used: |
-| "id" | **mandatory** | string or [variable object](#variable-object) | part of `_cast_spell`; define the id of spell to cast | 
-| "hit_self" | optional | boolean | part of `_cast_spell`; default false; if true, the spell could affect the caster (either as self damage from AoE spell, or as applying effect for buff spell) | 
-| "message" | optional | string or [variable object](#variable-object) | part of `_cast_spell`; message to send when spell is casted | 
-| "npc_message" | optional | string or [variable object](#variable-object) | part of `_cast_spell`; message if npc uses | 
-| "min_level", "max_level" | optional | int, float or [variable object](#variable-object) | part of `_cast_spell`; level of the spell that would be casted (min level define what the actual spell level would be casted, adding max_level make EoC pick a random level between min and max) | 
-| "targeted" | optional | boolean | default false; if true, allow you to aim casted spell, otherwise cast it in the location set by "loc" | 
+| "id" | **mandatory** | string or [variable object](#variable-object) | part of `_cast_spell`; define the id of spell to cast |
+| "hit_self" | optional | boolean | part of `_cast_spell`; default false; if true, the spell could affect the caster (either as self damage from AoE spell, or as applying effect for buff spell) |
+| "message" | optional | string or [variable object](#variable-object) | part of `_cast_spell`; message to send when spell is casted |
+| "npc_message" | optional | string or [variable object](#variable-object) | part of `_cast_spell`; message if npc uses |
+| "min_level", "max_level" | optional | int, float or [variable object](#variable-object) | part of `_cast_spell`; level of the spell that would be casted (min level define what the actual spell level would be casted, adding max_level make EoC pick a random level between min and max) |
+| "targeted" | optional | boolean | default false; if true, allow you to aim casted spell, otherwise cast it in the location set by "loc" |
 | "loc" | optional | [variable object](#variable-object) | Set target location of the spell. If not used, target to caster's location |
-| "true_eocs", "false_eocs" | optional | string, [variable object](#variable-object), inline EoC, or range of all of them | if spell was casted successfully, all EoCs from `true_eocs` are run, otherwise all EoCs from `false_eocs` are run | 
+| "true_eocs", "false_eocs" | optional | string, [variable object](#variable-object), inline EoC, or range of all of them | if spell was casted successfully, all EoCs from `true_eocs` are run, otherwise all EoCs from `false_eocs` are run |
 
 ##### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ |
 
 ##### Examples
@@ -4276,15 +4276,15 @@ You cast a `this_spell_can_target_only_robots` spell; if it success, `EOC_ROBOT_
 Modifies the levels of all known spells of a given class.
 
 | Syntax | Optionality | Value  | Info |
-| --- | --- | --- | --- | 
+| --- | --- | --- | --- |
 | "u_level_spell_class" / "npc_level_spell_class" | **mandatory** | `trait_id` | The `spell_class` that will be affected, can specifiy `"all"` instead of a class to affect all spells known by a character. |
-| "levels" | optional | int | Default value of `1` if unspecified.  The levels that will be added or removed from the affected class | 
+| "levels" | optional | int | Default value of `1` if unspecified.  The levels that will be added or removed from the affected class |
 | "random" | optional | boolean | Dafault value of `false`.  If true, only a single spell of the specified class will be affected. |
 
 ##### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 ##### Examples
@@ -4304,14 +4304,14 @@ The avatar levels up all spells of the MAGUS class by 5 levels, and a single spe
 NPC or character will start an activity
 
 | Syntax | Optionality | Value  | Info |
-| --- | --- | --- | --- | 
+| --- | --- | --- | --- |
 | "u_assign_activity" / "npc_assign_activity" | **mandatory** | string or [variable object](#variable-object), | id of activity to start |
-| "duration" | **mandatory** | int, duration or [variable object](#variable-object) | how long the activity would last | 
+| "duration" | **mandatory** | int, duration or [variable object](#variable-object) | how long the activity would last |
 
 ##### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 ##### Examples
@@ -4328,7 +4328,7 @@ NPC or character will stop their current activity
 ##### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |     
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 ##### Examples
@@ -4343,17 +4343,17 @@ You cancel activity `ACT_GAME` for 45 minutes
 You or NPC is teleported to `target_var` coordinates
 
 | Syntax | Optionality | Value  | Info |
-| --- | --- | --- | --- | 
+| --- | --- | --- | --- |
 | "u_teleport", / "npc_teleport" | **mandatory** | [variable object](#variable-object) | location to teleport; should use `target_var`, created previously |
-| "success_message" | optional | string or [variable object](#variable-object) | message, that would be printed, if teleportation was successful | 
-| "fail_message" | optional | string or [variable object](#variable-object) | message, that would be printed, if teleportation was failed, like if coordinates contained creature or impassable obstacle (like wall) | 
+| "success_message" | optional | string or [variable object](#variable-object) | message, that would be printed, if teleportation was successful |
+| "fail_message" | optional | string or [variable object](#variable-object) | message, that would be printed, if teleportation was failed, like if coordinates contained creature or impassable obstacle (like wall) |
 | "force" | optional | boolean | default false; if true, teleportation can't fail - any creature, that stand on target coordinates, would be brutally telefragged, and if impassable obstacle occur, the closest point would be picked instead |
 | "force_safe" | optional | boolean | default false; if true, teleportation cannot^(tm) fail.  If there is a creature or obstacle at the target coordinate, the closest passable point within 5 horizontal tiles is picked instead.  If there is no point, the creature remains where they are. |
 
 ##### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ❌ | ❌ | ✔️ | ✔️ |
 
 ##### Examples
@@ -4383,7 +4383,7 @@ Unloads the current dimension and loads the dimension with the specific ID, opti
 ##### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ❌ | ❌ | ❌ | ❌ | ❌ |
 
 
@@ -4404,10 +4404,10 @@ You teleport to a dimension with the ID of `test`, at the same position you're i
 Creates an explosion at talker position or at passed coordinate
 
 | Syntax | Optionality | Value  | Info |
-| --- | --- | --- | --- | 
+| --- | --- | --- | --- |
 | "u_explosion", / "npc_explosion" | **mandatory** | explosion_data | copies the `explosion` field from `"type": "ammo_effect"`, but allows to use variables; defines what type of explosion is occuring. |
-| "target_var" | optional | [variable object](#variable-object) | if used, explosion will occur where the variable point to | 
-| "emp_blast" | optional | bool | if used, the emp blast would appear at the center of the explosion (only at the center, no matter the size of explosion.  If you want the explosion to have an area, see examples below). Default false | 
+| "target_var" | optional | [variable object](#variable-object) | if used, explosion will occur where the variable point to |
+| "emp_blast" | optional | bool | if used, the emp blast would appear at the center of the explosion (only at the center, no matter the size of explosion.  If you want the explosion to have an area, see examples below). Default false |
 | "scrambler_blast" | optional | bool | if used, the scrambler blast would appear at the center of the explosion (only at the center, no matter the size of explosion). Default false |
 | "flashbang" | optional | bool | if used, the flashbang explosion happens. Default false |
 | "flashbang_avatar_is_immune" | optional | bool | if used with `flashbang`, the flashbang explosion won't affect the avatar (to protect alpha/beta talker, if they are not an avatar, other means need to be used, like FLASH_PROTECTION flag for character and FLASHBANGPROOF flag for monster ) |
@@ -4416,7 +4416,7 @@ Creates an explosion at talker position or at passed coordinate
 ##### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |    
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
 
 ##### Examples
@@ -4484,17 +4484,17 @@ You pick a tile using `u_query_tile`, pass it to `u_explosion`, with a flashbang
 Pushes the creature on the tile in specific direction
 
 | Syntax | Optionality | Value  | Info |
-| --- | --- | --- | --- | 
+| --- | --- | --- | --- |
 | "u_knockback", / "npc_knockback" | **mandatory** | int or [variable object](#variable-object) | how strong the push will be, in tiles |
 | "stun" | optional | int or [variable object](#variable-object) | how long `stunned` effect be applied on the talker |
 | "dam_mult" | optional | int or [variable object](#variable-object) | if target hit an obstacle in the middle of the knockback, it takes a damage and additional stun duraction equal to the knockback left multiplied by this dam_mult; if knockback is 10 (10 tiles), and creature hit an obstacle in 4 tiles, the rest 6 tiles would convert in 6 damage, multiplied by dam_mult (and adds 6 second of stun) |
-| "target_var" | optional | [variable object](#variable-object) | if used, instead of alpha or beta talker position, creature at this position will be sent flying | 
-| "direction_var" | optional | [variable object](#variable-object) | if used, the push would be calculated as coming from this direction (if creature is in the center, and direction_var is from west, the creature will be knockbacked to east ). If not used, the game would roll a random direction | 
+| "target_var" | optional | [variable object](#variable-object) | if used, instead of alpha or beta talker position, creature at this position will be sent flying |
+| "direction_var" | optional | [variable object](#variable-object) | if used, the push would be calculated as coming from this direction (if creature is in the center, and direction_var is from west, the creature will be knockbacked to east ). If not used, the game would roll a random direction |
 
 ##### Valid talkers:
 
 | Avatar | Character | NPC | Monster |  Furniture | Item |
-| ------  --------- | ---- | ------- | --- | 
+| ------ | --------- | ---- | ------- | --- |
 | ✔️ | ✔️ | ✔️ | ✔️ | ❌ | ❌ |
 
 ##### Examples
@@ -4533,20 +4533,20 @@ Store npc location in n_pos, then player picks a tile, centered around n_pos, to
 ```
 
 #### `u_query_omt`, `npc_query_omt`
-Opens a map, and allow you to pick an overmap tile to store in variable 
+Opens a map, and allow you to pick an overmap tile to store in variable
 
 | Syntax | Optionality | Value  | Info |
-| --- | --- | --- | --- | 
+| --- | --- | --- | --- |
 | "u_query_omt", / "npc_query_omt" | **mandatory** | [variable object](#variable-object) | variable, where coordinate be stored; if query is cancelled or player picks the tile farther than `distance_limit`, the variable is not stored, so conditoon like `{ "math": [ "has_var(_pos)" ] }` should be used to ensure variable was picked correctly |
-| "message" | **mandatory** | string or [variable object](#variable-object) | message, that is printed on upper left corner of overmap UI | 
-| "target_var" | optional | [variable object](#variable-object) | if set, the center is not where the avatar is, but this coordinate | 
-| "distance_limit" | optional | int or [variable object](#variable-object) | default infinite; radius, which player is able to pick, otherwise no variable is stored. The border is highlighted for user | 
+| "message" | **mandatory** | string or [variable object](#variable-object) | message, that is printed on upper left corner of overmap UI |
+| "target_var" | optional | [variable object](#variable-object) | if set, the center is not where the avatar is, but this coordinate |
+| "distance_limit" | optional | int or [variable object](#variable-object) | default infinite; radius, which player is able to pick, otherwise no variable is stored. The border is highlighted for user |
 | "spread" | optional | int or [variable object](#variable-object) | default 1; since map allows only precision of OMT level, the player choice is then converted to absolute coordinates, and adjusted to point to the center of overmap; spread respond for additional precision loss, "how far the tile gonna be picked from the center of OMT"; default value would result in you picking roughly the center of the OM |
 
 ##### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ❌ | ❌ | ❌ | ❌ | ❌ |
 
 ##### Examples
@@ -4605,17 +4605,17 @@ You pick a `distance_limit` using `num_input`, then open map, and if allowed OM 
 Ask the player to select a tile. If tile is selected, variable with coordinates is written in target_var;
 
 | Syntax | Optionality | Value  | Info |
-| --- | --- | --- | --- | 
+| --- | --- | --- | --- |
 | "u_query_tile", / "npc_query_tile" | **mandatory** | string | type of tile quering; possible values are:<br>- `anywhere` is the same as the "look around" UI <br>- `line_of_sight` only tiles that are visible at this moment (`range` is mandatory) |
-| "target_var" | optional | [variable object](#variable-object) | variable, where coordinate be stored; if query is cancelled, the variable is not stored, so conditoon like `{ "math": [ "has_var(_pos)" ] }` should be used to ensure variable was picked correctly | 
-| "range" | optional | int or [variable object](#variable-object) | defines the selectable range for `line_of_sight` (**mandatory** for `line_of_sight`, otherwise not required) | 
+| "target_var" | optional | [variable object](#variable-object) | variable, where coordinate be stored; if query is cancelled, the variable is not stored, so conditoon like `{ "math": [ "has_var(_pos)" ] }` should be used to ensure variable was picked correctly |
+| "range" | optional | int or [variable object](#variable-object) | defines the selectable range for `line_of_sight` (**mandatory** for `line_of_sight`, otherwise not required) |
 | "z_level" | optional | bool | if `anywhere` is picked, defines if you can pick tiles on another z-levels |
 | "message" | optional | string or [variable object](#variable-object) | text, that is displayed while selecting |
-| "center_var" | optional | [variable object](#variable-object) | if used, query would be centered around this coordinates, and not from talker current position. Works only for `anywhere` type | 
+| "center_var" | optional | [variable object](#variable-object) | if used, query would be centered around this coordinates, and not from talker current position. Works only for `anywhere` type |
 #### Valid talkers:
 
 | Avatar | Character | NPC | Monster |  Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ❌ | ❌ | ❌ | ❌ | ❌ |
 
 #### Examples
@@ -4633,9 +4633,9 @@ Display coordinates of selected tile.
 Allows to pick 9 tiles in close proximity to player
 
 | Syntax | Optionality | Value  | Info |
-| --- | --- | --- | --- | 
+| --- | --- | --- | --- |
 | "u_choose_adjacent_highlight", / "npc_choose_adjacent_highlight" | **mandatory** | [variable object](#variable-object) | variable, where coordinate be stored; if query is cancelled, player picks tile that is not allowed or cancels the input, the variable is not stored, so conditoon like `{ "math": [ "has_var(_pos)" ] }` should be used to ensure variable was picked correctly |
-| "target_var" | optional | [variable object](#variable-object) | if used, the 3x3 area would be centered not around talker, but around this point. Keybinds and picking would work as usually, you could pick it using numpad | 
+| "target_var" | optional | [variable object](#variable-object) | if used, the 3x3 area would be centered not around talker, but around this point. Keybinds and picking would work as usually, you could pick it using numpad |
 | "condition" | optional | condition | can be used to filter the specific tiles from the list. If not used, all tiles are allowed. Coordinates for tiles are stored in `loc` context variable, and checked one by one before showing to the player |
 | "allow_vertical" | optional | bool | if true, allows to pick tiles 1 z-level above or below. Default false |
 | "allow_autoselect" | optional | bool | if true, and there is only one matching result, and player has `AUTOSELECT_SINGLE_VALID_TARGET` on, the game gonna pick valid object automatically instead of asking player which one (literally) should be picked |
@@ -4646,7 +4646,7 @@ Allows to pick 9 tiles in close proximity to player
 #### Valid talkers:
 
 | Avatar | Character | NPC | Monster |  Furniture | Item |
-| ------  --------- | ---- | ------- | --- | 
+| ------ | --------- | ---- | ------- | --- |
 | ✔️ | ❌ | ❌ | ❌ | ❌ | ❌ |
 
 #### Examples
@@ -4693,15 +4693,15 @@ Allow to selects one tile with DIGGABLE flag around the u
 Picks two coordinates, and create a third one in opposite direction
 
 | Syntax | Optionality | Value  | Info |
-| --- | --- | --- | --- | 
-| "mirror_coordinates" | **mandatory** | [variable object](#variable-object) | variable, where the mirrored coordinate be stored | 
-| "center_var" | **mandatory** | [variable object](#variable-object) | variable with coordinates that would be the center between `relative_var` and `mirror_coordinates` | 
-| "relative_var" | **mandatory** | [variable object](#variable-object) | variable, that would be used to generate `mirror_coordinates` | 
+| --- | --- | --- | --- |
+| "mirror_coordinates" | **mandatory** | [variable object](#variable-object) | variable, where the mirrored coordinate be stored |
+| "center_var" | **mandatory** | [variable object](#variable-object) | variable with coordinates that would be the center between `relative_var` and `mirror_coordinates` |
+| "relative_var" | **mandatory** | [variable object](#variable-object) | variable, that would be used to generate `mirror_coordinates` |
 
 ##### Valid talkers:
 
 | Avatar | Character | NPC | Monster |  Furniture | Item |
-| ------  --------- | ---- | ------- | --- | 
+| ------ | --------- | ---- | ------- | --- |
 | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
 
 ##### Examples
@@ -4732,15 +4732,15 @@ Alpha or beta talker will instantly die.
 If the target is an item, it will be deleted.
 
 | Syntax | Optionality | Value  | Info |
-| --- | --- | --- | --- | 
-| "remove_corpse" | optional | bool | default false; if true, the corpse and all inside of it won't be spawned on death | 
-| "supress_message" | optional | bool | default false; if true, death would omit death message | 
-| "remove_from_creature_tracker" | optional | bool | default false; if true, and talker is monster, the monster instead removed from creature tracker, resulting not only in monster disappearing without message and corpse, but also bypasses any death effect they could fire before their death | 
+| --- | --- | --- | --- |
+| "remove_corpse" | optional | bool | default false; if true, the corpse and all inside of it won't be spawned on death |
+| "supress_message" | optional | bool | default false; if true, death would omit death message |
+| "remove_from_creature_tracker" | optional | bool | default false; if true, and talker is monster, the monster instead removed from creature tracker, resulting not only in monster disappearing without message and corpse, but also bypasses any death effect they could fire before their death |
 
 ##### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ✔️ | ❌ | ✔️ | ❌ |
 
 ##### Examples
@@ -4769,7 +4769,7 @@ You or NPC will be prevented from death. Intended for use in EoCs has `NPC_DEATH
 ##### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 ##### Examples
@@ -4802,16 +4802,16 @@ NPC is prevented from death.
 Alpha or beta talker forced to use a technique or special attack
 
 | Syntax | Optionality | Value  | Info |
-| --- | --- | --- | --- | 
+| --- | --- | --- | --- |
 | "u_attack" / "npc_attack" | **mandatory** | string, boolean or [variable object](#variable-object) | technique, that would be used; `"tec_none"` can be used, in this case a default autoattack would be used |
-| "allow_special" | optional | boolean | default true; if true, special attacks should be selected (`special_attack` that monsters can use, like `monster_attack` or `spell`) | 
-| "allow_unarmed" | optional | boolean | default true; if true, unarmed techniques can be considered | 
-| "forced_movecost" | optional | int or [variable object](#variable-object) | default -1; If used, attack will consume this amount of moves (100 moves = 1 second); negative value make it use the default movecost of attack | 
+| "allow_special" | optional | boolean | default true; if true, special attacks should be selected (`special_attack` that monsters can use, like `monster_attack` or `spell`) |
+| "allow_unarmed" | optional | boolean | default true; if true, unarmed techniques can be considered |
+| "forced_movecost" | optional | int or [variable object](#variable-object) | default -1; If used, attack will consume this amount of moves (100 moves = 1 second); negative value make it use the default movecost of attack |
 
 ##### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 ##### Examples
@@ -4863,13 +4863,13 @@ Picks random pankration technique, assign it to `pankration_random_attack`, and 
 Give item a flag
 
 | Syntax | Optionality | Value  | Info |
-| ------ | ----------- | ------ | ---- | 
+| ------ | ----------- | ------ | ---- |
 | "u_set_flag" / "npc_set_flag" | **mandatory** | string or [variable object](#variable-object) | id of flag that should be given |
 
 ##### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ❌ | ❌ | ❌ | ❌ | ✔️ | ❌ |
 
 ##### Examples
@@ -4882,13 +4882,13 @@ Make item filthy
 Remove a flag from item
 
 | Syntax | Optionality | Value  | Info |
-| ------ | ----------- | ------ | ---- | 
+| ------ | ----------- | ------ | ---- |
 | "u_unset_flag" / "npc_unset_flag" | **mandatory** | string or [variable object](#variable-object) | id of flag that should be remove |
 
 ##### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ❌ | ❌ | ❌ | ❌ | ✔️ | ❌ |
 
 ##### Examples
@@ -4901,14 +4901,14 @@ Make item clean
 You activate beta talker / NPC activates alpha talker. One must be a Character and the other an item.
 
 | Syntax | Optionality | Value  | Info |
-| ------ | ----------- | ------ | ---- | 
+| ------ | ----------- | ------ | ---- |
 | "u_activate" / "npc_activate" | **mandatory** | string or [variable object](#variable-object) |  use action id of item that activate |
-| "target_var" | optional | [variable object](#variable-object) | if set, target location is forced this variable's coordinates | 
+| "target_var" | optional | [variable object](#variable-object) | if set, target location is forced this variable's coordinates |
 
 ##### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
 
 ##### Examples
@@ -4921,15 +4921,15 @@ Force you consume drug item
 Applies a fault on item
 
 | Syntax | Optionality | Value  | Info |
-| ------ | ----------- | ------ | ---- | 
+| ------ | ----------- | ------ | ---- |
 | "u_set_fault" / "npc_set_fault" | **mandatory** | string or [variable object](#variable-object) | id of a fault applied |
-| "force" | optional | bool | if true, the fault is applied onto item even if item do not define it as possible fault. Default false | 
-| "message" | optional | bool | if truem the fault would print a message defined in fault `message` field. Default true | 
+| "force" | optional | bool | if true, the fault is applied onto item even if item do not define it as possible fault. Default false |
+| "message" | optional | bool | if truem the fault would print a message defined in fault `message` field. Default true |
 
 ##### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ❌ | ❌ | ❌ | ❌ | ✔️ | ❌ |
 
 ##### Examples
@@ -4942,15 +4942,15 @@ Beta talker adds `fault_electronic_blown_capacitor` as it's fault
 Picks a random fault from a type, and applies it onto item
 
 | Syntax | Optionality | Value  | Info |
-| ------ | ----------- | ------ | ---- | 
+| ------ | ----------- | ------ | ---- |
 | "u_set_random_fault_of_type" / "npc_set_random_fault_of_type" | **mandatory** | string or [variable object](#variable-object) | type of a fault applied |
-| "force" | optional | bool | if true, the fault is applied onto item even if item do not define it as possible fault. Default false | 
-| "message" | optional | bool | if truem the fault would print a message defined in fault `message` field. Default true | 
+| "force" | optional | bool | if true, the fault is applied onto item even if item do not define it as possible fault. Default false |
+| "message" | optional | bool | if truem the fault would print a message defined in fault `message` field. Default true |
 
 ##### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ❌ | ❌ | ❌ | ❌ | ✔️ | ❌ |
 
 ##### Examples
@@ -4965,7 +4965,7 @@ Beta talker adds a random fault from `shorted` type as it's fault
 Spawn and place the item
 
 | Syntax | Optionality | Value  | Info |
-| ------ | ----------- | ------ | ---- | 
+| ------ | ----------- | ------ | ---- |
 | "map_spawn_item" | **mandatory** | string or [variable object](#variable-object) | id of item or item group that should spawn |
 | "loc" | optional | [variable object](#variable-object) | Location that the item spawns. If not used, spawns from player's location |
 | "count" | optional | int or [variable object](#variable-object) | default 1; Number of item copies |
@@ -4994,11 +4994,11 @@ Map updates are related to  any change in the map, weather, or coordinates, and 
 Update the map with changes, described in `mapgen_update`
 
 | Syntax | Optionality | Value  | Info |
-| --- | --- | --- | --- | 
+| --- | --- | --- | --- |
 | "mapgen_update" | **mandatory** | string, [variable objects](#variable-object) or array | With no other parameters, update the overmap tile at player's current location with changes in `update_mapgen_id` id.  If array is used, the map would be updated for each id |
-| "time_in_future" | optional | int, duration, [variable object](#variable-object)) or value between two  | If used, the map change would be delayed for this amount of time.  "infinity" could be used, to make location not update until `key` event happen | 
-| "key" | optional | string or [variable object](#variable-object) | id of the event, that you can call outside of EoC to trigger map update.  Key should be [alter_timed_events](#alter_timed_events) | 
-| "target_var" | optional | [variable objects](#variable-object) | if used, the target from variable would be used instead of player's current location.  It uses [assign_mission_target](MISSIONS_JSON.md) syntax | 
+| "time_in_future" | optional | int, duration, [variable object](#variable-object)) or value between two  | If used, the map change would be delayed for this amount of time.  "infinity" could be used, to make location not update until `key` event happen |
+| "key" | optional | string or [variable object](#variable-object) | id of the event, that you can call outside of EoC to trigger map update.  Key should be [alter_timed_events](#alter_timed_events) |
+| "target_var" | optional | [variable objects](#variable-object) | if used, the target from variable would be used instead of player's current location.  It uses [assign_mission_target](MISSIONS_JSON.md) syntax |
 
 ##### Examples
 Update the map with `map_spawn_seller` map
@@ -5031,10 +5031,10 @@ Save picked location, and then restore it to this state
 Usually used as `revert_location` with `"time_in_future": "infinity"`, to save mold of location, and some `key`. Then `mapgen_update` is used to alter location. In the end,  `alter_timed_events` with `key`  is called to actually revert location.
 
 | Syntax | Optionality | Value  | Info |
-| --- | --- | --- | --- | 
+| --- | --- | --- | --- |
 | "revert_location" | **mandatory** | [variable object](#variable-object) | id of variable, where the location would be stored |
-| "time_in_future" | **mandatory** | int, duration, [variable object](#variable-object)) or value between two  | when the location should be reverted; "infinity" could be used, to make location not update until `key` event happen | 
-| "key" | optional | string or [variable objects](#variable-object) | id of the event, that you can call outside of EoC to trigger location reverse.  Key should be [alter_timed_events](#alter_timed_events) | 
+| "time_in_future" | **mandatory** | int, duration, [variable object](#variable-object)) or value between two  | when the location should be reverted; "infinity" could be used, to make location not update until `key` event happen |
+| "key" | optional | string or [variable objects](#variable-object) | id of the event, that you can call outside of EoC to trigger location reverse.  Key should be [alter_timed_events](#alter_timed_events) |
 
 ##### Examples
 Store `vitrified_farm_ground`. When `vitrified_farm_escape_key` is called, the location is reverted
@@ -5047,12 +5047,12 @@ Store `vitrified_farm_ground`. When `vitrified_farm_escape_key` is called, the l
 ```
 
 #### `alter_timed_events`
-All effects, that has this event as a `key`, would be triggered, if they did not yet.  Usually used with `mapgen_update` or `revert_location` with `"time_in_future": "infinite"` 
+All effects, that has this event as a `key`, would be triggered, if they did not yet.  Usually used with `mapgen_update` or `revert_location` with `"time_in_future": "infinite"`
 
 | Syntax | Optionality | Value  | Info |
-| --- | --- | --- | --- | 
+| --- | --- | --- | --- |
 | "alter_timed_events" | **mandatory** | string or [variable object](#variable-object) | id of the event, that you can call outside of EoC to trigger map update.  Key should be [alter_timed_events](#alter_timed_events) |
-| "time_in_future" | optional | int, duration, [variable object](#variable-object)) or value between two  | If used, all related effects would be triggered not instantly, but this amount of time after the trigger | 
+| "time_in_future" | optional | int, duration, [variable object](#variable-object)) or value between two  | If used, all related effects would be triggered not instantly, but this amount of time after the trigger |
 
 ##### Examples
 Trigger every effect, that has `portal_dungeon` as a key
@@ -5060,7 +5060,7 @@ Trigger every effect, that has `portal_dungeon` as a key
 { "alter_timed_events": "portal_dungeon" }
 ```
 
-for example, if this effect would exist, and `alter_timed_events` occur, the location would be reverted 
+for example, if this effect would exist, and `alter_timed_events` occur, the location would be reverted
 ```jsonc
 {
   "revert_location": { "global_val": "portal_dungeon" },
@@ -5079,10 +5079,10 @@ Forces a check for what weather it should be. Doesn't force the weather change i
 Sets the ambient light of the world for some amount of time, ignoring time or sun/moon light
 
 | Syntax | Optionality | Value  | Info |
-| --- | --- | --- | --- | 
+| --- | --- | --- | --- |
 | "custom_light_level" | **mandatory** | int, [variable object](#variable-object) or value between two | level of light from 0 to 125, where 0 is complete darkness, where 125 is daylight |
-| "length" | **mandatory** | int, duration, [variable object](#variable-object) or value between two | how long the effect would last | 
-| "key" | optional | string or [variable object](#variable-object) | id of the event, that you can call outside of EoC to trigger map update.  Key should be [alter_timed_events](#alter_timed_events) | 
+| "length" | **mandatory** | int, duration, [variable object](#variable-object) or value between two | how long the effect would last |
+| "key" | optional | string or [variable object](#variable-object) | id of the event, that you can call outside of EoC to trigger map update.  Key should be [alter_timed_events](#alter_timed_events) |
 
 ##### Examples
 Highlight the world for 1-10 seconds
@@ -5099,12 +5099,12 @@ Darken the world for 1 day or until `who_turn_off_the_light` would be triggered
 transform the territory around you, npc or target using `ter_furn_transform`
 
 | Syntax | Optionality | Value  | Info |
-| --- | --- | --- | --- | 
+| --- | --- | --- | --- |
 | "u_transform_radius" / "npc_transform_radius" | **mandatory** | int or [variable object](#variable-object) | range, where transformation occur |
-| "ter_furn_transform" | **mandatory** | string or [variable object](#variable-object) | [`ter_furn_transform`](#TER_FURN_TRANSFORM.md), that would be used to transform territory around | 
-| "target_var" | optional | [variable object](#variable-object) | if used, the target from variable would be used instead of player's current location.  It uses [assign_mission_target](MISSIONS_JSON.md) syntax | 
-| "time_in_future" | optional | int, duration, [variable object](#variable-object) or value between two | delay when the location should be transformed; "infinity" could be used, to make location not update until `key` event happen  | 
-| "key" | optional | string or [variable object](#variable-object)) | id of the event, that you can call outside of EoC to trigger map update.  Key should be [alter_timed_events](#alter_timed_events) | 
+| "ter_furn_transform" | **mandatory** | string or [variable object](#variable-object) | [`ter_furn_transform`](#TER_FURN_TRANSFORM.md), that would be used to transform territory around |
+| "target_var" | optional | [variable object](#variable-object) | if used, the target from variable would be used instead of player's current location.  It uses [assign_mission_target](MISSIONS_JSON.md) syntax |
+| "time_in_future" | optional | int, duration, [variable object](#variable-object) or value between two | delay when the location should be transformed; "infinity" could be used, to make location not update until `key` event happen  |
+| "key" | optional | string or [variable object](#variable-object)) | id of the event, that you can call outside of EoC to trigger map update.  Key should be [alter_timed_events](#alter_timed_events) |
 
 ##### Examples
 transform everything 5 tiles around player according to `merc_spike_transform`
@@ -5127,9 +5127,9 @@ transform the `door_transform` 2 tiles around player, according `detonate_the_do
 Transform terrain, furniture, fields or traps on a line between two coordinates
 
 | Syntax | Optionality | Value  | Info |
-| --- | --- | --- | --- | 
+| --- | --- | --- | --- |
 | "transform_line" | **mandatory** | string or [variable object](#variable-object) | [ter_furn_transform](TER_FURN_TRANSFORM.md), that would be used to transform terrain |
-| "first", "second" | **mandatory** | [variable object](#variable-object) | coordinates, created by `u_location_variable`, between which the line would be drawn | 
+| "first", "second" | **mandatory** | [variable object](#variable-object) | coordinates, created by `u_location_variable`, between which the line would be drawn |
 
 ##### Examples
 change the terrain between `point_0` and `point_1` according to `blood_trail` ter_furn_transform
@@ -5145,10 +5145,10 @@ change the terrain between `point_0` and `point_1` according to `blood_trail` te
 Override the current player location for some amount of time or until event would be called
 
 | Syntax | Optionality | Value  | Info |
-| --- | --- | --- | --- | 
+| --- | --- | --- | --- |
 | "place_override" | **mandatory** | string or [variable object](#variable-object) | new name of the location;  |
-| "length" | **mandatory** | int, duration, [variable object](#variable-object) or value between two | how long changed name would last; "infinity" could be used, to make location not revert until `key` event happen | 
-| "key" | optional | string or [variable object](#variable-object) | id of the event, that you can call outside of EoC to trigger map update.  Key should be [alter_timed_events](#alter_timed_events) | 
+| "length" | **mandatory** | int, duration, [variable object](#variable-object) or value between two | how long changed name would last; "infinity" could be used, to make location not revert until `key` event happen |
+| "key" | optional | string or [variable object](#variable-object) | id of the event, that you can call outside of EoC to trigger map update.  Key should be [alter_timed_events](#alter_timed_events) |
 
 ##### Examples
 change the name of your current location to `devilish place` to 11 minutes 6 seconds (666 seconds)
@@ -5182,23 +5182,23 @@ Set `place_name` to be one of five from a range randomly, then set it for `cell_
 Spawn some monsters around you, NPC or `target_var`
 
 | Syntax | Optionality | Value  | Info |
-| --- | --- | --- | --- | 
+| --- | --- | --- | --- |
 | "u_spawn_monster", "npc_spawn_monster" | **mandatory** | string or [variable object](#variable-object) | monster or monstergroup that would be spawned, using "" picks randomly from nearby monsters |
-| "real_count" | optional | int, [variable object](#variable-object) or value between two | default 0; amount of monsters, that would be spawned | 
+| "real_count" | optional | int, [variable object](#variable-object) or value between two | default 0; amount of monsters, that would be spawned |
 | "hallucination_count" | optional | int, [variable object](#variable-object) or value between two | default 0; amount of hallucination versions of the monster that would be spawned |
 | "group" | optional | boolean | default false; if true, `_spawn_monster` will spawn a monster from `monstergroup` |
-| "single_target" | optional | boolean | default false; if true, `_spawn_monster` the game pick only one monster from the provided `monstergroup` or from nearby monsters | 
-| "min_radius", "max_radius" | optional | int, [variable object](#variable-object) or value between two | default 1 and 10 respectively; range around the target, where the monster would spawn | 
-| "outdoor_only"/ "indoor_only" | optional | boolean | default false; if used, monsters would be able to spawn only outside or only inside buildings | 
-| "open_air_allowed" | optional | boolean | default false; if true, monsters can spawn in the open air | 
-| "target_range" | optional | int, [variable object](#variable-object) or value between two | if `_spawn_monster` is empty, pick a random hostile critter from this amount of tiles from target | 
-| "lifespan" | optional | int, duration, [variable object](#variable-object) or value between two | if used, critters would live that amount of time, and disappear in the end | 
-| "target_var" | optional | [variable object](#variable-object) | if used, the monster would spawn from this location instead of you or NPC | 
+| "single_target" | optional | boolean | default false; if true, `_spawn_monster` the game pick only one monster from the provided `monstergroup` or from nearby monsters |
+| "min_radius", "max_radius" | optional | int, [variable object](#variable-object) or value between two | default 1 and 10 respectively; range around the target, where the monster would spawn |
+| "outdoor_only"/ "indoor_only" | optional | boolean | default false; if used, monsters would be able to spawn only outside or only inside buildings |
+| "open_air_allowed" | optional | boolean | default false; if true, monsters can spawn in the open air |
+| "target_range" | optional | int, [variable object](#variable-object) or value between two | if `_spawn_monster` is empty, pick a random hostile critter from this amount of tiles from target |
+| "lifespan" | optional | int, duration, [variable object](#variable-object) or value between two | if used, critters would live that amount of time, and disappear in the end |
+| "target_var" | optional | [variable object](#variable-object) | if used, the monster would spawn from this location instead of you or NPC |
 | "temporary_drop_items" | optional | boolean | default false; if true, monsters summoned with a lifespan will still drop items and leave a corpse.
 | "mon_variables" | optional | [variable object](#variable-object) or [inline variables](#inline-variables) | if used, the monster would have this variables when spawned.
 | "summoner_is_alpha", "summoner_is_beta" | optional | bool | if used, the monster would define alpha/beta talker as it's summoner
-| "spawn_message", "spawn_message_plural" | optional | string or [variable object](#variable-object) | if you see monster or monsters that was spawned, related message would be printed | 
-| "true_eocs", "false_eocs" | optional | string, [variable object](#variable-object), inline EoC, or range of all of them | if at least 1 monster was spawned, all EoCs from `true_eocs` are run, otherwise all EoCs from `false_eocs` are run | 
+| "spawn_message", "spawn_message_plural" | optional | string or [variable object](#variable-object) | if you see monster or monsters that was spawned, related message would be printed |
+| "true_eocs", "false_eocs" | optional | string, [variable object](#variable-object), inline EoC, or range of all of them | if at least 1 monster was spawned, all EoCs from `true_eocs` are run, otherwise all EoCs from `false_eocs` are run |
 
 ##### Examples
 Spawn 2-5 zombies in range 3-24 around player with lifespan 40-120 seconds, with messages if player see spawn
@@ -5229,7 +5229,7 @@ spawns `mon_photokin_army_image`. assing alpha talker as it's summoner, and defi
   "u_spawn_monster": "mon_photokin_army_image",
   "real_count": [ { "math": [ "_real_count_low" ] }, { "math": [ "_real_count_high" ] } ],
   "summoner_is_alpha": true,
-  "mon_variables": { "can_do_backflips": "true" }, 
+  "mon_variables": { "can_do_backflips": "true" },
   "lifespan": "15 minutes",
   "min_radius": 1,
   "max_radius": 8
@@ -5240,22 +5240,22 @@ spawns `mon_photokin_army_image`. assing alpha talker as it's summoner, and defi
 Spawn some NPC near you or another NPC
 
 | Syntax | Optionality | Value  | Info |
-| --- | --- | --- | --- | 
+| --- | --- | --- | --- |
 | "u_spawn_npc", "npc_spawn_npc" | **mandatory** | string or [variable object](#variable-object) | class of NPC, that would be spawned |
-| "unique_id" | optional | string or [variable object](#variable-object) | --- | 
-| "traits" | optional | string, [variable object](#variable-object) or array | additional traits/mutations that NPC would have upon spawn | 
-| "real_count" | optional | int, [variable object](#variable-object) or value between two | default 0; amount of NPCs, that would be spawned | 
+| "unique_id" | optional | string or [variable object](#variable-object) | --- |
+| "traits" | optional | string, [variable object](#variable-object) or array | additional traits/mutations that NPC would have upon spawn |
+| "real_count" | optional | int, [variable object](#variable-object) or value between two | default 0; amount of NPCs, that would be spawned |
 | "hallucination_count" | optional | int, [variable object](#variable-object) or value between two | default 0; amount of hallucination versions of NPC that would be spawned |
-| "min_radius", "max_radius" | optional | int, [variable object](#variable-object) or value between two | default 1 and 10 respectively; range around the target, where the monster would spawn | 
-| "outdoor_only"/ "indoor_only" | optional | boolean | default false; if used, NPC would be able to spawn only outside or only inside buildings | 
-| "open_air_allowed" | optional | boolean | default false; if true, NPC can spawn in the open air | 
-| "lifespan" | optional | int, duration, [variable object](#variable-object) or value between two | if used, NPC would live that amount of time, and disappear in the end | 
-| "target_var" | optional | [variable object](#variable-object) | if used, the NPC would spawn from this location instead of you or NPC | 
-| "spawn_message", "spawn_message_plural" | optional | string or [variable object](#variable-object) | if you see NPC or NPCs that was spawned, related message would be printed | 
-| "true_eocs", "false_eocs" | optional | string, [variable object](#variable-object), inline EoC, or range of all of them | if at least 1 monster was spawned, all EoCs from `true_eocs` are run, otherwise all EoCs from `false_eocs` are run | 
+| "min_radius", "max_radius" | optional | int, [variable object](#variable-object) or value between two | default 1 and 10 respectively; range around the target, where the monster would spawn |
+| "outdoor_only"/ "indoor_only" | optional | boolean | default false; if used, NPC would be able to spawn only outside or only inside buildings |
+| "open_air_allowed" | optional | boolean | default false; if true, NPC can spawn in the open air |
+| "lifespan" | optional | int, duration, [variable object](#variable-object) or value between two | if used, NPC would live that amount of time, and disappear in the end |
+| "target_var" | optional | [variable object](#variable-object) | if used, the NPC would spawn from this location instead of you or NPC |
+| "spawn_message", "spawn_message_plural" | optional | string or [variable object](#variable-object) | if you see NPC or NPCs that was spawned, related message would be printed |
+| "true_eocs", "false_eocs" | optional | string, [variable object](#variable-object), inline EoC, or range of all of them | if at least 1 monster was spawned, all EoCs from `true_eocs` are run, otherwise all EoCs from `false_eocs` are run |
 
 ##### Examples
-Spawn 2 hallucination `portal_person`s, outdoor, 3-5 tiles around the player, for 1-3 minutes and with messages 
+Spawn 2 hallucination `portal_person`s, outdoor, 3-5 tiles around the player, for 1-3 minutes and with messages
 ```jsonc
 {
   "u_spawn_npc": "portal_person",
@@ -5273,14 +5273,14 @@ Spawn 2 hallucination `portal_person`s, outdoor, 3-5 tiles around the player, fo
 spawn a field in a square around player. it is recommended to not use it in favor of `u_transform_radius` or `u_emit` if possible
 
 | Syntax | Optionality | Value  | Info |
-| --- | --- | --- | --- | 
+| --- | --- | --- | --- |
 | "u_set_field", "npc_set_field" | **mandatory** | string or [variable object](#variable-object) | id of field to spawn around the player |
-| "intensity" | optional | int, [variable object](#variable-object) or value between two | default 1; intensity of field to spawn | 
-| "radius" | optional | int, [variable object](#variable-object) or value between two | default 10000000; radius of a field to spawn | 
-| "age" | optional | int, duration, [variable object](#variable-object) or value between two | how long the field would last | 
-| "outdoor_only"/ "indoor_only" | optional | boolean | default false; if used, field would be spawned only outside or only inside buildings | 
-| "hit_player" | optional | boolean | default true; if field spawn where the player is, process like player stepped on this field | 
-| "target_var" | optional | [variable object](#variable-object) | if used, the field would spawn from this location instead of you or NPC | 
+| "intensity" | optional | int, [variable object](#variable-object) or value between two | default 1; intensity of field to spawn |
+| "radius" | optional | int, [variable object](#variable-object) or value between two | default 10000000; radius of a field to spawn |
+| "age" | optional | int, duration, [variable object](#variable-object) or value between two | how long the field would last |
+| "outdoor_only"/ "indoor_only" | optional | boolean | default false; if used, field would be spawned only outside or only inside buildings |
+| "hit_player" | optional | boolean | default true; if field spawn where the player is, process like player stepped on this field |
+| "target_var" | optional | [variable object](#variable-object) | if used, the field would spawn from this location instead of you or NPC |
 
 ##### Examples
 Spawn blood 10 tiles around the player outdoor
@@ -5292,10 +5292,10 @@ Spawn blood 10 tiles around the player outdoor
 Emit a field using `type: emit`
 
 | Syntax | Optionality | Value  | Info |
-| --- | --- | --- | --- | 
+| --- | --- | --- | --- |
 | "u_emit", "npc_emit" | **mandatory** | string or [variable object](#variable-object) | id of emit that would be spawned |
-| "chance_mult" | optional | int, [variable object](#variable-object) or value between two | default 1; multiplies emit `chance` field on this number | 
-| "target_var" | optional | [variable object](#variable-object) | if used, the emission would spawn from this location instead of you or NPC | 
+| "chance_mult" | optional | int, [variable object](#variable-object) or value between two | default 1; multiplies emit `chance` field on this number |
+| "target_var" | optional | [variable object](#variable-object) | if used, the emission would spawn from this location instead of you or NPC |
 
 ##### Examples
 Spawn `emit_tear_gas_toad` (spawns 3 `fd_tear_gas`) with double of it's chance ( 15 * 2 = 30% chance ) around the player
@@ -5336,7 +5336,7 @@ Subtract this many turns from the alpha talker's moves.
 ##### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ❌ | ❌ | ❌ | ❌ | ❌ |
 
 
@@ -5365,7 +5365,7 @@ Convert the beta talker (which must be an item) into a different item, optionall
 ##### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
-| ------  --------- | ---- | ------- | --- | ---- |
+| ------ | --------- | ---- | ------- | --- | ---- |
 | ✔️ | ❌ | ❌ | ❌ | ❌ | ❌ |
 
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

For some reason a lot of markdown tables were missing a `|`.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Added the `|`.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

None. It had to be fixed.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Markdown table correctly generated with pandoc and vscodium markdown preview.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
