### PR TITLE
Make picking individual threads out of cotton scraps SUCK

### DIFF
--- a/data/json/morale_types.json
+++ b/data/json/morale_types.json
@@ -405,6 +405,16 @@
     "text": "Failure"
   },
   {
+    "id": "morale_fun_craft",
+    "type": "morale_type",
+    "text": "Got to enjoy crafting"
+  },
+  {
+    "id": "morale_shitty_craft",
+    "type": "morale_type",
+    "text": "Forced themself to work on crafting"
+  },
+  {
     "id": "morale_perm_debug",
     "type": "morale_type",
     "text": "Debug morale"

--- a/data/json/uncraft/recipe_deconstruction.json
+++ b/data/json/uncraft/recipe_deconstruction.json
@@ -2434,6 +2434,7 @@
     "type": "uncraft",
     "activity_level": "NO_EXERCISE",
     "time": "1 m",
+    "morale_modifier": [ -5, "2 hours" ],
     "qualities": [ { "id": "CUT", "level": 2 } ],
     "components": [ [ [ "thread", 1 ] ] ]
   },

--- a/doc/JSON/ITEM_CRAFT_AND_DISASSEMBLY.md
+++ b/doc/JSON/ITEM_CRAFT_AND_DISASSEMBLY.md
@@ -50,7 +50,7 @@ Crafting recipes are defined as a JSON object with the following fields:
 },
 "difficulty": 3,             // Difficulty of success check
 "time": "5 m",               // Preferred time to perform recipe, can specify in minutes, hours etc.
-"time": 5000,                // Legacy time to perform recipe (where 1000 ~= 10 turns ~= 10 seconds game time).
+"morale_modifier": [ -5, "2 hours" ], // Optional (int, time duration). Any morale penalty or bonus conferred by crafting this recipe. Penalties are conferred at the start of crafting, bonuses upon completion. The second member of the pair is how long the morale will last. Decay always starts after half of the total time.
 "reversible": true,          // Can be disassembled. Time taken is as long as to craft the item.
 "reversible": { "time": "30 s" }, // Can be disassembled. Time to disassemble as specified.
 "autolearn": true,           // Automatically learned upon gaining required skills

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -978,6 +978,9 @@ void Character::start_craft( craft_command &command, const std::optional<tripoin
         assign_activity( ACT_MULTIPLE_CRAFT );
     }
 
+    // Morale penalties happen on start, to penalize crafting speed during the craft.
+    making.apply_negative_morale_mods( *this );
+
     add_msg_player_or_npc(
         pgettext( "in progress craft", "You start working on the %s." ),
         pgettext( "in progress craft", "<npcname> starts working on the %s." ),
@@ -1585,6 +1588,9 @@ void Character::complete_craft( item &craft, const std::optional<tripoint_bub_ms
     recoil = MAX_RECOIL;
 
     inv->restack( *this );
+    // Positive morale bonuses only happen on completion, to avoid the player repeatedly re-crafting to spam morale
+    making.apply_positive_morale_mods( *this );
+
     for( const effect_on_condition_id &eoc : making.result_eocs ) {
         dialogue d( get_talker_for( *this ), nullptr );
         for( int i = 0; i < batch_size; i++ ) {
@@ -2735,6 +2741,9 @@ bool Character::disassemble( item_location target, bool interactive, bool disass
             activity.moves_left = r.time_to_craft_moves( *this, recipe_time_flag::ignore_proficiencies );
         }
     }
+
+    // Morale penalties happen on start, to penalize crafting speed during the craft.
+    r.apply_negative_morale_mods( *this );
 
     return true;
 }

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -3405,6 +3405,9 @@ void basecamp::start_crafting( const mission_id &miss_id )
         return;
     }
 
+    // Move this to applying when they return?
+    making->apply_all_morale_mods( *guy_to_send );
+
     // Now that we know the actual thing we're crafting we will properly form our mission_id
     mission_id actual_id = {miss_id.id, making->ident().str(), miss_id.mapgen_args, miss_id.dir };
     npc_ptr comp = start_mission( actual_id, work_days, true,

--- a/src/recipe.h
+++ b/src/recipe.h
@@ -196,6 +196,10 @@ class recipe
 
         bool npc_can_craft( std::string &reason ) const;
 
+        void apply_all_morale_mods( Character &guy ) const;
+        void apply_negative_morale_mods( Character &guy ) const;
+        void apply_positive_morale_mods( Character &guy ) const;
+
         /** Prevent this recipe from ever being added to the player's learned recipes ( used for special NPC crafting ) */
         bool never_learn = false;
 
@@ -212,6 +216,7 @@ class recipe
         /// @param decorated whether the result includes decoration (favorite mark, etc).
         std::string result_name( bool decorated = false ) const;
         std::vector<effect_on_condition_id> result_eocs;
+        std::pair<int, time_duration> morale_modifier;
         skill_id skill_used;
         std::map<skill_id, int> required_skills;
         std::vector<recipe_proficiency> proficiencies;


### PR DESCRIPTION
#### Summary
Balance "Make picking individual threads out of cotton scraps SUCK (for morale)"

#### Purpose of change
Lot of players shutting their characters into a cabin and forcing their character to mindnumbingly pick individual threads out of cotton scraps for days upon days

#### Describe the solution
Stop this abuse. ~~Start a rebellion~~ Make the characters depressed

Recipes can apply morale, starting either at the time of craft start (negative morale, to penalize work speed on the craft) or upon completion (positive morale, to avoid exploits)

This is a generic method added to the JSON definition for recipes. But it's only been applied to cotton scraps --> thread.

#### Describe alternatives you've considered
Make the PC rebel against this servitude...

#### Testing
<img width="450" height="381" alt="image" src="https://github.com/user-attachments/assets/9b6919a5-9e6e-48ad-91e5-f66be7fc072f" />


#### Additional context

