### PR TITLE
[Bugfix] Cosmetics not moved to new submap in EOC copy_location

### DIFF
--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -3772,6 +3772,8 @@ class jmapgen_terrain : public jmapgen_piece_with_has_vehicle_collision
                               terrain_here.id().str(), p.to_string(), error );
                 }
             }
+            // The graffiti is inherently tied to the terrain, so if the terrain is overwritten, the original graffiti should be deleted.
+            dat.m.delete_graffiti( p );
             dat.m.ter_set( p, chosen_id );
         }
 

--- a/src/submap.cpp
+++ b/src/submap.cpp
@@ -344,6 +344,9 @@ void submap::revert_submap( submap &sr )
             }
         }
     }
+    // copy cosmetics to new submap
+    // since their positions are stored in point_sm_ms, cosmetics do not require location updates.
+    cosmetics = sr.cosmetics;
 }
 
 submap submap::get_revert_submap() const
@@ -352,6 +355,7 @@ submap submap::get_revert_submap() const
     ret.uniform_ter = uniform_ter;
     if( !is_uniform() ) {
         ret.m = std::make_unique<maptile_soa>( *m );
+        ret.cosmetics = cosmetics;
     }
 
     return ret;


### PR DESCRIPTION
#### Summary
Bugfixes "Cosmetics not moved to new submap in EOC copy_location"

#### Purpose of change

I created a cold storage room in the Flying House with a low-temperature warning sign at the door. After a teleport, I realized the sign's message couldn't be read. I tested further by drawing a graffito, which remained behind after teleportation. I have now fixed this bug.

#### Describe the solution
In the code of EOC 'copy_location', move signage and graffiti to new submap, since their positions are stored in point_sm_ms, cosmetics do not require location updates.

#### Describe alternatives you've considered

No other alternative solutions have been identified so far.

#### Testing

Following the code fix, a teleport test with the Flying House was conducted. Results showed the graffiti was successfully moved and the cold storage warning sign functioned normally. A check of the original location confirmed that the original instances of both the graffito and sign were successfully cleared.

#### Additional context

Flying House is a Mod I developed, It is just like Vanishing Arc of Aftershock that you can teleport with the ship.
