### PR TITLE
Make Yrax Golden Monolith no longer teaches melee when hit and make their defence work

### DIFF
--- a/data/json/monsters/yrax.json
+++ b/data/json/monsters/yrax.json
@@ -205,6 +205,7 @@
     "dodge": 0,
     "melee_dice": 1,
     "melee_dice_sides": 1,
+    "melee_training_cap": 0,
     "flags": [ "GOODHEARING", "NOHEAD", "NO_BREATHE", "IMMOBILE", "PACIFIST" ],
     "special_attacks": [
       {
@@ -382,7 +383,7 @@
     "melee_skill": 5,
     "melee_dice": 2,
     "melee_dice_sides": 4,
-    "anger_triggers": [ "FRIEND_ATTACKED", "FRIEND_DIED", "HURT" ],
+    "anger_triggers": [ "FRIEND_ATTACKED", "FRIEND_DIED", "HURT", "PLAYER_CLOSE" ],
     "melee_damage": [ { "damage_type": "cut", "amount": 12 } ],
     "death_function": { "corpse_type": "BROKEN" },
     "extend": { "flags": [ "HIT_AND_RUN" ] },


### PR DESCRIPTION

#### Summary
None

#### Purpose of change
Found out that someone has been gaining melee skill by hitting the yrax golden monolith, which doesnt makes much sense cuz it is immobile and cant do anything in that form. Also the deltas dont do much to protect the golden monolith and just floating there with no care whatsoever.
#### Describe the solution
Give `"melee_training_cap"` to yrax golden monolith and give `"PLAYER_CLOSE"` to yrax delta's aggression trigger.

#### Describe alternatives you've considered

Not doing so.

#### Testing
Applied the change, i spawn in a yrax gold monolith and start hitting it. While it still gives some melee and unarmed xp, it's nowhere exceeding level 1.

I keep hitting the yrax golden monolith until it spawns in yrax deltas. said yrax deltas start hitting me.

#### Additional context



<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
