### PR TITLE
Remove 0 weight entries from monstergroups

### DIFF
--- a/data/json/monstergroups/bugs.json
+++ b/data/json/monstergroups/bugs.json
@@ -6,7 +6,6 @@
     "monsters": [
       { "monster": "mon_ant_larva", "weight": 40, "cost_multiplier": 0 },
       { "monster": "mon_ant_soldier", "weight": 90, "cost_multiplier": 5 },
-      { "monster": "mon_ant_queen", "weight": 0, "cost_multiplier": 0 },
       { "monster": "mon_ant_small", "weight": 870, "cost_multiplier": 0 }
     ]
   },
@@ -30,7 +29,6 @@
     "monsters": [
       { "monster": "mon_ant_acid_larva", "weight": 35, "cost_multiplier": 0 },
       { "monster": "mon_ant_acid_soldier", "weight": 100, "cost_multiplier": 5 },
-      { "monster": "mon_ant_acid_queen", "weight": 0, "cost_multiplier": 0 },
       { "monster": "mon_ant_acid_small", "weight": 865, "cost_multiplier": 0 }
     ]
   },

--- a/data/json/monstergroups/fungi.json
+++ b/data/json/monstergroups/fungi.json
@@ -8,12 +8,7 @@
       { "monster": "mon_fungaloid", "weight": 400, "cost_multiplier": 0 },
       { "monster": "mon_fungaloid_shambler", "weight": 200, "cost_multiplier": 0 },
       { "monster": "mon_fungaloid_young", "weight": 200, "cost_multiplier": 0 },
-      { "monster": "mon_whisper_fungus", "weight": 10, "cost_multiplier": 0 },
-      { "monster": "mon_zombie_fungus", "weight": 0, "cost_multiplier": 0 },
-      { "monster": "mon_boomer_fungus", "weight": 0, "cost_multiplier": 0 },
-      { "monster": "mon_zombie_child_fungus", "weight": 0, "cost_multiplier": 0 },
-      { "monster": "mon_fungal_wall", "weight": 0, "cost_multiplier": 0 },
-      { "monster": "mon_fungaloid_queen", "weight": 0, "cost_multiplier": 0 }
+      { "monster": "mon_whisper_fungus", "weight": 10, "cost_multiplier": 0 }
     ]
   },
   {
@@ -37,9 +32,7 @@
       { "monster": "mon_zombie_fungus", "weight": 75, "cost_multiplier": 0 },
       { "monster": "mon_boomer_fungus", "weight": 50, "cost_multiplier": 0 },
       { "monster": "mon_zombie_child_fungus", "weight": 50, "cost_multiplier": 0 },
-      { "monster": "mon_whisper_fungus", "weight": 10, "cost_multiplier": 0 },
-      { "monster": "mon_fungal_hedgerow", "weight": 0, "cost_multiplier": 0 },
-      { "monster": "mon_fungaloid_tower", "weight": 0, "cost_multiplier": 0 }
+      { "monster": "mon_whisper_fungus", "weight": 10, "cost_multiplier": 0 }
     ]
   },
   {
@@ -53,8 +46,7 @@
       { "monster": "mon_zombie_fungus", "weight": 100, "cost_multiplier": 0 },
       { "monster": "mon_boomer_fungus", "weight": 50, "cost_multiplier": 0 },
       { "monster": "mon_zombie_child_fungus", "weight": 50, "cost_multiplier": 0 },
-      { "monster": "mon_whisper_fungus", "weight": 10, "cost_multiplier": 0 },
-      { "monster": "mon_fungaloid_seeder", "weight": 0, "cost_multiplier": 0 }
+      { "monster": "mon_whisper_fungus", "weight": 10, "cost_multiplier": 0 }
     ]
   },
   {

--- a/data/json/monstergroups/kraken.json
+++ b/data/json/monstergroups/kraken.json
@@ -6,7 +6,6 @@
     "monsters": [
       { "monster": "mon_octupus_stalker_spawn", "weight": 40, "cost_multiplier": 0 },
       { "monster": "mon_kraken_guard", "weight": 90, "cost_multiplier": 5 },
-      { "monster": "mon_kraken_queen", "weight": 0, "cost_multiplier": 0 },
       { "monster": "mon_octupus_stalker", "weight": 870, "cost_multiplier": 0 }
     ]
   },

--- a/data/json/monstergroups/military.json
+++ b/data/json/monstergroups/military.json
@@ -9,7 +9,6 @@
       { "monster": "mon_dispatch", "weight": 10, "cost_multiplier": 50 },
       { "monster": "mon_dispatch_military", "weight": 5, "cost_multiplier": 80 },
       { "monster": "mon_talon_m202a1", "weight": 15, "cost_multiplier": 50 },
-      { "monster": "mon_zombie_military_pilot", "weight": 0 },
       { "monster": "mon_feral_soldier", "weight": 15 }
     ]
   },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
While working on #83559 I noticed we have 0 weight entries in some vanilla monstergroups, which does absolutely nothing except clutter the JSON
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
