### PR TITLE
[MoM] Some monster edits

### DIFF
--- a/data/json/monsters/rodentkin.json
+++ b/data/json/monsters/rodentkin.json
@@ -227,7 +227,7 @@
     "special_attacks": [ { "id": "teke_push" }, [ "EAT_FOOD", 120 ], [ "EAT_CARRION", 120 ] ],
     "zombify_into": "mon_meat_cocoon_tiny",
     "upgrades": false,
-    "flags": [ "SEES", "SMELLS", "HEARS", "WARM", "RANGED_ATTACKER", "PATH_AVOID_DANGER", "EATS" ],
+    "flags": [ "SEES", "SMELLS", "HEARS", "WARM", "HAS_MIND", "RANGED_ATTACKER", "PATH_AVOID_DANGER", "EATS" ],
     "armor": { "bash": 15, "cut": 3, "bullet": 26 }
   },
   {
@@ -264,7 +264,7 @@
     ],
     "zombify_into": "mon_meat_cocoon_tiny",
     "upgrades": false,
-    "flags": [ "SEES", "SMELLS", "HEARS", "WARM", "PATH_AVOID_DANGER", "EATS" ],
+    "flags": [ "SEES", "SMELLS", "HEARS", "HAS_MIND", "WARM", "PATH_AVOID_DANGER", "EATS" ],
     "dissect": "dissect_rat_sample_small",
     "armor": { "bash": 10, "cut": 10, "bullet": 6 }
   }

--- a/data/mods/MindOverMatter/monsters/monster_overrides.json
+++ b/data/mods/MindOverMatter/monsters/monster_overrides.json
@@ -324,13 +324,19 @@
     "id": "mon_shadow",
     "copy-from": "mon_shadow",
     "type": "MONSTER",
-    "extend": { "flags": [ "TEEP_IMMUNE", "TELEKIN_IMMUNE" ] }
+    "extend": { "flags": [ "TEEP_IMMUNE", "TELEKIN_IMMUNE" ], "armor": { "psi_photokinetic_damage": -40 } }
   },
   {
     "id": "mon_shadow_snake",
     "copy-from": "mon_shadow_snake",
     "type": "MONSTER",
-    "extend": { "flags": [ "TEEP_IMMUNE", "TELEKIN_IMMUNE" ] }
+    "extend": { "flags": [ "TEEP_IMMUNE", "TELEKIN_IMMUNE" ], "armor": { "psi_photokinetic_damage": -40 } }
+  },
+  {
+    "id": "mon_darkman",
+    "copy-from": "mon_darkman",
+    "type": "MONSTER",
+    "extend": { "flags": [ "TEEP_IMMUNE", "TELEKIN_IMMUNE" ], "armor": { "psi_photokinetic_damage": -80 } }
   },
   {
     "id": "mon_thing",
@@ -385,12 +391,6 @@
     "copy-from": "mon_nether_fish",
     "type": "MONSTER",
     "extend": { "flags": [ "TEEP_IMMUNE" ] }
-  },
-  {
-    "id": "mon_teke_mouse",
-    "copy-from": "mon_teke_mouse",
-    "type": "MONSTER",
-    "extend": { "armor": { "psi_telekinetic_damage": 25 } }
   },
   {
     "id": "mon_fungaloid_tower",

--- a/data/mods/MindOverMatter/monsters/rodentkin.json
+++ b/data/mods/MindOverMatter/monsters/rodentkin.json
@@ -9,7 +9,7 @@
         "attack_type": "melee",
         "id": "teke_push_nema",
         "cooldown": 20,
-        "move_cost": 200,
+        "move_cost": 100,
         "range": 6,
         "damage_max_instance": [ { "damage_type": "psi_telekinetic_damage", "amount": 20 } ],
         "hit_dmg_u": "%1$s stares at you intently and a sudden wind buffets you!",

--- a/data/mods/MindOverMatter/monsters/rodentkin.json
+++ b/data/mods/MindOverMatter/monsters/rodentkin.json
@@ -1,0 +1,40 @@
+[
+  {
+    "id": "mon_teke_mouse",
+    "copy-from": "mon_teke_mouse",
+    "type": "MONSTER",
+    "special_attacks": [
+      { "id": "teke_push" },
+      {
+        "id": "psi_teke_mouse_inertial_barrier",
+        "type": "spell",
+        "spell_data": { "id": "telekinetic_barrier_monster" },
+        "cooldown": 1,
+        "condition": {
+          "and": [ { "not": { "u_has_flag": "NO_PSIONICS" } }, { "not": { "u_has_effect": "effect_monster_inertial_barrier" } } ]
+        },
+        "monster_message": "The air around %1$s distorts."
+      },
+      {
+        "id": "smash",
+        "move_cost": 80,
+        "cooldown": { "math": [ "6 + rand(12)" ] },
+        "damage_max_instance": [ { "damage_type": "psi_telekinetic_damage", "amount": 0 } ],
+        "hitsize_min": 12,
+        "accuracy": 5,
+        "range": 5,
+        "throw_strength": 30,
+        "dodgeable": false,
+        "uncanny_dodgeable": true,
+        "blockable": false,
+        "condition": { "and": [ { "not": { "u_has_flag": "NO_PSIONICS" } }, { "not": { "npc_has_flag": "TELEKIN_SHIELD" } } ] },
+        "hit_dmg_u": "%1$s stares at you and a powerful force hurls you through the air!",
+        "hit_dmg_npc": "%1$s stares at <npcname> and a powerful force hurls them through the air!",
+        "miss_msg_u": "%s stares at you, and you feel a crushing pressure for a moment before the feeling vanishes!",
+        "miss_msg_npc": "%s stares at <npcname> but nothing happens!"
+      },
+      [ "EAT_FOOD", 120 ],
+      [ "EAT_CARRION", 120 ]
+    ]
+  }
+]

--- a/data/mods/MindOverMatter/monsters/rodentkin.json
+++ b/data/mods/MindOverMatter/monsters/rodentkin.json
@@ -4,7 +4,21 @@
     "copy-from": "mon_teke_mouse",
     "type": "MONSTER",
     "special_attacks": [
-      { "id": "teke_push" },
+      {
+        "type": "monster_attack",
+        "attack_type": "melee",
+        "id": "teke_push_nema",
+        "cooldown": 20,
+        "move_cost": 200,
+        "range": 6,
+        "damage_max_instance": [ { "damage_type": "psi_telekinetic_damage", "amount": 20 } ],
+        "hit_dmg_u": "%1$s stares at you intently and a sudden wind buffets you!",
+        "hit_dmg_npc": "%1$s stares intently at <npcname> and a hurricane force wind hits them!",
+        "no_dmg_msg_u": "%1$s's wind buffets your %2$s, but it doesn't catch hold.",
+        "no_dmg_msg_npc": "%1$s's winds hit <npcname>, but it doesn't catch hold.",
+        "miss_msg_u": "%s stares at you, but the wind blows past you!",
+        "miss_msg_npc": "%s's stares at <npcname>, but the wind blows past them!"
+      },
       {
         "id": "psi_teke_mouse_inertial_barrier",
         "type": "spell",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[MoM] Some monster edits"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Recent PRs made me think of these.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Make wraiths and shadows vulnerable to photokinetic damage. 

Buff the Mice of NEMA--they can now telekinetically throw you and create inertial barriers, and their wind attack does telekinetic damage.

Mice of NEMA and mausketeers have the `HAS_MIND` flag

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
