### PR TITLE
Make sample items active, including a tanning one

### DIFF
--- a/data/json/items/tool/explosives.json
+++ b/data/json/items/tool/explosives.json
@@ -424,7 +424,7 @@
     "use_action": { "type": "message", "message": "You've already pulled the %s's pin, try throwing it instead.", "name": "Pull pin" },
     "countdown_action": { "type": "explosion", "explosion": { "power": 240, "shrapnel": { "casing_mass": 217, "fragment_mass": 0.02 } } },
     "countdown_interval": "5 seconds",
-    "flags": [ "BOMB", "TRADER_AVOID", "DANGEROUS" ],
+    "flags": [ "BOMB", "TRADER_AVOID", "DANGEROUS", "SPAWN_ACTIVE" ],
     "melee_damage": { "bash": 2 }
   },
   {

--- a/data/json/items/tool/lighting.json
+++ b/data/json/items/tool/lighting.json
@@ -150,7 +150,15 @@
       "ammo_scale": 0
     },
     "light": 300,
-    "flags": [ "CHARGEDIM", "TRADER_AVOID", "BELT_CLIP", "WATER_BREAK", "HELMET_HEAD_ATTACHMENT", "HEAD_STRAP_MOUNT" ]
+    "flags": [
+      "CHARGEDIM",
+      "TRADER_AVOID",
+      "BELT_CLIP",
+      "WATER_BREAK",
+      "HELMET_HEAD_ATTACHMENT",
+      "HEAD_STRAP_MOUNT",
+      "SPAWN_ACTIVE"
+    ]
   },
   {
     "id": "diving_flashlight_small",

--- a/data/json/items/tool/tailoring.json
+++ b/data/json/items/tool/tailoring.json
@@ -280,6 +280,9 @@
     "material": [ "flesh", "leather" ],
     "symbol": ",",
     "color": "brown",
+    "countdown_interval": "8 hours",
+    "revert_to": "tanned_hide",
+    "//1": "Remove the use_action below when all items spawned without the auto activation changes (2025-11-30) are no longer supported",
     "use_action": {
       "target": "tanned_hide",
       "msg": "You carefully unfold the tanning leather hide and shake it clean.",
@@ -287,9 +290,9 @@
       "type": "delayed_transform",
       "transform_age": 28800,
       "not_ready_msg": "The tanning leather hide isn't done yet.",
-      "//": "2 days"
+      "//": "8 hours"
     },
-    "flags": [ "NO_SALVAGE" ]
+    "flags": [ "NO_SALVAGE", "SPAWN_ACTIVE" ]
   },
   {
     "id": "tanning_pelt",

--- a/data/json/items/tool/tailoring.json
+++ b/data/json/items/tool/tailoring.json
@@ -267,7 +267,7 @@
     "melee_damage": { "bash": 2 }
   },
   {
-    "id": "tanning_hide",
+    "id": "tanning_hide_active",
     "type": "ITEM",
     "subtypes": [ "TOOL" ],
     "category": "spare_parts",
@@ -282,16 +282,6 @@
     "color": "brown",
     "countdown_interval": "8 hours",
     "revert_to": "tanned_hide",
-    "//1": "Remove the use_action below when all items spawned without the auto activation changes (2025-11-30) are no longer supported",
-    "use_action": {
-      "target": "tanned_hide",
-      "msg": "You carefully unfold the tanning leather hide and shake it clean.",
-      "moves": 150,
-      "type": "delayed_transform",
-      "transform_age": 28800,
-      "not_ready_msg": "The tanning leather hide isn't done yet.",
-      "//": "8 hours"
-    },
     "flags": [ "NO_SALVAGE", "SPAWN_ACTIVE" ]
   },
   {

--- a/data/json/obsoletion_and_migration_0.J/tailoring.json
+++ b/data/json/obsoletion_and_migration_0.J/tailoring.json
@@ -1,0 +1,26 @@
+[
+  {
+    "id": "tanning_hide",
+    "type": "ITEM",
+    "subtypes": [ "TOOL" ],
+    "category": "spare_parts",
+    "name": { "str": "tanning leather hide" },
+    "description": "A treated animal hide that is undergoing the chemical processes required to become leather.  You will be able to activate it to unroll and make use of it when it is done.",
+    "weight": "600 g",
+    "volume": "1 L",
+    "price": "0 cent",
+    "price_postapoc": "0 cent",
+    "material": [ "flesh", "leather" ],
+    "symbol": ",",
+    "color": "brown",
+    "use_action": {
+      "target": "tanned_hide",
+      "msg": "You carefully unfold the tanning leather hide and shake it clean.",
+      "moves": 150,
+      "type": "delayed_transform",
+      "transform_age": 28800,
+      "not_ready_msg": "The tanning leather hide isn't done yet.",
+      "//": "2 days"
+    },
+    "flags": [ "NO_SALVAGE" ]
+  }]

--- a/data/json/obsoletion_and_migration_0.J/tailoring.json
+++ b/data/json/obsoletion_and_migration_0.J/tailoring.json
@@ -23,4 +23,5 @@
       "//": "2 days"
     },
     "flags": [ "NO_SALVAGE" ]
-  }]
+  }
+]

--- a/data/json/recipes/basecamps/base/recipe_bare_bones_basecamp/bare_bones_basecamp_recipe_groups.json
+++ b/data/json/recipes/basecamps/base/recipe_bare_bones_basecamp/bare_bones_basecamp_recipe_groups.json
@@ -123,7 +123,7 @@
       { "id": "tempered_glass_sheet", "description": " Craft: Tempered Sheet, Glass" },
       { "id": "cured_hide", "description": " Hideworking: Cured Hide" },
       { "id": "cured_pelt", "description": " Hideworking: Cured Pelt" },
