### PR TITLE
Zone sorting refactor

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -21,6 +21,7 @@
 #include "action.h"
 #include "activity_actor_definitions.h"
 #include "activity_handlers.h"
+#include "activity_item_handling.h"
 #include "advanced_inv.h"
 #include "avatar.h"
 #include "avatar_action.h"
@@ -157,6 +158,7 @@ static const activity_id ACT_MIGRATION_CANCEL( "ACT_MIGRATION_CANCEL" );
 static const activity_id ACT_MILK( "ACT_MILK" );
 static const activity_id ACT_MOP( "ACT_MOP" );
 static const activity_id ACT_MOVE_ITEMS( "ACT_MOVE_ITEMS" );
+static const activity_id ACT_MOVE_LOOT( "ACT_MOVE_LOOT" );
 static const activity_id ACT_MULTIPLE_CHOP_TREES( "ACT_MULTIPLE_CHOP_TREES" );
 static const activity_id ACT_OPEN_GATE( "ACT_OPEN_GATE" );
 static const activity_id ACT_OXYTORCH( "ACT_OXYTORCH" );
@@ -296,6 +298,7 @@ static const vproto_id vehicle_prototype_none( "none" );
 
 static const zone_type_id zone_type_LOOT_IGNORE( "LOOT_IGNORE" );
 static const zone_type_id zone_type_LOOT_IGNORE_FAVORITES( "LOOT_IGNORE_FAVORITES" );
+static const zone_type_id zone_type_LOOT_UNSORTED( "LOOT_UNSORTED" );
 static const zone_type_id zone_type_STRIP_CORPSES( "STRIP_CORPSES" );
 static const zone_type_id zone_type_UNLOAD_ALL( "UNLOAD_ALL" );
 
