### PR TITLE
Multi-activity overhaul, part 2: split up generic_multi_activity_locations()

### DIFF
--- a/src/activity_item_handling.h
+++ b/src/activity_item_handling.h
@@ -87,7 +87,28 @@ void move_item( Character &you, const std::optional<vpart_reference> &vpr_src,
 
 namespace multi_activity_actor
 {
+
+//TODO: move to JSON flag?
+bool can_do_in_dark( const activity_id &act_id );
+
 /* begin TODO: move to activity actor */
+
+//general function for non-specific multi activities
+std::unordered_set<tripoint_abs_ms> generic_locations( Character &you, const activity_id &act_id );
+std::unordered_set<tripoint_abs_ms> construction_locations( Character &you,
+        const activity_id &act_id );
+std::unordered_set<tripoint_abs_ms> tidy_up_locations( Character &you, const activity_id & );
+std::unordered_set<tripoint_abs_ms> read_locations( Character &you, const activity_id &act_id );
+std::unordered_set<tripoint_abs_ms> craft_locations( Character &you, const activity_id &act_id );
+std::unordered_set<tripoint_abs_ms> fetch_locations( Character &you, const activity_id & );
+std::unordered_set<tripoint_abs_ms> fish_locations( Character &you, const activity_id &act_id );
+std::unordered_set<tripoint_abs_ms> mop_locations( Character &you, const activity_id &act_id );
+void prune_same_tile_locations( Character &you, std::unordered_set<tripoint_abs_ms> &src_set );
+void prune_dark_locations( Character &you, std::unordered_set<tripoint_abs_ms> &src_set,
+                           const activity_id &act_id );
+void prune_dangerous_field_locations( std::unordered_set<tripoint_abs_ms> &src_set );
+std::unordered_set<tripoint_abs_ms> no_same_tile_locations( Character &you,
+        const activity_id &act_id );
 
 //shared helper function for deconstruction/repair
 activity_reason_info vehicle_work_can_do( const activity_id &, Character &you,


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Infrastructure "multi-activity overhaul, part 2: split up generic_multi_activity_locations()"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Continuing #83818

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

See title, same goal and general principle as #83818

My only concern is conflicting information with this line (and similar):
```c++
you.fine_detail_vision_mod( you.pos_bub() ) > 4.0 )
```

We have both this:
```c++
/** Returns a value from 1.0 to 11.0 that acts as a multiplier
 * for the time taken to perform tasks that require detail vision,
 * above 4.0 means these activities cannot be performed.
 * takes pos as a parameter so that remote spots can be judged
 * if they will potentially have enough light when player gets there */
float fine_detail_vision_mod( const tripoint_bub_ms &p = tripoint_bub_ms::invalid ) const;
```

And this:
```c++
// The lower threshold for seeing well enough to do detail work such as reading or crafting.
constexpr float LIGHT_AMBIENT_DIM = 5.0f;
```

I went with `LIGHT_AMBIENT_DIM` instead of `4.0`, let me know if that's an issue.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

I set up every multi-activity assignable for an NPC and made sure each one could be started and completed if possible.

CI pending

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
