### PR TITLE
Fix mouse positioning when UI is scaled

### DIFF
--- a/src/input_context.cpp
+++ b/src/input_context.cpp
@@ -31,6 +31,7 @@
 #include "point.h"
 #include "popup.h"
 #include "sdltiles.h" // IWYU pragma: keep
+#include "cursesport.h" // IWYU pragma: keep
 #include "string_formatter.h"
 #include "string_input_popup.h"
 #include "translations.h"
@@ -1198,10 +1199,21 @@ std::optional<point> input_context::get_coordinates_text( const catacurses::wind
         return std::nullopt;
     }
     const window_dimensions dim = get_window_dimensions( capture_win );
-    const int &fw = dim.scaled_font_size.x;
-    const int &fh = dim.scaled_font_size.y;
+    const int scaling_factor = get_scaling_factor();
+    point logical_coordinate = coordinate;
+    int fw = dim.scaled_font_size.x;
+    int fh = dim.scaled_font_size.y;
+    
+    // convert coordinate and font sizeto logical if UI is scaled
+    if( scaling_factor > 1 ) {
+        logical_coordinate.x /= scaling_factor;
+        logical_coordinate.y /= scaling_factor;
+        fw /= scaling_factor;
+        fh /= scaling_factor;
+    }
+    
     const point &win_min = dim.window_pos_pixel;
-    const point screen_pos = coordinate - win_min;
+    const point screen_pos = logical_coordinate - win_min;
     const point selected( divide_round_down( screen_pos.x, fw ),
                           divide_round_down( screen_pos.y, fh ) );
     return selected;

