### PR TITLE
[Xedra Evolved] Fix werewolf advancement eoc

### DIFF
--- a/data/mods/Xedra_Evolved/eocs/werewolf_advancement_eocs.json
+++ b/data/mods/Xedra_Evolved/eocs/werewolf_advancement_eocs.json
@@ -194,7 +194,7 @@
           "EOC_WEREWOLF_LUNAR_GIFT_LEVEL_TWO_WEREWOLF_EXTRA_WEAKPOINT_HITS",
           "EOC_WEREWOLF_LUNAR_GIFT_LEVEL_TWO_WEREWOLF_FAR_JUMP",
           "EOC_WEREWOLF_LUNAR_GIFT_LEVEL_TWO_WEREWOLF_CAMOUFLAGE_COAT",
-          "Go Back."
+          "EOC_WEREWOLF_LUNAR_GIFT_GO_BACK"
         ],
         "names": [
           "Learn <trait_name:WEREWOLF_SENSE_SPIRITS_AND_ALIENS>",
@@ -211,7 +211,7 @@
           "<trait_name:WEREWOLF_EXTRA_WEAKPOINT_HITS>\n<trait_description:WEREWOLF_EXTRA_WEAKPOINT_HITS>",
           "<trait_name:WEREWOLF_FAR_JUMP>\n<trait_description:WEREWOLF_FAR_JUMP>",
           "<trait_name:WEREWOLF_CAMOUFLAGE_COAT>\n<trait_description:WEREWOLF_CAMOUFLAGE_COAT>",
-          "Go Back."
+          "Go back to the Gift level selection."
         ],
         "allow_cancel": true
       }
@@ -273,7 +273,7 @@
           "EOC_WEREWOLF_LUNAR_GIFT_LEVEL_THREE_WEREWOLF_MANA_BONUS_AFTER_KILL",
           "EOC_WEREWOLF_LUNAR_GIFT_LEVEL_THREE_WEREWOLF_STRENGTH_BONUS",
           "EOC_WEREWOLF_LUNAR_GIFT_LEVEL_THREE_WEREWOLF_BATTLE_FURY",
-          "Go Back."
+          "EOC_WEREWOLF_LUNAR_GIFT_GO_BACK"
         ],
         "names": [
           "Learn <trait_name:WEREWOLF_SILVER_CLAWS>",
@@ -288,7 +288,7 @@
           "<trait_name:WEREWOLF_MANA_BONUS_AFTER_KILL>\n<trait_description:WEREWOLF_MANA_BONUS_AFTER_KILL>",
           "<trait_name:WEREWOLF_STRENGTH_BONUS>\n<trait_description:WEREWOLF_STRENGTH_BONUS>",
           "<trait_name:WEREWOLF_BATTLE_FURY>\n<trait_description:WEREWOLF_BATTLE_FURY>",
-          "Go Back."
+          "Go back to the Gift level selection."
         ],
         "allow_cancel": true
       }
@@ -340,7 +340,7 @@
           "EOC_WEREWOLF_LUNAR_GIFT_LEVEL_FOUR_WEREWOLF_SUPER_FAST_REGENERATION",
           "EOC_WEREWOLF_LUNAR_GIFT_LEVEL_FOUR_WEREWOLF_SUMMON_FOG",
           "EOC_WEREWOLF_LUNAR_GIFT_LEVEL_FOUR_WEREWOLF_MOON_ARMOR",
-          "Go Back."
+          "EOC_WEREWOLF_LUNAR_GIFT_GO_BACK"
         ],
         "names": [
           "Learn <trait_name:WEREWOLF_SUPER_FAST_REGENERATION>",
@@ -353,7 +353,7 @@
           "<trait_name:WEREWOLF_SUPER_FAST_REGENERATION>\n<trait_description:WEREWOLF_SUPER_FAST_REGENERATION>",
           "<trait_name:WEREWOLF_SUMMON_FOG>\n<trait_description:WEREWOLF_SUMMON_FOG>",
           "<trait_name:WEREWOLF_MOON_ARMOR>\n<trait_description:WEREWOLF_MOON_ARMOR>",
-          "Go Back."
+          "Go back to the Gift level selection."
         ],
         "allow_cancel": true
       }
