### PR TITLE
Migrate a few input popups to imgui

### DIFF
--- a/src/basecamp.cpp
+++ b/src/basecamp.cpp
@@ -25,6 +25,7 @@
 #include "faction.h"
 #include "faction_camp.h"
 #include "game.h"
+#include "input_popup.h"
 #include "inventory.h"
 #include "item.h"
 #include "map.h"
@@ -41,7 +42,6 @@
 #include "recipe_groups.h"
 #include "requirements.h"
 #include "string_formatter.h"
-#include "string_input_popup.h"
 #include "translations.h"
 #include "type_id.h"
 
@@ -670,15 +670,15 @@ comp_list basecamp::get_mission_workers( const mission_id &miss_id, bool contain
 
 void basecamp::query_new_name( bool force )
 {
-    string_input_popup input_popup;
+    string_input_popup_imgui input_popup( 40 );
     bool done = false;
     bool need_input = true;
+    std::string text;
     do {
-        input_popup.title( _( "Name this camp" ) )
-        .width( 40 )
-        .max_length( 25 )
-        .query();
-        if( input_popup.canceled() || input_popup.text().empty() ) {
+        input_popup.set_description( _( "Name this camp" ) );
+        input_popup.set_max_input_length( 25 );
+        text = input_popup.query();
+        if( input_popup.cancelled() || text.empty() ) {
             if( name.empty() || force ) {
                 popup( _( "You need to input the base camp name." ) );
             } else {
@@ -689,7 +689,7 @@ void basecamp::query_new_name( bool force )
         }
     } while( !done && need_input );
     if( done ) {
-        name = input_popup.text();
+        name = text;
     }
 }
 

--- a/src/clzones.cpp
+++ b/src/clzones.cpp
@@ -21,6 +21,7 @@
 #include "flexbuffer_json.h"
 #include "generic_factory.h"
 #include "iexamine.h"
+#include "input_popup.h"
 #include "item.h"
 #include "item_category.h"
 #include "item_group.h"
@@ -35,7 +36,6 @@
 #include "output.h"
 #include "path_info.h"
 #include "string_formatter.h"
-#include "string_input_popup.h"
 #include "translations.h"
 #include "uilist.h"
 #include "value_ptr.h"
@@ -265,14 +265,12 @@ ignorable_options::query_ignorable_result ignorable_options::query_ignorable()
 
 loot_options::query_loot_result loot_options::query_loot()
 {
-    string_input_popup()
-    .title( _( "Filter:" ) )
-    .description( item_filter_rule_string( item_filter_type::FILTER ) + "\n\n" )
-    .desc_color( c_white )
-    .width( 55 )
-    .identifier( "item_filter" )
-    .max_length( 256 )
-    .edit( mark );
+    string_input_popup_imgui input_popup( 55, mark );
+    input_popup.set_label( _( "Filter:" ) );
+    input_popup.set_description( item_filter_rule_string( item_filter_type::FILTER ) + "\n\n",
+                                 c_white, /*monofont=*/ true );
+    input_popup.set_identifier( "item_filter" );
+    mark = input_popup.query();
     return changed;
 }
 
@@ -571,16 +569,13 @@ void unload_options::deserialize( const JsonObject &jo_zone )
 
 std::optional<std::string> zone_manager::query_name( const std::string &default_name ) const
 {
-    string_input_popup popup;
-    popup
-    .title( _( "Zone name:" ) )
-    .width( 55 )
-    .text( default_name )
-    .query();
-    if( popup.canceled() ) {
+    string_input_popup_imgui popup( 55, default_name );
+    popup.set_label( _( "Zone name:" ) );
+    std::string text = popup.query();
+    if( popup.cancelled() ) {
         return {};
     } else {
-        return popup.text();
+        return text;
     }
 }
 

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -36,6 +36,7 @@
 #include "generic_factory.h"
 #include "input.h"
 #include "input_context.h"
+#include "input_popup.h"
 #include "inventory.h"
 #include "item.h"
 #include "item_group.h"
@@ -61,7 +62,6 @@
 #include "skill.h"
 #include "sounds.h"
 #include "string_formatter.h"
-#include "string_input_popup.h"
 #include "translation_cache.h"
 #include "translations.h"
 #include "trap.h"
@@ -1023,17 +1023,14 @@ construction_id construction_menu( const bool blueprint )
             blink = true;
         }
         if( action == "FILTER" ) {
-            string_input_popup popup;
-            popup
-            .title( _( "Search" ) )
-            .width( 50 )
-            .description( _( "Filter" ) )
-            .max_length( 100 )
-            .text( tabindex == tabcount - 1 ? filter : std::string() )
-            .identifier( "construction" )
-            .query_string();
-            if( popup.confirmed() ) {
-                filter = popup.text();
+            string_input_popup_imgui popup( 50 );
+            popup.set_label( _( "Search" ) );
+            popup.set_description( _( "Filter" ) );
+            popup.set_text( tabindex == tabcount - 1 ? filter : std::string() );
+            popup.set_identifier( "construction" );
+            std::string result = popup.query();
+            if( !popup.cancelled() ) {
+                filter = result;
                 uistate.construction_filter = filter;
                 update_info = true;
                 update_cat = true;
@@ -1796,10 +1793,9 @@ static vpart_id vpart_from_item( const itype_id &item_id )
 
 void construct::done_vehicle( const tripoint_bub_ms &p, Character & )
 {
-    std::string name = string_input_popup()
-                       .title( _( "Enter new vehicle name:" ) )
-                       .width( 60 )
-                       .query_string();
+    string_input_popup_imgui popup( 60 );
+    popup.set_label( _( "Enter new vehicle name:" ) );
+    std::string name = popup.query();
     if( name.empty() ) {
         name = _( "Car" );
     }

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -40,6 +40,7 @@
 #include "game_constants.h"
 #include "game_inventory.h"
 #include "handle_liquid.h"
+#include "input_popup.h"
 #include "inventory.h"
 #include "item.h"
 #include "item_components.h"
@@ -69,7 +70,6 @@
 #include "rng.h"
 #include "skill.h"
 #include "string_formatter.h"
-#include "string_input_popup.h"
 #include "talker.h"
 #include "translations.h"
 #include "type_id.h"
@@ -2629,6 +2629,17 @@ bool Character::disassemble()
     return disassemble( game_menus::inv::disassemble( *this ), false );
 }
 
+// returns 0 if cancelled
+static int query_disassemble_quantity( int num_dis, const item &obj )
+{
+    number_input_popup<int> popup_input( 0, num_dis );
+    const std::string title = string_format( _( "Disassemble how many %s [MAX: %d]: " ),
+                              obj.type_name( 1 ), obj.charges );
+    popup_input.set_label( title );
+    int result = popup_input.query();
+    return popup_input.cancelled() ? 0 : result;
+}
+
 bool Character::disassemble( item_location target, bool interactive, bool disassemble_all )
 {
     if( !target ) {
@@ -2693,11 +2704,8 @@ bool Character::disassemble( item_location target, bool interactive, bool disass
         int num_dis = 1;
         if( obj.count_by_charges() ) {
             if( !disassemble_all && obj.charges > 1 ) {
-                string_input_popup popup_input;
-                const std::string title = string_format( _( "Disassemble how many %s [MAX: %d]: " ),
-                                          obj.type_name( 1 ), obj.charges );
-                popup_input.title( title ).edit( num_dis );
-                if( popup_input.canceled() || num_dis <= 0 ) {
+                num_dis = query_disassemble_quantity( num_dis, obj );
+                if( num_dis <= 0 ) {
                     add_msg( _( "Never mind." ) );
                     return false;
                 }
@@ -2805,11 +2813,8 @@ void Character::complete_disassemble( item_location target )
     if( obj.count_by_charges() ) {
         // get_value( 0 ) is true if the player wants to disassemble all charges
         if( !activity.get_value( 0 ) && obj.charges > 1 ) {
-            string_input_popup popup_input;
-            const std::string title = string_format( _( "Disassemble how many %s [MAX: %d]: " ),
-                                      obj.type_name( 1 ), obj.charges );
-            popup_input.title( title ).edit( num_dis );
-            if( popup_input.canceled() || num_dis <= 0 ) {
+            num_dis = query_disassemble_quantity( num_dis, obj );
+            if( num_dis <= 0 ) {
                 add_msg( _( "Never mind." ) );
                 activity.set_to_null();
                 return;


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

I've seen a few PRs touch some input popups lately, which reminded me most are still unmigrated. It's a nice and simple thing to do on the side.

#### Describe the solution

Just migrate them.
The disassembly one was duplicated, so I extracted it into it's own method.
Also extracted the crafting menu filtering because the method became too long.

#### Describe alternatives you've considered



#### Testing

Tested all of them, except I'm not sure how to trigger the second disassembly one.

#### Additional context

