### PR TITLE
Removed c4 iuse action in favor of extended transformation logic

### DIFF
--- a/data/json/item_actions.json
+++ b/data/json/item_actions.json
@@ -281,11 +281,6 @@
   },
   {
     "type": "item_action",
-    "id": "C4",
-    "name": { "str": "Activate" }
-  },
-  {
-    "type": "item_action",
     "id": "CAMERA",
     "name": { "str": "Use camera" }
   },

--- a/data/json/items/tool/explosives.json
+++ b/data/json/items/tool/explosives.json
@@ -14,7 +14,7 @@
     "material": [ "rdx" ],
     "symbol": ";",
     "color": "light_gray",
-    "use_action": [ "C4" ],
+    "use_action": { "target": "c4armed", "set_timer": true, "menu_text": "Activate", "type": "transform" },
     "flags": [ "RADIO_MODABLE", "RADIO_INVOKE_PROC", "BOMB", "ALLOWS_REMOTE_USE" ]
   },
   {

--- a/doc/JSON/ITEM.md
+++ b/doc/JSON/ITEM.md
@@ -1179,6 +1179,8 @@ The contents of `use_action` fields can either be a string indicating a built-in
   "active": true,                           // Whether the item is active once transformed
   "ammo_scale": 0,                          // For use when an item automatically transforms into another when its ammo drops to 0, or to allow guns to transform with 0 ammo
   "msg": "You turn the lamp on.",           // Message to display when activated
+  "target_timer": 0,                        // (Optional) Set timer on transformed item. Mutually exclusive with set_timer.
+  "set_timer": false,                       // (optional) When true, asks PC to set a timer. An NPC uses the default of the transformed item.
   "need_fire": 1,                           // Whether fire is needed to activate
   "need_fire_msg": "You need a lighter!",   // Message to display if there is no fire
   "need_charges": 1,                        // Number of charges the item needs to transform

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -1937,7 +1937,6 @@ void Item_factory::init()
     add_iuse( "BLECH", &iuse::blech );
     add_iuse( "BLECH_BECAUSE_UNCLEAN", &iuse::blech_because_unclean );
     add_iuse( "BOLTCUTTERS", &iuse::boltcutters );
-    add_iuse( "C4", &iuse::c4 );
     add_iuse( "CAMERA", &iuse::camera );
     add_iuse( "CAN_GOO", &iuse::can_goo );
     add_iuse( "COIN_FLIP", &iuse::coin_flip );

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -268,7 +268,6 @@ static const itype_id itype_barometer( "barometer" );
 static const itype_id itype_battery( "battery" );
 static const itype_id itype_blood( "blood" );
 static const itype_id itype_blood_acid( "blood_acid" );
-static const itype_id itype_c4armed( "c4armed" );
 static const itype_id itype_canister_empty( "canister_empty" );
 static const itype_id itype_cig( "cig" );
 static const itype_id itype_cig_lit( "cig_lit" );
@@ -3502,30 +3501,6 @@ std::optional<int> iuse::granade_act( Character *, item *it, const tripoint_bub_
             }
             break;
     }
-    return 1;
-}
-
-std::optional<int> iuse::c4( Character *p, item *it, const tripoint_bub_ms & )
-{
-    int time = 0;
-    bool got_value = false;
-    if( p->is_avatar() ) {
-        got_value = query_int( time, false, _( "Set the timer to how many seconds (0 to cancel)?" ) );
-        if( !got_value || time <= 0 ) {
-            p->add_msg_if_player( _( "Never mind." ) );
-            return std::nullopt;
-        }
-    }
-    p->add_msg_if_player( n_gettext( "You set the timer to %d second.",
-                                     "You set the timer to %d seconds.", time ), time );
-    it->convert( itype_c4armed );
-    if( got_value ) {
-        it->countdown_point = calendar::turn + time_duration::from_seconds( time );
-    } else {
-        // Uses value from the converted type (e.g. currently hardcoded c4armed)
-        it->countdown_point = calendar::turn + it->type->countdown_interval;
-    }
-    it->active = true;
     return 1;
 }
 

--- a/src/iuse.h
+++ b/src/iuse.h
@@ -77,7 +77,6 @@ std::optional<int> bell( Character *, item *, const tripoint_bub_ms & );
 std::optional<int> blood_draw( Character *, item *, const tripoint_bub_ms & );
 std::optional<int> boltcutters( Character *, item *, const tripoint_bub_ms & );
 std::optional<int> break_stick( Character *, item *, const tripoint_bub_ms & );