@@ -397,7 +397,7 @@
           "EOC_WEREWOLF_LUNAR_GIFT_LEVEL_FIVE_WEREWOLF_CLOSE_TEAR_IN_REALITY",
           "EOC_WEREWOLF_LUNAR_GIFT_LEVEL_FIVE_WEREWOLF_WALK_THROUGH_WALLS",
           "EOC_WEREWOLF_LUNAR_GIFT_LEVEL_FIVE_WEREWOLF_SUMMON_SHADOW_PACK",
-          "Go Back."
+          "EOC_WEREWOLF_LUNAR_GIFT_GO_BACK"
         ],
         "names": [
           "Learn <trait_name:WEREWOLF_TRANSFORM_INTO_PRIMAL_FORM>",
@@ -412,7 +412,7 @@
           "<trait_name:WEREWOLF_CLOSE_TEAR_IN_REALITY>\n<trait_description:WEREWOLF_CLOSE_TEAR_IN_REALITY>",
           "<trait_name:WEREWOLF_WALK_THROUGH_WALLS>\n<trait_description:WEREWOLF_WALK_THROUGH_WALLS>",
           "<trait_name:WEREWOLF_SUMMON_SHADOW_PACK>\n<trait_description:WEREWOLF_SUMMON_SHADOW_PACK>",
-          "Go Back."
+          "Go back to the Gift level selection."
         ],
         "allow_cancel": true
       }

--- a/data/mods/Xedra_Evolved/eocs/werewolf_advancement_eocs.json
+++ b/data/mods/Xedra_Evolved/eocs/werewolf_advancement_eocs.json
@@ -134,7 +134,6 @@
     "condition": { "not": { "u_has_trait": "WEREWOLF_SMELL_NEARBY_ENEMIES" } },
     "effect": [
       { "set_string_var": "WEREWOLF_SMELL_NEARBY_ENEMIES", "target_var": { "u_val": "xe_werewolf_power_to_gain" } },
-      { "u_add_trait": { "u_val": "xe_werewolf_power_to_gain" } },
       { "u_assign_activity": "ACT_WEREWOLF_LEARNING_MOON_GIFT", "duration": [ "1 hours", "1 hours 30 minutes" ] }
     ]
   },
@@ -144,7 +143,6 @@
     "condition": { "not": { "u_has_trait": "WEREWOLF_NO_SCENT" } },
     "effect": [
       { "set_string_var": "WEREWOLF_NO_SCENT", "target_var": { "u_val": "xe_werewolf_power_to_gain" } },
-      { "u_add_trait": { "u_val": "xe_werewolf_power_to_gain" } },
       { "u_assign_activity": "ACT_WEREWOLF_LEARNING_MOON_GIFT", "duration": [ "1 hours", "1 hours 30 minutes" ] }
     ]
   },
@@ -154,7 +152,6 @@
     "condition": { "not": { "u_has_trait": "WEREWOLF_ILLUMINATE_TARGET" } },
     "effect": [
       { "set_string_var": "WEREWOLF_ILLUMINATE_TARGET", "target_var": { "u_val": "xe_werewolf_power_to_gain" } },
-      { "u_add_trait": { "u_val": "xe_werewolf_power_to_gain" } },
       { "u_assign_activity": "ACT_WEREWOLF_LEARNING_MOON_GIFT", "duration": [ "1 hours", "1 hours 30 minutes" ] }
     ]
   },
@@ -164,7 +161,6 @@
     "condition": { "not": { "u_has_trait": "WEREWOLF_FRIEND_TO_ANIMALS" } },
     "effect": [
       { "set_string_var": "WEREWOLF_FRIEND_TO_ANIMALS", "target_var": { "u_val": "xe_werewolf_power_to_gain" } },
-      { "u_add_trait": { "u_val": "xe_werewolf_power_to_gain" } },
       { "u_assign_activity": "ACT_WEREWOLF_LEARNING_MOON_GIFT", "duration": [ "1 hours", "1 hours 30 minutes" ] }
     ]
   },
