### PR TITLE
Remove item transform active in favor of SPAWN_ACTIVE flag (Xedra Evolved, MMA, test)

### DIFF
--- a/data/mods/MMA/martial.json
+++ b/data/mods/MMA/martial.json
@@ -121,13 +121,23 @@
     "description": "Focus your ki into magical attacks.",
     "price_postapoc": "120 USD",
     "use_action": {
-      "target": "ki_strike_scroll",
+      "target": "ki_strike_scroll_act",
       "msg": "You unroll the dragon scroll…",
       "target_timer": "1 seconds",
-      "active": true,
       "menu_text": "Unroll",
       "type": "transform"
-    },
+    }
+  },
+  {
+    "id": "ki_strike_scroll_act",
+    "copy-from": "scroll_martial_base",
+    "extend": { "flags": [ "SPAWN_ACTIVE" ] },
+    "type": "ITEM",
+    "subtypes": [ "TOOL" ],
+    "name": { "str": "dragon hand scroll" },
+    "description": "Focus your ki into magical attacks.",
+    "price_postapoc": "120 USD",
+    "countdown_interval": "1 second",
     "countdown_action": { "type": "cast_spell", "spell_id": "learn_ki_strike", "no_fail": true, "level": 0 }
   },
   {

--- a/data/mods/TEST_DATA/items.json
+++ b/data/mods/TEST_DATA/items.json
@@ -348,7 +348,6 @@
       "type": "transform",
       "msg": "Your %s activates.",
       "target": "test_shears_on",
-      "active": true,
       "need_charges": 1,
       "need_charges_msg": "The shears batteries are dead."
     },
@@ -374,7 +373,8 @@
     "power_draw": "10 W",
     "revert_to": "test_shears_off",
     "use_action": { "type": "transform", "msg": "Your %s deactivates.", "target": "test_shears_off" },
-    "qualities": [ [ "SHEAR", 3 ] ]
+    "qualities": [ [ "SHEAR", 3 ] ],
+    "extend": { "flags": [ "SPAWN_ACTIVE" ] }
   },
   {
     "id": "test_cordless_drill",
@@ -736,7 +736,6 @@
       "type": "transform",
       "msg": "You turn the flashlight on.",
       "target": "flashlight_on",
-      "active": true,
       "need_charges": 1,
       "need_charges_msg": "The flashlight's batteries are dead."
     },
@@ -1081,7 +1080,6 @@
         "target": "smart_phone_flashlight",
         "msg": "You activate the flashlight app.",
         "menu_text": "Turn on flashlight",
-        "active": true,
         "need_charges": 5,
         "need_charges_msg": "The smartphone's charge is too low.",
         "type": "transform"
@@ -3124,7 +3122,7 @@
     "power_armor": true,
     "material_thickness": 14,
     "environmental_protection": 16,
-    "use_action": { "type": "transform", "msg": "The %s engages.", "target": "test_power_armor_on", "active": true },
+    "use_action": { "type": "transform", "msg": "The %s engages.", "target": "test_power_armor_on" },
     "flags": [ "WATERPROOF", "STURDY", "ELECTRIC_IMMUNE" ],
     "armor": [
       {
@@ -3150,7 +3148,7 @@
     "subtypes": [ "TOOL", "ARMOR" ],
     "name": { "str": "test power armor (on)" },
     "description": "This is a prototype power armor just for testing.",
-    "flags": [ "USE_UPS", "WATERPROOF", "STURDY", "ELECTRIC_IMMUNE", "TRADER_AVOID" ],
+    "flags": [ "USE_UPS", "WATERPROOF", "STURDY", "ELECTRIC_IMMUNE", "TRADER_AVOID", "SPAWN_ACTIVE" ],
     "power_draw": "4 kW",
     "revert_to": "test_power_armor",
     "use_action": { "type": "transform", "menu_text": "Turn off", "msg": "The %s armor disengages.", "target": "test_power_armor" }
@@ -4679,7 +4677,6 @@
       "type": "transform",
       "msg": "Initiating\nRunning suit integrity diagnostics…\nAll systems operational.",
       "target": "phase_immersion_suit_on",
-      "active": true,
       "need_charges": 1,
       "need_charges_msg": "Warning: Operating on minimal power.  Protection compromised."
     },

--- a/data/mods/Xedra_Evolved/items/armor/integrated.json
+++ b/data/mods/Xedra_Evolved/items/armor/integrated.json
@@ -1046,7 +1046,6 @@
         "menu_text": "Hear the song",
         "msg": "The fruit's melody fills your mind.",
         "type": "transform",
-        "active": true,
         "need_charges": 0,
         "need_charges_msg": "Something is preventing this fruit from working.  Please report it on github."
       }
