### PR TITLE
add bone buttons and consolidate wood sealing requirements

### DIFF
--- a/data/json/itemgroups/SUS/clothes_store.json
+++ b/data/json/itemgroups/SUS/clothes_store.json
@@ -94,6 +94,7 @@
       { "item": "button_plastic", "count": [ 1, 5 ], "prob": 75 },
       { "item": "button_steel", "count": [ 1, 5 ], "prob": 75 },
       { "item": "button_wood", "count": [ 1, 5 ], "prob": 75 },
+      { "item": "button_bone", "count": [ 1, 5 ], "prob": 75 },
       { "item": "snapfastener_steel", "count": [ 1, 5 ], "prob": 75 },
       { "item": "zipper_long_plastic", "count": [ 1, 8 ], "prob": 75 },
       { "item": "zipper_short_plastic", "count": [ 1, 8 ], "prob": 75 }

--- a/data/json/itemgroups/SUS/domestic.json
+++ b/data/json/itemgroups/SUS/domestic.json
@@ -303,6 +303,7 @@
       { "item": "deck_of_cards", "prob": 30 },
       { "item": "glasses_reading", "prob": 30 },
       { "item": "button_wood", "prob": 30, "count": [ 1, 12 ], "charges": 1 },
+      { "item": "button_bone", "prob": 30, "count": [ 1, 12 ], "charges": 1 },
       { "item": "button_plastic", "prob": 30, "count": [ 2, 18 ], "charges": 1 },
       { "item": "bracelet_friendship", "count": [ 3, 6 ], "prob": 25 },
       { "item": "boxcutter", "prob": 20 },

--- a/data/json/itemgroups/SUS/trash.json
+++ b/data/json/itemgroups/SUS/trash.json
@@ -416,6 +416,7 @@
       { "item": "button_plastic", "charges": [ 1, 5 ], "prob": 5 },
       { "item": "button_steel", "charges": [ 1, 5 ], "prob": 5 },
       { "item": "button_wood", "charges": [ 1, 5 ], "prob": 5 },
+      { "item": "button_bone", "charges": [ 1, 5 ], "prob": 5 },
       { "item": "thread", "charges": [ 2, 7 ], "prob": 5 },
       { "item": "thread_nomex", "charges": [ 1, 2 ], "prob": 2 },
       { "item": "thread_kevlar", "charges": [ 1, 3 ], "prob": 2 },

--- a/data/json/items/resources/fasteners.json
+++ b/data/json/items/resources/fasteners.json
@@ -66,6 +66,15 @@
     "material": [ "wood" ]
   },
   {
+    "id": "button_bone",
+    "copy-from": "button_plastic",
+    "type": "ITEM",
+    "subtypes": [ "AMMO" ],
+    "name": { "str": "bone button" },
+    "description": "A crude bone button, usually found on very old clothing.",
+    "material": [ "bone" ]
+  },
+  {
     "id": "snapfastener_steel",
     "copy-from": "button_steel",
     "type": "ITEM",

--- a/data/json/recipes/other/materials.json
+++ b/data/json/recipes/other/materials.json
@@ -1540,6 +1540,28 @@
   },
   {
     "type": "recipe",
+    "activity_level": "MODERATE_EXERCISE",
+    "result": "button_bone",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_MATERIALS",
+    "skill_used": "fabrication",
+    "difficulty": 4,
+    "time": "2 h 10 m",
+    "charges": 50,
+    "autolearn": true,
+    "qualities": [
+      { "id": "SAW_W", "level": 1 },
+      [ { "id": "PUNCH", "level": 1 }, { "id": "DRILL", "level": 1 } ],
+      { "id": "CUT", "level": 2 },
+      { "id": "FILE", "level": 1 },
+      { "id": "BOIL", "level": 1 }
+    ],
+    "tools": [ [ [ "water_boiling_heat", 1, "LIST" ] ], [ [ "water", -1 ], [ "water_clean", -1 ] ] ],
+    "proficiencies": [ { "proficiency": "prof_carving", "time_multiplier": 1.25, "skill_penalty": 0.125 } ],
+    "components": [ [ "bone", 1 ] ]
+  },
+  {
+    "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",
     "result": "button_plastic",
     "category": "CC_OTHER",

--- a/data/json/recipes/other/materials.json
+++ b/data/json/recipes/other/materials.json
@@ -1558,7 +1558,7 @@
     ],
     "tools": [ [ [ "water_boiling_heat", 1, "LIST" ] ], [ [ "water", -1 ], [ "water_clean", -1 ] ] ],
     "proficiencies": [ { "proficiency": "prof_carving", "time_multiplier": 1.25, "skill_penalty": 0.125 } ],
-    "components": [ [ "bone", 1 ] ]
+    "components": [ [ "bone_sturdy", 1 ] ]
   },
   {
     "type": "recipe",

--- a/data/json/recipes/other/materials.json
+++ b/data/json/recipes/other/materials.json
@@ -1558,7 +1558,7 @@
     ],
     "tools": [ [ [ "water_boiling_heat", 1, "LIST" ] ], [ [ "water", -1 ], [ "water_clean", -1 ] ] ],
     "proficiencies": [ { "proficiency": "prof_carving", "time_multiplier": 1.25, "skill_penalty": 0.125 } ],
-    "components": [ [ [ "bone_sturdy", 1 ] ] ]
+    "components": [ [ [ "bone_sturdy", 1, "LIST" ] ] ]
   },
   {
     "type": "recipe",

--- a/data/json/recipes/other/materials.json
+++ b/data/json/recipes/other/materials.json
@@ -1529,6 +1529,7 @@
     "time": "2 h",
     "charges": 50,
     "autolearn": true,
+    "using": [ [ "wood_sealant_any_small", 1 ] ],
     "qualities": [
       { "id": "SAW_W", "level": 1 },
       [ { "id": "PUNCH", "level": 1 }, { "id": "DRILL", "level": 1 } ],
@@ -1536,7 +1537,7 @@
       { "id": "FILE", "level": 1 }
     ],
     "proficiencies": [ { "proficiency": "prof_carving", "time_multiplier": 1.25, "skill_penalty": 0.125 } ],
-    "components": [ [ [ "mop", 1 ], [ "stick", 1 ], [ "broom", 1 ] ], [ [ "wood_sealant_any_small", 1, "LIST" ] ] ]
+    "components": [ [ [ "mop", 1 ], [ "stick", 1 ], [ "broom", 1 ] ] ]
   },
   {
     "type": "recipe",

--- a/data/json/recipes/other/materials.json
+++ b/data/json/recipes/other/materials.json
@@ -1536,10 +1536,7 @@
       { "id": "FILE", "level": 1 }
     ],
     "proficiencies": [ { "proficiency": "prof_carving", "time_multiplier": 1.25, "skill_penalty": 0.125 } ],
