### PR TITLE
Add additional log message after LIXA elevator fall

### DIFF
--- a/data/json/furniture_and_terrain/LIXA_furniture_and_terrain.json
+++ b/data/json/furniture_and_terrain/LIXA_furniture_and_terrain.json
@@ -211,7 +211,9 @@
         "type": "bad"
       },
       { "u_teleport": { "context_val": "Lixa_teleport" }, "force": true },
-      {"u_message": "...After feeling indescribable pain mere moments ago, unexplainably, you awaken somewhere near the facility. Somehow your body has been restored, as if you haven't plummeted down the elevator in the first place."}
+      {
+        "u_message": "...After feeling indescribable pain mere moments ago, unexplainably, you awaken somewhere near the facility. Somehow your body has been restored, as if you haven't plummeted down the elevator in the first place."
+      }
     ]
   },
   {

--- a/data/json/furniture_and_terrain/LIXA_furniture_and_terrain.json
+++ b/data/json/furniture_and_terrain/LIXA_furniture_and_terrain.json
@@ -154,7 +154,9 @@
         "type": "bad"
       },
       { "u_teleport": { "context_val": "Lixa_teleport" }, "force": true },
-      {"u_message": "...After feeling indescribable pain mere moments ago, unexplainably, you awaken somewhere near the facility. Somehow your body has been restored, as if you haven't plummeted down the elevator in the first place."}
+      {
+        "u_message": "...After feeling indescribable pain mere moments ago, unexplainably, you awaken somewhere near the facility. Somehow your body has been restored, as if you haven't plummeted down the elevator in the first place."
+      }
     ]
   },
   {

--- a/data/json/furniture_and_terrain/LIXA_furniture_and_terrain.json
+++ b/data/json/furniture_and_terrain/LIXA_furniture_and_terrain.json
@@ -160,7 +160,7 @@
       },
       { "u_teleport": { "context_val": "Lixa_teleport" }, "force": true },
       {
-        "u_message": "...After feeling indescribable pain mere moments ago, unexplainably, you awaken somewhere near the facility.  Somehow your body has been restored, as if you haven't plummeted down the elevator in the first place."
+        "u_message": "…After feeling indescribable pain mere moments ago, unexplainably, you awaken somewhere near the facility.  Somehow your body has been restored, as if you haven't plummeted down the elevator in the first place."
       }
     ]
   },
@@ -186,7 +186,7 @@
       },
       { "u_teleport": { "context_val": "Lixa_teleport" }, "force": true },
       {
-        "u_message": "...Against all odds, you come back to your senses somewhere near the facility; your head still pounding from the inscrutable agony you went though.  Somehow your body has been reverted back to the state right before your fall."
+        "u_message": "…Against all odds, you come back to your senses somewhere near the facility; your head still pounding from the inscrutable agony you went though.  Somehow your body has been reverted back to the state right before your fall."
       }
     ]
   },
@@ -221,7 +221,7 @@
       },
       { "u_teleport": { "context_val": "Lixa_teleport" }, "force": true },
       {
-        "u_message": "...After feeling indescribable pain mere moments ago, unexplainably, you awaken somewhere near the facility.  Somehow your body has been restored, as if you haven't plummeted down the elevator in the first place."
+        "u_message": "…After feeling indescribable pain mere moments ago, unexplainably, you awaken somewhere near the facility.  Somehow your body has been restored, as if you haven't plummeted down the elevator in the first place."
       }
     ]
   },

--- a/data/json/furniture_and_terrain/LIXA_furniture_and_terrain.json
+++ b/data/json/furniture_and_terrain/LIXA_furniture_and_terrain.json
@@ -160,7 +160,7 @@
       },
       { "u_teleport": { "context_val": "Lixa_teleport" }, "force": true },
       {
-        "u_message": "...After feeling indescribable pain mere moments ago, unexplainably, you awaken somewhere near the facility. Somehow your body has been restored, as if you haven't plummeted down the elevator in the first place."
+        "u_message": "...After feeling indescribable pain mere moments ago, unexplainably, you awaken somewhere near the facility.  Somehow your body has been restored, as if you haven't plummeted down the elevator in the first place."
       }
     ]
   },
@@ -186,7 +186,7 @@
       },
       { "u_teleport": { "context_val": "Lixa_teleport" }, "force": true },
       {
-        "u_message": "...Against all odds, you come back to your senses somewhere near the facility; your head still pounding from the inscrutable agony you went though. Somehow your body has been reverted back to the state right before your fall."
+        "u_message": "...Against all odds, you come back to your senses somewhere near the facility; your head still pounding from the inscrutable agony you went though.  Somehow your body has been reverted back to the state right before your fall."
       }
     ]
   },
@@ -221,7 +221,7 @@
       },
       { "u_teleport": { "context_val": "Lixa_teleport" }, "force": true },
       {
-        "u_message": "...After feeling indescribable pain mere moments ago, unexplainably, you awaken somewhere near the facility. Somehow your body has been restored, as if you haven't plummeted down the elevator in the first place."
+        "u_message": "...After feeling indescribable pain mere moments ago, unexplainably, you awaken somewhere near the facility.  Somehow your body has been restored, as if you haven't plummeted down the elevator in the first place."
       }
     ]
   },

