### PR TITLE
Move ACT_VEHICLE handler to vehicle_activity_actor

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -37,6 +37,7 @@
 #include "contents_change_handler.h"
 #include "coordinates.h"
 #include "craft_command.h"
+#include "crafting.h"
 #include "creature.h"
 #include "creature_tracker.h"
 #include "debug.h"
@@ -59,6 +60,7 @@
 #include "item.h"
 #include "item_components.h"
 #include "item_contents.h"
+#include "item_group.h"
 #include "item_location.h"
 #include "itype.h"
 #include "iuse.h"
@@ -103,7 +105,9 @@
 #include "uistate.h"
 #include "units.h"
 #include "value_ptr.h"
+#include "veh_interact.h"
 #include "veh_type.h"
+#include "veh_utils.h"
 #include "vehicle.h"
 #include "vpart_position.h"
 #include "vpart_range.h"
@@ -185,6 +189,7 @@ static const activity_id ACT_TIDY_UP( "ACT_TIDY_UP" );
 static const activity_id ACT_TRY_SLEEP( "ACT_TRY_SLEEP" );
 static const activity_id ACT_UNLOAD( "ACT_UNLOAD" );
 static const activity_id ACT_UNLOAD_LOOT( "ACT_UNLOAD_LOOT" );
+static const activity_id ACT_VEHICLE( "ACT_VEHICLE" );
 static const activity_id ACT_VEHICLE_FOLD( "ACT_VEHICLE_FOLD" );
 static const activity_id ACT_VEHICLE_UNFOLD( "ACT_VEHICLE_UNFOLD" );
 static const activity_id ACT_WAIT_FOLLOWERS( "ACT_WAIT_FOLLOWERS" );
@@ -300,9 +305,12 @@ static const ter_str_id ter_t_stump( "t_stump" );
 static const ter_str_id ter_t_tree( "t_tree" );
 static const ter_str_id ter_t_trunk( "t_trunk" );
 
+static const trait_id trait_DEBUG_HS( "DEBUG_HS" );
 static const trait_id trait_NUMB( "NUMB" );
 static const trait_id trait_PSYCHOPATH( "PSYCHOPATH" );
 static const trait_id trait_STOCKY_TROGLO( "STOCKY_TROGLO" );
+
+static const vpart_id vpart_ap_wall_wiring( "ap_wall_wiring" );
 
 static const vpart_location_id vpart_location_structure( "structure" );
 
@@ -8362,6 +8370,428 @@ void unload_loot_activity_actor::stage_do( player_activity &, Character &you )
     stage = THINK;
 }
 
