### PR TITLE
[MoM] Remove broken shield belts as separate items

### DIFF
--- a/data/mods/MindOverMatter/itemgroups/feral_deathdrops.json
+++ b/data/mods/MindOverMatter/itemgroups/feral_deathdrops.json
@@ -254,7 +254,13 @@
         "distribution": [ { "item": "grenade_anti_psi", "prob": 50 }, { "item": "grenade_anti_psi_expended", "prob": 50 } ],
         "prob": 25
       },
-      { "group": "dist_shield_belts", "prob": 25, "damage": [ 1, 5 ] }
+      {
+        "distribution": [
+          { "group": "dist_shield_belts", "prob": 50, "damage": [ 1, 5 ] },
+          { "group": "dist_shield_belts", "prob": 50, "damage": [ 3, 5 ] }
+        ],
+        "prob": 25
+      }
     ]
   },
   {
@@ -275,7 +281,13 @@
       { "group": "feral_humans_crystal_drops_clair", "prob": 40 },
       { "group": "feral_humans_crystal_drops_vita", "prob": 25 },
       { "item": "phavian_psionic_martial_power_book", "prob": 8 },
-      { "group": "dist_psionic_shield_belts", "prob": 60, "damage": [ 1, 5 ] },
+      {
+        "distribution": [
+          { "group": "dist_psionic_shield_belts", "prob": 50, "damage": [ 1, 5 ] },
+          { "group": "dist_psionic_shield_belts", "prob": 50, "damage": [ 3, 5 ] }
+        ],
+        "prob": 50
+      },
       {
         "distribution": [ { "item": "grenade_anti_psi", "prob": 50 }, { "item": "grenade_anti_psi_expended", "prob": 50 } ],
         "prob": 25

--- a/data/mods/MindOverMatter/itemgroups/feral_deathdrops.json
+++ b/data/mods/MindOverMatter/itemgroups/feral_deathdrops.json
@@ -254,7 +254,7 @@
         "distribution": [ { "item": "grenade_anti_psi", "prob": 50 }, { "item": "grenade_anti_psi_expended", "prob": 50 } ],
         "prob": 25
       },
-      { "group": "dist_shield_belts", "prob": 25, "damage": [ 1, 4 ] }
+      { "group": "dist_shield_belts", "prob": 25, "damage": [ 1, 5 ] }
     ]
   },
   {
@@ -275,7 +275,7 @@
       { "group": "feral_humans_crystal_drops_clair", "prob": 40 },
       { "group": "feral_humans_crystal_drops_vita", "prob": 25 },
       { "item": "phavian_psionic_martial_power_book", "prob": 8 },
-      { "group": "dist_psionic_shield_belts", "prob": 60, "damage": [ 1, 4 ] },
+      { "group": "dist_psionic_shield_belts", "prob": 60, "damage": [ 1, 5 ] },
       {
         "distribution": [ { "item": "grenade_anti_psi", "prob": 50 }, { "item": "grenade_anti_psi_expended", "prob": 50 } ],
         "prob": 25

--- a/data/mods/MindOverMatter/itemgroups/matrix_technology_labs.json
+++ b/data/mods/MindOverMatter/itemgroups/matrix_technology_labs.json
@@ -81,25 +81,11 @@
         "prob": 1
       },
       {
-        "item": "medium_battery_electronoetic_refined",
-        "ammo-item": "battery",
-        "charges": [ 100, 448 ],
-        "container-item": "psionic_shield_belt_broken",
-        "prob": 6
-      },
-      {
         "item": "medium_battery_electronoetic",
         "ammo-item": "battery",
         "charges": [ 20, 168 ],
         "container-item": "psionic_shield_belt",
         "prob": 4
-      },
-      {
-        "item": "medium_battery_electronoetic",
-        "ammo-item": "battery",
-        "charges": [ 20, 168 ],
-        "container-item": "psionic_shield_belt_broken",
-        "prob": 14
       }
     ]
   },
