### PR TITLE
Make an alcohol vitamin, replace alcohol function (partialy) with it

### DIFF
--- a/data/json/items/comestibles/alcohol.json
+++ b/data/json/items/comestibles/alcohol.json
@@ -68,7 +68,6 @@
     "weight": "50 g",
     "color": "white",
     "addiction_type": "alcohol",
-    "use_action": [ "ALCOHOL" ],
     "stim": -12,
     "container": "bottle_glass",
     "comestible_type": "DRINK",
@@ -87,6 +86,7 @@
     "charges": 5,
     "flags": [ "EATEN_COLD", "NO_AUTO_CONSUME" ],
     "fun": 15,
+    "vitamins": [ [ "ethanol", 5 ] ],
     "freezing_point": -8
   },
   {
@@ -98,7 +98,6 @@
     "weight": "50 g",
     "color": "white",
     "addiction_type": "alcohol",
-    "use_action": [ "ALCOHOL" ],
     "stim": -12,
     "container": "bottle_glass",
     "comestible_type": "DRINK",
@@ -116,6 +115,7 @@
     "phase": "liquid",
     "charges": 5,
     "flags": [ "EATEN_COLD", "NO_AUTO_CONSUME" ],
+    "vitamins": [ [ "ethanol", 7 ] ],
     "fun": 15,
     "freezing_point": -8
   },
@@ -127,7 +127,6 @@
     "weight": "50 g",
     "color": "red",
     "addiction_type": "alcohol",
-    "use_action": [ "ALCOHOL" ],
     "stim": -12,
     "container": "bottle_glass",
     "comestible_type": "DRINK",
@@ -144,6 +143,7 @@
     "phase": "liquid",
     "charges": 5,
     "fun": 15,
+    "vitamins": [ [ "ethanol", 7 ] ],
     "freezing_point": -8
   },
   {
@@ -155,7 +155,6 @@
     "weight": "50 g",
     "color": "red",
     "addiction_type": "alcohol",
-    "use_action": [ "ALCOHOL" ],
     "stim": -12,
     "container": "bottle_glass",
     "comestible_type": "DRINK",
@@ -172,6 +171,7 @@
     "phase": "liquid",
     "charges": 5,
     "flags": [ "EATEN_COLD", "NO_AUTO_CONSUME" ],
+    "vitamins": [ [ "ethanol", 6 ] ],
     "fun": 16,
     "freezing_point": -9
   },
@@ -184,7 +184,6 @@
     "weight": "50 g",
     "color": "red",
     "addiction_type": "alcohol",
-    "use_action": [ "ALCOHOL" ],
     "stim": -12,
     "container": "bottle_glass",
     "comestible_type": "DRINK",
@@ -202,6 +201,7 @@
     "charges": 5,
     "flags": [ "EATEN_COLD", "NO_AUTO_CONSUME" ],
     "fun": 15,
+    "vitamins": [ [ "ethanol", 9 ] ],
     "freezing_point": -8
   },
   {
@@ -213,7 +213,6 @@
     "weight": "50 g",
     "color": "red",
     "addiction_type": "alcohol",
-    "use_action": [ "ALCOHOL" ],
     "stim": -12,
     "container": "bottle_glass",
     "comestible_type": "DRINK",
@@ -230,6 +229,7 @@
     "phase": "liquid",
     "charges": 5,
     "flags": [ "EATEN_COLD", "NO_AUTO_CONSUME" ],
+    "vitamins": [ [ "ethanol", 9 ] ],
     "fun": 15,
     "freezing_point": -8
   },
@@ -242,7 +242,6 @@
     "weight": "249 g",
     "color": "brown",
     "addiction_type": "alcohol",
-    "use_action": [ "ALCOHOL" ],
     "stim": -4,
     "container": "can_drink",
     "comestible_type": "DRINK",
@@ -262,7 +261,7 @@
     "flags": [ "EATEN_COLD", "NO_AUTO_CONSUME" ],
     "freezing_point": -5,
     "fun": 14,
