### PR TITLE
[MoM] Reduce portal storm awakening odds

### DIFF
--- a/data/mods/MindOverMatter/effectoncondition/eoc_awakening.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_awakening.json
@@ -720,19 +720,13 @@
     "deactivate_condition": { "not": { "is_weather": "distant_portal_storm" } },
     "effect": [
       { "math": [ "u_awakening_reducer = (portal_storm_awakening_odds(u_awakening_countup))" ] },
+      { "math": [ "_roll_chance = portal_storm_awakening_chance()" ] },
       {
-        "weighted_list_eocs": [
-          [ "EOC_PORTAL_NULL_AWAKENING", { "math": [ "portal_storm_awakening_odds()" ] } ],
-          [ "EOC_PORTAL_BIOKIN_AWAKENING", 1 ],
-          [ "EOC_PORTAL_CLAIR_AWAKENING", 1 ],
-          [ "EOC_PORTAL_ELECTRO_AWAKENING", 1 ],
-          [ "EOC_PORTAL_PHOTOKIN_AWAKENING", 1 ],
-          [ "EOC_PORTAL_PYRO_AWAKENING", 1 ],
-          [ "EOC_PORTAL_TELEKIN_AWAKENING", 1 ],
-          [ "EOC_PORTAL_TEEP_AWAKENING", 1 ],
-          [ "EOC_PORTAL_PORTER_AWAKENING", 1 ],
-          [ "EOC_PORTAL_VITA_AWAKENING", 1 ]
-        ]
+        "u_message": { "str": "Odds of awakening are 1 in <context_val:roll_chance>.", "//~": "NO_I18N" },
+        "type": "debug"
+      },
+      {
+        "weighted_list_eocs": [ [ "EOC_NONE", { "math": [ "_roll_chance" ] } ], [ "EOC_PORTAL_SUCCESSFUL_AWAKENING", 1 ] ]
       }
     ]
   },
@@ -754,19 +748,13 @@
     "deactivate_condition": { "not": { "is_weather": "portal_storm" } },
     "effect": [
       { "math": [ "u_awakening_reducer = (portal_storm_awakening_odds(u_awakening_countup))" ] },
+      { "math": [ "_roll_chance = portal_storm_awakening_chance()" ] },
       {
-        "weighted_list_eocs": [
-          [ "EOC_PORTAL_NULL_AWAKENING", { "math": [ "portal_storm_awakening_odds()" ] } ],
-          [ "EOC_PORTAL_BIOKIN_AWAKENING", 1 ],
-          [ "EOC_PORTAL_CLAIR_AWAKENING", 1 ],
-          [ "EOC_PORTAL_ELECTRO_AWAKENING", 1 ],
-          [ "EOC_PORTAL_PHOTOKIN_AWAKENING", 1 ],
-          [ "EOC_PORTAL_PYRO_AWAKENING", 1 ],
-          [ "EOC_PORTAL_TELEKIN_AWAKENING", 1 ],
-          [ "EOC_PORTAL_TEEP_AWAKENING", 1 ],
-          [ "EOC_PORTAL_PORTER_AWAKENING", 1 ],
-          [ "EOC_PORTAL_VITA_AWAKENING", 1 ]
-        ]
+        "u_message": { "str": "Odds of awakening are 1 in <context_val:roll_chance>.", "//~": "NO_I18N" },
+        "type": "debug"
+      },
+      {
+        "weighted_list_eocs": [ [ "EOC_NONE", { "math": [ "_roll_chance" ] } ], [ "EOC_PORTAL_SUCCESSFUL_AWAKENING", 1 ] ]
       }
     ]
   },