+void vehicle_activity_actor::start( player_activity &act, Character & )
+{
+    act.moves_left = to_moves<int>( vehicle_act_duration );
+}
+
+void vehicle_activity_actor::finish( player_activity &act, Character &you )
+{
+    map &here = get_map();
+    //Grab this now, in case the vehicle gets shifted
+    const optional_vpart_position vp = here.veh_at( here.get_bub( vp_location ) );
+    complete_vehicle( act, you );
+    // complete_vehicle set activity type to NULL if the vehicle
+    // was completely dismantled, otherwise the vehicle still exist and
+    // is to be examined again.
+    if( act.is_null() ) {
+        if( you.is_npc() ) {
+            npc *you_as_npc = you.as_npc();
+            you_as_npc->revert_after_activity();
+            you_as_npc->set_moves( 0 );
+        }
+        return;
+    }
+    act.set_to_null();
+    if( !you.is_npc() ) {
+        if( vp ) {
+            here.invalidate_map_cache( here.get_abs_sub().z() );
+            // TODO: Z (and also where the activity is queued)
+            // Or not, because the vehicle coordinates are dropped anyway
+            if( !activity_handlers::resume_for_multi_activities( you ) ) {
+                const point_rel_ms &mount_loc = vp_mount_location.xy();
+                if( vp->vehicle().is_appliance() ) {
+                    g->exam_appliance( vp->vehicle(), mount_loc );
+                } else {
+                    g->exam_vehicle( vp->vehicle(), mount_loc );
+                }
+            }
+            return;
+        } else {
+            debugmsg( "process_activity ACT_VEHICLE: vehicle not found" );
+        }
+    }
+}
+
+void vehicle_activity_actor::complete_vehicle( player_activity &act, Character &you )
+{
+    map &here = get_map();
+    const tripoint_abs_ms &act_pos = vp_location;
+    optional_vpart_position ovp = here.veh_at( act_pos );
+    if( !ovp ) {
+        // so the vehicle could have lost some of its parts from other NPCS works
+        // during this player/NPCs activity.
+        // check the vehicle points that were stored at beginning of activity.
+        for( const tripoint_abs_ms &pt : vehicle_points ) {
+            ovp = here.veh_at( here.get_bub( pt ) );
+            if( ovp ) {
+                break;
+            }
+        }
+        // check again, to see if it really is a case of vehicle gone missing.
+        if( !ovp ) {
+            debugmsg( "Activity ACT_VEHICLE: vehicle not found" );
+            return;
+        }
+    }
+
+    vehicle &veh = ovp->vehicle();
+    const point_rel_ms &d = vp_mount_location_opp.xy();
+    const vpart_id part_id = vp_id;
+    const vpart_info &vpinfo = part_id.obj();
+    const int vp_ind = vp_index;
+
+    switch( sub_activity ) {
+        case VEHICLE_INSTALL: {
+            const inventory &inv = you.crafting_inventory();
+            const requirement_data reqs = vpinfo.install_requirements();
+            if( !reqs.can_make_with_inventory( inv, is_crafting_component, 1, craft_flags::none, false ) ) {
+                you.add_msg_player_or_npc( m_info,
+                                           _( "You don't meet the requirements to install the %s." ),
+                                           _( "<npcname> doesn't meet the requirements to install the %s." ),
+                                           vpinfo.name() );
+                break;
+            }
+
+            // consume items extracting a match for the parts base item
+            item base;
+            std::vector<item> installed_with;
+            for( const std::vector<item_comp> &e : reqs.get_components() ) {
+                for( item &obj : you.consume_items( e, 1, is_crafting_component, [&vpinfo]( const itype_id & itm ) {
+                return itm == vpinfo.base_item;
+            }, false, true ) ) {
+                    if( obj.typeId() == vpinfo.base_item ) {
+                        base = obj;
+                    } else {
+                        installed_with.push_back( obj );
+                    }
+                }
+            }
+            if( base.is_null() ) {
+                if( !you.has_trait( trait_DEBUG_HS ) ) {
+                    add_msg( m_info, _( "Could not find base part in requirements for %s." ), vpinfo.name() );
+                    break;
+                } else {
+                    base = item( vpinfo.base_item );
+                }
+            }
+
+            for( const auto &e : reqs.get_tools() ) {
+                you.consume_tools( e );
+            }
+
+            you.invalidate_crafting_inventory();
+            const int partnum = veh.install_part( here, d, part_id, std::move( base ), installed_with );
+            if( partnum < 0 ) {
+                debugmsg( "complete_vehicle install part fails dx=%d dy=%d id=%s",
+                          d.x(), d.y(), part_id.c_str() );
+                break;
+            }
+            ::vehicle_part &vp_new = veh.part( partnum );
+            if( vp_new.info().variants.size() > 1 ) {
+                veh_interact::do_change_shape_menu( vp_new );
+            }
+
+            // Need map-relative coordinates to compare to output of look_around.
+            // Need to call coord_translate() directly since it's a new part.
+            const point_rel_ms q = veh.coord_translate( d );
+
+            if( vpinfo.has_flag( VPFLAG_CONE_LIGHT ) ||
+                vpinfo.has_flag( VPFLAG_WIDE_CONE_LIGHT ) ||
+                vpinfo.has_flag( VPFLAG_HALF_CIRCLE_LIGHT ) ) {
+                orient_part( here, &veh, vpinfo, partnum, q );
+            }
+
+            const tripoint_bub_ms vehp = veh.pos_bub( here ) + tripoint_rel_ms( q, 0 );
+            // TODO: allow boarding for non-players as well.
+            Character *const pl = get_creature_tracker().creature_at<Character>( vehp );
+            if( vpinfo.has_flag( VPFLAG_BOARDABLE ) && pl ) {
+                here.board_vehicle( vehp, pl );
+            }
+
+            you.add_msg_if_player( m_good, _( "You install a %1$s into the %2$s." ), vp_new.name(), veh.name );
+
+            for( const auto &sk : vpinfo.install_skills ) {
+                you.practice( sk.first, veh_utils::calc_xp_gain( vpinfo, sk.first, you ) );
+            }
+            here.add_vehicle_to_cache( &veh );
+            break;
+        }
+
+        case VEHICLE_REPAIR: {
+            vehicle_part &vp = veh.part( vp_ind );
+            veh_utils::repair_part( here, veh, vp, you );
+            break;
+        }
+
+        case VEHICLE_REFILL: {
+            if( !refill_location ) {
+                debugmsg( "Activity ACT_VEHICLE: missing refill source" );
+                break;
+            }
+
+            item_location &src = refill_location;
+            vehicle_part &vp = veh.part( vp_ind );
+            if( vp.is_tank() && src->is_container() && !src->empty() ) {
+                item_location contained( src, &src->only_item() );
+                contained->charges -= vp.base.fill_with( *contained, contained->charges );
+
+                contents_change_handler handler;
+                handler.unseal_pocket_containing( contained );
+
+                // if code goes here, we can assume "vp" has already refilled with "contained" something.
+                int remaining_ammo_capacity = vp.ammo_capacity( contained->ammo_type() ) - vp.ammo_remaining(
+                                              );
+
+                if( remaining_ammo_capacity ) {
+                    //~ 1$s vehicle name, 2$s tank name
+                    you.add_msg_if_player( m_good, _( "You refill the %1$s's %2$s." ), veh.name, vp.name() );
+                } else {
+                    //~ 1$s vehicle name, 2$s tank name
+                    you.add_msg_if_player( m_good, _( "You completely refill the %1$s's %2$s." ), veh.name, vp.name() );
+                }
+
+                if( contained->charges == 0 ) {
+                    contained.remove_item();
+                } else {
+                    you.add_msg_if_player( m_good, _( "There's some left over!" ) );
+                }
+
+                handler.handle_by( you );
+            } else if( vp.is_fuel_store() ) {
+                contents_change_handler handler;
+                handler.unseal_pocket_containing( src );
+
+                int qty = src->charges;
+                vp.base.reload( you, std::move( src ), qty );
+
+                //~ 1$s vehicle name, 2$s reactor name
+                you.add_msg_if_player( m_good, _( "You refuel the %1$s's %2$s." ), veh.name, vp.name() );
+
+                handler.handle_by( you );
+            } else {
+                debugmsg( "vehicle part is not reloadable" );
+                break;
+            }
+
+            veh.invalidate_mass();
+            break;
+        }
+
+        case VEHICLE_REMOVE_APPLIANCE:
+        case VEHICLE_REMOVE: {
+            int vp_index_copy = vp_ind;
+            if( vp_index_copy >= veh.part_count() ) {
+                vp_index_copy = veh.get_next_shifted_index( vp_index_copy, you );
+                if( vp_index_copy == -1 ) {
+                    you.add_msg_if_player( m_info,
+                                           //~ 1$s is the vehicle part name
+                                           _( "The %1$s has already been removed by someone else." ),
+                                           vpinfo.name() );
+                    return;
+                }
+            }
+            vehicle_part *vp = &veh.part( vp_index_copy );
+            const vpart_info &vpi = vp->info();
+            const bool appliance_removal = sub_activity == VEHICLE_REMOVE_APPLIANCE;
+            const bool wall_wire_removal = appliance_removal && vpi.id == vpart_ap_wall_wiring;
+            const bool broken = vp->is_broken();
+            const bool smash_remove = vpi.has_flag( "SMASH_REMOVE" );
+            const inventory &inv = you.crafting_inventory();
+            const requirement_data &reqs = vpi.removal_requirements();
+            if( !reqs.can_make_with_inventory( inv, is_crafting_component ) ) {
+                //~  1$s is the vehicle part name
+                add_msg( m_info, _( "You don't meet the requirements to remove the %1$s." ), vpi.name() );
+                break;
+            }
+            for( const auto &e : reqs.get_components() ) {
+                you.consume_items( e, 1, is_crafting_component );
+            }
+            for( const auto &e : reqs.get_tools() ) {
+                you.consume_tools( e );
+            }
+
+            you.invalidate_crafting_inventory();
+
+            // This will be a list of all the items which arise from this removal.
+            std::list<item> resulting_items;
+
+            // First we get all the contents of the part
+            vehicle_stack contents = veh.get_items( *vp );
+            resulting_items.insert( resulting_items.end(), contents.begin(), contents.end() );
+            contents.clear();
+
+            if( broken ) {
+                you.add_msg_if_player( _( "You remove the broken %1$s from the %2$s." ), vp->name(), veh.name );
+            } else if( smash_remove ) {
+                you.add_msg_if_player( _( "You smash the %1$s to bits, removing it from the %2$s." ),
+                                       vp->name(), veh.name );
+            } else {
+                you.add_msg_if_player( _( "You remove the %1$s from the %2$s." ), vp->name(), veh.name );
+            }
+
+            if( wall_wire_removal ) {
+                veh.part_to_item( here, *vp ); // what's going on here? this line isn't doing anything...
+            } else if( vpi.has_flag( "TOW_CABLE" ) ) {
+                veh.invalidate_towing( here, true, &you );
+            } else if( broken ) {
+                item_group::ItemList pieces = vp->pieces_for_broken_part();
+                resulting_items.insert( resulting_items.end(), pieces.begin(), pieces.end() );
+            } else {
+                if( smash_remove ) {
+                    item_group::ItemList pieces = vp->pieces_for_broken_part();
+                    resulting_items.insert( resulting_items.end(), pieces.begin(), pieces.end() );
+                } else {
+                    resulting_items.push_back( veh.removed_part( here, *vp ) );
+
+                    // damage reduces chance of success (0.8^damage_level)
+                    const double component_success_chance = std::pow( 0.8, vp->damage_level() );
+                    const double charges_min = std::clamp( component_success_chance, 0.0, 1.0 );
+                    const double charges_max = std::clamp( component_success_chance + 0.1, 0.0, 1.0 );
+                    for( item &it : vp->get_salvageable() ) {
+                        if( it.count_by_charges() ) {
+                            const int charges_befor = it.charges;
+                            it.charges *= rng_float( charges_min, charges_max );
+                            const int charges_destroyed = charges_befor - it.charges;
+                            if( charges_destroyed > 0 ) {
+                                you.add_msg_player_or_npc( m_bad,
+                                                           _( "You fail to recover %1$d %2$s." ),
+                                                           _( "<npcname> fails to recover %1$d %2$s." ),
+                                                           charges_destroyed,
+                                                           it.type_name( charges_destroyed ) );
+                            }
+                            if( it.charges > 0 ) {
+                                resulting_items.push_back( it );
+                            }
+                        } else if( component_success_chance > rng_float( 0, 1 ) ) {
+                            resulting_items.push_back( it );
+                        } else {
+                            you.add_msg_player_or_npc( m_bad,
+                                                       _( "You fail to recover %1$s." ),
+                                                       _( "<npcname> fails to recover %1$s." ),
+                                                       it.type_name() );
+                        }
+                    }
+                }
+                for( const std::pair<const skill_id, int> &sk : vpi.install_skills ) {
+                    // removal is half as educational as installation
+                    you.practice( sk.first, veh_utils::calc_xp_gain( vpi, sk.first, you ) / 2 );
+                }
+            }
+
+            // Power cables must remove parts from the target vehicle, too.
+            if( vpi.has_flag( VPFLAG_POWER_TRANSFER ) ) {
+                veh.remove_remote_part( here, *vp );
+            }
+
+            if( appliance_removal && veh.part_count() > 1 ) {
+                // Split up power grids
+                veh.find_and_split_vehicles( here, { vp_index } );
+                veh.part_removal_cleanup( here );
+                // Ensure the position, pivot, and precalc points are up-to-date
+                veh.pos -= veh.pivot_anchor[0];
+                veh.precalc_mounts( 0, veh.turn_dir, point_rel_ms::zero );
+                here.rebuild_vehicle_level_caches();
+
+                if( auto newpart = here.veh_at( act_pos ).part_with_feature( VPFLAG_APPLIANCE, false ) ) {
+                    vp = &newpart->part();
+                } else {
+                    debugmsg( "No appliance part left to remove after splitting vehicle!" );
+                    vp = nullptr;
+                }
+                //always stop after removing an appliance
+                act.set_to_null();
+            }
+
+            // Save these values now so they aren't lost when parts or vehicles are destroyed.
+            const point_rel_ms part_mount = vp->mount;
+            const tripoint_bub_ms part_pos = veh.bub_part_pos( here, *vp );
+
+            veh.unlink_cables( here, part_mount, you,
+                               false, /* unneeded as items will be unlinked if the connected part is removed */
+                               appliance_removal || vpi.location == vpart_location_structure,
+                               appliance_removal || vpi.has_flag( VPFLAG_CABLE_PORTS ) || vpi.has_flag( VPFLAG_BATTERY ) );
+
+            if( veh.part_count_real() <= 1 ) {
+                you.add_msg_if_player( _( "You completely dismantle the %s." ), veh.name );
+                act.set_to_null();
+                // destroy vehicle clears the cache
+                here.destroy_vehicle( &veh );
+            } else if( vp ) {
+                veh.remove_part( *vp );
+                // part_removal_cleanup calls refresh, so parts_at_relative is valid
+                veh.part_removal_cleanup( here );
+                if( veh.parts_at_relative( part_mount, true ).empty() ) {
+                    here.clear_vehicle_point_from_cache( &veh, part_pos );
+                }
+            }
+            // This will be part of an NPC "job" where they need to clean up the activity
+            // items afterwards
+            if( you.is_npc() ) {
+                for( item &it : resulting_items ) {
+                    it.set_var( "activity_var", you.name );
+                }
+            }
+            // Finally, put all the results somewhere (we wanted to wait until this
+            // point because we don't want to put them back into the vehicle part
+            // that just got removed).
+            std::vector<item_location> locs = put_into_vehicle_or_drop_ret_locs( you,
+                                              item_drop_reason::deliberate,
+                                              resulting_items );
+            if( you.is_npc() ) {
+                for( const item_location &itl : locs ) {
+                    you.may_activity_occupancy_after_end_items_loc.push_back( itl );
+                }
+            }
+            break;
+        }
+        case VEHICLE_UNPLUG: {
+            // Unplug action just sheds loose connections,
+            // assuming vehicle::shed_loose_parts was already called so that
+            // the removed parts have had time to be processed
+            you.add_msg_if_player( _( "You disconnect the %s's power connection." ), veh.name );
+            break;
+        }
+        default: {
+            break;
+        }
+    }
+    you.invalidate_crafting_inventory();
+    you.invalidate_weight_carried_cache();
+}
+
+void vehicle_activity_actor::serialize( JsonOut &jsout ) const
+{
+    jsout.start_object();
+    jsout.member( "sub_activity", sub_activity );
+    jsout.member( "vehicle_act_duration", vehicle_act_duration );
+    jsout.member( "vehicle_points", vehicle_points );
+    jsout.member( "vp_location", vp_location );
+    jsout.member( "vp_mount_location", vp_mount_location );
+    jsout.member( "vp_mount_location_opp", vp_mount_location_opp );
+    jsout.member( "vp_index", vp_index );
+    jsout.member( "vp_id", vp_id );
+    jsout.member( "refill_location", refill_location );
+    jsout.end_object();
+}
+
+std::unique_ptr<activity_actor> vehicle_activity_actor::deserialize( JsonValue &jsin )
+{
+    vehicle_activity_actor actor;
+    JsonObject data = jsin.get_object();
+    data.read( "sub_activity", actor.sub_activity );
+    data.read( "vehicle_act_duration", actor.vehicle_act_duration );
+    data.read( "vehicle_points", actor.vehicle_points );
+    data.read( "vp_location", actor.vp_location );
+    data.read( "vp_mount_location", actor.vp_mount_location );
+    data.read( "vp_mount_location_opp", actor.vp_mount_location_opp );
+    data.read( "vp_index", actor.vp_index );
+    data.read( "vp_id", actor.vp_id );
+    data.read( "refill_location", actor.refill_location );
+
+    return actor.clone();
+}
+
 bool vehicle_folding_activity_actor::fold_vehicle( Character &p, bool check_only ) const
 {
     map &here = get_map();
@@ -9738,6 +10168,7 @@ deserialize_functions = {
     { ACT_TRY_SLEEP, &try_sleep_activity_actor::deserialize },
     { ACT_UNLOAD, &unload_activity_actor::deserialize },
     { ACT_UNLOAD_LOOT, &unload_loot_activity_actor::deserialize },
+    { ACT_VEHICLE, &vehicle_activity_actor::deserialize },
     { ACT_VEHICLE_FOLD, &vehicle_folding_activity_actor::deserialize },
     { ACT_VEHICLE_UNFOLD, &vehicle_unfolding_activity_actor::deserialize },
     { ACT_WAIT_FOLLOWERS, &wait_followers_activity_actor::deserialize },

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -30,6 +30,7 @@
 #include "units.h"
 #include "units_fwd.h"
 #include "vehicle.h"
+#include "veh_interact.h"
 
 #include "activity_actor.h"
 
@@ -2074,6 +2075,80 @@ class haircut_activity_actor : public activity_actor
         void serialize( JsonOut & ) const override;
         static std::unique_ptr<activity_actor> deserialize( JsonValue & );
 };
+
+/** TODO: split up further by vehicle_action
+* vehicle_activity_actor currently handles all possible vehicle activities.
+* This was a carry-over from the legacy activity_handler
+* Notably, none of these activities use start/do_turn, just finish
+*/
+class vehicle_activity_actor : public activity_actor
+{
+    public:
+        vehicle_activity_actor() = default;
+        explicit vehicle_activity_actor(
+            vehicle_action sub_activity,
+            time_duration vehicle_act_duration,
+            vehicle *vehicle_target,
+            const tripoint_abs_ms &vp_location,
+            const tripoint_rel_ms &vp_mount_location,
+            int vp_index,
+            vpart_id vp_id,
+            const item_location &refill_location = item_location() ) :
+            sub_activity( sub_activity ), vehicle_act_duration( vehicle_act_duration ),
+            vp_location( vp_location ),
+            vp_mount_location( vp_mount_location ), vp_mount_location_opp( -vp_mount_location ),
+            vp_index( vp_index ), vp_id( vp_id ), refill_location( refill_location ) {
+            if( vehicle_target != nullptr ) {
+                for( const tripoint_abs_ms &pt : vehicle_target->get_points( true ) ) {
+                    vehicle_points.insert( pt );
+                }
+            }
+        };
+
+        const activity_id &get_type() const override {
+            static const activity_id ACT_VEHICLE( "ACT_VEHICLE" );
+            return ACT_VEHICLE;
+        }
+
+        void start( player_activity &act, Character & ) override;
+        void do_turn( player_activity &, Character & ) override {};
+        void finish( player_activity &act, Character &you ) override;
+
+        /**
+         * Called when the activity timer for installing parts, repairing, etc times
+         * out and the action is complete.
+         */
+        void complete_vehicle( player_activity &act, Character &you );
+
+        std::unique_ptr<activity_actor> clone() const override {
+            return std::make_unique<vehicle_activity_actor>( *this );
+        }
+
+        void serialize( JsonOut &jsout ) const override;
+        static std::unique_ptr<activity_actor> deserialize( JsonValue &jsin );
+    private:
+        //index
+        vehicle_action sub_activity;
+        //moves parameter
+        time_duration vehicle_act_duration;
+
+        //formerly coord_set
+        std::unordered_set<tripoint_abs_ms> vehicle_points;
+        //values[0/1] x/y AND placement[0]???, absolute mount
+        tripoint_abs_ms vp_location;
+        //values[2/3] x/y, mount, NEVER USED!?
+        tripoint_rel_ms vp_mount_location;
+        //values[4/5] x/y, -mount, referenced only in veh_interact::complete
+        tripoint_rel_ms vp_mount_location_opp;
+        //values[6]; index of vehicle part in vehicle
+        int vp_index;
+        //str_values[0]
+        vpart_id vp_id;
+        //targets[0]
+        item_location refill_location;
+
+};
+
 
 class vehicle_folding_activity_actor : public activity_actor
 {

--- a/src/activity_handlers.h
+++ b/src/activity_handlers.h
@@ -257,7 +257,6 @@ void study_spell_finish( player_activity *act, Character *you );
 void teach_finish( player_activity *act, Character *you );
 void toolmod_add_finish( player_activity *act, Character *you );
 void train_finish( player_activity *act, Character *you );
-void vehicle_finish( player_activity *act, Character *you );
 void vibe_finish( player_activity *act, Character *you );
 void wait_finish( player_activity *act, Character *you );
 void wait_npc_finish( player_activity *act, Character *you );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4984,12 +4984,7 @@ void game::save_cyborg( item *cyborg, const tripoint_bub_ms &couch_pos, Characte
 void game::exam_appliance( vehicle &veh, const point_rel_ms &c )
 {
     map &here = get_map();
-
-    player_activity act = veh_app_interact::run( here, veh, c );
-    if( act ) {
-        u.set_moves( 0 );
-        u.assign_activity( act );
-    }
+    veh_app_interact::run( here, veh, c );
 }
 
 void game::exam_vehicle( vehicle &veh, const point_rel_ms &c )
@@ -5000,11 +4995,7 @@ void game::exam_vehicle( vehicle &veh, const point_rel_ms &c )
         add_msg( m_info, _( "This is your %s" ), veh.name );
         return;
     }
-    player_activity act = veh_interact::run( here, veh, c );
-    if( act ) {
-        u.set_moves( 0 );
-        u.assign_activity( act );
-    }
+    veh_interact::run( here, veh, c );
 }
 
 void game::open_gate( const tripoint_bub_ms &p )

--- a/src/savegame_legacy.cpp
+++ b/src/savegame_legacy.cpp
@@ -31,7 +31,6 @@ static const activity_id ACT_REPAIR_ITEM( "ACT_REPAIR_ITEM" );
 static const activity_id ACT_START_ENGINES( "ACT_START_ENGINES" );
 static const activity_id ACT_START_FIRE( "ACT_START_FIRE" );
 static const activity_id ACT_TRAIN( "ACT_TRAIN" );
-static const activity_id ACT_VEHICLE( "ACT_VEHICLE" );
 static const activity_id ACT_VIBE( "ACT_VIBE" );
 static const activity_id ACT_WAIT( "ACT_WAIT" );
 static const activity_id ACT_WAIT_NPC( "ACT_WAIT_NPC" );
@@ -215,7 +214,7 @@ void player_activity::deserialize_legacy_type( int legacy_type, activity_id &des
         activity_id::NULL_ID(), // ACT_LONGSALVAGE is an actor now
         activity_id::NULL_ID(), // ACT_FORAGE is an actor now
         ACT_BUILD,
-        ACT_VEHICLE,
+        activity_id::NULL_ID(), // ACT_VEHICLE is an actor now
         activity_id::NULL_ID(), // ACT_REFILL_VEHICLE is deprecated
         ACT_TRAIN,
         ACT_WAIT_WEATHER,

--- a/src/veh_appliance.cpp
+++ b/src/veh_appliance.cpp
@@ -7,6 +7,7 @@
 #include <unordered_set>
 #include <utility>
 
+#include "activity_actor_definitions.h"
 #include "cached_options.h"
 #include "calendar.h"
 #include "cata_imgui.h"
@@ -45,8 +46,6 @@
 #include "vpart_range.h"
 
 class uilist_impl;
-
-static const activity_id ACT_VEHICLE( "ACT_VEHICLE" );
 
 static const itype_id fuel_type_battery( "battery" );
 static const itype_id itype_power_cord( "power_cord" );
@@ -152,11 +151,10 @@ bool place_appliance( map &here, const tripoint_bub_ms &p, const vpart_id &vpart
     return true;
 }
 
-player_activity veh_app_interact::run( map &here, vehicle &veh, const point_rel_ms &p )
+void veh_app_interact::run( map &here, vehicle &veh, const point_rel_ms &p )
 {
     veh_app_interact ap( veh, p );
     ap.app_loop( here );
-    return ap.act;
 }
 
 // Registers general appliance actions from keybindings
@@ -425,20 +423,13 @@ void veh_app_interact::refill( )
     item_location target = g->inv_map_splice( validate, string_format( _( "Refill %s" ), pt->name() ),
                            1 );
     if( target ) {
-        act = player_activity( ACT_VEHICLE, 1000, static_cast<int>( 'f' ) );
-        act.targets.push_back( target );
-        act.str_values.push_back( pt->info().id.str() );
         const point_rel_ms q = veh->coord_translate( pt->mount );
-        for( const tripoint_abs_ms &p : veh->get_points( true ) ) {
-            act.coord_set.insert( p );
-        }
-        act.values.push_back( veh->pos_abs().x() + q.x() );
-        act.values.push_back( veh->pos_abs().y() + q.y() );
-        act.values.push_back( a_point.x() );
-        act.values.push_back( a_point.y() );
-        act.values.push_back( -a_point.x() );
-        act.values.push_back( -a_point.y() );
-        act.values.push_back( veh->index_of_part( pt ) );
+        tripoint_abs_ms mount_adjusted = veh->pos_abs() + q;
+        Character &you = get_player_character();
+        you.set_moves( 0 );
+        you.assign_activity(
+            vehicle_activity_actor( VEHICLE_REFILL, 15_minutes, veh, mount_adjusted,
+                                    tripoint_rel_ms( a_point, 0 ), veh->index_of_part( pt ), pt->info().id, target ) );
     }
 }
 
@@ -517,18 +508,9 @@ void veh_app_interact::remove( map &here )
         popup( msg );
         //~ Prompt the player if they want to remove the appliance. %s = appliance name.
     } else if( query_yn( _( "Are you sure you want to take down the %s?" ), veh->name ) ) {
-        act = player_activity( ACT_VEHICLE, to_moves<int>( time ), static_cast<int>( 'O' ) );
-        act.str_values.push_back( vpinfo.id.str() );
-        for( const tripoint_abs_ms &p : veh->get_points( true ) ) {
-            act.coord_set.insert( p );
-        }
-        act.values.push_back( a_point_abs.x() );
-        act.values.push_back( a_point_abs.y() );
-        act.values.push_back( a_point.x() );
-        act.values.push_back( a_point.y() );
-        act.values.push_back( -a_point.x() );
-        act.values.push_back( -a_point.y() );
-        act.values.push_back( veh->index_of_part( vp ) );
+        you.set_moves( 0 );
+        you.assign_activity( vehicle_activity_actor( VEHICLE_REMOVE_APPLIANCE, time, veh,
+                             a_point_abs, tripoint_rel_ms( a_point, 0 ), veh->index_of_part( vp ), vpinfo.id ) );
     }
 }
 
