### PR TITLE
Some work zed evolution path changes

### DIFF
--- a/data/json/monstergroups/zombie_upgrades.json
+++ b/data/json/monstergroups/zombie_upgrades.json
@@ -222,9 +222,33 @@
     "id": "GROUP_ZOMBIE_MINER_UPGRADE",
     "type": "monstergroup",
     "monsters": [
-      { "monster": "mon_zombie_shady", "weight": 150 },
+      { "monster": "mon_zombie_shady", "weight": 90 },
+      { "monster": "mon_coal_zombie", "weight": 120 },
       { "monster": "mon_zombie_rust", "weight": 110 },
       { "monster": "mon_zombie_tough", "weight": 60 }
+    ]
+  },
+  {
+    "id": "GROUP_ZOMBIE_TECHNICIAN_UPGRADE",
+    "type": "monstergroup",
+    "monsters": [
+      { "monster": "mon_zombie_winged", "weight": 30 },
+      { "monster": "mon_zombie_static", "weight": 120 },
+      { "monster": "mon_zombie_smoker", "weight": 20 },
+      { "monster": "mon_zombie_tough", "weight": 60 },
+      { "monster": "mon_zombie_grabber", "weight": 10 },
+      { "monster": "mon_zombie_hunter", "weight": 10 },
+      { "monster": "mon_skeleton", "weight": 10 }
+    ]
+  },
+  {
+    "id": "GROUP_ZOMBIE_COP_UPGRADE",
+    "type": "monstergroup",
+    "monsters": [
+      { "monster": "mon_zombie_static", "weight": 50 },
+      { "monster": "mon_zombie_kevlar_0", "weight": 110 },
+      { "monster": "mon_zombie_smoker", "weight": 10 },
+      { "monster": "mon_zombie_grabber", "weight": 60 }
     ]
   }
 ]

--- a/data/json/monstergroups/zombie_upgrades.json
+++ b/data/json/monstergroups/zombie_upgrades.json
@@ -247,7 +247,7 @@
     "id": "GROUP_ZOMBIE_COP_UPGRADE",
     "type": "monstergroup",
     "monsters": [
-      { "monster": "mon_zombie_static", "weight": 50 },
+      { "monster": "mon_zombie_static", "weight": 40 },
       { "monster": "mon_zombie_kevlar_0", "weight": 40 },
       { "monster": "mon_zombie_smoker", "weight": 10 },
       { "monster": "mon_zombie_grabber", "weight": 60 },

--- a/data/json/monstergroups/zombie_upgrades.json
+++ b/data/json/monstergroups/zombie_upgrades.json
@@ -223,9 +223,10 @@
     "type": "monstergroup",
     "monsters": [
       { "monster": "mon_zombie_shady", "weight": 90 },
-      { "monster": "mon_coal_zombie", "weight": 120 },
       { "monster": "mon_zombie_rust", "weight": 110 },
-      { "monster": "mon_zombie_tough", "weight": 60 }
+      { "monster": "mon_zombie_tough", "weight": 60 },
+      { "monster": "mon_zombie_smoker", "weight": 30 },
+      { "monster": "mon_skeleton", "weight": 10 }
     ]
   },
   {
@@ -238,17 +239,8 @@
       { "monster": "mon_zombie_tough", "weight": 60 },
       { "monster": "mon_zombie_grabber", "weight": 10 },
       { "monster": "mon_zombie_hunter", "weight": 10 },
-      { "monster": "mon_skeleton", "weight": 10 }
-    ]
-  },
-  {
-    "id": "GROUP_ZOMBIE_COP_UPGRADE",
-    "type": "monstergroup",
-    "monsters": [
-      { "monster": "mon_zombie_static", "weight": 50 },
-      { "monster": "mon_zombie_kevlar_0", "weight": 110 },
-      { "monster": "mon_zombie_smoker", "weight": 10 },
-      { "monster": "mon_zombie_grabber", "weight": 60 }
+      { "monster": "mon_skeleton", "weight": 10 },
+      { "monster": "mon_zombie_rust", "weight": 30 }
     ]
   }
 ]

--- a/data/json/monstergroups/zombie_upgrades.json
+++ b/data/json/monstergroups/zombie_upgrades.json
@@ -242,5 +242,18 @@
       { "monster": "mon_skeleton", "weight": 10 },
       { "monster": "mon_zombie_rust", "weight": 30 }
     ]
