### PR TITLE
Don't save quickloaded/corrupt gamestates

### DIFF
--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -284,6 +284,7 @@ std::string enum_to_string<debug_menu::debug_menu_index>( debug_menu::debug_menu
         case debug_menu::debug_menu_index::EXPORT_FOLLOWER: return "EXPORT_FOLLOWER";
         case debug_menu::debug_menu_index::EXPORT_SELF: return "EXPORT_SELF";
 		case debug_menu::debug_menu_index::QUICK_SETUP: return "QUICK_SETUP";
+		case debug_menu::debug_menu_index::QUICK_SETUP_FLAG_DIRTY: return "QUICK_SETUP_FLAG_DIRTY";
 		case debug_menu::debug_menu_index::TOGGLE_SETUP_MUTATION: return "TOGGLE_SETUP_MUTATION";
 		case debug_menu::debug_menu_index::NORMALIZE_BODY_STAT: return "NORMALIZE_BODY_STAT";
 		case debug_menu::debug_menu_index::SIX_MILLION_DOLLAR_SURVIVOR: return "SIX_MILLION_DOLLAR_SURVIVOR";
@@ -1095,6 +1096,7 @@ static int quick_setup_uilist()
 {
     const std::vector<uilist_entry> uilist_initializer = {
         { uilist_entry( debug_menu_index::QUICK_SETUP, true, 'Q', _( "Quick setup…" ) ) },
+        { uilist_entry( debug_menu_index::QUICK_SETUP_FLAG_DIRTY, true, 'D', _( "Quick setup and flag save as dirty" ) ) },
         { uilist_entry( debug_menu_index::TOGGLE_SETUP_MUTATION, true, 't', _( "Toggle debug mutations" ) ) },
         { uilist_entry( debug_menu_index::NORMALIZE_BODY_STAT, true, 'n', _( "Normalize body stats" ) ) },
         { uilist_entry( debug_menu_index::SIX_MILLION_DOLLAR_SURVIVOR, true, 'B', _( "Install ALL bionics" ) ) },
@@ -4071,7 +4073,7 @@ static void write_global_vars()
     popup( _( "Var list written to var_list.output" ) );
 }
 
-void do_debug_quick_setup()
+void do_debug_quick_setup( bool flag_dirty )
 {
     if( !debug_mode ) {
         // Turn on debug mode if not already on, but without any filters enabled (to prevent log spam).
@@ -4091,6 +4093,9 @@ void do_debug_quick_setup()
         u.set_skill_level( pair.first, 10 );
     }
     map_reveal( static_cast<int>( om_vision_level::full ) );
+    if( flag_dirty ) {
+        g->save_is_dirty = true;
+    }
 }
 
 void debug()
@@ -4465,12 +4470,14 @@ void debug()
                     _( "Quit without saving?  This may cause issues such as duplicated or missing items and vehicles!" ) ) ) {
                 player_character.set_moves( 0 );
                 g->uquit = QUIT_NOSAVED;
+                g->save_is_dirty = true;
             }
             break;
         case debug_menu_index::QUICKLOAD:
             if( query_yn(
                     _( "Quickload without saving?  This may cause issues such as duplicated or missing items and vehicles!" ) ) ) {
                 g->quickload();
+                g->save_is_dirty = true;
             }
             break;
         case debug_menu_index::TEST_WEATHER: {
@@ -4580,6 +4587,11 @@ void debug()
 
         case debug_menu_index::QUICK_SETUP: {
             do_debug_quick_setup();
+            break;
+        }
+
+        case debug_menu_index::QUICK_SETUP_FLAG_DIRTY: {
+            do_debug_quick_setup( true );
             break;
         }
 

--- a/src/debug_menu.h
+++ b/src/debug_menu.h
@@ -111,6 +111,7 @@ enum class debug_menu_index : int {
     EXPORT_FOLLOWER,
     EXPORT_SELF,
     QUICK_SETUP,
+    QUICK_SETUP_FLAG_DIRTY,
     TOGGLE_SETUP_MUTATION,
     NORMALIZE_BODY_STAT,
     SIX_MILLION_DOLLAR_SURVIVOR,
@@ -144,7 +145,7 @@ void wishproficiency( Character *you );
 
 void debug();
 
-void do_debug_quick_setup();
+void do_debug_quick_setup( bool flag_dirty = false );
 
 /* Splits a string by @param delimiter and push_back's the elements into _Container */
 template<typename Container>

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -450,6 +450,7 @@ game::game() :
     scent( *scent_ptr ),
     timed_events( *timed_event_manager_ptr ),
     uquit( QUIT_NO ),
+    save_is_dirty( false ),
     safe_mode( SAFE_MODE_ON ),
     u_shared_ptr( &u, null_deleter{} ),
     next_npc_id( 1 ),

--- a/src/game.h
+++ b/src/game.h
@@ -1185,6 +1185,8 @@ class game
 
         /** Used in main.cpp to determine what type of quit is being performed. */
         quit_status uquit; // NOLINT(cata-serialize)
+        /** Flags if the game is currently in an unsupported state and cannot be saved. */
+        bool save_is_dirty; // NOLINT(cata-serialize)
         /** True if the game has just started or loaded, else false. */
         bool new_game = false; // NOLINT(cata-serialize)
 

--- a/src/game_io.cpp
+++ b/src/game_io.cpp
@@ -686,6 +686,10 @@ bool game::save_achievements()
 
 bool game::save()
 {
+    if( save_is_dirty ) {
+        popup( _( "The game is in an unsupported state after using debug tools and cannot be saved." ) );
+        return false;
+    }
     std::chrono::seconds time_since_load =
         std::chrono::duration_cast<std::chrono::seconds>(
             std::chrono::steady_clock::now() - time_of_last_load );

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -2921,6 +2921,10 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
                 if( save() ) {
                     player_character.set_moves( 0 );
                     uquit = QUIT_SAVED;
+                } else if( save_is_dirty && query_yn( _( "Unable to save, quit anyway?" ) ) ) {
+                    // Game refused to save because of unsupported game state. But we don't want to trap them here, so at least let give them the option.
+                    player_character.set_moves( 0 );
+                    uquit = QUIT_NOSAVED;
                 }
             }
             break;
@@ -2931,6 +2935,7 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
 
         case ACTION_QUICKLOAD:
             quickload();
+            g->save_is_dirty = true;
             return false;
 
         case ACTION_PL_INFO:


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
There are two main reasons I'm making this PR.

First, the main reason: I have accidentally overwritten test saves on many occasions. There are several ways in which saves need to be tested. Sometimes I set up specific scenarios for new content and repeatedly run through them again and again and again  to make sure the interactions work with every iteration. Sometimes I am loading saves from bug reports, and having the exact save state is critical.

On many occasions I have accidentally overwritten the save in question, which ranges from mildly annoying (I lost part of the test setup and need to remake it) to massively troublesome (I have completely nuked the save and need to reconstruct everything).

Second, the very annoying to me personally but probably not as good reason:  I recently had a conversation with someone who was repeatedly using the quickload feature and corrupting their save. Despite the very large prominent warning sign and my own personal interactions of telling them exactly why it would blow up their save. They persisted, and so I considered extra guard rails.

#### Describe the solution
The game simply refuses to save after a quickload has been performed. A message is presented to the player telling them this.

Handling has been added to the quit functions so that quitting the game is always possible.

A variant of quick setup, "Quick setup and flag dirty" was added for one of my usual use cases where I do not want to accidentally overwrite the save but still need to do some setup.

#### Describe alternatives you've considered


#### Testing
Load world, save game, all works normally.

Quickload, try to save again and it doesn't let me. Quick setup with flag also correctly flags it dirty.

#### Additional context

