### PR TITLE
[DDotD] Remove electric cars

### DIFF
--- a/data/mods/classic_zombies/vehicles/electric_bike_overrides.json
+++ b/data/mods/classic_zombies/vehicles/electric_bike_overrides.json
@@ -1,0 +1,14 @@
+[
+  {
+    "id": "bicycle_electric",
+    "copy-from": "bicycle_dirt",
+    "type": "vehicle",
+    "name": "SUV"
+  },
+  {
+    "id": "scooter_electric",
+    "copy-from": "scooter",
+    "type": "vehicle",
+    "name": "SUV"
+  }
+]

--- a/data/mods/classic_zombies/vehicles/electric_car_overrides.json
+++ b/data/mods/classic_zombies/vehicles/electric_car_overrides.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "car_hybrid",
+    "copy-from": "4x4_car",
+    "type": "vehicle",
+    "name": "4x4 Car"
+  },
+  {
+    "id": "car_micro_hybrid",
+    "copy-from": "car_micro",
+    "type": "vehicle",
+    "name": "Microcar"
+  },
+  {
+    "id": "car_micro_electric",
+    "copy-from": "car_micro",
+    "type": "vehicle",
+    "name": "Microcar"
+  },
+  {
+    "id": "scompact_hybrid",
+    "copy-from": "scompact",
+    "type": "vehicle",
+    "name": "Supercompact Car"
+  },
+  {
+    "id": "scompact_electric",
+    "copy-from": "scompact",
+    "type": "vehicle",
+    "name": "Supercompact Car"
+  },
+  {
+    "id": "scompact_tandem_electric_stow",
+    "copy-from": "scompact_tandem_stow",
+    "type": "vehicle",
+    "name": "Supercompact Tandem Car"
+  },
+  {
+    "id": "scompact_tandem_electric_hboard",
+    "copy-from": "scompact_tandem_hboard",
+    "type": "vehicle",
+    "name": "Supercompact Tandem Car"
+  },
+  {
+    "id": "scompact_tandem_electric_2wheel_stow",
+    "copy-from": "scompact_tandem_2wheel_stow",
+    "type": "vehicle",
+    "name": "Tandem Cabin Motorcycle"
+  },
+  {
+    "id": "scompact_tandem_electric_2wheel_hboard",
+    "copy-from": "scompact_tandem_2wheel_hboard",
+    "type": "vehicle",
+    "name": "Tandem Cabin Motorcycle"
+  },
+  {
+    "id": "scompact_tandem_electric_3wheel_stow",
+    "copy-from": "scompact_tandem_3wheel_stow",
+    "type": "vehicle",
+    "name": "Tandem Three-Wheeled Supercompact Car"
+  },
+  {
+    "id": "scompact_tandem_electric_3wheel_hboard",
+    "copy-from": "scompact_tandem_3wheel_hboard",
+    "type": "vehicle",
+    "name": "Tandem Three-Wheeled Supercompact Car"
+  },
+  {
+    "id": "car_shootingbrake_electric",
+    "copy-from": "car_shootingbrake_v12",
+    "type": "vehicle",
+    "name": "Premium Shooting Brake"
+  }
+]

