### PR TITLE
Add BLOCK_SUPERNATURAL_HEALING flag, apply it to Clay Golem attacks in Magiclysm

### DIFF
--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -499,6 +499,11 @@
     "//": "Like MYOPIC_IN_LIGHT, but can't be fixed by glasses."
   },
   {
+    "id": "BLOCK_SUPERNATURAL_HEALING",
+    "type": "json_flag",
+    "//": "Supernatural healing effects, like magical spells, do not work while you have this flag.  Does not block u_hp EoC effects"
+  },
+  {
     "id": "FILTHY",
     "type": "json_flag",
     "//": "Zombie-dropped clothing giving various penalties if Filthy mod is active.  Also CBMs harvested from zombies.",

--- a/data/mods/Magiclysm/Spells/biomancer.json
+++ b/data/mods/Magiclysm/Spells/biomancer.json
@@ -696,6 +696,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_BIOMANCER_SLOW_BLEEDING",
+    "condition": { "not": { "u_has_flag": "BLOCK_SUPERNATURAL_HEALING" } },
     "effect": {
       "switch": { "math": [ "u_spell_level('biomancer_slow_bleeding')" ] },
       "cases": [
@@ -721,7 +722,8 @@
           }
         }
       ]
-    }
+    },
+    "false_effect": [ { "u_message": "Your healing spell has no effect!", "type": "bad" } ]
   },
   {
     "id": "biomancer_scalpel_fingers",

--- a/data/mods/Magiclysm/effects/effects.json
+++ b/data/mods/Magiclysm/effects/effects.json
@@ -2015,6 +2015,19 @@
     ]
   },
   {
+    "type": "effect_type",
+    "id": "effect_clay_golem_unhealing",
+    "name": [ "Clay-Covered Wounds" ],
+    "desc": [ "Bits of clay are stuck in your wounds and you can't seem to get them out." ],
+    "apply_message": "Some of the golem's clay remains behind after it hits you.",
+    "remove_message": "The clay on your wounds finally flakes off.",
+    "rating": "bad",
+    "max_duration": "48 hours",
+    "show_in_info": true,
+    "enchantments": [ { "values": [ { "value": "REGEN_HP", "multiply": -1 } ] } ],
+    "flags": [ "BLOCK_SUPERNATURAL_HEALING" ]
+  },
+  {
     "id": "effect_dispel_magic",
     "type": "effect_type",
     "name": [ "Dispel Magic" ],
@@ -2250,7 +2263,8 @@
       "effect_feral_animist_guardian_spirit",
       "effect_feral_animist_inner_voice",
       "effect_migo_nether_shield_monster",
-      "effect_feral_druid_thornskin"
+      "effect_feral_druid_thornskin",
+      "effect_clay_golem_unhealing"
     ]
   },
   {

--- a/data/mods/Magiclysm/monsters/golems.json
+++ b/data/mods/Magiclysm/monsters/golems.json
@@ -20,6 +20,7 @@
     "melee_dice": 2,
     "melee_dice_sides": 10,
     "melee_damage": [ { "damage_type": "cut", "amount": 5 } ],
+    "attack_effs": [ { "id": "effect_clay_golem_unhealing", "duration": 1800 } ],
     "dodge": 0,
     "vision_day": 40,
     "vision_night": 40,

--- a/doc/JSON/JSON_FLAGS.md
+++ b/doc/JSON/JSON_FLAGS.md
@@ -348,6 +348,7 @@ Character flags can be `trait_id`, `json_flag_id` or `flag_id`.  Some of these a
 - ```BLEEDSLOW``` When bleeding, lose blood at 2/3 of the normal rate.
 - ```BLEEDSLOW2``` When bleeding, lose blood at 1/3 of the normal rate.
 - ```BLIND``` Makes you blind.
+- ```BLOCK_SUPERNATURAL_HEALING``` Blocks supernatural healing effects, like magical healing spells, from taking effect.  This flag does not block EoC-based healing like using the u_hp() effect.
 - ```BULLET_IMMUNE``` You are immune to bullet damage.
 - ```CANNIBAL``` Butcher humans, eat foods with the `CANNIBALISM` and `STRICT_HUMANITARIANISM` flags without a morale penalty.
 - ```CANNOT_ATTACK``` A creature with this flag cannot attack (includes spellcasting).

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -79,7 +79,8 @@ static const efftype_id effect_teleglow( "teleglow" );
 
 static const flag_id json_flag_FIT( "FIT" );
 
-static const json_character_flag json_flag_BLOCK_SUPERNATURAL_HEALING( "BLOCK_SUPERNATURAL_HEALING" );
+static const json_character_flag
+json_flag_BLOCK_SUPERNATURAL_HEALING( "BLOCK_SUPERNATURAL_HEALING" );
 static const json_character_flag json_flag_PRED1( "PRED1" );
 static const json_character_flag json_flag_PRED2( "PRED2" );
 static const json_character_flag json_flag_PRED3( "PRED3" );

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -624,10 +624,14 @@ static void damage_targets( const spell &sp, Creature &caster,
                 }
                 cr->deal_projectile_attack( &here, &caster, atk, atk.missed_by, true );
             }
