### PR TITLE
Mission Re-clarification: Cattail Gathering

### DIFF
--- a/data/json/npcs/missiondef.json
+++ b/data/json/npcs/missiondef.json
@@ -811,7 +811,7 @@
     "id": "MISSION_LEARN_ABOUT_CATTAIL_JELLY",
     "type": "mission_definition",
     "name": { "str": "Gather cattail stalks to create cattail jelly" },
-    "description": "Gather <color_light_blue>60 cattail stalks</color> from the swamp and bring them back to <color_light_red>learn how to craft cattail jelly</color>.  Raise your <color_light_blue>survival skill to at least 1</color> by harvesting cattail stalks.  <color_light_blue>Bring back the provided bag with the 60 cattail stalks in them</color> as well.",
+    "description": "Gather <color_yellow>60 cattail stalks</color> from the swamp and bring them back to <color_light_red>learn how to craft cattail jelly</color>.  Raise your <color_yellow>survival skill to at least 1</color> by harvesting cattail stalks.  <color_yellow>Bring back the provided bag with the 60 cattail stalks in them</color> as well.",
     "goal": "MGOAL_CONDITION",
     "goal_condition": {
       "and": [


### PR DESCRIPTION


#### Summary
None

#### Purpose of change
Change some text's color from light blue to yellow in the cattail gathering mission cuz yellow text pops up more noticeably.

#### Describe the solution
`<color_light_blue>` -> `<color_yellow>`.

#### Describe alternatives you've considered
Let it be confusing forever.

#### Testing
![Screenshot_20251117_014900](https://github.com/user-attachments/assets/de9046d6-d9ce-4f33-ad9c-a50fc9085506)

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
