### PR TITLE
Don't double move when vehicle traverses ramps

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -10554,7 +10554,7 @@ void game::vertical_move( int movez, bool force, bool peeking )
         if( crit->has_flag( mon_flag_RIDEABLE_MECH ) ) {
             crit->use_mech_power( u.current_movement_mode()->mech_power_use() + 1_kJ );
         }
-    } else {
+    } else if( !u.in_vehicle ) {
         u.mod_moves( -move_cost );
         u.burn_energy_all( -move_cost );
     }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Stop vertical movement resulting from vehicles moving across ramps from robbing the vehicle inhabitants of one turn+.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Exclude vehicle inhabitants from being hit by a 100 move penalty when traversing a ramp. This leads to double movements of the vehicle, and potential crashes as the driver can't provide any input (in particular braking, but also steering) between the first and second turn.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
I used my regular save where I've placed my vehicle on the road to a bridge. Before this change, the vehicle moves twice when going up and down the bridge's ramps (or, more correctly, when the PC gets moved up/down).

After the change the vehicle moves one turn's worth every PC turn input opportunity even when traversing the ramps.

Debug spawned a helicopter and flew it both straight up/down, and up/down while moving. It behaved as I would expect (with the previous experience just straight up/down, so not much to draw upon).

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
I've had several crashes due to this bug, both in the form of not being allowed to break when approaching obstacles on the bridge and after getting off it, and crashes into the railings because I wasn't allowed to break or turn (when clear of the ramp) when not aligned with the bridge (typically due to having to get around an obstacle, such as the stuff included in the now removed mine fields).

It can be noted that the edge case where the PC is in a falling vehicle is treated the same as if the PC is in control over one traversing ramps, i.e. an activity can be taken while in the air (if the fall is long enough), which probably is the correct behavior.

Also went for checking whether the character was in a vehicle rather than just being the driver in order for this to still work in the weird future case of a companion having learnt how to drive and the PC needing to e.g. man the turret while negotiating a bridge.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
