### PR TITLE
Fix translation artifact generation

### DIFF
--- a/.github/workflows/build-translations.yml
+++ b/.github/workflows/build-translations.yml
@@ -33,7 +33,7 @@ jobs:
         if: github.repository == 'CleverRaven/Cataclysm-DDA'
         env:
           TX_TOKEN: ${{ secrets.TX_TOKEN }}
-        run: tx pull --force
+        run: tx pull -a --force
       
       - name: Discard invalid translations
         run: ./lang/discard_invalid_po.sh


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Fix translations in release builds.
```
cataclysm-dda.credits-master [es_AR] - Pulling file
cataclysm-dda.credits-master [es_AR] - File was not found locally, skipping
cataclysm-dda.credits-master [es_ES] - Pulling file
cataclysm-dda.credits-master [es_ES] - File was not found locally, skipping
```

#### Describe the solution
> In case that there aren't any translation files, like in the structure above, then you must either use the -l/--language or the -a/--all flag.

https://developers.transifex.com/docs/using-the-client

#### Additional context
--force may no longer be necessary, but also does not hurt.