### PR TITLE
Adjusted activity processing

### DIFF
--- a/src/activity_handlers.h
+++ b/src/activity_handlers.h
@@ -57,6 +57,7 @@ enum class do_activity_reason : int {
     NO_COMPONENTS,          // can't do the activity there due to lack of components /tools
     DONT_HAVE_SKILL,        // don't have the required skill
     NO_ZONE,                // There is no required zone anymore
+    NO_VEHICLE,             // There is no vehicle or no accessible vehicle at this location
     ALREADY_DONE,           // the activity is done already ( maybe by someone else )
     UNKNOWN_ACTIVITY,       // This is probably an error - got to the end of function with no previous reason
     NEEDS_CLEARING,         // For farming - tile was neglected and became overgrown, can be cleared.

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -3004,7 +3004,6 @@ static requirement_check_result generic_multi_activity_check_requirement(
         requirement_data::alter_item_comp_vector component_reqs_vector = reqs.get_components();
         requirement_data::alter_tool_comp_vector reduced_tool_reqs_vector;
         requirement_data::alter_quali_req_vector reduced_quality_reqs_vector;
-        requirement_data::alter_item_comp_vector reduced_component_reqs_vector;
 
         inventory inv = you.crafting_inventory();
 
@@ -3036,22 +3035,8 @@ static requirement_check_result generic_multi_activity_check_requirement(
             }
         }
 
-        for( std::vector<item_comp> &components : component_reqs_vector ) {
-            bool found = false;
-
-            for( item_comp &component : components ) {
-                if( inv.has_components( component.type, component.count ) ) {
-                    found = true;
-                }
-            }
-
-            if( !found ) {
-                reduced_component_reqs_vector.push_back( components );
-            }
-        }
-
         reduced_reqs = requirement_data( reduced_tool_reqs_vector, reduced_quality_reqs_vector,
-                                         reduced_component_reqs_vector );
+                                         component_reqs_vector );
         const requirement_id req_id( std::to_string( reduced_reqs.make_hash() ) );
         if( requirement_data::all().count( req_id ) == 0 ) {
             requirement_data::save_requirement( reduced_reqs, req_id );

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -1463,12 +1463,14 @@ static activity_reason_info can_do_activity_there( const activity_id &act, Chara
         std::vector<int> already_working_indexes;
         vehicle *veh = veh_pointer_or_null( here.veh_at( src_loc ) );
         if( !veh || veh->is_appliance() ) {
-            return activity_reason_info::fail( do_activity_reason::NO_ZONE );
+            return activity_reason_info::fail( do_activity_reason::NO_VEHICLE );
         }
         // if the vehicle is moving or player is controlling it.
         if( std::abs( veh->velocity ) > 100 || veh->player_in_control( here, player_character ) ) {
-            return activity_reason_info::fail( do_activity_reason::NO_ZONE );
+            return activity_reason_info::fail( do_activity_reason::NO_VEHICLE );
         }
+        do_activity_reason result = do_activity_reason::NO_ZONE;
+
         for( const npc &guy : g->all_npcs() ) {
             if( &guy == &you ) {
                 continue;
@@ -1519,6 +1521,9 @@ static activity_reason_info can_do_activity_there( const activity_id &act, Chara
                 }
                 // don't have skill to remove it
                 if( !you.meets_skill_requirements( vpinfo.removal_skills ) ) {
+                    if( result == do_activity_reason::NO_ZONE ) {
+                        result = do_activity_reason::DONT_HAVE_SKILL;
+                    }
                     continue;
                 }
                 item base( vpinfo.base_item );
@@ -1526,6 +1531,7 @@ static activity_reason_info can_do_activity_there( const activity_id &act, Chara
                 const bool use_aid = max_lift >= base.weight();
                 const bool use_str = you.can_lift( base );
                 if( !( use_aid || use_str ) ) {
+                    result = do_activity_reason::NO_COMPONENTS;
                     continue;
                 }
                 const requirement_data &reqs = vpinfo.removal_requirements();
@@ -1562,6 +1568,9 @@ static activity_reason_info can_do_activity_there( const activity_id &act, Chara
                 // don't have skill to repair it
 
                 if( !you.meets_skill_requirements( vpinfo.repair_skills ) ) {
+                    if( result == do_activity_reason::NO_ZONE ) {
+                        result = do_activity_reason::DONT_HAVE_SKILL;
+                    }
                     continue;
                 }
                 const requirement_data &reqs = vpinfo.repair_requirements();
@@ -1579,7 +1588,7 @@ static activity_reason_info can_do_activity_there( const activity_id &act, Chara
             }
         }
         you.activity_vehicle_part_index = -1;
-        return activity_reason_info::fail( do_activity_reason::NO_ZONE );
+        return activity_reason_info::fail( result );
     }
     if( act == ACT_MULTIPLE_MINE ) {
         if( !here.has_flag( ter_furn_flag::TFLAG_MINEABLE, src_loc ) ) {
@@ -1889,7 +1898,7 @@ static activity_reason_info can_do_activity_there( const activity_id &act, Chara
             return activity_reason_info( do_activity_reason::NEEDS_DISASSEMBLE, false, req );
         } else {
             // nothing to disassemble
-            return activity_reason_info::fail( do_activity_reason::NO_ZONE );
+            return activity_reason_info::fail( do_activity_reason::NO_COMPONENTS );
         }
     }
     // Shouldn't get here because the zones were checked previously. if it does, set enum reason as "no zone"
@@ -2813,6 +2822,7 @@ static requirement_check_result generic_multi_activity_check_requirement(
     }
     if( reason == do_activity_reason::DONT_HAVE_SKILL ||
         reason == do_activity_reason::NO_ZONE ||
+        reason == do_activity_reason::NO_VEHICLE ||
         reason == do_activity_reason::ALREADY_DONE ||
         reason == do_activity_reason::BLOCKING_TILE ||
         reason == do_activity_reason::UNKNOWN_ACTIVITY ) {
@@ -2837,9 +2847,10 @@ static requirement_check_result generic_multi_activity_check_requirement(
         if( you.is_npc() ) {
             if( reason == do_activity_reason::DONT_HAVE_SKILL ) {
                 return requirement_check_result::SKIP_LOCATION_NO_SKILL;
-
             } else if( reason == do_activity_reason::NO_ZONE ) {
                 return requirement_check_result::SKIP_LOCATION_NO_ZONE;
+            } else if( reason == do_activity_reason::NO_VEHICLE ) {
+                return requirement_check_result::SKIP_LOCATION_NO_MATCH;
             } else if( reason == do_activity_reason::ALREADY_DONE ) {
                 return requirement_check_result::SKIP_LOCATION;
             } else if( reason == do_activity_reason::BLOCKING_TILE ) {
@@ -2984,6 +2995,69 @@ static requirement_check_result generic_multi_activity_check_requirement(
                            reason == do_activity_reason::NEEDS_VEH_DECONST ||
                            reason == do_activity_reason::NEEDS_VEH_REPAIR ||
                            reason == do_activity_reason::NEEDS_MINING;
+
+        // Remove the requirements already met
+        requirement_data reqs = what_we_need.obj();
+        requirement_data reduced_reqs;
+        requirement_data::alter_tool_comp_vector tool_reqs_vector = reqs.get_tools();
+        requirement_data::alter_quali_req_vector quality_reqs_vector = reqs.get_qualities();
+        requirement_data::alter_item_comp_vector component_reqs_vector = reqs.get_components();
+        requirement_data::alter_tool_comp_vector reduced_tool_reqs_vector;
+        requirement_data::alter_quali_req_vector reduced_quality_reqs_vector;
+        requirement_data::alter_item_comp_vector reduced_component_reqs_vector;
+
+        inventory inv = you.crafting_inventory();
+
+        for( std::vector<tool_comp> &tools : tool_reqs_vector ) {
+            bool found = false;
+
+            for( tool_comp &tool : tools ) {
+                if( inv.has_tools( tool.type, tool.count ) ) {
+                    found = true;
+                }
+            }
+
+            if( !found ) {
+                reduced_tool_reqs_vector.push_back( tools );
+            }
+        }
+
+        for( std::vector<quality_requirement> &qualities : quality_reqs_vector ) {
+            bool found = false;
+
+            for( quality_requirement &qual : qualities ) {
+                if( inv.has_quality( qual.type, qual.level ) ) {
+                    found = true;
+                }
+            }
+
+            if( !found ) {
+                reduced_quality_reqs_vector.push_back( qualities );
+            }
+        }
+
+        for( std::vector<item_comp> &components : component_reqs_vector ) {
+            bool found = false;
+
+            for( item_comp &component : components ) {
+                if( inv.has_components( component.type, component.count ) ) {
+                    found = true;
+                }
+            }
+
+            if( !found ) {
+                reduced_component_reqs_vector.push_back( components );
+            }
+        }
+
+        reduced_reqs = requirement_data( reduced_tool_reqs_vector, reduced_quality_reqs_vector,
+                                         reduced_component_reqs_vector );
+        const requirement_id req_id( std::to_string( reduced_reqs.make_hash() ) );
+        if( requirement_data::all().count( req_id ) == 0 ) {
+            requirement_data::save_requirement( reduced_reqs, req_id );
+        }
+        what_we_need = req_id;
+
         // is it even worth fetching anything if there isn't enough nearby?
         if( !are_requirements_nearby( tool_pickup ? loot_zone_spots : combined_spots, what_we_need, you,
                                       act_id, tool_pickup, src_loc ) ) {
@@ -3029,8 +3103,8 @@ static requirement_check_result generic_multi_activity_check_requirement(
                     for( const tripoint_bub_ms &point_elem :
                          here.points_in_radius( src_loc, /*radius=*/PICKUP_RANGE - 1, /*radiusz=*/0 ) ) {
                         // we don't want to place the components where they could interfere with our ( or someone else's ) construction spots
-                        if( !you.sees( here, point_elem ) || ( std::find( local_src_set.begin(), local_src_set.end(),
-                                                               point_elem ) != local_src_set.end() ) || !here.can_put_items_ter_furn( point_elem ) ) {
+                        if( ( std::find( local_src_set.begin(), local_src_set.end(),
+                                         point_elem ) != local_src_set.end() ) || !here.can_put_items_ter_furn( point_elem ) ) {
                             continue;
                         }
                         candidates.push_back( point_elem );
@@ -3385,7 +3459,9 @@ bool generic_multi_activity_handler( player_activity &act, Character &you, bool 
             activity_to_restore != ACT_MOVE_LOOT &&
             activity_to_restore != ACT_FETCH_REQUIRED &&
             you.fine_detail_vision_mod( you.pos_bub() ) > 4.0 ) {
-            you.add_msg_if_player( m_info, _( "It is too dark to work here." ) );
+            you.add_msg_player_or_npc( m_info, _( "It is too dark to work here." ),
+                                       _( "%s aborts the %s activity because it's too dark to continue." ), you.disp_name(),
+                                       activity_to_restore.c_str() );
             return false;
         }
         if( !check_only ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Improve the activity handling a bit, touching on some problems with #83732.
It's possible this would deal with #81103 (and other similar reports), as it stops tool hoarding, which may be a culprit.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
- Added code to remove requirements fullfilled by the character's inventory from task requirement profiles. This stops the incessant cycle of fetching additional tools with the same quality.
- Remove the requirement that the actor has to be able to see the target location. With it, one of the actors in the bug reports just fails to get on with vehicle deconstruction because the target location can't be seen from within the room he's in. I'm somewhat puzzled by this, as I thought this evalutation should only be done when at the scene. Note that this is also the reason only the character's inventory is considered in the point above. If the actors SHOULD be guaranteed to be at the location a normal crafting inventory range could have been used.
- Added a new failure reason for vehicle interactions and adjusted the processing vehicle interaction code so a sensible reason for failures is returned rather than NO ZONE. When the target sight condition is present at the point above, the bug report save returns missing skills instead, because skills are indeed missing to remove some components.
- Added a few feedback messages. While it technically isn't correct to inform the player that a companion can't work due to a lack of light when not visible, I believe there's a need for more feedback as to why companions stop their work prematurely.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
- Try to figure out if the light requirement is sort of valid and the character is supposed to be at the work site when evaluating resources, and, if so, figure out why that's not the case in the bug report save.
- There's a lot of weird stuff going on in the bug report save. Companions start activities by themselves, and switch activities, resulting in occasional error reports about starting activities when activites are active. I suspect it's some kind of camp automation going on, and I'll stay clear of that if I can. Regardless, I consider it out of scope.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
In the bug report save, characters start to work on the deconstruction of the vehicle, and there's no tool hoarding anymore.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
It doesn't help that the bug report save has active smoking going on, resulting in smoke that blocks companion pathing. They're apparently incapable of repathing around the temporary smoke, so they do a silly back and forth dance.

There's a LOT of work required to get this to both work smoothly, and to provide useful feedback to the player. Since it seems the requirements are available to the point where items are picked up/teleported, it ought to be possible to pick up/teleport multiple items from a source tile when available rather than one at a time. That may require the adjustment of the requirements data as requirements are fulfulled, unless it's all done in the same action (as opposed to one item per do_turn call).

I would appreciate help with understanding if characters are supposed to always be at the target site when evaluating resource needs, or it that might be something that's required only for certain activities that expect a lot of materials at the site.

Edit:
Reducing the requirements with carried components causes a test to fail, so that part was removed. I haven't analyzed it, but I suspect the code determining what to teleport to the construction site reduces the amount by what's already carried, and so removal from the requirements constitutes double dipping.

It can be noted that there may be a lingering issue with tools with charges, as the code only removes the requirement if the full amount of charges are carried, so the original behavior should remain when the carried charges are fewer than that. I don't know if the fetching code takes carried charges into consideration, or if the requirements reduction code should reduce the number of charges by what's already carried.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
