### PR TITLE
Fix IWYU

### DIFF
--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -72,7 +72,7 @@
 #include "point.h"
 #include "regional_settings.h"
 #include "rng.h"
-#include "sdltiles.h"
+#include "sdltiles.h" // IWYU pragma: keep
 #include "sounds.h"
 #include "string_formatter.h"
 #include "string_input_popup.h"


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
```
Problems found:
/home/runner/work/Cataclysm-DDA/Cataclysm-DDA/Cataclysm-DDA/src/overmap_ui.cpp:75:1: error: superfluous '#include "sdltiles.h"'
```

Due to the use of defines, this header is not used in the IWYU run, but is in a tiles build.

#### Testing
IWYU should pass.
