### PR TITLE
Honor THIEF_MODE preference in the Advanced Inventory Management screens

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -2235,8 +2235,19 @@ void move_items_activity_actor::do_turn( player_activity &act, Character &who )
         // Make a copy to be put in the destination location
         item newit = leftovers;
 
-        if( newit.is_owned_by( who, true ) ) {
-            newit.set_owner( who );
+        Character &player_character = get_player_character();
+
+        if( newit.is_owned_by( who, true ) ||
+            ( who.getID() == player_character.getID() &&
+              player_character.get_value( "THIEF_MODE" ).str() == "THIEF_STEAL" ) ) {
+            // There are two distinct reasons we could get here:
+            //
+            //  1. This item was already owned by our 'who' at top level.
+            //  2. This item is NOT owned by 'who,' but 'who' is a player character with a THIEF_STEAL preference.
+            //     By setting the preference, the player is explicitly telling us to steal it, so we do.
+            //
+            // Either way, handle_pickup_ownership() will do the right thing.
+            newit.handle_pickup_ownership( who );
         } else {
             continue;
         }


### PR DESCRIPTION
#### Summary

Features "Honor theft preference inside the Advanced Inventory Management screens"

#### Purpose of change

I found it maddeningly difficult to round up items from a bandit camp because both Advanced Inventory Management (AIM) and "sort zones" will refuse to steal items owned by another faction.

This has come up before, e.g. https://github.com/CleverRaven/Cataclysm-DDA/issues/66004

It was relatively easy to fix AIM.    "Sort zones" and generalized activity fixes will have to wait for another day.

#### Describe the solution

With this PR, AIM will now honor the preference set via `THIEF_MODE`

* If set to the default `THIEF_HONEST`, AIM will not move any non-owned item
* If set to `THIEF_ASK`, AIM will retain the default behavior, because it would be too annoying to deal with multiple prompts.
* Finally, if set to `THIEF_STEAL`, AIM will still display the red indicators that moving this item would be stealing, but it will honor your requests.

#### Describe alternatives you've considered

Ideally I would like to find a solution that covers both AIM and zone sorting stuff, since they both pass through activity_actor and friends.   I'm not there yet.

#### Testing

This works great as a practical matter.   As a player, I routinely change my THIEF_MODE with a keybinding based on whether I am looting a bandit camp or not.

I wrote no real tests, in the `ctest` sense. I didn't find any other testing for THIEF_MODE, so I wasn't super clear on what the setup should be. 

#### Additional context

N/A