### PR TITLE
Replace transformation EOCs with transformation iuse actions

### DIFF
--- a/data/json/items/tool/cooking.json
+++ b/data/json/items/tool/cooking.json
@@ -65,23 +65,12 @@
     "charges_per_use": 1,
     "use_action": [
       {
-        "type": "effect_on_conditions",
+        "target": "carver_on",
+        "msg": "The electric carver's serrated blades start buzzing!",
+        "sound_volume": 20,
         "menu_text": "Turn on",
-        "effect_on_conditions": [
-          {
-            "id": "EOC_toolweapon_activate__carver",
-            "effect": {
-              "run_eocs": "EOC_toolweapon_activate",
-              "variables": {
-                "turn_cost": 0.8,
-                "transform_target": "carver_on",
-                "success_message": { "i18n": true, "str": "The electric carver's serrated blades start buzzing!" },
-                "volume": 20,
-                "failure_message": { "i18n": true, "str": "You pull the trigger, but nothing happens." }
-              }
-            }
-          }
-        ]
+        "moves": 1,
+        "type": "transform"
       },
       { "type": "link_up", "cable_length": 2, "charge_rate": "120 W" }
     ],
@@ -101,17 +90,7 @@
     "revert_to": "carver_off",
     "qualities": [ [ "CUT", 2 ], [ "BUTCHER", 25 ] ],
     "use_action": [
-      {
-        "type": "effect_on_conditions",
-        "ammo_scale": 0,
-        "menu_text": "Turn off",
-        "effect_on_conditions": [
-          {
-            "id": "EOC_toolweapon_deactivate__carver",
-            "effect": { "run_eocs": "EOC_toolweapon_deactivate", "variables": { "transform_target": "carver_off" } }
-          }
-        ]
-      },
+      { "target": "carver_off", "msg": "Your %s goes quiet.", "menu_text": "Turn off", "type": "transform" },
       { "type": "link_up", "cable_length": 2, "charge_rate": "120 W" }
     ],
     "tick_action": {
@@ -131,7 +110,7 @@
         }
       ]
     },
-    "flags": [ "MESSY", "TRADER_AVOID", "NONCONDUCTIVE", "WATER_BREAK" ],
+    "flags": [ "MESSY", "TRADER_AVOID", "NONCONDUCTIVE", "WATER_BREAK", "SPAWN_ACTIVE" ],
     "melee_damage": { "bash": 2, "cut": 8 }
   },
   {

--- a/data/json/items/tool/landscaping.json
+++ b/data/json/items/tool/landscaping.json
@@ -453,17 +453,7 @@
     "power_draw": "500 W",
     "charges_per_use": 0,
     "revert_to": "trimmer_off",
-    "use_action": {
-      "type": "effect_on_conditions",
-      "ammo_scale": 0,
-      "menu_text": "Turn off",
-      "effect_on_conditions": [
-        {
-          "id": "EOC_toolweapon_deactivate__trimmer",
-          "effect": { "run_eocs": "EOC_toolweapon_deactivate", "variables": { "transform_target": "trimmer_off" } }
-        }
-      ]
-    },
+    "use_action": { "target": "trimmer_off", "msg": "Your %s goes quiet.", "menu_text": "Turn off", "type": "transform" },
     "tick_action": {
       "type": "effect_on_conditions",
       "effect_on_conditions": [
@@ -482,7 +472,7 @@
       ]
     },
     "qualities": [ [ "CUT", 1 ], [ "BUTCHER", -60 ] ],
-    "flags": [ "MESSY", "TRADER_AVOID", "NONCONDUCTIVE" ],
+    "flags": [ "MESSY", "TRADER_AVOID", "NONCONDUCTIVE", "SPAWN_ACTIVE" ],
     "melee_damage": { "bash": 4, "cut": 8 }
   }
 ]

--- a/data/json/items/tool/masonry.json
+++ b/data/json/items/tool/masonry.json
@@ -55,17 +55,7 @@
     "revert_to": "masonrysaw_off",
     "techniques": [ "SWEEP" ],
     "qualities": [ [ "AXE", 3 ], [ "BUTCHER", -100 ] ],
