### PR TITLE
Fix bugout_meds_prepper item group

### DIFF
--- a/data/json/itemgroups/stashes.json
+++ b/data/json/itemgroups/stashes.json
@@ -217,16 +217,64 @@
       { "group": "adhesive_bandages_box_full", "count": 1, "prob": 80 },
       { "group": "alcohol_wipes_box_full", "count": 1, "prob": 50 },
       { "group": "cotton_ball_bag_full", "count": 1, "prob": 60 },
-      { "item": "liq_bandage_spray", "count": 1, "prob": 30 },
+      { "item": "liq_bandage_spray", "charges": [ 1, -1 ], "prob": 30 },
       { "group": "vitc_tablet_bottle_full", "count": 1, "prob": 30 },
-      { "item": "calcium_tablet", "count": [ 30, -1 ], "prob": 30 },
-      { "item": "gummy_vitamins", "count": [ 30, -1 ], "container-item": "bottle_plastic", "prob": 20 },
-      { "item": "antibiotics", "count": [ 30, -1 ], "prob": 30 },
-      { "item": "iodine", "count": [ 30, -1 ], "prob": 30 },
-      { "item": "prussian_blue", "count": [ 12, -1 ], "prob": 20 },
-      { "item": "antifungal", "count": [ 30, -1 ], "prob": 10 },
-      { "item": "antiparasitic", "count": [ 30, -1 ], "prob": 10 },
-      { "item": "homeopathic_pills", "count": [ 30, -1 ], "prob": 10 },
+      {
+        "item": "calcium_tablet",
+        "entry-wrapper": "bottle_plastic_pill_supplement",
+        "container-item": "null",
+        "count": [ 30, -1 ],
+        "prob": 30
+      },
+      {
+        "item": "gummy_vitamins",
+        "entry-wrapper": "bottle_plastic_pill_supplement",
+        "container-item": "null",
+        "count": [ 25, -1 ],
+        "prob": 20
+      },
+      {
+        "item": "antibiotics",
+        "entry-wrapper": "bottle_plastic_pill_supplement",
+        "container-item": "null",
+        "count": [ 30, -1 ],
+        "prob": 30
+      },
+      {
+        "item": "iodine",
+        "entry-wrapper": "bottle_plastic_pill_supplement",
+        "container-item": "null",
+        "count": [ 30, -1 ],
+        "prob": 30
+      },
+      {
+        "item": "prussian_blue",
+        "entry-wrapper": "bottle_plastic_pill_supplement",
+        "container-item": "null",
+        "count": [ 12, -1 ],
+        "prob": 20
+      },
+      {
+        "item": "antifungal",
+        "entry-wrapper": "bottle_plastic_pill_supplement",
+        "container-item": "null",
+        "count": [ 30, -1 ],
+        "prob": 10
+      },
+      {
+        "item": "antiparasitic",
+        "entry-wrapper": "bottle_plastic_pill_supplement",
+        "container-item": "null",
+        "count": [ 30, -1 ],
+        "prob": 10
+      },
+      {
+        "item": "homeopathic_pills",
+        "entry-wrapper": "bottle_plastic_pill_supplement",
+        "container-item": "null",
+        "count": [ 30, -1 ],
+        "prob": 10
+      },
       { "group": "drugs_analgesic", "count": [ 1, 2 ], "prob": 40 },
       { "group": "drugs_misc", "count": [ 1, 2 ], "prob": 5 },
       { "group": "drugs_rare", "count": [ 1, 2 ], "prob": 5 },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Fixes bottle issues with bugout_meds_prepper item group"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Fixes #83480 

Some drugs in `bugout_meds_prepper` would spawn 1 pill per 1 bottle, for dozens of bottles. `liq_bandage_spray` would also only ever spawn with 0 charges. This PR fixes both, so that multiple pills can spawn per bottle and charges now spawn inside the spray bottle.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Edit `stashes.json` to define `entry-wrapper` and `container-item` for each entry.
Edit liq_bandage_spray entry to use correct charges.
I also had to reduce the max spawn of gummy-vitamin from 30 to 25 to make it fit in the supplement bottle.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

There's probably a way to do this without adding all these extra lines of code, but I don't know how.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Comprehensive testing of 50+ spawns of item group. See screenshots for before and after.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Before, with 20 instances of the item group:

<img width="603" height="641" alt="Screenshot_20251025_222647" src="https://github.com/user-attachments/assets/88b0ab8d-39bf-4ce0-840f-9846ee50ea17" />



After, with 20 instances of the item group:

<img width="710" height="1058" alt="image" src="https://github.com/user-attachments/assets/6860f7be-87f6-43fa-a16c-bf777ebd41b8" />

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
