### PR TITLE
Added SPAWN_ACTIVE flag to active items (2/2)

### DIFF
--- a/data/json/items/tool/explosives.json
+++ b/data/json/items/tool/explosives.json
@@ -34,7 +34,7 @@
     "use_action": { "type": "message", "message": "You've already set the %s's timer, you might want to get away from it." },
     "countdown_action": { "type": "explosion", "explosion": { "power": 2000 } },
     "countdown_interval": "6 seconds",
-    "flags": [ "NPC_THROW_NOW" ]
+    "flags": [ "NPC_THROW_NOW", "SPAWN_ACTIVE" ]
   },
   {
     "id": "dynamite",

--- a/data/json/items/tool/fire.json
+++ b/data/json/items/tool/fire.json
@@ -302,7 +302,7 @@
       }
     ],
     "light": 8,
-    "flags": [ "FIRE", "FIRESTARTER", "FLAMING", "TRADER_AVOID", "WATER_EXTINGUISH" ],
+    "flags": [ "FIRE", "FIRESTARTER", "FLAMING", "TRADER_AVOID", "WATER_EXTINGUISH", "SPAWN_ACTIVE" ],
     "tool_ammo": [ "lamp_oil" ]
   },
   {
@@ -379,7 +379,7 @@
         "type": "transform"
       }
     ],
-    "flags": [ "FIRESTARTER" ],
+    "flags": [ "FIRESTARTER", "SPAWN_ACTIVE" ],
     "tool_ammo": [ "tinder" ]
   },
   {

--- a/data/json/items/tool/firefighting.json
+++ b/data/json/items/tool/firefighting.json
@@ -179,7 +179,7 @@
     "color": "light_red",
     "emits": [ "emit_extinguisher_burst" ],
     "revert_to": "canister_empty",
-    "flags": [ "TRADER_AVOID" ],
+    "flags": [ "TRADER_AVOID", "SPAWN_ACTIVE" ],
     "melee_damage": { "bash": 2 }
   },
   {

--- a/data/json/items/tool/lighting.json
+++ b/data/json/items/tool/lighting.json
@@ -46,7 +46,7 @@
       }
     ],
     "light": 8,
-    "extend": { "flags": [ "WATER_EXTINGUISH", "TRADER_AVOID", "WIND_EXTINGUISH", "FIRESTARTER" ] }
+    "extend": { "flags": [ "WATER_EXTINGUISH", "TRADER_AVOID", "WIND_EXTINGUISH", "FIRESTARTER", "SPAWN_ACTIVE" ] }
   },
   {
     "id": "electric_lantern",
@@ -97,7 +97,7 @@
       { "type": "link_up", "cable_length": 2, "charge_rate": "20 W" }
     ],
     "light": 15,
-    "flags": [ "NO_UNLOAD", "NO_RELOAD", "RADIO_MODABLE", "RADIO_INVOKE_PROC", "TRADER_AVOID", "ALLOWS_REMOTE_USE" ]
+    "flags": [ "NO_UNLOAD", "NO_RELOAD", "RADIO_MODABLE", "RADIO_INVOKE_PROC", "TRADER_AVOID", "ALLOWS_REMOTE_USE", "SPAWN_ACTIVE" ]
   },
   {
     "id": "flashlight",
@@ -213,7 +213,7 @@
       "ammo_scale": 0
     },
     "light": 170,
-    "flags": [ "CHARGEDIM", "TRADER_AVOID", "BELT_CLIP", "HELMET_HEAD_ATTACHMENT", "HEAD_STRAP_MOUNT" ]
+    "flags": [ "CHARGEDIM", "TRADER_AVOID", "BELT_CLIP", "HELMET_HEAD_ATTACHMENT", "HEAD_STRAP_MOUNT", "SPAWN_ACTIVE" ]
   },
   {
     "id": "diving_flashlight_small_hipower",
@@ -268,13 +268,13 @@
       "ammo_scale": 0
     },
     "light": 450,
-    "flags": [ "CHARGEDIM", "TRADER_AVOID", "BELT_CLIP", "HELMET_HEAD_ATTACHMENT", "HEAD_STRAP_MOUNT" ]
+    "flags": [ "CHARGEDIM", "TRADER_AVOID", "BELT_CLIP", "HELMET_HEAD_ATTACHMENT", "HEAD_STRAP_MOUNT", "SPAWN_ACTIVE" ]
   },
   {
     "id": "diving_flashlight_variable",
     "type": "ITEM",
     "subtypes": [ "TOOL" ],
-    "name": { "str": "high-power mini diving flashlight (off)", "str_pl": "high-power mini diving flashlights (off)" },
+    "name": { "str": "variable power diving flashlight (off)", "str_pl": "variable power diving flashlights (off)" },
     "description": "A waterproof variable power flashlight with a plastic handle, powered by batteries.  Can be attached to some diving masks and hoods and onto a proprietary wrist mount.",
     "//": "Based on this: https://www.amazon.com/dp/B00DI5GMOM",
     "material": [ "plastic" ],
@@ -335,7 +335,16 @@
         "charge_rate": "20 W"
       }
     ],
