### PR TITLE
Adjust Irradiation Plant mapgen special spawn

### DIFF
--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -4202,7 +4202,7 @@
     "city_sizes": [ 6, -1 ],
     "occurrences": [ 70, 100 ],
     "//": "Inflated chance, effective rate ~40%",
-    "flags": [ "CLASSIC", "OVERMAP_UNIQUE", "MAN_MADE" ]
+    "flags": [ "CLASSIC", "GLOBALLY_UNIQUE", "MAN_MADE" ]
   },
   {
     "type": "overmap_special",


### PR DESCRIPTION


#### Summary
None

#### Purpose of change
Make the irradiation plant globally unique due to there being only 2 of it in the whole New England region according to what i have read about it.

#### Describe the solution

`OVERMAP_UNIQUE` -> `GLOBALLY_UNIQUE` on the irradiation plant's overmap json.

#### Describe alternatives you've considered
Just uproot it off the game?

#### Testing
Before change, i look around at a world and see like 3-4 irradiation plants in a 3×3 overmap and potentially more beyond.

After change, i only saw just the one irradiation plant.

#### Additional context
Why is it even able to run anyway? is the solar panels on top really runs strong enough to run a whole irradiation plant?


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
