### PR TITLE
Replaced transform active fields with SPAWN_ACTIVE flag

### DIFF
--- a/data/mods/CrazyCataclysm/crazy_items.json
+++ b/data/mods/CrazyCataclysm/crazy_items.json
@@ -329,7 +329,6 @@
     "use_action": {
       "target": "battletorch_lit",
       "msg": "You light the Louisville Slaughterer.",
-      "active": true,
       "need_fire": 1,
       "menu_text": "Light",
       "type": "transform"
@@ -361,13 +360,12 @@
       {
         "target": "battletorch",
         "msg": "The Louisville Slaughterer is extinguished.",
-        "active": false,
         "menu_text": "Extinguish",
         "type": "transform"
       }
     ],
     "light": 310,
-    "flags": [ "FIRE", "CHARGEDIM", "FLAMING", "DURABLE_MELEE", "TRADER_AVOID", "WATER_EXTINGUISH" ],
+    "flags": [ "FIRE", "CHARGEDIM", "FLAMING", "DURABLE_MELEE", "TRADER_AVOID", "WATER_EXTINGUISH", "SPAWN_ACTIVE" ],
     "melee_damage": { "bash": 18 }
   },
   {

--- a/data/mods/Magiclysm/items/caster_level_boosters.json
+++ b/data/mods/Magiclysm/items/caster_level_boosters.json
@@ -22,7 +22,6 @@
       "ammo_scale": 0,
       "target": "magus_booster_1_active",
       "msg": "You squeeze the machine and its interior starts spinning.",
-      "active": true,
       "menu_text": "Activate",
       "type": "transform",
       "target_charges": 100,
@@ -54,7 +53,7 @@
       "menu_text": "Stop",
       "type": "transform"
     },
-    "flags": [ "TRADER_AVOID" ]
+    "flags": [ "TRADER_AVOID", "SPAWN_ACTIVE" ]
   },
   {
     "id": "magus_booster_2",
@@ -74,8 +73,7 @@
     "use_action": {
       "target": "magus_booster_2_active",
       "msg": "You wind up the device and it starts making a ticking noise.",
-      "active": true,
-      "menu_text": "Activate",
+       "menu_text": "Activate",
       "type": "transform",
       "target_charges": 400,
       "target_ammo": "elastic_potential_energy",
@@ -106,7 +104,7 @@
       "menu_text": "Stop",
       "type": "transform"
     },
-    "flags": [ "TRADER_AVOID" ]
+    "flags": [ "TRADER_AVOID", "SPAWN_ACTIVE" ]
   },
   {
     "id": "kelvinist_booster_1",
@@ -128,7 +126,6 @@
     "use_action": {
       "target": "kelvinist_booster_1_active",
       "msg": "You light the candle.",
-      "active": true,
       "need_fire": 1,
       "menu_text": "Light",
       "type": "transform"
@@ -155,7 +152,7 @@
       }
     ],
     "light": 8,
