### PR TITLE
[Magiclysm/Bombastic Perks] Metamagic perks are toggleable

### DIFF
--- a/data/mods/BombasticPerks/perkdata/metamagic/careful.json
+++ b/data/mods/BombasticPerks/perkdata/metamagic/careful.json
@@ -1,13 +1,13 @@
 [
   {
     "type": "effect_on_condition",
-    "id": "EOC_metamagic_toggle_careful",
-    "condition": { "compare_string": [ "yes", { "u_val": "perk_metamagic_careful_deactivated" } ] },
+    "id": "EOC_metamagic_toggle_careful_on",
+    "effect": [ { "u_add_var": "perk_metamagic_careful_deactivated", "value": "no" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_metamagic_toggle_careful_off",
     "effect": [
-      { "u_message": "You activate your careful metamagic" },
-      { "u_add_var": "perk_metamagic_careful_deactivated", "value": "no" }
-    ],
-    "false_effect": [
       { "u_message": "You deactivate your careful metamagic" },
       { "u_add_var": "perk_metamagic_careful_deactivated", "value": "yes" }
     ]

--- a/data/mods/BombasticPerks/perkdata/metamagic/efficient.json
+++ b/data/mods/BombasticPerks/perkdata/metamagic/efficient.json
@@ -1,13 +1,13 @@
 [
   {
     "type": "effect_on_condition",
-    "id": "EOC_metamagic_toggle_efficient",
-    "condition": { "compare_string": [ "yes", { "u_val": "perk_metamagic_efficient_deactivated" } ] },
+    "id": "EOC_metamagic_toggle_efficient_on",
+    "effect": [ { "u_add_var": "perk_metamagic_efficient_deactivated", "value": "no" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_metamagic_toggle_efficient_off",
     "effect": [
-      { "u_message": "You activate your efficient metamagic" },
-      { "u_add_var": "perk_metamagic_efficient_deactivated", "value": "no" }
-    ],
-    "false_effect": [
       { "u_message": "You deactivate your efficient metamagic" },
       { "u_add_var": "perk_metamagic_efficient_deactivated", "value": "yes" }
     ]

--- a/data/mods/BombasticPerks/perkdata/metamagic/intuitive.json
+++ b/data/mods/BombasticPerks/perkdata/metamagic/intuitive.json
@@ -1,13 +1,13 @@
 [
   {
     "type": "effect_on_condition",
-    "id": "EOC_metamagic_toggle_intuitive",
-    "condition": { "compare_string": [ "yes", { "u_val": "perk_metamagic_intuitive_deactivated" } ] },
+    "id": "EOC_metamagic_toggle_intuitive_on",
+    "effect": [ { "u_add_var": "perk_metamagic_intuitive_deactivated", "value": "no" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_metamagic_toggle_intuitive_off",
     "effect": [
-      { "u_message": "You activate your intuitive metamagic" },
-      { "u_add_var": "perk_metamagic_intuitive_deactivated", "value": "no" }
-    ],
-    "false_effect": [
       { "u_message": "You deactivate your intuitive metamagic" },
       { "u_add_var": "perk_metamagic_intuitive_deactivated", "value": "yes" }
     ]

--- a/data/mods/BombasticPerks/perkdata/metamagic/quicken.json
+++ b/data/mods/BombasticPerks/perkdata/metamagic/quicken.json
@@ -1,13 +1,13 @@
 [
   {
     "type": "effect_on_condition",
-    "id": "EOC_metamagic_toggle_quicken",
-    "condition": { "compare_string": [ "yes", { "u_val": "perk_metamagic_quicken_deactivated" } ] },
+    "id": "EOC_metamagic_toggle_quicken_on",
+    "effect": [ { "u_add_var": "perk_metamagic_quicken_deactivated", "value": "no" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_metamagic_toggle_quicken_off",
     "effect": [
-      { "u_message": "You activate your quicken metamagic" },
-      { "u_add_var": "perk_metamagic_quicken_deactivated", "value": "no" }
-    ],
-    "false_effect": [
       { "u_message": "You deactivate your quicken metamagic" },
       { "u_add_var": "perk_metamagic_quicken_deactivated", "value": "yes" }
     ]

--- a/data/mods/BombasticPerks/perkdata/metamagic/reach.json
+++ b/data/mods/BombasticPerks/perkdata/metamagic/reach.json
@@ -1,13 +1,13 @@
 [
   {
     "type": "effect_on_condition",
-    "id": "EOC_metamagic_toggle_reach",
-    "condition": { "compare_string": [ "yes", { "u_val": "perk_metamagic_reach_deactivated" } ] },
+    "id": "EOC_metamagic_toggle_reach_on",
+    "effect": [ { "u_add_var": "perk_metamagic_reach_deactivated", "value": "no" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_metamagic_toggle_reach_off",
     "effect": [
-      { "u_message": "You activate your reach metamagic" },
-      { "u_add_var": "perk_metamagic_reach_deactivated", "value": "no" }
-    ],
-    "false_effect": [
       { "u_message": "You deactivate your reach metamagic" },
       { "u_add_var": "perk_metamagic_reach_deactivated", "value": "yes" }
     ]

--- a/data/mods/BombasticPerks/perkdata/metamagic/silent.json
+++ b/data/mods/BombasticPerks/perkdata/metamagic/silent.json
@@ -1,13 +1,13 @@
 [
   {
     "type": "effect_on_condition",
-    "id": "EOC_metamagic_toggle_silent",
-    "condition": { "compare_string": [ "yes", { "u_val": "perk_metamagic_silent_deactivated" } ] },
+    "id": "EOC_metamagic_toggle_silent_on",
+    "effect": [ { "u_add_var": "perk_metamagic_silent_deactivated", "value": "no" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_metamagic_toggle_silent_off",
     "effect": [
-      { "u_message": "You activate your silent metamagic" },
-      { "u_add_var": "perk_metamagic_silent_deactivated", "value": "no" }
-    ],
-    "false_effect": [
       { "u_message": "You deactivate your silent metamagic" },
       { "u_add_var": "perk_metamagic_silent_deactivated", "value": "yes" }
     ]

--- a/data/mods/BombasticPerks/perkdata/metamagic/still.json
+++ b/data/mods/BombasticPerks/perkdata/metamagic/still.json
@@ -1,13 +1,13 @@
 [
   {
     "type": "effect_on_condition",
-    "id": "EOC_metamagic_toggle_still",
-    "condition": { "compare_string": [ "yes", { "u_val": "perk_metamagic_still_deactivated" } ] },
+    "id": "EOC_metamagic_toggle_still_on",
+    "effect": [ { "u_add_var": "perk_metamagic_still_deactivated", "value": "no" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_metamagic_toggle_still_off",
     "effect": [
-      { "u_message": "You activate your still metamagic" },
-      { "u_add_var": "perk_metamagic_still_deactivated", "value": "no" }
-    ],
-    "false_effect": [
       { "u_message": "You deactivate your still metamagic" },
       { "u_add_var": "perk_metamagic_still_deactivated", "value": "yes" }
     ]

--- a/data/mods/BombasticPerks/perkdata/metamagic/widen.json
+++ b/data/mods/BombasticPerks/perkdata/metamagic/widen.json
@@ -1,13 +1,13 @@
 [
   {
     "type": "effect_on_condition",
-    "id": "EOC_metamagic_toggle_widen",
-    "condition": { "compare_string": [ "yes", { "u_val": "perk_metamagic_widen_deactivated" } ] },
+    "id": "EOC_metamagic_toggle_widen_on",
+    "effect": [ { "u_add_var": "perk_metamagic_widen_deactivated", "value": "no" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_metamagic_toggle_widen_off",
     "effect": [
-      { "u_message": "You activate your widen metamagic" },
-      { "u_add_var": "perk_metamagic_widen_deactivated", "value": "no" }
-    ],
-    "false_effect": [
       { "u_message": "You deactivate your widen metamagic" },
       { "u_add_var": "perk_metamagic_widen_deactivated", "value": "yes" }
     ]

--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -808,7 +808,10 @@
     "valid": false,
     "description": "You have learned to cast spells in a way that is much quicker, but also more wasteful.  -95% cast time, +100% cast cost.  Can be toggled on or of by activating this trait.  Does not work on spells that consumes runes.",
     "active": true,
-    "activated_eocs": [ "EOC_metamagic_toggle_quicken" ]
+    "activated_is_setup": true,
+    "activation_msg": "You activate your quicken metamagic.",
+    "activated_eocs": [ "EOC_metamagic_toggle_quicken_on" ],
+    "deactivated_eocs": [ "EOC_metamagic_toggle_quicken_off" ]
   },
   {
     "type": "mutation",
@@ -819,7 +822,10 @@
     "valid": false,
     "description": "You have learned to cast spells that affects a larger area.  +100% area of effect, +50% cast cost.  Can be toggled on or of by activating this trait.  Does not work on spells that consumes runes.",
     "active": true,
-    "activated_eocs": [ "EOC_metamagic_toggle_widen" ]
+    "activated_is_setup": true,
+    "activation_msg": "You activate your widen metamagic.",
+    "activated_eocs": [ "EOC_metamagic_toggle_widen_on" ],
+    "deactivated_eocs": [ "EOC_metamagic_toggle_widen_off" ]
   },
   {
     "type": "mutation",
@@ -830,7 +836,10 @@
     "valid": false,
     "description": "You have learned to cast spells from a longer distance.  +100% reach, +50% cast cost.  Can be toggled on or of by activating this trait.  Does not work on spells that consumes runes.",
     "active": true,
-    "activated_eocs": [ "EOC_metamagic_toggle_reach" ]
+    "activated_is_setup": true,
+    "activation_msg": "You activate your reach metamagic.",
+    "activated_eocs": [ "EOC_metamagic_toggle_reach_on" ],
+    "deactivated_eocs": [ "EOC_metamagic_toggle_reach_off" ]
   },
   {
     "type": "mutation",
@@ -841,7 +850,10 @@
     "valid": false,
     "description": "You have learned to cast spells quietly.  -100% noise, +20% cast cost, ignores mouth encumbrance.  Can be toggled on or of by activating this trait.  Does not work on spells that consumes runes.",
     "active": true,
-    "activated_eocs": [ "EOC_metamagic_toggle_silent" ]
+    "activated_is_setup": true,
+    "activation_msg": "You activate your silent metamagic.",
+    "activated_eocs": [ "EOC_metamagic_toggle_silent_on" ],
+    "deactivated_eocs": [ "EOC_metamagic_toggle_silent_off" ]
   },
   {
     "type": "mutation",
@@ -852,7 +864,10 @@
     "valid": false,
     "description": "You have learned to cast spells without moving.  +20% cast cost, ignores arm, leg, and hand encumbrance.  Can cast spells while holding items.  Can be toggled on or of by activating this trait.  Does not work on spells that consumes runes.",
     "active": true,
-    "activated_eocs": [ "EOC_metamagic_toggle_still" ]
+    "activated_is_setup": true,
+    "activation_msg": "You activate your still metamagic.",
+    "activated_eocs": [ "EOC_metamagic_toggle_still_on" ],
+    "deactivated_eocs": [ "EOC_metamagic_toggle_still_off" ]
   },
   {
     "type": "mutation",
@@ -863,7 +878,10 @@
     "valid": false,
     "description": "You take your time when casting spells in order to get it right.  +200% cast time, -5 difficulty.  Can be toggled on or of by activating this trait.",
     "active": true,
-    "activated_eocs": [ "EOC_metamagic_toggle_careful" ]
+    "activated_is_setup": true,
+    "activation_msg": "You activate your careful metamagic.",
+    "activated_eocs": [ "EOC_metamagic_toggle_careful_on" ],
+    "deactivated_eocs": [ "EOC_metamagic_toggle_careful_off" ]
   },
   {
     "type": "mutation",
@@ -874,7 +892,10 @@
     "valid": false,
     "description": "You can cast your spells more efficiently at the cost of a more difficult cast.  *75% casting cost, +5 difficulty.  Can be toggled on or of by activating this trait.",
     "active": true,
-    "activated_eocs": [ "EOC_metamagic_toggle_efficient" ]
+    "activated_is_setup": true,
+    "activation_msg": "You activate your efficient metamagic.",
+    "activated_eocs": [ "EOC_metamagic_toggle_efficient_on" ],
+    "deactivated_eocs": [ "EOC_metamagic_toggle_efficient_off" ]
   },
   {
     "type": "mutation",
@@ -885,7 +906,10 @@
     "valid": false,
     "description": "Casting spells comes more naturally for you.  You don't have to think as much when casting.  Focus no longer affects casting, +20% cast cost.  Can be toggled on or of by activating this trait.  Only affects spells that are affected by focus.  Does not work on spells that consumes runes.",
     "active": true,
-    "activated_eocs": [ "EOC_metamagic_toggle_intuitive" ]
+    "activated_is_setup": true,
+    "activation_msg": "You activate your intuitive metamagic.",
+    "activated_eocs": [ "EOC_metamagic_toggle_intuitive_on" ],
+    "deactivated_eocs": [ "EOC_metamagic_toggle_intuitive_off" ]
   },
   {
     "type": "mutation",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[Magiclysm/Bombastic Perks] Metamagic perks are toggleable"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Someone on the community discord mentioned it was difficult to tell if your metamagic perks are active or not.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add `"activated_is_setup": true` to all metamagic perks, causing them to turn green when active and stop being green when not active.

Rework the EoCs to account for this change.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Turned metamagic perks on and off, made sure they worked.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

In existing games you _may_ have to turn your perks on and off if you load a game with them active to set them properly, but doing that will reset all the variables
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