--- a/src/input_context.cpp
+++ b/src/input_context.cpp
@@ -1203,7 +1203,7 @@ std::optional<point> input_context::get_coordinates_text( const catacurses::wind
     point logical_coordinate = coordinate;
     int fw = dim.scaled_font_size.x;
     int fh = dim.scaled_font_size.y;
-    
+
     // convert coordinate and font sizeto logical if UI is scaled
     if( scaling_factor > 1 ) {
         logical_coordinate.x /= scaling_factor;
@@ -1211,7 +1211,7 @@ std::optional<point> input_context::get_coordinates_text( const catacurses::wind
         fw /= scaling_factor;
         fh /= scaling_factor;
     }
-    
+
     const point &win_min = dim.window_pos_pixel;
     const point screen_pos = logical_coordinate - win_min;
     const point selected( divide_round_down( screen_pos.x, fw ),

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -4101,7 +4101,7 @@ std::optional<tripoint_bub_ms> input_context::get_coordinates( const catacurses:
     point win_size = dim.window_size_pixel;
     point logical_coordinate = coordinate;
     const int scaling_factor = get_scaling_factor();
-    
+
     // convert window size and coordinate to logical if UI is scaled
     if( scaling_factor > 1 ) {
         logical_coordinate.x /= scaling_factor;
@@ -4114,7 +4114,7 @@ std::optional<tripoint_bub_ms> input_context::get_coordinates( const catacurses:
             win_size.y /= scaling_factor;
         }
     }
-    
+
     const point win_max = win_min + win_size;
 
     // Translate mouse coordinates to map coordinates based on tile size
@@ -4135,7 +4135,7 @@ std::optional<tripoint_bub_ms> input_context::get_coordinates( const catacurses:
         const bool is_terrain = use_tiles && g && capture_win == g->w_terrain;
         const bool is_overmap = use_tiles && use_tiles_overmap && g && capture_win == g->w_overmap;
 
-        if (is_terrain) {
+        if( is_terrain ) {
             logical_tile_size.x = tilecontext->get_tile_width();
             logical_tile_size.y = tilecontext->get_tile_height();
         } else if( is_overmap ) {

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -4098,22 +4098,60 @@ std::optional<tripoint_bub_ms> input_context::get_coordinates( const catacurses:
     const window_dimensions dim = get_window_dimensions( capture_win );
 
     const point &win_min = dim.window_pos_pixel;
-    const point &win_size = dim.window_size_pixel;
+    point win_size = dim.window_size_pixel;
+    point logical_coordinate = coordinate;
+    const int scaling_factor = get_scaling_factor();
+    
+    // convert window size and coordinate to logical if UI is scaled
+    if( scaling_factor > 1 ) {
+        logical_coordinate.x /= scaling_factor;
+        logical_coordinate.y /= scaling_factor;
+
+        const bool is_terrain_or_overmap = ( use_tiles && g && capture_win == g->w_terrain ) ||
+                                           ( use_tiles && use_tiles_overmap && g && capture_win == g->w_overmap );
+        if( !is_terrain_or_overmap ) {
+            win_size.x /= scaling_factor;
+            win_size.y /= scaling_factor;
+        }
+    }
+    
     const point win_max = win_min + win_size;
 
     // Translate mouse coordinates to map coordinates based on tile size
     // Check if click is within bounds of the window we care about
     const half_open_rectangle<point> win_bounds( win_min, win_max );
-    if( !win_bounds.contains( coordinate ) ) {
+    if( !win_bounds.contains( logical_coordinate ) ) {
         return std::nullopt;
     }
 
-    const point screen_pos = coordinate - win_min;
+    const point screen_pos = logical_coordinate - win_min;
+
     const bool use_isometric = g->w_overmap &&
                                capture_win == g->w_overmap ? false : g->is_tileset_isometric();
 
+    // convert tile size to logical if UI is scaled
+    point logical_tile_size;
+    if( scaling_factor > 1 ) {
+        const bool is_terrain = use_tiles && g && capture_win == g->w_terrain;
+        const bool is_overmap = use_tiles && use_tiles_overmap && g && capture_win == g->w_overmap;
+
+        if (is_terrain) {
+            logical_tile_size.x = tilecontext->get_tile_width();
+            logical_tile_size.y = tilecontext->get_tile_height();
+        } else if( is_overmap ) {
+            logical_tile_size.x = overmap_tilecontext->get_tile_width();
+            logical_tile_size.y = overmap_tilecontext->get_tile_height();
+        } else {
+            logical_tile_size = dim.scaled_font_size;
+            logical_tile_size.x /= scaling_factor;
+            logical_tile_size.y /= scaling_factor;
+        }
+    } else {
+        logical_tile_size = dim.scaled_font_size;
+    }
+
     const point_bub_ms p = cata_tiles::screen_to_player(
-                               screen_pos, dim.scaled_font_size, win_size,
+                               screen_pos, logical_tile_size, win_size,
                                point_bub_ms( offset ), use_isometric );
 
     return tripoint_bub_ms( p, get_map().get_abs_sub().z() );


### PR DESCRIPTION
#### Summary
Bugfixes "Fix mouse positioning when UI is scaled"

#### Purpose of change

Fixes #80724

Also fixes a similar problem where the mouse view is showing details for the wrong tile when the UI is scaled.

#### Describe the solution

When the UI is scaled, both `input_context::get_coordinates_text()` and the override of `input_context::get_coordinates()` in sdltiles.cpp ends up working with a mix of physical and logical coordinates and dimensions. The fix is to normalise everything to logical values before performing calculations.

The logic gets a little more complicated because terrain and overmap are already in logical sizes and don't need the adjustment.

#### Describe alternatives you've considered

None, although I did wonder why `input_context::get_coordinates()` is overridden in sdltiles.cpp and `input_context::get_coordinates_text()` uses `#if !defined( TILES )..#else`

#### Testing

Loaded and game with 2x scaling and:

- Verified that mouse view is working properly
- That move by clicking on terrain is not broken
- Mouse hover and click in the inventory and activate menus are working properly
- Mouse click in the overmap is working properly
- Main menus like world creation and options are working properly

Repeated the same with no scaling to verify it's not broken by the fix.

#### Additional context

none
