### PR TITLE
Removed 'active' field from item transformations

### DIFF
--- a/data/mods/aftershock_exoplanet/doc/suit_operating_time.md
+++ b/data/mods/aftershock_exoplanet/doc/suit_operating_time.md
@@ -55,7 +55,6 @@ Consider the Magellan exosuit, which has the following definition:
       "type": "transform",
       "msg": "You activate your %s.",
       "target": "afs_magellan_suit_on",
-      "active": true,
       "need_charges": 1,
       "need_charges_msg": "The %s's batteries are dead."
     },

--- a/data/mods/aftershock_exoplanet/items/tools.json
+++ b/data/mods/aftershock_exoplanet/items/tools.json
@@ -268,12 +268,7 @@
     "price_postapoc": "2 kUSD 500 USD",
     "material": [ "superalloy", "aluminum" ],
     "use_action": [
-      {
-        "target": "afs_atomic_wraitheon_flashlight",
-        "msg": "You activate the flashlight app.",
-        "active": true,
-        "type": "transform"
-      },
+      { "target": "afs_atomic_wraitheon_flashlight", "msg": "You activate the flashlight app.", "type": "transform" },
       "CAMERA",
       {
         "type": "mp3",

--- a/doc/JSON/ITEM.md
+++ b/doc/JSON/ITEM.md
@@ -960,8 +960,7 @@ Gun mods can be defined like this:
   "target_charges": 2,     // How many items should the transformation result in. Only works with items transformed into a container. Optional.
   "rand_target_charges": [ 10, 15, 25 ], // Randomize the charges the transformed item has. This example has a 50% chance of rng(10, 15) charges and a 50% chance of rng(15, 25) (endpoints are included)
   "target_ammo": 3,        // Number of charges (not count) the item should contain. Optional.
-  "target_timer": 1000,    // Set up a timer for the transformed object. Optional.
-  "active": true           // Set the transformed item to active. Optional.
+  "target_timer": 1000     // Set up a timer for the transformed object. Optional.
 },
 "revert_msg": "The torch fades out.", // Message to be printed when revert_to or transform_into performs its transformation
 "sub": "hotplate",         // optional; this tool has the same functions as another tool
@@ -1176,7 +1175,6 @@ The contents of `use_action` fields can either be a string indicating a built-in
   "target": "gasoline_lantern_on",          // The item to transform to
   "target_group": "twisted_geometry",       // If used, target is a random item from itemgroup
   "variant_type": "condom_plain",           // (optional) Defaults to `<any>`. Specific variant type to set for the transformed item. Special string `<any>` will pick a random variant from all available variants, based on the variant's defined weight
-  "active": true,                           // Whether the item is active once transformed
   "ammo_scale": 0,                          // For use when an item automatically transforms into another when its ammo drops to 0, or to allow guns to transform with 0 ammo
   "msg": "You turn the lamp on.",           // Message to display when activated
   "target_timer": 0,                        // (Optional) Set timer on transformed item. Mutually exclusive with set_timer.

--- a/src/item_transformation.cpp
+++ b/src/item_transformation.cpp
@@ -46,8 +46,6 @@ void item_transformation::deserialize( const JsonObject &jo )
     if( !ammo_type.is_empty() && !container.is_empty() ) {
         jo.throw_error_at( "target_ammo", "Transform actor specified both ammo type and container type" );
     }
-
-    optional( jo, false, "active", active, false );
 }
 
 void item_transformation::transform( Character *carrier, item &it, bool dont_take_off ) const
@@ -86,7 +84,7 @@ void item_transformation::transform( Character *carrier, item &it, bool dont_tak
             it.countdown_point = calendar::turn + target_timer;
         }
 
-        it.active = active || it.has_temperature() || it.has_flag( json_flag_SPAWN_ACTIVE )  ||
+        it.active = it.has_temperature() || it.has_flag( json_flag_SPAWN_ACTIVE )  ||
                     target_timer > 0_seconds;
 
     } else {
@@ -111,7 +109,8 @@ void item_transformation::transform( Character *carrier, item &it, bool dont_tak
             content.countdown_point = calendar::turn + target_timer;
         }
 
-        content.active = active || content.has_temperature() || target_timer > 0_seconds;
+        content.active = content.has_temperature() || content.has_flag( json_flag_SPAWN_ACTIVE ) ||
+                         target_timer > 0_seconds;
 
         for( int i = 0; i < count; i++ ) {
             if( !it.put_in( content, pocket_type::CONTAINER ).success() ) {

--- a/src/item_transformation.h
+++ b/src/item_transformation.h
@@ -44,9 +44,6 @@ struct item_transformation {
     /** if both this and ammo_qty are specified then set @ref target to this specific ammo */
     itype_id ammo_type;
 
-    /** used to set the active property of the transformed @ref target */
-    bool active = false;
-
     void deserialize( const JsonObject &jo );
     // Transforms the item.
     // dont_take_off blocks the removal of transformed "armor" when the caller relies


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Remove the redundant "active" field from item transformations, as the "SPAWN_ACTIVE" flag provides that functionality and should be on every active item.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Just remove the field, its usage, and its documentation. All usages have already been removed in previous PRs.
By-catch:
Found and fixed bug for containers, where the "SPAWN_ACTIVE" flag wasn't checked when determining whether the spawned container should be active. Currently has no effect as no transformation spawned containers are intended to be active.
Dealt with an aftershock straggler.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Loaded a regular game without issues.
The auto testing did indeed find a straggler in Aftershock. Corrected it and tested that it worked correctly (turning on light still transforms into active version that's actually active, and it can in its turn, be turned off, reverting to original version).

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
