### PR TITLE
Use 64 bit int to read 64 bit int values

### DIFF
--- a/src/units.cpp
+++ b/src/units.cpp
@@ -1,6 +1,5 @@
 #include "units.h"
 
-#include <cstdint>
 #include <optional>
 
 #include "calendar.h"

--- a/src/units.h
+++ b/src/units.h
@@ -1348,7 +1348,7 @@ T read_from_json_string_common( const std::string_view s,
             // above always throws but lambdas cannot be marked [[noreturn]]
             throw std::string( "Exceptionally impossible" );
         }
-        int value = 0;
+        int64_t value = 0;
         for( ; i < s.size() && isdigit( s[ i ] ); ++i ) {
             value = value * 10 + ( s[ i ] - '0' );
         }

--- a/src/units.h
+++ b/src/units.h
@@ -6,10 +6,10 @@
 #include <cctype>
 #include <cmath>
 #include <cstddef>
+#include <cstdint>
 #include <limits>
 #include <map>
 #include <sstream>
-#include <stdint.h>
 #include <string>
 #include <string_view>
 #include <type_traits>

--- a/src/units.h
+++ b/src/units.h
@@ -9,6 +9,7 @@
 #include <limits>
 #include <map>
 #include <sstream>
+#include <stdint.h>
 #include <string>
 #include <string_view>
 #include <type_traits>


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fix #83461, i.e. bugged reading of int64 values when integer part larger than int.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Use int64_t instead of int when parsing int64_t values.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Replace the stupid "correction" code in savegame_json.cpp that hides the error by setting the power to 0, and instead issue an error report to indicate something is wrong. Obviously not an alternative, but rather a complement.
It can be noted that there are other cases of this kind of "corrections" in the JSON parsing code.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Loaded the save that previously produced a 0 bionic power value and saw that it now shows the truncated value of the saved value (truncated due to UI size limitations).

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
A high level language would have thrown an exception when multiplying an int beyond its limits, rather than blitherly producing a garbage value that then is set to 0 in savegame_json.cpp without any thoughts to indicate the value is wrong.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
