### PR TITLE
manually install gcc 9 on runners as needed

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -143,6 +143,7 @@ jobs:
             title: GCC 9, Curses, LTO
             ccache_limit: 7.5G
             ccache_key: linux-gcc-9-lto
+            extra_package: g++-9
 
           - compiler: clang++-18
             os: ubuntu-latest
@@ -182,6 +183,7 @@ jobs:
             title: GCC 9, Ubuntu, Tiles, Sound, CMake
             ccache_limit: 1G
             ccache_key: linux-gcc-9-cmake
+            extra_package: g++-9
 
     name: ${{ matrix.title }}
     runs-on: ${{ matrix.os }}
@@ -234,7 +236,7 @@ jobs:
       if: ${{ env.SKIP == 'false' && runner.os == 'Linux' }}
       run: |
           sudo apt-get update
-          sudo apt-get install libncursesw5-dev ccache gettext parallel
+          sudo apt-get install libncursesw5-dev ccache gettext parallel ${{ matrix.extra_package }}
           sudo locale-gen en_US.UTF-8 de_DE.UTF-8
     - name: install SDL2 dependencies (ubuntu)
       if: ${{ env.SKIP == 'false' && runner.os == 'Linux' && matrix.tiles == 1 }}


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
GH has removed these from the 22.04 runner as per https://github.com/actions/runner-images/issues/12898 

#### Describe the solution
Manually install them for now.

#### Describe alternatives you've considered
We should discuss bumping the minimum gcc version to 10 or probably 11 but I want a quick fix to get the builds going again.

#### Testing
If the target CI stages run it's good.