@@ -174,7 +170,6 @@
     "condition": { "not": { "u_has_trait": "WEREWOLF_SMASH_TERRAIN" } },
     "effect": [
       { "set_string_var": "WEREWOLF_SMASH_TERRAIN", "target_var": { "u_val": "xe_werewolf_power_to_gain" } },
-      { "u_add_trait": { "u_val": "xe_werewolf_power_to_gain" } },
       { "u_assign_activity": "ACT_WEREWOLF_LEARNING_MOON_GIFT", "duration": [ "1 hours", "1 hours 30 minutes" ] }
     ]
   },
@@ -184,7 +179,6 @@
     "condition": { "not": { "u_has_trait": "WEREWOLF_CLIMB_IN_WOLF_FORM" } },
     "effect": [
       { "set_string_var": "WEREWOLF_CLIMB_IN_WOLF_FORM", "target_var": { "u_val": "xe_werewolf_power_to_gain" } },
-      { "u_add_trait": { "u_val": "xe_werewolf_power_to_gain" } },
       { "u_assign_activity": "ACT_WEREWOLF_LEARNING_MOON_GIFT", "duration": [ "1 hours", "1 hours 30 minutes" ] }
     ]
   },
@@ -229,7 +223,6 @@
     "condition": { "not": { "u_has_trait": "WEREWOLF_SENSE_SPIRITS_AND_ALIENS" } },
     "effect": [
       { "set_string_var": "WEREWOLF_SENSE_SPIRITS_AND_ALIENS", "target_var": { "u_val": "xe_werewolf_power_to_gain" } },
-      { "u_add_trait": { "u_val": "xe_werewolf_power_to_gain" } },
       { "u_assign_activity": "ACT_WEREWOLF_LEARNING_MOON_GIFT", "duration": [ "2 hours", "3 hours" ] }
     ]
   },
@@ -239,7 +232,6 @@
     "condition": { "not": { "u_has_trait": "WEREWOLF_STUN_MACHINE" } },
     "effect": [
       { "set_string_var": "WEREWOLF_STUN_MACHINE", "target_var": { "u_val": "xe_werewolf_power_to_gain" } },
-      { "u_add_trait": { "u_val": "xe_werewolf_power_to_gain" } },
       { "u_assign_activity": "ACT_WEREWOLF_LEARNING_MOON_GIFT", "duration": [ "2 hours", "3 hours" ] }
     ]
   },
@@ -249,7 +241,6 @@
     "condition": { "not": { "u_has_trait": "WEREWOLF_EXTRA_WEAKPOINT_HITS" } },
     "effect": [
       { "set_string_var": "WEREWOLF_EXTRA_WEAKPOINT_HITS", "target_var": { "u_val": "xe_werewolf_power_to_gain" } },
-      { "u_add_trait": { "u_val": "xe_werewolf_power_to_gain" } },
       { "u_assign_activity": "ACT_WEREWOLF_LEARNING_MOON_GIFT", "duration": [ "2 hours", "3 hours" ] }
     ]
   },
@@ -259,7 +250,6 @@
     "condition": { "not": { "u_has_trait": "WEREWOLF_FAR_JUMP" } },
     "effect": [
       { "set_string_var": "WEREWOLF_FAR_JUMP", "target_var": { "u_val": "xe_werewolf_power_to_gain" } },
-      { "u_add_trait": { "u_val": "xe_werewolf_power_to_gain" } },
       { "u_assign_activity": "ACT_WEREWOLF_LEARNING_MOON_GIFT", "duration": [ "2 hours", "3 hours" ] }
     ]
   },
