### PR TITLE
Bump up dmg size limit in macOS release build

### DIFF
--- a/build-data/osx/dmgsettings.py
+++ b/build-data/osx/dmgsettings.py
@@ -37,7 +37,7 @@ def icon_from_app(app_path):
 format = defines.get('format', 'UDBZ')
 
 # Volume size (must be large enough for your files)
-size = defines.get('size', '400M')
+size = defines.get('size', '500M')
 
 # Files to include
 files = [application]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Build "Fix Mac build (Bump up dmg size limit in macOS release build)"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Fix the macOS experimantal build.

```
ditto: /Volumes/Cataclysm DDA/Cataclysm.app/Contents/Resources/gfx/Altica/tall_overmap.png: No space left on device
ditto: /Volumes/Cataclysm DDA/Cataclysm.app/Contents/Info.plist: No space left on device
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/Current/bin/dmgbuild", line 7, in <module>
    sys.exit(main())
             ~~~~^^
  File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/site-packages/dmgbuild/__main__.py", line 56, in main
    build_dmg(
    ~~~~~~~~~^
        args.filename,
        ^^^^^^^^^^^^^^
    ...<4 lines>...
        detach_retries=args.detachRetries,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/site-packages/dmgbuild/core.py", line 720, in build_dmg
    os.symlink(target, name_in_image)
    ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
OSError: [Errno 28] No space left on device: '/Applications' -> '/Volumes/Cataclysm DDA/Applications'
make: *** [dmgdist] Error 1
```

#### Describe the solution

Increased DMG size from 400MB to 500MB (and wait for it to happen again)

#### Describe alternatives you've considered

#### Testing

#### Additional context

Perhaps it would be good to consider another solution for the future, because this happened already.

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
