### PR TITLE
Nails item damages wheel

### DIFF
--- a/data/json/items/ammo/nail.json
+++ b/data/json/items/ammo/nail.json
@@ -39,6 +39,7 @@
     "longest_side": "115 mm",
     "price": "1 USD 11 cent",
     "price_postapoc": "2 cent",
+    "flags": [ "DAMAGE_VEHICLE_WHEELS" ],
     "material": [ "lc_steel" ],
     "symbol": "=",
     "color": "cyan",


### PR DESCRIPTION

#### Summary
None

#### Purpose of change
Nail item damages wheel when it is on the ground. Suggested by @RenechCDDA .
#### Describe the solution

give the "DAMAGE_VEHICLE_WHEELS" flag.

#### Describe alternatives you've considered

Nah.

#### Testing

i place down a nail item and run over it with a bike. it breaks the wheel.
![Screenshot_20251108_223848](https://github.com/user-attachments/assets/93eca200-b9e1-45b3-80e6-80bf9dd86c37)


#### Additional context


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
