### PR TITLE
preserve contents when crafting a recipe that upgrades an item

### DIFF
--- a/src/recipe.cpp
+++ b/src/recipe.cpp
@@ -27,6 +27,7 @@
 #include "inventory.h"
 #include "item.h"
 #include "item_components.h"
+#include "item_contents.h"
 #include "item_group.h"
 #include "item_tname.h"
 #include "itype.h"

--- a/src/recipe.cpp
+++ b/src/recipe.cpp
@@ -787,6 +787,19 @@ std::vector<item> recipe::create_result( bool set_components, bool is_food,
                         newit.ammo_capacity( item::find_type( newit.ammo_default() )->ammo->type ) );
     }
 
+    // if the first component has compatible pockets, try to preserve the contents
+    if( used && !used->empty() ) {
+        const item_components::type_vector_pair &first_component_pair = *used->begin();
+
+        if( first_component_pair.second.size() == 1 ) {
+            const item &first_component = first_component_pair.second.front();
+
+            if( !first_component.get_contents().empty() ) {
+                newit.get_contents().combine( first_component.get_contents(), true );
+            }
+        }
+    }
+
     int amount = charges ? *charges : newit.count();
 
     bool is_cooked = hot_result() || removes_raw();


### PR DESCRIPTION
#### Summary
Bugfixes "preserve contents when crafting a recipe that upgrades an item"

#### Purpose of change

When a wearable camera or a wearable professional camera is crafted, the resulting item has all battery charges and photos removed, which is neither realistic nor desirable. We are just attaching a strap to the camera, so its internal stuff should be preserved.

#### Describe the solution

The fix takes the first component of the recipe, makes sure there's only one of the components of that type, and if it's not empty, calls `item:contents::combine()` with convert flag set to true, which seems to be intended to handle this exact scenario.

This kind of solution avoids adding any extra recipe flags to handle only these two recipes, while still allowing recipes to opt out of this behaviour by simply not listing the triggering item as the first component.

The fix should not activate for a hypothetical recipe that takes more than one camera or a similar item. I assume that recipe would involve somehow disassembling the cameras and putting them back together, so a loss of photos and battery charges would be more feasible.

There's no check for pocket compatibility because `item:contents::combine()` already handles not being able to put contents into the destination item. Battery charges and photos are `NO_DROP`, which would result in them being lost if the resulting item was unable to hold them as a container.

#### Describe alternatives you've considered

I've considered adding a recipe flag to explicitly opt into this behaviour, but it seems to be overkill just to handle two recipes.

#### Testing

Tested manually in the game with a wearable professional camera.

I've also tested with a headlamp because it triggers the fix code, but nothing happens because it contains a medium battery, which is already unloaded before the fix code is reached.

#### Additional context

none
