### PR TITLE
restrict follower sleep spot to the same vehicle when player sleeping in a vehicle

### DIFF
--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -1710,7 +1710,27 @@ void npc::execute_action( npc_action action )
             // Find a nice spot to sleep
             tripoint_bub_ms best_spot = pos_bub();
             int best_sleepy = evaluate_sleep_spot( best_spot );
-            for( const tripoint_bub_ms &p : closest_points_first( pos_bub(), MAX_VIEW_DISTANCE ) ) {
+
+            // first build a list of positions to search
+            std::vector<tripoint_bub_ms> search_positions;
+
+            if( is_walking_with() && player_character.in_vehicle && player_character.in_sleep_state() ) {
+                const optional_vpart_position player_part_pos = here.veh_at( player_character.pos_bub() );
+                if( player_part_pos ) {
+                    vehicle *player_vehicle = &player_part_pos->vehicle();
+                    for( const vpart_reference &part : player_vehicle->get_avail_parts( VPFLAG_BOARDABLE ) ) {
+                        search_positions.push_back( player_vehicle->bub_part_pos( here, part.part() ) );
+                    }
+                }
+            }
+
+            if( search_positions.empty() ) {
+                search_positions = closest_points_first( pos_bub(), MAX_VIEW_DISTANCE );
+            }
+
+
+            // then search through all positions to find the best sleep spot
+            for( const tripoint_bub_ms &p : search_positions ) {
                 if( !could_move_onto( p ) || !g->is_empty( p ) ) {
                     continue;
                 }
@@ -1724,6 +1744,7 @@ void npc::execute_action( npc_action action )
                     }
                 }
             }
+
             if( is_walking_with() ) {
                 complain_about( "napping", 30_minutes, chat_snippets().snip_warn_sleep.translated() );
             }


### PR DESCRIPTION
#### Summary
Features "Restrict follower sleep spot to the same vehicle when player is sleeping in a vehicle"

#### Purpose of change

When a follower goes to sleep because the player is sleeping, they will check the area in a radius of `MAX_VIEW_DISTANCE` for the most comfortable sleeping spot. This works well in safe areas, but when sleeping in a vehicle in the middle of a city, this leads to the followers leaving the vehicle to sleep in a nearby house, often resulting in them getting killed while sleeping.

#### Describe the solution

For followers following the player, when a player is sleeping in a vehicle, they will restrict their search to the same vehicle, only falling back to the default if no sleeping spot is found in the vehicle.

#### Describe alternatives you've considered

I've considered introducing a follower rule for how far away they can look for sleeping spots, but it seems like a hassle to manage.

I've considered preferring the follower's assigned crew spot in the vehicle, but that doesn't work well for vehicles with seats and beds: they would always prefer the assigned seat and never sleep in the bed.

I've considered just reducing the range instead of making it smart, but that doesn't work well for large bases and small vehicles.

#### Testing

Save-scummed my third follower death because of this issue and reloaded back to when they were alive. Initiated sleep in the vehicle and confirmed the follower no longer wanders off to get killed somewhere.

#### Additional context

none