### PR TITLE
Separate item spawn rate from combat difficulty slider

### DIFF
--- a/data/core/world_option_sliders.json
+++ b/data/core/world_option_sliders.json
@@ -112,9 +112,7 @@
         "level": 0,
         "name": "Abundant",
         "description": "Plenty of items can be found.",
-        "options": [
-          { "option": "ITEM_SPAWNRATE", "type": "float", "val": 1.5 }
-        ]
+        "options": [ { "option": "ITEM_SPAWNRATE", "type": "float", "val": 1.5 } ]
       },
       {
         "level": 1,

--- a/data/core/world_option_sliders.json
+++ b/data/core/world_option_sliders.json
@@ -136,10 +136,7 @@
         "level": 4,
         "name": "Rare loot",
         "description": "Items are half as likely to spawn.",
-        "options": [
-
-          { "option": "ITEM_SPAWNRATE", "type": "float", "val": 0.5 }
-        ]
+        "options": [ { "option": "ITEM_SPAWNRATE", "type": "float", "val": 0.5 } ]
       }
     ]
   },

--- a/data/core/world_option_sliders.json
+++ b/data/core/world_option_sliders.json
@@ -101,7 +101,7 @@
       }
     ]
   },
-    {
+  {
     "type": "option_slider",
     "id": "world_item_rarity",
     "context": "WORLDGEN",

--- a/data/core/world_option_sliders.json
+++ b/data/core/world_option_sliders.json
@@ -132,9 +132,7 @@
         "level": 3,
         "name": "Uncommon",
         "description": "Items are 25% less common than default.",
-        "options": [
-          { "option": "ITEM_SPAWNRATE", "type": "float", "val": 0.75 }
-        ]
+        "options": [ { "option": "ITEM_SPAWNRATE", "type": "float", "val": 0.75 } ]
       },
       {
         "level": 4,

--- a/data/core/world_option_sliders.json
+++ b/data/core/world_option_sliders.json
@@ -124,9 +124,7 @@
         "level": 2,
         "name": "Cataclysm",
         "description": "The default monster hunting and item collecting experience.",
-        "options": [
-          { "option": "ITEM_SPAWNRATE", "type": "float", "val": 1 }
-        ]
+        "options": [ { "option": "ITEM_SPAWNRATE", "type": "float", "val": 1 } ]
       },
       {
         "level": 3,

--- a/data/core/world_option_sliders.json
+++ b/data/core/world_option_sliders.json
@@ -118,9 +118,7 @@
         "level": 1,
         "name": "Common",
         "description": "Items spawn 25% more than default.",
-        "options": [
-          { "option": "ITEM_SPAWNRATE", "type": "float", "val": 1.25 }
-        ]
+        "options": [ { "option": "ITEM_SPAWNRATE", "type": "float", "val": 1.25 } ]
       },
       {
         "level": 2,

--- a/data/core/world_option_sliders.json
+++ b/data/core/world_option_sliders.json
@@ -36,13 +36,12 @@
       {
         "level": 0,
         "name": "Cakewalk?",
-        "description": "Monsters are much easier to deal with, and plenty of items can be found.",
+        "description": "Monsters are much easier to deal with.",
         "options": [
           { "option": "MONSTER_SPEED", "type": "int", "val": 90 },
           { "option": "MONSTER_RESILIENCE", "type": "int", "val": 75 },
           { "option": "SPAWN_DENSITY", "type": "float", "val": 0.8 },
-          { "option": "EVOLUTION_INVERSE_MULTIPLIER", "type": "float", "val": 2 },
-          { "option": "ITEM_SPAWNRATE", "type": "float", "val": 1.5 }
+          { "option": "EVOLUTION_INVERSE_MULTIPLIER", "type": "float", "val": 2 }
         ]
       },
       {
@@ -53,20 +52,18 @@
           { "option": "MONSTER_SPEED", "type": "int", "val": 100 },
           { "option": "MONSTER_RESILIENCE", "type": "int", "val": 85 },
           { "option": "SPAWN_DENSITY", "type": "float", "val": 0.9 },
-          { "option": "EVOLUTION_INVERSE_MULTIPLIER", "type": "float", "val": 1.5 },
-          { "option": "ITEM_SPAWNRATE", "type": "float", "val": 1 }
+          { "option": "EVOLUTION_INVERSE_MULTIPLIER", "type": "float", "val": 1.5 }
         ]
       },
       {
         "level": 2,
         "name": "Cataclysm",
-        "description": "The default monster hunting and item collecting experience.",
+        "description": "The default monster hunting experience.",
         "options": [
           { "option": "MONSTER_SPEED", "type": "int", "val": 100 },
           { "option": "MONSTER_RESILIENCE", "type": "int", "val": 100 },
           { "option": "SPAWN_DENSITY", "type": "float", "val": 1 },
-          { "option": "EVOLUTION_INVERSE_MULTIPLIER", "type": "float", "val": 1 },
-          { "option": "ITEM_SPAWNRATE", "type": "float", "val": 1 }
+          { "option": "EVOLUTION_INVERSE_MULTIPLIER", "type": "float", "val": 1 }
         ]
       },
       {
@@ -77,31 +74,78 @@
           { "option": "MONSTER_SPEED", "type": "int", "val": 100 },
           { "option": "MONSTER_RESILIENCE", "type": "int", "val": 120 },
           { "option": "SPAWN_DENSITY", "type": "float", "val": 1.5 },
-          { "option": "EVOLUTION_INVERSE_MULTIPLIER", "type": "float", "val": 0.91 },
-          { "option": "ITEM_SPAWNRATE", "type": "float", "val": 1 }
+          { "option": "EVOLUTION_INVERSE_MULTIPLIER", "type": "float", "val": 0.91 }
         ]
       },
       {
         "level": 4,
         "name": "Punish me",
-        "description": "Monsters are significantly tougher and faster, spawn more, and evolve faster.  Items are a bit rarer too.",
+        "description": "Monsters are significantly tougher and faster, spawn more, and evolve faster.",
         "options": [
           { "option": "MONSTER_SPEED", "type": "int", "val": 110 },
           { "option": "MONSTER_RESILIENCE", "type": "int", "val": 150 },
           { "option": "SPAWN_DENSITY", "type": "float", "val": 2 },
-          { "option": "EVOLUTION_INVERSE_MULTIPLIER", "type": "float", "val": 0.88 },
-          { "option": "ITEM_SPAWNRATE", "type": "float", "val": 0.8 }
+          { "option": "EVOLUTION_INVERSE_MULTIPLIER", "type": "float", "val": 0.88 }
         ]
       },
       {
         "level": 5,
         "name": "Punish me more!",
-        "description": "Monsters are much tougher, extremely fast, and spawn 3x more.  Items are half as likely to spawn.",
+        "description": "Monsters are much tougher, extremely fast, and spawn 3x more.",
         "options": [
           { "option": "MONSTER_SPEED", "type": "int", "val": 120 },
           { "option": "MONSTER_RESILIENCE", "type": "int", "val": 200 },
           { "option": "SPAWN_DENSITY", "type": "float", "val": 3 },
-          { "option": "EVOLUTION_INVERSE_MULTIPLIER", "type": "float", "val": 0.75 },
+          { "option": "EVOLUTION_INVERSE_MULTIPLIER", "type": "float", "val": 0.75 }
+        ]
+      }
+    ]
+  },
+    {
+    "type": "option_slider",
+    "id": "world_item_rarity",
+    "context": "WORLDGEN",
+    "name": "Item Rarity",
+    "default": 2,
+    "levels": [
+      {
+        "level": 0,
+        "name": "Abundant",
+        "description": "Plenty of items can be found.",
+        "options": [
+          { "option": "ITEM_SPAWNRATE", "type": "float", "val": 1.5 }
+        ]
+      },
+      {
+        "level": 1,
+        "name": "Common",
+        "description": "Items spawn 25% more than default.",
+        "options": [
+          { "option": "ITEM_SPAWNRATE", "type": "float", "val": 1.25 }
+        ]
+      },
+      {
+        "level": 2,
+        "name": "Cataclysm",
+        "description": "The default monster hunting and item collecting experience.",
+        "options": [
+          { "option": "ITEM_SPAWNRATE", "type": "float", "val": 1 }
+        ]
+      },
+      {
+        "level": 3,
+        "name": "Uncommon",
+        "description": "Items are 25% less common than default.",
+        "options": [
+          { "option": "ITEM_SPAWNRATE", "type": "float", "val": 0.75 }
+        ]
+      },
+      {
+        "level": 4,
+        "name": "Rare loot",
+        "description": "Items are half as likely to spawn.",
+        "options": [
+
           { "option": "ITEM_SPAWNRATE", "type": "float", "val": 0.5 }
         ]
       }


### PR DESCRIPTION
Decouple item spawn rate from combat difficulty and move it to its own slider

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Interface "Separate item spawn rate from combat difficulty slider"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

I didn’t like being forced to choose between high difficulty with low loot or low difficulty with high loot. I prefer easier combat with lower loot, and I feel these two systems shouldn’t be linked. Moving item spawn rate to its own slider provides flexibility while still maintaining constraints to avoid item-spawn oddities.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
I removed the item spawn rate fields from the Combat Difficulty slider and moved them into a dedicated Item Spawn Rate slider.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
none
#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->
I loaded multiple worlds using high-difficulty/high-loot and low-difficulty/low-loot combinations, and both behaved as expected with the intended results.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
