### PR TITLE
Fix base64 encoding of horde passability bitsets

### DIFF
--- a/src/catacharset.cpp
+++ b/src/catacharset.cpp
@@ -229,8 +229,8 @@ static constexpr const std::array<char, 256> base64_decoding_table = build_base6
 
 static const std::array<int, 3> mod_table = {{0, 2, 1}};
 
-static std::string base64_encode_raw( std::string_view bits );
-static std::string base64_decode_raw( std::string_view bits );
+static std::string base64_encode_raw( std::string_view str );
+static std::string base64_decode_raw( std::string_view instr );
 
 std::string base64_encode_bitset( const std::bitset<576> &bitset_to_encode )
 {

--- a/src/catacharset.cpp
+++ b/src/catacharset.cpp
@@ -204,7 +204,7 @@ std::string utf8_truncate( const std::string &s, size_t length )
     return s.substr( 0, last_pos );
 }
 
-static const std::array<char, 64> base64_encoding_table = {{
+static constexpr const std::array<char, 64> base64_encoding_table = {{
         'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H',
         'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P',
         'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X',
@@ -216,32 +216,70 @@ static const std::array<char, 64> base64_encoding_table = {{
     }
 };
 
-static       std::array<char, 256> base64_decoding_table;
+static constexpr std::array<char, 256> build_base64_decoding_table()
+{
+    std::array<char, 256> ret{ 0 };
+    for( int i = 0; i < 64; i++ ) {
+        ret[static_cast<unsigned char>( base64_encoding_table[i] )] = i;
+    }
+    return ret;
+}
+
+static constexpr const std::array<char, 256> base64_decoding_table = build_base64_decoding_table();
+
 static const std::array<int, 3> mod_table = {{0, 2, 1}};
 
-static void build_base64_decoding_table()
+static std::string base64_encode_raw( std::string_view bits );
+static std::string base64_decode_raw( std::string_view bits );
+
+std::string base64_encode_bitset( const std::bitset<576> &bitset_to_encode )
 {
-    static bool built = false;
-    if( !built ) {
-        for( int i = 0; i < 64; i++ ) {
-            base64_decoding_table[static_cast<unsigned char>( base64_encoding_table[i] )] = i;
+    std::string raw_bitset_data( 72, '\0' );
+    for( uint64_t i = 0; i < 9; ++i ) {
+        uint64_t bits = 0;
+        for( size_t j = 0; j < sizeof( bits ) * 8; ++j ) {
+            if( bitset_to_encode[( i * 64 ) + j] ) {
+                bits |= 1ULL << j;
+            }
         }
-        built = true;
+        memcpy( &raw_bitset_data[i * 8], &bits, sizeof( bits ) );
+    }
+    return base64_encode_raw( raw_bitset_data );
+}
+
+void base64_decode_bitset( std::string_view packed_bitset,
+                           std::bitset<576> &destination_bitset )
+{
+    if( !packed_bitset.empty() && packed_bitset[0] == '#' ) {
+        packed_bitset = packed_bitset.substr( 1 );
+    }
+    std::string decoded_string = base64_decode_raw( packed_bitset );
+    for( int i = 0; i < 9; i++ ) {
+        uint64_t bits;
+        memcpy( &bits, &decoded_string[( 8 - i ) * 8], sizeof( bits ) );
+        std::bitset<576> temp_bitset( bits );
+        destination_bitset <<= 64;
+        destination_bitset |= temp_bitset;
     }
 }
 
-std::string base64_encode( const std::string &str )
+std::string base64_encode( const std::string_view &str )
 {
     //assume it is already encoded
     if( !str.empty() && str[0] == '#' ) {
-        return str;
+        return std::string{ str };
     }
+    return "#" + base64_encode_raw( str );
+}
+
+std::string base64_encode_raw( std::string_view str )
+{
 
     int input_length = str.length();
     int output_length = 4 * ( ( input_length + 2 ) / 3 );
 
     std::string encoded_data( output_length, '\0' );
-    const unsigned char *data = reinterpret_cast<const unsigned char *>( str.c_str() );
+    const unsigned char *data = reinterpret_cast<const unsigned char *>( str.data() );
 
     for( int i = 0, j = 0; i < input_length; ) {
 
@@ -261,28 +299,25 @@ std::string base64_encode( const std::string &str )
         encoded_data[output_length - 1 - i] = '=';
     }
 
-    return "#" + encoded_data;
+    return encoded_data;
 }
 
-std::string base64_decode( const std::string &str )
+std::string base64_decode( const std::string_view &str )
 {
     // do not decode if it is not base64
-    if( str.empty() || str[0] != '#' ) {
-        return str;
+    if( str.empty() || str[0] != '#' || ( str.length() - 1 ) % 4 != 0 ) {
+        return std::string{ str };
     }
 
-    build_base64_decoding_table();
+    return base64_decode_raw( str.substr( 1 ) );
+}
 
-    std::string instr = str.substr( 1 );
-
+std::string base64_decode_raw( std::string_view instr )
+{
     int input_length = instr.length();
 
-    if( input_length % 4 != 0 ) {
-        return str;
-    }
-
     int output_length = input_length / 4 * 3;
-    const char *data = instr.c_str();
+    const char *data = instr.data();
 
     if( data[input_length - 1] == '=' ) {
         output_length--;

--- a/src/catacharset.h
+++ b/src/catacharset.h
@@ -4,6 +4,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <bitset>
 #include <iterator>
 #include <string>
 #include <string_view>
@@ -46,8 +47,12 @@ int center_text_pos( const utf8_wrapper &text, int start_pos, int end_pos );
 std::string utf32_to_utf8( uint32_t ch );
 std::string utf8_truncate( const std::string &s, size_t length );
 
-std::string base64_encode( const std::string &str );
-std::string base64_decode( const std::string &str );
+std::string base64_encode( const std::string_view &str );
+std::string base64_decode( const std::string_view &str );
+
+std::string base64_encode_bitset( const std::bitset<576> &bitset_to_encode );
+void base64_decode_bitset( std::string_view packed_bitset,
+                           std::bitset<576> &destination_bitset );
 
 std::wstring utf8_to_wstr( const std::string &str );
 std::string wstr_to_utf8( const std::wstring &wstr );

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -1912,7 +1912,7 @@ void construct::done_deconstruct( const tripoint_bub_ms &p, Character &player_ch
             drop = here.spawn_items( p, item_group::items_from( f.deconstruct->drop_group, calendar::turn ) );
         }
 
-        if( f.deconstruct->skill.has_value() ) {
+        if( f.deconstruct && f.deconstruct->skill.has_value() ) {
             deconstruction_practice_skill( f.deconstruct->skill.value() );
         }
         // if furniture has liquid in it and deconstructs into watertight containers then fill them
@@ -2195,12 +2195,12 @@ void construct::do_turn_deconstruct( const tripoint_bub_ms &p, Character &who )
         std::string tname;
         if( here.has_furn( p ) ) {
             const furn_t &f = here.furn( p ).obj();
-            if( f.deconstruct || !f.base_item.is_null() ) {
+            if( f.deconstruct && !f.base_item.is_null() ) {
                 deconstruct_query( f.deconstruct->potential_deconstruct_items( f ) );
             }
         } else {
             const ter_t &t = here.ter( p ).obj();
-            if( t.deconstruct || !t.base_item.is_null() ) {
+            if( t.deconstruct && !t.base_item.is_null() ) {
                 deconstruct_query( t.deconstruct->potential_deconstruct_items( t ) );
             }
         }

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -458,39 +458,6 @@ void overmap::unserialize( std::istream &fin )
     unserialize( jsin.get_object() );
 }
 
-// In global scope for testing
-// NOLINTNEXTLINE(cata-static-declarations)
-std::string base64_encode_bitset( const std::bitset<576> &bitset_to_encode );
-std::string base64_encode_bitset( const std::bitset<576> &bitset_to_encode )
-{
-    std::string raw_bitset_data( 72, '\0' );
-    for( uint64_t i = 0; i < 9; ++i ) {
-        uint64_t bits = 0;
-        for( size_t j = 0; j < sizeof( bits ) * 8; ++j ) {
-            if( bitset_to_encode[( i * 64 ) + j ] ) {
-                bits |= 1ULL << j;
-            }
-        }
-        memcpy( &raw_bitset_data[ i * 8 ], &bits, sizeof( bits ) );
-    }
-    return base64_encode( raw_bitset_data );
-}
-
-// In global scope for testing
-// NOLINTNEXTLINE(cata-static-declarations)
-void base64_decode_bitset( const std::string &packed_bitset, std::bitset<576> &destination_bitset );
-void base64_decode_bitset( const std::string &packed_bitset, std::bitset<576> &destination_bitset )
-{
-    std::string decoded_string = base64_decode( packed_bitset );
-    for( int i = 0; i < 9; i++ ) {
-        uint64_t bits;
-        memcpy( &bits, &decoded_string[( 8 - i ) * 8], sizeof( bits ) );
-        std::bitset<576> temp_bitset( bits );
-        destination_bitset <<= 64;
-        destination_bitset |= temp_bitset;
-    }
-}
-
 void overmap::unserialize( const JsonObject &jsobj )
 {
     // These must be read in this order.

--- a/tests/overmap_map_data_cache_test.cpp
+++ b/tests/overmap_map_data_cache_test.cpp
@@ -3,6 +3,7 @@
 #include <string>
 
 #include "cata_catch.h"
+#include "catacharset.h"
 #include "coordinates.h"
 #include "overmap.h"
 #include "overmap_map_data_cache.h"
@@ -65,11 +66,6 @@ TEST_CASE( "check_placeholders_in_isolation", "[map_data]" )
         }
     }
 }
-
-// NOLINTNEXTLINE(cata-static-declarations)
-std::string base64_encode_bitset( const std::bitset<576> &bitset_to_encode );
-// NOLINTNEXTLINE(cata-static-declarations)
-void base64_decode_bitset( const std::string &packed_bitset, std::bitset<576> &destination_bitset );
 
 TEST_CASE( "round_trip_bitset_to_base64", "[map_data][hordes]" )
 {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Fix rare overmap save corruption from specific horde metadata"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes #83516. Fixes #83423. Fixed #83395. We were getting many reports of people's saves loading weird and overmaps being regenerated. Turns out the base64 encode/decode code was very old and makes some assumptions about the inputs. Such as, if the input starts with a `#`, then it must already be base64 encoded. This is not correct for packed passability bitsets where the packed data can be any arbitrary character.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Rewrite the base64 encode/decode functions for strings and bitsets on top of a common core which does not do any prefix checks. Make the prefix checks only happen in the string functions. Handle loading encoded bitsets with a prefix to forward migrate data.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Before: bitset starts with `#` and gets encoded as the same (garbage data after not shown due to embedded null character).
<img width="1416" height="912" alt="image" src="https://github.com/user-attachments/assets/9202c141-52d9-4deb-b9ba-cd95221f1486" />

After: bitset is properly encoded in base64 without prefix.
<img width="1712" height="358" alt="image" src="https://github.com/user-attachments/assets/de60cdf1-222b-4b8b-93ac-3d1d1ce244ab" />

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
