### PR TITLE
Move highway intersection grid into a generic class

### DIFF
--- a/data/core/external_options.json
+++ b/data/core/external_options.json
@@ -499,5 +499,26 @@
     "stub": true,
     "stype": "string_input",
     "value": "normal"
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "HIGHWAY_GRID_ROW_SEPARATION",
+    "//": "The distance between east-west highways in overmaps, with the whole overmap gap being `grid_row_seperation` - 1.",
+    "stype": "int",
+    "value": 8
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "HIGHWAY_GRID_COLUMN_SEPARATION",
+    "//": "The distance between north-south highways in overmaps, with the whole overmap gap being `grid_column_seperation` - 1.",
+    "stype": "int",
+    "value": 10
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "HIGHWAY_GRID_VARIANCE",
+    "//": "The maximum number of overmaps that an intersection can deviate from its gridded position. Cannot be greater than or equal to row / 2 or column / 2, may cause bugs for > row / 4, column / 4.",
+    "stype": "int",
+    "value": 2
   }
 ]

--- a/data/json/region_settings/region_settings/regional_map_settings.json
+++ b/data/json/region_settings/region_settings/regional_map_settings.json
@@ -87,11 +87,8 @@
   {
     "type": "region_settings_highway",
     "id": "default",
-    "grid_column_seperation": 10,
-    "grid_row_seperation": 8,
     "width_of_segments": 2,
     "straightness_chance": 0.6,
-    "intersection_max_radius": 2,
     "reserved_terrain_id": "hw_reserved",
     "reserved_terrain_water_id": "hw_reserved_water",
     "segment_ramp_special": "highway_segment_ramp",

--- a/doc/JSON/REGION_SETTINGS.md
+++ b/doc/JSON/REGION_SETTINGS.md
@@ -388,15 +388,14 @@ The **overmap_connection_settings** section defines the `overmap_connection_id`s
 The **overmap_highway_settings** section defines the attributes used in generating highways
 on the overmap including the specials containing the maps used.
 
+Basic overmap settings can be found in external options.
+
 ### Fields
 
 |               Identifier          |                              Description                               
 | --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `grid_column_seperation`          | The distance between north-south highways in overmaps, with the whole overmap gap being `grid_column_seperation` - 1.                                                                                                                        |
-| `grid_row_seperation`             | The distance between east-west highways in overmaps, with the whole overmap gap being `grid_row_seperation` - 1.                                                                                                                             |
 | `width_of_segments`               | The width of the segments defined below in `om_terrain`s. Used to tell the C++ what width the segments provided are, not to change the width placed.                                                                                         |
 | `straightness_chance`             | For one overmap, the chance for a highway's end points to (mostly) line up.                                                                                                                                                                  |
-| `intersection_max_radius`         | The maximum number of overmaps that an intersection can deviate from its gridded position. Cannot be greater than or equal to row / 2 or column / 2, may cause bugs for > row / 4, column / 4.                                               |
 | `reserved_terrain_id`             | The `om_terrain` used to reserve land and air for highways before their actual `om_terrain` placement.                                                                                                                                       |
 | `reserved_terrain_water_id`       | The `om_terrain` used to reserve water for highways before their actual `om_terrain` placement.                                                                                                                                              |
 | `four_way_intersections`          | An object with a list of specials and their respective weights to place at four way highway intersections. The [0,0,0] point should be the NW corner of the intersection formed before placement.                                            |

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -22,10 +22,12 @@
 #include "cuboid_rectangle.h"
 #include "debug.h"
 #include "filesystem.h"
+#include "flexbuffer_json.h"
 #include "game.h"
 #include "horde_entity.h"
 #include "horde_map.h"
 #include "imgui/imgui.h"
+#include "json.h"
 #include "line.h"
 #include "map.h"
 #include "mapgendata.h"
@@ -43,7 +45,6 @@
 #include "overmap_types.h"
 #include "path_info.h"
 #include "point.h"
-#include "regional_settings.h"
 #include "rng.h"
 #include "simple_pathfinding.h"
 #include "string_formatter.h"
@@ -267,7 +268,6 @@ void overmap_global_state::clear()
     placed_unique_specials.clear();
     unique_special_count.clear();
     highway_intersections.clear();
-    highway_global_offset = point_abs_om::invalid;
     overmap_count = 0;
     major_river_count = 0;
 }
