### PR TITLE
Insulation works on map items, is now a pocket property.

### DIFF
--- a/data/json/items/containers/containers.json
+++ b/data/json/items/containers/containers.json
@@ -2266,11 +2266,11 @@
         "pocket_type": "CONTAINER",
         "rigid": true,
         "watertight": true,
+        "insulation": 10,
         "max_contains_volume": "1 L",
         "max_contains_weight": "4 kg"
       }
     ],
-    "insulation": 10,
     "flags": [ "COLLAPSE_CONTENTS" ]
   },
   {

--- a/data/mods/aftershock_exoplanet/items/containers.json
+++ b/data/mods/aftershock_exoplanet/items/containers.json
@@ -84,10 +84,10 @@
         "rigid": true,
         "watertight": true,
         "max_contains_volume": "1 L",
+        "insulation": 3000,
         "max_contains_weight": "4 kg"
       }
     ],
-    "insulation": 1600,
     "use_action": "HEAT_LIQUID_ITEMS",
     "flags": [ "COLLAPSE_CONTENTS", "BELT_CLIP" ]
   },

--- a/doc/JSON/ITEM.md
+++ b/doc/JSON/ITEM.md
@@ -125,7 +125,7 @@ These fields can be read by any ITEM regardless of subtypes:
 "longest_side": "15 cm",                     // Length of longest item dimension. Default is cube root of volume.
 "light": 300,                                // How much light this item emits, like a flashlight. 10 is equal 1 tile of light, so 300 would illuminate 30 tiles circle around the player.
 "rigid": false,                              // For non-rigid items volume (and for worn items encumbrance) increases proportional to contents
-"insulation": 1,                             // (Optional, default = 1) If container or vehicle part, how much insulation should it provide to the contents
+"insulation": 1,                             // (Optional, default = 1) How much insulation should it provide to the contents as a vehicle part.
 "price": "1 USD",                                // Barter value of an item. Used as barter value only when price_postapoc isn't defined. For stackable items (ammo, comestibles) this is the price for stack_size charges. Can use string "cent", "cents", "dollar", "dollars", "USD", or "kUSD".
 "price_postapoc": "1 USD",                       // Barter value of an item post-Cataclysm. Can use string "cent", "cents", "dollar", "dollars", "USD", or "kUSD".
 "stackable": true,                           // This item can be stacked together, similarly to `charges`
@@ -739,7 +739,7 @@ Any Item can be a container. To add the ability to contain things to an item, yo
     "item_restriction": [ "item_id" ],               // Only these item IDs can be placed into this pocket. Overrides ammo and flag restrictions.
     "material_restriction": [ "material_id" ],       // Only items that are mainly made of this material can enter.
 	// If multiple of "flag_restriction", "material_restriction" and "item_restriction" are used simultaneously then any item that matches any of them will be accepted.
-
+    "insulation": 1.0,                // Insulation value provided to items in this pocket.
     "sealed_data": { "spoil_multiplier": 0.0 },   // If a pocket has sealed_data, it will be sealed when the item spawns.  The sealed version of the pocket will override the unsealed version of the same datatype.
 
     "inherits_flags": true // Items in this pocket pass their flags to the parent item.

--- a/src/active_item_cache.cpp
+++ b/src/active_item_cache.cpp
@@ -27,6 +27,15 @@ bool item_reference::has_watertight_container() const
     } );
 }
 
+float item_reference::insulation() const
+{
+    return std::accumulate(
+               pocket_chain.begin(), pocket_chain.end(), 1.0F,
+    []( float a, item_pocket const * pk ) {
+        return a * pk->get_pocket_data()->insulation;
+    } );
+}
+
 bool active_item_cache::add( item &it, point_sm_ms location, item *parent,
                              std::vector<item_pocket const *> const &pocket_chain )
 {

--- a/src/active_item_cache.h
+++ b/src/active_item_cache.h
@@ -23,6 +23,7 @@ struct item_reference {
     std::vector<item_pocket const *> pocket_chain;
 
     float spoil_multiplier() const;
+    float insulation() const;
     bool has_watertight_container() const;
 };
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -3947,6 +3947,10 @@ void item::calc_temp( const units::temperature &temp, const float insulation,
                               new_specific_energy ) /
                             units::to_joule_per_gram( completely_liquid_specific_energy - completely_frozen_specific_energy );
     }
+    //Debug mode message for reporting insulation in objects
+    add_msg_debug( debugmode::DF_FOOD, "Insulation for %s: %.2f  New temp: %.2f Old temp: %.2f",
+                   tname(),
+                   insulation, new_item_temperature, old_temperature );
 
     temperature = units::from_kelvin( new_item_temperature );
     specific_energy = units::from_joule_per_gram( new_specific_energy );
