### PR TITLE
[WIP] Focus, Skill, and Proficiency rates balancing

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -2487,21 +2487,9 @@ bool Character::practice( const skill_id &id, int amount, int cap, bool suppress
         // They don't lose Focus when practicing combat skills.
         const bool predator_training_combat = has_flag( json_flag_PRED4 ) && skill.is_combat_skill();
         if( skill.training_consumes_focus() && !predator_training_combat ) {
-            // Base reduction on the larger of 1% of total, or practice amount.
-            // The latter kicks in when long actions like crafting
-            // apply many turns of gains at once.
-            int focus_drain = std::max( focus_pool / 100, amount );
-
-            // The purpose of having this squared is that it makes focus drain dramatically slower
-            // as it approaches zero. As such, the square function would not be used if the drain is
-            // larger or equal to 1000 to avoid the runaway, and the original drain gets applied instead.
-            if( focus_drain >= 1000 ) {
-                focus_pool -= focus_drain;
-            } else {
-                focus_pool -= ( focus_drain * focus_drain ) / 1000;
-            }
+            // Focus pool is 1-to-1 with practice experience amount.
+            focus_pool = std::max(focus_pool - amount, 0);
         }
-        focus_pool = std::max( focus_pool, 0 );
     }
 
     get_skill_level_object( id ).practice();

--- a/src/character_health.cpp
+++ b/src/character_health.cpp
@@ -583,8 +583,10 @@ int Character::calc_focus_change() const
 void Character::update_mental_focus()
 {
     // calc_focus_change() returns percentile focus, applying it directly
-    // to focus pool is an implicit / 100.
-    focus_pool += 10 * calc_focus_change();
+    // to focus pool is an implicit / 1000.
+    // Focus lerps to equilibrium at a rate of 0.5% per minute
+    // 90% of missing focus recovers in 7.65 hours
+    focus_pool += 5 * calc_focus_change();
 }
 
 void Character::calc_discomfort()

--- a/src/character_proficiency.cpp
+++ b/src/character_proficiency.cpp
@@ -84,7 +84,7 @@ bool Character::practice_proficiency( const proficiency_id &prof, const time_dur
 
     // Drain focus if necessary
     if( !ignore_focus && pct_after > pct_before ) {
-        focus_pool -= focus_pool / 100;
+        focus_pool -= focus_adjusted;
     }
 
     if( learned ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Balance "Rebalance focus mechanic"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
#84059 prompted me to examine the numbers and mechanics involving focus and its relationship with experience gain to see how it currently is and how I can nudge things to make the situation better and better follow the vision from times past.

Findings:
1. Skill practice from crafting happens *every second*
2. Skill practice has a base focus drain of max(1% of current focus, amount), where for crafting, amount is .1% of current focus.  This base consumption is squared for drain less than 1% focus, so the less focus you have the less drain you get.
3. 1 + 2 results in focus cratering from 100 to the low 20's in less than 3 minutes. Meaning, managing focus is near useless because it'll crater too fast for focus to matter
4. Despite the above, right now, you can level up from 0 to 1 in less than 3 minutes! Going from 0 to 4 takes around 6 hours of constant crafting, 0 to 7 takes only 30 hours. Provided materials and survival supplies and enough time left to scavenge more, you can take one crafting skill from 0 to 7 in a week, and be done with skill leveling by early summer.

There were already plans and visions laid out in past PRs and issues to slow down skill gain as practice activities, proficiency system, and NPC-aided crafting has become more robust than it was 5~10 years ago, so I feel like it is also prime time to apply those changes with this PR.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

1. Remove the 1% of current focus cost per practice that dominates focus drain in status quo, making focus drain solely based on XP gained. 
2. Removed focus_drain squared safeguard from skill XP gain, XP gain falloff from low focus is sufficient
3. Make crafting give XP every minute instead of every second for skill XP and every 5% of craft for proficiency
4. Slow focus regen from 1% per minute to 0.5% per minute

Consequences:
1. Skill gain from crafting slowed down by 8~10x overall (60x slower from changing gain rate every second to every minute, partially negated by much higher focus equilibrium). Current state of the PR makes it so that getting from 0 to 1 takes ~2 hours, 0 to 4 takes 58 hours, 0 to 7 takes 275 hours.
2. Learning drains less focus, which means more time spent learning in higher focus, buffing XP gain overall
3. Learning one thing at a time only slightly lowers focus. Learning multiple things at a time (crafting with missing proficiencies, intense fighting) can meaningfully lower focus, which makes taking a break worth doing
4. Focus becomes much more of a long-term mechanic, being consumed and regenerated less than it used to
5. Learning proficiency on the go while crafting a recipe that suffers from time penalty from the proficiency being learned missing is kinda weird. As you learn the proficiency, the craft speeds up and so does the rate of learning, which shows up as accelerating focus loss up until you complete learning the proficiency. bug or feature?
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
- Change XP needed per skill level (requires migration?)
- Implement #53372
- Give a base XP gain multiplier to make XP gain not fall off so much from status quo
- Pick from [any of the other mult/regen value combination](https://docs.google.com/spreadsheets/d/1vvwJ1sCh-3VI00zCNcpxGn9xdeqwki7wrNLvkJPPcQ4/edit?usp=sharing). Interest in particular toward decreasing focus regen rate further?

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Modeled a few mult/regen value combination with the same methodology as existing focus test (from 100 focus, how long of an uninterrupted craft does it take to raise a level?) and put the data into a [sheet](https://docs.google.com/spreadsheets/d/1vvwJ1sCh-3VI00zCNcpxGn9xdeqwki7wrNLvkJPPcQ4/edit?usp=sharing). 
Unit tests related to focus and learning are definitely borked with these changes
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
