### PR TITLE
Add proper beer six packs to the game, along with six pack rings

### DIFF
--- a/data/json/itemgroups/Food/food.json
+++ b/data/json/itemgroups/Food/food.json
@@ -1730,5 +1730,45 @@
     "type": "item_group",
     "subtype": "distribution",
     "items": [ { "group": "any_milk", "container-item": "jug_plastic" } ]
+  },
+  {
+    "id": "beer_in_six_pack_rings",
+    "type": "item_group",
+    "subtype": "distribution",
+    "container-item": "six_pack_rings",
+    "entries": [
+      { "prob": 35, "container-item": "can_drink", "count": 6, "item": "beer" },
+      { "prob": 25, "container-item": "can_drink", "count": 6, "item": "european_pilsner" },
+      { "prob": 25, "container-item": "can_drink", "count": 6, "item": "drink_hard_seltzer" },
+      { "prob": 25, "container-item": "can_drink", "count": 6, "item": "pale_ale" },
+      { "prob": 25, "container-item": "can_drink", "count": 6, "item": "india_pale_ale" },
+      { "prob": 15, "container-item": "can_drink", "count": 6, "item": "stout" },
+      { "prob": 10, "container-item": "can_drink", "count": 6, "item": "belgian_ale" },
+      { "prob": 4, "container-item": "can_drink", "count": 6, "item": "imperial_stout" },
+      { "prob": 2, "container-item": "can_drink", "count": 6, "item": "wine_barley" }
+    ]
+  },
+  {
+    "id": "beer_in_six_pack_cardboard",
+    "type": "item_group",
+    "subtype": "distribution",
+    "container-item": "box_medium",
+    "entries": [
+      { "prob": 35, "container-item": "bottle_glass_330ml", "count": 6, "item": "beer" },
+      { "prob": 25, "container-item": "bottle_glass_330ml", "count": 6, "item": "european_pilsner" },
+      { "prob": 25, "container-item": "bottle_glass_330ml", "count": 6, "item": "drink_hard_seltzer" },
+      { "prob": 25, "container-item": "bottle_glass_330ml", "count": 6, "item": "pale_ale" },
+      { "prob": 25, "container-item": "bottle_glass_330ml", "count": 6, "item": "india_pale_ale" },
+      { "prob": 15, "container-item": "bottle_glass_330ml", "count": 6, "item": "stout" },
+      { "prob": 10, "container-item": "bottle_glass_330ml", "count": 6, "item": "belgian_ale" },
+      { "prob": 4, "container-item": "bottle_glass_330ml", "count": 6, "item": "imperial_stout" },
+      { "prob": 2, "container-item": "bottle_glass_330ml", "count": 6, "item": "wine_barley" }
+    ]
+  },
+  {
+    "id": "beer_in_six_pack",
+    "type": "item_group",
+    "subtype": "distribution",
+    "entries": [ { "group": "beer_in_six_pack_rings" }, { "group": "beer_in_six_pack_cardboard" } ]
   }
 ]

--- a/data/json/itemgroups/SUS/fridges.json
+++ b/data/json/itemgroups/SUS/fridges.json
@@ -208,32 +208,12 @@
         ],
         "prob": 90
       },
-      {
-        "distribution": [
-          { "item": "beer", "count": [ 1, 6 ], "prob": 35 },
-          { "item": "european_pilsner", "count": [ 1, 6 ], "prob": 25 },
-          { "item": "pale_ale", "count": [ 1, 6 ], "prob": 25 },
-          { "item": "india_pale_ale", "count": [ 1, 6 ], "prob": 25 },
-          { "item": "drink_hard_seltzer", "count": [ 1, 6 ], "prob": 25 },
-          { "item": "stout", "count": [ 1, 6 ], "prob": 15 },
-          { "item": "belgian_ale", "count": [ 1, 6 ], "prob": 10 },
-          { "item": "imperial_stout", "count": [ 1, 6 ], "prob": 4 }
-        ],
-        "prob": 70
-      },
+      { "group": "beer_in_six_pack", "prob": 70 },
       {
         "distribution": [
           { "item": "apple_cider", "charges": [ 1, -1 ], "prob": 20, "container-item": "bottle_plastic", "sealed": false },
           { "item": "fruit_wine", "charges": [ 1, -1 ], "prob": 15 },
-          { "item": "beer", "charges": [ 1, -1 ], "prob": 35 },
-          { "item": "european_pilsner", "charges": [ 1, -1 ], "prob": 25 },
-          { "item": "pale_ale", "charges": [ 1, -1 ], "prob": 25 },
-          { "item": "india_pale_ale", "charges": [ 1, -1 ], "prob": 25 },
-          { "item": "drink_hard_seltzer", "charges": [ 1, -1 ], "prob": 25 },
-          { "item": "stout", "charges": [ 1, -1 ], "prob": 15 },
-          { "item": "belgian_ale", "charges": [ 1, -1 ], "prob": 10 },
-          { "item": "imperial_stout", "charges": [ 1, -1 ], "prob": 4 },
-          { "item": "wine_barley", "charges": [ 1, -1 ], "prob": 2 }
+          { "group": "beer_in_container", "prob": 166 }
         ],
         "prob": 60
       }
