### PR TITLE
Add my ko-fi link to the donation page

### DIFF
--- a/donations.md
+++ b/donations.md
@@ -11,3 +11,5 @@ If ever you wanted to give back to Cataclysm: Dark Days Ahead, this is the place
 [KorGgenT](https://github.com/CleverRaven/Cataclysm-DDA/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Amerged+author%3AKorGgenT) - [Donate via Github Sponsors](https://github.com/sponsors/KorGgenT)
 
 [John-Candlebury](https://github.com/CleverRaven/Cataclysm-DDA/pulls?q=is%3Apr+is%3Amerged+author%3AJohn-Candlebury) - [Donate via Patreon](https://www.patreon.com/Candlebury)
+
+[gettingusedto](https://github.com/I-am-Erk/CDDA-Tilesets/pulls?q=is%3Apr+is%3Amerged+author%3Agettingusedto+) - [Donate via Ko-fi](https://ko-fi.com/gettingusedto)


### PR DESCRIPTION


#### Summary
None

#### Purpose of change
I have this Ko-fi thing, might aswell put it in the donations page.

#### Describe the solution

adds the markdown and links

#### Describe alternatives you've considered

Putting my ko-fi elsewhere

#### Testing
Tested the links and the preview. the preview looks right and the links directs to the expected places.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
