### PR TITLE
Fix basic typos in code and comments

### DIFF
--- a/data/mods/MindOverMatter/PowerDescriptionSpoilers.md
+++ b/data/mods/MindOverMatter/PowerDescriptionSpoilers.md
@@ -294,7 +294,7 @@ This is natural painkiller and so has natural effects (reduces speed slightly)<b
 *Duration*: Instant or 30 minutes to 1 hour 15 minutes<br />
 *Stamina Cost*: 4500, minus 125 per level to a minimum of 2000<br />
 *Channeling Time*: 250 moves, minus 4.5 moves per level to a minimum of 100<br />
-*Effects*: Sense nearby radiation, either on the psion themselves (instant duration) or in their surrounding environment.  Radiation sense on the psion provides an idea of how much radiation they are suffering from; radiation sense on the environment reveals only its presence or absense.<br />
+*Effects*: Sense nearby radiation, either on the psion themselves (instant duration) or in their surrounding environment.  Radiation sense on the psion provides an idea of how much radiation they are suffering from; radiation sense on the environment reveals only its presence or absence.<br />
 *Prerequisites*: Special (must be studied from notes)<br />
 </details>
 <details>

--- a/data/mods/aftershock_exoplanet/items/gun/7.50mm.json
+++ b/data/mods/aftershock_exoplanet/items/gun/7.50mm.json
@@ -175,13 +175,13 @@
     "subtypes": [ "GUN" ],
     "reload_noise_volume": 10,
     "name": { "str": "G&W SR-P77" },
-    "description": "Compact and powerful, the SR-77 serves as the current main firearm of UICA assault teams, having replaced the SR-P9 in the very last decade of the reclamation wars.  Designed for combat withing the tight confines of spacecraft and habitats, the SR-77 is a bullpup carbine with a top-mounted magazine and a high rate of fire.  Performance in open terrain is subpar.",
+    "description": "Compact and powerful, the SR-77 serves as the current main firearm of UICA assault teams, having replaced the SR-P9 in the very last decade of the reclamation wars.  Designed for combat within the tight confines of spacecraft and habitats, the SR-77 is a bullpup carbine with a top-mounted magazine and a high rate of fire.  Performance in open terrain is subpar.",
     "variant_type": "gun",
     "variants": [
       {
         "id": "military",
         "name": { "str": "G&W SR-P77" },
-        "description": "Compact and powerful, the SR-77 serves as the current main firearm of UICA assault teams, having replaced the SR-P9 in the very last decade of the reclamation wars.  Designed for combat withing the tight confines of spacecraft and habitats, the SR-77 is a bullpup carbine with a top-mounted magazine and a high rate of fire.  Performance in open terrain is subpar.",
+        "description": "Compact and powerful, the SR-77 serves as the current main firearm of UICA assault teams, having replaced the SR-P9 in the very last decade of the reclamation wars.  Designed for combat within the tight confines of spacecraft and habitats, the SR-77 is a bullpup carbine with a top-mounted magazine and a high rate of fire.  Performance in open terrain is subpar.",
         "weight": 3
       },
       {

--- a/data/mods/aftershock_exoplanet/monsters/scavbots.json
+++ b/data/mods/aftershock_exoplanet/monsters/scavbots.json
@@ -73,7 +73,7 @@
         "target_moving_vehicles": true,
         "targeting_cost": 10,
         "targeting_timeout_extend": -1,
-        "targeting_sound": "\"Target Aquired.\"",
+        "targeting_sound": "\"Target Acquired.\"",
         "targeting_volume": 10
       }
     ],

--- a/doc/JSON/OVERMAP.md
+++ b/doc/JSON/OVERMAP.md
@@ -490,7 +490,7 @@ until all sectors are occupied). For specials that are not common enough to warr
 than once per overmap please use the "OVERMAP_UNIQUE" flag. For specials that should only have one instance
 per world use "GLOBALLY_UNIQUE".
 
