### PR TITLE
Revert - Remove razor blade tool tags I just added 

### DIFF
--- a/data/json/items/tool/toiletries.json
+++ b/data/json/items/tool/toiletries.json
@@ -170,8 +170,7 @@
     "weight": "1 g",
     "volume": "1 ml",
     "longest_side": "38 mm",
-    "melee_damage": { "cut": 1 },
-    "qualities": [ [ "BUTCHER", 2 ], [ "FABRIC_CUT", 1 ] ]
+    "melee_damage": { "cut": 1 }
   },
   {
     "id": "shavingkit",


### PR DESCRIPTION
#### Summary
Balance "Remove tool flags from razor blade I just added"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

I just added the makeshift single sided razor  along with tool tags to razor blades in  #84009 but not happy with them being added so reverting that with a new pr.

the double sided razor blade could arguably be used with thick gloves, but is not a viable tool without. The taped single sided razor I added already covers the tool use cases for the double sided razor 

The fabric cutting in particular was a bit overkill compared to what else has that tag. 

plus keeping the tags off the base item keeps the single sided taped razor something someone might want to ever craft sometime 

#### Describe the solution

remove tags

#### Describe alternatives you've considered

keep butchering level 2

#### Testing

none, but very simple json

#### Additional context

reverting a change of mine that got pushed like yesterday


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
