### PR TITLE
Removed redundant active transformation indication (2/2?)

### DIFF
--- a/data/json/items/armor/suits_protection.json
+++ b/data/json/items/armor/suits_protection.json
@@ -3660,7 +3660,6 @@
       "type": "transform",
       "msg": "You turn the climate control on.",
       "target": "armor_nomad_heavyplate_on",
-      "active": true,
       "need_charges_msg": "Your internal reservoir is empty."
     },
     "tool_ammo": "battery",

--- a/data/json/items/tool/electronics.json
+++ b/data/json/items/tool/electronics.json
@@ -164,7 +164,6 @@
       {
         "target": "cell_phone_flashlight",
         "msg": "You light up the screen.",
-        "active": true,
         "need_charges": 1,
         "need_charges_msg": "The cellphone's batteries need more charge.",
         "type": "transform"
@@ -258,7 +257,6 @@
         "menu_text": "Turn on the screen",
         "msg": "You power up the screen.",
         "target": "eink_tablet_pc_on",
-        "active": true,
         "need_charges": 1,
         "need_charges_msg": "The tablet batteries are dead."
       },
@@ -611,7 +609,6 @@
         "target": "laptop_screen_lit",
         "msg": "You light up the screen.",
         "menu_text": "Light up the screen",
-        "active": true,
         "need_charges": 1,
         "need_charges_msg": "The laptop's batteries need more charge.",
         "type": "transform"
@@ -717,13 +714,7 @@
     "symbol": ";",
     "color": "yellow",
     "charges_per_use": 1,
-    "use_action": {
-      "target": "noise_emitter_on",
-      "msg": "You turn the noise emitter on.",
-      "menu_text": "Turn on",
-      "active": true,
-      "type": "transform"
-    },
+    "use_action": { "target": "noise_emitter_on", "msg": "You turn the noise emitter on.", "menu_text": "Turn on", "type": "transform" },
     "flags": [ "RADIO_MODABLE", "RADIO_INVOKE_PROC", "WATER_BREAK" ],
     "pocket_data": [
       {
@@ -750,7 +741,6 @@
       "msg": "The infernal racket dies as the noise emitter turns off.",
       "ammo_scale": 0,
       "menu_text": "Turn off",
-      "active": false,
       "type": "transform"
     },
     "tick_action": [ "NOISE_EMITTER_ON" ],
@@ -776,7 +766,6 @@
       "type": "transform",
       "msg": "You turn the EMF detector on.",
       "target": "emf_detector_on",
-      "active": true,
       "need_charges_msg": "It's dead."
     },
     "flags": [ "WATER_BREAK", "ELECTRONIC" ],
@@ -866,7 +855,6 @@
         "target": "smart_phone_flashlight",
         "msg": "You activate the flashlight app.",
         "menu_text": "Turn on flashlight",
-        "active": true,
         "need_charges": 1,
         "need_charges_msg": "The smartphone's charge is too low.",
         "type": "transform"
@@ -943,7 +931,6 @@
         "target": "smart_phone_locked_flashlight",
         "msg": "You activate the flashlight app.",
         "menu_text": "Turn on flashlight",
-        "active": true,
         "need_charges": 1,
         "need_charges_msg": "The smartphone's charge is too low.",
         "type": "transform"
@@ -1078,7 +1065,6 @@
       "ammo_scale": 0,
       "target": "UPS_ON",
       "msg": "You turn the charger on.",
-      "active": true,
       "need_charges": 1,
       "need_charges_msg": "The charger's battery is empty.",
       "type": "transform"
@@ -1164,7 +1150,6 @@
     "use_action": {
       "target": "gas_charger_on",
       "msg": "You turn the charger on.",
-      "active": true,
       "need_charges": 1,
       "need_charges_msg": "The charger's tank is empty.",
       "type": "transform"
@@ -1212,7 +1197,6 @@
       "target": "noise_emitter_super_on",
       "msg": "You turn the super noise emitter on.",
       "menu_text": "Turn on",
-      "active": true,
       "type": "transform"
     },
     "flags": [ "RADIO_MODABLE", "RADIO_INVOKE_PROC", "WATER_BREAK" ],
@@ -1241,7 +1225,6 @@
       "msg": "The infernal racket dies as the super noise emitter turns off.",
       "ammo_scale": 0,
       "menu_text": "Turn off",
