### PR TITLE
Remove redundant active flag + smokes extinguish bug (1/?)

### DIFF
--- a/data/json/items/ammo/sling-ready_grenade.json
+++ b/data/json/items/ammo/sling-ready_grenade.json
@@ -20,7 +20,6 @@
       "target": "molotov_lit",
       "msg": "You light the Molotov cocktail!",
       "target_charges": 1,
-      "active": true,
       "moves": 1200,
       "need_fire": 1,
       "menu_text": "Light rag",
@@ -55,7 +54,6 @@
       "target": "grenade_act",
       "msg": "You snap the retaining fuse on the grenade.",
       "target_timer": "5 seconds",
-      "active": true,
       "menu_text": "Activate grenade",
       "type": "transform"
     },
@@ -88,7 +86,6 @@
       "target": "small_homemade_grenade_act",
       "msg": "You light the retaining fuse on the improvised grenade.  Throw it before it blows in your face!",
       "target_timer": "5 seconds",
-      "active": true,
       "need_fire": 1,
       "menu_text": "Light fuse",
       "type": "transform"
@@ -116,7 +113,6 @@
       "target": "homemade_grenade_act",
       "msg": "You light the retaining fuse on the improvised grenade.  Throw it before it blows in your face!",
       "target_timer": "5 seconds",
-      "active": true,
       "need_fire": 1,
       "menu_text": "Light fuse",
       "type": "transform"
@@ -144,7 +140,6 @@
       "target": "military_explosive_small_grenade_act",
       "msg": "You light the retaining fuse on the improvised grenade.  Throw it before it blows in your face!",
       "target_timer": "5 seconds",
-      "active": true,
       "need_fire": 1,
       "menu_text": "Light fuse",
       "type": "transform"
@@ -172,7 +167,6 @@
       "target": "military_explosive_grenade_act",
       "msg": "You light the retaining fuse on the improvised grenade.  Throw it before it blows in your face!",
       "target_timer": "5 seconds",
-      "active": true,
       "need_fire": 1,
       "menu_text": "Light fuse",
       "type": "transform"

--- a/data/json/items/armor/bespoke_armor/custom_bodysuits.json
+++ b/data/json/items/armor/bespoke_armor/custom_bodysuits.json
@@ -81,7 +81,6 @@
       "type": "transform",
       "msg": "You turn the climate control on.",
       "target": "armor_nomad_advanced_on",
-      "active": true,
       "need_charges": 1,
       "need_charges_msg": "Your internal reservoir is empty."
     },

--- a/data/json/items/armor/bespoke_armor/custom_storage.json
+++ b/data/json/items/armor/bespoke_armor/custom_storage.json
@@ -632,7 +632,6 @@
         "ammo_scale": 0,
         "msg": "You turn the shoulder mounted flashlight on.",
         "target": "nomad_rig_on",
-        "active": true,
         "need_charges": 1,
         "need_charges_msg": "Your internal reservoir is empty."
       },

--- a/data/json/items/armor/cloaks.json
+++ b/data/json/items/armor/cloaks.json
@@ -1959,7 +1959,6 @@
       "type": "transform",
       "msg": "Your optical cloak flickers as it becomes transparent.",
       "target": "optical_cloak_on",
-      "active": true,
       "need_charges": 20,
       "need_charges_msg": "You don't have enough UPS charges to turn on the %s"
     },

--- a/data/json/items/armor/combat_exoskeleton.json
+++ b/data/json/items/armor/combat_exoskeleton.json
@@ -165,7 +165,6 @@
       "type": "transform",
       "msg": "You turn the exoskeleton on.\n>>Initiating boot sequence…\n//Loading DoubleOS v1.38…\n//Loading calibration profile…\n//Activating atmospheric filtration…\n//Activating liquid cooling…\n//Activating sound dampeners…\n>>Boot successful.",
       "target": "combat_exoskeleton_heavy_on",
-      "active": true,
       "need_charges": 1,
       "need_charges_msg": "The exoskeleton batteries are empty."
     },
@@ -273,7 +272,6 @@
       "type": "transform",
       "msg": "You turn the exoskeleton on.\n>>Initiating boot sequence…\n//Loading DoubleOS v2.86…\n//Loading calibration profile…\n//Activating atmospheric filtration…\n//Activating liquid cooling…\n//Activating sound dampeners…\n>>Boot successful.",
       "target": "combat_exoskeleton_medium_on",
-      "active": true,
       "need_charges": 1,
       "need_charges_msg": "The exoskeleton batteries are empty."
     },
@@ -381,7 +379,6 @@
       "type": "transform",
       "msg": "You turn the exoskeleton on.\n>>Initiating boot sequence…\n//Loading DoubleOS v3.51…\n//Loading calibration profile…\n//Activating atmospheric filtration…\n//Activating liquid cooling…\n//Activating sound dampeners…\n>>Boot successful.",
       "target": "combat_exoskeleton_light_on",