-    "components": [
-      [ [ "mop", 1 ], [ "stick", 1 ], [ "broom", 1 ] ],
-      [ [ "wax_any", 1, "LIST" ], [ "rosin", 1 ], [ "any_tallow", 5, "LIST" ], [ "cooking_oil", 16 ] ]
-    ]
+    "components": [ [ [ "mop", 1 ], [ "stick", 1 ], [ "broom", 1 ] ], [ [ "wood_sealant_any_small", 1, "LIST" ] ] ]
   },
   {
     "type": "recipe",

--- a/data/json/recipes/other/materials.json
+++ b/data/json/recipes/other/materials.json
@@ -1536,7 +1536,10 @@
       { "id": "FILE", "level": 1 }
     ],
     "proficiencies": [ { "proficiency": "prof_carving", "time_multiplier": 1.25, "skill_penalty": 0.125 } ],
-    "components": [ [ [ "mop", 1 ], [ "stick", 1 ], [ "broom", 1 ] ], [ [ "wax_any", 1, "LIST" ], [ "rosin", 1 ] ] ]
+    "components": [
+      [ [ "mop", 1 ], [ "stick", 1 ], [ "broom", 1 ] ],
+      [ [ "wax_any", 1, "LIST" ], [ "rosin", 1 ], [ "any_tallow", 5, "LIST" ], [ "cooking_oil", 16 ] ]
+    ]
   },
   {
     "type": "recipe",

--- a/data/json/recipes/other/materials.json
+++ b/data/json/recipes/other/materials.json
@@ -1558,7 +1558,7 @@
     ],
     "tools": [ [ [ "water_boiling_heat", 1, "LIST" ] ], [ [ "water", -1 ], [ "water_clean", -1 ] ] ],
     "proficiencies": [ { "proficiency": "prof_carving", "time_multiplier": 1.25, "skill_penalty": 0.125 } ],
-    "components": [ [ "bone_sturdy", 1 ] ]
+    "components": [ [ [ "bone_sturdy", 1 ] ] ]
   },
   {
     "type": "recipe",

--- a/data/json/recipes/other/other.json
+++ b/data/json/recipes/other/other.json
@@ -69,20 +69,8 @@
     "components": [
       [ [ "paper", 1 ] ],
       [ [ "box_small", 1 ], [ "plastic_shopping_bag", 1 ] ],
-      [
-        [ "button_wood", 3 ],
-        [ "button_steel", 3 ],
-        [ "button_bronze", 3 ],
-        [ "button_plastic", 3 ],
-        [ "button_bone", 3 ]
-      ],
-      [
-        [ "button_wood", 3 ],
-        [ "button_steel", 3 ],
-        [ "button_bronze", 3 ],
-        [ "button_plastic", 3 ],
-        [ "button_bone", 3 ]
-      ]
+      [ [ "button", 3, "LIST" ] ],
+      [ [ "button", 3, "LIST" ] ]
     ]
   },
   {
@@ -112,13 +100,8 @@
     "components": [
       [ [ "paper", 1 ] ],
       [ [ "box_small", 1 ], [ "plastic_shopping_bag", 1 ] ],
-      [
-        [ "button_wood", 24 ],
-        [ "button_steel", 24 ],
-        [ "button_bronze", 24 ],
-        [ "button_plastic", 24 ],
-        [ "button_bone", 24 ]
-      ]
+      [ [ "button", 12, "LIST" ] ],
+      [ [ "button", 12, "LIST" ] ]
     ]
   },
   {

--- a/data/json/recipes/other/other.json
+++ b/data/json/recipes/other/other.json
@@ -112,7 +112,7 @@
     "components": [
       [ [ "paper", 1 ] ],
       [ [ "box_small", 1 ], [ "plastic_shopping_bag", 1 ] ],
-      [ [ "button_wood", 24 ], [ "button_steel", 24 ], [ "button_bronze", 24 ], [ "button_plastic", 24 ] ]
+      [ [ "button_wood", 24 ], [ "button_steel", 24 ], [ "button_bronze", 24 ], [ "button_plastic", 24 ], [ "button_bone", 24 ] ]
     ]
   },
   {

--- a/data/json/recipes/other/other.json
+++ b/data/json/recipes/other/other.json
@@ -112,7 +112,13 @@
     "components": [
       [ [ "paper", 1 ] ],
       [ [ "box_small", 1 ], [ "plastic_shopping_bag", 1 ] ],
-      [ [ "button_wood", 24 ], [ "button_steel", 24 ], [ "button_bronze", 24 ], [ "button_plastic", 24 ], [ "button_bone", 24 ] ]
+      [
+        [ "button_wood", 24 ],
+        [ "button_steel", 24 ],
+        [ "button_bronze", 24 ],
+        [ "button_plastic", 24 ],
+        [ "button_bone", 24 ]
+      ]
     ]
   },
   {

--- a/data/json/recipes/other/other.json
+++ b/data/json/recipes/other/other.json
@@ -69,8 +69,20 @@
     "components": [
       [ [ "paper", 1 ] ],
       [ [ "box_small", 1 ], [ "plastic_shopping_bag", 1 ] ],
-      [ [ "button_wood", 3 ], [ "button_steel", 3 ], [ "button_bronze", 3 ], [ "button_plastic", 3 ] ],
-      [ [ "button_wood", 3 ], [ "button_steel", 3 ], [ "button_bronze", 3 ], [ "button_plastic", 3 ] ]
+      [
+        [ "button_wood", 3 ],
+        [ "button_steel", 3 ],
+        [ "button_bronze", 3 ],
+        [ "button_plastic", 3 ],
+        [ "button_bone", 3 ]
+      ],
+      [
+        [ "button_wood", 3 ],
+        [ "button_steel", 3 ],
+        [ "button_bronze", 3 ],
+        [ "button_plastic", 3 ],
+        [ "button_bone", 3 ]
+      ]
     ]
   },
   {

--- a/data/json/recipes/other/parts_construction.json
+++ b/data/json/recipes/other/parts_construction.json
@@ -352,10 +352,7 @@
     "autolearn": true,
     "qualities": [ { "id": "SAW_W", "level": 1 }, { "id": "CUT", "level": 2 } ],
     "//": "a long pole is a single piece of wood, and the stout branch just isn't large enough.",
-    "components": [
-      [ [ "wooden_post_long", 1 ] ],
-      [ [ "any_tallow", 10, "LIST" ], [ "cooking_oil", 32 ], [ "lamp_oil", 500 ], [ "motor_oil", 500 ] ]
-    ]
+    "components": [ [ [ "wooden_post_long", 1 ] ], [ [ "wood_sealant_any", 2, "LIST" ] ] ]
   },
   {
     "type": "recipe",
@@ -375,16 +372,7 @@
       { "id": "CUT_FINE", "level": 1 },
       { "id": "FILE", "level": 1 }
     ],