-      "active": false,
       "type": "transform"
     },
     "tick_action": {

--- a/data/json/items/tool/explosives.json
+++ b/data/json/items/tool/explosives.json
@@ -58,7 +58,6 @@
       "target": "dynamite_act",
       "msg": "You light the dynamite.",
       "target_timer": "20 seconds",
-      "active": true,
       "need_fire": 1,
       "menu_text": "Light fuse",
       "type": "transform"
@@ -720,7 +719,6 @@
       "need_wielding": true,
       "target": "molotov_lit",
       "msg": "You light the Molotov cocktail!",
-      "active": true,
       "moves": 250,
       "need_fire": 1,
       "menu_text": "Light rag",

--- a/data/json/items/tool/fire.json
+++ b/data/json/items/tool/fire.json
@@ -254,7 +254,6 @@
       {
         "target": "ref_lighter_on",
         "msg": "You flick the lighter.",
-        "active": true,
         "need_charges": 1,
         "need_charges_msg": "Nothing happens.",
         "menu_text": "Light up",
@@ -296,7 +295,6 @@
       {
         "target": "ref_lighter",
         "msg": "You extinguish the lighter.",
-        "active": false,
         "menu_text": "Extinguish",
         "type": "transform"
       }
@@ -343,7 +341,6 @@
     "use_action": {
       "target": "tinderbox_on",
       "msg": "You light the tinder.",
-      "active": true,
       "need_fire": 1,
       "need_fire_msg": "You need a lighter or fire to light this.",
       "need_charges": 1,
@@ -371,13 +368,7 @@
     "//COMMENT": "~30 seconds to get the tinder out and spreading under optimal conditions.",
     "use_action": [
       { "type": "firestarter", "moves": 3000, "moves_slow": 30000 },
-      {
-        "target": "tinderbox",
-        "msg": "The ember is extinguished.",
-        "active": false,
-        "menu_text": "Extinguish",
-        "type": "transform"
-      }
+      { "target": "tinderbox", "msg": "The ember is extinguished.", "menu_text": "Extinguish", "type": "transform" }
     ],
     "flags": [ "FIRESTARTER", "SPAWN_ACTIVE" ],
     "tool_ammo": [ "tinder" ]

--- a/data/json/items/tool/firefighting.json
+++ b/data/json/items/tool/firefighting.json
@@ -152,11 +152,11 @@
     "symbol": "*",
     "color": "blue",
     "use_action": {
+      "need_wielding": true,
       "target": "throw_extinguisher_act",
       "target_timer": "3 seconds",
       "menu_text": "Pull plug",
       "msg": "You pull the plug on the extinguisher grenade.",
-      "active": true,
       "type": "transform"
     },
     "flags": [ "ACT_IN_FIRE", "BOMB", "GRENADE" ],

--- a/data/json/items/tool/lighting.json
+++ b/data/json/items/tool/lighting.json
@@ -16,14 +16,7 @@
     "color": "white",
     "charges_per_use": 1,
     "pocket_data": [ { "pocket_type": "MAGAZINE", "ammo_restriction": { "candle_wax": 100 }, "rigid": true } ],
-    "use_action": {
-      "target": "candle_lit",
-      "msg": "You light the candle.",
-      "active": true,
-      "need_fire": 1,
-      "menu_text": "Light",
-      "type": "transform"
-    },
+    "use_action": { "target": "candle_lit", "msg": "You light the candle.", "need_fire": 1, "menu_text": "Light", "type": "transform" },
     "flags": [ "BURNOUT", "NO_RELOAD", "NO_UNLOAD" ]
   },
   {
@@ -66,7 +59,6 @@
       {
         "type": "transform",
         "target": "electric_lantern_on",
-        "active": true,
         "msg": "You turn the lamp on.",
         "need_charges": 1,
         "need_charges_msg": "The lantern has no batteries."
@@ -120,7 +112,6 @@
       "type": "transform",
       "msg": "You turn the flashlight on.",
       "target": "flashlight_on",
-      "active": true,
       "need_charges": 1,
       "need_charges_msg": "The flashlight's batteries are dead."
     },
@@ -182,7 +173,6 @@
       "type": "transform",
       "msg": "You turn the flashlight on.",
       "target": "diving_flashlight_small_on",
-      "active": true,
       "need_charges": 1,
       "need_charges_msg": "The flashlight's batteries are dead."
     },
@@ -237,7 +227,6 @@
       "type": "transform",
       "msg": "You turn the flashlight on.",
       "target": "diving_flashlight_small_hipower_on",
-      "active": true,
       "need_charges": 1,
       "need_charges_msg": "The flashlight's batteries are dead."
     },
@@ -293,7 +282,6 @@
         "type": "transform",
         "msg": "You turn the flashlight on.",
         "target": "diving_flashlight_variable_on_hi",
-        "active": true,
         "need_charges": 1,
         "need_charges_msg": "The flashlight's batteries are dead."
       },
