### PR TITLE
Introduction of failure to damaged items to work for some items (2/?)

### DIFF
--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -928,6 +928,12 @@ std::optional<int> iuse::meth( Character *p, item *, const tripoint_bub_ms & )
 
 std::optional<int> iuse::flu_vaccine( Character *p, item *it, const tripoint_bub_ms & )
 {
+    if( !it->activation_success() ) {
+        p->add_msg_if_player( m_bad, _( "You try to inject the vaccine, but the %s injector is stuck." ),
+                              it->tname() );
+        return std::nullopt;
+    }
+
     p->add_msg_if_player( _( "You inject the vaccine." ) );
     time_point expiration_date = it->birthday() + 24_weeks;
     time_duration remaining_time = expiration_date - calendar::turn;
@@ -1792,6 +1798,14 @@ std::optional<int> iuse::fishing_rod( Character *p, item *it, const tripoint_bub
         p->add_msg_if_player( m_info, _( "You can't fish there!" ) );
         return std::nullopt;
     }
+
+    if( !it->activation_success() ) {
+        p->add_msg_if_player( m_bad,
+                              _( "You try to cast your line, but something with your %s prevents it from reeling out." ),
+                              it->tname() );
+        return std::nullopt;
+    }
+
     p->add_msg_if_player( _( "You cast your line and wait to hook something…" ) );
     p->assign_activity( fish_activity_actor( item_location( *p, it ),
                         g->get_fishable_locations_abs( MAX_VIEW_DISTANCE, *found ), 5_hours ) );
@@ -1832,6 +1846,14 @@ std::optional<int> iuse::fish_trap( Character *p, item *it, const tripoint_bub_m
     if( !good_fishing_spot( pnt, p ) ) {
         return std::nullopt;
     }
+
+    if( !it->activation_success() ) {
+        p->add_msg_if_player( m_bad,
+                              _( "You fail to place your %s such that the holes in it are blocked!" ),
+                              it->tname() );
+        return std::nullopt;
+    }
+
     it->active = true;
     it->set_age( 0_turns );
     here.add_item_or_charges( pnt, *it );
@@ -1948,6 +1970,12 @@ std::optional<int> iuse::extinguisher( Character *p, item *it, const tripoint_bu
     tripoint_bub_ms dest = *dest_;
 
     p->mod_moves( -to_moves<int>( 2_seconds ) );
+
+    if( !it->activation_success() ) {
+        p->add_msg_if_player( m_bad, _( "You aim your %s and activate it, but nothing happens." ),
+                              it->tname() );
+        return std::nullopt;
+    }
 
     map &here = get_map();
     // Reduce the strength of fire (if any) in the target tile.
@@ -4134,6 +4162,10 @@ std::optional<int> iuse::fitness_check( Character *p, item *it, const tripoint_b
     if( p->has_trait( trait_ILLITERATE ) ) {
         p->add_msg_if_player( m_info, _( "You don't know what you're looking at." ) );
         return std::nullopt;
+    } else if( !it->activation_success() ) {
+        p->add_msg_if_player( m_bad, _( "Your %s fails to display anything." ), it->tname() );
+        return std::nullopt;
+
     } else {
         //What else should block using f-band?
         std::string msg;
@@ -6804,6 +6836,12 @@ std::optional<int> iuse::foodperson( Character *p, item *it, const tripoint_bub_
 
     time_duration shift = time_duration::from_turns( it->magazine_current()->ammo_remaining( ) *
                           it->type->tool->turns_per_charge );
+
+    if( !it->activation_success() ) {
+        p->add_msg_if_player( m_info, _( "Your HUD of your %s remains dark." ),
+                              it->tname() );
+        return std::nullopt;
+    }
 
     p->add_msg_if_player( m_info, _( "Your HUD lights-up: \"Your shift ends in %s\"." ),
                           to_string( shift ) );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Implement the risk of damaged items to fail to work when activated.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Make a damaged item success check and display a failure message and abort on failure.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
- Make a damaged fish trap have a lower performance on FISH_TRAP_TICK.
- Make a damaged foodperson mask FOODPERSON_VOICE have failure effects (silence, garbled message, screeches, or similar). Requires messing with sound and snippets.
- FIRECRACKER_PACK_ACT might either cancel the activity early, or just have some of the individual crackers be counted as having gone off but without producing any sound.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Debug spawned and debug damaged an item of each kind to 2000 (50%) and activated them to see they could both succeed and fail, and that the failure message was correct.
The foodperson mask required donning it and activating it a number of times, while the flu shots required damaging a bunch of shots and try to use them until one failed (as the first few ones succeeded).  The failed flu shot could be tried again (which happened to be successful).

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Noted the add_iuse() introducing GASMASK_ACTIVATE has a custom text. Would that be useful for some other entries as well?
This provides an activation entry description when examining the item. Looks like an underused opportunity.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
