### PR TITLE
"Current mission" --> "Current objective"

### DIFF
--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -420,7 +420,7 @@ void overmap_sidebar::draw_mission_info()
         if( current_mission != nullptr ) {
             mission_name = player_character.get_active_mission()->name();
 
-            draw_sidebar_text( _( "Current mission:" ), c_white );
+            draw_sidebar_text( _( "Current objective:" ), c_white );
         } else {
             mission_name = player_character.get_active_point_of_interest().text;
 
@@ -942,7 +942,7 @@ static void draw_ascii( const catacurses::window &w, overmap_draw_data_t &data )
     const int om_half_height = om_map_height / 2;
 
     avatar &player_character = get_avatar();
-    // Target of current mission
+    // Target of current objective
     const tripoint_abs_omt target = player_character.get_active_mission_target();
     const bool has_target = !target.is_invalid();
     oter_id ccur_ter = oter_str_id::NULL_ID();


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
In #73134 I introduced a terminology change. We stopped calling the currently targeted mission the "Active mission" because you have a "Missions" tab and it has "Active" missions, and only one of them *might* be or is the actually "Active" mission.

Instead, we referred to it as the "Current objective".

In #83501 we had a bit of regression. Some strings got shuffled around, and it went back to being called the "Current mission" (which IMO is also unclear).

The mission UI continues to refer to it as "Current objective" and thus these two UIs now disagree on what it is.

#### Describe the solution
Normalize it by changing the new string to say "Current objective".

#### Describe alternatives you've considered
We could change all the mission UI strings to say "Current mission", but *objective* is a specific game concept that I think works well for communicating this.

#### Testing
Simple string change.

<img width="444" height="255" alt="image" src="https://github.com/user-attachments/assets/d4a73538-fbb2-4949-8d9b-70b3766a2176" />


#### Additional context
