### PR TITLE
remove stub section from doc

### DIFF
--- a/doc/MODDING.md
+++ b/doc/MODDING.md
@@ -22,7 +22,6 @@
   - [Adjusting monster stats](#adjusting-monster-stats)
   - [External options](#external-options)
   - [Important note on json files](#important-note-on-json-files)
-    - [That which cannot be modded](#that-which-cannot-be-modded)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -383,10 +382,3 @@ In game, that appears like this:
 `This is a shirt that says "I wanna kill ALL the zombies" on the front.`
 
 Many editors have features that let you track `{ [` and `] }` to see if they're balanced (ie, have a matching opposite); These editors will also respect escaped characters properly. [Notepad++](https://notepad-plus-plus.org/) is a popular, free editor on Windows that contains this feature.  On Linux, there are a plethora of options, and you probably already have a preferred one 🙂
-
-### That which cannot be modded
-
-Almost everything in this game can be modded. Almost. This section is intended to chart those areas not supported for modding to save time and headaches.
-
-The Names folder and contents (EN etcetera) confirmed 5/23/20
-Construction recipes. Can be worked around by adding requirements and modding those, confirmed 7/4/22


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
This section is inaccurate and unhelpful. Not *everything* is modable and tracking exceptions wouldn't be helpful even if we were doing it,  which we aren't.

#### Describe the solution
Just remove it.