### PR TITLE
Aftershock: Removed active in favor of SPAWN_ACTIVE

### DIFF
--- a/data/mods/aftershock_exoplanet/items/armor/exosuit/exosuit_frame.json
+++ b/data/mods/aftershock_exoplanet/items/armor/exosuit/exosuit_frame.json
@@ -305,7 +305,6 @@
       {
         "target": "modular_exosuit_on",
         "msg": "The %s engages.",
-        "active": true,
         "need_charges": 1,
         "need_charges_msg": "The suit does not have enough charge.",
         "type": "transform"
@@ -337,7 +336,8 @@
       "SUN_GLASSES",
       "FLASH_PROTECTION",
       "TARDIS",
-      "MODULE_HOLDER"
+      "MODULE_HOLDER",
+      "SPAWN_ACTIVE"
     ],
     "power_draw": "6460 mW",
     "revert_to": "modular_exosuit",
@@ -535,7 +535,6 @@
       {
         "target": "modular_exosuit_light_on",
         "msg": "The %s engages.",
-        "active": true,
         "need_charges": 1,
         "need_charges_msg": "The suit does not have enough charge.",
         "type": "transform"
@@ -565,7 +564,8 @@
       "SUN_GLASSES",
       "FLASH_PROTECTION",
       "TARDIS",
-      "MODULE_HOLDER"
+      "MODULE_HOLDER",
+      "SPAWN_ACTIVE"
     ],
     "power_draw": "5787 mW",
     "revert_to": "modular_exosuit_light",

--- a/data/mods/aftershock_exoplanet/items/armor/exosuit/exosuit_melee.json
+++ b/data/mods/aftershock_exoplanet/items/armor/exosuit/exosuit_melee.json
@@ -73,7 +73,6 @@
       "type": "transform",
       "msg": "You activate the drill's motor.",
       "target": "heavy_drill_on",
-      "active": true,
       "need_charges": 1,
       "need_charges_msg": "There is not enough charge to activate the drill."
     },
@@ -98,7 +97,7 @@
     "name": { "str": "heavy mining drill (on)", "str_pl": "heavy mining drills (on)" },
     "description": "This is a portable roadheader, designed to chew through the toughest rock.  Currently active, the drill heads are a blur.",
     "qualities": [ [ "HAMMER", 1 ], [ "DIG", 3 ] ],
-    "extend": { "flags": [ "POWERED", "EXO_LARGE_GADGET" ] },
+    "extend": { "flags": [ "POWERED", "EXO_LARGE_GADGET", "SPAWN_ACTIVE" ] },
     "to_hit": { "grip": "weapon", "length": "long", "surface": "every", "balance": "clumsy" },
     "power_draw": "1500 mW",
     "revert_to": "heavy_drill",
@@ -121,7 +120,7 @@
     "symbol": "[",
     "color": "light_gray",
     "power_armor": true,
-    "flags": [ "WATER_FRIENDLY", "DURABLE_MELEE", "OVERSIZE", "OUTER", "EXO_MEDIUM_GADGET" ],
+    "flags": [ "WATER_FRIENDLY", "DURABLE_MELEE", "OVERSIZE", "OUTER", "EXO_MEDIUM_GADGET", "SPAWN_ACTIVE" ],
     "armor": [
       {
         "material": [
@@ -210,7 +209,7 @@
       }
     ],
     "charges_per_use": 1,
-    "use_action": { "target": "exosuit_power_cutter_on", "msg": "You rev up the power cutter!", "active": true, "type": "transform" },
+    "use_action": { "target": "exosuit_power_cutter_on", "msg": "You rev up the power cutter!", "type": "transform" },
     "flags": [ "ALWAYS_TWOHAND", "NONCONDUCTIVE", "EXO_LARGE_GADGET" ],
     "armor": [
       {
@@ -243,7 +242,7 @@
       "type": "transform"
     },
     "qualities": [ [ "CUT", 3 ], [ "SAW_M", 20 ], [ "SAW_M_FINE", 1 ], [ "BUTCHER", -80 ] ],
-    "extend": { "flags": [ "MESSY" ] },
+    "extend": { "flags": [ "MESSY", "SPAWN_ACTIVE" ] },
     "melee_damage": { "bash": 10, "cut": 100 }
   }
 ]