@@ -1062,7 +1061,7 @@
     "name": { "str": "The fruit's song" },
     "description": "The song contained in the fruit is now struck in your head until it goes away.  Fortunately this song is enjoyable, increasing your mood while it lasts.",
     "charges_per_use": 0,
-    "flags": [ "INTEGRATED", "UNBREAKABLE", "PERSONAL", "NO_REPAIR", "ALLOWS_NATURAL_ATTACKS" ],
+    "flags": [ "INTEGRATED", "UNBREAKABLE", "PERSONAL", "NO_REPAIR", "ALLOWS_NATURAL_ATTACKS", "SPAWN_ACTIVE" ],
     "power_draw": "0 W",
     "revert_to": "corpse_ash",
     "tick_action": [ "MP3_ON" ]

--- a/data/mods/Xedra_Evolved/items/electronics.json
+++ b/data/mods/Xedra_Evolved/items/electronics.json
@@ -20,7 +20,6 @@
         "target": "laptop_xedra_lit",
         "msg": "You light up the screen.",
         "menu_text": "Light up the screen",
-        "active": true,
         "need_charges": 1,
         "need_charges_msg": "The laptop's batteries need more charge.",
         "type": "transform"
@@ -77,6 +76,6 @@
     ],
     "faults": [ { "fault_group": "electronic_general" } ],
     "light": 10,
-    "flags": [ "WATCH", "TRADER_AVOID", "WATER_BREAK", "ELECTRONIC" ]
+    "flags": [ "WATCH", "TRADER_AVOID", "WATER_BREAK", "ELECTRONIC", "SPAWN_ACTIVE" ]
   }
 ]

--- a/data/mods/Xedra_Evolved/items/hedge_magic_items.json
+++ b/data/mods/Xedra_Evolved/items/hedge_magic_items.json
@@ -136,7 +136,6 @@
     "use_action": {
       "type": "transform",
       "need_charges": 1,
-      "active": true,
       "target": "item_hedge_see_fae_necklace_on",
       "msg": "You recite that last part of the charm.",
       "need_worn": true
@@ -169,7 +168,7 @@
     "material": [ "leather", "veggy" ],
     "color": "green",
     "symbol": ",",
-    "flags": [ "ONE_PER_LAYER", "SKINTIGHT", "NO_UNLOAD", "NO_RELOAD", "HEDGE_ENCHANTED" ],
+    "flags": [ "ONE_PER_LAYER", "SKINTIGHT", "NO_UNLOAD", "NO_RELOAD", "HEDGE_ENCHANTED", "SPAWN_ACTIVE" ],
     "revert_to": "item_hedge_see_fae_necklace_done",
     "revert_msg": "Your otherworldly senses fade.",
     "tool_ammo": "glamour_charge",

--- a/data/mods/Xedra_Evolved/items/inventor/armor.json
+++ b/data/mods/Xedra_Evolved/items/inventor/armor.json
@@ -41,15 +41,7 @@
         "default_magazine": "medium_battery_cell"
       }
     ],
-    "use_action": [
-      {
-        "target": "helmet_inventor_on",
-        "need_charges": 1,
-        "active": true,
-        "msg": "The helmet turns on.",
-        "type": "transform"
-      }
-    ],
+    "use_action": [ { "target": "helmet_inventor_on", "need_charges": 1, "msg": "The helmet turns on.", "type": "transform" } ],
     "techniques": [ "WBLOCK_1" ],
     "flags": [ "MORPHIC", "WATERPROOF", "STURDY", "PADDED", "TRADER_AVOID", "PSYSHIELD_PARTIAL", "MUNDANE", "INVENTOR_CRAFTED" ],
     "tool_ammo": [ "battery" ],
@@ -60,6 +52,7 @@
     "type": "ITEM",
     "subtypes": [ "TOOL", "ARMOR" ],
     "copy-from": "helmet_inventor",
+    "extend": { "flags": [ "SPAWN_ACTIVE" ] },
     "name": { "str": "helmet of creative juices (on)", "str_pl": "helmets of creative juices (on)" },
     "power_draw": "7 W",
     "revert_to": "helmet_inventor",
@@ -170,12 +163,7 @@
     "looks_like": "legguard_hard",
     "color": "light_red",
     "flags": [ "MORPHIC", "STURDY", "OUTER", "BELTED", "MUNDANE", "INVENTOR_CRAFTED" ],
-    "use_action": {
-      "target": "inventor_leg_weight_on",
-      "msg": "You turn on the weight suspension system.",
-      "active": true,
-      "type": "transform"
-    },
+    "use_action": { "target": "inventor_leg_weight_on", "msg": "You turn on the weight suspension system.", "type": "transform" },
     "pocket_data": [
       {
         "pocket_type": "MAGAZINE_WELL",
@@ -211,6 +199,7 @@
   {
     "id": "inventor_leg_weight_on",
     "copy-from": "inventor_leg_weight",
+    "extend": { "flags": [ "SPAWN_ACTIVE" ] },
     "name": { "str": "leg weight suspension system" },
     "type": "ITEM",
     "subtypes": [ "TOOL", "ARMOR" ],
@@ -323,7 +312,6 @@
       {
         "target": "aura_force_on",
         "need_charges": 1,
-        "active": true,
         "msg": "The torus start to emit an invisible waves.",
         "type": "transform"
       }
@@ -349,6 +337,7 @@
     "type": "ITEM",
     "subtypes": [ "TOOL", "ARMOR" ],
     "copy-from": "aura_force",
+    "extend": { "flags": [ "SPAWN_ACTIVE" ] },
     "name": { "str": "force shield (on)", "str_pl": "force shields (on)" },
     "power_draw": "250 W",
     "revert_to": "aura_force",
@@ -377,7 +366,6 @@
         "target": "vision_halo_on",
         "msg": "Turn on.",
         "menu_text": "Turn on a battle mode",
-        "active": true,
         "need_charges": 1,
         "need_charges_msg": "The halo's charge is too low.",
         "type": "transform"
@@ -451,6 +439,7 @@
     "category": "armor",
     "name": { "str": "electronic halo (on)", "str_pl": "electronic halos (on)" },
     "copy-from": "vision_halo",
+    "extend": { "flags": [ "SPAWN_ACTIVE" ] },
     "power_draw": "500 W",
     "revert_to": "vision_halo",
     "use_action": [
@@ -461,7 +450,6 @@
         "target": "vision_halo",
         "msg": "Turn off.",
         "menu_text": "Turn off battle mode",
-        "active": false,
         "need_charges": 0,
         "type": "transform"
       }
@@ -562,7 +550,6 @@
         "target": "inventor_electric_fist_act",
         "msg": "Turn on.",
         "menu_text": "Turn on the overture",
-        "active": true,
         "need_charges": 1,
         "need_charges_msg": "The halo's charge is too low.",
         "type": "transform"
@@ -592,6 +579,7 @@
     "subtypes": [ "TOOL", "ARMOR" ],
     "id": "inventor_electric_fist_act",
     "copy-from": "inventor_electric_fist",
+    "extend": { "flags": [ "SPAWN_ACTIVE" ] },
     "symbol": "3",
     "color": "light_gray",
     "name": { "str": "\"Overture\" (on)", "str_pl": "\"Overtures\" (on)" },
@@ -636,7 +624,6 @@
         "target": "wolf_mask_act",
         "msg": "Turn on.",
         "menu_text": "Turn on the mask",
-        "active": true,
         "need_charges": 1,
         "need_charges_msg": "The mask's charge is too low.",
         "type": "transform"
@@ -650,6 +637,7 @@
     "type": "ITEM",
     "subtypes": [ "TOOL", "ARMOR" ],
     "copy-from": "wolf_mask",
+    "extend": { "flags": [ "SPAWN_ACTIVE" ] },
     "name": { "str": "wolf's mask (on)", "str_pl": "wolf's masks (on)" },
     "power_draw": "5 W",
     "environmental_protection": 25,

--- a/data/mods/Xedra_Evolved/items/inventor/gun.json
+++ b/data/mods/Xedra_Evolved/items/inventor/gun.json
@@ -651,7 +651,6 @@
       "menu_text": "Activate",
       "msg": "You trigger the mechanism, and it starts to whistle!",
       "target_timer": "70 seconds",
-      "active": true,
       "type": "transform"
     }
   },
@@ -668,6 +667,7 @@
     "symbol": "*",
     "color": "blue",
     "tick_action": [ { "type": "sound", "sound_message": "whistle", "sound_volume": 35, "sound_variant": "bomb_ticking" } ],
+    "countdown_interval": "70 seconds",
     "countdown_action": {
       "type": "explosion",
       "fields_type": "fd_electricity",
@@ -676,7 +676,7 @@
       "fields_max_intensity": 10,
       "emp_blast_radius": 12
     },
-    "flags": [ "TRADER_AVOID", "BOMB", "INVENTOR_CRAFTED" ]
+    "flags": [ "TRADER_AVOID", "BOMB", "INVENTOR_CRAFTED", "SPAWN_ACTIVE" ]
   },
   {
     "id": "inventor_grenade_noise_fire",

--- a/data/mods/Xedra_Evolved/items/inventor/melee.json
+++ b/data/mods/Xedra_Evolved/items/inventor/melee.json
@@ -41,7 +41,6 @@
     "use_action": {
       "target": "combatsaw_spear_on",
       "msg": "You turn on the chainsaw spear.",
-      "active": true,
       "type": "transform",
       "need_charges": 1,
       "need_charges_msg": "The chainsaw spear battery is dead."
@@ -79,8 +78,8 @@
     "melee_damage": { "bash": 8, "cut": 36 },
     "power_draw": "350 W",
     "revert_to": "combatsaw_spear_off",
-    "use_action": { "target": "combatsaw_spear_off", "msg": "You turn off the chainsaw spear.", "active": false, "type": "transform" },
-    "extend": { "flags": [ "MESSY" ] }
+    "use_action": { "target": "combatsaw_spear_off", "msg": "You turn off the chainsaw spear.", "type": "transform" },
+    "extend": { "flags": [ "MESSY", "SPAWN_ACTIVE" ] }
   },
   {
     "type": "ITEM",
@@ -146,7 +145,6 @@
     "use_action": {
       "target": "inventor_plasma_axe",
       "msg": "You turn on your \"Neon Angle\".",
-      "active": true,
       "type": "transform",
       "need_charges": 1,
       "need_charges_msg": "The \"Neon Angle\" battery is dead."
@@ -169,6 +167,7 @@
   {
     "id": "inventor_plasma_axe",
     "copy-from": "inventor_plasma_axe_off",
+    "extend": { "flags": [ "SPAWN_ACTIVE" ] },
     "type": "ITEM",
     "subtypes": [ "TOOL" ],
     "name": { "str": "\"Neon Angle\" (on)", "str_pl": "\"Neon Angles\" (on)" },
@@ -176,11 +175,6 @@
     "melee_damage": { "bash": 8, "heat": 46 },
     "power_draw": "900 W",
     "revert_to": "inventor_plasma_axe_off",
-    "use_action": {
-      "target": "inventor_plasma_axe_off",
-      "msg": "You turn off your \"Neon Angle\".",
-      "active": false,
-      "type": "transform"
-    }
+    "use_action": { "target": "inventor_plasma_axe_off", "msg": "You turn off your \"Neon Angle\".", "type": "transform" }
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Replace usage of redundant active item transformation field in favor of SPAWN_ACTIVE flags on active items (which also causes debug spawned items to spawn active).
This is the last PR in a series. When all PRs have been merged, the field can be removed from the code (and documentation).

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Remove the field, and the flag as needed.
The MMA case is unfortunate, as it was the single example of an item that could actually switch between being active and inactive.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Don't change the MMA usage, and abandon removal of the active field.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Tested all items in appropriate worlds, except for the test ones, which I expect to be used by the tests on this PR.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
For the Xedra changes:
- Item names were often the same for active, inactive, and/or spent items (evident when debug spawning). Might want to differentiate them.
- A number of items had "Turn On" messages for turning off active items. I assume you'd have to an explicit message strings to change the default if you wanted to change that.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