-    "components": [
-      [ [ "stick_long", 1 ] ],
-      [
-        [ "any_tallow", 5, "LIST" ],
-        [ "cooking_oil", 16 ],
-        [ "edible_tallow", 10, "LIST" ],
-        [ "lamp_oil", 250 ],
-        [ "motor_oil", 250 ]
-      ]
-    ]
+    "components": [ [ [ "stick_long", 1 ] ], [ [ "wood_sealant_any", 1, "LIST" ] ] ]
   },
   {
     "type": "recipe",

--- a/data/json/recipes/tools/containers.json
+++ b/data/json/recipes/tools/containers.json
@@ -1015,7 +1015,7 @@
     "difficulty": 3,
     "time": "30 m",
     "autolearn": true,
-    "using": [ [ "adhesive", 1 ], [ "waterproofing", 1 ] ],
+    "using": [ [ "adhesive", 1 ], [ "wood_sealant_nontoxic_small", 1 ] ],
     "qualities": [ { "id": "CUT", "level": 2 }, { "id": "SAW_W", "level": 2 } ],
     "tools": [ [ [ "surface_heat", 10, "LIST" ] ] ],
     "proficiencies": [ { "proficiency": "prof_metalworking" }, { "proficiency": "prof_carving" } ],

--- a/data/json/recipes/weapon/bashing.json
+++ b/data/json/recipes/weapon/bashing.json
@@ -60,7 +60,7 @@
     "qualities": [ { "id": "SAW_W", "level": 1 }, { "id": "CUT", "level": 2 } ],
     "proficiencies": [ { "proficiency": "prof_carving" } ],
     "tools": [ [ [ "char_smoker", 100 ] ] ],
-    "components": [ [ [ "log", 1 ] ], [ [ "butter", 30 ], [ "raw_butter", 30 ], [ "edible_tallow", 10, "LIST" ] ] ]
+    "components": [ [ [ "log", 1 ] ], [ [ "wood_sealant_any", 1, "LIST" ] ] ]
   },
   {
     "type": "recipe",
@@ -449,7 +449,7 @@
       { "id": "GRIND", "level": 1 },
       { "id": "FILE", "level": 1 }
     ],
-    "components": [ [ [ "2x4", 2 ] ], [ [ "any_tallow", 10, "LIST" ], [ "cooking_oil", 48 ], [ "lamp_oil", 500 ], [ "motor_oil", 500 ] ] ]
+    "components": [ [ [ "2x4", 2 ] ], [ [ "wood_sealant_any", 2, "LIST" ] ] ]
   },
   {
     "type": "recipe",
@@ -477,7 +477,7 @@
     ],
     "components": [
       [ [ "2x4", 2 ] ],
-      [ [ "any_tallow", 10, "LIST" ], [ "cooking_oil", 48 ], [ "lamp_oil", 500 ], [ "motor_oil", 500 ] ],
+      [ [ "wood_sealant_any", 2, "LIST" ] ],
       [ [ "leather", 3 ], [ "fur", 3 ], [ "faux_fur", 3 ] ]
     ]
   },
@@ -507,7 +507,7 @@
     ],
     "components": [
       [ [ "2x4", 2 ] ],
-      [ [ "any_tallow", 10, "LIST" ], [ "cooking_oil", 48 ], [ "lamp_oil", 500 ], [ "motor_oil", 500 ] ],
+      [ [ "wood_sealant_any", 2, "LIST" ] ],
       [ [ "leather", 3 ], [ "fur", 3 ], [ "faux_fur", 3 ] ]
     ]
   },
@@ -538,7 +538,7 @@
     ],
     "components": [
       [ [ "2x4", 2 ] ],
-      [ [ "any_tallow", 10, "LIST" ], [ "cooking_oil", 48 ], [ "lamp_oil", 500 ], [ "motor_oil", 500 ] ],
+      [ [ "wood_sealant_any", 2, "LIST" ] ],
       [ [ "leather", 3 ], [ "scrap_kevlar", 3 ] ]
     ]
   },
@@ -569,7 +569,7 @@
     ],
     "components": [
       [ [ "2x4", 2 ] ],
-      [ [ "any_tallow", 10, "LIST" ], [ "cooking_oil", 48 ], [ "lamp_oil", 500 ], [ "motor_oil", 500 ] ],
+      [ [ "wood_sealant_any", 2, "LIST" ] ],
       [ [ "leather", 3 ], [ "scrap_kevlar", 3 ] ]
     ]
   },
