### PR TITLE
[Bombastic Perks/XE] Alchemy perks activate automatically

### DIFF
--- a/data/mods/Xedra_Evolved/mod_interactions/bombastic_perks/perks/perk_data/Alchemy1.json
+++ b/data/mods/Xedra_Evolved/mod_interactions/bombastic_perks/perks/perk_data/Alchemy1.json
@@ -1,13 +1,53 @@
 [
   {
     "type": "effect_on_condition",
-    "id": "EOC_COMPLETED_ROLL_REMAINDER_ALCHEMY",
-    "effect": { "u_message": "You have learned all the secrets of this level." }
+    "id": "EOC_XE_ALCHEMY_PERK_WAKE_UP_RUN",
+    "eoc_type": "EVENT",
+    "required_event": "character_wakes_up",
+    "condition": {
+      "and": [
+        { "not": { "u_has_effect": "mental_exhaustion" } },
+        {
+          "u_has_any_trait": [ "perk_ALCHEMY1", "perk_ALCHEMY2", "perk_ALCHEMY3", "perk_ALCHEMY3_COLD_IRON", "perk_ALCHEMY4", "perk_ALCHEMY5" ]
+        }
+      ]
+    },
+    "effect": [
+      {
+        "if": { "and": [ { "u_has_trait": "perk_ALCHEMY5" }, { "not": { "u_has_effect": "mental_exhaustion" } } ] },
+        "then": { "run_eocs": "EOC_ALCHEMY5" },
+        "else": {
+          "if": { "and": [ { "u_has_trait": "perk_ALCHEMY4" }, { "not": { "u_has_effect": "mental_exhaustion" } } ] },
+          "then": { "run_eocs": "EOC_ALCHEMY4" },
+          "else": {
+            "if": {
+              "and": [
+                { "u_has_trait": "perk_ALCHEMY3" },
+                { "u_has_trait": "perk_ALCHEMY3_COLD_IRON" },
+                { "not": { "u_has_effect": "mental_exhaustion" } }
+              ]
+            },
+            "then": { "run_eocs": "EOC_ALCHEMY3_COLD_IRON" },
+            "else": {
+              "if": { "and": [ { "u_has_trait": "perk_ALCHEMY3" }, { "not": { "u_has_effect": "mental_exhaustion" } } ] },
+              "then": { "run_eocs": "EOC_ALCHEMY3" },
+              "else": {
+                "if": { "and": [ { "u_has_trait": "perk_ALCHEMY2" }, { "not": { "u_has_effect": "mental_exhaustion" } } ] },
+                "then": { "run_eocs": "EOC_ALCHEMY2" },
+                "else": { "if": { "not": { "u_has_effect": "mental_exhaustion" } }, "then": { "run_eocs": "EOC_ALCHEMY1" } }
+              }
+            }
+          }
+        }
+      }
+    ]
   },
   {
     "type": "effect_on_condition",
     "id": "EOC_SUCCESFUL_ROLL_REMAINDER_ALCHEMY",
-    "effect": { "u_message": "You learn a new secret of alchemy." }
+    "effect": {
+      "u_message": "As you wake up from vivid dreams, you realize your subconscious has revealed to you a new secret of alchemy."
+    }
   },
   {
     "type": "effect_on_condition",
@@ -17,12 +57,10 @@
       {
         "u_roll_remainder": [ "extra_str_aspirin", "blackout_rage_drink", "sixdust", "small_blessing_brigit" ],
         "type": "recipe",
-        "true_eocs": [ "EOC_SUCCESFUL_ROLL_REMAINDER_ALCHEMY" ],
-        "false_eocs": [ "EOC_COMPLETED_ROLL_REMAINDER_ALCHEMY" ]
+        "true_eocs": [ "EOC_SUCCESFUL_ROLL_REMAINDER_ALCHEMY" ]
       },
       { "u_add_effect": "mental_exhaustion", "intensity": 1, "duration": "24 hours" }
-    ],
-    "false_effect": [ { "u_message": "Your thoughts are too scattered to unearth more secrets of the universe." } ]
+    ]
   },
   {
     "type": "effect_on_condition",
@@ -39,11 +77,11 @@
         ],
         "type": "recipe",
         "true_eocs": [ "EOC_SUCCESFUL_ROLL_REMAINDER_ALCHEMY" ],
-        "false_eocs": [ "EOC_COMPLETED_ROLL_REMAINDER_ALCHEMY" ]
+        "false_eocs": [ "EOC_ALCHEMY1" ]
       },
       { "u_add_effect": "mental_exhaustion", "intensity": 1, "duration": "48 hours" }
     ],
-    "false_effect": [ { "u_message": "Your thoughts are too scattered to unearth more secrets of the universe." } ]
+    "false_effect": { "run_eocs": "EOC_ALCHEMY1" }
   },
   {
     "type": "effect_on_condition",
@@ -63,11 +101,11 @@
         ],
         "type": "recipe",
         "true_eocs": [ "EOC_SUCCESFUL_ROLL_REMAINDER_ALCHEMY" ],
-        "false_eocs": [ "EOC_COMPLETED_ROLL_REMAINDER_ALCHEMY" ]
+        "false_eocs": [ "EOC_ALCHEMY2" ]
       },
       { "u_add_effect": "mental_exhaustion", "intensity": 1, "duration": "96 hours" }
     ],
