### PR TITLE
Balancing time and energy consumption when heating liquids.

### DIFF
--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -8131,9 +8131,17 @@ static bool heat_items( Character *p, item *it, bool liquid_items, bool solid_it
             for( const auto &pair : locs ) {
                 used_volume +=  pair.first->volume( false, true, pair.second );
                 if( pair.first->has_own_flag( flag_FROZEN ) && !pair.first->has_own_flag( flag_EATEN_COLD ) ) {
-                    frozen_weight +=  pair.first->weight( false, false ) * pair.second ;
+                    if( pair.first->made_of_from_type( phase_id::LIQUID ) ) {
+                        frozen_weight +=  pair.first->weight( false, false ) * pair.second / 2 ;
+                    } else {
+                        frozen_weight +=  pair.first->weight( false, false ) * pair.second ;
+                    }
                 } else {
-                    not_frozen_weight +=  pair.first->weight( false, false ) * pair.second;
+                    if( pair.first->made_of_from_type( phase_id::LIQUID ) ) {
+                        not_frozen_weight +=  pair.first->weight( false, false ) * pair.second / 2 ;
+                    } else {
+                        not_frozen_weight +=  pair.first->weight( false, false ) * pair.second;
+                    }
                 }
             }
             heating_requirements required = heating_requirements_for_weight( frozen_weight, not_frozen_weight,

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -8132,13 +8132,13 @@ static bool heat_items( Character *p, item *it, bool liquid_items, bool solid_it
                 used_volume +=  pair.first->volume( false, true, pair.second );
                 if( pair.first->has_own_flag( flag_FROZEN ) && !pair.first->has_own_flag( flag_EATEN_COLD ) ) {
                     if( pair.first->made_of_from_type( phase_id::LIQUID ) ) {
-                        frozen_weight +=  pair.first->weight( false, false ) * pair.second / 2 ;
+                        frozen_weight +=  pair.first->weight( false, false ) * pair.second / 2;
                     } else {
-                        frozen_weight +=  pair.first->weight( false, false ) * pair.second ;
+                        frozen_weight +=  pair.first->weight( false, false ) * pair.second;
                     }
                 } else {
                     if( pair.first->made_of_from_type( phase_id::LIQUID ) ) {
-                        not_frozen_weight +=  pair.first->weight( false, false ) * pair.second / 2 ;
+                        not_frozen_weight +=  pair.first->weight( false, false ) * pair.second / 2;
                     } else {
                         not_frozen_weight +=  pair.first->weight( false, false ) * pair.second;
                     }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Balance "Balancing time and energy consumption when heating liquids"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Due to the convection effect in liquids, heating causes them to warm up more rapidly. 
The original heating code did not account for this factor, resulting in the process of heating frozen water consuming more energy and time than preparing clean water from dirty water.

Original requirement to heat a liquid :
<img width="307" height="168" alt="image" src="https://github.com/user-attachments/assets/8549cc8e-8a25-493f-b93a-64ab5fdb2afe" />
Clean water recipe :
<img width="385" height="482" alt="image" src="https://github.com/user-attachments/assets/d36a1d3d-0a01-4283-b969-06ae152171a6" />



<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
To reduce consumption when heating liquids, halve the estimated volume of liquid in the code.

In fact, during the heating of water, the rate of thermal convection far exceeds that of thermal conduction. This occurs because the upward movement of hot molecules expands the range of heat transfer between molecules with temperature differences. Dividing the value by two is merely a conservative estimate. For specific details, please refer to the link below.

Requirement to heat a liquid now :
<img width="391" height="203" alt="image" src="https://github.com/user-attachments/assets/5c03a91f-e287-4873-af84-36f284225189" />

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Testing
Both actual consumption and displayed content have been changed.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
#### Additional context

<img width="1200" height="800" alt="image" src="https://github.com/user-attachments/assets/ab1dd25c-0f0b-4eb7-b00e-24069178e073" />

[reference](https://engineersguidebook.com/heat-transfer-conduction-convection/)
