### PR TITLE
Update extractor, part 2

### DIFF
--- a/lang/string_extractor/parsers/body_part.py
+++ b/lang/string_extractor/parsers/body_part.py
@@ -6,40 +6,31 @@ def parse_body_part(json, origin):
     # See comments in `body_part_struct::load` of bodypart.cpp about why xxx
     # and xxx_multiple are not inside a single translation object.
 
-    name = ""
-    if "name" in json:
-        name = get_singular_name(json["name"])
-        write_text(json["name"], origin, comment="Name of body part")
-    elif "id" in json:
-        name = json["id"]
+    name = get_singular_name(json)
 
-    if "name_multiple" in json:
-        write_text(json["name_multiple"], origin, comment="Name of body part")
+    write_text(json.get("name"), origin,
+               comment="Name of body part")
 
-    if "accusative" in json:
-        write_text(json["accusative"], origin,
-                   comment="Accusative name of body part")
+    write_text(json.get("name_multiple"), origin,
+               comment="Name of body part")
 
-    if "accusative_multiple" in json:
-        write_text(json["accusative_multiple"], origin,
-                   comment="Accusative name of body part")
+    write_text(json.get("accusative"), origin,
+               comment="Accusative name of body part")
 
-    if "encumbrance_text" in json:
-        write_text(json["encumbrance_text"], origin,
-                   comment="Encumbrance text of body part \"{}\"".format(name))
+    write_text(json.get("accusative_multiple"), origin,
+               comment="Accusative name of body part")
 
-    if "heading" in json:
-        write_text(json["heading"], origin,
-                   comment="Heading of body part \"{}\"".format(name))
+    write_text(json.get("encumbrance_text"), origin,
+               comment=f"Encumbrance text of body part '{name}'")
 
-    if "heading_multiple" in json:
-        write_text(json["heading_multiple"], origin,
-                   comment="Heading of body part \"{}\"".format(name))
+    write_text(json.get("heading"), origin,
+               comment=f"Heading of body part '{name}'")
 
-    if "smash_message" in json:
-        write_text(json["smash_message"], origin,
-                   comment="Smash message of body part \"{}\"".format(name))
+    write_text(json.get("heading_multiple"), origin,
+               comment=f"Heading of body part '{name}'")
 
-    if "hp_bar_ui_text" in json:
-        write_text(json["hp_bar_ui_text"], origin,
-                   comment="HP bar UI text of body part \"{}\"".format(name))
+    write_text(json.get("smash_message"), origin,
+               comment=f"Smash message of body part '{name}'")
+
+    write_text(json.get("hp_bar_ui_text"), origin,
+               comment=f"HP bar UI text of body part '{name}'")

--- a/lang/string_extractor/parsers/climbing_aid.py
+++ b/lang/string_extractor/parsers/climbing_aid.py
@@ -3,29 +3,20 @@ from ..write_text import write_text
 
 
 def parse_climbing_aid(json, origin):
-    name = ""
-    if "name" in json:
-        name = get_singular_name(json["name"])
-        write_text(json["name"], origin, comment="Name of a gun", plural=True)
-    elif "id" in json:
-        name = json["id"]
 
-    down = None
-    if "down" in json:
-        down = json["down"]
+    down = json.get("down")
+    if not down:
+        return
 
-    if down and "menu_text" in down:
-        write_text(down["menu_text"], origin,
-                   comment="Menu text for descent with \"{}\"".format(name))
-    if down and "menu_cant" in down:
-        write_text(down["menu_cant"], origin,
-                   comment="Menu disables descent with \"{}\"".format(name))
-    if down and "confirm_text" in down:
-        write_text(down["confirm_text"], origin,
-                   comment="Query: really descend with \"{}\"?".format(name))
-    if down and "msg_before" in down:
-        write_text(down["msg_before"], origin,
-                   comment="Message before descent with \"{}\"".format(name))
-    if down and "msg_after" in down:
-        write_text(down["msg_after"], origin,
-                   comment="Message after descent with \"{}\"".format(name))
+    name = get_singular_name(json)
+
+    write_text(down.get("menu_text"), origin,
+               comment=f"Menu text for descent with '{name}'")
+    write_text(down.get("menu_cant"), origin,
+               comment=f"Menu disables descent with '{name}'")
+    write_text(down.get("confirm_text"), origin,
+               comment=f"Query: really descend with '{name}'?")
+    write_text(down.get("msg_before"), origin,
+               comment=f"Message before descent with '{name}'")
+    write_text(down.get("msg_after"), origin,
+               comment=f"Message after descent with '{name}'")

--- a/lang/string_extractor/parsers/enchant.py
+++ b/lang/string_extractor/parsers/enchant.py
@@ -4,23 +4,22 @@ from ..write_text import write_text
 
 
 def parse_enchant(json, origin):
-    if "name" in json:
-        name = get_singular_name(json["name"])
-        write_text(json["name"], origin,
-                   comment="Name of a enchantment")
+    if not (json and type(json) is dict):
+        return
 
-    if "description" in json:
-        write_text(json["description"], origin,
-                   comment="Description of enchantment \"{}\"".format(name))
+    name = get_singular_name(json)
+
+    write_text(json.get("name"), origin,
+               comment="Name of a enchantment")
+    write_text(json.get("description"), origin,
+               comment=f"Description of enchantment '{name}'")
 
     if "hit_me_effect" in json:
         parse_effect(json["hit_me_effect"], origin)
 
-    if "special_vision" in json:
-        for vision in json["special_vision"]:
-            if "descriptions" in vision:
-                for description in vision["descriptions"]:
-                    parse_description(description, origin)
+    for vision in json.get("special_vision", []):
+        for description in vision.get("descriptions", []):
+            parse_description(description, origin)
 
 
 def parse_description(description, origin):