-    "use_action": {
-      "type": "effect_on_conditions",
-      "menu_text": "Turn off",
-      "ammo_scale": 0,
-      "effect_on_conditions": [
-        {
-          "id": "EOC_toolweapon_deactivate__masonrysaw",
-          "effect": { "run_eocs": "EOC_toolweapon_deactivate", "variables": { "transform_target": "masonrysaw_off" } }
-        }
-      ]
-    },
+    "use_action": { "target": "masonrysaw_off", "msg": "Your %s goes quiet.", "menu_text": "Turn off", "type": "transform" },
     "tick_action": {
       "type": "effect_on_conditions",
       "effect_on_conditions": [
@@ -135,17 +125,7 @@
     "techniques": [ "SWEEP" ],
     "qualities": [ [ "AXE", 3 ], [ "BUTCHER", -100 ] ],
     "use_action": [
-      {
-        "type": "effect_on_conditions",
-        "menu_text": "Turn off",
-        "ammo_scale": 0,
-        "effect_on_conditions": [
-          {
-            "id": "EOC_toolweapon_deactivate__electric_masonrysaw",
-            "effect": { "run_eocs": "EOC_toolweapon_deactivate", "variables": { "transform_target": "electric_masonrysaw_off" } }
-          }
-        ]
-      },
+      { "target": "electric_masonrysaw_off", "msg": "Your %s goes quiet.", "menu_text": "Turn off", "type": "transform" },
       {
         "type": "link_up",
         "menu_text": "Plug in / Unplug",

--- a/data/json/items/tool/woodworking.json
+++ b/data/json/items/tool/woodworking.json
@@ -124,7 +124,7 @@
         }
       ]
     },
-    "flags": [ "MESSY", "TRADER_AVOID", "NONCONDUCTIVE", "POWERED", "FRAGILE_MELEE" ],
+    "flags": [ "MESSY", "TRADER_AVOID", "NONCONDUCTIVE", "POWERED", "FRAGILE_MELEE", "SPAWN_ACTIVE" ],
     "melee_damage": { "bash": 4, "cut": 18 }
   },
   {
@@ -147,23 +147,12 @@
     "charges_per_use": 5,
     "techniques": [ "SWEEP" ],
     "use_action": {
-      "type": "effect_on_conditions",
+      "target": "polesaw_on",
+      "msg": "With a roar, the pole saw screams to life!",
+      "sound_volume": 20,
       "menu_text": "Turn on",
-      "effect_on_conditions": [
-        {
-          "id": "EOC_toolweapon_activate__polesaw",
-          "effect": {
-            "run_eocs": "EOC_toolweapon_activate",
-            "variables": {
-              "turn_cost": 0.8,
-              "transform_target": "polesaw_on",
-              "success_message": { "i18n": true, "str": "With a roar, the pole saw screams to life!" },
-              "volume": 15,
-              "failure_message": { "i18n": true, "str": "You yank the cord, but nothing happens." }
-            }
-          }
-        }
-      ]
+      "moves": 1,
+      "type": "transform"
     },
     "flags": [ "POLEARM", "NONCONDUCTIVE", "FRAGILE_MELEE", "REACH_ATTACK" ],
     "melee_damage": { "bash": 6 },
@@ -182,17 +171,7 @@
     "revert_to": "polesaw_off",
     "techniques": [ "SWEEP" ],
     "qualities": [ [ "AXE", 2 ], [ "BUTCHER", -100 ] ],
-    "use_action": {
-      "type": "effect_on_conditions",
-      "menu_text": "Turn off",
-      "ammo_scale": 0,
-      "effect_on_conditions": [
-        {
-          "id": "EOC_toolweapon_deactivate__polesaw",
-          "effect": { "run_eocs": "EOC_toolweapon_deactivate", "variables": { "transform_target": "polesaw_off" } }
-        }
-      ]
-    },
+    "use_action": { "target": "polesaw_off", "msg": "Your %s goes quiet.", "menu_text": "Turn off", "type": "transform" },
     "tick_action": {
       "type": "effect_on_conditions",
       "effect_on_conditions": [
@@ -210,7 +189,7 @@
         }
       ]
     },