-        } else if( sp.damage( caster ) < 0 && !cr->has_flag( json_flag_BLOCK_SUPERNATURAL_HEALING ) ) {
-            sp.heal( target, caster );
-            add_msg_if_player_sees( cr->pos_bub(), m_good, _( "%s wounds are closing up!" ),
+        } else if( sp.damage( caster ) < 0 ) {
+            if ( !cr->has_flag( json_flag_BLOCK_SUPERNATURAL_HEALING ) ) {
+                sp.heal( target, caster );
+                add_msg_if_player_sees( cr->pos_bub(), m_good, _( "%s wounds are closing up!" ),
                                     cr->disp_name( true ) );
+            } else {
+                caster.add_msg_if_player( m_bad, _( "Your healing spell has no effect!" ) );
+            }
         }
 
         // handling DOTs here

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -79,6 +79,7 @@ static const efftype_id effect_teleglow( "teleglow" );
 
 static const flag_id json_flag_FIT( "FIT" );
 
+static const json_character_flag json_flag_BLOCK_SUPERNATURAL_HEALING( "BLOCK_SUPERNATURAL_HEALING" );
 static const json_character_flag json_flag_PRED1( "PRED1" );
 static const json_character_flag json_flag_PRED2( "PRED2" );
 static const json_character_flag json_flag_PRED3( "PRED3" );
@@ -623,7 +624,7 @@ static void damage_targets( const spell &sp, Creature &caster,
                 }
                 cr->deal_projectile_attack( &here, &caster, atk, atk.missed_by, true );
             }
-        } else if( sp.damage( caster ) < 0 ) {
+        } else if( sp.damage( caster ) < 0 && !cr->has_flag( json_flag_BLOCK_SUPERNATURAL_HEALING ) ) {
             sp.heal( target, caster );
             add_msg_if_player_sees( cr->pos_bub(), m_good, _( "%s wounds are closing up!" ),
                                     cr->disp_name( true ) );

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -629,7 +629,7 @@ static void damage_targets( const spell &sp, Creature &caster,
             if( !cr->has_flag( json_flag_BLOCK_SUPERNATURAL_HEALING ) ) {
                 sp.heal( target, caster );
                 add_msg_if_player_sees( cr->pos_bub(), m_good, _( "%s wounds are closing up!" ),
-                                    cr->disp_name( true ) );
+                                        cr->disp_name( true ) );
             } else {
                 caster.add_msg_if_player( m_bad, _( "Your healing spell has no effect!" ) );
             }

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -626,7 +626,7 @@ static void damage_targets( const spell &sp, Creature &caster,
                 cr->deal_projectile_attack( &here, &caster, atk, atk.missed_by, true );
             }
         } else if( sp.damage( caster ) < 0 ) {
-            if ( !cr->has_flag( json_flag_BLOCK_SUPERNATURAL_HEALING ) ) {
+            if( !cr->has_flag( json_flag_BLOCK_SUPERNATURAL_HEALING ) ) {
                 sp.heal( target, caster );
                 add_msg_if_player_sees( cr->pos_bub(), m_good, _( "%s wounds are closing up!" ),
                                     cr->disp_name( true ) );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "Add BLOCK_SUPERNATURAL_HEALING flag, apply it to Clay Golem attacks in Magiclysm"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Someone mentioned the Golemancer's powers were underwhelming and that led to me finding this line in an old monster manual:

>  Damage done by the golem can only be cured by a heal spell from a priest of 17th level or greater. 

And here we are.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add an `attack_eff` for the clay golem applying a healing-blocking effect that reduces REGEN_HP to zero. This applies to everyone, so deploying clay golems against regenerating monsters lets you turn off their regen.

Add the `BLOCK_SUPERNATURAL_HEALING` flag. When you have this flag, healing spells don't work and you receive a message to that effect. EoC effects that mess with u_hp do work and will have to be individually handled.

The _Disjunction_ spell removes the `Clay-Covered Wounds` effect.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Summoned a clay golem, got punched, cast `Knit the Rent Flesh`. It did nothing.

Summoned a clay golem and a shoggoth, had the clay golem fight the shoggoth, shot the shoggoth with an anti-materiel rifle. It didn't regenerate at all.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

This doesn't really make the Golemancer less underwhelming but that can come in another PR. 
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