@@ -28,4 +27,4 @@ def parse_description(description, origin):
         special_vision_id = description["id"]
         write_text(description["text"], origin,
                    comment="Description of creature revealed by special "
-                   "vision \"{}\"".format(special_vision_id))
+                   f"vision '{special_vision_id}'")

--- a/lang/string_extractor/parsers/faction_mission.py
+++ b/lang/string_extractor/parsers/faction_mission.py
@@ -3,29 +3,26 @@ from ..write_text import write_text
 
 
 def parse_faction_mission(json, origin):
-    name = get_singular_name(json.get("name", json["id"]))
-    if "name" in json:
-        write_text(json["name"], origin, comment="Faction mission name")
-    if "desc" in json:
-        write_text(json["desc"], origin,
-                   comment="Description of faction mission "
-                   "\"{}\"".format(name))
-    if "time" in json:
-        write_text(json["time"], origin,
-                   comment="Duration of faction mission \"{}\"".format(name))
-    if "footer" in json:
-        write_text(json["footer"], origin,
-                   comment="Footer of faction mission \"{}\"".format(name))
-    if "items_label" in json:
-        write_text(json["items_label"], origin,
-                   comment="Gather items header label of faction mission "
-                   "\"{}\"".format(name))
-    if "items_possibilities" in json:
-        for item in json["items_possibilities"]:
-            write_text(item, origin,
-                       comment="Possible item from faction mission "
-                       "\"{}\"".format(name))
-    if "effects" in json:
-        for item in json["effects"]:
-            write_text(item, origin,
-                       comment="Effect of faction mission \"{}\"".format(name))
+    name = get_singular_name(json)
+
+    write_text(json.get("name"), origin, comment="Faction mission name")
+
+    write_text(json.get("desc"), origin,
+               comment=f"Description of faction mission '{name}'")
+
+    write_text(json.get("time"), origin,
+               comment=f"Duration of faction mission '{name}'")
+
+    write_text(json.get("footer"), origin,
+               comment=f"Footer of faction mission '{name}'")
+
+    write_text(json.get("items_label"), origin,
+               comment=f"Gather items header of faction mission '{name}'")
+
+    for item in json.get("items_possibilities", []):
+        write_text(item, origin,
+                   comment=f"Possible item from faction mission '{name}'")
+
+    for item in json.get("effects", []):
+        write_text(item, origin,
+                   comment=f"Effect of faction mission '{name}'")

--- a/lang/string_extractor/parsers/field_type.py
+++ b/lang/string_extractor/parsers/field_type.py
@@ -1,3 +1,4 @@
+from ..helper import get_singular_name
 from ..write_text import write_text
 
 
@@ -5,27 +6,21 @@ def parse_field_type(json, origin):
     field_names = []
 
     for fd in json.get("intensity_levels", []):
-        if "name" in fd:
-            write_text(fd["name"], origin, comment="Field intensity level")
-            id_or_name = fd["name"]
-        else:
-            id_or_name = json["id"]
-        field_names.append(id_or_name)
+        name = get_singular_name(fd)
+        field_names.append(name)
+
+        write_text(fd.get("name"), origin, comment="Field intensity level")
+
         for eff in fd.get("effects", []):
-            if "message" in eff:
-                write_text(eff["message"], origin,
-                           comment="Player message on effect of field {}"
-                           .format(id_or_name))
-            if "message_npc" in eff:
-                write_text(eff["message_npc"], origin,
-                           comment="NPC message on effect of field {}"
-                           .format(id_or_name))
+            write_text(eff.get("message"), origin,
+                       comment=f"Player message on effect of field '{name}'")
+            write_text(eff.get("message_npc"), origin,
+                       comment=f"NPC message on effect of field '{name}'")
+
     if "npc_complain" in json:
         write_text(json["npc_complain"]["speech"], origin,
                    comment="Field NPC complaint")
 
-    if "bash" in json:
-        if "msg_success" in json["bash"]:
-            write_text(json["bash"]["msg_success"], origin,
-                       comment="Bashing message of fields {}"
-                       .format(", ".join(f"\"{n}\"" for n in field_names)))
+    if "msg_success" in json.get("bash", []):
+        write_text(json["bash"]["msg_success"], origin,
+                   comment=f"Bashing message of fields: {field_names}")

--- a/lang/string_extractor/parsers/gun.py
+++ b/lang/string_extractor/parsers/gun.py
@@ -1,48 +1,21 @@
 from ..helper import get_singular_name
-from .use_action import parse_use_action
 from ..write_text import write_text
 
 
 def parse_gun(json, origin):
-    name = ""
-    if "name" in json:
-        name = get_singular_name(json["name"])
-        write_text(json["name"], origin, comment="Name of a gun", plural=True)
-    elif "id" in json:
-        name = json["id"]
+    name = get_singular_name(json)
 
-    if "description" in json:
-        write_text(json["description"], origin,
-                   comment="Description of gun \"{}\"".format(name))
-
-    if "use_action" in json:
-        parse_use_action(json["use_action"], origin, name)
-
-    if "variants" in json:
-        for variant in json["variants"]:
-            variant_name = get_singular_name(variant["name"])
-            write_text(variant["name"], origin,
-                       comment="Variant name of gun \"{}\"".format(name),
-                       plural=True)
-            write_text(variant["description"], origin,
-                       comment="Description of variant \"{0}\" of gun \"{1}\""
-                       .format(name, variant_name))
-
-    if "modes" in json:
-        for mode in json["modes"]:
-            write_text(mode[1], origin,
-                       comment="Firing mode of gun")
+    for mode in json.get("modes", []):
+        write_text(mode[1], origin, comment="Firing mode of gun")
 
     if "skill" in json:
         if json["skill"] != "archery":
