### PR TITLE
Fix Some Other Description Mistakes

### DIFF
--- a/data/json/furniture_and_terrain/furniture-medical.json
+++ b/data/json/furniture_and_terrain/furniture-medical.json
@@ -432,7 +432,7 @@
     "type": "furniture",
     "id": "f_GC",
     "name": "gas chromatographer",
-    "description": "This high-tech tool would, with electricity and an experienced user, be a very useful way to separate chemicals in a gaseous phase based on their affinity to a stationary phase in a tube.  At least that's what the label says.",
+    "description": "This high-tech tool would, with electricity and an experienced user, be a very useful way to separate chemicals in a gaseous phase, based on their affinity, to a stationary phase in a tube.  At least that's what the label says.",
     "symbol": ":",
     "color": "blue_white",
     "move_cost_mod": -1,

--- a/data/json/furniture_and_terrain/furniture-medical.json
+++ b/data/json/furniture_and_terrain/furniture-medical.json
@@ -432,7 +432,7 @@
     "type": "furniture",
     "id": "f_GC",
     "name": "gas chromatographer",
-    "description": "This high-tech tool would, with electricity and an experienced user, be a very useful way to separate chemicals in a gaseous phase, based on their affinity, to a stationary phase in a tube.  At least, that's what the label says.",
+    "description": "This high-tech tool would, with electricity and an experienced user, be a very useful way to separate chemicals in a gaseous phase based on their affinity to a stationary phase in a tube.  At least that's what the label says.",
     "symbol": ":",
     "color": "blue_white",
     "move_cost_mod": -1,

--- a/data/json/furniture_and_terrain/furniture-storage.json
+++ b/data/json/furniture_and_terrain/furniture-storage.json
@@ -1694,7 +1694,7 @@
     "id": "f_exodii_kiln",
     "name": "Exodii kiln",
     "looks_like": "f_heavy_duty_freezer",
-    "description": "An imposing kiln produced by the Exodii, used to produce their ceramic armor",
+    "description": "An imposing kiln produced by the Exodii, used to produce their ceramic armor.",
     "symbol": "H",
     "color": "brown",
     "move_cost_mod": -1,

--- a/data/json/items/tool/workshop.json
+++ b/data/json/items/tool/workshop.json
@@ -1862,7 +1862,7 @@
     "id": "exodii_kiln",
     "type": "ITEM",
     "name": { "str": "Exodii kiln" },
-    "description": "An electric kiln, powered by your electric grid.  A bit larger than a refridgerator, this Exodii-manufactured kiln is large enough to repair the sheets of ceramic they use for armor.  It is designed for firing sheets of the Exodii's ceramic, but you could use it to fire anything made of clay.  A large and power-hungry appliance.",
+    "description": "An electric kiln, powered by your electric grid.  A bit larger than a refrigerator, this Exodii-manufactured kiln is large enough to repair the sheets of ceramic they use for armor.  It is designed for firing sheets of the Exodii's ceramic, but you could use it to fire anything made of clay.  A large and power-hungry appliance.",
     "weight": "175 kg",
     "volume": "1000 L",
     "price": "5000 USD",


### PR DESCRIPTION
#### Summary
Bugfixes "Descriptions of some furniture and items"

#### Purpose of change
To correct the typo and grammatical mistakes in the descriptions of the furtniture "Exodii kiln" and "gas chromatographer" and of the item "Exodii kiln".

#### Describe the solution
To correct the typo and grammatical mistakes in the descriptions of the furtniture "Exodii kiln" and "gas chromatographer" and of the item "Exodii kiln"...

For more info, check the commit.

#### Describe alternatives you've considered

#### Testing
These changes shouldn't and do not cause any unwanted results.

#### Additional context
