### PR TITLE
Zombie flesh is still human flesh

### DIFF
--- a/data/json/harvest.json
+++ b/data/json/harvest.json
@@ -1587,11 +1587,11 @@
     "message": "<zombie_humanoid_generic_harvest>",
     "extend": {
       "entries": [
-        { "drop": "meat_tainted", "type": "flesh", "mass_ratio": 0.25 },
-        { "drop": "blood_tainted", "type": "blood", "mass_ratio": 0.1 },
-        { "drop": "fat_tainted", "type": "flesh", "mass_ratio": 0.08 },
-        { "drop": "tainted_innards", "type": "offal", "mass_ratio": 0.15 },
-        { "drop": "tainted_marrow", "type": "bone", "mass_ratio": 0.005 },
+        { "drop": "meat_tainted_human", "type": "flesh", "mass_ratio": 0.25 },
+        { "drop": "blood_tainted_human", "type": "blood", "mass_ratio": 0.1 },
+        { "drop": "fat_tainted_human", "type": "flesh", "mass_ratio": 0.08 },
+        { "drop": "tainted_innards_human", "type": "offal", "mass_ratio": 0.15 },
+        { "drop": "tainted_marrow_human", "type": "bone", "mass_ratio": 0.005 },
         { "drop": "sinew", "type": "bone", "mass_ratio": 0.00035 }
       ]
     }
@@ -1624,7 +1624,17 @@
     "id": "zombie_humanoid_headless",
     "//": "humanoid zombies without a skull",
     "type": "harvest",
-    "copy-from": "zombie_animal",
+    "copy-from": "zombie_decay_bone",
+    "extend": {
+      "entries": [
+        { "drop": "meat_tainted_human", "type": "flesh", "mass_ratio": 0.25 },
+        { "drop": "blood_tainted_human", "type": "blood", "mass_ratio": 0.1 },
+        { "drop": "fat_tainted_human", "type": "flesh", "mass_ratio": 0.08 },
+        { "drop": "tainted_innards_human", "type": "offal", "mass_ratio": 0.15 },
+        { "drop": "tainted_marrow_human", "type": "bone", "mass_ratio": 0.005 },
+        { "drop": "sinew", "type": "bone", "mass_ratio": 0.00035 }
+      ]
+    },
     "message": "<zombie_humanoid_headless_harvest>"
   },
   {
@@ -1642,11 +1652,11 @@
     "message": "<zombie_humanoid_generic_harvest>",
     "extend": {
       "entries": [
-        { "drop": "meat_tainted", "type": "flesh", "mass_ratio": 0.25 },
-        { "drop": "blood_tainted", "type": "blood", "mass_ratio": 0.1 },
-        { "drop": "fat_tainted", "type": "flesh", "mass_ratio": 0.08 },
-        { "drop": "tainted_innards", "type": "offal", "mass_ratio": 0.15 },
-        { "drop": "tainted_marrow", "type": "bone", "mass_ratio": 0.005 },
+        { "drop": "meat_tainted_human", "type": "flesh", "mass_ratio": 0.25 },
+        { "drop": "blood_tainted_human", "type": "blood", "mass_ratio": 0.1 },
+        { "drop": "fat_tainted_human", "type": "flesh", "mass_ratio": 0.08 },
+        { "drop": "tainted_innards_human", "type": "offal", "mass_ratio": 0.15 },
+        { "drop": "tainted_marrow_human", "type": "bone", "mass_ratio": 0.005 },
         { "drop": "sinew", "type": "bone", "mass_ratio": 0.00035 }
       ]
     }
@@ -1674,7 +1684,7 @@
     "type": "harvest",
     "copy-from": "zombie_humanoid",
     "message": "<zombie_humanoid_acid_harvest>",
-    "delete": { "entries": [ { "drop": "blood_tainted", "type": "blood", "mass_ratio": 0.1 } ] },
+    "delete": { "entries": [ { "drop": "blood_tainted_human", "type": "blood", "mass_ratio": 0.1 } ] },
     "extend": { "entries": [ { "drop": "blood_acid", "type": "blood", "mass_ratio": 0.1 } ] }
   },
   {
@@ -1703,16 +1713,16 @@
     "message": "<zombie_screamer_harvest>",
     "delete": {
       "entries": [
-        { "drop": "meat_tainted", "type": "flesh", "mass_ratio": 0.25 },
-        { "drop": "fat_tainted", "type": "flesh", "mass_ratio": 0.08 },
-        { "drop": "tainted_innards", "type": "offal", "mass_ratio": 0.15 }
+        { "drop": "meat_tainted_human", "type": "flesh", "mass_ratio": 0.25 },
+        { "drop": "fat_tainted_human", "type": "flesh", "mass_ratio": 0.08 },
+        { "drop": "tainted_innards_human", "type": "offal", "mass_ratio": 0.15 }
       ]
     },
     "extend": {
       "entries": [
-        { "drop": "meat_tainted", "type": "flesh", "mass_ratio": 0.15 },
-        { "drop": "fat_tainted", "type": "flesh", "mass_ratio": 0.03 },
-        { "drop": "tainted_innards", "type": "offal", "mass_ratio": 0.1 }
+        { "drop": "meat_tainted_human", "type": "flesh", "mass_ratio": 0.15 },
+        { "drop": "fat_tainted_human", "type": "flesh", "mass_ratio": 0.03 },
+        { "drop": "tainted_innards_human", "type": "offal", "mass_ratio": 0.1 }
       ]
     }
   },
