### PR TITLE
[XE] Blind the Sun Rework

### DIFF
--- a/data/mods/Xedra_Evolved/effects/effects.json
+++ b/data/mods/Xedra_Evolved/effects/effects.json
@@ -3721,6 +3721,22 @@
   },
   {
     "type": "effect_type",
+    "id": "effect_vampire_albino",
+    "//": "Hidden effect, carries the flags so that vampires who blot out the sun with their powers don't burn in sunlight.",
+    "name": [ "" ],
+    "desc": [ "" ],
+    "flags": [ "ALBINO" ]
+  },
+  {
+    "type": "effect_type",
+    "id": "effect_vampire_burn_under_sunlight",
+    "//": "Hidden effect, carries the flags so that vampires who blot out the sun with their powers don't burn in sunlight.",
+    "name": [ "" ],
+    "desc": [ "" ],
+    "flags": [ "SUNBURN", "ALBINO" ]
+  },
+  {
+    "type": "effect_type",
     "id": "effect_vampire_burn_to_death_in_sunlight",
     "//": "Hidden effect, carries the flags so that vampires who blot out the sun with their powers don't burn in sunlight.",
     "name": [ "" ],

--- a/data/mods/Xedra_Evolved/effects/effects.json
+++ b/data/mods/Xedra_Evolved/effects/effects.json
@@ -3084,6 +3084,13 @@
   },
   {
     "type": "effect_type",
+    "id": "vampire_blind_the_sun",
+    "//": "Hidden effect.  Makes Blind the Sun protect against the sun.",
+    "name": [ "" ],
+    "desc": [ "" ]
+  },
+  {
+    "type": "effect_type",
     "id": "last_breath_mist_cooldown",
     "name": [ "Recovering from the last breath's mist" ],
     "desc": [

--- a/data/mods/Xedra_Evolved/eocs/eoc_conditions.json
+++ b/data/mods/Xedra_Evolved/eocs/eoc_conditions.json
@@ -69,7 +69,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_CONDITION_XE_VAMPIRE_AVOID_BURNING_IN_SUNLIGHT",
-    "condition": { "and": [ { "not": { "is_weather": "blotted_sun" } } ] },
+    "condition": { "and": [ { "not": { "u_has_effect": "vampire_blind_the_sun" } } ] },
     "effect": [  ]
   }
 ]

--- a/data/mods/Xedra_Evolved/mod_interactions/skyisland/vampire_sun_protection.json
+++ b/data/mods/Xedra_Evolved/mod_interactions/skyisland/vampire_sun_protection.json
@@ -2,7 +2,9 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_CONDITION_XE_VAMPIRE_AVOID_BURNING_IN_SUNLIGHT",
-    "condition": { "and": [ { "not": { "is_weather": "blotted_sun" } }, { "not": { "u_has_trait": "mut_skyisland_sunblock_real" } } ] },
+    "condition": {
+      "and": [ { "not": { "u_has_effect": "vampire_blind_the_sun" } }, { "not": { "u_has_trait": "mut_skyisland_sunblock_real" } } ]
+    },
     "effect": [  ]
   }
 ]

--- a/data/mods/Xedra_Evolved/monsters/monster_spells.json
+++ b/data/mods/Xedra_Evolved/monsters/monster_spells.json
@@ -807,7 +807,7 @@
         "then": { "u_add_effect": "blind", "duration": [ "5 seconds", "12 seconds" ] }
       },
       {
-        "if": { "or": [ { "u_has_flag": "SUNDEATH" }, { "u_has_flag": "SUNBURN" } ] },
+        "if": { "or": [ { "u_has_flag": "SUNDEATH" }, { "u_has_flag": "SUNBURN_SUPERNATURAL" } ] },
         "then": [ { "u_cast_spell": { "id": "solar_spirit_flare_spell_sundeath_hit_monster", "hit_self": true } } ]
       }
     ]

--- a/data/mods/Xedra_Evolved/mutations/mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/mutations.json
@@ -890,7 +890,13 @@
     "types": [ "TEETH" ],
     "valid": false,
     "vitamin_rates": [ [ "human_blood_vitamin", 720 ], [ "mutagen", 300 ], [ "mutagenic_slurry", 1 ] ],
