### PR TITLE
Change weakptr uilist_iml in uilist to a sharedptr

### DIFF
--- a/src/editmap.cpp
+++ b/src/editmap.cpp
@@ -1152,7 +1152,7 @@ void editmap::edit_feature()
         info_title_curr = info_title<T_t>();
         do_ui_invalidation();
 
-        emenu.query( true, get_option<int>( "BLINK_SPEED" ) );
+        emenu.query( false, get_option<int>( "BLINK_SPEED" ) );
         if( emenu.ret == UILIST_CANCEL ) {
             quit = true;
         } else if( ( emenu.ret >= 0 && static_cast<size_t>( emenu.ret ) < T_t::count() ) ||
@@ -1278,7 +1278,7 @@ void editmap::edit_fld()
         info_title_curr = pgettext( "Map editor: Editing field effects", "Field effects" );
         do_ui_invalidation();
 
-        fmenu.query( true, get_option<int>( "BLINK_SPEED" ) );
+        fmenu.query( false, get_option<int>( "BLINK_SPEED" ) );
         if( ( fmenu.ret > 0 && static_cast<size_t>( fmenu.ret ) < field_type::count() ) ||
             ( fmenu.ret == UILIST_ADDITIONAL && ( fmenu.ret_act == "LEFT" || fmenu.ret_act == "RIGHT" ) ) ) {
 
@@ -1891,7 +1891,7 @@ void editmap::mapgen_preview( const real_coords &tc, uilist &gmenu )
                                          oter_id( gmenu.selected ).id().str() );
         do_ui_invalidation();
 
-        gpmenu.query( true, get_option<int>( "BLINK_SPEED" ) * 3 );
+        gpmenu.query( false, get_option<int>( "BLINK_SPEED" ) * 3 );
 
         if( gpmenu.ret == 0 ) {
             cleartmpmap( tmpmap );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2222,7 +2222,7 @@ int game::inventory_item_menu( item_location locThisItem,
             }
 
             const int prev_selected = action_menu.selected;
-            action_menu.query( true );
+            action_menu.query( false );
             if( action_menu.ret >= 0 ) {
                 cMenu = action_menu.ret; /* Remember: hotkey == retval, see addentry above. */
             } else if( action_menu.ret == UILIST_UNBOUND && action_menu.ret_act == "RIGHT" ) {

--- a/src/uilist.cpp
+++ b/src/uilist.cpp
@@ -869,15 +869,14 @@ bool uilist::scrollby( const uilist::scroll_amount scrollby )
 
 shared_ptr_fast<uilist_impl> uilist::create_or_get_ui()
 {
-    shared_ptr_fast<uilist_impl> current_ui = ui.lock();
-    if( !current_ui ) {
+    if( !ui ) {
         if( title.empty() ) {
-            ui = current_ui = make_shared_fast<uilist_impl>( *this );
+            ui = make_shared_fast<uilist_impl>( *this );
         } else {
-            ui = current_ui = make_shared_fast<uilist_impl>( *this, title );
+            ui =  make_shared_fast<uilist_impl>( *this, title );
         }
     }
-    return current_ui;
+    return ui;
 }
 
 /**
@@ -959,6 +958,7 @@ void uilist::query( bool loop, int timeout, bool allow_unfiltered_hotkeys )
 
     input_context ctxt = create_main_input_context();
 
+    // Ensure we have a uilist to work on. Seems gross.
     shared_ptr_fast<uilist_impl> ui = create_or_get_ui();
 
 #if defined(__ANDROID__)

--- a/src/uilist.cpp
+++ b/src/uilist.cpp
@@ -958,7 +958,8 @@ void uilist::query( bool loop, int timeout, bool allow_unfiltered_hotkeys )
 
     input_context ctxt = create_main_input_context();
 
-    // Ensure we have a uilist to work on. Seems gross.
+    // Ensure we have a uilist to work on
+    // TODO: We don't even use the return value here, find a better solution
     shared_ptr_fast<uilist_impl> ui = create_or_get_ui();
 
 #if defined(__ANDROID__)

--- a/src/uilist.h
+++ b/src/uilist.h
@@ -488,7 +488,7 @@ class uilist // NOLINT(cata-xy)
         std::map<input_event, int, std::function<bool( const input_event &, const input_event & )>>
         keymap { input_event::compare_type_mod_code };
 
-        weak_ptr_fast<uilist_impl> ui;
+        shared_ptr_fast<uilist_impl> ui;
 
         std::unique_ptr<string_input_popup_imgui> filter_popup;
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Allow UI Scrolling and fix UI scroll bouncing"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

This reverts the changes in #82269, the problem was that uilist had no control over its internal uis lifetime. If `query` was part of a loop, and called with `false` for loop - the ui would be destroyed and recreated every call. Reverting that PR allows the UI's to be scrolled again, but still fixes the bouncing.

fixes #82428
fixes #78783
reverts #82269

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

Changing the internal `uilist_impl ui` from a weak ptr, to a shared ptr. This avoids recreating the ui constantly in cases like the one mentioned above.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
There were a few alternatives suggested - but I think this is the most "correct".

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

Ran tests, and tested menus in game. Implemented a patch to ensure bouncing (given by @Brambor  in their PR), this fixes that bouncing - and the bouncing in mentioned menus. It also allows scrolling in the menus.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