-      "active": true,
       "need_charges": 1,
       "need_charges_msg": "The exoskeleton batteries are empty."
     },

--- a/data/json/items/armor/head_attachments.json
+++ b/data/json/items/armor/head_attachments.json
@@ -236,7 +236,6 @@
       "type": "transform",
       "msg": "You activate your %s.",
       "target": "military_nvg_on",
-      "active": true,
       "need_charges": 1,
       "need_charges_msg": "The %s's batteries are dead."
     },
@@ -297,7 +296,6 @@
       "type": "transform",
       "msg": "You activate your %s.",
       "target": "advanced_gpnvg_on",
-      "active": true,
       "need_charges": 1,
       "need_charges_msg": "The %s's batteries are dead."
     },
@@ -366,7 +364,6 @@
       "type": "transform",
       "msg": "You activate your %s.",
       "target": "enhanced_nvg_on",
-      "active": true,
       "need_charges": 1,
       "need_charges_msg": "The %s's batteries are dead."
     },

--- a/data/json/items/armor/robofac_armor.json
+++ b/data/json/items/armor/robofac_armor.json
@@ -210,7 +210,6 @@
       "menu_text": "Turn on anchor",
       "msg": "You activate the anchor, and the Hub 01 logo on your front begins to glow white.",
       "target": "robofac_armor_anchor_on",
-      "active": true,
       "need_charges": 1,
       "need_charges_msg": "It seems like this device needs power."
     },
@@ -304,7 +303,6 @@
       "type": "transform",
       "msg": "You lower the visor and flick the control dial to light amplification mode.",
       "target": "robofac_head_rig_nv",
-      "active": true,
       "need_charges": 1,
       "need_charges_msg": "The visor's batteries are dead."
     },

--- a/data/json/items/armor/suits_protection.json
+++ b/data/json/items/armor/suits_protection.json
@@ -3522,7 +3522,6 @@
       "type": "transform",
       "msg": "You turn the climate control on.",
       "target": "armor_nomad_plate_on",
-      "active": true,
       "need_charges": 1,
       "need_charges_msg": "Your internal reservoir is empty."
     },
@@ -3592,7 +3591,6 @@
       "type": "transform",
       "msg": "You turn the climate control on.",
       "target": "armor_nomad_lightplate_on",
-      "active": true,
       "need_charges": 1,
       "need_charges_msg": "Your internal reservoir is empty."
     },
@@ -3663,7 +3661,6 @@
       "msg": "You turn the climate control on.",
       "target": "armor_nomad_heavyplate_on",
       "active": true,
-      "need_charges": 1,
       "need_charges_msg": "Your internal reservoir is empty."
     },
     "tool_ammo": "battery",
@@ -3731,7 +3728,6 @@
       "type": "transform",
       "msg": "You turn the climate control on.",
       "target": "armor_nomad_chainmail_on",
-      "active": true,
       "need_charges": 1,
       "need_charges_msg": "Your internal reservoir is empty."
     },

--- a/data/json/items/generic.json
+++ b/data/json/items/generic.json
@@ -2978,13 +2978,7 @@
     "//COMMENT": "Open flame or effectively so. ~5 seconds to transfer flame assuming optimal conditions, a minute at worst.",
     "use_action": [
       { "type": "firestarter", "moves": 500, "moves_slow": 6000 },
-      {
-        "target": "cigar_butt",
-        "msg": "You extinguish the cigar.",
-        "active": false,
-        "menu_text": "Extinguish",
-        "type": "transform"
-      }
+      { "target": "cigar_butt", "msg": "You extinguish the cigar.", "menu_text": "Extinguish", "type": "transform" }
     ],
     "material": [ "paper" ],
     "light": 8,
@@ -3027,13 +3021,7 @@
     "//COMMENT": "Open flame or effectively so. ~5 seconds to transfer flame assuming optimal conditions, a minute at worst.",
     "use_action": [
       { "type": "firestarter", "moves": 500, "moves_slow": 6000 },
-      {
-        "target": "cig_butt",
-        "msg": "You extinguish the cigarette.",
-        "active": false,
-        "menu_text": "Extinguish",
-        "type": "transform"
-      }
+      { "target": "cig_butt", "msg": "You extinguish the cigarette.", "menu_text": "Extinguish", "type": "transform" }
     ],
     "material": [ "paper" ],
     "light": 2,
@@ -3076,13 +3064,7 @@
     "//COMMENT": "Open flame or effectively so. ~5 seconds to transfer flame assuming optimal conditions, a minute at worst.",
     "use_action": [
       { "type": "firestarter", "moves": 500, "moves_slow": 6000 },
-      {
-        "target": "joint_roach",
-        "msg": "You extinguish the joint.",
-        "active": false,
-        "menu_text": "Extinguish",
-        "type": "transform"
-      }
+      { "target": "joint_roach", "msg": "You extinguish the joint.", "menu_text": "Extinguish", "type": "transform" }
     ],
     "material": [ "paper" ],
     "light": 2,