@@ -269,7 +259,6 @@
     "condition": { "not": { "u_has_trait": "WEREWOLF_CAMOUFLAGE_COAT" } },
     "effect": [
       { "set_string_var": "WEREWOLF_CAMOUFLAGE_COAT", "target_var": { "u_val": "xe_werewolf_power_to_gain" } },
-      { "u_add_trait": { "u_val": "xe_werewolf_power_to_gain" } },
       { "u_assign_activity": "ACT_WEREWOLF_LEARNING_MOON_GIFT", "duration": [ "2 hours", "3 hours" ] }
     ]
   },
@@ -311,7 +300,6 @@
     "condition": { "not": { "u_has_trait": "WEREWOLF_SILVER_CLAWS" } },
     "effect": [
       { "set_string_var": "WEREWOLF_SILVER_CLAWS", "target_var": { "u_val": "xe_werewolf_power_to_gain" } },
-      { "u_add_trait": { "u_val": "xe_werewolf_power_to_gain" } },
       { "u_assign_activity": "ACT_WEREWOLF_LEARNING_MOON_GIFT", "duration": [ "3 hours", "4 hours 30 minutes" ] }
     ]
   },
@@ -321,7 +309,6 @@
     "condition": { "not": { "u_has_trait": "WEREWOLF_MANA_BONUS_AFTER_KILL" } },
     "effect": [
       { "set_string_var": "WEREWOLF_MANA_BONUS_AFTER_KILL", "target_var": { "u_val": "xe_werewolf_power_to_gain" } },
-      { "u_add_trait": { "u_val": "xe_werewolf_power_to_gain" } },
       { "u_assign_activity": "ACT_WEREWOLF_LEARNING_MOON_GIFT", "duration": [ "3 hours", "4 hours 30 minutes" ] }
     ]
   },
@@ -331,7 +318,6 @@
     "condition": { "not": { "u_has_trait": "WEREWOLF_STRENGTH_BONUS" } },
     "effect": [
       { "set_string_var": "WEREWOLF_STRENGTH_BONUS", "target_var": { "u_val": "xe_werewolf_power_to_gain" } },
-      { "u_add_trait": { "u_val": "xe_werewolf_power_to_gain" } },
       { "u_assign_activity": "ACT_WEREWOLF_LEARNING_MOON_GIFT", "duration": [ "3 hours", "4 hours 30 minutes" ] }
     ]
   },
@@ -341,7 +327,6 @@
     "condition": { "not": { "u_has_trait": "WEREWOLF_BATTLE_FURY" } },
     "effect": [
       { "set_string_var": "WEREWOLF_BATTLE_FURY", "target_var": { "u_val": "xe_werewolf_power_to_gain" } },
-      { "u_add_trait": { "u_val": "xe_werewolf_power_to_gain" } },
       { "u_assign_activity": "ACT_WEREWOLF_LEARNING_MOON_GIFT", "duration": [ "3 hours", "4 hours 30 minutes" ] }
     ]
   },
@@ -380,7 +365,6 @@
     "condition": { "not": { "u_has_trait": "WEREWOLF_SUPER_FAST_REGENERATION" } },
     "effect": [
       { "set_string_var": "WEREWOLF_SUPER_FAST_REGENERATION", "target_var": { "u_val": "xe_werewolf_power_to_gain" } },
-      { "u_add_trait": { "u_val": "xe_werewolf_power_to_gain" } },
       { "u_assign_activity": "ACT_WEREWOLF_LEARNING_MOON_GIFT", "duration": [ "4 hours", "6 hours" ] }
     ]
   },
@@ -390,7 +374,6 @@
     "condition": { "not": { "u_has_trait": "WEREWOLF_SUMMON_FOG" } },
     "effect": [
       { "set_string_var": "WEREWOLF_SUMMON_FOG", "target_var": { "u_val": "xe_werewolf_power_to_gain" } },
-      { "u_add_trait": { "u_val": "xe_werewolf_power_to_gain" } },
       { "u_assign_activity": "ACT_WEREWOLF_LEARNING_MOON_GIFT", "duration": [ "4 hours", "6 hours" ] }
     ]
   },
