### PR TITLE
Blacklist evac flyer from exoplanet

### DIFF
--- a/data/mods/aftershock_exoplanet/setting_blacklists/item_blacklist.json
+++ b/data/mods/aftershock_exoplanet/setting_blacklists/item_blacklist.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "ITEM_BLACKLIST",
+    "whitelist": false,
+    "items": [ "flyer_evac" ]
+  }
+]


### PR DESCRIPTION

#### Summary
Bugfixes "Blacklists evac flyer with Exoplanet loaded"


#### Purpose of change
Remove evac flyer from exoplanet without replacing existing item groups, as it is not intended to spawn and causes a crash if used.
#### Describe the solution
Added item blacklist for the evac flyer. 

#### Describe alternatives you've considered
Considered adding new, exoplanet tailored item group. This could be a better alternative as some other things that may be added to or already exist in the trash item groups could be (or are) out of place on exoplanet. Adding a new item group would require it to be personalized to fit with exoplanets world and economy, which i am not fully confident in my knowledge of, though it would ultimately be a better solution than using a vanilla item group. The minimum required change to remove the existence of an item that can cause a crash is what i opted for.

#### Testing
Made a new character on a new world with only exoplanet enabled, debug>spawning>spawn an item group>SUS_trash_floor, floor_heavy, trashcan_full, etc. Also tried spawning the evac flyer directly (it still gives you the item but it despawns when dropped)

#### Additional context

