### PR TITLE
[Aftershock ] Fix UICA vehicle purchase

### DIFF
--- a/data/mods/aftershock_exoplanet/maps/mapgen/shuttlepad_salvors.json
+++ b/data/mods/aftershock_exoplanet/maps/mapgen/shuttlepad_salvors.json
@@ -533,7 +533,7 @@
   },
   {
     "type": "mapgen",
-    "update_mapgen_id": "afs_shuttlepad_salvors_garage_open",
+    "update_mapgen_id": "afs_shuttlepad_salvors_garage_open_and_remove_lynx",
     "object": {
       "set": [
         { "point": "terrain", "id": "t_grate", "x": 1, "y": 3 },
@@ -544,8 +544,14 @@
         { "point": "terrain", "id": "t_grate", "x": 1, "y": 8 },
         { "point": "terrain", "id": "t_door_metal_c", "x": 10, "y": 8 },
         { "point": "terrain", "id": "t_door_metal_c", "x": 9, "y": 10 }
-      ]
+      ],
+      "remove_vehicles": [ { "vehicles": [ "uica_lynx_ex" ], "x": [ 3, 8 ], "y": [ 4, 7 ] } ]
     }
+  },
+  {
+    "type": "mapgen",
+    "update_mapgen_id": "afs_shuttlepad_salvors_garage_place_lynx",
+    "object": { "place_vehicles": [ { "vehicle": "uica_lynx_ex", "x": 6, "y": 5, "status": 0, "faction": "your_followers" } ] }
   },
   {
     "type": "mapgen",

--- a/data/mods/aftershock_exoplanet/npcs/Salvor_Market/uica_vehicle_marchant_talk.json
+++ b/data/mods/aftershock_exoplanet/npcs/Salvor_Market/uica_vehicle_marchant_talk.json
@@ -270,7 +270,7 @@
     "type": "effect_on_condition",
     "effect": [
       { "npc_add_var": "player_has_bought_car", "value": "yes" },
-      { "mapgen_update": "afs_shuttlepad_salvors_garage_open", "om_terrain": "afs_shuttlepad_salvors_a1_1" }
+      { "mapgen_update": [ "afs_shuttlepad_salvors_garage_open_and_remove_lynx", "afs_shuttlepad_salvors_garage_place_lynx" ], "om_terrain": "afs_shuttlepad_salvors_a1_1" }
     ]
   },
   {

--- a/data/mods/aftershock_exoplanet/npcs/Salvor_Market/uica_vehicle_marchant_talk.json
+++ b/data/mods/aftershock_exoplanet/npcs/Salvor_Market/uica_vehicle_marchant_talk.json
@@ -270,7 +270,10 @@
     "type": "effect_on_condition",
     "effect": [
       { "npc_add_var": "player_has_bought_car", "value": "yes" },
-      { "mapgen_update": [ "afs_shuttlepad_salvors_garage_open_and_remove_lynx", "afs_shuttlepad_salvors_garage_place_lynx" ], "om_terrain": "afs_shuttlepad_salvors_a1_1" }
+      {
+        "mapgen_update": [ "afs_shuttlepad_salvors_garage_open_and_remove_lynx", "afs_shuttlepad_salvors_garage_place_lynx" ],
+        "om_terrain": "afs_shuttlepad_salvors_a1_1"
+      }
     ]
   },
   {


### PR DESCRIPTION
#### Summary
Mods "Fix Aftershock UICA vehicle purchase"

#### Purpose of change

Fixes #83445

#### Describe the solution

The bug is fixed by removing the vehicle, then placing it back with player faction as the owner as a separate mapgen update.

#### Describe alternatives you've considered

- The issue suggests setting the vehicle area to be owned by the player faction. It's not my favourite solution becuase if the player found some way to get into the garage without paying for the vehicle and otherwise angering UICA, they'd be free to take the vehicle as if it were theirs.
- At first, I searched for an effect that would simply set the owner of the existing vehicle, but I didn't find one.
- My next idea was to remove and place the vehicle in the same mapgen update, but that doesn't work because collision maps are not updated between effects, so after `remove_vehicles`, when `place_vehicles` checks for collisions it's not aware that the vehicle is going to be removed, so the whole mapgen update bails.

#### Testing

Loaded the game, bought the vehicle, and verified that it's owned by Your Followers. Took it for a spin just to make sure.

#### Additional context

none