### PR TITLE
[Bugfix] Z axis filter params funtionality bug for u_run_xxx_eocs

### DIFF
--- a/doc/JSON/EFFECT_ON_CONDITION.md
+++ b/doc/JSON/EFFECT_ON_CONDITION.md
@@ -2481,7 +2481,7 @@ NPC run EoCs, provided by this effect; can work outside of reality bubble
 | "u_run_npc_eocs"/ "npc_run_npc_eocs" | **mandatory** | array of eocs | EoCs that would be run by NPCs |
 | "unique_ids" | optional | string, [variable objects](#variable-object) or array | id of NPCs that would be affected; lack of ids make effect run EoC on every NPC in your reality bubble, if `"local": true`, and to every NPC in the world, if `"local": false`; unique ID of every npc is specified in mapgen, using `npcs` or `place_npcs` |
 | "local" | optional | boolean | default false; if true, the effect is run for every NPC in the world; if false, effect is run only to NPC in your reality bubble |
-| "npc_range" | optional | int or [variable object](#variable-object) | if used, only NPC in this range are affected |
+| "npc_range" | optional | int or [variable object](#variable-object) | if used and neither 'z_min' nor 'z_max' is specified, only NPC having the same z position as the player in this range are affected |
 | "z_min" | optional | int or [variable object](#variable-object) | if used, only NPC'z position >= z_min are affected |
 | "z_max" | optional | int or [variable object](#variable-object) | if used, only NPC'z position <= z_max are affected |
 | "npc_must_see" | optional | boolean | default false; if true, only NPC you can see are affected |
@@ -2548,7 +2548,7 @@ Monsters run EoCs, provided by this effect; only works inside reality bubble
 | --- | --- | --- | --- |
 | "u_run_monster_eocs"/ "npc_run_monster_eocs" | **mandatory** | array of eocs | EoCs that would be run by monsters |
 | "mtype_ids" | optional | array or [variable objects](#variable-object) | mtype_id(s) that should be affected |
-| "monster_range" | optional | int or [variable object](#variable-object) | if used, only monsters in this range are affected |
+| "monster_range" | optional | int or [variable object](#variable-object) | if used and neither 'z_min' nor 'z_max' is specified, only monsters having the same z position as the player in this range are affected |
 | "z_min" | optional | int or [variable object](#variable-object) | if used, only NPC'z position >= z_min are affected |
 | "z_max" | optional | int or [variable object](#variable-object) | if used, only NPC'z position <= z_max are affected |
 | "monster_must_see" | optional | boolean | default false; if true, only monsters you can see are affected |

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -6535,8 +6535,9 @@ talk_effect_fun_t::func f_run_npc_eocs( const JsonObject &jo,
                         break;
                     }
                 }
-                return id_valid && ( !npc_range.has_value() || actor_pos.z() == guy.posz() ) && ( !npc_must_see ||
-                        guy.sees( here, actor_pos ) ) &&
+                bool is_z_filter_set = z_min.has_value() || z_max.has_value();
+                return id_valid && ( !npc_range.has_value() || is_z_filter_set || actor_pos.z() == guy.posz() ) &&
+                       ( !npc_must_see || guy.sees( here, actor_pos ) ) &&
                        ( !npc_range.has_value() || rl_dist( actor_pos, guy.pos_bub( here ) ) <= npc_range.value() ) &&
                        ( !z_min.has_value() || guy.posz() >= z_min.value() ) &&
                        ( !z_max.has_value() || guy.posz() <= z_max.value() );
@@ -6610,10 +6611,10 @@ talk_effect_fun_t::func f_run_monster_eocs( const JsonObject &jo,
                     }
                 }
             }
-            return creature_is_monster && id_valid && ( !monster_range.has_value() ||
-                    actor_pos.z() == critter.posz() ) &&
-                   ( !monster_must_see ||
-                     critter.sees( here, actor_pos ) ) &&
+            bool is_z_filter_set = z_min.has_value() || z_max.has_value();
+            return creature_is_monster && id_valid &&
+                   ( !monster_range.has_value() || is_z_filter_set || actor_pos.z() == critter.posz() ) &&
+                   ( !monster_must_see || critter.sees( here, actor_pos ) ) &&
                    ( !monster_range.has_value() ||
                      rl_dist( actor_pos, critter.pos_bub( here ) ) <= monster_range.value() ) &&
                    ( !z_min.has_value() || critter.posz() >= z_min.value() ) &&
@@ -6652,7 +6653,7 @@ talk_effect_fun_t::func f_run_vehicle_eocs( const JsonObject &jo,
             if( z_min.has_value() && pos_abs.z() < z_min.value() ) {
                 continue;
             }
-            if( z_max.has_value() && pos_abs.z() > z_min.value() ) {
+            if( z_max.has_value() && pos_abs.z() > z_max.value() ) {
                 continue;
             }
             if( !vehicle_range.has_value() ||
@@ -6693,7 +6694,7 @@ talk_effect_fun_t::func f_run_fixed_zone_eocs( const JsonObject &jo,
             if( z_min.has_value() && pos_abs.z() < z_min.value() ) {
                 continue;
             }
-            if( z_max.has_value() && pos_abs.z() > z_min.value() ) {
+            if( z_max.has_value() && pos_abs.z() > z_max.value() ) {
                 continue;
             }
             if( !zone_range.has_value() ||


### PR DESCRIPTION
#### Summary
Bugfixes "Z axis filter params funtionality bug for u_run_xxx_eocs"

#### Purpose of change

I started working on a mod today. I designed a really cool flying house, similar to the Vanishing Arc in Aftershock, with a total of 3 floors. During testing, I discovered 2 bugs in the z filter param for u_run_xxx_eocs that I had added previously.‌

Bug1: When teleporting NPCs and monsters, I found that only NPCs and monsters with z=1 are being teleported, while monsters with z=2 are not.

Bug2: I've found that the z_max filter parameter I implemented is not working correctly for vehicle and fixed zone teleportation.

#### Describe the solution
I sincerely apologize that when I was playing Aftershock's Vanishing Arc, there were no such usage scenarios, and I failed to discover these two bugs during testing.

For Bug 1, I found that there's an implicit logic in the code of EoC 'u_run_npc_eocs' and 'u_run_monster_eocs': when npc_range/monster_range is specified, EoCs will only be applied to units with the same z pos as the player. This logic is not well-documented in the development documentation. To support the z-pos filtering params, I've modified this logic. Now, when npc_range/monster_range is specified and neither 'z_min' nor 'z_max' are provided, the EoCs will only be applied to units with the same z-pos as the player. This solution maintains backward compatibility while supporting the new z-pos filtering params.‌
Finally, I've also clearly documented this logic in the documentation.

For Bug 2, this was purely a stupid logical error on my part in the implementation. I sincerely apologize and have already fixed it.
Before：if( z_max.has_value() && pos_abs.z() > z_min.value() ) { continue; }
After fix: if( z_max.has_value() && pos_abs.z() > z_max.value() ) { continue; }

#### Testing

For Bug 1, I have placed NPCs and monsters on the z=0/1/2 floors of the flying house respectively, and then used a teleportation EoC implemented with u_run_npc_eocs/u_run_monster_eocs similar to Vanishing Arc, where the monsters and NPCs on the specified layers (0,1,2) were all teleported as expected.

For Bug 2, I use z_max = 2 to teleport npc, monster, vehicles and fixed zones in flying house, and only units at z = 2 are teleported as expected.

#### Additional context

None
