### PR TITLE
[DDotD] Greatly reduce incidence of solar power

### DIFF
--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -2342,7 +2342,7 @@
     "city_sizes": [ 4, -1 ],
     "occurrences": [ 0, 2 ],
     "spawns": { "group": "GROUP_SMALL_STATION", "population": [ 4, 10 ], "radius": [ 0, 0 ] },
-    "flags": [ "CLASSIC", "URBAN", "MAN_MADE" ]
+    "flags": [ "URBAN", "MAN_MADE" ]
   },
   {
     "type": "overmap_special",

--- a/data/mods/classic_zombies/furniture_and_terrain/solar.json
+++ b/data/mods/classic_zombies/furniture_and_terrain/solar.json
@@ -1,0 +1,35 @@
+[
+  {
+    "type": "vehicle_part",
+    "id": "solar_panel",
+    "categories": [ "energy" ],
+    "color": "yellow",
+    "broken_color": "yellow",
+    "damage_modifier": 10,
+    "durability": 20,
+    "epower": "33 W",
+    "item": "solar_panel",
+    "location": "on_roof",
+    "requirements": {
+      "install": {
+        "skills": [ [ "electronics", 2 ], [ "fabrication", 2 ] ],
+        "time": "30 m",
+        "using": [ [ "vehicle_wrench_2", 1 ], [ "drilling_standard", 20 ], [ "vehicle_bolt_install_simple", 1 ] ]
+      },
+      "removal": { "skills": [ [ "electronics", 1 ] ], "time": "10 m", "using": [ [ "vehicle_wrench_2", 1 ] ] },
+      "repair": {
+        "skills": [ [ "electronics", 6 ] ],
+        "time": "50 m",
+        "using": [ [ "vehicle_screw", 1 ], [ "solar_panel", 1 ], [ "soldering_standard", 8 ] ]
+      }
+    },
+    "flags": [ "SOLAR_PANEL" ],
+    "breaks_into": [
+      { "item": "lc_steel_lump", "count": [ 2, 4 ] },
+      { "item": "lc_steel_chunk", "count": [ 2, 4 ] },
+      { "item": "scrap", "charges": [ 2, 4 ] },
+      { "item": "solar_cell", "count": [ 1, 4 ] }
+    ],
+    "variants": [ { "symbols": "#", "symbols_broken": "x" } ]
+  }
+]

--- a/data/mods/classic_zombies/mapgen/solar_removals.json
+++ b/data/mods/classic_zombies/mapgen/solar_removals.json
@@ -1,0 +1,229 @@
+[
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "roof_2x2_utilities_c",
+    "weight": 1000000,
+    "object": {
+      "mapgensize": [ 2, 2 ],
+      "place_furniture": [ { "furn": "f_water_heater", "x": 0, "y": 0 } ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "roof_2x2_utilities",
+    "weight": 1000000,
+    "object": {
+      "mapgensize": [ 2, 2 ],
+      "place_furniture": [
+        { "furn": "f_water_heater", "x": 0, "y": 0 },
+        { "furn": "f_air_conditioner", "x": 1, "y": 0 },
+        { "furn": "f_water_purifier", "x": 1, "y": 1 }
+      ]
+    }
+  },
+   {
+    "type": "mapgen",
+    "nested_mapgen_id": "residential_6kW_solar_v1",
+     "weight": 1000000,
+    "object": {
+      "mapgensize": [ 5, 5 ],
+      "rotation": [ 0, 3 ],
+      "rows": [
+        "#####",
+        "#####",
+        "#####",
+        "#####",
+        "#####"
+      ],
+      "furniture": { "#": "f_null" }
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "residential_6kW_solar_v2",
+    "weight": 1000000,
+    "object": {
+      "mapgensize": [ 5, 5 ],
+      "rotation": [ 0, 3 ],
+      "rows": [
+        "###  ",
+        "###  ",
+        "?##  ",
+        " ##  ",
+        " ##  "
+      ],
+      "furniture": { "#": "f_null" }
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "residential_6kW_solar",
+    "weight": 1000000,
+    "object": {
+      "mapgensize": [ 5, 5 ],
+      "place_nested": [ { "chunks": [ "null" ], "x": 0, "y": 0 } ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "residential_7kW_solar_v1",
+    "weight": 1000000,
+    "object": {
+      "mapgensize": [ 6, 6 ],
+      "rotation": [ 0, 3 ],
+      "rows": [
+        "######",
+        "######",
+        "######",
+        "######",
+        "######",
+        "      "
+      ],
+      "furniture": { "#": "f_null" }
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "residential_7kW_solar_v2",
+    "weight": 1000000,
+    "object": {
+      "mapgensize": [ 6, 6 ],
+      "rotation": [ 0, 3 ],
+      "rows": [
+        "###   ",
+        "###   ",
+        "###   ",
+        "###   ",
+        "###   ",
+        "      "
+      ],
+      "furniture": { "#": "f_null" }
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "residential_7kW_solar",
+    "weight": 1000000,
+    "object": {
+      "mapgensize": [ 6, 6 ],
+      "place_nested": [ { "chunks": [ "null" ], "x": 0, "y": 0 } ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "residential_8kW_solar_v1",
+    "weight": 1000000,
+    "object": {
+      "mapgensize": [ 6, 6 ],
+      "rotation": [ 0, 3 ],
+      "rows": [
+        "######",
+        "######",
+        "######",
+        "######",
+        "######",
+        "######"
+      ],
+      "furniture": { "#": "f_null" }
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "residential_8kW_solar_v2",
+    "weight": 1000000,
+    "object": {
+      "mapgensize": [ 6, 6 ],
+      "rotation": [ 0, 3 ],
+      "rows": [
+        "###   ",
+        "###   ",
+        "###   ",
+        "###   ",
+        "###   ",
+        "###   "
+      ],
+      "furniture": { "#": "f_null" }
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "residential_8kW_solar",
+    "weight": 1000000,
+    "object": {
+      "mapgensize": [ 6, 6 ],
+      "place_nested": [ { "chunks": [ "null" ], "x": 0, "y": 0 } ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "residential_2x2_solar",
+    "weight": 50000,
+    "object": { "mapgensize": [ 2, 2 ], "place_furniture": [ { "furn": "f_null", "x": [ 0, 1 ], "y": [ 0, 1 ] } ] }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "residential_1x2_solar",
+    "weight": 50000,
+    "object": { "mapgensize": [ 2, 2 ], "place_furniture": [ { "furn": "f_null", "x": 0, "y": [ 0, 1 ] } ] }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "residential_1x3_solar",
+    "weight": 50000,
+    "object": { "mapgensize": [ 3, 3 ], "place_furniture": [ { "furn": "f_solar_unit", "x": 0, "y": [ 0, 2 ] } ] }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "residential_3x3_solar",
+    "weight": 50000,
+    "object": { "mapgensize": [ 3, 3 ], "place_furniture": [ { "furn": "f_solar_unit", "x": [ 0, 2 ], "y": [ 0, 2 ] } ] }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "industrial_1x5_solar",
+    "weight": 50000,
+    "object": { "mapgensize": [ 5, 5 ], "place_furniture": [ { "furn": "f_solar_unit", "x": [ 0, 4 ], "y": 0 } ] }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "industrial_1x1_solar",
+    "weight": 50000,
+    "object": { "mapgensize": [ 1, 1 ], "place_furniture": [ { "furn": "f_solar_unit", "x": 0, "y": 0 } ] }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "residential_2x2_solar_v2",
+    "weight": 1000000,
+    "object": { "mapgensize": [ 2, 2 ], "place_furniture": [ { "furn": "f_null", "x": [ 0, 1 ], "y": [ 0, 1 ] } ] }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "residential_1x2_solar_v2",
+    "weight": 1000000,
+    "object": { "mapgensize": [ 2, 2 ], "place_furniture": [ { "furn": "f_null", "x": 0, "y": [ 0, 1 ] } ] }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "residential_1x3_solar_v2",
+    "weight": 1000000,
+    "object": { "mapgensize": [ 3, 3 ], "place_furniture": [ { "furn": "f_null", "x": 0, "y": [ 0, 2 ] } ] }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "residential_3x3_solar_v2",
+    "weight": 1000000,
+    "object": { "mapgensize": [ 3, 3 ], "place_furniture": [ { "furn": "f_null", "x": [ 0, 2 ], "y": [ 0, 2 ] } ] }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "industrial_1x5_solar_v2",
+    "weight": 1000000,
+    "object": { "mapgensize": [ 5, 5 ], "place_furniture": [ { "furn": "f_null", "x": [ 0, 4 ], "y": 0 } ] }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "industrial_1x1_solar_v2",
+    "weight": 1000000,
+    "object": { "mapgensize": [ 1, 1 ], "place_furniture": [ { "furn": "f_null", "x": 0, "y": 0 } ] }
+  }
+]

--- a/data/mods/classic_zombies/mapgen/solar_removals.json
+++ b/data/mods/classic_zombies/mapgen/solar_removals.json
@@ -3,10 +3,7 @@
     "type": "mapgen",
     "nested_mapgen_id": "roof_2x2_utilities_c",
     "weight": 1000000,
-    "object": {
-      "mapgensize": [ 2, 2 ],
-      "place_furniture": [ { "furn": "f_water_heater", "x": 0, "y": 0 } ]
-    }
+    "object": { "mapgensize": [ 2, 2 ], "place_furniture": [ { "furn": "f_water_heater", "x": 0, "y": 0 } ] }
   },
   {
     "type": "mapgen",
@@ -21,10 +18,10 @@
       ]
     }
   },
-   {
+  {
     "type": "mapgen",
     "nested_mapgen_id": "residential_6kW_solar_v1",
-     "weight": 1000000,
+    "weight": 1000000,
     "object": {
       "mapgensize": [ 5, 5 ],
       "rotation": [ 0, 3 ],
@@ -48,7 +45,7 @@
       "rows": [
         "###  ",
         "###  ",
-        "?##  ",
+        " ##  ",
         " ##  ",
         " ##  "
       ],
@@ -59,10 +56,7 @@
     "type": "mapgen",
     "nested_mapgen_id": "residential_6kW_solar",
     "weight": 1000000,
-    "object": {
-      "mapgensize": [ 5, 5 ],
-      "place_nested": [ { "chunks": [ "null" ], "x": 0, "y": 0 } ]
-    }
+    "object": { "mapgensize": [ 5, 5 ], "place_nested": [ { "chunks": [ "null" ], "x": 0, "y": 0 } ] }
   },
   {
     "type": "mapgen",
@@ -104,10 +98,7 @@
     "type": "mapgen",
     "nested_mapgen_id": "residential_7kW_solar",
     "weight": 1000000,
-    "object": {
-      "mapgensize": [ 6, 6 ],
-      "place_nested": [ { "chunks": [ "null" ], "x": 0, "y": 0 } ]
-    }
+    "object": { "mapgensize": [ 6, 6 ], "place_nested": [ { "chunks": [ "null" ], "x": 0, "y": 0 } ] }
   },
   {
     "type": "mapgen",
@@ -149,10 +140,7 @@
     "type": "mapgen",
     "nested_mapgen_id": "residential_8kW_solar",
     "weight": 1000000,
-    "object": {
-      "mapgensize": [ 6, 6 ],
-      "place_nested": [ { "chunks": [ "null" ], "x": 0, "y": 0 } ]
-    }
+    "object": { "mapgensize": [ 6, 6 ], "place_nested": [ { "chunks": [ "null" ], "x": 0, "y": 0 } ] }
   },
   {
     "type": "mapgen",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[DDotD] Greatly reduce incidence of solar power"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

The ubiquity of modern solar power in MA doesn't fit the "You know it's like *waves hands* 30 years ago or something" setting of DDotD. For one, looking it up, there were no solar power farms in Canada in the 20th century. For another, total solar capacity in 2000 was _0.14%_ of what it was in 2025. If you go back to 1992 (the earliest year wikipedia has data), it's 0.02% of 2025. That doesn't fit big collections of solar panels on roofs.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Remove the CLASSIC flag from the Solar Farm special, preventing it from spawning in DDotD. 

Overwrite the rooftop solar nests. Since nested mapgen can't be blacklisted, this unfortunately means I have to do the "copy it all and set the new nest's weight to 1000000" trick. The smaller solar panel lists (like 1x2) I made the f_null versions weight 50000, so there will be some solar panels but they'll be very rare.

Set energy values from solar to 90s values. This looks to be about 1/3 less than modern values (the main reason for widescale solar adoption now is that it's much cheaper, not that it's much more efficient).

Maybe find some way to overwrite cars with solar panels (Edit: false alarm, #83649 removed them already)
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Went to a major city and spent five minutes teleporting from roof to roof. No large clusters of solar panels seen.

Debug-revealed 3x3 overmap area. No solar farms found. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