@@ -670,6 +652,7 @@ shared_ptr_fast<ui_adaptor> veh_app_interact::create_or_get_ui_adaptor( map &her
 void veh_app_interact::app_loop( map &here )
 {
     bool done = false;
+    Character &you = get_player_character();
     while( !done ) {
         // scope this tighter so that this ui is hidden when app_actions[ret]() triggers
         {
@@ -687,7 +670,7 @@ void veh_app_interact::app_loop( map &here )
             app_actions[ret]();
         }
         // Player activity queued up, close interaction menu
-        if( veh == nullptr || !act.is_null() || !get_player_character().activity.is_null() ) {
+        if( veh == nullptr || you.activity ) {
             done = true;
         }
     }

--- a/src/veh_appliance.h
+++ b/src/veh_appliance.h
@@ -47,10 +47,8 @@ class veh_app_interact
          *
          * @param veh The vehicle representing the appliance
          * @param p The point of interaction on the vehicle (Default = (0,0))
-         * @returns An activity to assign to the player (ACT_VEHICLE),
-         * or a null activity if no further action is required.
         */
-        static player_activity run( map &here, vehicle &veh, const point_rel_ms &p = point_rel_ms::zero );
+        static void run( map &here, vehicle &veh, const point_rel_ms &p = point_rel_ms::zero );
 
     private:
         explicit veh_app_interact( vehicle &veh, const point_rel_ms &p );
@@ -65,9 +63,6 @@ class veh_app_interact
         // to uilist entries in imenu.
         input_context ctxt;
         weak_ptr_fast<ui_adaptor> ui;
-        // Activity to be returned from run(), or a null activity if
-        // no further action is required.
-        player_activity act;
         // Functions corresponding to the actions listed in imenu.entries.
         std::vector<std::function<void()>> app_actions;
         // Curses window to represent the whole drawing area of the interaction UI.

--- a/src/veh_interact.h
+++ b/src/veh_interact.h
@@ -52,6 +52,24 @@ struct vehicle_part;
 // For marking 'leaking' tanks/reactors/batteries
 const std::string leak_marker = "<color_red>*</color>";
 
+// the action done by this vehicle activity
+enum vehicle_action {
+    VEHICLE_INSTALL,    // 'i'
+    VEHICLE_REPAIR,     // 'r'
+    VEHICLE_REFILL,     // 'f'
+    VEHICLE_REMOVE,     // 'o'
+    VEHICLE_REMOVE_APPLIANCE,     // 'O'
+    VEHICLE_UNPLUG,     // 'u'
+    VEHICLE_MEND_FAULTS,// 'm'
+    VEHICLE_SIPHON,     // 's'
+    VEHICLE_UNLOAD,     // 'd'
+    // not activities, legacy
+    VEHICLE_SHAPE,      // 'p'
+    VEHICLE_ASSIGN_CREW,// 'w'
+    VEHICLE_RELABEL,    // 'a'
+    VEHICLE_QUIT        // 'q' or ' '
+};
+
 class veh_interact
 {
         using part_selector = std::function<bool( const map &here, const vehicle_part &pt )>;
@@ -92,7 +110,7 @@ class veh_interact
         const vpart_info *sel_vpart_info = nullptr;
 
         // Command currently being run by the player
-        char sel_cmd = ' ';
+        vehicle_action sel_cmd = VEHICLE_QUIT;
 
         int cpart = -1;
         int page_size = 0;
@@ -151,7 +169,7 @@ class veh_interact
 
         int part_at( const point_rel_ms &d );
         void move_cursor( map &here, const point_rel_ms &d, int dstart_at = 0 );
-        task_reason cant_do( const map &here,  char mode );
+        task_reason cant_do( const map &here, vehicle_action mode );
         bool can_potentially_install( const vpart_info &vpart );
         /** Move index (parameter pos) according to input action:
          * (up or down, single step or whole page).

--- a/src/veh_interact.h
+++ b/src/veh_interact.h
@@ -70,7 +70,10 @@ class veh_interact
         explicit veh_interact( map &here, vehicle &veh, const point_rel_ms &p = point_rel_ms::zero );
         ~veh_interact();
 
-        point_rel_ms dd = point_rel_ms::zero;
+        // vehicle part mount position, only set during constructor
+        // functionally, this works as the cursor position for the top-down vehicle view
+        // see vehicle::build_interact_menu for initial assignment
+        point_rel_ms cursor_vp_mount = point_rel_ms::zero;
         /* starting offset for vehicle parts description display and max offset for scrolling */
         int start_at = 0;
         int start_limit = 0;

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -260,6 +260,7 @@ class turret_cpu
 struct vehicle_part {
         friend vehicle;
         friend class veh_interact;
+        friend class vehicle_activity_actor;
         friend class vehicle_cursor;
         friend class vehicle_stack;
         friend item_location;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Infrastructure "move ACT_VEHICLE handler to vehicle_activity_actor"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Update legacy activities.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

By commit:
1. Refactor `veh_interact::dd` to `veh_interact::cursor_vp_mount`. Note to contributors: avoid using two-letter variables for very vital data, it took me hours to figure out what this actually did.
2. Convert `char` arguments for ACT_VEHICLE sub-activity to enum. Note to contributors: don't use char when you could use an enum.
3. See title, all the work that involves the actual migration of the handler to the actor. This was a lot; vehicle_activity_actor is called with a ton of parameters from four different locations.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

I added a TODO to split up vehicle_activity_actor because it's bloated, probably into something like this:
- VEHICLE_INSTALL
- VEHICLE_REMOVE
- VEHICLE_REFILL_SIPHON
- VEHICLE_REPAIR
- VEHICLE_DECONSTRUCTION
- VEHICLE_UNLOAD_SOLID_FUEL (?)

Also, actions in the vehicle examine menu like `label` and `shape` shouldn't be activities at all.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Tested and confirmed the following vehicle actions work (from the examine vehicle menu):
- install, repair, mend, refill, remove, siphon, unload, crew, shape, rename, label

Also did the usual:
- Ordered an NPC to complete Vehicle Deconstruction and Repair multi-activity successfully.
- Ordered an NPC to do Vehicle Deconstruction in a 0.H save, confirmed activity was canceled when loaded with these changes. 
- Confirmed vehicle activity (de)serialized correctly with NPC still deconstructing for correct duration after a save/load

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Hopefully I haven't missed anything, the scope of what the vehicle handler touches is large

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
