### PR TITLE
[AFS] Fix Kinetic Annulment System deafening the player while inactive

### DIFF
--- a/data/mods/aftershock_exoplanet/player/bionics.json
+++ b/data/mods/aftershock_exoplanet/player/bionics.json
@@ -322,7 +322,8 @@
     "act_cost": "1500 kJ",
     "react_cost": "100 kJ",
     "time": "1 s",
-    "flags": [ "BIONIC_TOGGLED", "DEAF" ],
+    "flags": [ "BIONIC_TOGGLED" ],
+    "enchantments": [ { "condition": "ACTIVE", "mutations": [ "DEAF" ] } ],
     "activated_eocs": [
       {
         "id": "bio_shield_heavy_activate",


### PR DESCRIPTION
#### Summary
Mods "[AFS] Fix Kinetic Annulment System deafening the player while inactive"

#### Purpose of change

This bionic's activation message implies that it only deafens you while active, despite making you permanently deaf as long as you have it installed.

#### Describe the solution

Make it only deafen while active

#### Describe alternatives you've considered

None

#### Testing

Without deaf trait: can't discuss with npcs during use. Can discuss before and after use.
With deaf trait: can't discuss with npcs before, during and after use.

#### Additional context