### PR TITLE
Don't report butchery if things that aren't present +

### DIFF
--- a/src/butchery.cpp
+++ b/src/butchery.cpp
@@ -622,8 +622,6 @@ static std::vector<item> create_charge_items( const itype *drop, int count,
     return objs;
 }
 
-static const double skinning_factor = 0.85;
-
 bool butchery_drops_harvest( butchery_data bt, Character &you )
 {
     const butcher_type action = bt.b_type;
@@ -924,7 +922,7 @@ bool butchery_drops_harvest( butchery_data bt, Character &you )
             // 25% of the corpse weight is what's removed during field dressing
             monster_weight_remaining -= monster_weight * 3 / 4;
         } else if( action == butcher_type::SKIN ) {
-            monster_weight_remaining -= monster_weight * skinning_factor;
+            monster_weight_remaining -= monster_weight * 0.85;
         } else {
             // a carcass is 75% of the weight of the unmodified creature's weight
             if( ( corpse_item.has_flag( flag_FIELD_DRESS ) ||


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
- Don't report failures to recover products that aren't present.
- Don't spill copious amounts of (acid) blood from corpses that have already been bled.
- Don't claim you recover the blood you're actually dumping. Just leave the dumping message.
- Plug the loop hole of skinning quartered corpses. Quartering is described as destroying the skin.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
- Add the various checks needed to not report failures to recover bits that aren't present.
- Add the SKINNED flag to quartered corpse parts.
- Adjust the liquid product reporting.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
- Find out a way to dump a little (acid) blood even from bled corpses, necessitating at least protective footwear (or take damage).
- Don't try (and fail, in all my attempts) to recover a canine skull both from field dressing and from full butchery. Since the brain is a product of full butchery, I would expect the skull containing it to be as well. Considered out of scope.
- Introduce a new flag to indicate hides are destroyed rather than removed from quartered corpse parts and translate that into more butchery refuse. Seems like a fair bit of work for little benefit.
- Find out a way to mark spilled blood in red like other failures to recover products. Deemed to be out of scope.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Butchering of various types and orders of rabbits and bulldogs to see the reports end up as intended. Also did an acid ant to check bleeding->full butchery didn't do anything funny with acid blood (i.e. no blood was dropped).

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Note that this shouldn't change the newly increased butchering times, but rather the reporting of what's (failed) to be recovered once the butchering is done. It does block the ability to recover hides from quartered corpse parts, though, as that's in line with the quartering description, as well as the inability to recover hides when full butchering quartered corpse parts.

It can also be noted that it seems that the bleeding action would deal with any liquid, and so might be used to extract other fluids, such as e.g. venom from corpses. I don't know if that's done anywhere, but if it is, the description for the bleeding action should probably be adjusted to indicate that.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
