### PR TITLE
make dry_veggy not dryable

### DIFF
--- a/data/json/items/comestibles/veggy_dishes.json
+++ b/data/json/items/comestibles/veggy_dishes.json
@@ -1184,6 +1184,7 @@
       { "type": "COMPONENT_ID_SUBSTRING", "condition": "zucchini", "name": { "str_sp": "%s, zucchini" } }
     ],
     "copy-from": "veggy",
+    "smoking_result": "null",
     "proportional": { "weight": 0.5 },
     "color": "green",
     "spoils_in": "360 days",


### PR DESCRIPTION
#### Summary
Bugfixes "Make dry_veggy (dehydrated vegetable) not dryable"

#### Purpose of change

`dry_veggy` inherits from `veggy` using `copy-from`, so it also inherits `smoking_result`, which makes it dryable to produce another `dry_veggy`.

#### Describe the solution

Override `smoking_result` to `"null"` so that `dry_veggy` cannot be dried.

#### Describe alternatives you've considered

None, really. Let's not overthink this.

#### Testing

Loaded the game and verified that my "dehydrated vegetable, plant stalk (fresh)" is no longer available for inserting into the smoking rack.

#### Additional context

none