@@ -400,7 +383,6 @@
     "condition": { "not": { "u_has_trait": "WEREWOLF_MOON_ARMOR" } },
     "effect": [
       { "set_string_var": "WEREWOLF_MOON_ARMOR", "target_var": { "u_val": "xe_werewolf_power_to_gain" } },
-      { "u_add_trait": { "u_val": "xe_werewolf_power_to_gain" } },
       { "u_assign_activity": "ACT_WEREWOLF_LEARNING_MOON_GIFT", "duration": [ "4 hours", "6 hours" ] }
     ]
   },
@@ -442,7 +424,6 @@
     "condition": { "not": { "u_has_trait": "WEREWOLF_TRANSFORM_INTO_PRIMAL_FORM" } },
     "effect": [
       { "set_string_var": "WEREWOLF_TRANSFORM_INTO_PRIMAL_FORM", "target_var": { "u_val": "xe_werewolf_power_to_gain" } },
-      { "u_add_trait": { "u_val": "xe_werewolf_power_to_gain" } },
       { "u_assign_activity": "ACT_WEREWOLF_LEARNING_MOON_GIFT", "duration": [ "5 hours", "7 hours 30 minutes" ] }
     ]
   },
@@ -452,7 +433,6 @@
     "condition": { "not": { "u_has_trait": "WEREWOLF_CLOSE_TEAR_IN_REALITY" } },
     "effect": [
       { "set_string_var": "WEREWOLF_CLOSE_TEAR_IN_REALITY", "target_var": { "u_val": "xe_werewolf_power_to_gain" } },
-      { "u_add_trait": { "u_val": "xe_werewolf_power_to_gain" } },
       { "u_assign_activity": "ACT_WEREWOLF_LEARNING_MOON_GIFT", "duration": [ "5 hours", "7 hours 30 minutes" ] }
     ]
   },
@@ -462,7 +442,6 @@
     "condition": { "not": { "u_has_trait": "WEREWOLF_WALK_THROUGH_WALLS" } },
     "effect": [
       { "set_string_var": "WEREWOLF_WALK_THROUGH_WALLS", "target_var": { "u_val": "xe_werewolf_power_to_gain" } },
-      { "u_add_trait": { "u_val": "xe_werewolf_power_to_gain" } },
       { "u_assign_activity": "ACT_WEREWOLF_LEARNING_MOON_GIFT", "duration": [ "5 hours", "7 hours 30 minutes" ] }
     ]
   },
@@ -472,7 +451,6 @@
     "condition": { "not": { "u_has_trait": "WEREWOLF_SUMMON_SHADOW_PACK" } },
     "effect": [
       { "set_string_var": "WEREWOLF_SUMMON_SHADOW_PACK", "target_var": { "u_val": "xe_werewolf_power_to_gain" } },
-      { "u_add_trait": { "u_val": "xe_werewolf_power_to_gain" } },
       { "u_assign_activity": "ACT_WEREWOLF_LEARNING_MOON_GIFT", "duration": [ "5 hours", "7 hours 30 minutes" ] }
     ]
   }


### PR DESCRIPTION
#### Summary
Bugfixes "Fix werewolf advancement eoc"

#### Purpose of change
I was doing a run using the werewolf system in Xedra Evolved, and noticed I could get any amount of advancement traits without exp limitations by canceling the advancement activity mid-way. This is possible because the desired trait is given at the start of the activity, but the exp threshold for getting the next advancement is only bumped up once the activity finishes.

#### Describe the solution
I believe the desired behavior is for the trait to be given at the end of the activity, as the configs are actually already set up that way. It's just that the trait is *also* given at the start for some reason, perhaps a remnant of an earlier version or something. Either way that makes the fix simple, I just removed giving the trait at the start.

I also noticed that the back button in the lvl 2-5 traits selector was raising errors. Since I'm in this file, I figured I'd fix it by copying the config from the lvl 1 selector.

#### Describe alternatives you've considered
Not fixing it

#### Testing
Loaded up the game with this config and confirmed that advancing gives the traits as expected.

Also if I interrupt the activity mid-way, I no longer get the perk and have to try again.

Tested the back button as well, no errors anymore.

#### Additional context
None