@@ -645,7 +645,7 @@
     "components": [
       [ [ "spear_shaft", 1 ] ],
       [ [ "2x4", 1 ] ],
-      [ [ "any_tallow", 2, "LIST" ], [ "cooking_oil", 8 ], [ "lamp_oil", 125 ], [ "motor_oil", 125 ] ]
+      [ [ "wood_sealant_any", 1, "LIST" ] ]
     ]
   },
   {
@@ -675,7 +675,7 @@
     "components": [
       [ [ "spear_shaft", 1 ] ],
       [ [ "2x4", 1 ] ],
-      [ [ "any_tallow", 2, "LIST" ], [ "cooking_oil", 8 ], [ "lamp_oil", 125 ], [ "motor_oil", 125 ] ]
+      [ [ "wood_sealant_any", 1, "LIST" ] ]
     ]
   },
   {
@@ -705,7 +705,7 @@
     "components": [
       [ [ "spear_shaft", 1 ] ],
       [ [ "2x4", 1 ] ],
-      [ [ "any_tallow", 2, "LIST" ], [ "cooking_oil", 8 ], [ "lamp_oil", 125 ], [ "motor_oil", 125 ] ]
+      [ [ "wood_sealant_any", 1, "LIST" ] ]
     ]
   },
   {
@@ -736,7 +736,7 @@
     "components": [
       [ [ "spear_shaft", 1 ] ],
       [ [ "2x4", 1 ] ],
-      [ [ "any_tallow", 2, "LIST" ], [ "cooking_oil", 8 ], [ "lamp_oil", 125 ], [ "motor_oil", 125 ] ]
+      [ [ "wood_sealant_any", 1, "LIST" ] ]
     ]
   },
   {
@@ -767,7 +767,7 @@
     "components": [
       [ [ "spear_shaft", 1 ] ],
       [ [ "2x4", 1 ] ],
-      [ [ "any_tallow", 2, "LIST" ], [ "cooking_oil", 8 ], [ "lamp_oil", 125 ], [ "motor_oil", 125 ] ]
+      [ [ "wood_sealant_any", 1, "LIST" ] ]
     ]
   },
   {
@@ -1134,7 +1134,7 @@
     "//": "Bokken is a single piece of wood, and the stout branch just isn't large enough.",
     "components": [
       [ [ "stick_long", 1 ] ],
-      [ [ "any_tallow", 5, "LIST" ], [ "cooking_oil", 16 ], [ "lamp_oil", 250 ], [ "motor_oil", 250 ] ],
+      [ [ "wood_sealant_any", 1, "LIST" ] ],
       [ [ "fur", 2 ], [ "leather", 2 ] ],
       [ [ "duct_tape", 20 ], [ "filament", 20, "LIST" ] ]
     ]
@@ -1436,7 +1436,7 @@
     "//2": "Max experience set because waiting for oil to soak in isn't really teaching you anything.  Remove this when crafting time reduced to only carving time.",
     "components": [
       [ [ "stick_long", 1 ] ],
-      [ [ "any_tallow", 5, "LIST" ], [ "cooking_oil", 16 ], [ "lamp_oil", 250 ], [ "motor_oil", 250 ] ]
+      [ [ "wood_sealant_any", 1, "LIST" ] ]
     ]
   },
   {
@@ -1457,7 +1457,7 @@
     "//2": "Max experience set because waiting for oil to soak in isn't really teaching you anything.  Remove this when crafting time reduced to only carving time.",
     "components": [
       [ [ "q_staff", 1 ] ],
-      [ [ "any_tallow", 5, "LIST" ], [ "cooking_oil", 16 ], [ "lamp_oil", 250 ], [ "motor_oil", 250 ] ]
+      [ [ "wood_sealant_any", 1, "LIST" ] ]
     ]
   },
   {

--- a/data/json/recipes/weapon/bashing.json
+++ b/data/json/recipes/weapon/bashing.json
@@ -57,10 +57,11 @@
     "difficulty": 3,
     "time": "360 m",
     "autolearn": true,
+    "using": [ [ "wood_sealant_any", 1 ] ],
     "qualities": [ { "id": "SAW_W", "level": 1 }, { "id": "CUT", "level": 2 } ],
     "proficiencies": [ { "proficiency": "prof_carving" } ],
     "tools": [ [ [ "char_smoker", 100 ] ] ],
-    "components": [ [ [ "log", 1 ] ], [ [ "wood_sealant_any", 1, "LIST" ] ] ]
+    "components": [ [ [ "log", 1 ] ] ]
   },
   {
     "type": "recipe",
@@ -441,7 +442,7 @@
       { "proficiency": "prof_bladesmith" },
       { "proficiency": "prof_carving" }
     ],
-    "using": [ [ "blacksmithing_standard", 6 ], [ "lc_steel_standard", 3 ] ],
+    "using": [ [ "blacksmithing_standard", 6 ], [ "lc_steel_standard", 3 ], [ "wood_sealant_any", 2 ] ],
     "tools": [ [ [ "hotcut_any", 1, "LIST" ] ] ],
     "qualities": [
       { "id": "CUT", "level": 2 },
@@ -449,7 +450,7 @@
       { "id": "GRIND", "level": 1 },
       { "id": "FILE", "level": 1 }
     ],
-    "components": [ [ [ "2x4", 2 ] ], [ [ "wood_sealant_any", 2, "LIST" ] ] ]
+    "components": [ [ [ "2x4", 2 ] ] ]
   },
   {
     "type": "recipe",
@@ -467,7 +468,7 @@
       { "proficiency": "prof_bladesmith" },
       { "proficiency": "prof_carving" }
     ],
-    "using": [ [ "blacksmithing_standard", 6 ], [ "mc_steel_standard", 3 ] ],
+    "using": [ [ "blacksmithing_standard", 6 ], [ "mc_steel_standard", 3 ], [ "wood_sealant_any", 2 ] ],
     "tools": [ [ [ "hotcut_any", 1, "LIST" ] ] ],
     "qualities": [
       { "id": "CUT", "level": 2 },
@@ -477,7 +478,6 @@
     ],
     "components": [
       [ [ "2x4", 2 ] ],
-      [ [ "wood_sealant_any", 2, "LIST" ] ],
       [ [ "leather", 3 ], [ "fur", 3 ], [ "faux_fur", 3 ] ]
     ]
   },
@@ -497,7 +497,7 @@
       { "proficiency": "prof_bladesmith" },
       { "proficiency": "prof_carving" }
     ],
-    "using": [ [ "blacksmithing_standard", 6 ], [ "lc_steel_standard", 3 ] ],
+    "using": [ [ "blacksmithing_standard", 6 ], [ "lc_steel_standard", 3 ], [ "wood_sealant_any", 2] ],
     "tools": [ [ [ "hotcut_any", 1, "LIST" ] ] ],
     "qualities": [
       { "id": "CUT", "level": 2 },
@@ -507,7 +507,6 @@
     ],
     "components": [
       [ [ "2x4", 2 ] ],
-      [ [ "wood_sealant_any", 2, "LIST" ] ],
       [ [ "leather", 3 ], [ "fur", 3 ], [ "faux_fur", 3 ] ]
     ]
   },
@@ -528,7 +527,7 @@
       { "proficiency": "prof_carving" },
       { "proficiency": "prof_case_hardening" }
     ],
-    "using": [ [ "blacksmithing_standard", 6 ], [ "lc_steel_standard", 3 ], [ "carbon", 3 ] ],
+    "using": [ [ "blacksmithing_standard", 6 ], [ "lc_steel_standard", 3 ], [ "carbon", 3 ], [ "wood_sealant_any", 2 ] ],
     "tools": [ [ [ "hotcut_any", 1, "LIST" ] ] ],
     "qualities": [
       { "id": "CUT", "level": 2 },
@@ -538,7 +537,6 @@
     ],
     "components": [
       [ [ "2x4", 2 ] ],
-      [ [ "wood_sealant_any", 2, "LIST" ] ],
       [ [ "leather", 3 ], [ "scrap_kevlar", 3 ] ]
     ]
   },
