### PR TITLE
Fix masochist morale inconsistency

### DIFF
--- a/src/morale.cpp
+++ b/src/morale.cpp
@@ -189,7 +189,9 @@ void player_morale::morale_point::add( const int new_bonus, const int new_max_bo
     }
 
     int sqrt_of_sum_of_squares;
-    if( new_cap || !same_sign ) {
+    if( new_duration == 0_turns ) {
+        sqrt_of_sum_of_squares = new_bonus;
+    } else if( new_cap || !same_sign ) {
         // If the morale bonus is capped apply the full bonus
         // This is because some morale types build up slowly to a cap over time (e.g. morale_wet)
         // If the new bonus is opposing apply the full bonus


### PR DESCRIPTION
#### Summary

Bugfixes "Fix masochist morale inconsistency"

#### Purpose of change

closes #80368

Fixes a bug where players with masochist traits would see debug error about morale inconsistency. 
The masochist morale bonus is supposed to update based on current pain levels, but the it was incorrectly accumulating the bonus instead of replacing it, causing the displayed morale to become out of sync with the actual calculated morale.

#### Describe the solution

When updating permanent morale bonuses (like masochist), the game now replaces the old bonus value with the new one instead of adding them together.
0_turns here means that morale bonus is permanent one.

#### Describe alternatives you've considered


#### Testing

Tested with characters having masochist traits and verified that the inconsistency error no longer appears.
You must inflict some pain on them for testing!

Tested with NPCs having masochist trait 

#### Additional context
masochist mutation = pain driven

