### PR TITLE
Make focus widget number go UP when "optimizing" learning

### DIFF
--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -686,10 +686,10 @@ void widget::set_default_var_range( const avatar &ava )
             _var_max = 1000;
             break;
         case widget_var::focus:
-            _var_min = 0;
-            _var_max = 200;
+            _var_min = -100;
+            _var_max = 100;
             // Small range of normal focus that won't be color-coded
-            _var_norm = std::make_pair( 90, 110 );
+            _var_norm = std::make_pair( 0, 20 );
             break;
         case widget_var::health:
             _var_min = -200;
@@ -894,7 +894,7 @@ int widget::get_var_value( const avatar &ava ) const
             }
             break;
         case widget_var::focus:
-            value = ava.get_focus();
+            value = ava.calc_focus_equilibrium() - ava.get_focus();
             break;
         case widget_var::speed:
             value = ava.get_speed();

--- a/tests/widget_test.cpp
+++ b/tests/widget_test.cpp
@@ -718,9 +718,11 @@ TEST_CASE( "widgets_showing_avatar_attributes", "[widget][avatar]" )
         widget focus_w = widget_test_focus_num.obj();
 
         ava.set_focus( 75 );
-        CHECK( focus_w.layout( ava ) == "FOCUS: 75" );
+        // The Focus widget has been changed to show distance from equilibrium. During these tests, equilibrium is 100.
+        CHECK( focus_w.layout( ava ) == "FOCUS: 25" );
         ava.set_focus( 120 );
-        CHECK( focus_w.layout( ava ) == "FOCUS: 120" );
+        // In this case we're above the equilibrium and our focus_pool is going to drop, so we want to display a negative number.
+        CHECK( focus_w.layout( ava ) == "FOCUS: -20" );
     }
 
     SECTION( "mana pool" ) {
@@ -1893,17 +1895,17 @@ TEST_CASE( "layout_widgets_in_columns", "[widget][layout][columns]" )
 
     // Three columns
     // string ruler:                     1234567890123456789012345678901234567890
-    CHECK( three_w.layout( ava, 36 ) == "MOVE: 50     SPEED: 100   FOCUS: 120" );
-    CHECK( three_w.layout( ava, 37 ) == "MOVE: 50     SPEED: 100   FOCUS: 120 " );
-    CHECK( three_w.layout( ava, 38 ) == "MOVE: 50      SPEED: 100   FOCUS: 120 " );
-    CHECK( three_w.layout( ava, 39 ) == "MOVE: 50      SPEED: 100    FOCUS: 120 " );
-    CHECK( three_w.layout( ava, 40 ) == "MOVE: 50      SPEED: 100    FOCUS: 120  " );
-    CHECK( three_w.layout( ava, 41 ) == "MOVE: 50       SPEED: 100    FOCUS: 120  " );
-    CHECK( three_w.layout( ava, 42 ) == "MOVE: 50       SPEED: 100     FOCUS: 120  " );
-    CHECK( three_w.layout( ava, 43 ) == "MOVE: 50       SPEED: 100     FOCUS: 120   " );
-    CHECK( three_w.layout( ava, 44 ) == "MOVE: 50        SPEED: 100     FOCUS: 120   " );
-    CHECK( three_w.layout( ava, 45 ) == "MOVE: 50        SPEED: 100      FOCUS: 120   " );
-    CHECK( three_w.layout( ava, 46 ) == "MOVE: 50        SPEED: 100      FOCUS: 120    " );
+    CHECK( three_w.layout( ava, 36 ) == "MOVE: 50     SPEED: 100   FOCUS: -20" );
+    CHECK( three_w.layout( ava, 37 ) == "MOVE: 50     SPEED: 100   FOCUS: -20 " );
+    CHECK( three_w.layout( ava, 38 ) == "MOVE: 50      SPEED: 100   FOCUS: -20 " );
+    CHECK( three_w.layout( ava, 39 ) == "MOVE: 50      SPEED: 100    FOCUS: -20 " );
+    CHECK( three_w.layout( ava, 40 ) == "MOVE: 50      SPEED: 100    FOCUS: -20  " );
+    CHECK( three_w.layout( ava, 41 ) == "MOVE: 50       SPEED: 100    FOCUS: -20  " );
+    CHECK( three_w.layout( ava, 42 ) == "MOVE: 50       SPEED: 100     FOCUS: -20  " );
+    CHECK( three_w.layout( ava, 43 ) == "MOVE: 50       SPEED: 100     FOCUS: -20   " );
+    CHECK( three_w.layout( ava, 44 ) == "MOVE: 50        SPEED: 100     FOCUS: -20   " );
+    CHECK( three_w.layout( ava, 45 ) == "MOVE: 50        SPEED: 100      FOCUS: -20   " );
+    CHECK( three_w.layout( ava, 46 ) == "MOVE: 50        SPEED: 100      FOCUS: -20    " );
     // string ruler:                     1234567890123456789012345678901234567890123456
 
     // Four columns
@@ -1929,19 +1931,19 @@ TEST_CASE( "layout_widgets_in_columns", "[widget][layout][columns]" )
     // Layout keeps labels vertically aligned for layouts with the same number of widgets
     // string ruler:                    123456789012345678901234567890123456789012345678
     CHECK( stat_w.layout( ava, 48 ) == "STR: 8       DEX: 8       INT: 8      PER: 8    " );
-    CHECK( four_w.layout( ava, 48 ) == "MOVE: 50     SPEED: 100   FOCUS: 120  MANA: 1000" );
+    CHECK( four_w.layout( ava, 48 ) == "MOVE: 50     SPEED: 100   FOCUS: -20  MANA: 1000" );
 
     // string ruler:                    1234567890123456789012345678901234567890123456789012
     CHECK( stat_w.layout( ava, 52 ) == "STR: 8        DEX: 8        INT: 8       PER: 8     " );
-    CHECK( four_w.layout( ava, 52 ) == "MOVE: 50      SPEED: 100    FOCUS: 120   MANA: 1000 " );
+    CHECK( four_w.layout( ava, 52 ) == "MOVE: 50      SPEED: 100    FOCUS: -20   MANA: 1000 " );
 
     // string ruler:                    12345678901234567890123456789012345678901234567890123456
     CHECK( stat_w.layout( ava, 56 ) == "STR: 8         DEX: 8         INT: 8        PER: 8      " );
-    CHECK( four_w.layout( ava, 56 ) == "MOVE: 50       SPEED: 100     FOCUS: 120    MANA: 1000  " );
+    CHECK( four_w.layout( ava, 56 ) == "MOVE: 50       SPEED: 100     FOCUS: -20    MANA: 1000  " );
 
     // string ruler:                    123456789012345678901234567890123456789012345678901234567890
     CHECK( stat_w.layout( ava, 60 ) == "STR: 8          DEX: 8          INT: 8         PER: 8       " );
-    CHECK( four_w.layout( ava, 60 ) == "MOVE: 50        SPEED: 100      FOCUS: 120     MANA: 1000   " );
+    CHECK( four_w.layout( ava, 60 ) == "MOVE: 50        SPEED: 100      FOCUS: -20     MANA: 1000   " );
 }
 
 TEST_CASE( "widgets_showing_weather_conditions", "[widget][weather]" )
