### PR TITLE
Bypassing security is shoot on sight

### DIFF
--- a/data/json/furniture_and_terrain/terrain-fences-gates.json
+++ b/data/json/furniture_and_terrain/terrain-fences-gates.json
@@ -627,7 +627,17 @@
       "sound": "Snick, snick, gachunk!",
       "byproducts": [ { "item": "lc_wire", "count": 20 } ]
     },
-    "flags": [ "TRANSPARENT", "NOITEM", "THIN_OBSTACLE", "PERMEABLE", "UNSTABLE", "CLIMBABLE", "AUTO_WALL_SYMBOL", "BURROWABLE" ],
+    "flags": [
+      "TRANSPARENT",
+      "NOITEM",
+      "THIN_OBSTACLE",
+      "PERMEABLE",
+      "UNSTABLE",
+      "CLIMBABLE",
+      "AUTO_WALL_SYMBOL",
+      "BURROWABLE",
+      "FACTION_SECURITY"
+    ],
     "connect_groups": "CHAINFENCE",
     "connects_to": "CHAINFENCE",
     "examine_action": "chainfence",
@@ -863,6 +873,7 @@
       "FLAMMABLE_ASH",
       "CLIMBABLE",
       "AUTO_WALL_SYMBOL",
+      "FACTION_SECURITY",
       "BURROWABLE"
     ],
     "connect_groups": "WOODFENCE",

--- a/data/json/monsters/turrets.json
+++ b/data/json/monsters/turrets.json
@@ -410,6 +410,7 @@
     "starting_ammo": { "556": 100 },
     "aggression": -10,
     "aggro_character": false,