--- a/data/mods/aftershock_exoplanet/items/armor/exosuit/exosuit_modules.json
+++ b/data/mods/aftershock_exoplanet/items/armor/exosuit/exosuit_modules.json
@@ -168,7 +168,6 @@
       "target": "exo_carry_on",
       "msg": "The %s engages.",
       "menu_text": "Turn on module",
-      "active": true,
       "need_charges": 5,
       "need_charges_msg": "There is not enough charge to activate the module.",
       "type": "transform"
@@ -183,7 +182,7 @@
     "copy-from": "exo_carry",
     "name": { "str": "exosuit load support module (on)", "str_pl": "exosuit load support modules (on)" },
     "description": "This module significantly increases the exosuit's weight bearing at the cost of increased power consumption.  It is turned on and continually drawing power.  Use it to turn it off.",
-    "flags": [ "FRAGILE", "CANT_WEAR", "WATERPROOF", "USE_UPS", "EXO_MEDIUM_GADGET" ],
+    "flags": [ "FRAGILE", "CANT_WEAR", "WATERPROOF", "USE_UPS", "EXO_MEDIUM_GADGET", "SPAWN_ACTIVE" ],
     "max_worn": 1,
     "power_draw": "1 W",
     "revert_to": "exo_carry",
@@ -213,7 +212,6 @@
       "target": "exo_small_carry_on",
       "msg": "The %s engages.",
       "menu_text": "Turn on module",
-      "active": true,
       "need_charges": 5,
       "need_charges_msg": "There is not enough charge to activate the module.",
       "type": "transform"
@@ -228,7 +226,7 @@
     "copy-from": "exo_small_carry",
     "name": { "str": "exosuit small load support module (on)", "str_pl": "exosuit small load support modules (on)" },
     "description": "This module increases the exosuit's weight bearing at the cost of increased power consumption.  It is turned on and continually drawing power.  Use it to turn it off.",
-    "flags": [ "FRAGILE", "CANT_WEAR", "WATERPROOF", "USE_UPS", "EXO_SMALL_GADGET" ],
+    "flags": [ "FRAGILE", "CANT_WEAR", "WATERPROOF", "USE_UPS", "EXO_SMALL_GADGET", "SPAWN_ACTIVE" ],
     "power_draw": "500 mW",
     "revert_to": "exo_small_carry",
     "use_action": {
@@ -272,7 +270,6 @@
       "type": "transform",
       "msg": "You turn the lamp on low.",
       "target": "exo_flashlight_low",
-      "active": true,
       "need_charges": 1,
       "need_charges_msg": "There is not enough charge to activate the module."
     },
@@ -294,7 +291,7 @@
       "target": "exo_flashlight_high"
     },
     "light": 250,
-    "flags": [ "USE_UPS", "CANT_WEAR", "EXO_SMALL_GADGET" ]
+    "flags": [ "USE_UPS", "CANT_WEAR", "EXO_SMALL_GADGET", "SPAWN_ACTIVE" ]
   },
   {
     "id": "exo_flashlight_high",
@@ -312,7 +309,7 @@
       "target": "exo_flashlight"
     },
     "light": 500,
-    "flags": [ "USE_UPS", "CANT_WEAR", "EXO_SMALL_GADGET" ]
+    "flags": [ "USE_UPS", "CANT_WEAR", "EXO_SMALL_GADGET", "SPAWN_ACTIVE" ]
   },
   {
     "id": "exo_recoil",
@@ -333,7 +330,6 @@
       "type": "transform",
       "msg": "You activate your suit's recoil dampeners.",
       "target": "exo_recoil_on",
-      "active": true,
       "need_charges": 1,
       "need_charges_msg": "There is not enough charge to activate the module."
     },
@@ -355,7 +351,7 @@
       "msg": "You turn off the recoil mitigation system.",
       "target": "exo_recoil"
     },
-    "flags": [ "USE_UPS", "CANT_WEAR", "EXO_SMALL_GADGET" ],
+    "flags": [ "USE_UPS", "CANT_WEAR", "EXO_SMALL_GADGET", "SPAWN_ACTIVE" ],
     "max_worn": 1
   },
   {
@@ -388,7 +384,6 @@
       "menu_text": "Activate",
       "msg": "You activate your %s.",
       "target": "exo_bio_oxygen_on",
-      "active": true,
       "need_charges_msg": "The %s's tank is exhausted."
     },
     "tool_ammo": [ "oxygen" ],
