### PR TITLE
Aftershock: Fix a pair of comestible temperature bugs.

### DIFF
--- a/data/json/furniture_and_terrain/terrain-liquids.json
+++ b/data/json/furniture_and_terrain/terrain-liquids.json
@@ -484,7 +484,7 @@
     "flags": [ "TRANSPARENT", "LIQUID", "NO_SCENT", "SWIMMABLE", "SHALLOW_WATER" ],
     "connect_groups": "WATER",
     "connects_to": "WATER",
-    "liquid_source": { "id": "water_murky" },
+    "liquid_source": { "id": "water_murky", "min_temp": 70 },
     "examine_action": "water_source"
   },
   {

--- a/data/mods/aftershock_exoplanet/maps/furniture_and_terrain/furniture_spaceship.json
+++ b/data/mods/aftershock_exoplanet/maps/furniture_and_terrain/furniture_spaceship.json
@@ -10,7 +10,7 @@
     "move_cost_mod": -1,
     "coverage": 55,
     "required_str": -1,
-    "flags": [ "FLAMMABLE_ASH", "CONTAINER", "PLACE_ITEM", "ORGANIC", "MOUNTABLE", "FLAT_SURF", "NO_SELF_CONNECT" ],
+    "flags": [ "FLAMMABLE_ASH", "USABLE_FIRE", "CONTAINER", "PLACE_ITEM", "ORGANIC", "MOUNTABLE", "FLAT_SURF", "NO_SELF_CONNECT" ],
     "connect_groups": "COUNTER",
     "connects_to": "COUNTER",
     "deconstruct": {
@@ -19,8 +19,7 @@
         { "item": "rigid_plastic_sheet", "count": 1 },
         { "item": "polycarbonate_sheet", "count": [ 2, 8 ] }
       ]
-    },
-    "crafting_pseudo_item": "fire"
+    }
   },
   {
     "type": "furniture",

--- a/data/mods/aftershock_exoplanet/maps/furniture_and_terrain/terrain_groundxeno.json
+++ b/data/mods/aftershock_exoplanet/maps/furniture_and_terrain/terrain_groundxeno.json
@@ -493,7 +493,7 @@
     "emissions": [ "weak_toxic_dust" ],
     "color": "light_red",
     "move_cost": 6,
-    "liquid_source": { "id": "water_sewage" },
+    "liquid_source": { "id": "water_sewage", "min_temp": 18 },
     "flags": [ "TRANSPARENT", "SWIMMABLE", "SHALLOW_WATER" ],
     "examine_action": "water_source"
   }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -3581,7 +3581,7 @@ bool map::has_nearby_fire( const tripoint_bub_ms &p, int radius ) const
         if( has_field_at( pt, fd_fire ) ) {
             return true;
         }
-        if( has_flag_ter_or_furn( ter_furn_flag::TFLAG_USABLE_FIRE, p ) ) {
+        if( has_flag_ter_or_furn( ter_furn_flag::TFLAG_USABLE_FIRE, pt ) ) {
             return true;
         }
     }


### PR DESCRIPTION
#### Summary
Bugfixes "Fix heating items with lava and other 'fire' like map elements."

#### Purpose of change
Fix a bug that made the Ship kitchenette undetectable for heating purposes.

Also make water from hotsprings hot when picked up.

#### Describe the solution
Very small adjustments. See commits.

#### Testing
Drew some hotspring water and used the kitchenette to heat food.