-    "vitamins": [ [ "calcium", 1 ] ]
+    "vitamins": [ [ "ethanol", 5 ], [ "calcium", 1 ] ]
   },
   {
     "type": "ITEM",
@@ -272,7 +271,6 @@
     "weight": "36 g",
     "color": "brown",
     "addiction_type": "alcohol",
-    "use_action": [ "ALCOHOL" ],
     "stim": -12,
     "container": "bottle_glass",
     "comestible_type": "DRINK",
@@ -288,6 +286,7 @@
     "material": [ "alcohol" ],
     "volume": "250 ml",
     "flags": [ "EATEN_COLD", "NO_AUTO_CONSUME" ],
+    "vitamins": [ [ "ethanol", 16 ] ],
     "freezing_point": -30,
     "phase": "liquid",
     "charges": 7,
@@ -302,7 +301,6 @@
     "weight": "36 g",
     "color": "light_cyan",
     "addiction_type": "alcohol",
-    "use_action": [ "ALCOHOL" ],
     "stim": -12,
     "container": "bottle_glass",
     "comestible_type": "DRINK",
@@ -319,6 +317,7 @@
     "phase": "liquid",
     "charges": 7,
     "flags": [ "EATEN_COLD", "NUTRIENT_OVERRIDE", "NO_AUTO_CONSUME" ],
+    "vitamins": [ [ "ethanol", 15 ] ],
     "freezing_point": -30,
     "fun": 15
   },
@@ -331,7 +330,6 @@
     "weight": "36 g",
     "color": "light_cyan",
     "addiction_type": "alcohol",
-    "use_action": [ "ALCOHOL" ],
     "stim": -12,
     "container": "bottle_glass",
     "comestible_type": "DRINK",
@@ -349,6 +347,7 @@
     "charges": 7,
     "flags": [ "EATEN_COLD", "NO_AUTO_CONSUME" ],
     "freezing_point": -30,
+    "vitamins": [ [ "ethanol", 15 ] ],
     "fun": 15
   },
   {
@@ -360,7 +359,6 @@
     "weight": "36 g",
     "color": "light_cyan",
     "addiction_type": "alcohol",
-    "use_action": [ "ALCOHOL" ],
     "stim": -10,
     "container": "bottle_glass",
     "comestible_type": "DRINK",
@@ -378,6 +376,7 @@
     "charges": 7,
     "fun": 15,
     "flags": [ "EATEN_COLD", "NO_AUTO_CONSUME" ],
+    "vitamins": [ [ "ethanol", 15 ] ],
     "freezing_point": -30
   },
   {
@@ -389,7 +388,6 @@
     "weight": "36 g",
     "color": "yellow",
     "addiction_type": "alcohol",
-    "use_action": [ "ALCOHOL" ],
     "stim": -12,
     "container": "bottle_glass",
     "comestible_type": "DRINK",
@@ -407,6 +405,7 @@
     "charges": 7,
     "fun": 18,
     "flags": [ "EATEN_COLD", "NO_AUTO_CONSUME" ],
+    "vitamins": [ [ "ethanol", 16 ] ],
     "freezing_point": -30
   },
   {
@@ -418,7 +417,6 @@
     "weight": "36 g",
     "color": "light_cyan",
     "addiction_type": "alcohol",
-    "use_action": [ "ALCOHOL" ],
     "stim": -10,
     "container": "bottle_glass",
     "comestible_type": "DRINK",
@@ -433,6 +431,7 @@
     "material": [ "alcohol" ],
     "volume": "250 ml",
     "flags": [ "EDIBLE_FROZEN", "NO_AUTO_CONSUME" ],
+    "vitamins": [ [ "ethanol", 12 ] ],
     "freezing_point": -17,
     "phase": "liquid",
     "charges": 7,
@@ -464,6 +463,7 @@
     "phase": "liquid",
     "charges": 7,
     "flags": [ "EATEN_COLD", "NO_AUTO_CONSUME" ],
+    "vitamins": [ [ "ethanol", 4 ] ],
     "fun": 15,
     "freezing_point": -8
   },
@@ -476,7 +476,6 @@
     "weight": "36 g",
     "color": "white",
     "addiction_type": "alcohol",