-    "flags": [ "MESSY", "POLEARM", "TRADER_AVOID", "NONCONDUCTIVE", "POWERED", "FRAGILE_MELEE", "REACH_ATTACK" ],
+    "flags": [ "MESSY", "POLEARM", "TRADER_AVOID", "NONCONDUCTIVE", "POWERED", "FRAGILE_MELEE", "REACH_ATTACK", "SPAWN_ACTIVE" ],
     "melee_damage": { "bash": 4, "cut": 11 }
   },
   {
@@ -230,23 +209,12 @@
     "color": "yellow",
     "charges_per_use": 1,
     "use_action": {
-      "type": "effect_on_conditions",
+      "target": "circsaw_on",
+      "msg": "With a loud buzz, the %s roars to life!",
+      "sound_volume": 15,
       "menu_text": "Turn on",
-      "effect_on_conditions": [
-        {
-          "id": "EOC_toolweapon_activate__circsaw",
-          "effect": {
-            "run_eocs": "EOC_toolweapon_activate",
-            "variables": {
-              "turn_cost": 0.6,
-              "transform_target": "circsaw_on",
-              "success_message": { "i18n": true, "str": "With a loud buzz, the <npc_name> roars to life!" },
-              "volume": 15,
-              "failure_message": { "i18n": true, "str": "You flip the switch, but nothing happens." }
-            }
-          }
-        }
-      ]
+      "moves": 1,
+      "type": "transform"
     },
     "flags": [ "NONCONDUCTIVE" ],
     "pocket_data": [
@@ -267,17 +235,7 @@
     "power_draw": "1200 W",
     "revert_to": "circsaw_off",
     "qualities": [ [ "CUT", 1 ], [ "SAW_W", 2 ], [ "BUTCHER", -40 ] ],
-    "use_action": {
-      "type": "effect_on_conditions",
-      "menu_text": "Turn off",
-      "ammo_scale": 0,
-      "effect_on_conditions": [
-        {
-          "id": "EOC_toolweapon_deactivate__circsaw",
-          "effect": { "run_eocs": "EOC_toolweapon_deactivate", "variables": { "transform_target": "circsaw_off" } }
-        }
-      ]
-    },
+    "use_action": { "target": "circsaw_off", "msg": "Your %s goes quiet.", "menu_text": "Turn off", "type": "transform" },
     "tick_action": {
       "type": "effect_on_conditions",
       "effect_on_conditions": [
@@ -295,7 +253,7 @@
         }
       ]
     },
-    "flags": [ "MESSY", "TRADER_AVOID", "NONCONDUCTIVE" ],
+    "flags": [ "MESSY", "TRADER_AVOID", "NONCONDUCTIVE", "SPAWN_ACTIVE" ],
     "melee_damage": { "bash": 2, "cut": 10 }
   },
   {
@@ -436,17 +394,7 @@
     "charges_per_use": 0,
     "revert_to": "elec_chainsaw_off",
     "qualities": [ [ "AXE", 4 ], [ "BUTCHER", -100 ] ],
-    "use_action": {
-      "type": "effect_on_conditions",
-      "menu_text": "Turn off",
-      "ammo_scale": 0,
-      "effect_on_conditions": [
-        {
-          "id": "EOC_toolweapon_deactivate__elec_chainsaw",
-          "effect": { "run_eocs": "EOC_toolweapon_deactivate", "variables": { "transform_target": "elec_chainsaw_off" } }
-        }
-      ]
-    },
+    "use_action": { "target": "elec_chainsaw_off", "msg": "Your %s goes quiet.", "menu_text": "Turn off", "type": "transform" },
     "tick_action": {
       "type": "effect_on_conditions",
       "effect_on_conditions": [
@@ -464,7 +412,7 @@
         }
       ]
     },
-    "flags": [ "MESSY", "TRADER_AVOID", "NONCONDUCTIVE", "POWERED", "FRAGILE_MELEE" ],
+    "flags": [ "MESSY", "TRADER_AVOID", "NONCONDUCTIVE", "POWERED", "FRAGILE_MELEE", "SPAWN_ACTIVE" ],
     "melee_damage": { "bash": 4, "cut": 16 }
   },
   {
@@ -510,17 +458,7 @@
     "subtypes": [ "TOOL" ],
     "name": { "str": "corded electric chainsaw (on)", "str_pl": "corded electric chainsaws (on)" },
     "use_action": [
-      {
-        "type": "effect_on_conditions",
-        "menu_text": "Turn off",
-        "ammo_scale": 0,
-        "effect_on_conditions": [
-          {
-            "id": "EOC_toolweapon_deactivate__elec_chainsaw_cord",
-            "effect": { "run_eocs": "EOC_toolweapon_deactivate", "variables": { "transform_target": "elec_chainsaw_cord_off" } }
-          }
-        ]
-      },
+      { "target": "elec_chainsaw_cord_off", "msg": "Your %s goes quiet.", "menu_text": "Turn off", "type": "transform" },
       { "type": "link_up", "cable_length": 4, "charge_rate": "2400 W" }
     ],
     "tick_action": {
@@ -542,7 +480,7 @@
     },
     "power_draw": "2 kW",
     "qualities": [ [ "AXE", 4 ], [ "BUTCHER", -100 ] ],
-    "flags": [ "MESSY", "TRADER_AVOID", "NONCONDUCTIVE", "POWERED", "FRAGILE_MELEE" ],
+    "flags": [ "MESSY", "TRADER_AVOID", "NONCONDUCTIVE", "POWERED", "FRAGILE_MELEE", "SPAWN_ACTIVE" ],
     "pocket_data": [  ],
     "revert_to": "elec_chainsaw_cord_off"
   },

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -227,6 +227,7 @@ void iuse_transform::load( const JsonObject &obj, const std::string & )
     transform.deserialize( obj );
 
     optional( obj, false, "msg", msg_transform );