@@ -443,7 +431,6 @@
     "use_action": {
       "target": "gasoline_lantern_on",
       "msg": "You turn the lamp on.",
-      "active": true,
       "need_fire": 1,
       "need_charges": 1,
       "need_charges_msg": "The lamp is empty.",
@@ -490,13 +477,7 @@
     "symbol": ";",
     "color": "light_blue",
     "pocket_data": [ { "pocket_type": "MAGAZINE", "ammo_restriction": { "glowstick_juice": 1400 }, "rigid": true } ],
-    "use_action": {
-      "target": "glowstick_lit",
-      "msg": "You activate the glowstick.",
-      "active": true,
-      "menu_text": "Activate",
-      "type": "transform"
-    },
+    "use_action": { "target": "glowstick_lit", "msg": "You activate the glowstick.", "menu_text": "Activate", "type": "transform" },
     "flags": [ "NO_UNLOAD", "NO_RELOAD" ],
     "tool_ammo": "glowstick_juice"
   },
@@ -553,7 +534,6 @@
       "menu_text": "Strike the striker",
       "type": "transform",
       "target": "handflare_lit",
-      "active": true,
       "msg": "You strike your flare and light it."
     },
     "flags": [ "NO_UNLOAD", "NO_RELOAD" ],
@@ -614,7 +594,6 @@
         "type": "transform",
         "msg": "You turn the heavy-duty flashlight on.",
         "target": "heavy_flashlight_on",
-        "active": true,
         "need_charges": 1,
         "need_charges_msg": "The heavy-duty flashlight's battery is dead."
       },
@@ -667,13 +646,7 @@
     "light": 200,
     "flags": [ "NO_UNLOAD", "NO_RELOAD", "WATER_BREAK" ],
     "use_action": [
-      {
-        "target": "lightstrip_inactive",
-        "msg": "You turn off the LED strip.",
-        "active": true,
-        "need_charges": 1,
-        "type": "transform"
-      },
+      { "target": "lightstrip_inactive", "msg": "You turn off the LED strip.", "need_charges": 1, "type": "transform" },
       { "type": "link_up", "cable_length": 10, "charge_rate": "5 W" }
     ]
   },
@@ -692,7 +665,7 @@
     "color": "white",
     "//": "25 feet (7.5 m) + 1.5 meters for plug",
     "use_action": [
-      { "target": "lightstrip", "msg": "You turn on the LED strip.", "active": true, "need_charges": 1, "type": "transform" },
+      { "target": "lightstrip", "msg": "You turn on the LED strip.", "need_charges": 1, "type": "transform" },
       { "type": "link_up", "cable_length": 9, "charge_rate": "5 W" }
     ],
     "tool_ammo": [ "battery" ]
