### PR TITLE
[XEDRA Evolved] Update Gracken background recipes

### DIFF
--- a/data/mods/Xedra_Evolved/mutations/xe_playable_gracken.json
+++ b/data/mods/Xedra_Evolved/mutations/xe_playable_gracken.json
@@ -8,12 +8,18 @@
     "points": 4,
     "proficiencies": [ "prof_traps" ],
     "recipes": [
+      "gracken_shade_arms",
       "gracken_strong_arms",
       "gracken_long_arms",
-      "gracken_shade_arms",
       "gracken_shade_hands",
       "gracken_sharp_nails",
-      "gracken_dextrous_hands"
+      "gracken_dextrous_hands",
+      "gracken_carnivorous_stomach",
+      "gracken_herbivorous_stomach",
+      "gracken_omnivorous_stomach",
+      "gracken_shade_legs",
+      "gracken_short_legs",
+      "gracken_long_legs"
     ],
     "traits": [
       "THRESH_SPECIES_GRACKEN",

--- a/data/mods/Xedra_Evolved/player/professions.json
+++ b/data/mods/Xedra_Evolved/player/professions.json
@@ -197,12 +197,18 @@
     "name": "Xedra Offworld Team: Big Game Hunter",
     "description": "You are what Xedra refers to as a non-local guide.  A mature Gracken hired on to join the Offworld Acquisitions Team, you trained in human long distance weaponry in order to take down big game and create new improvements to bring back to your people.  They gave you a big gun and a little training in how to use it and in return you help them know what things in other dimensions to hunt and what to run from.",
     "recipes": [
+      "gracken_shade_arms",
       "gracken_strong_arms",
       "gracken_long_arms",
-      "gracken_shade_arms",
       "gracken_shade_hands",
       "gracken_sharp_nails",
-      "gracken_dextrous_hands"
+      "gracken_dextrous_hands",
+      "gracken_carnivorous_stomach",
+      "gracken_herbivorous_stomach",
+      "gracken_omnivorous_stomach",
+      "gracken_shade_legs",
+      "gracken_short_legs",
+      "gracken_long_legs"
     ],
     "traits": [
       "THRESH_SPECIES_GRACKEN",


### PR DESCRIPTION


#### Summary
None

#### Purpose of change
Theres some recipes the gracken background dont have, so i updated it.

#### Describe the solution
Update the recipes for both the gracken background and big game hunter gracken profession.

#### Describe alternatives you've considered
No.

#### Testing
Big Game Hunter gracken profession and Gracken background works.
![Screenshot_20251101_234118](https://github.com/user-attachments/assets/b785e773-b810-40bd-8448-771ff7e11026)
![Screenshot_20251101_234140](https://github.com/user-attachments/assets/c7810f85-1270-4bf0-b473-9811d1a06e46)


#### Additional context

There really should be a way for gracken prior to these kind of pr to get these recipes in game.


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
