### PR TITLE
Make name and description of variants optional

### DIFF
--- a/data/json/items/armor/ammo_pouch.json
+++ b/data/json/items/armor/ammo_pouch.json
@@ -140,7 +140,7 @@
     "variants": [
       {
         "id": "generic_chestrig",
-        "name": { "str": "chest rig" },
+        "//": "inherit name from item",
         "description": "Popularized during the Vietnam War, chest rigs like these are typically plain, barebones affairs consisting of three or more pouches in a row, with straps to secure them on your chest.  This one can hold four magazines in its pouches.",
         "weight": 30
       },

--- a/data/json/items/armor/ballistic_armor.json
+++ b/data/json/items/armor/ballistic_armor.json
@@ -13,7 +13,7 @@
     "variants": [
       {
         "id": "us_ballistic_vest",
-        "name": { "str": "US ballistic vest" },
+        "//": "inherit name from item",
         "description": "This version is patterned in multi-environment camouflage, and was standard-issue for the US Army.",
         "append": true
       },

--- a/data/json/items/armor/boots.json
+++ b/data/json/items/armor/boots.json
@@ -1724,12 +1724,7 @@
     "melee_damage": { "bash": 1 },
     "variant_type": "generic",
     "variants": [
-      {
-        "id": "generic_knee_high_boots",
-        "name": { "str_sp": "knee-high boots (pair)" },
-        "description": "Very long leather boots that cover the lower legs, they are cumbersome to wear.",
-        "weight": 10
-      },
+      { "id": "generic_knee_high_boots", "//": "inherit name and description from item", "weight": 10 },
       {
         "id": "jackboots",
         "name": { "str_sp": "jackboots (pair)" },

--- a/data/json/items/armor/cloaks.json
+++ b/data/json/items/armor/cloaks.json
@@ -84,16 +84,12 @@
     "color": "pink",
     "variant_type": "generic",
     "variants": [
-      {
-        "id": "rainbow_pride_flag",
-        "name": { "str": "pride flag" },
-        "description": "A large rainbow flag, The colors reflect the diversity of the LGBT community and the spectrum of human sexuality and gender.",
-        "weight": 10
-      },
+      { "id": "rainbow_pride_flag", "//": "inherit name and description from item", "weight": 10 },
       {
         "id": "progress_pride_flag",
         "name": { "str": "progress pride flag" },
-        "description": "A large rainbow flag, The colors reflect the diversity of the LGBT community and the spectrum of human sexuality and gender.  On the left side you can see a chevron that features black, brown, light blue, pink, and white stripes to bring those communities to the forefront; \"the arrow points to the right to show forward movement, while being along the left edge shows that progress still needs to be made\".",
+        "description": "On the left side you can see a chevron that features black, brown, light blue, pink, and white stripes to bring those communities to the forefront; \"the arrow points to the right to show forward movement, while being along the left edge shows that progress still needs to be made\".",
+        "append": true,
         "weight": 10
       },
       {

--- a/data/json/items/armor/coats.json
+++ b/data/json/items/armor/coats.json
@@ -2118,7 +2118,7 @@
     "variants": [
       {
         "id": "leather_police_jacket",
-        "name": { "str": "motorcycle police jacket" },
+        "//": "inherit name from item",
         "description": "It is emblazoned with the insignia of the local police force.",
         "weight": 0,
         "append": true

--- a/data/json/items/armor/hats.json
+++ b/data/json/items/armor/hats.json
@@ -171,12 +171,7 @@
     "description": "Whether yer hunting varmints, fixing up the ranch, or heading into the sunset, this is the hat for the job.",
     "variant_type": "generic",
     "variants": [
-      {
-        "id": "generic_cowboy_hat",
-        "name": { "str": "cowboy hat" },
-        "description": "Whether yer hunting varmints, fixing up the ranch, or heading into the sunset, this is the hat for the job.",
-        "weight": 30
-      },
+      { "id": "generic_cowboy_hat", "//": "inherit name and description from item", "weight": 30 },
       {
         "id": "flag_cowboy_hat",
         "name": { "str_sp": "American cowboy hat" },
@@ -370,12 +365,7 @@
     ],
     "variant_type": "generic",
     "variants": [
-      {
-        "id": "generic_hatball",
-        "name": { "str": "baseball cap" },
-        "description": "A cotton cap with a rounded crown, an adjustable strap, and a long visor.  It shields your eyes from the sun and provides a little bit of warmth.  Traditionally worn by baseball players.",
-        "weight": 40
-      },
+      { "id": "generic_hatball", "//": "inherit name and description from item", "weight": 40 },
       {
         "id": "baseball_fan_hatball",
         "name": { "str": "baseball fan cap" },
@@ -520,7 +510,7 @@
     "variants": [
       {
         "id": "white_hat_chef",
-        "name": { "str": "toque" },
+        "//": "inherit name from item",
         "description": "It's colored white.",
         "weight": 60,
         "append": true

--- a/data/json/items/armor/jewelry.json
+++ b/data/json/items/armor/jewelry.json
@@ -699,12 +699,7 @@
     "description": "A pair of cufflinks with inset rubies.",
     "variant_type": "generic",
     "variants": [
-      {
-        "id": "generic_ruby_silver_cufflinks",
-        "name": { "str_sp": "ruby and silver cufflinks" },
-        "description": "A pair of cufflinks with inset rubies.",
-        "weight": 99
-      },
+      { "id": "generic_ruby_silver_cufflinks", "//": "inherit name and description from item", "weight": 99 },
       {
         "id": "vampire_cufflinks",
         "name": { "str_sp": "vampire cufflinks" },
@@ -784,12 +779,7 @@
     "description": "A pair of cufflinks with inset onyx.",
     "variant_type": "generic",
     "variants": [
-      {
-        "id": "generic_onyx_silver_cufflinks",
-        "name": { "str_sp": "onyx and silver cufflinks" },
-        "description": "A pair of cufflinks with inset onyx.",
-        "weight": 99
-      },
+      { "id": "generic_onyx_silver_cufflinks", "//": "inherit name and description from item", "weight": 99 },
       {
         "id": "dark_cufflinks",
         "name": { "str_sp": "dark cufflinks" },
@@ -2036,12 +2026,7 @@
     "color": "pink",
     "variant_type": "generic",
     "variants": [
-      {
-        "id": "faux_fur_cat_ears",
-        "name": { "str_sp": "faux fur cat ears (pair)" },
-        "description": "A fuzzy pair of garishly colored cat ears on a headband.  It does nothing, but there's no reason not to look good even if no one's looking.",
-        "color": "pink"
-      },
+      { "id": "faux_fur_cat_ears", "//": "inherit name and description from item", "color": "pink" },
       {
         "id": "bunny_ears_white",
         "name": { "str_sp": "white bunny ears (pair)" },
@@ -2348,12 +2333,7 @@
     "description": "A pair of shiny ruby and silver earrings.",
     "variant_type": "generic",
     "variants": [
-      {
-        "id": "generic_ruby_silver_earring",
-        "name": { "str_sp": "ruby and silver earrings (pair)" },
-        "description": "A pair of shiny ruby and silver earrings.",
-        "weight": 99
-      },
+      { "id": "generic_ruby_silver_earring", "//": "inherit name and description from item", "weight": 99 },
       {
         "id": "vampire_earring",
         "name": { "str_sp": "vampire earrings (pair)" },
@@ -2433,12 +2413,7 @@
     "description": "A pair of shiny onyx and silver earrings.",
     "variant_type": "generic",
     "variants": [
-      {
-        "id": "generic_onyx_silver_earring",
-        "name": { "str_sp": "onyx and silver earrings (pair)" },
-        "description": "A pair of shiny onyx and silver earrings.",
-        "weight": 99
-      },
+      { "id": "generic_onyx_silver_earring", "//": "inherit name and description from item", "weight": 99 },
       {
         "id": "dark_earring",
         "name": { "str_sp": "dark earrings (pair)" },
@@ -2814,12 +2789,7 @@
     "description": "A silver ring with a ruby mounted on top of it.",
     "variant_type": "generic",
     "variants": [
-      {
-        "id": "generic_ruby_silver_ring",
-        "name": { "str": "ruby and silver ring" },
-        "description": "A silver ring with a ruby mounted on top of it.",
-        "weight": 99
-      },
+      { "id": "generic_ruby_silver_ring", "//": "inherit name and description from item", "weight": 99 },
       {
         "id": "vampire_ring",
         "name": { "str": "vampire ring" },
@@ -2899,12 +2869,7 @@
     "description": "A silver ring with an onyx mounted on top of it.",
     "variant_type": "generic",
     "variants": [
-      {
-        "id": "generic_onyx_silver_ring",
-        "name": { "str": "onyx and silver ring" },
-        "description": "A silver ring with an onyx mounted on top of it.",
-        "weight": 99
-      },
+      { "id": "generic_onyx_silver_ring", "//": "inherit name and description from item", "weight": 99 },
       {
         "id": "dark_ring",
         "name": { "str": "dark ring" },
@@ -3289,12 +3254,7 @@
     "description": "A silver bracelet with sparkling rubies.",
     "variant_type": "generic",
     "variants": [
-      {
-        "id": "generic_ruby_silver_bracelet",
-        "name": { "str": "ruby and silver bracelet" },
-        "description": "A silver bracelet with sparkling rubies.",
-        "weight": 99
-      },
+      { "id": "generic_ruby_silver_bracelet", "//": "inherit name and description from item", "weight": 99 },
       {
         "id": "vampire_bracelet",
         "name": { "str": "vampire bracelet" },
@@ -3374,12 +3334,7 @@
     "description": "A silver bracelet with striking onyx.",
     "variant_type": "generic",
     "variants": [
-      {
-        "id": "generic_onyx_silver_bracelet",
-        "name": { "str": "onyx and silver bracelet" },
-        "description": "A silver bracelet with striking onyx.",
-        "weight": 99
-      },
+      { "id": "generic_onyx_silver_bracelet", "//": "inherit name and description from item", "weight": 99 },
       {
         "id": "dark_bracelet",
         "name": { "str": "dark bracelet" },
@@ -3748,12 +3703,7 @@
     "description": "A shiny, silver necklace adorned with a ruby pendant.",
     "variant_type": "generic",
     "variants": [
-      {
-        "id": "generic_ruby_silver_pendant_necklace",
-        "name": { "str": "ruby and silver pendant necklace" },
-        "description": "A shiny, silver necklace adorned with a ruby pendant.",
-        "weight": 99
-      },
+      { "id": "generic_ruby_silver_pendant_necklace", "//": "inherit name and description from item", "weight": 99 },
       {
         "id": "vampire_necklace",
         "name": { "str": "vampire necklace" },
@@ -3833,12 +3783,7 @@
     "description": "A shiny, silver necklace adorned with an onyx pendant.",
     "variant_type": "generic",
     "variants": [
-      {
-        "id": "generic_onyx_silver_pendant_necklace",
-        "name": { "str": "onyx and silver pendant necklace" },
-        "description": "A shiny, silver necklace adorned with an onyx pendant.",
-        "weight": 99
-      },
+      { "id": "generic_onyx_silver_pendant_necklace", "//": "inherit name and description from item", "weight": 99 },
       {
         "id": "dark_necklace",
         "name": { "str": "dark necklace" },
@@ -4363,12 +4308,7 @@
     "description": "A shiny, silver tiara adorned with rubies.",
     "variant_type": "generic",
     "variants": [
-      {
-        "id": "generic_ruby_silver_tiara",
-        "name": { "str": "ruby and silver tiara" },
-        "description": "A shiny, silver tiara adorned with rubies.",
-        "weight": 99
-      },
+      { "id": "generic_ruby_silver_tiara", "//": "inherit name and description from item", "weight": 99 },
       {
         "id": "vampire_tiara",
         "name": { "str": "vampire tiara" },
@@ -4448,12 +4388,7 @@
     "description": "A shiny, silver tiara adorned with onyx.",
     "variant_type": "generic",
     "variants": [
-      {
-        "id": "generic_onyx_silver_tiara",
-        "name": { "str": "onyx and silver tiara" },
-        "description": "A shiny, silver tiara adorned with onyx.",
-        "weight": 99
-      },
+      { "id": "generic_onyx_silver_tiara", "//": "inherit name and description from item", "weight": 99 },
       { "id": "dark_tiara", "name": { "str": "dark tiara" }, "description": "A dark silver tiara adorned with onyx." }
     ],
     "color": "dark_gray"

--- a/data/json/items/armor/masks.json
+++ b/data/json/items/armor/masks.json
@@ -533,12 +533,7 @@
     "armor": [ { "encumbrance": 8, "coverage": 95, "covers": [ "head", "mouth" ] } ],
     "variant_type": "generic",
     "variants": [
-      {
-        "id": "zombie_mask",
-        "name": { "str": "zombie mask" },
-        "description": "A flimsy leather zombie mask.  When zombies were still works of fiction.",
-        "weight": 100
-      },
+      { "id": "zombie_mask", "//": "inherit name and description from item", "weight": 100 },
       {
         "id": "chicken_mask",
         "name": { "str": "chicken mask" },

--- a/data/json/items/armor/misc.json
+++ b/data/json/items/armor/misc.json
@@ -354,7 +354,7 @@
     "variants": [
       {
         "id": "dog_tag_id",
-        "name": { "str": "dog tag" },
+        "//": "inherit name from item",
         "description": "They have inscribed:\n<family_name>\n<given_name_army>\n<number><number><number><number><number><number><number><number><number><number>\n<blood_type_caps>\n<religion_caps>",
         "expand_snippets": true,
         "append": true,

--- a/data/json/items/armor/storage.json
+++ b/data/json/items/armor/storage.json
@@ -1614,20 +1614,20 @@
     "variants": [
       {
         "id": "black_leg_bag",
-        "name": { "str": "drop leg bag" },
+        "//": "inherit name from item",
         "description": "A black bag that can be worn on the thighs and hips using adjustable buckled straps.  Commonly used by motorcycle riders.",
         "weight": 50
       },
       {
         "id": "brown_leg_bag",
-        "name": { "str": "drop leg bag" },
+        "//": "inherit name from item",
         "description": "A khaki bag that can be worn on the thighs and hips using adjustable buckled straps.  Works nicely with a pair of khaki pants.",
         "color": "brown",
         "weight": 30
       },
       {
         "id": "purple_leg_bag",
-        "name": { "str": "drop leg bag" },
+        "//": "inherit name from item",
         "description": "A purple bag that can be worn on the thighs and hips using adjustable buckled straps.  Perfect for the ladies that want a cooler way of carrying their personal items.",
         "color": "magenta",
         "weight": 10

--- a/data/json/items/armor/storage_packs.json
+++ b/data/json/items/armor/storage_packs.json
@@ -4,7 +4,8 @@
     "type": "ITEM",
     "subtypes": [ "ARMOR" ],
     "name": { "str": "small backpack" },
-    "description": "A small simple backpack, probably sized for a kid.",
+    "description": "A little <color> backpack, probably sized for a kid.",
+    "expand_snippets": true,
     "weight": "333 g",
     "volume": "2 L",
     "price": "19 USD",
@@ -44,13 +45,7 @@
       }
     ],
     "variants": [
-      {
-        "id": "color",
-        "weight": 17,
-        "name": "small backpack",
-        "description": "A little <color> backpack, probably sized for a kid.",
-        "expand_snippets": true
-      },
+      { "id": "color", "weight": 17, "//": "inherit name and description from item" },
       {
         "id": "boy",
         "name": { "str": "boy's backpack" },

--- a/data/json/items/armor/suits_clothes.json
+++ b/data/json/items/armor/suits_clothes.json
@@ -885,12 +885,7 @@
     "flags": [ "VARSIZE", "HOOD" ],
     "variant_type": "generic",
     "variants": [
-      {
-        "id": "devil_onesie",
-        "name": { "str": "devil onesie" },
-        "description": "An encumbering red wool suit with a hood adorned with cartoonish devil horns and a devil's tail on the back.  It's for those who want to feel devilishly warm in their sleep.",
-        "color": "red"
-      },
+      { "id": "devil_onesie", "//": "inherit name and description from item", "color": "red" },
       {
         "id": "bunny_onesie",
         "name": { "str": "bunny onesie" },

--- a/data/json/items/armor/swimming.json
+++ b/data/json/items/armor/swimming.json
@@ -7,12 +7,7 @@
     "description": "Simple bikini bottoms.",
     "variant_type": "generic",
     "variants": [
-      {
-        "id": "generic_bikini_bottom",
-        "name": { "str_sp": "bikini bottoms" },
-        "description": "Simple bikini bottoms.",
-        "weight": 30
-      },
+      { "id": "generic_bikini_bottom", "//": "inherit name and description from item", "weight": 30 },
       {
         "id": "black_bikini_bottom",
         "name": { "str_sp": "black bikini bottoms" },
@@ -139,7 +134,7 @@
     "description": "A simple bikini top.",
     "variant_type": "generic",
     "variants": [
-      { "id": "generic_bikini_top", "name": { "str": "bikini top" }, "description": "A simple bikini top.", "weight": 30 },
+      { "id": "generic_bikini_top", "//": "inherit name and description from item", "weight": 30 },
       {
         "id": "black_bikini_top",
         "name": { "str": "black bikini top" },

--- a/data/json/items/armor/torso_clothes.json
+++ b/data/json/items/armor/torso_clothes.json
@@ -25,7 +25,7 @@
     "variants": [
       {
         "id": "generic_apron_cotton",
-        "name": { "str": "long waist apron" },
+        "//": "inherit name and description from item",
         "description": "It's colored white, like the ones commonly used by chefs, professional or otherwise.",
         "weight": 50,
         "append": true
@@ -160,7 +160,7 @@
     "variants": [
       {
         "id": "generic_apron_cotton",
-        "name": { "str": "short waist apron" },
+        "//": "inherit name from item",
         "description": "It's colored white, like the ones commonly used by chefs, professional or otherwise.",
         "weight": 50,
         "append": true
@@ -287,7 +287,7 @@
     "variants": [
       {
         "id": "generic_apron_cotton",
-        "name": { "str": "cotton apron" },
+        "//": "inherit name from item",
         "description": "It's colored white, like the ones commonly used by chefs, professional or otherwise.",
         "weight": 50,
         "append": true
@@ -558,7 +558,7 @@
     "flags": [ "VARSIZE", "OUTER" ],
     "variant_type": "generic",
     "variants": [
-      { "id": "generic", "name": { "str": "blazer" }, "description": "A professional-looking wool blazer." },
+      { "id": "generic", "//": "inherit name and description from item" },
       {
         "id": "bostonchan",
         "name": { "str": "Boston-Chan blazer" },
@@ -1206,11 +1206,7 @@
     "armor": [ { "breathability": "SECOND_SKIN", "coverage": 90, "covers": [ "torso", "arm_l", "arm_r" ] } ],
     "variant_type": "generic",
     "variants": [
-      {
-        "id": "generic",
-        "name": { "str": "sports jersey" },
-        "description": "A lightweight, breathable shirt made from synthetic fabric, designed for athletic performance and team identification."
-      },
+      { "id": "generic", "//": "inherit name and description from item" },
       {
         "id": "sportsteam",
         "name": { "str": "sports team jersey" },
@@ -1543,16 +1539,8 @@
     ],
     "variant_type": "generic",
     "variants": [
-      {
-        "id": "generic",
-        "name": { "str": "mail carrier shirt" },
-        "description": "A light blue button down shirt with a couple of pockets in front and the US postal service logo embroidered on it."
-      },
-      {
-        "id": "sheriff",
-        "name": { "str": "mail carrier shirt" },
-        "description": "A tan button-down shirt with long sleeves."
-      },
+      { "id": "generic", "//": "inherit name and description from item" },
+      { "id": "sheriff", "//": "inherit name from item", "description": "A tan button-down shirt with long sleeves." },
       {
         "id": "swat",
         "name": { "str": "SWAT shirt" },
@@ -1882,7 +1870,7 @@
     "material_thickness": 0.1,
     "variant_type": "generic",
     "variants": [
-      { "id": "generic_tshirt", "name": { "str": "t-shirt" }, "description": "A short-sleeved cotton shirt.", "weight": 40 },
+      { "id": "generic_tshirt", "//": "inherit name and description from item", "weight": 40 },
       {
         "id": "baseball_fan_tshirt",
         "name": { "str": "baseball t-shirt" },
@@ -2038,12 +2026,7 @@
     ],
     "variant_type": "generic",
     "variants": [
-      {
-        "id": "generic_tshirt",
-        "name": { "str": "crop top" },
-        "description": "A short-sleeved cotton shirt, cropped to expose the stomach.",
-        "weight": 1
-      },
+      { "id": "generic_tshirt", "//": "inherit name and description from item", "weight": 1 },
       {
         "id": "red_tshirt",
         "name": { "str": "red crop top" },

--- a/data/json/items/armor/undergarment.json
+++ b/data/json/items/armor/undergarment.json
@@ -340,13 +340,7 @@
     "flags": [ "VARSIZE", "SKINTIGHT" ],
     "armor": [ { "coverage": 100, "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_hip_l", "leg_hip_r" ] } ],
     "variants": [
-      {
-        "id": "boxer_brief_basic",
-        "name": { "str_sp": "boxer briefs" },
-        "description": "The age-old question, boxers or briefs?  Your answer?  Yes.",
-        "expand_snippets": true,
-        "weight": 100
-      },
+      { "id": "boxer_brief_basic", "//": "inherit name and description from item", "expand_snippets": true, "weight": 100 },
       {
         "id": "boxer_brief_makeshift",
         "name": { "str_sp": "homemade boxer briefs" },
@@ -408,12 +402,7 @@
     "description": "Men's boxer shorts.  More fashionable than briefs and just as comfortable.",
     "variant_type": "generic",
     "variants": [
-      {
-        "id": "generic_boxer_shorts",
-        "name": { "str_sp": "boxer shorts" },
-        "description": "Men's boxer shorts.  More fashionable than briefs and just as comfortable.",
-        "weight": 30
-      },
+      { "id": "generic_boxer_shorts", "//": "inherit name and description from item", "weight": 30 },
       {
         "id": "flag_boxer_shorts",
         "name": { "str_sp": "star-spangled boxer shorts" },
@@ -518,12 +507,7 @@
     "description": "Female underwear similar to men's boxer shorts, but much more close-fitting.",
     "variant_type": "generic",
     "variants": [
-      {
-        "id": "generic_boy_shorts",
-        "name": { "str_sp": "boy shorts" },
-        "description": "Female underwear similar to men's boxer shorts, but much more close-fitting.",
-        "weight": 30
-      },
+      { "id": "generic_boy_shorts", "//": "inherit name and description from item", "weight": 30 },
       {
         "id": "flag_boy_shorts",
         "name": { "str_sp": "star-spangled boy shorts" },

--- a/data/json/items/fluff.json
+++ b/data/json/items/fluff.json
@@ -20,7 +20,7 @@
     "type": "ITEM",
     "category": "other",
     "name": { "str": "deck of cards", "str_pl": "decks of cards" },
-    "description": "A deck of 52 playing cards.",
+    "description": "A fairly new, glossy deck of 52 playing cards.",
     "weight": "50 g",
     "volume": "100 ml",
     "price": "20 USD",
@@ -31,12 +31,7 @@
     "flags": [ "NO_REPAIR" ],
     "use_action": [ "PLAY_GAME" ],
     "variants": [
-      {
-        "id": "generic_deck_of_cards",
-        "name": { "str": "deck of cards", "str_pl": "decks of cards" },
-        "description": "A fairly new, glossy deck of 52 playing cards.",
-        "weight": 30
-      },
+      { "id": "generic_deck_of_cards", "//": "copy name and description from item", "weight": 30 },
       {
         "id": "deck_of_cards_worn",
         "name": { "str": "worn deck of cards", "str_pl": "worn decks of cards" },
@@ -904,11 +899,7 @@
     "flags": [ "NO_REPAIR" ],
     "use_action": [ "PLAY_GAME" ],
     "variants": [
-      {
-        "id": "terraforming_mercury",
-        "name": { "str": "Terraforming - Mercury", "str_pl": "sets of Terraforming - Mercury" },
-        "description": "This board game is set in the 4300s, where corporations are working together to terraform the planet Mercury, the smallest and innermost planet in our solar system.  Each player (or just the player) will have unique abilities and resources at their disposal, and they will need to strategize and cooperate with one another to achieve their goals."
-      },
+      { "id": "terraforming_mercury", "//": "copy name and description from item" },
       {
         "id": "terraforming_mars",
         "name": { "str": "Terraforming - Mars", "str_pl": "sets of Terraforming - Mars" },
@@ -1785,7 +1776,7 @@
     "variants": [
       {
         "id": "statue_person",
-        "name": { "str": "clay sculpture" },
+        "//": "inherit name from item",
         "description": "This statue depicts a <sculpture_person_description> <random_character_pose_statue>.",
         "append": true,
         "expand_snippets": true,

--- a/data/json/items/newspaper.json
+++ b/data/json/items/newspaper.json
@@ -155,7 +155,7 @@
     "variants": [
       {
         "id": "lab_file_mutation_testing_1",
-        "name": { "str_sp": "production tests" },
+        "//": "inherit name from item",
         "description": "\n\n<mutation_testing>",
         "append": true,
         "expand_snippets": true
@@ -172,7 +172,7 @@
     "variants": [
       {
         "id": "lab_file_serum_testing_regen",
-        "name": { "str_sp": "production tests" },
+        "//": "inherit name from item",
         "description": "\n\n<serum_testing_regen>",
         "append": true,
         "expand_snippets": true
@@ -627,14 +627,14 @@
     "variants": [
       {
         "id": "hp_original",
-        "name": { "str": "picture" },
+        "//": "inherit name from item",
         "description": { "str": "<home_pictures>", "//~": "NO_I18N" },
         "expand_snippets": true,
         "weight": 200
       },
       {
         "id": "hp_snippet_nested",
-        "name": { "str": "picture" },
+        "//": "inherit name from item",
         "description": { "str": "<hp_nested>", "//~": "NO_I18N" },
         "expand_snippets": true,
         "weight": 40

--- a/data/mods/CrazyCataclysm/crazy_items.json
+++ b/data/mods/CrazyCataclysm/crazy_items.json
@@ -645,16 +645,16 @@
     "copy-from": "pride_flag",
     "type": "ITEM",
     "subtypes": [ "ARMOR" ],
-    "description": "A large rainbow flag, The colors reflect the diversity of the LGBT community and the spectrum of human sexuality and gender.",
-    "variant_type": "generic",
-    "variants": [
-      {
-        "id": "newbrunswick_pride_flag",
-        "name": { "str": "NB flag" },
-        "description": "A yellow flag with a ship and lion, representing New Brunswick.  You have a feeling this might be the wrong NB flag.",
-        "weight": 5
-      }
-    ]
+    "extend": {
+      "variants": [
+        {
+          "id": "newbrunswick_pride_flag",
+          "name": { "str": "NB flag" },
+          "description": "A yellow flag with a ship and lion, representing New Brunswick.  You have a feeling this might be the wrong NB flag.",
+          "weight": 5
+        }
+      ]
+    }
   },
   {
     "id": "kitchen_gun",

--- a/data/mods/CrazyCataclysm/crazy_items.json
+++ b/data/mods/CrazyCataclysm/crazy_items.json
@@ -645,121 +645,14 @@
     "copy-from": "pride_flag",
     "type": "ITEM",
     "subtypes": [ "ARMOR" ],
-    "name": { "str": "pride flag" },
     "description": "A large rainbow flag, The colors reflect the diversity of the LGBT community and the spectrum of human sexuality and gender.",
     "variant_type": "generic",
     "variants": [
-      {
-        "id": "rainbow_pride_flag",
-        "name": { "str": "pride flag" },
-        "description": "A large rainbow flag, The colors reflect the diversity of the LGBT community and the spectrum of human sexuality and gender.",
-        "weight": 10
-      },
-      {
-        "id": "progress_pride_flag",
-        "name": { "str": "progress pride flag" },
-        "description": "A large rainbow flag, The colors reflect the diversity of the LGBT community and the spectrum of human sexuality and gender.  On the left side you can see a chevron that features black, brown, light blue, pink, and white stripes to bring those communities to the forefront; \"the arrow points to the right to show forward movement, while being along the left edge shows that progress still needs to be made\".",
-        "weight": 10
-      },
-      {
-        "id": "agender_pride_flag",
-        "name": { "str": "agender flag" },
-        "description": "A large green gray and black agender flag.  The black and white stripes represent complete absence of gender, gray represents being semi-genderless, and green represents non-binary gender.",
-        "weight": 2
-      },
-      {
-        "id": "bisexual_pride_flag",
-        "name": { "str": "bisexual flag" },
-        "description": "A large pink and blue bisexual flag.  The pink stripe represents homosexuality, while the blue stripe represents heterosexuality.  The purple stripe, the \"overlap\" of the blue and pink stripes, purple represents attraction regardless of sex or gender a.k.a bisexuality.",
-        "weight": 5
-      },
-      {
-        "id": "pansexual_pride_flag",
-        "name": { "str": "pansexual flag" },
-        "description": "A large pink, blue and yellow pansexual flag.  The pan-pride flag uses pink for people on the female-spectrum, blue for people on the male-spectrum, and yellow for non-binary or genderqueer people.",
-        "weight": 5
-      },
-      {
-        "id": "labrys_lesbian_pride_flag",
-        "name": { "str": "labrys lesbian flag" },
-        "description": "A large black and purple labrys lesbian flag.  On the flag you can see a labrys, a type of double-headed axe, superimposed on a downward-pointing black triangle, set against a violet background.",
-        "weight": 2
-      },
-      {
-        "id": "lesbian_pride_flag",
-        "name": { "str": "lesbian flag" },
-        "description": "A large pink, white and orange lesbian flag.  The dark orange representing \"gender non-conformity\", orange for \"independence\", light orange for \"community\", white for \"unique relationships to womanhood\", pink for \"serenity and peace\", dusty pink for \"love and sex\", and dark rose for \"femininity\".",
-        "weight": 5
-      },
-      {
-        "id": "asexual_pride_flag",
-        "name": { "str": "asexual flag" },
-        "description": "A large purple, white, gray and black asexual flag.  Black for asexuality (feeling no sexual attraction), gray for gray-asexuality and demisexuality (feeling sexual attraction only sometimes), white for non-asexual partners and allies, and purple for community.",
-        "weight": 2
-      },
-      {
-        "id": "aromantic_pride_flag",
-        "name": { "str": "aromantic flag" },
-        "description": "A large black, gray, white and green aromantic flag.  The green and light green stripes cover everyone under the aromantic spectrum, while represents nonromantic forms of love and attraction, and the gray and black represent all sexualities under the aromantic spectrum.",
-        "weight": 2
-      },
-      {
-        "id": "transgender_pride_flag",
-        "name": { "str": "transgender flag" },
-        "description": "A large white, pink, and blue transgender flag.  The stripes at the top and bottom are light blue, the traditional color for baby boys.  The stripes next to them are pink, the traditional color for baby girls.  The white stripe is for people that are nonbinary, feel that they don't have a gender.  The pattern is such that no matter which way you fly it, it is always correct, signifying finding correctness in one's life.",
-        "weight": 5
-      },
-      {
-        "id": "genderqueer_pride_flag",
-        "name": { "str": "genderqueer flag" },
-        "description": "A large green, white, and purple genderqueer flag.  Lavender, a mixture of blue and pink to represent androgynes and androgyny, white to represent agender identity, and green, the inverse of lavender, to represent all those who fall outside of the gender binary.",
-        "weight": 2
-      },
-      {
-        "id": "intersex_pride_flag",
-        "name": { "str": "intersex flag" },
-        "description": "A large yellow, and purple intersex flag.  It displays a purple circle on a yellow field.  Yellow and purple were chosen as colors as they were viewed as free from gender associations and were historically used to represent intersex people.  The circle is described as \"unbroken and unornamented, symbolizing wholeness and completeness, and our potentialities\".",
-        "weight": 2
-      },
-      {
-        "id": "genderfluid_pride_flag",
-        "name": { "str": "genderfluid flag" },
-        "description": "A large blue, black, purple, white and pink genderfluid flag.  The genderfluid flag has a pink stripe for femininity, a blue stripe for masculinity, a purple stripe for both masculinity and femininity, a black stripe for lack of gender, and a white stripe for all genders.",
-        "weight": 2
-      },
-      {
-        "id": "agender_pride_flag",
-        "name": { "str": "agender flag" },
-        "description": "A large green, white, gray and black agender flag.  The black and white stripes represent complete absence of gender, gray represents being semi-genderless, and green represents non-binary gender.  The symmetry of the pattern makes it so that it's correct no matter how it flies.",
-        "weight": 2
-      },
-      {
-        "id": "nonbinary_pride_flag",
-        "name": { "str": "non-binary flag" },
-        "description": "A large black, purple, white, and yellow non-binary flag.  Yellow for those whose gender exists outside of and without reference to the binary, white for those who have many or all genders, purple for those who feel their gender is between or a mix of female and male, and black for those who feel they are without gender.",
-        "weight": 5
-      },
       {
         "id": "newbrunswick_pride_flag",
         "name": { "str": "NB flag" },
         "description": "A yellow flag with a ship and lion, representing New Brunswick.  You have a feeling this might be the wrong NB flag.",
         "weight": 5
-      },
-      {
-        "id": "polysexual_pride_flag",
-        "name": { "str": "polysexual flag" },
-        "description": "A large blue, green, and pink polysexual flag.  Pink for people on the female-spectrum, blue for people on the male-spectrum, and green for non-binary or genderqueer people.",
-        "weight": 2
-      },
-      {
-        "id": "leather_pride_flag",
-        "name": { "str": "leather flag" },
-        "description": "A horizontally striped black and blue leather flag with a white band in the middle and red heart in a corner.  The black represents leather; the blue represents devotion, loyalty, and community; the white represents purity and innocence; and the red heart represents love for the community."
-      },
-      {
-        "id": "bear_pride_flag",
-        "name": { "str": "bear flag" },
-        "description": "A large black and orange international bear brotherhood flag.  The flag displays seven horizontal stripes of colors ranging from black to brown representing the colors of different bear species, you can see a black bear paw in the upper right corner."
       }
     ]
   },

--- a/doc/JSON/ITEM.md
+++ b/doc/JSON/ITEM.md
@@ -154,8 +154,8 @@ These fields can be read by any ITEM regardless of subtypes:
 "variants": [              // Cosmetic variants this item can have
   {
     "id": "variant_a",                           // id used in spawning to spawn this variant specifically
-    "name": { "str": "Variant A" },             // The name used instead of the default name when this variant is selected
-    "description": "A fancy variant A",         // The description used instead of the default when this variant is selected
+    "name": { "str": "Variant A" },             // The name used instead of the default name when this variant is selected. Optional, can be omitted to inherit the description of an item.
+    "description": "A fancy variant A",         // The description used instead of the default when this variant is selected. Optional, can be omitted to inherit the description of an item.
     "ascii_picture": "valid_ascii_art_id",      // An ASCII art picture used when this variant is selected. If there is none, the default (if it exists) is used.
     "symbol": "/",                              // Valid unicode character to replace the item symbol. If not specified, no change will be made.
     "color": "red",                             // Replacement color of item symbol. If not specified, no change will be made.

--- a/lang/string_extractor/parsers/generic.py
+++ b/lang/string_extractor/parsers/generic.py
@@ -46,14 +46,15 @@ def parse_generic(json, origin):
 
     if "variants" in json:
         for variant in json["variants"]:
-            variant_name = get_singular_name(variant["name"]) if "name" in variant else name
+            variant_name = get_singular_name(
+                variant["name"]) if "name" in variant else name
             if "name" in variant:
                 write_text(variant["name"], origin,
                            comment="Variant name of item \"{}\"".format(name),
                            plural=True)
             if "description" in variant:
-                write_text(variant["description"], origin,
-                           comment="Description of variant \"{1}\" of item \"{0}\""
+                write_text(variant["description"], origin, "",
+                           "Description of variant \"{1}\" of item \"{0}\""
                            .format(name, variant_name))
 
     if "snippet_category" in json and type(json["snippet_category"]) is list:

--- a/lang/string_extractor/parsers/generic.py
+++ b/lang/string_extractor/parsers/generic.py
@@ -46,13 +46,15 @@ def parse_generic(json, origin):
 
     if "variants" in json:
         for variant in json["variants"]:
-            variant_name = get_singular_name(variant["name"])
-            write_text(variant["name"], origin,
-                       comment="Variant name of item \"{}\"".format(name),
-                       plural=True)
-            write_text(variant["description"], origin,
-                       comment="Description of variant \"{1}\" of item \"{0}\""
-                       .format(name, variant_name))
+            variant_name = get_singular_name(variant["name"]) if "name" in variant else name
+            if "name" in variant:
+                write_text(variant["name"], origin,
+                           comment="Variant name of item \"{}\"".format(name),
+                           plural=True)
+            if "description" in variant:
+                write_text(variant["description"], origin,
+                           comment="Description of variant \"{1}\" of item \"{0}\""
+                           .format(name, variant_name))
 
     if "snippet_category" in json and type(json["snippet_category"]) is list:
         # snippet_category is either a simple string (the category ident)

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -331,7 +331,7 @@ void Item_factory::finalize_pre( itype &obj )
 
     // if variant omit it's name or description,
     // pick it from the item instead
-    for( auto &var : obj.variants ) {
+    for( itype_variant_data &var : obj.variants ) {
         if( var.alt_name.empty() ) {
             var.alt_name = obj.name;
         };

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -329,6 +329,17 @@ void Item_factory::finalize_pre( itype &obj )
                   obj.id.c_str() );
     }
 
+    // if variant omit it's name or description,
+    // pick it from the item instead
+    for( auto &var : obj.variants ) {
+        if( var.alt_name == translation() ) {
+            var.alt_name = obj.name;
+        };
+        if( var.alt_description == translation() ) {
+            var.alt_description = obj.name;
+        }
+    }
+
     // add usage methods (with default values) based upon qualities
     // if a method was already set the specific values remain unchanged
     for( const auto &q : obj.qualities ) {
@@ -2977,8 +2988,8 @@ void itype_variant_data::load( const JsonObject &jo )
 {
     alt_name.make_plural();
     mandatory( jo, false, "id", id );
-    mandatory( jo, false, "name", alt_name );
-    mandatory( jo, false, "description", alt_description );
+    optional( jo, false, "name", alt_name, translation() );
+    optional( jo, false, "description", alt_description, translation() );
     optional( jo, false, "symbol", alt_sym, std::nullopt );
     if( jo.has_string( "color" ) ) {
         alt_color = color_from_string( jo.get_string( "color" ) );

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -332,10 +332,10 @@ void Item_factory::finalize_pre( itype &obj )
     // if variant omit it's name or description,
     // pick it from the item instead
     for( auto &var : obj.variants ) {
-        if( var.alt_name == translation() ) {
+        if( var.alt_name.empty() ) {
             var.alt_name = obj.name;
         };
-        if( var.alt_description == translation() ) {
+        if( var.alt_description.empty() ) {
             var.alt_description = obj.name;
         }
     }
@@ -2988,8 +2988,8 @@ void itype_variant_data::load( const JsonObject &jo )
 {
     alt_name.make_plural();
     mandatory( jo, false, "id", id );
-    optional( jo, false, "name", alt_name, translation() );
-    optional( jo, false, "description", alt_description, translation() );
+    optional( jo, false, "name", alt_name );
+    optional( jo, false, "description", alt_description );
     optional( jo, false, "symbol", alt_sym, std::nullopt );
     if( jo.has_string( "color" ) ) {
         alt_color = color_from_string( jo.get_string( "color" ) );


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Close #81762
#### Describe the solution
Make name and description fields optional, if they are not loaded, the game picks it from the item data
While here, adress some items (from 1 to 50) listed in https://github.com/CleverRaven/Cataclysm-DDA/issues/81762#issuecomment-3070167765
While here, take advantage of variant copy-from inheritance and clean up NB flag in crazy cata
#### Testing
<img width="1995" height="810" alt="image" src="https://github.com/user-attachments/assets/4f5d2616-e99e-4f1e-869e-34f1f7e94d2e" />
<img width="453" height="189" alt="image" src="https://github.com/user-attachments/assets/128055f8-fc92-4259-91d4-334188ae92db" />
<img width="1060" height="842" alt="image" src="https://github.com/user-attachments/assets/15aa67f4-26df-424a-b51d-81df26aca5b2" />