### PR TITLE
Updating "military plutonium fuel cell (disposable)"'s plural form

### DIFF
--- a/data/json/items/battery.json
+++ b/data/json/items/battery.json
@@ -162,7 +162,7 @@
     "type": "ITEM",
     "subtypes": [ "MAGAZINE" ],
     "category": "tool_magazine",
-    "name": { "str": "military plutonium fuel cell (disposable)", "str_pl": "heavy plutonium fuel cells (disposable)" },
+    "name": { "str": "military plutonium fuel cell (disposable)", "str_pl": "military plutonium fuel cells (disposable)" },
     "description": "A battery that uses a huge plutonium-244 rod to stabilize an exotic nanocompound.  It was used in military mech-suits, was highly experimental, and had no civilian applications.  Although it stores a stupendous amount of power, it cannot be recharged.",
     "weight": "34000 g",
     "volume": "20 L",


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Changing item "military plutonium fuel cell (disposable)"'s plural form from "heavy plutonium fuel cells (disposable)" to "military plutonium fuel cells (disposable)"

#### Describe the solution
Changing item "military plutonium fuel cell (disposable)"'s plural form from "heavy plutonium fuel cells (disposable)" to "military plutonium fuel cells (disposable)"

#### Describe alternatives you've considered
None

#### Testing
None...?

#### Additional context
None