-    "extend": { "flags": [ "WATER_EXTINGUISH", "TRADER_AVOID", "FIRESTARTER" ] }
+    "extend": { "flags": [ "WATER_EXTINGUISH", "TRADER_AVOID", "FIRESTARTER", "SPAWN_ACTIVE" ] }
   },
   {
     "id": "kelvinist_booster_2",
@@ -177,7 +174,6 @@
     "use_action": {
       "target": "kelvinist_booster_2_active",
       "msg": "You light the lamp.",
-      "active": true,
       "need_fire": 1,
       "need_charges": 1,
       "need_charges_msg": "The lamp is empty.",
@@ -208,7 +204,7 @@
       { "type": "firestarter", "moves": 100 }
     ],
     "light": 10,
-    "flags": [ "TRADER_AVOID", "FIRE", "ALLOWS_REMOTE_USE", "WATER_EXTINGUISH", "FIRESTARTER" ]
+    "flags": [ "TRADER_AVOID", "FIRE", "ALLOWS_REMOTE_USE", "WATER_EXTINGUISH", "FIRESTARTER", "SPAWN_ACTIVE" ]
   },
   {
     "type": "ITEM",
@@ -261,7 +257,6 @@
     "use_action": {
       "target": "technomancer_booster_2_active",
       "msg": "You turn on the doodad and it starts to hum.",
-      "active": true,
       "menu_text": "Activate",
       "type": "transform"
     },
@@ -286,7 +281,7 @@
     "material": [ "steel" ],
     "symbol": "%",
     "color": "white",
-    "flags": [ "WATER_BREAK", "ELECTRONIC" ],
+    "flags": [ "WATER_BREAK", "ELECTRONIC", "SPAWN_ACTIVE" ],
     "faults": [ { "fault_group": "electronic_general" } ],
     "pocket_data": [
       {

--- a/data/mods/Magiclysm/items/caster_level_boosters.json
+++ b/data/mods/Magiclysm/items/caster_level_boosters.json
@@ -73,7 +73,7 @@
     "use_action": {
       "target": "magus_booster_2_active",
       "msg": "You wind up the device and it starts making a ticking noise.",
-       "menu_text": "Activate",
+      "menu_text": "Activate",
       "type": "transform",
       "target_charges": 400,
       "target_ammo": "elastic_potential_energy",

--- a/data/mods/Magiclysm/items/druid_items.json
+++ b/data/mods/Magiclysm/items/druid_items.json
@@ -165,7 +165,6 @@
       {
         "target": "mag_adult_weaver",
         "msg": "The %s matures.  Another pair of legs sharpen into blades for cutting fabric.  It still has some room to grow.",
-        "active": true,
         "moves": 50,
         "need_charges": 350,
         "need_charges_msg": "The weaver does not have enough liquid.",
@@ -208,13 +207,12 @@
     "sub": "sewing_kit",
     "copy-from": "mag_immature_weaver",
     "description": "This weaver is fully grown.  There's no light behind its eyes, yet.",
-    "extend": { "qualities": [ [ "CUT", 2 ], [ "FABRIC_CUT", 2 ] ] },
+    "extend": { "qualities": [ [ "CUT", 2 ], [ "FABRIC_CUT", 2 ] ], "flags": [ "SPAWN_ACTIVE" ] },
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "watertight": true, "ammo_restriction": { "mag_awakened_water": 300 } } ],
     "use_action": [
       {
         "target": "mag_awoken_weaver",
         "msg": "The %s awakens.  It gazes at you with its many eyes, ready to serve you.",
-        "active": true,
         "moves": 50,
         "need_charges": 300,
         "need_charges_msg": "The weaver does not have enough liquid.",
@@ -321,7 +319,6 @@
       {
         "target": "mag_large_wildwood_beetle_ball",
         "msg": "The %s surges in size.  It shudders and rolls around as the relief begins to move on its own.",
-        "active": true,
         "need_charges": 400,
         "need_charges_msg": "The beetle does not have enough liquid to grow.",
         "type": "delayed_transform",
@@ -340,6 +337,7 @@
     "weight": "850 g",
     "volume": "1000 ml",
     "copy-from": "mag_wildwood",
+    "extend": { "flags": [ "SPAWN_ACTIVE" ] },
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "watertight": true, "ammo_restriction": { "mag_awakened_water": 300 } } ],
     "charges_per_use": 100,
     "use_action": [ { "type": "cast_spell", "spell_id": "mag_open_beetle_ball_large", "no_fail": true, "level": 1 } ]

--- a/data/mods/Magiclysm/items/enchanted_belts.json
+++ b/data/mods/Magiclysm/items/enchanted_belts.json
@@ -252,7 +252,6 @@
       "type": "transform",
       "menu_text": "Extend",
       "target": "mwhip_iron",
-      "active": true,
       "moves": 20,
       "msg": "You grab the belt and it uncoils to become a flexible metal whip in your hand!"
     }
@@ -269,13 +268,12 @@
     "volume": "2 L",
     "price": "3 kUSD 500 USD",
     "material": [ "steel" ],
-    "flags": [ "REACH_ATTACK", "REACH3", "WHIP", "UNBREAKABLE_MELEE" ],
+    "flags": [ "REACH_ATTACK", "REACH3", "WHIP", "UNBREAKABLE_MELEE", "SPAWN_ACTIVE" ],
     "techniques": [ "WBLOCK_1", "SWEEP", "WHIP_DISARM", "WRAP" ],
     "use_action": {
       "type": "transform",
       "menu_text": "Collapse",
       "target": "mbelt_iron_whip",
-      "active": false,
       "moves": 20,
       "msg": "You loop the whip in your hand and it coils back into a belt form in an instant."
     },

--- a/data/mods/Magiclysm/items/enchanted_misc.json
+++ b/data/mods/Magiclysm/items/enchanted_misc.json
@@ -81,12 +81,7 @@
     "color": "brown",
     "techniques": [ "WBLOCK_1" ],
     "flags": [ "DURABLE_MELEE" ],
-    "use_action": {
-      "target": "mtorch_everburning_lit",
-      "msg": "You light the torch.",
-      "menu_text": "Light torch",
-      "type": "transform"
-    },
+    "use_action": { "target": "mtorch_everburning_lit", "msg": "You light the torch.", "menu_text": "Light torch", "type": "transform" },
     "melee_damage": { "bash": 8 }
   },
   {

--- a/data/mods/Magiclysm/items/enchanted_misc.json
+++ b/data/mods/Magiclysm/items/enchanted_misc.json
@@ -24,7 +24,6 @@
       {
         "type": "transform",
         "target": "heat_cube_torch_on",
-        "active": true,
         "msg": "You push the torch button and the cube emits a large flame from the top, one that does radiate heat, but won't burn anything.",
         "menu_text": "Activate torch mode",
         "moves": 150
@@ -46,7 +45,7 @@
     "use_action": { "target": "heat_cube", "msg": "The torch flame is extinguished.", "menu_text": "Turn off", "type": "transform" },
     "emits": [ "emit_hot_air2_stream" ],
     "light": 15,
-    "flags": [ "TRADER_AVOID", "ALLOWS_REMOTE_USE" ]
+    "flags": [ "TRADER_AVOID", "ALLOWS_REMOTE_USE", "SPAWN_ACTIVE" ]
   },
   {
     "id": "mkey_opening",
@@ -85,7 +84,6 @@
     "use_action": {
       "target": "mtorch_everburning_lit",
       "msg": "You light the torch.",
-      "active": true,
       "menu_text": "Light torch",
       "type": "transform"
     },
@@ -103,7 +101,6 @@
       {
         "target": "mtorch_everburning",
         "msg": "The torch is extinguished.",
-        "active": false,
         "menu_text": "Extinguish",
         "type": "transform"
       }
@@ -111,7 +108,7 @@
     "techniques": [ "WBLOCK_1" ],
     "sub": "fire",
     "light": 60,
-    "extend": { "flags": [ "FIRE", "FLAMING", "TRADER_AVOID", "WATER_EXTINGUISH" ] }
+    "extend": { "flags": [ "FIRE", "FLAMING", "TRADER_AVOID", "WATER_EXTINGUISH", "SPAWN_ACTIVE" ] }
   },
   {
     "name": { "str": "endless flask" },

--- a/data/mods/Magiclysm/items/enchanted_tokens.json
+++ b/data/mods/Magiclysm/items/enchanted_tokens.json
@@ -21,7 +21,6 @@
       "type": "transform",
       "menu_text": "Whisper command",
       "target": "longsword",
-      "active": false,
       "moves": 200,
       "msg": "You say the command word engraved on the token, and it rapidly grows and morphs into a shiny pristine longsword!"
     }
@@ -36,7 +35,6 @@
       "type": "transform",
       "menu_text": "Whisper command",
       "target": "arming_sword",
-      "active": false,
       "moves": 200,
       "msg": "You say the command word engraved on the token, and it rapidly grows and morphs into a shiny pristine arming sword!"
     }
@@ -51,7 +49,6 @@
       "type": "transform",
       "menu_text": "Whisper command",
       "target": "broadsword",
-      "active": false,
       "moves": 200,
       "msg": "You say the command word engraved on the token, and it rapidly grows and morphs into a shiny pristine broadsword!"
     }
@@ -66,7 +63,6 @@
       "type": "transform",
       "menu_text": "Whisper command",
       "target": "battleaxe",
-      "active": false,
       "moves": 200,
       "msg": "You say the command word engraved on the token, and it rapidly grows and morphs into a shiny pristine battle axe!"
     }