@@ -397,7 +392,7 @@
   {
     "id": "exo_bio_oxygen_on",
     "type": "ITEM",
-    "subtypes": [ "TOOL", "ARMOR" ],
+    "subtypes": [ "TOOL", "ARMOR", "ARTIFACT" ],
     "category": "exosuit",
     "name": { "str": "exosuit air supply module (on)", "str_pl": "exosuit air supply modules (on)" },
     "description": "This is a SCBA, a self-contained breathing apparatus.  A series of tanks contain a tailored bacteria that processes Co2 back into breathable air over time.  It is activated and will supply breathable air.",
@@ -409,7 +404,7 @@
     "color": "light_gray",
     "environmental_protection": 15,
     "armor": [ { "encumbrance": 5, "coverage": 100, "covers": [ "mouth" ] } ],
-    "flags": [ "WATER_FRIENDLY", "CANT_WEAR", "STURDY", "NO_UNLOAD", "NO_RELOAD", "REBREATHER", "EXO_MEDIUM_GADGET" ],
+    "flags": [ "WATER_FRIENDLY", "CANT_WEAR", "STURDY", "NO_UNLOAD", "NO_RELOAD", "REBREATHER", "EXO_MEDIUM_GADGET", "SPAWN_ACTIVE" ],
     "max_worn": 1,
     "turns_per_charge": 30,
     "pocket_data": [
@@ -595,7 +590,6 @@
       "target": "exo_AR_module_on",
       "msg": "The %s engages.",
       "menu_text": "Turn on module",
-      "active": true,
       "need_charges": 5,
       "need_charges_msg": "There is not enough charge to activate the module.",
       "type": "transform"
@@ -607,6 +601,7 @@
     "type": "ITEM",
     "subtypes": [ "TOOL" ],
     "copy-from": "exo_AR_module",
+    "extend": { "flags": [ "SPAWN_ACTIVE" ] },
     "name": { "str": "exosuit AR research module (on)", "str_pl": "exosuit AR research modules (on)" },
     "power_draw": "250 mW",
     "revert_to": "exo_AR_module",

--- a/data/mods/aftershock_exoplanet/items/armor/exosuit/exosuit_underlayers.json
+++ b/data/mods/aftershock_exoplanet/items/armor/exosuit/exosuit_underlayers.json
@@ -19,7 +19,6 @@
       "type": "transform",
       "msg": "You activate your %s.",
       "target": "afs_exo_standard_underlayer_on",
-      "active": true,
       "need_charges": 1,
       "need_charges_msg": "The %s's batteries are dead."
     },
@@ -63,7 +62,7 @@
     "copy-from": "afs_exo_standard_underlayer",
     "repairs_like": "afs_exo_standard_underlayer",
     "type": "ITEM",
-    "subtypes": [ "TOOL", "ARMOR" ],
+    "subtypes": [ "TOOL", "ARMOR", "ARTIFACT" ],
     "name": { "str": "exosuit underlayer (on)", "str_pl": "exosuit underlayers (on)" },
     "description": "A form-fitting suit meant to be worn by an exosuit pilot.  Although not a requirement for the operation of an exosuit, it features haptic feedback systems that offer improved performance and comfort while doing so.  The suit is not designed for use outside of armor.  This standard model uses a scale mail of overlapping plastic disks for incidental protection.\n\nIts temperature control unit is active and drawing power from its own battery port.",
     "power_draw": "10288 mW",
@@ -76,7 +75,7 @@
       "msg": "Your %s deactivates.",
       "target": "afs_exo_standard_underlayer"
     },
-    "extend": { "flags": [ "ACTIVE_CRYOSUIT" ] }
+    "extend": { "flags": [ "ACTIVE_CRYOSUIT", "SPAWN_ACTIVE" ] }
   },
   {
     "id": "afs_exo_combat_underlayer",
@@ -98,7 +97,6 @@
       "type": "transform",
       "msg": "You activate your %s.",
       "target": "afs_exo_combat_underlayer_on",
-      "active": true,
       "need_charges": 1,
       "need_charges_msg": "The %s's batteries are dead."
     },
@@ -142,7 +140,7 @@
     "copy-from": "afs_exo_combat_underlayer",
     "repairs_like": "afs_exo_combat_underlayer",
     "type": "ITEM",
