### PR TITLE
Update the sex shop mapgen and small related fixes

### DIFF
--- a/data/json/itemgroups/Locations_MapExtras/locations_commercial.json
+++ b/data/json/itemgroups/Locations_MapExtras/locations_commercial.json
@@ -1524,8 +1524,9 @@
   },
   {
     "type": "item_group",
-    "id": "porn_literature",
-    "items": [ [ "mag_porn", 70 ], [ "novel_erotic", 30 ] ]
+    "id": "SUS_commercial_shelf_porn_literature",
+    "subtype": "distribution",
+    "items": [ { "item": "mag_porn", "prob": 70, "count": [ 0, 40 ] }, { "item": "novel_erotic", "prob": 70, "count": [ 0, 20 ] } ]
   },
   {
     "type": "item_group",
@@ -2151,5 +2152,57 @@
     "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_canvas",
     "entries": [ { "item": "birdfood", "count": 60 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "SUS_sex_shop_stock",
+    "subtype": "collection",
+    "items": [
+      { "group": "SUS_sex_shop_shelf", "count": [ 0, 3 ] },
+      { "group": "SUS_commercial_shelf_porn_literature", "count": [ 0, 2 ] },
+      { "group": "sex_clothes", "count": [ 0, 20 ], "prob": 50 },
+      { "group": "underwear_womens", "count": [ 0, 20 ], "prob": 50 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "SUS_sex_shop_shelf",
+    "subtype": "distribution",
+    "items": [
+      {
+        "collection": [
+          { "item": "sextoy", "variant": "beads", "count": [ 0, 5 ] },
+          { "item": "sextoy", "variant": "plug", "count": [ 0, 5 ] },
+          { "item": "sextoy", "variant": "dildo", "count": [ 0, 5 ] }
+        ],
+        "prob": 40
+      },
+      {
+        "collection": [
+          { "item": "vibrator", "variant": "wand", "charges": 100, "count": [ 0, 5 ] },
+          { "item": "vibrator", "variant": "egg", "charges": 100, "count": [ 0, 5 ] },
+          { "item": "vibrator", "variant": "dildo", "charges": 100, "count": [ 0, 5 ] }
+        ],
+        "prob": 40
+      },
+      {
+        "collection": [
+          { "item": "rope_6", "count": [ 0, 3 ] },
+          { "item": "bullwhip", "count": [ 0, 3 ] },
+          { "item": "candle", "count": [ 0, 3 ] },
+          { "item": "handcuffs_leather", "count": [ 0, 3 ] },
+          { "item": "gag_ball", "count": [ 0, 3 ] },
+          { "item": "paddle_plastic", "count": [ 0, 3 ] }
+        ],
+        "prob": 10
+      },
+      {
+        "collection": [
+          { "item": "moisturizer", "variant": "lube", "container-item": "bottle_plastic_small", "count": [ 0, 15 ] },
+          { "item": "condom_sealed", "count": [ 0, 50 ] }
+        ],
+        "prob": 10
+      }
+    ]
   }
 ]

--- a/data/json/itemgroups/misc.json
+++ b/data/json/itemgroups/misc.json
@@ -420,43 +420,5 @@
       },
       { "item": "condom", "prob": 10 }
     ]
-  },
-  {
-    "type": "item_group",
-    "id": "sex_accessories_commercial",
-    "subtype": "distribution",
-    "entries": [
-      {
-        "distribution": [
-          { "distribution": [ { "item": "sextoy", "variant": "beads" }, { "item": "sextoy", "variant": "plug" } ], "prob": 46 },
-          {
-            "distribution": [
-              { "item": "rope_6" },
-              { "item": "bullwhip" },
-              { "item": "candle" },
-              { "item": "handcuffs_leather" },
-              { "item": "gag_ball" },
-              { "item": "paddle_plastic" }
-            ],
-            "prob": 27
-          },
-          { "item": "sextoy", "variant": "dildo", "prob": 35 },
-          {
-            "distribution": [ { "item": "moisturizer", "variant": "lube", "entry-wrapper": "bottle_plastic_small", "count": 8 } ],
-            "prob": 40
-          },
-          { "item": "vibrator", "variant": "egg", "charges": 100, "prob": 29 },
-          {
-            "distribution": [
-              { "item": "vibrator", "variant": "wand", "charges": 100, "prob": 30 },
-              { "item": "vibrator", "variant": "dildo", "charges": 100, "prob": 60 }
-            ],
-            "prob": 55
-          }
-        ],
-        "prob": 90
-      },
-      { "item": "condom", "prob": 10 }
-    ]
   }
 ]