-    "flags": [ "CANNIBAL", "ALBINO", "HEMOVORE" ],
+    "flags": [ "CANNIBAL", "HEMOVORE" ],
+    "enchantments": [
+      {
+        "condition": { "test_eoc": "EOC_CONDITION_XE_VAMPIRE_AVOID_BURNING_IN_SUNLIGHT" },
+        "ench_effects": [ { "effect": "effect_vampire_albino", "intensity": 1 } ]
+      }
+    ],
     "spells_learned": [ [ "vampire_drink_blood_with_fangs_spell", 1 ] ]
   },
   {
@@ -1064,10 +1070,14 @@
     "valid": false,
     "vitamins_absorb_multi": [ [ "all", [ [ "human_blood_vitamin", 1.25 ] ] ] ],
     "vitamin_rates": [ [ "human_blood_vitamin", 720 ], [ "mutagen", 300 ] ],
-    "flags": [ "CANNIBAL", "SUNBURN", "ALBINO", "DAYFEAR", "HEMOVORE" ],
+    "flags": [ "CANNIBAL", "DAYFEAR", "HEMOVORE" ],
     "enchantments": [
       { "condition": { "not": "is_day" }, "values": [ { "value": "OVERMAP_SIGHT", "add": 1 } ] },
-      { "values": [ { "value": "STAMINA_REGEN_MOD", "add": 0.2 }, { "value": "METABOLISM", "multiply": -0.2 } ] }
+      { "values": [ { "value": "STAMINA_REGEN_MOD", "add": 0.2 }, { "value": "METABOLISM", "multiply": -0.2 } ] },
+      {
+        "condition": { "test_eoc": "EOC_CONDITION_XE_VAMPIRE_AVOID_BURNING_IN_SUNLIGHT" },
+        "ench_effects": [ { "effect": "effect_vampire_burn_under_sunlight", "intensity": 1 } ]
+      }
     ]
   },
   {

--- a/data/mods/Xedra_Evolved/mutations/mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/mutations.json
@@ -1573,10 +1573,11 @@
     "purifiable": false,
     "valid": false,
     "name": { "str": "Blind the Sun" },
-    "description": "You mastery over the shadowed path of blood has become much more potent, allowing you to use your vampiric powers and a massive expense of blood to blot out the sun for a few dozen minutes.\n\n<color_light_red>Initial Blood Cost:</color> 3000 ml (<u_val:blood_amount_for_graph> ml current)",
+    "description": "You mastery over the shadowed path of blood has become much more potent, allowing you to use your vampiric powers and a massive expense of blood to shroud yourself from the sun for a short time.\n\n<color_light_red>Initial Blood Cost:</color> 1000 ml (<u_val:blood_amount_for_graph> ml current)\n<color_light_red>Periodic Blood Cost:</color> 700 ml",
     "active": true,
-    "activated_is_setup": false,
-    "activated_eocs": [ "EOC_VAMPIRE_BLIND_THE_SUN" ]
+    "activated_is_setup": true,
+    "activated_eocs": [ "EOC_BLIND_THE_SUN_activated" ],
+    "deactivated_eocs": [ "EOC_BLIND_THE_SUN_deactivated" ]
   },
   {
     "type": "mutation",
@@ -2053,7 +2054,7 @@
     "id": "ANATHEMA_WEAKNESS_SUN_BURN",
     "name": { "str": "Anathema's Weakness: Slain by the Sun" },
     "points": -10,
-    "description": "Vampires burn under the sun, and becoming more of a vampire made you burn far more than any other vampire would.  While under the sun, you will take constant damage no matter how covered you are.",
+    "description": "Vampires burn under the sun, and becoming more of a vampire made you burn far more than any other vampire would.  Being under the sun will quickly ignite your flesh.",
     "starting_trait": false,
     "purifiable": false,
     "valid": false

--- a/data/mods/Xedra_Evolved/mutations/vampire_trait_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/vampire_trait_eocs.json
@@ -2283,60 +2283,107 @@
   },
   {
     "type": "effect_on_condition",
-    "id": "EOC_VAMPIRE_BLIND_THE_SUN",
-    "condition": { "math": [ "u_vitamin('human_blood_vitamin') >= 2000" ] },
-    "effect": {
-      "run_eocs": [
-        {
-          "id": "EOC_BLIND_THE_SUN_CHECK_FOR_STORM",
-          "condition": { "or": [ { "is_weather": "portal_storm" }, { "is_weather": "early_portal_storm" } ] },
-          "effect": [
-            {
-              "u_message": "You feel that the anomalous energies of the storm would do quick work of any darkness you could summon, so you decide to not attempt to blot out the sun for now.",
-              "type": "bad"
-            }
-          ],
-          "false_effect": [
-            { "math": [ "u_vitamin('human_blood_vitamin') -= 3000" ] },
-            {
-              "math": [
-                "sunless_time",
-                "=",
-                "rng(0.75,1.25) * (300 + (vampire_total_tier_one_traits_plus_potency() * 33) + (vampire_total_tier_two_traits() * 75) + (vampire_total_tier_three_traits() * 125) + (vampire_total_tier_four_traits_plus_potence() * 200) + (vampire_total_tier_five_traits_plus_cauldron() * 270))"
+    "id": "EOC_BLIND_THE_SUN_activated",
+    "condition": { "not": { "u_has_effect": "eyegleam" } },
+    "effect": [
+      {
+        "run_eocs": [
+          {
+            "id": "EOC_BLIND_THE_SUN_activated_2",
+            "condition": { "math": [ "u_vitamin('human_blood_vitamin') >= 0" ] },
+            "effect": [
+              { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 1.25 },
+              { "math": [ "u_vitamin('human_blood_vitamin') -= 1000" ] },
+              { "u_add_effect": "vampire_blind_the_sun", "duration": "PERMANENT" },
+              {
+                "math": [
+                  "sunless_time",
+                  "=",
+                  "rng(0.75,1.25) * (60 + (vampire_total_tier_one_traits_plus_potency() * 5) + (vampire_total_tier_two_traits() * 15) + (vampire_total_tier_three_traits() * 25) + (vampire_total_tier_four_traits_plus_potence() * 35) + (vampire_total_tier_five_traits_plus_cauldron() * 45))"
+                ]
+              },
+              { "if": { "u_has_trait": "ANATHEMA_WEAKNESS_SUN_BURN" }, "then": { "math": [ "sunless_time /= 100" ] } },
+              {
+                "if": { "u_has_trait": "ANATHEMA_WEAKNESS_SUN_BURN" },
+                "then": {
+                  "u_message": "Using your mastery over the Shadowed Path, you form a sun-proof shield of darkness around you.  But you can already see the hateful sun burning through the darkness; you had better find shelter immediately.",
+                  "type": "mixed"
+                },
+                "else": {
+                  "u_message": "Using your mastery over the Shadowed Path, you form a sun-proof shield of darkness around you.",
+                  "type": "good"
+                }
+              },
+              { "run_eocs": [ "EOC_BLIND_THE_SUN_maintenance" ], "time_in_future": { "math": [ "sunless_time" ] } }
+            ],
+            "false_effect": [
+              { "u_message": "You don't have enough blood to shroud yourself from the sun.", "type": "bad" },
+              { "run_eocs": "EOC_BLIND_THE_SUN_deactivate_future", "time_in_future": 0 }
+            ]
+          }
+        ]
+      }
+    ],
+    "false_effect": [
+      {
+        "run_eocs": [
+          {
+            "id": "EOC_BLIND_THE_SUN_deactivated",
+            "condition": { "u_has_effect": "vampire_blind_the_sun" },
+            "effect": [
+              { "u_message": "The darkness shielding you fades.", "type": "neutral" },
+              { "u_lose_effect": "vampire_blind_the_sun" }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_BLIND_THE_SUN_deactivate_future",
+    "//": "This is necessary because calling u_deactivate_trait from within the trait EoC does not work",
+    "effect": { "u_deactivate_trait": "VAMPIRE_BLIND_THE_SUN" }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_BLIND_THE_SUN_maintenance",
+    "condition": { "u_has_effect": "vampire_blind_the_sun" },
+    "effect": [
+      {
+        "run_eocs": [
+          {
+            "id": "EOC_BLIND_THE_SUN_maintenance_2",
+            "condition": {
+              "and": [
+                { "math": [ "u_vitamin('human_blood_vitamin') >= 0" ] },
+                { "not": { "u_has_any_effect": [ "sleep", "narcosis", "effect_vampire_torpor" ] } }
               ]
             },
-            { "if": { "u_has_trait": "ANATHEMA_WEAKNESS_SUN_BURN" }, "then": { "math": [ "sunless_time /= 100" ] } },
-            { "run_eocs": [ "EOC_BLOT_THE_SUN" ] },
-            { "run_eocs": "EOC_UNBLOT_THE_SUN", "time_in_future": { "math": [ "sunless_time" ] } },
-            {
-              "if": { "u_has_trait": "ANATHEMA_WEAKNESS_SUN_BURN" },
-              "then": {
-                "u_message": "Using your mastery over the Shadowed Path, you blot out the sun, covering the region around you in darkness for a short period of time.  But you can already see the hateful sun burning through the shadows; you had better find shelter immediately.",
-                "type": "mixed"
+            "effect": [
+              { "math": [ "u_vitamin('human_blood_vitamin') -= 700" ] },
+              { "u_message": "You feel a momentary warmth as you maintain your shrouding shadows.", "type": "mixed" },
+              {
+                "math": [
+                  "sunless_time",
+                  "=",
+                  "rng(0.75,1.25) * (60 + (vampire_total_tier_one_traits_plus_potency() * 5) + (vampire_total_tier_two_traits() * 15) + (vampire_total_tier_three_traits() * 25) + (vampire_total_tier_four_traits_plus_potence() * 35) + (vampire_total_tier_five_traits_plus_cauldron() * 45))"
+                ]
               },
-              "else": {
-                "u_message": "Using your mastery over the Shadowed Path, you blot out the sun, covering the region around you in darkness for a short period of time.",
-                "type": "good"
-              }
-            }
-          ]
-        }
-      ]
-    },
-    "false_effect": [ { "u_message": "You don't have enough blood to blot out the sun.", "type": "bad" } ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "EOC_BLOT_THE_SUN",
-    "effect": [ { "math": [ "blotted_sun = 1" ] }, "next_weather" ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "EOC_UNBLOT_THE_SUN",
-    "effect": [
-      { "math": [ "blotted_sun = 0" ] },
-      "next_weather",
-      { "u_message": "The darkness you summoned fades away, clearing the sky.", "type": "bad" }
+              { "if": { "u_has_trait": "ANATHEMA_WEAKNESS_SUN_BURN" }, "then": { "math": [ "sunless_time /= 100" ] } },
+              { "run_eocs": [ "EOC_BLIND_THE_SUN_maintenance" ], "time_in_future": { "math": [ "sunless_time" ] } }
+            ],
+            "false_effect": [
+              {
+                "if": { "math": [ "u_vitamin('human_blood_vitamin') < 0" ] },
+                "then": { "u_message": "You don't have enough blood to maintain your shrouding shadows.", "type": "bad" }
+              },
+              { "u_lose_effect": "vampire_blind_the_sun" },
+              { "u_deactivate_trait": "VAMPIRE_BLIND_THE_SUN" }
+            ]
+          }
+        ]
+      }
     ]
   },
   {

--- a/data/mods/Xedra_Evolved/mutations/vampire_trait_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/vampire_trait_eocs.json
@@ -2299,7 +2299,7 @@
                 "math": [
                   "sunless_time",
                   "=",
-                  "rng(0.75,1.25) * (60 + (vampire_total_tier_one_traits_plus_potency() * 5) + (vampire_total_tier_two_traits() * 15) + (vampire_total_tier_three_traits() * 25) + (vampire_total_tier_four_traits_plus_potence() * 35) + (vampire_total_tier_five_traits_plus_cauldron() * 45))"
+                  "rng(0.75,1.25) * (20 + (vampire_total_tier_one_traits_plus_potency() * 2) + (vampire_total_tier_two_traits() * 5) + (vampire_total_tier_three_traits() * 8) + (vampire_total_tier_four_traits_plus_potence() * 12) + (vampire_total_tier_five_traits_plus_cauldron() * 15))"
                 ]
               },
               { "if": { "u_has_trait": "ANATHEMA_WEAKNESS_SUN_BURN" }, "then": { "math": [ "sunless_time /= 100" ] } },
@@ -2367,7 +2367,7 @@
                 "math": [
                   "sunless_time",
                   "=",
-                  "rng(0.75,1.25) * (60 + (vampire_total_tier_one_traits_plus_potency() * 5) + (vampire_total_tier_two_traits() * 15) + (vampire_total_tier_three_traits() * 25) + (vampire_total_tier_four_traits_plus_potence() * 35) + (vampire_total_tier_five_traits_plus_cauldron() * 45))"
+                  "rng(0.75,1.25) * (20 + (vampire_total_tier_one_traits_plus_potency() * 2) + (vampire_total_tier_two_traits() * 5) + (vampire_total_tier_three_traits() * 8) + (vampire_total_tier_four_traits_plus_potence() * 12) + (vampire_total_tier_five_traits_plus_cauldron() * 15))"
                 ]
               },
               { "if": { "u_has_trait": "ANATHEMA_WEAKNESS_SUN_BURN" }, "then": { "math": [ "sunless_time /= 100" ] } },

--- a/data/mods/Xedra_Evolved/npc/talk_read_vampire_anathema_book.json
+++ b/data/mods/Xedra_Evolved/npc/talk_read_vampire_anathema_book.json
@@ -51,7 +51,7 @@
   {
     "type": "talk_topic",
     "id": "TALK_ANATHEMA_DRAWBACKS",
-    "dynamic_line": "In addition to manifesting more of the vampires' classical weaknesses, some time after beginning to consume vampires for power I started to burn away under the sun even while fully covered.\nOnly being indoors or underground protected me if I didn't block the sun with shadows.\nI did felt a passing impulse to drink more vampire blood and the first few doses made me think my mind would unravel, but that passed.  It might be that this path gives a single weakness not seen in other vampires to those far enough on it, but testing this would require creating vampires and I won't ever tolerate this.",
+    "dynamic_line": "In addition to manifesting more of the vampires' classical weaknesses, some time after beginning to consume vampires for power the sun's rays started to ignite me, as I found the hard way when a fight lasted longer than planned.\nMy powers barely did anything to block them and I had to sink below the earth to survive that day.\nI did felt a passing impulse to drink more vampire blood and the first few doses made me think my mind would unravel, but that passed.  It might be that this path gives a single weakness not seen in other vampires to those far enough on it, but testing this would require creating vampires and I won't ever tolerate this.",
     "responses": [
       { "text": "[Read about their history]", "topic": "TALK_ANATHEMA_HISTORY" },
       { "text": "[Read about their recipe]", "topic": "TALK_ANATHEMA_RECIPE" },

--- a/data/mods/Xedra_Evolved/obsoletion_and_migration/eocs.json
+++ b/data/mods/Xedra_Evolved/obsoletion_and_migration/eocs.json
@@ -147,5 +147,19 @@
     "type": "effect_on_condition",
     "id": "EOC_VAMPIRE_TORPOR_RECOVER",
     "effect": [ { "math": [ "u_val('sleepiness') = 0" ] }, { "math": [ "u_val('sleep_deprivation') = 0" ] } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_BLOT_THE_SUN",
+    "effect": [ { "math": [ "blotted_sun = 1" ] }, "next_weather" ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_UNBLOT_THE_SUN",
+    "effect": [
+      { "math": [ "blotted_sun = 0" ] },
+      "next_weather",
+      { "u_message": "The darkness you summoned fades away, clearing the sky.", "type": "bad" }
+    ]
   }
 ]

--- a/data/mods/Xedra_Evolved/obsoletion_and_migration/weather.json
+++ b/data/mods/Xedra_Evolved/obsoletion_and_migration/weather.json
@@ -1,0 +1,22 @@
+[
+  {
+    "id": "blotted_sun",
+    "type": "weather_type",
+    "name": "Blotted Sun",
+    "color": "dark_gray",
+    "map_color": "i_blue",
+    "sym": "%",
+    "ranged_penalty": 0,
+    "sight_penalty": 1.0,
+    "light_modifier": -145,
+    "sun_multiplier": 0.01,
+    "sound_attn": 0,
+    "debug_cause_eoc": "EOC_BLOT_THE_SUN",
+    "debug_leave_eoc": "EOC_UNBLOT_THE_SUN",
+    "dangerous": false,
+    "precip": "none",
+    "rains": false,
+    "priority": 119,
+    "condition": { "math": [ "blotted_sun == 1" ] }
+  }
+]

--- a/data/mods/Xedra_Evolved/weather_type.json
+++ b/data/mods/Xedra_Evolved/weather_type.json
@@ -1,25 +1,5 @@
 [
   {
-    "id": "blotted_sun",
-    "type": "weather_type",
-    "name": "Blotted Sun",
-    "color": "dark_gray",
-    "map_color": "i_blue",
-    "sym": "%",
-    "ranged_penalty": 0,
-    "sight_penalty": 1.0,
-    "light_modifier": -145,
-    "sun_multiplier": 0.01,
-    "sound_attn": 0,
-    "debug_cause_eoc": "EOC_BLOT_THE_SUN",
-    "debug_leave_eoc": "EOC_UNBLOT_THE_SUN",
-    "dangerous": false,
-    "precip": "none",
-    "rains": false,
-    "priority": 119,
-    "condition": { "math": [ "blotted_sun == 1" ] }
-  },
-  {
     "id": "magic_weather_thick_fog",
     "type": "weather_type",
     "name": "Dense Fog",


### PR DESCRIPTION
#### Summary
Mods "[XE] Blind the Sun Rework"

#### Purpose of change

I ain't happy with the current state of this blood art:
-It lasts long enough that I could *work on construction projects* during the day. 
-3000 blood is a cost far too small to blanket an entire region in darkness.
-It is an activable mutation despite its non-maintained non-toggled effect.
-It costs bloods in far too big chunks.

These changes rework it to turn it into a personal anti-sun shield. which fits more while keeping the power expected from tier 5 blood arts.

#### Describe the solution

Blind the sun is now a maintained power that protects the player from the sun while active.
It costs 1000 units to activate and 700 units to maintain.

Ups:
-Costs less to activate 
-Can be used during portal storms.
-Maintained over time, so there's no need to frequently open the mutation menu.
-Protects against solar-type attacks too. (this required a slight modification of the solar spirit's EOC as it's another case of the conceptual sun burning away the unholy and not a case where UV rays burn uncovered skin)

Downs:
-Reduction in how long it last, resulting in a very high total cost increase.
-Won't protect others.
-Won't grant the advantage of night-stealth to diurnal vampires.
-DAYFEAR still applies. as it is the day and you hate and fear it.

The sun-slain still get their sun-proof time divided by 100.

Edit the sun-slain weakness and Anathema journal to account for this and for the recent vampire sun-burning changes.

#### Describe alternatives you've considered

Delete it. 
I like the idea of the most powerful vampires temporarily staving off a weakness at a high price, so it will stay in the game.

#### Testing

All tests as a tier 5 vampire with all powers.
-Outside at day without Blind active: Burned.
-Outside at day with Blind active: Didn't burn. Lasted 35 minutes with 5600 blood units, including costs of activation and dropping below zero blood units.
-Near solar spirit without Blind active: Got blinded and took damage.
-Near solar spirit with Blind active: Got blinded, took no damage.

#### Additional context

It also turns off if the player is asleep, anesthetized or in torpor. With how much it costs, it wouldn't last long anyway.

The name isn't changing, as you blind the sun to your presence under its rays.

This will make the sun-slain gain almost nothing from using this power, but being unable to withstand the sun is the point of this weakness. Regular vampires can endure and resist a little and shroud themselves, but the sun-slain will only gain a few seconds from this power. Depending on the situation, these precious seconds might be enough to save them.