### PR TITLE
[Xedra Evolved ] Fix Gracken Stomachs

### DIFF
--- a/data/mods/Xedra_Evolved/items/gracken_trait_improvements.json
+++ b/data/mods/Xedra_Evolved/items/gracken_trait_improvements.json
@@ -164,7 +164,7 @@
     "type": "effect_on_condition",
     "id": "herbivorous_stomach",
     "condition": { "not": { "u_has_trait": "SHADE_HERBIVORE" } },
-    "effect": [ { "u_message": "You exchanged your previous stomach for this." }, { "u_add_trait": "SHADE_HERBIVORE" } ],
+    "effect": [ { "u_message": "You exchanged your previous stomach for this." }, { "u_add_trait": "SHADE_HERBIVORE" }, { "u_lose_trait": "RADIOTROPHIC" } ],
     "false_effect": [ { "u_message": "You are already an herbivore.", "type": "neutral" } ]
   },
   {
@@ -172,7 +172,7 @@
     "copy-from": "gracken_improvement_general",
     "type": "ITEM",
     "subtypes": [ "TOOL" ],
-    "name": { "str_sp": "Gracken Dextrous Hands" },
+    "name": { "str_sp": "Gracken Omnivorous Stomach" },
     "looks_like": "offal",
     "description": "An organ that allows a mature Gracken to convert their diet to an omnivorous one.",
     "use_action": {
@@ -186,7 +186,7 @@
     "type": "effect_on_condition",
     "id": "omnivorous_stomach",
     "condition": { "not": { "u_has_trait": "SHADE_OMNIVORE" } },
-    "effect": [ { "u_message": "You exchanged your previous stomach for this." }, { "u_add_trait": "SHADE_OMNIVORE" } ],
+    "effect": [ { "u_message": "You exchanged your previous stomach for this." }, { "u_add_trait": "SHADE_OMNIVORE" }, { "u_lose_trait": "RADIOTROPHIC" } ],
     "false_effect": [ { "u_message": "You are already an omnivore.", "type": "neutral" } ]
   },
   {
@@ -194,7 +194,7 @@
     "copy-from": "gracken_improvement_general",
     "type": "ITEM",
     "subtypes": [ "TOOL" ],
-    "name": { "str_sp": "Gracken Dextrous Hands" },
+    "name": { "str_sp": "Gracken Carnivorous Stomach" },
     "looks_like": "offal",
     "description": "An organ that allows a mature Gracken to convert their diet to an carnivorous one.",
     "use_action": {
@@ -208,7 +208,7 @@
     "type": "effect_on_condition",
     "id": "carnivorous_stomach",
     "condition": { "not": { "u_has_trait": "SHADE_CARNIVORE" } },
-    "effect": [ { "u_message": "You exchanged your previous stomach for this." }, { "u_add_trait": "SHADE_CARNIVORE" } ],
+    "effect": [ { "u_message": "You exchanged your previous stomach for this." }, { "u_add_trait": "SHADE_CARNIVORE" }, { "u_lose_trait": "RADIOTROPHIC" } ],
     "false_effect": [ { "u_message": "You are already a carnivore.", "type": "neutral" } ]
   },
   {

--- a/data/mods/Xedra_Evolved/items/gracken_trait_improvements.json
+++ b/data/mods/Xedra_Evolved/items/gracken_trait_improvements.json
@@ -164,7 +164,11 @@
     "type": "effect_on_condition",
     "id": "herbivorous_stomach",
     "condition": { "not": { "u_has_trait": "SHADE_HERBIVORE" } },
-    "effect": [ { "u_message": "You exchanged your previous stomach for this." }, { "u_add_trait": "SHADE_HERBIVORE" }, { "u_lose_trait": "RADIOTROPHIC" } ],
+    "effect": [
+      { "u_message": "You exchanged your previous stomach for this." },
+      { "u_add_trait": "SHADE_HERBIVORE" },
+      { "u_lose_trait": "RADIOTROPHIC" }
+    ],
     "false_effect": [ { "u_message": "You are already an herbivore.", "type": "neutral" } ]
   },
   {
@@ -186,7 +190,11 @@
     "type": "effect_on_condition",
     "id": "omnivorous_stomach",
     "condition": { "not": { "u_has_trait": "SHADE_OMNIVORE" } },
-    "effect": [ { "u_message": "You exchanged your previous stomach for this." }, { "u_add_trait": "SHADE_OMNIVORE" }, { "u_lose_trait": "RADIOTROPHIC" } ],
+    "effect": [
+      { "u_message": "You exchanged your previous stomach for this." },
+      { "u_add_trait": "SHADE_OMNIVORE" },
+      { "u_lose_trait": "RADIOTROPHIC" }
+    ],
     "false_effect": [ { "u_message": "You are already an omnivore.", "type": "neutral" } ]
   },
   {
@@ -208,7 +216,11 @@
     "type": "effect_on_condition",
     "id": "carnivorous_stomach",
     "condition": { "not": { "u_has_trait": "SHADE_CARNIVORE" } },
-    "effect": [ { "u_message": "You exchanged your previous stomach for this." }, { "u_add_trait": "SHADE_CARNIVORE" }, { "u_lose_trait": "RADIOTROPHIC" } ],
+    "effect": [
+      { "u_message": "You exchanged your previous stomach for this." },
+      { "u_add_trait": "SHADE_CARNIVORE" },
+      { "u_lose_trait": "RADIOTROPHIC" }
+    ],
     "false_effect": [ { "u_message": "You are already a carnivore.", "type": "neutral" } ]
   },
   {

--- a/data/mods/Xedra_Evolved/mutations/gracken_trait_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/gracken_trait_eocs.json
@@ -2,7 +2,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_GRACKEN_CONVERT_RADS_TO_CALORIES",
-    "recurrence": [ "5 seconds", "15 seconds" ],
+    "recurrence": [ "75 seconds", "175 seconds" ],
     "condition": { "u_has_trait": "RADIOTROPHIC" },
     "deactivate_condition": { "not": { "u_has_trait": "RADIOTROPHIC" } },
     "effect": [

--- a/data/mods/Xedra_Evolved/mutations/xe_playable_gracken.json
+++ b/data/mods/Xedra_Evolved/mutations/xe_playable_gracken.json
@@ -322,6 +322,15 @@
     "category": [ "GRACKEN" ],
     "threshreq": [ "THRESH_SPECIES_GRACKEN" ],
     "flags": [ "CARNIVORE_DIET" ],
+    "enchantments": [
+      {
+        "values": [
+          { "value": "STRENGTH", "add": 1 },
+          { "value": "METABOLISM", "multiply": 0.8 },
+          { "value": "STOMACH_SIZE_MULTIPLIER", "add": 500 }
+        ]
+      }
+    ],
     "vitamin_rates": [ [ "vitC", -1200 ] ]
   },
   {
@@ -335,6 +344,16 @@
     "mixed_effect": true,
     "points": 1,
     "category": [ "GRACKEN" ],
+    "flags": "HERBIVORE_DIET",
+    "enchantments": [
+      {
+        "values": [
+          { "value": "KCAL", "multiply": 1.3 },
+          { "value": "DODGE_CHANCE", "add": 3 },
+          { "value": "STOMACH_SIZE_MULTIPLIER", "add": 1000 }
+        ]
+      }
+    ],
     "threshreq": [ "THRESH_SPECIES_GRACKEN" ]
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "XE Fix Gracken stomacks"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Make Gracken stomach choices matter.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Adds enchantments and flags as needed and removes radiotrophic.  Also makes radiotrophic less effective.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