-      { "id": "tanning_hide", "description": " Hideworking: Tanning Hide" },
+      { "id": "tanning_hide_active", "description": " Hideworking: Tanning Hide" },
       { "id": "tanning_pelt", "description": " Hideworking: Tanning Pelt" },
       { "id": "tanned_hide", "description": " Hideworking: Tanned Hide" },
       { "id": "leather", "description": " Hideworking: Leather" },

--- a/data/json/recipes/basecamps/expansion/recipe_modular_workshop/version_2/modular_workshop_recipe_groups.json
+++ b/data/json/recipes/basecamps/expansion/recipe_modular_workshop/version_2/modular_workshop_recipe_groups.json
@@ -320,7 +320,7 @@
     "recipes": [
       { "id": "cured_hide", "description": " Hideworking: Cured Hide" },
       { "id": "cured_pelt", "description": " Hideworking: Cured Pelt" },
-      { "id": "tanning_hide", "description": " Hideworking: Tanning Hide" },
+      { "id": "tanning_hide_active", "description": " Hideworking: Tanning Hide" },
       { "id": "tanning_pelt", "description": " Hideworking: Tanning Pelt" },
       { "id": "tanned_hide", "description": " Hideworking: Tanned Hide" },
       { "id": "leather", "description": " Hideworking: Leather" }

--- a/data/json/recipes/recipe_others.json
+++ b/data/json/recipes/recipe_others.json
@@ -2144,7 +2144,7 @@
   {
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",
-    "result": "tanning_hide",
+    "result": "tanning_hide_active",
     "category": "CC_OTHER",
     "subcategory": "CSC_OTHER_MATERIALS",
     "skill_used": "survival",
@@ -2212,7 +2212,7 @@
   {
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",
-    "result": "tanning_hide",
+    "result": "tanning_hide_active",
     "id_suffix": "modern",
     "name": "%s using lye powder",
     "category": "CC_OTHER",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Test PR to check if the changes are accepted for a broader adoption:
- Make a new active tanning item, causing it to transform when done rather than requiring player activation.
- Marking the old tanning object for obsoletion.
- Make active flashlight active on spawn.
- Make active grenade active on spawn.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
- Make use of the countdown functionality plus the "PAWN_ACTIVE flag to cause tanning_hide to transform automatically when the time is up. This is applied to a new tanning item without any manual transform.
- Mark the existing tanning item for obsoletion (still needed for existing saves).
- Added the SPAWN_ACTIVE flag to debug spawned active flashlight. This will presumably affect debug spawned items only, as flashlights that are turned on probably aren't spawned.
- Ditto for the active grenade.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
- Figure out how to make active electric items deplete their "charges" when time is debug forwarded or when active items enter the reality bubble. Considered out of scope.
- Make two (or more) full PRs to convert timed crafted items into self transforming ones, and active items spawned active, respectively. Decided this PR with potential backlash to be preferrable to putting in the effort and have the PR(s) rejected.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
- Debug spawned a tanning_hide.
- Debug waited a day, and saw the hide transform when taking a step.
- Crafted a tanning_hide and waited for 8 hours. Saw the hide transform (I'd taken a few steps before waiting, it it would have taken another tick).
- Loaded a save with an existing tanning_hide (generated through crafting), saved before the changes.
- Waited 8 hours and a bit, and the hide didn't transform (as expected).
- Activated the hide and it did transform.
- Debug spawned an active flashlight.
- Saw that it was on (and color coded as active).
- Waited a tick.
- Saw that the flashlight had turned off (it's spawned without a battery).
- Before the change it's spawned marked as (on), but it actually doesn't work. It won't turn off by itself, but can be turned off manually).
- Debug spawned an active grenade before the change, threw it.
- Waited a while and it didn't explode.
- Debug spawned an inactive grenade, activated it, and threw it.
- Waited a little bit and it exploded, with the first grenade still sort of blinking (because it's "active", but not actually active).
- Debug spawned an active grenade after the change and threw it. It exploded as expected.
Edit: After splitting the tanning item into a new and an old one:
- Crafted the (new) tanning hide using both of the recipes.
- Debug waited 10 hours.
- Saw the hides transform after taking two steps.
- Loaded a save with a tanning_hide, as above.
- Debug waited 10 hours.
- Activated the hide manually to transform it.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
As indicated above, if the PR is accepted without comments to the contrary, I'll follow it up with PR(s) to change crafting produced timed items into auto transforming ones instead of requiring manual transformation. There may be issues with liquids, but we'll see. A potential issue is when the products are easy to produce in large numbers (I believe I've seen a suggestion recently about 100 or so items that needed to be activated in turn). However, I don't think it should result in a huge additional strain, unless you've got a horde of minions crafting away (in which case things are probably going to go at a crawl anyway).

Also, I intend to make active items spawning as active, even if it only affects debug spawned items in practice. Again, it depends on not receicing indications that it's not a good idea.

Finally, it turns out this is fairly easy to do, as all the infrastructure is already in place (although finding it took a while).

One of the many unrelated test failures that was somewhat worrying was one where copying of a submap failed due to the presence of active objects (no further details, and no useful stack trace), which is something not yet supported (according to a comment in the code).
I looked for all usages of the three modified (to active) items in this PR in the JSON, and all of them are produced either through crafting or activation of an inactive version. There is also a flashlight weapons mod with an on version, but, again, there is nothing generating it (so there shouldn't be any weapons spawned with active flashlights).

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