-    "subtypes": [ "TOOL", "ARMOR" ],
+    "subtypes": [ "TOOL", "ARMOR", "ARTIFACT" ],
     "name": { "str": "exosuit combat underlayer (on)", "str_pl": "exosuit combat underlayers (on)" },
     "description": "A form-fitting suit meant to be worn by an exosuit pilot.  Although not a requirement for the operation of an exosuit, it features haptic feedback systems that offer improved performance and comfort while doing so.  The suit is not designed for use outside of armor.  This model includes tough Kevlar to protect from spalling.\n\nIts temperature control unit is active and drawing power from its own battery port.",
     "power_draw": "12626 mW",
@@ -155,7 +153,7 @@
       "msg": "Your %s deactivates.",
       "target": "afs_exo_combat_underlayer"
     },
-    "extend": { "flags": [ "ACTIVE_CRYOSUIT" ] }
+    "extend": { "flags": [ "ACTIVE_CRYOSUIT", "SPAWN_ACTIVE" ] }
   },
   {
     "id": "afs_exo_eva_underlayer",
@@ -177,7 +175,6 @@
       "type": "transform",
       "msg": "You activate your %s.",
       "target": "afs_exo_eva_underlayer_on",
-      "active": true,
       "need_charges": 1,
       "need_charges_msg": "The %s's batteries are dead."
     },
@@ -223,7 +220,7 @@
     "copy-from": "afs_exo_eva_underlayer",
     "repairs_like": "afs_exo_eva_underlayer",
     "type": "ITEM",
-    "subtypes": [ "TOOL", "ARMOR" ],
+    "subtypes": [ "TOOL", "ARMOR", "ARTIFACT" ],
     "name": { "str": "exosuit EVA underlayer (on)", "str_pl": "exosuit EVA underlayers (on)" },
     "description": "A form-fitting suit meant to be worn by an exosuit pilot.  Although not a requirement for the operation of an exosuit, it features haptic feedback systems that offer improved performance and comfort while doing so.  This model is designed for hazardous environments and sacrifices mobility for extra protection.\n\nIts temperature control unit is active and drawing power from its own battery port.",
     "power_draw": "15432 mW",
@@ -236,7 +233,7 @@
       "msg": "Your %s deactivates.",
       "target": "afs_exo_eva_underlayer"
     },
-    "extend": { "flags": [ "ACTIVE_CRYOSUIT" ] }
+    "extend": { "flags": [ "ACTIVE_CRYOSUIT", "SPAWN_ACTIVE" ] }
   },
   {
     "id": "afs_exo_hazard_underlayer",
@@ -258,7 +255,6 @@
       "type": "transform",
       "msg": "You activate your %s.",
       "target": "afs_exo_hazard_underlayer_on",
-      "active": true,
       "need_charges": 1,
       "need_charges_msg": "The %s's batteries are dead."
     },
@@ -304,7 +300,7 @@
     "copy-from": "afs_exo_hazard_underlayer",
     "repairs_like": "afs_exo_hazard_underlayer",
     "type": "ITEM",
-    "subtypes": [ "TOOL", "ARMOR" ],
+    "subtypes": [ "TOOL", "ARMOR", "ARTIFACT" ],
     "name": { "str": "exosuit utility underlayer (on)", "str_pl": "exosuit utility underlayers (on)" },
     "description": "A form-fitting suit meant to be worn by an exosuit pilot.  Although not a requirement for the operation of an exosuit, it features haptic feedback systems that offer improved performance and comfort while doing so.  This model is designed for hazardous environments and sacrifices mobility for extra protection.\n\nIts temperature control unit is active and drawing power from its own battery port.",
     "power_draw": "13227 mW",
@@ -317,6 +313,6 @@
       "msg": "Your %s deactivates.",
       "target": "afs_exo_hazard_underlayer"
     },
-    "extend": { "flags": [ "ACTIVE_CRYOSUIT" ] }
+    "extend": { "flags": [ "ACTIVE_CRYOSUIT", "SPAWN_ACTIVE" ] }
   }
 ]

--- a/data/mods/aftershock_exoplanet/items/armor/headsets.json
+++ b/data/mods/aftershock_exoplanet/items/armor/headsets.json
@@ -29,7 +29,6 @@
         "menu_text": "activate the infovisor",
         "msg": "You lower the visor and flick the control dial to active.",
         "type": "transform",
-        "active": true,
         "need_charges": 1,
         "need_charges_msg": "The visor's batteries are dead."
       }
