### PR TITLE
fix the loops on autodriving routes

### DIFF
--- a/src/vehicle_autodrive.cpp
+++ b/src/vehicle_autodrive.cpp
@@ -1303,7 +1303,6 @@ std::optional<navigation_step> vehicle::autodrive_controller::compute_next_step(
             square_dist( first_step.pos.xy().raw(), second_step.pos.xy().raw() ) !=
             square_dist( first_step.pos.xy().raw(), veh_pos.xy().raw() ) &&
             first_step.steering_dir == second_step.steering_dir ) {
-            data.path.pop_back();
             maintain_speed = true;
             data.path.clear();
         } else {
@@ -1443,8 +1442,12 @@ autodrive_result vehicle::do_autodrive( map &here, Character &driver )
     const tripoint_abs_ms veh_pos = pos_abs();
     const tripoint_abs_omt veh_omt = project_to<coords::omt>( veh_pos );
     std::vector<tripoint_abs_omt> &omt_path = driver.omt_path;
-    while( !omt_path.empty() && veh_omt.xy() == omt_path.back().xy() ) {
-        omt_path.pop_back();
+    const auto veh_on_path = std::find_if( omt_path.rbegin(),
+    omt_path.rend(), [xy = veh_omt.xy()]( const auto & path ) {
+        return path.xy() == xy;
+    } );
+    if( veh_on_path != omt_path.rend() ) {
+        omt_path.erase( ( veh_on_path + 1 ).base(), omt_path.end() );
     }
     if( omt_path.empty() ) {
         stop_autodriving( false );


### PR DESCRIPTION
#### Summary

Bugfixes "loops on autodrive routes"

#### Purpose of change

Fixes #83776

#### Describe the solution

Detailed problem description is in the issue, and the solution is removing not just the last matching node from the global path, but whole section of the global path from the end to the current vehicle position.
It scans the path from the end, so in the most cases it matches the first encountered element and removes it. But in case if we jumped over a few (most probably just one) path nodes, it removes the whole section to avoid "visiting" that skipped node. 

#### Describe alternatives you've considered

Don't know.

#### Testing

Using bug report save

#### Additional context

There is a single-line kind of unrelated change where I removed unnecessary `pop_back` just before explicit `clear` call. I don't feel that it requires separated PR, but it's doable.
