### PR TITLE
Allow magazines in guns/tools to regenerate ammo

### DIFF
--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -2599,7 +2599,8 @@ void item_contents::process( map &here, Character *carrier, const tripoint_bub_m
                              temperature_flag flag, float spoil_multiplier_parent, bool watertight_container )
 {
     for( item_pocket &pocket : contents ) {
-        if( pocket.is_type( pocket_type::CONTAINER ) || pocket.is_type( pocket_type::MOD ) ) {
+        if( pocket.is_type( pocket_type::CONTAINER ) || pocket.is_type( pocket_type::MOD ) ||
+            pocket.is_type( pocket_type::MAGAZINE_WELL ) )  {
             pocket.process( here, carrier, pos, insulation, flag, spoil_multiplier_parent,
                             watertight_container );
         }


### PR DESCRIPTION
#### Summary
Features "Allow magazines in guns/tools to regenerate ammo"

#### Purpose of change
Artifact magazines or batteries with "charge_info" ability did not regenerate ammo when loaded in a gun/tool.
I'm not sure if this was intended, but magic magazines that generate ammo are usually expected to work while loaded in a weapon, not just when stored separately.

#### Describe the solution
item_contents::process() now processes the MAGAZINE_WELL pocket as well as CONTAINER and MOD pockets.

#### Describe alternatives you've considered
Calling process_relic() specifically for magazines, but that would be inconsistent with how CONTAINER and MOD pockets are already processed.

#### Testing
- Add an artifact with "charge_info": "regenerate_ammo","periodic" to the game.
- Use the ammo.
1. Just wait
   1. Confirm that the magazine recharges ammo.
2. Load the magazine into random guns.
   1. Confirm that the magazine recharges ammo.


#### Additional context
None.