@@ -43,7 +42,7 @@
   {
     "id": "afs_combat_headset",
     "type": "ITEM",
-    "subtypes": [ "TOOL", "ARMOR" ],
+    "subtypes": [ "TOOL", "ARMOR", "ARTIFACT" ],
     "category": "clothing",
     "copy-from": "afs_combat_headset_off",
     "name": { "str": "tactical infovisor" },
@@ -60,7 +59,8 @@
       "SUN_GLASSES",
       "WATER_BREAK",
       "PADDED",
-      "ELECTRONIC"
+      "ELECTRONIC",
+      "SPAWN_ACTIVE"
     ],
     "faults": [ { "fault_group": "electronic_general" } ],
     "revert_to": "afs_combat_headset_off",

--- a/data/mods/aftershock_exoplanet/items/armor/winter_suits.json
+++ b/data/mods/aftershock_exoplanet/items/armor/winter_suits.json
@@ -17,7 +17,6 @@
       "type": "transform",
       "msg": "You activate your %s.",
       "target": "afs_magellan_suit_on",
-      "active": true,
       "need_charges": 1,
       "need_charges_msg": "The %s's batteries are dead."
     },
@@ -75,7 +74,7 @@
     "copy-from": "afs_magellan_suit",
     "repairs_like": "afs_magellan_suit",
     "type": "ITEM",
-    "subtypes": [ "TOOL", "ARMOR" ],
+    "subtypes": [ "TOOL", "ARMOR", "ARTIFACT" ],
     "name": { "str": "Magellan exosuit (on)", "str_pl": "Magellan exosuits (on)" },
     "looks_like": "afs_cryopod_bodyglove",
     "description": "The temperature control units of this high-tech garment are currently active, and continuously draining battery power.  Use it to turn them off.",
@@ -89,7 +88,7 @@
       "msg": "Your %s deactivates.",
       "target": "afs_magellan_suit"
     },
-    "extend": { "flags": [ "ACTIVE_CRYOSUIT" ] }
+    "extend": { "flags": [ "ACTIVE_CRYOSUIT", "SPAWN_ACTIVE" ] }
   },
   {
     "id": "afs_frontier_cryo",
@@ -109,7 +108,6 @@
       "type": "transform",
       "msg": "You activate your %s.",
       "target": "afs_frontier_cryo_on",
-      "active": true,
       "need_charges": 1,
       "need_charges_msg": "The %s's batteries are dead."
     },
@@ -163,14 +161,14 @@
     "copy-from": "afs_frontier_cryo",
     "repairs_like": "afs_frontier_cryo",
     "type": "ITEM",
-    "subtypes": [ "TOOL", "ARMOR" ],
+    "subtypes": [ "TOOL", "ARMOR", "ARTIFACT" ],
     "name": { "str": "frontier cryo suit (on)", "str_pl": "frontier cryo suits (on)" },
     "looks_like": "robofac_enviro_suit",
     "description": "The temperature control units of this high-tech garment are currently active, and continuously draining battery power.  Use it to turn them off.",
     "power_draw": "6944 mW",
     "warmth": 150,
     "revert_to": "afs_frontier_cryo",
-    "extend": { "flags": [ "ACTIVE_CRYOSUIT" ] },
+    "extend": { "flags": [ "ACTIVE_CRYOSUIT", "SPAWN_ACTIVE" ] },
     "use_action": {
       "type": "transform",
       "ammo_scale": 0,
@@ -198,7 +196,6 @@
       "type": "transform",
       "msg": "You activate your %s.",
       "target": "afs_combat_cryo_on",
-      "active": true,
       "need_charges": 1,
       "need_charges_msg": "The %s's batteries are dead."
     },
@@ -241,7 +238,7 @@
     "copy-from": "afs_combat_cryo",
     "repairs_like": "afs_frontier_cryo",
     "type": "ITEM",
-    "subtypes": [ "TOOL", "ARMOR" ],
+    "subtypes": [ "TOOL", "ARMOR", "ARTIFACT" ],
     "name": { "str": "combat cryo suit (on)", "str_pl": "combat cryo suits (on)" },
     "looks_like": "afs_cryopod_bodyglove",
     "description": "The temperature control units of this high-tech garment are currently active, and continuously draining battery power.  Use it to turn them off.",
@@ -255,7 +252,7 @@
       "msg": "Your %s deactivates.",
       "target": "afs_combat_cryo"
     },
