### PR TITLE
Pre-emptively kill some exploits related to fire-sound handling

### DIFF
--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -34,6 +34,7 @@
 #include "event_bus.h"
 #include "explosion.h"
 #include "faction.h"
+#include "field.h"
 #include "field_type.h"
 #include "flat_set.h"
 #include "game.h"
@@ -3998,7 +3999,10 @@ void monster::hear_sound( const tripoint_bub_ms &source, const int vol, const in
     bool probably_a_fire = false;
     map &here = get_map();
     for( const tripoint_bub_ms &pt : here.points_in_radius( source, 1, 1 ) ) {
-        if( here.get_field( pt, fd_fire ) ) {
+        const field_entry *fire_fld = here.get_field( pt, fd_fire );
+        // Only large, uncontained fires cause sounds to be ignored.
+        if( fire_fld && fire_fld->get_field_intensity() > 1 &&
+            !here.has_flag_ter_or_furn( ter_furn_flag::TFLAG_FIRE_CONTAINER, pt ) ) {
             probably_a_fire = true;
             break;
         }


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Followup to #83963

Players immediately doing their best to try not to play the game

#### Describe the solution
Immediately patch away any potential exploits.

I don't think it was reasonably possible to use this, because shooting a gun next to a fire requires a lot of setup *and* line of sight. The resulting line of sight negated any potential sound-related exploits.

But you know, we can just kill it to be sure.

#### Describe alternatives you've considered


#### Testing
Made myself debug invisible next to a small fire, fired a rifle. Zombies came running.

#### Additional context