+  },
+  {
+    "id": "GROUP_ZOMBIE_COP_UPGRADE",
+    "type": "monstergroup",
+    "monsters": [
+      { "monster": "mon_zombie_static", "weight": 50 },
+      { "monster": "mon_zombie_kevlar_0", "weight": 40 },
+      { "monster": "mon_zombie_smoker", "weight": 10 },
+      { "monster": "mon_zombie_grabber", "weight": 60 },
+      { "monster": "mon_skeleton", "weight": 10 },
+      { "monster": "mon_boomer", "weight": 10 },
+      { "monster": "mon_zombie_regenerating", "weight": 10 }
+    ]
   }
 ]

--- a/data/json/monsters/zed-classic.json
+++ b/data/json/monsters/zed-classic.json
@@ -91,7 +91,7 @@
     "melee_dice_sides": 4,
     "vision_day": 30,
     "death_drops": "mon_zombie_cop_death_drops",
-    "upgrades": { "half_life": 160, "into_group": "GROUP_ZOMBIE_COP_UPGRADE" },
+    "upgrades": false,
     "armor": { "bash": 6, "cut": 6, "stab": 6, "bullet": 6, "electric": 2 },
     "extend": { "weakpoint_sets": [ "wps_humanoid_body_armor", "wps_humanoid_open_helmet" ], "families": [ "prof_wp_syn_armored" ] }
   },

--- a/data/json/monsters/zed-classic.json
+++ b/data/json/monsters/zed-classic.json
@@ -91,7 +91,7 @@
     "melee_dice_sides": 4,
     "vision_day": 30,
     "death_drops": "mon_zombie_cop_death_drops",
-    "upgrades": false,
+    "upgrades": { "half_life": 160, "into_group": "GROUP_ZOMBIE_COP_UPGRADE" },
     "armor": { "bash": 6, "cut": 6, "stab": 6, "bullet": 6, "electric": 2 },
     "extend": { "weakpoint_sets": [ "wps_humanoid_body_armor", "wps_humanoid_open_helmet" ], "families": [ "prof_wp_syn_armored" ] }
   },

--- a/data/json/monsters/zed_ferrous.json
+++ b/data/json/monsters/zed_ferrous.json
@@ -14,7 +14,7 @@
     "attack_effs": [ { "id": "tetanus", "duration": 300, "chance": 10 } ],
     "burn_into": "mon_zombie_scorched_rust",
     "upgrades": { "half_life": 120, "into_group": "GROUP_FERROUS_UPGRADE" },
