### PR TITLE
[Bugfixes] Fixed weight and volume calculations in the insert ui for items counted by charge.

### DIFF
--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -4236,8 +4236,13 @@ inventory_selector::stats inventory_insert_selector::get_raw_stats() const
                         }
                     }
                 }
-                selected_weight += w * overflow_counter;
-                selected_volume += v * overflow_counter;
+                if( e->any_item()->count_by_charges() ) {
+                    selected_weight += w * e->chosen_count / e->get_total_charges();
+                    selected_volume += v * e->chosen_count / e->get_total_charges();
+                } else {
+                    selected_weight += w * overflow_counter;
+                    selected_volume += v * overflow_counter;
+                }
             }
         }
     }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Fixed weight and volume calculations in the insert ui for items counted by charge."

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes #81607
In the insert interface, selecting items counted by charge causes weight errors because the weight is multiplied an extra time by the selected quantity. 
May need a backport?
<img width="718" height="112" alt="image" src="https://github.com/user-attachments/assets/c1b27be4-ed79-41aa-bcd5-763c9eb57daa" />

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
By adding a check to calculate the percentage of the selected object and multiplying it with the object's data, the correct volume and weight are obtained.
The only issue is that I don't know how to hide the total quantity of the item. I'm not sure if this might cause confusion, but it's still better than the previous version, which was way off the mark.
<img width="1884" height="477" alt="image" src="https://github.com/user-attachments/assets/a5469d67-b8df-4489-a3ba-629b6a40c98e" />

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Everything appears to be functioning normally on my end.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