@@ -322,32 +302,12 @@
         ],
         "prob": 70
       },
-      {
-        "distribution": [
-          { "item": "beer", "count": [ 1, 6 ], "prob": 35 },
-          { "item": "european_pilsner", "count": [ 1, 6 ], "prob": 25 },
-          { "item": "pale_ale", "count": [ 1, 6 ], "prob": 25 },
-          { "item": "india_pale_ale", "count": [ 1, 6 ], "prob": 25 },
-          { "item": "drink_hard_seltzer", "count": [ 1, 6 ], "prob": 25 },
-          { "item": "stout", "count": [ 1, 6 ], "prob": 15 },
-          { "item": "belgian_ale", "count": [ 1, 6 ], "prob": 10 },
-          { "item": "imperial_stout", "count": [ 1, 6 ], "prob": 4 }
-        ],
-        "prob": 80
-      },
+      { "group": "beer_in_six_pack", "prob": 80 },
       {
         "distribution": [
           { "item": "apple_cider", "charges": [ 1, -1 ], "prob": 20 },
           { "item": "fruit_wine", "charges": [ 1, -1 ], "prob": 15 },
-          { "item": "beer", "charges": [ 1, -1 ], "prob": 35 },
-          { "item": "european_pilsner", "charges": [ 1, -1 ], "prob": 25 },
-          { "item": "pale_ale", "charges": [ 1, -1 ], "prob": 25 },
-          { "item": "india_pale_ale", "charges": [ 1, -1 ], "prob": 25 },
-          { "item": "drink_hard_seltzer", "charges": [ 1, -1 ], "prob": 25 },
-          { "item": "stout", "charges": [ 1, -1 ], "prob": 15 },
-          { "item": "belgian_ale", "charges": [ 1, -1 ], "prob": 10 },
-          { "item": "imperial_stout", "charges": [ 1, -1 ], "prob": 4 },
-          { "item": "wine_barley", "charges": [ 1, -1 ], "prob": 2 }
+          { "group": "beer_in_container", "prob": 166 }
         ],
         "prob": 70
       }
@@ -440,32 +400,12 @@
         ],
         "prob": 80
       },
-      {
-        "distribution": [
-          { "item": "beer", "count": [ 1, 6 ], "prob": 35 },
-          { "item": "european_pilsner", "count": [ 1, 6 ], "prob": 25 },
-          { "item": "pale_ale", "count": [ 1, 6 ], "prob": 25 },
-          { "item": "india_pale_ale", "count": [ 1, 6 ], "prob": 25 },
-          { "item": "drink_hard_seltzer", "count": [ 1, 6 ], "prob": 25 },
-          { "item": "stout", "count": [ 1, 6 ], "prob": 15 },
-          { "item": "belgian_ale", "count": [ 1, 6 ], "prob": 10 },
-          { "item": "imperial_stout", "count": [ 1, 6 ], "prob": 4 }
-        ],
-        "prob": 40
-      },
+      { "group": "beer_in_six_pack", "prob": 40 },
       {
         "distribution": [
           { "item": "apple_cider", "charges": [ 1, -1 ], "prob": 20 },
           { "item": "fruit_wine", "charges": [ 1, -1 ], "prob": 15 },
-          { "item": "beer", "charges": [ 1, -1 ], "prob": 35 },
-          { "item": "european_pilsner", "charges": [ 1, -1 ], "prob": 25 },
-          { "item": "pale_ale", "charges": [ 1, -1 ], "prob": 25 },
-          { "item": "india_pale_ale", "charges": [ 1, -1 ], "prob": 25 },
-          { "item": "drink_hard_seltzer", "charges": [ 1, -1 ], "prob": 25 },
-          { "item": "stout", "charges": [ 1, -1 ], "prob": 15 },
-          { "item": "belgian_ale", "charges": [ 1, -1 ], "prob": 10 },
-          { "item": "imperial_stout", "charges": [ 1, -1 ], "prob": 4 },
-          { "item": "wine_barley", "charges": [ 1, -1 ], "prob": 2 }
+          { "group": "beer_in_container", "prob": 166 }
         ],
         "prob": 40
       }