-std::optional<int> c4( Character *, item *, const tripoint_bub_ms & );
 std::optional<int> call_of_tindalos( Character *, item *, const tripoint_bub_ms & );
 std::optional<int> camera( Character *, item *, const tripoint_bub_ms & );
 std::optional<int> can_goo( Character *, item *, const tripoint_bub_ms & );

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -230,6 +230,12 @@ void iuse_transform::load( const JsonObject &obj, const std::string & )
 
     optional( obj, false, "moves", moves, numeric_bound_reader<int> { 0 }, 0 );
 
+    optional( obj, false, "set_timer", set_timer, false );
+
+    if( set_timer && transform.target_timer != 0_seconds ) {
+        obj.throw_error_at( "set_timer", "Cannot use both set_timer and target_timer at once" );
+    }
+
     optional( obj, false, "need_fire", need_fire, numeric_bound_reader<int> { 0 }, 0 );
     optional( obj, false, "need_charges_msg", need_charges_msg, to_translation( "The %s is empty!" ) );
 
@@ -275,6 +281,21 @@ std::optional<int> iuse_transform::use( Character *p, item &it, map *,
         }
     }
 
+    int timer_time = 0;
+    bool got_timer_value = false;
+
+    if( set_timer && p->is_avatar() ) {
+        got_timer_value = query_int( timer_time, false,
+                                     _( "Set the timer to how many seconds (0 to cancel)?" ) );
+        if( !got_timer_value || timer_time <= 0 ) {
+            p->add_msg_if_player( _( "Never mind." ) );
+            return std::nullopt;
+        }
+    }
+
+    p->add_msg_if_player( n_gettext( "You set the timer to %d second.",
+                                     "You set the timer to %d seconds.", timer_time ), timer_time );
+
     if( !msg_transform.empty() ) {
         p->add_msg_if_player( m_neutral, msg_transform, it.tname() );
     }
@@ -300,6 +321,15 @@ std::optional<int> iuse_transform::use( Character *p, item &it, map *,
         p->i_add_or_drop( take_one );
     } else {
         transform.transform( p, it, true );
+    }
+
+    if( set_timer ) {
+        if( got_timer_value ) {
+            it.countdown_point = calendar::turn + time_duration::from_seconds( timer_time );
+        } else {
+            // Uses value from the converted type
+            it.countdown_point = calendar::turn + it.type->countdown_interval;
+        }
     }
 
     if( it.is_tool() ) {

--- a/src/iuse_actor.h
+++ b/src/iuse_actor.h
@@ -64,6 +64,9 @@ class iuse_transform : public iuse_actor
         /** subtracted from @ref Creature::moves when transformation is successful */
         int moves = 0;
 
+        /** Asks you to set a timer for a countdown */
+        bool set_timer = false;
+
         /** minimum number of fire charges required (if any) for transformation */
         int need_fire = 0;
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Replace special handling with general functionality, i.e. allow iuse action transformation to set a timer and use that for C-4 rather than a C-4 special action.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
I believe the purpose describes it. Change code, JSON, and documentation. In the case of the documentation, I found the target_timer field was undocumented, so it was added.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
I originally had intended to roll the mininuke into this, but found that the mininuke action issues an event bus signal. I have no idea what this is used for, and testing showed the mininuke itself behaved the same with the common transform action, but the signal presumably serves some purpose, so I left it unchanged.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
- Debug spawn a C-4.
- Activate it and set the timer.
- Throw it and wait.
- See it explode approximately when it was supposed to.
- Change the code.
- Repeat the above, and see no changes in the behavior.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
The C-4 has a default timer, and a debug spawned active one exploded after approximately that time. This is what would be used if an NPC used it (and I think the BOMB flag allows NPCs to use the C-4).

I also debug spawned an active mininuke, and it does not explode (after a reasonable amount of time), as it doesn't have a default timer. I don't believe it can be activated by NPCs though, so it shouldn't matter.

I had originally intended to roll this into a larger item transform action update, but have since changed my mind and I'm now going for three sequential PRs, each of which would be implemented only after the previous one(s) has been merged to avoid merge conflict issues. The other two intended PRs is removal of a lot of tool transformation EoCs in favor of the standard transformation, extended with the ability to generate sound, and removal of the "active" field from the transformation once all the usages of it are gone (outstanding PRs). The order of these PRs depend on whether the outstanding PRs have been merged by the time this PR is merged or not.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
