### PR TITLE
Fix name of nested canvas trenchcoats recipe category

### DIFF
--- a/data/json/recipes/nested.json
+++ b/data/json/recipes/nested.json
@@ -423,7 +423,7 @@
     "activity_level": "LIGHT_EXERCISE",
     "category": "CC_*",
     "subcategory": "CSC_*_NESTED",
-    "name": "canvas dusters",
+    "name": "canvas trenchcoats",
     "description": "Recipes related to tailoring long coats from cotton, known as trenchcoats.",
     "skill_used": "tailor",
     "nested_category_data": [ "trenchcoat", "sleeveless_trenchcoat", "sleeveless_trenchcoat_from_trenchcoat" ],


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
There are 2 "canvas dusters" categories, the category for "canvas trenchcoats" was misnamed. 
