### PR TITLE
Fixes to work pants and coveralls

### DIFF
--- a/data/json/items/armor/legs_clothes.json
+++ b/data/json/items/armor/legs_clothes.json
@@ -2196,7 +2196,6 @@
         "material": [ { "type": "canvas", "covered_by_mat": 100, "thickness": 0.5 } ]
       },
       {
-        "encumbrance": [ 4, 9 ],
         "coverage": 100,
         "covers": [ "leg_l", "leg_r" ],
         "specifically_covers": [ "leg_knee_l", "leg_knee_r" ],

--- a/data/json/items/armor/suits_clothes.json
+++ b/data/json/items/armor/suits_clothes.json
@@ -550,10 +550,17 @@
         "encumbrance": [ 5, 5 ]
       },
       {
-        "covers": [ "leg_l", "leg_r" ],
-        "material": [ { "type": "canvas", "covered_by_mat": 100, "thickness": 0.5 } ],
+        "encumbrance": [ 5, 9 ],
         "coverage": 100,
-        "encumbrance": [ 5, 9 ]
+        "covers": [ "leg_l", "leg_r" ],
+        "specifically_covers": [ "leg_hip_l", "leg_upper_l", "leg_lower_l", "leg_hip_r", "leg_upper_r", "leg_lower_r" ],
+        "material": [ { "type": "canvas", "covered_by_mat": 100, "thickness": 0.5 } ]
+      },
+      {
+        "coverage": 100,
+        "covers": [ "leg_l", "leg_r" ],
+        "specifically_covers": [ "leg_knee_l", "leg_knee_r" ],
+        "material": [ { "type": "canvas", "covered_by_mat": 100, "thickness": 1 } ]
       }
     ],
     "pocket_data": [
@@ -645,13 +652,23 @@
         "encumbrance": [ 7, 7 ]
       },
       {
+        "encumbrance": [ 7, 11 ],
+        "coverage": 100,
         "covers": [ "leg_l", "leg_r" ],
+        "specifically_covers": [ "leg_hip_l", "leg_upper_l", "leg_lower_l", "leg_hip_r", "leg_upper_r", "leg_lower_r" ],
         "material": [
           { "type": "cotton", "covered_by_mat": 100, "thickness": 0.5 },
           { "type": "canvas", "covered_by_mat": 100, "thickness": 0.5 }
-        ],
+        ]
+      },
+      {
         "coverage": 100,
-        "encumbrance": [ 7, 11 ]
+        "covers": [ "leg_l", "leg_r" ],
+        "specifically_covers": [ "leg_knee_l", "leg_knee_r" ],
+        "material": [
+          { "type": "cotton", "covered_by_mat": 100, "thickness": 0.5 },
+          { "type": "canvas", "covered_by_mat": 100, "thickness": 1.0 }
+        ]
       }
     ],
     "pocket_data": [

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -10620,6 +10620,8 @@
     "description": "You are the natural leader of any group.  It's just part of who you are, groups naturally form around you and you need these groups to energize you.  Sometimes however, you give in to your worst impulses and this trait will flip.",
     "flags": [ "SOCIAL2" ],
     "category": [ "ALPHA" ],
+    "prereqs": [ "INT_ALPHA", "PER_ALPHA", "STR_ALPHA", "DEX_ALPHA" ],
+    "threshreq": [ "THRESH_ALPHA" ],
     "social_modifiers": { "intimidate": 5, "persuade": 15, "lie": 10 },
     "triggers": [
       [

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -10620,8 +10620,6 @@
     "description": "You are the natural leader of any group.  It's just part of who you are, groups naturally form around you and you need these groups to energize you.  Sometimes however, you give in to your worst impulses and this trait will flip.",
     "flags": [ "SOCIAL2" ],
     "category": [ "ALPHA" ],
-    "prereqs": [ "INT_ALPHA", "PER_ALPHA", "STR_ALPHA", "DEX_ALPHA" ],
-    "threshreq": [ "THRESH_ALPHA" ],
     "social_modifiers": { "intimidate": 5, "persuade": 15, "lie": 10 },
     "triggers": [
       [


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Work Pants don't have double encumbrance; similar coveralls also cover knees more too"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Work pants were changed to have double-thickness fabric on the knees, but accidentally included "encumbrance: [4, 9]" in both sublocations which resulted in the encumbrance being doubled over its intended value.
Also, work coveralls are similar to work pants, but didn't include the added thicknesses on the knees.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Remove the redundant encumbrance line from work pants.
Add double canvas knee coverage to (heavy) work coveralls.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Add padded elbows to coveralls too.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