--- a/data/mods/classic_zombies/vehicles/electric_car_overrides.json
+++ b/data/mods/classic_zombies/vehicles/electric_car_overrides.json
@@ -1,9 +1,9 @@
 [
   {
     "id": "car_hybrid",
-    "copy-from": "4x4_car",
+    "copy-from": "car_luxury",
     "type": "vehicle",
-    "name": "4x4 Car"
+    "name": "Luxury Station Wagon"
   },
   {
     "id": "car_micro_hybrid",
@@ -70,5 +70,95 @@
     "copy-from": "car_shootingbrake_v12",
     "type": "vehicle",
     "name": "Premium Shooting Brake"
+  },
+  {
+    "id": "car_shootingbrake_long_electric",
+    "copy-from": "car_shootingbrake_long_v12",
+    "type": "vehicle",
+    "name": "Premium Shooting Brake"
+  },
+  {
+    "id": "car_sedan_electric",
+    "copy-from": "car_sedan_luxury_v6",
+    "type": "vehicle",
+    "name": "Luxury Sedan"
+  },
+  {
+    "id": "car_sedan_luxury_electric",
+    "copy-from": "car_sedan_luxury_v6",
+    "type": "vehicle",
+    "name": "Luxury Sedan"
+  },
+  {
+    "id": "car_sedan_sports_electric",
+    "copy-from": "car_sedan_luxury_v6",
+    "type": "vehicle",
+    "name": "Luxury Sedan"
+  },
+  {
+    "id": "car_coupe_electric",
+    "copy-from": "car_coupe_sports_v6",
+    "type": "vehicle",
+    "name": "V6 Sports Coupe"
+  },
+  {
+    "id": "car_coupe_luxury_electric",
+    "copy-from": "car_coupe_luxury_v6",
+    "type": "vehicle",
+    "name": "Luxury Coupe"
+  },
+  {
+    "id": "car_coupe_sports_electric",
+    "copy-from": "car_coupe_sports_v12",
+    "type": "vehicle",
+    "name": "V12 Sports Coupe"
+  },
+  {
+    "id": "car_super_electric",
+    "copy-from": "car_super_v12",
+    "type": "vehicle",
+    "name": "V12 Super Car"
+  },
+  {
+    "id": "car_super_electric_alt",
+    "copy-from": "car_super_v12",
+    "type": "vehicle",
+    "name": "V12 Super Car"
+  },
+  {
+    "id": "car_sports_electric",
+    "copy-from": "car_super_v12",
+    "type": "vehicle",
+    "name": "Sports Car"
+  },
+  {
+    "id": "car_racing_electric",
+    "copy-from": "car_super_v12",
+    "type": "vehicle",
+    "name": "Sports Car"
+  },
+  {
+    "id": "electric_car",
+    "copy-from": "car_luxury",
+    "type": "vehicle",
+    "name": "Luxury Station Wagon"
+  },
+  {
+    "id": "suv_electric",
+    "copy-from": "suv",
+    "type": "vehicle",
+    "name": "SUV"
+  },
+  {
+    "id": "suv_electric_rack",
+    "type": "vehicle",
+    "copy-from": "suv",
+    "name": "SUV with Bike Rack",
+    "parts": [
+      { "x": -4, "y": -1, "parts": [ "bike_rack" ] },
+      { "x": -4, "y": 0, "parts": [ "bike_rack" ] },
+      { "x": -4, "y": 1, "parts": [ "bike_rack" ] },
+      { "x": -4, "y": 2, "parts": [ "bike_rack" ] }
+    ]
   }
 ]

--- a/data/mods/classic_zombies/vehicles/electric_vehicle_overrides.json
+++ b/data/mods/classic_zombies/vehicles/electric_vehicle_overrides.json
@@ -1,0 +1,32 @@
+[
+  {
+    "id": "autotractor",
+    "type": "vehicle",
+    "name": "Primitive Tractor",
+    "blueprint": [
+      [ " O  O " ],
+      [ "&&#==&" ],
+      [ " O  O " ]
+    ],
+    "parts": [
+      { "x": 0, "y": 0, "parts": [ "frame#vertical", "seat", "controls" ] },
+      { "x": 1, "y": 0, "parts": [ "frame#vertical", "halfboard#vertical" ] },
+      { "x": 2, "y": 0, "parts": [ "frame#horizontal_front", "halfboard#vertical" ] },
+      { "x": -1, "y": 0, "parts": [ "plow" ] },
+      { "x": 2, "y": -1, "parts": [ "frame#vertical_T_left", "wheel_mount_medium_steerable" ] },
+      { "x": 2, "y": 1, "parts": [ "frame#vertical_T_right", "wheel_mount_medium_steerable" ] },
+      { "x": -1, "y": -1, "parts": [ "frame#vertical_T_left", "wheel_mount_medium" ] },
+      { "x": -1, "y": 1, "parts": [ "frame#vertical_T_right", "wheel_mount_medium" ] },
+      { "x": 0, "y": 0, "parts": [ "dashboard" ] },
+      { "x": 1, "y": 0, "parts": [ "engine_steam_medium", "alternator_truck", "battery_car" ] },
+      { "x": 2, "y": -1, "parts": [ "wheel_wide_or" ] },
+      { "x": 2, "y": 0, "parts": [ { "part": "fuel_bunker", "fuel": "coal_lump" } ] },
+      { "x": 2, "y": 1, "parts": [ "wheel_wide_or" ] },
+      { "x": 3, "y": 0, "parts": [ "reaper" ] },
+      { "x": -1, "y": -1, "parts": [ "wheel_wide_or" ] },
+      { "x": -1, "y": 1, "parts": [ "wheel_wide_or" ] },
+      { "x": -2, "y": 0, "parts": [ "seed_drill" ] }
+    ],
+    "items": [  ]
+  }
+]


### PR DESCRIPTION
Added various electric vehicle overrides for the game.

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[DDotD] Remove electric cars"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Fully electric cars don't fit the time period (vaguely 1980s-late 1990s) that DDotD is set in.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

There's no vehicle blacklists, so instead use copy-from to overwrite electric cars with the nearest non-electric equivalents.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Spawned a bunch of vehicles with `electric` in the id--they were all gas-powered.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Due to the way vehicle spawns work, I was only able to copy-from replace vehicles with the exact same dimensions as their gasoline counterparts. Vehicles with no current in-game fossil fuel equivalent, like the electric forklift or the golf carts, will need a separate PR to produce new versions that match the electric version's dimensions

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