@@ -559,7 +557,7 @@
       { "proficiency": "prof_carving" },
       { "proficiency": "prof_quenching" }
     ],
-    "using": [ [ "blacksmithing_standard", 10 ], [ "mc_steel_standard", 3 ] ],
+    "using": [ [ "blacksmithing_standard", 10 ], [ "mc_steel_standard", 3 ], [ "wood_sealant_any", 2 ] ],
     "tools": [ [ [ "hotcut_any", 1, "LIST" ] ], [ [ "metal_tank", -1 ] ], [ [ "water", -120 ], [ "water_clean", -120 ] ] ],
     "qualities": [
       { "id": "CUT", "level": 2 },
@@ -569,7 +567,6 @@
     ],
     "components": [
       [ [ "2x4", 2 ] ],
-      [ [ "wood_sealant_any", 2, "LIST" ] ],
       [ [ "leather", 3 ], [ "scrap_kevlar", 3 ] ]
     ]
   },
@@ -634,7 +631,7 @@
       { "proficiency": "prof_bladesmith" },
       { "proficiency": "prof_carving" }
     ],
-    "using": [ [ "blacksmithing_standard", 2 ], [ "lc_steel_standard", 1 ] ],
+    "using": [ [ "blacksmithing_standard", 2 ], [ "lc_steel_standard", 1 ], [ "wood_sealant_any", 1 ] ],
     "tools": [ [ [ "hotcut_any", 1, "LIST" ] ] ],
     "qualities": [
       { "id": "CUT", "level": 2 },
@@ -644,8 +641,7 @@
     ],
     "components": [
       [ [ "spear_shaft", 1 ] ],
-      [ [ "2x4", 1 ] ],
-      [ [ "wood_sealant_any", 1, "LIST" ] ]
+      [ [ "2x4", 1 ] ]
     ]
   },
   {
@@ -664,7 +660,8 @@
       { "proficiency": "prof_bladesmith" },
       { "proficiency": "prof_carving" }
     ],
-    "using": [ [ "blacksmithing_standard", 2 ], [ "mc_steel_standard", 1 ] ],
+    "using": [ [ "blacksmithing_standard", 2 ], [ "mc_steel_standard", 1 ], [ "wood_sealant_any", 1 ] ],
+    
     "tools": [ [ [ "hotcut_any", 1, "LIST" ] ] ],
     "qualities": [
       { "id": "CUT", "level": 2 },
@@ -674,8 +671,7 @@
     ],
     "components": [
       [ [ "spear_shaft", 1 ] ],
-      [ [ "2x4", 1 ] ],
-      [ [ "wood_sealant_any", 1, "LIST" ] ]
+      [ [ "2x4", 1 ] ]
     ]
   },
   {
@@ -694,7 +690,7 @@
       { "proficiency": "prof_bladesmith" },
       { "proficiency": "prof_carving" }
     ],
-    "using": [ [ "blacksmithing_standard", 2 ], [ "hc_steel_standard", 1 ] ],
+    "using": [ [ "blacksmithing_standard", 2 ], [ "hc_steel_standard", 1 ], [ "wood_sealant_any", 1 ] ],
     "tools": [ [ [ "hotcut_any", 1, "LIST" ] ] ],
     "qualities": [
       { "id": "CUT", "level": 2 },
@@ -704,8 +700,7 @@
     ],
     "components": [
       [ [ "spear_shaft", 1 ] ],
-      [ [ "2x4", 1 ] ],
-      [ [ "wood_sealant_any", 1, "LIST" ] ]
+      [ [ "2x4", 1 ] ]
     ]
   },
   {
@@ -725,7 +720,7 @@
       { "proficiency": "prof_carving" },
       { "proficiency": "prof_case_hardening" }
     ],
-    "using": [ [ "blacksmithing_standard", 2 ], [ "lc_steel_standard", 1 ], [ "carbon", 1 ] ],
+    "using": [ [ "blacksmithing_standard", 2 ], [ "lc_steel_standard", 1 ], [ "carbon", 1 ], [ "wood_sealant_any", 1 ] ],
     "tools": [ [ [ "hotcut_any", 1, "LIST" ] ] ],
     "qualities": [
       { "id": "CUT", "level": 2 },
@@ -735,8 +730,7 @@
     ],
     "components": [
       [ [ "spear_shaft", 1 ] ],
-      [ [ "2x4", 1 ] ],
-      [ [ "wood_sealant_any", 1, "LIST" ] ]
+      [ [ "2x4", 1 ] ]
     ]
   },
   {
@@ -756,7 +750,7 @@
       { "proficiency": "prof_carving" },
       { "proficiency": "prof_quenching" }
     ],
