### PR TITLE
[XE] New vampire blood art refinements

### DIFF
--- a/data/mods/Xedra_Evolved/design_doc_spoilers.md
+++ b/data/mods/Xedra_Evolved/design_doc_spoilers.md
@@ -67,6 +67,9 @@ Principles of Blood Arts:
 - Blood Arts do not have levels, and are not subject to failure based on power or skill level.
 - Blood Arts that turn on and remain on until turned off should be implemented as activatable mutations, so that there's a easy screen where the player can see what all is active and turn them on and off. Blood Arts which create an instant or temporary effect should be implemented as spells in the Supernatural Powers menu.
 - It is currently possible for a player to eventually learn every single available Blood Art, so be careful of unexpected synergies. 
+- Blood Art refinements are boosts to one or more Blood Arts.  They cannot be granted by the disease and must be gained through research.
+- They have their own research recipe and EOC, and are intended to be harder to research than regular Blood Arts.
+- When creating a refinement, there is more leeway to the "vampire-y" theme and scope than for regular Blood Arts.
 - New vampire powers need to be added to the vampire virus EoC (\Xedra_Evolved\effects\vampvirus.json) in order for vampires to learn them. If it's a power that a dhampir could also learn, they should also be added to the dhampir learning EoC (\Xedra_Evolved\mutations\dhampir_eocs.json)
 
 ### Vampire Anathema