@@ -2965,6 +2968,26 @@ std::unique_ptr<activity_actor> ebooksave_activity_actor::deserialize( JsonValue
 
 namespace io
 {
+template<>
+std::string enum_to_string<zone_activity_stage>( zone_activity_stage stage )
+{
+    switch( stage ) {
+        case UNINIT: {
+            return "UNINIT";
+        };
+        case INIT: {
+            return "INIT";
+        };
+        case THINK: {
+            return "THINK";
+        };
+        case DO: {
+            return "DO";
+        };
+        default:
+            return "LAST";
+    }
+}
 template<>
 std::string enum_to_string<efile_action>( efile_action data )
 {
@@ -7839,7 +7862,7 @@ std::unique_ptr<activity_actor> mop_activity_actor::deserialize( JsonValue &jsin
     return actor.clone();
 }
 
-void unload_loot_activity_actor::serialize( JsonOut &jsout ) const
+void zone_activity_actor::serialize( JsonOut &jsout ) const
 {
     jsout.start_object();
 
@@ -7854,7 +7877,7 @@ void unload_loot_activity_actor::serialize( JsonOut &jsout ) const
 
 std::unique_ptr<activity_actor> unload_loot_activity_actor::deserialize( JsonValue &jsin )
 {
-    unload_loot_activity_actor actor( {} );
+    unload_loot_activity_actor actor;
 
     JsonObject data = jsin.get_object();
 
@@ -7867,7 +7890,7 @@ std::unique_ptr<activity_actor> unload_loot_activity_actor::deserialize( JsonVal
     return actor.clone();
 }
 
-void unload_loot_activity_actor::start( player_activity &act, Character & )
+void zone_activity_actor::start( player_activity &act, Character & )
 {
     act.moves_total = moves;
     act.moves_left = moves;
@@ -7916,322 +7939,140 @@ static void move_item( Character &you, item &it, const int quantity, const tripo
     }
 }
 
-void unload_loot_activity_actor::do_turn( player_activity &act, Character &you )
+void unload_loot_activity_actor::stage_init( player_activity &act, Character &you )
 {
-    enum activity_stage : int {
-        //Initial stage
-        INIT = 0,
-        //Think about what to do first: choose destination
-        THINK,
-        //Do activity
-        DO,
-    };
 
-    faction const *fac = you.get_faction();
-    faction_id fac_id = fac == nullptr ? faction_id() : fac->id;
-
-    map &here = get_map();
+    const zone_manager &mgr = zone_manager::get_manager();
+    const faction_id fac_id = you.get_faction_id();
     const tripoint_abs_ms abspos = you.pos_abs();
-    zone_manager &mgr = zone_manager::get_manager();
-    if( here.check_vehicle_zones( here.get_abs_sub().z() ) ) {
-        mgr.cache_vzones();
+
+    coord_set.clear();
+    for( const tripoint_abs_ms &p :
+         mgr.get_near( zone_type_UNLOAD_ALL, abspos, MAX_VIEW_DISTANCE, nullptr,
+                       fac_id ) ) {
+        coord_set.insert( p );
     }
 
-    if( stage == INIT ) {
-        coord_set.clear();
-        for( const tripoint_abs_ms &p :
-             mgr.get_near( zone_type_UNLOAD_ALL, abspos, MAX_VIEW_DISTANCE, nullptr,
-                           fac_id ) ) {
-            coord_set.insert( p );
-        }
-
-        for( const tripoint_abs_ms &p :
-             mgr.get_near( zone_type_STRIP_CORPSES, abspos, MAX_VIEW_DISTANCE, nullptr,
-                           fac_id ) ) {
-            coord_set.insert( p );
-        }
-        stage = THINK;
+    for( const tripoint_abs_ms &p :
+         mgr.get_near( zone_type_STRIP_CORPSES, abspos, MAX_VIEW_DISTANCE, nullptr,
+                       fac_id ) ) {
+        coord_set.insert( p );
     }
+    stage = THINK;
+}
 
-    if( stage == THINK ) {
-        // initialize num_processed
-        num_processed = 0;
-        std::vector<tripoint_abs_ms> src_set;
-        src_set.reserve( coord_set.size() );
-        for( const tripoint_abs_ms &p : coord_set ) {
-            src_set.emplace_back( p );
-        }
-        // sort source tiles by distance
-        const auto &src_sorted = get_sorted_tiles_by_distance( abspos, src_set );
+bool unload_loot_activity_actor::stage_think( player_activity &act, Character &you )
+{
 
-        for( const tripoint_abs_ms &src : src_sorted ) {
-            placement = src;
-            coord_set.erase( src );
+    const zone_manager &mgr = zone_manager::get_manager();
+    map &here = get_map();
+    const faction_id fac_id = you.get_faction_id();
+    const tripoint_abs_ms abspos = you.pos_abs();
 
-            const tripoint_bub_ms &src_loc = here.get_bub( src );
-            if( !here.inbounds( src_loc ) ) {
-                if( !here.inbounds( you.pos_bub() ) ) {
-                    // p is implicitly an NPC that has been moved off the map, so reset the activity
-                    // and unload them
-                    you.cancel_activity();
-                    you.assign_activity( ACT_UNLOAD_LOOT );
-                    you.set_moves( 0 );
-                    g->reload_npcs();
-                    return;
-                }
-                std::vector<tripoint_bub_ms> route;
-                route = here.route( you, pathfinding_target::point( src_loc ) );
-                if( route.empty() ) {
-                    // can't get there, can't do anything, skip it
-                    continue;
-                }
-                stage = DO;
-                you.set_destination( route, act );
-                you.activity.set_to_null();
-                return;
+    // initialize num_processed
+    num_processed = 0;
+    std::vector<tripoint_abs_ms> src_set;
+    src_set.reserve( coord_set.size() );
+    for( const tripoint_abs_ms &p : coord_set ) {
+        src_set.emplace_back( p );
+    }
+    // sort source tiles by distance
+    const auto &src_sorted = get_sorted_tiles_by_distance( abspos, src_set );
+
+    for( const tripoint_abs_ms &src : src_sorted ) {
+        placement = src;
+        coord_set.erase( src );
+
+        const tripoint_bub_ms &src_bub = here.get_bub( src );
+        if( !here.inbounds( src_bub ) ) {
+            if( zone_sorting::sorter_out_of_bounds( you ) ) {
+                return false;
             }
-
-            // skip tiles in IGNORE zone and tiles on fire
-            // (to prevent taking out wood off the lit brazier)
-            // and inaccessible furniture, like filled charcoal kiln
-            if( mgr.has( zone_type_LOOT_IGNORE, src, fac_id ) ||
-                here.get_field( src_loc, fd_fire ) != nullptr ||
-                !here.can_put_items_ter_furn( src_loc ) || here.impassable_field_at( src_loc ) ) {
+            if( !zone_sorting::route_to_destination( you, act, src_bub, stage ) ) {
                 continue;
             }
-
-            //nothing to sort?
-            const std::optional<vpart_reference> ovp = here.veh_at( src_loc ).cargo();
-            if( ( !ovp || ovp->items().empty() ) && here.i_at( src_loc ).empty() ) {
-                continue;
-            }
-
-            bool is_adjacent_or_closer = square_dist( you.pos_bub(), src_loc ) <= 1;
-            // before we unload any item, check if player is at or
-            // adjacent to the loot source tile
-            if( !is_adjacent_or_closer ) {
-                std::vector<tripoint_bub_ms> route;
-
-                // get either direct route or route to nearest adjacent tile if
-                // source tile is impassable
-                route = here.route( you, pathfinding_target::adjacent( src_loc ) );
-
-                // check if we found path to source / adjacent tile
-                if( route.empty() ) {
-                    add_msg( m_info, _( "%s can't reach the source tile." ),
-                             you.disp_name() );
-                    continue;
-                }
-
-                // set the destination and restart activity after player arrives there
-                // we don't need to check for safe mode,
-                // activity will be restarted only if
-                // player arrives on destination tile
-                stage = DO;
-                you.set_destination( route, act );
-                you.activity.set_to_null();
-                return;
-            }
-            stage = DO;
-            break;
+            return false;
         }
-    }
-    if( stage == DO ) {
-        const tripoint_abs_ms src( placement );
-        const tripoint_bub_ms src_loc = here.get_bub( src );
 
-        bool is_adjacent_or_closer = square_dist( you.pos_bub(), src_loc ) <= 1;
-        // before we move any item, check if player is at or
+        if( zone_sorting::ignore_zone_position( you, src, mgr.has( zone_type_LOOT_IGNORE, src,
+                                                fac_id ) ) ) {
+            continue;
+        }
+
+        //nothing to sort?
+        const std::optional<vpart_reference> ovp = here.veh_at( src_bub ).cargo();
+        if( ( !ovp || ovp->items().empty() ) && here.i_at( src_bub ).empty() ) {
+            continue;
+        }
+
+        bool is_adjacent_or_closer = square_dist( you.pos_bub(), src_bub ) <= 1;
+        // before we unload any item, check if player is at or
         // adjacent to the loot source tile
         if( !is_adjacent_or_closer ) {
-            stage = THINK;
-            return;
-        }
-
-        // the boolean in this pair being true indicates the item is from a vehicle storage space
-        auto items = std::vector<std::pair<item *, bool>>();
-        vehicle *src_veh;
-        int src_part;
-
-        //Check source for cargo part
-        //map_stack and vehicle_stack are different types but inherit from item_stack
-        // TODO: use one for loop
-        if( const std::optional<vpart_reference> ovp = here.veh_at( src_loc ).cargo() ) {
-            src_veh = &ovp->vehicle();
-            src_part = ovp->part_index();
-            vehicle_stack vp_items = ovp->items();
-            items.reserve( vp_items.size() );
-            for( item &it : vp_items ) {
-                items.emplace_back( &it, true );
-            }
-        } else {
-            src_veh = nullptr;
-            src_part = -1;
-        }
-        map_stack map_items = here.i_at( src_loc );
-        items.reserve( items.size() + map_items.size() );
-        for( item &it : map_items ) {
-            items.emplace_back( &it, false );
-        }
-
-        bool unload_mods = false;
-        bool unload_molle = false;
-        bool unload_sparse_only = false;
-        int unload_sparse_threshold = 0;
-
-        std::vector<zone_data const *> const zones = mgr.get_zones_at( src, zone_type_UNLOAD_ALL,
-                fac_id );
-
-        // get most open rules out of all stacked zones
-        for( zone_data const *zone : zones ) {
-            unload_options const &options = dynamic_cast<const unload_options &>( zone->get_options() );
-            unload_molle |= options.unload_molle();
-            unload_mods |= options.unload_mods();
-            unload_sparse_only |= options.unload_sparse_only();
-            if( options.unload_sparse_only() && options.unload_sparse_threshold() > unload_sparse_threshold ) {
-                unload_sparse_threshold = options.unload_sparse_threshold();
-            }
-        }
-
-        //Skip items that have already been processed
-        for( auto it = items.begin() + num_processed; it < items.end(); ++it ) {
-
-            item &thisitem = *it->first;
-
-            // skip unpickable liquid
-            if( thisitem.made_of_from_type( phase_id::LIQUID ) ) {
-                ++num_processed;
+            if( !zone_sorting::route_to_destination( you, act, src_bub, stage ) ) {
                 continue;
             }
-
-            // skip favorite items in ignore favorite zones
-            if( thisitem.is_favorite && mgr.has( zone_type_LOOT_IGNORE_FAVORITES, src, fac_id ) ) {
-                ++num_processed;
-                continue;
-            }
-
-            // Only if it's from a vehicle do we use the vehicle source location information.
-            vehicle *this_veh = it->second ? src_veh : nullptr;
-            const int this_part = it->second ? src_part : -1;
-
-            // if this item isn't going anywhere and its not sealed
-            // check if it is in a unload zone or a strip corpse zone
-            // then we should unload it and see what is inside
-            if( mgr.has_near( zone_type_UNLOAD_ALL, abspos, 1, fac_id ) ||
-                ( mgr.has_near( zone_type_STRIP_CORPSES, abspos, 1, fac_id ) && it->first->is_corpse() ) ) {
-                if( you.rate_action_unload( *it->first ) == hint_rating::good &&
-                    !it->first->any_pockets_sealed() ) {
-                    std::unordered_map<itype_id, int> item_counts;
-                    if( unload_sparse_only ) {
-                        for( item *contained : it->first->all_items_top( pocket_type::CONTAINER ) ) {
-                            if( !contained->made_of( phase_id::LIQUID ) && !contained->made_of( phase_id::GAS ) ) {
-                                item_counts[contained->typeId()]++;
-                            }
-                        }
-                    }
-                    for( item *contained : it->first->all_items_top( pocket_type::CONTAINER ) ) {
-                        // no liquids don't want to spill stuff
-                        if( !contained->made_of( phase_id::LIQUID ) && !contained->made_of( phase_id::GAS ) ) {
-                            if( unload_sparse_only &&
-                                item_counts[contained->typeId()] > unload_sparse_threshold ) {
-                                continue;
-                            }
-                            move_item( you, *contained, contained->count(), src_loc, src_loc, this_veh, this_part );
-                            it->first->remove_item( *contained );
-                        }
-                        if( you.get_moves() <= 0 ) {
-                            return;
-                        }
-                    }
-                    for( item *contained : it->first->all_items_top( pocket_type::MAGAZINE ) ) {
-                        // no liquids don't want to spill stuff
-                        if( !contained->made_of( phase_id::LIQUID ) && !contained->made_of( phase_id::GAS ) ) {
-                            if( it->first->is_ammo_belt() ) {
-                                if( it->first->type->magazine->linkage ) {
-                                    item link( *it->first->type->magazine->linkage, calendar::turn, contained->count() );
-                                    if( this_veh != nullptr ) {
-                                        vehicle_part &vp_this = this_veh->part( this_part );
-                                        this_veh->add_item( here, vp_this, link );
-                                    } else {
-                                        here.add_item_or_charges( src_loc, link );
-                                    }
-                                }
-                            }
-                            move_item( you, *contained, contained->count(), src_loc, src_loc, this_veh, this_part );
-                            it->first->remove_item( *contained );
-
-                            if( it->first->has_flag( flag_MAG_DESTROY ) && it->first->ammo_remaining( ) == 0 ) {
-                                if( this_veh != nullptr ) {
-                                    vehicle_part &vp_this = this_veh->part( this_part );
-                                    this_veh->remove_item( vp_this, it->first );
-                                } else {
-                                    here.i_rem( src_loc, it->first );
-                                }
-                            }
-                        }
-                        if( you.get_moves() <= 0 ) {
-                            return;
-                        }
-                    }
-                    for( item *contained : it->first->all_items_top( pocket_type::MAGAZINE_WELL ) ) {
-                        // no liquids don't want to spill stuff
-                        if( !contained->made_of( phase_id::LIQUID ) && !contained->made_of( phase_id::GAS ) ) {
-                            move_item( you, *contained, contained->count(), src_loc, src_loc, this_veh, this_part );
-                            it->first->remove_item( *contained );
-                        }
-                        if( you.get_moves() <= 0 ) {
-                            return;
-                        }
-                    }
-                }
-                // if unloading mods
-                if( unload_mods ) {
-                    // remove each mod, skip irremovable
-                    for( item *mod : it->first->gunmods() ) {
-                        if( mod->is_irremovable() ) {
-                            continue;
-                        }
-                        you.gunmod_remove( *it->first, *mod );
-                        if( you.get_moves() <= 0 ) {
-                            return;
-                        }
-                    }
-                }
-
-                // if unloading molle
-                if( unload_molle ) {
-                    while( !it->first->get_contents().get_added_pockets().empty() ) {
-                        item removed = it->first->get_contents().remove_pocket( 0 );
-                        move_item( you, removed, 1, src_loc, src_loc, this_veh, this_part );
-                        if( you.get_moves() <= 0 ) {
-                            return;
-                        }
-                    }
-                }
-
-                // after dumping items go back to start of activity loop
-                // so that can re-assess the items in the tile
-                ++num_processed;
-                return;
-            }
-
-            if( you.get_moves() <= 0 ) {
-                return;
-            }
+            return false;
         }
+        stage = DO;
+        break;
+    }
+    return true;
+}
 
-        //this location is sorted
+void unload_loot_activity_actor::stage_do( player_activity &act, Character &you )
+{
+
+    const zone_manager &mgr = zone_manager::get_manager();
+    const map &here = get_map();
+    const tripoint_abs_ms src( placement );
+    const tripoint_bub_ms src_bub = here.get_bub( src );
+    const faction_id fac_id = you.get_faction_id();
+
+    bool is_adjacent_or_closer = square_dist( you.pos_bub(), src_bub ) <= 1;
+    // before we move any item, check if player is at or
+    // adjacent to the loot source tile
+    if( !is_adjacent_or_closer ) {
         stage = THINK;
         return;
     }
 
-    // If we got here without restarting the activity, it means we're done
-    add_msg( m_info, _( "%s sorted out every item possible." ), you.disp_name( false, true ) );
-    if( you.is_npc() ) {
-        npc *guy = dynamic_cast<npc *>( &you );
-        guy->revert_after_activity();
+    zone_sorting::zone_items items = zone_sorting::populate_items( src_bub );
+
+    zone_sorting::unload_options zone_unload_options = zone_sorting::set_unload_options( you, src,
+            false, true );
+
+    //Skip items that have already been processed
+    for( auto it = items.begin() + num_processed; it < items.end(); ++it ) {
+
+        item &thisitem = *it->first;
+
+        // skip unpickable liquid
+        if( thisitem.made_of_from_type( phase_id::LIQUID ) ) {
+            ++num_processed;
+            continue;
+        }
+
+        // skip favorite items in ignore favorite zones
+        if( thisitem.is_favorite && mgr.has( zone_type_LOOT_IGNORE_FAVORITES, src, fac_id ) ) {
+            ++num_processed;
+            continue;
+        }
+
+        const std::optional<vpart_reference> vp = here.veh_at( src_bub ).cargo();
+        const std::unordered_set<tripoint_abs_ms> dest_set;
+
+        zone_sorting::unload_item( you, src,
+                                   zone_unload_options, vp, it->first, dest_set, num_processed );
+
+        if( you.get_moves() <= 0 ) {
+            return;
+        }
     }
-    act.set_to_null();
+
+    //this location is sorted
+    stage = THINK;
+    return;
 }
 
 bool vehicle_folding_activity_actor::fold_vehicle( Character &p, bool check_only ) const
@@ -9301,6 +9142,225 @@ std::unique_ptr<activity_actor> wait_followers_activity_actor::deserialize( Json
     return wait_stamina_activity_actor().clone();
 }
 
+void zone_activity_actor::do_turn( player_activity &act, Character &you )
+{
+    update_vehicle_zone_cache();
+
+    //Prepare activity stage
+    if( stage == UNINIT ) {
+        stage = INIT;
+    }
+    if( stage == INIT ) {
+        stage_init( act, you );
+    }
+    if( stage == THINK ) {
+        if( !stage_think( act, you ) ) {
+            return;
+        }
+    }
+    if( stage == DO ) {
+        //to end this activity, THINK stage must resolve all zone tiles
+        stage_do( act, you );
+        return;
+    }
+
+    // If we got here without restarting the activity, it means we're done
+    add_msg( m_info, _( "%s sorted out every item possible." ), you.disp_name( false, true ) );
+    if( you.is_npc() ) {
+        npc *guy = dynamic_cast<npc *>( &you );
+        guy->revert_after_activity();
+    }
+    act.set_to_null();
+}
+
+void zone_activity_actor::update_vehicle_zone_cache()
+{
+    map &here = get_map();
+    zone_manager &mgr = zone_manager::get_manager();
+
+    if( here.check_vehicle_zones( here.get_abs_sub().z() ) ) {
+        mgr.cache_vzones();
+    }
+}
+
+void zone_sort_activity_actor::update_other_activity_items()
+{
+    other_activity_items.clear();
+
+    //store other activity items so they aren't sorted later
+    for( const npc &guy : g->all_npcs() ) {
+        if( !guy.activity.targets.empty() ) {
+            for( const item_location &target : guy.activity.targets ) {
+                other_activity_items.push_back( target.get_item() );
+            }
+        }
+    }
+    for( const item_location &target : get_player_character().activity.targets ) {
+        other_activity_items.push_back( target.get_item() );
+    }
+}
+
+void zone_sort_activity_actor::do_turn( player_activity &act, Character &you )
+{
+    update_other_activity_items();
+    zone_activity_actor::do_turn( act, you );
+}
+
+void zone_sort_activity_actor::stage_init( player_activity &act, Character &you )
+{
+    const zone_manager &mgr = zone_manager::get_manager();
+    coord_set.clear();
+    for( const tripoint_abs_ms &p :
+         mgr.get_near( zone_type_LOOT_UNSORTED, you.pos_abs(), MAX_VIEW_DISTANCE, nullptr,
+                       you.get_faction_id() ) ) {
+        coord_set.insert( p );
+    }
+    stage = THINK;
+}
+
+bool zone_sort_activity_actor::stage_think( player_activity &act, Character &you )
+{
+
+    const map &here = get_map();
+
+    num_processed = 0;
+
+    // copy remaining zone positions, sort by closest distance
+    std::unordered_set<tripoint_abs_ms> src_set;
+    src_set.reserve( coord_set.size() );
+    for( const tripoint_abs_ms &p : coord_set ) {
+        src_set.emplace( p );
+    }
+    const auto &src_sorted = get_sorted_tiles_by_distance( you.pos_abs(), src_set );
+
+    // iterate over zone positions and look for items to move
+    for( const tripoint_abs_ms &src : src_sorted ) {
+        placement = src;
+        src_set.erase( src );
+
+        const tripoint_bub_ms src_bub = here.get_bub( src );
+        if( !here.inbounds( src_bub ) ) {
+            if( zone_sorting::sorter_out_of_bounds( you ) ) {
+                return false;
+            }
+            if( !zone_sorting::route_to_destination( you, act, src_bub, stage ) ) {
+                continue;
+            }
+            return false;
+        }
+
+        bool ignore_contents = zone_sorting::ignore_contents( you, src );
+
+        if( zone_sorting::ignore_zone_position( you, src, ignore_contents ) ) {
+            continue;
+        }
+
+        zone_sorting::unload_options zone_unload_options = zone_sorting::set_unload_options( you, src, true,
+                false );
+
+        const zone_sorting::zone_items items = zone_sorting::populate_items( src_bub );
+
+        // check if there is valid destination for any item of the tile
+        bool has_items_to_work_on = zone_sorting::has_items_to_sort( you, src, zone_unload_options,
+                                    other_activity_items, items );
+        if( !has_items_to_work_on ) {
+            continue;
+        }
+
+        bool is_adjacent_or_closer = square_dist( you.pos_bub(), src_bub ) <= 1;
+        // before we move any item, check if player is at or
+        // adjacent to the loot source tile
+        if( !is_adjacent_or_closer ) {
+            // check if we found path to source / adjacent tile
+            if( !zone_sorting::route_to_destination( you, act, src_bub, stage ) ) {
+                continue;
+            }
+            return false;
+        }
+        stage = DO;
+        break;
+    }
+    return true;
+}
+
+void zone_sort_activity_actor::stage_do( player_activity &act, Character &you )
+{
+    const map &here = get_map();
+    const zone_manager &mgr = zone_manager::get_manager();
+
+    const faction_id fac_id = you.get_faction_id();
+    const tripoint_abs_ms src( placement );
+    const tripoint_bub_ms src_bub = here.get_bub( src );
+    const tripoint_abs_ms abspos = you.pos_abs();
+
+    bool is_adjacent_or_closer = square_dist( you.pos_bub(), src_bub ) <= 1;
+    // before we move any item, check if player is at or
+    // adjacent to the loot source tile
+    if( !is_adjacent_or_closer ) {
+        stage = THINK;
+        return;
+    }
+
+    zone_sorting::zone_items items = zone_sorting::populate_items( src_bub );
+
+    zone_sorting::unload_options zone_unload_options = zone_sorting::set_unload_options( you, src,
+            false,
+            false );
+
+    const std::optional<vpart_reference> vp = here.veh_at( src_bub ).cargo();
+    //Skip items that have already been processed
+    for( zone_sorting::zone_items::iterator it = items.begin() + num_processed; it < items.end();
+         ++it ) {
+        ++num_processed;
+        item &thisitem = *it->first;
+
+        if( zone_sorting::sort_skip_item( you, it->first, other_activity_items,
+                                          mgr.has( zone_type_LOOT_IGNORE_FAVORITES, src, fac_id ), src ) ) {
+            continue;
+        }
+
+        // Only if it's from a vehicle do we use the vehicle source location information.
+        const std::optional<vpart_reference> vpr_src = it->second ? vp : std::nullopt;
+        const zone_type_id id = mgr.get_near_zone_type_for_item( thisitem, abspos,
+                                MAX_VIEW_DISTANCE, fac_id );
+
+        const std::unordered_set<tripoint_abs_ms> dest_set =
+            mgr.get_near( id, abspos, MAX_VIEW_DISTANCE, &thisitem, fac_id );
+
+        std::optional<bool> move_and_reset = zone_sorting::unload_item( you, src,
+                                             zone_unload_options, vp, it->first, dest_set, num_processed );
+        // out of moves, or unloaded item container was destroyed or prompted an activity restart
+        if( !move_and_reset ) {
+            return;
+        }
+
+        zone_sorting::move_item( you, vp, src_bub, dest_set, thisitem, num_processed );
+        // out of moves or item was unloaded
+        if( you.get_moves() <= 0 || *move_and_reset ) {
+            return;
+        }
+    }
+
+    //this location is sorted
+    stage = THINK;
+    return;
+}
+
+std::unique_ptr<activity_actor> zone_sort_activity_actor::deserialize( JsonValue &jsin )
+{
+    zone_sort_activity_actor actor;
+
+    JsonObject data = jsin.get_object();
+
+    data.read( "moves", actor.moves );
+    data.read( "num_processed", actor.num_processed );
+    data.read( "stage", actor.stage );
+    data.read( "coord_set", actor.coord_set );
+    data.read( "placement", actor.placement );
+
+    return actor.clone();
+}
+
 namespace activity_actors
 {
 
@@ -9353,6 +9413,7 @@ deserialize_functions = {
     { ACT_MILK, &milk_activity_actor::deserialize },
     { ACT_MOP, &mop_activity_actor::deserialize },
     { ACT_MOVE_ITEMS, &move_items_activity_actor::deserialize },
+    { ACT_MOVE_LOOT, &zone_sort_activity_actor::deserialize },
     { ACT_OPEN_GATE, &open_gate_activity_actor::deserialize },
     { ACT_OXYTORCH, &oxytorch_activity_actor::deserialize },
     { ACT_PICKUP, &pickup_activity_actor::deserialize },

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -44,6 +44,53 @@ class player_activity;
 struct islot_book;
 struct pulp_data;
 
+enum zone_activity_stage : int {
+    UNINIT = -1,
+    INIT,
+    THINK,
+    DO,
+    LAST
+};
+template<>
+struct enum_traits<zone_activity_stage> {
+    static constexpr zone_activity_stage last = LAST;
+};
+
+/**
+* Any activity that does operations in one or more zone types.
+*/
+class zone_activity_actor : public activity_actor
+{
+    public:
+        zone_activity_actor() = default;
+        explicit zone_activity_actor( int moves ) : moves( moves ) {}
+
+        void start( player_activity &act, Character &who ) override;
+        void do_turn( player_activity &act, Character &you ) override;
+        void finish( player_activity &act, Character &you ) override {};
+
+        // INIT: determine types of zones to use, coordinates of those zones
+        virtual void stage_init( player_activity &act, Character &you ) = 0;
+        // THINK: determine what to DO next
+        //if false, abort the current activity turn
+        virtual bool stage_think( player_activity &act, Character &you ) = 0;
+        // DO: run activity operation
+        virtual void stage_do( player_activity &act, Character &you ) = 0;
+
+        void serialize( JsonOut &jsout ) const override;
+
+        virtual std::unique_ptr<activity_actor> clone() const = 0;
+
+        void update_vehicle_zone_cache();
+
+    protected:
+        int moves;
+        int num_processed;
+        zone_activity_stage stage = UNINIT;
+        std::unordered_set<tripoint_abs_ms> coord_set;
+        tripoint_abs_ms placement;
+};
+
 class aim_activity_actor : public activity_actor
 {
     private:
@@ -2428,34 +2475,25 @@ class mop_activity_actor : public activity_actor
         int moves;
 };
 
-class unload_loot_activity_actor : public activity_actor
+class unload_loot_activity_actor : public zone_activity_actor
 {
     public:
         unload_loot_activity_actor() = default;
-        explicit unload_loot_activity_actor( int moves ) : moves( moves ) {}
 
         const activity_id &get_type() const override {
             static const activity_id ACT_UNLOAD_LOOT( "ACT_UNLOAD_LOOT" );
             return ACT_UNLOAD_LOOT;
         }
 
-        void start( player_activity &act, Character &who ) override;
-        void do_turn( player_activity &act, Character &you ) override;
-        void finish( player_activity &, Character & ) override {};
+        void stage_init( player_activity &act, Character &you ) override;
+        bool stage_think( player_activity &act, Character &you ) override;
+        void stage_do( player_activity &act, Character &you ) override;
 
         std::unique_ptr<activity_actor> clone() const override {
             return std::make_unique<unload_loot_activity_actor>( *this );
         }
 
-        void serialize( JsonOut &jsout ) const override;
         static std::unique_ptr<activity_actor> deserialize( JsonValue &jsin );
-
-    private:
-        int moves;
-        int num_processed;
-        int stage;
-        std::unordered_set<tripoint_abs_ms> coord_set;
-        tripoint_abs_ms placement;
 };
 
 class pulp_activity_actor : public activity_actor
@@ -2601,6 +2639,34 @@ class wait_followers_activity_actor : public activity_actor
 
         void serialize( JsonOut &jsout ) const override;
         static std::unique_ptr<activity_actor> deserialize( JsonValue &jsin );
+};
+
+class zone_sort_activity_actor : public zone_activity_actor
+{
+    public:
+        zone_sort_activity_actor() = default;
+
+        const activity_id &get_type() const override {
+            static const activity_id ACT_MOVE_LOOT( "ACT_MOVE_LOOT" );
+            return ACT_MOVE_LOOT;
+        }
+
+        std::unique_ptr<activity_actor> clone() const override {
+            return std::make_unique<zone_sort_activity_actor>( *this );
+        }
+
+        void do_turn( player_activity &act, Character &you ) override;
+
+        void stage_init( player_activity &act, Character &you ) override;
+        bool stage_think( player_activity &act, Character &you ) override;
+        void stage_do( player_activity &act, Character &you ) override;
+
+        static std::unique_ptr<activity_actor> deserialize( JsonValue &jsin );
+
+        void update_other_activity_items();
+
+    private:
+        std::vector<const item *> other_activity_items;
 };
 
 #endif // CATA_SRC_ACTIVITY_ACTOR_DEFINITIONS_H

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -67,7 +67,7 @@ class zone_activity_actor : public activity_actor
 
         void start( player_activity &act, Character &who ) override;
         void do_turn( player_activity &act, Character &you ) override;
-        void finish( player_activity &act, Character &you ) override {};
+        void finish( player_activity &, Character & ) override;
 
         // INIT: determine types of zones to use, coordinates of those zones
         virtual void stage_init( player_activity &act, Character &you ) = 0;
@@ -79,7 +79,7 @@ class zone_activity_actor : public activity_actor
 
         void serialize( JsonOut &jsout ) const override;
 
-        virtual std::unique_ptr<activity_actor> clone() const = 0;
+        std::unique_ptr<activity_actor> clone() const override = 0;
 
         void update_vehicle_zone_cache();
 
@@ -1166,6 +1166,7 @@ class safecracking_activity_actor : public activity_actor
         }
 };
 
+// for unloading items from the inventory
 class unload_activity_actor : public activity_actor
 {
     private:
@@ -2475,6 +2476,7 @@ class mop_activity_actor : public activity_actor
         int moves;
 };
 
+// for unloading items from zones
 class unload_loot_activity_actor : public zone_activity_actor
 {
     public:
@@ -2485,9 +2487,9 @@ class unload_loot_activity_actor : public zone_activity_actor
             return ACT_UNLOAD_LOOT;
         }
 
-        void stage_init( player_activity &act, Character &you ) override;
+        void stage_init( player_activity &, Character &you ) override;
         bool stage_think( player_activity &act, Character &you ) override;
-        void stage_do( player_activity &act, Character &you ) override;
+        void stage_do( player_activity &, Character &you ) override;
 
         std::unique_ptr<activity_actor> clone() const override {
             return std::make_unique<unload_loot_activity_actor>( *this );
@@ -2657,16 +2659,17 @@ class zone_sort_activity_actor : public zone_activity_actor
 
         void do_turn( player_activity &act, Character &you ) override;
 
-        void stage_init( player_activity &act, Character &you ) override;
+        void stage_init( player_activity &, Character &you ) override;
         bool stage_think( player_activity &act, Character &you ) override;
-        void stage_do( player_activity &act, Character &you ) override;
+        void stage_do( player_activity &, Character &you ) override;
 
+        void serialize( JsonOut &jsout ) const override;
         static std::unique_ptr<activity_actor> deserialize( JsonValue &jsin );
 
         void update_other_activity_items();
 
     private:
-        std::vector<const item *> other_activity_items;
+        std::vector<item_location> other_activity_items;
 };
 
 #endif // CATA_SRC_ACTIVITY_ACTOR_DEFINITIONS_H

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -116,7 +116,6 @@ static const activity_id ACT_HAND_CRANK( "ACT_HAND_CRANK" );
 static const activity_id ACT_HEATING( "ACT_HEATING" );
 static const activity_id ACT_JACKHAMMER( "ACT_JACKHAMMER" );
 static const activity_id ACT_MEND_ITEM( "ACT_MEND_ITEM" );
-static const activity_id ACT_MOVE_LOOT( "ACT_MOVE_LOOT" );
 static const activity_id ACT_MULTIPLE_BUTCHER( "ACT_MULTIPLE_BUTCHER" );
 static const activity_id ACT_MULTIPLE_CHOP_PLANKS( "ACT_MULTIPLE_CHOP_PLANKS" );
 static const activity_id ACT_MULTIPLE_CHOP_TREES( "ACT_MULTIPLE_CHOP_TREES" );

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -242,7 +242,6 @@ activity_handlers::do_turn_functions = {
     { ACT_CONSUME_FOOD_MENU, consume_food_menu_do_turn },
     { ACT_CONSUME_DRINK_MENU, consume_drink_menu_do_turn },
     { ACT_CONSUME_MEDS_MENU, consume_meds_menu_do_turn },
-    { ACT_MOVE_LOOT, move_loot_do_turn },
     { ACT_ARMOR_LAYERS, armor_layers_do_turn },
     { ACT_ATM, atm_do_turn },
     { ACT_FISH, fish_do_turn },
@@ -1612,11 +1611,6 @@ void activity_handlers::consume_meds_menu_do_turn( player_activity *, Character 
 {
     avatar &player_character = get_avatar();
     avatar_action::eat_or_use( player_character, game_menus::inv::consume_meds() );
-}
-
-void activity_handlers::move_loot_do_turn( player_activity *act, Character *you )
-{
-    activity_on_turn_move_loot( *act, *you );
 }
 
 void activity_handlers::travel_do_turn( player_activity *act, Character *you )

--- a/src/activity_handlers.h
+++ b/src/activity_handlers.h
@@ -153,7 +153,6 @@ struct activity_reason_info {
 
 // activity_item_handling.cpp
 void activity_on_turn_drop();
-void activity_on_turn_move_loot( player_activity &act, Character &you );
 //return true if there is an activity that can be done potentially, return false if no work can be found.
 bool generic_multi_activity_handler( player_activity &act, Character &you,
                                      bool check_only = false );
@@ -209,7 +208,6 @@ void game_do_turn( player_activity *act, Character *you );
 void generic_game_do_turn( player_activity *act, Character *you );
 void hand_crank_do_turn( player_activity *act, Character *you );
 void jackhammer_do_turn( player_activity *act, Character *you );
-void move_loot_do_turn( player_activity *act, Character *you );
 void multiple_butcher_do_turn( player_activity *act, Character *you );
 void multiple_chop_planks_do_turn( player_activity *act, Character *you );
 void multiple_construction_do_turn( player_activity *act, Character *you );

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -683,6 +683,397 @@ static void move_item( Character &you, item &it, const int quantity, const tripo
     }
 }
 
+namespace zone_sorting
+{
+// the boolean in this pair being true indicates the item is from a vehicle storage space
+using zone_items = std::vector<std::pair<item *, bool>>;
+
+struct options {
+    bool unload_mods = false;
+    bool unload_molle = false;
+    bool unload_always = false;
+    bool ignore_favorite = false;
+    bool unload_all = false;
+    bool unload_corpses = false;
+    bool unload_sparse_only = false;
+    int unload_sparse_threshold = 0;
+};
+
+/**
+* Returns true if the given item should be skipped while sorting
+*/
+static bool sort_skip_item( Character &you, const item *it,
+                            const std::vector<const item *> &other_activity_items,
+                            bool ignore_favorite, const tripoint_abs_ms &src )
+{
+    const zone_manager &mgr = zone_manager::get_manager();
+    // skip unpickable liquid
+    if( !it->made_of_from_type( phase_id::SOLID ) ) {
+        return true;
+    }
+
+    // don't steal disassembly in progress
+    if( it->has_var( "activity_var" ) ) {
+        return true;
+    }
+
+    // don't steal items from other activities, e.g. crafts in progress
+    if( std::find( other_activity_items.begin(), other_activity_items.end(),
+                   it ) != other_activity_items.end() ) {
+        return true;
+    }
+
+    // skip items not owned by you
+    if( !it->is_owned_by( you, true ) ) {
+        return true;
+    }
+
+    if( it->is_favorite && ignore_favorite ) {
+        return true;
+    }
+
+    const zone_type_id zt_id = mgr.get_near_zone_type_for_item( *it, you.pos_abs(),
+                               MAX_VIEW_DISTANCE, _fac_id( you ) );
+    // skip items that are already where they should be in for non-UNSORTED/CUSTOM zones
+    if( zt_id != zone_type_LOOT_CUSTOM && mgr.has( zt_id, src, _fac_id( you ) ) ) {
+        return true;
+    }
+    // ...and then for CUSTOM zones
+    if( zt_id == zone_type_LOOT_CUSTOM &&
+        mgr.custom_loot_has( src, it, zone_type_LOOT_CUSTOM, _fac_id( you ) ) ) {
+        return true;
+    }
+
+    return false;
+}
+
+static options set_sorting_options( Character &you, const tripoint_abs_ms &src, bool use_zone_type )
+{
+    const zone_manager &mgr = zone_manager::get_manager();
+    options zone_sort_options;
+
+    std::vector<zone_data const *> const zones = mgr.get_zones_at( src, zone_type_UNLOAD_ALL,
+            _fac_id( you ) );
+
+    // set rules from all zones in stack
+    for( zone_data const *zone : zones ) {
+        if( !zone->get_enabled() ) {
+            continue;
+        };
+        unload_options const &options = dynamic_cast<const unload_options &>( zone->get_options() );
+        zone_sort_options.unload_molle |= options.unload_molle();
+        zone_sort_options.unload_mods |= options.unload_mods();
+        zone_sort_options.unload_always |= options.unload_always();
+        if( use_zone_type ) {
+            zone_sort_options.ignore_favorite |= zone->get_type() == zone_type_LOOT_IGNORE_FAVORITES;
+
+            zone_sort_options.unload_all |= zone->get_type() == zone_type_UNLOAD_ALL;
+            zone_sort_options.unload_corpses |= zone->get_type() == zone_type_STRIP_CORPSES;
+        } else {
+            zone_sort_options.unload_sparse_only |= options.unload_sparse_only();
+            if( options.unload_sparse_only() &&
+                options.unload_sparse_threshold() > zone_sort_options.unload_sparse_threshold ) {
+                zone_sort_options.unload_sparse_threshold = options.unload_sparse_threshold();
+            }
+        }
+    }
+    return zone_sort_options;
+}
+
+// return items at the given location from vehicle cargo and ground
+// TODO: build into map class
+static zone_items populate_items( const tripoint_bub_ms &src_bub )
+{
+    map &here = get_map();
+    const std::optional<vpart_reference> vp = here.veh_at( src_bub ).cargo();
+
+    zone_items items;
+    // Check source for cargo part
+    // map_stack and vehicle_stack are different types but inherit from item_stack
+    // TODO: use one for loop
+    if( vp ) {
+        for( item &it : vp->items() ) {
+            items.emplace_back( &it, true );
+        }
+    }
+    for( item &it : here.i_at( src_bub ) ) {
+        items.emplace_back( &it, false );
+    }
+    return items;
+}
+
+// returns whether to ignore the zones at `src`
+// if one zone is ignored, all will be
+static bool ignore_contents( Character &you, const tripoint_abs_ms &src )
+{
+    const zone_manager &mgr = zone_manager::get_manager();
+    // check ignorable zones for ignore_contents enabled
+    for( const auto &zone_type : ignorable_zone_types ) {
+        // add zones using mgr.get_zones_at
+        for( zone_data const *zone : mgr.get_zones_at( src, zone_type, _fac_id( you ) ) ) {
+            ignorable_options const &options = dynamic_cast<const ignorable_options &>( zone->get_options() );
+            if( options.get_ignore_contents() ) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+// skip tiles in IGNORE zone or with ignore option,
+// tiles on fire (to prevent taking out wood off the lit brazier)
+// and inaccessible furniture, like filled charcoal kiln
+static bool ignore_zone_position( Character &you, const tripoint_abs_ms &src, bool ignore_contents )
+{
+    const zone_manager &mgr = zone_manager::get_manager();
+    map &here = get_map();
+    const tripoint_bub_ms src_bub = here.get_bub( src );
+
+    return mgr.has( zone_type_LOOT_IGNORE, src, _fac_id( you ) ) ||
+           ignore_contents ||
+           here.get_field( src_bub, fd_fire ) != nullptr ||
+           !here.can_put_items_ter_furn( src_bub ) ||
+           here.impassable_field_at( src_bub );
+}
+
+// of `items` at `src`, do any need to be sorted?
+static bool has_items_to_sort( Character &you, const tripoint_abs_ms &src,
+                               zone_sorting::options zone_sort_options,
+                               const std::vector<const item *> &other_activity_items,
+                               const zone_sorting::zone_items &items )
+{
+    const zone_manager &mgr = zone_manager::get_manager();
+    const tripoint_abs_ms &abspos = you.pos_abs();
+
+    for( std::pair<item *, bool> it_pair : items ) {
+        item *it = it_pair.first;
+        const zone_type_id zone_type_id = mgr.get_near_zone_type_for_item( *it, abspos,
+                                          MAX_VIEW_DISTANCE, _fac_id( you ) );
+
+        if( zone_sorting::sort_skip_item( you, it, other_activity_items,
+                                          zone_sort_options.ignore_favorite, src ) ) {
+            continue;
+        }
+
+        const std::unordered_set<tripoint_abs_ms> dest_set =
+            mgr.get_near( zone_type_id, abspos, MAX_VIEW_DISTANCE, it, _fac_id( you ) );
+
+        //if we're unloading all or a corpse
+        if( zone_sort_options.unload_all || ( zone_sort_options.unload_corpses && it->is_corpse() ) ) {
+            if( dest_set.empty() || zone_sort_options.unload_always ) {
+                if( you.rate_action_unload( *it ) == hint_rating::good &&
+                    !it->any_pockets_sealed() ) {
+                    //we can unload this item, so stop here
+                    return true;
+                }
+
+                // if unloading mods
+                if( zone_sort_options.unload_mods ) {
+                    // remove each mod, skip irremovable
+                    for( const item *mod : it->gunmods() ) {
+                        if( mod->is_irremovable() ) {
+                            continue;
+                        }
+                        // we can remove a mod, so stop here
+                        return true;
+                    }
+                }
+
+                // if unloading molle
+                if( zone_sort_options.unload_molle && !it->get_contents().get_added_pockets().empty() ) {
+                    // we can unload the MOLLE, so stop here
+                    return true;
+                }
+            }
+        }
+        // if item has destination
+        if( !dest_set.empty() ) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static bool can_unload( item *it )
+{
+    return it->made_of( phase_id::SOLID );
+}
+
+static void add_item( const std::optional<vpart_reference> vp, const tripoint_bub_ms &src_bub,
+                      const item &it )
+{
+    map &here = get_map();
+    if( vp ) {
+        vp->vehicle().add_item( here, vp->part(), it );
+    } else {
+        here.add_item_or_charges( src_bub, it );
+    }
+}
+
+static void remove_item( const std::optional<vpart_reference> vp, const tripoint_bub_ms &src_bub,
+                         item *it )
+{
+    map &here = get_map();
+    if( vp ) {
+        vp->vehicle().remove_item( vp->part(), it );
+    } else {
+        here.i_rem( src_bub, it );
+    }
+}
+
+static std::optional<bool> unload_item( Character &you, const tripoint_abs_ms &src,
+                                        zone_sorting::options zone_sort_options, const std::optional<vpart_reference> &vpr_src,
+                                        item *it, const std::unordered_set<tripoint_abs_ms> &dest_set,
+                                        int &num_processed )
+{
+    const zone_manager &mgr = zone_manager::get_manager();
+    map &here = get_map();
+    const tripoint_bub_ms src_bub = here.get_bub( src );
+    const tripoint_abs_ms &abspos = you.pos_abs();
+    // if this item isn't going anywhere and its not sealed
+    // check if it is in a unload zone or a strip corpse zone
+    // then we should unload it and see what is inside
+    bool move_and_reset = false;
+    bool moved_something = false;
+
+    // teleport an item to its zone destination
+    // TODO: remove this functionality
+    auto zone_teleport_item = [&you, &src_bub, &vpr_src, &it]( item * contained ) {
+        move_item( you, *contained, contained->count(), src_bub, src_bub, vpr_src );
+        it->remove_item( *contained );
+    };
+
+    if( mgr.has_near( zone_type_UNLOAD_ALL, abspos, 1, _fac_id( you ) ) ||
+        ( mgr.has_near( zone_type_STRIP_CORPSES, abspos, 1, _fac_id( you ) ) && it->is_corpse() ) ) {
+        if( dest_set.empty() || zone_sort_options.unload_always ) {
+
+            if( you.rate_action_unload( *it ) == hint_rating::good &&
+                !it->any_pockets_sealed() ) {
+
+                //first, count items by type at top-level
+                std::unordered_map<itype_id, int> item_counts;
+                if( zone_sort_options.unload_sparse_only ) {
+                    for( item *contained : it->all_items_top( pocket_type::CONTAINER ) ) {
+                        if( zone_sorting::can_unload( contained ) ) {
+                            item_counts[contained->typeId()]++;
+                        }
+                    }
+                }
+
+                //unload all containers
+                //if the item count is below the sparse threshold set above, don't unload
+                for( item *contained : it->all_items_top( pocket_type::CONTAINER ) ) {
+                    if( zone_sorting::can_unload( contained ) ) {
+                        if( zone_sort_options.unload_sparse_only &&
+                            item_counts[contained->typeId()] > zone_sort_options.unload_sparse_threshold ) {
+                            continue;
+                        }
+                        zone_teleport_item( contained );
+                    }
+                }
+
+                //unload all magazines
+                for( item *contained : it->all_items_top( pocket_type::MAGAZINE ) ) {
+                    if( zone_sorting::can_unload( contained ) ) {
+                        if( it->is_ammo_belt() ) {
+                            if( it->type->magazine->linkage ) {
+                                item link( *it->type->magazine->linkage, calendar::turn, contained->count() );
+                                zone_sorting::add_item( vpr_src, src_bub, link );
+                            }
+                        }
+                        zone_teleport_item( contained );
+                    }
+                }
+
+                //unload all magazine wells
+                for( item *contained : it->all_items_top( pocket_type::MAGAZINE_WELL ) ) {
+                    if( zone_sorting::can_unload( contained ) ) {
+                        zone_teleport_item( contained );
+                    }
+                }
+                moved_something = true;
+
+            }
+
+            // if unloading mods
+            if( zone_sort_options.unload_mods ) {
+                // remove each mod, skip irremovable
+                for( item *mod : it->gunmods() ) {
+                    if( mod->is_irremovable() ) {
+                        continue;
+                    }
+                    you.gunmod_remove( *it, *mod );
+                    // need to return so the activity starts
+                    return std::nullopt;
+                }
+            }
+
+            // if unloading molle
+            if( zone_sort_options.unload_molle ) {
+                while( !it->get_contents().get_added_pockets().empty() ) {
+                    item removed = it->get_contents().remove_pocket( 0 );
+                    move_item( you, removed, 1, src_bub, src_bub, vpr_src );
+                    moved_something = true;
+                }
+            }
+
+            // destroy fully unloaded magazines
+            if( it->has_flag( flag_MAG_DESTROY ) && it->ammo_remaining() == 0 ) {
+                zone_sorting::remove_item( vpr_src, src_bub, it );
+                num_processed = std::max( num_processed - 1, 0 );
+                return std::nullopt;
+            }
+
+            // after dumping items go back to start of activity loop
+            // so that can re-assess the items in the tile
+            // perhaps move the last item first however
+            if( zone_sort_options.unload_always && moved_something ) {
+                move_and_reset = true;
+            } else if( moved_something ) {
+                return std::nullopt;
+            }
+        }
+    }
+    return move_and_reset;
+}
+
+static void move_item( Character &you, const std::optional<vpart_reference> &vpr_src,
+                       const tripoint_bub_ms &src_bub, const std::unordered_set<tripoint_abs_ms> &dest_set,
+                       item &it, int &num_processed )
+{
+    map &here = get_map();
+
+    for( const tripoint_abs_ms &dest : dest_set ) {
+        const tripoint_bub_ms dest_loc = here.get_bub( dest );
+        units::volume free_space;
+
+        //Check destination for cargo part
+        if( const std::optional<vpart_reference> ovp = here.veh_at( dest_loc ).cargo() ) {
+            free_space = ovp->items().free_volume();
+        } else {
+            free_space = here.free_volume( dest_loc );
+        }
+
+        // skip tiles with inaccessible furniture, like filled charcoal kiln
+        if( !here.can_put_items_ter_furn( dest_loc ) ||
+            static_cast<int>( here.i_at( dest_loc ).size() ) >= MAX_ITEM_IN_SQUARE ) {
+            continue;
+        }
+
+        // check free space at destination
+        if( free_space >= it.volume() ) {
+            move_item( you, it, it.count(), src_bub, dest_loc, vpr_src );
+
+            // moved item away from source so decrement
+            if( num_processed > 0 ) {
+                --num_processed;
+            }
+            break;
+        }
+    }
+}
+} // namespace zone_sorting
+
 std::vector<tripoint_bub_ms> route_adjacent( const Character &you, const tripoint_bub_ms &dest )
 {
     std::unordered_set<tripoint_bub_ms> passable_tiles;
@@ -2047,23 +2438,43 @@ void activity_on_turn_move_loot( player_activity &act, Character &you )
     const tripoint_abs_ms abspos = you.pos_abs();
     zone_manager &mgr = zone_manager::get_manager();
 
-    std::vector<const item *> crafting_items;
+    //returns true if route successfully found
+    auto route_to_destination = [&here, &you, &stage, &act]( const tripoint_bub_ms dest ) {
+        //attempt to route to out-of-bubble position
+        std::vector<tripoint_bub_ms> route;
+        route = here.route( you, pathfinding_target::adjacent( dest ) );
+        if( route.empty() ) {
+            // can't get there, can't do anything, skip to next position
+            return false;
+        }
+        // set the destination and restart activity after player arrives there
+        // note: we don't need to check for safe mode,
+        // the activity will be restarted only if player arrives on destination tile
+        stage = DO;
+        you.set_destination( route, act );
+        you.activity.set_to_null();
+        return true;
+    };
 
+    std::vector<const item *> other_activity_items;
+
+    //store other activity items so they aren't sorted later
     for( const npc &guy : g->all_npcs() ) {
         if( !guy.activity.targets.empty() ) {
             for( const item_location &target : guy.activity.targets ) {
-                crafting_items.push_back( target.get_item() );
+                other_activity_items.push_back( target.get_item() );
             }
         }
     }
     for( const item_location &target : get_player_character().activity.targets ) {
-        crafting_items.push_back( target.get_item() );
+        other_activity_items.push_back( target.get_item() );
     }
 
     if( here.check_vehicle_zones( here.get_abs_sub().z() ) ) {
         mgr.cache_vzones();
     }
 
+    //store UNSORTED loot zone positions
     if( stage == INIT ) {
         act.coord_set.clear();
         for( const tripoint_abs_ms &p :
@@ -2075,22 +2486,24 @@ void activity_on_turn_move_loot( player_activity &act, Character &you )
     }
 
     if( stage == THINK ) {
-        //initialize num_processed
+
         num_processed = 0;
+
+        // copy remaining UNSORTED tile positions, sort by closest distance
         std::vector<tripoint_abs_ms> src_set;
         src_set.reserve( act.coord_set.size() );
         for( const tripoint_abs_ms &p : act.coord_set ) {
             src_set.emplace_back( p );
         }
-        // sort source tiles by distance
         const auto &src_sorted = get_sorted_tiles_by_distance( abspos, src_set );
 
+        // iterate over UNSORTED tile positions and look for items to move
         for( const tripoint_abs_ms &src : src_sorted ) {
             act.placement = src;
             act.coord_set.erase( src );
 
-            const tripoint_bub_ms src_loc = here.get_bub( src );
-            if( !here.inbounds( src_loc ) ) {
+            const tripoint_bub_ms src_bub = here.get_bub( src );
+            if( !here.inbounds( src_bub ) ) {
                 if( !here.inbounds( you.pos_bub() ) ) {
                     // p is implicitly an NPC that has been moved off the map, so reset the activity
                     // and unload them
@@ -2100,196 +2513,36 @@ void activity_on_turn_move_loot( player_activity &act, Character &you )
                     g->reload_npcs();
                     return;
                 }
-                std::vector<tripoint_bub_ms> route;
-                route = here.route( you, pathfinding_target::adjacent( src_loc ) );
-                if( route.empty() ) {
-                    // can't get there, can't do anything, skip it
+                if( !route_to_destination( src_bub ) ) {
                     continue;
                 }
-                stage = DO;
-                you.set_destination( route, act );
-                you.activity.set_to_null();
                 return;
             }
 
-            bool ignore_contents = false;
+            bool ignore_contents = zone_sorting::ignore_contents( you, src );
 
-            // check ignorable zones for ignore_contents enabled
-            for( const auto &zone_type : ignorable_zone_types ) {
-                // add zones using mgr.get_zones_at
-                for( zone_data const *zone : mgr.get_zones_at( src, zone_type, _fac_id( you ) ) ) {
-                    ignorable_options const &options = dynamic_cast<const ignorable_options &>( zone->get_options() );
-                    if( options.get_ignore_contents() ) {
-                        ignore_contents = true;
-                        break;
-                    }
-                }
-                if( ignore_contents ) {
-                    break;
-                }
-            }
-
-
-            // skip tiles in IGNORE zone or with ignore option,
-            // tiles on fire (to prevent taking out wood off the lit brazier)
-            // and inaccessible furniture, like filled charcoal kiln
-            if( mgr.has( zone_type_LOOT_IGNORE, src, _fac_id( you ) ) ||
-                ignore_contents ||
-                here.get_field( src_loc, fd_fire ) != nullptr ||
-                !here.can_put_items_ter_furn( src_loc ) || here.impassable_field_at( src_loc ) ) {
+            if( zone_sorting::ignore_zone_position( you, src, ignore_contents ) ) {
                 continue;
             }
 
-            //nothing to sort?
-            bool unload_mods = false;
-            bool unload_molle = false;
-            // bool unload_sparse_only = false;
-            // int unload_sparse_threshold = 20;
-            bool unload_always = false;
-            bool ignore_favorite = false;
-            bool unload_all = false;
-            bool unload_corpses = false;
+            zone_sorting::options zone_sort_options = zone_sorting::set_sorting_options( you, src, true );
 
-            std::vector<zone_data const *> const zones = mgr.get_zones_at( src, zone_type_UNLOAD_ALL,
-                    _fac_id( you ) );
+            const zone_sorting::zone_items items = zone_sorting::populate_items( src_bub );
 
-            // get most open rules out of all stacked zones
-            for( zone_data const *zone : zones ) {
-                if( !zone->get_enabled() ) {
-                    continue;
-                };
-                unload_options const &options = dynamic_cast<const unload_options &>( zone->get_options() );
-                unload_molle |= options.unload_molle();
-                unload_mods |= options.unload_mods();
-                unload_always |= options.unload_always();
-                ignore_favorite |= zone->get_type() == zone_type_LOOT_IGNORE_FAVORITES;
-
-                unload_all |= zone->get_type() == zone_type_UNLOAD_ALL;
-                unload_corpses |= zone->get_type() == zone_type_STRIP_CORPSES;
-            }
-
-            const std::optional<vpart_reference> vp = here.veh_at( src_loc ).cargo();
-            std::vector<const item *> items;
-            // populate items from the appropriate source
-            if( vp ) {
-                for( const item &it : vp->items() ) {
-                    items.push_back( &it );
-                }
-            } else {
-                for( const item &it : here.i_at( src_loc ) ) {
-                    items.push_back( &it );
-                }
-            }
             // check if there is valid destination for any item of the tile
-            bool has_items_to_work_on = false;
+            bool has_items_to_work_on = has_items_to_sort( you, src, zone_sort_options,
+                                        other_activity_items, items );
 
-            for( const item *it : items ) {
-
-                const zone_type_id zone_type_id = mgr.get_near_zone_type_for_item( *it, abspos,
-                                                  MAX_VIEW_DISTANCE, _fac_id( you ) );
-
-
-                if( has_items_to_work_on ) {
-                    break;
-                }
-
-                // don't steal disassembly in progress
-                if( it->has_var( "activity_var" ) ) {
-                    continue;
-                }
-
-                // don't steal crafts in progress
-                if( std::find( crafting_items.begin(), crafting_items.end(), it ) != crafting_items.end() ) {
-                    continue;
-                }
-
-                // skip items that allready sorted
-                if( zone_type_id != zone_type_LOOT_CUSTOM && mgr.has( zone_type_id, src, _fac_id( you ) ) ) {
-                    continue;
-                }
-
-                if( zone_type_id == zone_type_LOOT_CUSTOM &&
-                    mgr.custom_loot_has( src, it, zone_type_LOOT_CUSTOM, _fac_id( you ) ) ) {
-                    continue;
-                }
-
-                if( !it->is_owned_by( you, true ) ) {
-                    continue;
-                }
-
-                // skip unpickable liquid
-                if( !it->made_of_from_type( phase_id::SOLID ) ) {
-                    continue;
-                }
-
-                if( it->is_favorite && ignore_favorite ) {
-                    continue;
-                }
-
-                const std::unordered_set<tripoint_abs_ms> dest_set =
-                    mgr.get_near( zone_type_id, abspos, MAX_VIEW_DISTANCE, it, _fac_id( you ) );
-
-                if( unload_all || ( unload_corpses && it->is_corpse() ) ) {
-                    if( dest_set.empty() || unload_always ) {
-                        if( you.rate_action_unload( *it ) == hint_rating::good &&
-                            !it->any_pockets_sealed() ) {
-                            has_items_to_work_on = true;
-                            break;
-                        }
-
-                        // if unloading mods
-                        if( unload_mods ) {
-                            // remove each mod, skip irremovable
-                            for( const item *mod : it->gunmods() ) {
-                                if( mod->is_irremovable() ) {
-                                    continue;
-                                }
-                                has_items_to_work_on = true;
-                                break;
-                            }
-                        }
-
-                        // if unloading molle
-                        if( unload_molle && ! it->get_contents().get_added_pockets().empty() ) {
-                            has_items_to_work_on = true;
-                            break;
-                        }
-                    }
-                }
-                // if item has destination
-                if( !dest_set.empty() ) {
-                    has_items_to_work_on = true;
-                    break;
-                }
-            }
-            if( !has_items_to_work_on ) {
-                continue;
-            }
-
-            bool is_adjacent_or_closer = square_dist( you.pos_bub(), src_loc ) <= 1;
+            bool is_adjacent_or_closer = square_dist( you.pos_bub(), src_bub ) <= 1;
             // before we move any item, check if player is at or
             // adjacent to the loot source tile
             if( !is_adjacent_or_closer ) {
-                std::vector<tripoint_bub_ms> route;
-
-                // get either direct route or route to nearest adjacent tile if
-                // source tile is impassable
-                route = here.route( you, pathfinding_target::adjacent( src_loc ) );
-
                 // check if we found path to source / adjacent tile
-                if( route.empty() ) {
+                if( !route_to_destination( src_bub ) ) {
                     add_msg( m_info, _( "%s can't reach the source tile.  Try to sort out loot without a cart." ),
                              you.disp_name() );
                     continue;
                 }
-
-                // set the destination and restart activity after player arrives there
-                // we don't need to check for safe mode,
-                // activity will be restarted only if
-                // player arrives on destination tile
-                stage = DO;
-                you.set_destination( route, act );
-                you.activity.set_to_null();
                 return;
             }
             stage = DO;
@@ -2298,9 +2551,9 @@ void activity_on_turn_move_loot( player_activity &act, Character &you )
     }
     if( stage == DO ) {
         const tripoint_abs_ms src( act.placement );
-        const tripoint_bub_ms src_loc = here.get_bub( src );
+        const tripoint_bub_ms src_bub = here.get_bub( src );
 
-        bool is_adjacent_or_closer = square_dist( you.pos_bub(), src_loc ) <= 1;
+        bool is_adjacent_or_closer = square_dist( you.pos_bub(), src_bub ) <= 1;
         // before we move any item, check if player is at or
         // adjacent to the loot source tile
         if( !is_adjacent_or_closer ) {
@@ -2308,223 +2561,38 @@ void activity_on_turn_move_loot( player_activity &act, Character &you )
             return;
         }
 
-        // the boolean in this pair being true indicates the item is from a vehicle storage space
-        auto items = std::vector<std::pair<item *, bool>>();
-        const std::optional<vpart_reference> vpr = here.veh_at( src_loc ).cargo();
-        //Check source for cargo part
-        //map_stack and vehicle_stack are different types but inherit from item_stack
-        // TODO: use one for loop
-        if( vpr ) {
-            for( item &it : vpr->items() ) {
-                items.emplace_back( &it, true );
-            }
-        }
-        for( item &it : here.i_at( src_loc ) ) {
-            items.emplace_back( &it, false );
-        }
+        zone_sorting::zone_items items = zone_sorting::populate_items( src_bub );
 
-        bool unload_mods = false;
-        bool unload_molle = false;
-        bool unload_sparse_only = false;
-        int unload_sparse_threshold = 0;
-        bool unload_always = false;
+        zone_sorting::options zone_sort_options = zone_sorting::set_sorting_options( you, src, false );
 
-        std::vector<zone_data const *> const zones = mgr.get_zones_at( src, zone_type_UNLOAD_ALL,
-                _fac_id( you ) );
-
-        // get most open rules out of all stacked zones
-        for( zone_data const *zone : zones ) {
-            unload_options const &options = dynamic_cast<const unload_options &>( zone->get_options() );
-            unload_molle |= options.unload_molle();
-            unload_mods |= options.unload_mods();
-            unload_sparse_only |= options.unload_sparse_only();
-            if( options.unload_sparse_only() && options.unload_sparse_threshold() > unload_sparse_threshold ) {
-                unload_sparse_threshold = options.unload_sparse_threshold();
-            }
-            unload_always |= options.unload_always();
-        }
-
+        const std::optional<vpart_reference> vp = here.veh_at( src_bub ).cargo();
         //Skip items that have already been processed
-        for( auto it = items.begin() + num_processed; it < items.end(); ++it ) {
+        for( zone_sorting::zone_items::iterator it = items.begin() + num_processed; it < items.end();
+             ++it ) {
             ++num_processed;
             item &thisitem = *it->first;
 
-            // skip items not owned by you
-            if( !thisitem.is_owned_by( you, true ) ) {
+            if( zone_sorting::sort_skip_item( you, it->first, other_activity_items,
+                                              mgr.has( zone_type_LOOT_IGNORE_FAVORITES, src, _fac_id( you ) ), src ) ) {
                 continue;
             }
-
-            // skip unpickable liquid
-            if( !thisitem.made_of_from_type( phase_id::SOLID ) ) {
-                continue;
-            }
-
-            // skip favorite items in ignore favorite zones
-            if( thisitem.is_favorite && mgr.has( zone_type_LOOT_IGNORE_FAVORITES, src, _fac_id( you ) ) ) {
-                continue;
-            }
-
-            // don't steal disassembly in progress
-            if( thisitem.has_var( "activity_var" ) ) {
-                continue;
-            }
-            // don't steal crafts in progress
-            if( std::find( crafting_items.begin(), crafting_items.end(), it->first ) != crafting_items.end() ) {
-                continue;
-            }
-
 
             // Only if it's from a vehicle do we use the vehicle source location information.
-            const std::optional<vpart_reference> vpr_src = it->second ? vpr : std::nullopt;
+            const std::optional<vpart_reference> vpr_src = it->second ? vp : std::nullopt;
             const zone_type_id id = mgr.get_near_zone_type_for_item( thisitem, abspos,
                                     MAX_VIEW_DISTANCE, _fac_id( you ) );
-
-            // checks whether the item is already on correct loot zone or not
-            // if it is, we can skip such item, if not we move the item to correct pile
-            // think empty bag on food pile, after you ate the content
-            if( id != zone_type_LOOT_CUSTOM && mgr.has( id, src, _fac_id( you ) ) ) {
-                continue;
-            }
-
-            if( id == zone_type_LOOT_CUSTOM &&
-                mgr.custom_loot_has( src, &thisitem, zone_type_LOOT_CUSTOM, _fac_id( you ) ) ) {
-                continue;
-            }
 
             const std::unordered_set<tripoint_abs_ms> dest_set =
                 mgr.get_near( id, abspos, MAX_VIEW_DISTANCE, &thisitem, _fac_id( you ) );
 
-            // if this item isn't going anywhere and its not sealed
-            // check if it is in a unload zone or a strip corpse zone
-            // then we should unload it and see what is inside
-            bool move_and_reset = false;
-            bool moved_something = false;
-
-            if( mgr.has_near( zone_type_UNLOAD_ALL, abspos, 1, _fac_id( you ) ) ||
-                ( mgr.has_near( zone_type_STRIP_CORPSES, abspos, 1, _fac_id( you ) ) && it->first->is_corpse() ) ) {
-                if( dest_set.empty() || unload_always ) {
-                    if( you.rate_action_unload( *it->first ) == hint_rating::good &&
-                        !it->first->any_pockets_sealed() ) {
-                        std::unordered_map<itype_id, int> item_counts;
-                        if( unload_sparse_only ) {
-                            for( item *contained : it->first->all_items_top( pocket_type::CONTAINER ) ) {
-                                if( !contained->made_of( phase_id::LIQUID ) && !contained->made_of( phase_id::GAS ) ) {
-                                    item_counts[contained->typeId()]++;
-                                }
-                            }
-                        }
-                        for( item *contained : it->first->all_items_top( pocket_type::CONTAINER ) ) {
-                            // no liquids don't want to spill stuff
-                            if( !contained->made_of( phase_id::LIQUID ) && !contained->made_of( phase_id::GAS ) ) {
-                                if( unload_sparse_only &&
-                                    item_counts[contained->typeId()] > unload_sparse_threshold ) {
-                                    continue;
-                                }
-                                move_item( you, *contained, contained->count(), src_loc, src_loc, vpr_src );
-                                it->first->remove_item( *contained );
-                            }
-                        }
-                        for( item *contained : it->first->all_items_top( pocket_type::MAGAZINE ) ) {
-                            // no liquids don't want to spill stuff
-                            if( !contained->made_of( phase_id::LIQUID ) && !contained->made_of( phase_id::GAS ) ) {
-                                if( it->first->is_ammo_belt() ) {
-                                    if( it->first->type->magazine->linkage ) {
-                                        item link( *it->first->type->magazine->linkage, calendar::turn, contained->count() );
-                                        if( vpr_src ) {
-                                            vpr_src->vehicle().add_item( here, vpr_src->part(), link );
-                                        } else {
-                                            here.add_item_or_charges( src_loc, link );
-                                        }
-                                    }
-                                }
-                                move_item( you, *contained, contained->count(), src_loc, src_loc, vpr_src );
-                                it->first->remove_item( *contained );
-                            }
-                        }
-                        for( item *contained : it->first->all_items_top( pocket_type::MAGAZINE_WELL ) ) {
-                            // no liquids don't want to spill stuff
-                            if( !contained->made_of( phase_id::LIQUID ) && !contained->made_of( phase_id::GAS ) ) {
-                                move_item( you, *contained, contained->count(), src_loc, src_loc, vpr_src );
-                                it->first->remove_item( *contained );
-                            }
-                        }
-                        moved_something = true;
-
-                    }
-
-                    // if unloading mods
-                    if( unload_mods ) {
-                        // remove each mod, skip irremovable
-                        for( item *mod : it->first->gunmods() ) {
-                            if( mod->is_irremovable() ) {
-                                continue;
-                            }
-                            you.gunmod_remove( *it->first, *mod );
-                            // need to return so the activity starts
-                            return;
-                        }
-                    }
-
-                    // if unloading molle
-                    if( unload_molle ) {
-                        while( !it->first->get_contents().get_added_pockets().empty() ) {
-                            item removed = it->first->get_contents().remove_pocket( 0 );
-                            move_item( you, removed, 1, src_loc, src_loc, vpr_src );
-                            moved_something = true;
-                        }
-                    }
-                    if( it->first->has_flag( flag_MAG_DESTROY ) && it->first->ammo_remaining( ) == 0 ) {
-                        if( vpr_src ) {
-                            vpr_src->vehicle().remove_item( vpr_src->part(), it->first );
-                        } else {
-                            here.i_rem( src_loc, it->first );
-                        }
-                        num_processed = std::max( num_processed - 1, 0 );
-                        return;
-                    }
-
-                    // after dumping items go back to start of activity loop
-                    // so that can re-assess the items in the tile
-                    // perhaps move the last item first however
-                    if( unload_always && moved_something ) {
-                        move_and_reset = true;
-                    } else if( moved_something ) {
-                        return;
-                    }
-
-                }
-
+            std::optional<bool> move_and_reset = zone_sorting::unload_item( you, src,
+                                                 zone_sort_options, vp, it->first, dest_set, num_processed );
+            if( !move_and_reset ) {
+                return;
             }
 
-            for( const tripoint_abs_ms &dest : dest_set ) {
-                const tripoint_bub_ms dest_loc = here.get_bub( dest );
-                units::volume free_space;
-
-                //Check destination for cargo part
-                if( const std::optional<vpart_reference> ovp = here.veh_at( dest_loc ).cargo() ) {
-                    free_space = ovp->items().free_volume();
-                } else {
-                    free_space = here.free_volume( dest_loc );
-                }
-
-                // skip tiles with inaccessible furniture, like filled charcoal kiln
-                if( !here.can_put_items_ter_furn( dest_loc ) ||
-                    static_cast<int>( here.i_at( dest_loc ).size() ) >= MAX_ITEM_IN_SQUARE ) {
-                    continue;
-                }
-
-                // check free space at destination
-                if( free_space >= thisitem.volume() ) {
-                    move_item( you, thisitem, thisitem.count(), src_loc, dest_loc, vpr_src );
-
-                    // moved item away from source so decrement
-                    if( num_processed > 0 ) {
-                        --num_processed;
-                    }
-                    break;
-                }
-            }
-            if( you.get_moves() <= 0 || move_and_reset ) {
+            zone_sorting::move_item( you, vp, src_bub, dest_set, thisitem, num_processed );
+            if( you.get_moves() <= 0 || *move_and_reset ) {
                 return;
             }
         }

--- a/src/activity_item_handling.h
+++ b/src/activity_item_handling.h
@@ -1,12 +1,23 @@
-#include "activity_actor_definitions.h"
-#include "vpart_position.h"
+#include <optional>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include "coords_fwd.h"
+#include "item.h"
+
+class Character;
+class item_location;
+class player_activity;
+class vpart_reference;
+enum zone_activity_stage : int;
 
 namespace zone_sorting
 {
 // the boolean in this pair being true indicates the item is from a vehicle storage space
 using zone_items = std::vector<std::pair<item *, bool>>;
 
-struct unload_options {
+struct unload_sort_options {
     bool unload_mods = false;
     bool unload_molle = false;
     bool unload_always = false;
@@ -21,12 +32,12 @@ bool sorter_out_of_bounds( Character &you );
 
 //returns true if successfully routed to destination
 bool route_to_destination( Character &you, player_activity &act,
-                           const tripoint_bub_ms dest, zone_activity_stage &stage );
+                           const tripoint_bub_ms &dest, zone_activity_stage &stage );
 /**
 * Returns true if the given item should be skipped while sorting
 */
 bool sort_skip_item( Character &you, const item *it,
-                     const std::vector<const item *> &other_activity_items,
+                     const std::vector<item_location> &other_activity_items,
                      bool ignore_favorite, const tripoint_abs_ms &src );
 
 /**
@@ -34,8 +45,8 @@ bool sort_skip_item( Character &you, const item *it,
 * @param use_zone_type - check for zone types other than UNLOAD_ALL
 * @param unloading - whether to set unload_always
 */
-unload_options set_unload_options( Character &you, const tripoint_abs_ms &src,
-                                   bool use_zone_type, bool unloading );
+unload_sort_options set_unload_options( Character &you, const tripoint_abs_ms &src,
+                                        bool use_zone_type );
 
 // return items at the given location from vehicle cargo and ground
 // TODO: build into map class
@@ -51,19 +62,20 @@ bool ignore_zone_position( Character &you, const tripoint_abs_ms &src, bool igno
 
 // of `items` at `src`, do any need to be sorted?
 bool has_items_to_sort( Character &you, const tripoint_abs_ms &src,
-                        zone_sorting::unload_options zone_unload_options,
-                        const std::vector<const item *> &other_activity_items,
+                        zone_sorting::unload_sort_options zone_unload_options,
+                        const std::vector<item_location> &other_activity_items,
                         const zone_sorting::zone_items &items );
 bool can_unload( item *it );
-void add_item( const std::optional<vpart_reference> vp, const tripoint_bub_ms &src_bub,
+void add_item( const std::optional<vpart_reference> &vp, const tripoint_bub_ms &src_bub,
                const item &it );
-void remove_item( const std::optional<vpart_reference> vp, const tripoint_bub_ms &src_bub,
+void remove_item( const std::optional<vpart_reference> &vp, const tripoint_bub_ms &src_bub,
                   item *it );
 std::optional<bool> unload_item( Character &you, const tripoint_abs_ms &src,
-                                 zone_sorting::unload_options zone_unload_options, const std::optional<vpart_reference> &vpr_src,
+                                 zone_sorting::unload_sort_options zone_unload_options,
+                                 const std::optional<vpart_reference> &vpr_src,
                                  item *it, const std::unordered_set<tripoint_abs_ms> &dest_set,
                                  int &num_processed );
 void move_item( Character &you, const std::optional<vpart_reference> &vpr_src,
                 const tripoint_bub_ms &src_bub, const std::unordered_set<tripoint_abs_ms> &dest_set,
                 item &it, int &num_processed );
-}
+} //namespace zone_sorting

--- a/src/activity_item_handling.h
+++ b/src/activity_item_handling.h
@@ -1,0 +1,69 @@
+#include "activity_actor_definitions.h"
+#include "vpart_position.h"
+
+namespace zone_sorting
+{
+// the boolean in this pair being true indicates the item is from a vehicle storage space
+using zone_items = std::vector<std::pair<item *, bool>>;
+
+struct unload_options {
+    bool unload_mods = false;
+    bool unload_molle = false;
+    bool unload_always = false;
+    bool ignore_favorite = false;
+    bool unload_all = false;
+    bool unload_corpses = false;
+    bool unload_sparse_only = false;
+    int unload_sparse_threshold = 0;
+};
+
+bool sorter_out_of_bounds( Character &you );
+
+//returns true if successfully routed to destination
+bool route_to_destination( Character &you, player_activity &act,
+                           const tripoint_bub_ms dest, zone_activity_stage &stage );
+/**
+* Returns true if the given item should be skipped while sorting
+*/
+bool sort_skip_item( Character &you, const item *it,
+                     const std::vector<const item *> &other_activity_items,
+                     bool ignore_favorite, const tripoint_abs_ms &src );
+
+/**
+* Sets sorting options given nearby UNLOAD_ALL zones
+* @param use_zone_type - check for zone types other than UNLOAD_ALL
+* @param unloading - whether to set unload_always
+*/
+unload_options set_unload_options( Character &you, const tripoint_abs_ms &src,
+                                   bool use_zone_type, bool unloading );
+
+// return items at the given location from vehicle cargo and ground
+// TODO: build into map class
+zone_items populate_items( const tripoint_bub_ms &src_bub );
+// returns whether to ignore the zones at `src`
+// if one zone is ignored, all will be
+bool ignore_contents( Character &you, const tripoint_abs_ms &src );
+
+// skip tiles in IGNORE zone or with ignore option,
+// tiles on fire (to prevent taking out wood off the lit brazier)
+// and inaccessible furniture, like filled charcoal kiln
+bool ignore_zone_position( Character &you, const tripoint_abs_ms &src, bool ignore_contents );
+
+// of `items` at `src`, do any need to be sorted?
+bool has_items_to_sort( Character &you, const tripoint_abs_ms &src,
+                        zone_sorting::unload_options zone_unload_options,
+                        const std::vector<const item *> &other_activity_items,
+                        const zone_sorting::zone_items &items );
+bool can_unload( item *it );
+void add_item( const std::optional<vpart_reference> vp, const tripoint_bub_ms &src_bub,
+               const item &it );
+void remove_item( const std::optional<vpart_reference> vp, const tripoint_bub_ms &src_bub,
+                  item *it );
+std::optional<bool> unload_item( Character &you, const tripoint_abs_ms &src,
+                                 zone_sorting::unload_options zone_unload_options, const std::optional<vpart_reference> &vpr_src,
+                                 item *it, const std::unordered_set<tripoint_abs_ms> &dest_set,
+                                 int &num_processed );
+void move_item( Character &you, const std::optional<vpart_reference> &vpr_src,
+                const tripoint_bub_ms &src_bub, const std::unordered_set<tripoint_abs_ms> &dest_set,
+                item &it, int &num_processed );
+}

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -4566,6 +4566,12 @@ tripoint_bub_ms Character::adjacent_tile() const
     return random_entry( ret, pos_bub() ); // player position if no valid adjacent tiles
 }
 
+faction_id Character::get_faction_id() const
+{
+    const faction *fac = get_faction();
+    return fac == nullptr ? faction_id() : fac->id;
+}
+
 void Character::set_fac_id( const std::string &my_fac_id )
 {
     fac_id = faction_id( my_fac_id );

--- a/src/character.h
+++ b/src/character.h
@@ -782,6 +782,8 @@ class Character : public Creature, public visitable
         virtual faction *get_faction() const {
             return nullptr;
         }
+        /* returns the character's faction id, or an empty faction id if they have no faction */
+        faction_id get_faction_id() const;
         void set_fac_id( const std::string &my_fac_id );
         virtual bool is_ally( const Character &p ) const = 0;
         virtual bool is_obeying( const Character &p ) const = 0;

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -18,6 +18,7 @@
 #include <unordered_set>
 #include <vector>
 
+#include "activity_actor_definitions.h"
 #include "avatar.h"
 #include "basecamp.h"
 #include "build_reqs.h"
@@ -102,8 +103,6 @@
 #include "visitable.h"
 #include "vpart_position.h"
 #include "weather.h"
-
-static const activity_id ACT_MOVE_LOOT( "ACT_MOVE_LOOT" );
 
 static const addiction_id addiction_alcohol( "alcohol" );
 
@@ -2319,7 +2318,7 @@ void basecamp::start_menial_labor()
     }
     validate_sort_points();
 
-    comp->assign_activity( ACT_MOVE_LOOT );
+    comp->assign_activity( zone_sort_activity_actor() );
     popup( _( "%s goes off to clean toilets and sort loot." ), comp->disp_name() );
 }
 

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -1514,7 +1514,7 @@ static void loot()
     }
 
     // Manually update vehicle cache.
-    // In theory this would be handled by the related activity (activity_on_turn_move_loot())
+    // In theory this would be handled by the related activity (zone_sort_activity_actor())
     // but with a stale cache we never get that far.
     mgr.cache_vzones();
 
@@ -1629,7 +1629,7 @@ static void loot()
             add_msg( _( "Never mind." ) );
             break;
         case SortLoot:
-            player_character.assign_activity( ACT_MOVE_LOOT );
+            player_character.assign_activity( zone_sort_activity_actor() );
             break;
         case SortLootStatic:
             //temporarily disable personal zones
@@ -1644,7 +1644,7 @@ static void loot()
             if( recache ) {
                 mgr.cache_data();
             }
-            player_character.assign_activity( ACT_MOVE_LOOT );
+            player_character.assign_activity( zone_sort_activity_actor() );
             break;
         case SortLootPersonal:
             //temporarily disable non personal zones
@@ -1659,7 +1659,7 @@ static void loot()
             if( recache ) {
                 mgr.cache_data();
             }
-            player_character.assign_activity( ACT_MOVE_LOOT );
+            player_character.assign_activity( zone_sort_activity_actor() );
             break;
         case UnloadLoot:
             player_character.assign_activity( unload_loot_activity_actor() );

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -110,7 +110,6 @@ enum class direction : unsigned int;
 #endif
 
 static const activity_id ACT_FERTILIZE_PLOT( "ACT_FERTILIZE_PLOT" );
-static const activity_id ACT_MOVE_LOOT( "ACT_MOVE_LOOT" );
 static const activity_id ACT_MULTIPLE_BUTCHER( "ACT_MULTIPLE_BUTCHER" );
 static const activity_id ACT_MULTIPLE_CHOP_PLANKS( "ACT_MULTIPLE_CHOP_PLANKS" );
 static const activity_id ACT_MULTIPLE_CHOP_TREES( "ACT_MULTIPLE_CHOP_TREES" );

--- a/src/npctalk_funcs.cpp
+++ b/src/npctalk_funcs.cpp
@@ -61,7 +61,6 @@
 #include "viewer.h"
 
 static const activity_id ACT_FIND_MOUNT( "ACT_FIND_MOUNT" );
-static const activity_id ACT_MOVE_LOOT( "ACT_MOVE_LOOT" );
 static const activity_id ACT_MULTIPLE_BUTCHER( "ACT_MULTIPLE_BUTCHER" );
 static const activity_id ACT_MULTIPLE_CHOP_PLANKS( "ACT_MULTIPLE_CHOP_PLANKS" );
 static const activity_id ACT_MULTIPLE_CHOP_TREES( "ACT_MULTIPLE_CHOP_TREES" );
@@ -247,7 +246,7 @@ void talk_function::start_trade( npc &p )
 
 void talk_function::sort_loot( npc &p )
 {
-    p.assign_activity( ACT_MOVE_LOOT );
+    p.assign_activity( zone_sort_activity_actor() );
 }
 
 void talk_function::do_construction( npc &p )

--- a/tests/clzones_test.cpp
+++ b/tests/clzones_test.cpp
@@ -22,8 +22,6 @@
 #include "vehicle.h"
 #include "vpart_position.h"
 
-static const activity_id ACT_MOVE_LOOT( "ACT_MOVE_LOOT" );
-
 static const faction_id faction_your_followers( "your_followers" );
 
 static const itype_id itype_556( "556" );
@@ -117,7 +115,7 @@ TEST_CASE( "zone_unloading_ammo_belts", "[zones][items][ammo_belt][activities][u
             here.add_item_or_charges( tripoint_bub_ms( tripoint::east ), ammo_belt );
         }
         if( move_act ) {
-            dummy.assign_activity( player_activity( ACT_MOVE_LOOT ) );
+            dummy.assign_activity( zone_sort_activity_actor() );
         } else {
             dummy.assign_activity( unload_loot_activity_actor() );
         }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Infrastructure "zone sorting refactor"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Working on #81831

More specifically,
> Refactor the zone sorting code and review the logic, become familiar with how it works. Identify and fix any obvious flaws, but mainly, make sure the code is maintainable for the future.

This should happen before anything else regarding zone sorting, IMO

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

- splits up the 500-line `activity_on_turn_move_loot` into several helper functions
- migrates ACT_MOVE_LOOT from a legacy activity handler to an `activity_actor`
- deduplicates `unload_loot_activity_actor`; it was copy-pasted (!!) from `activity_on_turn_move_loot`

There shouldn't be any functional changes for zone sorting or unloading.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

I didn't run into any existing bugs, other than that removing gunmods while unloading cancels a sort/unload (designed intentionally).

- Tested all unload options separately
- Tested basic sorting into zones
- Tested ordering NPC to sort
- Tested migration by autosaving while doing a long sort with older experimental and loading it with my branch; zone sorting cancelled but could be restarted without errors

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

~TODO: test migration, CI changes~

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