-            write_text(json["skill"], origin, context="gun_type_type",
+            write_text(json["skill"], origin,
+                       context="gun_type_type",
                        comment="Skill associated with gun")
 
-    if "reload_noise" in json:
-        write_text(json["reload_noise"], origin,
-                   comment="Reload noise of gun \"{}\"".format(name))
+    write_text(json.get("reload_noise"), origin,
+               comment=f"Reload noise of gun '{name}'")
 
-    if "valid_mod_locations" in json:
-        for loc in json["valid_mod_locations"]:
-            write_text(loc[0], origin,
-                       comment="Valid mod location of gun")
+    for loc in json.get("valid_mod_locations", []):
+        write_text(loc[0], origin, comment="Location of gun mod")

--- a/lang/string_extractor/parsers/json_flag.py
+++ b/lang/string_extractor/parsers/json_flag.py
@@ -1,25 +1,23 @@
+from ..helper import get_singular_name
 from ..write_text import write_text
 
 
 def parse_json_flag(json, origin):
-    if "name" in json:
-        write_text(json["name"], origin,
-                   comment="Name of JSON flag \"{}\""
-                   .format(json["id"]))
-    if "info" in json:
-        write_text(json["info"], origin, comment=[
-            "Please leave anything in <angle brackets> unchanged.",
-            "Description of JSON flag \"{}\"".format(json["id"])
-        ])
-    if "restriction" in json:
-        write_text(json["restriction"], origin,
-                   comment="Description of restriction of JSON flag \"{}\""
-                   .format(json["id"]))
-    if "item_prefix" in json:
-        write_text(json["item_prefix"], origin,
-                   comment="This is custom prefix added to item name. \"{}\""
-                   .format(json["id"]))
-    if "item_suffix" in json:
-        write_text(json["item_suffix"], origin,
-                   comment="This is custom suffix added to item name. \"{}\""
-                   .format(json["id"]))
+    ident = json["id"]
+    name = get_singular_name(json)
+
+    write_text(json.get("name"), origin,
+               comment=f"Name of JSON flag '{ident}'")
+
+    write_text(json.get("info"), origin, comment=[
+        "Please leave anything in <angle_brackets> unchanged.",
+        f"Description of JSON flag '{name}'"])
+
+    write_text(json.get("restriction"), origin,
+               comment="Description of restriction "
+               f"of JSON flag '{name}'")
+
+    write_text(json.get("item_prefix"), origin,
+               comment="Custom prefix added to item name")
+    write_text(json.get("item_suffix"), origin,
+               comment="Custom suffix added to item name")

--- a/lang/string_extractor/parsers/mapgen.py
+++ b/lang/string_extractor/parsers/mapgen.py
@@ -6,14 +6,13 @@ def parse_mapgen(json, origin):
     if "object" not in json:
         return
 
-    om = ""
+    om = json.get("nested_mapgen_id", "???")
+
     if "om_terrain" in json:
         if type(json["om_terrain"]) is str:
             om = json["om_terrain"]
-        elif type(json["om_terrain"]) is list:
-            if len(json["om_terrain"]) == 0:
-                om = ""
-            elif type(json["om_terrain"][0]) is str:
+        elif type(json["om_terrain"]) is list and json["om_terrain"]:
+            if type(json["om_terrain"][0]) is str:
                 om = ", ".join(json["om_terrain"])
             elif type(json["om_terrain"][0]) is list:
                 om = ", ".join(", ".join(i) for i in json["om_terrain"])
@@ -25,64 +24,48 @@ def parse_mapgen_object(json, origin, om):
     if type(json) is list:
         for j in json:
             parse_mapgen_object(j, origin, om)
+        return
 
     for key in ["place_specials", "place_signs"]:
-        if key in json:
-            for sign in json[key]:
-                if "signage" in sign:
-                    write_text(sign["signage"], origin,
-                               comment="Signage placed on map {}".format(om))
+        for sign in json.get(key, []):
+            write_text(sign.get("signage"), origin,
+                       comment=f"Signage placed on map '{om}'")
 
-    if "signs" in json:
-        for sign in json["signs"]:
-            if "signage" in json["signs"][sign]:
-                write_text(json["signs"][sign]["signage"], origin,
-                           comment="Signage placed on map {}".format(om))
+    for sign in json.get("signs", []):
+        if "signage" in json["signs"][sign]:
+            write_text(json["signs"][sign]["signage"], origin,
+                       comment=f"Signage placed on map '{om}'")
 
-    if "computers" in json:
-        for key in json["computers"]:
-            com = json["computers"][key]
-            com_name = ""
-            if "name" in com:
-                com_name = get_singular_name(com["name"])
-                write_text(
-                    com["name"], origin,
-                    comment="Computer name placed on map {}".format(om))
-            for opt in com.get("options", []):
-                if "name" in opt:
-                    write_text(opt["name"], origin,
-                               comment="Interactive menu name in computer "
-                               "\"{}\" placed on map {}".format(com_name, om))
-            if "access_denied" in com:
-                write_text(com["access_denied"], origin,
-                           comment="Access denied message on computer \"{}\""
-                           " placed on map {}".format(com_name, om))
+    for computer in json.get("computers", {}).values():
+        com_name = get_singular_name(computer)
 
-    if "place_computers" in json:
-        for computer in json["place_computers"]:
-            if "name" in computer:
-                write_text(computer["name"], origin,
-                           comment="Computer name placed on map {}".format(om))
+        write_text(com_name, origin,
+                   comment=f"Computer name placed on map '{om}'")
 
-    monsters = []
-    if "place_monster" in json:
-        monsters += json["place_monster"]
+        write_text(computer.get("access_denied"), origin,
+                   comment="Access denied message on computer"
+                   f" '{com_name}'")
+
+        for option in computer.get("options", []):
+            write_text(option.get("name"), origin,
+                       comment="Interactive menu name in computer"
+                       f" '{com_name}'")
+
+    for computer in json.get("place_computers", []):
+        write_text(computer.get("name"), origin,
+                   comment=f"Computer name placed on map '{om}'")
+
+    monsters = json.get("place_monster", [])
     if "monster" in json:
         monsters += [*json["monster"].values()]
 
     for m in monsters:
         if "name" in m:
-            desc = ""
-            if "monster" in m:
-                desc = "\"{}\"".format(m["monster"])
-            elif "group" in m:
-                desc = "group \"{}\"".format(m["group"])
+            desc = m.get("monster") or "group " + m.get("group")
             write_text(m["name"], origin,
-                       comment="Name of the monster {} placed on map {}"
-                       .format(desc, om))
+                       comment="Name of the monster"
+                       f" '{desc}' placed on map {om}")
 
