### PR TITLE
[Bombastic Perks] Add Closetland Paths playstyle perk

### DIFF
--- a/data/mods/BombasticPerks/perkdata/closetland_paths.json
+++ b/data/mods/BombasticPerks/perkdata/closetland_paths.json
@@ -1,0 +1,171 @@
+[
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_BOMBASTIC_PERKS_CLOSET_STORAGE_DIFFERENT_PATHS_OF_CLOSETLAND",
+    "condition": { "not": { "current_dimension": "dimension_perk_closetland" } },
+    "effect": [
+      { "math": [ "u_closetland_perk_nearby_walls = 0" ] },
+      { "math": [ "u_closetland_perk_nearby_doors = 0" ] },
+      {
+        "u_map_run_eocs": [
+          {
+            "id": "EOC_BOMBASTIC_PERKS_CLOSET_STORAGE_DIFFERENT_PATHS_OF_CLOSETLAND_WALL_CHECK",
+            "effect": [ { "math": [ "u_closetland_perk_nearby_walls += 1" ] } ]
+          }
+        ],
+        "range": 1,
+        "store_coordinates_in": { "context_val": "closetland_terrain_check" },
+        "stop_at_first": false,
+        "condition": {
+          "or": [
+            { "map_furniture_with_flag": "BLOCKSDOOR", "loc": { "context_val": "closetland_terrain_check" } },
+            { "map_furniture_id": "f_safe_l", "loc": { "context_val": "closetland_terrain_check" } },
+            { "map_furniture_id": "f_safe_c", "loc": { "context_val": "closetland_terrain_check" } },
+            { "map_terrain_with_flag": "WALL", "loc": { "context_val": "closetland_terrain_check" } }
+          ]
+        }
+      },
+      {
+        "u_map_run_eocs": [
+          {
+            "id": "EOC_BOMBASTIC_PERKS_CLOSET_STORAGE_DIFFERENT_PATHS_OF_CLOSETLAND_DOOR_CHECK",
+            "effect": [ { "math": [ "u_closetland_perk_nearby_doors += 1" ] } ]
+          }
+        ],
+        "range": 1,
+        "store_coordinates_in": { "context_val": "closetland_terrain_check" },
+        "stop_at_first": true,
+        "condition": {
+          "or": [
+            { "map_terrain_with_flag": "DOOR", "loc": { "context_val": "closetland_terrain_check" } },
+            { "map_terrain_with_flag": "LOCKED", "loc": { "context_val": "closetland_terrain_check" } }
+          ]
+        }
+      },
+      {
+        "if": {
+          "and": [ { "math": [ "u_closetland_perk_nearby_walls == 7" ] }, { "math": [ "u_closetland_perk_nearby_doors == 1" ] } ]
+        },
+        "then": [ { "run_eocs": "EOC_BOMBASTIC_PERKS_CLOSET_STORAGE_DIFFERENT_PATHS_OF_CLOSETLAND_MEMORIZE" } ],
+        "else": [ { "u_message": "You're not in a closet, and there's no path here to remember." } ]
+      }
+    ],
+    "false_effect": [ { "run_eocs": "EOC_BOMBASTIC_PERKS_CLOSET_STORAGE_DIFFERENT_PATHS_OF_CLOSETLAND_TRAVEL" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_BOMBASTIC_PERKS_CLOSET_STORAGE_DIFFERENT_PATHS_OF_CLOSETLAND_MEMORIZE",
+    "effect": [
+      {
+        "run_eoc_selector": [
+          "EOC_BOMBASTIC_PERKS_CLOSET_STORAGE_DIFFERENT_PATHS_OF_CLOSETLAND_SELECTOR_01",
+          "EOC_BOMBASTIC_PERKS_CLOSET_STORAGE_DIFFERENT_PATHS_OF_CLOSETLAND_SELECTOR_02",
+          "EOC_BOMBASTIC_PERKS_CLOSET_STORAGE_DIFFERENT_PATHS_OF_CLOSETLAND_SELECTOR_03"
+        ],
+        "names": [
+          "Remember Closetland Path: <u_val:perk_closetland_paths_destination_name_1>",
+          "Remember Closetland Path: <u_val:perk_closetland_paths_destination_name_2>",
+          "Remember Closetland Path: <u_val:perk_closetland_paths_destination_name_3>"
+        ],
+        "keys": [ "1", "2", "3" ],
+        "descriptions": [ "Remember this Closetpath.", "Remember this Closetpath.", "Remember this Closetpath." ],
+        "hide_failing": true,
+        "allow_cancel": true
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_BOMBASTIC_PERKS_CLOSET_STORAGE_DIFFERENT_PATHS_OF_CLOSETLAND_SELECTOR_01",
+    "effect": [
+      {
+        "set_string_var": "Destination 1",
+        "string_input": { "title": "Input a destination name:", "description": "Destination Name:", "width": 35 },
+        "target_var": { "u_val": "perk_closetland_paths_destination_name_1" }
+      },
+      { "u_location_variable": { "u_val": "perk_closetland_paths_destination_1" }, "min_radius": 0, "max_radius": 0 }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_BOMBASTIC_PERKS_CLOSET_STORAGE_DIFFERENT_PATHS_OF_CLOSETLAND_SELECTOR_02",
+    "effect": [
+      {
+        "set_string_var": "Destination 1",
+        "string_input": { "title": "Input a destination name:", "description": "Destination Name:", "width": 35 },
+        "target_var": { "u_val": "perk_closetland_paths_destination_name_2" }
+      },
+      { "u_location_variable": { "u_val": "perk_closetland_paths_destination_2" }, "min_radius": 0, "max_radius": 0 }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_BOMBASTIC_PERKS_CLOSET_STORAGE_DIFFERENT_PATHS_OF_CLOSETLAND_SELECTOR_03",
+    "effect": [
+      {
+        "set_string_var": "Destination 1",
+        "string_input": { "title": "Input a destination name:", "description": "Destination Name:", "width": 35 },
+        "target_var": { "u_val": "perk_closetland_paths_destination_name_3" }
+      },
+      { "u_location_variable": { "u_val": "perk_closetland_paths_destination_3" }, "min_radius": 0, "max_radius": 0 }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_BOMBASTIC_PERKS_CLOSET_STORAGE_DIFFERENT_PATHS_OF_CLOSETLAND_TRAVEL",
+    "effect": [
+      {
+        "run_eoc_selector": [
+          "EOC_BOMBASTIC_PERKS_CLOSET_STORAGE_DIFFERENT_PATHS_OF_CLOSETLAND_TRAVEL_SELECTOR_01",
+          "EOC_BOMBASTIC_PERKS_CLOSET_STORAGE_DIFFERENT_PATHS_OF_CLOSETLAND_TRAVEL_SELECTOR_02",
+          "EOC_BOMBASTIC_PERKS_CLOSET_STORAGE_DIFFERENT_PATHS_OF_CLOSETLAND_TRAVEL_SELECTOR_03"
+        ],
+        "names": [
+          "Travel Closetland Path: <u_val:perk_closetland_paths_destination_name_1>",
+          "Travel Closetland Path: <u_val:perk_closetland_paths_destination_name_2>",
+          "Travel Closetland Path: <u_val:perk_closetland_paths_destination_name_3>"
+        ],
+        "keys": [ "1", "2", "3" ],
+        "descriptions": [ "Travel this Closetpath.", "Travel this Closetpath.", "Travel this Closetpath." ],
+        "hide_failing": true,
+        "allow_cancel": true
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_BOMBASTIC_PERKS_CLOSET_STORAGE_DIFFERENT_PATHS_OF_CLOSETLAND_TRAVEL_SELECTOR_01",
+    "condition": { "math": [ "has_var(u_perk_closetland_paths_destination_1)" ] },
+    "effect": [
+      { "u_add_effect": "blind", "duration": 0 },
+      { "u_travel_to_dimension": "default" },
+      { "u_teleport": { "u_val": "perk_closetland_paths_destination_1" } },
+      { "u_lose_effect": "blind" },
+      { "run_eocs": "EOC_BOMBASTIC_PERKS_CLOSET_STORAGE_TRAVEL_TO_CLOSETLAND_DEACTIVATE_FUTURE", "time_in_future": 0 }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_BOMBASTIC_PERKS_CLOSET_STORAGE_DIFFERENT_PATHS_OF_CLOSETLAND_TRAVEL_SELECTOR_02",
+    "condition": { "math": [ "has_var(u_perk_closetland_paths_destination_2)" ] },
+    "effect": [
+      { "u_add_effect": "blind", "duration": 0 },
+      { "u_travel_to_dimension": "default" },
+      { "u_teleport": { "u_val": "perk_closetland_paths_destination_2" } },
+      { "u_lose_effect": "blind" },
+      { "run_eocs": "EOC_BOMBASTIC_PERKS_CLOSET_STORAGE_TRAVEL_TO_CLOSETLAND_DEACTIVATE_FUTURE", "time_in_future": 0 }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_BOMBASTIC_PERKS_CLOSET_STORAGE_DIFFERENT_PATHS_OF_CLOSETLAND_TRAVEL_SELECTOR_03",
+    "condition": { "math": [ "has_var(u_perk_closetland_paths_destination_3)" ] },
+    "effect": [
+      { "u_add_effect": "blind", "duration": 0 },
+      { "u_travel_to_dimension": "default" },
+      { "u_teleport": { "u_val": "perk_closetland_paths_destination_3" } },
+      { "u_lose_effect": "blind" },
+      { "run_eocs": "EOC_BOMBASTIC_PERKS_CLOSET_STORAGE_TRAVEL_TO_CLOSETLAND_DEACTIVATE_FUTURE", "time_in_future": 0 }
+    ]
+  }
+]

--- a/data/mods/BombasticPerks/perkmenu.json
+++ b/data/mods/BombasticPerks/perkmenu.json
@@ -1786,6 +1786,25 @@
         "topic": "TALK_PERK_MENU_SELECT_PLAYSTYLE"
       },
       {
+        "condition": { "not": { "u_has_trait": "perk_secret_closet_teleporter_paths" } },
+        "text": "Gain [<trait_name:perk_secret_closet_teleporter_paths>]",
+        "effect": [
+          { "set_string_var": "<trait_name:perk_secret_closet_teleporter_paths>", "target_var": { "context_val": "trait_name" } },
+          {
+            "set_string_var": "<trait_description:perk_secret_closet_teleporter_paths>",
+            "target_var": { "context_val": "trait_description" }
+          },
+          { "set_string_var": "perk_secret_closet_teleporter_paths", "target_var": { "context_val": "trait_id" } },
+          {
+            "set_string_var": "Must have <trait_name:perk_secret_closet_storage>",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
+          { "set_condition": "perk_condition", "condition": { "u_has_trait": "perk_secret_closet_storage" } }
+        ],
+        "topic": "TALK_PERK_MENU_SELECT_PLAYSTYLE"
+      },
+      {
         "condition": { "not": { "u_has_trait": "perk_dexterous_speed" } },
         "text": "Gain [<trait_name:perk_dexterous_speed>]",
         "effect": [

--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -1359,5 +1359,17 @@
     "activated_eocs": [ "EOC_BOMBASTIC_PERKS_CLOSET_STORAGE_TRAVEL_TO_CLOSETLAND" ],
     "processed_eocs": [ "EOC_BOMBASTIC_PERKS_CLOSET_STORAGE_SLEEP_DEPRIVATION_COST_IN_CLOSETLAND" ],
     "deactivated_eocs": [ "EOC_BOMBASTIC_PERKS_CLOSET_STORAGE_TRAVEL_BACK_FROM_CLOSETLAND" ]
+  },
+  {
+    "type": "mutation",
+    "id": "perk_secret_closet_teleporter_paths",
+    "name": { "str": "Closetland Paths" },
+    "description": "Your experience with Closetland has grown and you think you can find your way back to other places you've been, not just the most recent place you left from\n\nWhen in a closet, you can memorize it and, when in Closetland, return there instead of the place you left from.",
+    "points": 0,
+    "purifiable": false,
+    "valid": false,
+    "category": [ "perk" ],
+    "active": true,
+    "activated_eocs": [ "EOC_BOMBASTIC_PERKS_CLOSET_STORAGE_DIFFERENT_PATHS_OF_CLOSETLAND" ]
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[Bombastic Perks] Add Closetland Paths playstyle perk"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Follow up to Closetland with my other idea.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add the Closetland Paths perk, which allows you to remember up to three (3) destinations. When in the real world, you can use Closetland Paths to memorize a closet. If you're in Closetland, you can use Closetland to walk back to any closet you remember.

I picked three deliberately so you have to make careful choices about what closets you remember

Note that you can use this to go from a random closet to Closetland and then back to your base, but without memorizing that random closet, you can't return--leaving from your base makes that your departure closet and you'll just go back there if you end the Closetland perk
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Memorized a closet.

Teleported across the map, went to Closetland from a different closet. Took the paths back to my memorized closet.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Thank you Gateway for letting me already figure out how to do this.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
