### PR TITLE
Withdraw weakpoint priviledges from electromagnetics, biochemistry, and burn care

### DIFF
--- a/data/json/monsters/power_leech.json
+++ b/data/json/monsters/power_leech.json
@@ -36,13 +36,7 @@
     ],
     "special_when_hit": [ "ZAPBACK", 100 ],
     "weakpoint_sets": [ "wps_power_leech" ],
-    "families": [
-      "prof_gross_anatomy",
-      "prof_intro_biology",
-      "prof_wp_power_leech_basic",
-      "prof_wp_power_leech_advanced",
-      "prof_electromagnetics"
-    ],
+    "families": [ "prof_gross_anatomy", "prof_intro_biology", "prof_wp_power_leech_basic", "prof_wp_power_leech_advanced" ],
     "harvest": "flesh_plant_bloom",
     "dissect": "dissect_plant_sample_large",
     "flags": [ "SEES", "NOHEAD", "IMMOBILE", "NO_BREATHE", "QUEEN", "HARDTOSHOOT" ],
@@ -83,13 +77,7 @@
     ],
     "special_when_hit": [ "ZAPBACK", 100 ],
     "weakpoint_sets": [ "wps_power_leech" ],
-    "families": [
-      "prof_gross_anatomy",
-      "prof_intro_biology",
-      "prof_wp_power_leech_basic",
-      "prof_wp_power_leech_advanced",
-      "prof_electromagnetics"
-    ],
+    "families": [ "prof_gross_anatomy", "prof_intro_biology", "prof_wp_power_leech_basic", "prof_wp_power_leech_advanced" ],
     "harvest": "flesh_plant",
     "dissect": "dissect_plant_sample_single",
     "flags": [ "SEES", "NOHEAD", "IMMOBILE", "NO_BREATHE", "HARDTOSHOOT" ],
@@ -118,13 +106,7 @@
     "luminance": 200,
     "special_when_hit": [ "ZAPBACK", 100 ],
     "weakpoint_sets": [ "wps_power_leech" ],
-    "families": [
-      "prof_gross_anatomy",
-      "prof_intro_biology",
-      "prof_wp_power_leech_basic",
-      "prof_wp_power_leech_advanced",
-      "prof_electromagnetics"
-    ],
+    "families": [ "prof_gross_anatomy", "prof_intro_biology", "prof_wp_power_leech_basic", "prof_wp_power_leech_advanced" ],
     "harvest": "flesh_plant",
     "dissect": "dissect_plant_sample_single",
     "flags": [ "SEES", "NOHEAD", "IMMOBILE", "NO_BREATHE", "HARDTOSHOOT" ],
@@ -160,13 +142,7 @@
       [ "LEECH_SPAWNER", 120 ]
     ],
     "weakpoint_sets": [ "wps_power_leech" ],
-    "families": [
-      "prof_gross_anatomy",
-      "prof_intro_biology",
-      "prof_wp_power_leech_basic",
-      "prof_wp_power_leech_advanced",
-      "prof_electromagnetics"
-    ],
+    "families": [ "prof_gross_anatomy", "prof_intro_biology", "prof_wp_power_leech_basic", "prof_wp_power_leech_advanced" ],
     "harvest": "flesh_plant",
     "dissect": "dissect_plant_sample_single",
     "flags": [ "SEES", "NOHEAD", "IMMOBILE", "NO_BREATHE" ],
@@ -211,13 +187,7 @@
     ],
     "special_when_hit": [ "ZAPBACK", 100 ],
     "weakpoint_sets": [ "wps_power_leech" ],
-    "families": [
-      "prof_gross_anatomy",
-      "prof_intro_biology",
-      "prof_wp_power_leech_basic",
-      "prof_wp_power_leech_advanced",
-      "prof_electromagnetics"
-    ],
+    "families": [ "prof_gross_anatomy", "prof_intro_biology", "prof_wp_power_leech_basic", "prof_wp_power_leech_advanced" ],
     "harvest": "flesh_plant",
     "dissect": "dissect_plant_sample_single",
     "flags": [ "SEES", "NOHEAD", "NO_BREATHE", "HARDTOSHOOT" ],
@@ -260,13 +230,7 @@
       [ "EVOLVE_KILL_STRIKE", 6 ]
     ],
     "weakpoint_sets": [ "wps_power_leech" ],
