### PR TITLE
Heating items now changes temperature, properly resets temp flags

### DIFF
--- a/data/mods/aftershock_exoplanet/items/containers.json
+++ b/data/mods/aftershock_exoplanet/items/containers.json
@@ -88,6 +88,7 @@
       }
     ],
     "insulation": 1600,
+    "use_action": "HEAT_LIQUID_ITEMS",
     "flags": [ "COLLAPSE_CONTENTS", "BELT_CLIP" ]
   },
   {

--- a/data/mods/aftershock_exoplanet/items/tools.json
+++ b/data/mods/aftershock_exoplanet/items/tools.json
@@ -882,9 +882,9 @@
     "flags": [ "ELECTRONIC", "ALLOWS_REMOTE_USE", "BELT_CLIP" ],
     "faults": [ { "fault_group": "electronic_general" } ],
     "power_draw": "100 W",
-    "qualities": [ [ "CONTAIN", 1 ] ],
+    "qualities": [ [ "COOK", 3 ], [ "BOIL", 2 ], [ "CONTAIN", 1 ], [ "HOTPLATE", 2 ], [ "CHEM", 1 ] ],
     "tick_action": "MULTICOOKER_TICK",
-    "use_action": [ "MULTICOOKER", "HOTPLATE", { "type": "link_up", "cable_length": 2, "charge_rate": "1000 W" } ],
+    "use_action": [ "MULTICOOKER", { "type": "link_up", "cable_length": 2, "charge_rate": "1000 W" } ],
     "pocket_data": [
       {
         "pocket_type": "MAGAZINE_WELL",

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -8348,8 +8348,7 @@ void heat_activity_actor::finish( player_activity &act, Character &p )
         if( cold_item->count_by_charges() ) {
             item copy( *cold_item );
             copy.charges = ait.second;
-            copy.unset_flag( flag_FROZEN );
-            copy.set_flag( flag_HOT );
+            copy.heat_up();
             cold_item->charges -= ait.second;
             if( cold_item->charges <= 0 ) {
                 cold_item.remove_item();
@@ -8360,8 +8359,7 @@ void heat_activity_actor::finish( player_activity &act, Character &p )
                 p.i_add_or_drop( copy );
             }
         } else {
-            cold_item->unset_flag( flag_FROZEN );
-            cold_item->set_flag( flag_HOT );
+            cold_item->heat_up();
             if( cold_item.get_item()->made_of( phase_id::LIQUID ) ) {
                 liquid_handler::handle_all_liquid( *cold_item, PICKUP_RANGE );
             } else {


### PR DESCRIPTION
#### Summary
Bugfixes "Heating items now changes temperature, properly resets temp flags"

#### Purpose of change
Heating items did not actuall update the temperature of items and instead manually cleared temp flags and replace them with the hot one. This resulted in bugs when you heated items from freezing in frozen environments (the items near instantly froze again, ir in liquids case, remained solid despite being hot).

#### Describe the solution
Use the heat() function on heating activity end, which sets item temp to 60C and properly resets temp flags. 

#### Testing
Tested water being liquid after heating.