### PR TITLE
Re-fix msvc ccache eviction after discovering original issue was just…

### DIFF
--- a/.github/workflows/msvc-full-features.yml
+++ b/.github/workflows/msvc-full-features.yml
@@ -141,18 +141,23 @@ jobs:
       run: |
           msbuild -m -p:Configuration=Release -p:Platform=x64 "-target:Cataclysm-vcpkg-static;Cataclysm-test-vcpkg-static;JsonFormatter-vcpkg-static;zzip" msvc-full-features/Cataclysm-vcpkg-static.sln
 
+    - name: Get ccache cache age cutoff
+      id: get-cache-age
+      run: |
+        NOW=`/bin/date +%s`
+        DELTA=$(( $NOW - ${{ steps.get-vars.outputs.datetime-seconds }} ))
+        echo "ccache-age=${DELTA}" >> $GITHUB_OUTPUT
+      shell: bash
+
     - name: Post-build ccache manipulation
       if: ${{ !failure() }}
       run: |
-        '${{ env.CDDA_CCACHE_PATH }}ccache.exe' -s -v
-        NOW=`/bin/date +%s`
-        DELTA=$(( $NOW - ${{ steps.get-vars.outputs.datetime-seconds }} ))
-        '${{ env.CDDA_CCACHE_PATH }}ccache.exe' --evict-older-than ${DELTA}s
-        '${{ env.CDDA_CCACHE_PATH }}ccache.exe' -s -v
-        '${{ env.CDDA_CCACHE_PATH }}ccache.exe' -M ${{ env.CCACHE_LIMIT }}
-        '${{ env.CDDA_CCACHE_PATH }}ccache.exe' -c
-        '${{ env.CDDA_CCACHE_PATH }}ccache.exe' -s -v
-      shell: bash
+        ${{ env.CDDA_CCACHE_PATH }}\ccache.exe -s -v
+        ${{ env.CDDA_CCACHE_PATH }}\ccache.exe --evict-older-than ${{ steps.get-cache-age.outputs.ccache-age }}s
+        ${{ env.CDDA_CCACHE_PATH }}\ccache.exe -s -v
+        ${{ env.CDDA_CCACHE_PATH }}\ccache.exe -M ${{ env.CCACHE_LIMIT }}
+        ${{ env.CDDA_CCACHE_PATH }}\ccache.exe -c
+        ${{ env.CDDA_CCACHE_PATH }}\ccache.exe -s -v
 
     - name: clear ccache on PRs
       if: ${{ github.ref_name != 'master' }}


### PR DESCRIPTION
… a typo

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
msvc ccache manipulation was still broken because when running ccache from bash it uses a different ccache folder than the same binary run from powershell.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Dig deeper and realize the original problem, not being able to read the age cutoff variable, was due to a typo in the step name. The net difference between this PR and my prior fix is below.
```
$ sl diff -r 03d00e00cbbcc98011d49bcd0e9da74365deea09 .github/workflows/msvc-full-features.yml
diff --git a/.github/workflows/msvc-full-features.yml b/.github/workflows/msvc-full-features.yml
--- a/.github/workflows/msvc-full-features.yml
+++ b/.github/workflows/msvc-full-features.yml
@@ -146,14 +146,14 @@
       run: |
         NOW=`/bin/date +%s`
         DELTA=$(( $NOW - ${{ steps.get-vars.outputs.datetime-seconds }} ))
-        echo "ccache-age=$(( $NOW - ${{ steps.get-vars.outputs.datetime-seconds }} ))" >> $GITHUB_OUTPUT
+        echo "ccache-age=${DELTA}" >> $GITHUB_OUTPUT
       shell: bash

     - name: Post-build ccache manipulation
       if: ${{ !failure() }}
       run: |
         ${{ env.CDDA_CCACHE_PATH }}\ccache.exe -s -v
-        ${{ env.CDDA_CCACHE_PATH }}\ccache.exe --evict-older-than ${{ steps.get-ccache-age.outputs.ccache-age }}
+        ${{ env.CDDA_CCACHE_PATH }}\ccache.exe --evict-older-than ${{ steps.get-cache-age.outputs.ccache-age }}s
         ${{ env.CDDA_CCACHE_PATH }}\ccache.exe -s -v
         ${{ env.CDDA_CCACHE_PATH }}\ccache.exe -M ${{ env.CCACHE_LIMIT }}
         ${{ env.CDDA_CCACHE_PATH }}\ccache.exe -
```
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
https://github.com/akrieger/Cataclysm-DDA/actions/runs/19313781133/job/55240351007#step:17:3
```
  D:\a\Cataclysm-DDA\Cataclysm-DDA\ccache\\ccache.exe -s -v
  D:\a\Cataclysm-DDA\Cataclysm-DDA\ccache\\ccache.exe --evict-older-than 3154s
  D:\a\Cataclysm-DDA\Cataclysm-DDA\ccache\\ccache.exe -s -v
  D:\a\Cataclysm-DDA\Cataclysm-DDA\ccache\\ccache.exe -M 10GB
  D:\a\Cataclysm-DDA\Cataclysm-DDA\ccache\\ccache.exe -c
  D:\a\Cataclysm-DDA\Cataclysm-DDA\ccache\\ccache.exe -s -v
```
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