-NOTE: currently, minimum occurences are NOT enforced in-game but ARE enforced by 
+NOTE: currently, minimum occurrences are NOT enforced in-game but ARE enforced by 
 test case `default_overmap_generation_always_succeeds`.
 
 ### Occurrences ( OVERMAP_UNIQUE, GLOBALLY_UNIQUE )

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -1049,7 +1049,7 @@ bool spell::can_cast( const Character &guy, std::map<magic_type_id, bool> &succe
 {
     if( type->magic_type.has_value() &&
         type->magic_type.value()->cannot_cast_message.has_value() ) {
-        // Insert first occurence of magic_type_id as false since only successful casts will be tracked.
+        // Insert first occurrence of magic_type_id as false since only successful casts will be tracked.
         if( success_tracker.count( type->magic_type.value() ) == 0 ) {
             success_tracker[type->magic_type.value()] = false;
         }

--- a/tests/json_test.cpp
+++ b/tests/json_test.cpp
@@ -853,7 +853,7 @@ TEST_CASE( "jsonin_get_string", "[json]" )
 
 TEST_CASE( "item_colony_ser_deser", "[json][item]" )
 {
-    // calculates the number of substring (needle) occurrences withing the target string (haystack)
+    // calculates the number of substring (needle) occurrences within the target string (haystack)
     // doesn't include overlaps
     const auto count_occurences = []( const std::string_view haystack, const std::string_view needle ) {
         int occurrences = 0;
@@ -890,7 +890,7 @@ TEST_CASE( "item_colony_ser_deser", "[json][item]" )
         CAPTURE( json );
         {
             INFO( "should be compressed into the single item" );
-            CHECK( count_occurences( json, "\"typeid\":\"test_rag\"" ) == 1 );
+            CHECK( count_occurrences( json, "\"typeid\":\"test_rag\"" ) == 1 );
         }
         {
             INFO( "should contain the number of items" );
@@ -926,7 +926,7 @@ TEST_CASE( "item_colony_ser_deser", "[json][item]" )
         CAPTURE( json );
         {
             INFO( "should not be compressed" );
-            CHECK( count_occurences( json, "\"typeid\":\"test_rag" ) == 2 );
+            CHECK( count_occurrences( json, "\"typeid\":\"test_rag" ) == 2 );
         }
         JsonValue jsin = json_loader::from_string( json );
         cata::colony<item> read_val;

--- a/tests/json_test.cpp
+++ b/tests/json_test.cpp
@@ -855,7 +855,8 @@ TEST_CASE( "item_colony_ser_deser", "[json][item]" )
 {
     // calculates the number of substring (needle) occurrences within the target string (haystack)
     // doesn't include overlaps
-    const auto count_occurrences= []( const std::string_view haystack, const std::string_view needle ) {
+    const auto count_occurrences = []( const std::string_view haystack,
+    const std::string_view needle ) {
         int occurrences = 0;
         std::string::size_type pos = 0;
         while( ( pos = haystack.find( needle, pos ) ) != std::string::npos ) {

--- a/tests/json_test.cpp
+++ b/tests/json_test.cpp
@@ -855,7 +855,7 @@ TEST_CASE( "item_colony_ser_deser", "[json][item]" )
 {
     // calculates the number of substring (needle) occurrences within the target string (haystack)
     // doesn't include overlaps
-    const auto count_occurences = []( const std::string_view haystack, const std::string_view needle ) {
+    const auto count_occurrences= []( const std::string_view haystack, const std::string_view needle ) {
         int occurrences = 0;
         std::string::size_type pos = 0;
         while( ( pos = haystack.find( needle, pos ) ) != std::string::npos ) {

--- a/tools/json_tools/util.py
+++ b/tools/json_tools/util.py
@@ -163,7 +163,7 @@ class WhereAction(argparse.Action):
 
 
 def key_counter(data, where_fn_list):
-    """Count occurences of keys found in data {list of dicts}
+    """Count occurrences of keys found in data {list of dicts}
     that also match each where_fn_list {list of fns}.
 
     Returns a tuple of data.


### PR DESCRIPTION
#### Summary
Bugfixes "Fix basic typos in code and comments"

#### Purpose of change

Fixed a few basic typos in code and comments. No grammar or word changes.

#### Describe the solution

Fixed the typos as I came across them.

#### Describe alternatives you've considered

Rewriting comments to be more thorough.

#### Testing

Automated GitHub testing. Did not try to compile and run.

#### Additional context

There is quite of bit of misspellings in in-game lore, such as messages and graffiti. It's hard to tell if those were intentional or not.