### PR TITLE
Prevent segfault when cancelling butchery

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -9137,14 +9137,11 @@ void butchery_activity_actor::do_turn( player_activity &act, Character &you )
     }
 
     if( this_bd->progress >= this_bd->time_to_butcher ) {
+        const butchery_data bd_copy = *this_bd;
+        bd.pop_back();
         // this corpse is done
-        destroy_the_carcass( *this_bd, you );
-        if( bd.empty() ) {
-            act.moves_left = 0;
-            return;
-        } else {
-            bd.pop_back();
-        }
+        destroy_the_carcass( bd_copy, you );
+        // WARNING: destroy_the_carcass might spill acid, which gives the player the option to cancel this activity. If so, then `this` might be invalidated, along with all `butchery_data` elements. So here we need to be sure to not use either of those after this call.
     } else {
         this_bd->progress += 1_seconds;
     }

--- a/src/butchery.cpp
+++ b/src/butchery.cpp
@@ -1175,7 +1175,7 @@ void destroy_the_carcass( const butchery_data &bd, Character &you )
     you.recoil = MAX_RECOIL;
 
     get_event_bus().send<event_type::character_butchered_corpse>( you.getID(),
-            corpse_item.get_mtype()->id, "ACT_" + io::enum_to_string<butcher_type>( bd.b_type ) );
+            corpse->id, "ACT_" + io::enum_to_string<butcher_type>( action ) );
 
 }
 


### PR DESCRIPTION


<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Prevent segfault when cancelling butchery"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

* Fixes #83352
* Prevents segfault caused by using `butchery_data` that was invalidated when the player cancels a butchery activity due to being hurt by spilled acid.
* The `butchery_activity_actor` is invalidated in `Character::cancel_activity`, which assigns `activity = player_activity()`, thus invalidating the old actor.


<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

* Instead, this commit copies the instance of `butchery_data` for the current butchery, and makes sure to instead work on that copy of the data. This way, it will still be valid even if `butchery_activity_actor` and its contained `butchery_data` elements are invalidted.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

* Can reliably reproduce the issue in #83352 on master. Can no longer reproduce the issue on this branch.
* I build with some hardening flags to provoke more reliable segfaults when accessing invalidated data: `-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -D_GLIBCXX_ASSERTIONS -fstrict-flex-arrays=3 -fstack-clash-protection -fstack-protector-strong -Wl,-z,nodlopen -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now`.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
