### PR TITLE
[ Xedra Evolved ] Time Freeze shouldn't protect from looping wound

### DIFF
--- a/data/mods/Xedra_Evolved/eocs/chronomancer_eocs.json
+++ b/data/mods/Xedra_Evolved/eocs/chronomancer_eocs.json
@@ -467,18 +467,13 @@
     "id": "EOC_XEDRA_CHRONOMANCER_LOOPING_WOUND_DAMAGE",
     "condition": { "u_has_trait": "XEDRA_CHRONOMANCER_LOOPING_WOUND" },
     "effect": [
-      {
-        "if": { "not": { "u_has_effect": "effect_xedra_time_freeze" } },
-        "then": [
-          { "u_message": "You feel a sharp jolt of pain as a stab wound suddenly opens in your belly!", "type": "bad" },
-          { "math": [ "u_hp('torso')-=10" ] },
-          { "math": [ "u_xedra_last_damage_taken=10" ] },
-          { "set_string_var": "torso", "target_var": { "u_val": "xedra_last_damage_taken_bodypart" } },
-          { "math": [ "u_pain()+=30" ] },
-          { "math": [ "u_xedra_last_pain_taken=30" ] },
-          { "u_add_effect": "bleed", "duration": "10 minutes", "target_part": "torso" }
-        ]
-      },
+      { "u_message": "You feel a sharp jolt of pain as a stab wound suddenly opens in your belly!", "type": "bad" },
+      { "math": [ "u_hp('torso')-=10" ] },
+      { "math": [ "u_xedra_last_damage_taken=10" ] },
+      { "set_string_var": "torso", "target_var": { "u_val": "xedra_last_damage_taken_bodypart" } },
+      { "math": [ "u_pain()+=30" ] },
+      { "math": [ "u_xedra_last_pain_taken=30" ] },
+      { "u_add_effect": "bleed", "duration": "10 minutes", "target_part": "torso" },
       { "run_eocs": "EOC_XEDRA_CHRONOMANCER_LOOPING_WOUND_DAMAGE", "time_in_future": "24 hours" }
     ]
   },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
I've thought about this for a couple days and I get that this is a clever approach but I think this made more sense when you leveled time freeze by use so you'd slowly overshoot your wound moment by more and more.  Now that you can choose to never level time freeze one playstyle is to set an alarm for 2 minutes before your wound loop and never level time freeze beyond that.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Removes the check for time freeze
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
More complicated solutions.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
