### PR TITLE
Crude bags use crude recipe

### DIFF
--- a/data/json/recipes/armor/storage.json
+++ b/data/json/recipes/armor/storage.json
@@ -1109,7 +1109,7 @@
     "time": "1 h",
     "autolearn": true,
     "reversible": { "time": "10 m" },
-    "using": [ [ "tailoring_leather_small", 3 ], [ "fastener_small", 1 ] ],
+    "using": [ [ "tailoring_leather_small_simple", 3 ], [ "fastener_small", 1 ] ],
     "proficiencies": [
       { "proficiency": "prof_closures" },
       { "proficiency": "prof_closures_waterproofing" },
@@ -1611,7 +1611,7 @@
     "time": "1 h",
     "reversible": true,
     "autolearn": true,
-    "using": [ [ "tailoring_cotton_patchwork", 1 ] ]
+    "using": [ [ "tailoring_cotton_patchwork_simple", 1 ] ]
   },
   {
     "result": "scabbard",

--- a/data/json/requirements/tailoring.json
+++ b/data/json/requirements/tailoring.json
@@ -443,6 +443,13 @@
     "components": [ [ [ "leather", 1 ] ], [ [ "filament", 3, "LIST" ] ] ]
   },
   {
+    "id": "tailoring_leather_small_simple",
+    "type": "requirement",
+    "//": "35g per unit. Crafting either small or patchwork leather items, per 37 g of leather; 2 g + excessive weight of material is wasted, producing leather patches as byproducts.  Time needed is usually 15 minutes per unit if hand-stitching. Used for simpler items where precision cutting is less important.",
+    "qualities": [ { "id": "SEW", "level": 1 }, { "id": "LEATHER_AWL", "level": 1 } ],
+    "components": [ [ [ "leather", 1 ] ], [ [ "filament", 3, "LIST" ] ] ]
+  },
+  {
     "id": "tailoring_lycra",
     "type": "requirement",
     "//": "30g per unit. Crafting Lycra items, per 33 g of Lycra; 3 g + excessive weight of material is wasted, producing Lycra scraps as byproducts.  Time needed is usually 60 minutes per unit if hand-stitching.",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Tailoring update added FC as a requirement broadly. 
Leather_pouch and (rag)Pouch are described as:
"A bag stitched together from leather scraps.  Doesn't hold an awful lot but is easy to wear."
"A makeshift bag, cobbled together from rags.  Really gets in the way, but provides a decent amount of storage."
Since these items are crude and makeshift, they should probably use the _simple recipes in /requirements/tailoring.json


<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
add tailoring_leather_small_simple as a requirement(based on leather_patchwork_simple) and changed the pouch recipes to use their simple variants, using the existing simple variant for ragpouch

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
leaving them as is, but they seem ideal for the "simple" requirements

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
made pouches
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