@@ -788,26 +776,32 @@
     "deactivate_condition": { "not": { "is_weather": "close_portal_storm" } },
     "effect": [
       { "math": [ "u_awakening_reducer = (portal_storm_awakening_odds(u_awakening_countup))" ] },
+      { "math": [ "_roll_chance = portal_storm_awakening_chance()" ] },
       {
-        "weighted_list_eocs": [
-          [ "EOC_PORTAL_NULL_AWAKENING", { "math": [ "portal_storm_awakening_odds()" ] } ],
-          [ "EOC_PORTAL_BIOKIN_AWAKENING", 1 ],
-          [ "EOC_PORTAL_CLAIR_AWAKENING", 1 ],
-          [ "EOC_PORTAL_ELECTRO_AWAKENING", 1 ],
-          [ "EOC_PORTAL_PHOTOKIN_AWAKENING", 1 ],
-          [ "EOC_PORTAL_PYRO_AWAKENING", 1 ],
-          [ "EOC_PORTAL_TELEKIN_AWAKENING", 1 ],
-          [ "EOC_PORTAL_TEEP_AWAKENING", 1 ],
-          [ "EOC_PORTAL_PORTER_AWAKENING", 1 ],
-          [ "EOC_PORTAL_VITA_AWAKENING", 1 ]
-        ]
+        "u_message": { "str": "Odds of awakening are 1 in <context_val:roll_chance>.", "//~": "NO_I18N" },
+        "type": "debug"
+      },
+      {
+        "weighted_list_eocs": [ [ "EOC_NONE", { "math": [ "_roll_chance" ] } ], [ "EOC_PORTAL_SUCCESSFUL_AWAKENING", 1 ] ]
       }
     ]
   },
   {
     "type": "effect_on_condition",
-    "id": "EOC_PORTAL_NULL_AWAKENING",
-    "effect": [ { "u_message": "" } ]
+    "id": "EOC_PORTAL_SUCCESSFUL_AWAKENING",
+    "effect": {
+      "weighted_list_eocs": [
+        [ "EOC_PORTAL_BIOKIN_AWAKENING", 1 ],
+        [ "EOC_PORTAL_CLAIR_AWAKENING", 1 ],
+        [ "EOC_PORTAL_ELECTRO_AWAKENING", 1 ],
+        [ "EOC_PORTAL_PHOTOKIN_AWAKENING", 1 ],
+        [ "EOC_PORTAL_PYRO_AWAKENING", 1 ],
+        [ "EOC_PORTAL_TELEKIN_AWAKENING", 1 ],
+        [ "EOC_PORTAL_TEEP_AWAKENING", 1 ],
+        [ "EOC_PORTAL_PORTER_AWAKENING", 1 ],
+        [ "EOC_PORTAL_VITA_AWAKENING", 1 ]
+      ]
+    }
   },
   {
     "type": "effect_on_condition",

--- a/data/mods/MindOverMatter/effectoncondition/eoc_awakening.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_awakening.json
@@ -722,7 +722,7 @@
       { "math": [ "u_awakening_reducer = (portal_storm_awakening_odds(u_awakening_countup))" ] },
       {
         "weighted_list_eocs": [
-          [ "EOC_PORTAL_NULL_AWAKENING", { "math": [ "147 * e^(-0.24 * ps_str) + 5" ] } ],
+          [ "EOC_PORTAL_NULL_AWAKENING", { "math": [ "portal_storm_awakening_odds()" ] } ],
           [ "EOC_PORTAL_BIOKIN_AWAKENING", 1 ],
           [ "EOC_PORTAL_CLAIR_AWAKENING", 1 ],
           [ "EOC_PORTAL_ELECTRO_AWAKENING", 1 ],
@@ -756,7 +756,7 @@
       { "math": [ "u_awakening_reducer = (portal_storm_awakening_odds(u_awakening_countup))" ] },
       {
         "weighted_list_eocs": [
-          [ "EOC_PORTAL_NULL_AWAKENING", { "math": [ "147 * e^(-0.24 * ps_str) + 5" ] } ],
+          [ "EOC_PORTAL_NULL_AWAKENING", { "math": [ "portal_storm_awakening_odds()" ] } ],
           [ "EOC_PORTAL_BIOKIN_AWAKENING", 1 ],
           [ "EOC_PORTAL_CLAIR_AWAKENING", 1 ],
           [ "EOC_PORTAL_ELECTRO_AWAKENING", 1 ],
@@ -790,7 +790,7 @@
       { "math": [ "u_awakening_reducer = (portal_storm_awakening_odds(u_awakening_countup))" ] },
       {
         "weighted_list_eocs": [
-          [ "EOC_PORTAL_NULL_AWAKENING", { "math": [ "147 * e^(-0.24 * ps_str) + 5" ] } ],
+          [ "EOC_PORTAL_NULL_AWAKENING", { "math": [ "portal_storm_awakening_odds()" ] } ],
           [ "EOC_PORTAL_BIOKIN_AWAKENING", 1 ],
           [ "EOC_PORTAL_CLAIR_AWAKENING", 1 ],
           [ "EOC_PORTAL_ELECTRO_AWAKENING", 1 ],

--- a/data/mods/MindOverMatter/jmath.json
+++ b/data/mods/MindOverMatter/jmath.json
@@ -139,7 +139,7 @@
     "type": "jmath_function",
     "id": "portal_storm_awakening_chance",
     "num_args": 0,
-    "return": "(450 * e^(-0.24 * ps_str) ) + 15"
+    "return": "((450 * e^(-0.24 * ps_str) ) + 15) * (u_effect_intensity('psi_nether_attention') > 0 ? 0.5 : 1)"
   },
   {
     "type": "jmath_function",

--- a/data/mods/MindOverMatter/jmath.json
+++ b/data/mods/MindOverMatter/jmath.json
@@ -137,6 +137,12 @@
   },
   {
     "type": "jmath_function",
+    "id": "portal_storm_awakening_chance",
+    "num_args": 0,
+    "return": "(450 * e^(-0.24 * ps_str) ) + 15"
+  },
+  {
+    "type": "jmath_function",
     "id": "concentration_trait_bonuses",
     "num_args": 0,
     "//": "Effects with an intelligence penalty have not been included below to avoid double counting",

--- a/data/mods/MindOverMatter/jmath.json
+++ b/data/mods/MindOverMatter/jmath.json
@@ -139,7 +139,7 @@
     "type": "jmath_function",
     "id": "portal_storm_awakening_chance",
     "num_args": 0,
-    "return": "((450 * e^(-0.24 * ps_str) ) + 15) * (u_effect_intensity('psi_nether_attention') > 0 ? 0.5 : 1)"
+    "return": "((450 * e^(-0.24 * ps_str) ) + 20) * (u_effect_intensity('psi_nether_attention') > 0 ? 0.5 : 1)"
   },
   {
     "type": "jmath_function",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[MoM] Reduce portal storm awakening odds"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

The odds of portal storm awakening are currently `147 * e^(-0.24 * ps_str) + 5`, which works out to about 1 in 120 in a strength 1 storm but rises very rapidly after that--it's 1 in 18 in a strength 10 storm and 1 in 9 in a strength 15 storm. But the thing is, at the center of the storm it runs every minute or two, so even a starter portal storm had extremely good odds of awakening you.

One way of dealing with this is making portal storms more dangerous, but reducing the odds has to be the other one.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Set the formula to jmath and change it to `((450 * e^(-0.24 * ps_str) ) + 20) * (u_effect_intensity('psi_nether_attention') > 0 ? 0.5 : 1)`. This works out to 1 in 373 in a strength 1 portal storm, 1 in 60 in a strength 10 portal storm, and 1 in 30 in a strength 15 storm. However, as you can see from the formula, having the Observed effect raises your odds--1 in 186 in a strength 1 storm, etc.

Observed raises your odds? Why is that? How exactly are these awakenings occurring, you ask? Hmm, hmm. I wonder.

Also replace `EOC_PORTAL_NULL_AWAKENING` with the generic `EOC_NONE`

To make the odds easy to calculate, roll the above chance vs a `EOC_PORTAL_SUCCESSFUL_AWAKENING` in a weighted list, which has a weight of 1. This is reduced from the previous weight of 1 for each of the 9 awakening types, so on the high end it also reduces your odds of awakening again. `EOC_PORTAL_SUCCESSFUL_AWAKENING` then has its own weighted list that calls `EOC_PORTAL_BIOKIN_AWAKENING` etc.

Add a debug message that tells you your chance to awaken when the roll happens. 

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Entered portal storm, checked for errors.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Might end up reducing the frequency of the checks but one thing at a time. I have more portal storm lethality measures too first.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