-    "flags": [ "NO_UNLOAD", "NO_RELOAD", "CHARGEDIM", "TRADER_AVOID", "BELT_CLIP", "HELMET_HEAD_ATTACHMENT", "HEAD_STRAP_MOUNT" ]
+    "flags": [
+      "NO_UNLOAD",
+      "NO_RELOAD",
+      "CHARGEDIM",
+      "TRADER_AVOID",
+      "BELT_CLIP",
+      "HELMET_HEAD_ATTACHMENT",
+      "HEAD_STRAP_MOUNT",
+      "SPAWN_ACTIVE"
+    ]
   },
   {
     "id": "diving_flashlight_variable_on_med",
@@ -367,7 +376,16 @@
       }
     ],
     "light": 200,
-    "flags": [ "NO_UNLOAD", "NO_RELOAD", "CHARGEDIM", "TRADER_AVOID", "BELT_CLIP", "HELMET_HEAD_ATTACHMENT", "HEAD_STRAP_MOUNT" ]
+    "flags": [
+      "NO_UNLOAD",
+      "NO_RELOAD",
+      "CHARGEDIM",
+      "TRADER_AVOID",
+      "BELT_CLIP",
+      "HELMET_HEAD_ATTACHMENT",
+      "HEAD_STRAP_MOUNT",
+      "SPAWN_ACTIVE"
+    ]
   },
   {
     "id": "diving_flashlight_variable_on_low",
@@ -396,7 +414,16 @@
       }
     ],
     "light": 80,
-    "flags": [ "NO_UNLOAD", "NO_RELOAD", "CHARGEDIM", "TRADER_AVOID", "BELT_CLIP", "HELMET_HEAD_ATTACHMENT", "HEAD_STRAP_MOUNT" ]
+    "flags": [
+      "NO_UNLOAD",
+      "NO_RELOAD",
+      "CHARGEDIM",
+      "TRADER_AVOID",
+      "BELT_CLIP",
+      "HELMET_HEAD_ATTACHMENT",
+      "HEAD_STRAP_MOUNT",
+      "SPAWN_ACTIVE"
+    ]
   },
   {
     "id": "gasoline_lantern",
@@ -447,7 +474,7 @@
       { "type": "firestarter", "moves": 500, "moves_slow": 6000 }
     ],
     "light": 15,
-    "flags": [ "TRADER_AVOID", "ALLOWS_REMOTE_USE", "FIRESTARTER", "FIRE" ]
+    "flags": [ "TRADER_AVOID", "ALLOWS_REMOTE_USE", "FIRESTARTER", "FIRE", "SPAWN_ACTIVE" ]
   },
   {
     "id": "glowstick",
@@ -506,7 +533,7 @@
     "revert_to": "glowstick_dead",
     "revert_msg": "The glowstick fades out.",
     "light": 8,
-    "flags": [ "TRADER_AVOID", "SLEEP_IGNORE", "NO_UNLOAD", "NO_RELOAD" ]
+    "flags": [ "TRADER_AVOID", "SLEEP_IGNORE", "NO_UNLOAD", "NO_RELOAD", "SPAWN_ACTIVE" ]
   },
   {
     "id": "handflare",
@@ -546,7 +573,7 @@
     "//COMMENT": "Open flame or effectively so. ~5 seconds to transfer flame assuming optimal conditions, a minute at worst.",
     "use_action": { "type": "firestarter", "moves": 500, "moves_slow": 6000 },
     "light": 240,
-    "flags": [ "FIRE", "CHARGEDIM", "FLAMING", "TRADER_AVOID", "FIRESTARTER", "NO_UNLOAD", "NO_RELOAD" ]
+    "flags": [ "FIRE", "CHARGEDIM", "FLAMING", "TRADER_AVOID", "FIRESTARTER", "NO_UNLOAD", "NO_RELOAD", "SPAWN_ACTIVE" ]
   },
   {
     "id": "sigflare_lit",
@@ -624,7 +651,7 @@
       { "type": "link_up", "cable_length": 3, "charge_rate": "20 W" }
     ],
     "light": 650,
