### PR TITLE
[Crazy Cataclysm] Rename "troglobite" to "gamer"

### DIFF
--- a/data/mods/CrazyCataclysm/crazy_effects.json
+++ b/data/mods/CrazyCataclysm/crazy_effects.json
@@ -1,0 +1,27 @@
+[
+  {
+    "type": "effect_type",
+    "id": "mutagen_troglobite",
+    "name": [ "Gamer Mutation", "Gamer Transformation", "Gamer Metamorphosis" ],
+    "desc": [
+      "You consumed gamer primer.",
+      "Down in the dark corners of the new world.  That's where you belong.",
+      "Deep and dark, your bones ache and twist."
+    ],
+    "max_intensity": 3,
+    "resist_traits": [ "THRESH_TROGLOBITE" ],
+    "base_mods": {
+      "hurt_min": [ 2 ],
+      "hurt_max": [ 3 ],
+      "hurt_chance": [ -22 ],
+      "hurt_tick": [ 150 ],
+      "pain_min": [ 1 ],
+      "pain_max": [ 2 ],
+      "pain_chance": [ 100 ],
+      "pain_tick": [ 75 ]
+    },
+    "scaling_mods": { "str_mod": [ 2 ], "per_mod": [ -2.5 ], "dex_mod": [ 1 ], "hurt_chance": [ 21, 0 ], "pain_chance": [ -30 ] },
+    "rating": "bad",
+    "blood_analysis_description": "Gamer Primer Contamination"
+  }
+]

--- a/data/mods/CrazyCataclysm/crazy_effects.json
+++ b/data/mods/CrazyCataclysm/crazy_effects.json
@@ -2,7 +2,7 @@
   {
     "type": "effect_type",
     "id": "mutagen_troglobite",
-    "name": [ "Gamer Mutation", "Gamer Transformation", "Gamer Metamorphosis" ],
+    "name": [ "Gamer Juice", "Gamer Fuel", "Gamer Thirst" ],
     "desc": [
       "You consumed gamer primer.",
       "Down in the dark corners of the new world.  That's where you belong.",

--- a/data/mods/CrazyCataclysm/crazy_items.json
+++ b/data/mods/CrazyCataclysm/crazy_items.json
@@ -667,7 +667,7 @@
     "copy-from": "troglobite_sample",
     "type": "ITEM",
     "name": { "str": "gamer sample" },
-    "description": "A slurry of... uhh..."
+    "description": "A slurry of… uhh…
   },
   {
     "id": "iv_mutagen_troglobite",

--- a/data/mods/CrazyCataclysm/crazy_items.json
+++ b/data/mods/CrazyCataclysm/crazy_items.json
@@ -661,5 +661,24 @@
     "name": { "str": "Kitchen Gun™", "str_pl": "Kitchen Guns™" },
     "description": "Say goodbye to daily stains and dirty surfaces with new Kitchen Gun!  Just aim at the dust, blood, or splinters, and then shoot it a bunch of times to clean it.  Blast the filth away with Kitchen Gun™!",
     "ammo_effects": [ "CLEAN_DUST", "CLEAN_SPLINTERS", "CLEAN_BLOOD" ]
+  },
+  {
+    "id": "troglobite_sample",
+    "copy-from": "troglobite_sample",
+    "type": "ITEM",
+    "name": { "str": "gamer sample" },
+    "description": "A slurry of... uhh..."
+  },
+  {
+    "id": "iv_mutagen_troglobite",
+    "copy-from": "iv_mutagen_troglobite",
+    "type": "ITEM",
+    "name": { "str": "gamer mutagenic primer" }
+  },
+  {
+    "id": "mutagen_troglobite",
+    "copy-from": "mutagen_troglobite",
+    "type": "ITEM",
+    "name": { "str": "gamer mutagen" }
   }
 ]

--- a/data/mods/CrazyCataclysm/crazy_items.json
+++ b/data/mods/CrazyCataclysm/crazy_items.json
@@ -667,7 +667,7 @@
     "copy-from": "troglobite_sample",
     "type": "ITEM",
     "name": { "str": "gamer sample" },
-    "description": "A slurry of… uhh…
+    "description": "A slurry of… uhh…",
   },
   {
     "id": "iv_mutagen_troglobite",

--- a/data/mods/CrazyCataclysm/crazy_items.json
+++ b/data/mods/CrazyCataclysm/crazy_items.json
@@ -667,7 +667,7 @@
     "copy-from": "troglobite_sample",
     "type": "ITEM",
     "name": { "str": "gamer sample" },
-    "description": "A slurry of… uhh…",
+    "description": "A slurry of… uhh…"
   },
   {
     "id": "iv_mutagen_troglobite",

--- a/data/mods/CrazyCataclysm/crazy_monsters.json
+++ b/data/mods/CrazyCataclysm/crazy_monsters.json
@@ -449,5 +449,12 @@
       { "u_deal_damage": "pure", "amount": 100000, "bodypart": "torso" },
       { "u_message": "You touch the snail and die instantly." }
     ]
+  },
+  {
+    "id": "mon_chud",
+    "type": "MONSTER",
+    "name": { "str": "feral gamer" },
+    "description": "This person has been without their games for far too long and gone mad, joining the side of the zombies.  With years spent hidden from the sun in the gamer zone having transformed them into some kind of subterranean monster, their hygiene is somehow even worse than that of the undead.",
+    "copy-from": "mon_chud"
   }
 ]

--- a/data/mods/CrazyCataclysm/crazy_mutations.json
+++ b/data/mods/CrazyCataclysm/crazy_mutations.json
@@ -20,5 +20,18 @@
     "valid": false,
     "chargen_allow_npc": false,
     "cancels": [ "LUCKY" ]
+  },
+  {
+    "type": "mutation",
+    "id": "TROGLO3",
+    "copy-from": "TROGLO3",
+    "name": { "str": "Gamer" }
+  },
+  {
+    "type": "mutation",
+    "id": "THRESH_TROGLOBITE",
+    "copy-from": "THRESH_TROGLOBITE",
+    "name": { "str": "Basement Dweller" },
+    "description": "It might not be your parents', but it's a home."
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
none

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Had the idea and found it too funny to not do this.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Rename troglobite mutagen to gamer mutagen. Rename feral troglobite to feral gamer. Rename the threshold to "basement dweller".
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Make the mutagen craft with mountain dew (various kinds of soda) and doritos (tortilla chips) instead of samples.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Loaded in game and everything seemed functional. Duplicating but renaming the effect appears to work correctly.
<img width="650" height="641" alt="image" src="https://github.com/user-attachments/assets/d0fb5f15-d360-4c32-8f61-85620b1c5214" />

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