-    "families": [
-      "prof_gross_anatomy",
-      "prof_intro_biology",
-      "prof_wp_power_leech_basic",
-      "prof_wp_power_leech_advanced",
-      "prof_electromagnetics"
-    ],
+    "families": [ "prof_gross_anatomy", "prof_intro_biology", "prof_wp_power_leech_basic", "prof_wp_power_leech_advanced" ],
     "harvest": "flesh_plant",
     "dissect": "dissect_plant_sample_single",
     "flags": [ "SEES", "NOHEAD", "NO_BREATHE", "HARDTOSHOOT" ],

--- a/data/json/monsters/rodentkin.json
+++ b/data/json/monsters/rodentkin.json
@@ -109,7 +109,7 @@
     "melee_dice_sides": 1,
     "special_when_hit": [ "ZAPBACK", 100 ],
     "special_attacks": [ [ "EAT_FOOD", 120 ], [ "EAT_CARRION", 120 ] ],
-    "families": [ "prof_gross_anatomy", "prof_intro_biology", "prof_physiology", "prof_electromagnetics" ],
+    "families": [ "prof_gross_anatomy", "prof_intro_biology", "prof_physiology" ],
     "upgrades": false,
     "flags": [ "SEES", "SMELLS", "HEARS", "WARM", "ELECTRIC", "ANIMAL", "PATH_AVOID_DANGER", "EATS", "SMALL_HIDER" ],
     "emit_fields": [ { "emit_id": "emit_shock_burst_rat", "delay": "5 s" } ]

--- a/data/json/monsters/zed-winged.json
+++ b/data/json/monsters/zed-winged.json
@@ -170,7 +170,7 @@
     "description": "This small, winged predator darts through the air on three thinly-haired wings that look like stretched human hands.  A jagged spike with a pulsing electrical glow juts out from the point where the wings meet.",
     "melee_damage": [ { "damage_type": "electric", "amount": 8 } ],
     "luminance": 8,
-    "families": [ "prof_gross_anatomy", "prof_intro_biology", "prof_physiology", "prof_wp_zombie", "prof_electromagnetics" ],
+    "families": [ "prof_gross_anatomy", "prof_intro_biology", "prof_physiology", "prof_wp_zombie" ],
     "special_attacks": [ { "id": "impale", "damage_max_instance": [ { "damage_type": "stab", "amount": 15, "armor_multiplier": 0.6 } ] } ],
     "special_when_hit": [ "ZAPBACK", 100 ],
     "upgrades": false,

--- a/data/json/monsters/zed_amalgamation.json
+++ b/data/json/monsters/zed_amalgamation.json
@@ -317,11 +317,7 @@
     "special_when_hit": [ "ZAPBACK", 100 ],
     "death_function": { "effect": { "id": "death_shock_blast", "hit_self": true } },
     "harvest": "zombie_amalgamation_electric",
-    "extend": {
-      "flags": [ "ELECTRIC", "PULP_PRYING" ],
-      "families": [ "prof_electromagnetics" ],
-      "weakpoint_sets": [ "wps_amalgamation_armor", "wps_amalgamation_electric" ]
-    }
+    "extend": { "flags": [ "ELECTRIC", "PULP_PRYING" ], "weakpoint_sets": [ "wps_amalgamation_armor", "wps_amalgamation_electric" ] }
   },
   {
     "type": "MONSTER",

--- a/data/json/monsters/zed_amphibian.json
+++ b/data/json/monsters/zed_amphibian.json
@@ -229,14 +229,7 @@
     "melee_dice": 2,
     "melee_damage": [ { "damage_type": "electric", "amount": 6 } ],
     "dodge": 2,
-    "families": [
-      "prof_gross_anatomy",
-      "prof_intro_biology",
-      "prof_physiology",
-      "prof_wp_basic_amphibian",
-      "prof_wp_zombie",
-      "prof_electromagnetics"
-    ],
+    "families": [ "prof_gross_anatomy", "prof_intro_biology", "prof_physiology", "prof_wp_basic_amphibian", "prof_wp_zombie" ],
     "weakpoint_sets": [ "wps_amphibian_body", "wps_amphibian_frog", "wps_amphibian_electric" ],
     "harvest": "zombie_animal_electric",
     "luminance": 16,

--- a/data/json/monsters/zed_electric.json
+++ b/data/json/monsters/zed_electric.json
@@ -19,7 +19,7 @@
     "special_attacks": [ [ "PARROT", 8 ], { "id": "smash", "throw_strength": 36, "cooldown": 30 } ],
     "special_when_hit": [ "ZAPBACK", 75 ],
     "upgrades": false,
-    "extend": { "families": [ "prof_electromagnetics" ], "flags": [ "ELECTRIC" ] }
+    "extend": { "flags": [ "ELECTRIC" ] }
   },
   {
     "id": "mon_zombie_electric",
@@ -40,7 +40,7 @@
     "special_attacks": [ [ "PARROT", 8 ] ],
     "special_when_hit": [ "ZAPBACK", 100 ],
     "upgrades": { "half_life": 168, "into_group": "GROUP_ZOMBIE_ELECTRIC_UPGRADE" },
-    "extend": { "families": [ "prof_electromagnetics" ], "flags": [ "ELECTRIC" ] }
+    "extend": { "flags": [ "ELECTRIC" ] }
   },
   {
     "id": "mon_zombie_nullfield",
@@ -65,7 +65,7 @@
     "emit_fields": [ { "emit_id": "emit_shock_cloud", "delay": "1 s" } ],
     "special_when_hit": [ "ZAPBACK", 75 ],
     "upgrades": false,
-    "extend": { "families": [ "prof_electromagnetics" ], "flags": [ "ELECTRIC", "ELECTRIC_FIELD" ] }
+    "extend": { "flags": [ "ELECTRIC", "ELECTRIC_FIELD" ] }
   },
   {
     "id": "mon_zombie_static",
@@ -83,6 +83,6 @@
     "harvest": "zombie_humanoid_electric",
     "special_when_hit": [ "ZAPBACK", 100 ],
     "upgrades": { "half_life": 112, "into": "mon_zombie_electric" },
-    "extend": { "families": [ "prof_electromagnetics" ], "flags": [ "ELECTRIC" ] }
+    "extend": { "flags": [ "ELECTRIC" ] }
   }
 ]

