### PR TITLE
make pockets check min-volume against volume of single charge

### DIFF
--- a/src/item_pocket.cpp
+++ b/src/item_pocket.cpp
@@ -1431,7 +1431,8 @@ ret_val<item_pocket::contain_code> item_pocket::is_compatible( const item &it ) 
                    contain_code::ERR_TOO_SMALL, _( "item is too short" ) );
     }
 
-    if( it.volume() < data->min_item_volume ) {
+    if( ( it.count_by_charges() ? it.volume( false, false, 1 ) : it.volume() )
+        < data->min_item_volume ) {
         return ret_val<item_pocket::contain_code>::make_failure(
                    contain_code::ERR_TOO_SMALL, _( "item is too small" ) );
     }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Make pockets check volume of a single charge against min_item_volume"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes a broken check that allowed various ways of inserting items into the inventory "directly" (without `g`etting them) to place count_by_charges items into a pocket with a min item volume higher than one charge of the item.

There are various ways to reproduce this, but the most direct one is:
Spawn a "holster" (min item volume: 0.25 L)
Wear the holster and remove all other items with pockets.
Spawn 20 Scrap Metal at once (0.5L for the stack, 0.025L each).
Observe that the scrap metal is somehow in the holster.
Drop the scrap metal.
Attempt to `g`et the scrap metal. Observe that the UI (correctly) prevents you even selecting the scrap, as each piece is too small to fit in your one pocket.

This is not limited to debug spawning. This can happen in gameplay by overfilling a vehicle cargo spot, reloading something while holding the stack of ammo you're reloading with if the reload target won't fit in your inventory (you must unwield the ammo, and the menu allows you to place the ammo stack in the holster if it's correctly sized), buying ammo from a vending machine, and other places.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Make `item_pocket::is_compatible` check min_item_volume against 1 charge of the given item, instead of the whole stack. `i_add` (`i_add_or_drop`, etc) which directly add items to the inventory use this to determine valid destination pockets.
The comment directly above this code says `// count_by_charges items check volume of single charge` which implies this fix is the intended behavior.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Modify i_add so that the item checked has 1 charge, like `Character::can_pickVolume_partial` does. is_compatible seems more comprehensive.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
While wearing a holster:
- spawned ~0.5L stacks of scrap metal and 5.56 ammo to see they are spawned on the ground.
- Wielded a stack of 1020 scrap metal and dropped it into into the bucket seat of a cube van to see the extra remains wielded instead of placed in inventory.
- While wielding 80 rounds of 5.56, reloaded a 40-round STANAG magazine that is on the ground (the holster must also blacklist the magazine). The option to stow the ammo is now not available, it can only be dropped.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
None
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
