### PR TITLE
[MoM] Add psi flesh-raptors

### DIFF
--- a/data/mods/MindOverMatter/monstergroups/monstergroups_new.json
+++ b/data/mods/MindOverMatter/monstergroups/monstergroups_new.json
@@ -297,7 +297,7 @@
   {
     "id": "GROUP_SPAWN_PSI_RAPTOR",
     "type": "monstergroup",
-    "monsters": [  ]
+    "monsters": [ { "monster": "mon_spawn_raptor_teke_push", "weight": 450 } ]
   },
   {
     "id": "GROUP_REPRODUCTION_COW_MUTANT_BABIES",

--- a/data/mods/MindOverMatter/monstergroups/monstergroups_new.json
+++ b/data/mods/MindOverMatter/monstergroups/monstergroups_new.json
@@ -297,7 +297,11 @@
   {
     "id": "GROUP_SPAWN_PSI_RAPTOR",
     "type": "monstergroup",
-    "monsters": [ { "monster": "mon_spawn_raptor_teke_push", "weight": 450 } ]
+    "monsters": [
+      { "monster": "mon_spawn_raptor_teke_push", "weight": 2 },
+      { "monster": "mon_spawn_raptor_pyro_hot_air", "weight": 1 },
+      { "monster": "mon_spawn_raptor_teleport_blink", "weight": 1 }
+    ]
   },
   {
     "id": "GROUP_REPRODUCTION_COW_MUTANT_BABIES",

--- a/data/mods/MindOverMatter/monstergroups/monstergroups_new.json
+++ b/data/mods/MindOverMatter/monstergroups/monstergroups_new.json
@@ -295,6 +295,11 @@
     ]
   },
   {
+    "id": "GROUP_SPAWN_PSI_RAPTOR",
+    "type": "monstergroup",
+    "monsters": [  ]
+  },
+  {
     "id": "GROUP_REPRODUCTION_COW_MUTANT_BABIES",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_cow_calf", "weight": 95 }, { "monster": "mon_hodag_calf", "weight": 95 } ]

--- a/data/mods/MindOverMatter/monstergroups/zombie_upgrades.json
+++ b/data/mods/MindOverMatter/monstergroups/zombie_upgrades.json
@@ -11,6 +11,7 @@
     "monsters": [
       { "monster": "mon_zombie_blank", "weight": 450 },
       { "monster": "mon_zombie_nullpsi", "weight": 225 },
+      { "monster": "mon_zombie_pupating_psi", "weight": 150 },
       { "monster": "mon_zombie_concentration_ender", "weight": 200 },
       { "monster": "mon_zombie_psi_void", "weight": 100 },
       { "monster": "mon_zombie_master", "weight": 25 }

--- a/data/mods/MindOverMatter/monsters/monsters_spells.json
+++ b/data/mods/MindOverMatter/monsters/monsters_spells.json
@@ -1548,5 +1548,21 @@
     "max_range": 0,
     "min_duration": 900000,
     "max_duration": 900000
+  },
+  {
+    "type": "SPELL",
+    "id": "small_psi_raptor_spawn",
+    "name": { "str": "Summon Psi Raptors", "//~": "NO_I18N" },
+    "description": { "str": "Summons a few zombiespawn psi raptors.", "//~": "NO_I18N" },
+    "flags": [ "HOSTILE_SUMMON", "RANDOM_DAMAGE", "PERMANENT", "NO_EXPLOSION_SFX", "SPAWN_GROUP" ],
+    "valid_targets": [ "ground", "self" ],
+    "min_damage": 1,
+    "max_damage": 2,
+    "min_aoe": 4,
+    "max_aoe": 4,
+    "extra_effects": [ { "id": "spawning_zombie_die", "hit_self": true } ],
+    "shape": "blast",
+    "effect": "summon",
+    "effect_str": "GROUP_SPAWN_PSI_RAPTOR"
   }
 ]

--- a/data/mods/MindOverMatter/monsters/zombies.json
+++ b/data/mods/MindOverMatter/monsters/zombies.json
@@ -284,6 +284,7 @@
           "cooldown": { "math": [ "10 + rand(20)" ] },
           "damage_max_instance": [ { "damage_type": "psi_telekinetic_damage", "amount": 3 } ],
           "effects": [ { "id": "downed", "duration": 2, "chance": 5 } ],
+          "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
           "effects_require_dmg": false,
           "hit_dmg_u": "%1$s hits your %2$s with a burst of telekinetic force!",
           "hit_dmg_npc": "%1$s hits <npcname> with a burst of telekinetic force!",
@@ -291,6 +292,38 @@
           "miss_msg_npc": "%1$s flaps its wings at <npcname>!",
           "no_dmg_msg_u": "%1$s hits your %2$s with a burst of telekinetic force, but fails to penetrate armor.",
           "no_dmg_msg_npc": "%1$s hits <npcname> with a burst of telekinetic force, but fails to penetrate armor."
