### PR TITLE
Fixing heatpack requiring appliances or fire

### DIFF
--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -4963,14 +4963,6 @@ std::optional<int> iuse::handle_ground_graffiti( Character &p, item *it, const s
     }
 }
 
-std::optional<int> iuse::heatpack( Character *p, item *it, const tripoint_bub_ms & )
-{
-    if( heat_solid_items( p, it, p->pos_bub(), true ) ) {
-        it->convert( itype_heatpack_used, p );
-    }
-    return 0;
-}
-
 std::optional<int> iuse::heat_food( Character *p, item *it, const tripoint_bub_ms & )
 {
     if( get_map().has_nearby_fire( p->pos_bub() ) ) {
@@ -8358,8 +8350,23 @@ static bool heat_items( Character *p, item *it, bool liquid_items, bool solid_it
     return true;
 }
 
-std::optional<int> iuse::heat_solid_items( Character *p, item *it, const tripoint_bub_ms &,
-        bool force_use_it )
+std::optional<int> iuse::heatpack( Character *p, item *it, const tripoint_bub_ms & )
+{
+    if( p->fine_detail_vision_mod() > 4 ) {
+        p->add_msg_if_player( _( "You can't see to do that!" ) );
+        return std::nullopt;
+    }
+    if( p->cant_do_mounted() ) {
+        return std::nullopt;
+    }
+
+    if( heat_items( p, it, false, true, true ) ) {
+        it->convert( itype_heatpack_used, p );
+    }
+    return 0;
+}
+
+std::optional<int> iuse::heat_solid_items( Character *p, item *it, const tripoint_bub_ms & )
 {
     if( p->fine_detail_vision_mod() > 4 ) {
         p->add_msg_if_player( _( "You can't see to do that!" ) );
@@ -8373,14 +8380,13 @@ std::optional<int> iuse::heat_solid_items( Character *p, item *it, const tripoin
         return std::nullopt;
     }
     //If *it don't have container,such like COOK level 1 tools(tongs,spear), you can only heat one solid item a time(and can't be liquid), but no volume limit on each batch.
-    if( heat_items( p, it, false, true, force_use_it ) ) {
+    if( heat_items( p, it, false, true ) ) {
         return 0;
     }
     return std::nullopt;
 }
 
-std::optional<int> iuse::heat_liquid_items( Character *p, item *it, const tripoint_bub_ms &,
-        bool force_use_it )
+std::optional<int> iuse::heat_liquid_items( Character *p, item *it, const tripoint_bub_ms & )
 {
     if( p->fine_detail_vision_mod() > 4 ) {
         p->add_msg_if_player( _( "You can't see to do that!" ) );
@@ -8394,14 +8400,13 @@ std::optional<int> iuse::heat_liquid_items( Character *p, item *it, const tripoi
         return std::nullopt;
     }
     //If *it don't have container,such like COOK level 1 tools(tongs,spear), you can only heat one solid item a time(and can't be liquid), but no volume limit on each batch.
-    if( heat_items( p, it, true, false, force_use_it ) ) {
+    if( heat_items( p, it, true, false ) ) {
         return 0;
     }
     return std::nullopt;
 }
 
-std::optional<int> iuse::heat_all_items( Character *p, item *it, const tripoint_bub_ms &,
-        bool force_use_it )
+std::optional<int> iuse::heat_all_items( Character *p, item *it, const tripoint_bub_ms & )
 {
     if( p->fine_detail_vision_mod() > 4 ) {
         p->add_msg_if_player( _( "You can't see to do that!" ) );
@@ -8415,7 +8420,7 @@ std::optional<int> iuse::heat_all_items( Character *p, item *it, const tripoint_
         return std::nullopt;
     }
     //If *it don't have container,such like COOK level 1 tools(tongs,spear), you can only heat one solid item a time(and can't be liquid), but no volume limit on each batch.
-    if( heat_items( p, it, true, true, force_use_it ) ) {
+    if( heat_items( p, it, true, true ) ) {
         return 0;
     }
     return std::nullopt;

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -4965,7 +4965,7 @@ std::optional<int> iuse::handle_ground_graffiti( Character &p, item *it, const s
 
 std::optional<int> iuse::heatpack( Character *p, item *it, const tripoint_bub_ms & )
 {
-    if( heat_solid_items( p, it, p->pos_bub() ) ) {
+    if( heat_solid_items( p, it, p->pos_bub(), true ) ) {
         it->convert( itype_heatpack_used, p );
     }
     return 0;
@@ -8158,7 +8158,7 @@ static std::optional<std::pair<tripoint_bub_ms, itype_id>> appliance_heater_sele
 
 }
 
-heater find_heater( Character *p, item *it )
+heater find_heater( Character *p, item *it, bool force_use_it )
 {
     map &here = get_map();
 
@@ -8174,7 +8174,7 @@ heater find_heater( Character *p, item *it )
     if( here.has_nearby_fire( p->pos_bub( here ) ) && !it->has_quality( qual_HOTPLATE ) ) {
         p->add_msg_if_player( m_info, _( "You put %1$s on fire to start heating." ), it->tname() );
         return {loc, false, 1, 0, vpt, pseudo_flag};
-    } else if( it->has_quality( qual_HOTPLATE ) ) {
+    } else if( it->has_quality( qual_HOTPLATE ) || force_use_it ) {
         if( it->ammo_remaining( ) >= it->type->charges_to_use() ) {
             p->add_msg_if_player( m_info, _( "You use %1$s to start heating." ), loc->tname() );
         } else if( !it->has_no_links() ) {
@@ -8241,12 +8241,13 @@ heater find_heater( Character *p, item *it )
 }
 
 
-static bool heat_items( Character *p, item *it, bool liquid_items, bool solid_items )
+static bool heat_items( Character *p, item *it, bool liquid_items, bool solid_items,
+                        bool force_use_it = false )
 {
     map &here = get_map();
 
     p->inv->restack( *p );
-    heater h = find_heater( p, it );
+    heater h = find_heater( p, it, force_use_it );
     if( h.available_heater == -1 ) {
         add_msg( m_info, _( "Never mind." ) );
         return false;
@@ -8357,7 +8358,8 @@ static bool heat_items( Character *p, item *it, bool liquid_items, bool solid_it
     return true;
 }
 
-std::optional<int> iuse::heat_solid_items( Character *p, item *it, const tripoint_bub_ms & )
+std::optional<int> iuse::heat_solid_items( Character *p, item *it, const tripoint_bub_ms &,
+        bool force_use_it )
 {
     if( p->fine_detail_vision_mod() > 4 ) {
         p->add_msg_if_player( _( "You can't see to do that!" ) );
@@ -8371,13 +8373,14 @@ std::optional<int> iuse::heat_solid_items( Character *p, item *it, const tripoin
         return std::nullopt;
     }
     //If *it don't have container,such like COOK level 1 tools(tongs,spear), you can only heat one solid item a time(and can't be liquid), but no volume limit on each batch.
-    if( heat_items( p, it, false, true ) ) {
+    if( heat_items( p, it, false, true, force_use_it ) ) {
         return 0;
     }
     return std::nullopt;
 }
 
-std::optional<int> iuse::heat_liquid_items( Character *p, item *it, const tripoint_bub_ms & )
+std::optional<int> iuse::heat_liquid_items( Character *p, item *it, const tripoint_bub_ms &,
+        bool force_use_it )
 {
     if( p->fine_detail_vision_mod() > 4 ) {
         p->add_msg_if_player( _( "You can't see to do that!" ) );
@@ -8391,13 +8394,14 @@ std::optional<int> iuse::heat_liquid_items( Character *p, item *it, const tripoi
         return std::nullopt;
     }
     //If *it don't have container,such like COOK level 1 tools(tongs,spear), you can only heat one solid item a time(and can't be liquid), but no volume limit on each batch.
-    if( heat_items( p, it, true, false ) ) {
+    if( heat_items( p, it, true, false, force_use_it ) ) {
         return 0;
     }
     return std::nullopt;
 }
 
-std::optional<int> iuse::heat_all_items( Character *p, item *it, const tripoint_bub_ms & )
+std::optional<int> iuse::heat_all_items( Character *p, item *it, const tripoint_bub_ms &,
+        bool force_use_it )
 {
     if( p->fine_detail_vision_mod() > 4 ) {
         p->add_msg_if_player( _( "You can't see to do that!" ) );
@@ -8411,7 +8415,7 @@ std::optional<int> iuse::heat_all_items( Character *p, item *it, const tripoint_
         return std::nullopt;
     }
     //If *it don't have container,such like COOK level 1 tools(tongs,spear), you can only heat one solid item a time(and can't be liquid), but no volume limit on each batch.
-    if( heat_items( p, it, true, true ) ) {
+    if( heat_items( p, it, true, true, force_use_it ) ) {
         return 0;
     }
     return std::nullopt;

--- a/src/iuse.h
+++ b/src/iuse.h
@@ -83,9 +83,12 @@ std::optional<int> camera( Character *, item *, const tripoint_bub_ms & );
 std::optional<int> can_goo( Character *, item *, const tripoint_bub_ms & );
 std::optional<int> capture_monster_act( Character *, item *, const tripoint_bub_ms & );
 std::optional<int> efiledevice( Character *, item *, const tripoint_bub_ms & );
-std::optional<int> heat_solid_items( Character *p, item *it, const tripoint_bub_ms & );
-std::optional<int> heat_liquid_items( Character *p, item *it, const tripoint_bub_ms & );
-std::optional<int> heat_all_items( Character *p, item *it, const tripoint_bub_ms & );
+std::optional<int> heat_solid_items( Character *p, item *it, const tripoint_bub_ms &,
+                                     bool force_use_it = false );
+std::optional<int> heat_liquid_items( Character *p, item *it, const tripoint_bub_ms &,
+                                      bool force_use_it = false );
+std::optional<int> heat_all_items( Character *p, item *it, const tripoint_bub_ms &,
+                                   bool force_use_it = false );
 std::optional<int> capture_monster_veh( Character *, item *, const tripoint_bub_ms & );
 std::optional<int> change_eyes( Character *, item *, const tripoint_bub_ms & );
 std::optional<int> change_skin( Character *, item *, const tripoint_bub_ms & );
@@ -268,7 +271,7 @@ struct heater {
     tripoint_abs_ms vpt;
     bool pseudo_flag;
 };
-heater find_heater( Character *, item * );
+heater find_heater( Character *, item *, bool force_use_it );
 heating_requirements heating_requirements_for_weight( const units::mass &,
         const units::mass &, const units::volume & );
 

--- a/src/iuse.h
+++ b/src/iuse.h
@@ -83,12 +83,9 @@ std::optional<int> camera( Character *, item *, const tripoint_bub_ms & );
 std::optional<int> can_goo( Character *, item *, const tripoint_bub_ms & );
 std::optional<int> capture_monster_act( Character *, item *, const tripoint_bub_ms & );
 std::optional<int> efiledevice( Character *, item *, const tripoint_bub_ms & );
-std::optional<int> heat_solid_items( Character *p, item *it, const tripoint_bub_ms &,
-                                     bool force_use_it = false );
-std::optional<int> heat_liquid_items( Character *p, item *it, const tripoint_bub_ms &,
-                                      bool force_use_it = false );
-std::optional<int> heat_all_items( Character *p, item *it, const tripoint_bub_ms &,
-                                   bool force_use_it = false );
+std::optional<int> heat_solid_items( Character *p, item *it, const tripoint_bub_ms & );
+std::optional<int> heat_liquid_items( Character *p, item *it, const tripoint_bub_ms & );
+std::optional<int> heat_all_items( Character *p, item *it, const tripoint_bub_ms & );
 std::optional<int> capture_monster_veh( Character *, item *, const tripoint_bub_ms & );
 std::optional<int> change_eyes( Character *, item *, const tripoint_bub_ms & );
 std::optional<int> change_skin( Character *, item *, const tripoint_bub_ms & );


### PR DESCRIPTION
#### Summary
Bugfixes "Fixing heatpack requiring appliances or fire to work"

#### Purpose of change

I saw that heatpack weren't working, so I tried to fix it

#### Describe the solution

Added a flag to force the use of the item in question even if it doesn't have the hotplate quality

#### Describe alternatives you've considered

1. Adding the hotplate quality to the item
2. Creating a new chemical_heater quality to the item

#### Testing

1. Spawned a new heatpack
2. Heated some pizza with it
3. Tested with other food heaters to see if they still worked