### PR TITLE
[Innawood] stone age ammo carriers

### DIFF
--- a/data/mods/innawood/items/armor/quivers.json
+++ b/data/mods/innawood/items/armor/quivers.json
@@ -69,5 +69,33 @@
     "use_action": { "type": "holster", "holster_prompt": "Stash javelins", "holster_msg": "You stash your %s." },
     "flags": [ "WATER_FRIENDLY", "OVERSIZE", "BELTED" ],
     "armor": [ { "encumbrance": 12, "coverage": 60, "covers": [ "torso" ], "specifically_covers": [ "torso_hanging_back" ] } ]
+  },
+  {
+    "id": "quiver",
+    "type": "ITEM",
+    "subtypes": [ "ARMOR" ],
+    "name": { "str": "quiver" },
+    "description": "A leather quiver worn at the waist that can hold 20 arrows or bolts.  Use insert to store arrows or bolts.",
+    "weight": "320 g",
+    "volume": "500 ml",
+    "price": "65 USD",
+    "price_postapoc": "10 USD",
+    "material": [ "leather" ],
+    "symbol": "[",
+    "looks_like": "bscabbard",
+    "color": "brown",
+    "sided": true,
+    "material_thickness": 1,
+    "pocket_data": [ { "ammo_restriction": { "arrow": 20, "bolt": 20 }, "moves": 20 } ],
+    "flags": [ "BELTED", "OVERSIZE", "WATER_FRIENDLY" ],
+    "armor": [
+      {
+        "encumbrance": 3,
+        "coverage": 25,
+        "covers": [ "leg_l", "leg_r" ],
+        "specifically_covers": [ "leg_upper_l", "leg_upper_r" ]
+      }
+    ],
+    "melee_damage": { "bash": 2 }
   }
 ]

--- a/data/mods/innawood/items/armor/quivers.json
+++ b/data/mods/innawood/items/armor/quivers.json
@@ -1,0 +1,73 @@
+[
+  {
+    "id": "javelin_bag_birchbark",
+    "type": "ITEM",
+    "subtypes": [ "ARMOR" ],
+    "name": { "str": "javelin bag" },
+    "description": "An open medieval-looking bag, designed to store javelins within easy reach.",
+    "weight": "1380 g",
+    "volume": "1250 ml",
+    "price": "60 USD",
+    "price_postapoc": "12 USD",
+    "material": [ "wood" ],
+    "symbol": "[",
+    "looks_like": "quiver_birchbark",
+    "color": "light_gray",
+    "material_thickness": 1,
+    "pocket_data": [
+      {
+        "pocket_type": "CONTAINER",
+        "min_item_volume": "250 ml",
+        "max_contains_volume": "1250 ml",
+        "max_contains_weight": "2 kg",
+        "moves": 60,
+        "flag_restriction": [ "JAVELIN" ],
+        "max_item_length": "150 cm",
+        "volume_encumber_modifier": 0.3
+      },
+      {
+        "pocket_type": "CONTAINER",
+        "min_item_volume": "250 ml",
+        "max_contains_volume": "1250 ml",
+        "max_contains_weight": "2 kg",
+        "moves": 60,
+        "flag_restriction": [ "JAVELIN" ],
+        "max_item_length": "150 cm",
+        "volume_encumber_modifier": 0.3
+      },
+      {
+        "pocket_type": "CONTAINER",
+        "min_item_volume": "250 ml",
+        "max_contains_volume": "1250 ml",
+        "max_contains_weight": "2 kg",
+        "moves": 60,
+        "flag_restriction": [ "JAVELIN" ],
+        "max_item_length": "150 cm",
+        "volume_encumber_modifier": 0.3
+      },
+      {
+        "pocket_type": "CONTAINER",
+        "min_item_volume": "250 ml",
+        "max_contains_volume": "1250 ml",
+        "max_contains_weight": "2 kg",
+        "moves": 60,
+        "flag_restriction": [ "JAVELIN" ],
+        "max_item_length": "150 cm",
+        "volume_encumber_modifier": 0.3
+      },
+      {
+        "pocket_type": "CONTAINER",
+        "min_item_volume": "250 ml",
+        "max_contains_volume": "1250 ml",
+        "max_contains_weight": "2 kg",
+        "moves": 60,
+        "flag_restriction": [ "JAVELIN" ],
+        "max_item_length": "150 cm",
+        "volume_encumber_modifier": 0.3
+      }
+    ],
+    "use_action": { "type": "holster", "holster_prompt": "Stash javelins", "holster_msg": "You stash your %s." },
+    "flags": [ "WATER_FRIENDLY", "OVERSIZE", "BELTED" ],
+    "armor": [ { "encumbrance": 12, "coverage": 60, "covers": [ "torso" ], "specifically_covers": [ "torso_hanging_back" ] } ]
+  }
+]

