### PR TITLE
Appease clang

### DIFF
--- a/src/worldfactory.cpp
+++ b/src/worldfactory.cpp
@@ -65,7 +65,7 @@ save_t save_t::from_save_id( const std::string &save_id )
     return save_t( save_id );
 }
 
-save_t save_t::from_base_path( const std::string &base_path )
+save_t save_t::from_base_path( const std::string_view base_path )
 {
     return save_t( base64_decode( base_path ) );
 }

--- a/src/worldfactory.h
+++ b/src/worldfactory.h
@@ -37,7 +37,7 @@ class save_t
         std::string base_path() const;
 
         static save_t from_save_id( const std::string &save_id );
-        static save_t from_base_path( const std::string &base_path );
+        static save_t from_base_path( std::string_view base_path );
 
         bool operator==( const save_t &rhs ) const {
             return name == rhs.name;


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
```
Error: /home/runner/work/Cataclysm-DDA/Cataclysm-DDA/src/worldfactory.cpp:68:32: error: Parameter 'base_path' of 'from_base_path' can be std::string_view. [cata-use-string_view,-warnings-as-errors]
   68 | save_t save_t::from_base_path( const std::string &base_path )
      |                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                const std::string_view base_path
```

#### Testing
clang-tidy should pass.