### PR TITLE
Don't count mounted vehicle's fuel as carrying vehicle's

### DIFF
--- a/src/vehicle_part.cpp
+++ b/src/vehicle_part.cpp
@@ -380,7 +380,7 @@ int vehicle_part::ammo_consume( int qty, map *here, const tripoint_bub_ms &pos )
 
 units::energy vehicle_part::consume_energy( const itype_id &ftype, units::energy wanted_energy )
 {
-    if( !is_fuel_store() ) {
+    if( !is_fuel_store() || has_flag( vp_flag::carried_flag ) ) {
         return 0_J;
     }
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
- Don't mess up the available fuel of a vehicle when mounting a vehicle with the same fuel on it.
- Attempt to address #83452, but don't know if it does, as the replication process is unknown.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
- Exclude carried vehicle's "fuel container" parts when checking available and maximum vehicle fuel (which the fuel display widget uses).
- Don't include carried vehicles' batteries in the "list" of a vehicle's batteries. This means they won't be checked in the code iterating over that "list", so batteries in carried vehicles shouldn't be checked when processing available grid electricity.
- Don't try to consume energy from a carried vehicle. That's likely to be a niche case, as I think carried vehicle parts are added to the end of the parts list, and so those would have only actually been used if all the real sources are drained (and you can't start an electric vehicle with no batteries on its own). However, debugging showed the code tried to drain energy from an MC battery, because the code tried every part in order to drain the residual energy less than a "charge" (and failing, as nothing could deduct less).

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
- Address the usages of the batteries "list". Decided it was safer and better not to include carried vehicle's batteries in the list in the first place. Both alternatives carries risks of having side effects, but examination of the usages indicated exclusion would be needed for all usages.
- Try to deal with the weird residual energy deduction loop. Decided against it, because I don't know what happens for energy sources other than batteries.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
- Checked the remaining fuel on a gas car with a bike rack.
- Mounted an MC on the bike rack.
- Verified the remaining fuel remained the same (prior to the change it dropped from 91% to 78%).
- Drove an elecric vehicle with a bike rack with an MC for a bit.
- Remove the MC from the bike rack.
- Saw no change in the available battery power compared to removing it before driving. This only indicates the code changes don't screw things up completely, but use of the code is probably needed to see if the bug has been fixed.
- A number of hours of usage saw no issues. It can be noted that the unwanted averaging of battery power (rather than drawing power from one battery at a time) has ceased to happen. Thus, it's probable the mounted vehicle was somehow detected to be linked electrically with the carrier as a separate vehicle, triggering energy transfer that results in averaging, and since the carried vehicle isn't fully independent, it probably screwed up the handling of its power.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Battery driven vehicle usage is odd with multiple batteries. Sometimes a single battery is drained completely before the next one is used, and sometimes the charges are averaged out, and I've seen that during testing, with the first battery being drained a bit, but then a little later it had more charges than before, as the charges were averaged out over the batteries. I've failed to locate the code that does this averaging, but it's a suspect for MC battery draining. However, my removal of the MC from the bike rack was made after that averaging, with no visible ill effects.

"Fuel" handling is messy. Parts of it is on the vehicle, parts is on the part, and parts of it is on a selected tile.

With the changed code, you can attach a jumper cable to a carried MC's battery, but it snaps away immediately. I don't know if that behavior has changed with this PR, but I suspect it has. I saw you can't start a vehicle with no battery off the battery of a carried vehicle before the PR, but didn't try an empty battery.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
