### PR TITLE
Cut the middleman: Washing Kit

### DIFF
--- a/data/json/itemgroups/SUS/supermarket.json
+++ b/data/json/itemgroups/SUS/supermarket.json
@@ -719,7 +719,7 @@
     "id": "commercial_household_laundry",
     "type": "item_group",
     "subtype": "distribution",
-    "items": [ [ "washboard", 1 ], [ "sponge", 1 ], [ "brush", 1 ], [ "liquid_soap", 1 ] ]
+    "items": [ [ "wash_kit", 1 ], [ "sponge", 1 ], [ "brush", 1 ], [ "liquid_soap", 1 ] ]
   },
   {
     "id": "SUS_shelf_commercial_laundry",

--- a/data/json/itemgroups/SUS/supermarket.json
+++ b/data/json/itemgroups/SUS/supermarket.json
@@ -719,7 +719,7 @@
     "id": "commercial_household_laundry",
     "type": "item_group",
     "subtype": "distribution",
-    "items": [ [ "wash_kit", 1 ], [ "sponge", 1 ], [ "brush", 1 ], [ "liquid_soap", 1 ] ]
+    "items": [ [ "sponge", 1 ], [ "brush", 1 ], [ "liquid_soap", 1 ] ]
   },
   {
     "id": "SUS_shelf_commercial_laundry",

--- a/data/json/itemgroups/art_antiques_crafts.json
+++ b/data/json/itemgroups/art_antiques_crafts.json
@@ -168,7 +168,7 @@
     "entries": [
       { "group": "coins", "prob": 1, "count": [ 1, 10 ] },
       { "item": "oxylamp", "prob": 50 },
-      { "item": "washboard", "prob": 20 },
+      { "item": "wash_kit", "prob": 20 },
       { "item": "cow_bell", "prob": 15 },
       { "item": "sickle", "prob": 2 },
       { "item": "scythe", "prob": 2 },

--- a/data/json/items/tool/toiletries.json
+++ b/data/json/items/tool/toiletries.json
@@ -259,24 +259,6 @@
     "tool_ammo": [ "soap" ]
   },
   {
-    "id": "washboard",
-    "type": "ITEM",
-    "subtypes": [ "TOOL" ],
-    "name": { "str": "washboard" },
-    "description": "A wooden washboard.  You can use it to wash filthy clothing if it's supplied with cleansing agent.",
-    "weight": "1160 g",
-    "volume": "900 ml",
-    "longest_side": "40 cm",
-    "price": "10 USD",
-    "price_postapoc": "50 cent",
-    "to_hit": { "grip": "solid", "length": "short", "surface": "any", "balance": "neutral" },
-    "material": [ "wood" ],
-    "symbol": ";",
-    "color": "white",
-    "use_action": [ "WASH_SOFT_ITEMS" ],
-    "flags": [ "ALLOWS_REMOTE_USE" ]
-  },
-  {
     "id": "wash_kit",
     "type": "ITEM",
     "subtypes": [ "TOOL" ],

--- a/data/json/obsoletion_and_migration_0.J/migration_items.json
+++ b/data/json/obsoletion_and_migration_0.J/migration_items.json
@@ -371,7 +371,7 @@
   },
   {
     "type": "MIGRATION",
-    "id": "washingboard",
+    "id": "washboard",
     "replace": "wash_kit"
   }
 ]

--- a/data/json/obsoletion_and_migration_0.J/migration_items.json
+++ b/data/json/obsoletion_and_migration_0.J/migration_items.json
@@ -368,5 +368,10 @@
     "type": "MIGRATION",
     "id": "mre_strawberry_cake",
     "replace": "mre_chocolate_cake"
+  },
+  {
+    "type": "MIGRATION",
+    "id": "washingboard",
+    "replace": "wash_kit"
   }
 ]

--- a/data/json/recipes/recipe_others.json
+++ b/data/json/recipes/recipe_others.json
@@ -2376,16 +2376,17 @@
   },
   {
     "type": "recipe",
-    "activity_level": "NO_EXERCISE",
+    "activity_level": "MODERATE_EXERCISE",
     "result": "wash_kit",
     "category": "CC_OTHER",
     "subcategory": "CSC_OTHER_TOOLS",
-    "skill_used": "survival",
-    "reversible": true,
-    "time": "1 s",
+    "skill_used": "fabrication",
+    "difficulty": 1,
+    "time": "25 m",
     "autolearn": true,
-    "components": [ [ [ "washboard", 1 ] ], [ [ "sponge", 1 ], [ "cotton_patchwork", 1 ], [ "brush", 1 ], [ "dish_towel", 1 ] ] ],
-    "flags": [ "BLIND_EASY" ]
+    "proficiencies": [ { "proficiency": "prof_carving" } ],
+    "qualities": [ { "id": "CUT", "level": 2 } ],
+    "components": [ [ [ "2x4", 1 ] ], [ [ "sponge", 1 ], [ "cotton_patchwork", 1 ], [ "brush", 1 ], [ "dish_towel", 1 ] ] ]
   },
   {
     "type": "recipe",

--- a/data/json/recipes/tools/tools_hand.json
+++ b/data/json/recipes/tools/tools_hand.json
@@ -1818,20 +1818,6 @@
   },
   {
     "type": "recipe",
-    "activity_level": "MODERATE_EXERCISE",
-    "result": "washboard",
-    "category": "CC_OTHER",
-    "subcategory": "CSC_OTHER_TOOLS",
-    "skill_used": "fabrication",
-    "difficulty": 1,
-    "time": "25 m",
-    "autolearn": true,
-    "proficiencies": [ { "proficiency": "prof_carving" } ],
-    "qualities": [ { "id": "CUT", "level": 2 } ],
-    "components": [ [ [ "2x4", 1 ] ] ]
-  },
-  {
-    "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",
     "result": "draw_plate",
     "category": "CC_OTHER",

--- a/data/mods/TEST_DATA/known_bad_density.json
+++ b/data/mods/TEST_DATA/known_bad_density.json
@@ -153,7 +153,6 @@
       "inj_iron",
       "gelatin_extracted",
       "nyquil",
-      "washboard",
       "steel_ballistic_plate",
       "wood_plate",
       "nailgun",

--- a/data/mods/TEST_DATA/known_bad_uncrafts.json
+++ b/data/mods/TEST_DATA/known_bad_uncrafts.json
@@ -2072,7 +2072,6 @@
       "wakizashi_fake",
       "wall_light",
       "walnut",
-      "wash_kit",
       "washing_machine",
       "water_mill",
       "water_purifier",


### PR DESCRIPTION

#### Summary
None

#### Purpose of change
Just cut the middle man and just remove washboard item in the washing kit recipe, make washing kit recipe directly make said washboard instead. Suggested by @RenechCDDA 

#### Describe the solution
Modify washing kit recipe to reflect the fact ya crafting a washboard when making it, obsolete washboard.

#### Describe alternatives you've considered

Nah.

#### Testing

![Screenshot_20251208_052336](https://github.com/user-attachments/assets/18ce0cd9-b067-44a8-a83f-ac17411f0e76)



#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