@@ -116,25 +102,11 @@
         "prob": 1
       },
       {
-        "item": "medium_battery_electronoetic_refined",
-        "ammo-item": "battery",
-        "charges": [ 100, 448 ],
-        "container-item": "psionic_fire_shield_belt_broken",
-        "prob": 6
-      },
-      {
         "item": "medium_battery_electronoetic",
         "ammo-item": "battery",
         "charges": [ 20, 168 ],
         "container-item": "psionic_fire_shield_belt",
         "prob": 4
-      },
-      {
-        "item": "medium_battery_electronoetic",
-        "ammo-item": "battery",
-        "charges": [ 20, 168 ],
-        "container-item": "psionic_fire_shield_belt_broken",
-        "prob": 14
       }
     ]
   },

--- a/data/mods/MindOverMatter/items/armor/belt.json
+++ b/data/mods/MindOverMatter/items/armor/belt.json
@@ -19,12 +19,13 @@
       {
         "type": "transform",
         "msg": "You flip the switch on the box and a red LED lights up.",
-        "damage_failure_msg": "You flip the switch on the box, but nothing happens."
+        "damage_failure_msg": "You flip the switch on the box, but nothing happens.",
         "target": "psionic_shield_belt_on",
         "need_charges": 1,
         "need_charges_msg": "The switch clicks but nothing happens.",
         "need_worn": true,
-        "menu_text": "Flip the switch"
+        "menu_text": "Flip the switch",
+        "moves": 75
       }
     ],
     "pocket_data": [
@@ -75,7 +76,8 @@
         "target": "psionic_shield_belt",
         "msg": "You flip the switch on the box and the red LED turns off.",
         "menu_text": "Flip the switch",
-        "type": "transform"
+        "type": "transform",
+        "moves": 75
       }
     ],
     "extend": { "flags": [ "NO_TAKEOFF", "SPAWN_ACTIVE" ] }
@@ -107,12 +109,13 @@
       {
         "type": "transform",
         "msg": "You flip the switch on the box and a red LED lights up.",
-        "damage_failure_msg": "You flip the switch on the box, but nothing happens."
+        "damage_failure_msg": "You flip the switch on the box, but nothing happens.",
         "target": "psionic_fire_shield_belt_on",
         "need_charges": 1,
         "need_charges_msg": "The switch clicks but nothing happens.",
         "need_worn": true,
-        "menu_text": "Flip the switch"
+        "menu_text": "Flip the switch",
+        "moves": 75
       }
     ],
     "flags": [ "BELTED", "OVERSIZE", "NONCONDUCTIVE", "NO_REPAIR", "COMBAT_TOGGLEABLE" ],
@@ -152,7 +155,8 @@
         "target": "psionic_fire_shield_belt",
         "msg": "You flip the switch on the box and the red LED turns off.",
         "menu_text": "Flip the switch",
-        "type": "transform"
+        "type": "transform",
+        "moves": 75
       }
     ],
     "extend": { "flags": [ "NO_TAKEOFF", "SPAWN_ACTIVE" ] }

