### PR TITLE
Remove from the correct set when sorting

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -9205,7 +9205,7 @@ bool zone_sort_activity_actor::stage_think( player_activity &act, Character &you
     // iterate over zone positions and look for items to move
     for( const tripoint_abs_ms &src : src_sorted ) {
         placement = src;
-        src_set.erase( src );
+        coord_set.erase( src );
 
         const tripoint_bub_ms src_bub = here.get_bub( src );
         if( !here.inbounds( src_bub ) ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fix #83745, i.e. sorting hangs when out of destinations.
Fix #83746, i.e. same thing.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Remove entries from the correct set so it actually shrinks when processed.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
- Change the do_think() processing for zones to check for viable target destinations. That would stop characters from running around to every unprocessed tile with items once the destinations are full. Out of scope.
- Plug a tiny hole in the logic whereby you can fail to sort everything. If two characters are sorting from the same tile but they "see" different zones, it's possible for one to remove an object (through teleportation to a destination) that the other one has passed by. Since processing is done via iterator start + item number, this means you'll skip one item when an item that was at a lower index gets removed. If the other character doesn't sort that item (because it's not within that characters zone set), it will be missed. This is a tiny hole with a low probability of happening (very specific conditions), and with a limited damage when it happens (some items may be left behind). Note that you don't run the risk of multiple characters sorting from the same tile concurrently messing things up in the normal case, becase they are processed sequentially, and each character's processing starts with the item state on the tile when it starts the current step. This will become an issue if parallel processing is introduced.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Loaded my harvesting save (progressed from that in the bug report, but the same basic premise) that hangs without the change and verified the PC is now sorting out as much as possible before running around to the rest like a headless chicken.

Loaded save from #83746 and followed the reproduction steps and then waited 5 minutes. The companions had successfully sorted out the loot.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
This doesn't address vehicle deconstruction issues (a different bug report), as this changes only zone sorting, not vehicle deconstruction. I've now tested this out, and this PR doesn't solve that issue.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