-    "flags": [ "NO_UNLOAD", "NO_RELOAD", "CHARGEDIM", "BELT_CLIP", "BELTED" ]
+    "flags": [ "NO_UNLOAD", "NO_RELOAD", "CHARGEDIM", "BELT_CLIP", "BELTED", "SPAWN_ACTIVE" ]
   },
   {
     "id": "lightstrip",
@@ -719,7 +746,7 @@
       { "type": "firestarter", "moves": 500, "moves_slow": 6000 }
     ],
     "light": 10,
-    "flags": [ "TRADER_AVOID", "FIRE", "ALLOWS_REMOTE_USE", "WATER_EXTINGUISH", "FIRESTARTER" ]
+    "flags": [ "TRADER_AVOID", "FIRE", "ALLOWS_REMOTE_USE", "WATER_EXTINGUISH", "FIRESTARTER", "SPAWN_ACTIVE" ]
   },
   {
     "id": "oil_lamp_clay",
@@ -772,7 +799,7 @@
       { "type": "firestarter", "moves": 500, "moves_slow": 6000 }
     ],
     "light": 10,
-    "flags": [ "TRADER_AVOID", "FIRE", "ALLOWS_REMOTE_USE", "WATER_EXTINGUISH", "WIND_EXTINGUISH", "FIRESTARTER" ]
+    "flags": [ "TRADER_AVOID", "FIRE", "ALLOWS_REMOTE_USE", "WATER_EXTINGUISH", "WIND_EXTINGUISH", "FIRESTARTER", "SPAWN_ACTIVE" ]
   },
   {
     "id": "oxylamp",
@@ -813,7 +840,7 @@
       { "type": "firestarter", "moves": 500, "moves_slow": 6000 }
     ],
     "light": 30,
-    "flags": [ "FIRESTARTER", "TRADER_AVOID", "FIRE", "ALLOWS_REMOTE_USE" ]
+    "flags": [ "FIRESTARTER", "TRADER_AVOID", "FIRE", "ALLOWS_REMOTE_USE", "SPAWN_ACTIVE" ]
   },
   {
     "id": "reading_light",
@@ -859,7 +886,7 @@
       "type": "transform"
     },
     "light": 15,
-    "flags": [ "NO_UNLOAD", "NO_RELOAD", "WATER_BREAK", "CHARGEDIM" ]
+    "flags": [ "NO_UNLOAD", "NO_RELOAD", "WATER_BREAK", "CHARGEDIM", "SPAWN_ACTIVE" ]
   },
   {
     "id": "smart_lamp",
@@ -931,7 +958,8 @@
       "RADIO_INVOKE_PROC",
       "RADIOSIGNAL_2",
       "CHARGEDIM",
-      "TRADER_AVOID"
+      "TRADER_AVOID",
+      "SPAWN_ACTIVE"
     ]
   },
   {
@@ -997,7 +1025,7 @@
     ],
     "techniques": [ "WBLOCK_1" ],
     "light": 60,
-    "flags": [ "FIRE", "CHARGEDIM", "FLAMING", "TRADER_AVOID", "WATER_EXTINGUISH", "BURNOUT" ],
+    "flags": [ "FIRE", "CHARGEDIM", "FLAMING", "TRADER_AVOID", "WATER_EXTINGUISH", "BURNOUT", "SPAWN_ACTIVE" ],
     "melee_damage": { "bash": 8 }
   },
   {
@@ -1048,7 +1076,7 @@
       { "type": "firestarter", "moves": 500, "moves_slow": 6000 }
     ],
     "light": 15,
-    "flags": [ "TRADER_AVOID", "ALLOWS_REMOTE_USE", "FIRESTARTER", "FIRE" ]
+    "flags": [ "TRADER_AVOID", "ALLOWS_REMOTE_USE", "FIRESTARTER", "FIRE", "SPAWN_ACTIVE" ]
   },
   {
     "id": "candle_small",
@@ -1096,7 +1124,7 @@
       }
     ],
     "light": 6,
-    "extend": { "flags": [ "WATER_EXTINGUISH", "TRADER_AVOID", "WIND_EXTINGUISH", "FIRESTARTER" ] }
+    "extend": { "flags": [ "WATER_EXTINGUISH", "TRADER_AVOID", "WIND_EXTINGUISH", "FIRESTARTER", "SPAWN_ACTIVE" ] }
   },
   {
     "id": "menorah",

--- a/data/json/items/tool/masonry.json
+++ b/data/json/items/tool/masonry.json
@@ -83,7 +83,7 @@
         }
       ]
     },