@@ -1746,11 +1756,11 @@
     "type": "harvest",
     "copy-from": "zombie_humanoid",
     "message": "<zombie_humanoid_mushroom_harvest>",
-    "delete": { "entries": [ { "drop": "tainted_innards", "type": "offal", "mass_ratio": 0.15 } ] },
+    "delete": { "entries": [ { "drop": "tainted_innards_human", "type": "offal", "mass_ratio": 0.15 } ] },
     "extend": {
       "entries": [
         { "drop": "veggy_tainted", "type": "offal", "mass_ratio": 0.07 },
-        { "drop": "tainted_innards", "type": "offal", "mass_ratio": 0.08 }
+        { "drop": "tainted_innards_human", "type": "offal", "mass_ratio": 0.08 }
       ]
     }
   },
@@ -1758,7 +1768,7 @@
     "id": "zombie_humanoid_mushroom_acid",
     "type": "harvest",
     "copy-from": "zombie_humanoid_mushroom",
-    "delete": { "entries": [ { "drop": "blood_tainted", "type": "blood", "mass_ratio": 0.1 } ] },
+    "delete": { "entries": [ { "drop": "blood_tainted_human", "type": "blood", "mass_ratio": 0.1 } ] },
     "extend": { "entries": [ { "drop": "blood_acid", "type": "blood", "mass_ratio": 0.1 } ] }
   },
   {
@@ -1813,11 +1823,11 @@
     "message": "<zombie_pupating_hulk_harvest>",
     "entries": [
       { "drop": "skull_human_tainted", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 },
-      { "drop": "meat_tainted", "type": "flesh", "mass_ratio": 0.18 },
-      { "drop": "blood_tainted", "type": "blood", "mass_ratio": 0.8 },
-      { "drop": "fat_tainted", "type": "flesh", "mass_ratio": 0.06 },
-      { "drop": "tainted_innards", "type": "offal", "mass_ratio": 0.08 },
-      { "drop": "tainted_marrow", "type": "bone", "mass_ratio": 0.003 },
+      { "drop": "meat_tainted_human", "type": "flesh", "mass_ratio": 0.18 },
+      { "drop": "blood_tainted_human", "type": "blood", "mass_ratio": 0.8 },
+      { "drop": "fat_tainted_human", "type": "flesh", "mass_ratio": 0.06 },
+      { "drop": "tainted_innards_human", "type": "offal", "mass_ratio": 0.08 },
+      { "drop": "tainted_marrow_human", "type": "bone", "mass_ratio": 0.003 },
       { "drop": "bone_tainted", "type": "bone", "mass_ratio": 0.07 },
       { "drop": "sinew", "type": "bone", "mass_ratio": 0.00035 }
     ]
@@ -1843,13 +1853,13 @@
     "message": "<zombie_humanoid_kevlar_harvest>",
     "entries": [
       { "drop": "skull_human_tainted", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 },
-      { "drop": "meat_tainted", "type": "flesh", "mass_ratio": 0.25 },
-      { "drop": "fat_tainted", "type": "flesh", "mass_ratio": 0.08 },
-      { "drop": "tainted_innards", "type": "offal", "mass_ratio": 0.15 },
+      { "drop": "meat_tainted_human", "type": "flesh", "mass_ratio": 0.25 },
+      { "drop": "fat_tainted_human", "type": "flesh", "mass_ratio": 0.08 },
+      { "drop": "tainted_innards_human", "type": "offal", "mass_ratio": 0.15 },
       { "drop": "bone_tainted", "type": "bone", "mass_ratio": 0.1 },
-      { "drop": "tainted_marrow", "type": "bone", "mass_ratio": 0.005 },
+      { "drop": "tainted_marrow_human", "type": "bone", "mass_ratio": 0.005 },
       { "drop": "sinew", "type": "bone", "mass_ratio": 0.00035 },
-      { "drop": "blood_tainted", "type": "blood", "mass_ratio": 0.1 },
+      { "drop": "blood_tainted_human", "type": "blood", "mass_ratio": 0.1 },
       { "drop": "kevlar_patch", "type": "skin", "mass_ratio": 0.02, "flags": [ "FILTHY" ] },
       { "drop": "sheet_kevlar", "type": "skin", "mass_ratio": 0.01, "flags": [ "FILTHY" ] },
       { "drop": "sheet_kevlar_layered", "type": "skin", "mass_ratio": 0.01, "flags": [ "FILTHY" ] },
@@ -1863,13 +1873,13 @@
     "message": "<zombie_kevlar_hulk_harvest>",
     "entries": [
       { "drop": "skull_human_tainted", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 },
-      { "drop": "meat_tainted", "type": "flesh", "mass_ratio": 0.25 },
-      { "drop": "fat_tainted", "type": "flesh", "mass_ratio": 0.08 },
-      { "drop": "tainted_innards", "type": "offal", "mass_ratio": 0.15 },
+      { "drop": "meat_tainted_human", "type": "flesh", "mass_ratio": 0.25 },
+      { "drop": "fat_tainted_human", "type": "flesh", "mass_ratio": 0.08 },
+      { "drop": "tainted_innards_human", "type": "offal", "mass_ratio": 0.15 },
       { "drop": "bone_tainted", "type": "bone", "mass_ratio": 0.1 },
-      { "drop": "tainted_marrow", "type": "bone", "mass_ratio": 0.005 },
+      { "drop": "tainted_marrow_human", "type": "bone", "mass_ratio": 0.005 },
       { "drop": "sinew", "type": "bone", "mass_ratio": 0.00035 },
-      { "drop": "blood_tainted", "type": "blood", "mass_ratio": 0.1 },
+      { "drop": "blood_tainted_human", "type": "blood", "mass_ratio": 0.1 },
       { "drop": "kevlar_patch", "type": "skin", "mass_ratio": 0.02, "flags": [ "FILTHY" ] },
       { "drop": "sheet_kevlar", "type": "skin", "mass_ratio": 0.01, "flags": [ "FILTHY" ] },
       { "drop": "sheet_kevlar_layered", "type": "skin", "mass_ratio": 0.01, "flags": [ "FILTHY" ] },
@@ -1882,13 +1892,13 @@
     "type": "harvest",
     "entries": [
       { "drop": "skull_human_tainted", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 },
-      { "drop": "meat_tainted", "type": "flesh", "mass_ratio": 0.25 },
-      { "drop": "fat_tainted", "type": "flesh", "mass_ratio": 0.08 },
-      { "drop": "tainted_innards", "type": "offal", "mass_ratio": 0.15 },
+      { "drop": "meat_tainted_human", "type": "flesh", "mass_ratio": 0.25 },
+      { "drop": "fat_tainted_human", "type": "flesh", "mass_ratio": 0.08 },
+      { "drop": "tainted_innards_human", "type": "offal", "mass_ratio": 0.15 },
       { "drop": "bone_tainted", "type": "bone", "mass_ratio": 0.1 },
-      { "drop": "tainted_marrow", "type": "bone", "mass_ratio": 0.005 },
+      { "drop": "tainted_marrow_human", "type": "bone", "mass_ratio": 0.005 },
       { "drop": "sinew", "type": "bone", "mass_ratio": 0.00035 },
-      { "drop": "blood_tainted", "type": "blood", "mass_ratio": 0.1 },
+      { "drop": "blood_tainted_human", "type": "blood", "mass_ratio": 0.1 },
       { "drop": "nomex", "type": "skin", "mass_ratio": 0.02, "flags": [ "FILTHY" ] },
       { "drop": "sheet_nomex", "type": "skin", "mass_ratio": 0.01, "flags": [ "FILTHY" ] },
       { "drop": "raw_tainted_leather", "type": "skin", "mass_ratio": 0.04 }
@@ -1924,8 +1934,8 @@
     "entries": [
       { "drop": "skull_human_tainted", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 },
       { "drop": "bone_tainted", "type": "flesh", "mass_ratio": 0.5 },
-      { "drop": "tainted_marrow", "type": "bone", "mass_ratio": 0.005 },
-      { "drop": "blood_tainted", "type": "blood", "mass_ratio": 0.01 },
+      { "drop": "tainted_marrow_human", "type": "bone", "mass_ratio": 0.005 },
+      { "drop": "blood_tainted_human", "type": "blood", "mass_ratio": 0.01 },
       { "drop": "sinew", "type": "bone", "mass_ratio": 0.001 }
     ]
   },
@@ -1937,8 +1947,8 @@
     "entries": [
       { "drop": "skull_human_tainted", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 },
       { "drop": "bone_tainted", "type": "flesh", "mass_ratio": 0.5 },
-      { "drop": "tainted_marrow", "type": "bone", "mass_ratio": 0.005 },
-      { "drop": "blood_tainted", "type": "blood", "mass_ratio": 0.01 },
+      { "drop": "tainted_marrow_human", "type": "bone", "mass_ratio": 0.005 },
+      { "drop": "blood_tainted_human", "type": "blood", "mass_ratio": 0.01 },
       { "drop": "sinew", "type": "bone", "mass_ratio": 0.001 }
     ]
   },
@@ -1974,8 +1984,8 @@
     "entries": [
       { "drop": "skull_human_tainted", "type": "bone", "scale_num": [ 1, 1 ], "max": 1 },
       { "drop": "bone_tainted", "type": "flesh", "mass_ratio": 0.5 },
-      { "drop": "tainted_marrow", "type": "bone", "mass_ratio": 0.005 },
-      { "drop": "blood_tainted", "type": "blood", "mass_ratio": 0.01 },
+      { "drop": "tainted_marrow_human", "type": "bone", "mass_ratio": 0.005 },
+      { "drop": "blood_tainted_human", "type": "blood", "mass_ratio": 0.01 },
       { "drop": "sinew", "type": "bone", "mass_ratio": 0.001 }
     ]
   },

--- a/data/json/items/comestibles/carnivore.json
+++ b/data/json/items/comestibles/carnivore.json
@@ -1762,7 +1762,7 @@
     "price": "0 cent",
     "price_postapoc": "10 cent",
     "material": [ "flesh" ],
-    "volume": "54 ml",
+    "volume": "50 ml",
     "fun": -10,
     "flags": [ "TRADER_AVOID", "RAW" ],
     "vitamins": [ [ "meat_allergen", 1 ] ]

--- a/data/json/items/comestibles/carnivore.json
+++ b/data/json/items/comestibles/carnivore.json
@@ -1762,7 +1762,7 @@
     "price": "0 cent",
     "price_postapoc": "10 cent",
     "material": [ "flesh" ],
-    "volume": "50 ml",
+    "volume": "54 ml",
     "fun": -10,
     "flags": [ "TRADER_AVOID", "RAW" ],
     "vitamins": [ [ "meat_allergen", 1 ] ]

--- a/data/json/items/comestibles/carnivore.json
+++ b/data/json/items/comestibles/carnivore.json
@@ -826,6 +826,16 @@
     "fun": -25
   },
   {
+    "id": "tainted_innards_human",
+    "copy-from": "tainted_innards",
+    "type": "ITEM",
+    "subtypes": [ "COMESTIBLE" ],
+    "name": { "str_sp": "tainted innards" },
+    "description": "An unidentifiable selection of rotted human innards that barely hold their form.  It is revolting and certainly no longer healthy to eat.",
+    "snippet_category": "tainted_innards_desc",
+    "vitamins": [ [ "calcium", 2 ], [ "iron", 16 ], [ "meat_allergen", 1 ], [ "human_flesh_vitamin", 1 ] ]
+  },
+  {
     "id": "mutant_bug_organs",
     "type": "ITEM",
     "subtypes": [ "COMESTIBLE" ],
@@ -1647,6 +1657,17 @@
   {
     "type": "ITEM",
     "subtypes": [ "COMESTIBLE" ],
+    "id": "meat_tainted_human",
+    "copy-from": "meat_tainted",
+    "category": "other",
+    "name": { "str": "chunk of tainted human meat", "str_pl": "chunks of tainted human meat" },
+    "description": "A piece of rotted meat that has been harvested from something human, or at the very least something once human, as if cannibalism wasn't abhorrent enough.",
+    "material": [ "hflesh" ],
+    "vitamins": [ [ "meat_allergen", 1 ], [ "human_flesh_vitamin", 1 ] ]
+  },
+  {
+    "type": "ITEM",
+    "subtypes": [ "COMESTIBLE" ],
     "id": "arm_zed",
     "category": "other",
     "name": { "str": "tainted limb" },
@@ -1708,6 +1729,23 @@
     "smoking_result": "null"
   },
   {
+    "id": "blood_tainted_human",
+    "type": "ITEM",
+    "subtypes": [ "COMESTIBLE" ],
+    "copy-from": "meat_tainted_human",
+    "name": { "str_sp": "tainted human blood" },
+    "description": "Blood that's obviously unhealthy, and from a human to boot.  You could drink it, but it will poison you.",
+    "weight": "262 g",
+    "volume": "250 ml",
+    "comestible_type": "DRINK",
+    "looks_like": "blood",
+    "symbol": "~",
+    "material": "hblood",
+    "charges": 1,
+    "phase": "liquid",
+    "smoking_result": "null"
+  },
+  {
     "type": "ITEM",
     "subtypes": [ "COMESTIBLE" ],
     "id": "tainted_marrow",
@@ -1732,6 +1770,17 @@
   {
     "type": "ITEM",
     "subtypes": [ "COMESTIBLE" ],
+    "id": "tainted_marrow_human",
+    "copy-from": "tainted_marrow",
+    "category": "other",
+    "name": { "str": "portion of tainted human bone marrow", "str_pl": "portions of tainted human bone marrow" },
+    "description": "A wet, green chunk of spongy goop extracted from a rotten human bone.  You could eat it, but it will poison you.",
+    "material": [ "hflesh" ],
+    "vitamins": [ [ "meat_allergen", 1 ], [ "human_flesh_vitamin", 1 ] ]
+  },
+  {
+    "type": "ITEM",
+    "subtypes": [ "COMESTIBLE" ],
     "id": "fat_tainted",
     "category": "other",
     "name": { "str": "chunk of tainted fat", "str_pl": "chunks of tainted fat" },
@@ -1751,6 +1800,18 @@
     "fun": -10,
     "flags": [ "RAW" ],
     "vitamins": [ [ "meat_allergen", 1 ] ]
+  },
+  {
+    "type": "ITEM",
+    "subtypes": [ "COMESTIBLE" ],
+    "id": "fat_tainted_human",
+    "copy-from": "fat_tainted",
+    "category": "other",
+    "name": { "str": "chunk of tainted human fat", "str_pl": "chunks of tainted human fat" },
+    "description": "A watery yellow glob of fat from some zombified human.  You could eat it, but it will poison you.",
+    "//": "Not for use in edible recipes, and should require ~200% as much as normal for applicable inedible recipes.",
+    "material": [ "hflesh" ],
+    "vitamins": [ [ "meat_allergen", 1 ], [ "human_flesh_vitamin", 1 ] ]
   },
   {
     "type": "ITEM",

--- a/data/json/recipes/chem/mutagens.json
+++ b/data/json/recipes/chem/mutagens.json
@@ -29,8 +29,10 @@
       [
         [ "tallow_tainted", 2 ],
         [ "meat_tainted", 3 ],
+        [ "meat_tainted_human", 3 ],
         [ "dry_meat_tainted", 3 ],
         [ "tainted_innards", 4 ],
+        [ "tainted_innards_human", 4 ],
         [ "fetus", 1 ],
         [ "arm", 2 ],
         [ "leg", 2 ]

--- a/data/json/recipes/food/dry.json
+++ b/data/json/recipes/food/dry.json
@@ -264,7 +264,7 @@
     "autolearn": true,
     "tools": [ [ [ "dehydrating_heat", 24, "LIST" ] ] ],
     "//": "238g of stuff",
-    "components": [ [ [ "meat_tainted", 1 ] ] ]
+    "components": [ [ [ "meat_tainted", 1 ], [ "meat_tainted_human", 1 ] ] ]
   },
   {
     "result": "dry_meat_tainted",
@@ -280,7 +280,7 @@
     "autolearn": true,
     "tools": [ [ [ "dehydrating_heat", 24, "LIST" ] ], [ [ "surface_heat", 16, "LIST" ] ] ],
     "//": "238g of stuff, 16u to cook it",
-    "components": [ [ [ "meat_tainted", 1 ] ] ]
+    "components": [ [ [ "meat_tainted", 1 ], [ "meat_tainted_human", 1 ] ] ]
   },
   {
     "type": "recipe",

--- a/data/json/recipes/recipe_medsandchemicals.json
+++ b/data/json/recipes/recipe_medsandchemicals.json
@@ -63,7 +63,7 @@
     "qualities": [ { "id": "CUT", "level": 2 }, { "id": "COOK", "level": 2 } ],
     "tools": [ [ [ "water_boiling_heat", 20, "LIST" ] ] ],
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_knife_skills" } ],
-    "components": [ [ [ "fat_tainted", 4 ] ], [ [ "water", 1 ], [ "water_clean", 1 ] ] ],
+    "components": [ [ [ "fat_tainted", 4 ], [ "fat_tainted_human", 4 ] ], [ [ "water", 1 ], [ "water_clean", 1 ] ] ],
     "charges": 2
   },
   {

--- a/data/mods/TEST_DATA/known_bad_density.json
+++ b/data/mods/TEST_DATA/known_bad_density.json
@@ -343,6 +343,7 @@
       "mutant_human_cracklins",
       "ammonia_liquid",
       "tainted_marrow",
+      "tainted_marrow_human",
       "shed_stick",
       "glasses_monocle",
       "broken_tazer_hack",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Eating human zombie flesh is cannibalism"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Human zombies, when butchered, give regular zombie flesh despite giving morale penalties for being human. This meant rat mutants could eat human zombies, which is a bit odd. This also still allows Chimera to eat human zombies, as they can eat humans. 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Makes zombies give tainted human flesh. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Butchering a zombie, zombie llama, and brainless zombie in that order. 
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/4f8df9ce-059d-483a-aa7d-6b753258bd54" />

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

I fully expect some weird copy-froms or harvest lists resulting in butchery giving inappropriate items. Churning through all of that json to find those few outliers (which may not exist) would take a lot of time, and is ultimately easier to hand that task off to our ~~playtesters~~ players. 
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
