### PR TITLE
Monsters forcing their way through bushes/SHARP terrain trample the terrain

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -9793,6 +9793,11 @@ std::vector<std::string> game::get_dangerous_tile( const tripoint_bub_ms &dest_l
         return u.immune_to( bp, { damage_cut, 10 } );
     };
 
+    // For future reference... It turns out that 78 is exactly the dex required to avoid all damage at the function call used elsewhere.
+    // That function call is:
+    // x_in_y(1+u.dex_cur/2, 40)
+    const int magic_number_78 = 78;
+
     if( here.has_flag( ter_furn_flag::TFLAG_ROUGH, dest_loc ) &&
         !here.has_flag( ter_furn_flag::TFLAG_ROUGH, u.pos_bub() ) &&
         !u.has_flag( json_flag_ALL_TERRAIN_NAVIGATION ) &&
@@ -9804,7 +9809,7 @@ std::vector<std::string> game::get_dangerous_tile( const tripoint_bub_ms &dest_l
                !here.has_flag( ter_furn_flag::TFLAG_SHARP, u.pos_bub() ) &&
                !u.has_flag( json_flag_ALL_TERRAIN_NAVIGATION ) &&
                !( u.in_vehicle || here.veh_at( dest_loc ) ) &&
-               u.dex_cur < 78 &&
+               u.dex_cur < magic_number_78 &&
                !( u.is_mounted() &&
                   u.mounted_creature->get_armor_type( damage_cut, bodypart_id( "torso" ) ) >= 10 ) &&
                !std::all_of( sharp_bps.begin(), sharp_bps.end(), sharp_bp_check ) ) {

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -2067,6 +2067,7 @@ bool monster::move_to( const tripoint_bub_ms &p, bool force, bool step_on_critte
             const int rough_damage = rng( 1, 2 );
             if( here.has_flag( ter_furn_flag::TFLAG_SHARP, pos ) && !one_in( 4 ) &&
                 get_armor_type( damage_cut, bodypart_id( "torso" ) ) < sharp_damage && get_hp() > sharp_damage ) {
+                here.bash( pos, sharp_damage ); // Moving through a sharp terrain also smashes the terrain, weakly.
                 apply_damage( nullptr, bodypart_id( "torso" ), sharp_damage );
             }
             if( here.has_flag( ter_furn_flag::TFLAG_ROUGH, pos ) && one_in( 6 ) &&


### PR DESCRIPTION
#### Summary
Balance "Monsters moving through SHARP terrain trample the terrain"

#### Purpose of change
Monsters walking back and forth over a bush until they're at a sliver of health. It was specifically removed from killing them in #62873 but this didn't address the root problem.

#### Describe the solution
Obviously, forcing your way through a thorny bush, or a broken glass window, etc. will destroy it eventually. It is not magic and not invincible.

So just apply the same damage right back to it. This will eventually destroy it.

(Also add a comment explaining some real magic number bullshit that came up while looking at this)

#### Describe alternatives you've considered
Also apply this damage to the ROUGH terrain. Ehhh less appropriate

#### Testing
<img width="2560" height="1400" alt="image" src="https://github.com/user-attachments/assets/24e9ca02-8c51-4a25-a3ed-0b779417ba61" />

<img width="2560" height="1400" alt="image" src="https://github.com/user-attachments/assets/918a1a17-d9f5-4a27-8558-d1506d28af87" />


#### Additional context

NPCs try to avoid walking into SHARP terrain but actually can't be damaged by it. Pre-existing issue.