### PR TITLE
[Bombastic Perks] Armor of Dreams/Closetland interaction

### DIFF
--- a/data/mods/BombasticPerks/perkdata/closetland.json
+++ b/data/mods/BombasticPerks/perkdata/closetland.json
@@ -138,8 +138,7 @@
       {
         "if": {
           "and": [
-            { "math": [ "u_val('sleep_deprivation') >= 1000" ] },
-            { "math": [ "u_val('sleepiness') > 250" ] },
+            { "or": [ { "math": [ "u_val('sleep_deprivation') >= 1000" ] }, { "math": [ "u_val('sleepiness') > 250" ] } ] },
             { "one_in_chance": 450 }
           ]
         },

--- a/data/mods/BombasticPerks/perkdata/closetland.json
+++ b/data/mods/BombasticPerks/perkdata/closetland.json
@@ -207,7 +207,7 @@
     },
     "effect": [
       {
-        "u_message": "You fall asleep for only a moment before being jerked awake.  The room is engufled in shadows, barely anything visible beyond the tip of your nose, but you feel a palpable sense of meance.  You scramble to your feet and, just as the shadows in the corner begin to grow even darker, frantically take the path away and out of Closetland.",
+        "u_message": "You fall asleep for only a moment before being jerked awake.  The room is engulfed in shadows, barely anything visible beyond the tip of your nose, but you feel a palpable sense of meance.  You scramble to your feet and, just as the shadows in the corner begin to grow even darker, frantically take the path away and out of Closetland.",
         "popup": true
       },
       "u_cancel_activity",

--- a/data/mods/BombasticPerks/perkdata/closetland.json
+++ b/data/mods/BombasticPerks/perkdata/closetland.json
@@ -207,7 +207,7 @@
     },
     "effect": [
       {
-        "u_message": "You fall asleep for only a moment before being jerked awake.  The room is engulfed in shadows, barely anything visible beyond the tip of your nose, but you feel a palpable sense of meance.  You scramble to your feet and, just as the shadows in the corner begin to grow even darker, frantically take the path away and out of Closetland.",
+        "u_message": "You fall asleep for only a moment before being jerked awake.  The room is engulfed in shadows, barely anything visible beyond the tip of your nose, but you feel a palpable sense of menace.  You scramble to your feet and, just as the shadows in the corner begin to grow even darker, frantically take the path away and out of Closetland.",
         "popup": true
       },
       "u_cancel_activity",

--- a/data/mods/BombasticPerks/perkdata/closetland.json
+++ b/data/mods/BombasticPerks/perkdata/closetland.json
@@ -17,9 +17,17 @@
     "flags": [ "LEVITATION" ]
   },
   {
+    "type": "effect_type",
+    "id": "effect_bombastic_escaped_closetland",
+    "//": "Hidden effect, used as a tracker",
+    "name": [ "" ],
+    "desc": [ "" ]
+  },
+  {
     "type": "effect_on_condition",
     "id": "EOC_BOMBASTIC_PERKS_CLOSET_STORAGE_TRAVEL_TO_CLOSETLAND",
     "//": "Searching for individual furniture IDs isn't great, but there's no obvious flag to check for.",
+    "condition": { "not": { "u_has_effect": "effect_bombastic_escaped_closetland" } },
     "effect": [
       { "math": [ "u_closetland_perk_nearby_walls = 0" ] },
       { "math": [ "u_closetland_perk_nearby_doors = 0" ] },
@@ -36,9 +44,9 @@
         "condition": {
           "or": [
             { "map_furniture_with_flag": "BLOCKSDOOR", "loc": { "context_val": "closetland_terrain_check" } },
+            { "map_terrain_with_flag": "WALL", "loc": { "context_val": "closetland_terrain_check" } },
             { "map_furniture_id": "f_safe_l", "loc": { "context_val": "closetland_terrain_check" } },
-            { "map_furniture_id": "f_safe_c", "loc": { "context_val": "closetland_terrain_check" } },
-            { "map_terrain_with_flag": "WALL", "loc": { "context_val": "closetland_terrain_check" } }
+            { "map_furniture_id": "f_safe_c", "loc": { "context_val": "closetland_terrain_check" } }
           ]
         }
       },
@@ -52,7 +60,12 @@
         "range": 1,
         "store_coordinates_in": { "context_val": "closetland_terrain_check" },
         "stop_at_first": true,
-        "condition": { "map_terrain_with_flag": "DOOR", "loc": { "context_val": "closetland_terrain_check" } }
+        "condition": {
+          "or": [
+            { "map_terrain_with_flag": "DOOR", "loc": { "context_val": "closetland_terrain_check" } },
+            { "map_terrain_with_flag": "LOCKED", "loc": { "context_val": "closetland_terrain_check" } }
+          ]
+        }
       },
       {
         "if": {
@@ -82,6 +95,13 @@
           }
         ]
       }