@@ -81,7 +77,6 @@
       "type": "transform",
       "menu_text": "Whisper command",
       "target": "pike",
-      "active": false,
       "moves": 200,
       "msg": "You say the command word engraved on the token, and it rapidly grows and morphs into a shiny pristine pike!"
     }
@@ -96,7 +91,6 @@
       "type": "transform",
       "menu_text": "Whisper command",
       "target": "mace",
-      "active": false,
       "moves": 200,
       "msg": "You say the command word engraved on the token, and it rapidly grows and morphs into a shiny pristine mace!"
     }
@@ -111,7 +105,6 @@
       "type": "transform",
       "menu_text": "Whisper command",
       "target": "q_staff",
-      "active": false,
       "moves": 200,
       "msg": "You say the command word engraved on the token, and it rapidly grows and morphs into a pristine quarterstaff!"
     }
@@ -126,7 +119,6 @@
       "type": "transform",
       "menu_text": "Whisper command",
       "target": "hammer",
-      "active": false,
       "moves": 200,
       "msg": "You say the command word engraved on the token, and it rapidly grows and morphs into a shiny pristine hammer!"
     }
@@ -141,7 +133,6 @@
       "type": "transform",
       "menu_text": "Whisper command",
       "target": "screwdriver_set",
-      "active": false,
       "moves": 200,
       "msg": "You say the command word engraved on the token, and it rapidly grows and morphs into a shiny pristine screwdriver set!"
     }