-    "use_action": [ "ALCOHOL" ],
     "stim": -12,
     "container": "bottle_glass",
     "comestible_type": "DRINK",
@@ -494,6 +493,7 @@
     "phase": "liquid",
     "charges": 7,
     "flags": [ "EATEN_COLD", "NUTRIENT_OVERRIDE", "NO_AUTO_CONSUME" ],
+    "vitamins": [ [ "ethanol", 5 ] ],
     "fun": 13,
     "freezing_point": -8
   },
@@ -506,7 +506,6 @@
     "weight": "36 g",
     "color": "red",
     "addiction_type": "alcohol",
-    "use_action": [ "ALCOHOL_WEAK" ],
     "stim": -2,
     "container": "jug_plastic",
     "sealed": false,
@@ -525,6 +524,7 @@
     "phase": "liquid",
     "charges": 7,
     "flags": [ "EATEN_COLD", "NO_AUTO_CONSUME" ],
+    "vitamins": [ [ "ethanol", 5 ] ],
     "fun": 10,
     "freezing_point": -6
   },
@@ -537,7 +537,6 @@
     "weight": "36 g",
     "color": "red",
     "addiction_type": "alcohol",
-    "use_action": [ "ALCOHOL" ],
     "stim": -15,
     "container": "jug_plastic",
     "sealed": false,
@@ -553,6 +552,8 @@
     "volume": "250 ml",
     "phase": "liquid",
     "charges": 7,
+    "vitamins": [ [ "ethanol", 15 ] ],
+    "//": "why nutrient override?",
     "flags": [ "EATEN_COLD", "NUTRIENT_OVERRIDE", "NO_AUTO_CONSUME" ],
     "freezing_point": -30,
     "fun": 5
@@ -566,7 +567,6 @@
     "weight": "248 g",
     "color": "light_red",
     "addiction_type": "alcohol",
-    "use_action": [ "ALCOHOL_WEAK" ],
     "stim": -4,
     "container": "jug_plastic",
     "sealed": false,
@@ -584,7 +584,9 @@
     "volume": "250 ml",
     "charges": 1,
     "phase": "liquid",
+    "//": "why nutrient override?",
     "flags": [ "EATEN_COLD", "NUTRIENT_OVERRIDE", "NO_AUTO_CONSUME" ],
+    "vitamins": [ [ "ethanol", 5 ] ],
     "freezing_point": -30,
     "fun": 4
   },
@@ -597,7 +599,6 @@
     "weight": "36 g",
     "color": "light_red",
     "addiction_type": "alcohol",
-    "use_action": [ "ALCOHOL_WEAK" ],
     "stim": -4,
     "container": "bottle_glass",
     "comestible_type": "DRINK",
@@ -617,7 +618,7 @@
     "flags": [ "EATEN_COLD", "NO_AUTO_CONSUME" ],
     "fun": 2,
     "freezing_point": -7,
