### PR TITLE
Fix scaling factor for high-dpi displays

### DIFF
--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -3628,7 +3628,9 @@ int projected_window_height()
 static std::pair<float, float> get_display_scale( int display_index )
 {
 #if SDL_VERSION_ATLEAST(2,26,0)
+    // NOLINTNEXTLINE(cata-combine-locals-into-point)
     int x = SDL_WINDOWPOS_CENTERED_DISPLAY( display_index );
+    // NOLINTNEXTLINE(cata-combine-locals-into-point)
     int y = SDL_WINDOWPOS_CENTERED_DISPLAY( display_index );
 
     SDL_Window *w = SDL_CreateWindow(
@@ -3641,9 +3643,11 @@ static std::pair<float, float> get_display_scale( int display_index )
         return std::make_pair( 1.0f, 1.0f );
     }
 
-    int lw, lh;
+    int lw = 0;
+    int lh = 0;
     SDL_GetWindowSize( w, &lw, &lh );
-    int pw, ph;
+    int pw;
+    int ph;
     SDL_GetWindowSizeInPixels( w, &pw, &ph );
     SDL_DestroyWindow( w );
 

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -3703,8 +3703,9 @@ static void init_term_size_and_scaling_factor()
 
             } else {
                 // For fullscreen or window borderless maximum size is the display size
-                max_width = current_display.w;
-                max_height = current_display.h;
+                auto [ dpi_scale_w, dpi_scale_h ] = get_display_scale( current_display_id );
+                max_width = dpi_scale_w * current_display.w;
+                max_height = dpi_scale_h * current_display.h;
             }
         } else {
             dbg( D_WARNING ) << "Failed to get current Display Mode, assuming infinite display size.";

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -3625,7 +3625,7 @@ int projected_window_height()
 }
 
 // Measures scaling factor for high-dpi displays
-static std::pair<float,float> get_display_scale( int display_index )
+static std::pair<float, float> get_display_scale( int display_index )
 {
     #if SDL_VERSION_ATLEAST(2,26,0)
     int x = SDL_WINDOWPOS_CENTERED_DISPLAY( display_index );

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -3651,7 +3651,7 @@ static std::pair<float, float> get_display_scale( int display_index )
     float scale_h = lh ? static_cast<float>( ph ) / static_cast<float>( lh ) : 1.0f;
     return std::make_pair( scale_w, scale_h );
 #else
-    (void)display_index; // avoid unused parameter lint
+    ( void )display_index; // avoid unused parameter lint
     return std::make_pair( 1.0f, 1.0f );
 #endif
 }

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -3651,6 +3651,7 @@ static std::pair<float, float> get_display_scale( int display_index )
     float scale_h = lh ? static_cast<float>( ph ) / static_cast<float>( lh ) : 1.0f;
     return std::make_pair( scale_w, scale_h );
 #else
+    (void)display_index; // avoid unused parameter lint
     return std::make_pair( 1.0f, 1.0f );
 #endif
 }

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -3627,30 +3627,32 @@ int projected_window_height()
 // Measures scaling factor for high-dpi displays
 static std::pair<float, float> get_display_scale( int display_index )
 {
-    #if SDL_VERSION_ATLEAST(2,26,0)
+#if SDL_VERSION_ATLEAST(2,26,0)
     int x = SDL_WINDOWPOS_CENTERED_DISPLAY( display_index );
     int y = SDL_WINDOWPOS_CENTERED_DISPLAY( display_index );
 
     SDL_Window *w = SDL_CreateWindow(
-        "probe",
-        x, y,
-        16, 16,
-        SDL_WINDOW_HIDDEN | SDL_WINDOW_ALLOW_HIGHDPI
-    );
+                        "probe",
+                        x, y,
+                        16, 16,
+                        SDL_WINDOW_HIDDEN | SDL_WINDOW_ALLOW_HIGHDPI
+                    );
     if( !w ) {
-      return std::make_pair( 1.0f, 1.0f );
+        return std::make_pair( 1.0f, 1.0f );
     }
 
-    int lw, lh; SDL_GetWindowSize( w, &lw, &lh );
-    int pw, ph; SDL_GetWindowSizeInPixels( w, &pw, &ph );
+    int lw, lh;
+    SDL_GetWindowSize( w, &lw, &lh );
+    int pw, ph;
+    SDL_GetWindowSizeInPixels( w, &pw, &ph );
     SDL_DestroyWindow( w );
 
     float scale_w = lw ? static_cast<float>( pw ) / static_cast<float>( lw ) : 1.0f;
     float scale_h = lh ? static_cast<float>( ph ) / static_cast<float>( lh ) : 1.0f;
     return std::make_pair( scale_w, scale_h );
-    #else
+#else
     return std::make_pair( 1.0f, 1.0f );
-    #endif
+#endif
 }
 
 static void init_term_size_and_scaling_factor()
@@ -3687,11 +3689,11 @@ static void init_term_size_and_scaling_factor()
                                                      SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI | SDL_WINDOW_MAXIMIZED
                                                    ) );
 
-                #if SDL_VERSION_ATLEAST(2,26,0)
+#if SDL_VERSION_ATLEAST(2,26,0)
                 SDL_GetWindowSizeInPixels( test_window.get(), &max_width, &max_height );
-                #else
+#else
                 SDL_GetWindowSize( test_window.get(), &max_width, &max_height );
-                #endif
+#endif
 
                 // If the video subsystem isn't reset the test window messes things up later
                 test_window.reset();


### PR DESCRIPTION
#### Summary
Bugfixes "Fix the scaling factor for high-dpi displays."

#### Purpose of change

The number of pixels returned by `SDL_GetWindowSize` do not take into account dpi scaling, like on Apple Retina displays. Thankfully SDL 2.26 (Nov 2022) provides a `SDL_GetWindowSizeInPixels` for accounting for exactly this.

Additionally, even in full screen mode the dimensions of `SDL_DisplayMode` are incorrect due to `SDL_GetDesktopDisplayMode` similarly not factoring in dpi scale.

#### Describe the solution

Switch to `SDL_GetWindowSizeInPixels` and implement a new `get_display_scale` function for measuring the dpi scaling ratios. The measurement creates a small, hidden window to quickly measure the horizontal and vertical stretch necessary to account for dpi. On failure the return values are 1x, ensuring no logical change.

#### Describe alternatives you've considered

One could perhaps imagine a larger refactor where we always perform window measurements, but even in this case we'd want precisely the same affordance provided by `get_display_scale`. This keeps things minimal and known to not break other platforms.

#### Testing

I've tested this on my MacBook in each mode, though given it's backend agnostic it should work cross-platform. A friend has also on Windows and I'll soon be on Linux with an intentionally out-dated SDL version too.

**EDIT:** Confirmed it works on Linux with and without old versions of SDL (pre 2022)

#### Additional context

None

Resolves #83682