### PR TITLE
Add clang tidy rule for unicode replacement character

### DIFF
--- a/src/butchery.cpp
+++ b/src/butchery.cpp
@@ -657,7 +657,7 @@ bool butchery_drops_harvest( butchery_data bt, Character &you )
         if( action != butcher_type::FIELD_DRESS && action != butcher_type::SKIN &&
             action != butcher_type::DISSECT ) {
             you.add_msg_if_player( m_bad,
-                                   _( "The corpse looks a little underweight�" ) );
+                                   _( "The corpse looks a little underweight…" ) );
         }
     }
     if( corpse_item.has_flag( flag_SKINNED ) ) {

--- a/src/text_style_check.h
+++ b/src/text_style_check.h
@@ -68,7 +68,7 @@ void text_style_check( Iter beg, Iter end,
     // always put the longest (in u32) symbols at the front, since we'll iterate
     // and search for them in this order.
     // *INDENT-OFF*
-    static const std::array<punctuation, 18> punctuations = {{
+    static const std::array<punctuation, 19> punctuations = {{
         // symbol,follow,    spaces,                                 replace,
         //                    check,  len, num spc,  end,start,before    yes,   string,     escaped,  symbol desc,      replc desc
         { U"...",    U"",   {  true, 0, 1, 0, 0, 0, 2, 2, 2, 2, 0 }, {  true, "\u2026", R"(\u2026)", "three dots",      "ellipsis" } },
@@ -86,6 +86,7 @@ void text_style_check( Iter beg, Iter end,
         { U"?",      U"!?", {  true, 0, 1, 1, 3, 2, 2, 2, 0, 0, 1 }, { false,                                                      } },
         { U":",      U"",   {  true, 0, 1, 1, 1, 1, 0, 1, 0, 0, 0 }, { false,                                                      } },
         { U",",      U"",   {  true, 0, 1, 1, 2, 1, 0, 1, 0, 0, 1 }, { false,                                                      } },
+        { U"�",      U"",   { false,                              }, {  true, "\u2026", R"(\u2026)", "replacement character", "ANYTHING" } },
         { U"\r",     U"",   { false,                              }, {  true, R"(\n)",  R"(\n)",     "carriage return", "new line" } },
         { U"\n",     U"",   {  true, 0, 0, 0, 0, 0, 1, 1, 0, 0, 1 }, { false,                                                      } },
         { U"\t",     U"",   { false,                              }, {  true, "    ",   "    ",      "tab",             "spaces"   } },

--- a/tools/clang-tidy-plugin/test/text-style.cpp
+++ b/tools/clang-tidy-plugin/test/text-style.cpp
@@ -70,6 +70,9 @@ static void bar()
     foo( "..." );
     // CHECK-MESSAGES: [[@LINE-1]]:11: warning: ellipsis preferred over three dots.
     // CHECK-FIXES: foo( "\u2026" );
+    foo( "�" );
+    // CHECK-MESSAGES: [[@LINE-1]]:11: warning: ANYTHING preferred over replacement character.
+    // CHECK-FIXES: foo( "\u2026" );
     foo( "foo..." );
     // CHECK-MESSAGES: [[@LINE-1]]:14: warning: ellipsis preferred over three dots.
     // CHECK-FIXES: foo( "foo\u2026" );


### PR DESCRIPTION
#### Summary
Infrastructure "Clang tidy rule to catch/reject unicode replacement character"

#### Purpose of change
We have had several occasions in the past where the unicode replacement character `�` got added to C++ strings.

There's one in-repo right now.
https://github.com/CleverRaven/Cataclysm-DDA/blob/fef027e4e777e1beba13244a946a19612d6680fa/src/butchery.cpp#L660

Most often this is because several text editors fail at parsing `…` (special unicode character for ellipsis). And our contributors were copy-pasting or otherwise, which replaced it. Then these errors go unnoticed, and cause issues down the line.

#### Describe the solution
Blindly cargo cult our clang tidy rule for ellipsis replacement. Throws a clang tidy error whenever the replacement character is encountered. Hopefully.

#### Describe alternatives you've considered

#### Testing
If it catches the pre-existing error in butchery.cpp then we'll know it works

If it doesn't, then it clearly doesn't work!

#### Additional context

