### PR TITLE
Add simple single sided razor tool 

### DIFF
--- a/data/json/items/tool/toiletries.json
+++ b/data/json/items/tool/toiletries.json
@@ -170,7 +170,8 @@
     "weight": "1 g",
     "volume": "1 ml",
     "longest_side": "38 mm",
-    "melee_damage": { "cut": 1 }
+    "melee_damage": { "cut": 1 },
+    "qualities": [ [ "BUTCHER", 2 ], [ "FABRIC_CUT", 1 ] ]
   },
   {
     "id": "shavingkit",

--- a/data/json/items/tool/workshop.json
+++ b/data/json/items/tool/workshop.json
@@ -1919,27 +1919,11 @@
   {
     "id": "razor_blade_taped",
     "copy-from": "razor_blade",
+    "looks_like": "razor_blade",
     "type": "ITEM",
     "subtypes": [ "TOOL" ],
     "name": { "str": "taped razorblade" },
     "description": "A double-edged razor blade with one side tapped to allow it's use as a basic tool.",
-    "qualities": [
-    [
-      "CUT",
-      1
-    ],
-    [
-      "CUT_FINE",
-      1
-    ],
-    [
-      "BUTCHER",
-      4
-    ],
-    [
-      "FABRIC_CUT",
-      1
-    ]
-  ]
+    "qualities": [ [ "CUT", 1 ], [ "CUT_FINE", 1 ], [ "BUTCHER", 4 ], [ "FABRIC_CUT", 1 ] ]
   }
 ]

--- a/data/json/items/tool/workshop.json
+++ b/data/json/items/tool/workshop.json
@@ -1924,6 +1924,6 @@
     "subtypes": [ "TOOL" ],
     "name": { "str": "taped razorblade" },
     "description": "A double-edged razor blade with one side taped to allow its use as a basic tool.",
-    "qualities": [ [ "CUT", 1 ], [ "CUT_FINE", 1 ], [ "BUTCHER", 4 ], [ "FABRIC_CUT", 1 ] ]
+    "qualities": [ [ "CUT", 1 ], [ "BUTCHER", 4 ], [ "FABRIC_CUT", 1 ] ]
   }
 ]

--- a/data/json/items/tool/workshop.json
+++ b/data/json/items/tool/workshop.json
@@ -1923,7 +1923,7 @@
     "type": "ITEM",
     "subtypes": [ "TOOL" ],
     "name": { "str": "taped razorblade" },
-    "description": "A double-edged razor blade with one side tapped to allow its use as a basic tool.",
+    "description": "A double-edged razor blade with one side taped to allow its use as a basic tool.",
     "qualities": [ [ "CUT", 1 ], [ "CUT_FINE", 1 ], [ "BUTCHER", 4 ], [ "FABRIC_CUT", 1 ] ]
   }
 ]

--- a/data/json/items/tool/workshop.json
+++ b/data/json/items/tool/workshop.json
@@ -1915,5 +1915,31 @@
     "proportional": { "weight": 1.1 },
     "material": [ "bronze" ],
     "color": "yellow"
+  },
+  {
+    "id": "razor_blade_taped",
+    "copy-from": "razor_blade",
+    "type": "ITEM",
+    "subtypes": [ "TOOL" ],
+    "name": { "str": "taped razorblade" },
+    "description": "A double-edged razor blade with one side tapped to allow it's use as a basic tool.",
+    "qualities": [
+    [
+      "CUT",
+      1
+    ],
+    [
+      "CUT_FINE",
+      1
+    ],
+    [
+      "BUTCHER",
+      4
+    ],
+    [
+      "FABRIC_CUT",
+      1
+    ]
+  ]
   }
 ]

--- a/data/json/items/tool/workshop.json
+++ b/data/json/items/tool/workshop.json
@@ -1923,7 +1923,7 @@
     "type": "ITEM",
     "subtypes": [ "TOOL" ],
     "name": { "str": "taped razorblade" },
-    "description": "A double-edged razor blade with one side tapped to allow it's use as a basic tool.",
+    "description": "A double-edged razor blade with one side tapped to allow its use as a basic tool.",
     "qualities": [ [ "CUT", 1 ], [ "CUT_FINE", 1 ], [ "BUTCHER", 4 ], [ "FABRIC_CUT", 1 ] ]
   }
 ]

--- a/data/json/recipes/recipe_others.json
+++ b/data/json/recipes/recipe_others.json
@@ -3402,5 +3402,17 @@
     "qualities": [ { "id": "CUT", "level": 2 } ],
     "components": [ [ [ "stick", 1 ] ], [ [ "sheet_canvas", 1 ], [ "sheet_canvas_patchwork", 1 ] ] ],
     "byproducts": [ [ "splinter", 8 ] ]
+  },
+  {
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "result": "razor_blade_taped",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_TOOLS",
+    "skill_used": "survival",
+    "time": "1 m",
+    "reversible": true,
+    "autolearn": true,
+    "components": [ [ [ "razor_blade", 1 ], [ "duct_tape", 5 ]  ] ]
   }
 ]

--- a/data/json/recipes/recipe_others.json
+++ b/data/json/recipes/recipe_others.json
@@ -3412,7 +3412,7 @@
     "skill_used": "survival",
     "difficulty": 0,
     "time": "1 m",
-    "reversible": true,
+    "reversible": false,
     "autolearn": true,
     "components": [ [ "razor_blade", 1 ], [ [ "duct_tape", 5 ], [ "medical_tape", 10 ] ] ]
   }

--- a/data/json/recipes/recipe_others.json
+++ b/data/json/recipes/recipe_others.json
@@ -3414,6 +3414,6 @@
     "time": "1 m",
     "reversible": false,
     "autolearn": true,
-    "components": [ [ "razor_blade", 1 ], [ [ "duct_tape", 5 ], [ "medical_tape", 10 ] ] ]
+    "components": [ [ [ "razor_blade", 1 ] ], [ [ "duct_tape", 5 ], [ "medical_tape", 10 ] ] ]
   }
 ]

--- a/data/json/recipes/recipe_others.json
+++ b/data/json/recipes/recipe_others.json
@@ -3410,9 +3410,10 @@
     "category": "CC_OTHER",
     "subcategory": "CSC_OTHER_TOOLS",
     "skill_used": "survival",
+    "difficulty": 0,
     "time": "1 m",
     "reversible": true,
     "autolearn": true,
-    "components": [ [ [ "razor_blade", 1 ], [ "duct_tape", 5 ]  ] ]
+    "components": [ [ "razor_blade", 1 ], [ [ "duct_tape", 5 ], [ "medical_tape", 10 ] ] ]
   }
 ]


### PR DESCRIPTION
#### Summary
Content "Add simple single sided razor tool"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

our razor double sided razor blade is a bit weird. It also doesn't have the cutting flag. This could make sense as it isn't really a tool at the moment. But if you tape one side with duct/medical tape you get an okay tool.   

#### Describe the solution

added a new recipe 

#### Describe alternatives you've considered

different flag levels?
currently have "qualities": [ [ "CUT", 1 ], [ "BUTCHER", 4 ], [ "FABRIC_CUT", 1 ] ] but can adjust as needed

#### Testing
ran the game and looked at the recipe 

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