-    if "place_graffiti" in json:
-        for graffiti in json["place_graffiti"]:
-            if "text" in graffiti:
-                write_text(graffiti["text"], origin,
-                           comment="Graffiti placed on map {}".format(om))
+    for graffiti in json.get("place_graffiti", []):
+        write_text(graffiti.get("text"), origin,
+                   comment=f"Graffiti placed on map '{om}'")

--- a/lang/string_extractor/parsers/martial_art.py
+++ b/lang/string_extractor/parsers/martial_art.py
@@ -3,42 +3,38 @@ from ..write_text import write_text
 
 
 def parse_martial_art(json, origin):
-    name = get_singular_name(json["name"])
+    name = get_singular_name(json)
+
     write_text(name, origin, comment="Name of martial art")
+    write_text(json.get("description"), origin,
+               comment=f"Description of martial art '{name}'")
 
-    if "description" in json:
-        write_text(json["description"], origin,
-                   comment="Description of martial art \"{}\"".format(name))
+    initiate = json.get("initiate", [])
+    if type(initiate) is str:
+        initiate = [initiate]
+    for msg in initiate:
+        write_text(msg, origin,
+                   comment=f"Initiate message of martial art '{name}'")
 
-    if "initiate" in json:
-        messages = json["initiate"]
-        if type(messages) is str:
-            messages = [messages]
-        for msg in messages:
-            write_text(msg, origin,
-                       comment="Initiate message of martial art \"{}\"".
-                       format(name))
-
-    onhit_buffs = json.get("onhit_buffs", list())
-    static_buffs = json.get("static_buffs", list())
-    onmove_buffs = json.get("onmove_buffs", list())
-    ondodge_buffs = json.get("ondodge_buffs", list())
-    onattack_buffs = json.get("onattack_buffs", list())
-    onpause_buffs = json.get("onpause_buffs", list())
-    onblock_buffs = json.get("onblock_buffs", list())
-    ongethit_buffs = json.get("ongethit_buffs", list())
-    onmiss_buffs = json.get("onmiss_buffs", list())
-    oncrit_buffs = json.get("oncrit_buffs", list())
-    onkill_buffs = json.get("onkill_buffs", list())
-
-    buffs = (onhit_buffs + static_buffs + onmove_buffs + ondodge_buffs +
-             onattack_buffs + onpause_buffs + onblock_buffs + ongethit_buffs +
-             onmiss_buffs + oncrit_buffs + onkill_buffs)
+    buffs = [
+        *json.get("onhit_buffs", []),
+        *json.get("static_buffs", []),
+        *json.get("onmove_buffs", []),
+        *json.get("ondodge_buffs", []),
+        *json.get("onattack_buffs", []),
+        *json.get("onpause_buffs", []),
+        *json.get("onblock_buffs", []),
+        *json.get("ongethit_buffs", []),
+        *json.get("onmiss_buffs", []),
+        *json.get("oncrit_buffs", []),
+        *json.get("onkill_buffs", [])
+    ]
 
     for buff in buffs:
-        buff_name = get_singular_name(buff["name"])
+        buff_name = get_singular_name(buff)
+
         write_text(buff_name, origin,
-                   comment="Buff name of martial art \"{}\"".format(name))
+                   comment=f"Buff name of martial art '{name}'")
+
         write_text(buff["description"], origin,
-                   comment="Description of buff \"{0}\" in martial art "
-                           "\"{1}\"".format(name, buff_name))
+                   comment=f"Description of buff '{buff_name}'")

--- a/lang/string_extractor/parsers/material.py
+++ b/lang/string_extractor/parsers/material.py
@@ -1,20 +1,21 @@
-from ..helper import get_singular_name
 from ..write_text import write_text
 
 
 def parse_material(json, origin):
-    name = get_singular_name(json["name"])
-    write_text(name, origin, comment="Name of material")
+    write_text(json["name"], origin, comment="Name of material")
 
-    if "bash_dmg_verb" in json:
-        write_text(json["bash_dmg_verb"], origin,
-                   comment="Bash damage verb of material")
+    write_text(json.get("bash_dmg_verb"), origin,
+               comment=[
+                   "Bash damage verb of material",
+                   "ex. 'Your helm is cracked!'"])
 
-    if "cut_dmg_verb" in json:
-        write_text(json["cut_dmg_verb"], origin,
-                   comment="Cut damage verb of material")
+    write_text(json.get("cut_dmg_verb"), origin,
+               comment=[
+                   "Cut damage verb of material",
+                   "ex. 'Your backpack is scratched!'"])
 
