### PR TITLE
Fix NPC error when auto performing loot sorting job at basecamp

### DIFF
--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -3378,7 +3378,8 @@ bool npc::find_job_to_perform()
         }
         player_activity scan_act = player_activity( elem );
         if( elem == ACT_MOVE_LOOT ) {
-            assign_activity( elem );
+            assign_activity( zone_sort_activity_actor() );
+            return true;
         } else if( generic_multi_activity_handler( scan_act, *this->as_character(), true ) ) {
             assign_activity( elem );
             return true;


### PR DESCRIPTION
#### Summary

Bugfixes "Fix NPC error when auto performing loot sorting job at basecamp"

#### Purpose of change

NPCs assigned to basecamp jobs crash with a debugmsg error when trying to perform the ACT_MOVE_LOOT (loot sorting) job. The error says "Tried to assign generic activity ACT_MOVE_LOOT to activity that has an actor!" 

Bug is present only in experimental
#### Describe the solution

Changed the code in npc::find_job_to_perform() to use assign_activity( zone_sort_activity_actor() ) instead of assign_activity( elem ) when the job is ACT_MOVE_LOOT. That's it.

Basically the code was trying to assign ACT_MOVE_LOOT as a generic activity but it actually needs to use the zone_sort_activity_actor. Simple fix.

#### Describe alternatives you've considered

Not really any alternatives. This is the correct way to assign activities that have actors. Other places in the codebase already do it this way (like activity_item_handling.cpp, faction_camp.cpp, etc).

#### Testing

Tested by assigning an NPC to a basecamp, setting ACT_MOVE_LOOT job priority > 0, and waiting for them to try to perform it. Before the fix it would crash show the error. After the fix it works fine and NPCs can sort loot without errors.

#### Additional context

The error happens in character.cpp when it detects that you're trying to assign a generic activity that has an actor. The fix makes sure we use the activity actor overload instead.

Here's the save. Load; Press wait for some time 
[Phenix-trimmed.tar.gz](https://github.com/user-attachments/files/23833261/Phenix-trimmed.tar.gz)


