### PR TITLE
[Mind over Matter] Removed active transformation field in favor of SPAWN_ACTIVE flag

### DIFF
--- a/data/mods/MindOverMatter/items/armor/belt.json
+++ b/data/mods/MindOverMatter/items/armor/belt.json
@@ -20,7 +20,6 @@
         "type": "transform",
         "msg": "You flip the switch on the box and a red LED lights up.",
         "target": "psionic_shield_belt_on",
-        "active": true,
         "need_charges": 1,
         "need_charges_msg": "The switch clicks but nothing happens.",
         "need_worn": true,
@@ -78,7 +77,7 @@
         "type": "transform"
       }
     ],
-    "extend": { "flags": [ "NO_TAKEOFF" ] }
+    "extend": { "flags": [ "NO_TAKEOFF", "SPAWN_ACTIVE" ] }
   },
   {
     "id": "psionic_shield_belt_broken",
@@ -126,7 +125,6 @@
         "type": "transform",
         "msg": "You flip the switch on the box and a red LED lights up.",
         "target": "psionic_fire_shield_belt_on",
-        "active": true,
         "need_charges": 1,
         "need_charges_msg": "The switch clicks but nothing happens.",
         "need_worn": true,
@@ -173,7 +171,7 @@
         "type": "transform"
       }
     ],
-    "extend": { "flags": [ "NO_TAKEOFF" ] }
+    "extend": { "flags": [ "NO_TAKEOFF", "SPAWN_ACTIVE" ] }
   },
   {
     "id": "psionic_fire_shield_belt_broken",

--- a/data/mods/MindOverMatter/items/armor/head.json
+++ b/data/mods/MindOverMatter/items/armor/head.json
@@ -59,7 +59,6 @@
       "type": "transform",
       "msg": "You activate your %s.",
       "target": "psionic_mindsight_glasses_on",
-      "active": true,
       "need_charges": 1,
       "need_charges_msg": "The %s's batteries are dead."
     },
@@ -106,6 +105,7 @@
       "msg": "Your %s deactivates.",
       "target": "psionic_mindsight_glasses"
     },
+    "extend": { "flags": [ "SPAWN_ACTIVE" ] },
     "power_draw": "3500 mW"
   }
 ]

--- a/data/mods/MindOverMatter/items/teleporter_start_items.json
+++ b/data/mods/MindOverMatter/items/teleporter_start_items.json
@@ -249,7 +249,6 @@
         "type": "transform",
         "msg": "You flip the switch and activate the helmet's functions.",
         "target": "mom_fifth_sun_eagle_tac_helmet_on",
-        "active": true,
         "need_charges": 1,
         "need_charges_msg": "The switch clicks but nothing happens.",
         "need_worn": true,
@@ -288,7 +287,17 @@
       }
     ],
     "extend": {
-      "flags": [ "FIX_FARSIGHT", "FIX_NEARSIGHT", "GAS_PROOF", "PARTIAL_DEAF", "PSYSHIELD_PARTIAL", "SUN_GLASSES", "ZOOM", "WATCH" ]
+      "flags": [
+        "FIX_FARSIGHT",
+        "FIX_NEARSIGHT",
+        "GAS_PROOF",
+        "PARTIAL_DEAF",
+        "PSYSHIELD_PARTIAL",
+        "SUN_GLASSES",
+        "ZOOM",
+        "WATCH",
+        "SPAWN_ACTIVE"
+      ]
     }
   },
   {
@@ -345,7 +354,6 @@
         "type": "transform",
         "msg": "You flip the switch and activate the ehēcatepantli barrier.",
         "target": "mom_fifth_sun_standard_body_armor_on",
-        "active": true,
         "need_charges": 1,
         "need_charges_msg": "The switch clicks but nothing happens.",
         "need_worn": true,
@@ -390,7 +398,7 @@
         "type": "transform"
       }
     ],
-    "extend": { "flags": [ "NO_TAKEOFF" ] }
+    "extend": { "flags": [ "NO_TAKEOFF", "SPAWN_ACTIVE" ] }
   },
   {
     "id": "mom_fifth_sun_standard_body_armor_non_fifth_sun",
@@ -404,7 +412,6 @@
         "type": "transform",
         "msg": "You flip the switch.",
         "target": "mom_fifth_sun_standard_body_armor_non_fifth_sun_on",
-        "active": true,
         "need_charges": 1,
         "need_charges_msg": "The switch clicks but nothing happens.",
         "need_worn": true,
@@ -448,7 +455,7 @@
         "type": "transform"
       }
     ],
-    "extend": { "flags": [ "NO_TAKEOFF" ] }
+    "extend": { "flags": [ "NO_TAKEOFF", "SPAWN_ACTIVE" ] }
   },
   {
     "id": "itzcuauhtli_cape",

--- a/data/mods/MindOverMatter/items/tools/lighting.json
+++ b/data/mods/MindOverMatter/items/tools/lighting.json
@@ -20,7 +20,6 @@
       "type": "transform",
       "msg": "You turn the flashlight on.",
       "target": "pyrokinetic_flashlight_on",
-      "active": true,
       "need_charges": 1,
       "need_charges_msg": "The flashlight's batteries are dead."
     },
@@ -50,7 +49,7 @@
       "ammo_scale": 0
     },
     "light": 225,