-    "vitamins": [ [ "fruit_allergen", 1 ] ]
+    "vitamins": [ [ "ethanol", 4 ], [ "fruit_allergen", 1 ] ]
   },
   {
     "type": "ITEM",
@@ -628,7 +629,6 @@
     "weight": "36 g",
     "color": "light_red",
     "addiction_type": "alcohol",
-    "use_action": [ "ALCOHOL" ],
     "stim": -12,
     "container": "bottle_glass",
     "comestible_type": "DRINK",
@@ -643,6 +643,7 @@
     "material": [ "alcohol" ],
     "volume": "250 ml",
     "flags": [ "EATEN_COLD", "NO_AUTO_CONSUME" ],
+    "vitamins": [ [ "ethanol", 15 ] ],
     "freezing_point": -30,
     "phase": "liquid",
     "charges": 7,
@@ -657,7 +658,6 @@
     "weight": "251 g",
     "color": "brown",
     "addiction_type": "alcohol",
-    "use_action": [ "ALCOHOL_WEAK" ],
     "stim": -4,
     "container": "can_drink",
     "comestible_type": "DRINK",
@@ -676,7 +676,7 @@
     "flags": [ "EATEN_COLD", "NO_AUTO_CONSUME" ],
     "freezing_point": -5,
     "fun": 18,
-    "vitamins": [ [ "calcium", 1 ] ]
+    "vitamins": [ [ "ethanol", 1 ], [ "calcium", 1 ] ]
   },
   {
     "type": "ITEM",
@@ -687,7 +687,6 @@
     "weight": "252 g",
     "color": "brown",
     "addiction_type": [ "alcohol", { "addiction": "caffeine", "potential": 3 } ],
-    "use_action": [ "ALCOHOL" ],
     "stim": 12,
     "container": "bottle_glass",
     "comestible_type": "DRINK",
@@ -706,7 +705,7 @@
     "phase": "liquid",
     "fun": 20,
     "flags": [ "EATEN_HOT", "NO_AUTO_CONSUME" ],
-    "vitamins": [ [ "milk_allergen", 1 ] ]
+    "vitamins": [ [ "ethanol", 20 ], [ "milk_allergen", 1 ] ]
   },
   {
     "type": "ITEM",
@@ -717,7 +716,6 @@
     "weight": "250 g",
     "color": "brown",
     "addiction_type": [ "alcohol", { "addiction": "caffeine", "potential": 3 } ],
-    "use_action": [ "ALCOHOL" ],
     "stim": 12,
     "container": "bottle_glass",
     "comestible_type": "DRINK",
@@ -735,6 +733,7 @@
     "charges": 1,
     "phase": "liquid",
     "fun": 20,
+    "vitamins": [ [ "ethanol", 50 ] ],
     "flags": [ "EATEN_HOT", "NO_AUTO_CONSUME" ]
   },
   {
@@ -746,7 +745,6 @@
     "weight": "252 g",
     "color": "brown",
     "addiction_type": "alcohol",
-    "use_action": [ "ALCOHOL" ],
     "stim": 3,
     "container": "bottle_glass",
     "comestible_type": "DRINK",
@@ -764,6 +762,7 @@
     "charges": 1,
     "phase": "liquid",
     "fun": 20,
+    "vitamins": [ [ "ethanol", 15 ] ],
     "flags": [ "EATEN_HOT", "NO_AUTO_CONSUME" ]
   },
   {
@@ -775,7 +774,6 @@
     "weight": "250 g",
     "color": "brown",
     "addiction_type": "alcohol",
-    "use_action": [ "ALCOHOL" ],
     "stim": -10,
     "container": "bottle_glass",
     "comestible_type": "DRINK",
@@ -795,7 +793,7 @@
     "//": "Includes cola, so presumed to be a 250mL cocktail like the others.",
     "flags": [ "EATEN_COLD", "NO_AUTO_CONSUME" ],
     "fun": 20,
-    "vitamins": [ [ "vitC", 1 ] ]
+    "vitamins": [ [ "ethanol", 55 ], [ "vitC", 1 ] ]
   },
   {
     "type": "ITEM",
@@ -807,7 +805,6 @@
     "weight": "252 g",
     "color": "yellow",
     "addiction_type": "alcohol",
-    "use_action": [ "ALCOHOL" ],
     "stim": -12,
     "container": "bottle_glass",
     "comestible_type": "DRINK",
@@ -826,7 +823,7 @@
     "flags": [ "EATEN_COLD", "NO_AUTO_CONSUME" ],
     "freezing_point": -34,
     "fun": 20,
-    "vitamins": [ [ "vitC", 118 ], [ "calcium", 2 ], [ "iron", 1 ], [ "fruit_allergen", 1 ] ]
+    "vitamins": [ [ "ethanol", 30 ], [ "vitC", 118 ], [ "calcium", 2 ], [ "iron", 1 ], [ "fruit_allergen", 1 ] ]
   },
   {
     "type": "ITEM",
@@ -837,7 +834,6 @@
     "weight": "252 g",
     "color": "brown",
     "addiction_type": "alcohol",
-    "use_action": [ "ALCOHOL" ],
     "stim": -12,
     "container": "bottle_glass",
     "comestible_type": "DRINK",
@@ -856,7 +852,7 @@
     "flags": [ "EATEN_COLD", "NO_AUTO_CONSUME" ],
     "freezing_point": -34,
     "fun": 20,
-    "vitamins": [ [ "vitC", 135 ], [ "calcium", 1 ], [ "iron", 1 ], [ "fruit_allergen", 1 ] ]
+    "vitamins": [ [ "ethanol", 20 ], [ "vitC", 135 ], [ "calcium", 1 ], [ "iron", 1 ], [ "fruit_allergen", 1 ] ]
   },
   {
     "type": "ITEM",
@@ -871,7 +867,6 @@
     "weight": "252 g",
     "color": "brown",
     "addiction_type": "alcohol",
-    "use_action": [ "ALCOHOL" ],
     "stim": -4,
     "container": "bottle_glass",
     "comestible_type": "DRINK",
@@ -891,7 +886,7 @@
     "flags": [ "EATEN_COLD", "NO_AUTO_CONSUME" ],
     "freezing_point": -30,
     "fun": 20,
-    "vitamins": [ [ "junk_allergen", 1 ] ]
+    "vitamins": [ [ "ethanol", 25 ], [ "junk_allergen", 1 ] ]
   },
   {
     "type": "ITEM",

--- a/data/json/vitamin.json
+++ b/data/json/vitamin.json
@@ -647,5 +647,31 @@
     "rate": "2 h",
     "flags": [ "NO_DISPLAY" ],
     "disease_excess": [ [ 15, 60 ], [ 61, 120 ], [ 121, 180 ], [ 181, 250 ] ]
+  },
+  {
+    "id": "ethanol",
+    "type": "vitamin",
+    "vit_type": "drug",
+    "name": { "str": "Alcohol" },
+    "//": "1 unit is 1 ml of pure ethanol",
+    "min": 0,
+    "max": 1000,
+    "rate": "1 s",
+    "//2": "For 70 kg person, BAC of 1 ml is about 0.0016%, so 16 units",
+    "//3": "TODO tie it somehow to body weight",
+    "decays_into": [ [ "BAC", 16 ] ]
+  },
+  {
+    "id": "BAC",
+    "type": "vitamin",
+    "vit_type": "drug",
+    "name": { "str": "Alcohol (BAC)" },
+    "excess": "drunk",
+    "//": "1 unit is 0.1 mg/dL, aka 0.0001% BAC. Average metabolic rate is 150 per hour. Anyhting bigger than 4000 should be deadly for average character",
+    "min": 0,
+    "max": 10000,
+    "rate": "24 s",
+    "//2": "TODO: update effect so vitamin excess scales correctly",
+    "disease_excess": [ [ 1, 1000 ], [ 1001, 2000 ], [ 2001, 3000 ], [ 3001, 4000 ], [ 4001, 10000 ] ]
   }
 ]


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Sounded like 20 minute adventure
Close #83668
#### Describe the solution
Make two vitamins: ethanol and BAC
1 ethanol represent 1 ml of pure ethanol in alcohol drank
1 BAC represent 0.1 ml/dL of alcohol in blood, aka 0.0001 BAC
First appears in organism 30 minutes after digesting, using generic digesting process for vitamins, and then instantly transforms into second one 
#### TODOs for another PRs after this one is merged
- remove the rest usages of ALCOHOL, ALCOHOL_WEAK and ALCOHOL_STRONG in comestibles in favor of vitamin (i covered only basic alcohols and few cocktails (holy fuck we have a lot of cocktails)) - afterwards the function can be removed completely
- handle removing of alcohol when cook?
- i thought about a third way to handle vitamins, as a percentage of volume of an item, specifically for alcohol, but failed to figure how to add a new unit type and if it's generally desired 
- (potentially) implement some way for drinks to digest in 10 minutes, or digest in 10-30 minutes range in waves?
- (very long term) make the transformation of ethanol use character weight, traits and whatever another stats to increase or decrease the ethanol -> BAC transformation
#### Testing
Drank a lot of rum, totalled a car in the process