### PR TITLE
[XEDRA Evolved] Give back Gracken Big Game Hunter's eyes back

### DIFF
--- a/data/mods/Xedra_Evolved/player/professions.json
+++ b/data/mods/Xedra_Evolved/player/professions.json
@@ -208,6 +208,7 @@
       "THRESH_SPECIES_GRACKEN",
       "GRACKEN_BUILD",
       "NIGHTVISION",
+      "SHADE_EYES",
       "SHADE_SKIN",
       "SHADE_LEGS",
       "SHADE_ARMS",


### PR DESCRIPTION

#### Summary
None

#### Purpose of change
Big Game Hunter gracken profession doesnt includes their shade eyes for some reason, so i gave them their eyes.

#### Describe the solution

Put `"SHADE_EYES",` in their profession's traits field.

#### Describe alternatives you've considered

No.

#### Testing

![Screenshot_20251101_022741](https://github.com/user-attachments/assets/88d0ef42-7fb6-40f6-82b2-b4caee653c74)
![Screenshot_20251101_022923](https://github.com/user-attachments/assets/14b656ea-a900-4649-afd0-e23f4ad6a10d)


#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