+    optional( obj, false, "sound_volume", sound_volume );
 
     optional( obj, false, "moves", moves, numeric_bound_reader<int> { 0 }, 0 );
 
@@ -254,7 +255,7 @@ void iuse_transform::load( const JsonObject &obj, const std::string & )
 }
 
 std::optional<int> iuse_transform::use( Character *p, item &it, map *,
-                                        const tripoint_bub_ms & ) const
+                                        const tripoint_bub_ms &pos ) const
 {
     int scale = 1;
     auto iter = it.type->ammo_scale.find( type );
@@ -291,13 +292,17 @@ std::optional<int> iuse_transform::use( Character *p, item &it, map *,
             p->add_msg_if_player( _( "Never mind." ) );
             return std::nullopt;
         }
-    }
 
-    p->add_msg_if_player( n_gettext( "You set the timer to %d second.",
-                                     "You set the timer to %d seconds.", timer_time ), timer_time );
+        p->add_msg_if_player( n_gettext( "You set the timer to %d second.",
+                                         "You set the timer to %d seconds.", timer_time ), timer_time );
+    }
 
     if( !msg_transform.empty() ) {
         p->add_msg_if_player( m_neutral, msg_transform, it.tname() );
+
+        if( sound_volume > 0 ) {
+            sounds::sound( pos, sound_volume, sounds::sound_t::combat, msg_transform );
+        }
     }
 
     // Uses the moves specified by iuse_actor's definition

--- a/src/iuse_actor.h
+++ b/src/iuse_actor.h
@@ -52,6 +52,9 @@ class iuse_transform : public iuse_actor
         /** displayed if player sees transformation with %s replaced by item name */
         translation msg_transform;
 
+        /** If non zero, issues the msg_transform as a sound as well*/
+        int sound_volume = 0;
+
         /**does the item requires to be worn to be activable*/
         bool need_worn = false;
 
@@ -89,7 +92,7 @@ class iuse_transform : public iuse_actor
         ~iuse_transform() override = default;
         void load( const JsonObject &obj, const std::string & ) override;
         using iuse_actor::use;
-        std::optional<int> use( Character *, item &, map *, const tripoint_bub_ms & ) const override;
+        std::optional<int> use( Character *, item &, map *, const tripoint_bub_ms &pos ) const override;
         using iuse_actor::can_use;
         ret_val<void> can_use( const Character &, const item &, map *here,
                                const tripoint_bub_ms & ) const override;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Replace redundant tool activation/deaction EOCs with standard transformations.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
- Extend the transformation use action to be able to produce sound.
- Replace the tool activations that can be replaced with transformations.
- Replace the tool deactivations that can be replaced with transformations.
By-catch:
- Fix bug in previous PR, causing a timer setting message to be produced on every transformation. Should obviously only appear if a timer is set.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Don't extend the transformation functionality and only go for redundant deactivations.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Created each of the modified items and verified they work the same as before.
See next section for elaborations.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
- The EOCs had failure messages that could never be generated because they were caught higher up in the call chain. They couldn't be generated with the transform either for the same reason, so they weren't copied over.
- There's something weird going on with the sound stuff. I've installed Fris0uman's sound pack, but none of the sounds that should be generated are generated, for whatever reason. I've verified that the added sound generation code is actually called by replacing the sound with that used by firecrackers, and that triggers.
- A number of tools weren't converted because they attempt to produce failures to start when the item is damaged. I say "attempts", because it only succeeds on a 5/11 chance with a pristine item (and it took a lot of attempts on one of them before I finally succeeded in turning it on so I could test turning it off).
- The active chainsaw has sound generated on deactivation, and thus wasn't converted, as the sound_effect and id parameters aren's supported by the activation transformation, and it seemed to be overkill to add those.
- There are actually two differences in the behavior:
  - The usage of %s causes the full item name to be written, with modifiers. They weren't present previously. That could be worked around by replacing the parameter with the item name directly.
  - For some reason, the "Turn on" prompt for transformations appear after cable management, while the EOC one ends up before it. Swapping the order of the entries in the JSON had no effect. It would be better if cable management ended up at the end, as that's probably the activity you use the least.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