-    "flags": [ "MESSY", "TRADER_AVOID", "NONCONDUCTIVE", "POWERED", "FRAGILE_MELEE" ],
+    "flags": [ "MESSY", "TRADER_AVOID", "NONCONDUCTIVE", "POWERED", "FRAGILE_MELEE", "SPAWN_ACTIVE" ],
     "melee_damage": { "bash": 4, "cut": 10 }
   },
   {
@@ -181,7 +181,8 @@
       "NO_UNLOAD",
       "NO_RELOAD",
       "WATER_BREAK",
-      "ELECTRONIC"
+      "ELECTRONIC",
+      "SPAWN_ACTIVE"
     ],
     "faults": [ { "fault_group": "electronic_general" } ],
     "melee_damage": { "bash": 4, "cut": 10 }

--- a/data/json/items/tool/misc.json
+++ b/data/json/items/tool/misc.json
@@ -420,7 +420,7 @@
     "power_draw": "1 kW",
     "emits": [ "emit_hot_air2_blast" ],
     "light": 2,
-    "flags": [ "ALLOWS_REMOTE_USE" ],
+    "flags": [ "ALLOWS_REMOTE_USE", "SPAWN_ACTIVE" ],
     "revert_to": "large_space_heater",
     "use_action": [
       {
@@ -632,7 +632,7 @@
     "power_draw": "500 W",
     "emits": [ "emit_hot_air2_stream" ],
     "light": 2,
-    "flags": [ "ALLOWS_REMOTE_USE" ],
+    "flags": [ "ALLOWS_REMOTE_USE", "SPAWN_ACTIVE" ],
     "revert_to": "small_space_heater",
     "use_action": [
       {
@@ -793,7 +793,7 @@
       "fields_min_intensity": 1,
       "fields_max_intensity": 3
     },
-    "flags": [ "TRADER_AVOID", "ZERO_WEIGHT" ]
+    "flags": [ "TRADER_AVOID", "ZERO_WEIGHT", "SPAWN_ACTIVE" ]
   },
   {
     "id": "teleumbrella",

--- a/data/json/items/tool/radio_tools.json
+++ b/data/json/items/tool/radio_tools.json
@@ -145,7 +145,7 @@
     ],
     "tick_action": [ "RADIO_TICK" ],
     "faults": [ { "fault_group": "electronic_general" } ],
-    "flags": [ "TRADER_AVOID", "WATER_BREAK", "ELECTRONIC" ]
+    "flags": [ "TRADER_AVOID", "WATER_BREAK", "ELECTRONIC", "SPAWN_ACTIVE" ]
   },
   {
     "id": "two_way_radio",

--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -789,7 +789,7 @@
     "subtypes": [ "TOOL", "ARMOR" ],
     "name": { "str_sp": "thermal electric socks (on) (pair)" },
     "description": "A pair of socks with internal battery-powered heating elements.  They are currently on, and continually draining batteries.  Use it to turn them off.",
-    "flags": [ "VARSIZE", "SKINTIGHT", "TRADER_AVOID" ],
+    "flags": [ "VARSIZE", "SKINTIGHT", "TRADER_AVOID", "SPAWN_ACTIVE" ],
     "power_draw": "400 mW",
     "revert_to": "thermal_socks",
     "use_action": {
@@ -845,7 +845,7 @@
     "subtypes": [ "TOOL", "ARMOR" ],
     "name": { "str": "thermal electric suit (on)", "str_pl": "thermal electric suits (on)" },
     "description": "A full-body suit of thin thermal underwear equipped with internal battery-powered heating elements.  It is currently on, and continually draining batteries.  Use it to turn it off.",
-    "flags": [ "VARSIZE", "SKINTIGHT", "TRADER_AVOID" ],
+    "flags": [ "VARSIZE", "SKINTIGHT", "TRADER_AVOID", "SPAWN_ACTIVE" ],
     "power_draw": "6800 mW",
     "revert_to": "thermal_suit",
     "warmth": 60,
@@ -901,7 +901,7 @@
     "subtypes": [ "TOOL", "ARMOR" ],
     "name": { "str_sp": "thermal electric gloves (on) (pair)" },
     "description": "A pair of gloves with internal battery-powered heating elements.  They are currently on, and continually draining batteries.  Use it to turn them off.",
-    "flags": [ "VARSIZE", "SKINTIGHT", "TRADER_AVOID" ],
+    "flags": [ "VARSIZE", "SKINTIGHT", "TRADER_AVOID", "SPAWN_ACTIVE" ],
     "power_draw": "400 mW",
     "revert_to": "thermal_gloves",
     "use_action": {
@@ -957,7 +957,7 @@
     "subtypes": [ "TOOL", "ARMOR" ],
     "name": { "str": "thermal electric balaclava (on)", "str_pl": "thermal electric balaclavas (on)" },
     "description": "A snug cloth mask with internal battery-powered heating elements.  It is are currently on, and continually draining batteries.  Use it to turn it off.",
-    "flags": [ "VARSIZE", "SKINTIGHT", "TRADER_AVOID" ],
+    "flags": [ "VARSIZE", "SKINTIGHT", "TRADER_AVOID", "SPAWN_ACTIVE" ],
     "power_draw": "400 mW",
     "revert_to": "thermal_mask",
     "use_action": {
@@ -1078,7 +1078,7 @@
     "subtypes": [ "TOOL", "ARMOR" ],
     "name": { "str": "headlamp (on)", "str_pl": "headlamps (on)" },
     "description": "An LED headlamp with an adjustable strap so as to be comfortably worn on your head or attached to your helmet.  It is turned on, and continually draining batteries.  Use it to turn it off.",
-    "flags": [ "CHARGEDIM", "OVERSIZE", "BELTED", "PADDED", "ALLOWS_NATURAL_ATTACKS", "TRADER_AVOID" ],
+    "flags": [ "CHARGEDIM", "OVERSIZE", "BELTED", "PADDED", "ALLOWS_NATURAL_ATTACKS", "TRADER_AVOID", "SPAWN_ACTIVE" ],
     "light": 300,
     "power_draw": "1560 mW",
     "revert_to": "wearable_light",
@@ -1097,7 +1097,7 @@
     "subtypes": [ "TOOL", "ARMOR" ],
     "name": { "str": "heavy-duty headlamp (on)", "str_pl": "heavy-duty headlamps (on)" },
     "description": "A heavy-duty LED headlamp with a durable polymer housing.  It's impact-resistant, chemical-resistant, waterproof and certified for use in hazardous environments.  Designed for firefighters, rescue personnel and miners.  Use it to turn it off.",
-    "flags": [ "CHARGEDIM", "OVERSIZE", "BELTED", "PADDED", "ALLOWS_NATURAL_ATTACKS", "TRADER_AVOID" ],
+    "flags": [ "CHARGEDIM", "OVERSIZE", "BELTED", "PADDED", "ALLOWS_NATURAL_ATTACKS", "TRADER_AVOID", "SPAWN_ACTIVE" ],
     "light": 650,
     "power_draw": "4 W",
     "revert_to": "wearable_big_light",
@@ -1303,7 +1303,7 @@
     "subtypes": [ "TOOL", "ARMOR" ],
     "copy-from": "helmet_eod",
     "name": { "str": "EOD helmet (on)", "str_pl": "EOD helmets (on)" },
-    "extend": { "flags": [ "CHARGEDIM", "TRADER_AVOID", "TWO_WAY_RADIO" ] },
+    "extend": { "flags": [ "CHARGEDIM", "TRADER_AVOID", "TWO_WAY_RADIO", "SPAWN_ACTIVE" ] },
     "light": 350,
     "power_draw": "10 W",
     "revert_to": "helmet_eod",
@@ -1439,7 +1439,8 @@
       "NO_UNLOAD",
       "COMBAT_TOGGLEABLE",
       "UNBREAKABLE_MELEE",
-      "USE_POWER_WHEN_HIT"
+      "USE_POWER_WHEN_HIT",
+      "SPAWN_ACTIVE"
     ],
     "material": [ "hyperweave_on", "carbide" ],
     "power_draw": "100 W",
@@ -1561,7 +1562,7 @@
       "msg": "The %s LED light flickers off.",
       "target": "dimensional_anchor"
     },
-    "flags": [ "DIMENSIONAL_ANCHOR", "OVERSIZE", "BELTED", "PORTAL_PROOF", "SOFT" ]
+    "flags": [ "DIMENSIONAL_ANCHOR", "OVERSIZE", "BELTED", "PORTAL_PROOF", "SOFT", "SPAWN_ACTIVE" ]
   },
   {
     "id": "broken_dimensional_anchor",
@@ -1574,7 +1575,6 @@
       "type": "transform",
       "msg": "The %s emits a low-pitched clicking alarm as its mounted LED light flashes yellow.",
       "target": "broken_dimensional_anchor",
-      "active": true,
       "need_charges": 1,
       "need_charges_msg": "It seems like this device needs power."
     }
@@ -1624,7 +1624,8 @@
       "USE_UPS",
       "NO_UNLOAD",
       "COMBAT_TOGGLEABLE",
-      "UNBREAKABLE_MELEE"
+      "UNBREAKABLE_MELEE",
+      "SPAWN_ACTIVE"
     ],
     "armor": [
       {
@@ -1791,7 +1792,7 @@
     "material": [ "plastic", "aluminum" ],
     "name": { "str": "rebreather mask (on)", "str_pl": "rebreather masks (on)" },
     "description": "A mask worn over your mouth which, when loaded with the proper filters, recycles your exhaled breath for rebreathing while underwater.  It is turned on, and continually consuming its filter.  Use it to turn it off.",
-    "flags": [ "WATER_FRIENDLY", "REBREATHER", "TRADER_AVOID" ],
+    "flags": [ "WATER_FRIENDLY", "REBREATHER", "TRADER_AVOID", "SPAWN_ACTIVE" ],
     "turns_per_charge": 60,
     "revert_to": "rebreather",
     "use_action": { "ammo_scale": 0, "type": "transform", "menu_text": "Turn off", "msg": "Your %s deactivates.", "target": "rebreather" },
@@ -1844,7 +1845,7 @@
     "name": { "str": "rebreather mask (on)", "str_pl": "rebreather masks (on)" },
     "material": [ "plastic", "aluminum" ],
     "description": "A mask worn over your mouth which, when loaded with the proper filters, recycles your exhaled breath for rebreathing while underwater.  This model has been expanded substantially and can accommodate exotic anatomy.  It is turned on, and continually consuming its filter.  Use it to turn it off.",
-    "flags": [ "WATER_FRIENDLY", "REBREATHER", "OVERSIZE", "PREFIX_XL", "TRADER_AVOID" ],
+    "flags": [ "WATER_FRIENDLY", "REBREATHER", "OVERSIZE", "PREFIX_XL", "TRADER_AVOID", "SPAWN_ACTIVE" ],
     "turns_per_charge": 60,
     "revert_to": "rebreather_xl",
     "use_action": {
@@ -1903,7 +1904,7 @@
     "subtypes": [ "TOOL", "ARMOR" ],
     "name": { "str": "rebreather mask (on)", "str_pl": "rebreather masks (on)" },
     "description": "A mask worn over your mouth which, when loaded with the proper filters, recycles your exhaled breath for rebreathing while underwater.  This model has been shrunk dramatically to fit a smaller face.  It is turned on, and continually consuming its filter.  Use it to turn it off.",
-    "flags": [ "WATER_FRIENDLY", "REBREATHER", "UNDERSIZE", "PREFIX_XS", "TRADER_AVOID" ],
+    "flags": [ "WATER_FRIENDLY", "REBREATHER", "UNDERSIZE", "PREFIX_XS", "TRADER_AVOID", "SPAWN_ACTIVE" ],
     "turns_per_charge": 60,
     "revert_to": "rebreather_xs",
     "use_action": {
@@ -2471,7 +2472,7 @@
     "name": { "str_sp": "light amp goggles (on)" },
     "description": "A pair of battery-powered goggles that use a infrared LED in conjunction with a IR camera, allowing you to see in the dark.  It is turned on, and continually draining batteries.  Use it to turn them off.",
     "material": [ "plastic", "steel" ],
-    "extend": { "flags": [ "TRADER_AVOID", "NVG_GREEN" ] },
+    "extend": { "flags": [ "TRADER_AVOID", "NVG_GREEN", "SPAWN_ACTIVE" ] },
     "//": "2019 commercial models can operate at under 0.375W with the IR illuminator on",
     "power_draw": "375 mW",
     "revert_to": "goggles_nv",
@@ -2527,7 +2528,7 @@
     "name": { "str_sp": "infrared goggles (on)" },
     "description": "A pair of battery-powered goggles that grant infrared vision, allowing you to see warm-blooded creatures in the dark.  Use it to turn them off.",
     "material": [ "plastic", "steel" ],
-    "extend": { "flags": [ "TRADER_AVOID" ] },
+    "extend": { "flags": [ "TRADER_AVOID", "SPAWN_ACTIVE" ] },
     "faults": [ { "fault_group": "electronic_general" } ],
     "power_draw": "1 W",
     "revert_to": "goggles_ir",
@@ -2643,7 +2644,7 @@
     "subtypes": [ "TOOL", "ARMOR" ],
     "name": { "str": "survivor divemask (on)", "str_pl": "survivor divemasks (on)" },
     "description": "A custom-built, armored rebreather mask that covers the face and eyes.  Provides excellent protection from harm as well providing breathing gas while underwater.  It is turned on, and continually consuming its filter.  Use it to turn it off.",
-    "flags": [ "VARSIZE", "STURDY", "WATER_FRIENDLY", "REBREATHER", "SWIM_GOGGLES" ],
+    "flags": [ "VARSIZE", "STURDY", "WATER_FRIENDLY", "REBREATHER", "SWIM_GOGGLES", "SPAWN_ACTIVE" ],
     "turns_per_charge": 60,
     "revert_to": "mask_h20survivor",
     "use_action": {
@@ -2700,7 +2701,17 @@
     "subtypes": [ "TOOL", "ARMOR" ],
     "name": { "str": "survivor divemask (on)", "str_pl": "survivor divemasks (on)" },
     "description": "A custom-built, armored rebreather mask that covers the face and eyes regardless of your state of mutation.  Provides excellent protection from harm as well providing breathing gas while underwater.  It is turned on, and continually consuming its filter.  Use it to turn it off.",
-    "flags": [ "VARSIZE", "STURDY", "WATER_FRIENDLY", "REBREATHER", "SWIM_GOGGLES", "OVERSIZE", "PREFIX_XL", "TRADER_AVOID" ],
+    "flags": [
+      "VARSIZE",
+      "STURDY",
+      "WATER_FRIENDLY",
+      "REBREATHER",
+      "SWIM_GOGGLES",
+      "OVERSIZE",
+      "PREFIX_XL",
+      "TRADER_AVOID",
+      "SPAWN_ACTIVE"
+    ],
     "turns_per_charge": 60,
     "revert_to": "mask_h20survivorxl",
     "use_action": {
@@ -2721,7 +2732,17 @@
     "name": { "str": "survivor divemask (on)", "str_pl": "survivor divemasks (on)" },
     "description": "A custom-built, armored rebreather mask that covers the face and eyes.  Provides excellent protection from harm as well providing breathing gas while underwater.  Use it to turn it on.",
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
-    "flags": [ "VARSIZE", "STURDY", "WATER_FRIENDLY", "REBREATHER", "SWIM_GOGGLES", "UNDERSIZE", "PREFIX_XS", "TRADER_AVOID" ],
+    "flags": [
+      "VARSIZE",
+      "STURDY",
+      "WATER_FRIENDLY",
+      "REBREATHER",
+      "SWIM_GOGGLES",
+      "UNDERSIZE",
+      "PREFIX_XS",
+      "TRADER_AVOID",
+      "SPAWN_ACTIVE"
+    ],
     "turns_per_charge": 60,
     "revert_to": "mask_h20survivorxs",
     "use_action": {
@@ -2899,7 +2920,7 @@
     "subtypes": [ "TOOL", "ARMOR" ],
     "name": { "str": "thermal electric outfit (on)", "str_pl": "thermal electric outfits (on)" },
     "description": "A suit of thin thermal underwear that covers you from head to toe and is equipped with internal battery-powered heating elements.  It is currently on, and continually draining batteries.  Use it to turn it off.",
-    "flags": [ "VARSIZE", "SKINTIGHT", "TRADER_AVOID" ],
+    "flags": [ "VARSIZE", "SKINTIGHT", "TRADER_AVOID", "SPAWN_ACTIVE" ],
     "power_draw": "8 W",
     "revert_to": "thermal_outfit",
     "use_action": {
@@ -3169,9 +3190,9 @@
     "category": "armor",
     "symbol": "[",
     "color": "blue",
-    "name": { "str_sp": "shooter's earmuffs" },
+    "name": { "str_sp": "shooter's earmuffs (on)" },
     "description": "A pair of earmuffs favored by shooters.  The earmuffs are turned on, and will block sounds over a certain decibel amount while otherwise allowing you to hear normally.",
-    "flags": [ "OVERSIZE", "BELTED", "ALLOWS_NATURAL_ATTACKS", "PARTIAL_DEAF", "WATER_BREAK", "ELECTRONIC" ],
+    "flags": [ "OVERSIZE", "BELTED", "ALLOWS_NATURAL_ATTACKS", "PARTIAL_DEAF", "WATER_BREAK", "ELECTRONIC", "SPAWN_ACTIVE" ],
     "faults": [ { "fault_group": "electronic_general" } ],
     "price": "125 USD",
     "price_postapoc": "7 USD 50 cent",
@@ -3239,7 +3260,7 @@
     "color": "blue",
     "name": { "str_sp": "shooter's ear plugs (on)" },
     "description": "A pair of in-ear drivers designed to dampen loud sounds and amplify quiet sounds.  The earplugs are turned on, and will block sounds over a certain decibel amount while otherwise allowing you to hear normally.",
-    "flags": [ "OVERSIZE", "PARTIAL_DEAF", "USE_UPS", "NO_UNLOAD", "NO_RELOAD" ],
+    "flags": [ "OVERSIZE", "PARTIAL_DEAF", "USE_UPS", "NO_UNLOAD", "NO_RELOAD", "SPAWN_ACTIVE" ],
     "//": "same power draw as the earmuffs, much smaller internal battery",
     "power_draw": "60 mW",
     "revert_to": "powered_earplugs",
@@ -3662,6 +3683,7 @@
     "name": { "str": "electric blanket (on)", "str_pl": "electric blankets (on)" },
     "description": "A heated blanket made of polyester.  It's turned on, making it nice and toasty while it lasts.",
     "copy-from": "electric_blanket",
+    "extend": { "flags": [ "SPAWN_ACTIVE" ] },
     "warmth": 90,
     "power_draw": "100 W",
     "revert_to": "electric_blanket",
@@ -3724,7 +3746,7 @@
     "use_action": [ "FOODPERSON" ],
     "tick_action": [ "FOODPERSON_VOICE" ],
     "light": 10,
-    "flags": [ "OUTER", "SUN_GLASSES", "NO_TAKEOFF", "WATCH", "NO_UNLOAD" ]
+    "flags": [ "OUTER", "SUN_GLASSES", "NO_TAKEOFF", "WATCH", "NO_UNLOAD", "SPAWN_ACTIVE" ]
   },
   {
     "id": "attached_ear_plugs_on",
@@ -3856,7 +3878,7 @@
     "symbol": "[",
     "looks_like": "helmet_motor",
     "color": "dark_gray",
-    "extend": { "flags": [ "PARTIAL_DEAF", "TWO_WAY_RADIO" ] },
+    "extend": { "flags": [ "PARTIAL_DEAF", "TWO_WAY_RADIO", "SPAWN_ACTIVE" ] },
     "delete": { "flags": [ "DEAF" ] },
     "power_draw": "60 mW",
     "revert_to": "flight_helmet",
@@ -3949,7 +3971,7 @@
     "subtypes": [ "TOOL", "ARMOR" ],
     "name": { "str": "battery powered utility exoskeleton (on)", "str_pl": "battery powered utility exoskeletons (on)" },
     "description": "A skeletal frame of sturdy metal with attached motors to allow the user to move heavier loads with less strain on the body.  It is turned on and continually drawing power.  Use it to turn it off.",
-    "flags": [ "STURDY", "OVERSIZE", "BELTED", "WATER_FRIENDLY", "TRADER_AVOID" ],
+    "flags": [ "STURDY", "OVERSIZE", "BELTED", "WATER_FRIENDLY", "TRADER_AVOID", "SPAWN_ACTIVE" ],
     "power_draw": "972216 mW",
     "//": "Battery should last two hours (02:00:07). Weight capacity bonus should include weight of item AND battery, plus 90kg.",
     "revert_to": "utility_exoskeleton_off",
@@ -4009,7 +4031,7 @@
     "subtypes": [ "TOOL", "ARMOR" ],
     "name": { "str": "ICE utility exoskeleton (on)", "str_pl": "ICE utility exoskeletons (on)" },
     "description": "A skeletal frame of sturdy metal with attached motors to allow the user to move heavier loads with less strain on the body.  This model uses a compact internal combustion engine for power.  It is turned on and continually draining gasoline.  Use it to turn it off.",
-    "flags": [ "STURDY", "OVERSIZE", "BELTED", "WATER_FRIENDLY", "TRADER_AVOID" ],
+    "flags": [ "STURDY", "OVERSIZE", "BELTED", "WATER_FRIENDLY", "TRADER_AVOID", "SPAWN_ACTIVE" ],
     "turns_per_charge": 1,
     "//": "Full tank lasts a bit under three hours (166.66 minutes). Has less carry bonus than the battery one since the weight of the fuel will drop over time.",
     "revert_to": "ice_utility_exoskeleton_off",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Ensure active items are spawned active.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add the SPAWN_ACTIVE flag to active items. It seems this covers everything intended to be covered.
By-catch:
- Renamed inactive variable diving flashlight to match the others. Probably a copy-paste error.
- Removed the activation of the malfunctioning Hub 01 5-point harness when used, as it "transforms" back to itself, which is inactive.
- Renamed the active shooter's earmuffs to distinguish them from the inactive version.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
- Try to find items activated implicitly. Known such devilries are the mp3 and EoC activations. The only such cases dealt with are ones stumbled upon by proximity (some mp3 in the previous PR and an EoC case here).
- Figure out the broken lightstrip mess. Neither version can get its activation operation active even when cables are connected.
- Try to sort out the space heater flag inconsistencies. The big and small ones have different flags, and the active versions seem to lack some.
- Try to understand the mutation activations to see if it's relevant.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Debug spawned (and saw) each of the modified items to verify their correctness. This was done gradually as items were modified, rather than a big activity at the end.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
- This PR shouldn't have any game play effect, as items shouldn't spawn active. It will have an effect when debug spawning items, though.
- Note that this PR doesn't deal with transformation of PC activated timed items into auto transforming ones. That's intended to be dealt with in a separate line of PRs.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
