### PR TITLE
Remove region overlays

### DIFF
--- a/data/mods/Magiclysm/worldgen/regional_overlay.json
+++ b/data/mods/Magiclysm/worldgen/regional_overlay.json
@@ -113,7 +113,6 @@
     "type": "map_extra_collection",
     "id": "forest_thick",
     "copy-from": "forest_thick",
-    "overlay_id": "forest_thick",
     "extend": { "extras": [ [ "mx_catoblepas_lair", 1 ] ] }
   },
   {

--- a/data/mods/railroads/region_overlay.json
+++ b/data/mods/railroads/region_overlay.json
@@ -1,8 +1,8 @@
 [
   {
-    "type": "region_overlay",
-    "id": "default_railroads",
-    "apply_to_tags": [ "all" ],
+    "type": "region_settings",
+    "id": "default",
+    "copy-from": "default",
     "highways": null,
     "place_railroads": true,
     "place_railroads_before_roads": true

--- a/doc/JSON/REGION_SETTINGS.md
+++ b/doc/JSON/REGION_SETTINGS.md
@@ -15,7 +15,6 @@ see their info later in this document.
 | ------------------------ | ----------------------------------- | --------------------------------------------------------------------- |
 | `type`                   |                                     | Type identifier. Must be "region_settings".                           |
 | `id`                     |                                     | Unique identifier for this region.                                    |
-| `tags`                   | array of string                     | An arbitrary list of tags for overlays to apply to.                   |
 | `place_swamps`           | boolean                             | Controls whether or not swamps will be placed (requires forests to be placed) |
 | `place_roads`            | boolean                             | Whether or not to generate road connections |
 | `place_railroads`        | boolean                             | Whether or not to generate railroad connections |
@@ -67,105 +66,11 @@ see their info later in this document.
   },
 ```
 
-# Region Overlay
+# Modifying a Region
 
-Loading `region_settings` poses an issue: what if we only want to add a map extra to 
-a set of regions instead of redefining the entire `region_settings` object? We can `copy-from`,
-but if more than one mod is loaded, we would have multiple separate `region_settings` objects
-but only one region available to use for the world.
+The region settings sub-objects and the top-level region settings object can be modified with copy-from. By convention, the 'default' id is used for regions that resemble the real world, and the objects with that id can be modified to change how the world generates.
 
-We get around these issues by using a `region_overlay`.
-
-A `region_overlay` is capable of extending the following types:
-- `region_settings_city`
-- `region_settings_highway`
-- `region_settings_forest_trail`
-- `region_settings_terrain_furniture`
-- `region_settings_map_extras`*
-- `region_settings_forest_composition`* 
-
-NOTE: the types with asterisks have collections of other types that must 
-be extended separately using "overlay_id". These types are:
-
-- `map_extra_collection`
-- `forest_biome`
-- `forest_biome_component`
-
-Study the below examples carefully; they are subtly different.
-
-The following example will append city building "dinozoo" to all 
-`region_settings_city` parks in all regions.
-
-### Example
-```jsonc
-{
-    "type": "region_overlay",
-    "id": "default_dinomod",
-	"apply_to_tags": [ "all" ],
-    "cities": "default_dinomod"
-},
-{
-    "type": "region_settings_city",
-    "id": "default_dinomod",
-    "parks": [ [ "dinozoo", 25 ] ]
-}
-```
-
-The following example will append the map extra *collections* in "default_crazy" 
-to map extra *collections* in all regions.
-### Example
-```jsonc
-{
-    "type": "region_overlay",
-    "id": "default_crazy",
-    "apply_to_tags": [ "all" ],
-    "map_extras": "default_crazy"
-},
-{
-    "type": "region_settings_map_extras",
-    "id": "default_crazy",
-    "extras": [ "forest_crazy" ]
-},
-{
-    "type": "map_extra_collection",
-    "id": "forest_crazy",
-    "extras": [ [ "mx_shia", 1 ] ]
-}
-```
-
-By adding "overlay_id": "forest" to the `map_extra_collection`, the above example would
-extend `map_extra_collection` "id": "forest", spawning "mx_shia" along with the
-other map extras in "forest".
-
-### Example
-```jsonc
-{
-    "type": "map_extra_collection",
-    "id": "forest_crazy",
-	"overlay_id": "forest",
-    "extras": [ [ "mx_shia", 1 ] ]
-}
-```
-
-### Tags
-
-The "apply_to_tags" field will apply the overlay to any `region_settings` with
-matching `tags`. Currently, using the tag "all" will apply the overlay to all regions:
-```jsonc
-{
-    "apply_to_tags": [ "all" ],
-}
-```
-
-If you wanted to apply the overlay only for regions with a "default" tag:
-```jsonc
-{
-    "apply_to_tags": [ "default" ],
-}
-```
-
-Tags are arbitrary strings and are only used to avoid referencing a likely-growing number
-of region_settings ids.
+Mods which aim to not be set in the real world (Aftershock, Isolation Protocol) use default region settings with different ids.
 
 ## Region Terrain / Furniture
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -435,7 +435,6 @@ void DynamicDataLoader::initialize()
     add( "map_extra_collection",
          &map_extra_collection::load_map_extra_collection );
     add( "region_settings", &region_settings::load_region_settings );
-    add( "region_overlay", &region_overlay::load_region_overlay_new );
 
     add( "ITEM_BLACKLIST", []( const JsonObject & jo ) {
         item_controller->load_item_blacklist( jo );
@@ -729,7 +728,6 @@ void DynamicDataLoader::unload_data()
     forest_biome_mapgen::reset();
     map_extra_collection::reset();
     region_settings::reset();
-    region_overlay::reset();
     reset_monster_adjustment();
     recipe_dictionary::reset();
     recipe_group::reset();
@@ -892,7 +890,6 @@ void DynamicDataLoader::finalize_loaded_data()
             { _( "Proficiency Categories" ), &proficiency_category::finalize_all },
             { _( "Qualities" ), &quality::finalize_all },
             { _( "Recipe Groups" ), &recipe_group::finalize },
-            { _( "Region Overlays" ), &region_overlay::finalize_all },
             { _( "Region Settings" ), &region_settings::finalize_all },
             { _( "Relic Procedural Generations" ), &relic_procgen_data::finalize_all },
             { _( "Speed Descriptions" ), &speed_description::finalize_all },

--- a/src/regional_settings.cpp
+++ b/src/regional_settings.cpp
@@ -55,7 +55,6 @@ generic_factory<forest_biome_component> forest_biome_feature_factory( "forest_bi
 generic_factory<forest_biome_mapgen> forest_biome_mapgen_factory( "forest_biome_mapgen" );
 generic_factory<map_extra_collection> map_extra_collection_factory( "map_extra_collection" );
 generic_factory<region_settings> region_settings_factory( "region_settings_new" );
-generic_factory<region_overlay> region_overlay_factory( "region_overlay" );
 } // namespace
 
 /** OBJ */
@@ -133,11 +132,6 @@ template<>
 const region_settings &string_id<region_settings>::obj() const
 {
     return region_settings_factory.obj( *this );
-}
-template<>
-const region_overlay &string_id<region_overlay>::obj() const
-{
-    return region_overlay_factory.obj( *this );
 }
 template<>
 const map_extra_collection &string_id<map_extra_collection>::obj() const
@@ -226,11 +220,6 @@ bool string_id<region_settings>::is_valid() const
 {
     return region_settings_factory.is_valid( *this );
 }
-template<>
-bool string_id<region_overlay>::is_valid() const
-{
-    return region_overlay_factory.is_valid( *this );
-}
 
 /** INIT LOAD */
 void region_settings_river::load_region_settings_river( const JsonObject &jo,
@@ -313,11 +302,6 @@ void region_settings::load_region_settings( const JsonObject &jo,
 {
     region_settings_factory.load( jo, src );
 }
-void region_overlay::load_region_overlay_new( const JsonObject &jo,
-        const std::string &src )
-{
-    region_overlay_factory.load( jo, src );
-}
 
 /** UNLOAD (RESET) */
 void region_settings_river::reset()
@@ -384,10 +368,6 @@ void region_settings::reset()
 {
     region_settings_factory.reset();
 }
-void region_overlay::reset()
-{
-    region_overlay_factory.reset();
-}
 
 template<typename T>
 void read_and_set_or_throw( const JsonObject &jo, const std::string &member, T &target,
@@ -405,7 +385,6 @@ void read_and_set_or_throw( const JsonObject &jo, const std::string &member, T &
 
 void forest_biome_component::load( const JsonObject &jo, std::string_view )
 {
-    optional( jo, was_loaded, "overlay_id", overlay_id );
     weighted_string_id_reader<ter_furn_id, int> ter_furn_reader( 1 );
     optional( jo, was_loaded, "chance", chance );
     optional( jo, was_loaded, "sequence", sequence );
@@ -421,7 +400,6 @@ void forest_biome_terrain_dependent_furniture_new::deserialize( const JsonObject
 void forest_biome_mapgen::load( const JsonObject &jo, std::string_view )
 {
 
-    optional( jo, was_loaded, "overlay_id", overlay_id );
     optional( jo, was_loaded, "terrains", terrains, string_id_reader<oter_type_t> {} );
     optional( jo, was_loaded, "sparseness_adjacency_factor", sparseness_adjacency_factor );
     optional( jo, was_loaded, "item_group", item_group );
@@ -431,24 +409,6 @@ void forest_biome_mapgen::load( const JsonObject &jo, std::string_view )
     optional( jo, was_loaded, "components", biome_components, string_id_reader<forest_biome_component> {} );
     optional( jo, was_loaded, "groundcover", groundcover, ter_reader );
     optional( jo, was_loaded, "terrain_furniture", terrain_dependent_furniture );
-}
-
-forest_biome_mapgen &forest_biome_mapgen::operator+=( const forest_biome_mapgen &rhs )
-{
-    for( const oter_type_str_id &ter_copy : rhs.terrains ) {
-        terrains.emplace( ter_copy );
-    }
-    for( const forest_biome_component_id &fbf : rhs.biome_components ) {
-        apply_region_overlay<forest_biome_component>( biome_components, fbf );
-    }
-    for( const std::pair<ter_id, int> &pr : rhs.groundcover ) {
-        groundcover.try_add( pr );
-    }
-    for( const std::pair<const int_id<ter_t>, forest_biome_terrain_dependent_furniture_new> &tdf_pr :
-         rhs.terrain_dependent_furniture ) {
-        terrain_dependent_furniture.emplace( tdf_pr.first, tdf_pr.second );
-    }
-    return *this;
 }
 
 void region_settings_forest_mapgen::load( const JsonObject &jo, std::string_view )
@@ -473,18 +433,6 @@ void region_settings_feature_flag::deserialize( const JsonObject &jo )
 {
     optional( jo, was_loaded, "blacklist", blacklist );
     optional( jo, was_loaded, "whitelist", whitelist );
-}
-
-region_settings_feature_flag &region_settings_feature_flag::operator+=
-( const region_settings_feature_flag &rhs )
-{
-    for( const std::string &bl_copy : rhs.blacklist ) {
-        blacklist.emplace( bl_copy );
-    }
-    for( const std::string &wl_copy : rhs.whitelist ) {
-        whitelist.emplace( wl_copy );
-    }
-    return *this;
 }
 
 void region_settings_forest::load( const JsonObject &jo, std::string_view )
@@ -614,56 +562,12 @@ void region_settings_terrain_furniture::load( const JsonObject &jo, std::string_
     optional( jo, was_loaded, "ter_furn", ter_furn, auto_flags_reader<region_terrain_furniture_id> {} );
 }
 
-region_settings_terrain_furniture &region_settings_terrain_furniture::operator+=
-( const region_settings_terrain_furniture &rhs )
-{
-    for( const region_terrain_furniture_id &rtf : rhs.ter_furn ) {
-        /**
-        * This is a copy of the templated apply_region_overlay
-        * it is necessary because terrain_furniture objects don't map with an overlay_id
-        */
-        furn_id f_overlay( rtf->replaced_furn_id );
-        ter_id t_overlay( rtf->replaced_ter_id );
-        bool valid_furniture = !f_overlay.id().is_null();
-        bool valid_terrain = !t_overlay.id().is_null();
-        auto predicate = [&valid_terrain, &valid_furniture, &f_overlay,
-                        &t_overlay]( const region_terrain_furniture_id & this_rtf ) {
-            if( valid_furniture ) {
-                return this_rtf->replaced_furn_id == f_overlay;
-            }
-            if( valid_terrain ) {
-                return this_rtf->replaced_ter_id == t_overlay;
-            }
-            return false;
-        };
-        auto find_collection = std::find_if( ter_furn.begin(), ter_furn.end(), predicate );
-        //found existing regional terrain/furniture, combine the objects
-        //if there isn't an existing ter/furn, we can't assume it should be added
-        if( find_collection != ter_furn.end() ) {
-            const_cast<region_terrain_furniture &>( find_collection->obj() ) += *rtf;
-        }
-    }
-    return *this;
-}
-
 void region_terrain_furniture::load( const JsonObject &jo, std::string_view )
 {
     optional( jo, was_loaded, "ter_id", replaced_ter_id );
     optional( jo, was_loaded, "furn_id", replaced_furn_id );
     optional( jo, was_loaded, "replace_with_terrain", terrain, ter_reader );
     optional( jo, was_loaded, "replace_with_furniture", furniture, furn_reader );
-}
-
-region_terrain_furniture &region_terrain_furniture::operator+=( const region_terrain_furniture
-        &rhs )
-{
-    for( const std::pair<ter_id, int> &pr : rhs.terrain ) {
-        terrain.try_add( pr );
-    }
-    for( const std::pair<furn_id, int> &pr : rhs.furniture ) {
-        furniture.try_add( pr );
-    }
-    return *this;
 }
 
 void region_settings_city::load( const JsonObject &jo, std::string_view )
@@ -697,14 +601,12 @@ std::set<map_extra_id> region_settings_map_extras::get_all_map_extras() const
 void map_extra_collection::load( const JsonObject &jo, std::string_view )
 {
     optional( jo, was_loaded, "chance", chance );
-    optional( jo, was_loaded, "overlay_id", overlay_id );
     weighted_string_id_reader<map_extra_id, int> extras_reader( 1 );
     optional( jo, was_loaded, "extras", values, extras_reader );
 }
 
 void region_settings::load( const JsonObject &jo, std::string_view )
 {
-    optional( jo, was_loaded, "tags", tags, auto_flags_reader{} );
     optional( jo, was_loaded, "default_oter", default_oter );
 
     optional( jo, was_loaded, "default_groundcover", default_groundcover, ter_reader );
@@ -766,64 +668,6 @@ void region_settings::finalize_all()
     if( !DEFAULT_REGION.is_valid() ) {
         debugmsg( "id: `default` region settings were not loaded or failed to load" );
     }
-}
-
-template<typename T>
-static void extend_settings( const std::optional<string_id<T>> &lhs,
-                             const std::optional<string_id<T>> &rhs )
-{
-    if( !rhs.has_value() || !rhs.value().is_valid() ) {
-        return;
-    }
-    // gross const casts
-    // the extend really should happen in the types, not here...
-    if( !lhs.has_value() ) {
-        const_cast<std::optional<string_id<T>> &>( lhs ) = rhs;
-        return;
-    }
-    const_cast<T &>( *lhs.value() ) += *rhs.value();
-}
-
-region_settings &region_settings::operator+=( const region_settings &rhs )
-{
-    extend_settings( city_spec, rhs.city_spec );
-    extend_settings( overmap_highway, rhs.overmap_highway );
-    extend_settings( forest_trail, rhs.forest_trail );
-    if( rhs.region_extras.is_valid() ) {
-        const_cast<region_settings_map_extras &>( *region_extras ) += *rhs.region_extras;
-    }
-    if( rhs.region_terrain_and_furniture.is_valid() ) {
-        const_cast<region_settings_terrain_furniture &>( *region_terrain_and_furniture ) +=
-            *rhs.region_terrain_and_furniture;
-    }
-    if( rhs.forest_composition.is_valid() ) {
-        const_cast<region_settings_forest_mapgen &>( *forest_composition ) += *rhs.forest_composition;
-    }
-    return *this;
-}
-
-void region_overlay::finalize()
-{
-    for( region_settings &region : region_settings_factory.get_all_mod() ) {
-        for( const std::string &tag : apply_to_tags ) {
-            if( apply_to_tags.count( "all" ) > 0 ||
-                std::find( region.tags.begin(), region.tags.end(), tag ) != region.tags.end() ) {
-                region += overlay;
-                break;
-            }
-        }
-    }
-}
-
-void region_overlay::finalize_all()
-{
-    region_overlay_factory.finalize();
-}
-
-void region_overlay::load( const JsonObject &jo, std::string_view )
-{
-    overlay.load( jo, std::string_view() );
-    optional( jo, false, "apply_to_tags", apply_to_tags );
 }
 
 void groundcover_extra::finalize()   // FIXME: return bool for failure

--- a/src/regional_settings.h
+++ b/src/regional_settings.h
@@ -48,32 +48,7 @@ class building_bin
             buildings.deserialize( jv );
         }
         weighted_int_list<overmap_special_id> buildings;
-        building_bin &operator+=( const building_bin &rhs ) {
-            for( const std::pair< overmap_special_id, int> &pr : rhs.buildings ) {
-                buildings.try_add( pr );
-            }
-            return *this;
-        }
 };
-
-/**
-* Applies the object to a string_id set by combining it with an already-existing string_id's object
-* or by emplacing it in the set if it doesn't exist.
-*/
-template<typename T>
-void apply_region_overlay( std::set<string_id<T>> collections,
-                           const string_id<T> &overlay_obj )
-{
-    string_id<T> overlay( overlay_obj->overlay_id );
-    auto find_collection = std::find( collections.begin(), collections.end(), overlay );
-    //if there's a valid overlay ID, combine the objects
-    if( overlay != string_id<T>::NULL_ID() &&
-        find_collection != collections.end() ) {
-        const_cast<T &>( find_collection->obj() ) += *overlay_obj;
-    } else { //just add like copy-from
-        collections.emplace( overlay_obj );
-    }
-}
 
 struct region_settings_city {
     region_settings_city_id id = region_settings_city_id::NULL_ID();
@@ -116,12 +91,6 @@ struct region_settings_city {
     weighted_int_list<overmap_special_id> get_all_parks() const {
         return parks.get_all_buildings();
     }
-    region_settings_city &operator+=( const region_settings_city &rhs ) {
-        houses += rhs.houses;
-        shops += rhs.shops;
-        parks += rhs.parks;
-        return *this;
-    }
 
     bool was_loaded = false;
     void load( const JsonObject &jo, std::string_view );
@@ -155,18 +124,10 @@ struct groundcover_extra {
 
 struct forest_biome_component {
     forest_biome_component_id id = forest_biome_component_id::NULL_ID();
-    std::string overlay_id;
 
     weighted_int_list<ter_furn_id> types;
     int sequence = 0;
     int chance = 0;
-
-    forest_biome_component &operator+=( const forest_biome_component &rhs ) {
-        for( const std::pair<ter_furn_id, int> &val : rhs.types ) {
-            types.try_add( val );
-        }
-        return *this;
-    }
 
     bool was_loaded = false;
     void finalize();
@@ -189,7 +150,6 @@ struct forest_biome_terrain_dependent_furniture_new {
 /** Defines forest mapgen */
 struct forest_biome_mapgen {
     forest_biome_mapgen_id id = forest_biome_mapgen_id::NULL_ID();
-    std::string overlay_id;
 
     std::set<oter_type_str_id> terrains;
     std::set<forest_biome_component_id> biome_components;
@@ -201,7 +161,6 @@ struct forest_biome_mapgen {
     int item_spawn_iterations = 0;
     item_group_id item_group;
 
-    forest_biome_mapgen &operator+=( const forest_biome_mapgen &rhs );
 
     ter_furn_id pick() const;
     bool was_loaded = false;
@@ -219,13 +178,6 @@ struct region_settings_forest_mapgen {
     std::set<forest_biome_mapgen_id> biomes;
     //use for convenience
     std::map<oter_type_id, forest_biome_mapgen_id> oter_to_biomes;
-
-    region_settings_forest_mapgen &operator+=( const region_settings_forest_mapgen &rhs ) {
-        for( const forest_biome_mapgen_id &fbm : rhs.biomes ) {
-            apply_region_overlay<forest_biome_mapgen>( biomes, fbm );
-        }
-        return *this;
-    }
 
     bool was_loaded = false;
     void finalize();
@@ -247,11 +199,6 @@ struct region_settings_forest_trail {
     int trailhead_road_distance = 6;
     building_bin trailheads;
 
-    region_settings_forest_trail &operator+=( const region_settings_forest_trail &rhs ) {
-        trailheads += rhs.trailheads;
-        return *this;
-    }
-
     bool was_loaded = false;
     void load( const JsonObject &jo, std::string_view );
     void finalize();
@@ -263,8 +210,6 @@ struct region_settings_forest_trail {
 struct region_settings_feature_flag {
     std::set<std::string> blacklist;
     std::set<std::string> whitelist;
-
-    region_settings_feature_flag &operator+=( const region_settings_feature_flag &rhs );
 
     bool was_loaded = false;
     void deserialize( const JsonObject &jo );
@@ -430,15 +375,6 @@ struct region_settings_highway {
     int longest_bend_length = 0;
     int HIGHWAY_MAX_DEVIANCE = 0;
 
-    region_settings_highway &operator+=( const region_settings_highway &rhs ) {
-        four_way_intersections += rhs.four_way_intersections;
-        three_way_intersections += rhs.three_way_intersections;
-        bends += rhs.bends;
-        interchanges += rhs.interchanges;
-        road_connections += rhs.road_connections;
-        return *this;
-    }
-
     bool was_loaded = false;
     void load( const JsonObject &jo, std::string_view );
     void finalize();
@@ -450,7 +386,6 @@ struct region_settings_highway {
 
 struct map_extra_collection {
     map_extra_collection_id id = map_extra_collection_id::NULL_ID();
-    std::string overlay_id;
 
     unsigned int chance = 1;
     weighted_int_list<map_extra_id> values;
@@ -458,13 +393,6 @@ struct map_extra_collection {
     map_extra_collection() : chance( 0 ) {}
     explicit map_extra_collection( const unsigned int embellished ) : chance( embellished ) {}
     map_extra_collection filtered_by( const mapgendata & ) const;
-
-    map_extra_collection &operator+=( const map_extra_collection &rhs ) {
-        for( const std::pair<map_extra_id, int> &val : rhs.values ) {
-            values.try_add( val );
-        }
-        return *this;
-    }
 
     bool was_loaded = false;
     void load( const JsonObject &jo, std::string_view );
@@ -475,13 +403,6 @@ struct map_extra_collection {
 struct region_settings_map_extras {
     region_settings_map_extras_id id = region_settings_map_extras_id::NULL_ID();
     std::set<map_extra_collection_id> extras;
-
-    region_settings_map_extras &operator+=( const region_settings_map_extras &rhs ) {
-        for( const map_extra_collection_id &mec : rhs.extras ) {
-            apply_region_overlay<map_extra_collection>( extras, mec );
-        }
-        return *this;
-    }
 
     //returns every map extra in this collection regardless of weight
     std::set<map_extra_id> get_all_map_extras() const;
@@ -497,8 +418,6 @@ struct region_settings_terrain_furniture {
     region_settings_terrain_furniture_id id = region_settings_terrain_furniture_id::NULL_ID();
 
     std::set<region_terrain_furniture_id> ter_furn;
-
-    region_settings_terrain_furniture &operator+=( const region_settings_terrain_furniture &rhs );
 
     ter_id resolve( const ter_id & ) const;
     furn_id resolve( const furn_id & ) const;
@@ -522,8 +441,6 @@ struct region_terrain_furniture {
     furn_id replaced_furn_id;
     weighted_int_list<ter_id> terrain;
     weighted_int_list<furn_id> furniture;
-
-    region_terrain_furniture &operator+=( const region_terrain_furniture &rhs );
 
     bool was_loaded = false;
     void finalize();
@@ -654,38 +571,11 @@ struct region_settings {
         return *region_extras;
     }
 
-    region_settings &operator+=( const region_settings &rhs );
-
-    //region overlays can apply to only selected tags
-    std::set<std::string> tags;
-
     bool was_loaded = false;
     void load( const JsonObject &jo, std::string_view );
     void finalize();
     static void finalize_all();
     static void load_region_settings( const JsonObject &jo, const std::string &src );
-    static void reset();
-};
-
-/**
-* Some mods do not redefine regions, but instead extend existing regions.
-* However, multiple mods that extend regions can be loaded simultaneously.
-* To solve this, we apply region_overlay.
-*
-* region_overlay should NEVER redefine or remove elements from a given setting!
-* overlays must always be applied before region_settings::finalize_all
-*/
-struct region_overlay {
-    region_overlay_id id = region_overlay_id::NULL_ID();
-    std::set<std::string> apply_to_tags;
-    region_settings overlay;
-    bool apply_to_all_regions = false;
-
-    bool was_loaded = false;
-    void load( const JsonObject &jo, std::string_view );
-    void finalize();
-    static void finalize_all();
-    static void load_region_overlay_new( const JsonObject &jo, const std::string &src );
     static void reset();
 };
 

--- a/src/type_id.h
+++ b/src/type_id.h
@@ -286,9 +286,6 @@ using region_settings_map_extras_id = string_id<region_settings_map_extras>;
 struct region_settings;
 using region_settings_id = string_id<region_settings>;
 
-struct region_overlay;
-using region_overlay_id = string_id<region_overlay>;
-
 struct requirement_data;
 using requirement_id = string_id<requirement_data>;
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Remove code support for region overlays, as a follow-up to https://github.com/CleverRaven/Cataclysm-DDA/pull/83530

#### Describe the solution
Update the docs to mention copy-from, remove all code support for overlay fields. Convert the railroad mod to no longer use an overlay.

#### Testing
`tools/load_all_mods.sh`