### PR TITLE
Fix tranlations in CI take 3

### DIFF
--- a/.github/workflows/build-translations.yml
+++ b/.github/workflows/build-translations.yml
@@ -1,6 +1,5 @@
 name: Build translations
 on:
-  workflow_dispatch:
   workflow_call:
     secrets:
       TX_TOKEN:
@@ -15,7 +14,6 @@ jobs:
         run: sudo apt-get install gettext
 
       - name: Install Transifex CLI
-        if: github.repository == 'CleverRaven/Cataclysm-DDA'
         run: |
           curl -sL https://github.com/transifex/cli/releases/download/v1.6.17/tx-linux-amd64.tar.gz | sudo tar zxvf - -C /usr/bin tx
 
@@ -30,11 +28,16 @@ jobs:
           fetch-depth: 1
 
       - name: Pull translations
-        if: github.repository == 'CleverRaven/Cataclysm-DDA'
+        continue-on-error: true
         env:
           TX_TOKEN: ${{ secrets.TX_TOKEN }}
-        run: tx pull --force
-      
+        run: |
+          if [ -z "${TX_TOKEN}" ]; then
+          echo "No TX_TOKEN secret set in this repo, not pulling translations from Transifex"
+          exit 1
+          fi
+          tx pull --all --force
+
       - name: Discard invalid translations
         run: ./lang/discard_invalid_po.sh
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
* Current workflow fails because it only pulls translations which have counterparts in repo, which is none. Instead we want to pull all translations.
* Make the workflow run on forks as well if TX_TOKEN is present, instead of checking for whether we're on CleverRaven.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Run the binaries produced from this experimental build on my branch: https://github.com/harakka/Cataclysm-DDA/actions/runs/19309300610

<img width="948" height="475" alt="image" src="https://github.com/user-attachments/assets/40d4a311-42ac-455a-9ce8-803cfac01e59" />
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
