### PR TITLE
Overmap sidebar ImGui conversion

### DIFF
--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -1230,6 +1230,20 @@
   },
   {
     "type": "keybinding",
+    "id": "COLLAPSE_OVERMAP_SIDEBAR_HEADERS",
+    "category": "OVERMAP",
+    "name": "Collapse all overmap sidebar headers",
+    "bindings": [ { "input_method": "keyboard_char", "key": "{" } ]
+  },
+  {
+    "type": "keybinding",
+    "id": "EXPAND_OVERMAP_SIDEBAR_HEADERS",
+    "category": "OVERMAP",
+    "name": "Expand all overmap sidebar headers",
+    "bindings": [ { "input_method": "keyboard_char", "key": "}" } ]
+  },
+  {
+    "type": "keybinding",
     "id": "TOGGLE_EXPLORED",
     "category": "OVERMAP",
     "name": "Toggle explored",

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -402,6 +402,9 @@ void uistatedata::serialize( JsonOut &json ) const
     json.member( "overmap_debug_mongroup", overmap_debug_mongroup );
     json.member( "overmap_fast_travel", overmap_fast_travel );
     json.member( "overmap_fast_scroll", overmap_fast_scroll );
+    json.member( "overmap_sidebar_quickref", overmap_sidebar_quickref );
+    json.member( "overmap_sidebar_layers", overmap_sidebar_layers );
+    json.member( "overmap_sidebar_debug", overmap_sidebar_debug );
     json.member( "distraction_noise", distraction_noise );
     json.member( "distraction_pain", distraction_pain );
     json.member( "distraction_attack", distraction_attack );
@@ -477,6 +480,9 @@ void uistatedata::deserialize( const JsonObject &jo )
     jo.read( "overmap_debug_mongroup", overmap_debug_mongroup );
     jo.read( "overmap_fast_travel", overmap_fast_travel );
     jo.read( "overmap_fast_scroll", overmap_fast_scroll );
+    jo.read( "overmap_sidebar_quickref", overmap_sidebar_quickref );
+    jo.read( "overmap_sidebar_layers", overmap_sidebar_layers );
+    jo.read( "overmap_sidebar_debug", overmap_sidebar_debug );
     jo.read( "distraction_noise", distraction_noise );
     jo.read( "distraction_pain", distraction_pain );
     jo.read( "distraction_attack", distraction_attack );

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -402,9 +402,6 @@ void uistatedata::serialize( JsonOut &json ) const
     json.member( "overmap_debug_mongroup", overmap_debug_mongroup );
     json.member( "overmap_fast_travel", overmap_fast_travel );
     json.member( "overmap_fast_scroll", overmap_fast_scroll );
-    json.member( "overmap_sidebar_quickref", overmap_sidebar_quickref );
-    json.member( "overmap_sidebar_layers", overmap_sidebar_layers );
-    json.member( "overmap_sidebar_debug", overmap_sidebar_debug );
     json.member( "distraction_noise", distraction_noise );
     json.member( "distraction_pain", distraction_pain );
     json.member( "distraction_attack", distraction_attack );
@@ -421,6 +418,9 @@ void uistatedata::serialize( JsonOut &json ) const
     json.member( "distraction_oxygen", distraction_oxygen );
     json.member( "distraction_withdrawal", distraction_withdrawal );
     json.member( "numpad_navigation", numpad_navigation );
+
+    json.member( "overmap_sidebar_uistate" );
+    overmap_sidebar_state.serialize( json );
 
     json.member( "input_history" );
     json.start_object();
@@ -480,9 +480,7 @@ void uistatedata::deserialize( const JsonObject &jo )
     jo.read( "overmap_debug_mongroup", overmap_debug_mongroup );
     jo.read( "overmap_fast_travel", overmap_fast_travel );
     jo.read( "overmap_fast_scroll", overmap_fast_scroll );
-    jo.read( "overmap_sidebar_quickref", overmap_sidebar_quickref );
-    jo.read( "overmap_sidebar_layers", overmap_sidebar_layers );
-    jo.read( "overmap_sidebar_debug", overmap_sidebar_debug );
+    jo.read( "overmap_sidebar_uistate", overmap_sidebar_state );
     jo.read( "distraction_noise", distraction_noise );
     jo.read( "distraction_pain", distraction_pain );
     jo.read( "distraction_attack", distraction_attack );

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -32,7 +32,6 @@
 #include "mapdata.h"
 #include "mapgen_parameter.h"
 #include "mapgendata.h"
-#include "monster.h"
 #include "mtype.h"
 #include "simple_pathfinding.h"
 #include "translation.h"
@@ -184,8 +183,6 @@ void overmap_sidebar::print_hint( const std::string &action, nc_color color )
 
 void overmap_sidebar::draw_tile_info()
 {
-
-    const tripoint_abs_omt &orig = draw_data.origin_pos;
     const tripoint_abs_omt &cursor_pos = draw_data.cursor_pos;
 
     avatar &player_character = get_avatar();
@@ -402,7 +399,6 @@ void overmap_sidebar::draw_mission_info()
 {
 
     const tripoint_abs_omt &cursor_pos = draw_data.cursor_pos;
-    const tripoint_abs_omt &orig = draw_data.origin_pos;
     avatar &player_character = get_avatar();
     const tripoint_abs_omt target = player_character.get_active_mission_target();
     const bool has_target = !target.is_invalid();
@@ -1258,297 +1254,6 @@ static void draw_ascii( const catacurses::window &w, overmap_draw_data_t &data )
     wnoutrefresh( w );
 }
 
-static void draw_om_sidebar( ui_adaptor &ui,
-                             const catacurses::window &wbar, const input_context &inp_ctxt, const overmap_draw_data_t &data )
-{
-    const tripoint_abs_omt &orig = data.origin_pos;
-    const tripoint_abs_omt &cursor_pos = data.cursor_pos;
-
-    avatar &player_character = get_avatar();
-    // Debug vision allows seeing everything
-    const bool has_debug_vision = player_character.has_trait( trait_DEBUG_NIGHTVISION );
-    // sight_points is hoisted for speed reasons.
-    const int sight_points = !has_debug_vision ?
-                             player_character.overmap_modified_sight_range( g->light_level( player_character.posz() ) ) :
-                             100;
-    om_vision_level center_vision = has_debug_vision ? om_vision_level::full :
-                                    overmap_buffer.seen( cursor_pos );
-    const tripoint_abs_omt target = player_character.get_active_mission_target();
-    const bool has_target = !target.is_invalid();
-    const bool viewing_weather = uistate.overmap_debug_weather || uistate.overmap_visible_weather;
-
-    // If we're debugging hordes, find the monsters we've selected
-    std::vector<std::unordered_map<tripoint_abs_ms, horde_entity>*> hordes;
-    if( uistate.overmap_debug_mongroup ) {
-        hordes = overmap_buffer.hordes_at( cursor_pos );
-    }
-
-    // Draw the vertical line
-    mvwvline( wbar, point::zero, c_white, LINE_XOXO, TERMY );
-
-    // Clear the legend
-    // NOLINTNEXTLINE(cata-use-named-point-constants)
-    mvwrectf( wbar, point( 1, 0 ), c_black, ' ', getmaxx( wbar ), TERMY );
-
-    // Draw text describing the overmap tile at the cursor position.
-    int lines = 1;
-    if( center_vision != om_vision_level::unseen ) {
-        if( !hordes.empty() ) {
-            const point desc_pos( 3, 6 );
-            ui.set_cursor( wbar, desc_pos );
-            int line_number = 0;
-            int horde_size = 0;
-            for( std::unordered_map<tripoint_abs_ms, horde_entity> *horde : hordes ) {
-                horde_size += horde->size();
-                // TODO: This overruns the sidebar, need to display better somehow, maybe a popup?
-#if 0
-                for( std::pair<const tripoint_abs_ms, horde_entity> &entity : *horde ) {
-                    wattron( wbar, c_blue );
-                    const mtype *horde_type = entity.second.get_type();
-                    mvwprintw( wbar, desc_pos + point( 0, line_number++ ),
-                               "  Species: %s", horde_type->nname() );
-                    mvwprintw( wbar, desc_pos + point( 0, line_number++ ),
-                               "  Interest: %d", entity.second.tracking_intensity );
-                    mvwprintw( wbar, desc_pos + point( 0, line_number++ ),
-                               "  Target: %s", entity.second.destination.to_string() );
-                    wattroff( wbar, c_blue );
-                    mvwprintz( wbar, desc_pos + point( 0, line_number++ ),
-                               c_red, "x" );
-                }
-#endif
-            }
-            mvwprintw( wbar, desc_pos + point( 0, line_number++ ), "Horde, population: %d", horde_size );
-        } else {
-            const oter_t &ter = overmap_buffer.ter( cursor_pos ).obj();
-            const auto sm_pos = project_to<coords::sm>( cursor_pos );
-
-            if( ter.blends_adjacent( center_vision ) ) {
-                oter_vision::blended_omt info = oter_vision::get_blended_omt_info( cursor_pos, center_vision );
-                // NOLINTNEXTLINE(cata-use-named-point-constants)
-                mvwputch( wbar, point( 1, 1 ), info.color, info.sym );
-            } else {
-                // NOLINTNEXTLINE(cata-use-named-point-constants)
-                mvwputch( wbar, point( 1, 1 ), ter.get_color( center_vision ), ter.get_symbol( center_vision ) );
-            }
-
-            const point desc_pos( 3, 1 );
-            ui.set_cursor( wbar, desc_pos );
-            lines = fold_and_print( wbar, desc_pos, getmaxx( wbar ) - desc_pos.x,
-                                    c_light_gray,
-                                    overmap_buffer.get_description_at( sm_pos ) );
-            if( center_vision != om_vision_level::full ) {
-                std::string vision_level_string;
-                switch( center_vision ) {
-                    case om_vision_level::vague:
-                        vision_level_string = _( "You can only make out vague details of what's here." );
-                        break;
-                    case om_vision_level::outlines:
-                        vision_level_string = _( "You can only make out outlines of what's here." );
-                        break;
-                    case om_vision_level::details:
-                        vision_level_string = _( "You can make out some details of what's here." );
-                        break;
-                    default:
-                        vision_level_string = _( "This is a bug!" );
-                        break;
-                }
-                lines += fold_and_print( wbar, point( 3, lines + 1 ), getmaxx( wbar ) - 3, c_light_gray,
-                                         vision_level_string );
-            }
-        }
-    } else {
-        const oter_t &ter = oter_unexplored.obj();
-
-        // NOLINTNEXTLINE(cata-use-named-point-constants)
-        mvwputch( wbar, point( 1, 1 ), ter.get_color( om_vision_level::full ),
-                  ter.get_symbol( om_vision_level::full ) );
-
-        const point desc_pos( 3, 1 );
-        ui.set_cursor( wbar, desc_pos );
-        lines = fold_and_print( wbar, desc_pos, getmaxx( wbar ) - desc_pos.x,
-                                ter.get_color( om_vision_level::full ), ter.get_name( om_vision_level::full ) );
-    }
-
-    // Describe the weather conditions on the following line, if weather is visible
-    if( viewing_weather ) {
-        const bool weather_is_visible = uistate.overmap_debug_weather ||
-                                        player_character.overmap_los( cursor_pos, sight_points * 2 );
-        if( weather_is_visible ) {
-            // NOLINTNEXTLINE(cata-use-named-point-constants)
-            mvwprintz( wbar, point( 3, ++lines ), get_weather_at_point( cursor_pos )->color,
-                       get_weather_at_point( cursor_pos )->name.translated() );
-        } else {
-            // NOLINTNEXTLINE(cata-use-named-point-constants)
-            mvwprintz( wbar, point( 1, ++lines ), c_dark_gray, _( "# Weather unknown" ) );
-        }
-    }
-
-    if( ( data.debug_editor && center_vision != om_vision_level::unseen ) || data.debug_info ) {
-        wattron( wbar, c_white );
-        mvwprintw( wbar, point( 1, ++lines ), "abs_omt: %s", cursor_pos.to_string() );
-        const oter_t &oter = overmap_buffer.ter( cursor_pos ).obj();
-        mvwprintw( wbar, point( 1, ++lines ), "oter: %s (rot %d)", oter.id.str(), oter.get_rotation() );
-        mvwprintw( wbar, point( 1, ++lines ), "oter_type: %s", oter.get_type_id().str() );
-        // tileset ids come with a prefix that must be stripped
-        mvwprintw( wbar, point( 1, ++lines ), "tileset id: '%s'",
-                   oter.get_tileset_id( center_vision ).substr( 3 ) );
-        std::vector<oter_id> predecessors = overmap_buffer.predecessors( cursor_pos );
-        if( !predecessors.empty() ) {
-            mvwprintw( wbar, point( 1, ++lines ), "predecessors:" );
-            for( auto pred = predecessors.rbegin(); pred != predecessors.rend(); ++pred ) {
-                mvwprintw( wbar, point( 1, ++lines ), "- %s", pred->id().str() );
-            }
-        }
-
-        auto print_arguments = [&]( std::unordered_map<std::string, cata_variant> &map ) {
-            for( const std::pair<const std::string, cata_variant> &arg : map ) {
-                mvwprintw( wbar, point( 1, ++lines ), "%s = %s", arg.first, arg.second.get_string() );
-            }
-        };
-        std::optional<mapgen_arguments> *args = overmap_buffer.mapgen_args( cursor_pos );
-        if( args ) {
-            if( *args ) {
-                print_arguments( ( **args ).map );
-            } else {
-                mvwprintw( wbar, point( 1, ++lines ), "Special scoped parameter values not set yet" );
-            }
-        }
-        std::optional<mapgen_arguments> args_omt_stack =
-            overmap_buffer.get_existing_omt_stack_arguments( cursor_pos.xy() );
-        if( args_omt_stack ) {
-            print_arguments( args_omt_stack->map );
-        }
-
-        for( cube_direction dir : all_enum_values<cube_direction>() ) {
-            if( std::string *join = overmap_buffer.join_used_at( { cursor_pos, dir } ) ) {
-                mvwprintw( wbar, point( 1, ++lines ), "join %s: %s", io::enum_to_string( dir ), *join );
-            }
-        }
-        wattroff( wbar, c_white );
-
-        wattron( wbar, c_red );
-        int monster_count = 0;
-        std::set<std::string> monster_types;
-        for( std::unordered_map<tripoint_abs_ms, horde_entity> *horde : overmap_buffer.hordes_at(
-                 cursor_pos ) ) {
-            for( std::pair<const tripoint_abs_ms, horde_entity> &entity : *horde ) {
-                monster_count++;
-                const mtype *entity_type = entity.second.get_type();
-                monster_types.insert( entity_type->nname() );
-            }
-        }
-        if( monster_count ) {
-            mvwprintw( wbar, point( 1, ++lines ), "Spotted %d entities", monster_count );
-            for( const std::string &monster_name : monster_types ) {
-                mvwprintw( wbar, point( 1, ++lines ), "Type %s", monster_name );
-            }
-        }
-        for( const mongroup *mg : overmap_buffer.monsters_at( cursor_pos ) ) {
-            mvwprintw( wbar, point( 1, ++lines ), "mongroup %s (%zu/%u), %s %s%s",
-                       mg->type.str(), mg->monsters.size(), mg->population,
-                       io::enum_to_string( mg->behaviour ),
-                       mg->dying ? "x" : "", mg->horde ? "h" : "" );
-            mvwprintw( wbar, point( 1, ++lines ), "target: %s (%d)",
-                       project_to<coords::omt>( mg->target ).to_string(), mg->interest );
-        }
-        wattroff( wbar, c_red );
-    }
-
-    wattron( wbar, c_white );
-    if( has_target ) {
-        const int distance = rl_dist( cursor_pos, target );
-        mvwprintw( wbar, point( 1, ++lines ), _( "Distance to current objective:" ) );
-        mvwprintw( wbar, point( 1, ++lines ), _( "%d tiles" ), distance );
-        // One OMT is 24 tiles across, at 1x1 meters each, so we can simply do number of OMTs * 24
-        mvwprintw( wbar, point( 1, ++lines ), _( "%s" ), length_to_string_approx( distance * 24_meter ) );
-
-        const int above_below = target.z() - orig.z();
-        std::string msg;
-        if( above_below > 0 ) {
-            msg = _( "Above us" );
-        } else if( above_below < 0 ) {
-            msg = _( "Below us" );
-        }
-        if( above_below != 0 ) {
-            mvwprintw( wbar, point( 1, ++lines ), _( "%s" ), msg );
-        }
-    }
-
-    //Show mission targets on this location
-    for( mission *&mission : player_character.get_active_missions() ) {
-        if( mission->get_target() == cursor_pos ) {
-            mvwprintw( wbar, point( 1, ++lines ), mission->name() );
-        }
-    }
-    wattroff( wbar, c_white );
-
-    const auto print_hint = [&]( const std::string & action, nc_color color = c_magenta ) {
-        lines += fold_and_print( wbar, point( 1, lines ), getmaxx( wbar ) - 1, color,
-                                 string_format( _( "%s - %s" ),  inp_ctxt.get_desc( action ), inp_ctxt.get_action_name( action ) ) );
-    };
-
-    if( data.debug_editor ) {
-        lines++;
-        print_hint( "REVEAL_MAP", c_light_blue );
-        print_hint( "LONG_TELEPORT", c_light_blue );
-        print_hint( "PLACE_SPECIAL", c_light_blue );
-        print_hint( "PLACE_TERRAIN", c_light_blue );
-        print_hint( "SET_SPECIAL_ARGS", c_light_blue );
-        print_hint( "MODIFY_HORDE", c_light_blue );
-        print_hint( "PRINT_NOISE_MAPS", c_light_blue );
-        lines--;
-    } else {
-        lines = 11;
-    }
-
-    wattron( wbar, c_magenta );
-    mvwprintw( wbar, point( 1, ++lines ), _( "Use movement keys to pan." ) );
-    mvwprintw( wbar, point( 1, ++lines ), string_format( _( "Press %s to preview route." ),
-               inp_ctxt.get_desc( "CHOOSE_DESTINATION" ) ) );
-    mvwprintw( wbar, point( 1, ++lines ), _( "Press again to confirm." ) );
-    lines += 2;
-    wattroff( wbar, c_magenta );
-
-    const bool show_overlays = uistate.overmap_show_overlays || uistate.overmap_blinking;
-    const bool is_explored = overmap_buffer.is_explored( cursor_pos );
-
-    print_hint( "LEVEL_UP" );
-    print_hint( "LEVEL_DOWN" );
-    print_hint( "look" );
-    print_hint( "CENTER" );
-    print_hint( "CENTER_ON_DESTINATION" );
-    print_hint( "GO_TO_DESTINATION" );
-    print_hint( "SEARCH" );
-    print_hint( "CREATE_NOTE" );
-    print_hint( "DELETE_NOTE" );
-    print_hint( "MARK_DANGER" );
-    print_hint( "LIST_NOTES" );
-    print_hint( "CREATE_POINT_OF_INTEREST" );
-    print_hint( "MISSIONS" );
-    print_hint( "TOGGLE_MAP_NOTES", uistate.overmap_show_map_notes ? c_pink : c_magenta );
-    print_hint( "TOGGLE_BLINKING", uistate.overmap_blinking ? c_pink : c_magenta );
-    print_hint( "TOGGLE_OVERLAYS", show_overlays ? c_pink : c_magenta );
-    if( debug_mode ) {
-        print_hint( "TOGGLE_LAND_USE_CODES", uistate.overmap_show_land_use_codes ? c_pink : c_magenta );
-    }
-    print_hint( "TOGGLE_CITY_LABELS", uistate.overmap_show_city_labels ? c_pink : c_magenta );
-    print_hint( "TOGGLE_HORDES", uistate.overmap_show_hordes ? c_pink : c_magenta );
-    print_hint( "TOGGLE_MAP_REVEALS", uistate.overmap_show_revealed_omts ? c_pink : c_magenta );
-    print_hint( "TOGGLE_EXPLORED", is_explored ? c_pink : c_magenta );
-    print_hint( "TOGGLE_FAST_SCROLL", uistate.overmap_fast_scroll ? c_pink : c_magenta );
-    print_hint( "TOGGLE_FOREST_TRAILS", uistate.overmap_show_forest_trails ? c_pink : c_magenta );
-    print_hint( "TOGGLE_FAST_TRAVEL", uistate.overmap_fast_travel ? c_pink : c_magenta );
-    print_hint( "TOGGLE_OVERMAP_WEATHER",
-                !get_map().is_outside( get_player_character().pos_bub() ) ? c_dark_gray :
-                uistate.overmap_visible_weather ? c_pink : c_magenta );
-    print_hint( "HELP_KEYBINDINGS" );
-    print_hint( "QUIT" );
-
-    const std::string coords = display::overmap_position_text( cursor_pos );
-    mvwprintz( wbar, point( 1, getmaxy( wbar ) - 1 ), c_red, coords );
-    wnoutrefresh( wbar );
-}
-
 #if defined(TILES)
 tiles_redraw_info redraw_info;
 #endif
@@ -1556,7 +1261,6 @@ tiles_redraw_info redraw_info;
 static void draw( overmap_draw_data_t &data )
 {
     cata_assert( static_cast<bool>( data.ui ) );
-    ui_adaptor *ui = data.ui.get();
 #if defined( TILES )
     if( use_tiles && use_tiles_overmap ) {
         redraw_info = tiles_redraw_info { data.cursor_pos, uistate.overmap_show_overlays };

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -2425,7 +2425,7 @@ static tripoint_abs_omt display()
         // If EDGE_SCROLL is disabled, it will have a value of -1.
         // blinking won't work if handle_input() is passed a negative integer.
         if( scroll_timeout < 0 ) {
-            scroll_timeout = get_option<int>( "BLINK_SPEED" );
+            scroll_timeout = 33;
         }
         action = ictxt.handle_input( scroll_timeout );
 #else

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -60,7 +60,6 @@
 #include "mapbuffer.h"
 #include "messages.h"
 #include "mission.h"
-#include "mod_manager.h"
 #include "mongroup.h"
 #include "npc.h"
 #include "omdata.h"
@@ -220,9 +219,7 @@ void overmap_sidebar::draw_tile_info()
         }
 
         ImGui::SameLine();
-        overmap_buffer.display_description_at( sm_pos, false );
-        ImGui::NewLine();
-        draw_sidebar_text( get_origin( ter.get_type_id()->src ), c_light_gray );
+        overmap_buffer.display_description_at( sm_pos, true );
         if( center_vision != om_vision_level::full ) {
             std::string vision_level_string;
             switch( center_vision ) {

--- a/src/overmap_ui.h
+++ b/src/overmap_ui.h
@@ -11,8 +11,10 @@
 #include <tuple>
 #include <vector>
 
+#include "cata_imgui.h"
 #include "city.h"
 #include "coordinates.h"
+#include "imgui/imgui.h"
 #include "input_context.h"
 #include "map_scale_constants.h"
 #include "point.h"
@@ -166,3 +168,30 @@ bool is_generated_omt( const point_abs_omt &omp );
 
 } // namespace overmap_ui
 #endif // CATA_SRC_OVERMAP_UI_H
+
+class overmap_sidebar : public cataimgui::window
+{
+        input_context *ctxt;
+        overmap_ui::overmap_draw_data_t &draw_data;
+        //uses input context to print a keybind hint
+        void draw_sidebar_text( const std::string &original_text, const nc_color &color );
+        void print_hint( const std::string &action, nc_color color = c_magenta );
+        void draw_tile_info();
+        void draw_mission_info();
+        void draw_settings_info();
+        void draw_quick_reference();
+        void draw_layer_info();
+        void draw_debug();
+    public:
+        int width = 0;
+        int x_pos = 0;
+        explicit overmap_sidebar( overmap_ui::overmap_draw_data_t &data );
+
+        void init();
+        void draw_controls() override;
+    protected:
+        cataimgui::bounds get_bounds() override;
+        void on_resized() override {
+            init();
+        };
+};

--- a/src/overmap_ui.h
+++ b/src/overmap_ui.h
@@ -171,7 +171,6 @@ bool is_generated_omt( const point_abs_omt &omp );
 
 class overmap_sidebar : public cataimgui::window
 {
-        input_context *ctxt;
         overmap_ui::overmap_draw_data_t &draw_data;
         //uses input context to print a keybind hint
         void draw_sidebar_text( const std::string &original_text, const nc_color &color );

--- a/src/overmap_ui.h
+++ b/src/overmap_ui.h
@@ -172,7 +172,7 @@ class overmap_sidebar : public cataimgui::window
 {
         overmap_ui::overmap_draw_data_t &draw_data;
         //uses input context to print a keybind hint
-        void draw_sidebar_text( const std::string &original_text, const nc_color &color );
+        void draw_sidebar_text( const std::string_view &original_text, const nc_color &color );
         void print_hint( const std::string &action, nc_color color = c_magenta );
         void draw_tile_info();
         void draw_mission_info();

--- a/src/overmap_ui.h
+++ b/src/overmap_ui.h
@@ -13,8 +13,8 @@
 
 #include "cata_imgui.h"
 #include "city.h"
+#include "color.h"
 #include "coordinates.h"
-#include "imgui/imgui.h"
 #include "input_context.h"
 #include "map_scale_constants.h"
 #include "point.h"
@@ -24,7 +24,6 @@ class ui_adaptor;
 
 constexpr int RANDOM_CITY_ENTRY = INT_MIN;
 
-class nc_color;
 class uilist;
 struct weather_type;
 

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -25,6 +25,7 @@
 #include "game.h"
 #include "horde_entity.h"
 #include "horde_map.h"
+#include "imgui/imgui.h"
 #include "line.h"
 #include "map.h"
 #include "mapgendata.h"
@@ -46,6 +47,7 @@
 #include "rng.h"
 #include "simple_pathfinding.h"
 #include "string_formatter.h"
+#include "text.h"
 #include "translations.h"
 #include "vehicle.h"
 
@@ -1907,7 +1909,7 @@ std::vector<point_abs_om> overmapbuffer::find_highway_intersection_bounds( const
 }
 
 
-std::string overmapbuffer::get_description_at( const tripoint_abs_sm &where )
+std::string overmapbuffer::get_description_at( const tripoint_abs_sm &where, bool draw_origin )
 {
     const oter_id oter = ter( project_to<coords::omt>( where ) );
     om_vision_level vision = seen( project_to<coords::omt>( where ) );
@@ -1927,7 +1929,11 @@ std::string overmapbuffer::get_description_at( const tripoint_abs_sm &where )
     const city_reference closest_cref = closest_known_city( where );
 
     if( !closest_cref ) {
-        return ter_name + "\n" + get_origin( oter->get_type_id()->src );
+        if( draw_origin ) {
+            return ter_name + "\n" + get_origin( oter->get_type_id()->src );
+        } else {
+            return ter_name;
+        }
     }
 
     const struct city &closest_city = *closest_cref.city;
@@ -1965,9 +1971,84 @@ std::string overmapbuffer::get_description_at( const tripoint_abs_sm &where )
         }
     }
 
-    format_string += "\n" + get_origin( oter->get_type_id()->src );
-
+    if( draw_origin ) {
+        format_string += "\n" + get_origin( oter->get_type_id()->src );
+    }
     return string_format( format_string, ter_name, dir_name, closest_city_name );
+}
+
+void overmapbuffer::display_description_at( const tripoint_abs_sm &where, bool draw_origin )
+{
+    const oter_id oter = ter( project_to<coords::omt>( where ) );
+    om_vision_level vision = seen( project_to<coords::omt>( where ) );
+    nc_color ter_color = oter->get_color( vision );
+    std::string ter_name = colorize( oter->get_name( vision ), ter_color );
+
+    auto draw_origin_line = [&draw_origin, &ter_color, &oter]() {
+        if( draw_origin ) {
+            ImGui::NewLine();
+            cataimgui::TextColoredParagraph( ter_color, get_origin( oter->get_type_id()->src ) );
+        }
+    };
+
+    if( oter->blends_adjacent( vision ) ) {
+        oter_vision::blended_omt blended = oter_vision::get_blended_omt_info(
+                                               project_to<coords::omt>( where ), vision );
+        ter_color = blended.color;
+        ter_name = colorize( blended.name, ter_color );
+    }
+
+    if( where.z() != 0 ) {
+        cataimgui::TextColoredParagraph( ter_color, ter_name );
+        return;
+    }
+
+    const city_reference closest_cref = closest_known_city( where );
+
+    if( !closest_cref ) {
+        cataimgui::TextColoredParagraph( ter_color, ter_name );
+        draw_origin_line();
+        return;
+    }
+
+    const struct city &closest_city = *closest_cref.city;
+    const std::string closest_city_name = colorize( closest_city.name, c_yellow );
+    const direction dir = direction_from( closest_cref.abs_sm_pos, where );
+    const std::string dir_name = colorize( direction_name( dir ), c_light_gray );
+
+    const int sm_size = omt_to_sm_copy( closest_cref.city->size );
+    const int sm_dist = closest_cref.distance;
+
+    //~ First parameter is a terrain name, second parameter is a direction, and third parameter is a city name.
+    std::string format_string = pgettext( "terrain description", "%1$s %2$s from %3$s" );
+    if( sm_dist <= 3 * sm_size / 4 ) {
+        if( sm_size >= 16 ) {
+            // The city is big enough to be split in districts.
+            if( sm_dist <= sm_size / 4 ) {
+                //~ First parameter is a terrain name, second parameter is a direction, and third parameter is a city name.
+                format_string = pgettext( "terrain description", "%1$s in central %3$s" );
+            } else {
+                //~ First parameter is a terrain name, second parameter is a direction, and third parameter is a city name.
+                format_string = pgettext( "terrain description", "%1$s in %2$s %3$s" );
+            }
+        } else {
+            //~ First parameter is a terrain name, second parameter is a direction, and third parameter is a city name.
+            format_string = pgettext( "terrain description", "%1$s in %3$s" );
+        }
+    } else if( sm_dist <= sm_size ) {
+        if( sm_size >= 8 ) {
+            // The city is big enough to have outskirts.
+            //~ First parameter is a terrain name, second parameter is a direction, and third parameter is a city name.
+            format_string = pgettext( "terrain description", "%1$s on the %2$s outskirts of %3$s" );
+        } else {
+            //~ First parameter is a terrain name, second parameter is a direction, and third parameter is a city name.
+            format_string = pgettext( "terrain description", "%1$s in %3$s" );
+        }
+    }
+
+    cataimgui::TextColoredParagraph( ter_color, string_format( format_string, ter_name, dir_name,
+                                     closest_city_name ) );
+    draw_origin_line();
 }
 
 void overmapbuffer::spawn_monster( const tripoint_abs_sm &p, bool spawn_nonlocal )

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -1984,10 +1984,11 @@ void overmapbuffer::display_description_at( const tripoint_abs_sm &where, bool d
     nc_color ter_color = oter->get_color( vision );
     std::string ter_name = colorize( oter->get_name( vision ), ter_color );
 
-    auto draw_origin_line = [&draw_origin, &ter_color, &oter]() {
+    auto draw_origin_line = [&draw_origin, &oter]() {
         if( draw_origin ) {
             ImGui::NewLine();
-            cataimgui::TextColoredParagraph( ter_color, get_origin( oter->get_type_id()->src ) );
+            cataimgui::TextColoredParagraph( c_light_gray, get_origin( oter->get_type_id()->src ) );
+            ImGui::NewLine();
         }
     };
 

--- a/src/overmapbuffer.h
+++ b/src/overmapbuffer.h
@@ -584,7 +584,10 @@ class overmapbuffer
 
         city_reference closest_known_city( const tripoint_abs_sm &center );
 
-        std::string get_description_at( const tripoint_abs_sm &where );
+        //TODO: use display_description_at when converting UIs to ImGui
+        std::string get_description_at( const tripoint_abs_sm &where, bool draw_origin = true );
+
+        void display_description_at( const tripoint_abs_sm &where, bool draw_origin = true );
 
         /**
          * Place the specified overmap special directly on the map using the provided location and rotation.

--- a/src/uistate.h
+++ b/src/uistate.h
@@ -97,6 +97,20 @@ struct advanced_inv_save_state {
 extern void save_inv_state( JsonOut &json );
 extern void load_inv_state( const JsonObject &jo );
 
+struct overmap_sidebar_uistate {
+    bool quickref_header = true;
+    bool layers_header = true;
+    bool debug_header = true;
+    //expands/collapses all sidebar headers
+    void set_all( bool state ) {
+        quickref_header = state;
+        layers_header = state;
+        debug_header = state;
+    }
+    void serialize( JsonOut &json ) const;
+    void deserialize( const JsonObject &jo );
+};
+
 /*
   centralized depot for trivial ui data such as sorting, string_input_popup history, etc.
   To use this, see the ****notes**** below
@@ -143,9 +157,8 @@ class uistatedata
         bool overmap_debug_mongroup = false;
         bool overmap_fast_travel = false;
         bool overmap_fast_scroll = false;
-        bool overmap_sidebar_quickref = true;
-        bool overmap_sidebar_layers = true;
-        bool overmap_sidebar_debug = true;
+
+        overmap_sidebar_uistate overmap_sidebar_state;
 
         // Distraction manager stuff
         bool distraction_noise = true;

--- a/src/uistate.h
+++ b/src/uistate.h
@@ -143,6 +143,9 @@ class uistatedata
         bool overmap_debug_mongroup = false;
         bool overmap_fast_travel = false;
         bool overmap_fast_scroll = false;
+        bool overmap_sidebar_quickref = true;
+        bool overmap_sidebar_layers = true;
+        bool overmap_sidebar_debug = true;
 
         // Distraction manager stuff
         bool distraction_noise = true;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Interface "overmap sidebar ImGui conversion"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

The overmap sidebar is so cluttered and inflexible that it's nearly impossible to add content to it. Also, it needs to be updated to ImGui.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Convert the overmap sidebar to ImGui.

Move basic info to top of sidebar and everything else into collapsing headers; this saves a huge amount of space on the sidebar, especially for experienced players that don't need the keybindings on-screen. It also allows for putting sidebar info into smaller categories. If you wish to view all the headers open at once, ImGui supports scrolling.

Removes the old hordes debug info in favor of the recently new one, though the output is very long and could be cleaned up.

TO-DO:
- [x] Fix strange mouse input bug where headers only collapse when the mouse is moving. See [c676c43](https://github.com/CleverRaven/Cataclysm-DDA/pull/83501/commits/c676c43eaa5cf56b260d53a4a12f61222dad3618), the timeout for `handle_input()` was the issue (only occurring if edge scrolling is disabled), this appeared to fix it. If there's a reason for the timeout to normally be so high, let me know.
- [x] Headers open/close state should be held in uistate and should start open for a new save
- [x] Keybind to open/close all headers
- [x] Headers scroll only, main info stays static at top of sidebar
 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Remove keybinding reference altogether because we have a keybindings menu, but I figured it could be kept for new players

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Looks fine on Windows, basic functionality seems fine as well.

The sidebar doesn't really affect gameplay, but I think I still need to know if it looks good on Linux/Android

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<details>
<summary>Screenshots</summary>

<img width="1360" height="702" alt="image" src="https://github.com/user-attachments/assets/95a6f2d8-5537-49cb-b354-f5bafa181818" />

Mission
<img width="261" height="137" alt="image" src="https://github.com/user-attachments/assets/021fc15b-871e-4ea1-b23b-6d3be0194072" />

Weather
<img width="245" height="89" alt="image" src="https://github.com/user-attachments/assets/bcec1978-056b-49a8-a916-69846942e164" />

Debug (only visible when debug mode is on or overmap editor is used)
<img width="273" height="700" alt="image" src="https://github.com/user-attachments/assets/d7025baf-96dc-47ff-b174-de88bc7675eb" />

EDIT: Most recent changes:
<img width="1201" height="701" alt="image" src="https://github.com/user-attachments/assets/2c6e38b3-963b-4c17-9411-027baaeb79af" />

</details>

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
