### PR TITLE
[alt-map-key] Vision level changes

### DIFF
--- a/data/mods/alt_map_key/vision_levels.json
+++ b/data/mods/alt_map_key/vision_levels.json
@@ -1,0 +1,270 @@
+[
+  {
+    "id": "isolated_building",
+    "//": "a building that is not in an area with other buildings around - isolated",
+    "type": "oter_vision",
+    "levels": [
+      { "name": "building", "sym": "c", "color": "brown", "looks_like": "cabin" },
+      { "name": "building", "sym": "c", "color": "brown", "looks_like": "cabin" },
+      { "name": "building", "sym": "c", "color": "brown", "looks_like": "cabin" }
+    ]
+  },
+  {
+    "id": "city_building",
+    "//": "a small building in a city setting - it blends in from afar",
+    "type": "oter_vision",
+    "levels": [
+      { "name": "city", "sym": "c", "color": "light_gray" },
+      { "name": "city building", "sym": "b", "color": "light_gray" },
+      { "name": "city building", "sym": "b", "color": "light_gray" }
+    ]
+  },
+  {
+    "id": "alien_tower",
+    "//": "a tower that looks alien - for mi-go camps/scout towers",
+    "type": "oter_vision",
+    "levels": [
+      { "name": "tall alien building", "sym": "a", "color": "pink" },
+      { "name": "alien tower", "sym": "a", "color": "pink" }
+    ]
+  },
+  {
+    "id": "isolated_tower",
+    "//": "a tall spire or tower outside of a city area - without other buildings around",
+    "type": "oter_vision",
+    "levels": [
+      { "name": "tall building", "sym": "t", "color": "light_gray" },
+      { "name": "tower", "sym": "t", "color": "light_gray" }
+    ]
+  },
+  {
+    "id": "isolated_camp",
+    "//": "If there's a tent, it's a camp",
+    "type": "oter_vision",
+    "levels": [
+      { "name": "tent", "sym": "t", "color": "light_gray", "looks_like": "campsite" },
+      { "name": "camp", "sym": "c", "color": "light_gray", "looks_like": "campsite" },
+      { "name": "camp", "sym": "c", "color": "light_gray", "looks_like": "campsite" }
+    ]
+  },
+  {
+    "id": "isolated_electronics",
+    "//": "power infrastructure, etc",
+    "type": "oter_vision",
+    "levels": [
+      { "name": "infrastructure", "sym": "i", "color": "light_gray" },
+      { "name": "electrical infrastructure", "sym": "a", "color": "light_gray" },
+      { "name": "electrical infrastructure", "sym": "a", "color": "light_gray" }
+    ]
+  },
+  {
+    "id": "industrial_building",
+    "//": "an industrial building that is neither a warehouse, nor having appliances installed",
+    "type": "oter_vision",
+    "levels": [
+      { "name": "building", "sym": "b", "color": "light_gray" },
+      { "name": "industrial building", "sym": "i", "color": "light_gray" },
+      { "name": "industrial building", "sym": "i", "color": "light_gray" }
+    ]
+  },
+  {
+    "id": "warehouse",
+    "//": "a warehouse or similar",
+    "type": "oter_vision",
+    "levels": [
+      { "name": "building", "sym": "b", "color": "light_gray" },
+      { "name": "warehouse", "sym": "w", "color": "light_gray" },
+      { "name": "warehouse", "sym": "w", "color": "light_gray" }
+    ]
+  },
+  {
+    "id": "island",
+    "//": "any island",
+    "type": "oter_vision",
+    "levels": [ { "blends_adjacent": true }, { "name": "island", "sym": "o", "color": "brown" } ]
+  },
+  {
+    "id": "wreckage",
+    "//": "wreckage or other destruction scattered on the ground",
+    "type": "oter_vision",
+    "levels": [ { "name": "wreckage", "sym": "w", "color": "dark_gray" }, { "name": "wreckage", "sym": "w", "color": "dark_gray" } ]
+  },
+  {
+    "id": "forested",
+    "//": "a forest or something that looks like a forest from afar",
+    "type": "oter_vision",
+    "levels": [
+      { "name": "forest", "sym": "#", "color": "light_green", "looks_like": "forest_thick" },
+      { "name": "forest", "sym": "#", "color": "light_green", "looks_like": "forest_thick" },
+      { "name": "forest", "sym": "#", "color": "light_green", "looks_like": "forest_thick" }
+    ]
+  },
+  {
+    "id": "first_glance_forest",
+    "//": "something that looks like a forest from afar, but at closer inspection is clearly-human managed",
+    "type": "oter_vision",
+    "levels": [
+      { "name": "forest", "sym": "#", "color": "light_green", "looks_like": "forest_thick" },
+      { "name": "managed forest", "sym": "#", "color": "light_green", "looks_like": "forest" }
+    ]
+  },
+  {
+    "id": "forested_swampy",
+    "//": "swamps or anything swampy that has tree cover",
+    "type": "oter_vision",
+    "levels": [
+      { "name": "forest", "sym": "#", "color": "light_green", "looks_like": "forest_thick" },
+      { "name": "swamp", "sym": "#", "color": "light_cyan", "looks_like": "forest_water" },
+      { "name": "swamp", "sym": "#", "color": "light_cyan", "looks_like": "forest_water" }
+    ]
+  },
+  {
+    "id": "open_land",
+    "//": "open cleared land with grasses or other groundcover",
+    "type": "oter_vision",
+    "levels": [
+      { "name": "field", "sym": ".", "color": "brown", "looks_like": "field" },
+      { "name": "field", "sym": ".", "color": "brown", "looks_like": "field" }
+    ]
+  },
+  {
+    "id": "farm_field",
+    "//": "cleared land for agricultural use",
+    "type": "oter_vision",
+    "levels": [
+      { "name": "field", "sym": ".", "color": "brown", "looks_like": "field" },
+      { "name": "farm field", "sym": "#", "color": "i_brown" }
+    ]
+  },
+  {
+    "id": "large_pavement",
+    "//": "parking lots primarily, but any other expanse of pavement",
+    "type": "oter_vision",
+    "levels": [ { "blends_adjacent": true }, { "name": "pavement", "sym": "-", "color": "dark_gray", "looks_like": "s_lot" } ]
+  },
+  {
+    "id": "single_water",
+    "//": "water that is not part of a larger water body",
+    "type": "oter_vision",
+    "levels": [
+      { "name": "water", "sym": "#", "color": "blue", "looks_like": "pond_field" },
+      { "name": "water", "sym": "#", "color": "blue", "looks_like": "pond_field" }
+    ]
+  },
+  {
+    "id": "water_body",
+    "//": "water that is part of a larger water body",
+    "type": "oter_vision",
+    "levels": [
+      { "name": "water body", "sym": "~", "color": "blue", "looks_like": "river_center" },
+      { "name": "water body", "sym": "~", "color": "blue", "looks_like": "river_center" }
+    ]
+  },
+  {
+    "id": "roof_or_air",
+    "//": "rooves or tiles that are clear",
+    "type": "oter_vision",
+    "levels": [
+      { "name": "open air", "color": "blue", "sym": ".", "looks_like": "open_air" },
+      { "name": "open air", "color": "blue", "sym": ".", "looks_like": "open_air" }
+    ]
+  },
+  {
+    "id": "underground_dirt",
+    "//": "Anything underground in the dirt layer",
+    "type": "oter_vision",
+    "levels": [ { "name": "underground", "color": "brown", "sym": "#" }, { "name": "basement", "color": "black", "sym": "b" } ]
+  },
+  {
+    "id": "underground_stone",
+    "//": "anything underground in a stone layer",
+    "type": "oter_vision",
+    "levels": [ { "name": "underground", "color": "dark_gray", "sym": "#" }, { "name": "basement", "color": "black", "sym": "b" } ]
+  },
+  {
+    "id": "large_building",
+    "//": "a large building (at least 2x2 overmap tiles) that is not in a city",
+    "type": "oter_vision",
+    "levels": [
+      { "name": "large building", "color": "white", "sym": "b" },
+      { "name": "large building", "color": "white", "sym": "b" },
+      { "name": "large building", "color": "white", "sym": "b" }
+    ]
+  },
+  {
+    "id": "large_city_building",
+    "//": "a large building (at least 2x2 overmap tiles) that is in a city",
+    "type": "oter_vision",
+    "levels": [
+      { "name": "city", "color": "light_gray", "sym": "c" },
+      { "name": "large building", "color": "light_gray", "sym": "b" },
+      { "name": "large building", "color": "light_gray", "sym": "b" }
+    ]
+  },
+  {
+    "id": "large_industrial_building",
+    "//": "a large industrial building (at least 2x2 overmap tiles)",
+    "type": "oter_vision",
+    "levels": [
+      { "name": "large industrial building", "color": "light_gray", "sym": "l" },
+      { "name": "large industrial building", "color": "light_gray", "sym": "l" },
+      { "name": "large industrial building", "color": "light_gray", "sym": "l" }
+    ]
+  },
+  {
+    "id": "large_structure",
+    "//": [
+      "A structure that would not be described as a building, easier to figure out what is than a building",
+      "used for the oil rig"
+    ],
+    "type": "oter_vision",
+    "levels": [
+      { "name": "structure", "color": "light_gray", "sym": "#" },
+      { "name": "structure", "color": "light_gray", "sym": "#" }
+    ]
+  },
+  {
+    "id": "large_ship",
+    "//": [ "Any ship that is not represented as a vehicle", "used for the aircraft carrier" ],
+    "type": "oter_vision",
+    "levels": [ { "name": "ship", "color": "red", "sym": "#" }, { "name": "ship", "color": "red", "sym": "#" } ]
+  },
+  {
+    "id": "large_outcropping",
+    "//": [ "large raised landscape features, that may look natural", "used for the exodii castle" ],
+    "type": "oter_vision",
+    "levels": [
+      { "name": "stone outcropping", "color": "light_gray", "sym": "o" },
+      { "name": "stone outcropping", "color": "light_gray", "sym": "o" }
+    ]
+  },
+  {
+    "id": "natural_outcropping",
+    "//": "A raised landscape feature that is or looks natural",
+    "type": "oter_vision",
+    "levels": [
+      { "blends_adjacent": true },
+      { "name": "outcropping", "color": "brown", "sym": "o" },
+      { "name": "outcropping", "color": "brown", "sym": "o" }
+    ]
+  },
+  {
+    "id": "natural_depression",
+    "//": "A lowered landscape feature that is not clearly artificial",
+    "type": "oter_vision",
+    "levels": [
+      { "blends_adjacent": true },
+      { "name": "depression", "color": "brown", "sym": "u" },
+      { "name": "depression", "color": "brown", "sym": "u" }
+    ]
+  },
+  {
+    "id": "unusual_structure",
+    "//": [ "can't even mistake it for something familiar", "triffid tree, bee hive" ],
+    "type": "oter_vision",
+    "levels": [
+      { "name": "unusual structure", "sym": "u", "color": "pink" },
+      { "name": "unusual structure", "sym": "u", "color": "pink" }
+    ]
+  }
+]

