### PR TITLE
Fix map extra spawning in Backrooms

### DIFF
--- a/data/mods/Backrooms/region_settings/region_settings/regional_map_settings.json
+++ b/data/mods/Backrooms/region_settings/region_settings/regional_map_settings.json
@@ -13,7 +13,7 @@
   },
   {
     "type": "map_extra_collection",
-    "id": "backrooms_backrooms",
+    "id": "backrooms",
     "chance": 30,
     "extras": [
       [ "mx_teleporter_node", 5000 ],
@@ -41,7 +41,7 @@
     "type": "region_settings_map_extras",
     "id": "default_backrooms",
     "copy-from": "default",
-    "extras": [ "backrooms_backrooms" ]
+    "extras": [ "backrooms" ]
   },
   {
     "type": "region_terrain_furniture",

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -917,8 +917,7 @@ void map::generate( const tripoint_abs_omt &p, const time_point &when, bool save
 
         if( any_missing || !save_results ) {
             const region_settings_map_extras settings_mx =
-                region_settings_default->get_settings_map_extras();
-            // At some point, we should add region information so we can grab the appropriate extras
+                region_settings_id( get_option<std::string>( "DEFAULT_REGION" ) )->get_settings_map_extras();
             auto mx_iter = settings_mx.extras.find( map_extra_collection_id( terrain_type->get_extras() ) );
             if( mx_iter != settings_mx.extras.end() ) {
                 const map_extra_collection &this_ex = **mx_iter;


### PR DESCRIPTION
#### Summary
Bugfixes "Fix spawning map extras with non-default region settings"

#### Purpose of change
Fixes https://github.com/CleverRaven/Cataclysm-DDA/issues/83366

#### Describe the solution
The id used by the terrain was incorrect, but more importantly, map extras were checked against the region with the id 'default', not the default region.

Change the id for the map extra collection to match that used by the terrains, and check the default region, not the region with the id 'default' for map extras.

#### Testing
Create a world with backrooms and move around it. Map extras are spawned.