### PR TITLE
Optimize vehicle planting

### DIFF
--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -6040,15 +6040,19 @@ void vehicle::idle( map &here, bool on_map )
 
     // FIXME/HACK: Always checks buckwheat seeds!
     // Returned string intentionally discarded!
-    ret_val<void>can_plant = warm_enough_to_plant( player_character.pos_bub(), itype_seed_buckwheat );
-    if( !can_plant.success() ) {
-        for( int i : planters ) {
-            vehicle_part &vp = parts[ i ];
-            if( vp.enabled ) {
-                add_msg_if_player_sees( pos_bub( here ),
-                                        _( "The %s's planter turns off due to unsuitable planting conditions." ),
-                                        name );
-                vp.enabled = false;
+    // TODO: move it to planter function that tries to plant, and maybe cache it there
+    // (warm_enough_to_plant() is very expensive)
+    if( !planters.empty() && calendar::once_every( 5_minutes ) ) {
+        ret_val<void>can_plant = warm_enough_to_plant( player_character.pos_bub(), itype_seed_buckwheat );
+        if( !can_plant.success() ) {
+            for( int i : planters ) {
+                vehicle_part &vp = parts[ i ];
+                if( vp.enabled ) {
+                    add_msg_if_player_sees( pos_bub( here ),
+                                            _( "The %s's planter turns off due to unsuitable planting conditions." ),
+                                            name );
+                    vp.enabled = false;
+                }
             }
         }
     }


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Perfed #83313, found terrible things:
<img width="2534" height="429" alt="image" src="https://github.com/user-attachments/assets/3bb3231c-0092-4647-8db0-f4ac5a4a0ea1" />

After consulting with Renech, fix was made
Fix #83313

#### Describe the solution
Stop checking if plants can grow for idle vehicle, if said vehicle do not have a planter in the first place
Even if it has, limit the check to once in 5 minutes
#### Testing
The game works noticeably faster
pre-perf:
<img width="2534" height="429" alt="image" src="https://github.com/user-attachments/assets/929615d5-bd29-442e-9fe6-1c681d7c063a" />
past-perf:
<img width="2533" height="429" alt="image" src="https://github.com/user-attachments/assets/b0905f57-74e9-46b2-ab33-499ff9f96a7a" />