### PR TITLE
Recipe description support parse_tags now

### DIFF
--- a/doc/JSON/ITEM_CRAFT_AND_DISASSEMBLY.md
+++ b/doc/JSON/ITEM_CRAFT_AND_DISASSEMBLY.md
@@ -83,9 +83,10 @@ Crafting recipes are defined as a JSON object with the following fields:
   "BLIND_EASY",
   "ANOTHERFLAG"
 ],
-"result_eocs": [ {"id": "TEST", "effect": { "u_message": "You feel Test" } } // List of inline effect_on_conditions or effect_on_condition ids that attempt to activate when this recipe is successfully finished.  If a value is provided a result becomes optional, though a name and id will be needed it it is missing.  If no result is provided and a description is present, that will be displayed as the result on the crafting gui.
+"result_eocs": [ {"id": "TEST", "effect": { "u_message": "You feel Test" } } // List of inline effect_on_conditions or effect_on_condition ids that attempt to activate when this recipe is successfully finished.  If a value is provided a result becomes optional, though a name and id will be needed it it is missing.  If no result is provided and a description is present, "description" will be displayed as the result on the crafting gui.
 ], 
 "name" : "%s with quern", // optional string to further describe recipe where %s is the recipe result name. Example if the result name is "flour", the final name will be "flour with quern". Especially useful for recipes with "id_suffix" that produce the same result as other recipes.
+"description": "foobar.  your name is <u_name>" // if crafting result is not an item, this text will be shown. Support color and NPC tags
 "construction_blueprint": "camp", // an optional string containing an update_mapgen_id.  Used by faction camps to upgrade their buildings
 "on_display": false,         // this is a hidden construction item, used by faction camps to calculate construction times but not available to the player
 "qualities": [               // Generic qualities of tools needed to craft

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -587,7 +587,7 @@ static std::string practice_recipe_description( const recipe &recp,
         const Character &crafter )
 {
     std::ostringstream oss;
-    oss << recp.description.translated() << "\n\n";
+    oss << recp.get_description( crafter ) << "\n\n";
     if( recp.practice_data->min_difficulty != recp.practice_data->max_difficulty ) {
         std::string txt = string_format( _( "Difficulty range: %d to %d" ),
                                          recp.practice_data->min_difficulty, recp.practice_data->max_difficulty );
@@ -817,7 +817,7 @@ item_info_data recipe_result_info_cache::get_result_data( const recipe *rec, con
     item dummy_result = get_recipe_result_item( *rec, crafter );
     std::string result_description;
     if( dummy_result.is_null() ) {
-        result_description = rec->description.translated();
+        result_description = rec->get_description( crafter );
     }
     bool result_uses_charges = dummy_result.count_by_charges();
     int const makes_amount = rec->makes_amount();
@@ -1628,7 +1628,7 @@ std::pair<Character *, const recipe *> select_crafter_and_crafting_recipe( int &
                             w_iteminfo ) ).apply( w_iteminfo );
                 wnoutrefresh( w_iteminfo );
             } else if( cur_recipe->is_nested() ) {
-                std::string desc = cur_recipe->description.translated() + "\n\n";
+                std::string desc = cur_recipe->get_description( *crafter ) + "\n\n";
                 desc += list_nested( *crafter, cur_recipe, available_recipes );
                 fold_and_print( w_iteminfo, point::zero, item_info_width, c_light_gray, desc );
                 scrollbar().offset_x( item_info_width - 1 ).offset_y( 0 ).content_size( 1 ).viewport_size( getmaxy(

--- a/src/recipe.cpp
+++ b/src/recipe.cpp
@@ -36,6 +36,7 @@
 #include "mapgen_parameter.h"
 #include "mapgendata.h"
 #include "math_defines.h"
+#include "npc.h"
 #include "output.h"
 #include "proficiency.h"
 #include "recipe_dictionary.h"
@@ -53,6 +54,13 @@ static const itype_id itype_hotplate( "hotplate" );
 
 static const std::string flag_FULL_MAGAZINE( "FULL_MAGAZINE" );
 
+
+std::string recipe::get_description( const Character &crafter ) const
+{
+    std::string desc = description.translated();
+    parse_tags( desc, crafter, crafter );
+    return desc;
+}
 
 int recipe::get_difficulty( const Character &crafter ) const
 {

--- a/src/recipe.h
+++ b/src/recipe.h
@@ -154,6 +154,8 @@ class recipe
         std::string subcategory;
 
         translation description;
+        // prefer calling this one if it's a description that player can see
+        std::string get_description( const Character &crafter ) const;
         // overrides the result name;
         translation name_;
 


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Close #83836
#### Describe the solution
Make a generic description that pulls crafting description with parse_tags(), replace calls to description with calls to this function where necessary
#### Testing
<img width="1314" height="340" alt="image" src="https://github.com/user-attachments/assets/299301a6-4211-4e02-82a4-f662c6b6ceca" />