### PR TITLE
Fix numerous basic typos in comments and documentation files

### DIFF
--- a/data/mods/BombasticPerks/docs/contributing.md
+++ b/data/mods/BombasticPerks/docs/contributing.md
@@ -15,7 +15,7 @@
 When adding stuff to the mod you should organize your files as follows:
 * the perks (which are implemented as mutations) go in the `perks.json` file.
 * any additional things for your perk: items, effects, spells, EOCs should be gathered in a single file called `[name_of_perk].json` in the `perkdata` folder.
-* perk menu expects a `menu entry` and a `confirmation menu` which go in `perkmenu.json`. These are explained bellow:
+* perk menu expects a `menu entry` and a `confirmation menu` which go in `perkmenu.json`. These are explained below:
 
 ### Menu Entry
 Each perk needs to be selectable in the menu itself. To do this append a response to `TALK_PERK_MENU_MAIN` with the following format:

--- a/data/mods/MindOverMatter/PowerDescriptionSpoilers.md
+++ b/data/mods/MindOverMatter/PowerDescriptionSpoilers.md
@@ -75,7 +75,7 @@ This is natural painkiller and so has natural effects (reduces speed slightly)<b
 <summary><h3>Hardened Skin (C)</h3></summary>
 
 *Difficulty*: 4
-*Duration*: 5 minutes and 56 seconds to 11 minutes and 33 seconds, plus 1 minute 26 seconds to to 4 minutes and 4 seconds per level.<br />
+*Duration*: 5 minutes and 56 seconds to 11 minutes and 33 seconds, plus 1 minute 26 seconds to 4 minutes and 4 seconds per level.<br />
 *Stamina Cost*: 2500, minus 125 per level to a minimum of 750<br />
 *Channeling Time*: 150 moves, minus 8.5 moves per level to a minimum of 50.<br />
 *Effects*: Increases piercing armor by 3, bashing armor by 6, and cutting armor by 4.  Also makes the psion immune to bleeding from wounds received during its duration (previous bleeding is unaffected) and reduces incoming pain by 2% per level.<br />

--- a/data/mods/aftershock_exoplanet/achievements/achievements.json
+++ b/data/mods/aftershock_exoplanet/achievements/achievements.json
@@ -68,7 +68,7 @@
         "event_statistic": "avatar_max_damage",
         "is": ">=",
         "target": 2500,
-        "description": "Recieve 2500 damage in a single attack and survive (optional)."
+        "description": "Receive 2500 damage in a single attack and survive (optional)."
       }
     ]
   },

--- a/data/mods/aftershock_exoplanet/doc/lore/ranged_weapon_balance.md
+++ b/data/mods/aftershock_exoplanet/doc/lore/ranged_weapon_balance.md
@@ -127,7 +127,7 @@ The current ballistic ammo calibres currently exist in the mod:
 | Rail Rod   | Steel rail     |              90   |            40 | Cleanly defeats heavy armor, deals with vehicle armor at a  disadvantage.                                                 |
 
 To balance specialty rounds use the following rule:
-- AP ammo recieves +15 ballistic armor piercing at the cost of -10 damage.
+- AP ammo receives +15 ballistic armor piercing at the cost of -10 damage.
 - Specialty ammo has the damage of AP ammo and the armor piercing capability of the default round + whatever special effect is granted. If the specialty effect is a strong AOE AP might be reduced further.
 
 ### Lasers

--- a/doc/FREQUENTLY_MADE_SUGGESTIONS.md
+++ b/doc/FREQUENTLY_MADE_SUGGESTIONS.md
@@ -154,7 +154,7 @@ Savescumming is not a normal part of the game, and there is no intention of ever
 
 If we allowed every stat to be increased during gameplay by doing [arbitrary timed activity] then a large portion of players would be convinced that they MUST do that on every character. Instead of just... starting with a reasonable amount of stat. And then they optimize fun out of the game, for themselves.
 
-We really do not want to encourage people picking lower starting stats with the idea that they will endlessly grind all of their characters up to some arbitary cap. There is nothing exciting or interesting about pressing the exercise button and watching the bar spin.
+We really do not want to encourage people picking lower starting stats with the idea that they will endlessly grind all of their characters up to some arbitrary cap. There is nothing exciting or interesting about pressing the exercise button and watching the bar spin.
 
 The absolute \#1 concern here is making sure that any implementation is not some hellish grind that looks even remotely attractive. Currently the game assumes you are starting in near-peak physical condition. It specifically and purposefully avoids this meaningless grind by simply letting you have the stats in the first place.
 

--- a/doc/ISSUE_TRIAGE.md
+++ b/doc/ISSUE_TRIAGE.md
@@ -15,7 +15,7 @@
 ## Why triage?
 
 Triage is a process of sanity checking and prioritizing issues. The term is adopted from medical contexts where patients are briefly examined to decide whether they need immediate care, or if their issue can wait until patients at greater risk can be handled first.