+    ],
+    "false_effect": [
+      {
+        "u_message": "After what just happened, going back there would be a terrible idea.  You'd better wait a bit for whatever that was to lose your trail.",
+        "type": "mixed"
+      },
+      { "run_eocs": "EOC_BOMBASTIC_PERKS_CLOSET_STORAGE_TRAVEL_TO_CLOSETLAND_DEACTIVATE_FUTURE", "time_in_future": 0 }
     ]
   },
   {
@@ -120,7 +140,7 @@
           "and": [
             { "math": [ "u_val('sleep_deprivation') >= 1000" ] },
             { "math": [ "u_val('sleepiness') > 250" ] },
-            { "one_in_chance": 150 }
+            { "one_in_chance": 450 }
           ]
         },
         "then": { "u_message": "You let out another yawn.  Did the shadows get darker for just a moment?", "type": "mixed" }
@@ -149,7 +169,21 @@
     "eoc_type": "EVENT",
     "required_event": "character_gains_effect",
     "condition": {
-      "and": [ { "current_dimension": "dimension_perk_closetland" }, { "compare_string": [ "sleep", { "context_val": "effect" } ] } ]
+      "and": [
+        { "current_dimension": "dimension_perk_closetland" },
+        { "compare_string": [ "sleep", { "context_val": "effect" } ] },
+        {
+          "or": [
+            {
+              "and": [
+                { "u_has_trait": "perk_dream_armor" },
+                { "compare_string": [ "yes", { "u_val": "bombastic_closetland_dream_armor_warning" } ] }
+              ]
+            },
+            { "not": { "u_has_trait": "perk_dream_armor" } }
+          ]
+        }
+      ]
     },
     "effect": [
       {
@@ -157,6 +191,30 @@
         "popup": true
       },
       "u_die"
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PERK_CLOSETLAND_FALL_ASLEEP_IN_CLOSETLAND_BUT_HAS_DREAM_ARMOR",
+    "eoc_type": "EVENT",
+    "required_event": "character_gains_effect",
+    "condition": {
+      "and": [
+        { "current_dimension": "dimension_perk_closetland" },
+        { "compare_string": [ "sleep", { "context_val": "effect" } ] },
+        { "u_has_trait": "perk_dream_armor" },
+        { "not": { "compare_string": [ "yes", { "u_val": "bombastic_closetland_dream_armor_warning" } ] } }
+      ]
+    },
+    "effect": [
+      {
+        "u_message": "You fall asleep for only a moment before being jerked awake.  The room is engufled in shadows, barely anything visible beyond the tip of your nose, but you feel a palpable sense of meance.  You scramble to your feet and, just as the shadows in the corner begin to grow even darker, frantically take the path away and out of Closetland.",
+        "popup": true
+      },
+      "u_cancel_activity",
+      { "u_add_effect": "effect_bombastic_escaped_closetland", "duration": "24 hours" },
+      { "u_add_var": "bombastic_closetland_dream_armor_warning", "value": "yes" },
+      { "u_deactivate_trait": "perk_secret_closet_storage" }
     ]
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[Bombastic Perks] Armor of Dreams/Closetland interaction"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Forgot about Armor of Dreams. Its entire point is that it protects you while you sleep, so it should have an interaction with Closetland
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

If you have Armor of Dreams and fall asleep in Closetland, you get to escape..._once_. You get woken up and leave just before the boogeyman shows up, and you can't return to Closetland for 24 hours. This might mean that you're Exhausted in hostile territory, depending on what the situation was when you left, so, good luck with that.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Slept in Closetland without Armor of Dreams, the boogeyman got me.

Slept in Closetland with Armor of Dreams, escaped. Waited out the debuff, went back, slept, the boogeyman got me.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