-    if "dmg_adj" in json:
-        for i in range(4):
-            write_text(json["dmg_adj"][i], origin,
-                       comment="Damage adjective of material")
+    for adj in json.get("dmg_adj", []):
+        write_text(adj, origin,
+                   comment=[
+                       "Damage adjective of material",
+                       "ex. 'dented cuirass'"])

--- a/lang/string_extractor/parsers/monster.py
+++ b/lang/string_extractor/parsers/monster.py
@@ -4,61 +4,49 @@ from .monster_attack import parse_monster_attack
 
 
 def parse_monster_concrete(json, origin, name):
-    if "description" in json:
-        write_text(json["description"], origin,
-                   comment="Description of monster \"{}\"".format(name))
+    write_text(json.get("description"), origin,
+               comment=f"Description of monster '{name}'")
 
     if "death_function" in json:
-        if "message" in json["death_function"]:
-            write_text(json["death_function"]["message"], origin,
-                       comment="Death message of monster \"{}\"".format(name))
+        write_text(json["death_function"].get("message"), origin,
+                   comment=f"Death message of monster '{name}'")
 
-    if "special_attacks" in json:
-        for attack in json["special_attacks"]:
-            if "type" in attack and attack["type"] == "monster_attack":
-                parse_monster_attack(attack, origin)
-                continue
-            if "description" in attack:
-                write_text(attack["description"], origin,
-                           comment="Description of special attack of monster "
-                           "\"{}\"".format(name))
-            if "monster_message" in attack:
-                write_text(attack["monster_message"], origin,
-                           comment="Monster message of special attack of "
-                           "monster \"{}\"".format(name))
-            if "targeting_sound" in attack:
-                write_text(attack["targeting_sound"], origin,
-                           comment="Targeting sound of special attack of "
-                           "monster \"{}\"".format(name))
-            if "no_ammo_sound" in attack:
-                write_text(attack["no_ammo_sound"], origin,
-                           comment="No ammo sound of special attack of "
-                           "monster \"{}\"".format(name))
+    for attack in json.get("special_attacks", []):
+        if not type(attack) is dict:
+            continue
+        if attack.get("type") == "monster_attack":
+            parse_monster_attack(attack, origin)
+            continue
 
-    if "weakpoints" in json:
-        for weakpoint in json["weakpoints"]:
-            if "name" in weakpoint:
-                write_text(weakpoint["name"], origin,
-                           comment="Sentence fragment describing a "
-                           "weakpoint for monster \"{}\"".format(name))
+        write_text(
+            attack.get("description"), origin,
+            comment=f"Description of special attack of monster '{name}'")
+        write_text(
+            attack.get("monster_message"), origin,
+            comment=f"Message of special attack of monster '{name}'")
+        write_text(
+            attack.get("targeting_sound"), origin,
+            comment=f"Targeting sound of special attack of monster '{name}'")
+        write_text(
+            attack.get("no_ammo_sound"), origin,
+            comment=f"No ammo sound of special attack of monster '{name}'")
+
+    for weakpoint in json.get("weakpoints", []):
+        write_text(weakpoint.get("name"), origin,
+                   comment="Sentence fragment describing a"
+                   f" weakpoint for monster '{name}'")
 
     if "petfood" in json:
-        if "feed" in json["petfood"]:
-            write_text(json["petfood"]["feed"], origin,
-                       comment="Feed message of monster \"{}\"".format(name))
-        if "pet" in json["petfood"]:
-            write_text(json["petfood"]["pet"], origin,
-                       comment="Pet message of monster \"{}\"".format(name))
+        write_text(json["petfood"].get("feed"), origin,
+                   comment=f"Feed message of monster '{name}'")
+        write_text(json["petfood"].get("pet"), origin,
+                   comment=f"Pet message of monster '{name}'")
 
 
 def parse_monster(json, origin):
-    name = ""
-    if "name" in json:
-        name = get_singular_name(json["name"])
-        write_text(json["name"], origin, comment="Monster name", plural=True)
-    elif "id" in json:
-        name = json["id"]
+    name = get_singular_name(json)
 
+    write_text(json.get("name"), origin, comment="Monster name", plural=True)
     parse_monster_concrete(json, origin, name)
 
     if "extend" in json:

--- a/lang/string_extractor/parsers/movement_mode.py
+++ b/lang/string_extractor/parsers/movement_mode.py
@@ -3,32 +3,32 @@ from ..write_text import write_text
 
 
 def parse_movement_mode(json, origin):
-    name = get_singular_name(json["name"])
+    name = get_singular_name(json)
+
     write_text(json["name"], origin, comment="Movement mode name")
+
     write_text(json["character"], origin,
                comment="Character displayed in the move menu for "
-               "movement mode \"{}\"".format(name))
+               f"movement mode '{name}'")
     write_text(json["panel_char"], origin,
                comment="Character displayed in the panel for "
-               "movement mode \"{}\"".format(name))
+               f"movement mode '{name}'")
     write_text(json["change_good_none"], origin,
                comment="Successfully switched to movement mode "
-               "\"{}\" with no steed".format(name))
+               f"'{name}' with no steed")
     write_text(json["change_good_animal"], origin,
                comment="Successfully switched to movement mode "
-               "\"{}\" with animal steed".format(name))
+               f"'{name}' with animal steed")
     write_text(json["change_good_mech"], origin,
                comment="Successfully switched to movement mode "
-               "\"{}\" with mechanical steed".format(name))
-    if "change_bad_none" in json:
-        write_text(json["change_bad_none"], origin,
-                   comment="Failed to switched to movement mode "
-                   "\"{}\" with no steed".format(name))
-    if "change_bad_animal" in json:
-        write_text(json["change_bad_animal"], origin,
-                   comment="Failed to switched to movement mode "
-                   "\"{}\" with animal steed".format(name))
-    if "change_bad_mech" in json:
-        write_text(json["change_bad_mech"], origin,
-                   comment="Failed to switched to movement mode "
-                   "\"{}\" with mechanical steed".format(name))
+               f"'{name}' with mechanical steed")
+
+    write_text(json.get("change_bad_none"), origin,
+               comment="Failed to switched to movement mode "
+               f"'{name}' with no steed")
+    write_text(json.get("change_bad_animal"), origin,
+               comment="Failed to switched to movement mode "
+               f"'{name}' with animal steed")
+    write_text(json.get("change_bad_mech"), origin,
+               comment="Failed to switched to movement mode "
+               f"'{name}' with mechanical steed")