-    "using": [ [ "blacksmithing_standard", 4 ], [ "mc_steel_standard", 1 ] ],
+    "using": [ [ "blacksmithing_standard", 4 ], [ "mc_steel_standard", 1 ], [ "wood_sealant_any", 1 ] ],
     "tools": [ [ [ "hotcut_any", 1, "LIST" ] ], [ [ "metal_tank", -1 ] ], [ [ "water", -120 ], [ "water_clean", -120 ] ] ],
     "qualities": [
       { "id": "CUT", "level": 2 },
@@ -766,8 +760,7 @@
     ],
     "components": [
       [ [ "spear_shaft", 1 ] ],
-      [ [ "2x4", 1 ] ],
-      [ [ "wood_sealant_any", 1, "LIST" ] ]
+      [ [ "2x4", 1 ] ]
     ]
   },
   {
@@ -1129,12 +1122,12 @@
     "difficulty": 3,
     "time": "5 h 40 m",
     "book_learn": [ [ "textbook_weapeast", 2 ] ],
+    "using": [ [ "wood_sealant_any_small", 1 ] ],
     "qualities": [ { "id": "SAW_W", "level": 1 }, { "id": "CUT", "level": 2 } ],
     "proficiencies": [ { "proficiency": "prof_carving", "skill_penalty": 0.5 } ],
     "//": "Bokken is a single piece of wood, and the stout branch just isn't large enough.",
     "components": [
       [ [ "stick_long", 1 ] ],
-      [ [ "wood_sealant_any_small", 1, "LIST" ] ],
       [ [ "fur", 2 ], [ "leather", 2 ] ],
       [ [ "duct_tape", 20 ], [ "filament", 20, "LIST" ] ]
     ]
@@ -1431,12 +1424,12 @@
     "time": "5 h",
     "//1": "TODO: adjust crafting time down by 4 hours when it's possible to separate the oiling time from the crafting time easily.",
     "autolearn": true,
+    "using": [ [ "wood_sealant_any", 1 ] ]
     "qualities": [ { "id": "CUT", "level": 2 }, { "id": "CUT_FINE", "level": 1 }, { "id": "FILE", "level": 1 } ],
     "proficiencies": [ { "proficiency": "prof_carving", "max_experience": "60 m", "skill_penalty": 0.5 } ],
     "//2": "Max experience set because waiting for oil to soak in isn't really teaching you anything.  Remove this when crafting time reduced to only carving time.",
     "components": [
-      [ [ "stick_long", 1 ] ],
-      [ [ "wood_sealant_any", 1, "LIST" ] ]
+      [ [ "stick_long", 1 ] ]
     ]
   },
   {
@@ -1452,12 +1445,12 @@
     "time": "270 m",
     "//1": "TODO: adjust crafting time down by 4 hours (240 minutes) when it's possible to separate the oiling time from the crafting time easily.",
     "autolearn": true,
+      "using": [ [ "wood_sealant_any", 1 ] ]
     "qualities": [ { "id": "CUT", "level": 2 }, { "id": "CUT_FINE", "level": 1 }, { "id": "FILE", "level": 1 } ],
     "proficiencies": [ { "proficiency": "prof_carving", "max_experience": "30 m", "skill_penalty": 0.2 } ],
     "//2": "Max experience set because waiting for oil to soak in isn't really teaching you anything.  Remove this when crafting time reduced to only carving time.",
     "components": [
-      [ [ "q_staff", 1 ] ],
-      [ [ "wood_sealant_any", 1, "LIST" ] ]
+      [ [ "q_staff", 1 ] ]
     ]
   },
   {

--- a/data/json/recipes/weapon/bashing.json
+++ b/data/json/recipes/weapon/bashing.json
@@ -1134,7 +1134,7 @@
     "//": "Bokken is a single piece of wood, and the stout branch just isn't large enough.",
     "components": [
       [ [ "stick_long", 1 ] ],
-      [ [ "wood_sealant_any", 1, "LIST" ] ],
+      [ [ "wood_sealant_any_small", 1, "LIST" ] ],
       [ [ "fur", 2 ], [ "leather", 2 ] ],
       [ [ "duct_tape", 20 ], [ "filament", 20, "LIST" ] ]
     ]

--- a/data/json/recipes/weapon/bashing.json
+++ b/data/json/recipes/weapon/bashing.json
@@ -476,10 +476,7 @@
       { "id": "GRIND", "level": 1 },
       { "id": "FILE", "level": 1 }
     ],
-    "components": [
-      [ [ "2x4", 2 ] ],
-      [ [ "leather", 3 ], [ "fur", 3 ], [ "faux_fur", 3 ] ]
-    ]
+    "components": [ [ [ "2x4", 2 ] ], [ [ "leather", 3 ], [ "fur", 3 ], [ "faux_fur", 3 ] ] ]
   },
   {
     "type": "recipe",
@@ -497,7 +494,7 @@
       { "proficiency": "prof_bladesmith" },
       { "proficiency": "prof_carving" }
     ],
-    "using": [ [ "blacksmithing_standard", 6 ], [ "lc_steel_standard", 3 ], [ "wood_sealant_any", 2] ],
+    "using": [ [ "blacksmithing_standard", 6 ], [ "lc_steel_standard", 3 ], [ "wood_sealant_any", 2 ] ],
     "tools": [ [ [ "hotcut_any", 1, "LIST" ] ] ],
     "qualities": [
       { "id": "CUT", "level": 2 },
@@ -505,10 +502,7 @@
       { "id": "GRIND", "level": 1 },
       { "id": "FILE", "level": 1 }
     ],
-    "components": [
-      [ [ "2x4", 2 ] ],
-      [ [ "leather", 3 ], [ "fur", 3 ], [ "faux_fur", 3 ] ]
-    ]
+    "components": [ [ [ "2x4", 2 ] ], [ [ "leather", 3 ], [ "fur", 3 ], [ "faux_fur", 3 ] ] ]
   },
   {
     "type": "recipe",
@@ -535,10 +529,7 @@
       { "id": "GRIND", "level": 1 },
       { "id": "FILE", "level": 1 }
     ],
-    "components": [
-      [ [ "2x4", 2 ] ],
-      [ [ "leather", 3 ], [ "scrap_kevlar", 3 ] ]
-    ]
+    "components": [ [ [ "2x4", 2 ] ], [ [ "leather", 3 ], [ "scrap_kevlar", 3 ] ] ]
   },
   {
     "type": "recipe",
@@ -565,10 +556,7 @@
       { "id": "GRIND", "level": 1 },
       { "id": "FILE", "level": 1 }
     ],
-    "components": [
-      [ [ "2x4", 2 ] ],
-      [ [ "leather", 3 ], [ "scrap_kevlar", 3 ] ]
-    ]
+    "components": [ [ [ "2x4", 2 ] ], [ [ "leather", 3 ], [ "scrap_kevlar", 3 ] ] ]
   },
   {
     "type": "recipe",
@@ -639,10 +627,7 @@
       { "id": "GRIND", "level": 1 },
       { "id": "FILE", "level": 1 }
     ],
-    "components": [
-      [ [ "spear_shaft", 1 ] ],
-      [ [ "2x4", 1 ] ]
-    ]
+    "components": [ [ [ "spear_shaft", 1 ] ], [ [ "2x4", 1 ] ] ]
   },
   {
     "type": "recipe",
@@ -661,7 +646,6 @@
       { "proficiency": "prof_carving" }
     ],
     "using": [ [ "blacksmithing_standard", 2 ], [ "mc_steel_standard", 1 ], [ "wood_sealant_any", 1 ] ],
-    
     "tools": [ [ [ "hotcut_any", 1, "LIST" ] ] ],
     "qualities": [
       { "id": "CUT", "level": 2 },
@@ -669,10 +653,7 @@
       { "id": "GRIND", "level": 1 },
       { "id": "FILE", "level": 1 }
     ],
-    "components": [
-      [ [ "spear_shaft", 1 ] ],
-      [ [ "2x4", 1 ] ]
-    ]
+    "components": [ [ [ "spear_shaft", 1 ] ], [ [ "2x4", 1 ] ] ]
   },
   {
     "type": "recipe",
@@ -698,10 +679,7 @@
       { "id": "GRIND", "level": 1 },
       { "id": "FILE", "level": 1 }
     ],
