### PR TITLE
Region settings defined city names

### DIFF
--- a/doc/JSON/REGION_SETTINGS.md
+++ b/doc/JSON/REGION_SETTINGS.md
@@ -542,6 +542,7 @@ relative placements of various classes of buildings.
 
 |       Identifier        |                            Description                             |
 | ----------------------- | ------------------------------------------------------------------ |
+| `name_snippet`          | Snippet used to generate city names. Default is `<city_name>`.     |
 | `shop_radius`           | Radial frequency of shop placement. Smaller number = more shops.   |
 | `park_radius`           | Radial frequency of park placement. Smaller number = more parks.   |
 | `houses`                | Weighted list of overmap terrains and specials used for houses.    |

--- a/src/city.cpp
+++ b/src/city.cpp
@@ -89,9 +89,14 @@ void city::check() const
 }
 
 city::city( const point_om_omt &P, int const S )
+    : city( SNIPPET.expand( "<city_name>" ), P, S )
+{
+}
+
+city::city( const std::string &N, const point_om_omt &P, int const S )
     : pos( P )
     , size( S )
-    , name( SNIPPET.expand( "<city_name>" ) )
+    , name( N )
 {
 }
 

--- a/src/city.h
+++ b/src/city.h
@@ -37,6 +37,7 @@ struct city {
     std::string name;
 
     explicit city( const point_om_omt &P = point_om_omt(), int S = -1 );
+    explicit city( const std::string &N, const point_om_omt &P = point_om_omt(), int S = -1 );
 
     explicit operator bool() const {
         return size >= 0;

--- a/src/overmap_city.cpp
+++ b/src/overmap_city.cpp
@@ -26,6 +26,7 @@
 #include "regional_settings.h"
 #include "rng.h"
 #include "simple_pathfinding.h"
+#include "text_snippets.h"
 #include "type_id.h"
 
 static const oter_str_id oter_road_nesw( "road_nesw" );
@@ -137,7 +138,7 @@ void overmap::place_cities()
     while( cities.size() < num_cities_on_this_overmap_count && !city_candidates.empty() ) {
 
         tripoint_om_omt selected_point;
-        city tmp;
+        city tmp( SNIPPET.expand( settings->get_settings_city().name_snippet ) );
         tmp.pos_om = pos();
         if( use_random_cities ) {
             // randomly make some cities smaller or larger

--- a/src/regional_settings.cpp
+++ b/src/regional_settings.cpp
@@ -671,6 +671,7 @@ void region_settings_city::load( const JsonObject &jo, std::string_view )
     optional( jo, was_loaded, "shop_sigma", shop_sigma );
     optional( jo, was_loaded, "park_radius", park_radius );
     optional( jo, was_loaded, "park_sigma", park_sigma );
+    optional( jo, was_loaded, "name_snippet", name_snippet, "<city_name>" );
     optional( jo, was_loaded, "houses", houses.buildings, building_bin_reader );
     optional( jo, was_loaded, "shops", shops.buildings, building_bin_reader );
     optional( jo, was_loaded, "parks", parks.buildings, building_bin_reader );

--- a/src/regional_settings.h
+++ b/src/regional_settings.h
@@ -87,6 +87,8 @@ struct region_settings_city {
     // We'll spread this out to the rest of the town.
     int park_sigma = 100 - park_radius;
 
+    std::string name_snippet = "<city_name>";
+
     building_bin houses;
     building_bin shops;
     building_bin parks;


### PR DESCRIPTION
#### Summary
Infrastructure "Allow specifying city name lists in region settings"

#### Purpose of change
Allow different regions to name cities different things.

#### Describe the solution
Pull the snippet category used to name the city from region settings, instead of always using `<city_name>`.

#### Testing
```diff
diff --git a/data/json/region_settings/region_settings/regional_map_settings.json b/data/json/region_settings/region_settings/regional_map_settings.json
index 1e9c79d459..0a980d8cee 100644
--- a/data/json/region_settings/region_settings/regional_map_settings.json
+++ b/data/json/region_settings/region_settings/regional_map_settings.json
@@ -366,6 +366,7 @@
   {
     "type": "region_settings_city",
     "id": "default",
+    "name_snippet": "Paradise <city_name>",
     "shop_radius": 30,
     "shop_sigma": 50,
     "park_radius": 20,
```
<img width="480" height="270" alt="A group of cities, named 'Paradise New Canaan', 'Paradise Stewart', 'Paradise Orient', and 'Paradise Royalston'." src="https://github.com/user-attachments/assets/9a644ad5-cd3c-4825-a7cc-5f4d4550911d" />