### PR TITLE
Remove focus from all default sidebars

### DIFF
--- a/data/json/ui/sidebar-legacy-compact.json
+++ b/data/json/ui/sidebar-legacy-compact.json
@@ -177,7 +177,7 @@
     "style": "layout",
     "arrange": "rows",
     "//": "TODO Make the temperature look like it used to.",
-    "widgets": [ "pain_desc_no_label", "body_temp_desc_no_label", "focus_num" ]
+    "widgets": [ "pain_desc_no_label", "body_temp_desc_no_label" ]
   },
   {
     "id": "lcom_needs_right_sa_layout",
@@ -185,7 +185,7 @@
     "style": "layout",
     "arrange": "rows",
     "//": "TODO Make the temperature look like it used to.",
-    "widgets": [ "pain_num_label", "body_temp_desc_no_label", "focus_num" ]
+    "widgets": [ "pain_num_label", "body_temp_desc_no_label" ]
   },
   {
     "id": "lcom_needs_layout",

--- a/data/json/ui/sidebar-legacy-labels-narrow.json
+++ b/data/json/ui/sidebar-legacy-labels-narrow.json
@@ -60,9 +60,9 @@
     "id": "ln_focus_move_layout",
     "type": "widget",
     "style": "layout",
-    "label": "Focus/Move",
+    "label": "Move",
     "arrange": "columns",
-    "widgets": [ "focus_num", "move_count_mode_desc" ]
+    "widgets": [ "move_count_mode_desc" ]
   },
   {
     "id": "ln_movement_layout",

--- a/data/json/ui/sidebar-legacy-labels.json
+++ b/data/json/ui/sidebar-legacy-labels.json
@@ -76,7 +76,7 @@
     "style": "layout",
     "label": "Movement",
     "arrange": "rows",
-    "widgets": [ "sound_mood_focus_layout", "ll_stamina_speed_move_layout" ]
+    "widgets": [ "sound_mood_layout", "ll_stamina_speed_move_layout" ]
   },
   {
     "id": "ll_str_dex_power_layout",

--- a/data/json/ui/sidebar-mobile.json
+++ b/data/json/ui/sidebar-mobile.json
@@ -1749,7 +1749,7 @@
     "width": 13,
     "style": "layout",
     "arrange": "minimum_columns",
-    "widgets": [ "l_mood", "i_mood_num", "l_space", "l_focus", "i_focus_num" ],
+    "widgets": [ "l_mood", "i_mood_num" ],
     "type": "widget"
   },
   {

--- a/data/json/ui/sidebar-thick-cleaner.json
+++ b/data/json/ui/sidebar-thick-cleaner.json
@@ -9,7 +9,7 @@
       "ll_limbs_layout",
       "spacer",
       "ll_stats_layout",
-      "sound_mood_focus_layout",
+      "sound_mood_layout",
       "spacer",
       "stamina_speed_layout_full",
       "weary_rest_layout",
@@ -33,7 +33,7 @@
     "arrange": "rows",
     "widgets": [
       "ll_stats_layout",
-      "sound_mood_focus_layout",
+      "sound_mood_layout",
       "spacer",
       "stamina_speed_layout_full",
       "weary_rest_layout",

--- a/data/json/ui/spacebar/spacebar_player_weariness_mood_block.json
+++ b/data/json/ui/spacebar/spacebar_player_weariness_mood_block.json
@@ -12,7 +12,7 @@
     "id": "player_weariness_mood_block_tmp",
     "type": "widget",
     "style": "layout",
-    "label": "Mood/Focus/Weariness",
+    "label": "Mood/Weariness",
     "arrange": "minimum_columns",
     "width": 56,
     "widgets": [ "spacebar_mood_focus_activity_layout", "spacebar_all_weariness_layout" ]
@@ -41,10 +41,10 @@
     "id": "spacebar_mood_focus_activity_layout",
     "type": "widget",
     "style": "layout",
-    "label": "Mood/Focus/Activity",
+    "label": "Mood/Activity",
     "arrange": "rows",
     "width": 28,
-    "widgets": [ "mood_desc_label", "spacebar_focus_graph", "activity_desc" ]
+    "widgets": [ "mood_desc_label", "activity_desc" ]
   },
   {
     "id": "spacebar_focus_graph",

--- a/data/json/ui/structured/structured_health_blocks.json
+++ b/data/json/ui/structured/structured_health_blocks.json
@@ -280,7 +280,7 @@
     "type": "widget",
     "style": "layout",
     "arrange": "minimum_columns",
-    "widgets": [ "structured_focus", "mood_desc_no_label" ]
+    "widgets": [ "mood_desc_no_label" ]
   },
   {
     "id": "structured_focus",

--- a/data/json/ui/zenfs/health.json
+++ b/data/json/ui/zenfs/health.json
@@ -5,7 +5,7 @@
     "style": "layout",
     "arrange": "rows",
     "width": 9,
-    "widgets": [ "mood_desc_label", "focus_num", "speed_num", "sound_num" ]
+    "widgets": [ "mood_desc_label", "speed_num", "sound_num" ]
   },
   {
     "id": "zenfs_weariness_trans_malus",

--- a/src/morale.cpp
+++ b/src/morale.cpp
@@ -725,8 +725,8 @@ void player_morale::display( int focus_eq, int pain_penalty, int sleepiness_pena
         );
     }
     bottom_lines.emplace_back(
-        _( "Focus trends towards:" ), focus_eq,
-        morale_line::number_format::normal,
+        _( "Focus (rate of learning) trends towards:" ), focus_eq,
+        morale_line::number_format::percent,
         morale_line::line_color::normal
     );
     bottom_lines.emplace_back();


### PR DESCRIPTION
#### Summary
Interface "Remove focus from all default sidebars"

#### Purpose of change
All of our sidebars have a "Focus" number.

It occupies valuable sidebar space. It must be important because it's on the sidebar. And worst of all: IT GO DOWN! NUMBER GO DOWN WHEN LEARN! "NUMBER GO DOWN BAD!"

Number going down is actually *good*, that means the focus is being spent and regenerating faster. But the number on the sidebar doesn't, and can't, convey that.

Its presence on the sidebar also suggests that the player should pay attention to it, or interact with it in some way. That they must *do* something.

In fact, there is no way to interact with focus. There are only indirect ways (by adjusting the character's mood) and that only changes the equilibrium. So its presence on the sidebar is a vicious noob trap, spawning hundreds of questions and confusing people ever since it was added.

(The above is basically a summary of a conversation I've had several times before, e.g. : )

<img width="1820" height="902" alt="image" src="https://github.com/user-attachments/assets/b72704ea-6b63-4b9c-aec4-17e785e1e02d" />

<img width="761" height="100" alt="image" src="https://github.com/user-attachments/assets/6a4544e5-2b6e-46dd-8379-aac12f21e184" />


#### Describe the solution
But, focus is doing basically what we want it to, so...

Simply remove it from the default display.

Focus is still there, doing its job. It's just not shoved in your face like it's important that you know the number. Because it's not.

Also updated the status screen --> morale display to more clearly explain what the number is telling you:

(Switched from raw number to displaying it as a percent, added a parenthesis explanation for what the heck `Focus` even is)
<img width="482" height="61" alt="image" src="https://github.com/user-attachments/assets/8617c13b-0980-4deb-a656-9341eb4bd397" />


#### Describe alternatives you've considered

#### Testing
I went through every one of the default sidebars and confirmed that Focus is not displayed anymore.

The layouts seem *okay* after the removal though for example the ZenFS sidebar's very information dense display has a small hole in the center now, which might not be 100% aesthetic.

Some of the alternate windows/that can be toggled on might still have focus displays, but I wasn't going to run down every single instance. It's definitely still available in custom.

#### Additional context

As always an effort was made to preserve sidebar widget IDs, even if they are now inaccurate. Should only be 1 or 2 like that though