### PR TITLE
Stop turning on *all* the debug mode filters on first open

### DIFF
--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -4073,12 +4073,9 @@ static void write_global_vars()
 
 void do_debug_quick_setup()
 {
-    if( !debug_mode ) {
-        // Turn on debug mode if not already on, but without any filters enabled (to prevent log spam).
-        // Save a few keypresses.
-        debug_mode = true;
-        debugmode::enabled_filters.clear();
-    }
+    // Turn on debug mode. Some debug information displays require just this to be on, so we want it on. Save a few keypresses.
+    debug_mode = true;
+
     Character &u = get_avatar();
     normalize_body( u );
     // Specifically only adds mutations instead of toggling them.

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -2055,15 +2055,6 @@ static void handle_debug_mode()
         }
     };
 
-    static bool first_time = true;
-    if( first_time ) {
-        first_time = false;
-        debugmode::enabled_filters.clear();
-        for( int i = 0; i < debugmode::DF_LAST; ++i ) {
-            debugmode::enabled_filters.emplace( static_cast<debugmode::debug_filter>( i ) );
-        }
-    }
-
     input_context ctxt( "DEFAULTMODE" );
     ctxt.register_action( "debug_mode" );
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Opening the debug mode menu turns on every single filter

If you then toggle debug mode on, you will be immediately hit with waves upon waves of log spam that makes it completely impossible to use debug mode. So you must always turn all filters *off*

#### Describe the solution
Skip the middleman, just stop turning on all the filters automatically. If someone wants an unreadable mess, they can press the button manually instead of everyone else having to turn them all off.

Enabling all the filters at once made more sense when the game was smaller and we had less debug coverage. Now we have a lot, so the resulting log messages are an absolute wall.

#### Describe alternatives you've considered


#### Testing

#### Additional context