--- a/data/json/mapgen/cs_sex_shop.json
+++ b/data/json/mapgen/cs_sex_shop.json
@@ -2,7 +2,6 @@
   {
     "type": "mapgen",
     "om_terrain": [ "cs_sex_shop" ],
-    "//": "Sex shop selling illegal drugs under the counter, with cops and police car",
     "weight": 1000,
     "object": {
       "fill_ter": "t_floor",
@@ -13,186 +12,68 @@
         "..y''''yoooy''''y''''y..",
         "..y''''yoooy''''y''''y..",
         "..#######X############..",
-        "..#bbbbb__,,,,,,,,,,,#..",
-        "..#,,,,Á__cccccccccc,#..",
-        "..#,,,,c__,,,,,,,,,,,#..",
-        "..#,cccc__cccccccccc,#..",
-        "..#,,,,,__,,,,,,,,,,,#..",
-        "..#b,_____cccccccccc,#..",
-        "..#b,_tt__,,,,,,,,,,,#..",
-        "..#b,_tt__cccccccccc,#..",
-        "..#b,_tt__________,,,#..",
-        "..#b,_________rr__bbb#..",
-        "..#b,,,,,,,,,_rr_____#..",
-        "..#bcccccccc,_____bbb#..",
+        "..#bbb #__           #..",
+        "..#    c__vvvvvvvvvv #..",
+        "..#    c__           #..",
+        "..# cccc__vvvvvvvvvv #..",
+        "..#     __           #..",
+        "..#b _____uuuuuuuuuu #..",
+        "..#b _tt__           #..",
+        "..#b _tt__uuuuuuuuuu #..",
+        "..#b _tt__________   #..",
+        "..#b _________tt__bbb#..",
+        "..#b         _tt_____#..",
+        "..#buuuuuuuu _____bbb#..",
         "..#|||||||||||||x||||#..",
-        "..#B,B,,BBB,|,,,,,D,T#..",
-        "..#BB,,,,,,,x,|||||||#..",
-        "..#BBB,,CCC,|,x,,,,,s#..",
-        "..###########X#hLLB,s#..",
+        "..#         |     x T#..",
+        "..#         x |||||||#..",
+        "..#     uuu | x     s#..",
+        "..###########X#hLL  s#..",
         "....4ooooooooo########.."
       ],
       "palettes": [ "parametrized_carpets_palette", "parametrized_walls_palette" ],
+      "place_nested": [ { "chunks": [ [ "sexshop_nest_legal", 9 ], [ "sexshop_nest_illegal", 1 ] ], "x": 0, "y": 0 } ],
       "terrain": {
         ".": "t_region_groundcover_urban",
-        ",": "t_floor",
         "_": { "param": "carpet_color_type", "fallback": "t_carpet_green" },
         "t": { "param": "carpet_color_type", "fallback": "t_carpet_green" },
-        "r": { "param": "carpet_color_type", "fallback": "t_carpet_green" },
         "X": "t_door_metal_pickable",
         "x": "t_door_locked_interior",
         "y": "t_pavement_y",
         "'": "t_pavement",
         "o": "t_sidewalk",
-        "4": "t_gutter_downspout",
-        "D": "t_door_c_peep"
+        "4": "t_gutter_downspout"
       },
       "furniture": {
-        "C": "f_rack",
-        "Á": "f_counter",
-        "c": "f_displaycase",
+        "c": "f_counter",
         "b": "f_bookcase",
         "t": "f_mannequin",
-        "r": "f_mannequin",
-        "B": "f_cardboard_box",
         "T": "f_toilet",
         "s": "f_sofa",
         "L": "f_locker",
-        "h": "f_armchair"
+        "h": "f_armchair",
+        "u": "f_rack",
+        "v": "f_displaycase"
       },
-      "toilets": { "T": {  } },
+      "place_items": [
+        { "item": "cash_register_random", "x": 7, "y": 7 },
+        { "item": "SUS_sex_shop_shelf", "x": [ 10, 19 ], "y": 7, "repeat": 9 },
+        { "item": "SUS_sex_shop_shelf", "x": [ 10, 19 ], "y": 9, "repeat": 9 },
+        { "item": "sex_clothes", "x": [ 10, 19 ], "y": 11, "repeat": [ 9, 90 ] },
+        { "item": "underwear_womens", "x": [ 10, 19 ], "y": 13, "repeat": [ 9, 90 ] },
+        { "item": "SUS_sex_shop_shelf", "x": [ 4, 11 ], "y": 17, "repeat": 7 },
+        { "item": "SUS_sex_shop_shelf", "x": [ 8, 10 ], "y": 21, "repeat": [ 6, 8 ] }
+      ],
+      "place_item": [ { "item": "extinguisher", "x": 6, "y": 6 } ],
       "items": {
-        "B": [
-          { "item": "stash_drugs", "chance": 30, "repeat": [ 1, 3 ] },
-          { "item": "porn_literature", "chance": 25, "repeat": [ 1, 3 ] },
-          { "item": "sex_accessories_commercial", "chance": 45, "repeat": [ 1, 3 ] },
-          { "item": "sex_clothes", "chance": 25, "repeat": [ 1, 3 ] }
-        ],
-        "C": [ { "item": "sex_accessories_commercial", "chance": 25 }, { "item": "sex_clothes", "chance": 15 } ],
-        "s": { "item": "backroom", "chance": 60 },
-        "c": { "item": "sex_accessories_commercial", "chance": 40, "repeat": [ 1, 3 ] },
-        "b": { "item": "porn_literature", "chance": 50, "repeat": [ 1, 3 ] },
-        "t": { "item": "sex_clothes", "chance": 80 },
-        "Á": { "item": "cash_register_random", "chance": 100 },
-        "r": { "item": "sex_accessories_commercial", "chance": 80, "repeat": [ 1, 3 ] },
-        "L": { "item": "cleaning", "chance": 30 },
-        "T": { "item": "SUS_toilet", "chance": 50 }
+        "s": { "item": "backroom" },
+        "c": { "item": "SUS_sex_shop_shelf" },
+        "b": { "item": "SUS_commercial_shelf_porn_literature" },
+        "t": { "item": "sex_clothes", "repeat": [ 3, 5 ] },
+        "L": { "item": "cleaning" },
+        "T": { "item": "SUS_toilet" }
       },
-      "place_loot": [
-        { "item": "roadmap", "x": 3, "y": 6, "chance": 10 },
-        { "item": "roadmap", "x": 5, "y": 6, "chance": 10 },
-        { "item": "touristmap", "x": 4, "y": 6, "chance": 10 },
-        { "item": "touristmap", "x": 6, "y": 6, "chance": 10 },
-        { "item": "syringe", "x": 20, "y": 19, "chance": 5 },
-        { "item": "mop", "x": [ 4, 5 ], "y": [ 7, 8 ], "chance": 2 },
-        { "item": "extinguisher", "x": 3, "y": 7, "chance": 5 },
-        { "item": "television", "x": 6, "y": 13, "chance": 5 },
-        { "item": "television", "x": 7, "y": 13, "chance": 5 }
-      ],
-      "place_vehicles": [
-        { "vehicle": "motorcycle", "x": 4, "y": 2, "rotation": 270, "chance": 25 },
-        { "vehicle": "motorcycle", "x": 6, "y": 2, "rotation": 90, "chance": 25 },
-        { "vehicle": "policecar", "x": 12, "y": 2, "rotation": 180, "chance": 90 },
-        { "vehicle": "car", "x": 19, "y": 2, "rotation": 0, "chance": 10 }
-      ],
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE_SEXSHOP_A", "x": [ 1, 23 ], "y": [ 0, 22 ], "density": 0.3 } ]
-    }
-  },
-  {
-    "type": "mapgen",
-    "om_terrain": [ "cs_sex_shop" ],
-    "//": "Same as the first sex shop but without drugs and no cops or a police car",
-    "weight": 1000,
-    "object": {
-      "fill_ter": "t_floor",
-      "rows": [
-        "..y''''yoooy''''y''''y..",
-        "..y''''yoooy''''y''''y..",
-        "..y''''yoooy''''y''''y..",
-        "..y''''yoooy''''y''''y..",
-        "..y''''yoooy''''y''''y..",
-        "..#######X############..",
-        "..#bbbbb__,,,,,,,,,,,#..",
-        "..#,,,,Á__cccccccccc,#..",
-        "..#,,,,c__,,,,,,,,,,,#..",
-        "..#,cccc__cccccccccc,#..",
-        "..#,,,,,__,,,,,,,,,,,#..",
-        "..#b,_____cccccccccc,#..",
-        "..#b,_tt__,,,,,,,,,,,#..",
-        "..#b,_tt__cccccccccc,#..",
-        "..#b,_tt__________,,,#..",
-        "..#b,_________rr__bbb#..",
-        "..#b,,,,,,,,,_rr_____#..",
-        "..#bcccccccc,_____bbb#..",
-        "..#|||||||||||||x||||#..",
-        "..#B,B,,BBB,|,,,,,D,T#..",
-        "..#BB,,,,,,,x,|||||||#..",
-        "..#BBB,,CCC,|,x,,,,,s#..",
-        "..###########X#hLLB,s#..",
-        "....4ooooooooo########.."
-      ],
-      "palettes": [ "parametrized_carpets_palette", "parametrized_walls_palette" ],
-      "terrain": {
-        ".": "t_region_groundcover_urban",
-        ",": "t_floor",
-        "_": { "param": "carpet_color_type", "fallback": "t_carpet_green" },
-        "t": { "param": "carpet_color_type", "fallback": "t_carpet_green" },
-        "r": { "param": "carpet_color_type", "fallback": "t_carpet_green" },
-        "X": "t_door_metal_pickable",
-        "x": "t_door_locked_interior",
-        "y": "t_pavement_y",
-        "'": "t_pavement",
-        "o": "t_sidewalk",
-        "4": "t_gutter_downspout",
-        "D": "t_door_c_peep"
-      },
-      "furniture": {
-        "C": "f_rack",
-        "Á": "f_counter",
-        "c": "f_displaycase",
-        "b": "f_bookcase",
-        "t": "f_mannequin",
-        "r": "f_mannequin",
-        "B": "f_cardboard_box",
-        "T": "f_toilet",
-        "s": "f_sofa",
-        "L": "f_locker",
-        "h": "f_armchair"
-      },
-      "toilets": { "T": {  } },
-      "items": {
-        "B": [
-          { "item": "porn_literature", "chance": 35, "repeat": [ 1, 3 ] },
-          { "item": "sex_accessories_commercial", "chance": 55, "repeat": [ 1, 3 ] },
-          { "item": "sex_clothes", "chance": 35, "repeat": [ 1, 3 ] }
-        ],
-        "C": [ { "item": "sex_accessories_commercial", "chance": 35 }, { "item": "sex_clothes", "chance": 25 } ],
-        "s": { "item": "backroom", "chance": 60 },
-        "c": { "item": "sex_accessories_commercial", "chance": 40, "repeat": [ 1, 3 ] },
-        "b": { "item": "porn_literature", "chance": 50, "repeat": [ 1, 3 ] },
-        "t": { "item": "sex_clothes", "chance": 80 },
-        "Á": { "item": "cash_register_random", "chance": 100 },
-        "r": { "item": "sex_accessories_commercial", "chance": 80, "repeat": [ 1, 3 ] },
-        "L": { "item": "cleaning", "chance": 30 },
-        "T": { "item": "SUS_toilet", "chance": 50 }
-      },
-      "place_loot": [
-        { "item": "roadmap", "x": 3, "y": 6, "chance": 10 },
-        { "item": "roadmap", "x": 5, "y": 6, "chance": 10 },
-        { "item": "touristmap", "x": 4, "y": 6, "chance": 10 },
-        { "item": "touristmap", "x": 6, "y": 6, "chance": 10 },
-        { "item": "syringe", "x": 20, "y": 19, "chance": 5 },
-        { "item": "mop", "x": [ 4, 5 ], "y": [ 7, 8 ], "chance": 2 },
-        { "item": "extinguisher", "x": 3, "y": 7, "chance": 5 },
-        { "item": "television", "x": 6, "y": 13, "chance": 5 },
-        { "item": "television", "x": 7, "y": 13, "chance": 5 }
-      ],
-      "place_vehicles": [
-        { "vehicle": "motorcycle", "x": 4, "y": 2, "rotation": 270, "chance": 25 },
-        { "vehicle": "motorcycle", "x": 6, "y": 2, "rotation": 90, "chance": 25 },
-        { "vehicle": "car", "x": 19, "y": 2, "rotation": 0, "chance": 10 }
-      ],
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE_SEXSHOP_B", "x": [ 1, 23 ], "y": [ 0, 22 ], "density": 0.2 } ]
+      "toilets": { "T": {  } }
     }
   },
   {
@@ -241,6 +122,87 @@
           "x": [ 4, 13 ],
           "y": [ 9, 12 ]
         }
