### PR TITLE
Fix: Allow custom bomb count in Minesweeper

### DIFF
--- a/src/iuse_software_minesweeper.cpp
+++ b/src/iuse_software_minesweeper.cpp
@@ -78,7 +78,7 @@ void minesweeper_game::new_level()
             const int area = new_level.x * new_level.y;
             int new_ibombs = area * 0.1;
 
-            set_num( _( "Number of bombs:" ), new_ibombs, new_ibombs, area * 0.6 );
+            set_num( _( "Number of bombs:" ), new_ibombs, 1, area * 0.6 );
 
             level = new_level;
             iBombs = new_ibombs;


### PR DESCRIPTION
The custom game mode in Minesweeper previously did not allow the user to select a number of bombs lower than the default. This change sets the minimum number of bombs to 1, allowing for a wider range of custom game configurations.