--- a/data/mods/MindOverMatter/items/armor/belt.json
+++ b/data/mods/MindOverMatter/items/armor/belt.json
@@ -19,6 +19,7 @@
       {
         "type": "transform",
         "msg": "You flip the switch on the box and a red LED lights up.",
+        "damage_failure_msg": "You flip the switch on the box, but nothing happens."
         "target": "psionic_shield_belt_on",
         "need_charges": 1,
         "need_charges_msg": "The switch clicks but nothing happens.",
@@ -80,24 +81,6 @@
     "extend": { "flags": [ "NO_TAKEOFF", "SPAWN_ACTIVE" ] }
   },
   {
-    "id": "psionic_shield_belt_broken",
-    "type": "ITEM",
-    "subtypes": [ "TOOL", "ARMOR" ],
-    "name": { "str": "shield belt" },
-    "copy-from": "psionic_shield_belt",
-    "description": "A simple synthetic fabric belt with a box to the right of the belt loop.  The box has a toggleable switch and a stylized shield with Ψ and the XEDRA logo inside it.  It also has a large crack across it and rattles when moved.",
-    "price_postapoc": "5 USD",
-    "use_action": [
-      {
-        "type": "transform",
-        "msg": "You flip the switch on the box, but nothing happens.",
-        "target": "psionic_shield_belt_broken",
-        "need_worn": true,
-        "menu_text": "Flip the switch"
-      }
-    ]
-  },
-  {
     "id": "psionic_fire_shield_belt",
     "type": "ITEM",
     "subtypes": [ "TOOL", "ARMOR", "ARTIFACT" ],
@@ -124,6 +107,7 @@
       {
         "type": "transform",
         "msg": "You flip the switch on the box and a red LED lights up.",
+        "damage_failure_msg": "You flip the switch on the box, but nothing happens."
         "target": "psionic_fire_shield_belt_on",
         "need_charges": 1,
         "need_charges_msg": "The switch clicks but nothing happens.",
@@ -172,31 +156,5 @@
       }
     ],
     "extend": { "flags": [ "NO_TAKEOFF", "SPAWN_ACTIVE" ] }
-  },
-  {
-    "id": "psionic_fire_shield_belt_broken",
-    "type": "ITEM",
-    "subtypes": [ "TOOL", "ARMOR" ],
-    "copy-from": "psionic_fire_shield_belt",
-    "name": { "str": "suppression belt" },
-    "description": "A simple synthetic fabric belt with a box to the right of the belt loop.  The box has a toggleable switch and a stylized flame with a large circle and line superimposed over it and a Ψ behind the XEDRA logo inside it.  It also has a large crack across it and rattles when moved.",
-    "price_postapoc": "5 USD",
-    "use_action": [
-      {
-        "type": "transform",
-        "msg": "You flip the switch on the box, but nothing happens.",
-        "target": "psionic_fire_shield_belt_broken",
-        "need_worn": true,
-        "menu_text": "Flip the switch"
-      }
-    ],
-    "pocket_data": [
-      {
-        "pocket_type": "MAGAZINE_WELL",
-        "rigid": true,
-        "flag_restriction": [ "BATTERY_MEDIUM" ],
-        "default_magazine": "medium_battery_electronoetic"
-      }
-    ]
   }
 ]

--- a/data/mods/MindOverMatter/obsolete/items.json
+++ b/data/mods/MindOverMatter/obsolete/items.json
@@ -4,5 +4,17 @@
     "//": "remove after 0.J",
     "id": [ "biokin_breathe_skin_item" ],
     "replace": "manual_swimming"
+  },
+  {
+    "type": "MIGRATION",
+    "//": "remove after 0.J",
+    "id": [ "psionic_shield_belt_broken" ],
+    "replace": "psionic_shield_belt"
+  },
+  {
+    "type": "MIGRATION",
+    "//": "remove after 0.J",
+    "id": [ "psionic_fire_shield_belt_broken" ],
+    "replace": "psionic_fire_shield_belt"
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[MoM] Remove broken shield belts as separate items"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

The point of broken shield belts as distinct items was to represent damage taken rendering them inoperable since you're taking them from feral corpses. However, #84034 allows this to occur without separate items
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Migrate the broken belts into the regular versions. Implement a failure message for the working belts when damage prevents them from functioning. Adjust itemgroups to reflect these changes. 

Add a `Moves: 75` movecost to turning the belt on and off.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Grabbed a mostly-broken belt, flipped the switch on and off five times before it finally activated. 

Checked itemgroups, belts were mostly beat to hell. If you want pristine belts, you'll need to loot them from labs (...when I add the telekinetic/pyrokinetic lab)
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

I just found a shield belt on my last Sky Island raid and threw it away because it was broken. Joke's on me. 
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