+    "luminance": 35.0,
     "anger_triggers": [ "FRIEND_ATTACKED", "FRIEND_DIED", "HURT" ],
     "armor": { "bash": 20, "cut": 22, "bullet": 20, "stab": 22 },
     "special_attacks": [

--- a/data/json/npcs/factions.json
+++ b/data/json/npcs/factions.json
@@ -540,6 +540,7 @@
     "type": "faction",
     "id": "isolated_artisans",
     "name": "Isolated Artisans",
+    "mon_faction": "isolated_artisans",
     "likes_u": 10,
     "respects_u": 0,
     "known_by_u": false,

--- a/doc/JSON/JSON_FLAGS.md
+++ b/doc/JSON/JSON_FLAGS.md
@@ -656,6 +656,7 @@ Can also be used as `pre_flags` for `construction`.
 - ```ELEVATOR``` Terrain with this flag will move player, NPCs, monsters, and items up and down when player activates nearby `elevator controls`.
 - ```EMPTY_SPACE``` Terrain without anything solid in it, including a floor, implying there should be no roof supporting terrain beneath it. It also should imply containment is broken (releasing air out, water etc. in, but that's currently not implemented).
 - ```EXAMINE_FROM_ABOVE``` Furniture can be <kbd>e</kbd> examined from a ledge above.  If deployed furniture is taken down it will be placed on the ledge.
+- ```FACTION_SECURITY``` This terrain/furniture is some sort of security measure, and interacting with it is extra upsetting to the local faction.
 - ```FIRE_CONTAINER``` Stops fire from spreading (brazier, wood stove, etc).
 - ```FISHABLE``` You can try to catch fish here.
 - ```FLAMMABLE_ASH``` Burns to ash rather than rubble.

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -836,8 +836,7 @@ std::pair<std::string, nc_color> display::faction_text( const Character &u )
         return std::pair( display_name, display_color );
     }
     display_name = owner->get_name();
-    // TODO: Make this magic number into a constant
-    if( owner->likes_u < -10 ) {
+    if( owner->guaranteed_hostile_to_player() ) {
         display_color = c_red;
     } else if( u.get_faction()->id == owner ) {
         display_color = c_blue;

--- a/src/faction.cpp
+++ b/src/faction.cpp
@@ -467,6 +467,11 @@ faction_price_rule const *faction::get_price_rules( item const &it, npc const &g
     return nullptr;
 }
 
+bool faction::guaranteed_hostile_to_player() const
+{
+    return likes_u < -10;
+}
+
 bool faction::has_relationship( const faction_id &guy_id, npc_factions::relationship flag ) const
 {
     for( const auto &rel_data : relations ) {

--- a/src/faction.cpp
+++ b/src/faction.cpp
@@ -153,7 +153,7 @@ faction_template::faction_template( const JsonObject &jsobj )
     lone_wolf_faction = jsobj.get_bool( "lone_wolf_faction", false );
     limited_area_claim = jsobj.get_bool( "limited_area_claim", false );
     load_relations( jsobj );
-    mon_faction = mfaction_str_id( jsobj.get_string( "mon_faction", "human" ) );
+    optional( jsobj, false, "mon_faction", mon_faction, mfaction_str_id::NULL_ID() );
     optional( jsobj, false, "epilogues", epilogue_data );
 }
 

--- a/src/faction.h
+++ b/src/faction.h
@@ -172,7 +172,7 @@ class faction_template
         std::vector<faction_price_rule> price_rules; // additional pricing rules
         std::map<std::string, std::bitset<static_cast<size_t>( npc_factions::relationship::rel_types )>>
                 relations;
-        mfaction_str_id mon_faction; // mon_faction_id of the monster faction; defaults to human
+        mfaction_str_id mon_faction; // associated monster faction, if any
         std::vector<faction_epilogue_data> epilogue_data;
 };
 

--- a/src/faction.h
+++ b/src/faction.h
@@ -198,6 +198,8 @@ class faction : public faction_template
 
         faction_price_rule const *get_price_rules( item const &it, npc const &guy ) const;
 
+        bool guaranteed_hostile_to_player() const;
+
         bool has_relationship( const faction_id &guy_id, npc_factions::relationship flag ) const;
         void add_to_membership( const character_id &guy_id, const std::string &guy_name, bool known );
         void remove_member( const character_id &guy_id );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5510,10 +5510,12 @@ void game::examine( const tripoint_bub_ms &examp, bool with_pickup )
 
     const tripoint_bub_ms player_pos = u.pos_bub();
 
+    // Normally examining terrain or furniture is a "minor" offense, but some might be flagged differently.
+    const bool extra_alarming_action = here.has_flag( "FACTION_SECURITY", examp );
     if( here.has_furn( examp ) ) {
         if( !u.cant_do_mounted() ) {
             if( !here.has_flag( "FREE_TO_EXAMINE", examp ) &&
-                !warn_player_maybe_anger_local_faction( false, true ) ) {
+                !warn_player_maybe_anger_local_faction( extra_alarming_action, true ) ) {
                 return; // player declined to mess with faction's stuff
             }
             xfurn_t.examine( u, examp );
@@ -5521,7 +5523,7 @@ void game::examine( const tripoint_bub_ms &examp, bool with_pickup )
     } else {
         if( xter_t.can_examine( examp ) && !u.is_mounted() ) {
             if( !here.has_flag( "FREE_TO_EXAMINE", examp ) &&
-                !warn_player_maybe_anger_local_faction( false, true ) ) {
+                !warn_player_maybe_anger_local_faction( extra_alarming_action, true ) ) {
                 return; // player declined to mess with faction's stuff
             }
             xter_t.examine( u, examp );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5600,8 +5600,7 @@ bool game::warn_player_maybe_anger_local_faction( bool really_bad_offense,
     }
 
     // The threshold for guaranteed hostility. Don't bother query/modifying relationship if they already hate us
-    // TODO: Make this magic number into a constant
-    if( actual_camp->get_owner()->likes_u < -10 ) {
+    if( actual_camp->get_owner()->guaranteed_hostile_to_player() ) {
         return true;
     }
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -877,8 +877,9 @@ void DynamicDataLoader::finalize_loaded_data()
                 }
             },
             { _( "Monster groups" ), &MonsterGroupManager::FinalizeMonsterGroups },
-            { _( "Monster factions" ), &monfactions::finalize },
+            // monfactions rely on npc_factions being finalized, so monfactions should always finalize afterwards.
             { _( "Factions" ), &npc_factions::finalize },
+            { _( "Monster factions" ), &monfactions::finalize },
             { _( "Move modes" ), &move_mode::finalize_all },
             { _( "Constructions" ), &finalize_constructions },
             { _( "Crafting recipes" ), &recipe_dictionary::finalize },

--- a/src/mattack_actors.cpp
+++ b/src/mattack_actors.cpp
@@ -1192,7 +1192,7 @@ bool gun_actor::call( monster &z ) const
     } else {
         target = z.attack_target();
         aim_at = target ? target->pos_bub( here ) : tripoint_bub_ms::zero;
-        if( !target || !z.sees( here, *target ) || ( !target->is_monster() && !z.aggro_character ) ) {
+        if( !target || !z.sees( here, *target ) ) {
             if( !target_moving_vehicles ) {
                 return false;
             }

--- a/src/monfaction.h
+++ b/src/monfaction.h
@@ -62,6 +62,9 @@ class monfaction
         std::vector<std::pair<mfaction_str_id, mod_id>> src;
         mfaction_str_id base_faction = mfaction_str_id::NULL_ID();
 
+        // What NPC faction (if any) are we associated with?
+        faction_id associated_faction = faction_id::NULL_ID();
+
     private:
         // used by generic_factory
         bool was_loaded = false;

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -1641,7 +1641,7 @@ Creature *monster::attack_target()
 
     Creature *target = get_creature_tracker().creature_at( get_dest() );
     if( target == nullptr || target == this ||
-        attitude_to( *target ) == Attitude::FRIENDLY || !sees( here,  *target ) ||
+        attitude_to( *target ) != Attitude::HOSTILE || !sees( here,  *target ) ||
         target->is_hallucination() ) {
         return nullptr;
     }

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -378,6 +378,11 @@ bool monster::can_upgrade() const
     return upgrades && get_option<float>( "EVOLUTION_INVERSE_MULTIPLIER" ) > 0.0;
 }
 
+faction_id monster::get_parent_faction() const
+{
+    return get_monster_faction()->associated_faction;
+}
+
 void monster::gravity_check()
 {
     monster::gravity_check( &get_map() );
@@ -1716,7 +1721,8 @@ Creature::Attitude monster::attitude_to( const Creature &other ) const
                 break;
         }
     }
-    // Should not happen!, creature should be either player or monster
+    // Should not happen!, creature should be either character or monster
+    cata_fatal( "Unexpected creature type specialization" );
     return Attitude::NEUTRAL;
 }
 

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -1760,6 +1760,11 @@ monster_attitude monster::attitude( const Character *u ) const
         return MATT_FLEE;
     }
 
+    if( u && u->is_avatar() && !get_parent_faction().is_null() &&
+        get_parent_faction()->guaranteed_hostile_to_player() ) {
+        return MATT_ATTACK;
+    }
+
     // CHECK FOR ANGER RELATIONS **HERE**
     bool target_has_anger_relation = false;
     if( u != nullptr ) {

--- a/src/monster.h
+++ b/src/monster.h
@@ -100,9 +100,12 @@ class monster : public Creature
             return this;
         }
 
+        // Get the monfaction associated with this monster
         mfaction_id get_monster_faction() const override {
             return faction.id();
         }
+        //Get the *NPC* faction associated with this monster's monfaction, may be null
+        faction_id get_parent_faction() const;
         void gravity_check() override;
         void gravity_check( map *here ) override;
         void poly( const mtype_id &id );

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1645,7 +1645,7 @@ void npc::form_opinion( const Character &you )
         set_attitude( NPCATT_TALK );
     } else if( op_of_u.fear - 2 * personality.aggression - personality.bravery < -30 ) {
         set_attitude( NPCATT_KILL );
-    } else if( my_fac && my_fac->likes_u < -10 ) {
+    } else if( my_fac && my_fac->guaranteed_hostile_to_player() ) {
         if( is_player_ally() ) {
             mutiny();
         }
@@ -1774,7 +1774,7 @@ void npc::mutiny()
         add_msg( m_bad, _( "%s is tired of your incompetent leadership and abuse!" ), disp_name() );
     }
     // NPCs leaving your faction due to mistreatment further reduce their opinion of you
-    if( my_fac->likes_u < -10 ) {
+    if( my_fac->guaranteed_hostile_to_player() ) {
         op_of_u.trust += my_fac->respects_u / 10;
         op_of_u.anger += my_fac->likes_u / 10;
     }
@@ -2532,7 +2532,7 @@ bool npc::is_minion() const
 bool npc::guaranteed_hostile() const
 {
     return attitude_to( get_player_character() ) == Attitude::HOSTILE || is_enemy() ||
-           ( my_fac && my_fac->likes_u < -10 );
+           ( my_fac && my_fac->guaranteed_hostile_to_player() );
 }
 
 bool npc::is_walking_with() const


### PR DESCRIPTION
#### Summary
Balance "Bypassing faction security is shoot on sight"

#### Purpose of change
Recent conversations pointed out to me that we allow players to bypass faction security and *get away with it* with a warning.

There is no need for a warning. The presence of security measures **is** plenty of warning .

#### Describe the solution
Certain examine actions are no longer minor offenses - jumping fences in particular.

There will be no second chances if you insist on being obviously hostile.

#### Describe alternatives you've considered


#### Testing
Made myself hostile to the artisans with the debug menu, the turrets immediately lit me up instead of just ignoring me.

#### Additional context
I also made the artisan turrets glow, so even if you stumble in in the middle of the night it's obvious that they're there.

Note: The artisans start at +10 `likes_u` so the default -20 when performing a serious offense to them puts them at exactly -10. Just above the threshold for guaranteed hostility.

This is irregular, and I'm not sure why they start at +10.