### PR TITLE
Add code for spell migration

### DIFF
--- a/doc/JSON/OBSOLETION_AND_MIGRATION.md
+++ b/doc/JSON/OBSOLETION_AND_MIGRATION.md
@@ -178,6 +178,22 @@ Prof migration can be migrated to new prof (with progress being transferred) or 
   }
 ```
 
+# Spell migration
+
+The only spells that require migration are one that are actual spells that character/player learned, so this section is more applicable to magic mods, and not applicable to, for example, a monster spells (monsters do not store it anywhere, just picking it up fron definition when needed)
+
+```jsonc
+  {
+    "type": "spell_migration",
+    "from": "spell_foo",  // Mandatory. Id of the spell that has been removed.
+    "to": "spell_bar"     // Optional. Id of the new spell that will be set instead. Can be omitted to remove the spell completely. If character already has this spell learned, it will not be modified
+  },
+  {
+    "type": "spell_migration",
+    "from": "spell_bar",
+  },
+```
+
 # Monster migration
 
 Monster can be removed without migration, the game replace all critters without matched monster id with mon_breather when loaded

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1017,7 +1017,7 @@ void DynamicDataLoader::check_consistency()
             { _( "Body graphs" ), &bodygraph::check_all },
             { _( "Anatomies" ), &anatomy::check_consistency },
             { _( "Spells" ), &spell_type::check_consistency },
-            { _( "Effect migration" ), &spell_migration::check },
+            { _( "Spell migration" ), &spell_migration::check },
             { _( "Transformations" ), &event_transformation::check_consistency },
             { _( "Statistics" ), &event_statistic::check_consistency },
             { _( "Scent types" ), &scent_type::check_scent_consistency },

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -487,6 +487,7 @@ void DynamicDataLoader::initialize()
     add( "anatomy", &anatomy::load_anatomy );
     add( "morale_type", &morale_type_data::load_type );
     add( "SPELL", &spell_type::load_spell );
+    add( "spell_migration", &spell_migration::load );
     add( "magic_type", &magic_type::load_magic_type );
     add( "clothing_mod", &clothing_mods::load );
     add( "ter_furn_transform", &ter_furn_transform::load_transform );
@@ -758,6 +759,7 @@ void DynamicDataLoader::unload_data()
     SNIPPET.clear_snippets();
     magic_type::reset_all();
     spell_type::reset_all();
+    spell_migration::reset();
     start_locations::reset();
     ter_furn_migrations::reset();
     ter_furn_transform::reset();
@@ -1015,6 +1017,7 @@ void DynamicDataLoader::check_consistency()
             { _( "Body graphs" ), &bodygraph::check_all },
             { _( "Anatomies" ), &anatomy::check_consistency },
             { _( "Spells" ), &spell_type::check_consistency },
+            { _( "Effect migration" ), &spell_migration::check },
             { _( "Transformations" ), &event_transformation::check_consistency },
             { _( "Statistics" ), &event_statistic::check_consistency },
             { _( "Scent types" ), &scent_type::check_scent_consistency },

--- a/src/magic.h
+++ b/src/magic.h
@@ -1007,7 +1007,6 @@ class spell_migration
 
         static void check();
 
-        /** Find the last migration entry of the given vpart_id */
         static const spell_migration *find_migration( const spell_id &original );
 };
 

--- a/src/magic.h
+++ b/src/magic.h
@@ -796,6 +796,8 @@ class known_magic
 
         void toggle_favorite( const spell_id &sp );
         bool is_favorite( const spell_id &sp );
+
+        void migrate_spells();
     private:
         // gets length of longest spell name
         int get_spellname_max_width();
@@ -991,6 +993,22 @@ struct area_expander {
     void sort_ascending();
 
     void sort_descending();
+};
+
+class spell_migration
+{
+    public:
+        spell_id id_old;
+        std::optional<spell_id> id_new;
+
+        static void load( const JsonObject &jo );
+
+        static void reset();
+
+        static void check();
+
+        /** Find the last migration entry of the given vpart_id */
+        static const spell_migration *find_migration( const spell_id &original );
 };
 
 #endif // CATA_SRC_MAGIC_H

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -785,6 +785,7 @@ void Character::load( const JsonObject &data )
     data.read( "moncams", moncams );
 
     data.read( "magic", magic );
+    magic->migrate_spells();
 
     data.read( "traits", my_traits );
     // If a trait has been migrated, we'll need to add it.
@@ -1717,8 +1718,6 @@ void avatar::load( const JsonObject &data )
           object_type::NONE : static_cast<object_type>(
               std::distance( obj_type_name.begin(), iter ) ),
           grab_point );
-
-    data.read( "magic", magic );
 
     calc_mutation_levels();
     drench_mut_calc();


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Json power
#### Describe the solution
add code for spell migration/obsoletion
also removed dummy magic deserialization code from avatar, since avatar do not store spells anymore, character does
#### Testing
Migrated few test spells to another spells, works fine
#### Additional context
I probably need to update my previous migration code, since it was not safe