@@ -648,32 +588,12 @@
         ],
         "prob": 20
       },
-      {
-        "distribution": [
-          { "item": "beer", "count": [ 1, 6 ], "prob": 35 },
-          { "item": "european_pilsner", "count": [ 1, 6 ], "prob": 25 },
-          { "item": "drink_hard_seltzer", "count": [ 1, 6 ], "prob": 25 },
-          { "item": "pale_ale", "count": [ 1, 6 ], "prob": 25 },
-          { "item": "india_pale_ale", "count": [ 1, 6 ], "prob": 25 },
-          { "item": "stout", "count": [ 1, 6 ], "prob": 15 },
-          { "item": "belgian_ale", "count": [ 1, 6 ], "prob": 10 },
-          { "item": "imperial_stout", "count": [ 1, 6 ], "prob": 4 }
-        ],
-        "prob": 20
-      },
+      { "group": "beer_in_six_pack", "prob": 20 },
       {
         "distribution": [
           { "item": "apple_cider", "charges": [ 1, -1 ], "prob": 20, "container-item": "bottle_plastic", "sealed": false },
           { "item": "fruit_wine", "charges": [ 1, -1 ], "prob": 15 },
-          { "item": "beer", "charges": [ 1, -1 ], "prob": 35 },
-          { "item": "european_pilsner", "charges": [ 1, -1 ], "prob": 25 },
-          { "item": "pale_ale", "charges": [ 1, -1 ], "prob": 25 },
-          { "item": "india_pale_ale", "charges": [ 1, -1 ], "prob": 25 },
-          { "item": "drink_hard_seltzer", "charges": [ 1, -1 ], "prob": 25 },
-          { "item": "stout", "charges": [ 1, -1 ], "prob": 15 },
-          { "item": "belgian_ale", "charges": [ 1, -1 ], "prob": 10 },
-          { "item": "imperial_stout", "charges": [ 1, -1 ], "prob": 4 },
-          { "item": "wine_barley", "charges": [ 1, -1 ], "prob": 2 }
+          { "group": "beer_in_container", "prob": 166 }
         ],
         "prob": 20
       }

--- a/data/json/items/containers/containers.json
+++ b/data/json/items/containers/containers.json
@@ -5347,7 +5347,7 @@
     "id": "six_pack_rings",
     "type": "ITEM",
     "category": "container",
-    "name": { "str": "six-pack rings" },
+    "name": { "str_sp": "six-pack rings" },
     "description": "A set of plastic rings meant to hold aluminum cans.",
     "symbol": "8",
     "color": "light_cyan",

--- a/data/json/items/containers/containers.json
+++ b/data/json/items/containers/containers.json
@@ -5342,5 +5342,22 @@
         "moves": 400
       }
     ]
+  },
+  {
+    "id": "six_pack_rings",
+    "type": "ITEM",
+    "category": "container",
+    "name": { "str": "six-pack rings" },
+    "description": "A set of plastic rings meant to hold aluminum cans.",
+    "symbol": "8",
+    "color": "light_cyan",
+    "price_postapoc": "1 cent",
+    "material": [ "plastic" ],
+    "weight": "1 g",
+    "volume": "1 ml",
+    "pocket_data": [
+      { "pocket_type": "CONTAINER", "max_contains_volume": "2500 ml", "max_contains_weight": "10 kg", "transparent": true }
+    ],
+    "flags": [ "NO_RELOAD" ]
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Content "Add proper beer six packs to the game, along with six pack rings"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
We still have plenty of beer spawning out of containers, I didn't fix some of these spawns previously because they were supposed to be six packs and I wanted to properly implement those.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add those. We get 3 itemgroups, `beer_in_six_pack`, `beer_in_six_pack_rings` and `beer_in_six_pack_cardboard` which should all be pretty self explanatory.

Add the six pack rings item for the one with rings, the other uses a slightly too big cardboard box.

Replace the old **awful** definitions with those, gaining 20 lines in the process and much better clarity and re-usability.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
I'm not super happy with some redundancy in the six pack groups definitions but I don't see how I could improve it.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Spawned them, works fine.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Alongside with #84035 may partially  fix #84033.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
