### PR TITLE
fix crafting menu popup crash

### DIFF
--- a/src/input_popup.cpp
+++ b/src/input_popup.cpp
@@ -1,5 +1,6 @@
 #include "input_popup.h"
 
+#include <algorithm>
 #include <cstddef>
 
 #include "imgui/imgui.h"
@@ -296,7 +297,7 @@ void string_input_popup_imgui::update_input_history( ImGuiInputTextCallbackData 
         if( history_index >= static_cast<int>( hist.size() ) ) {
             return;
         } else if( history_index == 0 ) {
-            session_input = text;
+            session_input.assign( data->Buf, data->BufTextLen );
 
             //avoid showing the same result twice (after reopen filter window without reset)
             if( hist.size() > 1 && session_input == hist.back() ) {
@@ -305,8 +306,7 @@ void string_input_popup_imgui::update_input_history( ImGuiInputTextCallbackData 
         }
     } else {
         if( history_index == 1 ) {
-            text = session_input;
-            ::set_text( data, text );
+            ::set_text( data, session_input );
             //show initial string entered and 'return'
             history_index = 0;
             return;
@@ -316,8 +316,8 @@ void string_input_popup_imgui::update_input_history( ImGuiInputTextCallbackData 
     }
 
     history_index += up ? 1 : -1;
-    text = hist[hist.size() - history_index];
-    ::set_text( data, text );
+    const std::string &new_text = hist[hist.size() - history_index];
+    ::set_text( data, new_text );
 }
 
 void string_input_popup_imgui::add_to_history( const std::string &value ) const

--- a/src/input_popup.cpp
+++ b/src/input_popup.cpp
@@ -1,6 +1,5 @@
 #include "input_popup.h"
 
-#include <algorithm>
 #include <cstddef>
 
 #include "imgui/imgui.h"


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Fix crafting menu history navigation crash"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fix a bug when navigating history in crafting menu. Game would crash sometimes.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
The code modified the text member variable during the ImGui input callback, changing the string's buffer pointer. ImGui's InputText still referenced the old buffer. When ImGui's resize callback checked IM_ASSERT(data->Buf == str->c_str()), the pointers didn't match, causing an abort.

Solution:
Stop modifying text during the callback. Only modify the buffer via ::set_text(), and let ImGui's resize callback sync text automatically.

Commit 86fa1b18bf2 in PR #83383 introduced the bug by reassigning text before updating the buffer. 
The fix updates the buffer first and lets ImGui handle string synchronization.


#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Tested the menu, works as intended.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
attached save for testing: open the crafting menu, then filter /, then press arrow key up to search history.
[Phenix-trimmed.tar.gz](https://github.com/user-attachments/files/23830384/Phenix-trimmed.tar.gz)


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
