### PR TITLE
Add vehicle zone enable/disable keys to the zone manager UI

### DIFF
--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -3643,6 +3643,28 @@
   },
   {
     "type": "keybinding",
+    "id": "ENABLE_VEHICLE_ZONES",
+    "category": "ZONES_MANAGER",
+    "name": "Enable vehicle zones",
+    "bindings": [
+      { "input_method": "keyboard_any", "key": "c" },
+      { "input_method": "keyboard_char", "key": "C" },
+      { "input_method": "keyboard_code", "key": "c", "mod": [ "shift" ] }
+    ]
+  },
+  {
+    "type": "keybinding",
+    "id": "DISABLE_VEHICLE_ZONES",
+    "category": "ZONES_MANAGER",
+    "name": "Disable vehicle zones",
+    "bindings": [
+      { "input_method": "keyboard_any", "key": "v" },
+      { "input_method": "keyboard_char", "key": "V" },
+      { "input_method": "keyboard_code", "key": "v", "mod": [ "shift" ] }
+    ]
+  },
+  {
+    "type": "keybinding",
     "id": "SHOW_ALL_ZONES",
     "category": "ZONES_MANAGER",
     "name": "Show all zones / hide distant zones",

--- a/src/zone_manager_ui.cpp
+++ b/src/zone_manager_ui.cpp
@@ -100,6 +100,8 @@ void zone_manager_ui::zones_manager_shortcuts( const catacurses::window &w_info,
     add_action_desc( "TOGGLE_ZONE_DISPLAY", pgettext( "zones manager", "Toggle zone display" ) );
     add_action_desc( "ENABLE_PERSONAL_ZONES", pgettext( "zones manager", "Enable personal" ) );
     add_action_desc( "DISABLE_PERSONAL_ZONES", pgettext( "zones manager", "Disable personal" ) );
+    add_action_desc( "ENABLE_VEHICLE_ZONES", pgettext( "zones manager", "Enable vehicle" ) );
+    add_action_desc( "DISABLE_VEHICLE_ZONES", pgettext( "zones manager", "Disable vehicle" ) );
     add_action_desc( "MOVE_ZONE_UP", pgettext( "zones manager", "Move up" ) );
     add_action_desc( "MOVE_ZONE_DOWN", pgettext( "zones manager", "Move down" ) );
     add_action_desc( "CONFIRM", pgettext( "zones manager", "Edit" ) );
@@ -226,6 +228,8 @@ void zone_manager_ui::display_zone_manager()
     ctxt.register_action( "TOGGLE_ZONE_DISPLAY" );
     ctxt.register_action( "ENABLE_PERSONAL_ZONES" );
     ctxt.register_action( "DISABLE_PERSONAL_ZONES" );
+    ctxt.register_action( "ENABLE_VEHICLE_ZONES" );
+    ctxt.register_action( "DISABLE_VEHICLE_ZONES" );
     ctxt.register_action( "SHOW_ALL_ZONES" );
     ctxt.register_action( "HELP_KEYBINDINGS" );
     if( debug_mode ) {
@@ -814,6 +818,36 @@ void zone_manager_ui::display_zone_manager()
                         continue;
                     }
                     if( zone.get_is_personal() ) {
+                        zone.set_enabled( false );
+                        zones_changed = true;
+                    }
+                }
+
+                stuff_changed = zones_changed;
+            } else if( action == "ENABLE_VEHICLE_ZONES" ) {
+                bool zones_changed = false;
+
+                for( const auto &i : zones ) {
+                    zone_data &zone = i.get();
+                    if( zone.get_enabled() ) {
+                        continue;
+                    }
+                    if( zone.get_is_vehicle() ) {
+                        zone.set_enabled( true );
+                        zones_changed = true;
+                    }
+                }
+
+                stuff_changed = zones_changed;
+            } else if( action == "DISABLE_VEHICLE_ZONES" ) {
+                bool zones_changed = false;
+
+                for( const auto &i : zones ) {
+                    zone_data &zone = i.get();
+                    if( !zone.get_enabled() ) {
+                        continue;
+                    }
+                    if( zone.get_is_vehicle() ) {
                         zone.set_enabled( false );
                         zones_changed = true;
                     }


### PR DESCRIPTION
#### Summary
Interface "Add vehicle zone enable/disable keys to the zone manager UI"

#### Purpose of changes

My personal use pattern with zones bound to vehicle cargo carriers / boxes is fairly complex.  I tend to have a large number of small zones that match very specific sets of items.

This is really annoying when I need to move a bunch of stuff into a vehicle or out of a vehicle, without regard to my normal zone definitions.  I end up manually enabling/disabling ~20 zones in the case of a giant, cancerous RV.

#### Describe the solution

My solution was to add keybindings to mass-enable and mass-disable vehicle zones.    This way, when I need to unload specific things from ALL vehicle zones, I can create a local "unsorted" zone, disable ALL vehicle zones instantly, and just have things dump to zones outside the vehicle when sorted.

To paraphrase famously bad repair manuals, loading is the opposite of unloading.

#### Describe alternatives you've considered

I am not sure it makes sense to have two keys to enable and disable vehicle zones.   I did this in order to follow the pattern set by personal zones on the adjacent `z`/`x` keys.

If it were left to me, I would just have a "toggle all vehicle zones" key.

#### Testing

When entering the zones manager UI (default: `Y`), you should see all zones bound to vehicle tiles listed.

When hitting "disable vehicle zones" (default: `v`), all vehicle zones should be disabled in one go, but personal and local zones should be left unchanged.

Similarly, when hitting "enable vehicle zones" (default: `c`), all vehicle zones should be enabled in a single go.

#### Additional context

N/A