### PR TITLE
Fix repeating dialogue bug with the predatory trader

### DIFF
--- a/data/json/npcs/godco/visitors/TALK_CARAVAN_MERCHANT_PREDATORY.json
+++ b/data/json/npcs/godco/visitors/TALK_CARAVAN_MERCHANT_PREDATORY.json
@@ -16,7 +16,11 @@
     "dynamic_line": "What can I do for you, <name_g>?",
     "responses": [
       { "text": "Do you have anything to trade?", "topic": "TALK_CARAVAN_MERCHANT_PREDATORY_Trade", "effect": "start_trade" },
-      { "text": "Your prices seem awfully high.", "topic": "TALK_CARAVAN_MERCHANT_PREDATORY_Price" },
+      {
+        "text": "Your prices seem awfully high.",
+        "topic": "TALK_CARAVAN_MERCHANT_PREDATORY_Price",
+        "condition": { "not": { "compare_string": [ "yes", { "npc_val": "general_meeting_u_paidoff" } ] } }
+      },
       { "text": "What's your story?", "topic": "TALK_CARAVAN_MERCHANT_PREDATORY_Story" },
       { "text": "Nothing much.  Just passing through.", "topic": "TALK_DONE" }
     ]
@@ -88,7 +92,11 @@
         "effect": "start_trade"
       },
       { "text": "You got anything else?", "topic": "TALK_CARAVAN_MERCHANT_PREDATORY_askinterval" },
-      { "text": "Your prices seem awfully high.", "topic": "TALK_CARAVAN_MERCHANT_PREDATORY_Price" },
+      {
+        "text": "Your prices seem awfully high.",
+        "topic": "TALK_CARAVAN_MERCHANT_PREDATORY_Price",
+        "condition": { "not": { "compare_string": [ "yes", { "npc_val": "general_meeting_u_paidoff" } ] } }
+      },
       { "text": "Thanks.  What were we talking about before?", "topic": "TALK_NONE" },
       { "text": "Thanks for that.  <end_talking_leave>", "topic": "TALK_DONE" }
     ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
You can call out the predatory trader for his practices and if you succeed the check get 50 merch then try again and get the 50 merch again on success, looping.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
If you accepted the merch from the trader, you can't call him out again.

Technically, it's just a condition on the topic that checks if you have the variable that got added while accepting his money.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Removing the second check since it may be redundant or unreachable, hard to say without a way to visualize the FSM.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Fixes #83552.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
