### PR TITLE
[DDotD] Default start is in a cabin, remove evac shelters

### DIFF
--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -1633,7 +1633,7 @@
     "city_distance": [ 3, 10 ],
     "city_sizes": [ 4, -1 ],
     "occurrences": [ 2, 9 ],
-    "flags": [ "CLASSIC", "URBAN", "MAN_MADE" ]
+    "flags": [ "URBAN", "MAN_MADE" ]
   },
   {
     "type": "overmap_special",
@@ -1648,7 +1648,7 @@
     "city_distance": [ 3, 10 ],
     "city_sizes": [ 4, -1 ],
     "occurrences": [ 1, 3 ],
-    "flags": [ "CLASSIC", "URBAN", "MAN_MADE" ]
+    "flags": [ "URBAN", "MAN_MADE" ]
   },
   {
     "type": "overmap_special",

--- a/data/mods/classic_zombies/exclusions.json
+++ b/data/mods/classic_zombies/exclusions.json
@@ -8,6 +8,7 @@
     "type": "SCENARIO_BLACKLIST",
     "subtype": "blacklist",
     "scenarios": [
+      "evacuee",
       "fungal_start",
       "hunted_start",
       "lab_cargo_staff_1",
@@ -37,5 +38,12 @@
     "recurrence": [ "10 days", "11 days" ],
     "global": true,
     "effect": [  ]
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "GENERIC_SCENARIO_ID",
+    "//": "The scenario selected by default in the character creator menu.",
+    "stype": "string_input",
+    "value": "ddotd_cabin"
   }
 ]

--- a/data/mods/classic_zombies/scenarios.json
+++ b/data/mods/classic_zombies/scenarios.json
@@ -1,0 +1,12 @@
+[
+  {
+    "type": "scenario",
+    "id": "ddotd_cabin",
+    "name": "Cabin in the Woods",
+    "points": 0,
+    "description": "You have survived the initial wave of panic, and have achieved (relative) safety in an isolated cabin away from the overrun cities.",
+    "allowed_locs": [ "sloc_cabin" ],
+    "start_name": "Isolated Cabin",
+    "flags": [ "CITY_START" ]
+  }
+]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[DDotD] Default start is in a cabin, remove evac shelters"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

The DDotD design doc says:

> The "default start" should put you in a cabin in the woods with one other survivor that already knows you and can tell you a bit about the setting. The rest of the start options should fit one of the two following categories:

...and I thought, huh, that doesn't happen.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Set the default start as "Cabin in the Woods" which places you in a cabin variant. You have an NPC with you and are away from civilization.

Remove the `CLASSIC` flag from evac shelters, preventing them from spawning, and blacklist the `evacuee` scenario start.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Loaded game, Cabin in the Woods was the default scenario. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
