### PR TITLE
Fix fishing on non river/lake-ocean tiles

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3705,7 +3705,8 @@ std::unordered_set<tripoint_bub_ms> game::get_fishable_locations_bub( int distan
     // to determine if any fishable monsters are in those locations.
     return ff::point_flood_fill_4_connected<std::unordered_set>( fish_pos, visited, [&here,
     &fishing_boundaries]( const tripoint_bub_ms & p ) {
-        return !fishing_boundaries.contains( p ) && here.has_flag( ter_furn_flag::TFLAG_FISHABLE, p );
+        return fishing_boundaries.contains( p ) && here.inbounds( p ) &&
+               here.has_flag( ter_furn_flag::TFLAG_FISHABLE, p );
     } );
 }
 

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -1765,7 +1765,8 @@ std::optional<int> iuse::remove_all_mods( Character *p, item *, const tripoint_b
 
 static bool good_fishing_spot( const tripoint_bub_ms &pos, Character *p )
 {
-    std::unordered_set<tripoint_bub_ms> fishable_locations = g->get_fishable_locations_bub( 60, pos );
+    std::unordered_set<tripoint_bub_ms> fishable_locations = g->get_fishable_locations_bub(
+                MAX_VIEW_DISTANCE, pos );
     std::vector<monster *> fishables = g->get_fishable_monsters( fishable_locations );
     map &here = get_map();
     // isolated little body of water with no definite fish population
@@ -1808,7 +1809,7 @@ std::optional<int> iuse::fishing_rod( Character *p, item *it, const tripoint_bub
     p->add_msg_if_player( _( "You cast your line and wait to hook something…" ) );
     p->assign_activity( ACT_FISH, to_moves<int>( 5_hours ), 0, 0, it->tname() );
     p->activity.targets.emplace_back( *p, it );
-    p->activity.coord_set = g->get_fishable_locations_abs( 60, *found );
+    p->activity.coord_set = g->get_fishable_locations_abs( MAX_VIEW_DISTANCE, *found );
     return 0;
 }
 
@@ -1908,7 +1909,8 @@ std::optional<int> iuse::fish_trap_tick( Character *p, item *it, const tripoint_
         }
 
         //get the fishables around the trap's spot
-        std::unordered_set<tripoint_bub_ms> fishable_locations = g->get_fishable_locations_bub( 60, pos );
+        std::unordered_set<tripoint_bub_ms> fishable_locations = g->get_fishable_locations_bub(
+                    MAX_VIEW_DISTANCE, pos );
         std::vector<monster *> fishables = g->get_fishable_monsters( fishable_locations );
         for( int i = 0; i < fishes; i++ ) {
             player.practice( skill_survival, rng( 3, 10 ) );

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -1772,12 +1772,12 @@ static bool good_fishing_spot( const tripoint_bub_ms &pos, Character *p )
     // isolated little body of water with no definite fish population
     const oter_id &cur_omt =
         overmap_buffer.ter( coords::project_to<coords::omt>( here.get_abs( pos ) ) );
-    std::string om_id = cur_omt.id().c_str();
     if( fishables.empty() && !here.has_flag( ter_furn_flag::TFLAG_CURRENT, pos ) &&
         // this is a ridiculous way to find a good fishing spot, but I'm just trying
         // to do oceans right now.  Maybe is_water_body() would be better?
         // if you find this comment still here and it's later than 2025, LOL.
-        om_id.find( "river_" ) == std::string::npos && !cur_omt->is_lake() && !cur_omt->is_ocean() &&
+        is_ot_match( "river_", cur_omt, ot_match_type::contains ) &&
+        !cur_omt->is_lake() && !cur_omt->is_ocean() &&
         !cur_omt->is_lake_shore() && !cur_omt->is_ocean_shore() ) {
         p->add_msg_if_player( m_info, _( "You doubt you will have much luck catching fish here." ) );
         return false;


### PR DESCRIPTION
#### Summary
Bugfixes "Fix fishing on non river/lake/ocean tiles"

#### Purpose of change
Fixes https://github.com/CleverRaven/Cataclysm-DDA/issues/83372

#### Describe the solution
In the conversion to use the generic flood-fill function, done in b5c9c6a, the predicate copied the bounds check but did not remove the negation. This means that any point added to the flood-fill set must be outside of fishing bounds, not inside them. Because the fishing bounds are drawn around the seed point, this is never true for the seed point and the flood fill always terminates immediately. Remove the negation.

Additionally, add some bounds checks, because this function is called in iuse::fish with bounds of 60, which allows it to go out of bounds.

#### Testing
Follow reproduction steps from the linked issue.

#### Additional context
There's also a commit changing the iuse fishing check to use `is_ot_match`.