### PR TITLE
[Bugfix] Appliances' cable connection failure after Vanishing Arc teleport

### DIFF
--- a/src/teleport.cpp
+++ b/src/teleport.cpp
@@ -402,6 +402,7 @@ bool teleport::teleport_vehicle( vehicle &veh, const tripoint_abs_ms &dp )
 
     Character &player_character = get_player_character();
     tripoint_bub_ms src = veh.pos_bub( here );
+    auto pos_abs_offset = dp - veh.pos_abs();
 
     map tm;
     point_sm_ms src_offset;
@@ -486,6 +487,8 @@ bool teleport::teleport_vehicle( vehicle &veh, const tripoint_abs_ms &dp )
         // Has to be after update_map or coordinates won't be valid
         g->setremoteveh( &veh );
     }
+    // Cables on vehicle need to translate to new postion to keep connection working
+    veh.translate_cables( pos_abs_offset );
     CleanUpAfterVehicleTeleport( veh, here, dp, smzs, src );
     return true;
 }

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -5784,6 +5784,19 @@ std::map<Vehicle *, float> vehicle::search_connected_vehicles( const map &here, 
     return distances;
 }
 
+void vehicle::translate_cables( const tripoint_rel_ms &offset )
+{
+    for( const int part_idx : loose_parts ) {
+        vehicle_part &vp = part( part_idx );
+        const vpart_info &vpi = vp.info();
+        if( !vpi.has_flag( VPFLAG_POWER_TRANSFER ) ) {
+            continue;
+        }
+        vp.target.first += offset;
+        vp.target.second += offset;
+    }
+}
+
 std::map<vehicle *, float> vehicle::search_connected_vehicles( const map &here )
 {
     return search_connected_vehicles( here, this );

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -2203,6 +2203,7 @@ class vehicle
          * the map is just shifted (in the later case simply set smx/smy directly).
          */
         void set_submap_moved( map *here, const tripoint_bub_sm &p );
+        void translate_cables( const tripoint_rel_ms &offset );
         void use_autoclave( map &here, int p );
         void use_washing_machine( map &here, int p );
         void use_dishwasher( map &here, int p );


### PR DESCRIPTION
#### Summary
Bugfixes "Appliances' cable connection failure after Vanishing Arc teleport"

#### Purpose of change

Close #83657 

Steps to reproduce
1、install 1 appliance and 1 battery on Vanishing Arc floor 1 and connect them with extension cable
2、turn on the appliance，it works fine
3、teleport to other omt location
4、open the action panel of the appliance，a tip telling “Appliance has no connection to a battery”

#### Describe the solution

I debug the code and find that cable is implemented as a vehicle part, when it connected with two appliances like battery and head light, the absolute positions of the two appliances are recorded in its field 'target'. So I make an translation of all cables' target postions when teleporting vehicles.

#### Describe alternatives you've considered

I considered translating all the positions recorded in the vehicle parts' target positions during vehicle teleportation, but this change would have too broad an impact, so I finally chose to make the minimal changes possible.

#### Testing

I am a heavy player of Vanishing Arc, I testing it by playing with Vanishing Arc，Now I can install electrical appliances on the Vanishing Arc, connect them with cables, and turn them on. Even after repeated teleportation, the cables remain firmly connected and fully functional.

#### Additional context

None
