### PR TITLE
Stop hiding the Exodii labyrinths behind a mutation

### DIFF
--- a/data/json/mutations/labyrinth_mutations_passcodes.json
+++ b/data/json/mutations/labyrinth_mutations_passcodes.json
@@ -1,16 +1,5 @@
 [
   {
-    "id": "LS_Alphatest",
-    "type": "mutation",
-    "name": { "str": "Alpha Test Labyrinths 0.1" },
-    "description": "Taking this mutation will allow you to talk to the Exodii Merchant Rubik and ask to travel to the early playtest version of the Labyrinthine Structure, an in-development dungeon set inside an alternate dimension.  This version is still very low on content, but your early feedback is highly valued!",
-    "points": 0,
-    "starting_trait": true,
-    "valid": false,
-    "purifiable": false,
-    "player_display": true
-  },
-  {
     "id": "LS_Passcode_0",
     "type": "mutation",
     "name": { "str": "Passcode: Thief's Pass" },

--- a/data/json/npcs/exodii/exodii_merchant_talk.json
+++ b/data/json/npcs/exodii/exodii_merchant_talk.json
@@ -30,12 +30,10 @@
       {
         "text": "[PLAYTEST] Send me to the Labyrinthine Structure alpha test 0.1, I know it's low on content and lacking combat balance, but I still want to check it out!",
         "effect": { "run_eocs": "EOC_LS_Teleport_to_labyrinth" },
-        "condition": { "u_has_trait": "LS_Alphatest" },
         "topic": "TALK_DONE"
       },
       {
         "text": "[PLAYTEST] Tell me more about the Labyrinthine Structure alpha test.",
-        "condition": { "u_has_trait": "LS_Alphatest" },
         "topic": "TALK_EXODII_MERCHANT_Alphatest"
       },
       { "text": "What've you got for trade?", "effect": "start_trade", "topic": "TALK_EXODII_MERCHANT_DoneTrade" },

--- a/data/json/obsoletion_and_migration_0.J/mutations.json
+++ b/data/json/obsoletion_and_migration_0.J/mutations.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "TRAIT_MIGRATION",
+    "id": "LS_Alphatest",
+    "remove": true
+  }
+]


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
<img width="565" height="126" alt="image" src="https://github.com/user-attachments/assets/787cfb4e-db9d-4ae7-a896-b38eca98e804" />


#### Describe the solution
Experimental is already the place where we do this!

There's no reason to EVER put it behind a random opt-in-testing-only mutation! You already have to select a specific dialogue option for it, and the dialogue option has big huge notes saying what it is.

#### Describe alternatives you've considered
I think we should also change the text to remove the 'meta' aspects, so that it's properly integrated into the game. But I don't really have the willpower to write dialogue right now.

#### Testing
Game should load (pass CI)

#### Additional context
~~No migration was provided for the trait because it never existed on stable~~ GuardianDll forced me to learn how to migrate traits at gunpoint
