### PR TITLE
[Bugfix] Magiclysm - Magic teleporters expire after EOC 'copy_location' run

### DIFF
--- a/src/magic_teleporter_list.cpp
+++ b/src/magic_teleporter_list.cpp
@@ -129,6 +129,26 @@ bool teleporter_list::knows_translocator( const tripoint_abs_omt &omt_pos ) cons
     return known_teleporters.find( omt_pos ) != known_teleporters.end();
 }
 
+bool teleporter_list::copy_translocator( const tripoint_abs_omt &omt_pos,
+        const tripoint_abs_omt &omt_pos_new )
+{
+    const bool activated = knows_translocator( omt_pos );
+    if( !activated ) {
+        return false;
+    }
+    std::string point_name = known_teleporters[omt_pos];
+    return known_teleporters.emplace( omt_pos_new, point_name ).second;
+}
+
+bool teleporter_list::remove_translocator( const tripoint_abs_omt &omt_pos )
+{
+    const bool activated = knows_translocator( omt_pos );
+    if( !activated ) {
+        return false;
+    }
+    return known_teleporters.erase( omt_pos ) > 0;
+}
+
 void teleporter_list::serialize( JsonOut &json ) const
 {
     json.start_object();

--- a/src/magic_teleporter_list.h
+++ b/src/magic_teleporter_list.h
@@ -26,6 +26,10 @@ class teleporter_list
         bool place_avatar_overmap( Character &you, const tripoint_abs_omt &omt_pt ) const;
     public:
         bool knows_translocator( const tripoint_abs_omt &omt_pos ) const;
+        // copy translocator at omt_pos to omt_pos_new, will do nothing and return false if it does not exist.
+        bool copy_translocator( const tripoint_abs_omt &omt_pos, const tripoint_abs_omt &omt_pos_new );
+        // remove translocator at omt_pos, will do nothing and return false if it does not exist.
+        bool remove_translocator( const tripoint_abs_omt &omt_pos );
         // adds teleporter to known_teleporters and does any other activation necessary
         bool activate_teleporter( const tripoint_abs_omt &omt_pt, const tripoint_bub_ms &local_pt );
         void deactivate_teleporter( const tripoint_abs_omt &omt_pt, const tripoint_bub_ms &local_pt );

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -102,6 +102,7 @@
 #include "vpart_range.h"
 #include "weighted_dbl_or_var_list.h"
 #include "weighted_list.h"
+#include "magic_teleporter_list.h"
 
 static const field_type_str_id field_fd_blood( "fd_blood" );
 static const field_type_str_id field_fd_fire( "fd_fire" );
@@ -8674,6 +8675,17 @@ ret_val<void> update_mapgen_function_json::update_map(
         // The loading of the Z level above is not necessary, but looks better.
         const tripoint_abs_omt omt_above = { omt_pos.x(), omt_pos.y(), omt_pos.z() + 1 };
         roof_smap.load( omt_above, false );
+    }
+
+    bool is_original_furn_removed = flags_.test( jmapgen_flags::dismantle_all_before_placing_terrain )
+                                    ||
+                                    flags_.test( jmapgen_flags::erase_all_before_placing_terrain ) ||
+                                    flags_.test( jmapgen_flags::dismantle_furniture_before_placing_terrain ) ||
+                                    flags_.test( jmapgen_flags::erase_furniture_before_placing_terrain );
+    if( is_original_furn_removed ) {
+        // Magic teleporters are special furniture. If furniture are deleted in mapgen, the corresponding translocator must also be deleted.
+        avatar &player_character = get_avatar();
+        player_character.translocators.remove_translocator( omt_pos );
     }
 
     return u;

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -83,6 +83,7 @@
 #include "itype.h"
 #include "kill_tracker.h"
 #include "magic.h"
+#include "magic_teleporter_list.h"
 #include "map.h"
 #include "map_iterator.h"
 #include "map_scale_constants.h"
@@ -4931,6 +4932,9 @@ talk_effect_fun_t::func f_copy_location( const JsonObject &jo, std::string_view 
                                         sm->get_revert_submap(), key.evaluate( d ) );
             }
         }
+        // We need to copy the translocator to target omt pos if it exists
+        avatar &player_character = get_avatar();
+        player_character.translocators.copy_translocator( omt_pos, omt_pos_new );
         reality_bubble().invalidate_map_cache( omt_pos_new.z() );
     };
 }


### PR DESCRIPTION
#### Summary
Bugfixes "Magic teleporters expire after copy_location EOC run"

#### Purpose of change

I build a teleporter 'f_magiclysm_greater_translocator_gate' at my Flying House and then I used EOC copy_location to teleport. when I use another teleporter to go back to the teleporter in Flying House, I found this teleporter expired and give me a error log telling "Failed to teleport.  Teleporter obstructed or destroyed.". This bug leading I can not teleport back to the teleporter in my Flying House.

#### Describe the solution

I fix this bug by copy affected teleporters at original omt pos of EOC 'copy_location' to omt pos of destination. Then in mapgen_update, if furniture clearing related flag is configured, it will delete the corresponding translocator.

#### Describe alternatives you've considered

No other alternative solutions have been identified so far.

#### Testing

After teleportation of Flying House, I used another teleporter outside of Flying House to go back to the teleporter installed in the house successfully. 

#### Additional context

Flying House is a Mod I developed, It is just like Vanishing Arc of Aftershock that you can teleport with the ship.