+      ]
+    }
+  },
+  {
+    "nested_mapgen_id": "sexshop_nest_legal",
+    "type": "mapgen",
+    "object": {
+      "mapgensize": [ 24, 24 ],
+      "rows": [
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "   B B  BBB             ",
+        "   BB                   ",
+        "   BBB                  ",
+        "                 B      ",
+        "                        "
+      ],
+      "furniture": { "B": "f_cardboard_box" },
+      "items": { "B": [ { "item": "SUS_sex_shop_stock" } ] },
+      "place_vehicles": [
+        { "vehicle": "motorcycle", "x": 4, "y": 2, "rotation": 270, "chance": 25 },
+        { "vehicle": "motorcycle", "x": 6, "y": 2, "rotation": 90, "chance": 25 },
+        { "vehicle": "car", "x": 19, "y": 2, "rotation": 0, "chance": 10 }
+      ]
+    }
+  },
+  {
+    "nested_mapgen_id": "sexshop_nest_illegal",
+    "type": "mapgen",
+    "object": {
+      "mapgensize": [ 24, 24 ],
+      "rows": [
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "   B B  BBB             ",
+        "   BB                   ",
+        "   BBB                  ",
+        "                 B      ",
+        "                        "
+      ],
+      "furniture": { "B": "f_cardboard_box" },
+      "items": { "B": [ { "item": "stash_drugs", "chance": 1, "repeat": [ 1, 20 ] }, { "item": "SUS_sex_shop_stock", "chance": 1 } ] },
+      "place_vehicles": [
+        { "vehicle": "motorcycle", "x": 4, "y": 2, "rotation": 270, "chance": 25 },
+        { "vehicle": "motorcycle", "x": 6, "y": 2, "rotation": 90, "chance": 25 },
+        { "vehicle": "policecar", "x": 12, "y": 2, "rotation": 180, "chance": 90 },
+        { "vehicle": "car", "x": 19, "y": 2, "rotation": 0, "chance": 10 }
       ]
     }
   }