--- a/lang/string_extractor/parsers/mutation.py
+++ b/lang/string_extractor/parsers/mutation.py
@@ -4,69 +4,57 @@ from ..write_text import write_text
 
 
 def parse_mutation(json, origin):
-    name = ""
-    if "name" in json:
-        name = get_singular_name(json["name"])
-        write_text(json["name"], origin, comment="Mutation name")
+    name = get_singular_name(json)
 
-    if "description" in json:
-        write_text(json["description"], origin,
-                   comment="Description of mutation \"{}\"".format(name))
+    write_text(json.get("name"), origin, comment="Mutation name")
+    write_text(json.get("description"), origin,
+               comment=f"Description of mutation '{name}'")
 
-    if "attacks" in json:
-        attacks = json["attacks"]
-        if type(attacks) is dict:
-            attacks = [attacks]
-        for attack in attacks:
-            if "attack_text_u" in attack:
-                write_text(attack["attack_text_u"], origin,
-                           comment="Message when player with mutation "
-                           "\"{}\" attacks".format(name))
-            if "attack_text_npc" in attack:
-                write_text(attack["attack_text_npc"], origin,
-                           comment="Message when NPC with mutation "
-                           "\"{}\" attacks".format(name))
+    attacks = json.get("attacks", [])
+    if type(attacks) is dict:
+        attacks = [attacks]
+
+    for attack in attacks:
+        write_text(attack.get("attack_text_u"), origin,
+                   comment="Message when player with mutation"
+                   f" '{name}' attacks")
+        write_text(attack.get("attack_text_npc"), origin,
+                   comment="Message when NPC with mutation"
+                   f" '{name}' attacks")
 
     if "ranged_mutation" in json:
-        if "message" in json["ranged_mutation"]:
-            write_text(json["ranged_mutation"]["message"], origin,
-                       comment="Message when firing ranged attack with "
-                       "mutation \"{}\"".format(name))
+        write_text(json["ranged_mutation"].get("message"), origin,
+                   comment="Message when firing ranged attack"
+                   f" with mutation '{name}'")
 
-    if "spawn_item" in json:
-        if "message" in json["spawn_item"]:
-            write_text(json["spawn_item"]["message"], origin,
-                       comment="Message when spawning item \"{}\" "
-                       "with mutation \"{}\""
-                       .format(json["spawn_item"]["type"], name))
+    if "message" in json.get("spawn_item", []):
+        spawn_type = json["spawn_item"]["type"]
+        write_text(json["spawn_item"]["message"], origin,
+                   comment="Message when spawning item"
+                   f" '{spawn_type}' with mutation '{name}'")
 
-    if "triggers" in json:
-        for arr in json["triggers"]:
-            for trigger in arr:
-                if "msg_on" in trigger and "text" in trigger["msg_on"]:
-                    write_text(trigger["msg_on"]["text"], origin,
-                               comment="Trigger message of mutation \"{}\""
-                               .format(name))
-                if "msg_off" in trigger and "text" in trigger["msg_off"]:
-                    write_text(trigger["msg_off"]["text"], origin,
-                               comment="Trigger message of mutation \"{}\""
-                               .format(name))
+    for arr in json.get("triggers", []):
+        for trigger in arr:
+            if "msg_on" in trigger:
+                write_text(trigger["msg_on"].get("text"), origin,
+                           comment=f"Trigger message of mutation '{name}'")
+            if "msg_off" in trigger:
+                write_text(trigger["msg_off"].get("text"), origin,
+                           comment=f"Trigger message of mutation '{name}'")
 
-    if "variants" in json:
-        for variant in json["variants"]:
-            variant_name = get_singular_name(variant["name"])
-            write_text(variant["name"], origin,
-                       comment="Variant name of mutation \"{}\"".format(name))
-            write_text(variant["description"], origin,
-                       comment="Description of variant " +
-                       "\"{1}\" of mutation\"{0}\"".format(name, variant_name))
+    for variant in json.get("variants", []):
+        variant_name = get_singular_name(variant)
+        write_text(variant["name"], origin,
+                   comment=f"Variant name of mutation '{name}'")
+        write_text(variant["description"], origin,
+                   comment="Description of variant"
+                   f" '{name}' of mutation '{variant_name}'")
 
     if "transform" in json:
+        target_id = json["transform"]["target"]
         write_text(json["transform"]["msg_transform"], origin,
-                   comment="Message when transforming from mutation "
-                   " \"{}\" to \"{}\""
-                   .format(name, json["transform"]["target"]))
+                   comment="Message when transforming from mutation"
+                   f" '{name}' to '{target_id}'")
 
-    if "enchantments" in json:
-        for enchantment in json["enchantments"]:
-            parse_enchant(enchantment, origin)
+    for enchantment in json.get("enchantments", []):
+        parse_enchant(enchantment, origin)

--- a/lang/string_extractor/parsers/mutation_category.py
+++ b/lang/string_extractor/parsers/mutation_category.py
@@ -3,26 +3,25 @@ from ..write_text import write_text
 
 
 def parse_mutation_category(json, origin):