@@ -715,7 +688,6 @@
     "use_action": {
       "target": "oil_lamp_on",
       "msg": "You turn the lamp on.",
-      "active": true,
       "need_fire": 1,
       "need_charges": 1,
       "need_charges_msg": "The lamp is empty.",
@@ -766,7 +738,6 @@
     "use_action": {
       "target": "oil_lamp_clay_on",
       "msg": "You light the lamp.",
-      "active": true,
       "need_fire": 1,
       "need_charges": 1,
       "need_charges_msg": "The lamp is empty.",
@@ -819,7 +790,6 @@
       "type": "transform",
       "msg": "You light the %s.",
       "target": "oxylamp_on",
-      "active": true,
       "need_charges": 1,
       "need_charges_msg": "The %s must be attached to a gas cylinder to light."
     },
@@ -861,7 +831,6 @@
     "use_action": {
       "target": "reading_light_on",
       "msg": "You switch on the reading light.",
-      "active": true,
       "need_charges": 1,
       "need_charges_msg": "The reading light winks out.",
       "type": "transform"
@@ -908,7 +877,6 @@
       {
         "target": "smart_lamp_on",
         "msg": "You turn the smart lamp on.",
-        "active": true,
         "need_charges": 1,
         "need_charges_msg": "The smart lamp batteries are dead.",
         "type": "transform"
@@ -984,7 +952,6 @@
     "use_action": {
       "target": "torch_lit",
       "msg": "You light the torch.",
-      "active": true,
       "need_fire": 1,
       "menu_text": "Light torch",
       "type": "transform"
@@ -1015,13 +982,7 @@
     "//COMMENT": "Open flame or effectively so. ~5 seconds to transfer flame assuming optimal conditions, a minute at worst.",
     "use_action": [
       { "type": "firestarter", "moves": 500, "moves_slow": 6000 },
-      {
-        "target": "torch",
-        "msg": "The torch is extinguished.",
-        "active": false,
-        "menu_text": "Extinguish",
-        "type": "transform"
-      }
+      { "target": "torch", "msg": "The torch is extinguished.", "menu_text": "Extinguish", "type": "transform" }
     ],
     "techniques": [ "WBLOCK_1" ],
     "light": 60,
@@ -1046,7 +1007,6 @@
     "use_action": {
       "target": "propane_lantern_on",
       "msg": "You turn the lamp on.",
-      "active": true,
       "need_charges": 1,
       "need_charges_msg": "The lamp is empty.",
       "type": "transform"
@@ -1097,7 +1057,6 @@
     "use_action": {
       "target": "candle_small_lit",
       "msg": "You light the candle.",
-      "active": true,
       "need_fire": 1,
       "menu_text": "Light",
       "type": "transform"

--- a/data/json/items/tool/masonry.json
+++ b/data/json/items/tool/masonry.json
@@ -105,7 +105,7 @@
     "charges_per_use": 5,
     "techniques": [ "SWEEP" ],
     "use_action": [
-      { "target": "electric_masonrysaw_on", "msg": "You turn on the masonry saw.", "active": true, "type": "transform" },
+      { "target": "electric_masonrysaw_on", "msg": "You turn on the masonry saw.", "type": "transform" },
       {
         "type": "link_up",
         "menu_text": "Plug in / Unplug",

--- a/data/json/items/tool/misc.json
+++ b/data/json/items/tool/misc.json
@@ -391,7 +391,6 @@
       {
         "target": "large_space_heater_on",
         "msg": "You turn on the heater.",
-        "active": true,
         "need_charges": 1,
         "need_charges_msg": "The heater needs more charge.",
         "menu_text": "Turn on",
@@ -603,7 +602,6 @@
       {
         "target": "small_space_heater_on",
         "msg": "You turn on the heater.",
-        "active": true,
         "need_charges": 1,
         "need_charges_msg": "The heater needs more charge.",
         "menu_text": "Turn on",

--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -765,7 +765,6 @@
       "type": "transform",
       "msg": "You activate your %s.",
       "target": "thermal_socks_on",
-      "active": true,
       "need_charges": 1,
       "need_charges_msg": "The %s's batteries are dead."
     },
@@ -821,7 +820,6 @@
       "type": "transform",
       "msg": "You activate your %s.",
       "target": "thermal_suit_on",
-      "active": true,
       "need_charges": 1,
       "need_charges_msg": "The %s's batteries are dead."
     },
@@ -877,7 +875,6 @@
       "type": "transform",
       "msg": "You activate your %s.",
       "target": "thermal_gloves_on",
-      "active": true,
       "need_charges": 1,
       "need_charges_msg": "The %s's batteries are dead."
     },
@@ -933,7 +930,6 @@
       "type": "transform",
       "msg": "You activate your %s.",
       "target": "thermal_mask_on",
-      "active": true,
       "need_charges": 1,
       "need_charges_msg": "The %s's batteries are dead."
     },
@@ -1014,7 +1010,6 @@
       "type": "transform",
       "msg": "You turn the headlamp on.",
       "target": "wearable_light_on",
-      "active": true,
       "need_charges": 1,
       "need_charges_msg": "The headlamp batteries are dead."
     },
@@ -1130,7 +1125,6 @@
       "type": "transform",
       "msg": "You turn the headlamp on.",
       "target": "wearable_big_light_on",
-      "active": true,
       "need_charges": 1,
       "need_charges_msg": "The headlamp batteries are dead."
     },
@@ -1290,7 +1284,6 @@
       "menu_text": "Turn on headlamps",
       "msg": "\"Activating illumination.\"",
       "target": "helmet_eod_on",
-      "active": true,
       "need_charges": 1,
       "need_charges_msg": "\"Illumination disabled, low power.\""
     },
@@ -1347,7 +1340,6 @@
       "type": "transform",
       "msg": "You activate your RM13 combat armor.\nRivtech Model 13 RivOS v2.19:   ONLINE.\nCBRN defense system:            ONLINE.\nAcoustic dampening system:      ONLINE.\nThermal regulation system:      ONLINE.\nVision enhancement system:      ONLINE.\nElectro-reactive armor system:  ONLINE.\nAll systems nominal.",
       "target": "rm13_armor_on",
-      "active": true,
       "need_worn": true,
       "need_charges": 1,
       "need_charges_msg": "The RM13 combat armor's battery is dead."
@@ -1535,7 +1527,6 @@
       "type": "transform",
       "msg": "An LED light in the %s flickers on.",
       "target": "dimensional_anchor_on",
-      "active": true,
       "need_charges": 1,
       "need_charges_msg": "It seems like this device needs power."
     },
@@ -1599,7 +1590,6 @@
       "type": "transform",
       "msg": "Initiating\nRunning suit integrity diagnostics…\nAll systems operational.",
       "target": "phase_immersion_suit_on",
-      "active": true,
       "need_charges": 1,
       "need_charges_msg": "Warning: Operating on minimal power.  Protection compromised."
     },
@@ -1624,8 +1614,7 @@
       "USE_UPS",
       "NO_UNLOAD",
       "COMBAT_TOGGLEABLE",
-      "UNBREAKABLE_MELEE",
-      "SPAWN_ACTIVE"
+      "UNBREAKABLE_MELEE"
     ],
     "armor": [
       {
@@ -1743,7 +1732,8 @@
       "USE_UPS",
       "NO_UNLOAD",
       "COMBAT_TOGGLEABLE",
-      "UNBREAKABLE_MELEE"
+      "UNBREAKABLE_MELEE",
+      "SPAWN_ACTIVE"
     ]
   },
   {
@@ -1774,7 +1764,6 @@
       "type": "transform",
       "msg": "You activate your %s.",
       "target": "rebreather_on",
-      "active": true,
       "need_charges": 1,
       "need_charges_msg": "The %s's filter is used up."
     },
