### PR TITLE
Adding missing cooked fae meat recipes

### DIFF
--- a/data/mods/Xedra_Evolved/items/carnivore.json
+++ b/data/mods/Xedra_Evolved/items/carnivore.json
@@ -94,7 +94,7 @@
     "spoils_in": "1 day",
     "type": "ITEM",
     "subtypes": [ "COMESTIBLE" ],
-    "name": { "str_sp": "cooked meat" },
+    "name": { "str_sp": "cooked fae meat" },
     "description": "This is a chunk of freshly cooked fae meat.  It's filling and nutritious, but unseasoned and a bit bland.",
     "price": "7 USD 50 cent",
     "price_postapoc": "1 USD",

--- a/data/mods/Xedra_Evolved/recipes/food/recipe_food.json
+++ b/data/mods/Xedra_Evolved/recipes/food/recipe_food.json
@@ -1,0 +1,29 @@
+[
+  {
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "result": "fae_meat_cooked",
+    "category": "CC_FOOD",
+    "subcategory": "CSC_FOOD_MEAT",
+    "skill_used": "cooking",
+    "time": "15 m",
+    "autolearn": true,
+    "batch_time_factors": [ 67, 5 ],
+    "qualities": [ { "id": "COOK", "level": 1 } ],
+    "tools": [ [ [ "surface_heat", 20, "LIST" ] ] ],
+    "//": "20u energy to cook a meat chunk per standard",
+    "proficiencies": [ { "proficiency": "prof_food_prep" } ],
+    "components": [ [ [ "fae_meat", 1 ] ] ]
+  },
+  {
+    "type": "recipe",
+    "activity_level": "NO_EXERCISE",
+    "result": "fae_meat_scrap_cooked",
+    "copy-from": "fae_meat_cooked",
+    "time": "45 s",
+    "qualities": [ { "id": "COOK", "level": 1 } ],
+    "tools": [ [ [ "surface_heat", 2, "LIST" ] ] ],
+    "//": "2u heat to cook 30g of flesh",
+    "components": [ [ [ "fae_meat_scrap", 1 ] ] ]
+  }
+]


### PR DESCRIPTION
There items, but none recipes to make them. It's old issue, reported #77460 and even earlier if look in discord history.

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:

#### Summary
None

#### Purpose of change

There was cooked version of fae meat but none recipes, so i done them. It's old issue.

#### Describe alternatives you've considered

Add items and recipes not only to mere cooked, but other feat meat's food. For example pepper meat.

#### Testing

Spawn fae meat and scrap, spawn cooking implemetn, cook them
