### PR TITLE
Fixing various UI issues

### DIFF
--- a/src/editmap.cpp
+++ b/src/editmap.cpp
@@ -1129,6 +1129,9 @@ void editmap::edit_feature()
 
     blink = true;
     bool quit = false;
+
+    // Hold list till end
+    shared_ptr_fast<uilist_impl> ui_impl;
     do {
         const T_id override( emenu.selected );
         if( override ) {
@@ -1152,7 +1155,7 @@ void editmap::edit_feature()
         info_title_curr = info_title<T_t>();
         do_ui_invalidation();
 
-        emenu.query( false, get_option<int>( "BLINK_SPEED" ) );
+        ui_impl = emenu.query( false, get_option<int>( "BLINK_SPEED" ) );
         if( emenu.ret == UILIST_CANCEL ) {
             quit = true;
         } else if( ( emenu.ret >= 0 && static_cast<size_t>( emenu.ret ) < T_t::count() ) ||
@@ -1252,6 +1255,7 @@ void editmap::edit_fld()
     restore_on_out_of_scope info_title_prev( info_title_curr );
     map &here = get_map();
 
+    shared_ptr_fast<uilist_impl> ui_impl;
     blink = true;
     do {
         const field_type_id override( fmenu.selected );
@@ -1278,7 +1282,7 @@ void editmap::edit_fld()
         info_title_curr = pgettext( "Map editor: Editing field effects", "Field effects" );
         do_ui_invalidation();
 
-        fmenu.query( false, get_option<int>( "BLINK_SPEED" ) );
+        ui_impl = fmenu.query( false, get_option<int>( "BLINK_SPEED" ) );
         if( ( fmenu.ret > 0 && static_cast<size_t>( fmenu.ret ) < field_type::count() ) ||
             ( fmenu.ret == UILIST_ADDITIONAL && ( fmenu.ret_act == "LEFT" || fmenu.ret_act == "RIGHT" ) ) ) {
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2108,6 +2108,7 @@ int game::inventory_item_menu( item_location locThisItem,
         bool first_execution = true;
         static int lang_version = detail::get_current_language_version();
         catacurses::window w_info;
+        shared_ptr_fast<uilist_impl> ui_impl;
         do {
             //lang check here is needed to redraw the menu when using "Toggle language to English" option
             if( first_execution || lang_version != detail::get_current_language_version() ) {
@@ -2222,7 +2223,7 @@ int game::inventory_item_menu( item_location locThisItem,
             }
 
             const int prev_selected = action_menu.selected;
-            action_menu.query( false );
+            ui_impl = action_menu.query( false );
             if( action_menu.ret >= 0 ) {
                 cMenu = action_menu.ret; /* Remember: hotkey == retval, see addentry above. */
             } else if( action_menu.ret == UILIST_UNBOUND && action_menu.ret_act == "RIGHT" ) {

--- a/src/uilist.cpp
+++ b/src/uilist.cpp
@@ -947,7 +947,7 @@ shared_ptr_fast<uilist_impl> uilist::query( bool loop, int timeout, bool allow_u
         } else {
             ret = UILIST_ERROR;
         }
-        return;
+        return nullptr;
     }
 #endif
     ret_evt = input_event();

--- a/src/uilist.cpp
+++ b/src/uilist.cpp
@@ -510,10 +510,6 @@ void uilist::init()
 
     input_category = "UILIST";
     additional_actions.clear();
-
-    if( ui ) {
-        ui.reset();
-    }
 }
 
 input_context uilist::create_main_input_context() const
@@ -873,21 +869,22 @@ bool uilist::scrollby( const uilist::scroll_amount scrollby )
 
 shared_ptr_fast<uilist_impl> uilist::create_or_get_ui()
 {
-    if( !ui ) {
+    shared_ptr_fast<uilist_impl> current_ui = ui.lock();
+    if( !current_ui ) {
         if( title.empty() ) {
-            ui = make_shared_fast<uilist_impl>( *this );
+            ui = current_ui = make_shared_fast<uilist_impl>( *this );
         } else {
-            ui =  make_shared_fast<uilist_impl>( *this, title );
+            ui = current_ui = make_shared_fast<uilist_impl>( *this, title );
         }
     }
-    return ui;
+    return current_ui;
 }
 
 /**
  * Handle input and update display
  *
  */
-void uilist::query( bool loop, int timeout, bool allow_unfiltered_hotkeys )
+shared_ptr_fast<uilist_impl> uilist::query( bool loop, int timeout, bool allow_unfiltered_hotkeys )
 {
 #if defined(__ANDROID__)
     if( get_option<bool>( "ANDROID_NATIVE_UI" ) && !entries.empty() && !desired_bounds ) {
@@ -956,14 +953,12 @@ void uilist::query( bool loop, int timeout, bool allow_unfiltered_hotkeys )
     ret_evt = input_event();
     if( entries.empty() ) {
         ret = UILIST_ERROR;
-        return;
+        return nullptr;
     }
     ret = UILIST_WAIT_INPUT;
 
     input_context ctxt = create_main_input_context();
 
-    // Ensure we have a uilist to work on
-    // TODO: We don't even use the return value here, find a better solution
     shared_ptr_fast<uilist_impl> ui = create_or_get_ui();
 
 #if defined(__ANDROID__)
@@ -1041,6 +1036,8 @@ void uilist::query( bool loop, int timeout, bool allow_unfiltered_hotkeys )
             }
         }
     } while( loop && ret == UILIST_WAIT_INPUT );
+
+    return ui;
 }
 
 ///@}

--- a/src/uilist.h
+++ b/src/uilist.h
@@ -314,7 +314,7 @@ class uilist // NOLINT(cata-xy)
             };
         };
         bool scrollby( uilist::scroll_amount scrollby );
-        void query( bool loop = true, int timeout = 50, bool allow_unfiltered_hotkeys = false );
+        shared_ptr_fast<uilist_impl> query( bool loop = true, int timeout = 50, bool allow_unfiltered_hotkeys = false );
         void filterlist();
         // In add_entry/add_entry_desc/add_entry_col, int k only support letters
         // (a-z, A-Z) and digits (0-9), MENU_AUTOASSIGN, and 0 or ' ' (disable
@@ -488,7 +488,7 @@ class uilist // NOLINT(cata-xy)
         std::map<input_event, int, std::function<bool( const input_event &, const input_event & )>>
         keymap { input_event::compare_type_mod_code };
 
-        shared_ptr_fast<uilist_impl> ui;
+        weak_ptr_fast<uilist_impl> ui;
 
         std::unique_ptr<string_input_popup_imgui> filter_popup;
 

--- a/src/uilist.h
+++ b/src/uilist.h
@@ -314,7 +314,8 @@ class uilist // NOLINT(cata-xy)
             };
         };
         bool scrollby( uilist::scroll_amount scrollby );
-        shared_ptr_fast<uilist_impl> query( bool loop = true, int timeout = 50, bool allow_unfiltered_hotkeys = false );
+        shared_ptr_fast<uilist_impl> query( bool loop = true, int timeout = 50,
+                                            bool allow_unfiltered_hotkeys = false );
         void filterlist();
         // In add_entry/add_entry_desc/add_entry_col, int k only support letters
         // (a-z, A-Z) and digits (0-9), MENU_AUTOASSIGN, and 0 or ' ' (disable


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Various UI problems caused by shared_ptr change"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

This fixes a bunch of issues caused by my shared_ptr change
Fixes #83854
Fixes #83870
Fixes #83873

and reverts the shared_ptr change
Reverts #83856
Reverts #83832

BUT still fixes the UI bouncing in
Fixes #78783

And scrolling:
Fixes #82428

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
I've reverted the shared_ptr change as it affected to many parts of the code.
Now it is just a weak_ptr, but when it is locked it optionally passes out the shared_ptr to the calling function.
This allows the calling function to stop the UI being created over and over if its looping over the query()

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

Tested ALL issues that have been posted, and tested the bouncing.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
