### PR TITLE
Less mines

### DIFF
--- a/data/json/overmap/overmap_mutable/mine_mutable.json
+++ b/data/json/overmap/overmap_mutable/mine_mutable.json
@@ -5,8 +5,8 @@
     "subtype": "mutable",
     "locations": [ "subterranean_empty", "land", "open_air" ],
     "city_distance": [ 10, 40 ],
-    "occurrences": [ 0, 2 ],
-    "flags": [ "MAN_MADE" ],
+    "occurrences": [ 10, 80 ],
+    "flags": [ "MAN_MADE", "OVERMAP_UNIQUE" ],
     "check_for_locations": [
       [ [ 0, -1, 0 ], [ "land", "road" ] ],
       [ [ 0, 0, 0 ], [ "land" ] ],

--- a/data/json/overmap/overmap_special/mine.json
+++ b/data/json/overmap/overmap_special/mine.json
@@ -36,8 +36,8 @@
     "locations": [ "wilderness" ],
     "city_distance": [ 10, 40 ],
     "city_sizes": [ 4, -1 ],
-    "occurrences": [ 0, 1 ],
-    "flags": [ "MAN_MADE" ]
+    "occurrences": [ 1, 80 ],
+    "flags": [ "MAN_MADE", "OVERMAP_UNIQUE" ]
   },
   {
     "type": "overmap_special",
@@ -70,8 +70,8 @@
     "locations": [ "wilderness" ],
     "city_distance": [ 10, 40 ],
     "city_sizes": [ 4, -1 ],
-    "occurrences": [ 0, 1 ],
-    "flags": [ "MAN_MADE" ]
+    "occurrences": [ 1, 80 ],
+    "flags": [ "MAN_MADE", "OVERMAP_UNIQUE" ]
   },
   {
     "type": "overmap_special",
@@ -99,7 +99,7 @@
     "locations": [ "wilderness" ],
     "city_distance": [ 10, 40 ],
     "city_sizes": [ 4, -1 ],
-    "occurrences": [ 0, 1 ],
-    "flags": [ "MAN_MADE" ]
+    "occurrences": [ 1, 80 ],
+    "flags": [ "MAN_MADE", "OVERMAP_UNIQUE" ]
   }
 ]

--- a/data/json/overmap/overmap_special/mine.json
+++ b/data/json/overmap/overmap_special/mine.json
@@ -37,7 +37,7 @@
     "city_distance": [ 10, 40 ],
     "city_sizes": [ 4, -1 ],
     "occurrences": [ 1, 80 ],
-    "flags": [ "MAN_MADE", "OVERMAP_UNIQUE" ]
+    "flags": [ "MAN_MADE", "GLOBALLY_UNIQUE" ]
   },
   {
     "type": "overmap_special",
@@ -71,7 +71,7 @@
     "city_distance": [ 10, 40 ],
     "city_sizes": [ 4, -1 ],
     "occurrences": [ 1, 80 ],
-    "flags": [ "MAN_MADE", "OVERMAP_UNIQUE" ]
+    "flags": [ "MAN_MADE", "GLOBALLY_UNIQUE" ]
   },
   {
     "type": "overmap_special",
@@ -100,6 +100,6 @@
     "city_distance": [ 10, 40 ],
     "city_sizes": [ 4, -1 ],
     "occurrences": [ 1, 80 ],
-    "flags": [ "MAN_MADE", "OVERMAP_UNIQUE" ]
+    "flags": [ "MAN_MADE", "GLOBALLY_UNIQUE" ]
   }
 ]


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
I noticed that there's a lot of mines in game, like a bit too many per OM than in real life Massachussets. Also most of it is the ones with finale, which is a bit odd. So im making it rarer.

#### Describe the solution
Give the mines OVERMAP_UNIQUE flag and adjust their occurance. Make the generic mine common. Make the mines with finales has `GLOBALLY_UNIQUE` flag because while there might be more than 1 generic mines, there wouldnt be multiple amigara faults.

#### Describe alternatives you've considered
Not doing so and pretend the whole place is just the whole place is just Worcester county, Massachusetts.

#### Testing
Before the change (32 mines) in 3×3 OM
![Screenshot_20251017_204528](https://github.com/user-attachments/assets/fada27e2-41af-45d2-acdd-a0e2f148587c)

After the change (6 mines) in 3×3 OM
![Screenshot_20251017_211204](https://github.com/user-attachments/assets/0e39e3d0-9c48-4ecc-b797-0013701014fc)


#### Additional context
https://wwwn.cdc.gov/niosh-mining/MMWC/MineMap/Table
<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