-Software issue triage is not life-or-death, but it does adress the same fundamental problem, which is that there is a limited amount of attention and skill that can be brought to bear on issues at any given time, and some issues have higher *impact* than others.
+Software issue triage is not life-or-death, but it does address the same fundamental problem, which is that there is a limited amount of attention and skill that can be brought to bear on issues at any given time, and some issues have higher *impact* than others.
 
 If issues are properly triaged, contributors with time available can focus on getting things done instead of searching through issues for something to work on and fix.
 

--- a/doc/JSON/HELP_MENU.md
+++ b/doc/JSON/HELP_MENU.md
@@ -11,7 +11,7 @@ Each category is made up of a json object which for mods can be placed anywhere 
 | `"type"`     | (required) must be `"help"`                                                                                                                                                                                                                                                                           |
 | `"order"`    | (required) integer, where this category should appear in the list relative to others from the same source, with 0 being first. Must be unique per source (Every mod can start from 0). Each mods categories are appended to the end of the list per their load order.                                 |
 | `"name"`     | (required) string, name of the category, can use [color tags](/doc/user-guides/COLOR.md#color-tags)                                                                                                                                                                                                                  |
-| `"messages"` | (required) array of strings, each string respresents a new line seperated paragraph containing information for this category, can use [color tags](/doc/user-guides/COLOR.md#color-tags) and [keybind tags](#keybind-tags). Seperated mainly for ease of editing the json as `\n` lets you add newlines within strings |
+| `"messages"` | (required) array of strings, each string respresents a new line seperated paragraph containing information for this category, can use [color tags](/doc/user-guides/COLOR.md#color-tags) and [keybind tags](#keybind-tags). Separated mainly for ease of editing the json as `\n` lets you add newlines within strings |
 
 ### Keybind tags
 

--- a/doc/JSON/MAPGEN.md
+++ b/doc/JSON/MAPGEN.md
@@ -93,7 +93,7 @@ Cataclysm creates buildings and terrain on discovery via 'mapgen'; functions spe
 you see in `[m]`ap are also determined by overmap terrain). Overmap terrains ("oter") are defined in
 `overmap_terrain.json`.
 
-By default, an oter has a single built-in mapgen function which matches the '"id"' in it's json entry (examples:
+By default, an oter has a single built-in mapgen function which matches the '"id"' in its json entry (examples:
 "house", "bank", etc). Multiple functions also possible. When a player moves into range of an area marked on the map as
 a house, the game chooses semi-randomly from a list of functions for "house", picks one, and runs it, laying down walls
 and adding items, monsters, rubber chickens and whatnot. This is all done in a fraction of a second (something to keep
@@ -532,7 +532,7 @@ See terrain.json, furniture.json, and trap.json for "id" strings.
 
 | Field  | Description
 | ---    | ---
-| point  | Allowed values: `"terrain"`, `"furniture"`, `"trap"`, `"trap_remove"`, `"item_remove"`, `"field_remove"`, `"radiation"`, `"variable"`, `"creature_remove"`, `"bash"` and `"burn"`. Bash does one guarenteed bash while burn destroys terrain/furniture with FLAMMABLE/FLAMMABLE_HARD/FLAMMABLE_ASH and flammable items.
+| point  | Allowed values: `"terrain"`, `"furniture"`, `"trap"`, `"trap_remove"`, `"item_remove"`, `"field_remove"`, `"radiation"`, `"variable"`, `"creature_remove"`, `"bash"` and `"burn"`. Bash does one guaranteed bash while burn destroys terrain/furniture with FLAMMABLE/FLAMMABLE_HARD/FLAMMABLE_ASH and flammable items.
 | id     | Terrain, furniture, trap ID or the variable's name. Examples: `"id": "f_counter"`, `"id": "tr_beartrap"`. Omit for "radiation", "item_remove", "creature_remove", and "field_remove". For `trap_remove` if tr_null is used any traps present will be removed.
 | x, y   | X, Y coordinates. Value from `0-23`, or range `[ 0-23, 0-23 ]` for a random value in that range. Example: `"x": 12, "y": [ 5, 15 ]`
 | z      | (optional) Z coordinate. Value from `-20 to 20`. The value is *relative* to the Z level nominally modified, cannot have a range, and can only be used for faction camps.

--- a/doc/JSON/MUTATIONS.md
+++ b/doc/JSON/MUTATIONS.md
@@ -39,7 +39,7 @@ Traits and mutations are the same thing in DDA's code. The terms are used interc
 
 There are two substances required to mutate: mutagen and primer. All mutagen and primers are handled as vitamins in the code.
 
-Mutagen is the core nutrient, and it's what is required to initiate and maintain mutation. Thematically, this is the stuff that stimulates the character's infection and gets them mutating. It comes in a ingestable liquid form (which is toxic and generally a bad idea to drink without further refinement) and an injectable catalyst form (which is much safer and much more powerful).
+Mutagen is the core nutrient, and it's what is required to initiate and maintain mutation. Thematically, this is the stuff that stimulates the character's infection and gets them mutating. It comes in an ingestible liquid form (which is toxic and generally a bad idea to drink without further refinement) and an injectable catalyst form (which is much safer and much more powerful).
 
 Primers do not cause mutations to happen on their own, but instead influence what mutations the player gains. Think of mutagen as a car that can only drive on roads, and each type of primer as a possible road for the car to drive on. Every type of mutation category has an associated primer vitamin, and when mutating, the game will mutate down the category that has the most respective primer present. The car can't drive without any roads, but at the same time, the roads will do nothing without the car. Both nutrients are needed to cause mutation.
 
@@ -282,7 +282,7 @@ Specific mutations are extremely versatile. A mutation only needs to have a few 
       "msg_sleep": { "text": "You fall asleep.", "rating": "good" }                 // Message displayed when falling asleep.
     }
   ],
-  "activated_is_setup": true,                 // If this is true the bellow activated EOC runs then the mutation turns on for processing every turn. If this is false the below "activated_eocs" will run and then the mod will turn itself off.
+  "activated_is_setup": true,                 // If this is true the below activated EOC runs then the mutation turns on for processing every turn. If this is false the below "activated_eocs" will run and then the mod will turn itself off.
   "activated_eocs": [ "eoc_id_1" ],           // List of effect_on_conditions that attempt to activate when this mutation is successfully activated.
   "processed_eocs": [ "eoc_id_1" ],           // List of effect_on_conditions that attempt to activate every time (defined above) units of time. Time of 0 means every turn it processes. Processed when the mutation is active for activatable mutations and always for non-activatable ones.
   "deactivated_eocs": [ "eoc_id_1" ],         // List of effect_on_conditions that attempt to activate when this mutation is successfully deactivated.

--- a/doc/JSON/NPCs.md
+++ b/doc/JSON/NPCs.md
@@ -669,7 +669,7 @@ The short format is equivalent to (an unconditional switching of the topic, `eff
 }
 ```
 
-When using a conditional you can specify the response to still appear but be marked as unavailable. This can be done by adding a `failure_explanation` or `failure_topic` in the bellow example if the condition fails `*Didn't have enough: I, the player, say to you...` will be what appears in the responses, and if selected it will instead go to `TALK_EXPLAIN_FAILURE` and wont trigger the other effects:
+When using a conditional you can specify the response to still appear but be marked as unavailable. This can be done by adding a `failure_explanation` or `failure_topic` in the below example if the condition fails `*Didn't have enough: I, the player, say to you...` will be what appears in the responses, and if selected it will instead go to `TALK_EXPLAIN_FAILURE` and wont trigger the other effects:
 ```jsonc
 {
   "condition": "...something...",
@@ -1177,7 +1177,7 @@ Condition | Type | Description
 ## Utility Structures
 
 ### Variable Object
-`variable_object`: This is either an object, a `math` [expression](#math) or array describing a variable name. It can either describe a double, a time duration or a string. If it is an array it must have 2 values the first of which will be a minimum and the second will be a maximum, the value will be randomly between the two. If it is a double `default` is a double which will be the value returned if the variable is not defined. If is it a duration then `default` can be either an int or a string describing a time span. `u_val`, `npc_val`, `context_val`, `var_val` or `global_val` can be the used for the variable name element.  If `u_val` is used it describes a variable on player u, if `npc_val` is used it describes a variable on player npc, if `context_val` is used it describes a variable on the current dialogue context, `var_val` tries to resolve a variable stored in a `context_val` (more explanation bellow), if `global_val` is used it describes a global variable.  If this is a duration `infinite` will be accepted to be a virtually infinite value(it is actually more than a year, if longer is needed a code change to make this a flag or something will be needed).
+`variable_object`: This is either an object, a `math` [expression](#math) or array describing a variable name. It can either describe a double, a time duration or a string. If it is an array it must have 2 values the first of which will be a minimum and the second will be a maximum, the value will be randomly between the two. If it is a double `default` is a double which will be the value returned if the variable is not defined. If it is a duration then `default` can be either an int or a string describing a time span. `u_val`, `npc_val`, `context_val`, `var_val` or `global_val` can be used for the variable name element.  If `u_val` is used it describes a variable on player u, if `npc_val` is used it describes a variable on player npc, if `context_val` is used it describes a variable on the current dialogue context, `var_val` tries to resolve a variable stored in a `context_val` (more explanation below), if `global_val` is used it describes a global variable.  If this is a duration `infinite` will be accepted to be a virtually infinite value(it is actually more than a year, if longer is needed a code change to make this a flag or something will be needed).
 
 Example:
 ```jsonc

--- a/doc/JSON/OPTIONS.md
+++ b/doc/JSON/OPTIONS.md
@@ -6,7 +6,7 @@ DDA has a moderately complex system for recording user preferences about the ope
 
 The load ordering and override behavior has more accreted than been designed, so it's a bit gnarly.
 
-In main(), we init the option manager and initalize options with hard-coded defaults.
+In main(), we init the option manager and initialize options with hard-coded defaults.
 Immediately afterwards we load config/options.json.
 In init(), we load json, including data/core/external_options.json.
 During world load, we load save/world/worldoptions.json.
@@ -15,13 +15,13 @@ Later in world load, we load mods and external options defined there.
 The ordering is important, because at each stage, the previous values can be overwritten.
 
 Options must be defined at either the first stage of hardcoded option enumeration or in an external_option json entry. Options not present in one of these two sources, but present in options.json or worldoptions.json are ignored.
-config/options.json stores most options, and is persistent across seperate game worlds.
+config/options.json stores most options, and is persistent across separate game worlds.
 save/<world>/worldoptions.json stores just a subset of options that are appropriate to change on a per-world basis, and override options specified in options.json when present.
 
-Options are split into "menu options" and "external options", which are usually seperate, but options can be migrated back and forth.
+Options are split into "menu options" and "external options", which are usually separate, but options can be migrated back and forth.
 "menu options" are displayed in an in-game menu for adjustment, and are intended to be adjusted by plyters to tune the game to their liking. Their use is documented within this menu.
-"external options" are mostly intended to be used to expose options to mods that have imact on the game outside the norm for adjustments we expect players to make, though if you have a text editior you can still hve at it. Expected uses for these options are included in their entry in data/core/external_options.json
+"external options" are mostly intended to be used to expose options to mods that have an impact on the game outside the norm for adjustments we expect players to make, though if you have a text editior you can still have at it. Expected uses for these options are included in their entry in data/core/external_options.json
 
 ### Hack for migrating menu options
-In the case when a menu option is migrated to an external option, it is desireable to have already-adjusted world or global options take precedence over the new external option.
-In this case, leave the hard-coded defintion of the option in place in options.cpp, but add the COPT_HIDE flag to the definition to hide it from the menu.  If it is a "world_default" type entry, leave it defined as such.  Then add a redundant entry to data/core/external_options.json with the addition of the "stub": true member, which indicates to the loading code that this entry should not override already-set values.
+In the case when a menu option is migrated to an external option, it is desirable to have already-adjusted world or global options take precedence over the new external option.
+In this case, leave the hard-coded definition of the option in place in options.cpp, but add the COPT_HIDE flag to the definition to hide it from the menu.  If it is a "world_default" type entry, leave it defined as such.  Then add a redundant entry to data/core/external_options.json with the addition of the "stub": true member, which indicates to the loading code that this entry should not override already-set values.

--- a/doc/JSON/OVERMAP.md
+++ b/doc/JSON/OVERMAP.md
@@ -741,9 +741,9 @@ symetrical while binomial can be skewed by altering p to result in most values b
 on the lower end of the range 0-n or vice versa useful to produce more consistent results
 with rarer chances of large or small values or just one kind respectively.  Hard bounds
 may be specified in addition to poisson or binomial to limit the range of possibilities,
-useful for guarenteeing a max of at least 1 or to prevent large values making overall
+useful for guaranteeing a max of at least 1 or to prevent large values making overall
 size management difficult.  To do this add an array `bounds` such as
-`"max": { "poisson": 5, "bounds": [ 1, -1 ] }` in this case guarenteeing at least a max
+`"max": { "poisson": 5, "bounds": [ 1, -1 ] }` in this case guaranteeing at least a max
 of 1 without bounding upper values.  Any value that would fall outside of these bounds
 becomes the relevant bound (as opposed to being rerolled).
 

--- a/doc/JSON/REGION_SETTINGS.md
+++ b/doc/JSON/REGION_SETTINGS.md
@@ -164,7 +164,7 @@ If you wanted to apply the overlay only for regions with a "default" tag:
 }
 ```
 
-Tags are arbitary strings and are only used to avoid referencing a likely-growing number
+Tags are arbitrary strings and are only used to avoid referencing a likely-growing number
 of region_settings ids.
 
 ## Region Terrain / Furniture

--- a/doc/design-balance-lore/lore.md
+++ b/doc/design-balance-lore/lore.md
@@ -139,7 +139,7 @@ When creating a faction in Cataclysm, consider the following:
 
 *    All factions were part of the same overall culture only a few months ago.  We're not at a Mad Max: Fury Road stage yet, and if anyone's acting that way they're probably basing it on a major motion picture.
 *    No faction should be "good".  Everyone is in this for themselves, everyone is scared, everyone's first goal is not being eaten by zombies and their second goal is making it to the next winter.  There is no time for altruism.
-*    No faction should be "evil".  No one is the villain of their own story.  Raiders may not be nice, but they believe they're doing what they need to to survive in this harsh world.
+*    No faction should be "evil".  No one is the villain of their own story.  Raiders may not be nice, but they believe they're doing what they need to do to survive in this harsh world.
 *    Factions should avoid having a single "schtick".  The Free Merchants are merchants who believe in a free market, but that's by far not everything they stand for.  Think about what the average member of your faction does in their day to day life, and remember they can't spend all their time just thinking about how much they like the free market, or cannibalism, or whatever your cool initial idea was.  Expand.
 
 #### Major Factions

--- a/doxygen_doc/doxygen_conf.txt
+++ b/doxygen_doc/doxygen_conf.txt
@@ -333,7 +333,7 @@ MARKDOWN_SUPPORT       = YES
 
 # When enabled doxygen tries to link words that correspond to documented
 # classes, or namespaces to their corresponding documentation. Such a link can
-# be prevented in individual cases by by putting a % sign in front of the word
+# be prevented in individual cases by putting a % sign in front of the word
 # or globally by setting AUTOLINK_SUPPORT to NO.
 
 AUTOLINK_SUPPORT       = YES

--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -714,7 +714,7 @@ int advanced_inventory::print_header( advanced_inventory_pane &pane, aim_locatio
                             data_location <= AIM_NORTHEAST );
         nc_color bcolor = c_red;
         nc_color kcolor = c_red;
-        // Highlight location [#] if it can recieve items,
+        // Highlight location [#] if it can receive items,
         // or highlight container [C] if container mode is active.
         if( can_put_items ) {
             bcolor = in_vehicle ? c_light_blue :

--- a/src/character.h
+++ b/src/character.h
@@ -3495,7 +3495,7 @@ class Character : public Creature, public visitable
         double compute_effective_food_volume_ratio( const item &food ) const;
         /** Used to calculate water and dry volume of a chewed food **/
         std::pair<units::volume, units::volume> masticated_volume( const item &food ) const;
-        /** Used to to display how filling a food is. */
+        /** Used to display how filling a food is. */
         int compute_calories_per_effective_volume( const item &food,
                 const nutrients *nutrient = nullptr ) const;
         /** Handles the effects of consuming an item. Returns false if nothing was consumed */

--- a/src/character_attire.cpp
+++ b/src/character_attire.cpp
@@ -858,7 +858,7 @@ static void layer_item( std::map<bodypart_id, encumbrance_data> &vals, const ite
             // do the sublayers of this armor conflict
             bool conflicts = false;
 
-            // check if we've already added conflict for the layer and body part since each sbp is check individually
+            // check if we've already added conflict for the layer and body part since each sbp is checked individually
             std::map<layer_level, bool> bpcovered;
 
             // add the sublocations to the overall body part layer and update if we are conflicting
@@ -2037,7 +2037,7 @@ std::unordered_set<bodypart_id> outfit::where_discomfort( const Character &guy )
             if( !i.is_bp_rigid_selective( sbp ) && !i.is_bp_comfortable( sbp ) &&
                 i.weight() > units::from_gram( 250 ) ) {
 
-                // need to go through each locations under location to check if its covered, since secondary locations can cover multiple underlying locations
+                // need to go through each locations under location to check if it's covered, since secondary locations can cover multiple underlying locations
                 for( const sub_bodypart_str_id &under_sbp : sbp->locations_under ) {
                     if( covered_sbps.count( under_sbp ) != 1 ) {
                         guy.add_msg_if_player(
@@ -2291,7 +2291,7 @@ void outfit::prepare_bodymap_info( bodygraph_info &info, const bodypart_id &bp,
         }
         info.avg_coverage += temp_coverage;
 
-        // need to do each sub part seperately and then average them if need be
+        // need to do each sub part separately and then average them if need be
         for( const sub_bodypart_id &sbp : sub_parts ) {
             int coverage = armor.get_coverage( sbp );
 

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -1712,7 +1712,7 @@ conditional_t::func f_map_in_city( const JsonObject &jo, std::string_view member
     return [target]( const_dialogue const & d ) {
         tripoint_abs_omt target_pos = project_to<coords::omt>( read_var_value( target, d ).tripoint() );
 
-        // TODO: Remove this in favour of a seperate condition for location z-level that can be used in conjunction with this map_in_city as needed
+        // TODO: Remove this in favour of a separate condition for location z-level that can be used in conjunction with this map_in_city as needed
         if( target_pos.z() < -1 ) {
             return false;
         }

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -1586,7 +1586,7 @@ bool construct::check_support( const tripoint_bub_ms &p )
         }
     }
 
-    //TODO: This doesn't make any sense for the original purpose of check_support and should be seperated
+    //TODO: This doesn't make any sense for the original purpose of check_support and should be separated
 
     // We want to find "walls" below (including windows and doors), but not open rooms and the like.
     if( here.has_flag( ter_furn_flag::TFLAG_SUPPORTS_ROOF, p + tripoint::below ) &&

--- a/src/diary.h
+++ b/src/diary.h
@@ -144,7 +144,7 @@ class diary
 
         /*Uses editor window class to edit the text.*/
         void edit_page_ui( const std::function<catacurses::window()> &create_window );
-        /*set page to be be shown in ui*/
+        /*set page to be shown in ui*/
         int set_opened_page( int pagenum );
         /*create a new page and adds current character progression*/
         void new_page();
@@ -153,7 +153,7 @@ class diary
         /*delite current page*/
         void delete_page();
 
-        /*get opened page nummer*/
+        /*get opened page number*/
         int get_opened_page_num() const;
         /*returns a list with all pages by the its date*/
         std::vector<std::string> get_pages_list() const;
@@ -192,7 +192,7 @@ class diary
         void mission_changes();
         void spell_changes();
 
-        /*expots the diary to a readable .txt file. If its the lastexport, its exportet to memorial otherwise its exportet to the world folder*/
+        /*exports the diary to a readable .txt file. If it's the lastexport, it's exported to memorial otherwise it's exported to the world folder*/
         void export_to_txt( bool lastexport = false );
         /* add a change to the change list, with optional description. returns the index of the new entry.*/
         size_t add_to_change_list( const std::string &entry, const std::string &desc = "" );

--- a/src/item_degrade.cpp
+++ b/src/item_degrade.cpp
@@ -886,14 +886,14 @@ item::armor_status item::damage_armor_durability( damage_unit &du, damage_unit &
     }
     /*
     * Armor damage chance is calculated using the logistics function.
-    *  No matter the damage dealt, an armor piece has at at most 80% chance of being damaged.
+    *  No matter the damage dealt, an armor piece has at most 80% chance of being damaged.
     *  Chance of damage is 40% when the premitigation damage is equal to armor*1.333
     *  Sturdy items will not take damage if premitigation damage isn't higher than armor*1.333.
     *
     *  Non fragile items are considered to always have at least 10 points of armor, this is to prevent
     *  regular clothes from exploding into ribbons whenever you get punched.
     *
-    *  Fragile items have have a smaller growth rate for damage chance (k) and are more likely to be damaged
+    *  Fragile items have a smaller growth rate for damage chance (k) and are more likely to be damaged
     *  even at low damage absorbed.
     */
     armors_own_resist = has_flag( flag_FRAGILE ) ? armors_own_resist * 0.6666 : std::max( 10.0,

--- a/src/itype.cpp
+++ b/src/itype.cpp
@@ -390,7 +390,7 @@ bool armor_portion_data::should_consolidate( const armor_portion_data &l,
 int armor_portion_data::calc_encumbrance( units::mass weight, bodypart_id bp ) const
 {
     // this function takes some fixed points for mass to encumbrance and interpolates them to get results for head encumbrance
-    // TODO: Generalize this for other body parts (either with a modifier or seperated point graphs)
+    // TODO: Generalize this for other body parts (either with a modifier or separated point graphs)
     // TODO: Handle distributed weight
 
     int encumbrance = 0;
@@ -404,7 +404,7 @@ int armor_portion_data::calc_encumbrance( units::mass weight, bodypart_id bp ) c
         return 100;
     }
 
-    // get the bound bellow our given weight
+    // get the bound below our given weight
     --itt;
 
     std::map<units::mass, int>::iterator next_itt = std::next( itt );
@@ -435,7 +435,7 @@ int armor_portion_data::calc_encumbrance( units::mass weight, bodypart_id bp ) c
     // modify by flat
     encumbrance += additional_encumbrance;
 
-    // cap encumbrance at at least 1
+    // cap encumbrance at least 1
     return std::max( encumbrance, 1 );
 }
 

--- a/src/itype.h
+++ b/src/itype.h
@@ -392,7 +392,7 @@ struct armor_portion_data {
     // if this item only conflicts with rigid items that share a direct layer with it
     bool rigid_layer_only = false;
 
-    // if this item is comfortable to wear without other items bellow it
+    // if this item is comfortable to wear without other items below it
     bool comfortable = false; // NOLINT(cata-serialize)
 
     /**

--- a/src/mapdata.h
+++ b/src/mapdata.h
@@ -103,8 +103,8 @@ struct map_fd_bash_info : map_common_bash_info {
 };
 struct map_deconstruct_skill {
     skill_id id; // Id of skill to increase on successful deconstruction
-    int min; // Minimum level to recieve xp
-    int max; // Level cap after which no xp is recieved but practise still occurs delaying rust
+    int min; // Minimum level to receive xp
+    int max; // Level cap after which no xp is received but practise still occurs delaying rust
     double multiplier; // Multiplier of the base xp given that's calced using the mean of the min and max
 };
 struct map_common_deconstruct_info {

--- a/src/mutation.h
+++ b/src/mutation.h
@@ -256,13 +256,13 @@ struct mutation_branch {
         /**Species ignoring character with the mutation*/
         std::vector<species_id> ignored_by;
 
-        /**Map of angered species and there intensity*/
+        /**Map of angered species and their intensity*/
         std::map<species_id, int> anger_relations;
 
         std::vector<species_id> empathize_with;
         std::vector<species_id> no_empathize_with;
 
-        /**List of material required for food to be be edible*/
+        /**List of material required for food to be edible*/
         std::set<material_id> can_only_eat;
 
         /**List of healing items allowed*/

--- a/src/npc.h
+++ b/src/npc.h
@@ -176,7 +176,7 @@ enum npc_mission : int {
     NPC_MISSION_LEGACY_3,
 
     NPC_MISSION_GUARD_ALLY, // Assigns an allied NPC to guard a position
-    NPC_MISSION_GUARD, // Assigns an non-allied NPC to remain in place
+    NPC_MISSION_GUARD, // Assigns a non-allied NPC to remain in place
     NPC_MISSION_GUARD_PATROL, // Assigns a non-allied NPC to guard and investigate
     NPC_MISSION_ACTIVITY, // Perform a player_activity until it is complete
     NPC_MISSION_TRAVELLING
@@ -1351,7 +1351,7 @@ class npc : public Character
         tripoint_bub_ms wanted_item_pos; // The square containing an item we want
         // These are the coordinates that a guard will return to inside of their goal tripoint
         std::optional<tripoint_abs_ms> guard_pos;
-        // This is the spot the NPC wants to move to to sit and relax.
+        // This is the spot the NPC wants to move to sit and relax.
         std::optional<tripoint_abs_ms> chair_pos;
         std::optional<tripoint_abs_omt> base_location; // our faction base location in OMT coords.
         /**

--- a/src/overmap.h
+++ b/src/overmap.h
@@ -637,7 +637,7 @@ class overmap
          * When monsters despawn during map-shifting they will also be added here.
          * map::spawn_monsters will load them and place them into the reality bubble
          * (adding it to the creature tracker and putting it onto the map).
-         * This stores each submap worth of monsters in a seperate tree.
+         * This stores each submap worth of monsters in a separate tree.
          */
         horde_map hordes;
 
@@ -953,12 +953,12 @@ struct oter_display_options {
     bool hilite_mission = false;
     // Draw the PC location with `hilite()` (blue bg-ish) on terrain at loc instead of '@'
     bool hilite_pc = false;
-    // If false, and there is a mission, draw an an indicator towards the mission target on an edge
+    // If false, and there is a mission, draw an indicator towards the mission target on an edge
     bool mission_inbounds = true;
     // Darken explored tiles
     bool show_explored = true;
     bool showhordes = true;
-    // Hilight oters revealed by map use
+    //Highlight others revealed by map use
     bool show_map_revealed = false;
     // Draw anything for the PC (assumed to be at center)
     bool show_pc = true;

--- a/src/overmap_water.cpp
+++ b/src/overmap_water.cpp
@@ -774,7 +774,7 @@ void overmap::build_river_shores( const std::vector<const overmap *> &neighbor_o
         };
 
         if( mask == 15 ) {
-            // Trim corners if neccessary
+            // Trim corners if necessary
             // We assume if corner are not inbounds then we are placed because of neighbouring overmap river
             const std::array<oter_str_id, 4> trimmed_corner_ters = { oter_river_c_not_ne, oter_river_c_not_se, oter_river_c_not_sw, oter_river_c_not_nw };
             for( int i = 0; i < 4; i++ ) {

--- a/src/sdlsound.cpp
+++ b/src/sdlsound.cpp
@@ -783,7 +783,7 @@ struct sound_effect_handler {
                     low_index = 0; // (low_index can often equal high_index so it might require the same treatment)
                 }
 
-                // have to handle each ear seperately for stereo audio
+                // have to handle each ear separately for stereo audio
                 for( int ear_offset = 0; ear_offset < 4;
                      ear_offset += 2 ) {
                     sample low_value;
@@ -1052,7 +1052,7 @@ void load_soundset()
     std::string current_soundpack = get_option<std::string>( "SOUNDPACKS" );
     cata_path soundpack_path;
 
-    // Get current soundpack and it's directory path.
+    // Get current soundpack and its directory path.
     if( current_soundpack.empty() ) {
         dbg( D_ERROR ) << "Soundpack not set in options or empty.";
         soundpack_path = default_path;

--- a/src/subbodypart.h
+++ b/src/subbodypart.h
@@ -61,7 +61,7 @@ struct sub_body_part_type {
 
     // the locations that are under this location
     // used with secondary locations to define what sublocations
-    // exist bellow them for things like discomfort
+    // exist below them for things like discomfort
     std::vector<sub_bodypart_str_id> locations_under;
 
     // These subparts act like this limb for armor coverage

--- a/tests/battery_density_test.cpp
+++ b/tests/battery_density_test.cpp
@@ -44,7 +44,7 @@ static const std::map<itype_id, std::string> battery_to_chemistry = {
     {itype_id( "battery_motorbike" ), "Lead-acid"},
     {itype_id( "battery_motorbike_small" ), "Lead-acid"},
 
-    // These are in a seperate group because the car batteries might
+    // These are in a separate group because the car batteries might
     // end up being switched to something different.
     {itype_id( "large_storage_battery" ), "LiON"},
     {itype_id( "medium_storage_battery" ), "LiON"},
@@ -83,7 +83,7 @@ static const std::map<itype_id, std::string> battery_to_chemistry = {
 // Zinc-Manganese Dioxide
 // https://en.wikipedia.org/wiki/Energy_density_Extended_Reference_Table
 
-// Lithium/Iron Disulfide gravimetric energy density is picked from enerizer documentation
+// Lithium/Iron Disulfide gravimetric energy density is picked from Energizer documentation
 // https://data.energizer.com/pdfs/lithiuml91l92_appman.pdf
 // Volumetric is a lower bound from this article (560 Wh/L), rounded up to 600
 // https://www.sciencedirect.com/science/article/abs/pii/S2590116819300104

--- a/tests/coverage_test.cpp
+++ b/tests/coverage_test.cpp
@@ -317,7 +317,7 @@ TEST_CASE( "vest_with_plate_coverage", "[coverage]" )
 
 TEST_CASE( "Off_Limb_Ghost_ablative_vest", "[coverage]" )
 {
-    SECTION( "Ablative not covered seperate limb" ) {
+    SECTION( "Ablative not covered separate limb" ) {
         item full = item( itype_test_ghost_vest );
         full.force_insert_item( item( itype_test_plate_skirt_super ), pocket_type::CONTAINER );
 

--- a/tests/horde_map_test.cpp
+++ b/tests/horde_map_test.cpp
@@ -58,7 +58,7 @@ static void place_monster_as_entity( horde_map &test_horde, monster &mon )
  * The main things to test here are the automatic filtering based on monster attributes and
  * simple round-tripping.
  * Specifically dormant monsters, idle monsters (with no current destination) and
- * active monsters (that DO have a current destination) are handled seperately.
+ * active monsters (that DO have a current destination) are handled separately.
 */
 TEST_CASE( "horde_map_insertion_and_retrieval", "[hordes]" )
 {

--- a/tests/nest_conditional_placement_test.cpp
+++ b/tests/nest_conditional_placement_test.cpp
@@ -23,7 +23,7 @@ static const ter_str_id ter_t_linoleum_white( "t_linoleum_white" ); //Signifies 
 //Check unconditional nests place and that each nest condition works as intended
 TEST_CASE( "nest_conditional_placement", "[map][nest]" )
 {
-    //Create a fresh overmap with no specials to guarentee no preexisting joins. Placed at an arbitary point so it doesn't overwrite other tests overmaps
+    //Create a fresh overmap with no specials to guarantee no preexisting joins. Placed at an arbitrary point so it doesn't overwrite other tests overmaps
     const point_abs_om overmap_point( 122, 122 );
     const std::vector<const overmap_special *> empty_specials;
     overmap_special_batch empty_special_batch( overmap_point, empty_specials );
@@ -37,7 +37,7 @@ TEST_CASE( "nest_conditional_placement", "[map][nest]" )
     const om_direction::type dir = om_direction::type::north;
     const city cit;
 
-    //Add land to guarentee mutable placement
+    //Add land to guarantee mutable placement
     for( int i = -1; i < 2; i++ ) {
         for( int j = -1; j < 2; j++ ) {
             tripoint_rel_omt offset( i, j, 0 );


### PR DESCRIPTION
#### Summary
Bugfixes "Fix numerous basic typos in comments and documentation files"

#### Purpose of change
Quite a lot of CDDA's files comments and documentation are ancient and have been built upon over the years or have been left untouched for quite a while. To improve readability and understanding for new devs I have gone over quite a lot of CDDA's comments and docs and found numerous basic typos and repeated words. 

#### Describe the solution

Corrected basic typos and repeated words as I found them. Fixed one typo in an achievement description.

#### Describe alternatives you've considered

Rewriting comments sections for old code, contacting devs to make better documentation. 

#### Testing

Proofread my grammar changes and used GitHub's automated tests. I did not compile, with so many changes, it could be possible that existing syntax or memory errors in the files changed could have been immeasurably affected. 

#### Additional context

Perhaps each stable release should come with a campaign to proofread English and make sure all documentation gets eyeballs
