### PR TITLE
Add trait flag to not block you from learning advanced versions of a spell

### DIFF
--- a/data/mods/Sorcerer/traits/classes.json
+++ b/data/mods/Sorcerer/traits/classes.json
@@ -9,6 +9,7 @@
     "purifiable": false,
     "valid": false,
     "cancels": [ "ANIMIST", "MAGUS", "KELVINIST", "STORMSHAPER", "EARTHSHAPER", "TECHNOMANCER", "DRUID", "BIOMANCER" ],
+    "flags": [ "ALLOW_ADVANCED_SPELLS" ],
     "active": true,
     "activated_eocs": [ "EOC_open_sorcerer_menu" ]
   }

--- a/doc/JSON/JSON_FLAGS.md
+++ b/doc/JSON/JSON_FLAGS.md
@@ -338,6 +338,7 @@ Character flags can be `trait_id`, `json_flag_id` or `flag_id`.  Some of these a
 - ```ACID_IMMUNE``` You are immune to acid damage.
 - ```ALARMCLOCK``` You always can set alarms.
 - ```ALBINO``` Cause you to have painful sunburns.
+- ```ALLOW_ADVANCED_SPELLS``` Allows you to learn advanced versions of spells even if this mutation would normaly conflict with said spell.
 - ```ATTUNEMENT``` Turns a mutation with this flag green on the list.  Currently used in mods for mutations that grant spellcasting or other supernatural powers.
 - ```BARKY``` Makes you considered to be made of bark for the purposes of making blistering harder.
 - ```BASH_IMMUNE``` You are immune to bashing damage.

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -3471,7 +3471,7 @@ void spell_events::notify( const cata::event &e )
                 int learn_at_level = it->second;
                 const std::string learn_spell_id = it->first;
                 if( learn_at_level <= slvl && !get_player_character().magic->knows_spell( learn_spell_id ) ) {
-                    get_player_character().magic->learn_spell( learn_spell_id, get_player_character() );
+                    get_player_character().magic->learn_spell( learn_spell_id, get_player_character(), true );
                     spell_type spell_learned = spell_factory.obj( spell_id( learn_spell_id ) );
                     add_msg(
                         _( "Your experience and knowledge in creating and manipulating magical energies to cast %s have opened your eyes to new possibilities, you can now cast %s." ),

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -2401,7 +2401,8 @@ void known_magic::set_spell_exp( const spell_id &sp, int new_exp, const Characte
     }
 }
 
-bool known_magic::can_learn_spell( const Character &guy, const spell_id &sp, bool improved_spell ) const
+bool known_magic::can_learn_spell( const Character &guy, const spell_id &sp,
+                                   bool improved_spell ) const
 {
     const spell_type &sp_t = sp.obj();
     if( sp_t.spell_class == trait_NONE ) {

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -72,6 +72,7 @@ struct species_type;
 
 static const ammo_effect_str_id ammo_effect_MAGIC( "MAGIC" );
 
+static const json_character_flag json_flag_ALLOW_ADVANCED_SPELLS( "ALLOW_ADVANCED_SPELLS" );
 static const json_character_flag json_flag_CANNOT_ATTACK( "CANNOT_ATTACK" );
 static const json_character_flag json_flag_SILENT_SPELL( "SILENT_SPELL" );
 static const json_character_flag json_flag_SUBTLE_SPELL( "SUBTLE_SPELL" );
@@ -2400,7 +2401,7 @@ void known_magic::set_spell_exp( const spell_id &sp, int new_exp, const Characte
     }
 }
 
-bool known_magic::can_learn_spell( const Character &guy, const spell_id &sp ) const
+bool known_magic::can_learn_spell( const Character &guy, const spell_id &sp, bool improved_spell ) const
 {
     const spell_type &sp_t = sp.obj();
     if( sp_t.spell_class == trait_NONE ) {
@@ -2408,9 +2409,16 @@ bool known_magic::can_learn_spell( const Character &guy, const spell_id &sp ) co
     }
     if( sp_t.spell_tags[spell_flag::MUST_HAVE_CLASS_TO_LEARN] ) {
         return guy.has_trait( sp_t.spell_class );
-    } else {
-        return !guy.has_opposite_trait( sp_t.spell_class );
     }
+    if ( improved_spell ) {
+        for ( trait_id trait : guy.get_opposite_traits( sp_t.spell_class ) ) {
+            if ( trait->flags.count( json_flag_ALLOW_ADVANCED_SPELLS ) == 0 ) {
+                return false;
+            }
+        }
+        return true;
+    }
+    return !guy.has_opposite_trait( sp_t.spell_class );
 }
 
 spell &known_magic::get_spell( const spell_id &sp )
@@ -3470,7 +3478,7 @@ void spell_events::notify( const cata::event &e )
                  it != spell_cast.learn_spells.end(); ++it ) {
                 int learn_at_level = it->second;
                 const std::string learn_spell_id = it->first;
-                if( learn_at_level <= slvl && !get_player_character().magic->knows_spell( learn_spell_id ) ) {
+                if( learn_at_level <= slvl && !get_player_character().magic->knows_spell( learn_spell_id ) && get_player_character().magic->can_learn_spell( get_player_character(), spell_id( learn_spell_id), true ) ) {
                     get_player_character().magic->learn_spell( learn_spell_id, get_player_character(), true );
                     spell_type spell_learned = spell_factory.obj( spell_id( learn_spell_id ) );
                     add_msg(

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -2411,9 +2411,9 @@ bool known_magic::can_learn_spell( const Character &guy, const spell_id &sp,
     if( sp_t.spell_tags[spell_flag::MUST_HAVE_CLASS_TO_LEARN] ) {
         return guy.has_trait( sp_t.spell_class );
     }
-    if ( improved_spell ) {
-        for ( trait_id trait : guy.get_opposite_traits( sp_t.spell_class ) ) {
-            if ( trait->flags.count( json_flag_ALLOW_ADVANCED_SPELLS ) == 0 ) {
+    if( improved_spell ) {
+        for( trait_id trait : guy.get_opposite_traits( sp_t.spell_class ) ) {
+            if( trait->flags.count( json_flag_ALLOW_ADVANCED_SPELLS ) == 0 ) {
                 return false;
             }
         }

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -3479,7 +3479,9 @@ void spell_events::notify( const cata::event &e )
                  it != spell_cast.learn_spells.end(); ++it ) {
                 int learn_at_level = it->second;
                 const std::string learn_spell_id = it->first;
-                if( learn_at_level <= slvl && !get_player_character().magic->knows_spell( learn_spell_id ) && get_player_character().magic->can_learn_spell( get_player_character(), spell_id( learn_spell_id), true ) ) {
+                if( learn_at_level <= slvl && !get_player_character().magic->knows_spell( learn_spell_id ) &&
+                    get_player_character().magic->can_learn_spell( get_player_character(), spell_id( learn_spell_id ),
+                            true ) ) {
                     get_player_character().magic->learn_spell( learn_spell_id, get_player_character(), true );
                     spell_type spell_learned = spell_factory.obj( spell_id( learn_spell_id ) );
                     add_msg(

--- a/src/magic.h
+++ b/src/magic.h
@@ -739,7 +739,7 @@ class known_magic
         // time in moves for the Character to memorize the spell
         int time_to_learn_spell( const Character &guy, const spell_id &sp ) const;
         int time_to_learn_spell( const Character &guy, const std::string &str ) const;
-        bool can_learn_spell( const Character &guy, const spell_id &sp ) const;
+        bool can_learn_spell( const Character &guy, const spell_id &sp, bool improved_spell = false ) const;
         bool knows_spell( const std::string &sp ) const;
         bool knows_spell( const spell_id &sp ) const;
         // does the Character know a spell?


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "[Sorcerer] Sorcerers can learn advanced versions of spells though having high enough spell level of the base spell"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes #83483
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Sorcerers are not supposed to be able to learn spells from Magiclysm books. To enforce this, sorcerers are given a trait that conflicts with all Magiclysm schools.
When you level up some spells enough, they teach you an advanced version of the spell. However, when doing this, it first checks if you have a trait that conflicts with the school of the spell you are learning.
My change adds the flag ALLOW_ADVANCED_SPELLS to the sorcerer trait, and changes how the game checks if you are able to learn a spell when you learn it from leveling up a spell you know.
If you have a conflicting trait without the new flag, the game does not try to teach you the new spell.
If you have a conflicting trait with the new flag, you learn the new advanced version of the spell.
If you have both a conflicting trait with and without the new flag, you do not learn the new spell.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

- Figure out a more elegant way to prevent sorcerers from reading spellbooks. Would have to only apply to spellbooks from Magiclysm though.
- Give sorcerers the advanced spells known at level = (level of base spell, ignoring level cap) - (level at witch the advanced spell is learned)
- Make the advanced spells available as possible sorcerer spell picks at higher levels
- Don't give sorcerers access to advanced version of the spells with the justification that those are wizard-only.


<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Tested both without the flag, with the flag, and having both the sorcerer trait with the flag and a conflicting school trait without the flag. All tests worked as expected, detailed above.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
