### PR TITLE
[XEDRA Evolved] Giant Vampire Bat slowdown

### DIFF
--- a/data/mods/Xedra_Evolved/monsters/bloodsuckers.json
+++ b/data/mods/Xedra_Evolved/monsters/bloodsuckers.json
@@ -957,7 +957,7 @@
     "volume": "4 L",
     "weight": "6 kg",
     "hp": 40,
-    "speed": 1700,
+    "speed": 170,
     "material": [ "flesh" ],
     "symbol": "w",
     "color": "brown",


### PR DESCRIPTION


#### Summary
None

#### Purpose of change
Giant Vampire Bat has 1700 speed, which doesnt sounds intended and too fast than the other bats, so i slow em down.

#### Describe the solution
`1700` -> `170`

#### Describe alternatives you've considered

Make it on par with vampire bat's 190 speed?

#### Testing
Well, it rans and doesnt crash. Spawning the giant bat in, it does moves slower than before.

####Additional context
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