-    "armor": { "bash": 1, "cut": 2, "stab": 1}
+    "armor": { "bash": 1, "cut": 2, "stab": 1 }
   },
   {
     "id": "mon_zombie_shell",

--- a/data/json/monsters/zed_ferrous.json
+++ b/data/json/monsters/zed_ferrous.json
@@ -34,7 +34,7 @@
     "attack_effs": [ { "id": "tetanus", "duration": 300, "chance": 10 } ],
     "burn_into": "mon_zombie_scorched_rust",
     "upgrades": { "half_life": 120, "into": "mon_zombie_plated" },
-    "armor": { "bash": 14, "cut": 14, "stab": 14, "bullet": 14, "heat": 2 },
+    "armor": { "bash": 14, "cut": 14, "stab": 14, "bullet": 14 },
     "extend": { "weakpoint_sets": [ "wps_metal_shell_armor" ], "families": [ "prof_wp_nat_armored" ], "flags": [ "PULP_PRYING" ] }
   },
   {
@@ -59,7 +59,7 @@
     "attack_effs": [ { "id": "tetanus", "duration": 300, "chance": 10 } ],
     "burn_into": "mon_zombie_scorched_rust",
     "upgrades": false,
-    "armor": { "bash": 18, "cut": 18, "stab": 18, "bullet": 18, "heat": 6 },
+    "armor": { "bash": 18, "cut": 18, "stab": 18, "bullet": 18, "heat": 2 },
     "extend": {
       "flags": [ "SMELLS", "PULP_PRYING" ],
       "weakpoint_sets": [ "wps_metal_shell_armor" ],

--- a/data/json/monsters/zed_ferrous.json
+++ b/data/json/monsters/zed_ferrous.json
@@ -14,7 +14,7 @@
     "attack_effs": [ { "id": "tetanus", "duration": 300, "chance": 10 } ],
     "burn_into": "mon_zombie_scorched_rust",
     "upgrades": { "half_life": 120, "into_group": "GROUP_FERROUS_UPGRADE" },
-    "armor": { "bash": 1, "cut": 2, "stab": 1 }
+    "armor": { "bash": 1, "cut": 2, "stab": 1}
   },
   {
     "id": "mon_zombie_shell",
@@ -34,7 +34,7 @@
     "attack_effs": [ { "id": "tetanus", "duration": 300, "chance": 10 } ],
     "burn_into": "mon_zombie_scorched_rust",
     "upgrades": { "half_life": 120, "into": "mon_zombie_plated" },
-    "armor": { "bash": 14, "cut": 14, "stab": 14, "bullet": 14 },
+    "armor": { "bash": 14, "cut": 14, "stab": 14, "bullet": 14, "heat": 2 },
     "extend": { "weakpoint_sets": [ "wps_metal_shell_armor" ], "families": [ "prof_wp_nat_armored" ], "flags": [ "PULP_PRYING" ] }
   },
   {
@@ -59,7 +59,7 @@
     "attack_effs": [ { "id": "tetanus", "duration": 300, "chance": 10 } ],
     "burn_into": "mon_zombie_scorched_rust",
     "upgrades": false,
-    "armor": { "bash": 18, "cut": 18, "stab": 18, "bullet": 18 },
+    "armor": { "bash": 18, "cut": 18, "stab": 18, "bullet": 18, "heat": 6 },
     "extend": {
       "flags": [ "SMELLS", "PULP_PRYING" ],
       "weakpoint_sets": [ "wps_metal_shell_armor" ],

--- a/data/json/monsters/zed_misc.json
+++ b/data/json/monsters/zed_misc.json
@@ -898,42 +898,6 @@
     "extend": { "flags": [ "HARDTOSHOOT", "RANGED_ATTACKER" ] },
     "delete": { "flags": [ "SMELLS" ] }
   },
-  {
-    "id": "mon_coal_zombie",
-    "type": "MONSTER",
-    "name": { "str": "anthracite zombie" },
-    "description": "This zombie’s body is blackened and twisted, Its coal-dusted flesh and tattered work gear are wreathed in a constant haze of black smoke.",
-    "copy-from": "mon_zombie_miner",
-    "color": "dark_gray",
-    "looks_like": "mon_zombie_smoker",
-    "bleed_rate": 40,
-    "emit_fields": [ { "emit_id": "emit_smoke_stream", "delay": "2 s" } ],
-    "death_function": { "effect": { "id": "death_smokeburst", "hit_self": true }, "message": "The %s explodes!" },
-    "fungalize_into": "mon_zombie_smoker_dusted",
-    "upgrades": { "half_life": 120, "into": "mon_coal_brute" },
-    "armor": { "bash": 1, "cut": 2, "stab": 3, "bullet": 2, "electric": 8, "heat": -10 },
-    "extend": { "weakpoint_sets": [ "wps_humanoid_open_helmet" ], "flags": [ "HARDTOSHOOT" ] }
-  },
-  {
-    "id": "mon_coal_brute",
-    "type": "MONSTER",
-    "name": { "str": "anthracite brawler" },
-    "description": "This zombie’s body is blackened and twisted, Its coal-dusted flesh and tattered work gear are wreathed in a constant haze of black smoke.",
-    "copy-from": "mon_zombie_brute",
-    "hp": 160,
-    "looks_like": "mon_smoker_brute",
-    "bleed_rate": 30,
-    "emit_fields": [ { "emit_id": "emit_smoke_stream", "delay": "1 s" } ],
-    "death_function": { "effect": { "id": "death_smokeburst", "hit_self": true }, "message": "The %s explodes!" },
-    "special_attacks": [
-      { "id": "smash", "throw_strength": 50, "cooldown": 30 },
-      { "id": "grab_drag" },
-      { "id": "drag_followup" }
-    ],
-    "upgrades": false,
-    "armor": { "bash": 2, "cut": 10, "stab": 10, "bullet": 8, "electric": 16, "heat": -20 },
-    "extend": { "weakpoint_sets": [ "wps_humanoid_open_helmet" ], "flags": [ "HARDTOSHOOT" ] },
-    "delete": { "flags": [ "SMELLS" ] }
   },
   {
     "id": "mon_zombie_swimmer_base",

--- a/data/json/monsters/zed_misc.json
+++ b/data/json/monsters/zed_misc.json
@@ -899,6 +899,43 @@
     "delete": { "flags": [ "SMELLS" ] }
   },
   {
+    "id": "mon_coal_zombie",
+    "type": "MONSTER",
+    "name": { "str": "anthracite zombie" },
+    "description": "This zombie’s body is blackened and twisted, Its coal-dusted flesh and tattered work gear are wreathed in a constant haze of black smoke.",
+    "copy-from": "mon_zombie_miner",
+    "color": "dark_gray",
+    "looks_like": "mon_zombie_smoker",
+    "bleed_rate": 40,
+    "emit_fields": [ { "emit_id": "emit_smoke_stream", "delay": "2 s" } ],
+    "death_function": { "effect": { "id": "death_smokeburst", "hit_self": true }, "message": "The %s explodes!" },
+    "fungalize_into": "mon_zombie_smoker_dusted",
+    "upgrades": { "half_life": 120, "into": "mon_coal_brute" },
+    "armor": { "bash": 1, "cut": 2, "stab": 3, "bullet": 2, "electric": 8, "heat": -10 },
+    "extend": { "weakpoint_sets": [ "wps_humanoid_open_helmet" ], "flags": [ "HARDTOSHOOT" ] }
+  },
+  {
+    "id": "mon_coal_brute",
+    "type": "MONSTER",
+    "name": { "str": "anthracite brawler" },
+    "description": "This zombie’s body is blackened and twisted, Its coal-dusted flesh and tattered work gear are wreathed in a constant haze of black smoke.",
+    "copy-from": "mon_zombie_brute",
+    "hp": 160,
+    "looks_like": "mon_smoker_brute",
+    "bleed_rate": 30,
+    "emit_fields": [ { "emit_id": "emit_smoke_stream", "delay": "1 s" } ],
+    "death_function": { "effect": { "id": "death_smokeburst", "hit_self": true }, "message": "The %s explodes!" },
+    "special_attacks": [
+      { "id": "smash", "throw_strength": 50, "cooldown": 30 },
+      { "id": "grab_drag" },
+      { "id": "drag_followup" }
+    ],
+    "upgrades": false,
+    "armor": { "bash": 2, "cut": 10, "stab": 10, "bullet": 8, "electric": 16, "heat": -20 },
+    "extend": { "weakpoint_sets": [ "wps_humanoid_open_helmet" ], "flags": [ "HARDTOSHOOT" ] },
+    "delete": { "flags": [ "SMELLS" ] }
+  },
+  {
     "id": "mon_zombie_swimmer_base",
     "type": "MONSTER",
     "name": { "str": "swimmer zombie" },
@@ -948,6 +985,7 @@
     "vision_day": 15,
     "vision_night": 2,
     "death_drops": "mon_zombie_technician_death_drops",
+    "upgrades": { "half_life": 130, "into_group": "GROUP_ZOMBIE_TECHNICIAN_UPGRADE" },
     "armor": { "bash": 2, "cut": 2, "bullet": 2, "electric": 3 },
     "extend": { "weakpoint_sets": [ "wps_humanoid_open_helmet" ] }
   },

--- a/data/json/monsters/zed_misc.json
+++ b/data/json/monsters/zed_misc.json
@@ -898,7 +898,6 @@
     "extend": { "flags": [ "HARDTOSHOOT", "RANGED_ATTACKER" ] },
     "delete": { "flags": [ "SMELLS" ] }
   },
-  },
   {
     "id": "mon_zombie_swimmer_base",
     "type": "MONSTER",


### PR DESCRIPTION
#### Summary
Balance "New work zeds and evolution paths"

#### Purpose of change

I noticed the miner zombies only ever evolve to 3 zombies, and never evolve into smoker zombies, which make sense thematically. I also noticed the technician zombies did not have their own upgrade path. Also, cop zombies dont upgrade for some reason

#### Describe the solution


I set the technician zombies to have a new upgrade group, with increased chances of zapper zombies, among others

I added very slight heat resistance to the plated zombie.

Added a few more types of zombies from our existing ones for the miner zed to pull from. 

also made it so cop zeds evolve now, with a new evolution group, albeit with a long half life. 

#### Describe alternatives you've considered

Could do more custom monsters instead of using existing.
Ideally I want to come back to this with a few new monster types.



#### Testing

ran the game

#### Additional context

Still WIP atm
