### PR TITLE
Inventory/Compare: show loose gunmods; hide installed when not visible (#83192)

### DIFF
--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -58,7 +58,7 @@
 #include "uistate.h"
 #include "units.h"
 #include "units_utility.h"
-#include "value_ptr.h" 
+#include "value_ptr.h"
 #include "vehicle.h"
 #include "vehicle_selector.h"
 #include "vpart_position.h"

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -58,6 +58,7 @@
 #include "uistate.h"
 #include "units.h"
 #include "units_utility.h"
+#include "value_ptr.h" 
 #include "vehicle.h"
 #include "vehicle_selector.h"
 #include "vpart_position.h"
@@ -701,6 +702,18 @@ inventory_selector_preset::inventory_selector_preset()
     std::function<std::string( const inventory_entry & )>( [ this ]( const inventory_entry & entry ) {
         return get_caption( entry );
     } ) );
+}
+
+bool inventory_selector_preset::is_shown( const item_location &loc ) const
+{
+    if( loc->is_gunmod() ) {
+        item_location parent = loc.parent_item();
+        const bool installed = parent && parent->is_gun();
+        if( installed && !loc->type->gunmod->is_visible_when_installed ) {
+            return false;
+        }
+    }
+    return true;
 }
 
 bool inventory_selector_preset::sort_compare( const inventory_entry &lhs,

--- a/src/inventory_ui.h
+++ b/src/inventory_ui.h
@@ -26,14 +26,12 @@
 #include "input_context.h"
 #include "item.h"
 #include "item_location.h"
-#include "itype.h"
 #include "memory_fast.h"
 #include "pimpl.h"
 #include "pocket_type.h"
 #include "point.h"
 #include "translations.h"
 #include "units.h"
-#include "value_ptr.h"
 
 class Character;
 class JsonObject;
@@ -241,12 +239,8 @@ class inventory_selector_preset
         virtual ~inventory_selector_preset() = default;
 
         /** Does this entry satisfy the basic preset conditions? */
-        virtual bool is_shown( const item_location &loc ) const {
-            if( loc->is_gunmod() && !loc->type->gunmod->is_visible_when_installed ) {
-                return false;
-            }
-            return true;
-        }
+        virtual bool is_shown( const item_location &loc ) const;
+
 
         /**
          * The reason why this entry cannot be selected.


### PR DESCRIPTION
#### Summary
Interface "Hide installed gunmods when installed, show loose gunmods in the inventory UI"

**PR Description:**  
Inventory/Compare menus were hiding all gunmods of a type when that type had is_visible_when_installed = false, even if the specific item was loose (not installed). This change makes visibility depend on the item’s actual install state, restoring expected behavior: loose gunmods are shown; installed gunmods are hidden unless their JSON allows visibility.

**Purpose of change:**
Make Inventory/Compare accurately reflect what the player can act on: show loose attachments you can pick up/move/compare; hide the ones already installed when the type is meant to be hidden.

**Describe the solution:**
In src/inventory_ui.h, update is_shown( const item_location &loc ) to determine per-item install state:
If loc->is_gunmod():
Get the parent item: const item *parent = loc.parent_item();
Consider it installed iff parent && parent->is_gun().
Hide only when installed and the gunmod type has !is_visible_when_installed.
Otherwise, show normally.
No JSON or menu layout changes; logic is confined to the common visibility predicate used by Inventory/Compare.

**Describe alternatives you've considered:**
-N/A

**Testing:**
New world, spawn a gun + two identical gunmods. Install one; keep the other loose (also tried placing the loose one inside a backpack).
Inventory (i) / filter: loose mod appears; installed mod does not (unless the JSON sets is_visible_when_installed = true).
Compare: same as Inventory.
Drop/Multidrop: unchanged; loose mod listed, installed mod not listed.
Platform: Windows (MSYS2 UCRT64), Tiles build. Verified after a clean rebuild.


**Additional context:**
Fixes #83192 and Duplicates