### PR TITLE
Remove obsolete grip mount

### DIFF
--- a/data/json/itemgroups/Weapons_Mods_Ammo/gunmod.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/gunmod.json
@@ -169,7 +169,7 @@
     "id": "mosin_mods",
     "//": "Default mods for the EBR variants of the Mosin carbine and battle rifle",
     "subtype": "collection",
-    "entries": [ { "item": "grip_mount" }, { "item": "rail_mount" }, { "item": "stock_mount" } ]
+    "entries": [ { "item": "rail_mount" }, { "item": "stock_mount" } ]
   },
   {
     "type": "item_group",

--- a/data/json/items/gunmod/mount.json
+++ b/data/json/items/gunmod/mount.json
@@ -1,26 +1,5 @@
 [
   {
-    "id": "grip_mount",
-    "type": "ITEM",
-    "subtypes": [ "GUNMOD" ],
-    "name": { "str": "replaceable furniture kit" },
-    "description": "A kit consisting of various steel and plastic parts.  When installed, it will permanently modify and partially replace some of the weapon's furniture so that it can be easily changed if needed.  This allows installing any kind of more advanced grips or other furniture.",
-    "weight": "80 g",
-    "volume": "50 ml",
-    "integral_volume": "0 ml",
-    "price": "60 USD",
-    "price_postapoc": "5 USD",
-    "material": [ "steel", "plastic" ],
-    "symbol": ":",
-    "color": "light_gray",
-    "location": "grip mount",
-    "mod_targets": [ "smg", "rifle", "pistol", "shotgun", "crossbow", "launcher" ],
-    "install_time": "20 m",
-    "min_skills": [ [ "gun", 5 ] ],
-    "add_mod": [ [ "grip", 1 ] ],
-    "flags": [ "INSTALL_DIFFICULT", "IRREMOVABLE" ]
-  },
-  {
     "id": "rail_mount",
     "type": "ITEM",
     "subtypes": [ "GUNMOD" ],

--- a/data/json/recipes/nested.json
+++ b/data/json/recipes/nested.json
@@ -4500,7 +4500,6 @@
     "description": "Recipes related to making mounts for attachments on older or makeshift guns.",
     "skill_used": "fabrication",
     "nested_category_data": [
-      "grip_mount",
       "rail_mount",
       "rail_bayonet_lug",
       "sights_mount",

--- a/data/json/recipes/weapon/mods.json
+++ b/data/json/recipes/weapon/mods.json
@@ -461,33 +461,6 @@
     "components": [ [ [ "scrap", 3 ] ] ]
   },
   {
-    "result": "grip_mount",
-    "type": "recipe",
-    "activity_level": "LIGHT_EXERCISE",
-    "category": "CC_*",
-    "subcategory": "CSC_*_NESTED",
-    "skill_used": "fabrication",
-    "difficulty": 3,
-    "skills_required": [ [ "gun", 5 ] ],
-    "time": "30 m",
-    "book_learn": [
-      [ "mag_guns", 4 ],
-      [ "mag_pistol", 4 ],
-      [ "mag_shotgun", 4 ],
-      [ "mag_smg", 4 ],
-      [ "mag_rifle", 4 ],
-      [ "manual_gun", 4 ],
-      [ "manual_pistol", 4 ],
-      [ "manual_shotgun", 4 ],
-      [ "manual_smg", 4 ],
-      [ "manual_rifle", 4 ]
-    ],
-    "using": [ [ "soldering_standard", 15 ] ],
-    "qualities": [ { "id": "HAMMER_FINE", "level": 1 }, { "id": "SAW_M_FINE", "level": 1 } ],
-    "tools": [ [ [ "large_repairkit", 10 ], [ "small_repairkit", 30 ] ] ],
-    "components": [ [ [ "scrap", 1 ] ], [ [ "plastic_chunk", 3 ] ] ]
-  },
-  {
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",
     "result": "tele_sight",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Grip mods were removed a while back but this mod still exists as a way to allow nonexistent mods to be attached.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Remove it.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Fixes #83420.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
