### PR TITLE
Update debug warnings to reflect #83956

### DIFF
--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -4464,7 +4464,7 @@ void debug()
             break;
         case debug_menu_index::QUIT_NOSAVE:
             if( query_yn(
-                    _( "Quit without saving?  This may cause issues such as duplicated or missing items and vehicles!" ) ) ) {
+                    _( "Quit without saving?  This will mark save as 'dirty' and disable future saving to prevent accidental overwriting save.  Also this may cause issues such as duplicated or missing items and vehicles!" ) ) ) {
                 player_character.set_moves( 0 );
                 g->uquit = QUIT_NOSAVED;
                 g->save_is_dirty = true;
@@ -4472,7 +4472,7 @@ void debug()
             break;
         case debug_menu_index::QUICKLOAD:
             if( query_yn(
-                    _( "Quickload without saving?  This may cause issues such as duplicated or missing items and vehicles!" ) ) ) {
+                    _( "Quickload without saving?  This will mark save as 'dirty' and disable future saving to prevent accidental overwriting save.  Also this may cause issues such as duplicated or missing items and vehicles!" ) ) ) {
                 g->quickload();
                 g->save_is_dirty = true;
             }

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -4464,7 +4464,7 @@ void debug()
             break;
         case debug_menu_index::QUIT_NOSAVE:
             if( query_yn(
-                    _( "Quit without saving?  This will mark save as 'dirty' and disable future saving to prevent accidental overwriting save.  Also this may cause issues such as duplicated or missing items and vehicles!" ) ) ) {
+                    _( "Quit without saving?  This may cause issues such as duplicated or missing items and vehicles!" ) ) ) {
                 player_character.set_moves( 0 );
                 g->uquit = QUIT_NOSAVED;
                 g->save_is_dirty = true;


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

There are big difference "have chances to corrupt/break save" and "will disable saving", that was added by #83956. With this change debug user will fully informed about сonsequences of this actions.

#### Describe alternatives you've considered

add option to quit without saving that not mark save as dirty, like there two quick setup options one usual, and one that marks save as dirty. You still can quit without saving and dirtying save by killing game process task manager, so it's optional. 