@@ -2718,7 +2720,7 @@ TEST_CASE( "widget_rows_in_columns", "[widget]" )
         const std::string expected = string_join( std::vector<std::string> {
             brown_dot, brown_dot, brown_dot, "         MOVE:  0    STR: 8    \n",
             brown_dot, h_brown_dot, brown_dot, "         SPEED: 100  DEX: 8    \n",
-            brown_dot, brown_dot, brown_dot, "         FOCUS: 100  INT: 8    \n",
+            brown_dot, brown_dot, brown_dot, "         FOCUS: 0    INT: 8    \n",
             "            MANA: 1000  PER: 8    "
         }, "" );
         widget wgt = widget_test_layout_rows_in_columns.obj();
@@ -2751,7 +2753,7 @@ TEST_CASE( "widget_rows_in_columns", "[widget]" )
                 brown_dot,
                 brown_dot,
                 brown_dot,
-                "         FOCUS: 100  INT: 8   \n"
+                "         FOCUS: 0    INT: 8   \n"
             }, "" ),
             "                                               MANA: 1000  PER: 8   "
         }, "" );


### PR DESCRIPTION
#### Summary
Interface "Make focus widget number go UP when 'optimizing' learning"

#### Purpose of change
Alternative to #84059

#### Describe the solution
Once again we abuse human psychology

#### Describe alternatives you've considered
Honestly I have been taken by arguments for removing focus entirely. But that is a ton of work, so maybe this little bit will be enough.

#### Testing
<img width="90" height="29" alt="image" src="https://github.com/user-attachments/assets/19a993d7-ee38-48c1-8808-447ad5363792" />

"Focus" continues to rise as you're spending the most possible focus_pool

"Focus" drops when you're not spending as much as possible.


#### Additional context
