### PR TITLE
Update description for "Breacher load bearing vest"

### DIFF
--- a/data/json/items/armor/ammo_pouch.json
+++ b/data/json/items/armor/ammo_pouch.json
@@ -870,7 +870,7 @@
     "subtypes": [ "ARMOR" ],
     "copy-from": "heavy_load_bearing_vest",
     "name": { "str": "breacher load bearing vest" },
-    "description": "This massive vest covered in MOLLE webbing is designed to attach a large number of pouches, holsters and other PALS compatible accessories.  This one has a single point sling wrapped around the shoulders using a system to keep your weapon extra secure, as well as a set of strong magnets attached to the torso and waist to hold a breaching shotgun.",
+    "description": "This massive vest covered in MOLLE webbing is designed to attach a large number of pouches, holsters and other PALS compatible accessories.  This one has a single point sling wrapped around the shoulders using a system to keep your weapon extra secure, as well as a set of strong magnets attached to the torso and waist to hold an extra medium-sized firearm - normally a short-barrel shotgun for breaching.",
     "use_action": [ { "type": "holster" }, { "type": "attach_molle", "size": 8 }, { "type": "detach_molle" } ],
     "weight": "2900 g",
     "armor": [


### PR DESCRIPTION
#### Summary
none

#### Purpose of change
https://github.com/CleverRaven/Cataclysm-DDA/pull/83780#issuecomment-3540243506
TLDR: with the recent removal of the Breaching Shotgun (870 breacher), now none of the shotgun form the base game has their name or description indicate they are intended (or currently being used) for breaching purpose (excluding "HWP **breacher** configuration"), making the current desc for "Breacher load bearing vest" - _...as well as a set of strong magnets attached to the torso and waist to hold a **breaching shotgun**._ - bit weird.

#### Describe the solution
update the description.
(might need some tweak since Eng is not my native language, but the idea should be delivered(?)

#### Describe alternatives you've considered
none

#### Testing
none

#### Additional context
none