### PR TITLE
Introduced damage failure risk and message on item transformation use actions

### DIFF
--- a/data/json/items/tool/lighting.json
+++ b/data/json/items/tool/lighting.json
@@ -113,7 +113,8 @@
       "msg": "You turn the flashlight on.",
       "target": "flashlight_on",
       "need_charges": 1,
-      "need_charges_msg": "The flashlight's batteries are dead."
+      "need_charges_msg": "The flashlight's batteries are dead.",
+      "damage_failure_msg": "You press the button on your %s, but nothing happens."
     },
     "pocket_data": [
       {

--- a/src/item.h
+++ b/src/item.h
@@ -1417,6 +1417,12 @@ class item : public visitable
         /** @see itype::damage_level(). */
         int damage_level( bool precise = false ) const;
 
+        /** Whether activation of an item should be successful based on it's damage level and chance
+        * Note that it does not perform any activation: that's up to the caller. Also, it's based
+        * on damage only, without any considerations for faults.
+        */
+        bool activation_success() const;
+
         /** Modifiy melee weapon damage to account for item's damage. */
         float damage_adjusted_melee_weapon_damage( float value, const damage_type_id &dt ) const;
         /** Modifiy gun damage to account for item's damage. */

--- a/src/item_degrade.cpp
+++ b/src/item_degrade.cpp
@@ -206,6 +206,12 @@ int item::damage_level( bool precise ) const
     return precise ? damage_ : type->damage_level( damage_ );
 }
 
+bool item::activation_success() const
+{
+    // Should be itype::damage_max_ - 1, but for some reason it's private.
+    return rng( 0, 3999 ) - damage_ >= 0;
+}
+
 float item::damage_adjusted_melee_weapon_damage( float value, const damage_type_id &dt ) const
 {
     if( type->count_by_charges() ) {

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -128,8 +128,6 @@ static const efftype_id effect_recover( "recover" );
 static const efftype_id effect_sleep( "sleep" );
 static const efftype_id effect_stunned( "stunned" );
 
-static const flag_id json_flag_SPAWN_ACTIVE( "SPAWN_ACTIVE" );
-
 static const fault_id fault_bionic_salvaged( "fault_bionic_salvaged" );
 
 static const furn_str_id furn_f_kiln_empty( "f_kiln_empty" );
@@ -176,8 +174,6 @@ static const skill_id skill_fabrication( "fabrication" );
 static const skill_id skill_firstaid( "firstaid" );
 static const skill_id skill_survival( "survival" );
 static const skill_id skill_traps( "traps" );
-
-static const std::string fault_type_shorted = "shorted";
 
 static const trait_id trait_DEBUG_BIONICS( "DEBUG_BIONICS" );
 static const trait_id trait_ILLITERATE( "ILLITERATE" );

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -128,6 +128,8 @@ static const efftype_id effect_recover( "recover" );
 static const efftype_id effect_sleep( "sleep" );
 static const efftype_id effect_stunned( "stunned" );
 
+static const flag_id json_flag_SPAWN_ACTIVE( "SPAWN_ACTIVE" );
+
 static const fault_id fault_bionic_salvaged( "fault_bionic_salvaged" );
 
 static const furn_str_id furn_f_kiln_empty( "f_kiln_empty" );
@@ -174,6 +176,8 @@ static const skill_id skill_fabrication( "fabrication" );
 static const skill_id skill_firstaid( "firstaid" );
 static const skill_id skill_survival( "survival" );
 static const skill_id skill_traps( "traps" );
+
+static const std::string fault_type_shorted = "shorted";
 
 static const trait_id trait_DEBUG_BIONICS( "DEBUG_BIONICS" );
 static const trait_id trait_ILLITERATE( "ILLITERATE" );
@@ -237,6 +241,9 @@ void iuse_transform::load( const JsonObject &obj, const std::string & )
         obj.throw_error_at( "set_timer", "Cannot use both set_timer and target_timer at once" );
     }
 
+    optional( obj, false, "damage_failure_msg", damage_failure_msg,
+              to_translation( "Activation of your damaged %s fails." ) );
+
     optional( obj, false, "need_fire", need_fire, numeric_bound_reader<int> { 0 }, 0 );
     optional( obj, false, "need_charges_msg", need_charges_msg, to_translation( "The %s is empty!" ) );
 
@@ -280,6 +287,12 @@ std::optional<int> iuse_transform::use( Character *p, item &it, map *,
         if( p->cant_do_underwater() ) {
             return std::nullopt;
         }
+    }
+
+    if( !it.activation_success() ) {
+        p->add_msg_if_player( m_bad,
+                              damage_failure_msg, it.tname() );
+        return std::nullopt;
     }
 
     int timer_time = 0;

--- a/src/iuse_actor.h
+++ b/src/iuse_actor.h
@@ -70,6 +70,9 @@ class iuse_transform : public iuse_actor
         /** Asks you to set a timer for a countdown */
         bool set_timer = false;
 
+        /** displayed if activation fails due to damage, with %s replaced by item name */
+        translation damage_failure_msg;
+
         /** minimum number of fire charges required (if any) for transformation */
         int need_fire = 0;
 


### PR DESCRIPTION

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
- Introduce an item operation to determine whether an item should be activated successfully based on its damage.
- Use that operation to fail standard item transformation use actions based on that operation, with a standard and optional failure message.
- Modify the normal flashlight to provide the optional message as an example.

Addresses half of #84014.

This is intended to provide means for applying the failure logic to more use_action operations, as well as to allow contributors to customize failure messages on more transformations.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
What the purpose said.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Move the check higher up in the call chain so it applies to all use actions. I don't think that's a good idea, because:
- It will make it impossible to provide custom messages, like the current checks for lack of power causes the messages provided for that case to be useless (there might be some edge cases where you might be able to trigger them, but I've failed to find any).

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
- Debug spawned a standard flashlight and a battery for it, loaded the battery into it.
- Dropped the flashlight and a pristine heavy flashlight already in the PC's inventory on the ground.
- Debug set the damage of the flashlight to 500 and the heavy flashlight to 2000 (out of 4000).
- Activated and deactivated the flashlight until it failed and the custom message showed up, it took a number of attempts, consistent with its supposed 1/8 chance to fail.
- Activated and deactivated the heavy flashlight in a similar manner. It took fewer attempts to fail, consistent with a 1/2 chance of failure.
<img width="3440" height="1440" alt="Screenshot (26)" src="https://github.com/user-attachments/assets/36fb9bd8-3c6f-4177-ba21-886ff6917e4c" />

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
You could argue that turning the heavy flashlight off shouldn't fail, but a mechanical failure could cause the switch to not work correctly. Also, the default failure message is a bit odd in that situation (which could be changed with a custom failure message, e.g. "You try to deactivate your %s, but the button doesn't do anything.").

I'm open to suggestions for a better default failure message.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
