### PR TITLE
Update pot_diff.py

### DIFF
--- a/.github/workflows/text-changes-analyzer.yml
+++ b/.github/workflows/text-changes-analyzer.yml
@@ -53,9 +53,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ steps.get-commit-hash.outputs.test_merge_commit }}
-      - name: "List text changes"
-        run: |
-          python3 ./tools/pot_diff.py ~/base.pot ~/merge.pot
       - name: "Write text changes"
         run: |
           python3 ./tools/pot_diff.py ~/base.pot ~/merge.pot -j ~/pot_diff.json


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
1. pot_diff.py ignored the msgctxt of messages, using only their text, which caused all distinct strings to be treated as identical.
2. In CI, the script ran twice, and reading large .pot files is somewhat slow.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
1. Added context to the console output. The JSON output for the spell checker remains unchanged.
2. The script now runs once and immediately outputs the message list to both the console and JSON.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Works as intended with test data. Text coloring remains functional. Spellchecker works.

<img width="808" height="679" alt="изображение" src="https://github.com/user-attachments/assets/46424f95-0567-4cd7-b0cd-e9cb7986b382" />

<details><summary>Old JSON output</summary>
<p>

```json
{
  "deleted": [
    "DELETED\nAAAAA\nBBBBBB\nCCCCCC",
    "Deleted singular string",
    "Deleted singular string with context",
    "Deleted string",
    "Deleted string with context",
    "Deleted strings",
    "Deleted strings with context"
  ],
  "added": [ "AAAAA\nBBBBBB\nCCCCCC", "New singular string", "New string", "New string with context", "New strings" ]
}
```

</p>
</details> 

<details><summary>Updated JSON output</summary>
<p>


```json
{
  "deleted": [
    "DELETED\nAAAAA\nBBBBBB\nCCCCCC",
    "Deleted singular string",
    "Deleted singular string with context",
    "String with different context",
    "Deleted string",
    "Deleted strings",
    "Deleted strings with context",
    "Deleted string with context"
  ],
  "added": [
    "AAAAA\nBBBBBB\nCCCCCC",
    "Light",
    "String with different context",
    "New singular string",
    "New string with context",
    "New strings",
    "New string"
  ]
}
```

</p>
</details> 

<details><summary>Old output</summary>
<p>

```
Reading lang/po/test-master.pot
30 message(s) read from lang/po/test-master.pot

Reading lang/po/test.pot
28 message(s) read from lang/po/test.pot

Computing differences...

7 message(s) deleted:
--------------------------------------------------------------------------------
DELETED
AAAAA
BBBBBB
CCCCCC
--------------------------------------------------------------------------------
Deleted singular string
--------------------------------------------------------------------------------
Deleted singular string with context
--------------------------------------------------------------------------------
Deleted string
--------------------------------------------------------------------------------
Deleted string with context
--------------------------------------------------------------------------------
Deleted strings
--------------------------------------------------------------------------------
Deleted strings with context
--------------------------------------------------------------------------------

5 message(s) added:
--------------------------------------------------------------------------------
AAAAA
BBBBBB
CCCCCC
--------------------------------------------------------------------------------
New singular string
--------------------------------------------------------------------------------
New string
--------------------------------------------------------------------------------
New string with context
--------------------------------------------------------------------------------
New strings
```

</p>
</details> 

<details><summary>Updated output</summary>
<p>

```
Reading 'lang/po/test-master.pot'...
  Read 37 message(s)

Reading 'lang/po/test.pot'...
  Read 38 message(s)

Computing differences...

Comparison result written to 'aaa.json'

9 message(s) deleted:
--------------------------------------------------------------------------------
DELETED
AAAAA
BBBBBB
CCCCCC
--------------------------------------------------------------------------------
Deleted singular string
--------------------------------------------------------------------------------
[Context] Deleted singular string with context
--------------------------------------------------------------------------------
Deleted string
--------------------------------------------------------------------------------
[Context] Deleted string with context
--------------------------------------------------------------------------------
Deleted strings
--------------------------------------------------------------------------------
[Context] Deleted strings with context
--------------------------------------------------------------------------------
[training intensity] Light
--------------------------------------------------------------------------------
[Test1] String with different context
--------------------------------------------------------------------------------

10 message(s) added:
--------------------------------------------------------------------------------
AAAAA
BBBBBB
CCCCCC
--------------------------------------------------------------------------------
[Context] Light
--------------------------------------------------------------------------------
New singular string
--------------------------------------------------------------------------------
[Context] New singular string
--------------------------------------------------------------------------------
New string
--------------------------------------------------------------------------------
New string with context
--------------------------------------------------------------------------------
[Context1] New string with context
--------------------------------------------------------------------------------
[Context2] New string with context
--------------------------------------------------------------------------------
New strings
--------------------------------------------------------------------------------
[Test2] String with different context
--------------------------------------------------------------------------------
```

</p>
</details> 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