-    "extend": { "flags": [ "ACTIVE_CRYOSUIT" ] }
+    "extend": { "flags": [ "ACTIVE_CRYOSUIT", "SPAWN_ACTIVE" ] }
   },
   {
     "id": "afs_combat_cryo_xl",
@@ -269,7 +266,6 @@
       "type": "transform",
       "msg": "You activate your %s.",
       "target": "afs_combat_cryo_on_xl",
-      "active": true,
       "need_charges": 1,
       "need_charges_msg": "The %s's batteries are dead."
     },
@@ -290,7 +286,7 @@
       "msg": "Your %s deactivates.",
       "target": "afs_combat_cryo_xl"
     },
-    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL", "ACTIVE_CRYOSUIT" ] }
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL", "ACTIVE_CRYOSUIT", "SPAWN_ACTIVE" ] }
   },
   {
     "id": "afs_cryopod_bodyglove",
@@ -320,7 +316,6 @@
       "type": "transform",
       "msg": "You activate your %s.",
       "target": "afs_cryopod_bodyglove_on",
-      "active": true,
       "need_charges": 5,
       "need_charges_msg": "The %s's batteries are dead."
     },
@@ -355,7 +350,7 @@
     "copy-from": "afs_cryopod_bodyglove",
     "repairs_like": "afs_cryopod_bodyglove",
     "type": "ITEM",
-    "subtypes": [ "TOOL", "ARMOR" ],
+    "subtypes": [ "TOOL", "ARMOR", "ARTIFACT" ],
     "name": { "str": "cryopod bodyglove (on)", "str_pl": "cryopod bodygloves (on)" },
     "looks_like": "afs_cryopod_bodyglove",
     "description": "A dark orange bodyglove, hundreds of tubes curl over its surface, tracing the contours of human musculature.  Meant to control body temperature during prolonged cryopreservation, it could easily keep you comfortable in any earthly climate.  The temperature control units of this high-tech garment are currently active, and continuously draining battery power.  Use it to turn them off.",
@@ -378,7 +373,8 @@
       "PADDED",
       "THERMOMETER",
       "HYGROMETER",
-      "ACTIVE_CRYOSUIT"
+      "ACTIVE_CRYOSUIT",
+      "SPAWN_ACTIVE"
     ]
   }
 ]

--- a/data/mods/aftershock_exoplanet/items/tools.json
+++ b/data/mods/aftershock_exoplanet/items/tools.json
@@ -15,12 +15,7 @@
     "symbol": ";",
     "color": "light_green",
     "use_action": [
-      {
-        "target": "afs_atomic_smartphone_flashlight",
-        "msg": "You activate the flashlight app.",
-        "active": true,
-        "type": "transform"
-      },
+      { "target": "afs_atomic_smartphone_flashlight", "msg": "You activate the flashlight app.", "type": "transform" },
       "CAMERA",
       {
         "type": "mp3",
@@ -147,7 +142,6 @@
       "type": "transform",
       "target": "afs_motion_sensor_on",
       "need_charges": 1,
-      "active": true,
       "msg": "The %s screen flashes on."
     },
     "melee_damage": { "bash": 6 },
@@ -176,7 +170,8 @@
       "type": "transform",
       "target": "afs_motion_sensor",
       "msg": "The %s screen flashes briefly before fading out."
-    }
+    },
+    "extend": { "flags": [ "SPAWN_ACTIVE" ] }
   },
   {
     "id": "afs_welding_paste",
@@ -236,15 +231,10 @@
       "PORTABLE_GAME",
       "E_FILE_DEVICE",
       "EBOOKSAVE",
-      {
-        "type": "mp3",
-        "transform": "afs_atomic_smartphone_music",
-        "message": "The phone turns off.",
-        "activate": false
-      }
+      { "type": "mp3", "transform": "afs_atomic_smartphone", "message": "The phone turns off.", "activate": false }
     ],
     "tick_action": [ "MP3_ON" ],
-    "extend": { "flags": [ "TRADER_AVOID" ] }
+    "extend": { "flags": [ "TRADER_AVOID", "SPAWN_ACTIVE" ] }
   },
   {
     "id": "afs_atomic_smartphone_flashlight",
@@ -265,7 +255,7 @@
       }
     ],
     "light": 25,
-    "extend": { "flags": [ "TRADER_AVOID" ] }
+    "extend": { "flags": [ "TRADER_AVOID", "SPAWN_ACTIVE" ] }
   },
   {
     "id": "afs_wraitheon_smartphone",
@@ -322,7 +312,7 @@
       "EBOOKSAVE",
       { "type": "mp3", "transform": "afs_wraitheon_smartphone", "message": "The phone turns off.", "activate": false }
     ],
