### PR TITLE
Add `lab_notes` terminals to microlabs

### DIFF
--- a/data/json/mapgen/microlab/microlab_computer_nests.json
+++ b/data/json/mapgen/microlab/microlab_computer_nests.json
@@ -1,0 +1,19 @@
+[
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "microlab_research_notes_computer",
+    "object": {
+      "mapgensize": [ 1, 1 ],
+      "rows": [ "6" ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
+      "computers": {
+        "6": {
+          "name": "Log Console",
+          "security": 3,
+          "options": [ { "name": "View Research Logs", "action": "research", "security": 0 } ],
+          "failures": [ { "action": "alarm" }, { "action": "shutdown" } ]
+        }
+      }
+    }
+  }
+]

--- a/data/json/mapgen_palettes/microlab.json
+++ b/data/json/mapgen_palettes/microlab.json
@@ -115,7 +115,8 @@
       "N": { "item": "fireman_cabinet", "chance": 100 },
       ";": { "item": "SUS_toilet", "chance": 50 }
     },
-    "vendingmachines": { "V": {  } }
+    "vendingmachines": { "V": {  } },
+    "nested": { "6": { "chunks": [ [ "null", 20 ], [ "microlab_research_notes_computer", 1 ] ] } }
   },
   {
     "type": "palette",
@@ -207,6 +208,7 @@
       "c": { "monster": "mon_zombie_living_wall", "chance": 3 },
       "@": { "monster": "mon_zombie_living_wall", "chance": 80 }
     },
-    "vendingmachines": { "V": {  } }
+    "vendingmachines": { "V": {  } },
+    "nested": { "6": { "chunks": [ [ "null", 20 ], [ "microlab_research_notes_computer", 1 ] ] } }
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Content "Add `lab_notes` terminals to microlabs"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

While looking into something else I realized that the various `lab_notes` snippets only appear when checking computers using the `Research` action, which can only be done in old labs. So in the interest of moving content out of old labs, you should be able to do that in subway microlabs too. 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add a nest to the `microlab` palette that has a 5% chance to overwrite a broken terminal with a working one. This working one is hackable and, if you hack it, give you the Read Research Notes action (putting up a snippet from `lab_notes`). If you fail, it either sounds an alarm or the console shuts off. Unlike old lab terminals you do not get the option to check satellite maps from every terminal as well.

Some of the `lab_notes` are out of place with current lore, but I think the solution there is changing those notes, not abandoning the entire mechanic.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Went to a lab and teleported around. Read notes on a few computers. Hacked one before I remembered to up my computer skill and it shut down.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
