### PR TITLE
Update version.cmake to show versions above 0.G-19098-gb374081a98

### DIFF
--- a/src/version.cmake
+++ b/src/version.cmake
@@ -6,7 +6,7 @@ list(APPEND CMAKE_MODULE_PATH
     ${CMAKE_SOURCE_DIR}/CMakeModules)
 include(GetGitRevisionDescription)
 
-git_describe(GIT_VERSION --tags --always --match "[0-9A-Z]*.[0-9A-Z]*")
+git_describe(GIT_VERSION --tags --always --match "cdda-*")
 
 if(EXISTS ${GIT_EXECUTABLE})
     execute_process(COMMAND ${GIT_EXECUTABLE} -c core.safecrlf=false diff --quiet


### PR DESCRIPTION
# If this commit is applied, it will ....
Show versions above `0.G-19098-gb374081a98`
EX:
`cdda-0.I-2025-10-22-0304`
`cdda-experimental-2025-10-25-0651`
`cdda-0.H-2025-07-10-0402`

# Explain why this change is being made
#### Summary
None

#### Purpose of change
Version naming format looks to have changed pinning versions 
presented on the main screen to `0.G-19098-gb374081a98`,
as it was the last matching tag.


cmake:
```bash
cmake -S "$CDDA_SRC" -B build \
  -DCURSES=OFF \
  -DTILES=ON \
  -DSOUND=ON \
  -DLOCALIZE=ON \
  -DRELEASE=1 \
  -DDISABLE_WERROR=ON \
  -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
  -DCMAKE_CXX_FLAGS="-Wno-error -Wno-error=maybe-uninitialized"

# Build the tiles GUI
cmake --build build -j$(nproc)
```

#### Describe the solution

Updated the blob to look for tag starting with cdda-, this looks to be the new naming format.
Correct me if I have misunderstood this.

#### Describe alternatives you've considered

`cdda-*` looks to be appropriate,if the intention is to match both major and experimental releases

If only major releases are intended the following should fit:
`cdda-[0-9].[A-Z]*`

#### Testing

Ran the above cmake before and after changes on branches `0.H-branch` and `0.I-branch`
Version was seen to update from `0.G-19098-gb374081a98`, to the appropriate version.

#### Additional context
###### 0.I pre change
<img width="1919" height="1079" alt="0 I pre change" src="https://github.com/user-attachments/assets/2eb89c23-d3b3-4e1d-8691-88686f355212" />

###### 0.I post change dirty
<img width="1919" height="1079" alt="0 I post change" src="https://github.com/user-attachments/assets/dd368bc9-f1f2-48a3-a5d4-a7b3a7ca8b8b" />


###### 0.I post change cherrypicked
<img width="1919" height="1079" alt="0 I post change" src="https://github.com/user-attachments/assets/c877c9d2-e0b8-4e28-9949-92261f57d325" />