### PR TITLE
Fix typos in balthazar.json

### DIFF
--- a/data/mods/Isolation-Protocol/NPC/balthazar.json
+++ b/data/mods/Isolation-Protocol/NPC/balthazar.json
@@ -157,7 +157,7 @@
     "responses": [
       {
         "condition": { "math": [ "iso_balthazar_aid_value > 11" ] },
-        "text": "Ask for increased combat abilities.",
+        "text": "Ask for increasing combat abilities.",
         "topic": "TALK_DONE",
         "show_always": true,
         "show_reason": "Insufficient power.",
@@ -186,7 +186,7 @@
     "type": "talk_topic",
     "id": "ISO_BALTHAZAR_HOW_ARE_YOU",
     "dynamic_line": "<BALTHAZAR_HOW_ARE_YOU>",
-    "responses": [ { "text": "Thats great.", "topic": "TALK_NONE" } ]
+    "responses": [ { "text": "That's great.", "topic": "TALK_NONE" } ]
   },
   {
     "type": "snippet",


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Fix typos for reading smoothness.
The word 'increased' is not proper in meaning. 
The use of 'Thats great.' is kind of network language, but not suitable here, for which you can just use 'Great.'.
 
#### Describe the solution

Fix typos.

#### Describe alternatives you've considered

'Thats great.' -----can also be ----> 'Great.'

#### Testing

Typos.

#### Additional context

Found during localization.

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