--- a/data/json/items/gunmod/underbarrel.json
+++ b/data/json/items/gunmod/underbarrel.json
@@ -615,7 +615,6 @@
       "type": "transform",
       "msg": "You turn the mounted flashlight on.",
       "target": "mounted_flashlight_on",
-      "active": true,
       "need_charges": 1,
       "need_charges_msg": "The mounted flashlight's batteries are dead."
     },

--- a/data/json/items/items_holiday.json
+++ b/data/json/items/items_holiday.json
@@ -26,7 +26,6 @@
     "use_action": {
       "target": "plastic_jack_o_lantern_lit",
       "msg": "You flip the switch in the jack-o'-lantern.",
-      "active": true,
       "menu_text": "Light",
       "type": "transform"
     },
@@ -70,7 +69,6 @@
     "use_action": {
       "target": "jackolantern_lit",
       "msg": "You light the jack-o'-lantern.",
-      "active": true,
       "need_fire": 1,
       "menu_text": "Light",
       "type": "transform"

--- a/data/json/items/melee/bludgeons.json
+++ b/data/json/items/melee/bludgeons.json
@@ -439,7 +439,6 @@
       "type": "transform",
       "msg": "You turn the wizard cane on.",
       "target": "wizard_cane_cheap_on",
-      "active": true,
       "need_charges": 1,
       "need_charges_msg": "The wizard cane's batteries are dead."
     },
@@ -493,7 +492,6 @@
       "type": "transform",
       "msg": "You turn the wizard cane on.",
       "target": "wizard_cane_on",
-      "active": true,
       "need_charges": 1,
       "need_charges_msg": "The wizard cane's batteries are dead."
     },

--- a/data/json/items/ranged/archery.json
+++ b/data/json/items/ranged/archery.json
@@ -275,7 +275,6 @@
       "target": "arrow_flamming",
       "target_timer": "20 seconds",
       "msg": "You light the arrow.",
-      "active": true,
       "need_fire": 1,
       "menu_text": "Light arrow",
       "type": "transform"
@@ -293,6 +292,7 @@
     "color": "brown",
     "revert_to": "arrow_field_point_fletched",
     "recovery_chance": 97,
+    "use_action": { "target": "flamable_arrow", "menu_text": "Extinguish arrow", "type": "transform" },
     "effects": [ "IGNITE" ],
     "extend": { "flags": [ "TRADER_AVOID", "SPAWN_ACTIVE" ] }
   },

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -299,7 +299,7 @@ std::optional<int> iuse_transform::use( Character *p, item &it, map *,
         // TODO: Change to map aware operation when available
         p->i_add_or_drop( take_one );
     } else {
-        transform.transform( p, it );
+        transform.transform( p, it, true );
     }
 
     if( it.is_tool() ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Remove redundant "active" flag from transformations, with the hope to eventually be able to remove the flag completely (if no usages requiring it remain). It ought to be sufficient to have the "SPAWN_ACTIVE" flag on the active version(s) of the item.

Fixed mistake causing occasional crashes when extinguishing smokes. The take off code still destroys the original item, causing users to reference freed memory if the item is continued to be used.

No functional changes (apart from extinguishing smokes randomly either crashes or creates a butt in the inventory while deleting the worn smokes). This should be a reversion to the behavior prior to the introduction of the transform_into format.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Remove "active" entries. "SPAWN_ACTIVE" should be sufficient (as well as its absence, when disabling activity).
Block taking off action when item is transformed due to being extinguished. This is the same approach that was taken for smokes that run out of smoke, and should be the original behavior.
Introduce an extinguish action of flaming arrow to override the inherited Light action.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Figure out how to get rid of the inherited use action from flaming arrow, but my attempts failed. Not inheriting would be an option, if the ability to extinguish the arrow is too offensive.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Debug spawn each changed item and then transform it and transform it back (where applicable).

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Tested to activate a mounted flashlight after it was mounted, and deactivate it. That worked, but there is no indication it's active (apart from the area around the PC lighting up, if dark enough). That's probably something for those dealing with gun mods to look into, as I believe that's rather separate from normal item transformation. I also haven't tried to wait until the battery runs out to see what happens to the gun. Basically, a weapon with an active mod should probably indicate it's active.

This should be the first in a series of of PRs removing these entries (with testing them taking the time). There is other transformation related stuff in the pipline, such as transformation from the "revert_to" format to the "transform_into" format, as well as examination of custom transformations to see if they can be removed in favor of the general one.

The good thing about these PRs is that they're likely to be independent of each other to a large extend.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
