### PR TITLE
fix mod item name inheritance

### DIFF
--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -4134,10 +4134,7 @@ void itype::load( const JsonObject &jo, std::string_view src )
         degrade_increments_ = std::isnan( adjusted_inc ) ? 0 : std::round( adjusted_inc );
     }
 
-    if( !was_loaded ) {
-        name = translation( translation::plural_tag() );
-    }
-
+    name.make_plural();
     mandatory( jo, was_loaded, "name", name );
     optional( jo, was_loaded, "conditional_names", conditional_names );
     optional( jo, was_loaded, "description", description );

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -4134,7 +4134,10 @@ void itype::load( const JsonObject &jo, std::string_view src )
         degrade_increments_ = std::isnan( adjusted_inc ) ? 0 : std::round( adjusted_inc );
     }
 
-    name = translation( translation::plural_tag() );
+    if( !was_loaded ) {
+        name = translation( translation::plural_tag() );
+    }
+
     mandatory( jo, was_loaded, "name", name );
     optional( jo, was_loaded, "conditional_names", conditional_names );
     optional( jo, was_loaded, "description", description );

--- a/tests/json_load_test.cpp
+++ b/tests/json_load_test.cpp
@@ -39,6 +39,14 @@ TEST_CASE( "damage_instance_load_does_not_extend", "[json][damage][load]" )
     CHECK( overwrite.type_damage( damage_heat ) == 0.f );
 }
 
+TEST_CASE( "item_name_inherited_from_copy_from", "[json][item][load]" )
+{
+    REQUIRE( itype_test_copyfrom_base.is_valid() );
+    REQUIRE( itype_test_copyfrom_overwrite.is_valid() );
+
+    CHECK( itype_test_copyfrom_overwrite->nname( 1 ) == "base" );
+}
+
 TEST_CASE( "monster_special_attack_cooldown_inheritance", "[json][monster][load]" )
 {
     REQUIRE( mon_test_base.is_valid() );


### PR DESCRIPTION
#### Summary
Bugfixes "Keep original name when a mod item inherits base item with copy-from but doesn't specify a name"

#### Purpose of change

When a mod inherits from a base item using `copy-from`, and does not specify the `name` property, as Aftershock does for fish, like this:
```
  {
    "type": "ITEM",
    "id": "fish",
    "copy-from": "fish",
    "subtypes": [ "COMESTIBLE" ],
    "comestible_type": "FOOD",
    "variants": [
      {
        "id": "synth",
        "name": { "str_sp": "synth fish" },
        "description": "Pink flesh from a non-existent species of fish, grown in a vat.  Of particularly high quality, it makes for a decent meal even when raw."
      },
      {
        "id": "insect",
        "name": { "str_sp": "arthropod meat" },
        "description": "A large white fillet of meat from the thorax of an alien insect.  It has a slightly sweet taste, and is very nutritious.  Used interchangeably with fish in many recipes."
      }
    ]
  },
```

The expectation is that the `name` will be inherited from the base item. However, it is instead overwritten by an empty string, and the `mandatory()` check is fooled into thinking everything is fine. The item is listed in the recipe components list as an empty string, and the recipes are not searchable by it using the c: prefix.

<img width="1290" height="1660" alt="image" src="https://github.com/user-attachments/assets/65420972-5f46-4309-b140-726d63c91fa0" />
 


#### Describe the solution

The line that sets `name` to `translation( translation::plural_tag() )` basically initialises it in a mode that supports plural with both forms reset to an empty string. However, in the second pass, after `copy-from` has already been processed, `name` is already initialised in this mode and populated with the base item string. To properly override name only if it's specified in the inheriting item, we simply execute this line only if `was_loaded` is `false`, which will always be the case in the first pass, when `copy-from` is being handled.

#### Describe alternatives you've considered

At first, I thought this would be an Aftershock JSON fix, but I realised it's trying to do a legit thing, and the base game has a bug which makes it impossible.

It's still a bit strange that items called "synth fish" and "arthropod meat" cannot be searched in the recipes because they appear as "fillet of fish", but that's a different problem.

#### Testing

Used TDD to confirm the bug and then implement the solution to make it pass.

Manually tested that intentionally overriding the base name also works by temporarily editing the Aftershock JSON.

#### Additional context

I had some test failures for achievements, but they failed both with and without my change.
