### PR TITLE
Innawoods bronze tongs can be made without already having tongs

### DIFF
--- a/data/mods/innawood/recipes/tools_hand.json
+++ b/data/mods/innawood/recipes/tools_hand.json
@@ -98,5 +98,24 @@
       { "proficiency": "prof_toolsmithing" }
     ],
     "components": [ [ [ "2x4", 1 ] ] ]
+  },
+  {
+  "type": "recipe",
+  "activity_level": "MODERATE_EXERCISE",
+  "result": "metalworking_tongs_bronze",
+  "category": "CC_OTHER",
+  "subcategory": "CSC_OTHER_TOOLS",
+  "skill_used": "fabrication",
+  "difficulty": 2,
+  "time": "60 m",
+  "autolearn": true,
+  "using": [ [ "blacksmithing_standard", 3 ], [ "bronze_tiny", 3 ] ],
+  "proficiencies": [
+    { "proficiency": "prof_metalworking", "required": true },
+    { "proficiency": "prof_redsmithing", "required": true },
+    { "proficiency": "prof_redsmithing_adv" },
+    { "proficiency": "prof_toolsmithing" }
+  ],
+  "components": [ [ [ "nails", 1, "LIST" ], [ "nuts_bolts", 1 ] ] ]
   }
 ]

--- a/data/mods/innawood/recipes/tools_hand.json
+++ b/data/mods/innawood/recipes/tools_hand.json
@@ -129,10 +129,7 @@
     "difficulty": 3,
     "time": "125 m",
     "autolearn": true,
-    "proficiencies": [
-      { "proficiency": "prof_metalworking", "required": true }, 
-      { "proficiency": "prof_toolsmithing" }
-    ],
+    "proficiencies": [ { "proficiency": "prof_metalworking", "required": true }, { "proficiency": "prof_toolsmithing" } ],
     "using": [ [ "forging_standard", 3 ], [ "bronze_tiny", 3 ], [ "bronzesmithing_tools", 1 ] ],
     "tools": [ [ [ "casting_mold_large", -1 ], [ "casting_mold_long", -1 ] ] ],
     "components": [ [ [ "nails", 1, "LIST" ], [ "nuts_bolts", 1 ] ] ]

--- a/data/mods/innawood/recipes/tools_hand.json
+++ b/data/mods/innawood/recipes/tools_hand.json
@@ -129,9 +129,12 @@
     "difficulty": 3,
     "time": "125 m",
     "autolearn": true,
-    "proficiencies": [ { "proficiency": "prof_metalworking", "required": true }, { "proficiency": "prof_toolsmithing" } ],
+    "proficiencies": [
+      { "proficiency": "prof_metalworking", "required": true }, 
+      { "proficiency": "prof_toolsmithing" }
+    ],
     "using": [ [ "forging_standard", 3 ], [ "bronze_tiny", 3 ], [ "bronzesmithing_tools", 1 ] ],
     "tools": [ [ [ "casting_mold_large", -1 ], [ "casting_mold_long", -1 ] ] ],
     "components": [ [ [ "nails", 1, "LIST" ], [ "nuts_bolts", 1 ] ] ]
-}
+  }
 ]

--- a/data/mods/innawood/recipes/tools_hand.json
+++ b/data/mods/innawood/recipes/tools_hand.json
@@ -100,22 +100,38 @@
     "components": [ [ [ "2x4", 1 ] ] ]
   },
   {
-  "type": "recipe",
-  "activity_level": "MODERATE_EXERCISE",
-  "result": "metalworking_tongs_bronze",
-  "category": "CC_OTHER",
-  "subcategory": "CSC_OTHER_TOOLS",
-  "skill_used": "fabrication",
-  "difficulty": 2,
-  "time": "60 m",
-  "autolearn": true,
-  "using": [ [ "blacksmithing_standard", 3 ], [ "bronze_tiny", 3 ] ],
-  "proficiencies": [
-    { "proficiency": "prof_metalworking", "required": true },
-    { "proficiency": "prof_redsmithing", "required": true },
-    { "proficiency": "prof_redsmithing_adv" },
-    { "proficiency": "prof_toolsmithing" }
-  ],
-  "components": [ [ [ "nails", 1, "LIST" ], [ "nuts_bolts", 1 ] ] ]
-  }
+    "type": "recipe",
+    "activity_level": "MODERATE_EXERCISE",
+    "result": "metalworking_tongs_bronze",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_TOOLS",
+    "skill_used": "fabrication",
+    "difficulty": 2,
+    "time": "60 m",
+    "autolearn": true,
+    "using": [ [ "blacksmithing_standard", 3 ], [ "bronze_tiny", 3 ] ],
+    "proficiencies": [
+      { "proficiency": "prof_metalworking", "required": true },
+      { "proficiency": "prof_redsmithing", "required": true },
+      { "proficiency": "prof_redsmithing_adv" },
+      { "proficiency": "prof_toolsmithing" }
+    ],
+    "components": [ [ [ "nails", 1, "LIST" ], [ "nuts_bolts", 1 ] ] ]
+  },
+  {
+    "type": "recipe",
+    "activity_level": "MODERATE_EXERCISE",
+    "result": "metalworking_tongs_bronze",
+    "id_suffix": "casting",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_TOOLS",
+    "skill_used": "fabrication",
+    "difficulty": 3,
+    "time": "125 m",
+    "autolearn": true,
+    "proficiencies": [ { "proficiency": "prof_metalworking", "required": true }, { "proficiency": "prof_toolsmithing" } ],
+    "using": [ [ "forging_standard", 3 ], [ "bronze_tiny", 3 ], [ "bronzesmithing_tools", 1 ] ],
+    "tools": [ [ [ "casting_mold_large", -1 ], [ "casting_mold_long", -1 ] ] ],
+    "components": [ [ [ "nails", 1, "LIST" ], [ "nuts_bolts", 1 ] ] ]
+},
 ]

--- a/data/mods/innawood/recipes/tools_hand.json
+++ b/data/mods/innawood/recipes/tools_hand.json
@@ -133,5 +133,5 @@
     "using": [ [ "forging_standard", 3 ], [ "bronze_tiny", 3 ], [ "bronzesmithing_tools", 1 ] ],
     "tools": [ [ [ "casting_mold_large", -1 ], [ "casting_mold_long", -1 ] ] ],
     "components": [ [ [ "nails", 1, "LIST" ], [ "nuts_bolts", 1 ] ] ]
-},
+}
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "Innawoods progression fix"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
fixes #81659
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

manual tooling prof not **required** for bronze tongs (for innawoods mod only)

#### Describe alternatives you've considered
leaving it, making blacksmithing more accessible than bronzesmithing for no reason

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
tested, made tongs without manual tooling prof
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
