### PR TITLE
Replace custom EOCs with standard monster placement

### DIFF
--- a/data/json/effects_on_condition/misc_effect_on_condition.json
+++ b/data/json/effects_on_condition/misc_effect_on_condition.json
@@ -124,41 +124,6 @@
   },
   {
     "type": "effect_on_condition",
-    "id": "yrax_trifacet_activation",
-    "effect": [
-      { "u_spawn_monster": "mon_yrax_trifacet", "real_count": 1, "min_radius": 1, "max_radius": 2 },
-      { "u_message": "The hostile trifacet violently unfolds just clear of your hand!", "type": "bad" }
-    ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "yrax_triakis_activation",
-    "effect": [
-      { "u_spawn_monster": "mon_yrax_triakis", "real_count": 1, "min_radius": 1, "max_radius": 2 },
-      { "u_message": "The hostile triakis violently unfolds just clear of your hand!", "type": "bad" }
-    ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "yrax_golden_monolith_activation",
-    "effect": [
-      { "u_spawn_monster": "mon_golden_monolith", "real_count": 1, "min_radius": 1, "max_radius": 2 },
-      {
-        "u_message": "You notice a brief lull in the ambient noise around you, but its otherwise impossible to know if you allowed something to happen.",
-        "type": "bad"
-      }
-    ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "yrax_delta_activation",
-    "effect": [
-      { "u_spawn_monster": "mon_yrax_delta", "real_count": 1, "min_radius": 1, "max_radius": 2 },
-      { "u_message": "The hostile delta starts flying just as you release it!", "type": "bad" }
-    ]
-  },
-  {
-    "type": "effect_on_condition",
     "id": "add_effect",
     "effect": { "u_add_effect": { "context_val": "effect" }, "duration": { "context_val": "duration" } }
   },

--- a/data/json/items/corpses/inactive_bots.json
+++ b/data/json/items/corpses/inactive_bots.json
@@ -736,10 +736,13 @@
     "symbol": ",",
     "color": "cyan",
     "use_action": {
-      "type": "effect_on_conditions",
-      "consume": true,
-      "menu_text": "Activate",
-      "effect_on_conditions": [ "yrax_trifacet_activation" ]
+      "type": "place_monster",
+      "monster_id": "mon_yrax_trifacet",
+      "difficulty": 10000,
+      "hostile_msg": "The hostile trifacet violently unfolds just clear of your hand!",
+      "place_randomly": true,
+      "moves": 1,
+      "is_pet": false
     },
     "flags": [ "SINGLE_USE" ]
   },
@@ -758,10 +761,13 @@
     "weight": "221 kg",
     "flags": [ "TRADER_AVOID", "NO_REPAIR", "SINGLE_USE" ],
     "use_action": {
-      "type": "effect_on_conditions",
-      "consume": true,
-      "menu_text": "Activate",
-      "effect_on_conditions": [ "yrax_triakis_activation" ]
+      "type": "place_monster",
+      "monster_id": "mon_yrax_triakis",
+      "difficulty": 10000,
+      "hostile_msg": "The hostile triakis violently unfolds just clear of your hand!",
+      "place_randomly": true,
+      "moves": 1,
+      "is_pet": false
     }
   },
   {
@@ -780,10 +786,13 @@
     "color": "yellow",
     "flags": [ "TRADER_AVOID", "NO_REPAIR", "SINGLE_USE" ],
     "use_action": {
-      "type": "effect_on_conditions",
-      "consume": true,
-      "menu_text": "Activate",
-      "effect_on_conditions": [ "yrax_golden_monolith_activation" ]
+      "type": "place_monster",
+      "monster_id": "mon_golden_monolith",
+      "difficulty": 10000,
+      "hostile_msg": "You notice a brief lull in the ambient noise around you, but its otherwise impossible to know if you allowed something to happen.",
+      "place_randomly": true,
+      "moves": 1,
+      "is_pet": false
     }
   },
   {
@@ -807,10 +816,13 @@
     "qualities": [ [ "CUT", 1 ], [ "BUTCHER", 8 ] ],
     "flags": [ "TRADER_AVOID", "NO_REPAIR", "ALLOWS_BODY_BLOCK", "SHEATH_KNIFE", "SINGLE_USE" ],
     "use_action": {
-      "type": "effect_on_conditions",
-      "consume": true,
-      "menu_text": "Activate",
-      "effect_on_conditions": [ "yrax_delta_activation" ]
+      "type": "place_monster",
+      "monster_id": "mon_yrax_delta",
+      "difficulty": 10000,
+      "hostile_msg": "The hostile delta starts flying just as you release it!",
+      "place_randomly": true,
+      "moves": 1,
+      "is_pet": false
     }
   },
   {

--- a/data/json/items/corpses/inactive_bots.json
+++ b/data/json/items/corpses/inactive_bots.json
@@ -738,7 +738,7 @@
     "use_action": {
       "type": "place_monster",
       "monster_id": "mon_yrax_trifacet",
-      "difficulty": 10000,
+      "difficulty": -1,
       "hostile_msg": "The hostile trifacet violently unfolds just clear of your hand!",
       "place_randomly": true,
       "moves": 1,
@@ -763,7 +763,7 @@
     "use_action": {
       "type": "place_monster",
       "monster_id": "mon_yrax_triakis",
-      "difficulty": 10000,
+      "difficulty": -1,
       "hostile_msg": "The hostile triakis violently unfolds just clear of your hand!",
       "place_randomly": true,
       "moves": 1,
@@ -788,7 +788,7 @@
     "use_action": {
       "type": "place_monster",
       "monster_id": "mon_golden_monolith",
-      "difficulty": 10000,
+      "difficulty": -1,
       "hostile_msg": "You notice a brief lull in the ambient noise around you, but its otherwise impossible to know if you allowed something to happen.",
       "place_randomly": true,
       "moves": 1,
@@ -818,7 +818,7 @@
     "use_action": {
       "type": "place_monster",
       "monster_id": "mon_yrax_delta",
-      "difficulty": 10000,
+      "difficulty": -1,
       "hostile_msg": "The hostile delta starts flying just as you release it!",
       "place_randomly": true,
       "moves": 1,

--- a/doc/JSON/ITEM.md
+++ b/doc/JSON/ITEM.md
@@ -1256,7 +1256,7 @@ The contents of `use_action` fields can either be a string indicating a built-in
 "use_action": {
   "type": "place_monster",          // Place a turret / manhack / whatever monster on the map
   "monster_id": "mon_manhack",      // Monster ID, see monsters.json
-  "difficulty": 4,                  // Difficulty for programming it (manhacks have 4, turrets 6, etc.)
+  "difficulty": 4,                  // Difficulty for programming it (manhacks have 4, turrets 6, etc.). Negative means it always is hostile.
   "hostile_msg": "It's hostile!",   // (optional) Message when programming the monster failed and it's hostile
   "friendly_msg": "Good!",          // (optional) Message when the monster is programmed properly and it's friendly
   "place_randomly": true,           // Places the monster randomly around the player or lets the player decide where to put it (default: false)

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -1018,7 +1018,7 @@ std::optional<int> place_monster_iuse::use( Character *p, item &it, map *here,
         skill_offset += p->get_skill_level( sk ) / 2.0f;
     }
     /** @EFFECT_INT increases chance of a placed turret being friendly */
-    if( rng( 0, p->int_cur / 2 ) + skill_offset < rng( 0, difficulty ) ) {
+    if( difficulty < 0 || rng( 0, p->int_cur / 2 ) + skill_offset < rng( 0, difficulty ) ) {
         if( hostile_msg.empty() ) {
             p->add_msg_if_player( m_bad, _( "You deploy the %s wrong.  It is hostile!" ), newmon.name() );
         } else {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Don't reinvent the wheel. Use standard place_monster use_action rather than a custom EOC for each yrax.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Replace the use_actions and remove the EOCs.
Modify the hacking chance check to disable the ability to do so on a negative difficulty value.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Debug spawned one of each of the transforming yrax items and activated them. Saw them spawn and the same message appear, as well as the source items disappearing.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
