### PR TITLE
[Bugfix]Aftershock - Fix vehicle、monster、NPC z position all set to 1 after Vanishing Arc teleport and fixed zones on ship not teleported

### DIFF
--- a/data/mods/aftershock_exoplanet/EOC/ship_eoc.json
+++ b/data/mods/aftershock_exoplanet/EOC/ship_eoc.json
@@ -175,7 +175,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_SHIP_veh",
-    "effect": [ { "u_run_vehicle_eocs": [ "EOC_SHIP_TP" ], "vehicle_range": 24, "z_min": 1} ]
+    "effect": [ { "u_run_vehicle_eocs": [ "EOC_SHIP_TP" ], "vehicle_range": 24, "z_min": 1 } ]
   },
   {
     "type": "effect_on_condition",

--- a/data/mods/aftershock_exoplanet/EOC/ship_eoc.json
+++ b/data/mods/aftershock_exoplanet/EOC/ship_eoc.json
@@ -166,6 +166,7 @@
       { "run_eocs": "EOC_SHIP_veh" },
       { "run_eocs": "EOC_SHIP_npc" },
       { "run_eocs": "EOC_SHIP_mon" },
+      { "run_eocs": "EOC_SHIP_zone" },
       { "run_eocs": "EOC_SHIP_TP" },
       { "run_eocs": "EOC_SHIP_CLEANUP", "time_in_future": "1s" },
       { "run_eocs": "EOC_SHIP_VER", "time_in_future": "1s" }
@@ -174,17 +175,22 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_SHIP_veh",
-    "effect": [ { "u_run_vehicle_eocs": [ "EOC_SHIP_TP" ], "vehicle_range": 24 } ]
+    "effect": [ { "u_run_vehicle_eocs": [ "EOC_SHIP_TP" ], "vehicle_range": 24, "z_min": 1} ]
   },
   {
     "type": "effect_on_condition",
     "id": "EOC_SHIP_npc",
-    "effect": [ { "u_run_npc_eocs": [ "EOC_SHIP_TP" ], "npc_range": 24, "local": true } ]
+    "effect": [ { "u_run_npc_eocs": [ "EOC_SHIP_TP" ], "npc_range": 24, "local": true, "z_min": 1 } ]
   },
   {
     "type": "effect_on_condition",
     "id": "EOC_SHIP_mon",
-    "effect": [ { "u_run_monster_eocs": [ "EOC_SHIP_TP" ], "monster_range": 24 } ]
+    "effect": [ { "u_run_monster_eocs": [ "EOC_SHIP_TP" ], "monster_range": 24, "z_min": 1 } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_SHIP_zone",
+    "effect": [ { "u_run_fixed_zone_eocs": [ "EOC_SHIP_TP" ], "zone_range": 24, "z_min": 1 } ]
   },
   {
     "type": "effect_on_condition",
@@ -194,7 +200,6 @@
       { "u_location_variable": { "context_val": "my_pos" } },
       { "math": [ "_new_ship_x = 12*round(ship_new.x/ 12) - _my_pos.x + ( (_my_pos.x%24 + 24)%24 -12 )" ] },
       { "math": [ "_new_ship_y = 12*round(ship_new.y/ 12) - _my_pos.y + ( (_my_pos.y%24 + 24)%24 - 12)" ] },
-      { "math": [ "_my_pos.z = ship_new.z" ] },
       { "math": [ "_my_pos.x += _new_ship_x" ] },
       { "math": [ "_my_pos.y += _new_ship_y" ] },
       { "u_teleport": { "context_val": "my_pos" }, "force": true }

--- a/doc/JSON/EFFECT_ON_CONDITION.md
+++ b/doc/JSON/EFFECT_ON_CONDITION.md
@@ -2482,6 +2482,8 @@ NPC run EoCs, provided by this effect; can work outside of reality bubble
 | "unique_ids" | optional | string, [variable objects](#variable-object) or array | id of NPCs that would be affected; lack of ids make effect run EoC on every NPC in your reality bubble, if `"local": true`, and to every NPC in the world, if `"local": false`; unique ID of every npc is specified in mapgen, using `npcs` or `place_npcs` |
 | "local" | optional | boolean | default false; if true, the effect is run for every NPC in the world; if false, effect is run only to NPC in your reality bubble |
 | "npc_range" | optional | int or [variable object](#variable-object) | if used, only NPC in this range are affected |
+| "z_min" | optional | int or [variable object](#variable-object) | if used, only NPC'z position >= z_min are affected |
+| "z_max" | optional | int or [variable object](#variable-object) | if used, only NPC'z position <= z_max are affected |
 | "npc_must_see" | optional | boolean | default false; if true, only NPC you can see are affected |
 
 example of specifying `unique_id` in mapgen using `npcs`:
@@ -2547,6 +2549,8 @@ Monsters run EoCs, provided by this effect; only works inside reality bubble
 | "u_run_monster_eocs"/ "npc_run_monster_eocs" | **mandatory** | array of eocs | EoCs that would be run by monsters |
 | "mtype_ids" | optional | array or [variable objects](#variable-object) | mtype_id(s) that should be affected |
 | "monster_range" | optional | int or [variable object](#variable-object) | if used, only monsters in this range are affected |
+| "z_min" | optional | int or [variable object](#variable-object) | if used, only NPC'z position >= z_min are affected |
+| "z_max" | optional | int or [variable object](#variable-object) | if used, only NPC'z position <= z_max are affected |
 | "monster_must_see" | optional | boolean | default false; if true, only monsters you can see are affected |
 
 ##### Valid talkers:
@@ -2645,6 +2649,50 @@ Pick all items with `RECHARGE` _or_ `ELECTRONIC` flags, and run `EOC_PRINT_ITEM_
     }
   ]
 }
+```
+
+#### `u_run_fixed_zone_eocs`, `npc_run_fixed_zone_eocs`
+Fix zones run EoCs, provided by this effect; can work outside of reality bubble
+
+Note: current version only supports run EoC "u_location_variable" "u_teleport" to move fix zones.
+
+| Syntax | Optionality | Value  | Info |
+| --- | --- | --- | --- |
+| "u_run_fixed_zone_eocs"/ "npc_run_fixed_zone_eocs" | **mandatory** | array of eocs | EoCs that would be run by fixed zones |
+| "zone_range" | optional | int or [variable object](#variable-object) | if used, only fixed zone in this range are affected |
+| "z_min" | optional | int or [variable object](#variable-object) | if used, only fixed zone'z position >= z_min are affected |
+| "z_max" | optional | int or [variable object](#variable-object) | if used, only fixed zone'z position <= z_max are affected |
+
+##### Valid talkers:
+
+| Avatar | NPC | Monster | Furniture | Item | Vehicle | Fixed Zone|
+| ------ | --------- | ---- | ------- | --- | ---- | ----|
+| ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✔️ |
+
+##### Examples
+
+All fixed zones in range 24, z position >= 1, that you can see, run `u_location_variable` and `u_teleport`, we move fix zones in this example
+```jsonc
+{
+    "type": "effect_on_condition",
+    "id": "EOC_SHIP_zone",
+    "effect": [
+      { 
+        "u_run_fixed_zone_eocs": [ "EOC_SHIP_TP" ],
+        "zone_range": 24, 
+        "z_min": 1
+      } 
+    ]
+},
+{
+  "type": "effect_on_condition",
+  "id": "EOC_SHIP_TP",
+  "effect": [
+    { "u_location_variable": { "context_val": "my_pos" } },
+    { "u_teleport": { "context_val": "my_pos" }, "force": true }
+  ]
+},
+
 ```
 
 #### `u_map_run_eocs`, `npc_map_run_eocs`

--- a/src/clzones.cpp
+++ b/src/clzones.cpp
@@ -1880,7 +1880,7 @@ void mapgen_place_zone( tripoint_abs_ms const &start, tripoint_abs_ms const &end
     mgr.add( name, type, fac, false, true, s_, e_, options, true, pmap );
 }
 
-std::unique_ptr<talker> get_talker_for(zone_data& me)
+std::unique_ptr<talker> get_talker_for( zone_data &me )
 {
     return std::make_unique<talker_zone>(&me);
 }

--- a/src/clzones.cpp
+++ b/src/clzones.cpp
@@ -1882,7 +1882,7 @@ void mapgen_place_zone( tripoint_abs_ms const &start, tripoint_abs_ms const &end
 
 std::unique_ptr<talker> get_talker_for( zone_data &me )
 {
-    return std::make_unique<talker_zone>(&me);
+    return std::make_unique<talker_zone>( &me );
 }
 
 std::unique_ptr<const_talker> get_talker_for(const zone_data& me)

--- a/src/clzones.cpp
+++ b/src/clzones.cpp
@@ -1887,7 +1887,7 @@ std::unique_ptr<talker> get_talker_for( zone_data &me )
 
 std::unique_ptr<const_talker> get_talker_for( const zone_data &me )
 {
-    return std::make_unique<talker_zone_const>(&me);
+    return std::make_unique<talker_zone_const>( &me );
 }
 
 std::unique_ptr<talker> get_talker_for(zone_data* me)

--- a/src/clzones.cpp
+++ b/src/clzones.cpp
@@ -42,6 +42,7 @@
 #include "vehicle.h"
 #include "visitable.h"
 #include "vpart_position.h"
+#include "talker_zone.h"
 
 static const faction_id faction_your_followers( "your_followers" );
 
@@ -1877,4 +1878,19 @@ void mapgen_place_zone( tripoint_abs_ms const &start, tripoint_abs_ms const &end
         }
     }
     mgr.add( name, type, fac, false, true, s_, e_, options, true, pmap );
+}
+
+std::unique_ptr<talker> get_talker_for(zone_data& me)
+{
+    return std::make_unique<talker_zone>(&me);
+}
+
+std::unique_ptr<const_talker> get_talker_for(const zone_data& me)
+{
+    return std::make_unique<talker_zone_const>(&me);
+}
+
+std::unique_ptr<talker> get_talker_for(zone_data* me)
+{
+    return std::make_unique<talker_zone>(me);
 }

--- a/src/clzones.cpp
+++ b/src/clzones.cpp
@@ -1885,7 +1885,7 @@ std::unique_ptr<talker> get_talker_for( zone_data &me )
     return std::make_unique<talker_zone>( &me );
 }
 
-std::unique_ptr<const_talker> get_talker_for(const zone_data& me)
+std::unique_ptr<const_talker> get_talker_for( const zone_data &me )
 {
     return std::make_unique<talker_zone_const>(&me);
 }

--- a/src/clzones.h
+++ b/src/clzones.h
@@ -35,6 +35,9 @@ class JsonValue;
 class input_context;
 class item;
 class map;
+class talker;
+class const_talker;
+class talker_zone;
 struct construction;
 
 inline const faction_id your_fac( "your_followers" );
@@ -697,5 +700,7 @@ void mapgen_place_zone( tripoint_abs_ms const &start, tripoint_abs_ms const &end
                         zone_type_id const &type,
                         faction_id const &fac = your_fac, std::string const &name = {},
                         std::string const &filter = {}, map *pmap = nullptr );
-
+std::unique_ptr<talker> get_talker_for(zone_data& me);
+std::unique_ptr<const_talker> get_talker_for(const zone_data& me);
+std::unique_ptr<talker> get_talker_for(zone_data* me);
 #endif // CATA_SRC_CLZONES_H

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -6673,8 +6673,8 @@ talk_effect_fun_t::func f_run_fixed_zone_eocs(const JsonObject& jo,
         zone_range = jo.get_int("zone_range");
     }
     std::optional<int> z_min;
-    if (jo.has_int("z_min")) {
-        z_min = jo.get_int("z_min");
+    if( jo.has_int( "z_min" ) ) {
+        z_min = jo.get_int( "z_min" );
     }
     std::optional<int> z_max;
     if( jo.has_int( "z_max" ) ) {

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -6694,11 +6694,11 @@ talk_effect_fun_t::func f_run_fixed_zone_eocs(const JsonObject& jo,
             if( z_max.has_value() && pos_abs.z() > z_min.value() ) {
                 continue;
             }
-            if (!zone_range.has_value() ||
-                rl_dist(actor_pos, zone.get_start_point()) <= zone_range.value()) {
-                for (const effect_on_condition_id& eoc : eocs) {
-                    dialogue newDialog( get_talker_for(zone), nullptr, d.get_conditionals(), d.get_context());
-                    eoc->activate(newDialog);
+            if( !zone_range.has_value() ||
+                rl_dist( actor_pos, zone.get_start_point() ) <= zone_range.value() ) {
+                for( const effect_on_condition_id &eoc : eocs ) {
+                    dialogue newDialog( get_talker_for( zone ), nullptr, d.get_conditionals(), d.get_context() );
+                    eoc->activate( newDialog );
                 }
             }
         }

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -6691,7 +6691,7 @@ talk_effect_fun_t::func f_run_fixed_zone_eocs(const JsonObject& jo,
             if( z_min.has_value() && pos_abs.z() < z_min.value() ) {
                 continue;
             }
-            if (z_max.has_value() && pos_abs.z() > z_min.value()) {
+            if( z_max.has_value() && pos_abs.z() > z_min.value() ) {
                 continue;
             }
             if (!zone_range.has_value() ||

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -6688,7 +6688,7 @@ talk_effect_fun_t::func f_run_fixed_zone_eocs(const JsonObject& jo,
                 continue;
             }
             auto pos_abs = zone.get_start_point();
-            if (z_min.has_value() && pos_abs.z() < z_min.value()) {
+            if( z_min.has_value() && pos_abs.z() < z_min.value() ) {
                 continue;
             }
             if (z_max.has_value() && pos_abs.z() > z_min.value()) {

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -182,6 +182,7 @@ static const trait_id trait_PROF_FOODP( "PROF_FOODP" );
 
 static const zone_type_id zone_type_NPC_INVESTIGATE_ONLY( "NPC_INVESTIGATE_ONLY" );
 static const zone_type_id zone_type_NPC_NO_INVESTIGATE( "NPC_NO_INVESTIGATE" );
+static const faction_id faction_your_followers("your_followers");
 
 static std::map<std::string, json_talk_topic> json_talk_topics;
 
@@ -6507,16 +6508,24 @@ talk_effect_fun_t::func f_run_npc_eocs( const JsonObject &jo,
     if( jo.has_int( "npc_range" ) ) {
         npc_range = jo.get_int( "npc_range" );
     }
+    std::optional<int> z_min;
+    if (jo.has_int("z_min")) {
+        z_min = jo.get_int("z_min");
+    }
+    std::optional<int> z_max;
+    if (jo.has_int("z_max")) {
+        z_max = jo.get_int("z_max");
+    }
     bool npc_must_see = jo.get_bool( "npc_must_see", false );
     if( local ) {
-        return [eocs, unique_ids, npc_must_see, npc_range, is_npc, &here]( dialogue const & d ) {
+        return [eocs, unique_ids, npc_must_see, npc_range, z_min, z_max, is_npc, &here]( dialogue const & d ) {
             tripoint_bub_ms actor_pos = d.actor( is_npc )->pos_bub( here );
             std::vector<std::string> ids;
             ids.reserve( unique_ids.size() );
             for( const str_or_var &id : unique_ids ) {
                 ids.emplace_back( id.evaluate( d ) );
             }
-            const std::vector<npc *> available = g->get_npcs_if( [npc_must_see, npc_range, actor_pos,
+            const std::vector<npc *> available = g->get_npcs_if( [npc_must_see, npc_range, z_min, z_max, actor_pos,
                           ids, &here]( const npc & guy ) {
                 bool id_valid = ids.empty();
                 for( const std::string &id : ids ) {
@@ -6527,7 +6536,9 @@ talk_effect_fun_t::func f_run_npc_eocs( const JsonObject &jo,
                 }
                 return id_valid && ( !npc_range.has_value() || actor_pos.z() == guy.posz() ) && ( !npc_must_see ||
                         guy.sees( here, actor_pos ) ) &&
-                       ( !npc_range.has_value() || rl_dist( actor_pos, guy.pos_bub( here ) ) <= npc_range.value() );
+                       ( !npc_range.has_value() || rl_dist( actor_pos, guy.pos_bub( here ) ) <= npc_range.value() &&
+                       ( !z_min.has_value() || guy.posz() >= z_min.value()) &&
+                       ( !z_max.has_value() || guy.posz() <= z_max.value()) );
             } );
             for( npc *target : available ) {
                 for( const effect_on_condition_id &eoc : eocs ) {
@@ -6569,8 +6580,16 @@ talk_effect_fun_t::func f_run_monster_eocs( const JsonObject &jo,
     if( jo.has_int( "monster_range" ) ) {
         monster_range = jo.get_int( "monster_range" );
     }
+    std::optional<int> z_min;
+    if (jo.has_int("z_min")) {
+        z_min = jo.get_int("z_min");
+    }
+    std::optional<int> z_max;
+    if (jo.has_int("z_max")) {
+        z_max = jo.get_int("z_max");
+    }
     bool monster_must_see = jo.get_bool( "monster_must_see", false );
-    return [eocs, mtype_ids, monster_must_see, monster_range, is_npc, &here]( dialogue const & d ) {
+    return [eocs, mtype_ids, monster_must_see, monster_range, z_min, z_max, is_npc, &here]( dialogue const & d ) {
         std::vector<mtype_id> ids;
         ids.reserve( mtype_ids.size() );
         for( const str_or_var &id : mtype_ids ) {
@@ -6578,7 +6597,7 @@ talk_effect_fun_t::func f_run_monster_eocs( const JsonObject &jo,
         }
         tripoint_bub_ms actor_pos = d.actor( is_npc )->pos_bub( here );
         const std::vector<Creature *> available = g->get_creatures_if( [ ids, monster_must_see,
-             monster_range, actor_pos, &here ]( const Creature & critter ) {
+             monster_range, z_min, z_max, actor_pos, &here ]( const Creature & critter ) {
             bool id_valid = ids.empty();
             bool creature_is_monster = critter.is_monster();
             if( creature_is_monster ) {
@@ -6594,7 +6613,9 @@ talk_effect_fun_t::func f_run_monster_eocs( const JsonObject &jo,
                    ( !monster_must_see ||
                      critter.sees( here, actor_pos ) ) &&
                    ( !monster_range.has_value() ||
-                     rl_dist( actor_pos, critter.pos_bub( here ) ) <= monster_range.value() );
+                     rl_dist( actor_pos, critter.pos_bub( here ) ) <= monster_range.value() &&
+                   ( !z_min.has_value() || critter.posz() >= z_min.value() ) &&
+                   ( !z_max.has_value() || critter.posz() <= z_max.value() ));
         } );
         for( Creature *target : available ) {
             for( const effect_on_condition_id &eoc : eocs ) {
@@ -6613,10 +6634,25 @@ talk_effect_fun_t::func f_run_vehicle_eocs( const JsonObject &jo,
     if( jo.has_int( "vehicle_range" ) ) {
         vehicle_range = jo.get_int( "vehicle_range" );
     }
-    return [eocs, vehicle_range, is_npc]( dialogue const & d ) {
+    std::optional<int> z_min;
+    if (jo.has_int("z_min")) {
+        z_min = jo.get_int("z_min");
+    }
+    std::optional<int> z_max;
+    if (jo.has_int("z_max")) {
+        z_max = jo.get_int("z_max");
+    }
+    return [eocs, vehicle_range, z_min, z_max, is_npc]( dialogue const & d ) {
         tripoint_abs_ms actor_pos = d.actor( is_npc )->pos_abs();
         for( wrapped_vehicle &elem : get_map().get_vehicles() ) {
             vehicle &veh = *elem.v;
+            auto pos_abs = veh.pos_abs();
+            if (z_min.has_value() && pos_abs.z() < z_min.value()) {
+                continue;
+            }
+            if (z_max.has_value() && pos_abs.z() > z_min.value()) {
+                continue;
+            }
             if( !vehicle_range.has_value() ||
                 rl_dist( actor_pos, veh.pos_abs() ) <= vehicle_range.value() ) {
                 for( const effect_on_condition_id &eoc : eocs ) {
@@ -6626,6 +6662,47 @@ talk_effect_fun_t::func f_run_vehicle_eocs( const JsonObject &jo,
             }
         }
     };
+}
+
+talk_effect_fun_t::func f_run_fixed_zone_eocs(const JsonObject& jo,
+    std::string_view member, std::string_view src, bool is_npc)
+{
+    std::vector<effect_on_condition_id> eocs = load_eoc_vector(jo, member, src);
+    std::optional<int> zone_range;
+    if (jo.has_int("zone_range")) {
+        zone_range = jo.get_int("zone_range");
+    }
+    std::optional<int> z_min;
+    if (jo.has_int("z_min")) {
+        z_min = jo.get_int("z_min");
+    }
+    std::optional<int> z_max;
+    if (jo.has_int("z_max")) {
+        z_max = jo.get_int("z_max");
+    }
+    return [eocs, zone_range, z_min, z_max, is_npc](dialogue const& d) {
+        zone_manager& mgr = zone_manager::get_manager();
+        tripoint_abs_ms actor_pos = d.actor(is_npc)->pos_abs();
+        for (zone_data& zone : mgr.get_zones()) {
+            if (zone.get_is_personal() || zone.get_is_vehicle()) {
+                continue;
+            }
+            auto pos_abs = zone.get_start_point();
+            if (z_min.has_value() && pos_abs.z() < z_min.value()) {
+                continue;
+            }
+            if (z_max.has_value() && pos_abs.z() > z_min.value()) {
+                continue;
+            }
+            if (!zone_range.has_value() ||
+                rl_dist(actor_pos, zone.get_start_point()) <= zone_range.value()) {
+                for (const effect_on_condition_id& eoc : eocs) {
+                    dialogue newDialog( get_talker_for(zone), nullptr, d.get_conditionals(), d.get_context());
+                    eoc->activate(newDialog);
+                }
+            }
+        }
+        };
 }
 
 talk_effect_fun_t::func f_run_inv_eocs( const JsonObject &jo,
@@ -7695,6 +7772,15 @@ talk_effect_fun_t::func f_teleport( const JsonObject &jo, std::string_view membe
                 add_msg( fail_message.evaluate( d ) );
             }
         }
+        zone_data* zone = d.actor(is_npc)->get_zone();
+        if (zone) {
+            if (teleport::teleport_zone(*zone, target_pos)) {
+                add_msg(success_message.evaluate(d));
+            }
+            else {
+                add_msg(fail_message.evaluate(d));
+            }
+        }
     };
 }
 
@@ -7946,6 +8032,7 @@ parsers = {
     { "u_run_npc_eocs", "npc_run_npc_eocs", jarg::array, &talk_effect_fun::f_run_npc_eocs },
     { "u_run_monster_eocs", "npc_run_monster_eocs", jarg::array, &talk_effect_fun::f_run_monster_eocs },
     { "u_run_vehicle_eocs", "npc_run_vehicle_eocs", jarg::array, &talk_effect_fun::f_run_vehicle_eocs },
+    { "u_run_fixed_zone_eocs", "npc_run_fixed_zone_eocs", jarg::array, &talk_effect_fun::f_run_fixed_zone_eocs },
     { "u_run_inv_eocs", "npc_run_inv_eocs", jarg::member, &talk_effect_fun::f_run_inv_eocs },
     { "u_roll_remainder", "npc_roll_remainder", jarg::member, &talk_effect_fun::f_roll_remainder },
     { "u_set_fac_relation", "npc_set_fac_relation", jarg::member, &talk_effect_fun::f_set_fac_relation },

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -6677,14 +6677,14 @@ talk_effect_fun_t::func f_run_fixed_zone_eocs(const JsonObject& jo,
         z_min = jo.get_int("z_min");
     }
     std::optional<int> z_max;
-    if (jo.has_int("z_max")) {
-        z_max = jo.get_int("z_max");
+    if( jo.has_int( "z_max" ) ) {
+        z_max = jo.get_int( "z_max" );
     }
-    return [eocs, zone_range, z_min, z_max, is_npc](dialogue const& d) {
-        zone_manager& mgr = zone_manager::get_manager();
-        tripoint_abs_ms actor_pos = d.actor(is_npc)->pos_abs();
-        for (zone_data& zone : mgr.get_zones()) {
-            if (zone.get_is_personal() || zone.get_is_vehicle()) {
+    return [eocs, zone_range, z_min, z_max, is_npc]( dialogue const & d ) {
+        zone_manager &mgr = zone_manager::get_manager();
+        tripoint_abs_ms actor_pos = d.actor( is_npc )->pos_abs();
+        for( zone_data &zone : mgr.get_zones() ) {
+            if( zone.get_is_personal() || zone.get_is_vehicle() ) {
                 continue;
             }
             auto pos_abs = zone.get_start_point();

--- a/src/talker.h
+++ b/src/talker.h
@@ -24,6 +24,7 @@ class Character;
 class recipe;
 struct tripoint;
 class vehicle;
+class zone_data;
 struct mutation_variant;
 enum class get_body_part_flags;
 
@@ -72,6 +73,10 @@ class const_talker
             return nullptr;
         }
         virtual vehicle const *get_const_vehicle() const {
+            return nullptr;
+        }
+
+        virtual zone_data const* get_const_zone() const {
             return nullptr;
         }
 
@@ -749,6 +754,9 @@ class talker: virtual public const_talker
             return nullptr;
         }
         virtual vehicle *get_vehicle() {
+            return nullptr;
+        }
+        virtual zone_data* get_zone() {
             return nullptr;
         }
         virtual void set_pos( tripoint_bub_ms ) {}

--- a/src/talker_zone.cpp
+++ b/src/talker_zone.cpp
@@ -1,0 +1,22 @@
+#include <cmath>
+#include <map>
+#include <utility>
+#include <vector>
+
+#include "avatar.h"
+#include "character.h"
+#include "coordinates.h"
+#include "effect.h"
+#include "effect_source.h"
+#include "map.h"
+#include "math_parser_diag_value.h"
+#include "talker_zone.h"
+#include "tileray.h"
+#include "units.h"
+#include "clzones.h"
+
+tripoint_abs_ms talker_zone_const::pos_abs() const
+{
+    return me_zone_const->get_start_point();
+}
+

--- a/src/talker_zone.h
+++ b/src/talker_zone.h
@@ -1,0 +1,58 @@
+#pragma once
+#ifndef CATA_SRC_TALKER_ZONE_H
+#define CATA_SRC_TALKER_ZONE_H
+
+#include <memory>
+#include <string>
+
+#include "coords_fwd.h"
+#include "talker.h"
+#include "type_id.h"
+
+class zone_data;
+
+/*
+ * Talker wrapper class for zone.
+ */
+class talker_zone_const : public const_talker_cloner<talker_zone_const>
+{
+public:
+    explicit talker_zone_const(const zone_data* new_me) : me_zone_const(new_me) {};
+    talker_zone_const() = default;
+    talker_zone_const(const talker_zone_const&) = default;
+    talker_zone_const(talker_zone_const&&) = delete;
+    talker_zone_const& operator=(const talker_zone_const&) = default;
+    talker_zone_const& operator=(talker_zone_const&&) = delete;
+    ~talker_zone_const() override = default;
+
+    zone_data const* get_const_zone() const override {
+        return me_zone_const;
+    }
+
+    tripoint_abs_ms pos_abs() const override;
+
+private:
+    const zone_data* me_zone_const{};
+};
+
+class talker_zone : public talker_zone_const, public talker_cloner<talker_zone>
+{
+public:
+    explicit talker_zone(zone_data* new_me) : talker_zone_const(new_me), me_zone(new_me) {};
+    talker_zone() = default;
+    talker_zone(const talker_zone&) = default;
+    talker_zone(talker_zone&&) = delete;
+    talker_zone& operator=(const talker_zone&) = default;
+    talker_zone& operator=(talker_zone&&) = delete;
+    ~talker_zone() override = default;
+
+    // underlying element accessor functions
+    zone_data* get_zone() override {
+        return me_zone;
+    }
+private:
+    zone_data* me_zone{};
+};
+
+#endif // CATA_SRC_talker_zone_H
+#pragma once

--- a/src/teleport.cpp
+++ b/src/teleport.cpp
@@ -489,3 +489,10 @@ bool teleport::teleport_vehicle( vehicle &veh, const tripoint_abs_ms &dp )
     CleanUpAfterVehicleTeleport( veh, here, dp, smzs, src );
     return true;
 }
+
+bool teleport::teleport_zone(zone_data& zone, const tripoint_abs_ms& dp)
+{
+    auto new_end_point = dp + (zone.get_end_point() - zone.get_start_point());
+    zone.set_position(std::make_pair(dp, new_end_point));
+    return true;
+}

--- a/src/teleport.h
+++ b/src/teleport.h
@@ -5,6 +5,7 @@
 
 class Creature;
 class vehicle;
+class zone_data;
 class teleport
 {
     public:
@@ -17,6 +18,7 @@ class teleport
         static bool teleport_to_point( Creature &critter, tripoint_bub_ms target, bool safe,
                                        bool add_teleglow, bool display_message = true, bool force = false, bool force_safe = false );
         static bool teleport_vehicle( vehicle &veh, const tripoint_abs_ms &dp );
+        static bool teleport_zone(zone_data& zone, const tripoint_abs_ms& dp);
 
 };
 


### PR DESCRIPTION
#### Summary
1. Bugfixes "Fix vehicle、monster、NPC z position all set to 1 after Vanishing Arc teleport"
2. Bugfixes "Fix fixed zones created on ship not teleported after Vanishing Arc teleport"

#### Purpose of change
Hi，I am playing Aftershock, I found 2 bugs for Vanishing Arc'c teleport funtionality. This pr is to fix these bugs
Bug 1:
I park a car on floor 0 under Vanishing Arc, after I teleport to new location，I found the car is teleported too.
I found the bug is caused by this line, leading all teleported unit's z to be 1
<img width="608" height="294" alt="image" src="https://github.com/user-attachments/assets/052095d7-8e5d-4b31-b130-6dcacd47b7ca" />
I try to solve it by EoC condition, but the performance is too poor, and I think a sound solution is to integrate z range filter to these u_run_xxx_eocs

Close #83622 

Bug 2:
I found fixed zones I created on Vanishing Arc are not teleported, so I add a new EoC u_run_fixed_zones_eocs to support move fixed zones.

PS; I update the doc for new added EoC and params.


#### Describe the solution
For bug 1, I try to solve it by EoC condition, but the performance is too poor, and I think a sound solution is to integrate z range params to these u_run_xxx_eocs
For bug 2, I add a new EoC u_run_fixed_zones_eocs to support move fixed zones

#### Describe alternatives you've considered
For bug 1, I try to solve it by EoC condition, but the performance is too poor causing by batch units process
For bug 2, currently no suitable EoC provided to fix

#### Testing

I testing it for a week playing with Vanishing Arc，I put car on floor 0, create fixed zones on floor 1 of ship, and then I teleport with Vanishing Arc, everying performed perfectly and didn't encounter any other error.

#### Additional context

None
