### PR TITLE
Added wheel miss chance

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1023,23 +1023,9 @@ vehicle *map::move_vehicle( vehicle &veh, const tripoint_rel_ms &dp, const tiler
                 const int wheel_damage = vpi_wheel.wheel_info->contact_area / vehicle_grounded_wheel_area *
                                          vehicle_mass_kg * weight_to_damage_factor;
 
-                // We've already stored the damage the wheel will inflict, so now we can (possibly) damage the wheels from running stuff over.
-                // Also we stash the wheel messages so we can play them afterwards.
-                // This needs to happen before smashing the items on the ground so we can calculate wheel damage based on the properties of the items we ran over.
-                const std::vector<std::string> wheel_damage_messages = veh.handle_item_roadkill( this, wheel_p,
-                        vp_wheel );
-
                 //~ %1$s: vehicle name
-                smash_items( wheel_p, wheel_damage, string_format( _( "weight of %1$s" ), veh.disp_name() ) );
-
-                const bool player_is_driver = &get_player_character() == veh.get_driver( *this );
-                const bool player_sees_damage = get_player_character().sees( *this, wheel_p );
-                if( !wheel_damage_messages.empty() && ( player_is_driver || player_sees_damage ) ) {
-                    for( const std::string &msg : wheel_damage_messages ) {
-                        add_msg( m_bad, msg );
-                    }
-                }
-
+                smash_items( wheel_p, wheel_damage, string_format( _( "weight of %1$s" ), veh.disp_name() ),
+                             &vp_wheel, &veh );
             }
         }
     }
@@ -3824,7 +3810,8 @@ void map::collapse_at( const tripoint_bub_ms &p, const bool silent, const bool w
     // that's not handled for now
 }
 