-    "components": [
-      [ [ "spear_shaft", 1 ] ],
-      [ [ "2x4", 1 ] ]
-    ]
+    "components": [ [ [ "spear_shaft", 1 ] ], [ [ "2x4", 1 ] ] ]
   },
   {
     "type": "recipe",
@@ -728,10 +706,7 @@
       { "id": "GRIND", "level": 1 },
       { "id": "FILE", "level": 1 }
     ],
-    "components": [
-      [ [ "spear_shaft", 1 ] ],
-      [ [ "2x4", 1 ] ]
-    ]
+    "components": [ [ [ "spear_shaft", 1 ] ], [ [ "2x4", 1 ] ] ]
   },
   {
     "type": "recipe",
@@ -758,10 +733,7 @@
       { "id": "GRIND", "level": 1 },
       { "id": "FILE", "level": 1 }
     ],
-    "components": [
-      [ [ "spear_shaft", 1 ] ],
-      [ [ "2x4", 1 ] ]
-    ]
+    "components": [ [ [ "spear_shaft", 1 ] ], [ [ "2x4", 1 ] ] ]
   },
   {
     "type": "recipe",
@@ -1126,11 +1098,7 @@
     "qualities": [ { "id": "SAW_W", "level": 1 }, { "id": "CUT", "level": 2 } ],
     "proficiencies": [ { "proficiency": "prof_carving", "skill_penalty": 0.5 } ],
     "//": "Bokken is a single piece of wood, and the stout branch just isn't large enough.",
-    "components": [
-      [ [ "stick_long", 1 ] ],
-      [ [ "fur", 2 ], [ "leather", 2 ] ],
-      [ [ "duct_tape", 20 ], [ "filament", 20, "LIST" ] ]
-    ]
+    "components": [ [ [ "stick_long", 1 ] ], [ [ "fur", 2 ], [ "leather", 2 ] ], [ [ "duct_tape", 20 ], [ "filament", 20, "LIST" ] ] ]
   },
   {
     "type": "recipe",
@@ -1424,13 +1392,11 @@
     "time": "5 h",
     "//1": "TODO: adjust crafting time down by 4 hours when it's possible to separate the oiling time from the crafting time easily.",
     "autolearn": true,
-    "using": [ [ "wood_sealant_any", 1 ] ]
+    "using": [ [ "wood_sealant_any", 1 ] ],
     "qualities": [ { "id": "CUT", "level": 2 }, { "id": "CUT_FINE", "level": 1 }, { "id": "FILE", "level": 1 } ],
     "proficiencies": [ { "proficiency": "prof_carving", "max_experience": "60 m", "skill_penalty": 0.5 } ],
     "//2": "Max experience set because waiting for oil to soak in isn't really teaching you anything.  Remove this when crafting time reduced to only carving time.",
-    "components": [
-      [ [ "stick_long", 1 ] ]
-    ]
+    "components": [ [ [ "stick_long", 1 ] ] ]
   },
   {
     "type": "recipe",
@@ -1445,13 +1411,11 @@
     "time": "270 m",
     "//1": "TODO: adjust crafting time down by 4 hours (240 minutes) when it's possible to separate the oiling time from the crafting time easily.",
     "autolearn": true,
-      "using": [ [ "wood_sealant_any", 1 ] ]
+    "using": [ [ "wood_sealant_any", 1 ] ],
     "qualities": [ { "id": "CUT", "level": 2 }, { "id": "CUT_FINE", "level": 1 }, { "id": "FILE", "level": 1 } ],
     "proficiencies": [ { "proficiency": "prof_carving", "max_experience": "30 m", "skill_penalty": 0.2 } ],
     "//2": "Max experience set because waiting for oil to soak in isn't really teaching you anything.  Remove this when crafting time reduced to only carving time.",
-    "components": [
-      [ [ "q_staff", 1 ] ]
-    ]
+    "components": [ [ [ "q_staff", 1 ] ] ]
   },
   {
     "type": "recipe",

--- a/data/json/requirements/materials.json
+++ b/data/json/requirements/materials.json
@@ -52,7 +52,7 @@
     "//": "Paraffin, motor oil, kerosene, tainted, rosin",
     "components": [
       [
-        [ "wood_sealant_nontoxic", 1, "LIST" ],
+        [ "wood_sealant_nontoxic_small", 1, "LIST" ],
         [ "any_tallow", 2, "LIST" ],
         [ "lamp_oil", 125 ],
         [ "motor_oil", 125 ],

--- a/data/json/requirements/materials.json
+++ b/data/json/requirements/materials.json
@@ -33,7 +33,6 @@
     "id": "wood_sealant_any",
     "type": "requirement",
     "//": "Any kind of wood, for handicrafts and staves etc. Includes toxic sealants like motor oil. Each unit is up to 1500cm^2 of coverage.",
-    "//": "Paraffin, motor oil, kerosene, tainted, rosin",
     "components": [
       [
         [ "wood_sealant_nontoxic", 1, "LIST" ],
@@ -48,8 +47,7 @@
   {
     "id": "wood_sealant_any_small",
     "type": "requirement",
-    "//": "Any kind of wood, for handicrafts and staves etc. Includes toxic sealants like motor oil. Each unit is up to 1500cm^2 of coverage.",
-    "//": "Paraffin, motor oil, kerosene, tainted, rosin",
+    "//": "Any kind of wood, for handicrafts and staves etc. Includes toxic sealants like motor oil. Each unit is up to 750cm^2 of coverage.",
     "components": [
       [
         [ "wood_sealant_nontoxic_small", 1, "LIST" ],
@@ -79,7 +77,7 @@
   {
     "id": "wood_sealant_nontoxic_small",
     "type": "requirement",
-    "//": "Wood sealant, for handicrafts and staves etc. Only sealants that can be used on food surfaces allowed. Each unit is 1500cm^2 of coverage.",
+    "//": "Wood sealant, for handicrafts and staves etc. Only sealants that can be used on food surfaces allowed. Each unit is 750cm^2 of coverage.",
     "components": [
       [
         [ "cooking_oil", 8 ],

--- a/data/json/requirements/materials.json
+++ b/data/json/requirements/materials.json
@@ -46,10 +46,50 @@
     ]
   },
   {
+    "id": "wood_sealant_any_small",
+    "type": "requirement",
+    "//": "Any kind of wood, for handicrafts and staves etc. Includes toxic sealants like motor oil. Each unit is up to 1500cm^2 of coverage.",
+    "//": "Paraffin, motor oil, kerosene, tainted, rosin",
+    "components": [
+      [
+        [ "wood_sealant_nontoxic", 1, "LIST" ],
+        [ "any_tallow", 2, "LIST" ],
+        [ "lamp_oil", 125 ],
+        [ "motor_oil", 125 ],
+        [ "wax_any", 1, "LIST" ],
+        [ "rosin", 1 ]
+      ]
+    ]
+  },
+  {
     "id": "wood_sealant_nontoxic",
     "type": "requirement",
     "//": "Wood sealant, for handicrafts and staves etc. Only sealants that can be used on food surfaces allowed. Each unit is 1500cm^2 of coverage.",
-    "components": [ [ [ "cooking_oil", 16 ], [ "edible_tallow", 5, "LIST" ], [ "wax", 1 ], [ "pine_resin", 1 ] ] ]
+    "components": [
+      [
+        [ "cooking_oil", 16 ],
+        [ "edible_tallow", 5, "LIST" ],
+        [ "wax", 1 ],
+        [ "pine_resin", 1 ],
+        [ "raw_butter", 20 ],
+        [ "butter", 20 ]
+      ]
+    ]
+  },
+  {
+    "id": "wood_sealant_nontoxic_small",
+    "type": "requirement",
+    "//": "Wood sealant, for handicrafts and staves etc. Only sealants that can be used on food surfaces allowed. Each unit is 1500cm^2 of coverage.",
+    "components": [
+      [
+        [ "cooking_oil", 8 ],
+        [ "edible_tallow", 2, "LIST" ],
+        [ "wax", 1 ],
+        [ "pine_resin", 1 ],
+        [ "raw_butter", 10 ],
+        [ "butter", 10 ]
+      ]
+    ]
   },
   {
     "id": "concrete_materials_dry",

--- a/data/json/requirements/materials.json
+++ b/data/json/requirements/materials.json
@@ -30,6 +30,28 @@
     "components": [ [ [ "adhesive", 1, "LIST" ], [ "cordage", 1, "LIST" ] ] ]
   },
   {
+    "id": "wood_sealant_any",
+    "type": "requirement",
+    "//": "Any kind of wood, for handicrafts and staves etc. Includes toxic sealants like motor oil. Each unit is up to 1500cm^2 of coverage.",
+    "//": "Paraffin, motor oil, kerosene, tainted, rosin",
+    "components": [
+      [
+        [ "wood_sealant_nontoxic", 1, "LIST" ],
+        [ "any_tallow", 5, "LIST" ],
+        [ "lamp_oil", 250 ],
+        [ "motor_oil", 250 ],
+        [ "wax_any", 1, "LIST" ],
+        [ "rosin", 1 ]
+      ]
+    ]
+  },
+  {
+    "id": "wood_sealant_nontoxic",
+    "type": "requirement",
+    "//": "Wood sealant, for handicrafts and staves etc. Only sealants that can be used on food surfaces allowed. Each unit is 1500cm^2 of coverage.",
+    "components": [ [ [ "cooking_oil", 16 ], [ "edible_tallow", 5, "LIST" ], [ "wax", 1 ], [ "pine_resin", 1 ] ] ]
+  },
+  {
     "id": "concrete_materials_dry",
     "type": "requirement",
     "//": "Materials, that are used in making concrete.  Adjusted for 1 unit of water with 1 cement / 0.6 water ratio per one requirement, and 3 cement/2 sand/1 aggregate ratio of ingredients by volume",

--- a/data/json/requirements/tailoring.json
+++ b/data/json/requirements/tailoring.json
@@ -98,7 +98,9 @@
     "id": "button",
     "type": "requirement",
     "//": "All kinds of clothing buttons.",
-    "components": [ [ [ "button_plastic", 1 ], [ "button_wood", 1 ], [ "button_steel", 1 ], [ "button_bronze", 1 ] ] ]
+    "components": [
+      [ [ "button_plastic", 1 ], [ "button_wood", 1 ], [ "button_steel", 1 ], [ "button_bronze", 1 ], [ "button_bone", 1 ] ]
+    ]
   },
   {
     "id": "strap_small",

--- a/data/mods/TEST_DATA/item_demographics.json
+++ b/data/mods/TEST_DATA/item_demographics.json
@@ -147,6 +147,7 @@
         "scrap",
         "welding_rod_alloy",
         "button_wood",
+        "button_bone",
         "marble",
         "button_plastic",
         "tin",

--- a/src/requirements.cpp
+++ b/src/requirements.cpp
@@ -1715,7 +1715,7 @@ deduped_requirement_data::deduped_requirement_data( const requirement_data &in,
         // sanity check to prevent things getting too far out of control.
         // The worst case in the core game currently is boots_fur
         // with 104 alternatives.
-        static constexpr size_t max_alternatives = 105;
+        static constexpr size_t max_alternatives = 115;
         if( alternatives_.size() + pending.size() > max_alternatives ) {
             debugmsg( "Construction of deduped_requirement_data generated too many alternatives.  "
                       "The recipe %1s should be simplified.  See the Recipe section in "

--- a/src/requirements.cpp
+++ b/src/requirements.cpp
@@ -1714,7 +1714,7 @@ deduped_requirement_data::deduped_requirement_data( const requirement_data &in,
         // Because this algorithm is super-exponential in the worst case, add a
         // sanity check to prevent things getting too far out of control.
         // The worst case in the core game currently is boots_fur
-        // with 104 alternatives.
+        // with 114 alternatives.
         static constexpr size_t max_alternatives = 115;
         if( alternatives_.size() + pending.size() > max_alternatives ) {
             debugmsg( "Construction of deduped_requirement_data generated too many alternatives.  "


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
No bone buttons, despite being a common fastener irl today and historically
Wood sealing was pretty restrictive and unevenly applied, and was begging to become a requirement. I have made consolidated requirements for sealing wooden items across the board, from wood buttons to bo staves 

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add bone buttons, about as common as wood buttons, similar crafting recipe but slightly more labor intensive
edit: also sanify wooden button recipe to use oils, like the bo staff

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Leaving no bone buttons :(

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Had to update alt testing in src/requirements to allow for a higher max alternate recipe size(105-115) since fur boots went from 104 to 114 alts.  This should only affect fur boots and a handful of other recipes in terms of alt size

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
<img width="718" height="750" alt="image" src="https://github.com/user-attachments/assets/8c07e94f-cce4-4dc2-8973-16a29f06b7c0" />

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