@@ -1827,7 +1816,6 @@
       "type": "transform",
       "msg": "You activate your %s.",
       "target": "rebreather_xl_on",
-      "active": true,
       "need_charges": 1,
       "need_charges_msg": "The %s's filter is used up."
     },
@@ -1886,7 +1874,6 @@
       "type": "transform",
       "msg": "You activate your %s.",
       "target": "rebreather_xs_on",
-      "active": true,
       "need_charges": 1,
       "need_charges_msg": "The %s's filter is used up."
     },
@@ -2445,7 +2432,6 @@
       "type": "transform",
       "msg": "You activate your %s.",
       "target": "goggles_nv_on",
-      "active": true,
       "need_charges": 1,
       "need_charges_msg": "The %s's batteries are dead."
     },
@@ -2501,7 +2487,6 @@
       "type": "transform",
       "msg": "You activate your %s.",
       "target": "goggles_ir_on",
-      "active": true,
       "need_charges": 1,
       "need_charges_msg": "The %s's batteries are dead."
     },
@@ -2605,7 +2590,6 @@
       "type": "transform",
       "msg": "You activate your %s.",
       "target": "mask_h20survivor_on",
-      "active": true,
       "need_charges": 1,
       "need_charges_msg": "The %s's filter is used up."
     },
@@ -2670,7 +2654,6 @@
       "type": "transform",
       "msg": "You activate your %s.",
       "target": "mask_h20survivorxl_on",
-      "active": true,
       "need_charges": 1,
       "need_charges_msg": "The %s's filter is used up."
     }
@@ -2688,7 +2671,6 @@
       "type": "transform",
       "msg": "You activate your %s.",
       "target": "mask_h20survivorxs_on",
-      "active": true,
       "need_charges": 1,
       "need_charges_msg": "The %s's filter is used up."
     },
@@ -2891,7 +2873,6 @@
       "type": "transform",
       "msg": "You activate your %s.",
       "target": "thermal_outfit_on",
