### PR TITLE
Fix Zone Crashes re #82524

### DIFF
--- a/src/clzones.h
+++ b/src/clzones.h
@@ -400,6 +400,7 @@ class zone_data
             faction = _faction;
             invert = _invert;
             enabled = _enabled;
+            temporarily_disabled = false;
             is_vehicle = false;
             is_displayed = _is_displayed;
 


### PR DESCRIPTION
#### Summary
Bugfixes "Fixes the [zone crash bug #82524](https://github.com/CleverRaven/Cataclysm-DDA/issues/82524) by initializing a previously uninitialized variable."

#### Testing

Tried out in save files that were previously crashing. Seems to do the job.