### PR TITLE
Make overmapbuffer zzip aware

### DIFF
--- a/src/auto_note.cpp
+++ b/src/auto_note.cpp
@@ -26,6 +26,7 @@
 #include "ui_helpers.h"
 #include "ui_manager.h"
 #include "uilist.h"
+#include "worldfactory.h"
 
 namespace auto_notes
 {
@@ -43,7 +44,7 @@ void auto_note_settings::clear()
 bool auto_note_settings::save( bool bCharacter )
 {
     if( bCharacter && ( !file_exist( PATH_INFO::player_base_save_path() + ".sav" ) &&
-                        !file_exist( PATH_INFO::player_base_save_path() + ".sav.zzip" ) ) ) {
+                        !file_exist( PATH_INFO::player_base_save_path() + ".sav" + zzip_suffix ) ) ) {
         return true;
     }
     cata_path sGlobalFile = PATH_INFO::autonote();

--- a/src/auto_pickup.cpp
+++ b/src/auto_pickup.cpp
@@ -43,6 +43,7 @@
 #include "ui_manager.h"
 #include "uilist.h"
 #include "units.h"
+#include "worldfactory.h"
 
 using namespace auto_pickup;
 
@@ -880,7 +881,7 @@ bool player_settings::save( const bool bCharacter )
         savefile = PATH_INFO::player_base_save_path() + ".apu.json";
 
         const cata_path player_save = PATH_INFO::player_base_save_path() + ".sav";
-        const cata_path player_save_zzip = player_save + ".zzip";
+        const cata_path player_save_zzip = player_save + zzip_suffix;
         //Character not saved yet.
         if( !file_exist( player_save ) || !file_exist( player_save_zzip ) ) {
             return true;

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -391,7 +391,7 @@ bool _trim_mapbuffer( std::filesystem::path const &dep, rdi_t &iter,
 {
     // discard map memory outside of current region and adjacent regions
     if( dep.parent_path().extension() == std::filesystem::u8path( ".mm1" ) ) {
-        if( dep.has_extension() && dep.extension() == ".zzip" ) { // NOLINT(cata-u8-path)
+        if( dep.has_extension() && dep.extension() == zzip_suffix ) { // NOLINT(cata-u8-path)
             // Compressed map memory has to be handled separately
             return false;
         }
@@ -404,7 +404,7 @@ bool _trim_mapbuffer( std::filesystem::path const &dep, rdi_t &iter,
     if( dep.parent_path().filename() == std::filesystem::u8path( "maps" ) ) {
         std::filesystem::path map_folder = dep.filename();
         std::string map_coords;
-        if( map_folder.extension().string() == ".zzip" ) {
+        if( map_folder.extension().string() == zzip_suffix ) {
             map_coords = map_folder.stem().string();
         } else {
             map_coords = map_folder.filename().string();
@@ -419,7 +419,7 @@ bool _trim_mapbuffer( std::filesystem::path const &dep, rdi_t &iter,
 
 bool _trim_overmapbuffer( std::filesystem::path const &dep, tripoint_range<tripoint> const &oms )
 {
-    std::string const fname = dep.extension() == ".zzip" ?  // NOLINT(cata-u8-path)
+    std::string const fname = dep.extension() == zzip_suffix ?  // NOLINT(cata-u8-path)
                               dep.filename().replace_extension( "" ).generic_u8string() : // NOLINT(cata-u8-path)
                               dep.filename().generic_u8string();
 
@@ -480,7 +480,7 @@ void write_min_archive()
                     }
                 }
                 std::filesystem::path min_mmr_save_rel = ( std::filesystem::path{ entry_filename } / // NOLINT(cata-u8-path)
-                        entry_filename ).concat( ".cold.zzip" ); // NOLINT(cata-u8-path)
+                        entry_filename ).concat( ".cold" + std::string( zzip_suffix ) ); // NOLINT(cata-u8-path)
                 std::filesystem::path min_mmr_temp_zzip_path = ( PATH_INFO::world_base_save_path() /
                         min_mmr_save_rel +
                         ".temp" ).get_unrelative_path();

--- a/src/game_io.cpp
+++ b/src/game_io.cpp
@@ -350,7 +350,7 @@ bool game::load( const save_t &name )
                     u.set_save_id( name.decoded_name() );
 
                     if( world_generator->active_world->has_compression_enabled() ) {
-                        std::optional<zzip> z = zzip::load( ( save_file_path + ".zzip" ).get_unrelative_path() );
+                        std::optional<zzip> z = zzip::load( ( save_file_path + zzip_suffix ).get_unrelative_path() );
                         abort = !z.has_value() ||
                         !read_from_zzip_optional( z.value(), save_file_path.get_unrelative_path().filename(),
                         [this]( std::string_view sv ) {
@@ -596,7 +596,7 @@ bool game::save_player_data()
         std::stringstream save;
         serialize_json( save );
         std::filesystem::path save_path = ( playerfile + SAVE_EXTENSION +
-                                            ".zzip" ).get_unrelative_path();
+                                            zzip_suffix ).get_unrelative_path();
         std::filesystem::path tmp_path = save_path;
         tmp_path.concat( ".tmp" ); // NOLINT(cata-u8-path)
         std::optional<zzip> z = zzip::load( save_path );

--- a/src/mapbuffer.cpp
+++ b/src/mapbuffer.cpp
@@ -156,7 +156,7 @@ bool mapbuffer::submap_exists_approx( const tripoint_abs_sm &p )
 
             if( world_generator->active_world->has_compression_enabled() ) {
                 cata_path zzip_name = dirname;
-                zzip_name += ".zzip";
+                zzip_name += zzip_suffix;
                 if( !file_exist( zzip_name ) ) {
                     return false;
                 }
@@ -249,7 +249,7 @@ void mapbuffer::save_quad(
 
     std::optional<zzip> z;
     cata_path zzip_name = dirname;
-    zzip_name += ".zzip";
+    zzip_name += zzip_suffix;
     // The number of uniform submaps is so enormous that the filesystem overhead
     // for this step of just checking if the quad exists approaches 70% of the
     // total cost of saving the mapbuffer, in one test save I had.
@@ -375,7 +375,7 @@ submap *mapbuffer::unserialize_submaps( const tripoint_abs_sm &p )
         if( world_generator->active_world->has_compression_enabled() )
         {
             cata_path zzip_name = dirname;
-            zzip_name += ".zzip";
+            zzip_name += zzip_suffix;
             if( !file_exist( zzip_name ) ) {
                 return false;
             }

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -3961,12 +3961,13 @@ void overmap::place_radios()
 void overmap::open( overmap_special_batch &enabled_specials )
 {
     if( world_generator->active_world->has_compression_enabled() ) {
-        assure_dir_exist( PATH_INFO::current_dimension_save_path() / "overmaps" );
+        assure_dir_exist( PATH_INFO::current_dimension_save_path() / zzip_overmap_directory );
         const std::string terfilename = overmapbuffer::terrain_filename( loc );
         const std::filesystem::path terfilename_path = std::filesystem::u8path( terfilename );
-        const cata_path zzip_path = PATH_INFO::current_dimension_save_path() / "overmaps" / terfilename_path
+        const cata_path zzip_path = PATH_INFO::current_dimension_save_path() / zzip_overmap_directory /
+                                    terfilename_path
                                     +
-                                    ".zzip";
+                                    zzip_suffix;
         if( file_exist( zzip_path ) ) {
             std::optional<zzip> z = zzip::load( zzip_path.get_unrelative_path(),
                                                 ( PATH_INFO::world_base_save_path() / "overmaps.dict" ).get_unrelative_path()
@@ -4018,9 +4019,9 @@ void overmap::save() const
     if( world_generator->active_world->has_compression_enabled() ) {
         const std::string terfilename = overmapbuffer::terrain_filename( loc );
         const std::filesystem::path terfilename_path = std::filesystem::u8path( terfilename );
-        const cata_path overmaps_folder = PATH_INFO::current_dimension_save_path() / "overmaps";
+        const cata_path overmaps_folder = PATH_INFO::current_dimension_save_path() / zzip_overmap_directory;
         assure_dir_exist( overmaps_folder );
-        const cata_path zzip_path = overmaps_folder / terfilename_path + ".zzip";
+        const cata_path zzip_path = overmaps_folder / terfilename_path + zzip_suffix;
         std::optional<zzip> z = zzip::load( zzip_path.get_unrelative_path(),
                                             ( PATH_INFO::world_base_save_path() / "overmaps.dict" ).get_unrelative_path()
                                           );

--- a/src/overmap.h
+++ b/src/overmap.h
@@ -62,8 +62,8 @@ struct map_data_summary;
 struct region_settings;
 template <typename T> struct enum_traits;
 
-static const std::string zzip_overmap_directory = "overmaps";
-static const std::string zzip_suffix = ".zzip";
+const std::string zzip_overmap_directory = "overmaps";
+const std::string zzip_suffix = ".zzip";
 
 struct om_note {
     std::string text;

--- a/src/overmap.h
+++ b/src/overmap.h
@@ -62,9 +62,6 @@ struct map_data_summary;
 struct region_settings;
 template <typename T> struct enum_traits;
 
-const std::string zzip_overmap_directory = "overmaps";
-const std::string zzip_suffix = ".zzip";
-
 struct om_note {
     std::string text;
     point_om_omt p;

--- a/src/overmap.h
+++ b/src/overmap.h
@@ -62,6 +62,9 @@ struct map_data_summary;
 struct region_settings;
 template <typename T> struct enum_traits;
 
+static const std::string zzip_overmap_directory = "overmaps";
+static const std::string zzip_suffix = ".zzip";
+
 struct om_note {
     std::string text;
     point_om_omt p;

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -51,6 +51,7 @@
 #include "text.h"
 #include "translations.h"
 #include "vehicle.h"
+#include "worldfactory.h"
 
 static const oter_type_str_id oter_type_bridgehead_ground( "bridgehead_ground" );
 static const oter_type_str_id oter_type_bridgehead_ramp( "bridgehead_ramp" );
@@ -340,8 +341,23 @@ overmap *overmapbuffer::get_existing( const point_abs_om &p )
         // checked in a previous call of this function).
         return nullptr;
     }
-    assure_dir_exist( PATH_INFO::current_dimension_save_path() );
-    if( file_exist( terrain_filename( p ) ) ) {
+
+    cata_path path;
+
+    const std::string terfilename = overmapbuffer::terrain_filename( p );
+    const std::filesystem::path terfilename_path = std::filesystem::u8path( terfilename );
+
+    if( world_generator->active_world->has_compression_enabled() ) {
+        assure_dir_exist( PATH_INFO::current_dimension_save_path() / zzip_overmap_directory );
+        path = PATH_INFO::current_dimension_save_path() / zzip_overmap_directory / terfilename_path
+               +
+               zzip_suffix;
+    } else {
+        assure_dir_exist( PATH_INFO::current_dimension_save_path() );
+        path = PATH_INFO::current_dimension_save_path() / terfilename_path;
+    }
+
+    if( file_exist( path ) ) {
         // File exists, load it normally (the get function
         // indirectly call overmap::open to do so).
         return &get( p );

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdlib>
+#include <filesystem>
 #include <iterator>
 #include <limits>
 #include <map>

--- a/src/safemode_ui.cpp
+++ b/src/safemode_ui.cpp
@@ -32,6 +32,7 @@
 #include "translations.h"
 #include "uilist.h"
 #include "ui_manager.h"
+#include "worldfactory.h"
 
 safemode &get_safemode()
 {
@@ -789,7 +790,7 @@ bool safemode::save( const bool is_character_in )
     if( is_character ) {
         file = PATH_INFO::player_base_save_path() + ".sfm.json";
         if( !file_exist( PATH_INFO::player_base_save_path() + ".sav" ) ||
-            !file_exist( PATH_INFO::player_base_save_path() + ".sav.zzip" ) ) {
+            !file_exist( PATH_INFO::player_base_save_path() + ".sav" + zzip_suffix ) ) {
             return true; //Character not saved yet.
         }
     }

--- a/src/worldfactory.cpp
+++ b/src/worldfactory.cpp
@@ -2130,7 +2130,7 @@ bool WORLD::set_compression_enabled( bool enabled ) const
                     ui_manager::redraw();
                     refresh_display();
                     inp_mngr.pump_events();
-                    if( !zzip::create_from_folder( ( map_folder + ".zzip" ).get_unrelative_path(),
+                    if( !zzip::create_from_folder( ( map_folder + zzip_suffix ).get_unrelative_path(),
                                                    map_folder.get_unrelative_path(), maps_dict_path ) ) {
                         return false;
                     }
@@ -2142,7 +2142,7 @@ bool WORLD::set_compression_enabled( bool enabled ) const
                 files_to_clean.reserve( files_to_clean.size() + overmaps.size() );
                 size_t done = 0;
                 std::error_code ec;
-                assure_dir_exist( dimension_folder / "overmaps" );
+                assure_dir_exist( dimension_folder / zzip_overmap_directory );
                 std::filesystem::path world_folder_unrelative_path = dimension_folder.get_unrelative_path();
                 for( const cata_path &overmap : overmaps ) {
                     // Some random other files might have `o.` in the name. We only care about the actual
@@ -2159,7 +2159,7 @@ bool WORLD::set_compression_enabled( bool enabled ) const
 
                     // Each overmap gets put into its own zzip indexed by its own file name.
                     std::optional<zzip> overmap_zzip = zzip::create_from_folder_with_files( (
-                                                           dimension_folder / "overmaps" / overmap_file_name + ".zzip" ).get_unrelative_path(),
+                                                           dimension_folder / zzip_overmap_directory / overmap_file_name + zzip_suffix ).get_unrelative_path(),
                                                        world_folder_unrelative_path, { overmap_file_path }, 0,
                                                        overmaps_dict.get_unrelative_path() );
                     if( !overmap_zzip ) {
@@ -2244,7 +2244,7 @@ bool WORLD::set_compression_enabled( bool enabled ) const
                     };
 
                     std::optional<zzip> save_zzip = zzip::load( ( dimension_folder / save_file_name +
-                                                    ".zzip" ).get_unrelative_path() );
+                                                    zzip_suffix ).get_unrelative_path() );
                     if( !save_zzip ) {
                         return false;
                     }
@@ -2287,11 +2287,13 @@ bool WORLD::set_compression_enabled( bool enabled ) const
 
             std::vector<cata_path> maps_zzips = get_files_from_path( "zzip", dimension_folder / "maps", false,
                                                 true );
-            std::vector<cata_path> overmap_zzips = get_files_from_path( "zzip", dimension_folder / "overmaps",
+            std::vector<cata_path> overmap_zzips = get_files_from_path( "zzip",
+                                                   dimension_folder / zzip_overmap_directory,
                                                    false, true );
             std::vector<cata_path> character_map_memory_folders = get_files_from_path( ".mm1",
                     dimension_folder, false, true );
-            std::vector<cata_path> save_zzips = get_files_from_path( ".sav.zzip", dimension_folder,
+            std::vector<cata_path> save_zzips = get_files_from_path( ".sav" + std::string( zzip_suffix ),
+                                                dimension_folder,
                                                 false, true );
 
             zzips_to_clean.reserve( maps_zzips.size() + overmap_zzips.size() +
@@ -2331,7 +2333,7 @@ bool WORLD::set_compression_enabled( bool enabled ) const
                     }
                     zzips_to_clean.push_back( std::move( overmap_zzip ) );
                 }
-                zzips_to_clean.push_back( dimension_folder / "overmaps" );
+                zzips_to_clean.push_back( dimension_folder / zzip_overmap_directory );
             }
             {
                 size_t done = 0;
@@ -2352,11 +2354,13 @@ bool WORLD::set_compression_enabled( bool enabled ) const
                     }
 
                     character_map_memory_zzips.emplace_back( character_map_memory_zzip /
-                            dest_folder_name.filename().concat( ".cold.zzip" ) ); // NOLINT(cata-u8-path)
+                            dest_folder_name.filename().concat( ".cold" + std::string(
+                                        zzip_suffix ) ) ); // NOLINT(cata-u8-path)
                     character_map_memory_zzips.emplace_back( character_map_memory_zzip /
-                            dest_folder_name.filename().concat( ".warm.zzip" ) ); // NOLINT(cata-u8-path)
+                            dest_folder_name.filename().concat( ".warm" + std::string(
+                                        zzip_suffix ) ) ); // NOLINT(cata-u8-path)
                     character_map_memory_zzips.emplace_back( character_map_memory_zzip /
-                            dest_folder_name.filename().concat( ".hot.zzip" ) ); // NOLINT(cata-u8-path)
+                            dest_folder_name.filename().concat( ".hot" + std::string( zzip_suffix ) ) ); // NOLINT(cata-u8-path)
                 }
                 zzips_to_clean.insert( zzips_to_clean.end(), character_map_memory_zzips.begin(),
                                        character_map_memory_zzips.end() );

--- a/src/worldfactory.cpp
+++ b/src/worldfactory.cpp
@@ -2354,10 +2354,10 @@ bool WORLD::set_compression_enabled( bool enabled ) const
                     }
 
                     character_map_memory_zzips.emplace_back( character_map_memory_zzip /
-                            dest_folder_name.filename().concat( ".cold" + std::string(
+                            dest_folder_name.filename().concat( ".cold" + std::string( // NOLINT(cata-u8-path)
                                         zzip_suffix ) ) ); // NOLINT(cata-u8-path)
                     character_map_memory_zzips.emplace_back( character_map_memory_zzip /
-                            dest_folder_name.filename().concat( ".warm" + std::string(
+                            dest_folder_name.filename().concat( ".warm" + std::string( // NOLINT(cata-u8-path)
                                         zzip_suffix ) ) ); // NOLINT(cata-u8-path)
                     character_map_memory_zzips.emplace_back( character_map_memory_zzip /
                             dest_folder_name.filename().concat( ".hot" + std::string( zzip_suffix ) ) ); // NOLINT(cata-u8-path)

--- a/src/worldfactory.h
+++ b/src/worldfactory.h
@@ -20,8 +20,8 @@ enum class special_game_type;
 class JsonArray;
 class JsonObject;
 
-static constexpr std::string_view zzip_overmap_directory = "overmaps";
-static constexpr std::string_view zzip_suffix = ".zzip";
+constexpr std::string_view zzip_overmap_directory = "overmaps";
+constexpr std::string_view zzip_suffix = ".zzip";
 
 namespace catacurses
 {

--- a/src/worldfactory.h
+++ b/src/worldfactory.h
@@ -9,6 +9,7 @@
 #include <memory>
 #include <vector>
 #include <string>
+#include <string_view>
 
 #include "cuboid_rectangle.h"
 #include "options.h"

--- a/src/worldfactory.h
+++ b/src/worldfactory.h
@@ -20,6 +20,9 @@ enum class special_game_type;
 class JsonArray;
 class JsonObject;
 
+static constexpr std::string_view zzip_overmap_directory = "overmaps";
+static constexpr std::string_view zzip_suffix = ".zzip";
+
 namespace catacurses
 {
 class window;

--- a/src/zzip_stack.cpp
+++ b/src/zzip_stack.cpp
@@ -241,7 +241,7 @@ bool zzip_stack::compact( double bloat_factor )
     // Finally normal compact on cold.
     std::filesystem::path tmp_path = path_ / "cold.zzip.tmp"; // NOLINT(cata-u8-path)
     if( cold_->compact_to( tmp_path, std::max( bloat_factor / 2.0, 1.0 ) ) ) {
-        return rename_file( tmp_path, path_ / "cold.zzip" ); // NOLINT(cata-u8-path)
+        return rename_file( tmp_path, path_ / kColdSuffix ); // NOLINT(cata-u8-path)
     }
     return true;
 }

--- a/tools/save/zzip_main.cpp
+++ b/tools/save/zzip_main.cpp
@@ -658,7 +658,7 @@ static int handle_file_contextual( std::filesystem::path const &input_file )
         throw IDK( input_file );
     }
 
-    world_relative_zzip.concat( ".zzip" );
+    world_relative_zzip.concat( kZzipExt );
     return compress_to( world_root / world_relative_zzip, entry_key, world_root / relative_input,
                         dict );
 }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fix #84123.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Copy the zzip administration for overmap files to overmapbuffer. Defined constants for repeatedly used strings, especially since this now spreads the usage to another file.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
- Let the overmapbuffer::terrain_filename() add the zzip suffix if zzip is active. Made an attempt which failed for some reason. Gave up without investigating further.
- Change overmapbuffer::terrain_filename() to include the "overmaps" path segment when zzip is active. Probably doesn't work since different file systems use different separators.
- Change overmapbuffer::terrain_filename() to return a complete path rather than a simple file name. May be the cleanest solution, but didn't want to expand this activity further.
- Introduce an overmap::file_exist(point_abs_om) operation for usage by overmapbuffer.cpp and an overmap::om_path(point_abs_om) operation for usage both by the new operation and the two places in overmap.cpp where paths are calculated (you'd still have to process the file differently depending on zzip usage, but you can have a common local constant for the path to the file).

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Limited to:
- Loaded the save from #84123 and verified activating the modified radio did generate a target location. Also verified the overmap looked approximately the same as it did originally ("approximately", because I don't have photographic memory).
- Loaded my save, which doesn't use zzip compression, and verified the overmap looked reasonable.
- Loaded my save, debug spawned a modified radio, verified coordinates to the facility were generated anew when it was activated (I've already been there before, but have noted previously that activating the radio again generates the quest again). So this shows it still happens.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