--- a/data/json/mapgen/nested/strip_mall_nested.json
+++ b/data/json/mapgen/nested/strip_mall_nested.json
@@ -1448,8 +1448,8 @@
         "m": { "item": "underwear_womens", "chance": 100 },
         "C": { "item": "underwear_womens", "chance": 80, "repeat": [ 4, 8 ] },
         "k": { "item": "SUS_toilet", "chance": 100 },
-        "c": { "item": "sex_accessories_commercial", "chance": 65, "repeat": [ 3, 4 ] },
-        "b": { "item": "porn_literature", "chance": 70, "repeat": [ 3, 4 ] },
+        "c": { "item": "SUS_sex_shop_shelf", "chance": 65 },
+        "b": { "item": "SUS_commercial_shelf_porn_literature", "chance": 70, "repeat": [ 3, 4 ] },
         "t": { "item": "sex_clothes", "chance": 95 },
         "A": { "item": "cash_register_random", "chance": 100 }
       },

--- a/data/json/monstergroups/zombies.json
+++ b/data/json/monstergroups/zombies.json
@@ -793,36 +793,6 @@
     ]
   },
   {
-    "type": "monstergroup",
-    "id": "GROUP_ZOMBIE_SEXSHOP_A",
-    "monsters": [
-      { "monster": "mon_zombie_cop", "weight": 250, "cost_multiplier": 2 },
-      { "monster": "mon_feral_cop", "weight": 2, "cost_multiplier": 3 },
-      { "monster": "mon_zombie_swat", "weight": 25, "cost_multiplier": 2 },
-      { "monster": "mon_zombie_medical", "weight": 50, "cost_multiplier": 2 },
-      { "monster": "mon_zombie", "weight": 325 },
-      {
-        "monster": "mon_zombie_swimmer_base",
-        "weight": 150,
-        "cost_multiplier": 0,
-        "ends": "660 days",
-        "conditions": [ "SPRING", "SUMMER", "AUTUMN" ]
-      },
-      { "monster": "mon_feral_swimmer_kickboard", "weight": 20, "cost_multiplier": 0 },
-      { "monster": "mon_zombie_resort_dancer", "weight": 150, "cost_multiplier": 0 }
-    ]
-  },
-  {
-    "type": "monstergroup",
-    "id": "GROUP_ZOMBIE_SEXSHOP_B",
-    "default": "mon_zombie",
-    "monsters": [
-      { "monster": "mon_zombie", "weight": 250 },
-      { "monster": "mon_zombie_swimmer_base", "weight": 500 },
-      { "monster": "mon_zombie_resort_dancer", "weight": 500 }
-    ]
-  },
-  {
     "id": "GROUP_FIRE",
     "type": "monstergroup",
     "monsters": [


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Content "Update the sex shop mapgen and small related fixes"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Our sex shop mapgen has issues, both code-wise and in terms of simulation.

1. Duplicate mapgen for a "legal" and "illegal" version. That's not how things are done nowadays, it should use nests, parameterized palettes etc.
2. Weird layout, no counter for the cash register, all glass display cases, even for clothes.
3. Complex `rows` field with `,` symbols for the floor that are unnecessary.
4. Very very little loot overall, either people bought all the toys for the cataclysm or something's wrong.
5. Disorganized loot pools, things should be organized in rows and individual shelves as much as possible.
6. Very few SUS itemgroups. The commercial sex toy itemgroup is inappropriate for a store.
7. The illegal version has too little drugs, assuming they're selling it they should have some stock. Not 3 joints in the backroom.
8. Very goofy zombie group spawns, the doors are closed and locked, there is no reason for them to be here, and if they aren't they should be outside. Let a random system spawn zombies here if necessary. The illegal group is even worse, what are the feral policemen still doing here? They aren't going to use the dildos and the drug dealers are zombified.
9. Oh, also 50/50 on sex shops selling drugs? Wtf.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
1. Nests the legal/illegal versions, the mapgen is now unique.
2. Improve layout and furniture.
3. Replace the useless terrain definitions and symbol usage when empty spaces can do the job better, improves readability.
4. Increase the spawns a lot, now you can actually believe a customer could find something in there.
5. Shelves have specific things they spawn, underwear, costumes, toys, smut literature.
6. Sussify a few related itemgroups, rename some, delete some.
7. More drugs in stock.
8. Yeet the zombie group, it's stupid.
9. The illegal shop is only a 10% chance (probably still too high).
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Plenty, behaves as expected.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