+        }
+      ]
+    }
+  },
+  {
+    "id": "mon_spawn_raptor_pyro_hot_air",
+    "copy-from": "mon_spawn_raptor",
+    "looks_like": "mon_spawn_raptor",
+    "type": "MONSTER",
+    "name": { "str": "heatwave flesh-raptor" },
+    "description": "This small, winged predator darts through the air on three thinly-haired wings that look like stretched human hands.  A sheer, jagged spike juts out from the point where the wings meet.  It looks like nothing you've seen on Earth, and yet strangely like it is made of human parts.  The air around it shimmers with heat haze.",
+    "upgrades": {  },
+    "emit_fields": [ { "emit_id": "emit_pyrokinetic_summon_heat_3", "delay": "1 s" } ]
+  },
+  {
+    "id": "mon_spawn_raptor_teleport_blink",
+    "copy-from": "mon_spawn_raptor",
+    "looks_like": "mon_spawn_raptor",
+    "type": "MONSTER",
+    "name": { "str": "blinking flesh-raptor" },
+    "description": "This small, winged predator darts through the air on three thinly-haired wings that look like stretched human hands.  A sheer, jagged spike juts out from the point where the wings meet.  It looks like nothing you've seen on Earth, and yet strangely like it is made of human parts.  Occasionally, it vanishes and reappears elsewhere.",
+    "upgrades": {  },
+    "extend": {
+      "special_attacks": [
+        {
+          "type": "leap",
+          "cooldown": { "math": [ "3 + rand(6)" ] },
+          "move_cost": 50,
+          "allow_no_target": true,
+          "max_range": 6,
+          "message": "%1$s vanishes and reappears elsewhere!",
+          "condition": { "not": { "u_has_flag": "NO_PSIONICS" } }
         }
       ]
     }

--- a/data/mods/MindOverMatter/monsters/zombies.json
+++ b/data/mods/MindOverMatter/monsters/zombies.json
@@ -268,5 +268,31 @@
       "psi_teleporter_teleporting_damage": 999,
       "psi_enervation_damage": 999
     }
+  },
+  {
+    "id": "mon_spawn_raptor_teke_push",
+    "copy-from": "mon_spawn_raptor",
+    "looks_like": "mon_spawn_raptor",
+    "type": "MONSTER",
+    "name": { "str": "forcewave flesh-raptor" },
+    "description": "This small, winged predator darts through the air on three thinly-haired wings that look like stretched human hands.  A sheer, jagged spike juts out from the point where the wings meet.  It looks like nothing you've seen on Earth, and yet strangely like it is made of human parts.  As it darts through the air, nearby obstacles sometimes bend slightly away from it.",
+    "upgrades": {  },
+    "extend": {
+      "special_attacks": [
+        {
+          "id": "scratch",
+          "cooldown": { "math": [ "10 + rand(20)" ] },
+          "damage_max_instance": [ { "damage_type": "psi_telekinetic_damage", "amount": 3 } ],
+          "effects": [ { "id": "downed", "duration": 2, "chance": 5 } ],
+          "effects_require_dmg": false,
+          "hit_dmg_u": "%1$s hits your %2$s with a burst of telekinetic force!",
+          "hit_dmg_npc": "%1$s hits <npcname> with a burst of telekinetic force!",
+          "miss_msg_u": "%1$s flaps its wings and a burst of wind whistles around you!",
+          "miss_msg_npc": "%1$s flaps its wings at <npcname>!",
+          "no_dmg_msg_u": "%1$s hits your %2$s with a burst of telekinetic force, but fails to penetrate armor.",
+          "no_dmg_msg_npc": "%1$s hits <npcname> with a burst of telekinetic force, but fails to penetrate armor."
+        }
+      ]
+    }
   }
 ]

--- a/data/mods/MindOverMatter/monsters/zombies.json
+++ b/data/mods/MindOverMatter/monsters/zombies.json
@@ -241,5 +241,32 @@
       "psi_teleporter_teleporting_damage": 999,
       "psi_enervation_damage": 999
     }
+  },
+  {
+    "id": "mon_zombie_pupating_psi",
+    "copy-from": "mon_zombie_pupa",
+    "type": "MONSTER",
+    "name": { "str": "pupating blank" },
+    "description": "This human corpse is wrapped in sticky black fibers that cover everything from the neck down.  Beneath the wrapping there is a strange rhythmic movement, grotesque to behold.  When you look directly at it, gray static flickers on the edge of your vision and you hear a very low droning hum.",
+    "species": [ "ZOMBIE", "PSI_NULL" ],
+    "emit_fields": [ { "emit_id": "emit_anti_psi", "delay": "1 s" } ],
+    "color": "dark_gray_white",
+    "extend": { "flags": [ "ENERVATE_IMMUNE", "PHOTOKIN_MONSTER_IMMUNE", "TELEPORT_IMMUNE", "TEEP_IMMUNE", "TELEKIN_IMMUNE" ] },
+    "special_attacks": [
+      { "type": "bite", "cooldown": 3 },
+      {
+        "type": "spell",
+        "spell_data": { "id": "small_psi_raptor_spawn", "hit_self": true },
+        "cooldown": 50,
+        "monster_message": "%s bursts, and gore-smeared winged beasts climb out of the corpse!"
+      }
+    ],
+    "armor": {
+      "electric": 1,
+      "psi_telekinetic_damage": 999,
+      "psi_telepathic_damage": 999,
+      "psi_teleporter_teleporting_damage": 999,
+      "psi_enervation_damage": 999
+    }
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[MoM] Add psi flesh-raptors"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Another blank evolution
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add `pupating blanks`, which spawn various kinds of flesh-raptors. At the moment we have `forcewave flesh-raptor`, which uses little bursts of telekinesis and can knock you off your feet, `heatwave flesh-raptor` which has hot air around it, and `blinking flesh-raptor` which teleports short distances

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Spawned some pupating zombies, fleshraptors appeared from them, checked their abilities.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

These are all kind of weak. More powerful fleshraptors will come.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
