### PR TITLE
Super Glue can be used for wound care

### DIFF
--- a/data/json/items/chemicals_and_resources.json
+++ b/data/json/items/chemicals_and_resources.json
@@ -2386,7 +2386,7 @@
     "//": "Represents all glues that can withstand >1800 psi of tensile strength, such as cyanoacrylate, polyurethane and epoxy.",
     "//1": "1 charge of strong glue should cover an area of 5mm^2",
     "name": { "str_sp": "strong glue" },
-    "description": "A strong adhesive to use for structural repairs or other high stress applications.  You can't sniff it. But, you can use it to close up wounds in a pinch.",
+    "description": "A strong adhesive to use for structural repairs or other high stress applications.  You can't sniff it, but you can use it to close up wounds in a pinch.",
     "price_postapoc": "10 cents",
     "use_action": { "type": "heal", "bandages_power": 1, "bleed": 5, "move_cost": 400 }
   }

--- a/data/json/items/chemicals_and_resources.json
+++ b/data/json/items/chemicals_and_resources.json
@@ -2387,6 +2387,7 @@
     "//1": "1 charge of strong glue should cover an area of 5mm^2",
     "name": { "str_sp": "strong glue" },
     "description": "A strong adhesive to use for structural repairs or other high stress applications.  You can't sniff it.",
-    "price_postapoc": "10 cents"
+    "price_postapoc": "10 cents",
+    "use_action": { "type": "heal", "bandages_power": 1, "bleed": 5, "move_cost": 400 }
   }
 ]

--- a/data/json/items/chemicals_and_resources.json
+++ b/data/json/items/chemicals_and_resources.json
@@ -2388,6 +2388,6 @@
     "name": { "str_sp": "strong glue" },
     "description": "A strong adhesive to use for structural repairs or other high stress applications.  You can't sniff it. But, you can use it to close up wounds in a pinch.",
     "price_postapoc": "10 cents",
-    "use_action": { "type": "heal", "bandages_power": 2, "bleed": 5, "move_cost": 400 }
+    "use_action": { "type": "heal", "bandages_power": 1, "bleed": 5, "move_cost": 400 }
   }
 ]

--- a/data/json/items/chemicals_and_resources.json
+++ b/data/json/items/chemicals_and_resources.json
@@ -2386,8 +2386,8 @@
     "//": "Represents all glues that can withstand >1800 psi of tensile strength, such as cyanoacrylate, polyurethane and epoxy.",
     "//1": "1 charge of strong glue should cover an area of 5mm^2",
     "name": { "str_sp": "strong glue" },
-    "description": "A strong adhesive to use for structural repairs or other high stress applications.  You can't sniff it.",
+    "description": "A strong adhesive to use for structural repairs or other high stress applications.  You can't sniff it. But, you can use it to close up wounds in a pinch.",
     "price_postapoc": "10 cents",
-    "use_action": { "type": "heal", "bandages_power": 1, "bleed": 5, "move_cost": 400 }
+    "use_action": { "type": "heal", "bandages_power": 2, "bleed": 5, "move_cost": 400 }
   }
 ]

--- a/data/json/items/chemicals_and_resources.json
+++ b/data/json/items/chemicals_and_resources.json
@@ -2388,6 +2388,6 @@
     "name": { "str_sp": "strong glue" },
     "description": "A strong adhesive to use for structural repairs or other high stress applications.  You can't sniff it, but you can use it to close up wounds in a pinch.",
     "price_postapoc": "10 cents",
-    "use_action": { "type": "heal", "bandages_power": 1, "bleed": 5, "move_cost": 400 }
+    "use_action": { "type": "heal", "bandages_power": 1, "bleed": 4, "move_cost": 1000 }
   }
 ]


### PR DESCRIPTION
#### Summary
Balance "Super Glue can be used for wound care"
#### Purpose of change

Superglue cannot be used for wound care at the moment. IRL, it is alright for wound care, even invented originally for that purpose.

Also, more options for a desperate survivor are a good thing, especially if you would expect them to be viable IRL. 

#### Describe the solution

Gave it the wound care use action. It is not particularly great, having values ~ that of a makeshift bandage.

#### Describe alternatives you've considered

different values? I gave it the bandage strength of a makeshift bandage, slightly less bleeding protection but better use time 4 seconds, (~80% longer then adhesive bandage spray) 

I dont have hard numbers on this, but i think 10 uses for wound care for a small superglue bottle seems reasonable, so I think default units / charge usage is fine here.  

#### Testing
let a zombie wack me and used the glue to patch it up. 

#### Additional context
https://www.mayoclinichealthsystem.org/hometown-health/speaking-of-health/should-super-glue-be-in-your-first-aid-kit'


'super glue can be a viable option if used under the right circumstances (small and clean cut, not too deep and not infectious)'
