### PR TITLE
Remove wheel damage chance from sharp rocks

### DIFF
--- a/data/json/items/resources/misc.json
+++ b/data/json/items/resources/misc.json
@@ -169,7 +169,7 @@
     "longest_side": "8 cm",
     "to_hit": { "grip": "none", "length": "hand", "surface": "line", "balance": "neutral" },
     "qualities": [ [ "CUT", 1 ], [ "BUTCHER", -50 ] ],
-    "flags": [ "ALLOWS_BODY_BLOCK", "DAMAGE_VEHICLE_WHEELS" ],
+    "flags": [ "ALLOWS_BODY_BLOCK" ],
     "melee_damage": { "bash": 5, "cut": 3 },
     "weapon_category": [ "SHIVS" ]
   },


### PR DESCRIPTION
#### Summary
Balance "Remove wheel damage chance from sharp rocks"

#### Purpose of change
Rocks are incredibly common, and because they're made of *rock* incredibly lethal vs wheels

There are few "sharp rocks" that should actually be found, and the ones that are don't have the kind of cutting power necessary to puncture a rubber tire.

Some rocks could damage a vehicle by being run over, but really not in the way we represent.

#### Describe the solution
Squash this outlier. Remove the wheel damage flag from sharp rocks.

#### Describe alternatives you've considered


#### Testing


#### Additional context

