### PR TITLE
Fix 'it's own' -> 'its own' grammar errors

### DIFF
--- a/data/json/monsters/fungus.json
+++ b/data/json/monsters/fungus.json
@@ -517,7 +517,7 @@
     "id": "mon_wasp_fungus",
     "type": "MONSTER",
     "name": { "str": "giant fungal wasp" },
-    "description": "A gigantic wasp worker, It's body now a host for a plethora of mushrooms and spores.  Her abdomen glows faintly with a blue light, each pulse bringing a new crack for fungal growths to escape from.  It's stinger seems to have a soul of it's own, reaching out towards anything that isn't infested like itself.",
+    "description": "A gigantic wasp worker, Its body now a host for a plethora of mushrooms and spores.  Her abdomen glows faintly with a blue light, each pulse bringing a new crack for fungal growths to escape from.  Its stinger seems to have a soul of its own, reaching out towards anything that isn't infested like itself.",
     "default_faction": "fungus",
     "bodytype": "flying insect",
     "species": [ "FUNGUS" ],

--- a/data/json/monsters/fungus.json
+++ b/data/json/monsters/fungus.json
@@ -517,7 +517,7 @@
     "id": "mon_wasp_fungus",
     "type": "MONSTER",
     "name": { "str": "giant fungal wasp" },
-    "description": "A gigantic wasp worker, Its body now a host for a plethora of mushrooms and spores.  Her abdomen glows faintly with a blue light, each pulse bringing a new crack for fungal growths to escape from.  Its stinger seems to have a soul of its own, reaching out towards anything that isn't infested like itself.",
+    "description": "A gigantic wasp worker, its body now a host for a plethora of mushrooms and spores.  Her abdomen glows faintly with a blue light, each pulse bringing a new crack for fungal growths to escape from.  Its stinger seems to have a soul of its own, reaching out towards anything that isn't infested like itself.",
     "default_faction": "fungus",
     "bodytype": "flying insect",
     "species": [ "FUNGUS" ],

--- a/data/json/snippets/robot_finds_kitten.json
+++ b/data/json/snippets/robot_finds_kitten.json
@@ -325,7 +325,7 @@
       "It's a free Dmitry Sklyarov!",
       "It's a free Jon Johansen!",
       "It's a hundred-dollar bill.",
-      "It's a lost wallet.  It's owner didn't have pets, so you discard it.",
+      "It's a lost wallet.  Its owner didn't have pets, so you discard it.",
       "It's a moment of silence.",
       "It's a mousetrap, baited with soap.",
       "It's a piece of cloth used to cover a stage in between performances.",

--- a/data/mods/Xedra_Evolved/snippets/addiction_snippets.json
+++ b/data/mods/Xedra_Evolved/snippets/addiction_snippets.json
@@ -37,7 +37,7 @@
       },
       {
         "id": "lotus_addiction_3",
-        "text": "Your eye twitches on it's own for several minutes.  From the top corner near your temple down into the cheek."
+        "text": "Your eye twitches on its own for several minutes.  From the top corner near your temple down into the cheek."
       }
     ]
   },

--- a/data/mods/aftershock_exoplanet/itemgroups/money_groups.json
+++ b/data/mods/aftershock_exoplanet/itemgroups/money_groups.json
@@ -51,7 +51,7 @@
   {
     "id": "afs_register_looted",
     "type": "item_group",
-    "//": "If aftershock adds it's own lore correct survivor notes this could be a place to put one",
+    "//": "If aftershock adds its own lore correct survivor notes this could be a place to put one",
     "container-item": "cash_register",
     "items": [ { "group": "afs_banknotes", "prob": 15, "count": [ 1, 2 ] } ]
   },

--- a/data/mods/aftershock_exoplanet/npcs/cyrus_whately.json
+++ b/data/mods/aftershock_exoplanet/npcs/cyrus_whately.json
@@ -193,7 +193,7 @@
     "type": "mission_definition",
     "name": "A-Mi-go, You-go find me some brains",
     "description": "Find 6 living brains in jars.",
-    "//": "Sometime consider changing the end effect of this item and making the test site it's own quest.",
+    "//": "Sometime consider changing the end effect of this item and making the test site its own quest.",
     "goal": "MGOAL_FIND_ITEM",
     "difficulty": 8,
     "value": 0,

--- a/data/mods/aftershock_exoplanet/ter_fur_transform.json
+++ b/data/mods/aftershock_exoplanet/ter_fur_transform.json
@@ -82,7 +82,7 @@
       {
         "result": "f_security_panel_locked",
         "valid_furniture": [ "f_security_panel", "f_security_panel_10" ],
-        "message": "You trip the security failsafe and the panel fries it's own electronics."
+        "message": "You trip the security failsafe and the panel fries its own electronics."
       },
       {
         "result": "f_reinforced_displaycase_locked",


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Fixed a common grammar error where the possessive pronoun 'its' was incorrectly written as the contraction 'it's' (it is/has).

#### Describe the solution
Changed 'it's own' to 'its own' in 6 files:
- data/json/monsters/fungus.json (giant fungal wasp description - also fixed 'It's body' and 'It's stinger')
- data/json/snippets/robot_finds_kitten.json (lost wallet snippet - 'It's owner')
- data/mods/aftershock_exoplanet/ter_fur_transform.json
- data/mods/aftershock_exoplanet/itemgroups/money_groups.json
- data/mods/aftershock_exoplanet/npcs/cyrus_whately.json
- data/mods/Xedra_Evolved/snippets/addiction_snippets.json

#### Testing
Verified JSON syntax is valid after changes.