--- a/data/mods/Xedra_Evolved/effects/effects.json
+++ b/data/mods/Xedra_Evolved/effects/effects.json
@@ -1001,7 +1001,7 @@
       { "mutations": [ "WINTER_FEIGN_DEATH_TRAITS" ] },
       { "ench_effects": [ { "effect": "downed", "intensity": 1 } ] },
       {
-        "condition": { "u_has_trait": "TORPOR_REFINEMENT_FEIGN_DEATH" },
+        "condition": { "u_has_trait": "VAMPIRE_TORPOR_REFINEMENT_FEIGN_DEATH" },
         "values": [
           {
             "value": "REGEN_HP",

--- a/data/mods/Xedra_Evolved/effects/effects.json
+++ b/data/mods/Xedra_Evolved/effects/effects.json
@@ -862,6 +862,26 @@
   },
   {
     "type": "effect_type",
+    "id": "effect_vampire_stamina_for_blood_cardio_bonus",
+    "//": "Hidden effect, boost cardio when using Unholy Endurance and possessing the Incarnadine Relentlessness refinement.",
+    "name": [ "" ],
+    "desc": [ "" ],
+    "int_add_val": 1,
+    "max_intensity": 5,
+    "max_duration": "20 m",
+    "enchantments": [
+      {
+        "values": [
+          {
+            "value": "CARDIO_MULTIPLIER",
+            "multiply": { "math": [ "0.15 * u_effect_intensity('effect_vampire_stamina_for_blood_cardio_bonus')" ] }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "effect_type",
     "id": "blood_weave",
     "name": [ "Blood Weave" ],
     "desc": [ "Immunity to bleeding and bites, increased stamina regeneration, increased hunger and thirst gain." ],
@@ -894,6 +914,16 @@
           { "value": "STRENGTH", "add": { "math": [ "2 + u_has_trait('VAMPIRE4') + u_has_trait('BLOOD_DRINKER')" ] } },
           {
             "value": "DEXTERITY",
+            "add": { "math": [ "2 + u_has_trait('VAMPIRE4') + u_has_trait('BLOOD_DRINKER')" ] }
+          }
+        ]
+      },
+      {
+        "condition": { "u_has_trait": "VAMPIRE_BLOOD_TEMPORARY_BOOST_REFINEMENT_MIND_BOOST" },
+        "values": [
+          { "value": "INTELLIGENCE", "add": { "math": [ "2 + u_has_trait('VAMPIRE4') + u_has_trait('BLOOD_DRINKER')" ] } },
+          {
+            "value": "PERCEPTION",
             "add": { "math": [ "2 + u_has_trait('VAMPIRE4') + u_has_trait('BLOOD_DRINKER')" ] }
           }
         ]
@@ -967,7 +997,33 @@
     "desc": [ "Nothing here but a corpse." ],
     "remove_message": "You end your imitation of death.",
     "rating": "mixed",
-    "enchantments": [ { "mutations": [ "WINTER_FEIGN_DEATH_TRAITS" ], "ench_effects": [ { "effect": "downed", "intensity": 1 } ] } ],
+    "enchantments": [
+      { "mutations": [ "WINTER_FEIGN_DEATH_TRAITS" ] },
+      { "ench_effects": [ { "effect": "downed", "intensity": 1 } ] },
+      {
+        "condition": { "u_has_trait": "TORPOR_REFINEMENT_FEIGN_DEATH" },
+        "values": [
+          {
+            "value": "REGEN_HP",
+            "multiply": {
+              "math": [
+                "(u_vampire_total_tier_one_traits_plus_potency * 0.02) + (u_vampire_total_tier_two_traits * 0.03) + (u_vampire_total_tier_three_traits * 0.04) + (vampire_total_tier_four_traits_plus_potence() * 0.05) + (u_vampire_total_tier_five_traits_plus_cauldron * 0.06)"
+              ]
+            }
+          },
+          {
+            "value": "MENDING_MODIFIER",
+            "multiply": {
+              "math": [
+                "(u_vampire_total_tier_one_traits_plus_potency * 0.03) + (u_vampire_total_tier_two_traits * 0.04) + (u_vampire_total_tier_three_traits * 0.05) + (vampire_total_tier_four_traits_plus_potence() * 0.06) + (u_vampire_total_tier_five_traits_plus_cauldron * 0.07)"
+              ]
+            }
+          },
+          { "value": "REGEN_HP_AWAKE", "multiply": 1 },
+          { "value": "SLEEPINESS", "multiply": -0.5 }
+        ]
+      }
+    ],
     "flags": [ "CANNOT_ATTACK", "CANNOT_MOVE", "NO_BODY_HEAT" ]
   },
   {

--- a/data/mods/Xedra_Evolved/mutations/mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/mutations.json
@@ -1336,10 +1336,13 @@
     "player_display": false,
     "enchantments": [
       {
+        "condition": { "not": { "u_has_trait": "VAMPIRE_BAT_FORM_REFINEMENT_SWARM" } },
+        "values": [ { "value": "MAX_HP", "multiply": -0.85 } ]
+      },
+      {
         "condition": "ALWAYS",
         "values": [
           { "value": "SPEED", "multiply": 0.1 },
-          { "value": "MAX_HP", "multiply": -0.85 },
           { "value": "MELEE_DAMAGE", "multiply": -0.95 },
           { "value": "NIGHT_VIS", "add": 6 },
           { "value": "DEXTERITY", "add": 8 },

--- a/data/mods/Xedra_Evolved/mutations/vampire_trait_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/vampire_trait_eocs.json
@@ -1760,7 +1760,10 @@
     "vitamins": [ { "vitamin": "human_blood_vitamin", "rate": [ [ 1, 1 ] ], "tick": [ "8 m" ] } ],
     "flags": [ "DEAF", "BLIND" ],
     "enchantments": [
-      { "condition": { "u_has_trait": "TORPOR_REFINEMENT_FEIGN_DEATH" }, "mutations": [ "WINTER_FEIGN_DEATH_TRAITS" ] },
+      {
+        "condition": { "u_has_trait": "VAMPIRE_TORPOR_REFINEMENT_FEIGN_DEATH" },
+        "mutations": [ "WINTER_FEIGN_DEATH_TRAITS" ]
+      },
       {
         "values": [
           {

--- a/data/mods/Xedra_Evolved/mutations/vampire_trait_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/vampire_trait_eocs.json
@@ -1811,8 +1811,15 @@
               { "u_add_trait": "ECHOLOCATION" },
               { "math": [ "u_calories('dont_affect_weariness': true) /= 4" ] },
               {
-                "u_message": "Your fingers lengthen as flaps of skin grow between them and as your legs shorten, you take to the air.",
-                "type": "good"
+                "if": { "u_has_trait": "VAMPIRE_BAT_FORM_REFINEMENT_SWARM" },
+                "then": {
+                  "u_message": "Your body splits into a multitude of bats and as your transformation completes, you take to the air on many wings.",
+                  "type": "good"
+                },
+                "else": {
+                  "u_message": "Your fingers lengthen as flaps of skin grow between them and as your legs shorten, you take to the air.",
+                  "type": "good"
+                }
               }
             ],
             "false_effect": [

--- a/data/mods/Xedra_Evolved/mutations/vampire_trait_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/vampire_trait_eocs.json
@@ -1760,6 +1760,7 @@
     "vitamins": [ { "vitamin": "human_blood_vitamin", "rate": [ [ 1, 1 ] ], "tick": [ "8 m" ] } ],
     "flags": [ "DEAF", "BLIND" ],
     "enchantments": [
+      { "condition": { "u_has_trait": "TORPOR_REFINEMENT_FEIGN_DEATH" }, "mutations": [ "WINTER_FEIGN_DEATH_TRAITS" ] },
       {
         "values": [
           {

--- a/data/mods/Xedra_Evolved/mutations/vampire_trait_refinements.json
+++ b/data/mods/Xedra_Evolved/mutations/vampire_trait_refinements.json
@@ -46,7 +46,7 @@
   },
   {
     "type": "mutation",
-    "id": "TORPOR_REFINEMENT_FEIGN_DEATH",
+    "id": "VAMPIRE_TORPOR_REFINEMENT_FEIGN_DEATH",
     "points": 3,
     "starting_trait": false,
     "purifiable": false,

--- a/data/mods/Xedra_Evolved/mutations/vampire_trait_refinements.json
+++ b/data/mods/Xedra_Evolved/mutations/vampire_trait_refinements.json
@@ -43,5 +43,49 @@
     "name": { "str": "Soulsight" },
     "description": "You can see invisible creatures.",
     "flags": [ "TRUE_SEEING" ]
+  },
+  {
+    "type": "mutation",
+    "id": "TORPOR_REFINEMENT_FEIGN_DEATH",
+    "points": 3,
+    "starting_trait": false,
+    "purifiable": false,
+    "valid": false,
+    "player_display": false,
+    "name": { "str": "Corpse's Torpor" },
+    "description": "You gain some of Torpor's benefits while using Corpse's Countenance and benefit from the effects of Corpse's countenance while in torpor."
+  },
+  {
+    "type": "mutation",
+    "id": "VAMPIRE_BLOOD_TEMPORARY_BOOST_REFINEMENT_MIND_BOOST",
+    "points": 3,
+    "starting_trait": false,
+    "purifiable": false,
+    "valid": false,
+    "player_display": false,
+    "name": { "str": "Carmine Clarity" },
+    "description": "The bonuses gained from Carmine Vitality also apply to your intelligence and perception."
+  },
+  {
+    "type": "mutation",
+    "id": "VAMPIRE_BAT_FORM_REFINEMENT_SWARM",
+    "points": 3,
+    "starting_trait": false,
+    "purifiable": false,
+    "valid": false,
+    "player_display": false,
+    "name": { "str": "Shape of the Night Fliers' Swarm" },
+    "description": "Your hit points aren't reduced while in bat form."
+  },
+  {
+    "type": "mutation",
+    "id": "VAMPIRE_CARDIO_BONUS_REFINEMENT_STAMINAFORBLOOD",
+    "points": 3,
+    "starting_trait": false,
+    "purifiable": false,
+    "valid": false,
+    "player_display": false,
+    "name": { "str": "Incarnadine Relentlessness" },
+    "description": "You gain a temporary stackable cardio boost when using Unholy Endurance."
   }
 ]

--- a/data/mods/Xedra_Evolved/recipes/vampire.json
+++ b/data/mods/Xedra_Evolved/recipes/vampire.json
@@ -448,6 +448,10 @@
             "EOC_REFINE_BLOOD_DRIVEN_SPEED_WATER_RUNNING",
             "EOC_REFINE_SANGUINE_RESILIENCE_INVINCIBILITY",
             "EOC_REFINE_HEIGHTENED_SENSES_SEE_INVISIBLE",
+            "EOC_REFINE_VAMPIRE_TORPOR_REFINEMENT_FEIGN_DEATH",
+            "EOC_REFINE_VAMPIRE_BLOOD_TEMPORARY_BOOST_REFINEMENT_MIND_BOOST",
+            "EOC_REFINE_VAMPIRE_BAT_FORM_REFINEMENT_SWARM",
+            "EOC_REFINE_VAMPIRE_CARDIO_BONUS_REFINEMENT_STAMINAFORBLOOD",
             "EOC_NONE"
           ],
           "allow_cancel": true,
@@ -456,6 +460,10 @@
             "Refine Blood-driven Speed: Zephyr",
             "Refine Sanguine Resilience: Flesh of Marble",
             "Refine Predator's Senses/Crimson Vision: Soulsight",
+            "Refine Corpse's Countenance/Torpor: Corpse's Torpor",
+            "Refine Carmine Vitality: Carmine Clarity",
+            "Refine Shape of the Night Flier: Shape of the Night Fliers' Swarm",
+            "Refine Incarnadine Energy/Unholy Endurance: Incarnadine Relentlessness",
             "Nothing"
           ],
           "title": "Your research uncovers…",
@@ -464,6 +472,10 @@
             "With your Blood-driven Speed, move so quickly that you can even run on water.",
             "Improve Sanguine Resilience so the first attack after activating it shatters on your undead flesh.",
             "Combine your Predator's Senses with your Crimson Vision and learn to see even invisible creatures.",
+            "Combine your Corpse's Countenance with your Torpor so that you gain some of each's benefits while using the other.",
+            "Refine your Carmine Vitality so it increases intelligence and perception as well.",
+            "Modify your Shape of the Night Flier to turn in a multitude of bats, making you as durable in this form as you are in your default form.",
+            "Expand your Incarnadine Energy so that each use of Unholy Endurance temporarily increases its effect.",
             "End your research."
           ]
         }
@@ -530,6 +542,72 @@
       { "u_add_trait": "VAMPIRE_HEIGHTENED_SENSES_REFINEMENT_SEE_INVISIBLE" },
       {
         "u_message": "You learned Soulsight, a new use for your Predator's Senses and Crimson Vision Blood Arts.",
+        "type": "good"
+      },
+      { "run_eocs": "EOC_XE_VAMPIRE_BLOOD_REFINEMENT_RESEARCH_SUCCESS" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_REFINE_VAMPIRE_TORPOR_REFINEMENT_FEIGN_DEATH",
+    "condition": {
+      "and": [
+        { "u_has_trait": "VAMPIRE_FEIGN_DEATH" },
+        { "u_has_trait": "VAMPIRE_TORPOR" },
+        { "not": { "u_has_trait": "TORPOR_REFINEMENT_FEIGN_DEATH" } }
+      ]
+    },
+    "effect": [
+      { "u_add_trait": "VAMPIRE_TORPOR_REFINEMENT_FEIGN_DEATH" },
+      {
+        "u_message": "You learned Corpse's Torpor, a new use for your Corpse's Countenance and Torpor Blood Arts.",
+        "type": "good"
+      },
+      { "run_eocs": "EOC_XE_VAMPIRE_BLOOD_REFINEMENT_RESEARCH_SUCCESS" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_REFINE_VAMPIRE_BLOOD_TEMPORARY_BOOST_REFINEMENT_MIND_BOOST",
+    "condition": {
+      "and": [
+        { "u_has_trait": "VAMPIRE_BLOOD_TEMPORARY_BOOST" },
+        { "not": { "u_has_trait": "VAMPIRE_BLOOD_TEMPORARY_BOOST_REFINEMENT_MIND_BOOST" } }
+      ]
+    },
+    "effect": [
+      { "u_add_trait": "VAMPIRE_BLOOD_TEMPORARY_BOOST_REFINEMENT_MIND_BOOST" },
+      { "u_message": "You learned Carmine Clarity, a new use for your Carmine Vitality Blood Art.", "type": "good" },
+      { "run_eocs": "EOC_XE_VAMPIRE_BLOOD_REFINEMENT_RESEARCH_SUCCESS" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_REFINE_VAMPIRE_BAT_FORM_REFINEMENT_SWARM",
+    "condition": { "and": [ { "u_has_trait": "VAMPIRE_BAT_FORM" }, { "not": { "u_has_trait": "VAMPIRE_BAT_FORM_REFINEMENT_SWARM" } } ] },
+    "effect": [
+      { "u_add_trait": "VAMPIRE_BAT_FORM_REFINEMENT_SWARM" },
+      {
+        "u_message": "You learned Shape of the Night Fliers' Swarm, a new use for your Shape of the Night Flier Blood Art.",
+        "type": "good"
+      },
+      { "run_eocs": "EOC_XE_VAMPIRE_BLOOD_REFINEMENT_RESEARCH_SUCCESS" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_REFINE_VAMPIRE_CARDIO_BONUS_REFINEMENT_STAMINAFORBLOOD",
+    "condition": {
+      "and": [
+        { "u_has_trait": "VAMPIRE_CARDIO_BONUS" },
+        { "u_has_trait": "STAMINAFORBLOOD" },
+        { "not": { "u_has_trait": "VAMPIRE_CARDIO_BONUS_REFINEMENT_STAMINAFORBLOOD" } }
+      ]
+    },
+    "effect": [
+      { "u_add_trait": "VAMPIRE_CARDIO_BONUS_REFINEMENT_STAMINAFORBLOOD" },
+      {
+        "u_message": "You learned Incarnadine Relentlessness, a new use for your Incarnadine Energy and Unholy Endurance Blood Arts.",
         "type": "good"
       },
       { "run_eocs": "EOC_XE_VAMPIRE_BLOOD_REFINEMENT_RESEARCH_SUCCESS" }

--- a/data/mods/Xedra_Evolved/recipes/vampire.json
+++ b/data/mods/Xedra_Evolved/recipes/vampire.json
@@ -554,7 +554,7 @@
       "and": [
         { "u_has_trait": "VAMPIRE_FEIGN_DEATH" },
         { "u_has_trait": "VAMPIRE_TORPOR" },
-        { "not": { "u_has_trait": "TORPOR_REFINEMENT_FEIGN_DEATH" } }
+        { "not": { "u_has_trait": "VAMPIRE_TORPOR_REFINEMENT_FEIGN_DEATH" } }
       ]
     },
     "effect": [

--- a/data/mods/Xedra_Evolved/spells/vampire_spells.json
+++ b/data/mods/Xedra_Evolved/spells/vampire_spells.json
@@ -101,7 +101,27 @@
     "spell_class": "VAMPIRE_BLOOD_ARTS",
     "base_energy_cost": 100,
     "base_casting_time": 100,
-    "difficulty": 5
+    "difficulty": 5,
+    "extra_effects": [ { "id": "vampire_stamina_for_blood_cardio_bonus" } ]
+  },
+  {
+    "id": "vampire_stamina_for_blood_cardio_bonus",
+    "type": "SPELL",
+    "name": { "str": "Incarnadine relentlessness.", "//~": "NO_I18N" },
+    "description": { "str": "This applies the cardio boost if you have the refinement.", "//~": "NO_I18N" },
+    "teachable": false,
+    "magic_type": "xe_vampire_blood_powers",
+    "effect": "attack",
+    "effect_str": "effect_vampire_stamina_for_blood_cardio_bonus",
+    "condition": { "u_has_trait": "VAMPIRE_CARDIO_BONUS_REFINEMENT_STAMINAFORBLOOD" },
+    "shape": "blast",
+    "valid_targets": [ "self" ],
+    "min_duration": 60000,
+    "max_duration": 120000,
+    "flags": [ "NO_HANDS", "SILENT", "NO_FAIL", "RANDOM_DAMAGE", "NO_SFX" ],
+    "skill": "deduction",
+    "spell_class": "VAMPIRE_BLOOD_ARTS",
+    "difficulty": 0
   },
   {
     "id": "vampire_commune_with_night_spell",


### PR DESCRIPTION
#### Summary
Mods "[XE] New vampire blood art refinements"

#### Purpose of change

I like the concept of blood art refinements, so I decided to add my own to the pile.

#### Describe the solution

Add the following refinements:

-Corpse's Torpor (Corpse's Countenance/Torpor)
While feigning death, your injuries regenerate more quickly and your tiredness won't increase as quickly.
While using Torpor, count as feigning death for monster aggression purposes.

-Carmine Clarity (Carmine Vitality)
The boost from Carmine Vitality also applies to intelligence and perception.

-Shape of the Night Fliers' Swarm (Shape of the Night Flier)
Your hp isn't reduced while in bat form (As you're now a multitude of bats instead of one) (no, you can't split this bat swarm, like you can't split your own body)

-Incarnadine Relentlessness (Incarnadine Energy/Unholy Endurance)
When using Unholy Endurance, gain a stackable temporary cardio boost.

#### Describe alternatives you've considered

Add refinements to Earthen Slumber and Spider's walk.
I wasn't satisfied with them, so I left them out.

#### Testing

Game loads without errors.
All the new refinements work.
Doesn't get the refinements' bonuses without having the refinements.

#### Additional context
I've also added a note about blood art refinements in the design doc.