### PR TITLE
Correcting an unnecessary function call

### DIFF
--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -502,8 +502,8 @@ bool check_recipe_produces_liquids( const recipe &rec )
     // We check byproducts
     for( const auto &bp : rec.get_byproducts() ) {
         const itype_id &bp_id = bp.first;
-        const itype *bp_itype = item_controller->find_template(bp_id);
-        if (bp_itype->phase == phase_id::LIQUID) {
+        const itype *bp_itype = item_controller->find_template( bp_id );
+        if( bp_itype->phase == phase_id::LIQUID ) {
             return true;  // We found the liquid in byproducts — we're leaving
         }
     }

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -494,8 +494,8 @@ bool check_recipe_produces_liquids( const recipe &rec )
 {
     // Checking the main result
     const itype_id &main_result_id = rec.result();
-    const itype *main_itype = item_controller->find_template(main_result_id);
-    if ((main_itype && main_itype->phase == phase_id::LIQUID)) {
+    const itype *main_itype = item_controller->find_template( main_result_id );
+    if( ( main_itype && main_itype->phase == phase_id::LIQUID ) ) {
         return true;  // We've already found the liquid — it's coming out.
     }
 

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -500,7 +500,7 @@ bool check_recipe_produces_liquids( const recipe &rec )
     }
 
     // We check byproducts
-    for (const auto &bp : rec.get_byproducts()) {
+    for( const auto &bp : rec.get_byproducts() ) {
         const itype_id &bp_id = bp.first;
         const itype *bp_itype = item_controller->find_template(bp_id);
         if (bp_itype->phase == phase_id::LIQUID) {

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -495,7 +495,7 @@ bool check_recipe_produces_liquids( const recipe &rec )
     // Checking the main result
     const itype_id &main_result_id = rec.result();
     const itype *main_itype = item_controller->find_template( main_result_id );
-    if( ( main_itype && main_itype->phase == phase_id::LIQUID ) ) {
+    if( main_itype && main_itype->phase == phase_id::LIQUID ) {
         return true;  // We've already found the liquid — it's coming out.
     }
 

--- a/src/crafting.h
+++ b/src/crafting.h
@@ -6,6 +6,7 @@
 
 class Character;
 class item;
+class recipe;
 template <typename E> struct enum_traits;
 
 enum class craft_flags : int {
@@ -25,4 +26,6 @@ void remove_ammo( item &dis_item, Character &p );
 void remove_ammo( std::list<item> &dis_items, Character &p );
 
 void drop_or_handle( const item &newit, Character &p );
+
+bool check_recipe_produces_liquids( const recipe &rec );
 #endif // CATA_SRC_CRAFTING_H

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -1932,18 +1932,24 @@ std::pair<Character *, const recipe *> select_crafter_and_crafting_recipe( int &
             } else if( current[line]->is_nested() ) {
                 nested_toggle( current[line]->ident(), recalc, keepline );
             } else if( !available[line].can_craft ||
-                       !available[line].crafter_has_primary_skill ) {
+                    !available[line].crafter_has_primary_skill ) {
                 popup( _( "Crafter can't craft that!" ) );
-            } else if( available[line].inv_override == nullptr &&
-                       !crafter->check_eligible_containers_for_crafting( *current[line], batch ? line + 1 : 1 ) ) {
-                // popup is already inside check
-            } else if( crafter->lighting_craft_speed_multiplier( *current[line] ) <= 0.0f ) {
-                popup( _( "Crafter can't see!" ) );
             } else {
-                chosen = current[line];
-                batch_size_out = batch ? line + 1 : 1;
-                done = true;
-                uistate.read_recipes.insert( chosen->ident() );
+                if( check_recipe_produces_liquids( *current[line] ) ) {
+                    if( available[line].inv_override == nullptr &&
+                        !crafter->check_eligible_containers_for_crafting( *current[line], batch ? line + 1 : 1 ) ) {
+                        continue;
+                    }
+                }
+                // popup is already inside check
+                if( crafter->lighting_craft_speed_multiplier( *current[line] ) <= 0.0f ) {
+                    popup( _( "Crafter can't see!" ) );
+                } else {
+                    chosen = current[line];
+                    batch_size_out = batch ? line + 1 : 1;
+                    done = true;
+                    uistate.read_recipes.insert( chosen->ident() );
+                }
             }
         } else if( action == "HELP_RECIPE" && selection_ok( current, line, false ) ) {
             uistate.read_recipes.insert( current[line]->ident() );

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -1932,7 +1932,7 @@ std::pair<Character *, const recipe *> select_crafter_and_crafting_recipe( int &
             } else if( current[line]->is_nested() ) {
                 nested_toggle( current[line]->ident(), recalc, keepline );
             } else if( !available[line].can_craft ||
-                    !available[line].crafter_has_primary_skill ) {
+                       !available[line].crafter_has_primary_skill ) {
                 popup( _( "Crafter can't craft that!" ) );
             } else {
                 if( check_recipe_produces_liquids( *current[line] ) ) {


### PR DESCRIPTION
#### Summary

Performance "Fixing an unnecessary call to the liquid container inspection function when creating solid objects"

#### Purpose of change

Remove unnecessary calls to functions for creating objects and others

#### Describe the solution

When creating items, regardless of the aggregate state, a check (check_eligible_containers_for_crafting) is run to determine whether they will fit or not. At the beginning of the check, items and by-products are "created". And then each unit of production is checked to see if it is liquid. I have implemented a function that immediately checks the final result of crafting, since it is known in advance. And if the result is liquids, then the container check is started in full as before, and if there are no liquids, then the check is not necessary.

#### Describe alternatives you've considered

It may be worth redoing the check_eligible_containers_for_crafting check to check all the liquids at once, rather than creating them.

#### Testing

Created item that have only non-liquid results, which have only liquid results and mixed results.

#### Additional context
