### PR TITLE
Fix assignment of un-alert monsters to immobile horde map

### DIFF
--- a/src/horde_map.cpp
+++ b/src/horde_map.cpp
@@ -142,9 +142,9 @@ std::unordered_map<tripoint_abs_ms, horde_entity>::iterator horde_map::spawn_ent
 {
     std::unordered_map <tripoint_om_sm, std::unordered_map<tripoint_abs_ms, horde_entity>> &target_map =
                 mon.type->has_flag( mon_flag_DORMANT ) ? dormant_monster_map :
+                !is_alert( *mon.type ) ? immobile_monster_map :
                 ( mon.has_dest() || mon.wandf > 0 ) ? active_monster_map :
-                is_alert( *mon.type ) ? idle_monster_map :
-                immobile_monster_map;
+                idle_monster_map;
     std::unordered_map<tripoint_abs_ms, horde_entity>::iterator result;
     point_abs_om omp;
     tripoint_om_sm sm;


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Fixes #83306 
Fixes #83234 
Fixes #83427
After #83157 immobile monsters were not supposed to move as horde entities, but there remains a logic error.  When moving monsters from the main map to horde maps, it checked if monsters had a destination before checking whether they were eligible for horde movement, so monsters with a destination would move onto the active horde map and then move around, as well as respond to sounds.

#### Describe the solution
Fix the logic error by moving the immobility check to come before the "has a destination" check.

#### Describe alternatives you've considered
See #83157 but mostly, there are a lot of options for how to make this determination, and it will need to evolve over time, but I think this is fine for now.

#### Testing
Reproduced #83306 by spawning and tying down a bulldog then wandering away then back.
Before this change the bulldog would sometimes move but remain tied down.
After this change the bulldog would stay at its initial location.
Same for a spawned spotlight.