-    name = get_singular_name(json["name"])
+    name = get_singular_name(json)
+
     write_text(json["name"], origin, comment="Mutation class name")
 
-    for key in ["mutagen_message",
-                "iv_message",
-                "iv_sleep_message",
-                "iv_sound_message",
-                "junkie_message"
-                ]:
-        if key in json:
-            write_text(json[key], origin,
-                       comment="\"{}\" of mutation class \"{}\""
-                       .format(key, name))
+    for key in [
+        "mutagen_message",
+        "iv_message",
+        "iv_sleep_message",
+        "iv_sound_message",
+        "junkie_message"
+    ]:
+        write_text(json.get(key), origin,
+                   comment=f"Message of mutation class '{name}'")
 
-    if "memorial_message" in json:
-        write_text(json["memorial_message"], origin,
-                   context="memorial_male",
-                   comment="Memorial message of mutation class "
-                   "\"{}\" for male".format(name))
-        write_text(json["memorial_message"], origin,
-                   context="memorial_female",
-                   comment="Memorial message of mutation class "
-                   "\"{}\" for female".format(name))
+    write_text(json.get("memorial_message"), origin,
+               context="memorial_male",
+               comment="Memorial message of mutation class "
+               f"'{name}' for male")
+    write_text(json.get("memorial_message"), origin,
+               context="memorial_female",
+               comment="Memorial message of mutation class "
+               f"'{name}' for female")

--- a/lang/string_extractor/parsers/npc.py
+++ b/lang/string_extractor/parsers/npc.py
@@ -80,16 +80,15 @@ chatbin_snippets = [
 def parse_npc(json, origin):
     gender = "an"
     if "gender" in json:
-        gender = "a {}".format(json["gender"])
-    comment = json.get("//", None)
-    if "name_unique" in json:
-        write_text(json["name_unique"], origin,
-                   comment=["Unique name of {} NPC".format(gender), comment])
-    if "name_suffix" in json:
-        write_text(json["name_suffix"], origin,
-                   comment=["Name suffix of {} NPC".format(gender), comment])
+        gender = "a " + json["gender"]
+
+    comment = json.get("//")
+
+    write_text(json.get("name_unique"), origin,
+               comment=[f"Unique name of {gender} NPC", comment])
+    write_text(json.get("name_suffix"), origin,
+               comment=[f"Name suffix of {gender} NPC", comment])
+
     for snip in chatbin_snippets:
-        if snip in json:
-            write_text(json[snip], origin,
-                       comment=["Chatbin snippet {} of {} NPC"
-                                .format(snip, gender), comment])
+        write_text(json.get(snip), origin,
+                   comment=[f"Snippet '{snip}' of {gender} NPC", comment])

--- a/lang/string_extractor/parsers/profession.py
+++ b/lang/string_extractor/parsers/profession.py
@@ -4,6 +4,7 @@ from ..write_text import write_text
 def parse_profession(json, origin):
     name_male = ""
     name_female = ""
+
     if "name" not in json:
         name_male = name_female = json["id"]
     elif type(json["name"]) is dict:
@@ -12,10 +13,15 @@ def parse_profession(json, origin):
     elif type(json["name"]) is str:
         name_male = name_female = json["name"]
 
+    write_text(name_male, origin, context="profession_male",
+               comment="Profession name for male")
+    write_text(name_female, origin, context="profession_female",
+               comment="Profession name for female")
+
     desc_male = ""
     desc_female = ""
-    has_description = "description" in json
-    if has_description:
+
+    if "description" in json:
         if type(json["description"]) is dict:
             if "male" in json["description"]:
                 desc_male = json["description"]["male"]
@@ -25,16 +31,9 @@ def parse_profession(json, origin):
         else:
             desc_male = desc_female = json["description"]
 
-    write_text(name_male, origin, context="profession_male",
-               comment="Profession name for male")
-    if has_description:
         write_text(desc_male, origin, context="prof_desc_male",
-                   comment="Description of profession \"{}\" for male".
-                   format(name_male))
-
-    write_text(name_female, origin, context="profession_female",
-               comment="Profession name for female")
-    if has_description:
+                   comment=f"Description of profession '{name_male}'"
+                   " for male")
         write_text(desc_female, origin, context="prof_desc_female",
-                   comment="Description of profession \"{}\" for female".
-                   format(name_female))
+                   comment=f"Description of profession '{name_female}'"
+                   " for female")

--- a/lang/string_extractor/parsers/recipe_category.py
+++ b/lang/string_extractor/parsers/recipe_category.py
@@ -2,18 +2,22 @@ from ..write_text import write_text
 
 
 def parse_recipe_category(json, origin):
-    cid = json["id"]
-    if cid == 'CC_NONCRAFT':
+    ident = json["id"]
+    if ident == 'CC_NONCRAFT':
         return
-    cat_name = cid.split("_")[1]
-    write_text(cat_name, origin, comment="Crafting recipes category name")
+
+    cat_name = ident.split("_")[1]
+    write_text(cat_name, origin, comment="Crafting recipes category")
 
     for subcat in json.get("recipe_subcategories", []):
-        if subcat == 'CSC_ALL':
-            write_text("ALL", origin,
-                       comment="Crafting recipes subcategory \"all\"")
-        else:
-            subcat_name = subcat.split('_')[2]
-            write_text(subcat_name, origin,
-                       comment="Crafting recipes subcategory of \"{}\" cat."
-                       .format(cat_name))
+        subcat_name = subcat.split('_')[-1]
+        write_text(subcat_name, origin,
+                   comment=f"Crafting recipes subcategory of '{cat_name}'")
+        # if subcat == 'CSC_ALL':
+        #     write_text("ALL", origin,
+        #                comment="Crafting recipes subcategory 'all'")
+        # else:
+        #     subcat_name = subcat.split('_')[2]
+        #     write_text(subcat_name, origin,
+        #                comment="Crafting recipes subcategory "
+        #                f"of '{cat_name}'.")