@@ -4323,7 +4327,7 @@ bool item::process( map &here, Character *carrier, const tripoint_bub_ms &pos, f
 {
     process_relic( carrier, pos );
     if( recursive ) {
-        contents.process( here, carrier, pos, type->insulation_factor * insulation, flag,
+        contents.process( here, carrier, pos, insulation, flag,
                           spoil_multiplier_parent, watertight_container );
     }
     return process_internal( here, carrier, pos, insulation, flag, spoil_multiplier_parent,

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -2601,7 +2601,8 @@ void item_contents::process( map &here, Character *carrier, const tripoint_bub_m
     for( item_pocket &pocket : contents ) {
         if( pocket.is_type( pocket_type::CONTAINER ) || pocket.is_type( pocket_type::MOD ) ||
             pocket.is_type( pocket_type::MAGAZINE_WELL ) )  {
-            pocket.process( here, carrier, pos, insulation, flag, spoil_multiplier_parent,
+            pocket.process( here, carrier, pos, std::max( pocket.insulation(), insulation ), flag,
+                            spoil_multiplier_parent,
                             watertight_container );
         }
     }

--- a/src/item_pocket.cpp
+++ b/src/item_pocket.cpp
@@ -180,6 +180,7 @@ void pocket_data::load( const JsonObject &jo )
         optional( jo, was_loaded, "activity_noise", activity_noise );
     }
     optional( jo, was_loaded, "spoil_multiplier", spoil_multiplier, 1.0f );
+    optional( jo, was_loaded, "insulation", insulation, 1.0f );
     optional( jo, was_loaded, "weight_multiplier", weight_multiplier, 1.0f );
     optional( jo, was_loaded, "volume_multiplier", volume_multiplier, 1.0f );
     optional( jo, was_loaded, "magazine_well", magazine_well, volume_reader(), 0_ml );
@@ -669,6 +670,11 @@ float item_pocket::spoil_multiplier() const
     } else {
         return data->spoil_multiplier;
     }
+}
+
+float item_pocket::insulation() const
+{
+    return data->insulation;
 }
 
 int item_pocket::moves() const

--- a/src/item_pocket.h
+++ b/src/item_pocket.h
@@ -237,6 +237,8 @@ class item_pocket
         /** gets the spoilage multiplier depending on sealed data */
         float spoil_multiplier() const;
 
+        float insulation() const;
+
         int moves() const;
 
         int best_quality( const quality_id &id ) const;
@@ -498,6 +500,8 @@ class pocket_data
         pocket_noise activity_noise;
         // multiplier for spoilage rate of contained items
         float spoil_multiplier = 1.0f;
+        // insulation of contained items.
+        float insulation = 1.0f;
         // items' weight in this pocket are modified by this number
         float weight_multiplier = 1.0f;
         // items' volume in this pocket are modified by this number for calculation of the containing object

--- a/src/itype.h
+++ b/src/itype.h
@@ -1532,9 +1532,9 @@ struct itype {
         nc_color color = c_white; // Color on the map (color.h)
 
         /**
-        * How much insulation this item provides, either as a container, or as
-        * a vehicle base part.  Larger means more insulation, less than 1 but
-        * greater than zero, transfers faster, cannot be less than zero.
+        * How much insulation this item provides, as a vehicle base part.
+        * Larger means more insulation, less than 1 but greater than zero,
+        * transfers faster, cannot be less than zero.
         */
         float insulation_factor = 1.0f;
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -5859,9 +5859,8 @@ void map::process_items_in_submap( submap &current_submap, const tripoint_rel_sm
         bool furniture_is_sealed = has_flag( ter_furn_flag::TFLAG_SEALED, map_location );
 
         map_stack items = i_at( map_location );
-
         process_map_items( *this, items, active_item_ref.item_ref, active_item_ref.parent,
-                           map_location, 1, flag,
+                           map_location, active_item_ref.insulation(), flag,
                            spoil_multiplier * active_item_ref.spoil_multiplier(),
                            furniture_is_sealed || active_item_ref.has_watertight_container() );
     }


### PR DESCRIPTION
#### Summary
Bugfixes "Insulation works on map items, is now a pocket property."

#### Purpose of change
This fixes thermoses you drop in the map not actually insulating things. Which doesnt matter much for vanilla but is of critical imprtance for aftershock.

#### Describe the solution
Pockets now define insulation for items within. The general item level "insulation" property remains for vehicle parts/appliances.

#### Describe alternatives you've considered
I replace all the ice in exoplanet with lava.

#### Testing
Waited out a day in the frozen wastes and had some hot tea after that.

#### Additional context
None