-    "extend": { "flags": [ "TRADER_AVOID" ] },
+    "extend": { "flags": [ "TRADER_AVOID", "SPAWN_ACTIVE" ] },
     "tick_action": [ "MP3_ON" ]
   },
   {
@@ -330,7 +320,7 @@
     "copy-from": "afs_atomic_smartphone_flashlight",
     "type": "ITEM",
     "subtypes": [ "TOOL" ],
-    "name": { "str": "Executive's smartphone - Flashlight", "str_pl": "Executive's smartphones - Flashlight" },
+    "name": { "str": "Wraitheon executive's smartphone - Flashlight", "str_pl": "Executive's smartphones - Flashlight" },
     "revert_to": "afs_atomic_smartphone",
     "use_action": [
       "PORTABLE_GAME",
@@ -342,7 +332,8 @@
         "menu_text": "Turn off flashlight",
         "type": "transform"
       }
-    ]
+    ],
+    "extend": { "flags": [ "SPAWN_ACTIVE" ] }
   },
   {
     "id": "afs_atompot",
@@ -377,7 +368,7 @@
     "color": "light_red",
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "watertight": true, "ammo_restriction": { "gasoline": 500 } } ],
     "charges_per_use": 1,
-    "use_action": { "target": "afs_power_cutter_on", "msg": "You rev up the power cutter!", "active": true, "type": "transform" },
+    "use_action": { "target": "afs_power_cutter_on", "msg": "You rev up the power cutter!", "type": "transform" },
     "flags": [ "ALWAYS_TWOHAND", "NONCONDUCTIVE" ],
     "melee_damage": { "bash": 7, "cut": 3 },
     "tool_ammo": [ "gasoline" ]
@@ -399,7 +390,7 @@
       "type": "transform"
     },
     "qualities": [ [ "CUT", 2 ], [ "SAW_M", 20 ], [ "SAW_M_FINE", 1 ], [ "BUTCHER", -70 ] ],
-    "flags": [ "ALWAYS_TWOHAND", "MESSY", "TRADER_AVOID", "NONCONDUCTIVE" ],
+    "flags": [ "ALWAYS_TWOHAND", "MESSY", "TRADER_AVOID", "NONCONDUCTIVE", "SPAWN_ACTIVE" ],
     "melee_damage": { "bash": 7, "cut": 80 }
   },
   {
@@ -419,7 +410,7 @@
     "color": "yellow",
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "watertight": true, "ammo_restriction": { "gasoline": 500 } } ],
     "charges_per_use": 1,
-    "use_action": { "target": "afs_murdersaw_on", "msg": "You rev up the murdersaw!", "active": true, "type": "transform" },
+    "use_action": { "target": "afs_murdersaw_on", "msg": "You rev up the murdersaw!", "type": "transform" },
     "flags": [ "ALWAYS_TWOHAND", "NONCONDUCTIVE" ],
     "melee_damage": { "bash": 6, "cut": 3 },
     "tool_ammo": [ "gasoline" ]
@@ -441,7 +432,7 @@
       "type": "transform"
     },
     "qualities": [ [ "CUT", 2 ], [ "SAW_M", 10 ], [ "BUTCHER", -50 ] ],
-    "flags": [ "ALWAYS_TWOHAND", "MESSY", "TRADER_AVOID", "NONCONDUCTIVE" ],
+    "flags": [ "ALWAYS_TWOHAND", "MESSY", "TRADER_AVOID", "NONCONDUCTIVE", "SPAWN_ACTIVE" ],
     "melee_damage": { "bash": 6, "cut": 80 }
   },
   {
@@ -553,7 +544,6 @@
         "target": "control_laptop_screen_lit",
         "msg": "You light up the screen.",
         "menu_text": "Light up the screen",
-        "active": true,
         "need_charges": 1,
         "need_charges_msg": "The laptop's batteries need more charge.",
         "type": "transform"
@@ -594,7 +584,7 @@
       "type": "transform"
     },
     "light": 10,
