### PR TITLE
Fix hang when mission special reveal fails

### DIFF
--- a/src/mission_util.cpp
+++ b/src/mission_util.cpp
@@ -203,7 +203,12 @@ static std::optional<tripoint_abs_omt> find_or_create_om_terrain(
         find_params.om_special = special_id;
 
         if( overmap_buffer.contains_unique_special( special_id ) ) {
-            return overmap_buffer.find_existing_globally_unique( origin_pos, find_params );
+            target_pos = overmap_buffer.find_existing_globally_unique( origin_pos, find_params );
+            if( target_pos.is_invalid() ) {
+                debugmsg( "Couldn't find placed overmap special %s???", special_id.str() );
+                return std::nullopt;
+            }
+            return target_pos;
         }
     }
     auto get_target_position = [&]() {


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Workaround (???) for https://github.com/CleverRaven/Cataclysm-DDA/issues/82635

#### Describe the solution
Don't treat an invalid tripoint as valid, and try to reveal (and thus generate) overmaps around it.

#### Testing
Follow reproduction steps from https://github.com/CleverRaven/Cataclysm-DDA/issues/82635#issuecomment-3445916071 (ask Smokes about other settlements).