### PR TITLE
Remove "u" from Rock Island Armory

### DIFF
--- a/data/json/items/gun/shot.json
+++ b/data/json/items/gun/shot.json
@@ -1052,7 +1052,7 @@
         "id": "vr80",
         "name": { "str": "VR 80" },
         "weight": 575,
-        "description": "The work of Rock Island Armoury, this AR-12-style shotgun affords both the comfort of being similar to a rifle and the ability to use MKA 1919 shotgun magazines."
+        "description": "The work of Rock Island Armory, this AR-12-style shotgun affords both the comfort of being similar to a rifle and the ability to use MKA 1919 shotgun magazines."
       },
       {
         "id": "boss25",


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Remove "u" from Rock Island Armory to fix typo.