-    "flags": [ "WATCH", "TRADER_AVOID" ]
+    "flags": [ "WATCH", "TRADER_AVOID", "SPAWN_ACTIVE" ]
   },
   {
     "id": "vr_laptop",
@@ -616,7 +606,6 @@
         "target": "vr_laptop_holosuite",
         "msg": "The holosuite comes to life around you.",
         "menu_text": "power on holosuite",
-        "active": true,
         "need_charges": 1,
         "need_charges_msg": "The laptop's batteries need more charge.",
         "type": "transform"
@@ -682,7 +671,7 @@
       "menu_text": "Turn off",
       "type": "transform"
     },
-    "flags": [ "WATCH", "TRADER_AVOID" ],
+    "flags": [ "WATCH", "TRADER_AVOID", "SPAWN_ACTIVE" ],
     "passive_effects": [
       {
         "has": "WORN",
@@ -1047,13 +1036,7 @@
     "category": "tools",
     "name": { "str": "atomic lamp (covered)", "str_pl": "atomic lamps (covered)" },
     "description": "A fairly hefty and frankly ugly lamp with a thick base and an odd spheroidal \"shade\".  While this is a commercial product, early versions were made from scavenged landing or spacecraft lights.  While the appeal of them there was to lower the maintence burden, as a lamp it's nothing more than a gimmick of infinite, albeit dim light.  This one has been closed.",
-    "use_action": {
-      "target": "afs_atomic_lamp",
-      "active": true,
-      "msg": "You open the lamp's cover.",
-      "menu_text": "Open cover",
-      "type": "transform"
-    },
+    "use_action": { "target": "afs_atomic_lamp", "msg": "You open the lamp's cover.", "menu_text": "Open cover", "type": "transform" },
     "flags": [ "LEAK_DAM", "RADIOACTIVE", "ALLOWS_REMOTE_USE" ]
   },
   {
@@ -1088,7 +1071,6 @@
     "description": "A commercially produced reading light, with the gimmick of never having to replace batteries thanks to its nuclear decay powered power source.  Instead of having an on/off switch, there is instead a cover you close over it.",
     "use_action": {
       "target": "afs_atomic_light",
-      "active": true,
       "msg": "You open the nightlight's cover.",
       "menu_text": "Open cover",
       "type": "transform"
@@ -1151,8 +1133,7 @@
       "type": "transform",
       "msg": "You open the headlamp's cover.",
       "menu_text": "Open cover",
-      "target": "afs_atomic_headlamp",
-      "active": true
+      "target": "afs_atomic_headlamp"
     }
   }
 ]

--- a/data/mods/aftershock_exoplanet/items/weapons.json
+++ b/data/mods/aftershock_exoplanet/items/weapons.json
@@ -23,8 +23,7 @@
       "target": "afs_energy_saber_on",
       "msg": "You activate the claw, and its bludgeoning surface slowly flattens into an edge as it begins to glow red-hot",
       "need_charges": 1,
-      "need_charges_msg": "The claw is out of charge.",
-      "active": true
+      "need_charges_msg": "The claw is out of charge."
     },
     "flags": [ "BELT_CLIP", "DURABLE_MELEE" ],
     "pocket_data": [
@@ -52,7 +51,7 @@
     "color": "light_blue",
     "looks_like": "arming_sword",
     "turns_per_charge": 4,
-    "flags": [ "DURABLE_MELEE" ],
+    "flags": [ "DURABLE_MELEE", "SPAWN_ACTIVE" ],
     "techniques": [ "WBLOCK_2" ],
     "revert_to": "afs_energy_saber_off",
     "use_action": {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Remove usage of redundant active transformation field in favor of SPAWN_ACTIVE on active items.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Remove the redundant field and add the flag.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Debug spawned each of the active and inactive items and transformed them to verify it worked, with exceptions and notes under Additional context.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
- The UPS units in the mod should be updated to distinguish between on and off status (has been done in the base game).
- A number of active versions of items were given the "ARTIFACT" type matching the base item, as debug spawed items wouldn't display the same otherwise.
- Couldn't test exo_AR_module, as I could find no way to power it to allow it to be turned on.
- The atomic smartphone music was bugged. Transformed into itself when turned off. Fixed.
- Wratheon phone name changed for lit version. Fixed.
- VR glasses: Why is the active holo stuff artifact, but not the base laptop? This causes the debug spawned item to display differently (and possibly behave differently). Overall, it appears item conversion doesn't create subtypes. I leave this for the maintainers to sort out.
- CE-4: Why isn't it compatible with reusable light batteries (which was the ones I debug spawned to try to power it before finding it's not compatible)?

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
