### PR TITLE
[Magiclysm] Magiclysm butchering empathy fix

### DIFF
--- a/data/mods/Magiclysm/mod_interactions/xedra_evolved/traits.json
+++ b/data/mods/Magiclysm/mod_interactions/xedra_evolved/traits.json
@@ -10,6 +10,7 @@
     "starting_trait": false,
     "purifiable": false,
     "valid": false,
+    "empathize_with": [ "GOBLIN", "RAVENFOLK", "LIZARDFOLK", "ELF", "DWARF", "HUMAN" ],
     "flags": [ "HERITAGE" ]
   }
 ]

--- a/data/mods/Magiclysm/monsters/zombified_fantasy_species.json
+++ b/data/mods/Magiclysm/monsters/zombified_fantasy_species.json
@@ -4,6 +4,7 @@
     "id": "mon_zombie_dwarf",
     "name": { "str": "zombie dwarf", "str_pl": "zombie dwarves" },
     "copy-from": "mon_zombie_tough",
+    "species": [ "ZOMBIE", "DWARF" ],
     "description": "Once a dwarf, this zombie now has rent flesh and a beard in tatters.  Its face is twisted in an expression of rage.",
     "proportional": { "volume": 0.7, "weight": 0.9 },
     "speed": 65,
@@ -17,6 +18,7 @@
     "id": "mon_zombie_dwarf_miner",
     "name": { "str": "zombie dwarven miner" },
     "copy-from": "mon_zombie_miner",
+    "species": [ "ZOMBIE", "DWARF" ],
     "description": "Once a dwarven miner, this zombie now has rent flesh and a beard in tatters.  Its face is twisted in an expression of rage.",
     "proportional": { "hp": 1.2, "volume": 0.7, "weight": 0.9, "speed": 0.9 },
     "//": "Better night vision than default zombies, but not as good as living dwarves, and worse day vision.",
@@ -29,6 +31,7 @@
     "id": "mon_zombie_elf",
     "name": { "str": "zombie elf", "str_pl": "zombie elves" },
     "copy-from": "mon_zombie",
+    "species": [ "ZOMBIE", "ELF" ],
     "description": "Its face twisted in an expression of pure rage and with glassy eyes, this elf looks nothing like the ethereal elves from before the Cataclysm.  Though it also lacks the elves' characteristic grace, its movements are quieter than the other dead.",
     "proportional": { "hp": 0.82, "speed": 1.03, "weight": 0.85 },
     "//": "Better night vision than default zombies, but not as good as living elves.",
@@ -116,7 +119,7 @@
     ],
     "vision_day": 35,
     "death_drops": "feral_ravenfolk_death_drops",
-    "upgrades": { "half_life": 360, "into_group": "GROUP_ZOMBIE_RAVENFOLK_UPGRADE" }
+    "upgrades": { "half_life": 120, "into_group": "GROUP_ZOMBIE_RAVENFOLK_UPGRADE" }
   },
   {
     "id": "mon_zombie_lizardfolk",
@@ -124,7 +127,7 @@
     "type": "MONSTER",
     "name": { "str_sp": "zombie lizardfolk" },
     "description": "A proud servant of dragons reduced to a walking corpse, this lizardfolk's scales are streaked with grime and its black eyes burn with rage.  It has not lost its teeth and claws in the transition to undeath.",
-    "species": [ "LIZARDFOLK" ],
+    "species": [ "LIZARDFOLK", "ZOMBIE" ],
     "volume": "80 L",
     "weight": "100 kg",
     "weakpoint_sets": [ "wps_humanoid_body" ],

--- a/data/mods/Magiclysm/mutations/mutation_paths/fantasy_species.json
+++ b/data/mods/Magiclysm/mutations/mutation_paths/fantasy_species.json
@@ -13,6 +13,7 @@
     "points": 1,
     "visibility": 2,
     "description": "Elves might say you are short-lived, and goblins might say you are strong, but the one thing humans really are is tenacious.  Hopefully that will serve you well after the Cataclysm.",
+    "empathize_with": [ "GOBLIN", "RAVENFOLK", "LIZARDFOLK", "ELF", "DWARF", "HUMAN" ],
     "flags": [ "HERITAGE" ]
   },
   {
@@ -183,6 +184,7 @@
     "ugliness": 0,
     "description": "Dwarves are smaller than humans, the better to deal with confined spaces underground, but as solid as the mountains (+2 STR, -1 DEX).",
     "category": [ "SPECIES_DWARF" ],
+    "empathize_with": [ "GOBLIN", "RAVENFOLK", "LIZARDFOLK", "ELF", "DWARF", "HUMAN" ],
     "enchantments": [
       {
         "values": [
@@ -328,6 +330,7 @@
     "description": "Elves are more lithe and frail than humans, but possess an almost otherworldly grace (-1 STR, +2 DEX).",
     "category": [ "SPECIES_ELF" ],
     "threshreq": [ "THRESH_SPECIES_ELF" ],
+    "empathize_with": [ "GOBLIN", "RAVENFOLK", "LIZARDFOLK", "ELF", "DWARF", "HUMAN" ],
     "enchantments": [
       {
         "condition": "ALWAYS",
@@ -552,6 +555,7 @@
     "category": [ "SPECIES_GOBLIN" ],
     "anger_relations": [ [ "WARG", -90 ] ],
     "spells_learned": [ [ "goblin_tame_warg_spell", 1 ] ],
+    "empathize_with": [ "GOBLIN", "RAVENFOLK", "LIZARDFOLK", "ELF", "DWARF", "HUMAN" ],
     "enchantments": [
       {
         "values": [
@@ -653,6 +657,7 @@
     "ugliness": 0,
     "description": "Lizardfolk are taller and stronger than humans but not much thicker and are surprisingly fast for their size (+1 STR, +1 DEX).",
     "category": [ "SPECIES_LIZARDFOLK" ],
+    "empathize_with": [ "GOBLIN", "RAVENFOLK", "LIZARDFOLK", "ELF", "DWARF", "HUMAN" ],
     "enchantments": [
       { "condition": { "u_has_trait": "SLIT_NOSTRILS" }, "encumbrance_modifier": [ { "part": "mouth", "add": -10 } ] },
       { "condition": { "u_has_trait": "SCALES" }, "encumbrance_modifier": [ { "part": "mouth", "add": -1 } ] },
@@ -788,6 +793,7 @@
     "description": "Ravenfolk are about the same size as humans, though their feathers and wings obviously set them apart.",
     "category": [ "SPECIES_RAVENFOLK" ],
     "enchantments": [ { "values": [ { "value": "WEIGHT", "multiply": -0.25 } ] } ],
+    "empathize_with": [ "GOBLIN", "RAVENFOLK", "LIZARDFOLK", "ELF", "DWARF", "HUMAN" ],
     "flags": [ "HERITAGE" ]
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "[Magiclysm] Magiclysm butchering empathy fix"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Goblins, ravenfolk, and lizardfolk weren't triggering the butchering empathy checks. Basically all the species lived among each other and saw each other as people, so this doesn't make sense.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add `"empathize_with": [ "GOBLIN", "RAVENFOLK", "LIZARDFOLK", "ELF", "DWARF", "HUMAN" ]` to each of the species traits, including for humans, making sure all species empathize with each other.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

As an elf, tried to butcher the corpse of a feral lizardfolk, a feral goblin, and a ravenfolk zombie. In each cases, the desecration warning popped up.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