--- a/lang/string_extractor/parsers/scenario.py
+++ b/lang/string_extractor/parsers/scenario.py
@@ -1,26 +1,19 @@
+from ..helper import get_singular_name
 from ..write_text import write_text
 
 
 def parse_scenario(json, origin):
-    name = ""
-    if "name" in json:
-        name = json["name"]
-        write_text(name, origin, context="scenario_male",
-                   comment="Scenario name for male")
-        write_text(name, origin, context="scenario_female",
-                   comment="Scenario name for female")
-    if name == "":
-        name = json["id"]
+    name = get_singular_name(json)
 
-    if "description" in json:
-        write_text(json["description"], origin, context="scen_desc_male",
-                   comment="Description of scenario \"{}\" for male"
-                   .format(name))
-        write_text(json["description"], origin, context="scen_desc_female",
-                   comment="Description of scenario \"{}\" for female"
-                   .format(name))
+    write_text(json.get("name"), origin, context="scenario_male",
+               comment="Scenario name for male")
+    write_text(json.get("name"), origin, context="scenario_female",
+               comment="Scenario name for female")
 
-    if "start_name" in json:
-        write_text(json["start_name"], origin, context="start_name",
-                   comment="Starting location of scenario \"{}\""
-                   .format(name))
+    write_text(json.get("description"), origin, context="scen_desc_male",
+               comment=f"Description of scenario '{name}' for male")
+    write_text(json.get("description"), origin, context="scen_desc_female",
+               comment=f"Description of scenario '{name}' for female")
+
+    write_text(json.get("start_name"), origin, context="start_name",
+               comment=f"Starting location of scenario '{name}'")

--- a/lang/string_extractor/parsers/ter_furn_transform.py
+++ b/lang/string_extractor/parsers/ter_furn_transform.py
@@ -21,18 +21,15 @@ def transform_result(result):
 
 
 def parse_ter_furn_transform(json, origin):
-    if "fail_message" in json:
-        write_text(json["fail_message"], origin,
-                   comment="Failure message of terrain furniture transform")
-    if "terrain" in json:
-        for terrain in json["terrain"]:
-            if "message" in terrain:
-                write_text(terrain["message"], origin,
-                           comment="Message after transforming to \"{}\"".
-                           format(transform_result(terrain["result"])))
-    if "furniture" in json:
-        for furniture in json["furniture"]:
-            if "message" in furniture:
-                write_text(furniture["message"], origin,
-                           comment="Message after transforming to \"{}\""
-                           .format(transform_result(furniture["result"])))
+    write_text(json.get("fail_message"), origin,
+               comment="Failure message of terrain furniture transform")
+
+    for terrain in json.get("terrain", []):
+        write_text(terrain.get("message"), origin,
+                   comment="Message after transforming to '{}'".
+                   format(transform_result(terrain["result"])))
+
+    for furniture in json.get("furniture", []):
+        write_text(furniture.get("message"), origin,
+                   comment="Message after transforming to '{}'"
+                   .format(transform_result(furniture["result"])))

--- a/lang/string_extractor/parsers/widget.py
+++ b/lang/string_extractor/parsers/widget.py
@@ -2,28 +2,25 @@ from ..write_text import write_text
 
 
 def parse_widget(json, origin):
-    id = json["id"]
-    if "label" in json:
-        write_text(json["label"], origin,
-                   comment="Label of UI widget \"{}\"".format(id))
-    if "description" in json:
-        write_text(json["description"], origin,
-                   comment="Description of UI widget \"{}\"".format(id))
-    if "string" in json:
-        write_text(json["string"], origin,
-                   comment="Text in UI widget \"{}\"".format(id))
-    if "phrases" in json:
-        for phrase in json["phrases"]:
-            comment = "Text in portion of UI widget \"{}\"".format(id)
-            if "text" in phrase:
-                write_text(phrase["text"], origin, comment=comment)
-    if "default_clause" in json and "text" in json["default_clause"]:
-        write_text(json["default_clause"]["text"], origin,
-                   comment="Default clause of UI widget \"{}\"".format(id))
-    if "clauses" in json:
-        for clause in json["clauses"]:
-            if "text" not in clause:
-                continue
-            write_text(clause["text"], origin,
-                       comment="Clause text \"{}\" of UI widget \"{}\""
-                       .format(clause["id"], id))
+    name = json["id"]
+
+    write_text(json.get("label"), origin,
+               comment=f"Label of UI widget '{name}'")
+
+    write_text(json.get("description"), origin,
+               comment=f"Description of UI widget '{name}'")
+
+    write_text(json.get("string"), origin,
+               comment=f"Text in UI widget '{name}'")
+
+    for phrase in json.get("phrases", []):
+        write_text(phrase.get("text"), origin,
+                   comment=f"Text in portion of UI widget '{name}'")
+
+    if "default_clause" in json:
+        write_text(json["default_clause"].get("text"), origin,
+                   comment=f"Default clause of UI widget '{name}'")
+
+    for clause in json.get("clauses", []):
+        write_text(clause.get("text"), origin,
+                   comment=f"Clause text of UI widget '{name}'")


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Continuation of #83371

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Added more description to the verbs and adjectives of the materials.
```
Bash damage verb of material
ex. 'Your helm is cracked!'

Cut damage verb of material
ex. 'Your backpack is scratched!'

Damage adjective of material
ex. 'dented cuirass'
```
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
The same output as in the master branch. The text of the comments has changed as intended.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
