### PR TITLE
Record a snapshot of external options for save archive

### DIFF
--- a/src/game.h
+++ b/src/game.h
@@ -918,6 +918,7 @@ class game
         //private save functions.
         // returns false if saving failed for whatever reason
         bool save_factions_missions_npcs();
+        bool save_external_options_record();
         bool save_dimension_data();
         bool load_dimension_data();
         void reset_npc_dispositions();

--- a/src/game_io.cpp
+++ b/src/game_io.cpp
@@ -23,6 +23,7 @@
 #include <sstream>
 #include <string>
 #include <string_view>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -684,6 +685,41 @@ bool game::save_achievements()
 
 }
 
+bool game::save_external_options_record()
+{
+    const cata_path externals = PATH_INFO::world_base_save_path() / PATH_INFO::external_options();
+    const bool saved_externals = write_to_file( externals, [&]( std::ostream & fout ) {
+        JsonOut jout( fout );
+        fout << "# This is saved for debugging purposes only.  Nothing in this file is ever read by the game."
+             << std::endl;
+
+        fout << "# This includes the values of all options, including externals, at the exact time of saving.  The purpose of this is to store a record of the game state as it existed."
+             << std::endl;
+
+        fout << "# Externals 'forced on' by mods or user edits to data/core/external_options.json would not normally be visible in the save."
+             << std::endl;
+
+        jout.start_array();
+
+        const options_manager::options_container &options = get_options().get_raw_options();
+
+        for( const auto &elem : options ) {
+            jout.start_object();
+
+            jout.member( "info", elem.second.getTooltip() );
+            jout.member( "default", elem.second.getDefaultText( false ) );
+            jout.member( "name", elem.first );
+            jout.member( "value", elem.second.getValue( true ) );
+
+            jout.end_object();
+        }
+
+        jout.end_array();
+    }, _( "external options record" ) );
+
+    return saved_externals;
+}
+
 bool game::save()
 {
     std::chrono::seconds time_since_load =
@@ -695,6 +731,7 @@ bool game::save()
         if( !save_player_data() ||
             !save_achievements() ||
             !save_factions_missions_npcs() ||
+            !save_external_options_record() ||
             !save_dimension_data() ||
             !save_maps() ||
             !get_auto_pickup().save_character() ||

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -4137,6 +4137,11 @@ options_manager::cOpt &options_manager::get_option( const std::string &name )
     return wopt->second;
 }
 
+options_manager::options_container options_manager::get_raw_options()
+{
+    return options;
+}
+
 options_manager::options_container options_manager::get_world_defaults() const
 {
     std::unordered_map<std::string, cOpt> result;

--- a/src/options.h
+++ b/src/options.h
@@ -229,6 +229,9 @@ class options_manager
          */
         options_container get_world_defaults() const;
 
+        // Return a bare copy of all options in raw form, for debugging use only.
+        options_container get_raw_options();
+
         void set_world_options( options_container *options );
 
         /** Check if an option exists? */

--- a/src/path_info.cpp
+++ b/src/path_info.cpp
@@ -417,6 +417,10 @@ std::string PATH_INFO::worldoptions()
 {
     return "worldoptions.json";
 }
+std::string PATH_INFO::external_options()
+{
+    return "external_options.json";
+}
 std::string PATH_INFO::world_timestamp()
 {
     return "world_timestamp.json";

--- a/src/path_info.h
+++ b/src/path_info.h
@@ -47,6 +47,9 @@ std::string langdir();
 std::string lang_file();
 std::string soundpack_conf();
 
+// Debugging information. Saved only, not read.
+std::string external_options();
+
 std::string credits();
 std::string motd();
 std::string title( holiday current_holiday );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
I've realized that having people directly edit externals leaves us with even less ability to know if they've broken their game. Because externals don't get saved as *world options* there's no trace of their changes in the save.

#### Describe the solution
Dump all options when saving the game. This gets packaged normally into save archives, so we can root through it if needed.

#### Describe alternatives you've considered
I wanted to have it only write for the save archive, but virtualizing a file into it would be more technically challenging. So we just write it during the normal save process instead, with a big comment at the top telling people it doesn't do anything for the save.

#### Testing
Exported save archive which contains an `external_options.json`
[EXTERNALS-trimmed.tar.gz](https://github.com/user-attachments/files/23788086/EXTERNALS-trimmed.tar.gz)


#### Additional context
