### PR TITLE
Remove slime weakpoint proficiencies

### DIFF
--- a/data/json/monster_weakpoints/slime_weakpoints.json
+++ b/data/json/monster_weakpoints/slime_weakpoints.json
@@ -9,15 +9,6 @@
         "crit_mult": { "all": 0.75 },
         "difficulty": { "ranged": 4, "melee": 3 },
         "coverage_mult": { "point": 0.75 },
-        "effects": [
-          { "effect": "staggered", "chance": 15, "message": "The %s is knocked off-balance!", "damage_required": [ 10, 30 ] },
-          {
-            "effect": "staggered",
-            "chance": 25,
-            "message": "The %s is knocked off-balance!",
-            "damage_required": [ 31, 100 ]
-          }
-        ],
         "coverage": 6
       },
       {
@@ -28,45 +19,6 @@
         "crit_mult": { "all": 0.75 },
         "coverage_mult": { "melee": 0.75 },
         "coverage": 3
-      },
-      {
-        "id": "organ",
-        "name": "an organ inside the slime, causing the slime to freeze up briefly as it reconstitutes it",
-        "crit_mult": { "all": 0.75 },
-        "difficulty": { "melee": 3, "ranged": 5 },
-        "coverage_mult": { "melee": 0.75 },
-        "effects": [
-          {
-            "effect": "stunned",
-            "duration": [ 1, 2 ],
-            "chance": 5,
-            "message": "The %s is stunned!",
-            "damage_required": [ 1, 10 ]
-          },
-          {
-            "effect": "stunned",
-            "duration": [ 1, 2 ],
-            "chance": 25,
-            "message": "The %s is stunned!",
-            "damage_required": [ 11, 50 ]
-          },
-          {
-            "effect": "stunned",
-            "duration": [ 1, 2 ],
-            "chance": 45,
-            "message": "The %s is stunned!",
-            "damage_required": [ 51, 100 ]
-          }
-        ],
-        "coverage": 3
-      },
-      {
-        "id": "fragment",
-        "name": "the body, separating a fragment that you manage to keep from rejoining the slime until the fragment melts away",
-        "crit_mult": { "all": 0.75 },
-        "difficulty": { "ranged": 3, "melee": 1 },
-        "coverage_mult": { "point": 0.75 },
-        "coverage": 5
       },
       {
         "id": "pseudopod",

--- a/data/json/monsters/slimes.json
+++ b/data/json/monsters/slimes.json
@@ -24,7 +24,6 @@
     "melee_damage": [ { "damage_type": "cut", "amount": 0 } ],
     "bleed_rate": 30,
     "weakpoint_sets": [ "wps_slime" ],
-    "families": [ "prof_gross_anatomy", "prof_intro_biology", "prof_wp_slime_basic", "prof_wp_slime_advanced" ],
     "harvest": "exempt",
     "special_attacks": [ [ "FORMBLOB", 30 ] ],
     "death_function": {
@@ -60,7 +59,6 @@
     "melee_damage": [ { "damage_type": "cut", "amount": 0 } ],
     "bleed_rate": 20,
     "weakpoint_sets": [ "wps_slime" ],
-    "families": [ "prof_gross_anatomy", "prof_intro_biology", "prof_wp_slime_basic", "prof_wp_slime_advanced" ],
     "harvest": "exempt",
     "special_attacks": [ [ "CALLBLOBS", 0 ] ],
     "death_function": {
@@ -97,7 +95,6 @@
     "melee_damage": [ { "damage_type": "cut", "amount": 0 } ],
     "bleed_rate": 30,
     "weakpoint_sets": [ "wps_slime" ],
-    "families": [ "prof_gross_anatomy", "prof_intro_biology", "prof_wp_slime_basic", "prof_wp_slime_advanced" ],
     "harvest": "exempt",
     "special_attacks": [ [ "FORMBLOB", 20 ] ],
     "death_function": {
@@ -132,7 +129,6 @@
     "melee_dice_sides": 4,
     "melee_damage": [ { "damage_type": "cut", "amount": 0 } ],
     "weakpoint_sets": [ "wps_slime" ],
-    "families": [ "prof_gross_anatomy", "prof_intro_biology", "prof_wp_slime_basic", "prof_wp_slime_advanced" ],
     "harvest": "exempt",
     "death_function": { "message": "The %s's body melts away.", "corpse_type": "NO_CORPSE" },
     "death_drops": "mon_blob_small_deathdrops",
@@ -161,7 +157,6 @@
     "melee_dice_sides": 3,
     "melee_damage": [ { "damage_type": "cut", "amount": 0 } ],
     "weakpoint_sets": [ "wps_slime" ],
-    "families": [ "prof_gross_anatomy", "prof_intro_biology", "prof_wp_slime_basic", "prof_wp_slime_advanced" ],
     "harvest": "exempt",
     "death_drops": "slime_sample_small",
     "special_attacks": [ [ "FORMBLOB", 4 ] ],
@@ -196,7 +191,6 @@
     "vision_day": 16,
     "vision_night": 10,
     "weakpoint_sets": [ "wps_slime" ],
-    "families": [ "prof_gross_anatomy", "prof_intro_biology", "prof_wp_slime_basic", "prof_wp_slime_advanced" ],
     "harvest": "exempt",
     "special_attacks": [ [ "SLIMESPRING", 15 ] ],
     "fear_triggers": [ "FIRE" ],
@@ -234,7 +228,6 @@
     "vision_day": 30,
     "vision_night": 10,
     "weakpoint_sets": [ "wps_slime" ],
-    "families": [ "prof_gross_anatomy", "prof_intro_biology", "prof_wp_slime_basic", "prof_wp_slime_advanced" ],
     "harvest": "exempt",
     "special_attacks": [ { "id": "tentacle", "throw_strength": 10 } ],
     "death_function": {

--- a/data/json/proficiencies/weakpoints.json
+++ b/data/json/proficiencies/weakpoints.json
@@ -327,30 +327,6 @@
   },
   {
     "type": "proficiency",
-    "id": "prof_wp_slime_basic",
-    "category": "prof_weakpoint",
-    "name": { "str": "Slime basic weaknesses" },
-    "description": "After having engaged slimes to a significant extent you have started to get better at exploiting weaknesses in their behavior and, for lack of better terms, \"physiology\".",
-    "can_learn": true,
-    "required_proficiencies": [ "prof_gross_anatomy" ],
-    "time_to_learn": "30 m",
-    "default_weakpoint_bonus": 1,
-    "default_weakpoint_penalty": -2
-  },
-  {
-    "type": "proficiency",
-    "id": "prof_wp_slime_advanced",
-    "category": "prof_weakpoint",
-    "name": { "str": "Slime detailed weaknesses" },
-    "description": "You've probably reached the pinnacle of slime weakness exploitation, but it has taken an enormous amount of combat to acquire it.",
-    "can_learn": true,
-    "time_to_learn": "1 h",
-    "required_proficiencies": [ "prof_wp_slime_basic" ],
-    "default_weakpoint_bonus": 2,
-    "default_weakpoint_penalty": -2
-  },
-  {
-    "type": "proficiency",
     "id": "prof_wp_triffid_basic",
     "category": "prof_weakpoint",
     "name": { "str": "Triffid basic anatomy" },

--- a/data/mods/Magiclysm/monsters/monsters.json
+++ b/data/mods/Magiclysm/monsters/monsters.json
@@ -62,7 +62,6 @@
     "path_settings": { "avoid_traps": true, "avoid_sharp": true },
     "dissect": "dissect_slime_sample_single",
     "weakpoint_sets": [ "wps_slime" ],
-    "families": [ "prof_wp_slime_basic", "prof_wp_slime_advanced" ],
     "death_function": { "corpse_type": "NO_CORPSE", "message": "The %s melts away." },
     "special_attacks": [
       {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Please do not give amorphous blobs without physiology a physiology. It's okay for some things to *not* have discernible weakpoints, not everything needs them. A liquid ooze without discernible organs should not have anatomical weakpoints, and from the conversations among developers "behavior" ties more with skills than with weakpoints, so that's not gonna fly
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
- Remove slime-specific weakpoint proficiencies
- Make slimes no longer give gross anatomy or biology intro because their anatomy and biology is not even remotely comparable to that of earth animals
- Remove organs from slime weakpoints
- Remove the "fragment" weakpoint, not sure what that's even supposed to be about? A weakpoint should include hitting the opponent, not "keeping the separated fragment away long enough"
- Make body hits no longer stagger slimes. It's a liquid, why would it stagger
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
I initially thought I'd be cutting the weakpoint set entirely, but a "hardpoint" of a spot that the slime doesn't care even remotely about is pretty cool and on brand for hitting what is effectively predatory pudding
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
I noticed our plant-specific critters give basic anatomy as well and I am VERY skeptical of that as well. Looks like we were way too generous with dishing proficiencies out
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
