### PR TITLE
[AFS] Frozen human flesh is people

### DIFF
--- a/data/mods/aftershock_exoplanet/items/comestibles/alienfood.json
+++ b/data/mods/aftershock_exoplanet/items/comestibles/alienfood.json
@@ -55,7 +55,7 @@
     "healthy": -1,
     "fun": -10,
     "cooks_like": "meat_cooked",
-    "vitamins": [ [ "vitC", 13 ], [ "calcium", 2 ], [ "iron", 53 ], [ "mutant_toxin", 25 ] ],
+    "vitamins": [ [ "vitC", 13 ], [ "calcium", 2 ], [ "iron", 53 ], [ "mutant_toxin", 25 ], [ "human_flesh_vitamin", 1 ] ],
     "flags": [ "RAW" ],
     "smoking_result": "meat_smoked"
   },
@@ -81,7 +81,7 @@
     "description": "A shriveled gray stomach, it hasn't seen use in a very long time.",
     "weight": "72 g",
     "volume": "250 ml",
-    "vitamins": [ [ "mutant_toxin", 25 ] ],
+    "vitamins": [ [ "mutant_toxin", 25 ], [ "human_flesh_vitamin", 1 ] ],
     "price_postapoc": "25 cent",
     "price": "2 USD",
     "spoils_in": "8 hours",
@@ -105,7 +105,7 @@
     "price_postapoc": "10 cent",
     "material": [ "bone" ],
     "volume": "250 ml",
-    "vitamins": [ [ "calcium", 96 ], [ "mutant_toxin", 25 ], [ "meat_allergen", 1 ] ],
+    "vitamins": [ [ "calcium", 96 ], [ "mutant_toxin", 25 ], [ "meat_allergen", 1 ], [ "human_flesh_vitamin", 1 ] ],
     "into": "meal_bone",
     "recipe": "meal_bone_mill_1_4"
   },
@@ -127,7 +127,7 @@
     "price": "0 cent",
     "material": [ "flesh" ],
     "volume": "250 ml",
-    "vitamins": [ [ "mutant_toxin", 25 ], [ "meat_allergen", 1 ] ],
+    "vitamins": [ [ "mutant_toxin", 25 ], [ "meat_allergen", 1 ], [ "human_flesh_vitamin", 1 ] ],
     "parasites": 32,
     "fun": -20
   },
@@ -148,7 +148,7 @@
     "description": "A smooth light green block of cleaned and rendered human fat.  While it'll remain edible for a very long time, it won't be the most appetizing.",
     "price": "5 USD",
     "volume": "250 ml",
-    "vitamins": [ [ "mutant_toxin", 25 ], [ "meat_allergen", 1 ] ],
+    "vitamins": [ [ "mutant_toxin", 25 ], [ "meat_allergen", 1 ], [ "human_flesh_vitamin", 1 ] ],
     "parasites": 32,
     "fun": -20,
     "material": [ "hflesh" ]
@@ -173,7 +173,7 @@
     "price_postapoc": "20 cent",
     "material": [ "flesh" ],
     "flags": [ "TRADER_AVOID" ],
-    "vitamins": [ [ "mutant_toxin", 25 ], [ "meat_allergen", 1 ] ],
+    "vitamins": [ [ "mutant_toxin", 25 ], [ "meat_allergen", 1 ], [ "human_flesh_vitamin", 1 ] ],
     "fun": -12
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Apparently a few frozen human flesh items don't trigger the cannibal debuffs. I suspect this is because they don't have the human vitamin in them.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Assuming this is unintentional, add the vitamin to the human flesh consumables in the file.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
This is a super quick fix, maybe I missed more items where this can apply.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
