### PR TITLE
Adjusted weight + freeze temp of foul acidic blood

### DIFF
--- a/data/json/items/chemicals_and_resources.json
+++ b/data/json/items/chemicals_and_resources.json
@@ -2224,6 +2224,9 @@
     "name": { "str_sp": "foul acidic blood" },
     "symbol": "~",
     "color": "red",
+    "//": "weight and freezing temp adjusted assuming the acid is diluted by essentially 50% water",
+    "weight": "352 g",
+    "freezing_point": -18,
     "description": "Blood mixed with acidic compounds, foul-smelling and extremely corrosive, a means of refining this could net some useful chemicals."
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Adjust properties of foul acidic blood to indicate it's diluted sulphuric acid, not concentrated.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Adjust the weight to reflect 50% sulphuric acid and 50% water (assuming regular blood specific weight being sufficiently close to water for the difference not to matter). This matches the recipe for extracting sulphuric acid out of the blood, with 2 units (500 ml) of blood resulting in 1 unit (250 ml) of acid (with the remainder presumably boiled off or discarded).
Adjust the freezing temperature to halfway between that of sulphuric acid and water. It probably doesn't matter, as I suspect it won't rot anyway.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Debug spawned foul acidic blood. Examined the bottle it was spawned in, and saw that the reported weight of the contents matched the adjusted weight of the blood.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Triggered by harvesting blood and being puzzled by the inability to fill either a plastic or a steel jerrycan with blood (probably horrible choices in reality, should you somehow get hold of such blood, but game containers don't care about corrosion). After some investigation, found that it was due to the weight of the blood, as it exceeded the weight capacity of the containers before the volume capacity was reached (a specific weight of 1.5 for the containers, while the acid is at about 1.8).
After some mulling, I eventually came to the conclusion that it actually makes sense to reduce the weight of the blood since it isn't pure acid. As a side effect of that, it should now be possible to fill at least those containers to capacity, even if it wasn't the main objective.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
