### PR TITLE
fix smartphone advanced recovery

### DIFF
--- a/data/json/effects_on_condition/computer_eocs.json
+++ b/data/json/effects_on_condition/computer_eocs.json
@@ -125,8 +125,7 @@
     "id": "EOC_SMARTPHONE_RECOVERY_ADVANCED",
     "condition": {
       "and": [
-        { "u_has_item": "software_hacking" },
-        { "u_has_items": { "item": "laptop", "charges": 20 } },
+        { "u_has_software": { "item": "software_hacking", "charges": 20, "device": "laptop" } },
         { "math": [ "u_skill('computer') >= 4" ] }
       ]
     },

--- a/doc/JSON/EFFECT_ON_CONDITION.md
+++ b/doc/JSON/EFFECT_ON_CONDITION.md
@@ -714,6 +714,40 @@ check do you have 3 manuals in inventory
 ```
 
 
+### `u_has_software`, `npc_has_software`
+- type: [variable object](#variable-object)
+- return true if alpha or beta talker has software specified as `item` in one of the devices in their inventory
+- `item` - the software we are looking for
+- `charges` - optionally, the device in which the software is found has to have at least this number of charges or be plugged into a power grid (if omitted or 0, devices with no charges are matched too)
+- `device` - optionally, match only the software in this device
+
+#### Valid talkers:
+
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------ | --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
+
+#### Examples
+check do you have hackPRO software
+```jsonc
+{ "u_has_software": { "item": "software_hacking" } }
+```
+
+check do you have hackPRO software in a device with 20 charges
+```jsonc
+{ "u_has_software": { "item": "software_hacking", "charges": 20 } }
+```
+
+check do you have hackPRO software in a laptop with 20 charges
+```jsonc
+{ "u_has_software": { "item": "software_hacking", "charges": 20, "device": "laptop" } }
+```
+
+check do you have hackPRO software in a laptop, regardless of charges
+```jsonc
+{ "u_has_software": { "item": "software_hacking", "charges": 0, "device": "laptop" } }
+```
+
 
 ### `u_has_items_sum`, `npc_has_items_sum`
 - type: array of pairs, pair is string or [variable object](#variable-object) and int or [variable object](#variable-object)

--- a/src/character.h
+++ b/src/character.h
@@ -2084,6 +2084,10 @@ class Character : public Creature, public visitable
         /** Returns the amount of software `type' that are in the inventory */
         int count_softwares( const itype_id &id );
 
+        /** Returns whether the character has software on a device with a desired number of charges */
+        bool has_software( const itype_id &software_id, int min_charges = 0,
+                           const itype_id &device_id = itype_id::NULL_ID() ) const;
+
         /** Returns nearby items which match the provided predicate */
         std::vector<item_location> nearby( const std::function<bool( const item *, const item * )> &func,
                                            int radius = 1 ) const;

--- a/src/character_inventory.cpp
+++ b/src/character_inventory.cpp
@@ -230,6 +230,47 @@ int Character::count_softwares( const itype_id &id )
     return count;
 }
 