--- a/data/json/monsters/zed_skeletal.json
+++ b/data/json/monsters/zed_skeletal.json
@@ -82,11 +82,7 @@
     "fungalize_into": "mon_skeleton_dusted",
     "upgrades": false,
     "armor": { "cut": 15, "stab": 30, "acid": 3, "bullet": 30 },
-    "extend": {
-      "weakpoint_sets": [ "wps_bone_armor" ],
-      "families": [ "prof_wp_skeleton", "prof_electromagnetics" ],
-      "flags": [ "ELECTRIC", "PULP_PRYING" ]
-    },
+    "extend": { "weakpoint_sets": [ "wps_bone_armor" ], "families": [ "prof_wp_skeleton" ], "flags": [ "ELECTRIC", "PULP_PRYING" ] },
     "delete": { "flags": [ "STUMBLES" ] }
   },
   {

--- a/data/json/proficiencies/chemistry.json
+++ b/data/json/proficiencies/chemistry.json
@@ -86,9 +86,7 @@
     "default_time_multiplier": 1.5,
     "default_skill_penalty": 0.25,
     "required_proficiencies": [ "prof_organic_chemistry", "prof_intro_biology" ],
-    "time_to_learn": "8 h",
-    "default_weakpoint_bonus": 2,
-    "default_weakpoint_penalty": 0
+    "time_to_learn": "8 h"
   },
   {
     "type": "proficiency",

--- a/data/json/proficiencies/electronics.json
+++ b/data/json/proficiencies/electronics.json
@@ -54,9 +54,7 @@
     "can_learn": true,
     "default_time_multiplier": 2.5,
     "default_skill_penalty": 0.25,
-    "time_to_learn": "8 h",
-    "default_weakpoint_bonus": 2,
-    "default_weakpoint_penalty": 0
+    "time_to_learn": "8 h"
   },
   {
     "type": "proficiency",

--- a/data/json/proficiencies/health_care.json
+++ b/data/json/proficiencies/health_care.json
@@ -32,8 +32,7 @@
     "default_time_multiplier": 2,
     "default_skill_penalty": 0.25,
     "time_to_learn": "12 h",
-    "default_weakpoint_bonus": 2,
-    "default_weakpoint_penalty": 0
+    "required_proficiencies": [ "prof_wound_care" ]
   },
   {
     "type": "proficiency",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Those three were fundamentally unrelated to any form of combat, but in the past had all been used as dummy weakpoint proficiencies (electromagnetics even up until now), which makes no sense. It's been brought up over and over on the devcord, and honestly I am kind of fed up with how nonsense our weakpoint proficiencies are so I am starting to crack down on them a little
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
- Destroy any weakpoint fields from electromagnetics, biochemistry, and burn care
- Make electromagnetics not learnable by dissecting electric enemies
- Give burn care basic wound care as a prerequisite, for when we eventually hopefully make it learnable? (and also it just makes sense)
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Burn Care currently has no use in vanilla, I believe, but the proficiency makes sense to exist and is already used for its intended purpose in mods, so it stays
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