--- a/data/mods/innawood/recipes/armor/quivers.json
+++ b/data/mods/innawood/recipes/armor/quivers.json
@@ -66,6 +66,28 @@
     "components": [ [ [ "strap_large", 1, "LIST" ] ] ]
   },
   {
+    "result": "javelin_bag_large",
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "category": "CC_*",
+    "subcategory": "CSC_*_NESTED",
+    "skill_used": "tailor",
+    "difficulty": 4,
+    "skills_required": [ [ "survival", 2 ], [ "archery", 2 ] ],
+    "time": "15 h",
+    "reversible": true,
+    "decomp_learn": 4,
+    "autolearn": true,
+    "book_learn": [ [ "recipe_arrows", 3 ] ],
+    "qualities": [ { "id": "CUT", "level": 2 } ],
+    "proficiencies": [
+      { "proficiency": "prof_basketweaving" },
+      { "proficiency": "prof_closures" },
+      { "proficiency": "prof_closures_waterproofing" }
+    ],
+    "components": [ [ [ "birchbark", 18 ] ], [ [ "filament", 10, "LIST" ] ], [ [ "strap_large", 1, "LIST" ] ] ]
+  },
+  {
     "result": "stone_pouch",
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",

--- a/data/mods/innawood/recipes/armor/quivers.json
+++ b/data/mods/innawood/recipes/armor/quivers.json
@@ -66,7 +66,7 @@
     "components": [ [ [ "strap_large", 1, "LIST" ] ] ]
   },
   {
-    "result": "javelin_bag_large",
+    "result": "javelin_bag_birchbark",
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",
     "category": "CC_*",

--- a/data/mods/innawood/recipes/armor/quivers.json
+++ b/data/mods/innawood/recipes/armor/quivers.json
@@ -1,0 +1,97 @@
+[
+  {
+    "result": "quiver",
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "category": "CC_*",
+    "subcategory": "CSC_*_NESTED",
+    "skill_used": "tailor",
+    "difficulty": 2,
+    "skills_required": [ "archery", 1 ],
+    "time": "9 h",
+    "reversible": true,
+    "decomp_learn": 3,
+    "autolearn": true,
+    "book_learn": [ [ "recipe_arrows", 1 ] ],
+    "using": [ [ "tailoring_leather_patchwork_simple", 1 ], [ "fastener_large", 2 ] ],
+    "proficiencies": [
+      { "proficiency": "prof_closures" },
+      { "proficiency": "prof_closures_waterproofing" },
+      { "proficiency": "prof_leatherworking_basic" }
+    ],
+    "components": [ [ [ "strap_large", 1, "LIST" ] ] ]
+  },
+  {
+    "result": "quiver_large",
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "category": "CC_*",
+    "subcategory": "CSC_*_NESTED",
+    "skill_used": "tailor",
+    "difficulty": 3,
+    "skills_required": [ "archery", 1 ],
+    "time": "30 h",
+    "reversible": true,
+    "decomp_learn": 3,
+    "autolearn": true,
+    "book_learn": [ [ "recipe_arrows", 2 ] ],
+    "using": [ [ "tailoring_leather_patchwork_simple", 3 ], [ "strap_large", 2 ] ],
+    "qualities": [ { "id": "HAMMER", "level": 2 } ],
+    "proficiencies": [
+      { "proficiency": "prof_closures" },
+      { "proficiency": "prof_closures_waterproofing" },
+      { "proficiency": "prof_leatherworking_basic" }
+    ],
+    "components": [ [ [ "fastener_large", 3, "LIST" ] ] ]
+  },
+  {
+    "result": "javelin_bag",
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_STORAGE",
+    "skill_used": "tailor",
+    "skills_required": [ [ "throw", 1 ] ],
+    "difficulty": 2,
+    "time": "30 h",
+    "autolearn": true,
+    "reversible": true,
+    "using": [ [ "tailoring_leather_patchwork_simple", 3 ], [ "fastener_large", 2 ] ],
+    "proficiencies": [
+      { "proficiency": "prof_closures" },
+      { "proficiency": "prof_closures_waterproofing" },
+      { "proficiency": "prof_leatherworking" },
+      { "proficiency": "prof_leatherworking_basic" }
+    ],
+    "components": [ [ [ "strap_large", 1, "LIST" ] ] ]
+  },
+  {
+    "result": "stone_pouch",
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "category": "CC_*",
+    "subcategory": "CSC_*_NESTED",
+    "skill_used": "tailor",
+    "difficulty": 3,
+    "skills_required": [ [ "throw", 1 ] ],
+    "time": "3 h",
+    "autolearn": true,
+    "reversible": true,
+    "using": [ [ "strap_large", 1 ], [ "tailoring_cotton_patchwork_simple", 1 ], [ "fastener_small", 2 ] ],
+    "proficiencies": [ { "proficiency": "prof_closures" }, { "proficiency": "prof_closures_waterproofing" } ]
+  },
+  {
+    "result": "leather_stone_pouch",
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "category": "CC_*",
+    "subcategory": "CSC_*_NESTED",
+    "skill_used": "tailor",
+    "difficulty": 3,
+    "time": "3 h",
+    "autolearn": true,
+    "reversible": true,
+    "using": [ [ "strap_large", 1 ], [ "tailoring_leather_patchwork_simple", 1 ], [ "fastener_small", 2 ] ],
+    "proficiencies": [ { "proficiency": "prof_closures" }, { "proficiency": "prof_leatherworking_basic" } ]
+  }
+]


### PR DESCRIPTION
allows for making sling pouches and javelin bags without industrial tools

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "Innawoods primitive pebble bags"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Players cant make crude bags to hold rocks and wooden spears until after making an anvil

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Allow for crafting some stone age quivers without fabric cutting by making their requirements using patchwork_leather_simple

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
adding fabric cutting to some early knife, but this doesnt really seem right

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
working on it

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
pitching to base game atm see linked
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