--- a/data/mods/alt_map_key/vision_levels.json
+++ b/data/mods/alt_map_key/vision_levels.json
@@ -133,7 +133,7 @@
     "type": "oter_vision",
     "levels": [
       { "name": "field", "sym": ".", "color": "brown", "looks_like": "field" },
-      { "name": "farm field", "sym": "#", "color": "i_brown" }
+      { "name": "farm field", "sym": "#", "color": "brown" }
     ]
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[alt-map-key] Vision level changes"
Changes vision level ascii tiles to match this mods changes

#### Purpose of change
Since vision levels were implemented for overmap tiles, this mod never received an update to fit vision levels into the sweeping changes this mod makes to the ascii tiles

#### Describe the solution
To make the difference between a tile with full vision and a tile without immediately obvious, I changed all building tile vision levels to be lower case letters. Lowercase will mean you can't see it and uppercase means you have full vision of it. I did not change the name for each level of vision and matched the letter to the name of the tile for each vision level as well.
This is not doable for terrain as it uses symbols so I went with lighter colors where possible. 

#### Describe alternatives you've considered
Using letters or other symbols for low vision level terrain, I am still unsure if colors are the best option for this but playing with it for a bit, I am okay with it. I am open to alternatives for this

#### Testing
Unexplored forest and swamp tiles are now the same symbol as explored but just lighter colors. There are also many unexplored city building tiles present as well as an isolated structure to the north that looks like a cabin
<img width="626" height="499" alt="image" src="https://github.com/user-attachments/assets/ffeef356-1f5a-4e13-a8f8-ba5aff25e406" />

The edge of a city with most of the city as blended together as 'c' with some buildings having higher visibility as 'b' and some full on the edge with normal uppercase tiles

I revealed the overmap with lowest visibility level with debug, normally unable to see this much unexplored terrain at once. 
<img width="749" height="682" alt="image" src="https://github.com/user-attachments/assets/854edb23-4099-424e-bf88-709ee531ff7e" />



#### Additional context

