### PR TITLE
Allow variants for brewing and composting results

### DIFF
--- a/doc/JSON/ITEM.md
+++ b/doc/JSON/ITEM.md
@@ -1002,7 +1002,8 @@ If an item is BREWABLE, it can be placed in a vat and will ferment into a differ
 "name": { "str_sp": "whiskey wort" },
 "description": "Unfermented whiskey.  The base of a fine drink.  Not the traditional preparation, but you don't have the time.  You need to put it in a fermenting vat to brew it.",
 "brew_time": "7 days",  // A time duration: how long the fermentation will take.
-"brew_results": [ "wash_whiskey", "yeast" ], // IDs with a multiplier for the amount of results per charge of the brewable items.
+"brew_results": [ "wash_whiskey", { "item": "yeast", "variant": "foo", "count": 3 } ], // IDs with a multiplier for the amount of results per charge of the brewable items.
+"brew_results": { "wash_whiskey": 2, "yeast": 3 }, // Alternate format
 ...
 //comestible fields
 ```
@@ -1024,6 +1025,7 @@ If an item is BREWABLE, it can be placed in a vat and will ferment into a differ
 "charges": 1,
 "compost_time": "60 days", // the amount of time required to fully compost this item
 "compost_results": { "fermented_fertilizer_liquid": 1, "biogas": 250 }, //item IDs and quantities resulting from compost
+"compost_results": [ "fermented_fertilizer_liquid", { "item": "biogas", "variant": "foo", "count": "250" } ], // alternate format
 ...
 //COMESTIBLE fields
 ```

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -4011,22 +4011,24 @@ void iexamine::fvat_full( Character &you, const tripoint_bub_ms &examp )
         }
 
         if( query_yn( _( "Finish brewing?" ) ) ) {
-            const std::map<itype_id, int> results = brew_i.brewing_results();
+            const std::map<std::pair<itype_id, std::string>, int> &results = brew_i.brewing_results();
             const int count = brew_i.count();
             const time_point birthday = brew_i.birthday();
 
             here.i_clear( examp );
-            for( const std::pair<const itype_id, int> &result : results ) {
+            for( const std::pair<const std::pair<itype_id, std::string>, int> &result : results ) {
                 int amount = result.second * count;
+                const itype_id &item_type = result.first.first;
                 // TODO: Different age based on settings
-                item booze( result.first, birthday );
-                if( result.first->phase == phase_id::LIQUID ) {
+                item booze( item_type, birthday );
+                booze.set_itype_variant( result.first.second );
+                if( item_type->phase == phase_id::LIQUID ) {
                     booze.charges = amount;
                     here.add_item( examp, booze );
-                    add_msg( _( "The %s is now ready for bottling." ), result.first->nname( amount ) );
+                    add_msg( _( "The %s is now ready for bottling." ), item_type->nname( amount ) );
                 } else {
                     you.i_add_or_drop( booze, amount );
-                    add_msg( _( "You remove the %s from the vat." ), result.first->nname( amount ) );
+                    add_msg( _( "You remove the %s from the vat." ), item_type->nname( amount ) );
                 }
             }
 
@@ -4253,18 +4255,20 @@ void iexamine::compost_full( Character &you, const tripoint_bub_ms &examp )
             }
             if( to_days<int>( progress ) >= 30 && gas_gatherable >= 1 ) {
                 if( query_yn( _( "Gather biogas?  Can't stop once releasing started." ) ) ) {
-                    const std::map<itype_id, int> results = compost_i.composting_results();
+                    const std::map<std::pair<itype_id, std::string>, int> &results = compost_i.composting_results();
                     const int count = compost_i.count();
                     const time_point gas_birthday = compost_i.birthday();
                     if( !max_gas_gatherable ) {
                         add_msg( _( "No biogas gathered." ) );
                     } else {
-                        for( const std::pair<const itype_id, int> &result : results ) {
-                            item biogas( result.first, gas_birthday );
+                        for( const std::pair<const std::pair<itype_id, std::string>, int> &result : results ) {
+
+                            item biogas( result.first.first, gas_birthday );
+                            biogas.set_itype_variant( result.first.second );
                             // 40 L biogas for 1 KG of biomass over the whole anaerobic digestion process.
                             // 1 unit of biomass(0.5 KG) for 80 units(0.25 L for each unit) of biogas.
                             int gas_amount = count * max_gas_gatherable * 80 / 30;
-                            if( result.first->phase == phase_id::GAS ) {
+                            if( result.first.first->phase == phase_id::GAS ) {
                                 if( !you.can_pickVolume_partial( biogas ) ) {
                                     add_msg( _( "You released some biogas from the tank." ) );
                                 } else {
@@ -4285,20 +4289,22 @@ void iexamine::compost_full( Character &you, const tripoint_bub_ms &examp )
         }
 
         if( query_yn( _( "Finish fermenting?" ) ) ) {
-            const std::map<itype_id, int> results = compost_i.composting_results();
+            const std::map<std::pair<itype_id, std::string>, int> &results = compost_i.composting_results();
             const int count = compost_i.count();
             const time_point birthday = compost_i.birthday();
 
             here.i_clear( examp );
-            for( const std::pair<const itype_id, int> &result : results ) {
+            for( const std::pair<const std::pair<itype_id, std::string>, int> &result : results ) {
                 int amount = result.second * count;
                 // TODO: Different age based on settings
-                item compost( result.first, birthday );
-                if( result.first->phase == phase_id::LIQUID ) {
+                const itype_id &item_type = result.first.first;
+                item compost( item_type, birthday );
+                compost.set_itype_variant( result.first.second );
+                if( item_type->phase == phase_id::LIQUID ) {
                     compost.charges = amount;
                     here.add_item( examp, compost );
-                    add_msg( _( "The %s is now ready for use." ), result.first->nname( amount ) );
-                } else if( result.first->phase == phase_id::GAS ) {
+                    add_msg( _( "The %s is now ready for use." ), item_type->nname( amount ) );
+                } else if( item_type->phase == phase_id::GAS ) {
                     int gas_amount = count * max_gas_gatherable * 80 / 30;
                     if( !gas_amount || !you.can_pickVolume_partial( compost ) ) {
                         add_msg( _( "You released some biogas from the tank." ) );
@@ -4309,7 +4315,7 @@ void iexamine::compost_full( Character &you, const tripoint_bub_ms &examp )
                     }
                 } else {
                     you.i_add_or_drop( compost, amount );
-                    add_msg( _( "You removed the %s from the tank." ), result.first->nname( amount ) );
+                    add_msg( _( "You removed the %s from the tank." ), item_type->nname( amount ) );
                 }
             }
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -2283,9 +2283,9 @@ time_duration item::brewing_time() const
     return is_brewable() ? type->brewable->time * calendar::season_from_default_ratio() : 0_turns;
 }
 
-const std::map<itype_id, int> &item::brewing_results() const
+const std::map<std::pair<itype_id, std::string>, int> &item::brewing_results() const
 {
-    static const std::map<itype_id, int> nulresult{};
+    static const std::map<std::pair<itype_id, std::string>, int> nulresult{};
     return is_brewable() ? type->brewable->results : nulresult;
 }
 
@@ -2294,9 +2294,9 @@ time_duration item::composting_time() const
     return is_compostable() ? type->compostable->time * calendar::season_from_default_ratio() : 0_turns;
 }
 
-const std::map<itype_id, int> &item::composting_results() const
+const std::map<std::pair<itype_id, std::string>, int> &item::composting_results() const
 {
-    static const std::map<itype_id, int> nulresult{};
+    static const std::map<std::pair<itype_id, std::string>, int> nulresult{};
     return is_compostable() ? type->compostable->results : nulresult;
 }
 

--- a/src/item.h
+++ b/src/item.h
@@ -1219,12 +1219,12 @@ class item : public visitable
         /** Time for this item to be fully fermented. */
         time_duration brewing_time() const;
         /** The results of fermenting this item. */
-        const std::map<itype_id, int> &brewing_results() const;
+        const std::map<std::pair<itype_id, std::string>, int> &brewing_results() const;
 
         /** Time for this item to be fully fermented. */
         time_duration composting_time() const;
         /** The results of fermenting this item. */
-        const std::map<itype_id, int> &composting_results() const;
+        const std::map<std::pair<itype_id, std::string>, int> &composting_results() const;
 
         /**
          * Detonates the item and adds remains (if any) to drops.

--- a/src/item_info.cpp
+++ b/src/item_info.cpp
@@ -3828,11 +3828,12 @@ void item::final_info( std::vector<iteminfo> &info, const iteminfo_query *parts,
             }
         }
         if( parts->test( iteminfo_parts::DESCRIPTION_BREWABLE_PRODUCTS ) ) {
-            for( const std::pair<const itype_id, int> &res : brewed.brewing_results() ) {
+            for( const std::pair<const std::pair<itype_id, std::string>, int> &res :
+                 brewed.brewing_results() ) {
                 info.emplace_back( "DESCRIPTION",
                                    string_format( _( "* Fermenting this will produce "
                                                      "<neutral>%s</neutral>." ),
-                                                  res.first->nname( res.second ) ) );
+                                                  res.first.first->nname( res.second ) ) );
             }
         }
     }
@@ -3858,11 +3859,12 @@ void item::final_info( std::vector<iteminfo> &info, const iteminfo_query *parts,
             }
         }
         if( parts->test( iteminfo_parts::DESCRIPTION_COMPOSTABLE_PRODUCTS ) ) {
-            for( const std::pair<const itype_id, int> &res : composted.composting_results() ) {
+            for( const std::pair<const std::pair<itype_id, std::string>, int> &res :
+                 composted.composting_results() ) {
                 info.emplace_back( "DESCRIPTION",
                                    string_format( _( "* Fermenting this will produce "
                                                      "<neutral>%s</neutral>." ),
-                                                  res.first->nname( res.second ) ) );
+                                                  res.first.first->nname( res.second ) ) );
             }
         }
     }

--- a/src/itype.h
+++ b/src/itype.h
@@ -255,7 +255,7 @@ struct islot_comestible {
 
 struct islot_brewable {
     /** What are the results of fermenting this item? */
-    std::map<itype_id, int> results;
+    std::map<std::pair<itype_id, std::string>, int> results;
 
     /** How long for this brew to ferment. */
     time_duration time = 0_turns;
@@ -266,7 +266,7 @@ struct islot_brewable {
 
 struct islot_compostable {
     /** What are the results of fermenting this item? */
-    std::map<itype_id, int> results;
+    std::map<std::pair<itype_id, std::string>, int> results;
 
     /** How long for this compost to ferment. */
     time_duration time = 0_turns;


### PR DESCRIPTION
#### Summary
Infrastructure "Allow specifying variants for brewing and compost results"

#### Purpose of change
Fixes https://github.com/CleverRaven/Cataclysm-DDA/issues/83584

#### Describe the solution
Replace itype with pair<itype, string>. Set the variant on creation. Add a reader to handle the format.

#### Testing
Add an item with a variant to brewing results.

#### Additional context
`nname` is problematic for variants and I don't know how to handle it.