### PR TITLE
Name smaller solar panels as small

### DIFF
--- a/data/json/items/vehicle/solar.json
+++ b/data/json/items/vehicle/solar.json
@@ -3,7 +3,7 @@
     "//": "Assumed to be ~0.5 m x 0.5 m to fit in a vehicle tile",
     "type": "ITEM",
     "id": "solar_panel",
-    "name": { "str": "solar panel" },
+    "name": { "str": "small solar panel" },
     "description": "An electronic device that can convert solar radiation into electric power.  Useful for a vehicle or a static power grid.",
     "//1": [
       "66 in x 40 in x 2 in = 68 L solar panels weigh 40 lbs, for density of ~210 g/L",
@@ -36,7 +36,7 @@
     "type": "ITEM",
     "copy-from": "solar_panel",
     "id": "folding_solar_panel",
-    "name": { "str": "folding solar panel" },
+    "name": { "str": "small folding solar panel" },
     "description": "This \"little\" solar panel folds up to carry around, in case you need to charge anything on the go.  Its small size means in might take quite some time to charge, however.",
     "//": [
       "Based on https://www.bluettipower.com/products/bluetti-pv120-120w-solar-panel",
@@ -103,7 +103,7 @@
   {
     "type": "ITEM",
     "id": "reinforced_solar_panel",
-    "name": { "str": "reinforced solar panel" },
+    "name": { "str": "small reinforced solar panel" },
     "description": "A solar panel that has been covered with a pane of reinforced glass to protect the delicate solar cells from zombies or errant baseballs.  The glass causes this panel to produce slightly less power than a normal panel.",
     "weight": "24153 g",
     "color": "light_blue",
@@ -117,7 +117,7 @@
     "//": "Assumed to be ~0.5 m x 0.5 m to fit in a vehicle tile",
     "type": "ITEM",
     "id": "solar_panel_v2",
-    "name": { "str": "advanced solar panel" },
+    "name": { "str": "small advanced solar panel" },
     "description": "An electronic device that can convert solar radiation into electric power.  This one is a high-performance type made with monocrystalline silicon cells.",
     "price": "1 kUSD 900 USD",
     "price_postapoc": "30 USD",
@@ -135,7 +135,7 @@
   {
     "type": "ITEM",
     "id": "reinforced_solar_panel_v2",
-    "name": { "str": "advanced reinforced solar panel" },
+    "name": { "str": "small advanced reinforced solar panel" },
     "description": "An advanced solar panel that has been covered with a pane of reinforced glass to protect the delicate solar cells from zombies or errant baseballs.  The glass causes this panel to produce slightly less power than a normal advanced panel.",
     "price": "2 kUSD 400 USD",
     "price_postapoc": "35 USD",

--- a/data/json/items/vehicle/solar.json
+++ b/data/json/items/vehicle/solar.json
@@ -3,7 +3,7 @@
     "//": "Assumed to be ~0.5 m x 0.5 m to fit in a vehicle tile",
     "type": "ITEM",
     "id": "solar_panel",
-    "name": { "str": "small solar panel" },
+    "name": { "str": "vehicle solar panel" },
     "description": "An electronic device that can convert solar radiation into electric power.  Useful for a vehicle or a static power grid.",
     "//1": [
       "66 in x 40 in x 2 in = 68 L solar panels weigh 40 lbs, for density of ~210 g/L",
@@ -103,7 +103,7 @@
   {
     "type": "ITEM",
     "id": "reinforced_solar_panel",
-    "name": { "str": "small reinforced solar panel" },
+    "name": { "str": "vehicle reinforced solar panel" },
     "description": "A solar panel that has been covered with a pane of reinforced glass to protect the delicate solar cells from zombies or errant baseballs.  The glass causes this panel to produce slightly less power than a normal panel.",
     "weight": "24153 g",
     "color": "light_blue",
@@ -117,7 +117,7 @@
     "//": "Assumed to be ~0.5 m x 0.5 m to fit in a vehicle tile",
     "type": "ITEM",
     "id": "solar_panel_v2",
-    "name": { "str": "small advanced solar panel" },
+    "name": { "str": "vehicle advanced solar panel" },
     "description": "An electronic device that can convert solar radiation into electric power.  This one is a high-performance type made with monocrystalline silicon cells.",
     "price": "1 kUSD 900 USD",
     "price_postapoc": "30 USD",
@@ -135,7 +135,7 @@
   {
     "type": "ITEM",
     "id": "reinforced_solar_panel_v2",
-    "name": { "str": "small advanced reinforced solar panel" },
+    "name": { "str": "vehicle advanced reinforced solar panel" },
     "description": "An advanced solar panel that has been covered with a pane of reinforced glass to protect the delicate solar cells from zombies or errant baseballs.  The glass causes this panel to produce slightly less power than a normal advanced panel.",
     "price": "2 kUSD 400 USD",
     "price_postapoc": "35 USD",


### PR DESCRIPTION

#### Summary
None

#### Purpose of change
Adds ~~"small"~~ "vehicle" on the smaller solar panel item names to make it clear that it is smaller than solar panel array.

#### Describe the solution

Put the word ~~"small"~~ "vehicle" at the beginning of the smaller solar panel item names.

#### Describe alternatives you've considered

Not doing so.

#### Testing
![Screenshot_20251108_212831](https://github.com/user-attachments/assets/79a81279-f693-4010-851e-9a43975c4f47)
![Screenshot_20251108_212758](https://github.com/user-attachments/assets/0c6302a5-3910-4959-a8dd-5f023987f125)



#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
