### PR TITLE
expose signal_hordes() to eoc

### DIFF
--- a/doc/JSON/EFFECT_ON_CONDITION.md
+++ b/doc/JSON/EFFECT_ON_CONDITION.md
@@ -2801,6 +2801,28 @@ Teleport player to `new_map`
 }
 ```
 
+#### `signal_hordes`
+Alert all hordes nearby to this location, akin to explosion
+
+| Syntax | Optionality | Value  | Info |
+| --- | --- | --- | --- |
+| "signal_hordes" | **mandatory** | [variable object](#variable-object) | location variable that horde will try to reach |
+| "signal_power" | **mandatory** | int or [variable object](#variable-object) | default 0; the strength of a signal, ie how far it would propagate around the signal, in tiles |
+
+##### Examples
+
+Alert horde in 200 meter range
+```jsonc
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_TEST",
+    "effect": [
+      { "u_location_variable": { "context_val": "your_pos" } },
+      { "signal_hordes": { "context_val": "your_pos" }, "signal_power": 200 }
+    ]
+  },
+```
+
 #### `reveal_map`
 Reveal the overmap area around specific location variable
 

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -5532,6 +5532,19 @@ talk_effect_fun_t::func f_give_achievment( const JsonObject &jo, std::string_vie
     };
 }
 
+talk_effect_fun_t::func f_signal_hordes( const JsonObject &jo, std::string_view member,
+        std::string_view )
+{
+    var_info var = read_var_info( jo.get_object( member ) );
+    dbl_or_var signal_power = get_dbl_or_var( jo, "signal_power", true, 0 );
+    return [var, signal_power]( dialogue & d ) {
+        tripoint_abs_ms loc_ms = read_var_value( var, d ).tripoint();
+        tripoint_abs_sm loc_sm = project_to<coords::sm>( loc_ms );
+
+        overmap_buffer.signal_hordes( loc_sm, signal_power.evaluate( d ) );
+    };
+}
+
 talk_effect_fun_t::func f_cast_spell( const JsonObject &jo, std::string_view member,
                                       std::string_view src, bool is_npc )
 {
@@ -8022,6 +8035,7 @@ parsers = {
     { "u_set_talker", "npc_set_talker", jarg::member, &talk_effect_fun::f_set_talker },
     { "turn_cost", jarg::member, &talk_effect_fun::f_turn_cost },
     { "transform_item", jarg::member, &talk_effect_fun::f_transform_item },
+    { "signal_hordes", jarg::member, &talk_effect_fun::f_signal_hordes },
     // since parser checks all effects in order, having "message" field in any another effect (like in f_roll_remainder)
     // would cause parser to think it's a "message" effect
     { "message", "message", jarg::member, &talk_effect_fun::f_message },


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Some support for #83498
#### Describe the solution
Expose signal_hordes() to eoc
#### Testing
After single test i confirm that hordes walked to me as expected
#### Additional context
The function itself if probably quite raw, same as horde stuff, but exposing it should bring no harm