+bool Character::has_software( const itype_id &software_id, int min_charges,
+                              const itype_id &device_id ) const
+{
+    map &here = get_map();
+
+    for( const item_location &it_loc : const_cast<Character *>( this )->all_items_loc() ) {
+        if( !it_loc->is_estorage() ) {
+            continue;
+        }
+
+        if( !device_id.is_null() && it_loc->typeId() != device_id ) {
+            continue;
+        }
+
+        bool has_software = false;
+        for( const item *software : it_loc->softwares() ) {
+            if( software->typeId() == software_id ) {
+                has_software = true;
+                break;
+            }
+        }
+
+        if( !has_software ) {
+            continue;
+        }
+
+        if( min_charges <= 0 ) {
+            return true;
+        }
+
+        if( it_loc->is_tool() ) {
+            const int device_charges = it_loc->ammo_remaining_linked( here, this );
+            if( device_charges >= min_charges ) {
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
 units::length Character::max_single_item_length() const
 {
     return std::max( weapon.max_containable_length(), worn.max_single_item_length() );

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -795,6 +795,25 @@ conditional_t::func f_has_item_category( const JsonObject &jo, std::string_view 
     };
 }
 
+conditional_t::func f_has_software( const JsonObject &jo, std::string_view member, bool is_npc )
+{
+    JsonObject has_software = jo.get_object( member );
+
+    str_or_var software_id = get_str_or_var( has_software.get_member( "item" ), "item", true );
+    dbl_or_var charges = get_dbl_or_var( has_software, "charges", false, 0.0 );
+    str_or_var device_id = get_str_or_var( has_software.get_member( "device" ), "device", false );
+
+    return [software_id, charges, device_id, is_npc]( const_dialogue const & d ) {
+        const_talker const *actor = d.const_actor( is_npc );
+        itype_id soft_id = itype_id( software_id.evaluate( d ) );
+        int min_charges = static_cast<int>( charges.evaluate( d ) );
+        itype_id dev_id = device_id.evaluate( d ).empty() ? itype_id::NULL_ID() : itype_id(
+                              device_id.evaluate( d ) );
+
+        return actor->has_software( soft_id, min_charges, dev_id );
+    };
+}
+
 conditional_t::func f_has_bionics( const JsonObject &jo, std::string_view member,
                                    bool is_npc )
 {
@@ -2430,6 +2449,7 @@ parsers = {
     {"u_has_items", "npc_has_items", jarg::member, &conditional_fun::f_has_items },
     {"u_has_items_sum", "npc_has_items_sum", jarg::array, &conditional_fun::f_has_items_sum },
     {"u_has_item_category", "npc_has_item_category", jarg::member, &conditional_fun::f_has_item_category },
+    {"u_has_software", "npc_has_software", jarg::member, &conditional_fun::f_has_software },
     {"u_has_bionics", "npc_has_bionics", jarg::member, &conditional_fun::f_has_bionics },
     {"u_has_any_effect", "npc_has_any_effect", jarg::array, &conditional_fun::f_has_any_effect },
     {"u_has_effect", "npc_has_effect", jarg::member, &conditional_fun::f_has_effect },

--- a/src/talker.h
+++ b/src/talker.h
@@ -402,6 +402,10 @@ class const_talker
         virtual int cash_to_favor( int ) const {
             return 0;
         }
+        virtual bool has_software( const itype_id &, int = 0,
+                                   const itype_id & = itype_id::NULL_ID() ) const {
+            return false;
+        }
 
         // missions
         virtual std::vector<mission *> available_missions() const {

--- a/src/talker_character.cpp
+++ b/src/talker_character.cpp
@@ -710,6 +710,12 @@ bool talker_character_const::has_stolen_item( const_talker const &guy ) const
     return false;
 }
 
+bool talker_character_const::has_software( const itype_id &software_id, int min_charges,
+        const itype_id &device_id ) const
+{
+    return me_chr_const->has_software( software_id, min_charges, device_id );
+}
+
 faction *talker_character_const::get_faction() const
 {
     return me_chr_const->get_faction();

--- a/src/talker_character.h
+++ b/src/talker_character.h
@@ -143,6 +143,8 @@ class talker_character_const: virtual public const_talker
         bool unarmed_attack() const override;
         bool can_stash_weapon() const override;
         bool has_stolen_item( const_talker const &guy ) const override;
+        bool has_software( const itype_id &software_id, int min_charges = 0,
+                           const itype_id &device_id = itype_id::NULL_ID() ) const override;
 
         // factions and alliances
         faction *get_faction() const override;


### PR DESCRIPTION
#### Summary
Bugfixes "Smartphone advanced recovery fix"

#### Purpose of change

Fixes #80549

#### Describe the solution

This PR fixes the linked bug by creating and using a new EOC condition `u_has_software`, which checks if the character has a device of a certain type, with a certain number of charges and a software in it. If called without a device ID, it will match any device. If called without charges, it will match any number of charges, including devices without charges.

This also changes the original condition, which would also pass if you had a laptop with 20 charges and hackPRO on a laptop with no charges or on another smartphone.

#### Describe alternatives you've considered

Considered 100% matching the original condition, which would have been easier, but I think it was written when there were only laptops, cellphones and USB sticks. In the current state, it would pass for some weird combinations. The new condition requires hackPRO to be on the laptop with at least 20 charges, which is more realistic.


#### Testing

Loaded up a save where I have hackPRO on a laptop and a bunch of locked phones. Verified that advanced recovery can be activated and works as expected.

Also verified that basic recovery is not broken.

Moved hackPRO to a laptop with 15 charges and verified that I am not able to use advanced recovery any more.

Plugged the laptop with 15 charges and hackPRO into the power grid and verified that advanced recovery can be used and works as expected.

#### Additional context

none
