### PR TITLE
Added recipe to reverse the disassembly of the Army helmet

### DIFF
--- a/data/json/recipes/armor/head.json
+++ b/data/json/recipes/armor/head.json
@@ -458,20 +458,19 @@
     "using": [ [ "tailoring_cotton_small", 16 ], [ "cordage", 2 ] ]
   },
   {
-  "result": "helmet_army",
-  "type": "recipe",
-  "activity_level": "LIGHT_EXERCISE",
-  "category": "CC_ARMOR",
-  "subcategory": "CSC_ARMOR_HEAD",
-  "skill_used": "fabrication",
-  "difficulty": 1,
-  "time": "5 m",
-  "autolearn": true,
-  "components": [ [ "helmet_mounting_brackets", 1 ], [ "helmet_army_stripped", 1 ] ],
-  "qualities": [
-    { "id": "SCREW", "level": 1 } ]
-},
-{
+    "result": "helmet_army",
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_HEAD",
+    "skill_used": "fabrication",
+    "difficulty": 1,
+    "time": "5 m",
+    "autolearn": true,
+    "components": [ [ "helmet_mounting_brackets", 1 ], [ "helmet_army_stripped", 1 ] ],
+    "qualities": [ { "id": "SCREW", "level": 1 } ]
+  },
+  {
     "result": "helmet_aztec",
     "//": "A log is required in this recipe, as I don't think you can bend 2x4s into the shape of an eagle.",
     "type": "recipe",

--- a/data/json/recipes/armor/head.json
+++ b/data/json/recipes/armor/head.json
@@ -458,6 +458,20 @@
     "using": [ [ "tailoring_cotton_small", 16 ], [ "cordage", 2 ] ]
   },
   {
+  "result": "helmet_army",
+  "type": "recipe",
+  "activity_level": "LIGHT_EXERCISE",
+  "category": "CC_ARMOR",
+  "subcategory": "CSC_ARMOR_HEAD",
+  "skill_used": "fabrication",
+  "difficulty": 1,
+  "time": "5 m",
+  "autolearn": true,
+  "components": [ [ "helmet_mounting_brackets", 1 ], [ "helmet_army_stripped", 1 ] ],
+  "qualities": [
+    { "id": "SCREW", "level": 1 } ]
+},
+{
     "result": "helmet_aztec",
     "//": "A log is required in this recipe, as I don't think you can bend 2x4s into the shape of an eagle.",
     "type": "recipe",


### PR DESCRIPTION

#### Summary
Bugfixes "Currently you can strip the Army Helmet to get it's brackets and put them into other helmet. However, there's no recipe to add them back."

#### Purpose of change

Adds the option to restore the Army helmet's full functionality.
