### PR TITLE
Striped tshirts

### DIFF
--- a/data/json/items/armor/torso_clothes.json
+++ b/data/json/items/armor/torso_clothes.json
@@ -2190,6 +2190,125 @@
         "color": "magenta",
         "description": "This magnificent piece of clothing contains not one, not two, but THREE WOLVES.  THREE WOLVES HOWLING AT THE MOON!  It is the most badass item of clothing ever produced.",
         "weight": 1
+      },
+      {
+        "id": "pride_default",
+        "name": { "str": "pride flag t-shirt" },
+        "description": "This one has patterns akin to the pride flag.",
+        "color": "yellow",
+        "append": true
+      },
+      {
+        "id": "pride_lesbian",
+        "name": { "str": "lesbian flag t-shirt" },
+        "color": "red",
+        "description": "This one has patterns akin to the lesbian flag.",
+        "append": true
+      },
+      {
+        "id": "pride_bisexual",
+        "name": { "str": "bisexual flag t-shirt" },
+        "color": "red",
+        "description": "This one has patterns akin to the bisexual flag.",
+        "append": true
+      },
+      {
+        "id": "pride_transgender",
+        "name": { "str": "transgender flag t-shirt" },
+        "color": "blue",
+        "description": "This one has patterns akin to the transgender flag.",
+        "append": true
+      },
+      {
+        "id": "pride_asexual",
+        "name": { "str": "asexual flag t-shirt" },
+        "color": "magenta",
+        "description": "This one has patterns akin to the asexual flag.",
+        "append": true
+      },
+      {
+        "id": "pride_aromantic",
+        "name": { "str": "aromantic flag t-shirt" },
+        "color": "green",
+        "description": "This one has patterns akin to the aromantic flag.",
+        "append": true
+      },
+      {
+        "id": "pride_pansexual",
+        "name": { "str": "pansexual flag t-shirt" },
+        "color": "blue",
+        "description": "This one has patterns akin to the pansexual flag.",
+        "append": true
+      },
+      {
+        "id": "pride_genderqueer",
+        "name": { "str": "genderqueer flag t-shirt" },
+        "color": "magenta",
+        "description": "This one has patterns akin to the genderqueer flag.",
+        "append": true
+      },
+      {
+        "id": "pride_genderfluid",
+        "name": { "str": "genderfluid flag t-shirt" },
+        "color": "magenta",
+        "description": "This one has patterns akin to the genderfluid flag.",
+        "append": true
+      },
+      {
+        "id": "pride_agender",
+        "name": { "str": "agender flag t-shirt" },
+        "color": "dark_gray",
+        "description": "This one has patterns akin to the agender flag.",
+        "append": true
+      },
+      {
+        "id": "pride_nonbinary",
+        "name": { "str": "non-binary flag t-shirt" },
+        "color": "yellow",
+        "description": "This one has patterns akin to the non-binary flag.",
+        "append": true
+      },
+      {
+        "id": "pride_intersex",
+        "name": { "str": "intersex flag t-shirt" },
+        "color": "yellow",
+        "description": "This one has patterns akin to the intersex flag.",
+        "append": true
+      },
+      {
+        "id": "pride_polysexual",
+        "name": { "str": "polysexual flag t-shirt" },
+        "color": "green",
+        "description": "This one has patterns akin to the polysexual flag.",
+        "append": true
+      },
+      {
+        "id": "striped_blue_yellow",
+        "name": { "str": "blue-yellow striped t-shirt" },
+        "color": "blue",
+        "description": "This one has blue-yellow pattern.",
+        "append": true
+      },
+      {
+        "id": "striped_red_yellow",
+        "name": { "str": "red-yellow striped t-shirt" },
+        "color": "red",
+        "description": "This one has red-yellow pattern.",
+        "append": true
+      },
+      {
+        "id": "striped_yellow_green",
+        "name": { "str": "yellow-green striped t-shirt" },
+        "color": "yellow",
+        "description": "This one has yellow-green pattern.",
+        "append": true
+      },
+      {
+        "id": "striped_blue_white",
+        "name": { "str": "blue-white striped t-shirt" },
+        "color": "blue",
+        "description": "This one has blue-white pattern.",
+        "append": true
       }
     ],
     "flags": [ "VARSIZE", "SKINTIGHT" ],


### PR DESCRIPTION


#### Summary
None

#### Purpose of change
Adds some more variants to tshirt cuz why not.

#### Describe the solution
adds pride striped tshirt variants and some generic striped tshirts

#### Describe alternatives you've considered

Keeping it to myself.

#### Testing
<img width="569" height="116" alt="debug _2025-11-10T16-26-09_1_1" src="https://github.com/user-attachments/assets/8a68e1e0-1825-47da-b7d2-3fbfaabb1108" />


#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
