### PR TITLE
Optional balance mod to disable wheel damage from items

### DIFF
--- a/data/core/external_options.json
+++ b/data/core/external_options.json
@@ -120,6 +120,13 @@
   },
   {
     "type": "EXTERNAL_OPTION",
+    "name": "NO_ITEM_WHEEL_DAMAGE",
+    "//": "If true, items with the DAMAGE_VEHICLE_WHEELS flag will not damage wheels when driving over them.",
+    "stype": "bool",
+    "value": false
+  },
+  {
+    "type": "EXTERNAL_OPTION",
     "name": "NO_VITAMINS",
     "//": "Disables tracking vitamins in food items.  If true, disables vitamin tracking and vitamin disorders.",
     "stype": "bool",

--- a/data/mods/No_Wheel_Damage_From_Items/modinfo.json
+++ b/data/mods/No_Wheel_Damage_From_Items/modinfo.json
@@ -1,0 +1,18 @@
+[
+  {
+    "type": "MOD_INFO",
+    "id": "no_wheel_damage_from_items",
+    "name": "No wheel damage from items",
+    "authors": [ "Maari" ],
+    "maintainers": [ "Maari" ],
+    "description": "Prevents wheels from being damaged by driving over items.",
+    "category": "rebalance",
+    "dependencies": [ "dda" ]
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "NO_ITEM_WHEEL_DAMAGE",
+    "stype": "bool",
+    "value": true
+  }
+]

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -1259,7 +1259,8 @@ static std::pair<double, double> item_hardness_calc( const item &it )
 
 double vehicle::wheel_damage_chance_vs_item( const item &it, vehicle_part &vp_wheel ) const
 {
-    if( !it.has_flag( json_flag_DAMAGE_VEHICLE_WHEELS ) ) {
+    if( !it.has_flag( json_flag_DAMAGE_VEHICLE_WHEELS ) ||
+        get_option<bool>( "NO_ITEM_WHEEL_DAMAGE" ) ) {
         return 0.0;
     }
     // Wheels use the worst/softest possible value, the squishy parts. In other words, a wheel is damaged


### PR DESCRIPTION
#### Summary
Balance "In-repo mod to disable wheel damage from items"

#### Purpose of change

Creates a small mod that allows users to opt out of the recent change to driving mechanics introduced in #83004 which causes wheels to take damage when moving over items with the DAMAGE_VEHICLE_WHEELS flag

#### Describe the solution

Uses the same general approach as the no_npc_needs mod, introducing an external_option boolean that the base game checks for when deciding to damage wheels or not.

#### Describe alternatives you've considered

complaining in discord until someone else does it

#### Testing

Without the mod (base game):
![cb1jSA9](https://github.com/user-attachments/assets/a5395bc5-8efd-4358-b9e8-e59ee45b1e7d)

With the mod enabled:
![dB2ispD](https://github.com/user-attachments/assets/33981f18-20a0-407d-8750-dba1d49d1533)


#### Additional context

I am in no way comfortable with c++. If there is a more elegant solution (specifically on the c++ side of things), I would welcome feedback or corrections.

c: