### PR TITLE
Implement u_spell_level dynamic tag

### DIFF
--- a/doc/JSON/NPCs.md
+++ b/doc/JSON/NPCs.md
@@ -374,9 +374,10 @@ Certain entries like the snippets above are taken from the game state as opposed
 | `<item_name:ID>`                              | N/A            | gets replaced with the name of the item from ID
 | `<item_description:ID>`                       | N/A            | gets replaced with the description of the item from ID
 | `<trait_name:ID>`                             | N/A            | gets replaced with the name of the trait from ID
-| `<trait_description:ID>`                      | beta           | gets replaced with the description of the trait from ID (uses beta talker to grab the description)
-| `<spell_name:ID>`                             | N/A            | gets replaced with the description of the name from ID
-| `<spell_description:ID>`                      | N/A            | gets replaced with the description of the trait from ID
+| `<trait_description:ID>`                      | N/A            | gets replaced with the description of the trait from ID (avatar variant of trait is used, if avatar has such trait)
+| `<spell_name:ID>`                             | N/A            | gets replaced with the name of the spell from ID
+| `<spell_description:ID>`                      | N/A            | gets replaced with the description of the spell from id
+| `<u_spell_level:ID>`                          | alpha          | gets replaced with the spell level of corresponding spell alpha talker has. If alpha talker has no such spell, it returns -1
 | `<keybind:ID>` and `<keybind:CATEGORY_ID:ID>` | N/A            | gets replaced with the keys bound to a specific `"type": "keybind"` found in data/raw or "Unbound globally/locally! (<keybind_name> in keybind category CATEGORY_ID)" if unbound.
 | `<city>`                                      | N/A            | gets replaced with the name of the closest city to the avatar
 | `<time_survived>`                             | N/A            | gets replaced with time since start of the game

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -2521,52 +2521,49 @@ void parse_tags( std::string &phrase, const_talker const &u, const_talker const 
             // attempt to cast as an item
             phrase.replace( fa, l, itype_id( var )->nname( 1 ) );
         } else if( tag.find( "<item_description:" ) == 0 ) {
-            //embedding an items name in the string
             std::string var = tag.substr( tag.find( ':' ) + 1 );
             // remove the trailing >
             var.pop_back();
             // resolve nest
             parse_tags( var, u, me, d, item_type );
-            // attempt to cast as an item
             phrase.replace( fa, l, itype_id( var )->description.translated() );
         } else if( tag.find( "<trait_name:" ) == 0 ) {
-            //embedding an items name in the string
             std::string var = tag.substr( tag.find( ':' ) + 1 );
             // remove the trailing >
             var.pop_back();
             // resolve nest
             parse_tags( var, u, me, d, item_type );
-            // attempt to cast as an item
             phrase.replace( fa, l, trait_id( var )->name() );
         } else if( tag.find( "<trait_description:" ) == 0 ) {
-            //embedding an items name in the string
             std::string var = tag.substr( tag.find( ':' ) + 1 );
             // remove the trailing >
             var.pop_back();
             // resolve nest
             parse_tags( var, u, me, d, item_type );
-            // attempt to cast as an item
+            // this probably will benefit from grabbing alpha/beta talker instead of avatar
             phrase.replace( fa, l, me_chr->mutation_desc( trait_id( var ) ) );
         } else if( tag.find( "<spell_name:" ) == 0 ) {
-            //embedding an items name in the string
             std::string var = tag.substr( tag.find( ':' ) + 1 );
             // remove the trailing >
             var.pop_back();
             // resolve nest
             parse_tags( var, u, me, d, item_type );
-            // attempt to cast as an item
             phrase.replace( fa, l, spell_id( var )->name.translated() );
         } else if( tag.find( "<spell_description:" ) == 0 ) {
-            //embedding an items name in the string
             std::string var = tag.substr( tag.find( ':' ) + 1 );
             // remove the trailing >
             var.pop_back();
             // resolve nest
             parse_tags( var, u, me, d, item_type );
-            // attempt to cast as an item
             phrase.replace( fa, l, spell_id( var )->description.translated() );
+        } else if( tag.find( "<u_spell_level:" ) == 0 ) {
+            std::string var = tag.substr( tag.find( ':' ) + 1 );
+            // remove the trailing >
+            var.pop_back();
+            // resolve nest
+            parse_tags( var, u, me, d, item_type );
+            phrase.replace( fa, l, std::to_string( u.get_spell_level( spell_id( var ) ) ) );
         } else if( tag.find( "<keybind:" ) == 0 ) {
-            //embedding an items name in the string
             std::string var = tag.substr( tag.find( ':' ) + 1 );
             // remove the trailing >
             var.pop_back();


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Json power
#### Describe the solution
Add tag to print current spell level of alpha talker
Document
Minor cleanup of comments and docs
#### Describe alternatives you've considered
Implement full-scale math within parse_tags - people way too often think they are related, and try to call math operation inside tag. probably not feasible without some workaround for `<>` signs, and in general sound very scary
#### Testing
<img width="1371" height="354" alt="image" src="https://github.com/user-attachments/assets/8761197d-8faa-4621-8164-6b6fe517b730" />
<img width="1340" height="304" alt="image" src="https://github.com/user-attachments/assets/748a5743-b038-4e86-8d68-8ce7f9abd6d9" />