### PR TITLE
Fix .460 S&W description

### DIFF
--- a/data/json/items/gun/460sw.json
+++ b/data/json/items/gun/460sw.json
@@ -6,7 +6,7 @@
     "type": "ITEM",
     "subtypes": [ "GUN" ],
     "name": { "str": ".460 S&W Magnum revolver" },
-    "description": "A behemoth of a revolver, with an 8.38\" barrel, weighing almost 2 kilograms, and sporting an impressive muzzle break.  With how powerful the .460 S&W Magnum round is, those features won't be taken for granted.  Often used as a hunting handgun, or as a bush gun, this large revolver is a formidable threat.",
+    "description": "A behemoth of a revolver, with an 8.38\" barrel, weighing over 2 kilograms, and sporting an impressive muzzle break.  With how powerful the .460 S&W Magnum round is, those features won't be taken for granted.  Often used as a hunting handgun, or as a bush gun, this large revolver is a formidable threat.",
     "weight": "2041 g",
     "volume": "1167 ml",
     "variant_type": "gun",
@@ -14,7 +14,7 @@
       {
         "id": "460_xvr",
         "name": { "str_sp": "S&W 460XVR" },
-        "description": "The S&W 460 XVR is a behemoth of a revolver, with an 8.38\" barrel, weighing almost 2 kilograms, and sporting an impressive muzzle break.  With how powerful the .460 S&W Magnum round is, those features won't be taken for granted.  Often used as a hunting handgun, or as a bush gun, this large revolver is a formidable threat."
+        "description": "The S&W 460 XVR is a behemoth of a revolver, with an 8.38\" barrel, weighing over 2 kilograms, and sporting an impressive muzzle break.  With how powerful the .460 S&W Magnum round is, those features won't be taken for granted.  Often used as a hunting handgun, or as a bush gun, this large revolver is a formidable threat."
       }
     ],
     "longest_side": "332 mm",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Fix .460 S&W description"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

.460 revolver is 2041 grams. Description says it is 'almost' 2 kilograms. 'Almost' in this usage would imply it is below 2kg, but it is not.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Update the description from 'almost' to 'over' 2kg
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Putting metric units in a description seems weird since we allow the option for the player to change unit types. Could probably just remove the whole clause or replace it with something else. Could also rewrite the first sentence since it's incomplete, "_This is_ a behemoth..."
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Just a json change.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<img width="655" height="292" alt="image" src="https://github.com/user-attachments/assets/c0b9f29d-b64d-4cc0-8cfc-ca26c83dd1ed" />


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
