### PR TITLE
Remove semicolons after namespace

### DIFF
--- a/src/overmap_debug.cpp
+++ b/src/overmap_debug.cpp
@@ -122,4 +122,4 @@ void export_interpreted_noise(
     testfile.close();
 }
 
-}; // namespace om_debug
+} // namespace om_debug

--- a/src/overmap_debug.h
+++ b/src/overmap_debug.h
@@ -9,7 +9,7 @@
 namespace om_noise
 {
 class om_noise_layer;
-}; // namespace om_noise
+} // namespace om_noise
 
 namespace om_debug
 {
@@ -22,6 +22,6 @@ void export_raw_noise( const std::string &filename, const om_noise::om_noise_lay
 void export_interpreted_noise( const std::string &filename, const om_noise::om_noise_layer &noise,
                                int width, int height, float threshold, bool invert );
 
-}; // namespace om_debug
+} // namespace om_debug
 
 #endif // CATA_SRC_OVERMAP_DEBUG_H


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Added in https://github.com/CleverRaven/Cataclysm-DDA/pull/83332, merged (just) before I could correct it.
GCC 9 complains about these, but none of the other builds
https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/18564294129/job/52927120336

#### Testing
The GCC 9 build should pass.