--- a/data/json/furniture_and_terrain/LIXA_furniture_and_terrain.json
+++ b/data/json/furniture_and_terrain/LIXA_furniture_and_terrain.json
@@ -89,7 +89,12 @@
             {
               "run_eoc_selector": [ "EOC_PEEK_DOWN_pseudo", "EOC_CLIMB_DOWN_pseudo", "EOC_JUMP_ACROSS_pseudo", "EOC_FALL_DOWN_pseudo" ],
               "allow_cancel": true,
-              "names": [ "Peek down.", "Climb down by lowering yourself from the ledge.", "Can't jump across (need a small gap).", "Fall down." ],
+              "names": [
+                "Peek down.",
+                "Climb down by lowering yourself from the ledge.",
+                "Can't jump across (need a small gap).",
+                "Fall down."
+              ],
               "title": "There is a ledge here.  What do you want to do?",
               "descriptions": [
                 "You look down as far as you can see.",
@@ -180,7 +185,9 @@
         "type": "bad"
       },
       { "u_teleport": { "context_val": "Lixa_teleport" }, "force": true },
-      {"u_message": "...Against all odds, you come back to your senses somewhere near the facility; your head still pounding from the inscrutable agony you went though. Somehow your body has been reverted back to the state right before your fall."}
+      {
+        "u_message": "...Against all odds, you come back to your senses somewhere near the facility; your head still pounding from the inscrutable agony you went though. Somehow your body has been reverted back to the state right before your fall."
+      }
     ]
   },
   {

--- a/data/json/furniture_and_terrain/LIXA_furniture_and_terrain.json
+++ b/data/json/furniture_and_terrain/LIXA_furniture_and_terrain.json
@@ -89,7 +89,7 @@
             {
               "run_eoc_selector": [ "EOC_PEEK_DOWN_pseudo", "EOC_CLIMB_DOWN_pseudo", "EOC_JUMP_ACROSS_pseudo", "EOC_FALL_DOWN_pseudo" ],
               "allow_cancel": true,
-              "names": [ "Peek down", "Climb down by lowering yourself from the ledge", "Can't jump across (need a small gap)", "Fall down" ],
+              "names": [ "Peek down.", "Climb down by lowering yourself from the ledge.", "Can't jump across (need a small gap).", "Fall down." ],
               "title": "There is a ledge here.  What do you want to do?",
               "descriptions": [
                 "You look down as far as you can see.",
@@ -138,7 +138,7 @@
     ],
     "effect": [
       {
-        "npc_location_variable": { "context_val": "Lixa_teleport" },
+        "u_location_variable": { "context_val": "Lixa_teleport" },
         "target_params": {
           "om_terrain": "LIXA_entry_1",
           "om_terrain_match_type": "CONTAINS",
@@ -149,10 +149,12 @@
         }
       },
       {
-        "npc_message": "You receive an uncontrollable compulsion to step forward into the open elevator shaft.  As you step into the open air… you fall.  Then you keep falling.  The shaft you thought was only a few stories in height must be miles.  You lose count repeatedly but slowly, finally, the floor approaches… THUMP!  You feel searing final pain as every part of your body breaks when you hit the ground.",
-        "popup": true
+        "u_message": "You receive an uncontrollable compulsion to step forward into the open elevator shaft.  As you step into the open air… you fall.  Then you keep falling.  The shaft you thought was only a few stories in height must be miles.  You lose count repeatedly but slowly, finally, the floor approaches… THUMP!  You feel searing final pain as every part of your body breaks when you hit the ground.",
+        "popup": true,
+        "type": "bad"
       },
-      { "npc_teleport": { "context_val": "Lixa_teleport" }, "force": true }
+      { "u_teleport": { "context_val": "Lixa_teleport" }, "force": true },
+      {"u_message": "...After feeling indescribable pain mere moments ago, unexplainably, you awaken somewhere near the facility. Somehow your body has been restored, as if you haven't plummeted down the elevator in the first place."}
     ]
   },
   {
@@ -172,9 +174,11 @@
       },
       {
         "u_message": "You climb down as far as you can and then you let go… you fall.  Then you keep falling.  The shaft you thought was only a few stories in height must be miles.  You try to count but every so often you scrape up against the wall abrading the skin from your limbs, and bruising you to the bone.  You pass out long before you ever hit the bottom.",
-        "popup": true
+        "popup": true,
+        "type": "bad"
       },
-      { "u_teleport": { "context_val": "Lixa_teleport" }, "force": true }
+      { "u_teleport": { "context_val": "Lixa_teleport" }, "force": true },
+      {"u_message": "...Against all odds, you come back to your senses somewhere near the facility; your head still pounding from the inscrutable agony you went though. Somehow your body has been reverted back to the state right before your fall."}
     ]
   },
   {
@@ -203,9 +207,11 @@
       },
       {
         "u_message": "As you step into the open air… you fall.  Then you keep falling.  The shaft you thought was only a few stories in height must be miles.  You lose count repeatedly but slowly, finally, the floor approaches…  THUMP!  You feel searing final pain as every part of your body breaks when you hit the ground.",
-        "popup": true
+        "popup": true,
+        "type": "bad"
       },
-      { "u_teleport": { "context_val": "Lixa_teleport" }, "force": true }
+      { "u_teleport": { "context_val": "Lixa_teleport" }, "force": true },
+      {"u_message": "...After feeling indescribable pain mere moments ago, unexplainably, you awaken somewhere near the facility. Somehow your body has been restored, as if you haven't plummeted down the elevator in the first place."}
     ]
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
If you fall down the LIXA elevator you get a text pop-up explaining how you fall for miles and die. However, you don't actually die and instead get teleported next to the facility instead. From the explanation I received its supposed to be you "dying" and then looping back in time, but there isn't any message hints about it.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
add a couple log messages explaining what happened after you fall down the elevator.
since the first pop-up message still prints into the log, I made it red so it would be easier to see the message after.

I also added dots to the EOC selector names so it would look more like a normal ledge.

apparently you can fall down the elevator with "Peek down" if your morale is very low, but it was borked so I fixed it.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
seems to work fine
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
<img width="416" height="325" alt="изображение" src="https://github.com/user-attachments/assets/6ad902bf-b658-4851-bde6-6204e4158db1" />

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