@@ -156,7 +147,6 @@
       "type": "transform",
       "menu_text": "Whisper command",
       "target": "crowbar",
-      "active": false,
       "moves": 200,
       "msg": "You say the command word engraved on the token, and it rapidly grows and morphs into a shiny pristine crowbar!"
     }

--- a/data/mods/innawood/items/lighting.json
+++ b/data/mods/innawood/items/lighting.json
@@ -68,14 +68,13 @@
       {
         "target": "torch",
         "msg": "The torch is extinguished.",
-        "active": false,
         "menu_text": "Extinguish",
         "type": "transform"
       }
     ],
     "techniques": [ "WBLOCK_1" ],
     "light": 60,
-    "flags": [ "FIRE", "CHARGEDIM", "FLAMING", "TRADER_AVOID", "WATER_EXTINGUISH", "BURNOUT" ],
+    "flags": [ "FIRE", "CHARGEDIM", "FLAMING", "TRADER_AVOID", "WATER_EXTINGUISH", "BURNOUT", "SPAWN_ACTIVE" ],
     "melee_damage": { "bash": 8 }
   }
 ]

--- a/data/mods/innawood/items/lighting.json
+++ b/data/mods/innawood/items/lighting.json
@@ -65,12 +65,7 @@
     "revert_to": "torch_done",
     "use_action": [
       { "type": "firestarter", "moves": 30 },
-      {
-        "target": "torch",
-        "msg": "The torch is extinguished.",
-        "menu_text": "Extinguish",
-        "type": "transform"
-      }
+      { "target": "torch", "msg": "The torch is extinguished.", "menu_text": "Extinguish", "type": "transform" }
     ],
     "techniques": [ "WBLOCK_1" ],
     "light": 60,


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Replace usage of item transform active field with SPAWN_ACTIVE flag on active items.
This time for Crazy Cataclysm, Innawood, and Magiclysm.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Get rid of the field and apply the flag on items that should be active. This also means debug spawned items are spawned active.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
- Created a world of each type with a random character.
- Debug spawned each modified item.
- Examined the items to verify the look correct (active, in particular).
- Transformed each item to verify transformations worked correctly.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
The Magiclysm druid_item things could use delayed transforms if it wasn't for them requiring charges.
The last druid_item weaver form has an artifact subtype, which causes debug spawned object to look different from transformed ones. I'm not convinced the artifact subtype does anything at all on transformed items unless it's present on the source one, as item transformation doesn't seem to create missing subtypes. That's something for the mod maintainer to look into.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
