### PR TITLE
[DDotD/XE] Mi-go appear (rarely) in DDotD/XE

### DIFF
--- a/data/mods/Xedra_Evolved/mod_interactions/classic_zombies/locations.json
+++ b/data/mods/Xedra_Evolved/mod_interactions/classic_zombies/locations.json
@@ -14,5 +14,65 @@
     "occurrences": [ 75, 100 ],
     "flags": [ "MI-GO", "WILDERNESS", "CLASSIC", "OVERMAP_UNIQUE" ],
     "spawns": { "group": "GROUP_MI-GO_CAMP_OM", "population": [ 1, 2 ], "radius": [ 2, 30 ] }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "mi-go_encampment1_room14",
+    "weight": 1000000,
+    "//": "monster holding cell",
+    "object": {
+      "mapgensize": [ 6, 6 ],
+      "rotation": [ 0, 3 ],
+      "rows": [
+        ".|||..",
+        "|| +..",
+        "|##|||",
+        "|1  P|",
+        "|  1||",
+        "|||||;"
+      ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
+      "palettes": [ "mi-go_palette" ],
+      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 1, 3 ], "y": [ 3, 4 ], "repeat": [ 1, 2 ] } ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "mi-go_scout_tower_cells",
+    "weight": 1000000,
+    "object": {
+      "mapgensize": [ 18, 18 ],
+      "rotation": [ 0, 3 ],
+      "rows": [
+        "vvvvvvvv||vvvvvvvv",
+        "vvvvvv||||||vvvvvv",
+        "vvvv|||PPPP|||vvvv",
+        "vv|||PP    #1|||vv",
+        "|||VP  i   ### ||v",
+        "|<       P   #2 |v",
+        "|>  TnT    i ###||",
+        ".|i nnn        #3|",
+        ".|i nnn &      # |",
+        ".|  TnT      ###||",
+        "||        i  #4 |v",
+        "|P    P ###  ###|v",
+        "|  i    # ####5||v",
+        "|||VPPP #7#6 |||vv",
+        "..||||||||# ||vvvv",
+        ".||vvvvvv||||vvvvv",
+        ".vvv..............",
+        ".................."
+      ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
+      "palettes": [ "mi-go_palette" ],
+      "npcs": {
+        "1": { "class": "mi-go_prisoner" },
+        "2": { "class": "mi-go_prisoner" },
+        "3": { "class": "mi-go_prisoner" },
+        "4": { "class": "mi-go_prisoner" },
+        "6": { "class": "mi-go_prisoner" },
+        "7": { "class": "mi-go_prisoner" }
+      }
+    }
   }
 ]

--- a/data/mods/Xedra_Evolved/mod_interactions/classic_zombies/locations.json
+++ b/data/mods/Xedra_Evolved/mod_interactions/classic_zombies/locations.json
@@ -1,0 +1,18 @@
+[
+  {
+    "type": "overmap_special",
+    "id": "Mi-Go Scout Tower",
+    "overmaps": [
+      { "point": [ 0, 0, 0 ], "overmap": "mi-go_scout_tower_1_north" },
+      { "point": [ 0, 0, 1 ], "overmap": "mi-go_scout_tower_2_north" },
+      { "point": [ 0, 0, 2 ], "overmap": "mi-go_scout_tower_3_north" },
+      { "point": [ 0, 0, 3 ], "overmap": "mi-go_scout_tower_4_north" }
+    ],
+    "locations": [ "wilderness" ],
+    "city_distance": [ 15, -1 ],
+    "city_sizes": [ 0, 20 ],
+    "occurrences": [ 75, 100 ],
+    "flags": [ "MI-GO", "WILDERNESS", "CLASSIC", "OVERMAP_UNIQUE" ],
+    "spawns": { "group": "GROUP_MI-GO_CAMP_OM", "population": [ 1, 2 ], "radius": [ 2, 30 ] }
+  }
+]

--- a/data/mods/Xedra_Evolved/mod_interactions/classic_zombies/monsters.json
+++ b/data/mods/Xedra_Evolved/mod_interactions/classic_zombies/monsters.json
@@ -1,0 +1,38 @@
+[
+  {
+    "id": "mon_mi_go",
+    "copy-from": "mon_mi_go",
+    "type": "MONSTER",
+    "categories": [ "CLASSIC" ]
+  },
+  {
+    "id": "mon_mi_go_scout",
+    "copy-from": "mon_mi_go_scout",
+    "type": "MONSTER",
+    "categories": [ "CLASSIC" ]
+  },
+  {
+    "id": "mon_mi_go_guard",
+    "copy-from": "mon_mi_go_guard",
+    "type": "MONSTER",
+    "categories": [ "CLASSIC" ]
+  },
+  {
+    "id": "mon_mi_go_slaver",
+    "copy-from": "mon_mi_go_slaver",
+    "type": "MONSTER",
+    "categories": [ "CLASSIC" ]
+  },
+  {
+    "id": "mon_mi_go_surgeon",
+    "copy-from": "mon_mi_go_surgeon",
+    "type": "MONSTER",
+    "categories": [ "CLASSIC" ]
+  },
+  {
+    "id": "mon_mi_go_myrmidon",
+    "copy-from": "mon_mi_go_myrmidon",
+    "type": "MONSTER",
+    "categories": [ "CLASSIC" ]
+  }
+]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[DDotD/XE] Mi-go appear (rarely) in DDotD/XE"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Thought this made sense
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Mi-go and mi-go scout towers can appear if you mix DDotD and XE, but rarely--rather than 0 to 3 per overmap, the odds are 60% chance of a scout tower per overmap.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Loaded game, found a scout tower, went there and saw some mi-go. 

No mi-go prisoners are spawning, I'm not sure why. 

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
