### PR TITLE
Fix NPC bleed assessment checking wrong character / Remove correct NPC on caravan death

### DIFF
--- a/src/mission_companion.cpp
+++ b/src/mission_companion.cpp
@@ -1436,7 +1436,7 @@ void talk_function::caravan_return( npc &p, const std::string &dest, const missi
     for( const auto &elem : caravan_party ) {
         //Scrub temporary party members and the dead
         if( elem->get_part_hp_cur( bodypart_id( "torso" ) ) == 0 && elem->has_companion_mission() ) {
-            overmap_buffer.remove_npc( comp->getID() );
+            overmap_buffer.remove_npc( elem->getID() );
             merch_amount += ( time / 600 ) * 4;
         } else if( elem->has_companion_mission() ) {
             merch_amount += ( time / 600 ) * 7;

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -519,7 +519,7 @@ float npc::evaluate_character( const Character &candidate, bool my_gun, bool ene
     float speed = std::max( 0.25f, candidate.get_speed() / 100.0f );
     bool is_fleeing = candidate.has_effect( effect_npc_run_away );
     int perception_inverted = std::max( ( 20 - get_per() ), 0 );
-    if( has_effect( effect_bleed ) ) {
+    if( candidate.has_effect( effect_bleed ) ) {
         int bleed_intensity = 0;
         for( const bodypart_id &bp : candidate.get_all_body_parts() ) {
             const effect &bleediness = candidate.get_effect( effect_bleed, bp );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Some very sneaky bugs.

#### Describe the solution
Port fixes for them.

Ports https://github.com/Cataclysm-TLG/Cataclysm-TLG/pull/1727 by @Isoceth

Ports https://github.com/Cataclysm-TLG/Cataclysm-TLG/pull/1729 by @Isoceth

#### Describe alternatives you've considered


#### Testing
These are just prima facie fixes. I am extremely confident in them. No manual testing performed.

#### Additional context