-      "active": true,
       "need_charges": 1,
       "need_charges_msg": "The %s's batteries are dead."
     },
@@ -3166,7 +3147,6 @@
       "type": "transform",
       "msg": "You turn the earmuffs on.",
       "target": "powered_earmuffs_on",
-      "active": true,
       "need_charges": 1,
       "need_charges_msg": "The earmuff's batteries are dead."
     },
@@ -3243,7 +3223,6 @@
       "type": "transform",
       "msg": "You turn the earplugs on.",
       "target": "powered_earplugs_on",
-      "active": true,
       "need_charges": 1,
       "need_charges_msg": "The earplugs' batteries are dead."
     },
@@ -3652,7 +3631,6 @@
         "type": "transform",
         "msg": "You turn the blanket's heating elements on.",
         "target": "electric_blanket_on",
-        "active": true,
         "need_charges": 1,
         "need_charges_msg": "The blanket's batteries are dead."
       },
@@ -3718,7 +3696,6 @@
       "type": "transform",
       "msg": "Your HUD lights-up: \"Greetings Foodperson, your shift begins now.  Good luck!\"",
       "target": "foodperson_mask_on",
-      "active": true,
       "need_worn": true,
       "need_charges": 1,
       "need_charges_msg": "The mask's batteries are dead."
@@ -3844,7 +3821,6 @@
       "type": "transform",
       "msg": "You turn the flight helmet on.",
       "target": "flight_helmet_on",
-      "active": true,
       "need_charges": 1,
       "need_charges_msg": "The helmet's batteries are dead."
     },
@@ -3945,7 +3921,7 @@
     "material_thickness": 8,
     "environmental_protection": 0,
     "charges_per_use": 1,
-    "use_action": { "type": "transform", "msg": "The %s engages.", "target": "utility_exoskeleton_on", "active": true },
+    "use_action": { "type": "transform", "msg": "The %s engages.", "target": "utility_exoskeleton_on" },
     "flags": [ "STURDY", "OVERSIZE", "BELTED", "WATER_FRIENDLY", "ELECTRONIC" ],
     "faults": [ { "fault_group": "electronic_general" } ],
     "armor": [
@@ -4005,7 +3981,7 @@
     "material_thickness": 8,
     "environmental_protection": 0,
     "charges_per_use": 1,
-    "use_action": { "type": "transform", "msg": "The %s engages.", "target": "ice_utility_exoskeleton_on", "active": true },
+    "use_action": { "type": "transform", "msg": "The %s engages.", "target": "ice_utility_exoskeleton_on" },
     "flags": [ "STURDY", "OVERSIZE", "BELTED", "WATER_FRIENDLY", "ELECTRONIC" ],
     "faults": [ { "fault_group": "electronic_general" } ],
     "armor": [


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Remove redundant "active" specification from use_action transformations (the info is already provided by the SPAWN_ACTIVE flag).

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
See purpose...
By-catches:
- Throwable fire extinguisher: Require wielding, as testing had it activate before it could be wielded.
- Phase immersion suit: The SPAWN_ACTIVE flag was on the wrong version. Moved it.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
- Debug spawned each item in its inactive form, activated it (after loading it with "fuel" in needed), verified it was active, deactivated it, and verified it reverted correctly.
- The UPS has its own special processing. Verified it still works by activating UPS supported items and seeing the charges being drawn from the UPS.
- The foodperson mask ran out of power when I waited for 1 hour (and it couldn't be taken off for 53 minutes). Didn't bother to try again and wait in segments to pass the "shift end" time, but expect it to revert properly in that case as well.


<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
- The weird UPS_Off item (as opposed to UPS_OFF) is used only as junk sold by GODCO. This is most likely a bug, but could be intentional to sell useless junk (it can't be activated).
- Someone probably should look at the description of the Electric Lantern (Off) (haven't checked (On): "You could install it into a vehicle: atomic lamp and atomic nightlight". I don't know why this item refers to these removed ones, but it's probably wrong.
- The LED strips/lightstrips are still broken, and so couldn't be tested. You can't turn the on even when connected to power, because the require a battery while not having a battery slot.
- Noted the EoCs can have "active" fields in their transformations, and removing the one I tested caused it to fail. Something to look at later.
- The exosuits took two ticks to register their transformation effects on the PC stat sidebar both on activation and deactivation.
- There may be a need for another PR covering included mods.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
