### PR TITLE
[XEDRA Evolved] Arm the Bannermen

### DIFF
--- a/data/mods/Xedra_Evolved/itemgroups/itemgroups.json
+++ b/data/mods/Xedra_Evolved/itemgroups/itemgroups.json
@@ -261,15 +261,15 @@
   {
     "type": "item_group",
     "id": "bannerman_armor",
-    "subtype": "distribution",
+    "subtype": "collection",
     "entries": [
-      { "item": "mt_chainmail_arms", "prob": 20 },
+      { "item": "mt_chainmail_arms", "prob": 50 },
       { "group": "banner_group", "prob": 20 },
-      { "item": "mt_chainmail_hood", "prob": 20 },
-      { "item": "mt_chainmail_hands", "prob": 20 },
-      { "item": "mt_chainmail_legs", "prob": 20 },
-      { "item": "mt_chainmail_vest", "prob": 20 },
-      { "item": "mt_chainmail_feet", "prob": 20 }
+      { "item": "mt_chainmail_hood", "prob": 50 },
+      { "item": "mt_chainmail_hands", "prob": 50 },
+      { "item": "mt_chainmail_legs", "prob": 50 },
+      { "item": "mt_chainmail_vest", "prob": 50 },
+      { "item": "mt_chainmail_feet", "prob": 50 }
     ]
   },
   {

--- a/data/mods/Xedra_Evolved/itemgroups/monster_drops.json
+++ b/data/mods/Xedra_Evolved/itemgroups/monster_drops.json
@@ -72,10 +72,10 @@
           }
         ]
       },
-      { "group": "bannerman_armor", "prob": 20, "damage": [ 0, 5 ] },
+      { "group": "bannerman_armor", "prob": 100, "damage": [ 2, 5 ] },
       { "group": "pendant_necklaces_silver", "prob": 5 },
       { "group": "clothing_watch", "prob": 5 },
-      { "group": "bannerman_weapons", "prob": 50, "damage": [ 0, 5 ] },
+      { "group": "bannerman_weapons", "prob": 100, "damage": [ 2, 5 ] },
       { "item": "baldric", "prob": 100 },
       { "item": "scrap_dreamdross", "prob": 75, "count": [ 1, 4 ] }
     ]
@@ -219,9 +219,9 @@
           }
         ]
       },
-      { "group": "bannerman_armor", "prob": 20, "damage": [ 0, 4 ] },
+      { "group": "bannerman_armor", "prob": 100, "damage": [ 0, 4 ] },
       { "group": "pendant_necklaces_silver", "prob": 5 },
-      { "item": "winter_lord_estoc", "prob": 25, "damage": [ 0, 5 ] },
+      { "item": "winter_lord_estoc", "prob": 100, "damage": [ 1, 5 ] },
       { "item": "baldric", "prob": 100 },
       { "item": "purity_crackers", "prob": 10 },
       { "item": "golden_bridle", "prob": 5 },


### PR DESCRIPTION

#### Summary
None

#### Purpose of change
I find it odd that the changeling bannermen and march lord are really underarmored and sometimes lacking in weapons. surely they be more prepared for marching into the New Realm than that, so i fixed it.

#### Describe the solution
Make the bannermen armor itemgroup a collection instead of distribution, made armor and weapon 100 prob in bannermen and march lord death drops.
#### Describe alternatives you've considered
Go play Mount and Blade i guess?

#### Testing
![Screenshot_20251124_121000](https://github.com/user-attachments/assets/675f1b03-71f4-4774-a046-d0146fbf4a20)
![Screenshot_20251124_120840](https://github.com/user-attachments/assets/3b9f4c2f-25d7-4c8c-8202-34891830e3d4)


#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
