### PR TITLE
Butchery proficiencies give their benefits below 100% learned

### DIFF
--- a/src/butchery.cpp
+++ b/src/butchery.cpp
@@ -461,8 +461,13 @@ int butcher_time_to_cut( Character &you, const item &corpse_item, const butcher_
     double penalty_small = 0.5;
     double penalty_big = 1.5;
 
-    int prof_butch_penalty = penalty_big * ( 1 - butch_basic ) + penalty_small * ( 1 - butch_adv );
-    int prof_skin_penalty = penalty_small * ( 1 - skin_basic );
+    double prof_butch_penalty = penalty_big * ( 1.0 - butch_basic ) + penalty_small *
+                                ( 1.0 - butch_adv );
+    double prof_skin_penalty = penalty_small * ( 1.0 - skin_basic );
+
+    add_msg_debug( debugmode::DF_ACT_BUTCHER,
+                   "Time penalties for butchering:\n Butchery proficiencies penalty: %.2f%%\n Skinning proficiency penalty: %.2f%%",
+                   prof_butch_penalty * 100.0, prof_skin_penalty * 100.0 );
 
     // there supposed to be a code for book mitigation, but we don't have any book fitting for this
 

--- a/tests/harvest_test.cpp
+++ b/tests/harvest_test.cpp
@@ -153,8 +153,8 @@ static void do_butchery_timing( time_duration expected_time, butcher_type butche
     CHECK( p_act.moves_left <= 0 );
     const time_duration time_taken = time_duration::from_turns( turns_taken );
     CAPTURE( to_string( time_taken ) );
-    CHECK( time_taken > expected_time * 0.9 );
-    CHECK( time_taken < expected_time * 1.1 );
+    CHECK( time_taken > ( expected_time * 0.9 ) );
+    CHECK( time_taken < ( expected_time * 1.1 ) );
     here.i_clear( animal_loc );
     u.move_to( orig_pos );
 }


### PR DESCRIPTION
#### Summary
Bugfixes "Butchery proficiencies give their benefits below 100% learned"

#### Purpose of change
Butchery proficiencies didn't work at all before 100% learned, because they were being cast to int.

#### Describe the solution
Properly handle them as a (double-precision) float.

Also add some debug plumbing to check this in the future.

Extracted from #83314

#### Describe alternatives you've considered


#### Testing


#### Additional context
