### PR TITLE
[Bombastic Perks] Add Artifact Resonance perks

### DIFF
--- a/data/mods/BombasticPerks/perkdata/nether_resonator.json
+++ b/data/mods/BombasticPerks/perkdata/nether_resonator.json
@@ -4,12 +4,22 @@
     "id": "EOC_perk_artifact_resonance_detection",
     "effect": [
       {
-        "u_run_inv_eocs": "wielded_only",
+        "u_run_inv_eocs": "all",
+        "search_data": [ { "wielded_only": true } ],
         "true_eocs": [
           {
             "id": "EOC_perk_artifact_resonance_detection_active",
             "effect": [
               { "math": [ "_artifact_resonance = n_artifact_resonance()" ] },
+              { "math": [ "_your_total_resonance = u_artifact_resonance()" ] },
+              {
+                "u_message": { "str": "Exact resonance is <context_val:artifact_resonance>.", "//~": "NO_I18N" },
+                "type": "debug"
+              },
+              {
+                "u_message": { "str": "Your actual resonance is <context_val:your_total_resonance>.", "//~": "NO_I18N" },
+                "type": "debug"
+              },
               {
                 "switch": { "math": [ "_artifact_resonance" ] },
                 "cases": [
@@ -24,8 +34,8 @@
                     "effect": { "u_message": "The artifact hums strongly and your skin tingles (resonance 1501-2500)." }
                   },
                   {
-                    "case": 5001,
-                    "effect": { "u_message": "The artifact's hums loudly enough that it's almost vibrating (resonance 2501-5000)" }
+                    "case": 2501,
+                    "effect": { "u_message": "The artifact hums loudly enough that it's almost vibrating (resonance 2501-5000)" }
                   },
                   {
                     "case": 5001,

--- a/data/mods/BombasticPerks/perkdata/nether_resonator.json
+++ b/data/mods/BombasticPerks/perkdata/nether_resonator.json
@@ -1,0 +1,42 @@
+[
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_perk_artifact_resonance_detection",
+    "effect": [
+      {
+        "u_run_inv_eocs": "wielded_only",
+        "true_eocs": [
+          {
+            "id": "EOC_perk_artifact_resonance_detection_active",
+            "effect": [
+              { "math": [ "_artifact_resonance = n_artifact_resonance()" ] },
+              {
+                "switch": { "math": [ "_artifact_resonance" ] },
+                "cases": [
+                  { "case": 0, "effect": { "u_message": "The artifact barely hums at all (resonance 0-250)." } },
+                  { "case": 251, "effect": { "u_message": "The artifact hums gently (resonance 251-750)." } },
+                  {
+                    "case": 751,
+                    "effect": { "u_message": "The artifact hums with a steady pulsing (resonance 751-1500)." }
+                  },
+                  {
+                    "case": 1501,
+                    "effect": { "u_message": "The artifact hums strongly and your skin tingles (resonance 1501-2500)." }
+                  },
+                  {
+                    "case": 5001,
+                    "effect": { "u_message": "The artifact's hums loudly enough that it's almost vibrating (resonance 2501-5000)" }
+                  },
+                  {
+                    "case": 5001,
+                    "effect": { "u_message": "The artifact's hum drowns out all other sounds for a moment (resonance 5001+)" }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/data/mods/BombasticPerks/perkmenu.json
+++ b/data/mods/BombasticPerks/perkmenu.json
@@ -1122,6 +1122,44 @@
         "topic": "TALK_PERK_MENU_SELECT"
       },
       {
+        "condition": { "not": { "u_has_trait": "perk_artifact_resonance_detection" } },
+        "text": "Gain [<trait_name:perk_artifact_resonance_detection>]",
+        "effect": [
+          { "set_string_var": "<trait_name:perk_artifact_resonance_detection>", "target_var": { "context_val": "trait_name" } },
+          {
+            "set_string_var": "<trait_description:perk_artifact_resonance_detection>",
+            "target_var": { "context_val": "trait_description" }
+          },
+          { "set_string_var": "perk_artifact_resonance_detection", "target_var": { "context_val": "trait_id" } },
+          {
+            "set_string_var": "No Requirements",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
+          { "set_condition": "perk_condition", "condition": { "math": [ "0 == 0" ] } }
+        ],
+        "topic": "TALK_PERK_MENU_SELECT"
+      },
+      {
+        "condition": { "not": { "u_has_trait": "perk_artifact_resonance_reduction" } },
+        "text": "Gain [<trait_name:perk_artifact_resonance_reduction>]",
+        "effect": [
+          { "set_string_var": "<trait_name:perk_artifact_resonance_reduction>", "target_var": { "context_val": "trait_name" } },
+          {
+            "set_string_var": "<trait_description:perk_artifact_resonance_reduction>",
+            "target_var": { "context_val": "trait_description" }
+          },
+          { "set_string_var": "perk_artifact_resonance_reduction", "target_var": { "context_val": "trait_id" } },
+          {
+            "set_string_var": "Must have <trait_name:perk_artifact_resonance_detection>.",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
+          { "set_condition": "perk_condition", "condition": { "u_has_trait": "perk_artifact_resonance_detection" } }
+        ],
+        "topic": "TALK_PERK_MENU_SELECT"
+      },
+      {
         "condition": { "not": { "u_has_trait": "perk_crafty_hands" } },
         "text": "Gain [<trait_name:perk_crafty_hands>]",
         "effect": [

--- a/data/mods/BombasticPerks/perkmenu.json
+++ b/data/mods/BombasticPerks/perkmenu.json
@@ -1151,7 +1151,7 @@
           },
           { "set_string_var": "perk_artifact_resonance_reduction", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "Must have <trait_name:perk_artifact_resonance_detection>.",
+            "set_string_var": "Must have <trait_name:perk_artifact_resonance_detection>",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },

--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -730,8 +730,8 @@
     "points": 0,
     "purifiable": false,
     "valid": false,
-    "description": "Your frequent handling of artifacts has allowed you to bleed off some of the side effects of their presence.  Your accumulated artifact resonance is reduced by 2000.",
-    "enchantments": [ { "condition": "ALWAYS", "values": [ { "value": "ARTIFACT_RESONANCE", "add": -2000 } ] } ]
+    "description": "Your frequent handling of artifacts has allowed you to bleed off some of the side effects of their presence.  Your accumulated artifact resonance is reduced by 1500.",
+    "enchantments": [ { "condition": "ALWAYS", "values": [ { "value": "ARTIFACT_RESONANCE", "add": -1500 } ] } ]
   },
   {
     "type": "mutation",

--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -720,6 +720,7 @@
     "valid": false,
     "description": "You get a tingling feeling when you hold the objects that the Cataclysm seems to have given anomalous properties to.  Activate to determine roughly how much resonance an artifact has.",
     "active": true,
+    "activation_msg": "You close your eyes for a moment and look for the inner hum.",
     "activated_eocs": [ "EOC_perk_artifact_resonance_detection" ]
   },
   {
@@ -729,8 +730,8 @@
     "points": 0,
     "purifiable": false,
     "valid": false,
-    "description": "Your frequent handling of artifacts has allowed you to bleed off some of the side effects of their presence.  Your accumulated artifact resonance is reduced by 25%.",
-    "enchantments": [ { "condition": "ALWAYS", "values": [ { "value": "ARTIFACT_RESONANCE", "multiply": -0.25 } ] } ]
+    "description": "Your frequent handling of artifacts has allowed you to bleed off some of the side effects of their presence.  Your accumulated artifact resonance is reduced by 2000.",
+    "enchantments": [ { "condition": "ALWAYS", "values": [ { "value": "ARTIFACT_RESONANCE", "add": -2000 } ] } ]
   },
   {
     "type": "mutation",

--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -713,6 +713,27 @@
   },
   {
     "type": "mutation",
+    "id": "perk_artifact_resonance_detection",
+    "name": { "str": "Nether Resonator" },
+    "points": 0,
+    "purifiable": false,
+    "valid": false,
+    "description": "You get a tingling feeling when you hold the objects that the Cataclysm seems to have given anomalous properties to.  Activate to determine roughly how much resonance an artifact has.",
+    "active": true,
+    "activated_eocs": [ "EOC_perk_artifact_resonance_detection" ]
+  },
+  {
+    "type": "mutation",
+    "id": "perk_artifact_resonance_reduction",
+    "name": { "str": "Relic Wielder" },
+    "points": 0,
+    "purifiable": false,
+    "valid": false,
+    "description": "Your frequent handling of artifacts has allowed you to bleed off some of the side effects of their presence.  Your accumulated artifact resonance is reduced by 25%.",
+    "enchantments": [ { "condition": "ALWAYS", "values": [ { "value": "ARTIFACT_RESONANCE", "multiply": -0.25 } ] } ]
+  },
+  {
+    "type": "mutation",
     "id": "perk_frakenstein",
     "name": { "str": "Playing God" },
     "points": 0,

--- a/doc/JSON/MAGIC.md
+++ b/doc/JSON/MAGIC.md
@@ -970,7 +970,7 @@ The following is a list of possible enchantment `values`:
 Character status value  | Description
 ---                     |---
 `ARMOR_ALL`             | Gives this amount of protection against any damage type except one with "no_resist": true. For more precise changes use incoming_damage_mod or item_armor_bonus
-`ARTIFACT_RESONANCE`    | Affects the level of artifact resonance you have, which causes various hardcoded penalties as it rises.
+`ARTIFACT_RESONANCE`    | Affects the level of artifact resonance you have, which causes various hardcoded penalties as it rises (note: only add works, not multiply).
 `ATTACK_NOISE`          | Affects the amount of noise you make while melee attacking.
 `ATTACK_SPEED`          | Affects attack speed of item, even if it's not the one you're wielding, and throwing cost (capped at 25 moves). `"add": 10` adds 10 moves to each attack (makes it longer), `"add": -10` makes each attack faster for 10 moves; `"multiply": 1` doubles the speed of each attack
 `AVOID_FRIENDRY_FIRE`   | Flat chance for your character to avoid friendry fire if there is a friend in the line of fire. From 0.0 (no chance) to 1.0 (never frindly fire).

--- a/doc/JSON/MAGIC.md
+++ b/doc/JSON/MAGIC.md
@@ -970,6 +970,7 @@ The following is a list of possible enchantment `values`:
 Character status value  | Description
 ---                     |---
 `ARMOR_ALL`             | Gives this amount of protection against any damage type except one with "no_resist": true. For more precise changes use incoming_damage_mod or item_armor_bonus
+`ARTIFACT_RESONANCE`    | Affects the level of artifact resonance you have, which causes various hardcoded penalties as it rises.
 `ATTACK_NOISE`          | Affects the amount of noise you make while melee attacking.
 `ATTACK_SPEED`          | Affects attack speed of item, even if it's not the one you're wielding, and throwing cost (capped at 25 moves). `"add": 10` adds 10 moves to each attack (makes it longer), `"add": -10` makes each attack faster for 10 moves; `"multiply": 1` doubles the speed of each attack
 `AVOID_FRIENDRY_FIRE`   | Flat chance for your character to avoid friendry fire if there is a friend in the line of fire. From 0.0 (no chance) to 1.0 (never frindly fire).
@@ -996,8 +997,6 @@ Character status value  | Description
 `EXTRA_ELEC_PAIN`       | Multiplier on electric damage received, the result is applied as extra pain.
 `EVASION`               | Flat chance for your character to dodge incoming attacks regardless of other modifiers.  From 0.0 (no evasion chance) to 1.0 (100% evasion chance).
 `FALL_DAMAGE`           | Affects the amount of fall damage you take.
-`SLEEPINESS`               | Affects how fast your sleepiness grows over time - bigger value makes you tired faster. Since it's a percent, using `multiply` is recommended.
-`SLEEPINESS_REGEN`         | Affects how much of your sleepiness and sleep deprivation drops when resting. Since it's a percent, using `multiply` is recommended.
 `FAT_TO_MAX_HP`         | Changes the amount of HP, that is given to you by your fat. Formula is `((your_calories/7716.17)/((your_height_in_cm/100)^2))*hitsize_of_all_non_bionic_bodyparts`. Using `add` works just as adding HP, so use `multiply` instead
 `FOOTSTEP_NOISE`        | 
 `FORCEFIELD`            | Chance your character reduces incoming damage to 0. From 0.0 (no chance), to 1.0 (100% chance to avoid attacks).
@@ -1058,6 +1057,8 @@ Character status value  | Description
 `SHOUT_NOISE`           | Changes how loud your shouts are (default 10)
 `SHOUT_NOISE_STR_MULT`  | Modifies the `shout_multiplier`, that affect how much your strength affects noise level (default 2, meaning one point of strength adds 2 units of noise )
 `SKILL_RUST_RESIST`     | when `add`, chance / 100 to resist skill rust; when `multiply`, multiplier for skill rust amount - the smaller, the less experience you will rust
+`SLEEPINESS`               | Affects how fast your sleepiness grows over time - bigger value makes you tired faster. Since it's a percent, using `multiply` is recommended.
+`SLEEPINESS_REGEN`         | Affects how much of your sleepiness and sleep deprivation drops when resting. Since it's a percent, using `multiply` is recommended.
 `SLEEPY`                | The higher this the easier you fall asleep.
 `SOCIAL_INTIMIDATE`     | Affects your ability to intimidate.
 `SOCIAL_LIE`            | Affects your ability to lie.


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[Bombastic Perks] Add Artifact Resonance perks"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

I discovered that ARTIFACT_RESONANCE is an enchant val like STRENGTH or MELEE_DAMAGE or any other, so let's make a perk about it.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add two perks:

- Nether Resonator: You can roughly detect how much resonance an artifact has if you're holding it. 
- Relic Wielder (requires Nether Resonator): Your total artifact resonance is reduced by 1500 (around one nice but not amazing artifact's worth). 

Also document ARTIFACT_RESONANCE in Magic.md

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Used Nether Resonator, learned rough resonance.

Added Relic Wielder, resonance went down
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Some kind of playstyle perk where your resonance goes way down if you do weird behaviors would be neat too, but I can't (at the moment) think of what would work. 
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