-    "flags": [ "CHARGEDIM", "TRADER_AVOID", "BELT_CLIP", "WATER_BREAK" ]
+    "flags": [ "CHARGEDIM", "TRADER_AVOID", "BELT_CLIP", "WATER_BREAK", "SPAWN_ACTIVE" ]
   },
   {
     "id": "pyrokinetic_lamp",
@@ -69,7 +68,6 @@
     "use_action": {
       "type": "transform",
       "target": "pyrokinetic_lamp_on",
-      "active": true,
       "need_charges": 1,
       "need_charges_msg": "The lamp's batteries are dead.",
       "msg": "You open the lamp's cover.",
@@ -83,6 +81,7 @@
         "default_magazine": "light_battery_cell"
       }
     ],
+    "tool_ammo": [ "battery" ],
     "flags": [ "LEAK_DAM", "ALLOWS_REMOTE_USE", "WATER_BREAK_ACTIVE" ]
   },
   {
@@ -95,7 +94,7 @@
     "power_draw": "250 mW",
     "use_action": { "type": "transform", "target": "pyrokinetic_lamp", "msg": "You close the lamp's cover.", "menu_text": "Close cover" },
     "light": 150,
-    "flags": [ "LEAK_DAM", "ALLOWS_REMOTE_USE", "CHARGEDIM", "TRADER_AVOID", "WATER_BREAK" ]
+    "flags": [ "LEAK_DAM", "ALLOWS_REMOTE_USE", "CHARGEDIM", "TRADER_AVOID", "WATER_BREAK", "SPAWN_ACTIVE" ]
   },
   {
     "type": "ITEM",

--- a/data/mods/MindOverMatter/items/tools/travel.json
+++ b/data/mods/MindOverMatter/items/tools/travel.json
@@ -40,7 +40,6 @@
     "use_action": {
       "target": "psionic_transporter_remote_on",
       "msg": "You turn the transporter remote on and the screen begins displaying coordinates.",
-      "active": true,
       "need_charges": 1,
       "need_charges_msg": "The transporter remote's batteries need more charge.",
       "type": "transform"
@@ -88,7 +87,7 @@
         "effect_on_conditions": [ "EOC_PSI_TRANSPORTER_REMOTE_TELEPORT" ]
       }
     ],
-    "flags": [ "TRADER_AVOID", "WATER_BREAK", "ELECTRONIC" ],
+    "flags": [ "TRADER_AVOID", "WATER_BREAK", "ELECTRONIC", "SPAWN_ACTIVE" ],
     "faults": [ { "fault_group": "electronic_general" } ],
     "pocket_data": [
       {

--- a/data/mods/MindOverMatter/items/weapons.json
+++ b/data/mods/MindOverMatter/items/weapons.json
@@ -20,7 +20,6 @@
       "target": "grenade_inferno_act",
       "msg": "You pull the pin on the grenade.",
       "target_timer": "5 seconds",
-      "active": true,
       "menu_text": "Pull pin",
       "type": "transform"
     },
@@ -50,8 +49,9 @@
       "fields_min_intensity": 2,
       "fields_max_intensity": 3
     },
+    "countdown_interval": "5 seconds",
     "revert_to": "canister_empty",
-    "flags": [ "ACT_IN_FIRE", "BOMB", "TRADER_AVOID", "DANGEROUS" ]
+    "flags": [ "ACT_IN_FIRE", "BOMB", "TRADER_AVOID", "DANGEROUS", "SPAWN_ACTIVE" ]
   },
   {
     "id": "grenade_inferno_makeshift",
@@ -74,7 +74,6 @@
       "target": "grenade_inferno_makeshift_act",
       "msg": "You pull the pin on the grenade.",
       "target_timer": "5 seconds",
-      "active": true,
       "menu_text": "Pull pin",
       "type": "transform"
     },
@@ -104,8 +103,9 @@
       "fields_min_intensity": 2,
       "fields_max_intensity": 3
     },
+    "countdown_interval": "5 seconds",
     "revert_to": "canister_empty",
-    "flags": [ "ACT_IN_FIRE", "BOMB", "TRADER_AVOID", "DANGEROUS" ]
+    "flags": [ "ACT_IN_FIRE", "BOMB", "TRADER_AVOID", "DANGEROUS", "SPAWN_ACTIVE" ]
   },
   {
     "id": "grenade_anti_psi",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Remove active flag in item transformations in favor of SPAWN_ACTIVE flags on active items.
This time for Mind over Matter.

The aim is to eventually remove the active flag from item transformations, as it's redundant when the SPAWN_ACTIVE flag is present on active items (which it should be, so debug spawned active items actually are active).

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Remove the field and add the flag.
By-catch:
- Fix lamp so it can be loaded with a battery.
- Fix grenades so debug spawned active ones explode.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
- Created a Mind over Matter world and a character in it.
- Saved (which crashed midway due to som issue with zzip).
- Loaded the save (partially broken, as the building the PC is in gets generated differently each load, and monsters are probably different as well).
- Debug spawned inactive and active versions of each item (sequentially, and over several sessions, as bugs in items were discovered and fixed).
- Deactivated the active version and checked it reverted.
- Activated the inactive version (which may involve spawning batteries, reloading batteries, and possibly wearing/wielding the item).
- Thew active grenades and inactive ones after activation to verify they exploded.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
- As indicated, the matrix lamp was fixed to allow it to actually load a battery.
- Similarly, the active grenades were fixed so they explode after a timeout (only affect debug spawning, so no actual game play impact).
- There was some broken version of an modified item with the same name as the unbroken one. It should probably be addressed (there was something else that had a distinct name for the corresponding version).

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