@@ -1776,62 +1776,63 @@ city_reference overmapbuffer::closest_known_city( const tripoint_abs_sm &center 
     return city_reference::invalid;
 }
 
-interhighway_node overmapbuffer::get_overmap_highway_intersection_point(
-    const point_abs_om &p )
+void overmap_feature_grid::clear()
 {
-    return global_state.highway_intersections[p.to_string_writable()];
+    grid_origin = point_abs_om::invalid;
+    feature_grid.clear();
 }
 
-void overmapbuffer::set_overmap_highway_intersection_point( const point_abs_om &p,
-        const interhighway_node &intersection )
+void overmap_feature_grid::set_grid_origin( const point_abs_om &p )
 {
-    global_state.highway_intersections[p.to_string_writable()] = intersection;
+    grid_origin = p;
 }
 
-
-void overmapbuffer::set_highway_global_offset()
+point_abs_om overmap_feature_grid::get_grid_origin() const
 {
-    //this only happens exactly once, upon generation of the first overmap
-    //TODO: there should be an intersection around the avatar's start location, not 0,0
-    global_state.highway_global_offset = point_abs_om();
+    return grid_origin;
 }
 
-point_abs_om overmapbuffer::get_highway_global_offset() const
+std::vector<overmap_feature_grid_node>
+overmap_feature_grid::find_grid_adjacent_features( const point_abs_om &generated_om_pos )
 {
-    return global_state.highway_global_offset;
-}
-
-std::vector<interhighway_node>
-overmapbuffer::find_highway_adjacent_intersections( const point_abs_om &generated_om_pos )
-{
-    const region_settings_highway &highway_settings = get_default_settings(
-                generated_om_pos ).get_settings_highway();
-    const int c_seperation = highway_settings.grid_column_seperation;
-    const int r_seperation = highway_settings.grid_row_seperation;
+    const int c_seperation = column_separation;
+    const int r_seperation = row_separation;
 
     //generate adjacent intersection points
-    std::vector<interhighway_node> adjacent_intersections;
+    std::vector<overmap_feature_grid_node> adjacent_features;
     for( const point &cardinal : four_adjacent_offsets ) {
         const point_abs_om p( generated_om_pos.x() + cardinal.x * c_seperation,
                               generated_om_pos.y() + cardinal.y * r_seperation );
-        if( !highway_intersection_exists( p ) ) {
-            generate_highway_intersection_point( p );
+        if( !feature_point_exists( p ) ) {
+            generate_feature_point( p );
         }
-        adjacent_intersections.emplace_back( overmap_buffer.get_overmap_highway_intersection_point( p ) );
+        adjacent_features.emplace_back( get_feature_point( p ) );
     }
 
     //store adjacencies in calling intersection point
-    interhighway_node this_intersection =
-        overmap_buffer.get_overmap_highway_intersection_point( generated_om_pos );
+    overmap_feature_grid_node this_feature = get_feature_point( generated_om_pos );
     const int adjacencies = four_adjacent_offsets.size();
     for( int i = 0; i < adjacencies; i++ ) {
-        if( this_intersection.adjacent_intersections[i].is_invalid() ) {
-            this_intersection.adjacent_intersections[i] = adjacent_intersections[i].grid_pos;
+        if( this_feature.get_adjacent_pos( i ).is_invalid() ) {
+            this_feature.set_adjacent_pos( adjacent_features[i].get_grid_pos(), i );
         }
     }
-    overmap_buffer.set_overmap_highway_intersection_point( generated_om_pos, this_intersection );
+    set_feature_point( generated_om_pos, this_feature );
 
-    return adjacent_intersections;
+    return adjacent_features;
+}
+
+void overmap_feature_grid::serialize( JsonOut &out ) const
+{
+    out.start_object();
+    out.member( "overmap_highway_offset", grid_origin );
+    out.member( "overmap_highway_intersections", feature_grid );
+    out.end_object();
+}
+void overmap_feature_grid::deserialize( const JsonObject &obj )
+{
+    obj.read( "overmap_highway_offset", grid_origin );
+    obj.read( "overmap_highway_intersections", feature_grid );
 }
 
 int overmapbuffer::get_unique_special_count( const overmap_special_id &id )
@@ -1854,55 +1855,50 @@ void overmapbuffer::inc_major_river_count()
     global_state.major_river_count++;
 }
 
-bool overmapbuffer::highway_intersection_exists( const point_abs_om &intersection_om ) const
+bool overmap_feature_grid::feature_point_exists( const point_abs_om &intersection_om ) const
 {
-    return global_state.highway_intersections.find( intersection_om.to_string_writable() ) !=
-           global_state.highway_intersections.end();
+    return feature_grid.find( intersection_om.to_string_writable() ) !=
+           feature_grid.end();
 }
 
-void overmapbuffer::generate_highway_intersection_point( const point_abs_om &generated_om_pos )
+void overmap_feature_grid::generate_feature_point( const point_abs_om &generated_om_pos )
 {
-    const region_settings_highway &highway_settings = get_default_settings(
-                generated_om_pos ).get_settings_highway();
-    const int intersection_max_radius = highway_settings.intersection_max_radius;
-    if( !highway_intersection_exists( generated_om_pos ) ) {
-        interhighway_node new_intersection( generated_om_pos );
-        new_intersection.generate_offset( intersection_max_radius );
+    if( !feature_point_exists( generated_om_pos ) ) {
+        overmap_feature_grid_node new_intersection( generated_om_pos );
+        generate_offset( new_intersection );
         add_msg_debug( debugmode::DF_HIGHWAY, "Generated intersection at overmap %s.",
-                       new_intersection.offset_pos.to_string_writable() );
-        global_state.highway_intersections.insert( { generated_om_pos.to_string_writable(), new_intersection } );
+                       new_intersection.get_offset_pos().to_string_writable() );
+        feature_grid.insert( { generated_om_pos.to_string_writable(), new_intersection } );
     }
 }
 
-std::vector<point_abs_om> overmapbuffer::find_highway_intersection_bounds( const point_abs_om
+std::vector<point_abs_om> overmap_feature_grid::find_feature_point_bounds( const point_abs_om
         & generated_om_pos )
 {
-    const region_settings_highway &highway_settings = get_default_settings(
-                generated_om_pos ).get_settings_highway();
-    const int c_seperation = highway_settings.grid_column_seperation;
-    const int r_seperation = highway_settings.grid_row_seperation;
+    const int c_separation = column_separation;
+    const int r_separation = row_separation;
 
-    const point_abs_om center = global_state.highway_global_offset;
+    const point_abs_om center = grid_origin;
     const point_rel_om diff = generated_om_pos - center;
 
-    const double col_diff = diff.x() / static_cast<double>( c_seperation );
-    const double row_diff = diff.y() / static_cast<double>( r_seperation );
+    const double col_diff = diff.x() / static_cast<double>( c_separation );
+    const double row_diff = diff.y() / static_cast<double>( r_separation );
     const int colsign = std::copysign( 1.0, col_diff );
     const int rowsign = std::copysign( 1.0, row_diff );
-    const bool col_aligned = diff.x() % c_seperation == 0;
-    const bool row_aligned = diff.y() % r_seperation == 0;
+    const bool col_aligned = diff.x() % c_separation == 0;
+    const bool row_aligned = diff.y() % r_separation == 0;
     const int col = static_cast<int>( col_diff ) + ( colsign == -1 && !col_aligned ? -1 : 0 );
     const int row = static_cast<int>( row_diff ) + ( rowsign == -1 && !row_aligned ? -1 : 0 );
 
-    point_abs_om top_left( center.x() + col * c_seperation, center.y() + row * r_seperation );
-    std::vector<point_abs_om> bounds = { top_left + point_rel_om( c_seperation, r_seperation ),
-                                         top_left + point_rel_om( 0, r_seperation ),
-                                         top_left + point_rel_om( c_seperation, 0 ),
+    point_abs_om top_left( center.x() + col * c_separation, center.y() + row * r_separation );
+    std::vector<point_abs_om> bounds = { top_left + point_rel_om( c_separation, r_separation ),
+                                         top_left + point_rel_om( 0, r_separation ),
+                                         top_left + point_rel_om( c_separation, 0 ),
                                          top_left
                                        };
     for( const point_abs_om &p : bounds ) {
-        if( !highway_intersection_exists( p ) ) {
-            generate_highway_intersection_point( p );
+        if( !feature_point_exists( p ) ) {
+            generate_feature_point( p );
         }
     }
     return bounds;

--- a/src/overmapbuffer.h
+++ b/src/overmapbuffer.h
@@ -165,10 +165,8 @@ struct overmap_global_state {
     int overmap_count = 0;
     // Global count of major rivers generated for this world
     int major_river_count = 0;
-    // most central overmap highway intersection
-    point_abs_om highway_global_offset = point_abs_om::invalid;
     // all highway intersections
-    std::map<std::string, interhighway_node> highway_intersections;
+    highway_intersection_grid highway_intersections;
 
     void clear();
     void reset();
@@ -621,26 +619,6 @@ class overmapbuffer
         int get_overmap_count() const;
         int get_major_river_count() const;
         void inc_major_river_count();
-
-        interhighway_node get_overmap_highway_intersection_point( const point_abs_om &p );
-        void set_overmap_highway_intersection_point( const point_abs_om &p,
-                const interhighway_node &intersection );
-        void set_highway_global_offset();
-        point_abs_om get_highway_global_offset() const;
-        /*
-        * given an overmap point, finds and generates cardinal-adjacent highway intersection points
-        */
-        std::vector<interhighway_node>
-        find_highway_adjacent_intersections( const point_abs_om &generated_om_pos );
-        bool highway_intersection_exists( const point_abs_om &intersection_om ) const;
-        void generate_highway_intersection_point( const point_abs_om &generated_om_pos );
-        /**
-        * given an overmap point, finds and generates the highway intersection points boxing it in,
-        * aligning to the top-left-most point; this point is always last in the returned list
-        * NOTE: this function can be generalized if necessary
-        */
-        std::vector<point_abs_om> find_highway_intersection_bounds( const point_abs_om
-                & generated_om_pos );
 
     private:
         /**

--- a/src/regional_settings.cpp
+++ b/src/regional_settings.cpp
@@ -524,9 +524,6 @@ void region_settings_ocean::load( const JsonObject &jo, std::string_view )
 
 void region_settings_highway::load( const JsonObject &jo, std::string_view )
 {
-    optional( jo, was_loaded, "grid_column_seperation", grid_column_seperation );
-    optional( jo, was_loaded, "grid_row_seperation", grid_row_seperation );
-    optional( jo, was_loaded, "intersection_max_radius", intersection_max_radius );
     optional( jo, was_loaded, "width_of_segments", width_of_segments );
     optional( jo, was_loaded, "straightness_chance", straightness_chance );
     optional( jo, was_loaded, "reserved_terrain_id", reserved_terrain_id );

--- a/src/regional_settings.h
+++ b/src/regional_settings.h
@@ -339,10 +339,7 @@ struct region_settings_overmap_connection {
 struct region_settings_highway {
     region_settings_highway_id id = region_settings_highway_id::NULL_ID();
 
-    int grid_column_seperation = 10;
-    int grid_row_seperation = 8;
     int width_of_segments = 2;
-    int intersection_max_radius = 3;
     double straightness_chance = 0.6;
     oter_type_str_id reserved_terrain_id;
     oter_type_str_id reserved_terrain_water_id;

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -1994,8 +1994,7 @@ void overmap_global_state::serialize( JsonOut &json ) const
     json.write_as_array( placed_unique_specials );
     json.member( "overmap_count", overmap_count );
     json.member( "unique_special_count", unique_special_count );
-    json.member( "overmap_highway_intersections", highway_intersections );
-    json.member( "overmap_highway_offset", highway_global_offset );
+    json.member( "overmap_highway_intersection_grid", highway_intersections );
     json.member( "major_river_count", major_river_count );
 
     json.end_object();
@@ -2013,8 +2012,18 @@ void overmap_global_state::deserialize( const JsonObject &json )
     json.read( "overmap_count", overmap_count );
 
     highway_intersections.clear();
-    json.read( "overmap_highway_intersections", highway_intersections );
-    json.read( "overmap_highway_offset", highway_global_offset );
+    //TODO: remove legacy loading in 0.J
+    if( json.has_member( "overmap_highway_intersections" ) ) {
+        std::map<std::string, overmap_feature_grid_node> feature_grid;
+        json.read( "overmap_highway_intersections", feature_grid );
+        point_abs_om highway_global_offset;
+        json.read( "overmap_highway_offset", highway_global_offset );
+
+        highway_intersections.set_feature_grid( feature_grid );
+        highway_intersections.set_grid_origin( highway_global_offset );
+    } else {
+        json.read( "overmap_highway_intersection_grid", highway_intersections );
+    }
     json.read( "major_river_count", major_river_count );
 }
 

--- a/tests/overmap_test.cpp
+++ b/tests/overmap_test.cpp
@@ -32,13 +32,13 @@
 #include "map_scale_constants.h"
 #include "mapbuffer.h"
 #include "omdata.h"
+#include "options.h"
 #include "output.h"
 #include "overmap.h"
 #include "overmap_types.h"
 #include "overmapbuffer.h"
 #include "point.h"
 #include "recipe.h"
-#include "regional_settings.h"
 #include "rng.h"
 #include "test_data.h"
 #include "type_id.h"
@@ -658,13 +658,13 @@ TEST_CASE( "overmap_terrain_coverage", "[overmap][slow]" )
 TEST_CASE( "highway_find_intersection_bounds", "[overmap]" )
 {
     overmap_buffer.clear();
-    overmap_buffer.set_highway_global_offset();
-    point_abs_om pos = overmap_buffer.get_highway_global_offset();
-    const region_settings_highway &highway_settings = overmap_buffer.get_default_settings(
-                pos ).get_settings_highway();
+    highway_intersection_grid &highway_grid =
+        overmap_buffer.global_state.highway_intersections;
+    highway_grid.set_grid_origin( point_abs_om::zero );
+    point_abs_om pos = highway_grid.get_grid_origin();
 
-    const int c_seperation = highway_settings.grid_column_seperation;
-    const int r_seperation = highway_settings.grid_row_seperation;
+    const int c_seperation = get_option<int>( "HIGHWAY_GRID_COLUMN_SEPARATION" );
+    const int r_seperation = get_option<int>( "HIGHWAY_GRID_ROW_SEPARATION" );
 
     const int col_test = c_seperation / 2;
     const int row_test = r_seperation / 2;
@@ -699,7 +699,7 @@ TEST_CASE( "highway_find_intersection_bounds", "[overmap]" )
     };
 
     for( const std::pair<point_rel_om, point_rel_om> &p : input_output_pairs ) {
-        std::vector<point_abs_om> bounds = overmap_buffer.find_highway_intersection_bounds( pos + p.first );
+        std::vector<point_abs_om> bounds = highway_grid.find_feature_point_bounds( pos + p.first );
         CHECK( bounds.back() == pos + p.second );
     }
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Infrastructure "move highway intersection grid into a generic class"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Highways use a grid structure to generate intersection locations by overmap. This grid structure is built into the highway code, and I'm not satisfied with it organizationally (nor was I when I wrote it) and want to preempt copy-pastes for future features.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Moves the highway intersection grid into a generic `overmap_feature_grid` class that is extended by `highway_intersection_grid`.

Additionally, moves highway grid settings to external options. When we have multiple regions in the future, highways as currently implemented would not actually account for different grid settings per-region, so the grid settings shouldn't be in region settings.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

- Loaded game without errors
- Revealed several highway intersections on overmap, looks correct. Saved + loaded, retried to make sure serialization works.
- Loaded an old save to make sure the old highway grid data loads into the new grid correctly, again looks correct. If you notice obvious highway errors in your save, report them.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