-void map::smash_items( const tripoint_bub_ms &p, int power, const std::string &cause_message )
+void map::smash_items( const tripoint_bub_ms &p, int power, const std::string &cause_message,
+                       vehicle_part *vp_wheel, vehicle *veh )
 {
     if( !has_items( p ) || has_flag_ter_or_furn( ter_furn_flag::TFLAG_PLANT, p ) ) {
         return;
@@ -3838,11 +3825,24 @@ void map::smash_items( const tripoint_bub_ms &p, int power, const std::string &c
 
     std::vector<item> contents;
     map_stack items = i_at( p );
+    std::vector<std::string> wheel_damage_messages;
+    int damage_levels = 0;
+
     for( auto i = items.begin(); i != items.end() && power > 0; ) {
         if( i->made_of( phase_id::LIQUID ) ) {
             i++;
             continue;
         }
+
+        if( vp_wheel != nullptr && vehicle::hit_probability( *i, vp_wheel ) < rng_float( 0.0, 1.0 ) ) {
+            // The wheel missed the item.
+            continue;
+        }
+
+        if( vp_wheel != nullptr ) {
+            veh->damage_wheel_on_item( vp_wheel, *i, &damage_levels, &wheel_damage_messages );
+        }
+
         if( i->active ) {
             // Get the explosion item actor
             if( i->type->get_use( "explosion" ) != nullptr ) {
@@ -3951,6 +3951,30 @@ void map::smash_items( const tripoint_bub_ms &p, int power, const std::string &c
                                 _( "The %1$s damages the %2$s." ),
                                 cause_message,
                                 damaged_item_name );
+    }
+
+    if( damage_levels > 0 ) {
+        veh->damage_direct( bubble_map, *vp_wheel, damage_levels );
+
+        const bool player_is_driver = veh != nullptr && &get_player_character() == veh->get_driver( *this );
+        const bool player_sees_damage = get_player_character().sees( *this, p );
+
+        if( !wheel_damage_messages.empty() && ( player_is_driver || player_sees_damage ) ) {
+            for( const std::string &msg : wheel_damage_messages ) {
+                add_msg( m_bad, msg );
+            }
+        }
+
+        bool existing = false;
+        for( int wheel : veh->wheelcache ) {
+            if( veh->bub_part_pos( *this, veh->part( wheel ) ) == p ) {
+                existing = true;
+                break;
+            }
+        }
+        if( existing ) {
+            add_msg( m_bad, _( "The %s has been degraded by the damage" ), vp_wheel->name() );
+        }
     }
 
     for( const item &it : contents ) {

--- a/src/map.h
+++ b/src/map.h
@@ -1155,8 +1155,10 @@ class map
         /** Causes a collapse at p, such as from destroying a wall */
         void collapse_at( const tripoint_bub_ms &p, bool silent, bool was_supporting = false,
                           bool destroy_pos = true );
-        /** Tries to smash the items at the given tripoint. Used by the explosion code */
-        void smash_items( const tripoint_bub_ms &p, int power, const std::string &cause_message );
+        /** Tries to smash the items at the given tripoint. Used by the explosion code. vp_wheel and veh are
+        used when running over items, and are assumed to either both be nullptr or be valid pointers */
+        void smash_items( const tripoint_bub_ms &p, int power, const std::string &cause_message,
+                          vehicle_part *vp_wheel = nullptr, vehicle *veh = nullptr );
         /**
          * Returns a pair where first is whether anything was smashed and second is if it was destroyed.
          *

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -829,10 +829,12 @@ class vehicle
         bool is_connected( const vehicle_part &to, const vehicle_part &from,
                            const vehicle_part &excluded ) const;
 
+    public:
         // direct damage to part (armor protection and internals are not counted)
         // @returns damage still left to apply
         int damage_direct( map &here, vehicle_part &vp, int dmg,
                            const damage_type_id &type = damage_type_id( "pure" ) );
+    private:
         // Removes the part, breaks it into pieces and possibly removes parts attached to it
         int break_off( map &here, vehicle_part &vp, int dmg );
         // Returns if it did actually explode
@@ -1858,14 +1860,15 @@ class vehicle
         veh_collision part_collision( map &here, int part, const tripoint_abs_ms &p,
                                       bool just_detect, bool bash_floor );
 
-        // extracted helper for calculating damage chance in handle_item_roadkill(). Used for tests.
+        // Probability that the wheel will hit the item.
+        static double hit_probability( const item &it, const vehicle_part *vp_wheel );
+
+        // extracted helper for calculating damage chance in damage_wheel_on_item(). Used for tests.
         double wheel_damage_chance_vs_item( const item &it, vehicle_part &vp_wheel ) const;
 
-        // Handle damage to vehicle's wheels from running over items (and only items)
-        // Returns a string of damage messages so that they can be played back later (in the "correct" log order as opposed to order of execution)
-        // **Does not** damage or modify the items on the ground in any way.
-        std::vector<std::string> handle_item_roadkill( map *here, const tripoint_bub_ms &p,
-                vehicle_part &vp_wheel );
+        // Calculates damage on the wheel from running over item and adds damage levels and messages to the vector if needed.
+        void damage_wheel_on_item( vehicle_part *vp_wheel, const item &it, int *damage_levels,
+                                   std::vector<std::string> *messages );
 
         // Process the trap beneath
         void handle_trap( map *here, const tripoint_bub_ms &p, vehicle_part &vp_wheel );

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -1868,7 +1868,7 @@ class vehicle
 
         // Calculates damage on the wheel from running over item and adds damage levels and messages to the vector if needed.
         void damage_wheel_on_item( vehicle_part *vp_wheel, const item &it, int *damage_levels,
-                                   std::vector<std::string> *messages );
+                                   std::vector<std::string> *messages ) const;
 
         // Process the trap beneath
         void handle_trap( map *here, const tripoint_bub_ms &p, vehicle_part &vp_wheel );

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -1296,7 +1296,7 @@ double vehicle::wheel_damage_chance_vs_item( const item &it, vehicle_part &vp_wh
 }
 
 void vehicle::damage_wheel_on_item( vehicle_part *vp_wheel, const item &it, int *damage_levels,
-                                    std::vector<std::string> *messages )
+                                    std::vector<std::string> *messages ) const
 {
     // bullshit to work around vehicle::damage_direct() --> vehicle::mod_hp() doing incorrect(??) calculations.
     // Each damage instance should be worth exactly one 'level' of vehicle part damage.

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -1283,16 +1283,14 @@ double vehicle::wheel_damage_chance_vs_item( const item &it, vehicle_part &vp_wh
     double item_hardness = item_hardness_calc( it ).second;
     // It is exponentially more difficult for soft items to damage wheels, even if you're hitting a lot of them.
     const double chance_to_damage = std::min( std::pow( item_hardness / wheel_hardness, 2.0 ), 1.0 );
-    const double chance_to_hit = hit_probability( it, &vp_wheel );
     add_msg_debug( debugmode::DF_VEHICLE_MOVE,
                    "Vehicle %s running over item %s."
                    "\n Chance to damage: %f%%."
-                   "\n Chance to hit: %f%%."
                    "\n Item hardness: %f"
                    "\n Wheel hardness: %f",
-                   disp_name(), it.tname(), chance_to_damage * 100.0, chance_to_hit * 100.0, item_hardness,
+                   disp_name(), it.tname(), chance_to_damage * 100.0, item_hardness,
                    wheel_hardness );
-    return chance_to_damage * chance_to_hit;
+    return chance_to_damage;
 }
 
 void vehicle::damage_wheel_on_item( vehicle_part *vp_wheel, const item &it, int *damage_levels,

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -1258,12 +1258,12 @@ static std::pair<double, double> item_hardness_calc( const item &it )
     return std::make_pair( min_hardness, max_hardness );
 }
 
-static double hit_probability( const item &it, vehicle_part &vp_wheel )
+double vehicle::hit_probability( const item &it, const vehicle_part *vp_wheel )
 {
     // We don't have item widths, so just go with length. This will cause long narrow items to cover the maximum
     // extent at all times, rather than account for orientation.
     const double item_coverage = std::min( to_millimeter( it.length() ), 1000 ) / 1000.0;
-    const double wheel_coverage = vp_wheel.get_base().type->wheel->width * 0.0254;
+    const double wheel_coverage = vp_wheel->get_base().type->wheel->width * 0.0254;
     return std::min( wheel_coverage + item_coverage, 1.0 );
 }
 
@@ -1283,7 +1283,7 @@ double vehicle::wheel_damage_chance_vs_item( const item &it, vehicle_part &vp_wh
     double item_hardness = item_hardness_calc( it ).second;
     // It is exponentially more difficult for soft items to damage wheels, even if you're hitting a lot of them.
     const double chance_to_damage = std::min( std::pow( item_hardness / wheel_hardness, 2.0 ), 1.0 );
-    const double chance_to_hit = hit_probability( it, vp_wheel );
+    const double chance_to_hit = hit_probability( it, &vp_wheel );
     add_msg_debug( debugmode::DF_VEHICLE_MOVE,
                    "Vehicle %s running over item %s."
                    "\n Chance to damage: %f%%."
@@ -1295,40 +1295,24 @@ double vehicle::wheel_damage_chance_vs_item( const item &it, vehicle_part &vp_wh
     return chance_to_damage * chance_to_hit;
 }
 
-std::vector<std::string> vehicle::handle_item_roadkill( map *here, const tripoint_bub_ms &p,
-        vehicle_part &vp_wheel )
+void vehicle::damage_wheel_on_item( vehicle_part *vp_wheel, const item &it, int *damage_levels,
+                                    std::vector<std::string> *messages )
 {
-    std::vector<std::string> ret;
-    const map_stack roadkill = here->i_at( p );
-
-    int damage_to_deal = 0;
-
     // bullshit to work around vehicle::damage_direct() --> vehicle::mod_hp() doing incorrect(??) calculations.
     // Each damage instance should be worth exactly one 'level' of vehicle part damage.
-    const int one_damage_level = vp_wheel.info().durability *
-                                 ( static_cast<double>( itype::damage_scale ) / vp_wheel.max_damage() );
+    const int one_damage_level = vp_wheel->info().durability *
+                                 ( static_cast<double>( itype::damage_scale ) / vp_wheel->max_damage() );
 
+    const double chance_to_damage = wheel_damage_chance_vs_item( it, *vp_wheel );
 
-    for( const item &it : roadkill ) {
-        const double chance_to_damage = wheel_damage_chance_vs_item( it, vp_wheel );
-        if( chance_to_damage > 0.0 ) {
-            if( chance_to_damage >= rng_float( 0.0, 1.0 ) ) {
-                damage_to_deal += one_damage_level; // One 'level' worth of damage per successful damage roll
-                //~%1$s vehicle name, %1$s vehicle part name, %3$s name of item being run over
-                ret.emplace_back( string_format( _( "The %1$s's %2$s is damaged by running over %3$s!" ),
-                                                 disp_name(), vp_wheel.info().name(), it.tname() ) );
-            } else {
-                //~%1$s vehicle name, %1$s vehicle part name, %3$s name of item being run over
-                ret.emplace_back( string_format( _( "The %1$s's %2$s avoided damage from running over %3$s!" ),
-                                                 disp_name(), vp_wheel.info().name(), it.tname() ) );
-            }
+    if( chance_to_damage > 0.0 ) {
+        if( chance_to_damage >= rng_float( 0.0, 1.0 ) ) {
+            *damage_levels += one_damage_level;
+            //~%1$s vehicle name, %1$s vehicle part name, %3$s name of item being run over
+            messages->emplace_back( string_format( _( "The %1$s's %2$s is damaged by running over the %3$s!" ),
+                                                   disp_name(), vp_wheel->info().name(), it.tname() ) );
         }
     }
-
-    // We only damage the part once, to avoid having to check for/replace/abort early if the vehicle part is destroyed by damage. Makes things much simpler and safer.
-    damage_direct( *here, vp_wheel, damage_to_deal );
-
-    return ret;
 }
 
 void vehicle::handle_trap( map *here, const tripoint_bub_ms &p, vehicle_part &vp_wheel )

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -1262,7 +1262,8 @@ double vehicle::hit_probability( const item &it, const vehicle_part *vp_wheel )
 {
     // We don't have item widths, so just go with length. This will cause long narrow items to cover the maximum
     // extent at all times, rather than account for orientation.
-    const double item_coverage = std::min( to_millimeter( it.length() ), 1000 ) / 1000.0;
+    const double item_coverage = to_millimeter( it.length() ) / 1000.0;
+    // wheel width is in inches, so this scales it to a meter, i.e. the nominal width of a tile.
     const double wheel_coverage = vp_wheel->get_base().type->wheel->width * 0.0254;
     return std::min( wheel_coverage + item_coverage, 1.0 );
 }

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -40,6 +40,7 @@
 #include "trap.h"
 #include "units.h"
 #include "units_utility.h"
+#include "value_ptr.h"
 #include "veh_type.h"
 #include "vpart_position.h"
 #include "vpart_range.h"


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Reworked:
- Add a probability of actually hitting items in the tile the wheel runs over. If the wheel doesn't hit the item it won't be damaged, nor will the wheel be damaged.
- Added a message to inform the player of how bad the damage to the wheel is, unless it's destroyed, in which case a notification was already produced when the wheel was destroyed.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add a function to use item length and wheel width to calculate a sort of probability the wheel will hit the item.
Also add the message of damage being avoided.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
- Address the weird behavior of stacks of items only damaging the top item, while at the same time all items in the stack can damage wheels.
- Change the behavior to not damaging the wheel when the damage is calculated to apply it directy so that the damage message can convey the extent of the damage (by printing the message version that includes state). This would remove the need to print a final result message after the damage has been applied. I don't understand the comment about printing messages in the correct order, though.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Dropped a pile of sharp rocks behind a vehicle with armored wheels, and driving back and forth over them.
This produced messages of rock damage without wheel damage, wheel and rock damages, and cases where neither was damaged (because the wheel missed all items).
Continued until a wheel was destroyed. Noted the spreading of lumps of steel that would finialze the destruction of the wheels hadn't the destruction of the first wheel rendered the vehicle inoperable (because another wheel was at XX status).

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
As noted, wheel destruction invites a wheel destroying Kesseler syndorme by spreading additional destructive items around. Collisions will probably do the same.

Moved the wheel destruction messages after the item destruction ones, as I consider those to be more important for the player to see.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
