### PR TITLE
Fix ACT_BLEED serialization

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -749,6 +749,16 @@ std::unique_ptr<activity_actor> bash_activity_actor::deserialize( JsonValue &jsi
     return actor.clone();
 }
 
+void bleed_activity_actor::serialize( JsonOut &jsout ) const
+{
+    jsout.write_null();
+}
+
+std::unique_ptr<activity_actor> bleed_activity_actor::deserialize( JsonValue & )
+{
+    return bleed_activity_actor().clone();
+}
+
 void gunmod_remove_activity_actor::start( player_activity &act, Character & )
 {
     act.moves_total = moves_total;
@@ -9348,6 +9358,7 @@ deserialize_functions = {
     { ACT_AIM, &aim_activity_actor::deserialize },
     { ACT_AUTODRIVE, &autodrive_activity_actor::deserialize },
     { ACT_BASH, &bash_activity_actor::deserialize },
+       { ACT_BLEED, &bleed_activity_actor::deserialize },
     { ACT_BIKERACK_RACKING, &bikerack_racking_activity_actor::deserialize },
     { ACT_BIKERACK_UNRACKING, &bikerack_unracking_activity_actor::deserialize },
     { ACT_BINDER_COPY_RECIPE, &bookbinder_copy_activity_actor::deserialize },

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -225,24 +225,30 @@ class bleed_activity_actor : public activity_actor
 {
 public:
     bleed_activity_actor() = default;
+    explicit bleed_activity_actor( butchery_data bd ) : bd( { std::move( bd ) } ) {}
+    explicit bleed_activity_actor( std::vector<butchery_data> bd ) : bd( std::move( bd ) ) {}
 
     const activity_id &get_type() const override {
         static const activity_id ACT_BLEED( "ACT_BLEED" );
         return ACT_BLEED;
     }
 
-    void start( player_activity &, Character & ) override {}
-    void do_turn( player_activity &act, Character & ) override {
-        act.set_to_null();
-    }
-    void finish( player_activity &, Character & ) override {}
+    void start( player_activity &, Character & ) override {};
+    bool initiate_butchery(player_activity& act, Character& you, butchery_data& this_bd);
+    void do_turn( player_activity &act, Character &you ) override;
+    void finish( player_activity &act, Character & ) override;
+    void canceled( player_activity &act, Character &you ) override;
 
     std::unique_ptr<activity_actor> clone() const override {
         return std::make_unique<bleed_activity_actor>( *this );
     }
 
     void serialize( JsonOut &jsout ) const override;
-    static std::unique_ptr<activity_actor> deserialize( JsonValue & );
+    static std::unique_ptr<activity_actor> deserialize( JsonValue &jsin );
+    void calculate_butchery_data(Character& you, butchery_data& this_bd);
+
+private:
+    std::vector<butchery_data> bd;
 };
 
 class gunmod_remove_activity_actor : public activity_actor

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -221,6 +221,30 @@ class bash_activity_actor : public activity_actor
         static std::unique_ptr<activity_actor> deserialize( JsonValue &jsin );
 };
 
+class bleed_activity_actor : public activity_actor
+{
+public:
+    bleed_activity_actor() = default;
+
+    const activity_id &get_type() const override {
+        static const activity_id ACT_BLEED( "ACT_BLEED" );
+        return ACT_BLEED;
+    }
+
+    void start( player_activity &, Character & ) override {}
+    void do_turn( player_activity &act, Character & ) override {
+        act.set_to_null();
+    }
+    void finish( player_activity &, Character & ) override {}
+
+    std::unique_ptr<activity_actor> clone() const override {
+        return std::make_unique<bleed_activity_actor>( *this );
+    }
+
+    void serialize( JsonOut &jsout ) const override;
+    static std::unique_ptr<activity_actor> deserialize( JsonValue & );
+};
+
 class gunmod_remove_activity_actor : public activity_actor
 {
     private:


### PR DESCRIPTION
#### Summary
Bugfixes "Add dummy serialization for ACT_BLEED, preventing saved games from corrupting when saved mid-bleed.  Also fixes afflicted game saves."

#### Purpose of change

Currently ACT_BLEED has no serialization or deserialization.  This is mostly fine because most things bleed quickly.  Black dragons, as I learned, do not bleed quickly, and if your game autosaves mid-bleed, then you quit before another save overwrites it, your save is now toast.  

#### Describe the solution

This adds a dummy activity serializer/deserializer for ACT_BLEED.  I'm sure there's a better, non-dummy way to do it, but I'm pretty new to the codebase and this method worked.  If someone has an example of a better way to achieve this, I'm happy to update.  Similarly, I'm a new contributor, so apologies if I got anything wrong!

#### Describe alternatives you've considered

Not doing this and letting my save remain broken.

#### Testing

My save didn't load prior to the change. I made the change, recompiled, save loaded fine.

#### Additional context
N/A

