### PR TITLE
configure translation workflow to accept tx_token

### DIFF
--- a/.github/workflows/build-translations.yml
+++ b/.github/workflows/build-translations.yml
@@ -2,6 +2,9 @@ name: Build translations
 on:
   workflow_dispatch:
   workflow_call:
+    secrets:
+      TX_TOKEN:
+        required: true
 
 jobs:
   build-translations:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,8 @@ jobs:
     uses: ./.github/workflows/compose-tilesets.yml
   build-translations:
     uses: ./.github/workflows/build-translations.yml
+      secrets:
+        TX_TOKEN: ${{ secrets.TX_TOKEN }}
 
   builds:
     needs:


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
The new translation pulling nested workflow is failing to supply the transifex token.

#### Describe the solution
As outlined in https://docs.github.com/en/actions/how-tos/reuse-automations/reuse-workflows#using-inputs-and-secrets-in-a-reusable-workflow you need extraconfig to forward tokens to nested workflows.
Do that. 

#### Testing
No real option other than merging and setting if it fixes it.