-    "false_effect": [ { "u_message": "Your thoughts are too scattered to unearth more secrets of the universe." } ]
+    "false_effect": { "run_eocs": "EOC_ALCHEMY2" }
   },
   {
     "type": "effect_on_condition",
@@ -84,11 +122,11 @@
         "u_roll_remainder": [ "cold_iron_knife", "cold_iron_arming_sword", "cold_iron_warhammer", "cold_iron_battleaxe", "blood_of_saints" ],
         "type": "recipe",
         "true_eocs": [ "EOC_SUCCESFUL_ROLL_REMAINDER_ALCHEMY" ],
-        "false_eocs": [ "EOC_COMPLETED_ROLL_REMAINDER_ALCHEMY" ]
+        "false_eocs": [ "EOC_ALCHEMY3" ]
       },
       { "u_add_effect": "mental_exhaustion", "intensity": 1, "duration": "96 hours" }
     ],
-    "false_effect": [ { "u_message": "Your thoughts are too scattered to unearth more secrets of the universe." } ]
+    "false_effect": { "run_eocs": "EOC_ALCHEMY3" }
   },
   {
     "type": "effect_on_condition",
@@ -99,11 +137,11 @@
         "u_roll_remainder": [ "life_extension_potion", "potion_strength", "potion_dex", "hares_leap_potion", "nether_snare" ],
         "type": "recipe",
         "true_eocs": [ "EOC_SUCCESFUL_ROLL_REMAINDER_ALCHEMY" ],
-        "false_eocs": [ "EOC_COMPLETED_ROLL_REMAINDER_ALCHEMY" ]
+        "false_eocs": [ "EOC_ALCHEMY3_COLD_IRON" ]
       },
       { "u_add_effect": "mental_exhaustion", "intensity": 1, "duration": "192 hours" }
     ],
-    "false_effect": [ { "u_message": "Your thoughts are too scattered to unearth more secrets of the universe." } ]
+    "false_effect": { "run_eocs": "EOC_ALCHEMY3_COLD_IRON" }
   },
   {
     "type": "effect_on_condition",
@@ -114,10 +152,10 @@
         "u_roll_remainder": [ "plant_imbuement", "earth_imbuement", "water_imbuement", "air_imbuement", "fire_imbuement", "doll_imbuement" ],
         "type": "recipe",
         "true_eocs": [ "EOC_SUCCESFUL_ROLL_REMAINDER_ALCHEMY" ],
-        "false_eocs": [ "EOC_COMPLETED_ROLL_REMAINDER_ALCHEMY" ]
+        "false_eocs": [ "EOC_ALCHEMY4" ]
       },
       { "u_add_effect": "mental_exhaustion", "intensity": 1, "duration": "384 hours" }
     ],
-    "false_effect": [ { "u_message": "Your thoughts are too scattered to unearth more secrets of the universe." } ]
+    "false_effect": { "run_eocs": "EOC_ALCHEMY4" }
   }
 ]

--- a/data/mods/Xedra_Evolved/mod_interactions/bombastic_perks/perks/perks.json
+++ b/data/mods/Xedra_Evolved/mod_interactions/bombastic_perks/perks/perks.json
@@ -8,9 +8,7 @@
     "category": [ "perk" ],
     "starting_trait": false,
     "valid": false,
-    "purifiable": false,
-    "active": true,
-    "activated_eocs": [ "EOC_ALCHEMY1" ]
+    "purifiable": false
   },
   {
     "type": "mutation",
@@ -21,9 +19,7 @@
     "category": [ "perk" ],
     "starting_trait": false,
     "valid": false,
-    "purifiable": false,
-    "active": true,
-    "activated_eocs": [ "EOC_ALCHEMY2" ]
+    "purifiable": false
   },
   {
     "type": "mutation",
@@ -34,9 +30,7 @@
     "category": [ "perk" ],
     "starting_trait": false,
     "valid": false,
-    "purifiable": false,
-    "active": true,
-    "activated_eocs": [ "EOC_ALCHEMY3" ]
+    "purifiable": false
   },
   {
     "type": "mutation",
@@ -47,9 +41,7 @@
     "category": [ "perk" ],
     "starting_trait": false,
     "valid": false,
-    "purifiable": false,
-    "active": true,
-    "activated_eocs": [ "EOC_ALCHEMY3_COLD_IRON" ]
+    "purifiable": false
   },
   {
     "type": "mutation",
@@ -60,9 +52,7 @@
     "category": [ "perk" ],
     "starting_trait": false,
     "valid": false,
-    "purifiable": false,
-    "active": true,
-    "activated_eocs": [ "EOC_ALCHEMY4" ]
+    "purifiable": false
   },
   {
     "type": "mutation",
@@ -73,9 +63,7 @@
     "category": [ "perk" ],
     "starting_trait": false,
     "valid": false,
-    "purifiable": false,
-    "active": true,
-    "activated_eocs": [ "EOC_ALCHEMY5" ]
+    "purifiable": false
   },
   {
     "type": "mutation",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[Bombastic Perks/XE] Alchemy perks activate automatically"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

I think that having perks you activate only very very rarely, and which you never activate again after a few tries, should be passive and have other means of activation.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Remove active from all the alchemy recipe perks. Instead, when you sleep if you don't have mental exhaustion and have an alchemy perk, you learn an alchemy recipe. It happens entirely passively in the background and you can never forget to learn anything.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Gave myself a couple perks. Slept. Gained a recipe for a potion of wicked quick hands
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
