### PR TITLE
Fix missing tilesets in releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,7 @@ jobs:
             mxe: none
             ext: zip
             content: application/zip
+            tiles: 1
             sound: 0
           - name: Windows Tiles Sounds x64 MSVC
             artifact: windows-with-graphics-and-sounds-x64
@@ -76,6 +77,7 @@ jobs:
             mxe: none
             ext: zip
             content: application/zip
+            tiles: 1
             sound: 1
           - name: Linux Tiles x64
             os: ubuntu-22.04
@@ -126,6 +128,7 @@ jobs:
           - name: Android x64
             os: ubuntu-latest
             mxe: none
+            tiles: 1
             android: arm64
             artifact: android-x64
             ext: apk
@@ -133,6 +136,7 @@ jobs:
           - name: Android x32
             os: ubuntu-latest
             mxe: none
+            tiles: 1
             android: arm32
             artifact: android-x32
             ext: apk
@@ -143,6 +147,7 @@ jobs:
           #  artifact: wasm
           #  ext: zip
           #  content: application/zip
+          #  tiles: 1
           #  sound: 0
           #  wasm: true
     name: ${{ matrix.name }}


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes  #83484 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add tiles=1 to builds that use tiles. Even though the release workflow matrix job is a mess it looks like they all use the same checkout so this should in principle do the job.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Ran the release workflow on my fork: https://github.com/harakka/Cataclysm-DDA/actions/runs/18818903564
The resulting release is here: https://github.com/harakka/Cataclysm-DDA/releases/tag/cdda-experimental-2025-10-26-1514
The Windows (and MacOS) builds from this have the expected gfx folder contents. Android builds are failing because our Android builds don't work on forks because of lack of signing. I think it's ok to merge this as is to fix Windows, and go back to Android separately if this doesn't resolve the issue there, but it should.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
